### PR TITLE
fix(treeview): Accept filters as kwargs to avoid TypeError

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -36,7 +36,7 @@ def get_all_nodes(doctype, label, parent, tree_method, **filters):
 	return out
 
 @frappe.whitelist()
-def get_children(doctype, parent=''):
+def get_children(doctype, parent='', **filters):
 	return _get_children(doctype, parent)
 
 def _get_children(doctype, parent='', ignore_permissions=False):


### PR DESCRIPTION
Fixes:

Traceback
```
Traceback (most recent call last):
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 32, in handle
    data = execute_cmd(cmd)
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 1179, in call
    return fn(*args, **newargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/treeview.py", line 21, in get_all_nodes
    data = tree_method(doctype, parent, **filters)
TypeError: get_children() got an unexpected keyword argument 'is_root'
```

<img width="1440" alt="Screenshot 2021-04-20 at 2 46 38 PM" src="https://user-images.githubusercontent.com/13928957/115371320-7e18bd80-a1e7-11eb-801a-3b10ce0ea0fe.png">

---

Even though `filters` is not used in the function it is passed by [get_all_nodes](https://github.com/frappe/frappe/compare/develop...surajshetty3416:fix-treeview#diff-fe268eea0e4e0537f2bb0b89d7263a3e01149a169050cadb3d2da5ee0b728b5aR21) assuming other `get_children` function will use it.

`**filters` was removed in [this PR](https://github.com/frappe/frappe/pull/12763/) as a part of refactor.