### PR TITLE
chore: replace assertEquals with alias assertEqual

### DIFF
--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -173,7 +173,7 @@ class TestAutoRepeat(unittest.TestCase):
 			fields=['docstatus'],
 			limit=1
 		)
-		self.assertEquals(docnames[0].docstatus, 1)
+		self.assertEqual(docnames[0].docstatus, 1)
 
 
 def make_auto_repeat(**args):

--- a/frappe/core/doctype/activity_log/test_activity_log.py
+++ b/frappe/core/doctype/activity_log/test_activity_log.py
@@ -65,12 +65,12 @@ class TestActivityLog(unittest.TestCase):
 		frappe.local.login_manager = LoginManager()
 
 		auth_log = self.get_auth_log()
-		self.assertEquals(auth_log.status, 'Success')
+		self.assertEqual(auth_log.status, 'Success')
 
 		# test user logout log
 		frappe.local.login_manager.logout()
 		auth_log = self.get_auth_log(operation='Logout')
-		self.assertEquals(auth_log.status, 'Success')
+		self.assertEqual(auth_log.status, 'Success')
 
 		# test invalid login
 		frappe.form_dict.update({ 'pwd': 'password' })

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -106,7 +106,7 @@ class TestReport(unittest.TestCase):
 		else:
 			report = frappe.get_doc('Report', 'Test Report')
 
-		self.assertNotEquals(report.is_permitted(), True)
+		self.assertNotEqual(report.is_permitted(), True)
 		frappe.set_user('Administrator')
 
 	# test for the `_format` method if report data doesn't have sort_by parameter

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -46,7 +46,7 @@ class TestUserPermission(unittest.TestCase):
 		frappe.set_user('test_user_perm1@example.com')
 		doc = frappe.new_doc("Blog Post")
 
-		self.assertEquals(doc.blog_category, 'general')
+		self.assertEqual(doc.blog_category, 'general')
 		frappe.set_user('Administrator')
 
 	def test_apply_to_all(self):
@@ -54,7 +54,7 @@ class TestUserPermission(unittest.TestCase):
 		user = create_user('test_bulk_creation_update@example.com')
 		param = get_params(user, 'User', user.name)
 		is_created = add_user_permissions(param)
-		self.assertEquals(is_created, 1)
+		self.assertEqual(is_created, 1)
 
 	def test_for_apply_to_all_on_update_from_apply_all(self):
 		user = create_user('test_bulk_creation_update@example.com')
@@ -63,11 +63,11 @@ class TestUserPermission(unittest.TestCase):
 		# Initially create User Permission document with apply_to_all checked
 		is_created = add_user_permissions(param)
 
-		self.assertEquals(is_created, 1)
+		self.assertEqual(is_created, 1)
 		is_created = add_user_permissions(param)
 
 		# User Permission should not be changed
-		self.assertEquals(is_created, 0)
+		self.assertEqual(is_created, 0)
 
 	def test_for_applicable_on_update_from_apply_to_all(self):
 		''' Update User Permission from all to some applicable Doctypes'''
@@ -77,7 +77,7 @@ class TestUserPermission(unittest.TestCase):
 		# Initially create User Permission document with apply_to_all checked
 		is_created = add_user_permissions(get_params(user, 'User', user.name))
 
-		self.assertEquals(is_created, 1)
+		self.assertEqual(is_created, 1)
 
 		is_created = add_user_permissions(param)
 		frappe.db.commit()
@@ -92,7 +92,7 @@ class TestUserPermission(unittest.TestCase):
 		# Check that User Permissions for applicable is created
 		self.assertIsNotNone(is_created_applicable_first)
 		self.assertIsNotNone(is_created_applicable_second)
-		self.assertEquals(is_created, 1)
+		self.assertEqual(is_created, 1)
 
 	def test_for_apply_to_all_on_update_from_applicable(self):
 		''' Update User Permission from some to all applicable Doctypes'''
