### PR TITLE
fix: Allow to duplicate standard notification

### DIFF
--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -102,7 +102,8 @@
    "default": "0",
    "fieldname": "is_standard",
    "fieldtype": "Check",
-   "label": "Is Standard"
+   "label": "Is Standard",
+   "no_copy": 1
   },
   {
    "depends_on": "is_standard",
@@ -281,7 +282,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-11-24 14:25:43.245677",
+ "modified": "2021-05-04 11:17:11.882314",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -65,10 +65,6 @@ def get_context(context):
 """)
 
 	def validate_standard(self):
-		# indicates that this is a new doc
-		if self._doc_before_save is None and not frappe.conf.developer_mode:
-			self.is_standard = False
-			return
 		if self.is_standard and not frappe.conf.developer_mode:
 			frappe.throw(_('Cannot edit Standard Notification. To edit, please disable this and duplicate it'))
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -65,6 +65,10 @@ def get_context(context):
 """)
 
 	def validate_standard(self):
+		# indicates that this is a new doc
+		if self._doc_before_save == None and not frappe.conf.developer_mode:
+			self.is_standard = False
+			return
 		if self.is_standard and not frappe.conf.developer_mode:
 			frappe.throw(_('Cannot edit Standard Notification. To edit, please disable this and duplicate it'))
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -66,7 +66,7 @@ def get_context(context):
 
 	def validate_standard(self):
 		# indicates that this is a new doc
-		if self._doc_before_save == None and not frappe.conf.developer_mode:
+		if self._doc_before_save is None and not frappe.conf.developer_mode:
 			self.is_standard = False
 			return
 		if self.is_standard and not frappe.conf.developer_mode:


### PR DESCRIPTION
Cannot create a duplicate of standard Notification
![asdf](https://user-images.githubusercontent.com/30859809/116869447-66512880-ac2e-11eb-9e4a-13adea74bf7d.gif)

