### PR TITLE
test: no need to blur text editor

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -8,7 +8,7 @@ context('Form', () => {
 	});
 	it('create a new form', () => {
 		cy.visit('/app/todo/new');
-		cy.fill_field('description', 'this is a test todo', 'Text Editor').blur();
+		cy.fill_field('description', 'this is a test todo', 'Text Editor');
 		cy.wait(300);
 		cy.get('.page-title').should('contain', 'Not Saved');
 		cy.intercept({


### PR DESCRIPTION
Blurring used to [fail randomly](https://github.com/frappe/frappe/pull/12878/checks?check_run_id=2368287568#step:16:554). As the change gets updated in the `doc` object on Quill's `text-change` event, using `blur` is unnecessary.