### PR TITLE
fix: Kanban board sync issue

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -306,6 +306,7 @@ frappe.provide("frappe.views");
 			store.on('change:cur_list', setup_restore_columns);
 			store.on('change:columns', setup_restore_columns);
 			store.on('change:empty_state', show_empty_state);
+			fluxify.doAction('update_order');
 		}
 
 		function prepare() {


### PR DESCRIPTION
Recent refactoring introduced an issue of not syncing board data(comes from
reference doctype) into Kanban board columns DB. Changed to sync it at time
of creating Kanban board.
