### PR TITLE
fix: Revert naming for custom naming series

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -203,6 +203,7 @@ def revert_series_if_last(key, name, doc=None):
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:
 			key = key.rsplit(".")
+			# get the hash part from the key
 			hash = list(filter(re.compile(".*#").match, key))[0]
 			if not hash:
 				return

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -202,13 +202,13 @@ def revert_series_if_last(key, name, doc=None):
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:
-			key = key.rsplit(".")
+			key = key.split(".")
 			# get the hash part from the key
 			hash = list(filter(re.compile(".*#").match, key))[0]
 			if not hash:
 				return
 			name = name.replace(hashes, "")
-			prefix, hashes = key[:key.index(hash)+1]
+			prefix = prefix.replace(".{}".format(hash), "")
 	else:
 		prefix = key
 

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -214,7 +214,7 @@ def revert_series_if_last(key, name, doc=None):
 
 	*Example:*
 		1. key = SINV-.YYYY.- 
-  			* If key doesn't have hash it will add hash at the end
+			* If key doesn't have hash it will add hash at the end
 			* prefix will be SINV-YYYY based on this will get current index from Series table.
 		2. key = SINV-.####.-2021
 			* now prefix = SINV-#### and hashes = 2021 (hash doesn't exist)

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -202,7 +202,12 @@ def revert_series_if_last(key, name, doc=None):
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:
-			return
+			key = key.rsplit(".")
+			hash = list(filter(re.compile(".*#").match, key))[0]
+			if not hash:
+				return
+			name = name.replace(hashes, "")
+			prefix, hashes = key[:key.index(hash)+1]
 	else:
 		prefix = key
 

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -199,16 +199,39 @@ def getseries(key, digits):
 
 
 def revert_series_if_last(key, name, doc=None):
-	if ".#" in key:
+	"""
+	Reverts the series for particular naming series:
+	* key is naming series		- SINV-.YYYY-.####
+	* name is actual name		- SINV-2021-0001
+		
+	1. This function split the key into two parts prefix (SINV-YYYY) & hashes (####).
+	2. Use prefix to get the current index of that naming series from Series table
+	3. Then revert the current index.
+
+	*For custom naming series:*
+	1. hash can exist anywhere, if it exist in hashes then it take normal flow.
+	2. If hash doesn't exit in hashes, we get the hash from prefix, then update name and prefix accordingly.
+
+	*Example:*
+		1. key = SINV-.YYYY.- 
+  			* If key doesn't have hash it will add hash at the end
+			* prefix will be SINV-YYYY based on this will get current index from Series table.
+		2. key = SINV-.####.-2021
+			* now prefix = SINV-#### and hashes = 2021 (hash doesn't exist)
+			* will search hash in key then accordingly get prefix = SINV-
+		3. key = ####.-2021
+			* prefix = #### and hashes = 2021 (hash doesn't exist)
+			* will search hash in key then accordingly get prefix = "" 
+	"""
+	if ".#" in key: 
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:
-			key = key.split(".")
 			# get the hash part from the key
-			hash = list(filter(re.compile(".*#").match, key))[0]
+			hash = re.search("#+", key)
 			if not hash:
 				return
 			name = name.replace(hashes, "")
-			prefix = prefix.replace(".{}".format(hash), "")
+			prefix = prefix.replace(hash.group(), "")
 	else:
 		prefix = key
 

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -106,7 +106,7 @@ class TestNaming(unittest.TestCase):
 
 		self.assertEqual(count.get('current'), 2)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
-  
+
 		series = ''
 		key = '.#####.-2021-22'
 		name = '00003-2021-22'

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -16,50 +16,50 @@ class TestNaming(unittest.TestCase):
 		todo_doctype.autoname = 'hash'
 		todo_doctype.save()
 
-	# def test_append_number_if_name_exists(self):
-	# 	'''
-	# 	Append number to name based on existing values
-	# 	if Bottle exists
-	# 		Bottle -> Bottle-1
-	# 	if Bottle-1 exists
-	# 		Bottle -> Bottle-2
-	# 	'''
+	def test_append_number_if_name_exists(self):
+		'''
+		Append number to name based on existing values
+		if Bottle exists
+			Bottle -> Bottle-1
+		if Bottle-1 exists
+			Bottle -> Bottle-2
+		'''
 
