### PR TITLE
feat: Add option to mention a group of users

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -42,6 +42,8 @@ def get_bootinfo():
 		bootinfo.user_info = get_user_info()
 		bootinfo.sid = frappe.session['sid']
 
+	bootinfo.user_groups = frappe.get_all('User Group', pluck="name")
+
 	bootinfo.modules = {}
 	bootinfo.module_list = []
 	load_desktop_data(bootinfo)

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -231,7 +231,7 @@ class TestUser(unittest.TestCase):
 
 		doc = frappe.get_doc({
 			'doctype': 'User Group',
-			'group_name': 'Team',
+			'name': 'Team',
 			'user_group_members': [{
 				'user': 'test@example.com'
 			}, {

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -229,6 +229,28 @@ class TestUser(unittest.TestCase):
 		self.assertEqual(extract_mentions(comment)[0], "test_user@example.com")
 		self.assertEqual(extract_mentions(comment)[1], "test.again@example1.com")
 
+		doc = frappe.get_doc({
+			'doctype': 'User Group',
+			'group_name': 'Team',
+			'user_group_members': [{
+				'user': 'test@example.com'
+			}, {
+				'user': 'test1@example.com'
+			}]
+		})
+		doc.insert(ignore_if_duplicate=True)
+
+		comment = '''
+			<div>
+				Testing comment for
+				<span class="mention" data-id="Team" data-value="Team" data-is-group="true" data-denotation-char="@">
+					<span><span class="ql-mention-denotation-char">@</span>Team</span>
+				</span>
+				please check
+			</div>
+		'''
+		self.assertListEqual(extract_mentions(comment), ['test@example.com', 'test1@example.com'])
+
 	def test_rate_limiting_for_reset_password(self):
 		# Allow only one reset request for a day
 		frappe.db.set_value("System Settings", "System Settings", "password_reset_limit", 1)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1019,8 +1019,11 @@ def extract_mentions(txt):
 	emails = []
 	for mention in soup.find_all(class_='mention'):
 		if mention.get('data-is-group'):
-			user_group = frappe.get_cached_doc('User Group', mention['data-id'])
-			emails += [d.user for d in user_group.user_group_members]
+			try:
+				user_group = frappe.get_cached_doc('User Group', mention['data-id'])
+				emails += [d.user for d in user_group.user_group_members]
+			except frappe.DoesNotExistError:
+				pass
 			continue
 		email = mention['data-id']
 		emails.append(email)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1018,8 +1018,13 @@ def extract_mentions(txt):
 	soup = BeautifulSoup(txt, 'html.parser')
 	emails = []
 	for mention in soup.find_all(class_='mention'):
+		if mention.get('data-is-group'):
+			user_group = frappe.get_cached_doc('User Group', mention['data-id'])
+			emails += [d.user for d in user_group.user_group_members]
+			continue
 		email = mention['data-id']
 		emails.append(email)
+
 	return emails
 
 def handle_password_test_fail(result):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1018,7 +1018,7 @@ def extract_mentions(txt):
 	soup = BeautifulSoup(txt, 'html.parser')
 	emails = []
 	for mention in soup.find_all(class_='mention'):
-		if mention.get('data-is-group'):
+		if mention.get('data-is-group') == 'true':
 			try:
 				user_group = frappe.get_cached_doc('User Group', mention['data-id'])
 				emails += [d.user for d in user_group.user_group_members]

--- a/frappe/core/doctype/user_group/test_user_group.py
+++ b/frappe/core/doctype/user_group/test_user_group.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestUserGroup(unittest.TestCase):
+	pass

--- a/frappe/core/doctype/user_group/user_group.js
+++ b/frappe/core/doctype/user_group/user_group.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('User Group', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe/core/doctype/user_group/user_group.json
+++ b/frappe/core/doctype/user_group/user_group.json
@@ -1,23 +1,14 @@
 {
  "actions": [],
- "autoname": "field:group_name",
+ "autoname": "Prompt",
  "creation": "2021-04-12 15:17:24.751710",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "group_name",
   "user_group_members"
  ],
  "fields": [
-  {
-   "fieldname": "group_name",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Group Name",
-   "reqd": 1,
-   "unique": 1
-  },
   {
    "fieldname": "user_group_members",
    "fieldtype": "Table MultiSelect",
@@ -28,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-04-15 12:17:04.625640",
+ "modified": "2021-04-15 14:24:23.168485",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Group",

--- a/frappe/core/doctype/user_group/user_group.json
+++ b/frappe/core/doctype/user_group/user_group.json
@@ -19,7 +19,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-04-15 14:24:23.168485",
+ "modified": "2021-04-15 16:12:31.455401",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Group",
@@ -36,6 +36,10 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "All"
   }
  ],
  "sort_field": "modified",

--- a/frappe/core/doctype/user_group/user_group.json
+++ b/frappe/core/doctype/user_group/user_group.json
@@ -13,19 +13,22 @@
   {
    "fieldname": "group_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Group Name",
+   "reqd": 1,
    "unique": 1
   },
   {
    "fieldname": "user_group_members",
    "fieldtype": "Table MultiSelect",
    "label": "User Group Members",
-   "options": "User Group Member"
+   "options": "User Group Member",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-04-12 15:17:24.751710",
+ "modified": "2021-04-15 12:17:04.625640",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Group",

--- a/frappe/core/doctype/user_group/user_group.json
+++ b/frappe/core/doctype/user_group/user_group.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "autoname": "field:group_name",
+ "creation": "2021-04-12 15:17:24.751710",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "group_name",
+  "user_group_members"
+ ],
+ "fields": [
+  {
+   "fieldname": "group_name",
+   "fieldtype": "Data",
+   "label": "Group Name",
+   "unique": 1
+  },
+  {
+   "fieldname": "user_group_members",
+   "fieldtype": "Table MultiSelect",
+   "label": "User Group Members",
+   "options": "User Group Member"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2021-04-12 15:17:24.751710",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "User Group",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/core/doctype/user_group/user_group.py
+++ b/frappe/core/doctype/user_group/user_group.py
@@ -5,6 +5,11 @@
 from __future__ import unicode_literals
 # import frappe
 from frappe.model.document import Document
+import frappe
 
 class UserGroup(Document):
-	pass
+	def after_insert(self):
+		frappe.publish_realtime('user_group_added', self.name)
+
+	def on_trash(self):
+		frappe.publish_realtime('user_group_deleted', self.name)

--- a/frappe/core/doctype/user_group/user_group.py
+++ b/frappe/core/doctype/user_group/user_group.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class UserGroup(Document):
+	pass

--- a/frappe/core/doctype/user_group_member/test_user_group_member.py
+++ b/frappe/core/doctype/user_group_member/test_user_group_member.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestUserGroupMember(unittest.TestCase):
+	pass

--- a/frappe/core/doctype/user_group_member/user_group_member.js
+++ b/frappe/core/doctype/user_group_member/user_group_member.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('User Group Member', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe/core/doctype/user_group_member/user_group_member.json
+++ b/frappe/core/doctype/user_group_member/user_group_member.json
@@ -1,0 +1,32 @@
+{
+ "actions": [],
+ "creation": "2021-04-12 15:16:29.279107",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2021-04-12 15:17:18.773046",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "User Group Member",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/core/doctype/user_group_member/user_group_member.py
+++ b/frappe/core/doctype/user_group_member/user_group_member.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class UserGroupMember(Document):
+	pass

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -113,7 +113,7 @@ frappe.Application = Class.extend({
 			dialog.get_close_btn().toggle(false);
 		});
 
-		this.setup_social_listeners();
+		this.setup_user_group_listeners();
 
 		// listen to build errors
 		this.setup_build_error_listener();
@@ -592,11 +592,12 @@ frappe.Application = Class.extend({
 		}
 	},
 
-	setup_social_listeners() {
-		frappe.realtime.on('mention', (message) => {
-			if (frappe.get_route()[0] !== 'social') {
-				frappe.show_alert(message);
-			}
+	setup_user_group_listeners() {
+		frappe.realtime.on('user_group_added', (user_group) => {
+			frappe.boot.user_groups && frappe.boot.user_groups.push(user_group);
+		});
+		frappe.realtime.on('user_group_deleted', (user_group) => {
+			frappe.boot.user_groups = (frappe.boot.user_groups || []).filter(el => el !== user_group);
 		});
 	},
 

--- a/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/blots/mention.js
@@ -15,6 +15,7 @@ class MentionBlot extends Embed {
     node.dataset.id = data.id;
     node.dataset.value = data.value;
     node.dataset.denotationChar = data.denotationChar;
+	node.dataset.isGroup = data.isGroup;
     if (data.link) {
       node.dataset.link = data.link;
     }
@@ -27,6 +28,7 @@ class MentionBlot extends Embed {
       value: domNode.dataset.value,
       link: domNode.dataset.link || null,
       denotationChar: domNode.dataset.denotationChar,
+      isGroup: domNode.dataset.isGroup,
     };
   }
 }

--- a/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
+++ b/frappe/public/js/frappe/form/controls/quill-mention/quill.mention.js
@@ -149,6 +149,7 @@ class Mention {
         this.mentionList.childNodes[this.itemIndex].dataset.value,
       link: itemLink || null,
       denotationChar: this.mentionList.childNodes[this.itemIndex].dataset.denotationChar,
+      isGroup: this.mentionList.childNodes[this.itemIndex].dataset.isGroup,
     };
   }
 
@@ -197,6 +198,7 @@ class Mention {
         li.dataset.index = i;
         li.dataset.id = data[i].id;
         li.dataset.value = data[i].value;
+        li.dataset.isGroup = Boolean(data[i].is_group);
         li.dataset.denotationChar = mentionChar;
         if (data[i].link) {
           li.dataset.link = data[i].link;

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1285,6 +1285,15 @@ Object.assign(frappe.utils, {
 					value: frappe.boot.user_info[user].fullname,
 				};
 			});
+
+		frappe.boot.user_groups && frappe.boot.user_groups.map(group => {
+			names_for_mentions.push({
+				id: group,
+				value: group,
+				is_group: true
+			});
+		});
+
 		return names_for_mentions;
 	},
 	print(doctype, docname, print_format, letterhead, lang_code) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1290,7 +1290,8 @@ Object.assign(frappe.utils, {
 			names_for_mentions.push({
 				id: group,
 				value: group,
-				is_group: true
+				is_group: true,
+				link: frappe.utils.get_form_link('User Group', group)
 			});
 		});
 

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -119,7 +119,7 @@
 	border: 1px solid var(--border-color);
 	padding: 2px 5px;
 	font-size: var(--text-sm);
-	background-color: var(--fg-color);
+	background-color: var(--user-mention-bg-color);
 }
 
 // table
@@ -174,7 +174,7 @@
 .ql-editor.read-mode {
 	padding: 0;
 	.mention {
-		background-color: var(--control-bg);
+		--user-mention-bg-color: var(--control-bg);
 	}
 }
 
@@ -193,5 +193,5 @@
 }
 
 .mention[data-is-group="true"] {
-	background-color: var(--purple-100) !important;
+	background-color: var(--group-mention-bg-color);
 }

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -120,6 +120,9 @@
 	padding: 2px 5px;
 	font-size: var(--text-sm);
 	background-color: var(--user-mention-bg-color);
+	a[href] {
+		text-decoration: none;
+	}
 }
 
 // table

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -191,3 +191,7 @@
 .mention>span {
 	margin: 0 3px;
 }
+
+.mention[data-is-group="true"] {
+	background-color: var(--purple-100) !important;
+}

--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -59,6 +59,10 @@ $input-height: 28px !default;
 	--timeline-content-max-width: 700px;
 	--timeline-left-padding: calc(var(--padding-xl) + var(--timeline-item-icon-size) / 2);
 
+	// mentions
+	--user-mention-bg-color: var(--fg-color);
+	--group-mention-bg-color: var(--bg-purple);
+
 	// skeleton
 	--skeleton-bg: var(--gray-100);
 

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -99,7 +99,7 @@
 	.ql-editor {
 		color: var(--text-on-gray);
 		&.read-mode {
-			span,
+			span:not(.mention),
 			p,
 			u,
 			strong {

--- a/frappe/public/scss/desk/timeline.scss
+++ b/frappe/public/scss/desk/timeline.scss
@@ -77,6 +77,7 @@ $threshold: 34;
 		}
 	}
 	.document-email-link-container {
+		@extend .ellipsis;
 		position: relative;
 		padding: var(--padding-sm);
 		font-size: var(--text-sm);

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -177,7 +177,7 @@ acceptable_attributes = [
 	'data-value', 'role', 'frameborder', 'allowfullscreen', 'spellcheck',
 	'data-mode', 'data-gramm', 'data-placeholder', 'data-comment',
 	'data-id', 'data-denotation-char', 'itemprop', 'itemscope',
-	'itemtype', 'itemid', 'itemref', 'datetime'
+	'itemtype', 'itemid', 'itemref', 'datetime', 'data-is-group'
 ]
 
 mathml_attributes = [


### PR DESCRIPTION
DocTypes Introduced
- User Group & User Group Members (child)

### Feature
Once a user group is created, it will be available in the mention option. All members of the group will be notified if a group is mentioned.

### Usage
**User Group**
<img width="1298" alt="Screenshot 2021-04-14 at 11 36 24 AM" src="https://user-images.githubusercontent.com/13928957/114662443-4f49a580-9d16-11eb-918b-cfc44fd620d4.png">

**Mentions**

<img width="792" alt="Screenshot 2021-04-14 at 11 43 51 AM" src="https://user-images.githubusercontent.com/13928957/114662666-b8311d80-9d16-11eb-8655-0b9288543741.png">
Purple color to differentiate group mentions.

--
> no-docs


- [x] Add test
- [x] fix caching
- [x] Update boot.user_groups on adding new User Group