### PR TITLE
fix(kanban): Freeze screen till the background request is complete

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -1,3 +1,5 @@
+// TODO: Refactor for better UX
+
 frappe.provide("frappe.views");
 
 (function() {
@@ -185,7 +187,7 @@ frappe.provide("frappe.views");
 						new_index: card.new_index,
 					};
 				}
-
+				frappe.dom.freeze();
 				frappe.call({
 					method: method_prefix + method_name,
 					args: args,
@@ -198,6 +200,7 @@ frappe.provide("frappe.views");
 							cards: cards,
 							columns: columns
 						});
+						frappe.dom.unfreeze();
 					}
 				}).fail(function() {
 					// revert original order
@@ -205,6 +208,7 @@ frappe.provide("frappe.views");
 						cards: _cards,
 						columns: _columns
 					});
+					frappe.dom.unfreeze();
 				});
 			},
 			update_order: function(updater) {


### PR DESCRIPTION
Freeze screen till the background request is complete so that client-side & server-side data are in sync before performing any new action.

fixes following random issue while moving cards
<img width="1440" alt="Screenshot 2021-04-26 at 1 12 51 PM" src="https://user-images.githubusercontent.com/13928957/116193115-7a87b800-a74c-11eb-9cee-bcd7cd7363fa.png">
