### PR TITLE
fix: Loading Translation messages fix

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -116,7 +116,7 @@ def get_dict(fortype, name=None):
 			messages = deduplicate_messages(messages)
 
 			messages += frappe.db.sql("""select 'navbar', item_label from `tabNavbar Item` where item_label is not null""")
-			messages = get_messages_from_include_files()
+			messages += get_messages_from_include_files()
 			messages += frappe.db.sql("select 'Print Format:', name from `tabPrint Format`")
 			messages += frappe.db.sql("select 'DocType:', name from tabDocType")
 			messages += frappe.db.sql("select 'Role:', name from tabRole")


### PR DESCRIPTION
There was a typo in https://github.com/frappe/frappe/pull/12848/files#diff-e4c5479669e595d33f505872bedf9d52b2570e2a75b4e8f8cccc3834d3cd86a2L112 which makes messages again empty.
Because of which some Texts were not translating.