### PR TITLE
chore: remove py2 specific code from boilerplate

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/controller._py
+++ b/frappe/core/doctype/doctype/boilerplate/controller._py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) {year}, {app_publisher} and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 # import frappe
 {base_class_import}
 

--- a/frappe/core/doctype/doctype/boilerplate/test_controller._py
+++ b/frappe/core/doctype/doctype/boilerplate/test_controller._py
@@ -1,7 +1,5 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) {year}, {app_publisher} and Contributors
 # See license.txt
-from __future__ import unicode_literals
 
 # import frappe
 import unittest

--- a/frappe/core/doctype/report/boilerplate/controller.py
+++ b/frappe/core/doctype/report/boilerplate/controller.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2013, {app_publisher} and contributors
 # For license information, please see license.txt
 
-from __future__ import unicode_literals
 # import frappe
 
 def execute(filters=None):

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
 from __future__ import unicode_literals, print_function
@@ -126,16 +126,12 @@ recursive-include {app_name} *.svg
 recursive-include {app_name} *.txt
 recursive-exclude {app_name} *.pyc"""
 
-init_template = """# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
+init_template = """
 __version__ = '0.0.1'
 
 """
 
-hooks_template = """# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from . import __version__ as app_version
+hooks_template = """from . import __version__ as app_version
 
 app_name = "{app_name}"
 app_title = "{app_title}"
@@ -321,9 +317,7 @@ user_data_fields = [
 
 """
 
-desktop_template = """# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-from frappe import _
+desktop_template = """from frappe import _
 
 def get_data():
 	return [
@@ -337,8 +331,7 @@ def get_data():
 	]
 """
 
-setup_template = """# -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
+setup_template = """from setuptools import setup, find_packages
 
 with open('requirements.txt') as f:
 	install_requires = f.read().strip().split('\\n')


### PR DESCRIPTION
UTF-8 is the default in python3. Since we don't support Py2 since version-13, there is no need to keep these declarations and imports in the codebase anymore.