### PR TITLE
fix: adding printview.css explictly to make sure HTML has loaded boot…

### DIFF
--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -5,7 +5,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>{{ title }}</title>
 	<meta name="generator" content="frappe">
-	<link type="text/css" rel="stylesheet" href="/assets/css/printview.css">
+	<link type="text/css" rel="stylesheet" href="{{ host_name }}/assets/css/printview.css">
 	{%- if has_rtl -%}
 		<link type="text/css" rel="stylesheet" href="assets/css/frappe-rtl.css">
 	{%- endif -%}

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -41,6 +41,7 @@ def get_context(context):
 	make_access_log(doctype=frappe.form_dict.doctype, document=frappe.form_dict.name, file_type='PDF', method='Print')
 
 	return {
+		"host_name": frappe.conf.host_name,
 		"body": get_rendered_template(doc, print_format = print_format,
 			meta=meta, trigger_print = frappe.form_dict.trigger_print,
 			no_letterhead=frappe.form_dict.no_letterhead, letterhead=letterhead,


### PR DESCRIPTION
…strap css before transferring to PDF

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

I was using bootstrap class for one of my custom print format in ERPNext.

I have found that the bootstrap.css stylesheet is not loaded because of the relative href url.
The issue is hard to detect as when user click preview, the stylesheet is loaded in website asset so preview is fine.

But when user clicks the PDF button, chrome browser will open a new tab to load the PDF generating from server.
![image](https://user-images.githubusercontent.com/30763348/114969883-65e62d00-9ecd-11eb-918e-146910763123.png)

Then I found all the bootstrap class is not working.





<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

My fix will fetch the "host_name" from site_config.json and then pass through this attribute to render_template with the `printview.html` template.

This will add the absolute href of the printview.css in the HTML template which the PDF generated is displayed correct as Bootstrap class that I epexcted.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
