### PR TITLE
fix: cannot read property `doc` of undefined

### DIFF
--- a/frappe/core/doctype/communication/communication_list.js
+++ b/frappe/core/doctype/communication/communication_list.js
@@ -20,6 +20,6 @@ frappe.listview_settings['Communication'] = {
 	},
 
 	primary_action: function() {
-		new frappe.views.CommunicationComposer({ doc: {} });
+		new frappe.views.CommunicationComposer();
 	}
 };

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -7,6 +7,10 @@ const separator_element = '<div>---</div>';
 frappe.views.CommunicationComposer = class {
 	constructor(opts) {
 		$.extend(this, opts);
+		if (!this.doc) {
+			this.doc = this.frm && this.frm.doc || {};
+		}
+
 		this.make();
 	}
 
@@ -269,7 +273,7 @@ frappe.views.CommunicationComposer = class {
 				method: 'frappe.email.doctype.email_template.email_template.get_email_template',
 				args: {
 					template_name: email_template,
-					doc: me.frm.doc,
+					doc: me.doc,
 					_lang: me.dialog.get_value("language_sel")
 				},
 				callback(r) {
@@ -382,11 +386,10 @@ frappe.views.CommunicationComposer = class {
 	}
 
 	setup_print_language() {
-		const doc = this.frm && this.frm.doc;
 		const fields = this.dialog.fields_dict;
 
 		//Load default print language from doctype
-		this.lang_code = doc.language
+		this.lang_code = this.doc.language
 			|| this.get_print_format().default_print_language
 			|| frappe.boot.lang;
 
@@ -612,7 +615,7 @@ frappe.views.CommunicationComposer = class {
 
 	send_email(btn, form_values, selected_attachments, print_html, print_format) {
 		const me = this;
-		me.dialog.hide();
+		this.dialog.hide();
 
 		if (!form_values.recipients) {
 			frappe.msgprint(__("Enter Email Recipient(s)"));
@@ -625,7 +628,7 @@ frappe.views.CommunicationComposer = class {
 		}
 
 
-		if (this.frm && !frappe.model.can_email(me.doc.doctype, this.frm)) {
+		if (this.frm && !frappe.model.can_email(this.doc.doctype, this.frm)) {
 			frappe.msgprint(__("You are not allowed to send emails related to this document"));
 			return;
 		}

--- a/frappe/public/js/frappe/views/inbox/inbox_view.js
+++ b/frappe/public/js/frappe/views/inbox/inbox_view.js
@@ -204,9 +204,7 @@ frappe.views.InboxView = class InboxView extends frappe.views.ListView {
 			};
 			frappe.new_doc('Email Account');
 		} else {
-			new frappe.views.CommunicationComposer({
-				doc: {}
-			});
+			new frappe.views.CommunicationComposer();
 		}
 	}
 };


### PR DESCRIPTION
Resolves https://github.com/frappe/frappe/pull/12878#issuecomment-821932653
Thanks to @gmplab for the report!

Tested Locally:

![Screenshot-2021-04-18-122333](https://user-images.githubusercontent.com/16315650/115137000-014bdf00-a041-11eb-939a-8d9028425507.png)


---

- `opts` are optional when using `frappe.views.CommunicationComposer` now:

  ![Screenshot-2021-04-18-122219](https://user-images.githubusercontent.com/16315650/115137015-10cb2800-a041-11eb-8ee4-ceb80a4b90c1.png)

  Consequently, they have been removed where unnecessary.