### PR TITLE
fix: disable reloading files in `__pycache__` directory

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -327,6 +327,13 @@ def serve(port=8000, profile=False, no_reload=False, no_threading=False, site=No
 		threaded=not no_threading)
 
 def patch_werkzeug_reloader():
+	"""
+	This function monkey patches Werkzeug reloader to ignore reloading files in
+	the __pycache__ directory.
+
+	To be deprecated when upgrading to Werkzeug 2.
+	"""
+
 	from werkzeug._reloader import WatchdogReloaderLoop
 
 	trigger_reload = WatchdogReloaderLoop.trigger_reload

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -294,6 +294,7 @@ def serve(port=8000, profile=False, no_reload=False, no_threading=False, site=No
 	_sites_path = sites_path
 
 	from werkzeug.serving import run_simple
+	patch_werkzeug_reloader()
 
 	if profile:
 		application = ProfilerMiddleware(application, sort_by=('cumtime', 'calls'))
@@ -324,3 +325,16 @@ def serve(port=8000, profile=False, no_reload=False, no_threading=False, site=No
 		use_debugger=not in_test_env,
 		use_evalex=not in_test_env,
 		threaded=not no_threading)
+
+def patch_werkzeug_reloader():
+	from werkzeug._reloader import WatchdogReloaderLoop
+
+	trigger_reload = WatchdogReloaderLoop.trigger_reload
+
+	def custom_trigger_reload(self, filename):
+		if os.path.basename(os.path.dirname(filename)) == "__pycache__":
+			return
+
+		return trigger_reload(self, filename)
+
+	WatchdogReloaderLoop.trigger_reload = custom_trigger_reload


### PR DESCRIPTION
Werkzeug reloader considers `.pyc` files as valid files that need reloading (many programs ship with compiled code). Because of this any code changed reloads twice:
 - first when the `.py` file is detected as changed
 - during runtime when the `.pyc` file is detected as changed

This PR patches Werkzeug code to ignore any file that is a part of the `__pycache__` directory. Alternatively, any `.pyc` file may be ignored.

Related Werkzeug issue: https://github.com/pallets/werkzeug/issues/1333
**Note:** Werkzeug 2 ([releasing soon](https://github.com/pallets/werkzeug/releases)) fixes this issue.

What does this mean for Frappe?
- Users setting up a developer site for the first time needn't **Retry** the setup wizard multiple times before getting a usable site (Tested Locally)
- Developers needn't deal with `ERR_EMPTY_RESPONSE` due to Werkzeug reloader.

fixes: 
https://discuss.erpnext.com/t/running-setup-wizard-setup-failed/67940
https://discuss.erpnext.com/t/erpnext-setup-failed-with-new-site/71568