### PR TITLE
fix: Grid row color picker field not working

### DIFF
--- a/frappe/public/js/frappe/form/controls/color.js
+++ b/frappe/public/js/frappe/form/controls/color.js
@@ -48,7 +48,24 @@ frappe.ui.form.ControlColor = frappe.ui.form.ControlData.extend({
 			$(window).off('hashchange.color-popover');
 		});
 
-		this.$wrapper.find('.control-input').on('click', (e) => {
+		this.picker.on_change = (color) => {
+			this.set_value(color);
+		};
+
+		if (!this.selected_color) {
+			this.selected_color = $(`<div class="selected-color"></div>`);
+			this.selected_color.insertAfter(this.$input);
+		}
+
+		if (!this.$wrapper.find('.control-input').get(0)) {
+			this.$wrapper.find('.selected-color')
+				.css({
+					"top": "calc(23% + 1px)",
+					"z-index": "2"
+				});
+		}
+
+		this.$wrapper.find('.selected-color').parent().on('click', (e) => {
 			this.$wrapper.popover('toggle');
 			if (!this.get_color()) {
 				this.$input.val('');
@@ -63,15 +80,6 @@ frappe.ui.form.ControlColor = frappe.ui.form.ControlData.extend({
 				this.$wrapper.popover('hide');
 			});
 		});
-
-		this.picker.on_change = (color) => {
-			this.set_value(color);
-		};
-
-		if (!this.selected_color) {
-			this.selected_color = $(`<div class="selected-color"></div>`);
-			this.selected_color.insertAfter(this.$input);
-		}
 	},
 	refresh() {
 		this._super();

--- a/frappe/public/js/frappe/form/controls/color.js
+++ b/frappe/public/js/frappe/form/controls/color.js
@@ -57,14 +57,6 @@ frappe.ui.form.ControlColor = frappe.ui.form.ControlData.extend({
 			this.selected_color.insertAfter(this.$input);
 		}
 
-		if (!this.$wrapper.find('.control-input').get(0)) {
-			this.$wrapper.find('.selected-color')
-				.css({
-					"top": "calc(23% + 1px)",
-					"z-index": "2"
-				});
-		}
-
 		this.$wrapper.find('.selected-color').parent().on('click', (e) => {
 			this.$wrapper.popover('toggle');
 			if (!this.get_color()) {

--- a/frappe/public/js/frappe/form/controls/color.js
+++ b/frappe/public/js/frappe/form/controls/color.js
@@ -6,6 +6,7 @@ frappe.ui.form.ControlColor = frappe.ui.form.ControlData.extend({
 		this.make_color_input();
 	},
 	make_color_input: function () {
+		this.df.placeholder = __('Choose a color');
 		let picker_wrapper = $('<div>');
 		this.picker = new Picker({
 			parent: picker_wrapper[0],
@@ -83,8 +84,7 @@ frappe.ui.form.ControlColor = frappe.ui.form.ControlData.extend({
 	},
 	set_formatted_input: function(value) {
 		this._super(value);
-
-		this.$input.val(value || __('Choose a color'));
+		this.$input.val(value);
 		this.selected_color.css({
 			"background-color": value || 'transparent',
 		});

--- a/frappe/public/js/frappe/form/controls/color.js
+++ b/frappe/public/js/frappe/form/controls/color.js
@@ -2,11 +2,11 @@ import Picker from '../../color_picker/color_picker';
 
 frappe.ui.form.ControlColor = frappe.ui.form.ControlData.extend({
 	make_input: function () {
+		this.df.placeholder = this.df.placeholder || __('Choose a color');
 		this._super();
 		this.make_color_input();
 	},
 	make_color_input: function () {
-		this.df.placeholder = __('Choose a color');
 		let picker_wrapper = $('<div>');
 		this.picker = new Picker({
 			parent: picker_wrapper[0],

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -292,12 +292,12 @@ frappe.form.formatters = {
 		return formatted_values.join(', ');
 	},
 	Color: (value) => {
-		return `<div>
+		return value ? `<div>
 			<div class="selected-color" style="background-color: ${value}"></div>
 			<span class="color-value">${value}</span>
-		</div>`;
+		</div>` : '';
 	}
-}
+};
 
 frappe.form.get_formatter = function(fieldtype) {
 	if(!fieldtype)

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -422,7 +422,7 @@ export default class GridRow {
 			field.$input
 				.addClass('input-sm')
 				.attr('data-col-idx', column.column_index)
-				.attr('placeholder', __(df.label));
+				.attr('placeholder', __(df.placeholder || df.label));
 			// flag list input
 			if (this.columns_list && this.columns_list.slice(-1)[0]===column) {
 				field.$input.attr('data-last-input', 1);

--- a/frappe/public/scss/common/color_picker.scss
+++ b/frappe/public/scss/common/color_picker.scss
@@ -121,3 +121,10 @@
 		}
 	}
 }
+
+.data-row.row {
+	.selected-color {
+		top: calc(50% - 11px);
+		z-index: 2;
+	}
+}

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -196,7 +196,7 @@
 		margin-left: 1rem;
 	}
 
-	.grid-static-col[data-fieldtype="Code"] {
+	.grid-static-col[data-fieldtype="Code"], .grid-static-col[data-fieldtype="HTML Editor"] {
 		overflow: hidden;
 
 		.static-area {


### PR DESCRIPTION
Fixes:
- The Color Picker field not working when it's added inside any grid. Also, the positioning of the color icon is a little off.
	**BEFORE:**
	<img width="300" src="https://user-images.githubusercontent.com/30859809/116524980-a72b0380-a8f5-11eb-9cdd-e0250fb25e51.png">
	When we click on it:
	<img width="300" src="https://user-images.githubusercontent.com/30859809/116525088-cc1f7680-a8f5-11eb-88e5-2efc2cdd9b43.png">

	**AFTER:**
	<img width="300" src="https://user-images.githubusercontent.com/30859809/116525543-3e905680-a8f6-11eb-9267-9494a94e0bdc.png">
	When we click on it:
	<img width="300" src="https://user-images.githubusercontent.com/30859809/116525631-58319e00-a8f6-11eb-854a-f7f7ef71c611.png">

- State when there's no color value set 
	**Before**
	<img width="450" alt="Screenshot 2021-04-29 at 5 31 21 PM" src="https://user-images.githubusercontent.com/13928957/116548849-6beafd80-a912-11eb-99bc-c77792edf5b1.png">
	**After**
	<img width="430" alt="Screenshot 2021-04-29 at 5 44 49 PM" src="https://user-images.githubusercontent.com/13928957/116549020-9dfc5f80-a912-11eb-88ba-e6b358afbf50.png">

- HTML editor in grid
	**Before**
	<img width="1027" alt="Screenshot 2021-04-29 at 5 53 37 PM" src="https://user-images.githubusercontent.com/13928957/116550439-67274900-a914-11eb-9d6f-665e4e05feff.png">
	**After**
	<img width="1027" alt="Screenshot 2021-04-29 at 5 54 55 PM" src="https://user-images.githubusercontent.com/13928957/116550483-74dcce80-a914-11eb-8949-f64565bb1711.png">



