### PR TITLE
feat: Add "only_select" in docfield

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -45,6 +45,7 @@
   "allow_on_submit",
   "report_hide",
   "remember_last_selected_value",
+  "only_select",
   "ignore_xss_filter",
   "hide_border",
   "property_depends_on_section",
@@ -481,13 +482,20 @@
    "fieldname": "non_negative",
    "fieldtype": "Check",
    "label": "Non Negative"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:(doc.fieldtype == 'Link')",
+   "fieldname": "only_select",
+   "fieldtype": "Check",
+   "label": "Only Select"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-29 06:09:26.454990",
+ "modified": "2021-05-09 20:04:52.007086",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",


### PR DESCRIPTION
Adding "only_select" option in docfield to hide "Create New" option in Link field. This hide feature was existing, but requires `set_df_property`.

Ref code: https://github.com/frappe/frappe/blob/1c0233ccd878a7d3b943b548442b7e72671c80d1/frappe/public/js/frappe/form/controls/link.js#L199-L210

