### PR TITLE
fix: id_token format

### DIFF
--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -133,7 +133,7 @@ def get_token(*args, **kwargs):
 			}
 
 			id_token_encoded = jwt.encode(id_token, client_secret, algorithm='HS256', headers=id_token_header)
-			out.update({"id_token": str(id_token_encoded)})
+			out.update({"id_token": frappe.safe_decode(id_token_encoded)})
 
 		frappe.local.response = out
 


### PR DESCRIPTION
Front port of https://github.com/frappe/frappe/pull/12892

decode bytes to utf-8 string