### PR TITLE
fix:  Typo in get_all_language_with_name

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -827,7 +827,7 @@ def get_all_languages(with_language_name=False):
 		return frappe.db.sql_list('select name from tabLanguage')
 
 	def get_all_language_with_name():
-		return frappe.db.get_all('language', ['language_code', 'language_name'])
+		return frappe.db.get_all('Language', ['language_code', 'language_name'])
 
 	if not frappe.db:
 		frappe.connect()


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/home/frappe/version13/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.handler.handle()
  File "/home/frappe/version13/apps/frappe/frappe/handler.py", line 32, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/version13/apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 1166, in call
    return fn(*args, **newargs)
  File "/home/frappe/version13/apps/frappe/frappe/translate.py", line 836, in get_all_languages
    return frappe.cache().get_value('languages_with_name', get_all_language_with_name)
  File "/home/frappe/version13/apps/frappe/frappe/utils/redis_wrapper.py", line 79, in get_value
    val = generator()
  File "/home/frappe/version13/apps/frappe/frappe/translate.py", line 830, in get_all_language_with_name
    return frappe.db.get_all('language', ['language_code', 'language_name'])
  File "/home/frappe/version13/apps/frappe/frappe/database/database.py", line 535, in get_all
    return frappe.get_all(*args, **kwargs)
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 1430, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 1403, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/version13/apps/frappe/frappe/model/db_query.py", line 101, in execute
    self.columns = self.get_table_columns()
  File "/home/frappe/version13/apps/frappe/frappe/model/db_query.py", line 338, in get_table_columns
    return get_table_columns(self.doctype)
  File "/home/frappe/version13/apps/frappe/frappe/model/meta.py", line 49, in get_table_columns
    return frappe.db.get_table_columns(doctype)
  File "/home/frappe/version13/apps/frappe/frappe/database/database.py", line 896, in get_table_columns
    raise self.TableMissingError('DocType', doctype)
pymysql.err.ProgrammingError: ('DocType', 'language')
```
