### PR TITLE
fix: Get defaults from user_defaults based on fieldname

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -177,7 +177,9 @@ $.extend(frappe.model, {
 						// Use User Permission value when only when it has a single value
 						user_default = user_defaults[0];
 					}
-				} else if (!user_default) {
+				}
+				
+				if (!user_default) {
 					user_default = frappe.defaults.get_user_default(df.fieldname);
 				} else if (
 					!user_default &&


### PR DESCRIPTION
Get defaults from `user_defaults` based on field name

- Fixes an issue where the default value for a field was not getting set if a field had `ignore_user_permission` enabled. 