### PR TITLE
fix: Allow only_for for Cards

### DIFF
--- a/frappe/desk/doctype/workspace_link/workspace_link.json
+++ b/frappe/desk/doctype/workspace_link/workspace_link.json
@@ -8,13 +8,13 @@
   "type",
   "label",
   "icon",
+  "only_for",
   "hidden",
   "link_details_section",
   "link_type",
   "link_to",
   "column_break_7",
   "dependencies",
-  "only_for",
   "onboard",
   "is_query_report"
  ],
@@ -84,7 +84,7 @@
   {
    "fieldname": "only_for",
    "fieldtype": "Link",
-   "label": "Only for ",
+   "label": "Only for",
    "options": "Country"
   },
   {
@@ -104,7 +104,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-01-12 13:13:12.379443",
+ "modified": "2021-05-13 13:10:18.128512",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Link",


### PR DESCRIPTION
It seems strange to filter out only workspace links and not whole card sections, like Accounting Indian GST