### PR TITLE
fix: Cannot read property `current` of undefined

### DIFF
--- a/frappe/public/js/frappe/form/form_viewers.js
+++ b/frappe/public/js/frappe/form/form_viewers.js
@@ -7,6 +7,11 @@ frappe.ui.form.FormViewers = class FormViewers {
 
 	refresh() {
 		let users = this.frm.get_docinfo()['viewers'];
+		if (!users || !users.current || !users.current.length) {
+			this.parent.empty();
+			return;
+		}
+
 		let currently_viewing = users.current.filter(user => user != frappe.session.user);
 		let avatar_group = frappe.avatar_group(currently_viewing, 5, {'align': 'left', 'overlap': true});
 		this.parent.empty().append(avatar_group);


### PR DESCRIPTION
```
form_viewers.js:10 Uncaught TypeError: Cannot read property 'current' of undefined
    at FormViewers.refresh (form_viewers.js:10)
    at Function.frappe.ui.form.FormViewers.set_users (form_viewers.js:38)
    at n.<anonymous> (formview.js:53)
    at n.emit (libs.min.js?ver=1618584578.0:242)
    at n.onevent (libs.min.js?ver=1618584578.0:244)
    at n.onpacket (libs.min.js?ver=1618584578.0:244)
    at n.<anonymous> (libs.min.js?ver=1618584578.0:244)
    at n.emit (libs.min.js?ver=1618584578.0:242)
    at n.ondecoded (libs.min.js?ver=1618584578.0:242)
    at a.<anonymous> (libs.min.js?ver=1618584578.0:244)
```