### PR TITLE
fix: newly created Workspace not being accessible unless a shortcut u…

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -63,7 +63,7 @@ class Workspace:
 		for section in cards:
 			links = loads(section.get('links')) if isinstance(section.get('links'), string_types) else section.get('links')
 			for item in links:
-				if self.is_item_allowed(item.get('name'), item.get('type')):
+				if self.is_item_allowed(item.get('link_to'), item.get('link_type')):
 					return True
 
 		def _in_active_domains(item):


### PR DESCRIPTION
### Changes made:

In desktop.py file -

1. pass doctype name ('link_to') instead of doctype hash id ('name').

- Reason: The `user_perm_can_read` key that is stored in Redis, is an array of doctype names that a logged-in user is permitted to access. `is_item_allowed` method is receiving the doctype hash but not its name, hence Redis check for permissions always fails.


2. pass 'link_type' instead of type of 'link' cards section

- Reason: The `is_item_allowed` method that is called during `is_page_allowed` while loading the workspaces in desktop.py file, checks for doctype, page, report, help, and dashboard in item type. The item type is being passed as 'links' instead of its link type which should be one of doctype, page, report, etc...

Fixes https://github.com/frappe/frappe/issues/12865


