### PR TITLE
fix: reset user type if master record no preset against the user

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -216,6 +216,9 @@ class User(Document):
 
 				frappe.msgprint(_('Role has been set as per the user type {0}')
 					.format(self.user_type), alert=True)
+			else:
+				user_type = frappe.db.get_value('User', self.name, 'user_type')
+				self.user_type = user_type if user_type else 'Website User'
 
 		user_type_doc.update_modules_in_user(self)
 


### PR DESCRIPTION
- User type is set as Employee Self Service even the Employee record was not preset against the User