### PR TITLE
fix: Load server translations in boot

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -109,6 +109,13 @@ def get_dict(fortype, name=None):
 		elif fortype=="jsfile":
 			messages = get_messages_from_file(name)
 		elif fortype=="boot":
+			messages = []
+			apps = frappe.get_all_apps(True)
+			for app in apps:
+				messages.extend(get_server_messages(app))
+			messages = deduplicate_messages(messages)
+
+			messages += frappe.db.sql("""select "navbar", item_label from `tabNavbar Item` where item_label is not null""")
 			messages = get_messages_from_include_files()
 			messages += frappe.db.sql("select 'Print Format:', name from `tabPrint Format`")
 			messages += frappe.db.sql("select 'DocType:', name from tabDocType")


### PR DESCRIPTION
This PR takes on the previous PR (#12479) that fixes a problem with the translations in v13, where some translation strings were not being loaded to the bootinfo resulting in some keys not being translated in the frontend

fixes https://github.com/frappe/erpnext/issues/23900
fixes  frappe/erpnext#23858
fixes  frappe/erpnext#25285
fixes  frappe/erpnext#25160