### PR TITLE
fix: Typo in RecorderDetail.vue

### DIFF
--- a/frappe/public/js/frappe/recorder/RecorderDetail.vue
+++ b/frappe/public/js/frappe/recorder/RecorderDetail.vue
@@ -155,7 +155,7 @@ export default {
 				number: 1,
 				status: (current_page == 1) ? "disabled" : "",
 			},{
-				label: __("Previous)",
+				label: __("Previous"),
 				number: Math.max(current_page - 1, 1),
 				status: (current_page == 1) ? "disabled" : "",
 			}, {


### PR DESCRIPTION
Typo introduced via https://github.com/frappe/frappe/pull/13046