### PR TITLE
fix: Do not skip data in save while using shortcut

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -474,14 +474,19 @@ frappe.Application = Class.extend({
 		$('<link rel="icon" href="' + link + '" type="image/x-icon">').appendTo("head");
 	},
 	trigger_primary_action: function() {
-		if(window.cur_dialog && cur_dialog.display) {
-			// trigger primary
-			cur_dialog.get_primary_btn().trigger("click");
-		} else if(cur_frm && cur_frm.page.btn_primary.is(':visible')) {
-			cur_frm.page.btn_primary.trigger('click');
-		} else if(frappe.container.page.save_action) {
-			frappe.container.page.save_action();
-		}
+		// to trigger change event on active input before triggering primary action
+		$(document.activeElement).blur();
+		// wait for possible JS validations triggered after blur (it might change primary button)
+		setTimeout(() => {
+			if (window.cur_dialog && cur_dialog.display) {
+				// trigger primary
+				cur_dialog.get_primary_btn().trigger("click");
+			} else if (cur_frm && cur_frm.page.btn_primary.is(':visible')) {
+				cur_frm.page.btn_primary.trigger('click');
+			} else if (frappe.container.page.save_action) {
+				frappe.container.page.save_action();
+			}
+		}, 100);
 	},
 
 	set_rtl: function() {


### PR DESCRIPTION
Previously, sometimes using a shortcut to save form quickly after data change resulted in partial data save.
**Before:**
![do-not-skip-data-bug](https://user-images.githubusercontent.com/13928957/117617529-4d92c680-b18a-11eb-83a9-16b3dd293eda.gif)

**Now:**
![do-not-skip-data-fix](https://user-images.githubusercontent.com/13928957/117617536-508db700-b18a-11eb-9665-433a4665b4d4.gif)

The handling was removed in https://github.com/frappe/frappe/pull/12326