### PR TITLE
feat(DX): sourceURL for injected javascript

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -109,8 +109,9 @@ class FormMeta(Meta):
 	def _add_code(self, path, fieldname):
 		js = get_js(path)
 		if js:
-			self.set(fieldname, (self.get(fieldname) or "")
-				+ "\n\n/* Adding {0} */\n\n".format(path) + js)
+			comment = f"\n\n/* Adding {path} */\n\n"
+			sourceURL = f"\n\n//# sourceURL={scrub(self.name) + fieldname}"
+			self.set(fieldname, (self.get(fieldname) or "") + comment + js + sourceURL)
 
 	def add_html_templates(self, path):
 		if self.custom:
@@ -144,6 +145,10 @@ class FormMeta(Meta):
 
 			if script.view == 'Form':
 				form_script += script.script
+
+		file = scrub(self.name)
+		form_script += f"\n\n//# sourceURL={file}__custom_js"
+		list_script += f"\n\n//# sourceURL={file}__custom_list_js"
 
 		self.set("__custom_js", form_script)
 		self.set("__custom_list_js", list_script)


### PR DESCRIPTION
Adds sourceURL to injected javascript code, this helps in debugging injected javascript using client script or doctype specific javascript.

MDN reference: https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Debug_eval_sources 

`no-docs`

Chrome:
![image](https://user-images.githubusercontent.com/9079960/116121292-19290000-a6de-11eb-9cd7-ad561e33a51f.png)

Firefox:
![image](https://user-images.githubusercontent.com/9079960/116121322-1f1ee100-a6de-11eb-917f-800ce0d13e36.png)


