### PR TITLE
feat: Add autocompletion items in Server Script

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -18,7 +18,7 @@ global_cache_keys = ("app_hooks", "installed_apps", 'all_apps',
 		'scheduler_events', 'time_zone', 'webhooks', 'active_domains',
 		'active_modules', 'assignment_rule', 'server_script_map', 'wkhtmltopdf_version',
 		'domain_restricted_doctypes', 'domain_restricted_pages', 'information_schema:counts',
-		'sitemap_routes', 'db_tables') + doctype_map_keys
+		'sitemap_routes', 'db_tables', 'server_script_autocompletion_items') + doctype_map_keys
 
 user_cache_keys = ("bootinfo", "user_recent", "roles", "user_doc", "lang",
 		"defaults", "user_permissions", "home_page", "linked_with",

--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -13,7 +13,7 @@ frappe.ui.form.on('Server Script', {
 		frm.call('get_autocompletion_items')
 			.then(r => r.message)
 			.then(items => {
-				frm.set_df_property('script', 'autocompletions', items)
+				frm.set_df_property('script', 'autocompletions', items);
 			});
 	},
 

--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -9,6 +9,12 @@ frappe.ui.form.on('Server Script', {
 		if (frm.doc.script_type != 'Scheduler Event') {
 			frm.dashboard.hide();
 		}
+
+		frm.call('get_autocompletion_items')
+			.then(r => r.message)
+			.then(items => {
+				frm.set_df_property('script', 'autocompletions', items)
+			});
 	},
 
 	setup_help(frm) {

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -162,7 +162,7 @@ class ServerScript(Document):
 			return out
 
 		items = frappe.cache().get_value('server_script_autocompletion_items')
-		if not items or True:
+		if not items:
 			unsorted_items = get_keys(get_safe_globals())
 			sorted_items = sorted(unsorted_items, key=lambda k: k[1])
 			items = [d[0] for d in sorted_items]

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -140,32 +140,31 @@ class ServerScript(Document):
 				value = obj[key]
 				if isinstance(value, (NamespaceDict, dict)) and value:
 					if key == 'form_dict':
-						out.append(['form_dict', 3])
+						out.append(['form_dict', 7])
 						continue
 					for subkey, score in get_keys(value):
 						fullkey = f'{key}.{subkey}'
 						out.append([fullkey, score])
 				else:
-					if isinstance(value, ModuleType):
+					if isinstance(value, type) and issubclass(value, Exception):
 						score = 0
+					elif isinstance(value, ModuleType):
+						score = 10
 					elif isinstance(value, (FunctionType, MethodType)):
-						score = 1
-					elif isinstance(value, type) and issubclass(value, Exception):
 						score = 9
 					elif isinstance(value, type):
-						score = 2
+						score = 8
 					elif isinstance(value, dict):
-						score = 3
+						score = 7
 					else:
-						score = 4
+						score = 6
 					out.append([key, score])
 			return out
 
 		items = frappe.cache().get_value('server_script_autocompletion_items')
 		if not items:
-			unsorted_items = get_keys(get_safe_globals())
-			sorted_items = sorted(unsorted_items, key=lambda k: k[1])
-			items = [d[0] for d in sorted_items]
+			items = get_keys(get_safe_globals())
+			items = [{'value': d[0], 'score': d[1]} for d in items]
 			frappe.cache().set_value('server_script_autocompletion_items', items)
 		return items
 

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -66,12 +66,16 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 					if (autocompletions.length) {
 						callback(
 							null,
-							autocompletions.map(a => ({
-								name: 'frappe',
-								value: a,
-								score: 100,
-								meta: 'Frappe API'
-							}))
+							autocompletions.map(a => {
+								if (typeof a === 'string') {
+									a = { value: a };
+								}
+								return {
+									name: 'frappe',
+									value: a.value,
+									score: a.score
+								}
+							})
 						);
 					}
 				}

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -74,7 +74,7 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 									name: 'frappe',
 									value: a.value,
 									score: a.score
-								}
+								};
 							})
 						);
 					}

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -53,11 +53,10 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 		ace.config.loadModule("ace/ext/language_tools", langTools => {
 			this.editor.setOptions({
 				enableBasicAutocompletion: true,
-				enableSnippets: true,
 				enableLiveAutocompletion: true
 			});
 
-			let completer = {
+			langTools.addCompleter({
 				getCompletions: function(editor, session, pos, prefix, callback) {
 					if (prefix.length === 0) {
 						callback(null, []);
@@ -76,10 +75,8 @@ frappe.ui.form.ControlCode = frappe.ui.form.ControlText.extend({
 						);
 					}
 				}
-			}
-			langTools.addCompleter(completer);
+			});
 		});
-
 		this._autocompletion_setup = true;
 	},
 


### PR DESCRIPTION
### Add autocompletion items in Server Script

![server-script-autocompletion](https://user-images.githubusercontent.com/9355208/115121807-48e75200-9fd2-11eb-92f3-8527e178d899.gif)

### API to add autocompletion items in Code field

```js
// this will enable autocompletions in Code field
frm.set_df_property('script', 'autocompletions', ['frappe', 'frappe.utils.today', ...])
```

> no-docs