### PR TITLE
refactor(CLI): Show config

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -10,11 +10,10 @@ be used to build database driven apps.
 
 Read the documentation: https://frappeframework.com/docs
 """
-from __future__ import unicode_literals, print_function
 
-from six import iteritems, binary_type, text_type, string_types, PY2
+from six import iteritems, binary_type, text_type, string_types
 from werkzeug.local import Local, release_local
-import os, sys, importlib, inspect, json
+import os, sys, importlib, inspect, json, warnings
 import typing
 from past.builtins import cmp
 import click
@@ -27,19 +26,14 @@ from .utils.lazy_loader import lazy_import
 # Lazy imports
 faker = lazy_import('faker')
 
-
-# Harmless for Python 3
-# For Python 2 set default encoding to utf-8
-if PY2:
-	reload(sys)
-	sys.setdefaultencoding("utf-8")
-
 __version__ = '14.0.0-dev'
 
 __title__ = "Frappe Framework"
 
 local = Local()
 controllers = {}
+warnings.simplefilter('always', DeprecationWarning)
+warnings.simplefilter('always', PendingDeprecationWarning)
 
 class _dict(dict):
 	"""dict like object that exposes keys as attributes"""

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -254,9 +254,7 @@ def list_apps(context, format):
 		frappe.destroy()
 
 	if format == "json":
-		import json
-
-		click.echo(json.dumps(summary_dict))
+		click.echo(frappe.as_json(summary_dict))
 
 @click.command('add-system-manager')
 @click.argument('email')

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -690,20 +690,21 @@ def make_app(destination, app_name):
 @click.command('set-config')
 @click.argument('key')
 @click.argument('value')
-@click.option('-g', '--global', 'global_', is_flag = True, default = False, help = 'Set Global Site Config')
-@click.option('--as-dict', is_flag=True, default=False)
+@click.option('-g', '--global', 'global_', is_flag=True, default=False, help='Set value in bench config')
+@click.option('-p', '--parse', '--as-dict', is_flag=True, default=False, help='Evaluate as Python Object')
 @pass_context
-def set_config(context, key, value, global_ = False, as_dict=False):
+def set_config(context, key, value, global_=False, parse=False):
 	"Insert/Update a value in site_config.json"
 	from frappe.installer import update_site_config
-	import ast
-	if as_dict:
+
+	if parse:
+		import ast
 		value = ast.literal_eval(value)
 
 	if global_:
-		sites_path = os.getcwd() # big assumption.
+		sites_path = os.getcwd()
 		common_site_config_path = os.path.join(sites_path, 'common_site_config.json')
-		update_site_config(key, value, validate = False, site_config_path = common_site_config_path)
+		update_site_config(key, value, validate=False, site_config_path=common_site_config_path)
 	else:
 		for site in context.sites:
 			frappe.init(site=site)

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -143,7 +143,7 @@ def show_config(context, format):
 		frappe.destroy()
 
 	if format == "json":
-		click.echo(sites_config)
+		click.echo(frappe.as_json(sites_config))
 
 
 @click.command('reset-perms')

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -105,6 +105,7 @@ def show_config(context, format):
 		raise SiteNotSpecifiedError
 
 	sites_config = {}
+	sites_path = os.getcwd()
 
 	from frappe.utils.commands import render_table
 
@@ -129,7 +130,6 @@ def show_config(context, format):
 				click.echo()
 			click.secho(f"Site {site}", fg="yellow")
 
-		sites_path = frappe.get_site_path()
 		configuration = frappe.get_site_config(sites_path=sites_path, site_path=site)
 
 		if format == "text":

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -760,50 +760,6 @@ def rebuild_global_search(context, static_pages=False):
 	if not context.sites:
 		raise SiteNotSpecifiedError
 
-@click.command('auto-deploy')
-@click.argument('app')
-@click.option('--migrate', is_flag=True, default=False, help='Migrate after pulling')
-@click.option('--restart', is_flag=True, default=False, help='Restart after migration')
-@click.option('--remote', default='upstream', help='Remote, default is "upstream"')
-@pass_context
-def auto_deploy(context, app, migrate=False, restart=False, remote='upstream'):
-	'''Pull and migrate sites that have new version'''
-	from frappe.utils.gitutils import get_app_branch
-	from frappe.utils import get_sites
-
-	branch = get_app_branch(app)
-	app_path = frappe.get_app_path(app)
-
-	# fetch
-	subprocess.check_output(['git', 'fetch', remote, branch], cwd = app_path)
-
-	# get diff
-	if subprocess.check_output(['git', 'diff', '{0}..{1}/{0}'.format(branch, remote)], cwd = app_path):
-		print('Updates found for {0}'.format(app))
-		if app=='frappe':
-			# run bench update
-			import shlex
-			subprocess.check_output(shlex.split('bench update --no-backup'), cwd = '..')
-		else:
-			updated = False
-			subprocess.check_output(['git', 'pull', '--rebase', remote, branch],
-				cwd = app_path)
-			# find all sites with that app
-			for site in get_sites():
-				frappe.init(site)
-				if app in frappe.get_installed_apps():
-					print('Updating {0}'.format(site))
-					updated = True
-					subprocess.check_output(['bench', '--site', site, 'clear-cache'], cwd = '..')
-					if migrate:
-						subprocess.check_output(['bench', '--site', site, 'migrate'], cwd = '..')
-				frappe.destroy()
-
-			if updated or restart:
-				subprocess.check_output(['bench', 'restart'], cwd = '..')
-	else:
-		print('No Updates')
-
 
 commands = [
 	build,

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -502,6 +502,7 @@ def console(context):
 			locals()[app] = __import__(app)
 		except ModuleNotFoundError:
 			failed_to_import.append(app)
+			all_apps.remove(app)
 
 	print("Apps in this namespace:\n{}".format(", ".join(all_apps)))
 	if failed_to_import:

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -691,11 +691,17 @@ def make_app(destination, app_name):
 @click.argument('key')
 @click.argument('value')
 @click.option('-g', '--global', 'global_', is_flag=True, default=False, help='Set value in bench config')
-@click.option('-p', '--parse', '--as-dict', is_flag=True, default=False, help='Evaluate as Python Object')
+@click.option('-p', '--parse', is_flag=True, default=False, help='Evaluate as Python Object')
+@click.option('--as-dict', is_flag=True, default=False, help='Legacy: Evaluate as Python Object')
 @pass_context
-def set_config(context, key, value, global_=False, parse=False):
+def set_config(context, key, value, global_=False, parse=False, as_dict=False):
 	"Insert/Update a value in site_config.json"
 	from frappe.installer import update_site_config
+
+	if as_dict:
+		from frappe.utils.commands import warn
+		warn("--as-dict will be deprecated in v14. Use --parse instead", category=PendingDeprecationWarning)
+		parse = as_dict
 
 	if parse:
 		import ast

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -216,7 +216,7 @@ class TestCommands(BaseTestCommands):
 
 		# test 7: take a backup with frappe.conf.backup.includes
 		self.execute(
-			"bench --site {site} set-config backup '{includes}' --as-dict",
+			"bench --site {site} set-config backup '{includes}' --parse",
 			{"includes": json.dumps(backup["includes"])},
 		)
 		self.execute("bench --site {site} backup --verbose")
@@ -226,7 +226,7 @@ class TestCommands(BaseTestCommands):
 
 		# test 8: take a backup with frappe.conf.backup.excludes
 		self.execute(
-			"bench --site {site} set-config backup '{excludes}' --as-dict",
+			"bench --site {site} set-config backup '{excludes}' --parse",
 			{"excludes": json.dumps(backup["excludes"])},
 		)
 		self.execute("bench --site {site} backup --verbose")
@@ -383,7 +383,7 @@ class TestCommands(BaseTestCommands):
 
 		# test 2: test keys in table text
 		self.execute(
-			"bench --site {site} set-config test_key '{second_order}' --as-dict",
+			"bench --site {site} set-config test_key '{second_order}' --parse",
 			{"second_order": json.dumps({"test_key": "test_value"})},
 		)
 		self.execute("bench --site {site} show-config")

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -376,6 +376,32 @@ class TestCommands(BaseTestCommands):
 		self.execute("bench --site {site} list-apps -f json")
 		self.assertIsInstance(json.loads(self.stdout), dict)
 
+	def test_show_config(self):
+		# test 1: sanity check for command
+		self.execute("bench --site all show-config")
+		self.assertEquals(self.returncode, 0)
+
+		# test 2: test keys in table text
+		self.execute(
+			"bench --site {site} set-config test_key '{second_order}' --as-dict",
+			{"second_order": json.dumps({"test_key": "test_value"})},
+		)
+		self.execute("bench --site {site} show-config")
+		self.assertEquals(self.returncode, 0)
+		self.assertIn("test_key.test_key", self.stdout.split())
+		self.assertIn("test_value", self.stdout.split())
+
+		# test 3: parse json format
+		self.execute("bench --site all show-config --format json")
+		self.assertEquals(self.returncode, 0)
+		self.assertIsInstance(json.loads(self.stdout), dict)
+
+		self.execute("bench --site {site} show-config --format json")
+		self.assertIsInstance(json.loads(self.stdout), dict)
+
+		self.execute("bench --site {site} show-config -f json")
+		self.assertIsInstance(json.loads(self.stdout), dict)
+
 	def test_get_bench_relative_path(self):
 		bench_path = frappe.utils.get_bench_path()
 		test1_path = os.path.join(bench_path, "test1.txt")

--- a/frappe/utils/commands.py
+++ b/frappe/utils/commands.py
@@ -1,11 +1,10 @@
 import functools
-import requests
-from terminaltables import AsciiTable
-
 
 @functools.lru_cache(maxsize=1024)
 def get_first_party_apps():
 	"""Get list of all apps under orgs: frappe. erpnext from GitHub"""
+	import requests
+
 	apps = []
 	for org in ["frappe", "erpnext"]:
 		req = requests.get(f"https://api.github.com/users/{org}/repos", {"type": "sources", "per_page": 200})
@@ -15,6 +14,8 @@ def get_first_party_apps():
 
 
 def render_table(data):
+	from terminaltables import AsciiTable
+
 	print(AsciiTable(data).table)
 
 
@@ -49,3 +50,9 @@ def log(message, colour=''):
 	colour = colours.get(colour, "")
 	end_line = '\033[0m'
 	print(colour + message + end_line)
+
+
+def warn(message, category=None):
+	from warnings import warn
+
+	warn(message=message, category=category, stacklevel=2)


### PR DESCRIPTION
## Show config for a single site

![Screenshot 2021-05-04 at 6 06 26 PM](https://user-images.githubusercontent.com/36654812/117004347-961e3000-ad03-11eb-9004-ba7c2105ceb0.png)

![Screenshot 2021-05-04 at 6 07 12 PM](https://user-images.githubusercontent.com/36654812/117004357-99b1b700-ad03-11eb-8a25-9a1d8b8d1eb6.png)

## Show config for all sites

![Screenshot 2021-05-03 at 7 31 57 PM](https://user-images.githubusercontent.com/36654812/116886424-af14db80-ac46-11eb-8a95-6204162b675d.png)

![Screenshot 2021-05-03 at 7 50 59 PM](https://user-images.githubusercontent.com/36654812/116888387-087e0a00-ac49-11eb-9a1a-38ea1e4f4384.png)


## No site specified and default site not set

![Screenshot 2021-05-03 at 7 32 40 PM](https://user-images.githubusercontent.com/36654812/116886419-ae7c4500-ac46-11eb-923a-25892374bc77.png)


---

**Pending:**

- [x] Tests
- [x] Docs: https://github.com/frappe/frappe_docs/pull/132

---

**Other Changes**

- Refactored `bench set-config`
- set-config: Pending deprecation for `--as-dict` in favour of `--parse`
- Set always show filter for `DeprecationWarning`, `PendingDeprecationWarning` via frappe module

Closes #13100