@@ -102,7 +102,7 @@ class TestUserPermission(unittest.TestCase):
 		# create User permissions that with applicable
 		is_created = add_user_permissions(get_params(user, 'User', user.name, applicable = ["Chat Room", "Chat Message"]))
 
-		self.assertEquals(is_created, 1)
+		self.assertEqual(is_created, 1)
 
 		is_created = add_user_permissions(param)
 		is_created_apply_to_all = frappe.db.exists("User Permission", get_exists_param(user))
@@ -115,7 +115,7 @@ class TestUserPermission(unittest.TestCase):
 		# Check that all User Permission with applicable is removed
 		self.assertIsNone(removed_applicable_first)
 		self.assertIsNone(removed_applicable_second)
-		self.assertEquals(is_created, 1)
+		self.assertEqual(is_created, 1)
 
 	def test_user_perm_for_nested_doctype(self):
 		"""Test if descendants' visibility is controlled for a nested DocType."""
@@ -183,7 +183,7 @@ class TestUserPermission(unittest.TestCase):
 
 		# User perm is created on ToDo but for doctype Assignment Rule only
 		# it should not have impact on Doc A
-		self.assertEquals(new_doc.doc, "ToDo")
+		self.assertEqual(new_doc.doc, "ToDo")
 
 		frappe.set_user('Administrator')
 		remove_applicable(["Assignment Rule"], "new_doc_test@example.com", "DocType", "ToDo")
@@ -228,7 +228,7 @@ class TestUserPermission(unittest.TestCase):
 
 		# User perm is created on ToDo but for doctype Assignment Rule only
 		# it should not have impact on Doc A
-		self.assertEquals(new_doc.doc, "ToDo")
+		self.assertEqual(new_doc.doc, "ToDo")
 
 		frappe.set_user('Administrator')
 		clear_session_defaults()

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -47,64 +47,64 @@ class TestCustomizeForm(unittest.TestCase):
 		self.assertEqual(len(d.get("fields")), 0)
 
 		d = self.get_customize_form("Event")
-		self.assertEquals(d.doc_type, "Event")
-		self.assertEquals(len(d.get("fields")), 36)
+		self.assertEqual(d.doc_type, "Event")
+		self.assertEqual(len(d.get("fields")), 36)
 
 		d = self.get_customize_form("Event")
-		self.assertEquals(d.doc_type, "Event")
+		self.assertEqual(d.doc_type, "Event")
 
 		self.assertEqual(len(d.get("fields")),
 			len(frappe.get_doc("DocType", d.doc_type).fields) + 1)
-		self.assertEquals(d.get("fields")[-1].fieldname, "test_custom_field")
-		self.assertEquals(d.get("fields", {"fieldname": "event_type"})[0].in_list_view, 1)
+		self.assertEqual(d.get("fields")[-1].fieldname, "test_custom_field")
+		self.assertEqual(d.get("fields", {"fieldname": "event_type"})[0].in_list_view, 1)
 
 		return d
 
 	def test_save_customization_property(self):
 		d = self.get_customize_form("Event")
