### PR TITLE
refactor: set amended docname to original docname

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -544,7 +544,7 @@ class DocType(Document):
 	def make_cancellable(self):
 		"""If is_submittable is set, add original_name docfield."""
 		if self.is_submittable and\
-			not frappe.db.get_value('DocField', {'fieldname': 'amended_from', 'parent': self.name}):
+			not frappe.db.get_value('DocField', {'fieldname': 'original_name', 'parent': self.name}):
 
 			self.append("fields", {
 				"label": "Original Name",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -74,6 +74,7 @@ class DocType(Document):
 		if not self.istable:
 			validate_permissions(self)
 
+		self.make_cancellable()
 		self.make_amendable()
 		self.make_repeatable()
 		self.validate_nestedset()
@@ -536,6 +537,21 @@ class DocType(Document):
 						"fieldname": "amended_from",
 						"options": self.name,
 						"read_only": 1,
+						"print_hide": 1,
+						"no_copy": 1
+					})
+
+	def make_cancellable(self):
+		"""If is_submittable is set, add original_name docfield."""
+		if self.is_submittable:
+			if not frappe.db.sql("""select name from tabDocField
+				where fieldname = 'original_name' and parent = %s""", self.name):
+					self.append("fields", {
+						"label": "Original Name",
+						"fieldtype": "Text",
+						"fieldname": "original_name",
+						"read_only": 1,
+						"hidden": 1,
 						"print_hide": 1,
 						"no_copy": 1
 					})

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -531,15 +531,15 @@ class DocType(Document):
 		if self.is_submittable:
 			if not frappe.db.sql("""select name from tabDocField
 				where fieldname = 'amended_from' and parent = %s""", self.name):
-					self.append("fields", {
-						"label": "Amended From",
-						"fieldtype": "Link",
-						"fieldname": "amended_from",
-						"options": self.name,
-						"read_only": 1,
-						"print_hide": 1,
-						"no_copy": 1
-					})
+				self.append("fields", {
+					"label": "Amended From",
+					"fieldtype": "Link",
+					"fieldname": "amended_from",
+					"options": self.name,
+					"read_only": 1,
+					"print_hide": 1,
+					"no_copy": 1
+				})
 
 	def make_cancellable(self):
 		"""If is_submittable is set, add original_name docfield."""

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -528,33 +528,33 @@ class DocType(Document):
 
 	def make_amendable(self):
 		"""If is_submittable is set, add amended_from docfields."""
-		if self.is_submittable:
-			if not frappe.db.sql("""select name from tabDocField
-				where fieldname = 'amended_from' and parent = %s""", self.name):
-				self.append("fields", {
-					"label": "Amended From",
-					"fieldtype": "Link",
-					"fieldname": "amended_from",
-					"options": self.name,
-					"read_only": 1,
-					"print_hide": 1,
-					"no_copy": 1
-				})
+		if self.is_submittable and\
+			not frappe.db.get_value('DocField', {'fieldname': 'amended_from', 'parent': self.name}):
+
+			self.append("fields", {
+				"label": "Amended From",
+				"fieldtype": "Link",
+				"fieldname": "amended_from",
+				"options": self.name,
+				"read_only": 1,
+				"print_hide": 1,
+				"no_copy": 1
+			})
 
 	def make_cancellable(self):
 		"""If is_submittable is set, add original_name docfield."""
-		if self.is_submittable:
-			if not frappe.db.sql("""select name from tabDocField
-				where fieldname = 'original_name' and parent = %s""", self.name):
-					self.append("fields", {
-						"label": "Original Name",
-						"fieldtype": "Text",
-						"fieldname": "original_name",
-						"read_only": 1,
-						"hidden": 1,
-						"print_hide": 1,
-						"no_copy": 1
-					})
+		if self.is_submittable and\
+			not frappe.db.get_value('DocField', {'fieldname': 'amended_from', 'parent': self.name}):
+
+			self.append("fields", {
+				"label": "Original Name",
+				"fieldtype": "Text",
+				"fieldname": "original_name",
+				"read_only": 1,
+				"hidden": 1,
+				"print_hide": 1,
+				"no_copy": 1
+			})
 
 	def make_repeatable(self):
 		"""If allow_auto_repeat is set, add auto_repeat custom field."""

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -350,6 +350,7 @@ class TestDocType(unittest.TestCase):
 		dump_docs = json.dumps(docs.get('docs'))
 		cancel_all_linked_docs(dump_docs)
 		data_link_doc.cancel()
