### PR TITLE
fix: Error while exporting reports with duration field

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -377,7 +377,11 @@ def handle_duration_fieldtype_values(result, columns):
 
 		if fieldtype == "Duration":
 			for entry in range(0, len(result)):
-				val_in_seconds = result[entry][i]
+				row = result[entry]
+				if isinstance(row, dict):
+					val_in_seconds = row[col.fieldname]
+				else:
+					val_in_seconds = row[entry][i]
 				if val_in_seconds:
 					duration_val = format_duration(val_in_seconds)
 					result[entry][i] = duration_val

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -380,11 +380,14 @@ def handle_duration_fieldtype_values(result, columns):
 				row = result[entry]
 				if isinstance(row, dict):
 					val_in_seconds = row[col.fieldname]
+					if val_in_seconds:
+						duration_val = format_duration(val_in_seconds)
+						row[col.fieldname] = duration_val
 				else:
-					val_in_seconds = row[entry][i]
-				if val_in_seconds:
-					duration_val = format_duration(val_in_seconds)
-					result[entry][i] = duration_val
+					val_in_seconds = row[i]
+					if val_in_seconds:
+						duration_val = format_duration(val_in_seconds)
+						row[i] = duration_val
 
 	return result
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/handler.py", line 32, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 1175, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/desk/query_report.py", line 353, in export_query
    data.get("result"), data.get("columns")
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/desk/query_report.py", line 380, in handle_duration_fieldtype_values
    val_in_seconds = result[entry][i]
KeyError: 9
```