### PR TITLE
fix: hook format for user_data_fields

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -288,24 +288,24 @@ app_license = "{app_license}"
 # --------------------
 
 # user_data_fields = [
-# 	{
+# 	{{
 # 		"doctype": "{{doctype_1}}",
 # 		"filter_by": "{{filter_by}}",
 # 		"redact_fields": ["{{field_1}}", "{{field_2}}"],
 # 		"partial": 1,
-# 	},
-# 	{
+# 	}},
+# 	{{
 # 		"doctype": "{{doctype_2}}",
 # 		"filter_by": "{{filter_by}}",
 # 		"partial": 1,
-# 	},
-# 	{
+# 	}},
+# 	{{
 # 		"doctype": "{{doctype_3}}",
 # 		"strict": False,
-# 	},
-# 	{
+# 	}},
+# 	{{
 # 		"doctype": "{{doctype_4}}"
-# 	}
+# 	}}
 # ]
 
 # Authentication and authorization


### PR DESCRIPTION
problem: new app creation will fail.

![image](https://user-images.githubusercontent.com/9079960/117291813-16bc6800-ae8d-11eb-82cc-9101bbaa5660.png)


add format characters back, which required for writing template. Problem introduced by my old pr: https://github.com/frappe/frappe/pull/13134 

