### PR TITLE
fix: Moving Site folder across different FileSystems failed

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -513,7 +513,7 @@ def move(dest_dir, site):
 		site_dump_exists = os.path.exists(final_new_path)
 		count = int(count or 0) + 1
 
-	os.rename(old_path, final_new_path)
+	shutil.move(old_path, final_new_path)
 	frappe.destroy()
 	return final_new_path
 


### PR DESCRIPTION
1. Scenario:
Production app using Docker images from [frappe_docker](https://github.com/frappe/frappe_docker)
bench_manager installer
2. Issue:
Drop site which is created by [bench_manager](https://github.com/frappe/bench_manager) result in OSError: [Errno 18] Invalid cross-device link
3. Root cause:
The docker container backing file system is different from the host's file system, so moving the site to archived folder failed.

4. Solution:
Use shutil.move instead since it not use "link" and take care of the filesystem differences ( tested )