### PR TITLE
fix: Grid Form buttons Insert Above, Insert Below not hidden when can…

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -555,6 +555,15 @@ export default class GridRow {
 		this.grid_form.render();
 		this.row.toggle(false);
 		// this.form_panel.toggle(true);
+
+		if (this.grid.cannot_add_rows || (this.grid.df && this.grid.df.cannot_add_rows)) {
+			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row')
+				.addClass('hidden')
+		} else {
+			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row')
+				.removeClass('hidden')
+		}
+
 		frappe.dom.freeze("", "dark");
 		if (cur_frm) cur_frm.cur_grid = this;
 		this.wrapper.addClass("grid-row-open");

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -558,10 +558,10 @@ export default class GridRow {
 
 		if (this.grid.cannot_add_rows || (this.grid.df && this.grid.df.cannot_add_rows)) {
 			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row')
-				.addClass('hidden')
+				.addClass('hidden');
 		} else {
 			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row')
-				.removeClass('hidden')
+				.removeClass('hidden');
 		}
 
 		frappe.dom.freeze("", "dark");


### PR DESCRIPTION
Issue: 
On using `grid.cannot_add_rows = true`, the user shouldn't be able to add any more rows to the table, but it only removes the `Add Row` and `Add Multiple` buttons. The grid row's form view would still have the `Insert Above` and `Insert Below` and `Duplicate` options. Ideally, these should also be removed then.

Before: 
![Screenshot 2021-04-19 at 4 10 46 PM](https://user-images.githubusercontent.com/30859809/115223968-0173d980-a12a-11eb-84af-9695e085089a.png)

After:
![Screenshot 2021-04-19 at 4 11 38 PM](https://user-images.githubusercontent.com/30859809/115224020-0afd4180-a12a-11eb-9c7c-d725bb350937.png)
