### PR TITLE
fix(UI): dont disable dialog scroll on focusing a Link/Autocomplete field

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -319,7 +319,7 @@ frappe.get_data_pill = (label, target_id=null, remove_action=null, image=null) =
 
 frappe.get_modal = function(title, content) {
 	return $(`<div class="modal fade" style="overflow: auto;" tabindex="-1">
-		<div class="modal-dialog modal-dialog-scrollable">
+		<div class="modal-dialog">
 			<div class="modal-content">
 				<div class="modal-header">
 					<div class="fill-width flex title-section">

--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -90,16 +90,10 @@ frappe.ui.form.ControlAutocomplete = frappe.ui.form.ControlData.extend({
 		});
 
 		this.$input.on("awesomplete-open", () => {
-			this.toggle_container_scroll('.modal-dialog', 'modal-dialog-scrollable');
-			this.toggle_container_scroll('.grid-form-body .form-area', 'scrollable');
-
 			this.autocomplete_open = true;
 		});
 
 		this.$input.on("awesomplete-close", () => {
-			this.toggle_container_scroll('.modal-dialog', 'modal-dialog-scrollable', true);
-			this.toggle_container_scroll('.grid-form-body .form-area', 'scrollable', true);
-
 			this.autocomplete_open = false;
 		});
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -241,16 +241,10 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 		});
 
 		this.$input.on("awesomplete-open", () => {
-			this.toggle_container_scroll('.modal-dialog', 'modal-dialog-scrollable');
-			this.toggle_container_scroll('.grid-form-body .form-area', 'scrollable');
-
 			this.autocomplete_open = true;
 		});
 
 		this.$input.on("awesomplete-close", () => {
-			this.toggle_container_scroll('.modal-dialog', 'modal-dialog-scrollable', true);
-			this.toggle_container_scroll('.grid-form-body .form-area', 'scrollable', true);
-
 			this.autocomplete_open = false;
 		});
 

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -66,7 +66,7 @@ export default class GridRowForm {
 				</div>
 			</div>
 			<div class="grid-form-body">
-				<div class="form-area scrollable"></div>
+				<div class="form-area"></div>
 				<div class="grid-footer-toolbar hidden-xs flex justify-between">
 					<div class="grid-shortcuts">
 						<span> ${frappe.utils.icon("keyboard", "md")} </span>

--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -36,18 +36,6 @@ frappe.ui.FieldSelect = Class.extend({
 			var item = me.awesomplete.get_item(value);
 			me.$input.val(item.label);
 		});
-		this.$input.on("awesomplete-open", () => {
-			let modal = this.$input.parents('.modal-dialog')[0];
-			if (modal) {
-				$(modal).removeClass("modal-dialog-scrollable");
-			}
-		});
-		this.$input.on("awesomplete-close", () => {
-			let modal = this.$input.parents('.modal-dialog')[0];
-			if (modal) {
-				$(modal).addClass("modal-dialog-scrollable");
-			}
-		});
 
 		if(this.filter_fields) {
 			for(var i in this.filter_fields)

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -17,9 +17,13 @@ body.modal-open[style^="padding-right"] {
 		border-color: var(--border-color);
 	}
 	.modal-header {
+		position: sticky;
+		top: 0;
+		z-index: 3;
+		background: inherit;
 		padding: var(--padding-md) var(--padding-lg);
-		padding-bottom: 0;
-		border-bottom: 0;
+		// padding-bottom: 0;
+		border-bottom: 1px solid var(--border-color);
 
 		.modal-title {
 			font-weight: 500;
@@ -64,9 +68,17 @@ body.modal-open[style^="padding-right"] {
 		}
 	}
 
+	.awesomplete ul {
+		z-index: 2;
+	}
+
 	.modal-footer {
+		position: sticky;
+		bottom: 0;
+		z-index: 1;
+		background: inherit;
 		padding: var(--padding-md) var(--padding-lg);
-		border-top: 0;
+		border-top: 1px solid var(--border-color);
 		justify-content: space-between;
 
 		button {

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -13,6 +13,22 @@ body.modal-open[style^="padding-right"] {
 }
 
 .modal {
+	// Same scrollbar as body
+	scrollbar-width: auto;
+	&::-webkit-scrollbar {
+		width: 12px;
+		height: 12px;
+	}
+
+	// Hide scrollbar on touch devices
+	@media(max-width: 991px) {
+		scrollbar-width: none;
+		&::-webkit-scrollbar {
+			width: 0;
+			height: 0;
+		}
+	}
+
 	.modal-content {
 		border-color: var(--border-color);
 	}
@@ -29,6 +45,7 @@ body.modal-open[style^="padding-right"] {
 			font-weight: 500;
 			line-height: 2em;
 			font-size: $font-size-lg;
+			max-width: calc(100% - 80px);
 		}
 
 		.modal-actions {

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -2,10 +2,14 @@ h5.modal-title {
 	margin: 0px !important;
 }
 
-body.modal-open {
-	overflow: auto;
-	height: auto;
-	min-height: 100%;
+// Hack to fix incorrect padding applied by Bootstrap
+body.modal-open[style^="padding-right"] {
+	padding-right: 12px !important;
+
+	header.navbar {
+		padding-right: 12px !important;
+		margin-right: -12px !important;
+	}
 }
 
 .modal {

--- a/frappe/public/scss/desk/scrollbar.scss
+++ b/frappe/public/scss/desk/scrollbar.scss
@@ -4,7 +4,7 @@
 	scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
 }
 
-html, .modal {
+html {
 	scrollbar-width: auto;
 }
 
@@ -23,7 +23,7 @@ html, .modal {
 	height: 6px;
 }
 
-body::-webkit-scrollbar, .modal::-webkit-scrollbar {
+body::-webkit-scrollbar {
 	width: 12px;
 	height: 12px;
 }

--- a/frappe/public/scss/desk/scrollbar.scss
+++ b/frappe/public/scss/desk/scrollbar.scss
@@ -4,16 +4,11 @@
 	scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
 }
 
-html {
+html, .modal {
 	scrollbar-width: auto;
 }
 
 /* Works on Chrome, Edge, and Safari */
-*::-webkit-scrollbar {
-	width: 6px;
-	height: 6px;
-}
-
 *::-webkit-scrollbar-thumb {
 	background: var(--scrollbar-thumb-color);
 }
@@ -23,7 +18,12 @@ html {
 	background: var(--scrollbar-track-color);
 }
 
-body::-webkit-scrollbar {
-	width: unset;
-	height: unset;
+*::-webkit-scrollbar {
+	width: 6px;
+	height: 6px;
+}
+
+body::-webkit-scrollbar, .modal::-webkit-scrollbar {
+	width: 12px;
+	height: 12px;
 }

--- a/frappe/website/js/bootstrap-4.js
+++ b/frappe/website/js/bootstrap-4.js
@@ -21,7 +21,7 @@ $('.dropdown-menu a.dropdown-toggle').on('click', function (e) {
 frappe.get_modal = function (title, content) {
 	return $(
 		`<div class="modal" tabindex="-1" role="dialog">
-			<div class="modal-dialog modal-dialog-scrollable" role="document">
+			<div class="modal-dialog" role="document">
 				<div class="modal-content">
 					<div class="modal-header">
 						<h5 class="modal-title">${title}</h5>


### PR DESCRIPTION
This PR is a design proposal. 

Currently, when we focus on a link / autocomplete field that's part of a modal, the modal ceases to be scrollable. Then, when we select a value / blur the link field, modal again becomes scrollable.

 This PR proposes removing this behavior because:
 - It will lead to more consistent UI. Link fields that are part of the main form do not disable scroll for the whole page:
 
  
![can scroll](https://user-images.githubusercontent.com/16315650/115708149-4186c680-a38d-11eb-9f6e-334f3302d35d.gif)

 - These dialogs anyway continue to be scrollable (see scrollbar next to main scrollbar).
 - It will improve client-side performance.

## Screenshots

### Before

(Notice how a scrollbar shows up next to the main scrollbar when focusing on the field)

![before](https://user-images.githubusercontent.com/16315650/115709358-c2928d80-a38e-11eb-8723-72c400f282c1.gif)

### After

![after](https://user-images.githubusercontent.com/16315650/115709394-caeac880-a38e-11eb-818a-8ed65de107f7.gif)

---
Resolves https://github.com/frappe/frappe/pull/12878#issuecomment-821820333