### PR TITLE
fix: Patch Update Notification channel

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -336,3 +336,4 @@ frappe.patches.v13_0.remove_twilio_settings
 frappe.patches.v12_0.rename_uploaded_files_with_proper_name
 frappe.patches.v13_0.queryreport_columns
 frappe.patches.v13_0.jinja_hook
+frappe.patches.v13_0.update_notification_channel_if_empty

--- a/frappe/patches/v13_0/update_notification_channel_if_empty.py
+++ b/frappe/patches/v13_0/update_notification_channel_if_empty.py
@@ -3,7 +3,6 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe.model.utils.rename_field import rename_field
 
 def execute():
 

--- a/frappe/patches/v13_0/update_notification_channel_if_empty.py
+++ b/frappe/patches/v13_0/update_notification_channel_if_empty.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+from frappe.model.utils.rename_field import rename_field
+
+def execute():
+
+	frappe.reload_doc("Email", "doctype", "Notification")
+
+	notifications = frappe.get_all('Notification', {'is_standard': 1}, {'name', 'channel'})
+	for notification in notifications:
+		if not notification.channel:
+			frappe.db.set_value("Notification", notification.name, "channel", "Email", update_modified=False)
+			frappe.db.commit()


### PR DESCRIPTION
Some Standard Notification does not have a `channel` field, since its a mandatory field we cannot edit those Notification
![channel](https://user-images.githubusercontent.com/30859809/116886722-0d41be80-ac47-11eb-90ce-9061f099cd96.gif)
