### PR TITLE
fix: allow to override dashboard chart properties type/color

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -535,14 +535,14 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	render_graph(args) {
 		this.chart_area.show();
 		this.chart_area.body.empty();
-		$.extend(args, {
+		$.extend({
 			type: 'line',
 			colors: ['green'],
 			truncateLegends: 1,
 			axisOptions: {
 				shortenYAxisNumbers: 1
 			}
-		});
+		}, args);
 		this.show();
 
 		this.chart = new frappe.Chart('.form-graph', args);


### PR DESCRIPTION
**Issue-** Rendered chart didn't show the proper chart type(always show line chart) and color(green).