### PR TITLE
feat: switch theme with left/right keys

### DIFF
--- a/frappe/public/js/frappe/ui/theme_switcher.js
+++ b/frappe/public/js/frappe/ui/theme_switcher.js
@@ -11,6 +11,34 @@ frappe.ui.ThemeSwitcher = class ThemeSwitcher {
 			title: __("Switch Theme")
 		});
 		this.body = $(`<div class="theme-grid"></div>`).appendTo(this.dialog.$body);
+		this.bind_events();
+	}
+
+	bind_events() {
+		this.dialog.$wrapper.on('keydown', (e) => {
+			if (!this.themes) return;
+
+			const key = frappe.ui.keys.get_key(e);
+			let increment_by;
+
+			if (key === "right") {
+				increment_by = 1;
+			} else if (key === "left") {
+				increment_by = -1;
+			} else {
+				return;
+			}
+
+			const current_index = this.themes.findIndex(theme => {
+				return theme.name === this.current_theme;
+			});
+
+			const new_theme = this.themes[current_index + increment_by];
+			if (!new_theme) return;
+
+			new_theme.$html.click();
+			return false;
+		});
 	}
 
 	refresh() {


### PR DESCRIPTION
There's a keyboard shortcut to open the **Switch Theme** dialog, but then we need to use mouse to switch to a new theme. This PR completes the keyboard experience for switching themes:
- <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> to open dialog
- <kbd>←</kbd>  /   <kbd>→</kbd> to switch theme
-  <kbd>Esc</kbd> to close dialog

---

![switch theme keys](https://user-images.githubusercontent.com/16315650/116781765-bac79d00-aaa2-11eb-9566-f954d7019481.gif)

> no-docs