### PR TITLE
fix: do not empty viewers parent on form refresh

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -360,6 +360,7 @@ frappe.ui.form.Form = class FrappeForm {
 			grid_obj.grid.grid_pagination.go_to_page(1, true);
 		});
 		frappe.ui.form.close_grid_form();
+		this.viewers && this.viewers.parent.empty();
 		this.docname = docname;
 		this.setup_docinfo_change_listener();
 	}

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -211,7 +211,6 @@ frappe.ui.form.Toolbar = class Toolbar {
 
 	make_viewers() {
 		if (this.frm.viewers) {
-			this.frm.viewers.parent.empty();
 			return;
 		}
 		this.frm.viewers = new frappe.ui.form.FormViewers({


### PR DESCRIPTION
Form viewers were being cleared on form refresh, they should be cleared on doc change only.