### PR TITLE
test: multiple cypress fixes

### DIFF
--- a/cypress/integration/relative_time_filters.js
+++ b/cypress/integration/relative_time_filters.js
@@ -1,7 +1,4 @@
 context('Relative Timeframe', () => {
-	beforeEach(() => {
-		cy.login();
-	});
 	before(() => {
 		cy.login();
 		cy.visit('/app/website');

--- a/cypress/integration/table_multiselect.js
+++ b/cypress/integration/table_multiselect.js
@@ -1,5 +1,5 @@
 context('Table MultiSelect', () => {
-	beforeEach(() => {
+	before(() => {
 		cy.login();
 	});
 

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -11,7 +11,7 @@ import click
 import frappe
 from frappe.commands import get_site, pass_context
 from frappe.exceptions import SiteNotSpecifiedError
-from frappe.utils import get_bench_path, update_progress_bar
+from frappe.utils import get_bench_path, update_progress_bar, cint
 
 
 @click.command('build')
@@ -567,11 +567,14 @@ def run_ui_tests(context, app, headless=False):
 
 	node_bin = subprocess.getoutput("npm bin")
 	cypress_path = "{0}/cypress".format(node_bin)
-	plugin_path = "{0}/cypress-file-upload".format(node_bin)
+	plugin_path = "{0}/../cypress-file-upload".format(node_bin)
 
 	# check if cypress in path...if not, install it.
-	if not (os.path.exists(cypress_path) or os.path.exists(plugin_path)) \
-		or not subprocess.getoutput("npm view cypress version").startswith("6."):
+	if not (
+		os.path.exists(cypress_path)
+		and os.path.exists(plugin_path)
+		and cint(subprocess.getoutput("npm view cypress version")[:1]) >= 6
+	):
 		# install cypress
 		click.secho("Installing Cypress...", fg="yellow")
 		frappe.commands.popen("yarn add cypress@^6 cypress-file-upload@^5 --no-lockfile")


### PR DESCRIPTION
- Fixed code to install cypress on developer machines
  - The **Cypress File Upload** plugin does not have a binary, check plugin directory instead.
  - Cypress version 7 is out, so checking if version is more than or equal to 6.
 
- Remove unnecessary calls to `cy.login`