### PR TITLE
fix: Use grid docfield list while creating grid_row docfield copy

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -6,6 +6,7 @@ export default class GridRow {
 		this.on_grid_fields = [];
 		$.extend(this, opts);
 		if (this.doc && this.parent_df.options) {
+			frappe.meta.make_docfield_copy_for(this.parent_df.options, this.doc.name, this.docfields);
 			this.docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
 		}
 		this.columns = {};

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -38,14 +38,14 @@ $.extend(frappe.meta, {
 		frappe.meta.docfield_list[df.parent].push(df);
 	},
 
-	make_docfield_copy_for: function(doctype, docname) {
+	make_docfield_copy_for: function(doctype, docname, docfield_list=null) {
 		var c = frappe.meta.docfield_copy;
 		if(!c[doctype])
 			c[doctype] = {};
 		if(!c[doctype][docname])
 			c[doctype][docname] = {};
 
-		var docfield_list = frappe.meta.docfield_list[doctype] || [];
+		docfield_list = docfield_list || frappe.meta.docfield_list[doctype] || [];
 		for(var i=0, j=docfield_list.length; i<j; i++) {
 			var df = docfield_list[i];
 			c[doctype][docname][df.fieldname || df.label] = copy_dict(df);


### PR DESCRIPTION
Use Grid docfield list while creating a Grid Row docfield list copy...
Previously, it was using doctype level docfield list which did not have the updated docfields for a grid.

**Fixes**:
![y2eflK9](https://user-images.githubusercontent.com/13928957/115529362-796c0c00-a2b0-11eb-8dd0-b636e2bc77b7.gif)
fields were not getting populated after doctype selection in Notification DocType.
https://frappe.io/app/internal-issue/FR-ISS-271250

This fix is a continuation of https://github.com/frappe/frappe/pull/12839