### PR TITLE
refactor: Remove events to redraw charts

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -25,7 +25,6 @@ export default class ChartWidget extends Widget {
 		delete this.dashboard_chart;
 		this.set_body();
 		this.make_chart();
-		this.setup_events();
 	}
 
 	set_chart_title() {
@@ -746,19 +745,5 @@ export default class ChartWidget extends Widget {
 					}
 				}
 			});
-	}
-
-	setup_events() {
-		$(document.body).on('toggleSidebar', () => {
-			this.dashboard_chart && this.dashboard_chart.draw(true);
-		});
-
-		$(document.body).on('toggleListSidebar', () => {
-			this.dashboard_chart && this.dashboard_chart.draw(true);
-		});
-
-		$(document.body).on('toggleFullWidth', () => {
-			this.dashboard_chart && this.dashboard_chart.draw(true);
-		});
 	}
 }


### PR DESCRIPTION
The recent Frappe Charts release includes a `ResizeObserver`, this ensures that the charts will react to the width of it's container. 

The previous hack depended on events that may or may not alter the width of the widget container, this is not required anymore

Frappe Charts: https://github.com/frappe/charts/releases/tag/v1.6.1

P.S. This changes are also present in `2.0.0-rc13`