### PR TITLE
fix: Changed shorcut widgets color picker to dropdown

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -2,7 +2,6 @@ import Widget from "./base_widget.js";
 
 frappe.provide("frappe.utils");
 
-const INDICATOR_COLORS = ["Grey", "Green", "Red", "Orange", "Pink", "Yellow", "Blue", "Cyan", "Teal"];
 export default class ShortcutWidget extends Widget {
 	constructor(opts) {
 		opts.shadow = true;
@@ -79,7 +78,7 @@ export default class ShortcutWidget extends Widget {
 
 		this.action_area.empty();
 		const label = get_label();
-		let color = INDICATOR_COLORS.includes(this.color) && count ? this.color.toLowerCase() : 'gray';
+		let color = this.color && count ? this.color.toLowerCase() : 'gray';
 		$(`<div class="indicator-pill ellipsis ${color}">${label}</div>`).appendTo(this.action_area);
 	}
 }

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -240,7 +240,7 @@ class ShortcutDialog extends WidgetDialog {
 				fieldtype: "Select",
 				fieldname: "color",
 				label: __("Color"),
-				options: ["Grey", "Green", "Red", "Orange", "Pink", "Yellow", "Blue", "Cyan", "Teal"],
+				options: ["Grey", "Green", "Red", "Orange", "Pink", "Yellow", "Blue", "Cyan"],
 				default: "Grey",
 				onchange: () => {
 					let color = this.dialog.fields_dict.color.value.toLowerCase();
@@ -248,7 +248,7 @@ class ShortcutDialog extends WidgetDialog {
 					if (!$select.parent().find('.color-box').get(0)) {
 						$(`<div class="color-box"></div>`).insertBefore($select.get(0));
 					}
-					$select.parent().find('.color-box').get(0).style.backgroundColor = color;
+					$select.parent().find('.color-box').get(0).style.backgroundColor = `var(--text-on-${color})`;
 				}
 			},
 			{

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -237,9 +237,19 @@ class ShortcutDialog extends WidgetDialog {
 				hidden: 1,
 			},
 			{
-				fieldtype: "Color",
+				fieldtype: "Select",
 				fieldname: "color",
 				label: __("Color"),
+				options: ["Grey", "Green", "Red", "Orange", "Pink", "Yellow", "Blue", "Cyan", "Teal"],
+				default: "Grey",
+				onchange: () => {
+					let color = this.dialog.fields_dict.color.value.toLowerCase();
+					let $select = this.dialog.fields_dict.color.$input;
+					if (!$select.parent().find('.color-box').get(0)) {
+						$(`<div class="color-box"></div>`).insertBefore($select.get(0));
+					}
+					$select.parent().find('.color-box').get(0).style.backgroundColor = color;
+				}
 			},
 			{
 				fieldtype: "Column Break",

--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -24,6 +24,17 @@
 	--blue-100: #D3E9FC;
 	--blue-50 : #F0F8FE;
 
+	--cyan-900: #006464; 
+	--cyan-800: #007272;
+	--cyan-700: #008b8b;
+	--cyan-600: #02c5c5;
+	--cyan-500: #00ffff;
+	--cyan-400: #2ef8f8;
+	--cyan-300: #6efcfc;
+	--cyan-200: #a0f8f8;
+	--cyan-100: #c7fcfc;
+	--cyan-50 : #dafafa;
+
 	--green-900: #2D401D;
 	--green-800: #44622A;
 	--green-700: #518B21;
@@ -151,6 +162,8 @@
 	--bg-gray: var(--gray-200);
 	--bg-light-gray: var(--gray-100);
 	--bg-purple: var(--purple-100);
+	--bg-pink: var(--pink-50);
+	--bg-cyan: var(--cyan-50);
 
 	--text-on-blue: var(--blue-600);
 	--text-on-light-blue: var(--blue-500);
@@ -163,6 +176,8 @@
 	--text-on-gray: var(--gray-600);
 	--text-on-light-gray: var(--gray-800);
 	--text-on-purple: var(--purple-500);
+	--text-on-pink: var(--pink-500);
+	--text-on-cyan: var(--cyan-600);
 
 	--awesomplete-hover-bg: var(--control-bg);
 

--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -76,6 +76,22 @@ input[type="checkbox"] {
 	@include card();
 }
 
+.frappe-control[data-fieldtype="Select"].frappe-control[data-fieldname="color"] {
+	select {
+		padding-left: 40px;
+	}
+
+	.color-box {
+		position: absolute;
+		top: calc(50% - 11px);
+		left: 8px;
+		width: 22px;
+		height: 22px;
+		border-radius: 5px;
+		z-index: 1;
+	}
+}
+
 .frappe-control[data-fieldtype="Select"] .control-input,
 .frappe-control[data-fieldtype="Select"].form-group {
 	position: relative;

--- a/frappe/public/scss/common/indicator.scss
+++ b/frappe/public/scss/common/indicator.scss
@@ -77,6 +77,16 @@
 	@include indicator-pill-color('green');
 }
 
+.indicator.cyan {
+	@include indicator-color('cyan');
+}
+
+.indicator-pill.cyan,
+.indicator-pill-right.cyan,
+.indicator-pill-round.cyan {
+	@include indicator-pill-color('cyan');
+}
+
 .indicator.blue {
 	@include indicator-color('blue');
 }
@@ -129,6 +139,16 @@
 .indicator-pill-right.red,
 .indicator-pill-round.red {
 	@include indicator-pill-color('red');
+}
+
+.indicator.pink {
+	@include indicator-color('pink');
+}
+
+.indicator-pill.pink,
+.indicator-pill-right.pink,
+.indicator-pill-round.pink {
+	@include indicator-pill-color('pink');
 }
 
 .indicator-pill.darkgrey,


### PR DESCRIPTION
In Shortcut Widget, the color picker for indicator pill only allows `INDICATOR_COLORS` ('Red', 'Green', 'Blue' ...)
Color picker is not suitable for this, so replacing it with dropdown.

Before: 
![image](https://user-images.githubusercontent.com/30859809/116658837-3a277480-a9ae-11eb-9dda-7aff91016823.png)
After:
![image](https://user-images.githubusercontent.com/30859809/116658896-56c3ac80-a9ae-11eb-94d9-ced680fd8ccb.png)
