### PR TITLE
fix: Added conditional rendering for content field in split section w…

### DIFF
--- a/frappe/website/web_template/split_section_with_image/split_section_with_image.html
+++ b/frappe/website/web_template/split_section_with_image/split_section_with_image.html
@@ -16,7 +16,9 @@
 	{%- endif -%}
 	<div class="split-section-content col-12 {{ left_col if image_on_right else right_col }} {{ align_content }}">
 		<h2>{{ title }}</h2>
+		{%- if content -%}
 		<p>{{ content }}</p>
+		{%- endif -%}
 
 		{%- if link_label and link_url -%}
 		<a href="{{ link_url }}">{{ link_label }}</a>


### PR DESCRIPTION
The Web template split_section_with_template did not have the conditional rendering for content context. So it was rendering the template tag on the client-side. I, therefore, added the if template tag.

Before:

![Screenshot from 2021-05-01 19-49-13](https://user-images.githubusercontent.com/44427574/116785643-557ea680-aab8-11eb-91ae-3f53f6578657.png)

After:

![Screenshot from 2021-05-01 19-49-35](https://user-images.githubusercontent.com/44427574/116785656-629b9580-aab8-11eb-89b2-2453d153ef26.png)