-	# 	note = frappe.new_doc('Note')
-	# 	note.title = 'Test'
-	# 	note.insert()
+		note = frappe.new_doc('Note')
+		note.title = 'Test'
+		note.insert()
 
-	# 	title2 = append_number_if_name_exists('Note', 'Test')
-	# 	self.assertEqual(title2, 'Test-1')
+		title2 = append_number_if_name_exists('Note', 'Test')
+		self.assertEqual(title2, 'Test-1')
 
-	# 	title2 = append_number_if_name_exists('Note', 'Test', 'title', '_')
-	# 	self.assertEqual(title2, 'Test_1')
+		title2 = append_number_if_name_exists('Note', 'Test', 'title', '_')
+		self.assertEqual(title2, 'Test_1')
 
-	# def test_format_autoname(self):
-	# 	'''
-	# 	Test if braced params are replaced in format autoname
-	# 	'''
-	# 	doctype = 'ToDo'
+	def test_format_autoname(self):
+		'''
+		Test if braced params are replaced in format autoname
+		'''
+		doctype = 'ToDo'
 
-	# 	todo_doctype = frappe.get_doc('DocType', doctype)
-	# 	todo_doctype.autoname = 'format:TODO-{MM}-{status}-{##}'
-	# 	todo_doctype.save()
+		todo_doctype = frappe.get_doc('DocType', doctype)
+		todo_doctype.autoname = 'format:TODO-{MM}-{status}-{##}'
+		todo_doctype.save()
 
-	# 	description = 'Format'
+		description = 'Format'
 
-	# 	todo = frappe.new_doc(doctype)
-	# 	todo.description = description
-	# 	todo.insert()
+		todo = frappe.new_doc(doctype)
+		todo.description = description
+		todo.insert()
 
-	# 	series = getseries('', 2)
+		series = getseries('', 2)
 
-	# 	series = str(int(series)-1)
+		series = str(int(series)-1)
 
-	# 	if len(series) < 2:
-	# 		series = '0' + series
+		if len(series) < 2:
+			series = '0' + series
 
-	# 	self.assertEqual(todo.name, 'TODO-{month}-{status}-{series}'.format(
-	# 		month=now_datetime().strftime('%m'), status=todo.status, series=series))
+		self.assertEqual(todo.name, 'TODO-{month}-{status}-{series}'.format(
+			month=now_datetime().strftime('%m'), status=todo.status, series=series))
 
 	def test_revert_series(self):
 		from datetime import datetime

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -70,9 +70,9 @@ class TestNaming(unittest.TestCase):
 		name = 'TEST-{}-00001'.format(year)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 1)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 0)
+		self.assertEqual(current_index.get('current'), 0)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 		series = 'TEST-{}-'.format(year)
@@ -80,9 +80,9 @@ class TestNaming(unittest.TestCase):
 		name = 'TEST-{}-00002'.format(year)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 2)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 1)
+		self.assertEqual(current_index.get('current'), 1)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 		series = 'TEST-'
@@ -91,9 +91,9 @@ class TestNaming(unittest.TestCase):
 		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 2)
+		self.assertEqual(current_index.get('current'), 2)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 		series = 'TEST1-'
@@ -102,9 +102,9 @@ class TestNaming(unittest.TestCase):
 		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 2)
+		self.assertEqual(current_index.get('current'), 2)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 		series = ''
@@ -113,7 +113,7 @@ class TestNaming(unittest.TestCase):
 		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 2)
+		self.assertEqual(current_index.get('current'), 2)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -16,50 +16,50 @@ class TestNaming(unittest.TestCase):
 		todo_doctype.autoname = 'hash'
 		todo_doctype.save()
 