+		data_doc.name = '{}-1'.format(data_doc.name)
 		data_doc.load_from_db()
 		self.assertEqual(data_link_doc.docstatus, 2)
 		self.assertEqual(data_doc.docstatus, 2)
@@ -435,7 +436,10 @@ class TestDocType(unittest.TestCase):
 		self.assertRaises(frappe.LinkExistsError, data_link_doc_1.cancel)
 
 		data_doc.load_from_db()
+
+		data_doc_2.name = '{}-1'.format(data_doc_2.name)
 		data_doc_2.load_from_db()
+
 		self.assertEqual(data_link_doc_1.docstatus, 2)
 
 		#linked doc is canceled

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -7,7 +7,7 @@ import time
 from frappe import _, msgprint, is_whitelisted
 from frappe.utils import flt, cstr, now, get_datetime_str, file_lock, date_diff
 from frappe.model.base_document import BaseDocument, get_controller
-from frappe.model.naming import set_new_name
+from frappe.model.naming import set_new_name, rename_cancelled_doc
 from six import iteritems, string_types
 from werkzeug.exceptions import NotFound, Forbidden
 import hashlib, json
@@ -919,6 +919,14 @@ class Document(BaseDocument):
 	@whitelist.__func__
 	def _cancel(self):
 		"""Cancel the document. Sets `docstatus` = 2, then saves."""
+
+		# for backward compatibility
+		if self.amended_from and not self.original_name:
+			self.original_name = None
+		else:
+			self.original_name = self.name
+
+		self.name = rename_cancelled_doc(self)
 		self.docstatus = 2
 		self.save()
 

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -199,6 +199,14 @@ def getseries(key, digits):
 
 
 def revert_series_if_last(key, name, doc=None):
