### PR TITLE
fix: Ignore non utf-8 files for translation scan

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -518,8 +518,13 @@ def get_messages_from_file(path):
 	apps_path = get_bench_dir()
 	if os.path.exists(path):
 		with open(path, 'r') as sourcefile:
+			try:
+				file_contents = sourcefile.read()
+			except:
+				print("Could not scan file for translation: {0}".format(path))
+				return []
 			data = [(os.path.relpath(path, apps_path), message, context, line) \
-				for line, message, context in  extract_messages_from_code(sourcefile.read())]
+				for line, message, context in  extract_messages_from_code(file_contents)]
 			return data
 	else:
 		# print "Translate: {0} missing".format(os.path.abspath(path))

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -520,11 +520,11 @@ def get_messages_from_file(path):
 		with open(path, 'r') as sourcefile:
 			try:
 				file_contents = sourcefile.read()
-			except:
+			except Exception:
 				print("Could not scan file for translation: {0}".format(path))
 				return []
 			data = [(os.path.relpath(path, apps_path), message, context, line) \
-				for line, message, context in  extract_messages_from_code(file_contents)]
+				for line, message, context in extract_messages_from_code(file_contents)]
 			return data
 	else:
 		# print "Translate: {0} missing".format(os.path.abspath(path))


### PR DESCRIPTION
Ignore non-utf8 files for translation scan