### PR TITLE
fix: Use node.string to extract style and script

### DIFF
--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -242,11 +242,11 @@ def extract_script_and_style_tags(html):
 	styles = []
 
 	for script in soup.find_all('script'):
-		scripts.append(script.text)
+		scripts.append(script.string)
 		script.extract()
 
 	for style in soup.find_all('style'):
-		styles.append(style.text)
+		styles.append(style.string)
 		style.extract()
 
 	return str(soup), scripts, styles


### PR DESCRIPTION
- node.text stopped working in beautifulsoup 4.9.x

https://github.com/frappe/frappe/pull/12784 This PR updated beautifulsoup to 4.9 and introduced the bug