### PR TITLE
fix(FrappeClient): fixes for frappeclient post_api call being redirected to…

### DIFF
--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -294,7 +294,7 @@ class FrappeClient(object):
 		return self.post_process(res)
 
 	def post_api(self, method, params={}):
-		res = self.session.post(self.url + "/api/method/" + method + "/",
+		res = self.session.post(self.url + "/api/method/" + method,
 			params=params, verify=self.verify, headers=self.headers)
 		return self.post_process(res)
 


### PR DESCRIPTION
I figured out frappeclient post_api calls being redirected to  GET call due to trailing slash.
I was able to fix the issue by removing the trailing slash.
