### PR TITLE
fix: parse Today default value for date docfield

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -13,9 +13,11 @@ frappe.ui.form.ControlDate = frappe.ui.form.ControlData.extend({
 		this._super(value);
 		if (this.timepicker_only) return;
 		if (!this.datepicker) return;
-		if(!value) {
+		if (!value) {
 			this.datepicker.clear();
 			return;
+		} else if (value === "Today") {
+			value = this.get_now_date();
 		}
 
 		let should_refresh = this.last_value && this.last_value !== value;


### PR DESCRIPTION
- If `Today` is set as default in Date docfield, it breaks the value being set for quick entry

- Before fix
- ![image](https://user-images.githubusercontent.com/7310479/117407690-86cdfb00-af2c-11eb-8f7a-8e7932ff43b9.png)
- ![image](https://user-images.githubusercontent.com/7310479/117407613-6c941d00-af2c-11eb-98b3-4935d9f5c255.png)
- ![image](https://user-images.githubusercontent.com/7310479/117407731-964d4400-af2c-11eb-864c-3c8d69a18b81.png)

- After fix
- ![Peek 2021-05-07 12-08](https://user-images.githubusercontent.com/7310479/117408013-f643ea80-af2c-11eb-998b-2caeac2c05f8.gif)
