### PR TITLE
fix: Report column context

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1094,7 +1094,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 			return Object.assign(column, {
 				id: column.fieldname,
-				name: __(column.label),
+				name: __(column.label, null, `Column of report '${this.report_name}'`), // context has to match context in   get_messages_from_report in translate.py
 				width: parseInt(column.width) || null,
 				editable: false,
 				compareValue: compareFn,

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -443,8 +443,12 @@ def get_messages_from_report(name):
 	messages = _get_messages_from_page_or_report("Report", name,
 		frappe.db.get_value("DocType", report.ref_doctype, "module"))
 
+	if report.columns:
+		messages.extend([(None, column.label) for column in report.columns])
+
 	if report.query:
 		messages.extend([(None, message) for message in re.findall('"([^:,^"]*):', report.query) if is_translatable(message)])
+
 	messages.append((None,report.report_name))
 	return messages
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -444,7 +444,10 @@ def get_messages_from_report(name):
 		frappe.db.get_value("DocType", report.ref_doctype, "module"))
 
 	if report.columns:
-		messages.extend([(None, column.label) for column in report.columns])
+		messages.extend([(None, report_column.label) for report_column in report.columns])
+
+	if report.filters:
+		messages.extend([(None, report_filter.label) for report_filter in report.filters])
 
 	if report.query:
 		messages.extend([(None, message) for message in re.findall('"([^:,^"]*):', report.query) if is_translatable(message)])

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -444,7 +444,8 @@ def get_messages_from_report(name):
 		frappe.db.get_value("DocType", report.ref_doctype, "module"))
 
 	if report.columns:
-		messages.extend([(None, report_column.label) for report_column in report.columns])
+		context = "Column of report '%s'" % report.name # context has to match context in `prepare_columns` in query_report.js
+		messages.extend([(None, report_column.label, context) for report_column in report.columns])
 
 	if report.filters:
 		messages.extend([(None, report_filter.label) for report_filter in report.filters])


### PR DESCRIPTION
Add context to translations of report columns. Because automatic context is the best context 😎 

Right now the solution is not very pretty: we have to rely on the context being the same in frontend and backend. Any improvements are welcome.

Depends on #12943