### PR TITLE
chore: Bump version to v13.1.1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -143,6 +143,7 @@
 		"Cypress": true,
 		"cy": true,
 		"it": true,
+		"describe": true,
 		"expect": true,
 		"context": true,
 		"before": true,

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -33,7 +33,7 @@ if PY2:
 	reload(sys)
 	sys.setdefaultencoding("utf-8")
 
-__version__ = '13.1.0'
+__version__ = '13.1.1'
 
 __title__ = "Frappe Framework"
 

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -159,9 +159,10 @@ frappe.ui.form.Control = Class.extend({
 	},
 	validate_and_set_in_model: function(value, e) {
 		var me = this;
-		if(this.inside_change_event) {
+		if (this.inside_change_event || this.get_model_value() === value) {
 			return Promise.resolve();
 		}
+
 		this.inside_change_event = true;
 		var set = function(value) {
 			me.inside_change_event = false;

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -66,6 +66,10 @@ frappe.ui.form.ControlTableMultiSelect = frappe.ui.form.ControlLink.extend({
 		this._rows_list = this.rows.map(row => row[link_field.fieldname]);
 		return this.rows;
 	},
+	get_model_value() {
+		let value = this._super();
+		return value ? value.filter(d => !d.__islocal) : value;
+	},
 	validate(value) {
 		const rows = (value || []).slice();
 

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -290,7 +290,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 
 		// bind links
 		transactions_area_body.find(".badge-link").on('click', function() {
-			me.open_document_list($(this).parent());
+			me.open_document_list($(this).closest('.document-link'));
 		});
 
 		// bind reports

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -6,6 +6,7 @@ export default class GridRow {
 		this.on_grid_fields = [];
 		$.extend(this, opts);
 		if (this.doc && this.parent_df.options) {
+			frappe.meta.make_docfield_copy_for(this.parent_df.options, this.doc.name, this.docfields);
 			this.docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
 		}
 		this.columns = {};

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -38,14 +38,14 @@ $.extend(frappe.meta, {
 		frappe.meta.docfield_list[df.parent].push(df);
 	},
 
-	make_docfield_copy_for: function(doctype, docname) {
+	make_docfield_copy_for: function(doctype, docname, docfield_list=null) {
 		var c = frappe.meta.docfield_copy;
 		if(!c[doctype])
 			c[doctype] = {};
 		if(!c[doctype][docname])
 			c[doctype][docname] = {};
 
-		var docfield_list = frappe.meta.docfield_list[doctype] || [];
+		docfield_list = docfield_list || frappe.meta.docfield_list[doctype] || [];
 		for(var i=0, j=docfield_list.length; i<j; i++) {
 			var df = docfield_list[i];
 			c[doctype][docname][df.fieldname || df.label] = copy_dict(df);

--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -60,7 +60,7 @@
 		window.is_chat_enabled = {{ chat_enable }};
 	</script>
 </head>
-<body frappe-session-status="{{ 'logged-in' if frappe.session.user != 'Guest' else 'logged-out'}}" data-path="{{ path | e }}" {%- if template and template.endswith('.md') %} frappe-content-type="markdown" {% endif -%} class="{{ body_class or ''}}">
+<body frappe-session-status="{{ 'logged-in' if frappe.session.user != 'Guest' else 'logged-out'}}" data-path="{{ path | e }}" {%- if template and template.endswith('.md') %} frappe-content-type="markdown" {%- endif %} class="{{ body_class or ''}}">
 	{% include "public/icons/timeless/symbol-defs.svg" %}
 	{%- block banner -%}
 		{% include "templates/includes/banner_extension.html" ignore missing %}

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -115,7 +115,7 @@ def get_dict(fortype, name=None):
 				messages.extend(get_server_messages(app))
 			messages = deduplicate_messages(messages)
 
-			messages += frappe.db.sql("""select "navbar", item_label from `tabNavbar Item` where item_label is not null""")
+			messages += frappe.db.sql("""select 'navbar', item_label from `tabNavbar Item` where item_label is not null""")
 			messages = get_messages_from_include_files()
 			messages += frappe.db.sql("select 'Print Format:', name from `tabPrint Format`")
 			messages += frappe.db.sql("select 'DocType:', name from tabDocType")


### PR DESCRIPTION
- fix: Use grid docfield list while creating grid_row docfield copy ([#12940](https://github.com/frappe/frappe/pull/12940))
- fix: Invalid HTML generated by the base template ([#12953](https://github.com/frappe/frappe/pull/12953))
- fix(query): Use single quotes for string constant ([#12948](https://github.com/frappe/frappe/pull/12948))
- fix: Form Dashboard reference link ([#12945](https://github.com/frappe/frappe/pull/12945))