### PR TITLE
fix: focus jumps to first field

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -451,7 +451,7 @@ frappe.ui.form.Form = class FrappeForm {
 						return this.script_manager.trigger("onload_post_render");
 					}
 				},
-				() => this.is_new() && this.focus_on_first_input(),
+				() => this.cscript.is_onload && this.is_new() && this.focus_on_first_input(),
 				() => this.run_after_load_hook(),
 				() => this.dashboard.after_refresh()
 			]);


### PR DESCRIPTION
Issue:
Focus jumping to first field when some other field changes

Reason:
Purchase Order doctype calls `frm.refresh` on editing of some fields
`frm.refresh` actually calls the onload methods which has the code to focus on first field

Steps to Reproduce
Go to Purchase Order Doctype
select supplier,focus will go to the Series field

Solution:
Test if the call is made by onload or refresh