### PR TITLE
fix: Ignore "lft" and "rgt" when importing/exporting fixtures

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -211,7 +211,7 @@ def export_json(
 	doctype, path, filters=None, or_filters=None, name=None, order_by="creation asc"
 ):
 	def post_process(out):
-		del_keys = ("modified_by", "creation", "owner", "idx")
+		del_keys = ("modified_by", "creation", "owner", "idx", "lft", "rgt")
 		for doc in out:
 			for key in del_keys:
 				if key in doc:

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -211,6 +211,11 @@ def export_json(
 	doctype, path, filters=None, or_filters=None, name=None, order_by="creation asc"
 ):
 	def post_process(out):
+		# Note on Tree DocTypes:
+		# The tree structure is maintained in the database via the fields "lft"
+		# and "rgt". They are automatically set and kept up-to-date. Importing
+		# them would destroy any existing tree structure. For this reason they
+		# are not exported as well.
 		del_keys = ("modified_by", "creation", "owner", "idx", "lft", "rgt")
 		for doc in out:
 			for key in del_keys:

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -107,6 +107,10 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 
 	doc = frappe.get_doc(docdict)
 
+	if doc.meta.is_tree:
+		doc.lft = None
+		doc.rgt = None
+
 	doc.run_method("before_import")
 
 	doc.flags.ignore_version = ignore_version

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -107,7 +107,7 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 
 	doc = frappe.get_doc(docdict)
 
-	if doc.meta.is_tree:
+	if hasattr(doc.meta, 'is_tree') and getattr(doc.meta, 'is_tree'):
 		doc.lft = None
 		doc.rgt = None
 

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -107,7 +107,7 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 
 	doc = frappe.get_doc(docdict)
 
-	if hasattr(doc.meta, 'is_tree') and getattr(doc.meta, 'is_tree'):
+	if getattr(doc.meta, 'is_tree', None):
 		doc.lft = None
 		doc.rgt = None
 

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -107,7 +107,12 @@ def import_doc(docdict, force=False, data_import=False, pre_process=None,
 
 	doc = frappe.get_doc(docdict)
 
-	if getattr(doc.meta, 'is_tree', None):
+	# Note on Tree DocTypes:
+	# The tree structure is maintained in the database via the fields "lft" and
+	# "rgt". They are automatically set and kept up-to-date. Importing them
+	# would destroy any existing tree structure.
+	if getattr(doc.meta, 'is_tree', None) and any([doc.lft, doc.rgt]):
+		print('Ignoring values of `lft` and `rgt` for {} "{}"'.format(doc.doctype, doc.name))
 		doc.lft = None
 		doc.rgt = None
 


### PR DESCRIPTION
### Problem

- In a tree doctype, the values of the fields "lft" and "rgt" are responsible for a correct tree structure in the database (see [Nested Set Model](https://en.wikipedia.org/wiki/Nested_set_model)).
- When exporting a record of a tree doctype as a fixture, the values of "lft" and "rgt" get exported as well.
- During operation the values of "lft" and "rgt" are changing all the time to keep the tree structure up to date as new records get created.
- When running `bench migrate`, the values from the fixtures overwrite the current values.
- This destroys the tree. Operators like "descendants of" won't work anymore.

### Fix 

Ignore "lft" and "rgt" when importing records from a tree DocType.

Docs: https://github.com/frappe/frappe_docs/pull/138