### PR TITLE
feat: low priority for backups using nice

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -16,7 +16,6 @@ from six import iteritems, binary_type, text_type, string_types, PY2
 from werkzeug.local import Local, release_local
 import os, sys, importlib, inspect, json
 import typing
-from past.builtins import cmp
 import click
 
 # Local application imports
@@ -634,6 +633,20 @@ def only_for(roles, message=False):
 		if message:
 			msgprint(_('This action is only allowed for {}').format(bold(', '.join(roles))), _('Not Permitted'))
 		raise PermissionError
+
+def low_priority(func):
+	"""Decorator for executing a function with low CPU priority."""
+	from functools import wraps
+
+	@wraps(func)
+	def reniced(*args, **kwargs):
+		os.nice(10)
+		try:
+			return func(*args,**kwargs)
+		finally:
+			os.nice(-10)
+
+	return reniced
 
 def get_domain_data(module):
 	try:

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -314,6 +314,7 @@ class BackupGenerator:
 			template = "{{0:{0}}}: {{1:{1}}} {{2}}".format(title, path)
 			print(template.format(_type.title(), info["path"], info["size"]))
 
+	@frappe.low_priority
 	def backup_files(self):
 		import subprocess
 
@@ -341,6 +342,7 @@ class BackupGenerator:
 		with open(site_config_backup_path, "w") as n, open(site_config_path) as c:
 			n.write(c.read())
 
+	@frappe.low_priority
 	def take_dump(self):
 		import frappe.utils
 		from frappe.utils.change_log import get_app_branch


### PR DESCRIPTION
 ## Description
 Over the time, the size of a site's database is bound to increase. When the backup command is being run in the background, it consumes a lot of CPU. To give it a low priority, this PR proposes using `nice`.

## Implementation
- Created a decorator `low_priority` that sets and unsets nice value before and after the function call.
- Added the decorator to `take_dump` and `backup_files`.

**Tested Locally**

> Since `low_priority` is added to `__init__.py` it can be used anywhere using `@frappe.low_priority` decorator.

<!--no-docs-->