### PR TITLE
fix: connected app auto_refresh credentials and mandatory fields

### DIFF
--- a/frappe/integrations/doctype/connected_app/connected_app.json
+++ b/frappe/integrations/doctype/connected_app/connected_app.json
@@ -54,7 +54,8 @@
    "fieldname": "client_id",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Client Id"
+   "label": "Client Id",
+   "mandatory_depends_on": "eval:doc.redirect_uri"
   },
   {
    "fieldname": "redirect_uri",
@@ -96,12 +97,14 @@
   {
    "fieldname": "authorization_uri",
    "fieldtype": "Data",
-   "label": "Authorization URI"
+   "label": "Authorization URI",
+   "mandatory_depends_on": "eval:doc.redirect_uri"
   },
   {
    "fieldname": "token_uri",
    "fieldtype": "Data",
-   "label": "Token URI"
+   "label": "Token URI",
+   "mandatory_depends_on": "eval:doc.redirect_uri"
   },
   {
    "fieldname": "revocation_uri",
@@ -136,7 +139,7 @@
    "link_fieldname": "connected_app"
   }
  ],
- "modified": "2020-11-16 16:29:50.277405",
+ "modified": "2021-05-10 05:03:06.296863",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Connected App",

--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -26,20 +26,27 @@ class ConnectedApp(Document):
 		self.redirect_uri = urljoin(base_url, callback_path)
 
 	def get_oauth2_session(self, user=None, init=False):
+		"""Return an auto-refreshing OAuth2 session which is an extension of a requests.Session()"""
 		token = None
 		token_updater = None
+		auto_refresh_kwargs = None
 
 		if not init:
 			user = user or frappe.session.user
 			token_cache = self.get_user_token(user)
 			token = token_cache.get_json()
 			token_updater = token_cache.update_data
+			auto_refresh_kwargs = {'client_id': self.client_id}
+			client_secret = self.get_password('client_secret')
+			if client_secret:
+				auto_refresh_kwargs['client_secret'] = client_secret
 
 		return OAuth2Session(
 			client_id=self.client_id,
 			token=token,
 			token_updater=token_updater,
 			auto_refresh_url=self.token_uri,
+			auto_refresh_kwargs=auto_refresh_kwargs,
 			redirect_uri=self.redirect_uri,
 			scope=self.get_scopes()
 		)


### PR DESCRIPTION
I have recently been testing connected app against Xero and works well, except the client_id and client_secret were not included in the auto_refresh_token. This appears to be a common requirement and the extra arguments are recommended at the bottom of [the oauthlib docs](https://requests-oauthlib.readthedocs.io/en/latest/oauth2_workflow.html#third-recommended-define-automatic-token-refresh-and-update)

Also a few tweaks to the mandatory fields to make it clearer for people new to oauth2