### PR TITLE
feat(DX): Add simple __repr__ for DocTypes

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1347,6 +1347,22 @@ class Document(BaseDocument):
 		from frappe.desk.doctype.tag.tag import DocTags
 		return DocTags(self.doctype).get_tags(self.name).split(",")[1:]
 
+	def __repr__(self):
+		name = self.name or "unsaved"
+		doctype = self.__class__.__name__
+
+		docstatus = f" docstatus={self.docstatus}" if self.docstatus else ""
+		parent = f" parent={self.parent}" if self.parent else ""
+
+		return f"<{doctype}: {name}{docstatus}{parent}>"
+
+	def __str__(self):
+		name = self.name or "unsaved"
+		doctype = self.__class__.__name__
+
+		return f"{doctype}({name})"
+
+
 def execute_action(doctype, name, action, **kwargs):
 	"""Execute an action on a document (called by background worker)"""
 	doc = frappe.get_doc(doctype, name)


### PR DESCRIPTION
- Add `__repr__` method on `frappe.model.Document`
- Useful while printing / debugging. Other standard fields can be considered but the noise-to-information ratio is important to consider.
- Show doctype and name
- if docstatus != 0, show docstatus (this is to avoid printing it in non-submittable doctypes)
- if child doctype, show the parent

Before: (default repr, shows memory address and class path)
![image](https://user-images.githubusercontent.com/9079960/117102468-0d9c9f80-ad96-11eb-9ef9-48089c835701.png)


After: (doctype and `self.name`)
![image](https://user-images.githubusercontent.com/9079960/117156222-1794c180-addb-11eb-8556-050dfe603760.png)




`no-docs`

