### PR TITLE
fix: naming section display

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -278,6 +278,7 @@
   },
   {
    "collapsible": 1,
+   "depends_on": "doc_type",
    "fieldname": "naming_section",
    "fieldtype": "Section Break",
    "label": "Naming"
@@ -295,7 +296,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-03-22 12:27:15.462727",
+ "modified": "2021-04-29 21:21:06.476372",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",


### PR DESCRIPTION
**Fix-** Don't show naming section if doctype is not selected