### PR TITLE
feat: Added image field to the section_with_cards template

### DIFF
--- a/frappe/public/scss/website/page_builder.scss
+++ b/frappe/public/scss/website/page_builder.scss
@@ -154,6 +154,10 @@
 		line-height: 1;
 	}
 
+	img {
+		padding: 1rem;
+	}
+
 	&.card-sm {
 		.card-body {
 			padding: 1.5rem;

--- a/frappe/public/scss/website/page_builder.scss
+++ b/frappe/public/scss/website/page_builder.scss
@@ -154,10 +154,6 @@
 		line-height: 1;
 	}
 
-	img {
-		padding: 1rem;
-	}
-
 	&.card-sm {
 		.card-body {
 			padding: 1.5rem;

--- a/frappe/website/web_template/section_with_cards/section_with_cards.html
+++ b/frappe/website/web_template/section_with_cards/section_with_cards.html
@@ -11,9 +11,10 @@
 }) -%}
 <div class="mt-6 {{ col_classes }}">
 	<div class="card {{ card_classes }} h-100">
-	        {%- if image -%}
-	        {{ frappe.render_template('templates/includes/image_with_blur.html', {
+		{%- if image -%}
+		{{ frappe.render_template('templates/includes/image_with_blur.html', {
 			"src": image,
+			"class": ["card-img-top"]
 		}) }}
 		{%- endif -%}
 		<div class="card-body">

--- a/frappe/website/web_template/section_with_cards/section_with_cards.html
+++ b/frappe/website/web_template/section_with_cards/section_with_cards.html
@@ -1,4 +1,4 @@
-{%- macro card(title, content, url) -%}
+{%- macro card(title, content, url, image) -%}
 {%- set col_classes = resolve_class({
 	'col-12 col-sm-6 col-lg-3': card_size == 'Small',
 	'col-12 col-sm-6 col-lg-4': card_size == 'Medium',
@@ -11,6 +11,12 @@
 }) -%}
 <div class="mt-6 {{ col_classes }}">
 	<div class="card {{ card_classes }} h-100">
+	    {%- if image -%}
+	    {{ frappe.render_template('templates/includes/image_with_blur.html', {
+			"src": image,
+			"class": ["card-img-top p-2"]
+		}) }}
+		{%- endif -%}
 		<div class="card-body">
 			<h3 class="card-title">{{ title or '' }}</h3>
 			<p class="card-text">{{ content or '' }}</p>
@@ -34,8 +40,9 @@
 			{%- set title = values['card_' + index + '_title'] -%}
 			{%- set content = values['card_' + index + '_content'] -%}
 			{%- set url = values['card_' + index + '_url'] -%}
+			{%- set image = values['card_' + index + '_image'] -%}
 			{%- if title -%}
-			{{ card(title, content, url) }}
+			{{ card(title, content, url, image) }}
 			{%- endif -%}
 			{%- endfor -%}
 		</div>

--- a/frappe/website/web_template/section_with_cards/section_with_cards.html
+++ b/frappe/website/web_template/section_with_cards/section_with_cards.html
@@ -11,10 +11,9 @@
 }) -%}
 <div class="mt-6 {{ col_classes }}">
 	<div class="card {{ card_classes }} h-100">
-	    {%- if image -%}
-	    {{ frappe.render_template('templates/includes/image_with_blur.html', {
+	        {%- if image -%}
+	        {{ frappe.render_template('templates/includes/image_with_blur.html', {
 			"src": image,
-			"class": ["card-img-top p-2"]
 		}) }}
 		{%- endif -%}
 		<div class="card-body">

--- a/frappe/website/web_template/section_with_cards/section_with_cards.json
+++ b/frappe/website/web_template/section_with_cards/section_with_cards.json
@@ -42,6 +42,12 @@
    "reqd": 0
   },
   {
+   "fieldname": "card_1_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
+   "reqd": 0
+  },
+  {
    "fieldname": "card_1_url",
    "fieldtype": "Data",
    "label": "URL",
@@ -63,6 +69,12 @@
    "fieldname": "card_2_content",
    "fieldtype": "Small Text",
    "label": "Content",
+   "reqd": 0
+  },
+  {
+   "fieldname": "card_2_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
    "reqd": 0
   },
   {
@@ -90,6 +102,12 @@
    "reqd": 0
   },
   {
+   "fieldname": "card_3_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
+   "reqd": 0
+  },
+  {
    "fieldname": "card_3_url",
    "fieldtype": "Data",
    "label": "URL",
@@ -111,6 +129,12 @@
    "fieldname": "card_4_content",
    "fieldtype": "Small Text",
    "label": "Content",
+   "reqd": 0
+  },
+  {
+   "fieldname": "card_4_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
    "reqd": 0
   },
   {
@@ -138,6 +162,12 @@
    "reqd": 0
   },
   {
+   "fieldname": "card_5_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
+   "reqd": 0
+  },
+  {
    "fieldname": "card_5_url",
    "fieldtype": "Data",
    "label": "URL",
@@ -159,6 +189,12 @@
    "fieldname": "card_6_content",
    "fieldtype": "Small Text",
    "label": "Content",
+   "reqd": 0
+  },
+  {
+   "fieldname": "card_6_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
    "reqd": 0
   },
   {
@@ -186,6 +222,12 @@
    "reqd": 0
   },
   {
+   "fieldname": "card_7_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
+   "reqd": 0
+  },
+  {
    "fieldname": "card_7_url",
    "fieldtype": "Data",
    "label": "URL",
@@ -207,6 +249,12 @@
    "fieldname": "card_8_content",
    "fieldtype": "Small Text",
    "label": "Content",
+   "reqd": 0
+  },
+  {
+   "fieldname": "card_8_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
    "reqd": 0
   },
   {
@@ -234,6 +282,12 @@
    "reqd": 0
   },
   {
+   "fieldname": "card_9_image",
+   "fieldtype": "Attach Image",
+   "label": "Image",
+   "reqd": 0
+  },
+  {
    "fieldname": "card_9_url",
    "fieldtype": "Data",
    "label": "URL",
@@ -241,7 +295,7 @@
   }
  ],
  "idx": 0,
- "modified": "2020-10-26 17:42:53.356024",
+ "modified": "2021-05-03 13:26:34.470232",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Section with Cards",


### PR DESCRIPTION
The section_with_cards web template did not have the image field option for rendering an image inside a card. This adds the optional image field to the template.

![Screenshot from 2021-05-03 16-23-19](https://user-images.githubusercontent.com/44427574/116868187-f772d000-ac2b-11eb-99bb-01fd483048ed.png)

> no-docs