### PR TITLE
test: omit commands directory since it is tested seperately

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -520,7 +520,7 @@ def run_tests(context, app=None, module=None, doctype=None, test=(), profile=Fal
 
 		# Generate coverage report only for app that is being tested
 		source_path = os.path.join(get_bench_path(), 'apps', app or 'frappe')
-		cov = Coverage(source=[source_path], omit=[
+		omit=[
 			'*.html',
 			'*.js',
 			'*.xml',
@@ -529,9 +529,13 @@ def run_tests(context, app=None, module=None, doctype=None, test=(), profile=Fal
 			'*.scss',
 			'*.vue',
 			'*/doctype/*/*_dashboard.py',
-			'*/patches/*',
-			'*/commands/*'
-		])
+			'*/patches/*'
+		]
+
+		if not app or app=='frappe':
+			omit.append('frappe/commands/*')
+
+		cov = Coverage(source=[source_path], omit=omit)
 		cov.start()
 
 	ret = frappe.test_runner.main(app, module, doctype, context.verbose, tests=tests,

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -533,7 +533,7 @@ def run_tests(context, app=None, module=None, doctype=None, test=(), profile=Fal
 		]
 
 		if not app or app=='frappe':
-			omit.append('frappe/commands/*')
+			omit.append('*/commands/*')
 
 		cov = Coverage(source=[source_path], omit=omit)
 		cov.start()

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -532,7 +532,7 @@ def run_tests(context, app=None, module=None, doctype=None, test=(), profile=Fal
 			'*/patches/*'
 		]
 
-		if not app or app=='frappe':
+		if not app or app == 'frappe':
 			omit.append('*/commands/*')
 
 		cov = Coverage(source=[source_path], omit=omit)

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -529,7 +529,8 @@ def run_tests(context, app=None, module=None, doctype=None, test=(), profile=Fal
 			'*.scss',
 			'*.vue',
 			'*/doctype/*/*_dashboard.py',
-			'*/patches/*'
+			'*/patches/*',
+			'*/commands/*'
 		])
 		cov.start()
 


### PR DESCRIPTION
commands are tested here https://github.com/frappe/frappe/blob/develop/frappe/tests/test_commands.py so coverage does not know it is getting tested