-		self.assertEquals(frappe.db.get_value("Property Setter",
+		self.assertEqual(frappe.db.get_value("Property Setter",
 			{"doc_type": "Event", "property": "allow_copy"}, "value"), None)
 
 		d.allow_copy = 1
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Property Setter",
+		self.assertEqual(frappe.db.get_value("Property Setter",
 			{"doc_type": "Event", "property": "allow_copy"}, "value"), '1')
 
 		d.allow_copy = 0
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Property Setter",
+		self.assertEqual(frappe.db.get_value("Property Setter",
 			{"doc_type": "Event", "property": "allow_copy"}, "value"), None)
 
 	def test_save_customization_field_property(self):
 		d = self.get_customize_form("Event")
-		self.assertEquals(frappe.db.get_value("Property Setter",
+		self.assertEqual(frappe.db.get_value("Property Setter",
 			{"doc_type": "Event", "property": "reqd", "field_name": "repeat_this_event"}, "value"), None)
 
 		repeat_this_event_field = d.get("fields", {"fieldname": "repeat_this_event"})[0]
 		repeat_this_event_field.reqd = 1
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Property Setter",
+		self.assertEqual(frappe.db.get_value("Property Setter",
 			{"doc_type": "Event", "property": "reqd", "field_name": "repeat_this_event"}, "value"), '1')
 
 		repeat_this_event_field = d.get("fields", {"fieldname": "repeat_this_event"})[0]
 		repeat_this_event_field.reqd = 0
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Property Setter",
+		self.assertEqual(frappe.db.get_value("Property Setter",
 			{"doc_type": "Event", "property": "reqd", "field_name": "repeat_this_event"}, "value"), None)
 
 	def test_save_customization_custom_field_property(self):
 		d = self.get_customize_form("Event")
-		self.assertEquals(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 0)
+		self.assertEqual(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 0)
 
 		custom_field = d.get("fields", {"fieldname": "test_custom_field"})[0]
 		custom_field.reqd = 1
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 1)
+		self.assertEqual(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 1)
 
 		custom_field = d.get("fields", {"is_custom_field": True})[0]
 		custom_field.reqd = 0
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 0)
+		self.assertEqual(frappe.db.get_value("Custom Field", "Event-test_custom_field", "reqd"), 0)
 
 	def test_save_customization_new_field(self):
 		d = self.get_customize_form("Event")
@@ -115,14 +115,14 @@ class TestCustomizeForm(unittest.TestCase):
 			"is_custom_field": 1
 		})
 		d.run_method("save_customization")
