### PR TITLE
fix(control): Check if same value is set to avoid unnecessary change triggers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,6 +143,7 @@
 		"Cypress": true,
 		"cy": true,
 		"it": true,
+		"describe": true,
 		"expect": true,
 		"context": true,
 		"before": true,

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -159,9 +159,10 @@ frappe.ui.form.Control = Class.extend({
 	},
 	validate_and_set_in_model: function(value, e) {
 		var me = this;
-		if(this.inside_change_event) {
+		if (this.inside_change_event || this.get_model_value() === value) {
 			return Promise.resolve();
 		}
+
 		this.inside_change_event = true;
 		var set = function(value) {
 			me.inside_change_event = false;

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -66,6 +66,10 @@ frappe.ui.form.ControlTableMultiSelect = frappe.ui.form.ControlLink.extend({
 		this._rows_list = this.rows.map(row => row[link_field.fieldname]);
 		return this.rows;
 	},
+	get_model_value() {
+		let value = this._super();
+		return value ? value.filter(d => !d.__islocal) : value;
+	},
 	validate(value) {
 		const rows = (value || []).slice();
 


### PR DESCRIPTION
- Link field used to call `parse_validate_and_set_in_model` twice. First via `awesomplete-select` and second via `change`. This was causing unexpected behavior like the following.
![UVcRIKn](https://user-images.githubusercontent.com/13928957/115670148-b5fa3f00-a366-11eb-96f9-1af97b5452bc.gif)
Two dialog boxes because the change event for the field was getting triggerd twice.


