### PR TITLE
fix(UI): Broken styles

### DIFF
--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -164,7 +164,7 @@
 }
 
 .ql-editor td {
-	border: 1px solid var(--border-color);
+	border: 1px solid var(---dark-border-color);
 }
 
 .ql-editor blockquote {

--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -161,7 +161,8 @@
 	.summary-item {
 		// SIZE & SPACING
 		margin: 0px 30px;
-		width: 180px;
+		min-width: 180px;
+		max-width: 300px;
 		height: 62px;
 
 		// LAYOUT


### PR DESCRIPTION
**Table style before:**
<img width="400" alt="Screenshot 2021-05-07 at 9 21 30 AM" src="https://user-images.githubusercontent.com/13928957/117401896-0787f980-af23-11eb-9e1a-9ae25ef3f3f6.png">
**Now:**
<img width="400" alt="Screenshot 2021-05-07 at 9 20 49 AM" src="https://user-images.githubusercontent.com/13928957/117401901-0951bd00-af23-11eb-97c1-9b3de892dc21.png">

Avoid clipping of report summary
**Before:**
<img width="400" alt="Screenshot 2021-05-07 at 11 01 59 AM" src="https://user-images.githubusercontent.com/13928957/117402260-b62c3a00-af23-11eb-81a9-9efdb4bb8ea7.png">
**Now:**
<img width="400" alt="Screenshot 2021-05-07 at 11 01 28 AM" src="https://user-images.githubusercontent.com/13928957/117402309-c8a67380-af23-11eb-9545-263c5d010e0c.png">

