### PR TITLE
fix: check if grid_rows exists

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -910,6 +910,10 @@ export default class Grid {
 
 	update_docfield_property(fieldname, property, value) {
 		// update the docfield of each row
+		if (!this.grid_rows) {
+			return;
+		}
+
 		for (let row of this.grid_rows) {
 			let docfield = row.docfields.find(d => d.fieldname === fieldname);
 			if (docfield) {


### PR DESCRIPTION
If a grid is hidden, `grid_rows` doesn't exist.

Fixes:
<img width="1791" alt="Screenshot 2021-05-13 at 2 00 55 PM" src="https://user-images.githubusercontent.com/19775888/118100044-a7e29000-b3f3-11eb-933b-794a5582b988.png">
