### PR TITLE
fix(UI): consistent checkboxes on all browsers

### DIFF
--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -16,66 +16,54 @@
 	}
 }
 
+$check-icon: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1 4.00001L2.66667 5.80001L7 1.20001' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+
 input[type="checkbox"] {
 	position: relative;
-	width: 0 !important;
-	height: var(--custom-checkbox-size);
-	margin-right: calc(var(--custom-checkbox-size) + var(--checkbox-right-margin)) !important;
-	font-size: calc(var(--custom-checkbox-size) - 1px);
+	width: var(--checkbox-size) !important;
+	height: var(--checkbox-size);
+	margin-right: var(--checkbox-right-margin) !important;
+	background-repeat: no-repeat;
+	background-position: center;
+	border: 1px solid var(--gray-400);
+	box-sizing: border-box;
+	box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
+	border-radius: 4px;
 
-	&:before {
-		width: var(--custom-checkbox-size);
-		height: var(--custom-checkbox-size);
-		position: absolute;
-		top: 0;
-		display: inline-block;
-		line-height: 1;
-		text-align: center;
-		content: ' ';
-		border: 1px solid var(--gray-400);
-		box-sizing: border-box;
-		box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
-		border-radius: 4px;
+	// Reset Browser Behavior
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+
+	-webkit-print-color-adjust: exact;
+	color-adjust: exact;
+
+	.grid-static-col & {
+		margin-right: 0 !important;
 	}
 
-	&:checked:before {
-		content: url("data: image/svg+xml;utf8, <svg width='8' height='7' viewBox='0 0 8 7' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1 4.00001L2.66667 5.80001L7 1.20001' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-		background: linear-gradient(180deg, #4AC3F8 -124.51%, #2490EF 100%);
+	&:checked {
+		background-color: #2490EF;
+		background-image: $check-icon, linear-gradient(180deg, #4AC3F8 -124.51%, #2490EF 100%);
+		background-size: 57%, 100%;
 		box-shadow: none;
 		border: none;
 	}
 
-
-	&.disabled-deselected:before, &:disabled:not([checked])::before {
-		background: var(--disabled-control-bg);
-		border: 0.5px solid var(--gray-300);
-		box-sizing: border-box;
+	&.disabled-deselected, &:disabled {
+		background-color: var(--disabled-control-bg);
 		box-shadow: inset 0px 1px 7px rgba(0, 0, 0, 0.1);
-		border-radius: 4px;
+		border: 0.5px solid var(--gray-300);
 		pointer-events: none;
 	}
 
-	&.disabled-selected:before, &:disabled:checked::before {
-		content: url("data: image/svg+xml;utf8, <svg width='8' height='7' viewBox='0 0 8 7' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1 4.00001L2.66667 5.80001L7 1.20001' stroke='white' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
-		background: var(--gray-500);
-		box-sizing: border-box;
+	&.disabled-selected, &:disabled:checked {
+		background-color: var(--gray-500);
+		background-image: $check-icon;
+		background-size: 57%;
 		box-shadow: inset 0px 1px 3px rgba(0, 0, 0, 0.1);
-		border-radius: 4px;
-		line-height: 10px;
+		border: none;
 		pointer-events: none;
-	}
-}
-
-// Firefox doesn't support
-// pseudo elements on checkbox
-html.firefox, html.safari {
-	:root {
-		--custom-checkbox-size: 0px;
-	}
-	input[type="checkbox"] {
-		width: var(--base-checkbox-size) !important;
-		height: var(--base-checkbox-size);
-		margin-right: var(--checkbox-right-margin) !important;
 	}
 }
 

--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -30,7 +30,7 @@ input[type="checkbox"] {
 	box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.1);
 	border-radius: 4px;
 
-	// Reset Browser Behavior
+	// Reset browser behavior
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
@@ -52,11 +52,7 @@ input[type="checkbox"] {
 
 	&:focus {
 		outline: none; // Prevent browser behavior
-		box-shadow: 0 0 0 2px var(--gray-300);
-
-		[data-theme="dark"] & {
-			box-shadow: 0 0 0 2px var(--gray-600);
-		}
+		box-shadow: var(--checkbox-focus-shadow);
 	}
 
 	&.disabled-deselected, &:disabled {

--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -50,6 +50,15 @@ input[type="checkbox"] {
 		border: none;
 	}
 
+	&:focus {
+		outline: none; // Prevent browser behavior
+		box-shadow: 0 0 0 2px var(--gray-300);
+
+		[data-theme="dark"] & {
+			box-shadow: 0 0 0 2px var(--gray-600);
+		}
+	}
+
 	&.disabled-deselected, &:disabled {
 		background-color: var(--disabled-control-bg);
 		box-shadow: inset 0px 1px 7px rgba(0, 0, 0, 0.1);

--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -31,9 +31,6 @@ $input-height: 28px !default;
 	--modal-bg: white;
 	--toast-bg: var(--modal-bg);
 	--popover-bg: white;
-	--checkbox-right-margin: var(--margin-xs);
-	--base-checkbox-size: 14px;
-	--custom-checkbox-size: 14px;
 
 	--appreciation-color: var(--dark-green-600);
 	--appreciation-bg: var(--dark-green-100);
@@ -51,6 +48,10 @@ $input-height: 28px !default;
 	// input
 	--input-height: #{$input-height};
 	--input-disabled-bg: var(--gray-200);
+
+	// checkbox
+	--checkbox-right-margin: var(--margin-xs);
+	--checkbox-size: 14px;
 
 	// timeline
 	--timeline-item-icon-size: 34px;

--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -52,6 +52,7 @@ $input-height: 28px !default;
 	// checkbox
 	--checkbox-right-margin: var(--margin-xs);
 	--checkbox-size: 14px;
+	--checkbox-focus-shadow: 0 0 0 2px var(--gray-300);
 
 	// timeline
 	--timeline-item-icon-size: 34px;

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -78,6 +78,9 @@
 	// input
 	--input-disabled-bg: none;
 
+	// checkbox
+	--checkbox-focus-shadow: 0 0 0 2px var(--gray-600);
+
 	color-scheme: dark;
 
 	.frappe-card {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -197,8 +197,7 @@ $level-margin-right: 8px;
 
 input.list-check-all, input.list-row-checkbox {
 	margin-top: 0px;
-	margin-left: calc(var(--custom-checkbox-size) / 2);
-	--checkbox-right-margin: #{$level-margin-right};
+	--checkbox-right-margin: calc(var(--checkbox-size) / 2 + #{$level-margin-right});
 }
 
 .filterable {


### PR DESCRIPTION
Bootstrap 5 inspired checkbox design for consistency across browsers.

## Screenshots

### Before

 - Chrome
  
    ![Screenshot-2021-04-28-165816](https://user-images.githubusercontent.com/16315650/116396809-6b376600-a843-11eb-9d0d-fb320707e82d.png)

 - Firefox

   ![Screenshot-2021-04-28-170012](https://user-images.githubusercontent.com/16315650/116396825-71c5dd80-a843-11eb-8c8e-f4187671deb8.png)


- Grid View
  
  ![grid before](https://user-images.githubusercontent.com/16315650/116397767-9f5f5680-a844-11eb-9ecf-893ceda8dfd8.gif)

### After

- Chrome

  ![Screenshot-2021-04-28-165644](https://user-images.githubusercontent.com/16315650/116396240-c87ee780-a842-11eb-8f29-94905f8e3158.png)

- Firefox

  ![Screenshot-2021-04-28-170246](https://user-images.githubusercontent.com/16315650/116397001-a9348a00-a843-11eb-8d1c-3b1330ad953c.png)

- Grid View

  ![grid after](https://user-images.githubusercontent.com/16315650/116397854-ba31cb00-a844-11eb-94e9-1d04a2f8f618.gif)


#### Tabbed Navigation

Previously, there was no way to ascertain which checkbox is in focus when navigating a form with the <kbd>Tab</kbd> key.

- Light Mode

  ![tab light mode](https://user-images.githubusercontent.com/16315650/116395920-59a18e80-a842-11eb-882f-f9efc74870a4.gif)

- Dark Mode

  ![tab dark mode](https://user-images.githubusercontent.com/16315650/116395939-5efed900-a842-11eb-8c62-583b34202a08.gif)

## Other Changes

- Create Sass Variable `check-icon`
- Replace CSS Variables `--base-checkbox-size` and `--custom-checkbox-size` with `--checkbox-size`
- Change list view CSS to accommodate this change. The result looks same before / after.

fixes: https://github.com/frappe/frappe/issues/12901