### PR TITLE
feat: Added real time chart javascript API

### DIFF
--- a/frappe/public/js/frappe/ui/chart.js
+++ b/frappe/public/js/frappe/ui/chart.js
@@ -1,3 +1,39 @@
 import { Chart } from "frappe-charts/dist/frappe-charts.esm";
 
+frappe.provide("frappe.ui");
 frappe.Chart = Chart;
+
+frappe.ui.RealtimeChart = class RealtimeChart extends frappe.Chart {
+	constructor(element, socketEvent, maxLabelPoints = 8, data) {
+		super(element, data);
+		if (data.data.datasets[0].values.length > maxLabelPoints) {
+			frappe.throw(
+				__(
+					"Length of passed data array is greater than value of maximum allowed label points!"
+				)
+			);
+		}
+		this.currentSize = data.data.datasets[0].values.length;
+		this.socketEvent = socketEvent;
+		this.maxLabelPoints = maxLabelPoints;
+
+		this.start_updating = function() {
+			frappe.realtime.on(this.socketEvent, data => {
+				this.update_chart(data.label, data.points);
+			});
+		};
+
+		this.stop_updating = function() {
+			frappe.realtime.off(this.socketEvent);
+		};
+
+		this.update_chart = function(label, data) {
+			if (this.currentSize >= this.maxLabelPoints) {
+				this.removeDataPoint(0);
+			} else {
+				this.currentSize++;
+			}
+			this.addDataPoint(label, data);
+		};
+	}
+};


### PR DESCRIPTION
This PR provides a javascript API called `frappe.ui.RealtimeChart` which has the capability to update a Frappe chart in real-time using socketio and can be used anywhere to plot a real-time updating chart. 

It takes the following parameters:
1. Element selector
2. Socket event name
3.  Maximum label allowed on x-axis
4. data (Uses frappe. Chart's data)

On the server-side one can put the socket event emitting function into a hook.py file in scheduler_events  and the emitted data should be of the form:

```
data = {
  "label": String for x-axis label,
  "data": A javascript array containing values depending on the number of line charts in the frappe chart.
}
```

and `frappe.publish_realtime(event, data)` can be used. The event name should be the same in the python function and javascript API.

### Sample Initialization

![Screenshot from 2021-05-11 20-48-55](https://user-images.githubusercontent.com/44427574/117841142-68546080-b29a-11eb-849f-8d3195cf7fb9.png)

### Demonstration

https://user-images.githubusercontent.com/44427574/117838366-e5caa180-b297-11eb-8ef4-871f78b0bec1.mp4

here is the documentation's PR - 

https://github.com/frappe/frappe_docs/pull/144