### PR TITLE
fix: whitelist login method to fetch session id remotely

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -120,6 +120,7 @@ class LoginManager:
 				self.make_session()
 				self.set_user_info()
 
+	@frappe.whitelist()
 	def login(self):
 		# clear cache
 		frappe.clear_cache(user = frappe.form_dict.get('usr'))


### PR DESCRIPTION
The login method is sometimes used from another site via the API to get session details like "sid", hence needs to be whitelisted.
Without this, you get 503 errors.