### PR TITLE
feat: Add log_error and FrappeClient to restricted python

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -12,6 +12,7 @@ from frappe.modules import scrub
 from frappe.www.printview import get_visible_columns
 import frappe.exceptions
 import frappe.integrations.utils
+from frappe.frappeclient import FrappeClient
 
 class ServerScriptNotEnabled(frappe.PermissionError):
 	pass
@@ -104,8 +105,10 @@ def get_safe_globals():
 			make_post_request = frappe.integrations.utils.make_post_request,
 			socketio_port=frappe.conf.socketio_port,
 			get_hooks=frappe.get_hooks,
-			sanitize_html=frappe.utils.sanitize_html
+			sanitize_html=frappe.utils.sanitize_html,
+			log_error=frappe.log_error
 		),
+		FrappeClient=FrappeClient,
 		style=frappe._dict(
 			border_color='#d1d8dd'
 		),


### PR DESCRIPTION
Add log_error and FrappeClient to restricted python utils

Docs: https://github.com/frappe/frappe_docs/pull/118