### PR TITLE
chore: frappe.whitelist for doc methods

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -24,6 +24,7 @@ class Newsletter(WebsiteGenerator):
 		if self.send_from:
 			validate_email_address(self.send_from, True)
 
+	@frappe.whitelist()
 	def test_send(self, doctype="Lead"):
 		self.recipients = frappe.utils.split_emails(self.test_email_id)
 		self.queue_all(test_email=True)


### PR DESCRIPTION
- Added `frappe.whitelist()` wherever required for methods being called from `options` in fieldtype Button.
 
Extends #12720