### PR TITLE
fix: preload URLs breaking for external requests

### DIFF
--- a/frappe/website/render.py
+++ b/frappe/website/render.py
@@ -149,8 +149,8 @@ def add_preload_headers(response):
 			preload.append(("style", elem.get("href")))
 
 		links = []
-		for type, link in preload:
-			links.append("</{}>; rel=preload; as={}".format(link.lstrip("/"), type))
+		for _type, link in preload:
+			links.append("<{}>; rel=preload; as={}".format(link, _type))
 
 		if links:
 			response.headers["Link"] = ",".join(links)


### PR DESCRIPTION
**Overview** (from PR #11344)
#10422 added the ability to preload HTTP links, but the format for setting these links was causing issues with external requests - namely, Frappe would prepend the base site URL to the href, causing malformed URLs.

Version 12 backport of #11344

Reason for the PR: The `version-12-hotfix` mergify backport failed
