### PR TITLE
fix: Missing `export all` checkbox for custom reports

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -860,16 +860,17 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	get_count_str() {
-		let current_count = this.data.length;
-		let count_without_children = this.data.uniqBy((d) => d.name).length;
+		this.current_count = this.data.length;
+		this.count_without_children = this.data.uniqBy((d) => d.name).length;
 
 		return frappe.db.count(this.doctype, {
 			filters: this.get_filters_for_args()
 		}).then(total_count => {
-			this.total_count = total_count || current_count;
-			let str = __('{0} of {1}', [current_count, this.total_count]);
-			if (count_without_children !== current_count) {
-				str = __('{0} of {1} ({2} rows with children)', [count_without_children, this.total_count, current_count]);
+			this.total_count = total_count || this.current_count;
+			let str = __('{0} of {1}', [this.current_count, this.total_count]);
+			if (this.count_without_children !== this.current_count) {
+				str = __('{0} of {1} ({2} rows with children)',
+					[this.count_without_children, this.total_count, this.current_count]);
 			}
 			return str;
 		});

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1395,11 +1395,17 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						}
 					];
 
-					if (this.total_count > args.page_length) {
+					// display export all option, if all the records are not loaded or not dispalyed.
+					if (this.total_count > this.count_without_children || this.current_count > args.page_length) {
+						let label = __('Export All {0} records?', [(this.total_count + "").bold()]);
+						if (this.count_without_children != this.current_count) {
+							label = __('Export All {0} and its children records?', [(this.total_count + "").bold()]);
+						}
+
 						fields.push({
 							fieldtype: 'Check',
 							fieldname: 'export_all_rows',
-							label: __('Export All {0} rows?', [(this.total_count + "").bold()])
+							label: label
 						});
 					}
 

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1399,7 +1399,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					if (this.total_count > this.count_without_children || this.current_count > args.page_length) {
 						let label = __('Export All {0} records?', [(this.total_count + "").bold()]);
 						if (this.count_without_children != this.current_count) {
-							label = __('Export All {0} and its children records?', [(this.total_count + "").bold()]);
+							label = __('Export All {0} and its children records?', [(String(this.total_count)).bold()]);
 						}
 
 						fields.push({


### PR DESCRIPTION
Currently we are ignoring children records while displaying `Export All` button.

Modified condition to display `Export All` button is:
* Display if not all the records loaded into browser
* Incase of all records loaded, display if limited records are viewed.

![Screenshot 2021-04-15 at 5 32 20 PM](https://user-images.githubusercontent.com/36557/114865908-8b613100-9e10-11eb-8e50-b4418bf7251d.png)


