### PR TITLE
fix: OAuth token expiry

### DIFF
--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -64,8 +64,6 @@ def get_oauth2_authorize_url(provider, redirect_to):
 
 	state = { "site": frappe.utils.get_url(), "token": frappe.generate_hash(), "redirect_to": redirect_to 	}
 
-	frappe.cache().set_value("{0}:{1}".format(provider, state["token"]), True, expires_in_sec=120)
-
 	# relative to absolute url
 	data = {
 		"redirect_uri": get_redirect_uri(provider),
@@ -174,11 +172,6 @@ def login_oauth_user(data=None, provider=None, state=None, email_id=None, key=No
 
 	if not (state and state["token"]):
 		frappe.respond_as_web_page(_("Invalid Request"), _("Token is missing"), http_status_code=417)
-		return
-
-	token = frappe.cache().get_value("{0}:{1}".format(provider, state["token"]), expires=True)
-	if not token:
-		frappe.respond_as_web_page(_("Invalid Request"), _("Invalid Token"), http_status_code=417)
 		return
 
 	user = get_email(data)

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -96,14 +96,6 @@ def login_via_office365(code, state):
 	login_via_oauth2_id_token("office_365", code, state, decoder=decoder_compat)
 
 @frappe.whitelist(allow_guest=True)
-def login_oauth_user(data=None, provider=None, state=None, email_id=None, key=None, generate_login_token=False):
-	if not ((data and provider and state) or (email_id and key)):
-		frappe.respond_as_web_page(_("Invalid Request"), _("Missing parameters for login"), http_status_code=417)
-		return
-
-	_login_oauth_user(data, provider, state, email_id, key, generate_login_token)
-
-@frappe.whitelist(allow_guest=True)
 def login_via_token(login_token):
 	sid = frappe.cache().get_value("login_token:{0}".format(login_token), expires=True)
 	if not sid:


### PR DESCRIPTION
We generate a random token to keep the OAuth state dynamic. Removing expiry check on that token as it is not of much use.

Fixes #12818 
