### PR TITLE
fix: Add breadcrumbs for list view

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -68,6 +68,8 @@ frappe.breadcrumbs = {
 			if (breadcrumbs.doctype && ["print", "form"].includes(view)) {
 				this.set_list_breadcrumb(breadcrumbs);
 				this.set_form_breadcrumb(breadcrumbs, view);
+			} else if (breadcrumbs.doctype && view === 'list') {
+				this.set_list_breadcrumb(breadcrumbs);
 			}
 		}
 


### PR DESCRIPTION
In list view, breadcrumbs is not showing current doctype.

Before:
![image](https://user-images.githubusercontent.com/30859809/116842766-4e13e600-abfb-11eb-9a16-b57249b94c6a.png)

After:
![image](https://user-images.githubusercontent.com/30859809/116842697-0f7e2b80-abfb-11eb-8531-b52707d9aa4c.png)
