### PR TITLE
test: fix PermissionError in test_token_cache

### DIFF
--- a/frappe/integrations/doctype/token_cache/test_token_cache.py
+++ b/frappe/integrations/doctype/token_cache/test_token_cache.py
@@ -13,7 +13,7 @@ class TestTokenCache(unittest.TestCase):
 	def setUp(self):
 		self.token_cache = frappe.get_last_doc('Token Cache')
 		self.token_cache.update({'connected_app': frappe.get_last_doc('Connected App').name})
-		self.token_cache.save()
+		self.token_cache.save(ignore_permissions=True)
 
 	def test_get_auth_header(self):
 		self.token_cache.get_auth_header()


### PR DESCRIPTION
Fix this error:

```
ERROR: test_get_auth_header (frappe.integrations.doctype.token_cache.test_token_cache.TestTokenCache)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/frappe/frappe/integrations/doctype/token_cache/test_token_cache.py", line 16, in setUp
    self.token_cache.save()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 284, in save
    return self._save(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 309, in _save
    self.check_permission("write", "save")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 186, in check_permission
    self.raise_no_permission_to(permlevel or permtype)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 200, in raise_no_permission_to
    raise frappe.PermissionError
frappe.exceptions.PermissionError
```

https://github.com/frappe/frappe/pull/12715/checks?check_run_id=2370259521#step:16:244