### PR TITLE
fix: Select appropriate email template response

### DIFF
--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -105,6 +105,10 @@ def send_welcome_email(welcome_email, email, email_group):
 		email=email,
 		email_group=email_group
 	)
-
-	message = frappe.render_template(welcome_email.response, args)
+	if welcome_email.response is None:
+		email_message=welcome_email.response_html
+	else:
+		email_message=welcome_email.response
+	message = frappe.render_template(email_message, args)
 	frappe.sendmail(email, subject=welcome_email.subject, message=message)
+

--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -105,10 +105,6 @@ def send_welcome_email(welcome_email, email, email_group):
 		email=email,
 		email_group=email_group
 	)
-	if welcome_email.response is None:
-		email_message=welcome_email.response_html
-	else:
-		email_message=welcome_email.response
+	email_message = welcome_email.response or welcome_email.response_html
 	message = frappe.render_template(email_message, args)
 	frappe.sendmail(email, subject=welcome_email.subject, message=message)
-


### PR DESCRIPTION
Fix: Select appropriate email template response, Welcome email template can be either html or rich text


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

<!--Please provide enough information so that others can review your pull request:-->
When adding members in e-mail group, there is an option to send welcome email by selecting the email template. The email template can be in the form of plain text or HTML, in the current implementation, the email template having HTML as the template isn't getting considered as the body is only considering the data available in "response" while the body can be in "response_html". This fix is to select the email template whether HTML or plain text while sending the welcome mail.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

>  **details** for making this change

The problem of selecting the right email template's body while sending welcome mail to the members of a email group.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
