### PR TITLE
fix: decrease debounce rate to allow barcode scanners to enter input

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -227,7 +227,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 					me.toggle_href(doctype);
 				}
 			});
-		}, 500));
+		}, 10));
 
 		this.$input.on("blur", function() {
 			if(me.selected) {
@@ -509,4 +509,3 @@ if (Awesomplete) {
 		});
 	};
 }
-


### PR DESCRIPTION
**Problem:**

When a barcode scanner enters input into a Link / Dynamic Link / Table MultiSelect field, there is a race condition between the string being entered into the field and the "Enter" keypress being simulated from the scanner.

This happens due to the debounce between inputs, and causes the wrong selection to appear in the field.

**Consideration:**

Although we've reduced the debounce rate to allow the system to start polling quicker for input, this trades off with more number of network calls for Link-type fields.

**Alternatives:**

We can look into implementing a third-party library to read input from barcode scanners, like [onscan.js](https://github.com/axenox/onscan.js/).

<hr>

**GIFs:**

Before:

![debounce-before](https://user-images.githubusercontent.com/13396535/115030687-fed47280-9ee4-11eb-9d42-4d4e5ea23e4f.gif)

After

![debounce-after](https://user-images.githubusercontent.com/13396535/115030685-fda34580-9ee4-11eb-9781-9a4a46504c19.gif)

fixes: https://github.com/frappe/frappe/issues/5999