-	def test_append_number_if_name_exists(self):
-		'''
-		Append number to name based on existing values
-		if Bottle exists
-			Bottle -> Bottle-1
-		if Bottle-1 exists
-			Bottle -> Bottle-2
-		'''
+	# def test_append_number_if_name_exists(self):
+	# 	'''
+	# 	Append number to name based on existing values
+	# 	if Bottle exists
+	# 		Bottle -> Bottle-1
+	# 	if Bottle-1 exists
+	# 		Bottle -> Bottle-2
+	# 	'''
 
-		note = frappe.new_doc('Note')
-		note.title = 'Test'
-		note.insert()
+	# 	note = frappe.new_doc('Note')
+	# 	note.title = 'Test'
+	# 	note.insert()
 
-		title2 = append_number_if_name_exists('Note', 'Test')
-		self.assertEqual(title2, 'Test-1')
+	# 	title2 = append_number_if_name_exists('Note', 'Test')
+	# 	self.assertEqual(title2, 'Test-1')
 
-		title2 = append_number_if_name_exists('Note', 'Test', 'title', '_')
-		self.assertEqual(title2, 'Test_1')
+	# 	title2 = append_number_if_name_exists('Note', 'Test', 'title', '_')
+	# 	self.assertEqual(title2, 'Test_1')
 
-	def test_format_autoname(self):
-		'''
-		Test if braced params are replaced in format autoname
-		'''
-		doctype = 'ToDo'
+	# def test_format_autoname(self):
+	# 	'''
+	# 	Test if braced params are replaced in format autoname
+	# 	'''
+	# 	doctype = 'ToDo'
 
-		todo_doctype = frappe.get_doc('DocType', doctype)
-		todo_doctype.autoname = 'format:TODO-{MM}-{status}-{##}'
-		todo_doctype.save()
+	# 	todo_doctype = frappe.get_doc('DocType', doctype)
+	# 	todo_doctype.autoname = 'format:TODO-{MM}-{status}-{##}'
+	# 	todo_doctype.save()
 
-		description = 'Format'
+	# 	description = 'Format'
 
-		todo = frappe.new_doc(doctype)
-		todo.description = description
-		todo.insert()
+	# 	todo = frappe.new_doc(doctype)
+	# 	todo.description = description
+	# 	todo.insert()
 
-		series = getseries('', 2)
+	# 	series = getseries('', 2)
 
-		series = str(int(series)-1)
+	# 	series = str(int(series)-1)
 
-		if len(series) < 2:
-			series = '0' + series
+	# 	if len(series) < 2:
+	# 		series = '0' + series
 
-		self.assertEqual(todo.name, 'TODO-{month}-{status}-{series}'.format(
-			month=now_datetime().strftime('%m'), status=todo.status, series=series))
+	# 	self.assertEqual(todo.name, 'TODO-{month}-{status}-{series}'.format(
+	# 		month=now_datetime().strftime('%m'), status=todo.status, series=series))
 
 	def test_revert_series(self):
 		from datetime import datetime
@@ -88,6 +88,28 @@ class TestNaming(unittest.TestCase):
 		series = 'TEST-'
 		key = 'TEST-'
 		name = 'TEST-00003'
+		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
+		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
+		revert_series_if_last(key, name)
+		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+
+		self.assertEqual(count.get('current'), 2)
+		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+
+		series = 'TEST1-'
+		key = 'TEST1-.#####.-2021-22'
+		name = 'TEST1-00003-2021-22'
+		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
+		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
+		revert_series_if_last(key, name)
+		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+
+		self.assertEqual(count.get('current'), 2)
+		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+  
+		series = ''
+		key = '.#####.-2021-22'
+		name = '00003-2021-22'
 		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)


### PR DESCRIPTION
When we delete some of the documents the naming of those documents also gets reverted.
e.g If there are 5 documents with the name - `SINV-2021-0001`, `SINV-2021-0002`, `SINV-2021-0003`, `SINV-2021-0004`, `SINV-2021-0005`
Now if we delete 4th and 5th the naming series should get reverted and if we create another document the naming should be `SINV-2021-0004`

This works for default naming series, but if we have some custom naming series it doesn't work.

e.g MD-.###./2021-22 - Doesn't Work