### PR TITLE
fix: Respond to /api requests as JSON by default

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -201,12 +201,20 @@ def handle_exception(e):
 	response = None
 	http_status_code = getattr(e, "http_status_code", 500)
 	return_as_message = False
+	accept_header = frappe.get_request_header("Accept") or ""
+	respond_as_json = (
+		frappe.get_request_header('Accept')
+		and (frappe.local.is_ajax or 'application/json' in accept_header)
+		or (
+			frappe.local.request.path.startswith("/api/") and not accept_header.startswith("text")
+		)
+	)
 
 	if frappe.conf.get('developer_mode'):
 		# don't fail silently
 		print(frappe.get_traceback())
 
-	if frappe.get_request_header('Accept') and (frappe.local.is_ajax or 'application/json' in frappe.get_request_header('Accept')):
+	if respond_as_json:
 		# handle ajax responses first
 		# if the request is ajax, send back the trace or error message
 		response = frappe.utils.response.report_error(http_status_code)


### PR DESCRIPTION
**Before**

If header `'Accept: application/json'` isn't set, the failure responses to `/api/` endpoints are HTML. Success responses are of type JSON.

![Screenshot 2021-04-29 at 11 10 42 AM](https://user-images.githubusercontent.com/36654812/116506835-b43af900-a8db-11eb-8e26-38cdd08f16a1.png)

![Screenshot 2021-04-29 at 11 11 29 AM](https://user-images.githubusercontent.com/36654812/116506839-b604bc80-a8db-11eb-8b20-47ae3ad914c1.png)

**After**

If the header `Accept` isn't set, the failure responses to `/api/` endpoints are of type JSON. Success responses are of type JSON as well. To receive responses in HTML, you can set the header `'Accept: text/html'`, though any `text/` mime type will only return an HTML response at this point.

![Screenshot 2021-04-29 at 11 07 14 AM](https://user-images.githubusercontent.com/36654812/116506829-b1d89f00-a8db-11eb-9f8d-deeeac37474d.png)

![Screenshot 2021-04-29 at 11 11 36 AM](https://user-images.githubusercontent.com/36654812/116506843-b735e980-a8db-11eb-8652-04d9a1232f9c.png)
