### PR TITLE
fix: Conditionally hide grid Add Row & Add Multiple buttons

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -387,7 +387,7 @@ export default class Grid {
 			this.wrapper.find('.grid-footer').toggle(false);
 		}
 
-		this.wrapper.find('.grid-add-row, .grid-add-multiple-rows').toggle(this.is_editable())
+		this.wrapper.find('.grid-add-row, .grid-add-multiple-rows').toggle(this.is_editable());
 
 	}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -387,6 +387,8 @@ export default class Grid {
 			this.wrapper.find('.grid-footer').toggle(false);
 		}
 
+		this.wrapper.find('.grid-add-row, .grid-add-multiple-rows').toggle(this.is_editable())
+
 	}
 
 	truncate_rows() {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -557,13 +557,10 @@ export default class GridRow {
 		this.row.toggle(false);
 		// this.form_panel.toggle(true);
 
-		if (this.grid.cannot_add_rows || (this.grid.df && this.grid.df.cannot_add_rows)) {
-			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row, .grid-append-row')
-				.addClass('hidden');
-		} else {
-			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row, .grid-append-row')
-				.removeClass('hidden');
-		}
+		let cannot_add_rows = this.grid.cannot_add_rows || (this.grid.df && this.grid.df.cannot_add_rows);
+		this.wrapper
+			.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row, .grid-append-row')
+			.toggle(!cannot_add_rows);
 
 		frappe.dom.freeze("", "dark");
 		if (cur_frm) cur_frm.cur_grid = this;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -558,10 +558,10 @@ export default class GridRow {
 		// this.form_panel.toggle(true);
 
 		if (this.grid.cannot_add_rows || (this.grid.df && this.grid.df.cannot_add_rows)) {
-			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row')
+			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row, .grid-append-row')
 				.addClass('hidden');
 		} else {
-			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row')
+			this.wrapper.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row, .grid-append-row')
 				.removeClass('hidden');
 		}
 

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -119,7 +119,7 @@ export default class GridRowForm {
 		});
 	}
 	toggle_add_delete_button_display($parent) {
-		$parent.find(".row-actions")
+		$parent.find(".row-actions, .grid-append-row")
 			.toggle(this.row.grid.is_editable());
 	}
 	refresh_field(fieldname) {


### PR DESCRIPTION
When a document for example Sales Order is in the Draft state we can Add Items in the grid or Edit them but when it is Submitted (To Deliver) we can no longer edit the grid items (since `is_editable()` is false).

But still, we can see the Add Row and Add Multiple buttons on the grid, when we click them it doesn't do anything
![image](https://user-images.githubusercontent.com/30859809/115671899-9ebc5100-a368-11eb-9894-2a873465f59f.png)

Ideally, these buttons should be hidden.

After Fix:
![image](https://user-images.githubusercontent.com/30859809/115672309-0d99aa00-a369-11eb-8df5-c0d155fb4e31.png)

Sales Order in Draft state
![image](https://user-images.githubusercontent.com/30859809/115672614-5baead80-a369-11eb-857b-9ba6f8e9485f.png)
