### PR TITLE
fix: error for bench drop-site. Added missing import.

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1,6 +1,7 @@
 # imports - standard imports
 import os
 import sys
+import shutil
 
 # imports - third party imports
 import click


### PR DESCRIPTION
`bench drop-site` was giving me the following error (stacktracce):
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 101, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 495, in drop_site
    _drop_site(site, root_login, root_password, archived_sites_path, force, no_backup)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 531, in _drop_site
    move(archived_sites_path, site)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 550, in move
    shutil.move(old_path, final_new_path)
NameError: name 'shutil' is not defined
```

This was caused by a missing import of the `shutil` package. This patch only adds this missing import.

