### PR TITLE
fix: Misc fixes

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1178,13 +1178,10 @@ def get_newargs(fn, kwargs):
 	if hasattr(fn, 'fnargs'):
 		fnargs = fn.fnargs
 	else:
-		try:
-			fnargs, varargs, varkw, defaults = inspect.getargspec(fn)
-		except ValueError:
-			fnargs = inspect.getfullargspec(fn).args
-			varargs = inspect.getfullargspec(fn).varargs
-			varkw = inspect.getfullargspec(fn).varkw
-			defaults = inspect.getfullargspec(fn).defaults
+		fnargs = inspect.getfullargspec(fn).args
+		varargs = inspect.getfullargspec(fn).varargs
+		varkw = inspect.getfullargspec(fn).varkw
+		defaults = inspect.getfullargspec(fn).defaults
 
 	newargs = {}
 	for a in kwargs:

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -327,7 +327,7 @@ def make_asset_dirs(make_copy=False, restore=False):
 					except OSError:
 						print("Cannot link {} to {}".format(source, target))
 			else:
-				# warnings.warn('Source {source} does not exist.'.format(source = source))
+				warnings.warn('Source {source} does not exist.'.format(source = source))
 				pass
 
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -1,5 +1,3 @@
-import warnings
-
 import pymysql
 from pymysql.constants import ER, FIELD_TYPE
 from pymysql.converters import conversions, escape_string
@@ -55,7 +53,6 @@ class MariaDBDatabase(Database):
 		}
 
 	def get_connection(self):
-		warnings.filterwarnings('ignore', category=pymysql.Warning)
 		usessl = 0
 		if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
 			usessl = 1

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import re
 import frappe
 import psycopg2
@@ -65,7 +63,6 @@ class PostgresDatabase(Database):
 		}
 
 	def get_connection(self):
-		# warnings.filterwarnings('ignore', category=psycopg2.Warning)
 		conn = psycopg2.connect("host='{}' dbname='{}' user='{}' password='{}' port={}".format(
 			self.host, self.user, self.user, self.password, self.port
 		))

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -228,10 +228,7 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 	is_whitelisted(fn)
 	is_valid_http_method(fn)
 
-	try:
-		fnargs = inspect.getargspec(method_obj)[0]
-	except ValueError:
-		fnargs = inspect.getfullargspec(method_obj).args
+	fnargs = inspect.getfullargspec(method_obj).args
 
 	if not fnargs or (len(fnargs)==1 and fnargs[0]=="self"):
 		response = doc.run_method(method)

--- a/frappe/website/context.py
+++ b/frappe/website/context.py
@@ -52,7 +52,7 @@ def update_controller_context(context, controller):
 		if hasattr(module, "get_context"):
 			import inspect
 			try:
-				if inspect.getargspec(module.get_context).args:
+				if inspect.getfullargspec(module.get_context).args:
 					ret = module.get_context(context)
 				else:
 					ret = module.get_context()


### PR DESCRIPTION
**Changes**

* Update usages of inspect getargspec

Deprecated since version 3.0: Use getfullargspec() for an updated API that is usually a drop-in replacement, but also correctly handles function annotations and keyword-only parameters.

ref: https://docs.python.org/3/library/inspect.html#inspect.getargspec

* Don't hide warnings unnecessarily
