### PR TITLE
feat(UI): consistently themed scrollbars

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -169,6 +169,9 @@
 	// Other Colors
 	--sidebar-select-color: var(--gray-200);
 
+	--scrollbar-thumb-color: var(--gray-400);
+	--scrollbar-track-color: var(--gray-200);
+
 	--shadow-inset: inset 0px -1px 0px var(--gray-300);
 	--border-color: var(--gray-100);
 	--dark-border-color: var(--gray-300);

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -65,6 +65,9 @@
 
 	--sidebar-select-color: var(--gray-800);
 
+	--scrollbar-thumb-color: var(--gray-600);
+	--scrollbar-track-color: var(--gray-700);
+
 	--shadow-inset: var(--fg-color);
 	--border-color: var(--gray-700);
 	--dark-border-color: var(--gray-600);
@@ -74,6 +77,8 @@
 
 	// input
 	--input-disabled-bg: none;
+
+	color-scheme: dark;
 
 	.frappe-card {
 		.btn-default {

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -754,7 +754,28 @@ body {
 			.layout-side-section, .layout-main-section-wrapper {
 				height: 100%;
 				overflow-y: auto;
+				padding-right: 25px;
+				scrollbar-color: var(--gray-200) transparent;
+				[data-theme="dark"] & {
+					scrollbar-color: var(--gray-800) transparent;
+				}
+
+				&::-webkit-scrollbar-track {
+					background: transparent;
+				}
+
+				&::-webkit-scrollbar-thumb {
+					background: var(--gray-200);
+					[data-theme="dark"] & {
+						background: var(--gray-800);
+					}
+				}
 			}
+
+			.layout-side-section {
+				margin-right: 20px;
+			}
+
 			.desk-sidebar {
 				margin-bottom: var(--margin-2xl);
 			}

--- a/frappe/public/scss/desk/index.scss
+++ b/frappe/public/scss/desk/index.scss
@@ -10,6 +10,7 @@
 @import "mobile";
 @import "form";
 @import "print_preview";
+@import "scrollbar";
 @import "navbar";
 @import "../common/modal";
 @import "slides";

--- a/frappe/public/scss/desk/scrollbar.scss
+++ b/frappe/public/scss/desk/scrollbar.scss
@@ -1,0 +1,29 @@
+/* Works on Firefox */
+* {
+	scrollbar-width: thin;
+	scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
+}
+
+html {
+	scrollbar-width: auto;
+}
+
+/* Works on Chrome, Edge, and Safari */
+*::-webkit-scrollbar {
+	width: 6px;
+	height: 6px;
+}
+
+*::-webkit-scrollbar-thumb {
+	background: var(--scrollbar-thumb-color);
+}
+
+*::-webkit-scrollbar-track,
+*::-webkit-scrollbar-corner {
+	background: var(--scrollbar-track-color);
+}
+
+body::-webkit-scrollbar {
+	width: unset;
+	height: unset;
+}


### PR DESCRIPTION
## Changes Made
- Stylized native scrollbars.
- Standardized scrollbars across all browsers.
- Added support for both light and dark theme.

## Screenshots

### Before:

![image](https://user-images.githubusercontent.com/38958184/115107247-4c092080-9f87-11eb-8146-91b21dd9d764.png)

![image](https://user-images.githubusercontent.com/38958184/115107201-0b110c00-9f87-11eb-88fd-509f0ed19e60.png)

![image](https://user-images.githubusercontent.com/38958184/115110209-d8bbda80-9f97-11eb-989a-ac6733076eb2.png)

![image](https://user-images.githubusercontent.com/38958184/115110138-75ca4380-9f97-11eb-8d4a-558719b7fec2.png)


### After:

![image](https://user-images.githubusercontent.com/38958184/115108937-b4103480-9f90-11eb-9f02-a5f49f7bb81b.png)

![image](https://user-images.githubusercontent.com/38958184/115108947-c12d2380-9f90-11eb-9b0e-be5e21060eb7.png)

![image](https://user-images.githubusercontent.com/38958184/115110083-23892280-9f97-11eb-8afc-f6bb6927ab30.png)

![image](https://user-images.githubusercontent.com/38958184/115110096-33086b80-9f97-11eb-8c1a-95f40c065091.png)

<!--
**Firefox**
![Screenshot from 2021-04-17 13-46-01](https://user-images.githubusercontent.com/38958184/115107091-6393d980-9f86-11eb-80f4-c34bb5628efa.png)
![Screenshot from 2021-04-17 13-46-16](https://user-images.githubusercontent.com/38958184/115107093-64c50680-9f86-11eb-91d6-ae62b7c2a63f.png)
![Screenshot from 2021-04-17 13-45-46](https://user-images.githubusercontent.com/38958184/115107096-668eca00-9f86-11eb-9c8c-efb752d5309e.png)
![Screenshot from 2021-04-17 13-45-26](https://user-images.githubusercontent.com/38958184/115107097-6989ba80-9f86-11eb-9337-c0ab0fbbed5b.png)

![image](https://user-images.githubusercontent.com/38958184/115107257-5f1bf080-9f87-11eb-80f0-f63b419ca0d5.png)
![image](https://user-images.githubusercontent.com/38958184/115107266-6a6f1c00-9f87-11eb-89a3-ce6d582c6116.png)

![image](https://user-images.githubusercontent.com/38958184/115108970-e1f57900-9f90-11eb-8e19-4cab9651e814.png)
![image](https://user-images.githubusercontent.com/38958184/115108958-d1dd9980-9f90-11eb-95d7-d2aec8ecec1a.png)

-->

<!--no-docs-->