-		self.assertEquals(frappe.db.get_value("Custom Field",
+		self.assertEqual(frappe.db.get_value("Custom Field",
 			"Event-test_add_custom_field_via_customize_form", "fieldtype"), "Data")
 
-		self.assertEquals(frappe.db.get_value("Custom Field",
+		self.assertEqual(frappe.db.get_value("Custom Field",
 			"Event-test_add_custom_field_via_customize_form", 'insert_after'), last_fieldname)
 
 		frappe.delete_doc("Custom Field", "Event-test_add_custom_field_via_customize_form")
-		self.assertEquals(frappe.db.get_value("Custom Field",
+		self.assertEqual(frappe.db.get_value("Custom Field",
 			"Event-test_add_custom_field_via_customize_form"), None)
 
 
@@ -142,7 +142,7 @@ class TestCustomizeForm(unittest.TestCase):
 		d.doc_type = "Event"
 		d.run_method('reset_to_defaults')
 
-		self.assertEquals(d.get("fields", {"fieldname": "repeat_this_event"})[0].in_list_view, 0)
+		self.assertEqual(d.get("fields", {"fieldname": "repeat_this_event"})[0].in_list_view, 0)
 
 		frappe.local.test_objects["Property Setter"] = []
 		make_test_records_for_doctype("Property Setter")
@@ -156,7 +156,7 @@ class TestCustomizeForm(unittest.TestCase):
 		d = self.get_customize_form("Event")
 
 		# don't allow for standard fields
-		self.assertEquals(d.get("fields", {"fieldname": "subject"})[0].allow_on_submit or 0, 0)
+		self.assertEqual(d.get("fields", {"fieldname": "subject"})[0].allow_on_submit or 0, 0)
 
 		# allow for custom field
 		self.assertEqual(d.get("fields", {"fieldname": "test_custom_field"})[0].allow_on_submit, 1)

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -17,14 +17,14 @@ class TestDocumentFollow(unittest.TestCase):
 
 		document_follow.unfollow_document("Event", event_doc.name, user.name)
 		doc = document_follow.follow_document("Event", event_doc.name, user.name)
-		self.assertEquals(doc.user, user.name)
+		self.assertEqual(doc.user, user.name)
 
 		document_follow.send_hourly_updates()
 
 		email_queue_entry_name = frappe.get_all("Email Queue", limit=1)[0].name
 		email_queue_entry_doc = frappe.get_doc("Email Queue", email_queue_entry_name)
 
-		self.assertEquals((email_queue_entry_doc.recipients[0].recipient), user.name)
+		self.assertEqual((email_queue_entry_doc.recipients[0].recipient), user.name)
 
 		self.assertIn(event_doc.doctype, email_queue_entry_doc.message)
 		self.assertIn(event_doc.name, email_queue_entry_doc.message)

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -78,7 +78,7 @@ class TestEnergyPointLog(unittest.TestCase):
 		points_after_closing_todo = get_points('test@example.com')
 
 		# test max_points cap
-		self.assertNotEquals(points_after_closing_todo,
+		self.assertNotEqual(points_after_closing_todo,
 			energy_point_of_user + round(todo_point_rule.points * multiplier_value))
 
 		self.assertEqual(points_after_closing_todo,

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -115,12 +115,12 @@ class TestCommands(BaseTestCommands):
 	def test_execute(self):
 		# test 1: execute a command expecting a numeric output
 		self.execute("bench --site {site} execute frappe.db.get_database_size")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertIsInstance(float(self.stdout), float)
 
 		# test 2: execute a command expecting an errored output as local won't exist
 		self.execute("bench --site {site} execute frappe.local.site")
-		self.assertEquals(self.returncode, 1)
+		self.assertEqual(self.returncode, 1)
 		self.assertIsNotNone(self.stderr)
 
 		# test 3: execute a command with kwargs
@@ -128,8 +128,8 @@ class TestCommands(BaseTestCommands):
 		# terminal command has been escaped to avoid .format string replacement
 		# The returned value has quotes which have been trimmed for the test
 		self.execute("""bench --site {site} execute frappe.bold --kwargs '{{"text": "DocType"}}'""")
-		self.assertEquals(self.returncode, 0)
-		self.assertEquals(self.stdout[1:-1], frappe.bold(text="DocType"))
+		self.assertEqual(self.returncode, 0)
+		self.assertEqual(self.stdout[1:-1], frappe.bold(text="DocType"))
 
 	def test_backup(self):
 		backup = {
@@ -155,7 +155,7 @@ class TestCommands(BaseTestCommands):
 		self.execute("bench --site {site} backup")
 		after_backup = fetch_latest_backups()
 
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertIn("successfully completed", self.stdout)
 		self.assertNotEqual(before_backup["database"], after_backup["database"])
 
@@ -164,7 +164,7 @@ class TestCommands(BaseTestCommands):
 		self.execute("bench --site {site} backup --with-files")
 		after_backup = fetch_latest_backups()
 
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertIn("successfully completed", self.stdout)
 		self.assertIn("with files", self.stdout)
 		self.assertNotEqual(before_backup, after_backup)
@@ -175,7 +175,7 @@ class TestCommands(BaseTestCommands):
 		backup_path = os.path.join(home, "backups")
 		self.execute("bench --site {site} backup --backup-path {backup_path}", {"backup_path": backup_path})
 
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertTrue(os.path.exists(backup_path))
 		self.assertGreaterEqual(len(os.listdir(backup_path)), 2)
 
@@ -200,19 +200,19 @@ class TestCommands(BaseTestCommands):
 			kwargs,
 		)
 
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		for path in kwargs.values():
 			self.assertTrue(os.path.exists(path))
 
 		# test 5: take a backup with --compress
 		self.execute("bench --site {site} backup --with-files --compress")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		compressed_files = glob.glob(site_backup_path + "/*.tgz")
 		self.assertGreater(len(compressed_files), 0)
 
 		# test 6: take a backup with --verbose
 		self.execute("bench --site {site} backup --verbose")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 
 		# test 7: take a backup with frappe.conf.backup.includes
 		self.execute(
@@ -220,7 +220,7 @@ class TestCommands(BaseTestCommands):
 			{"includes": json.dumps(backup["includes"])},
 		)
 		self.execute("bench --site {site} backup --verbose")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		database = fetch_latest_backups(partial=True)["database"]
 		self.assertTrue(exists_in_backup(backup["includes"]["includes"], database))
 
@@ -230,7 +230,7 @@ class TestCommands(BaseTestCommands):
 			{"excludes": json.dumps(backup["excludes"])},
 		)
 		self.execute("bench --site {site} backup --verbose")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		database = fetch_latest_backups(partial=True)["database"]
 		self.assertFalse(exists_in_backup(backup["excludes"]["excludes"], database))
 		self.assertTrue(exists_in_backup(backup["includes"]["includes"], database))
@@ -240,7 +240,7 @@ class TestCommands(BaseTestCommands):
 			"bench --site {site} backup --include '{include}'",
 			{"include": ",".join(backup["includes"]["includes"])},
 		)
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		database = fetch_latest_backups(partial=True)["database"]
 		self.assertTrue(exists_in_backup(backup["includes"]["includes"], database))
 
@@ -249,13 +249,13 @@ class TestCommands(BaseTestCommands):
 			"bench --site {site} backup --exclude '{exclude}'",
 			{"exclude": ",".join(backup["excludes"]["excludes"])},
 		)
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		database = fetch_latest_backups(partial=True)["database"]
 		self.assertFalse(exists_in_backup(backup["excludes"]["excludes"], database))
 
 		# test 11: take a backup with --ignore-backup-conf
 		self.execute("bench --site {site} backup --ignore-backup-conf")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		database = fetch_latest_backups()["database"]
 		self.assertTrue(exists_in_backup(backup["excludes"]["excludes"], database))
 
@@ -296,7 +296,7 @@ class TestCommands(BaseTestCommands):
 		)
 		site_data.update({"database": json.loads(self.stdout)["database"]})
 		self.execute("bench --site {another_site} restore {database}", site_data)
-		self.assertEquals(self.returncode, 1)
+		self.assertEqual(self.returncode, 1)
 
 	def test_partial_restore(self):
 		_now = now()
@@ -319,8 +319,8 @@ class TestCommands(BaseTestCommands):
 		frappe.db.commit()
 
 		self.execute("bench --site {site} partial-restore {path}", {"path": db_path})
-		self.assertEquals(self.returncode, 0)
-		self.assertEquals(frappe.db.count("ToDo"), todo_count)
+		self.assertEqual(self.returncode, 0)
+		self.assertEqual(frappe.db.count("ToDo"), todo_count)
 
 	def test_recorder(self):
 		frappe.recorder.stop()
@@ -343,18 +343,18 @@ class TestCommands(BaseTestCommands):
 
 		# test 1: remove app from installed_apps global default
 		self.execute("bench --site {site} remove-from-installed-apps {app}", {"app": app})
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.execute("bench --site {site} list-apps")
 		self.assertNotIn(app, self.stdout)
 
 	def test_list_apps(self):
 		# test 1: sanity check for command
 		self.execute("bench --site all list-apps")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 
 		# test 2: bare functionality for single site
 		self.execute("bench --site {site} list-apps")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		list_apps = set([
 			_x.split()[0] for _x in self.stdout.split("\n")
 		])
@@ -367,7 +367,7 @@ class TestCommands(BaseTestCommands):
 
 		# test 3: parse json format
 		self.execute("bench --site all list-apps --format json")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertIsInstance(json.loads(self.stdout), dict)
 
 		self.execute("bench --site {site} list-apps --format json")
@@ -379,7 +379,7 @@ class TestCommands(BaseTestCommands):
 	def test_show_config(self):
 		# test 1: sanity check for command
 		self.execute("bench --site all show-config")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 
 		# test 2: test keys in table text
 		self.execute(
@@ -387,13 +387,13 @@ class TestCommands(BaseTestCommands):
 			{"second_order": json.dumps({"test_key": "test_value"})},
 		)
 		self.execute("bench --site {site} show-config")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertIn("test_key.test_key", self.stdout.split())
 		self.assertIn("test_value", self.stdout.split())
 
 		# test 3: parse json format
 		self.execute("bench --site all show-config --format json")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertIsInstance(json.loads(self.stdout), dict)
 
 		self.execute("bench --site {site} show-config --format json")
@@ -423,6 +423,6 @@ class TestCommands(BaseTestCommands):
 	def test_frappe_site_env(self):
 		os.putenv('FRAPPE_SITE', frappe.local.site)
 		self.execute("bench execute frappe.ping")
-		self.assertEquals(self.returncode, 0)
+		self.assertEqual(self.returncode, 0)
 		self.assertIn("pong", self.stdout)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -18,7 +18,7 @@ class TestDB(unittest.TestCase):
 	def test_get_value(self):
 		self.assertEqual(frappe.db.get_value("User", {"name": ["=", "Administrator"]}), "Administrator")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["like", "Admin%"]}), "Administrator")
-		self.assertNotEquals(frappe.db.get_value("User", {"name": ["!=", "Guest"]}), "Guest")
+		self.assertNotEqual(frappe.db.get_value("User", {"name": ["!=", "Guest"]}), "Guest")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<", "Adn"]}), "Administrator")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<=", "Administrator"]}), "Administrator")
 

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -48,7 +48,7 @@ class TestWebsite(unittest.TestCase):
 		set_request(method='POST', path='login')
 		response = render.render()
 
