### PR TITLE
fix: Revert naming for custom naming series (bp-v12)

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -170,10 +170,37 @@ def getseries(key, digits):
 
 
 def revert_series_if_last(key, name, doc=None):
+	"""
+	Reverts the series for particular naming series:
+	* key is naming series		- SINV-.YYYY-.####
+	* name is actual name		- SINV-2021-0001
+		
+	1. This function split the key into two parts prefix (SINV-YYYY) & hashes (####).
+	2. Use prefix to get the current index of that naming series from Series table
+	3. Then revert the current index.
+	*For custom naming series:*
+	1. hash can exist anywhere, if it exist in hashes then it take normal flow.
+	2. If hash doesn't exit in hashes, we get the hash from prefix, then update name and prefix accordingly.
+	*Example:*
+		1. key = SINV-.YYYY.- 
+			* If key doesn't have hash it will add hash at the end
+			* prefix will be SINV-YYYY based on this will get current index from Series table.
+		2. key = SINV-.####.-2021
+			* now prefix = SINV-#### and hashes = 2021 (hash doesn't exist)
+			* will search hash in key then accordingly get prefix = SINV-
+		3. key = ####.-2021
+			* prefix = #### and hashes = 2021 (hash doesn't exist)
+			* will search hash in key then accordingly get prefix = "" 
+	"""
 	if ".#" in key:
 		prefix, hashes = key.rsplit(".", 1)
 		if "#" not in hashes:
-			return
+			# get the hash part from the key
+			hash = re.search("#+", key)
+			if not hash:
+				return
+			name = name.replace(hashes, "")
+			prefix = prefix.replace(hash.group(), "")
 	else:
 		prefix = key
 

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -70,9 +70,9 @@ class TestNaming(unittest.TestCase):
 		name = 'TEST-{}-00001'.format(year)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 1)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 0)
+		self.assertEqual(current_index.get('current'), 0)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 		series = 'TEST-{}-'.format(year)
@@ -80,9 +80,9 @@ class TestNaming(unittest.TestCase):
 		name = 'TEST-{}-00002'.format(year)
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 2)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 1)
+		self.assertEqual(current_index.get('current'), 1)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
 
 		series = 'TEST-'
@@ -90,7 +90,7 @@ class TestNaming(unittest.TestCase):
 		name = 'TEST-00003'
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)
-		count = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
+		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
-		self.assertEqual(count.get('current'), 2)
+		self.assertEqual(current_index.get('current'), 2)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/pull/13142

When we delete some of the documents the naming of those documents also gets reverted.
e.g If there are 5 documents with the name - SINV-2021-0001, SINV-2021-0002, SINV-2021-0003, SINV-2021-0004, SINV-2021-0005
Now if we delete 4th and 5th the naming series should get reverted and if we create another document the naming should be SINV-2021-0004

This works for default naming series, but if we have some custom naming series it doesn't work.

e.g MD-.###./2021-22 - Doesn't Work