+	# do not revert if doc is amended, since cancelled docs still exist
+	if doc.docstatus != 2 and doc.amended_from:
+		return
+
+	# for first cancelled doc
+	if doc.docstatus == 2 and not doc.amended_from and doc.original_name:
+		name = doc.original_name
+
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:
@@ -277,14 +285,48 @@ def append_number_if_name_exists(doctype, value, fieldname="name", separator="-"
 
 
 def _set_amended_name(doc):
+	if doc.original_name:
+		doc.name = doc.original_name
+	else:
+		original_name = get_original_name(doc)
+		doc.name = doc.amended_from
+
+		# rename original doc to next name in series, and set amended doc name as original name
+		next_name_in_series = get_new_name_from_amended_from(doc)
+		frappe.rename_doc(doc.doctype, original_name, next_name_in_series, force=True, show_alert=False)
+		doc.name = original_name
+		doc.amended_from = next_name_in_series
+		doc.original_name = original_name
+
+	return doc.name
+
+def get_original_name(doc):
+	# get original doc name from chain of amended docs
+	amended_from = original_name = doc.amended_from
+	while amended_from:
+		original_name = amended_from
+		amended_from = frappe.db.get_value(doc.doctype, amended_from, "amended_from")
+
+	return original_name
+
+def get_new_name_from_amended_from(doc):
 	am_id = 1
-	am_prefix = doc.amended_from
-	if frappe.db.get_value(doc.doctype, doc.amended_from, "amended_from"):
+	am_prefix = doc.name
+	if frappe.db.get_value(doc.doctype, doc.name, "amended_from"):
 		am_id = cint(doc.amended_from.split("-")[-1]) + 1
 		am_prefix = "-".join(doc.amended_from.split("-")[:-1])  # except the last hyphen
 
-	doc.name = am_prefix + "-" + str(am_id)
-	return doc.name
+	new_name = am_prefix + "-" + str(am_id)
+	if new_name == doc.name:
+		am_id += 1
+		new_name = am_prefix + "-" + str(am_id)
+	return new_name
+
+def rename_cancelled_doc(doc):
+	doc = frappe.parse_json(doc)
+	new_name = get_new_name_from_amended_from(doc)
+	frappe.rename_doc(doc.doctype, doc.name, new_name, force=True, show_alert=False)
+	return new_name
 
 
 def _field_autoname(autoname, doc, skip_slicing=None):

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -199,13 +199,15 @@ def getseries(key, digits):
 
 
 def revert_series_if_last(key, name, doc=None):
-	# do not revert if doc is amended, since cancelled docs still exist
-	if doc.docstatus != 2 and doc.amended_from:
-		return
 
-	# for first cancelled doc
-	if doc.docstatus == 2 and not doc.amended_from and doc.original_name:
-		name = doc.original_name
+	if hasattr(doc, 'amended_from'):
+		# do not revert if doc is amended, since cancelled docs still exist
+		if doc.docstatus != 2 and doc.amended_from:
+			return
+
+		# for first cancelled doc
+		if doc.docstatus == 2 and not doc.amended_from and doc.original_name:
+			name = doc.original_name
 
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -337,3 +337,4 @@ frappe.patches.v12_0.rename_uploaded_files_with_proper_name
 frappe.patches.v13_0.queryreport_columns
 frappe.patches.v13_0.jinja_hook
 frappe.patches.v13_0.update_notification_channel_if_empty
+frappe.patches.v13_0.add_original_name_docfield_to_submittable_doctypes #######

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -337,4 +337,4 @@ frappe.patches.v12_0.rename_uploaded_files_with_proper_name
 frappe.patches.v13_0.queryreport_columns
 frappe.patches.v13_0.jinja_hook
 frappe.patches.v13_0.update_notification_channel_if_empty
-frappe.patches.v13_0.add_original_name_docfield_to_submittable_doctypes #######
+frappe.patches.v13_0.add_original_name_docfield_to_submittable_doctypes

--- a/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
+++ b/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
@@ -1,9 +1,11 @@
 import frappe
+from frappe.database.schema import add_column
 
 def execute():
 	for doctype in frappe.db.get_all('DocType'):
 		doctype = frappe.get_doc('DocType', doctype.name)
 		if doctype.is_submittable and frappe.db.table_exists(doctype.name):
 			doctype.make_cancellable()
-			frappe.reload_doctype(doctype.name)
+			if not frappe.db.has_column(doctype.name, 'original_name'):
+				add_column(doctype.name, 'original_name', 'Text')
 			doctype.db_update_all()

--- a/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
+++ b/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
@@ -1,0 +1,11 @@
+import frappe
+from frappe.database.schema import add_column
+
+def execute():
+	for doctype in frappe.db.get_all('DocType'):
+		doctype = frappe.get_doc("DocType", doctype.name)
+		if doctype.is_submittable and frappe.db.table_exists(doctype.name):
+			doctype.make_cancellable()
+			if not frappe.db.has_column(doctype.name, 'original_name'):
+				add_column(doctype.name, 'original_name', 'Text')
+			doctype.db_update_all()

--- a/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
+++ b/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
@@ -2,7 +2,7 @@ import frappe
 
 def execute():
 	for doctype in frappe.db.get_all('DocType'):
-		doctype = frappe.get_meta(doctype.name)
+		doctype = frappe.get_doc('DocType', doctype.name)
 		if doctype.is_submittable and frappe.db.table_exists(doctype.name):
 			doctype.make_cancellable()
 			frappe.reload_doctype(doctype.name)

--- a/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
+++ b/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
@@ -1,11 +1,9 @@
 import frappe
-from frappe.database.schema import add_column
 
 def execute():
 	for doctype in frappe.db.get_all('DocType'):
 		doctype = frappe.get_doc("DocType", doctype.name)
 		if doctype.is_submittable and frappe.db.table_exists(doctype.name):
 			doctype.make_cancellable()
-			if not frappe.db.has_column(doctype.name, 'original_name'):
-				add_column(doctype.name, 'original_name', 'Text')
+			frappe.reload_doctype(doctype.name)
 			doctype.db_update_all()

--- a/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
+++ b/frappe/patches/v13_0/add_original_name_docfield_to_submittable_doctypes.py
@@ -2,7 +2,7 @@ import frappe
 
 def execute():
 	for doctype in frappe.db.get_all('DocType'):
-		doctype = frappe.get_doc("DocType", doctype.name)
+		doctype = frappe.get_meta(doctype.name)
 		if doctype.is_submittable and frappe.db.table_exists(doctype.name):
 			doctype.make_cancellable()
 			frappe.reload_doctype(doctype.name)

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -764,32 +764,36 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	_cancel(btn, callback, on_error, skip_confirm) {
-		const me = this;
 		const cancel_doc = () => {
 			frappe.validated = true;
-			me.script_manager.trigger("before_cancel").then(() => {
+			this.script_manager.trigger("before_cancel").then(() => {
 				if (!frappe.validated) {
-					return me.handle_save_fail(btn, on_error);
+					return this.handle_save_fail(btn, on_error);
 				}
 
-				var after_cancel = function(r) {
+				const original_name = this.docname;
+				const after_cancel = (r) => {
 					if (r.exc) {
-						me.handle_save_fail(btn, on_error);
+						this.handle_save_fail(btn, on_error);
 					} else {
 						frappe.utils.play_sound("cancel");
-						me.refresh();
 						callback && callback();
-						me.script_manager.trigger("after_cancel");
+						this.script_manager.trigger("after_cancel");
+						frappe.run_serially([
+							() => this.rename_notify(this.doctype, original_name, r.docs[0].name),
+							() => frappe.router.clear_re_route(this.doctype, original_name),
+							() => this.refresh(),
+						]);
 					}
 				};
-				frappe.ui.form.save(me, "cancel", after_cancel, btn);
+				frappe.ui.form.save(this, "cancel", after_cancel, btn);
 			});
 		}
 
 		if (skip_confirm) {
 			cancel_doc();
 		} else {
-			frappe.confirm(__("Permanently Cancel {0}?", [this.docname]), cancel_doc, me.handle_save_fail(btn, on_error));
+			frappe.confirm(__("Permanently Cancel {0}?", [this.docname]), cancel_doc, this.handle_save_fail(btn, on_error));
 		}
 	};
 
@@ -811,7 +815,7 @@ frappe.ui.form.Form = class FrappeForm {
 			'docname': this.doc.name
 		}).then(is_amended => {
 			if (is_amended) {
-				frappe.throw(__('This document is already amended, you cannot ammend it again'));
+				frappe.throw(__('This document is already amended, you cannot amend it again'));
 			}
 			this.validate_form_action("Amend");
 			var me = this;

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -235,6 +235,12 @@ frappe.router = {
 		}
 	},
 
+	clear_re_route(doctype, docname) {
+		delete frappe.re_route[
+			`${encodeURIComponent(frappe.router.slug(doctype))}/${encodeURIComponent(docname)}`
+		];
+	},
+
 	set_title(sub_path) {
 		if (frappe.route_titles[sub_path]) {
 			frappe.utils.set_title(frappe.route_titles[sub_path]);

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -97,7 +97,7 @@ class TestNaming(unittest.TestCase):
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 	def test_naming_for_cancelled_and_amended_doc(self):
-		frappe.get_doc({
+		submittable_doctype = frappe.get_doc({
 			"doctype": "DocType",
 			"module": "Core",
 			"custom": 1,
@@ -127,3 +127,5 @@ class TestNaming(unittest.TestCase):
 		amended_doc.submit()
 		amended_doc.cancel()
 		self.assertEqual(amended_doc.name, "{}-2".format(original_name))
+
+		submittable_doctype.delete()

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -109,7 +109,7 @@ class TestNaming(unittest.TestCase):
 			"name": 'Submittable Doctype'
 		}).insert()
 
-		doc = frappe.new_doc('Submittable DocType')
+		doc = frappe.new_doc('Submittable Doctype')
 		doc.save()
 		original_name = doc.name
 

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -97,18 +97,17 @@ class TestNaming(unittest.TestCase):
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 	def test_naming_for_cancelled_and_amended_doc(self):
-		if not frappe.db.exists('DocType', 'Submittable Doctype'):
-			frappe.get_doc({
-				"doctype": "DocType",
-				"module": "Core",
-				"custom": 1,
-				"is_submittable": 1,
-				"permissions": [{
-					"role": "System Manager",
-					"read": 1
-				}],
-				"name": 'Submittable Doctype'
-			}).insert()
+		frappe.get_doc({
+			"doctype": "DocType",
+			"module": "Core",
+			"custom": 1,
+			"is_submittable": 1,
+			"permissions": [{
+				"role": "System Manager",
+				"read": 1
+			}],
+			"name": 'Submittable Doctype'
+		}).insert()
 
 		doc = frappe.new_doc('Submittable DocType')
 		doc.save()


### PR DESCRIPTION
Currently, whenever a document is amended it's name is set to name-1, name-2 when amended again and so on.

In this PR, we introduce a docfield `original_name` where we store the original name of the document and set the amended doc name to `original_name` instead. To allow this to happen, the naming of cancelled docs is changed to name-1 for the first cancelled doc, name-2 for the second and so on.

**Example:**
1. Sales Invoice ID is INV-0009
2. When it is canceled, ID is changed to INV-0009-1
3. When amended, name is set to INV-0009 (same as original invoice)
4. If INV-0009 is canceled again, canceled invoice ID is renamed to INV-009-2, giving scope for the new amended document to be saved as INV-0009 (again).
