### PR TITLE
fix: replace parseFloat by Number

### DIFF
--- a/frappe/public/js/frappe/form/controls/currency.js
+++ b/frappe/public/js/frappe/form/controls/currency.js
@@ -1,7 +1,7 @@
 frappe.ui.form.ControlCurrency = frappe.ui.form.ControlFloat.extend({
 	format_for_input: function(value) {
 		var formatted_value = format_number(value, this.get_number_format(), this.get_precision());
-		return isNaN(parseFloat(value)) ? "" : formatted_value;
+		return isNaN(Number(value)) ? "" : formatted_value;
 	},
 
 	get_precision: function() {

--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -10,7 +10,7 @@ frappe.ui.form.ControlFloat = frappe.ui.form.ControlInt.extend({
 			number_format = this.get_number_format();
 		}
 		var formatted_value = format_number(value, number_format, this.get_precision());
-		return isNaN(parseFloat(value)) ? "" : formatted_value;
+		return isNaN(Number(value)) ? "" : formatted_value;
 	},
 
 	get_number_format: function() {


### PR DESCRIPTION
Issue:
Typing 0 in a Currency Field replaces it by emplty string

Expected:
It should stay as 0

Problem: 
parseFloat return NaN for empty string thus empty string is used instead of 0

Solution:
Use Number since it returns 0 for 0