-		self.assertEquals(response.status_code, 200)
+		self.assertEqual(response.status_code, 200)
 
 		html = frappe.safe_decode(response.get_data())
 
@@ -76,27 +76,27 @@ class TestWebsite(unittest.TestCase):
 
 		set_request(method='GET', path='/testfrom')
 		response = render.render()
-		self.assertEquals(response.status_code, 301)
-		self.assertEquals(response.headers.get('Location'), r'://testto1')
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(response.headers.get('Location'), r'://testto1')
 
 		set_request(method='GET', path='/testfromregex/test')
 		response = render.render()
-		self.assertEquals(response.status_code, 301)
-		self.assertEquals(response.headers.get('Location'), r'://testto2')
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(response.headers.get('Location'), r'://testto2')
 
 		set_request(method='GET', path='/testsub/me')
 		response = render.render()
-		self.assertEquals(response.status_code, 301)
-		self.assertEquals(response.headers.get('Location'), r'://testto3/me')
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(response.headers.get('Location'), r'://testto3/me')
 
 		set_request(method='GET', path='/test404')
 		response = render.render()
-		self.assertEquals(response.status_code, 404)
+		self.assertEqual(response.status_code, 404)
 
 		set_request(method='GET', path='/testsource')
 		response = render.render()
-		self.assertEquals(response.status_code, 301)
-		self.assertEquals(response.headers.get('Location'), '/testtarget')
+		self.assertEqual(response.status_code, 301)
+		self.assertEqual(response.headers.get('Location'), '/testtarget')
 
 		delattr(frappe.hooks, 'website_redirects')
 		frappe.cache().delete_key('app_hooks')

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -42,7 +42,7 @@ class TestWebForm(unittest.TestCase):
 			'name': self.event_name
 		}
 
-		self.assertNotEquals(frappe.db.get_value("Event",
+		self.assertNotEqual(frappe.db.get_value("Event",
 			self.event_name, "description"), doc.get('description'))
 
 		accept(web_form='manage-events', docname=self.event_name, data=json.dumps(doc))


### PR DESCRIPTION
`assertEquals` has been deprecated, while not fully removed it will
still keep giving warnings in tests / CI.

ref: https://docs.python.org/3/library/unittest.html#deprecated-aliases
