### PR TITLE
fix: Use docfields from options if no docfields are returned from meta

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -7,7 +7,8 @@ export default class GridRow {
 		$.extend(this, opts);
 		if (this.doc && this.parent_df.options) {
 			frappe.meta.make_docfield_copy_for(this.parent_df.options, this.doc.name, this.docfields);
-			this.docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
+			const docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
+			this.docfields = docfields.length ? docfields : opts.docfields;
 		}
 		this.columns = {};
 		this.columns_list = [];


### PR DESCRIPTION
On web forms, the row tries to get the docfields of the new added row from the metadata, but the metadata does not have this docfields. 

If there are no results from the meta, use the provided docfields on instantiation.

Closes #13105 