### PR TITLE
feat: static importing of controllers

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -13,6 +13,8 @@ from frappe.utils.data import comma_and
 
 
 class AssignmentRule(Document):
+	_DOCTYPE_NAME = "Assignment Rule"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/assignment_rule_day/assignment_rule_day.py
+++ b/frappe/automation/doctype/assignment_rule_day/assignment_rule_day.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class AssignmentRuleDay(Document):
+	_DOCTYPE_NAME = "Assignment Rule Day"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/assignment_rule_user/assignment_rule_user.py
+++ b/frappe/automation/doctype/assignment_rule_user/assignment_rule_user.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class AssignmentRuleUser(Document):
+	_DOCTYPE_NAME = "Assignment Rule User"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -42,6 +42,8 @@ week_map = {
 
 
 class AutoRepeat(Document):
+	_DOCTYPE_NAME = "Auto Repeat"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/auto_repeat_day/auto_repeat_day.py
+++ b/frappe/automation/doctype/auto_repeat_day/auto_repeat_day.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class AutoRepeatDay(Document):
+	_DOCTYPE_NAME = "Auto Repeat Day"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/auto_repeat_user/auto_repeat_user.py
+++ b/frappe/automation/doctype/auto_repeat_user/auto_repeat_user.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class AutoRepeatUser(Document):
+	_DOCTYPE_NAME = "Auto Repeat User"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/milestone/milestone.py
+++ b/frappe/automation/doctype/milestone/milestone.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class Milestone(Document):
+	_DOCTYPE_NAME = "Milestone"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class MilestoneTracker(Document):
+	_DOCTYPE_NAME = "Milestone Tracker"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/automation/doctype/reminder/reminder.py
+++ b/frappe/automation/doctype/reminder/reminder.py
@@ -9,6 +9,8 @@ from frappe.utils.data import add_to_date, get_datetime, now_datetime
 
 
 class Reminder(Document):
+	_DOCTYPE_NAME = "Reminder"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -15,6 +15,8 @@ from frappe.utils import cstr
 
 
 class Address(Document):
+	_DOCTYPE_NAME = "Address"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/contacts/doctype/address_template/address_template.py
+++ b/frappe/contacts/doctype/address_template/address_template.py
@@ -8,6 +8,8 @@ from frappe.utils.jinja import validate_template
 
 
 class AddressTemplate(Document):
+	_DOCTYPE_NAME = "Address Template"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -13,6 +13,8 @@ from frappe.utils import cstr, has_gravatar
 
 
 class Contact(Document):
+	_DOCTYPE_NAME = "Contact"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/contacts/doctype/contact_email/contact_email.py
+++ b/frappe/contacts/doctype/contact_email/contact_email.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class ContactEmail(Document):
+	_DOCTYPE_NAME = "Contact Email"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/contacts/doctype/contact_phone/contact_phone.py
+++ b/frappe/contacts/doctype/contact_phone/contact_phone.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class ContactPhone(Document):
+	_DOCTYPE_NAME = "Contact Phone"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/contacts/doctype/gender/gender.py
+++ b/frappe/contacts/doctype/gender/gender.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class Gender(Document):
+	_DOCTYPE_NAME = "Gender"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/contacts/doctype/salutation/salutation.py
+++ b/frappe/contacts/doctype/salutation/salutation.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class Salutation(Document):
+	_DOCTYPE_NAME = "Salutation"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/access_log/access_log.py
+++ b/frappe/core/doctype/access_log/access_log.py
@@ -10,6 +10,8 @@ from frappe.utils import cstr
 
 
 class AccessLog(Document):
+	_DOCTYPE_NAME = "Access Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/activity_log/activity_log.py
+++ b/frappe/core/doctype/activity_log/activity_log.py
@@ -10,6 +10,8 @@ from frappe.utils import get_fullname, now, strip_html
 
 
 class ActivityLog(Document):
+	_DOCTYPE_NAME = "Activity Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/amended_document_naming_settings/amended_document_naming_settings.py
+++ b/frappe/core/doctype/amended_document_naming_settings/amended_document_naming_settings.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class AmendedDocumentNamingSettings(Document):
+	_DOCTYPE_NAME = "Amended Document Naming Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/api_request_log/api_request_log.py
+++ b/frappe/core/doctype/api_request_log/api_request_log.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class APIRequestLog(Document):
+	_DOCTYPE_NAME = "API Request Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -11,6 +11,8 @@ from frappe.utils import compare
 
 
 class AuditTrail(Document):
+	_DOCTYPE_NAME = "Audit Trail"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/block_module/block_module.py
+++ b/frappe/core/doctype/block_module/block_module.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class BlockModule(Document):
+	_DOCTYPE_NAME = "Block Module"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -12,6 +12,8 @@ from frappe.website.utils import clear_cache
 
 
 class Comment(Document):
+	_DOCTYPE_NAME = "Comment"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -32,6 +32,8 @@ exclude_from_linked_with = True
 
 
 class Communication(Document, CommunicationEmailMixin):
+	_DOCTYPE_NAME = "Communication"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/communication_link/communication_link.py
+++ b/frappe/core/doctype/communication_link/communication_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class CommunicationLink(Document):
+	_DOCTYPE_NAME = "Communication Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/custom_docperm/custom_docperm.py
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class CustomDocPerm(Document):
+	_DOCTYPE_NAME = "Custom DocPerm"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/custom_role/custom_role.py
+++ b/frappe/core/doctype/custom_role/custom_role.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class CustomRole(Document):
+	_DOCTYPE_NAME = "Custom Role"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/data_export/data_export.py
+++ b/frappe/core/doctype/data_export/data_export.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class DataExport(Document):
+	_DOCTYPE_NAME = "Data Export"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -23,6 +23,8 @@ BLOCKED_DOCTYPES = CORE_DOCTYPES - {"User", "Role", "Print Format"}
 
 
 class DataImport(Document):
+	_DOCTYPE_NAME = "Data Import"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/data_import_log/data_import_log.py
+++ b/frappe/core/doctype/data_import_log/data_import_log.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DataImportLog(Document):
+	_DOCTYPE_NAME = "Data Import Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/defaultvalue/defaultvalue.py
+++ b/frappe/core/doctype/defaultvalue/defaultvalue.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DefaultValue(Document):
+	_DOCTYPE_NAME = "DefaultValue"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/deleted_document/deleted_document.py
+++ b/frappe/core/doctype/deleted_document/deleted_document.py
@@ -11,6 +11,8 @@ from frappe.model.workflow import get_workflow_name
 
 
 class DeletedDocument(Document):
+	_DOCTYPE_NAME = "Deleted Document"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DocField(Document):
+	_DOCTYPE_NAME = "DocField"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/docperm/docperm.py
+++ b/frappe/core/doctype/docperm/docperm.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class DocPerm(Document):
+	_DOCTYPE_NAME = "DocPerm"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/docshare/docshare.py
+++ b/frappe/core/doctype/docshare/docshare.py
@@ -10,6 +10,8 @@ exclude_from_linked_with = True
 
 
 class DocShare(Document):
+	_DOCTYPE_NAME = "DocShare"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -2058,7 +2058,7 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 def check_fieldname_conflicts(docfield):
 	"""Checks if fieldname conflicts with methods or properties"""
 	doc = frappe.get_doc({"doctype": docfield.dt})
-	available_objects = [x for x in dir(doc) if isinstance(x, str)]
+	available_objects = [x for x in dir(doc) if isinstance(x, str) and x != "docs"]
 	property_list = [x for x in available_objects if is_a_property(getattr(type(doc), x, None))]
 	method_list = [x for x in available_objects if x not in property_list and callable(getattr(doc, x))]
 	msg = _("Fieldname {0} conflicting with meta object").format(docfield.fieldname)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -86,6 +86,8 @@ form_grid_templates = {"fields": "templates/form_grid/fields.html"}
 
 
 class DocType(Document):
+	_DOCTYPE_NAME = "DocType"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/doctype_action/doctype_action.py
+++ b/frappe/core/doctype/doctype_action/doctype_action.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DocTypeAction(Document):
+	_DOCTYPE_NAME = "DocType Action"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/doctype_link/doctype_link.py
+++ b/frappe/core/doctype/doctype_link/doctype_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DocTypeLink(Document):
+	_DOCTYPE_NAME = "DocType Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/doctype_state/doctype_state.py
+++ b/frappe/core/doctype/doctype_state/doctype_state.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DocTypeState(Document):
+	_DOCTYPE_NAME = "DocType State"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -9,6 +9,8 @@ from frappe.utils.data import evaluate_filters
 
 
 class DocumentNamingRule(Document):
+	_DOCTYPE_NAME = "Document Naming Rule"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.py
+++ b/frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DocumentNamingRuleCondition(Document):
+	_DOCTYPE_NAME = "Document Naming Rule Condition"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -15,6 +15,8 @@ class NamingSeriesNotSetError(frappe.ValidationError):
 
 
 class DocumentNamingSettings(Document):
+	_DOCTYPE_NAME = "Document Naming Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/document_share_key/document_share_key.py
+++ b/frappe/core/doctype/document_share_key/document_share_key.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class DocumentShareKey(Document):
+	_DOCTYPE_NAME = "Document Share Key"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/domain/domain.py
+++ b/frappe/core/doctype/domain/domain.py
@@ -8,6 +8,8 @@ from frappe.utils import cint
 
 
 class Domain(Document):
+	_DOCTYPE_NAME = "Domain"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/domain_settings/domain_settings.py
+++ b/frappe/core/doctype/domain_settings/domain_settings.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DomainSettings(Document):
+	_DOCTYPE_NAME = "Domain Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/dynamic_link/dynamic_link.py
+++ b/frappe/core/doctype/dynamic_link/dynamic_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DynamicLink(Document):
+	_DOCTYPE_NAME = "Dynamic Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -8,6 +8,8 @@ from frappe.query_builder.functions import Now
 
 
 class ErrorLog(Document):
+	_DOCTYPE_NAME = "Error Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -47,6 +47,8 @@ FILE_ENCODING_OPTIONS = ("utf-8-sig", "utf-8", "windows-1250", "windows-1252")
 
 
 class File(Document):
+	_DOCTYPE_NAME = "File"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/has_domain/has_domain.py
+++ b/frappe/core/doctype/has_domain/has_domain.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class HasDomain(Document):
+	_DOCTYPE_NAME = "Has Domain"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/has_role/has_role.py
+++ b/frappe/core/doctype/has_role/has_role.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class HasRole(Document):
+	_DOCTYPE_NAME = "Has Role"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/installed_application/installed_application.py
+++ b/frappe/core/doctype/installed_application/installed_application.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class InstalledApplication(Document):
+	_DOCTYPE_NAME = "Installed Application"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -14,6 +14,8 @@ class InvalidAppOrder(frappe.ValidationError):
 
 
 class InstalledApplications(Document):
+	_DOCTYPE_NAME = "Installed Applications"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/language/language.py
+++ b/frappe/core/doctype/language/language.py
@@ -10,6 +10,8 @@ from frappe.model.document import Document
 
 
 class Language(Document):
+	_DOCTYPE_NAME = "Language"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/log_setting_user/log_setting_user.py
+++ b/frappe/core/doctype/log_setting_user/log_setting_user.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class LogSettingUser(Document):
+	_DOCTYPE_NAME = "Log Setting User"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -29,6 +29,8 @@ def _supports_log_clearing(doctype: str) -> bool:
 
 
 class LogSettings(Document):
+	_DOCTYPE_NAME = "Log Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/logs_to_clear/logs_to_clear.py
+++ b/frappe/core/doctype/logs_to_clear/logs_to_clear.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class LogsToClear(Document):
+	_DOCTYPE_NAME = "Logs To Clear"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -12,6 +12,8 @@ from frappe.modules.export_file import delete_folder
 
 
 class ModuleDef(Document):
+	_DOCTYPE_NAME = "Module Def"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/module_profile/module_profile.py
+++ b/frappe/core/doctype/module_profile/module_profile.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class ModuleProfile(Document):
+	_DOCTYPE_NAME = "Module Profile"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/navbar_item/navbar_item.py
+++ b/frappe/core/doctype/navbar_item/navbar_item.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class NavbarItem(Document):
+	_DOCTYPE_NAME = "Navbar Item"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 
 class NavbarSettings(Document):
+	_DOCTYPE_NAME = "Navbar Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/package/package.py
+++ b/frappe/core/doctype/package/package.py
@@ -15,6 +15,8 @@ LICENSES = (
 
 
 class Package(Document):
+	_DOCTYPE_NAME = "Package"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/package_import/package_import.py
+++ b/frappe/core/doctype/package_import/package_import.py
@@ -16,6 +16,8 @@ from frappe.utils import get_files_path
 
 
 class PackageImport(Document):
+	_DOCTYPE_NAME = "Package Import"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/package_release/package_release.py
+++ b/frappe/core/doctype/package_release/package_release.py
@@ -12,6 +12,8 @@ from frappe.query_builder.functions import Max
 
 
 class PackageRelease(Document):
+	_DOCTYPE_NAME = "Package Release"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -15,6 +15,8 @@ from frappe.model.utils import render_include
 
 
 class Page(Document):
+	_DOCTYPE_NAME = "Page"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/patch_log/patch_log.py
+++ b/frappe/core/doctype/patch_log/patch_log.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class PatchLog(Document):
+	_DOCTYPE_NAME = "Patch Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/permission_inspector/permission_inspector.py
+++ b/frappe/core/doctype/permission_inspector/permission_inspector.py
@@ -7,6 +7,8 @@ from frappe.permissions import _pop_debug_log, has_permission
 
 
 class PermissionInspector(Document):
+	_DOCTYPE_NAME = "Permission Inspector"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/permission_log/permission_log.py
+++ b/frappe/core/doctype/permission_log/permission_log.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class PermissionLog(Document):
+	_DOCTYPE_NAME = "Permission Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/permission_type/permission_type.py
+++ b/frappe/core/doctype/permission_type/permission_type.py
@@ -14,6 +14,8 @@ CUSTOM_FIELD_TARGET = ["Custom DocPerm", "DocPerm", "DocShare"]
 
 
 class PermissionType(Document):
+	_DOCTYPE_NAME = "Permission Type"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -26,6 +26,8 @@ REPORT_TIMEOUT = 25 * 60
 
 
 class PreparedReport(Document):
+	_DOCTYPE_NAME = "Prepared Report"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/recorder/recorder.py
+++ b/frappe/core/doctype/recorder/recorder.py
@@ -16,6 +16,8 @@ from frappe.utils.caching import redis_cache
 
 
 class Recorder(Document):
+	_DOCTYPE_NAME = "Recorder"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/recorder_query/recorder_query.py
+++ b/frappe/core/doctype/recorder_query/recorder_query.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class RecorderQuery(Document):
+	_DOCTYPE_NAME = "Recorder Query"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/recorder_suggested_index/recorder_suggested_index.py
+++ b/frappe/core/doctype/recorder_suggested_index/recorder_suggested_index.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class RecorderSuggestedIndex(Document):
+	_DOCTYPE_NAME = "Recorder Suggested Index"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -19,6 +19,8 @@ from frappe.utils.xlsxutils import XLSXMetadata, XLSXStyleBuilder
 
 
 class Report(Document):
+	_DOCTYPE_NAME = "Report"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/report_column/report_column.py
+++ b/frappe/core/doctype/report_column/report_column.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class ReportColumn(Document):
+	_DOCTYPE_NAME = "Report Column"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/report_filter/report_filter.py
+++ b/frappe/core/doctype/report_filter/report_filter.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class ReportFilter(Document):
+	_DOCTYPE_NAME = "Report Filter"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -11,6 +11,8 @@ STANDARD_ROLES = ("Administrator", "System Manager", "Script Manager", "All", "G
 
 
 class Role(Document):
+	_DOCTYPE_NAME = "Role"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
+++ b/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
@@ -8,6 +8,8 @@ from frappe.permissions import ALL_USER_ROLE
 
 
 class RolePermissionforPageandReport(Document):
+	_DOCTYPE_NAME = "Role Permission for Page and Report"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/role_profile/role_profile.py
+++ b/frappe/core/doctype/role_profile/role_profile.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class RoleProfile(Document):
+	_DOCTYPE_NAME = "Role Profile"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -39,6 +39,8 @@ def check_permissions(method):
 
 
 class RQJob(Document):
+	_DOCTYPE_NAME = "RQ Job"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/rq_worker/rq_worker.py
+++ b/frappe/core/doctype/rq_worker/rq_worker.py
@@ -13,6 +13,8 @@ from frappe.utils.background_jobs import get_workers
 
 
 class RQWorker(Document):
+	_DOCTYPE_NAME = "RQ Worker"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/scheduled_job_log/scheduled_job_log.py
+++ b/frappe/core/doctype/scheduled_job_log/scheduled_job_log.py
@@ -8,6 +8,8 @@ from frappe.query_builder.functions import Now
 
 
 class ScheduledJobLog(Document):
+	_DOCTYPE_NAME = "Scheduled Job Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -19,6 +19,8 @@ parse_cron = lru_cache(croniter)  # Cache parsed cron-expressions
 
 
 class ScheduledJobType(Document):
+	_DOCTYPE_NAME = "Scheduled Job Type"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/scheduler_event/scheduler_event.py
+++ b/frappe/core/doctype/scheduler_event/scheduler_event.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SchedulerEvent(Document):
+	_DOCTYPE_NAME = "Scheduler Event"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/security_settings/security_settings.py
+++ b/frappe/core/doctype/security_settings/security_settings.py
@@ -18,6 +18,8 @@ from frappe.utils import (
 
 
 class SecuritySettings(Document):
+	_DOCTYPE_NAME = "Security Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/security_settings_contact/security_settings_contact.py
+++ b/frappe/core/doctype/security_settings_contact/security_settings_contact.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SecuritySettingsContact(Document):
+	_DOCTYPE_NAME = "Security Settings Contact"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/security_settings_language/security_settings_language.py
+++ b/frappe/core/doctype/security_settings_language/security_settings_language.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SecuritySettingsLanguage(Document):
+	_DOCTYPE_NAME = "Security Settings Language"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
 
 
 class ServerScript(Document):
+	_DOCTYPE_NAME = "Server Script"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/session_default/session_default.py
+++ b/frappe/core/doctype/session_default/session_default.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SessionDefault(Document):
+	_DOCTYPE_NAME = "Session Default"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/session_default_settings/session_default_settings.py
+++ b/frappe/core/doctype/session_default_settings/session_default_settings.py
@@ -10,6 +10,8 @@ from frappe.model.document import Document
 
 
 class SessionDefaultSettings(Document):
+	_DOCTYPE_NAME = "Session Default Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/sms_log/sms_log.py
+++ b/frappe/core/doctype/sms_log/sms_log.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SMSLog(Document):
+	_DOCTYPE_NAME = "SMS Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/sms_parameter/sms_parameter.py
+++ b/frappe/core/doctype/sms_parameter/sms_parameter.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class SMSParameter(Document):
+	_DOCTYPE_NAME = "SMS Parameter"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -8,6 +8,8 @@ from frappe.utils import nowdate
 
 
 class SMSSettings(Document):
+	_DOCTYPE_NAME = "SMS Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/submission_queue/submission_queue.py
+++ b/frappe/core/doctype/submission_queue/submission_queue.py
@@ -15,6 +15,8 @@ from frappe.utils.data import cint
 
 
 class SubmissionQueue(Document):
+	_DOCTYPE_NAME = "Submission Queue"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/success_action/success_action.py
+++ b/frappe/core/doctype/success_action/success_action.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class SuccessAction(Document):
+	_DOCTYPE_NAME = "Success Action"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -10,6 +10,8 @@ from frappe.utils import cint, today
 
 
 class SystemSettings(Document):
+	_DOCTYPE_NAME = "System Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -8,6 +8,8 @@ from frappe.utils import sanitize_html
 
 
 class Translation(Document):
+	_DOCTYPE_NAME = "Translation"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -57,6 +57,8 @@ desk_properties = (
 
 
 class User(Document):
+	_DOCTYPE_NAME = "User"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_document_type/user_document_type.py
+++ b/frappe/core/doctype/user_document_type/user_document_type.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UserDocumentType(Document):
+	_DOCTYPE_NAME = "User Document Type"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_email/user_email.py
+++ b/frappe/core/doctype/user_email/user_email.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class UserEmail(Document):
+	_DOCTYPE_NAME = "User Email"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_group/user_group.py
+++ b/frappe/core/doctype/user_group/user_group.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class UserGroup(Document):
+	_DOCTYPE_NAME = "User Group"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_group_member/user_group_member.py
+++ b/frappe/core/doctype/user_group_member/user_group_member.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UserGroupMember(Document):
+	_DOCTYPE_NAME = "User Group Member"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_invitation/user_invitation.py
+++ b/frappe/core/doctype/user_invitation/user_invitation.py
@@ -9,6 +9,8 @@ from frappe.permissions import get_roles
 
 
 class UserInvitation(Document):
+	_DOCTYPE_NAME = "User Invitation"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -13,6 +13,8 @@ from frappe.utils import cstr
 
 
 class UserPermission(Document):
+	_DOCTYPE_NAME = "User Permission"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_role/user_role.py
+++ b/frappe/core/doctype/user_role/user_role.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UserRole(Document):
+	_DOCTYPE_NAME = "User Role"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_role_profile/user_role_profile.py
+++ b/frappe/core/doctype/user_role_profile/user_role_profile.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UserRoleProfile(Document):
+	_DOCTYPE_NAME = "User Role Profile"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_select_document_type/user_select_document_type.py
+++ b/frappe/core/doctype/user_select_document_type/user_select_document_type.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UserSelectDocumentType(Document):
+	_DOCTYPE_NAME = "User Select Document Type"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_session_display/user_session_display.py
+++ b/frappe/core/doctype/user_session_display/user_session_display.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UserSessionDisplay(Document):
+	_DOCTYPE_NAME = "User Session Display"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_social_login/user_social_login.py
+++ b/frappe/core/doctype/user_social_login/user_social_login.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class UserSocialLogin(Document):
+	_DOCTYPE_NAME = "User Social Login"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -11,6 +11,8 @@ from frappe.utils.modules import get_modules_from_app
 
 
 class UserType(Document):
+	_DOCTYPE_NAME = "User Type"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/user_type_module/user_type_module.py
+++ b/frappe/core/doctype/user_type_module/user_type_module.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UserTypeModule(Document):
+	_DOCTYPE_NAME = "User Type Module"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -13,6 +13,8 @@ FIELDTYPES_TO_IGNORE = frozenset(fieldtype for fieldtype in no_value_fields if f
 
 
 class Version(Document):
+	_DOCTYPE_NAME = "Version"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/core/doctype/view_log/view_log.py
+++ b/frappe/core/doctype/view_log/view_log.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class ViewLog(Document):
+	_DOCTYPE_NAME = "View Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/custom/doctype/client_script/client_script.py
+++ b/frappe/custom/doctype/client_script/client_script.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class ClientScript(Document):
+	_DOCTYPE_NAME = "Client Script"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -14,6 +14,8 @@ from frappe.utils import cstr, random_string
 
 
 class CustomField(Document):
+	_DOCTYPE_NAME = "Custom Field"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -28,6 +28,8 @@ from frappe.utils import cint
 
 
 class CustomizeForm(Document):
+	_DOCTYPE_NAME = "Customize Form"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class CustomizeFormField(Document):
+	_DOCTYPE_NAME = "Customize Form Field"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/custom/doctype/doctype_layout/doctype_layout.py
+++ b/frappe/custom/doctype/doctype_layout/doctype_layout.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 
 class DocTypeLayout(Document):
+	_DOCTYPE_NAME = "DocType Layout"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/custom/doctype/doctype_layout_field/doctype_layout_field.py
+++ b/frappe/custom/doctype/doctype_layout_field/doctype_layout_field.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DocTypeLayoutField(Document):
+	_DOCTYPE_NAME = "DocType Layout Field"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -9,6 +9,8 @@ not_allowed_fieldtype_change = ["naming_series"]
 
 
 class PropertySetter(Document):
+	_DOCTYPE_NAME = "Property Setter"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -12,6 +12,8 @@ from frappe.utils.scheduler import is_scheduler_inactive
 
 
 class BulkUpdate(Document):
+	_DOCTYPE_NAME = "Bulk Update"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/calendar_view/calendar_view.py
+++ b/frappe/desk/doctype/calendar_view/calendar_view.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class CalendarView(Document):
+	_DOCTYPE_NAME = "Calendar View"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/changelog_feed/changelog_feed.py
+++ b/frappe/desk/doctype/changelog_feed/changelog_feed.py
@@ -11,6 +11,8 @@ from frappe.utils.data import add_to_date
 
 
 class ChangelogFeed(Document):
+	_DOCTYPE_NAME = "Changelog Feed"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/console_log/console_log.py
+++ b/frappe/desk/doctype/console_log/console_log.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class ConsoleLog(Document):
+	_DOCTYPE_NAME = "Console Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/custom_html_block/custom_html_block.py
+++ b/frappe/desk/doctype/custom_html_block/custom_html_block.py
@@ -8,6 +8,8 @@ from frappe.utils import has_common
 
 
 class CustomHTMLBlock(Document):
+	_DOCTYPE_NAME = "Custom HTML Block"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -12,6 +12,8 @@ from frappe.utils.modules import get_modules_from_all_apps_for_user
 
 
 class Dashboard(Document):
+	_DOCTYPE_NAME = "Dashboard"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -340,6 +340,8 @@ def get_charts_for_user(
 
 
 class DashboardChart(Document):
+	_DOCTYPE_NAME = "Dashboard Chart"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/dashboard_chart_field/dashboard_chart_field.py
+++ b/frappe/desk/doctype/dashboard_chart_field/dashboard_chart_field.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DashboardChartField(Document):
+	_DOCTYPE_NAME = "Dashboard Chart Field"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/dashboard_chart_link/dashboard_chart_link.py
+++ b/frappe/desk/doctype/dashboard_chart_link/dashboard_chart_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DashboardChartLink(Document):
+	_DOCTYPE_NAME = "Dashboard Chart Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py
+++ b/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.py
@@ -20,6 +20,8 @@ def get_config(name: str) -> str:
 
 
 class DashboardChartSource(Document):
+	_DOCTYPE_NAME = "Dashboard Chart Source"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
@@ -11,6 +11,8 @@ from frappe.model.document import Document
 
 
 class DashboardSettings(Document):
+	_DOCTYPE_NAME = "Dashboard Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -14,6 +14,8 @@ from frappe.modules.utils import create_directory_on_app_path, get_app_level_dir
 
 
 class DesktopIcon(Document):
+	_DOCTYPE_NAME = "Desktop Icon"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/desktop_layout/desktop_layout.py
+++ b/frappe/desk/doctype/desktop_layout/desktop_layout.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 
 
 class DesktopLayout(Document):
+	_DOCTYPE_NAME = "Desktop Layout"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/desktop_settings/desktop_settings.py
+++ b/frappe/desk/doctype/desktop_settings/desktop_settings.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DesktopSettings(Document):
+	_DOCTYPE_NAME = "Desktop Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -48,6 +48,8 @@ if TYPE_CHECKING:
 
 
 class Event(Document):
+	_DOCTYPE_NAME = "Event"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/event_notifications/event_notifications.py
+++ b/frappe/desk/doctype/event_notifications/event_notifications.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class EventNotifications(Document):
+	_DOCTYPE_NAME = "Event Notifications"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/event_participants/event_participants.py
+++ b/frappe/desk/doctype/event_participants/event_participants.py
@@ -4,6 +4,8 @@ from frappe.model.document import Document
 
 
 class EventParticipants(Document):
+	_DOCTYPE_NAME = "Event Participants"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/form_tour/form_tour.py
+++ b/frappe/desk/doctype/form_tour/form_tour.py
@@ -10,6 +10,8 @@ from frappe.modules.export_file import export_to_files
 
 
 class FormTour(Document):
+	_DOCTYPE_NAME = "Form Tour"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/form_tour_step/form_tour_step.py
+++ b/frappe/desk/doctype/form_tour_step/form_tour_step.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class FormTourStep(Document):
+	_DOCTYPE_NAME = "Form Tour Step"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/global_search_doctype/global_search_doctype.py
+++ b/frappe/desk/doctype/global_search_doctype/global_search_doctype.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class GlobalSearchDocType(Document):
+	_DOCTYPE_NAME = "Global Search DocType"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 
 
 class GlobalSearchSettings(Document):
+	_DOCTYPE_NAME = "Global Search Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 
 
 class KanbanBoard(Document):
+	_DOCTYPE_NAME = "Kanban Board"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/kanban_board_column/kanban_board_column.py
+++ b/frappe/desk/doctype/kanban_board_column/kanban_board_column.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class KanbanBoardColumn(Document):
+	_DOCTYPE_NAME = "Kanban Board Column"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/list_filter/list_filter.py
+++ b/frappe/desk/doctype/list_filter/list_filter.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class ListFilter(Document):
+	_DOCTYPE_NAME = "List Filter"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class ListViewSettings(Document):
+	_DOCTYPE_NAME = "List View Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/module_onboarding/module_onboarding.py
+++ b/frappe/desk/doctype/module_onboarding/module_onboarding.py
@@ -8,6 +8,8 @@ from frappe.modules.export_file import export_to_files
 
 
 class ModuleOnboarding(Document):
+	_DOCTYPE_NAME = "Module Onboarding"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -8,6 +8,8 @@ UNSEEN_NOTES_KEY = "unseen_notes::"
 
 
 class Note(Document):
+	_DOCTYPE_NAME = "Note"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/note_seen_by/note_seen_by.py
+++ b/frappe/desk/doctype/note_seen_by/note_seen_by.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class NoteSeenBy(Document):
+	_DOCTYPE_NAME = "Note Seen By"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -12,6 +12,8 @@ from frappe.utils.caching import http_cache
 
 
 class NotificationLog(Document):
+	_DOCTYPE_NAME = "Notification Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class NotificationSettings(Document):
+	_DOCTYPE_NAME = "Notification Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/notification_subscribed_document/notification_subscribed_document.py
+++ b/frappe/desk/doctype/notification_subscribed_document/notification_subscribed_document.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class NotificationSubscribedDocument(Document):
+	_DOCTYPE_NAME = "Notification Subscribed Document"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -18,6 +18,8 @@ from frappe.utils.modules import get_modules_from_all_apps_for_user
 
 
 class NumberCard(Document):
+	_DOCTYPE_NAME = "Number Card"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/number_card_link/number_card_link.py
+++ b/frappe/desk/doctype/number_card_link/number_card_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class NumberCardLink(Document):
+	_DOCTYPE_NAME = "Number Card Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/onboarding_permission/onboarding_permission.py
+++ b/frappe/desk/doctype/onboarding_permission/onboarding_permission.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class OnboardingPermission(Document):
+	_DOCTYPE_NAME = "Onboarding Permission"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.py
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 
 
 class OnboardingStep(Document):
+	_DOCTYPE_NAME = "Onboarding Step"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/onboarding_step_map/onboarding_step_map.py
+++ b/frappe/desk/doctype/onboarding_step_map/onboarding_step_map.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class OnboardingStepMap(Document):
+	_DOCTYPE_NAME = "Onboarding Step Map"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/route_history/route_history.py
+++ b/frappe/desk/doctype/route_history/route_history.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 
 
 class RouteHistory(Document):
+	_DOCTYPE_NAME = "Route History"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/sidebar_item_group/sidebar_item_group.py
+++ b/frappe/desk/doctype/sidebar_item_group/sidebar_item_group.py
@@ -10,6 +10,8 @@ from frappe.modules.utils import create_directory_on_app_path, get_app_level_dir
 
 
 class SidebarItemGroup(Document):
+	_DOCTYPE_NAME = "Sidebar Item Group"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/sidebar_item_group_link/sidebar_item_group_link.py
+++ b/frappe/desk/doctype/sidebar_item_group_link/sidebar_item_group_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SidebarItemGroupLink(Document):
+	_DOCTYPE_NAME = "Sidebar Item Group Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -9,6 +9,8 @@ from frappe.utils.safe_exec import read_sql, safe_exec
 
 
 class SystemConsole(Document):
+	_DOCTYPE_NAME = "System Console"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/system_health_report/system_health_report.py
+++ b/frappe/desk/doctype/system_health_report/system_health_report.py
@@ -71,6 +71,8 @@ def health_check(step: str):
 
 
 class SystemHealthReport(Document):
+	_DOCTYPE_NAME = "System Health Report"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/system_health_report_errors/system_health_report_errors.py
+++ b/frappe/desk/doctype/system_health_report_errors/system_health_report_errors.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SystemHealthReportErrors(Document):
+	_DOCTYPE_NAME = "System Health Report Errors"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/system_health_report_failing_jobs/system_health_report_failing_jobs.py
+++ b/frappe/desk/doctype/system_health_report_failing_jobs/system_health_report_failing_jobs.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SystemHealthReportFailingJobs(Document):
+	_DOCTYPE_NAME = "System Health Report Failing Jobs"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/system_health_report_queue/system_health_report_queue.py
+++ b/frappe/desk/doctype/system_health_report_queue/system_health_report_queue.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SystemHealthReportQueue(Document):
+	_DOCTYPE_NAME = "System Health Report Queue"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/system_health_report_tables/system_health_report_tables.py
+++ b/frappe/desk/doctype/system_health_report_tables/system_health_report_tables.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SystemHealthReportTables(Document):
+	_DOCTYPE_NAME = "System Health Report Tables"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/system_health_report_workers/system_health_report_workers.py
+++ b/frappe/desk/doctype/system_health_report_workers/system_health_report_workers.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SystemHealthReportWorkers(Document):
+	_DOCTYPE_NAME = "System Health Report Workers"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -9,6 +9,8 @@ from frappe.utils import unique
 
 
 class Tag(Document):
+	_DOCTYPE_NAME = "Tag"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/tag_link/tag_link.py
+++ b/frappe/desk/doctype/tag_link/tag_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class TagLink(Document):
+	_DOCTYPE_NAME = "Tag Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -12,6 +12,8 @@ exclude_from_linked_with = True
 
 
 class ToDo(Document):
+	_DOCTYPE_NAME = "ToDo"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -17,6 +17,8 @@ from frappe.utils import strip_html
 
 
 class Workspace(Document):
+	_DOCTYPE_NAME = "Workspace"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_chart/workspace_chart.py
+++ b/frappe/desk/doctype/workspace_chart/workspace_chart.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkspaceChart(Document):
+	_DOCTYPE_NAME = "Workspace Chart"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_custom_block/workspace_custom_block.py
+++ b/frappe/desk/doctype/workspace_custom_block/workspace_custom_block.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkspaceCustomBlock(Document):
+	_DOCTYPE_NAME = "Workspace Custom Block"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_link/workspace_link.py
+++ b/frappe/desk/doctype/workspace_link/workspace_link.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkspaceLink(Document):
+	_DOCTYPE_NAME = "Workspace Link"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_number_card/workspace_number_card.py
+++ b/frappe/desk/doctype/workspace_number_card/workspace_number_card.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkspaceNumberCard(Document):
+	_DOCTYPE_NAME = "Workspace Number Card"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_quick_list/workspace_quick_list.py
+++ b/frappe/desk/doctype/workspace_quick_list/workspace_quick_list.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkspaceQuickList(Document):
+	_DOCTYPE_NAME = "Workspace Quick List"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.py
+++ b/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkspaceShortcut(Document):
+	_DOCTYPE_NAME = "Workspace Shortcut"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
+++ b/frappe/desk/doctype/workspace_sidebar/workspace_sidebar.py
@@ -16,6 +16,8 @@ from frappe.utils.caching import site_cache
 
 
 class WorkspaceSidebar(Document):
+	_DOCTYPE_NAME = "Workspace Sidebar"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
+++ b/frappe/desk/doctype/workspace_sidebar_item/workspace_sidebar_item.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkspaceSidebarItem(Document):
+	_DOCTYPE_NAME = "Workspace Sidebar Item"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -35,6 +35,8 @@ from frappe.utils.xlsxutils import make_xlsx
 
 
 class AutoEmailReport(Document):
+	_DOCTYPE_NAME = "Auto Email Report"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/document_follow/document_follow.py
+++ b/frappe/email/doctype/document_follow/document_follow.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class DocumentFollow(Document):
+	_DOCTYPE_NAME = "Document Follow"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -51,6 +51,8 @@ def cache_email_account(cache_name):
 
 
 class EmailAccount(Document):
+	_DOCTYPE_NAME = "Email Account"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -53,6 +53,8 @@ def handle_error(event):
 
 
 class EmailDomain(Document):
+	_DOCTYPE_NAME = "Email Domain"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_flag_queue/email_flag_queue.py
+++ b/frappe/email/doctype/email_flag_queue/email_flag_queue.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class EmailFlagQueue(Document):
+	_DOCTYPE_NAME = "Email Flag Queue"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -10,6 +10,8 @@ from frappe.utils import parse_addr, validate_email_address
 
 
 class EmailGroup(Document):
+	_DOCTYPE_NAME = "Email Group"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_group_member/email_group_member.py
+++ b/frappe/email/doctype/email_group_member/email_group_member.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class EmailGroupMember(Document):
+	_DOCTYPE_NAME = "Email Group Member"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
 
 
 class EmailQueue(Document):
+	_DOCTYPE_NAME = "Email Queue"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_queue_recipient/email_queue_recipient.py
+++ b/frappe/email/doctype/email_queue_recipient/email_queue_recipient.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class EmailQueueRecipient(Document):
+	_DOCTYPE_NAME = "Email Queue Recipient"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_rule/email_rule.py
+++ b/frappe/email/doctype/email_rule/email_rule.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class EmailRule(Document):
+	_DOCTYPE_NAME = "Email Rule"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_template/email_template.py
+++ b/frappe/email/doctype/email_template/email_template.py
@@ -10,6 +10,8 @@ from frappe.utils.jinja import validate_template
 
 
 class EmailTemplate(Document):
+	_DOCTYPE_NAME = "Email Template"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py
+++ b/frappe/email/doctype/email_unsubscribe/email_unsubscribe.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 
 class EmailUnsubscribe(Document):
+	_DOCTYPE_NAME = "Email Unsubscribe"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/imap_folder/imap_folder.py
+++ b/frappe/email/doctype/imap_folder/imap_folder.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class IMAPFolder(Document):
+	_DOCTYPE_NAME = "IMAP Folder"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -25,6 +25,8 @@ DATE_BASED_EVENTS = frozenset(("Days Before", "Days After"))
 
 
 class Notification(Document):
+	_DOCTYPE_NAME = "Notification"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/notification_recipient/notification_recipient.py
+++ b/frappe/email/doctype/notification_recipient/notification_recipient.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class NotificationRecipient(Document):
+	_DOCTYPE_NAME = "Notification Recipient"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/reply_to_address/reply_to_address.py
+++ b/frappe/email/doctype/reply_to_address/reply_to_address.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class ReplyToAddress(Document):
+	_DOCTYPE_NAME = "Reply To Address"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/email/doctype/unhandled_email/unhandled_email.py
+++ b/frappe/email/doctype/unhandled_email/unhandled_email.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UnhandledEmail(Document):
+	_DOCTYPE_NAME = "Unhandled Email"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/geo/doctype/country/country.py
+++ b/frappe/geo/doctype/country/country.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document, bulk_insert
 
 
 class Country(Document):
+	_DOCTYPE_NAME = "Country"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/geo/doctype/currency/currency.py
+++ b/frappe/geo/doctype/currency/currency.py
@@ -8,6 +8,8 @@ DEFAULT_ENABLED_CURRENCIES = ("INR", "USD", "GBP", "EUR", "AED", "AUD", "JPY", "
 
 
 class Currency(Document):
+	_DOCTYPE_NAME = "Currency"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -20,6 +20,8 @@ os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
 
 
 class ConnectedApp(Document):
+	_DOCTYPE_NAME = "Connected App"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/geolocation_settings/geolocation_settings.py
+++ b/frappe/integrations/doctype/geolocation_settings/geolocation_settings.py
@@ -12,6 +12,8 @@ from .providers.nomatim import Nomatim
 
 
 class GeolocationSettings(Document):
+	_DOCTYPE_NAME = "Geolocation Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -80,6 +80,8 @@ allow_google_calendar_label = _lt("Allow Google Calendar Access")
 
 
 class GoogleCalendar(Document):
+	_DOCTYPE_NAME = "Google Calendar"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/google_contacts/google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.py
@@ -13,6 +13,8 @@ from frappe.model.document import Document
 
 
 class GoogleContacts(Document):
+	_DOCTYPE_NAME = "Google Contacts"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/google_settings/google_settings.py
+++ b/frappe/integrations/doctype/google_settings/google_settings.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class GoogleSettings(Document):
+	_DOCTYPE_NAME = "Google Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/integration_request/integration_request.py
+++ b/frappe/integrations/doctype/integration_request/integration_request.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 
 
 class IntegrationRequest(Document):
+	_DOCTYPE_NAME = "Integration Request"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/ldap_group_mapping/ldap_group_mapping.py
+++ b/frappe/integrations/doctype/ldap_group_mapping/ldap_group_mapping.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class LDAPGroupMapping(Document):
+	_DOCTYPE_NAME = "LDAP Group Mapping"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
 
 class LDAPSettings(Document):
+	_DOCTYPE_NAME = "LDAP Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/oauth_authorization_code/oauth_authorization_code.py
+++ b/frappe/integrations/doctype/oauth_authorization_code/oauth_authorization_code.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class OAuthAuthorizationCode(Document):
+	_DOCTYPE_NAME = "OAuth Authorization Code"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/oauth_bearer_token.py
@@ -9,6 +9,8 @@ from frappe.utils.data import add_to_date
 
 
 class OAuthBearerToken(Document):
+	_DOCTYPE_NAME = "OAuth Bearer Token"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/oauth_client/oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.py
@@ -12,6 +12,8 @@ from frappe.permissions import SYSTEM_USER_ROLE
 
 
 class OAuthClient(Document):
+	_DOCTYPE_NAME = "OAuth Client"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/oauth_client_role/oauth_client_role.py
+++ b/frappe/integrations/doctype/oauth_client_role/oauth_client_role.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class OAuthClientRole(Document):
+	_DOCTYPE_NAME = "OAuth Client Role"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
+++ b/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 
 class OAuthProviderSettings(Document):
+	_DOCTYPE_NAME = "OAuth Provider Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/oauth_scope/oauth_scope.py
+++ b/frappe/integrations/doctype/oauth_scope/oauth_scope.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class OAuthScope(Document):
+	_DOCTYPE_NAME = "OAuth Scope"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/oauth_settings/oauth_settings.py
+++ b/frappe/integrations/doctype/oauth_settings/oauth_settings.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class OAuthSettings(Document):
+	_DOCTYPE_NAME = "OAuth Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 
 class PushNotificationSettings(Document):
+	_DOCTYPE_NAME = "Push Notification Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/query_parameters/query_parameters.py
+++ b/frappe/integrations/doctype/query_parameters/query_parameters.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class QueryParameters(Document):
+	_DOCTYPE_NAME = "Query Parameters"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py
+++ b/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py
@@ -20,6 +20,8 @@ error_messages = {
 
 
 class SlackWebhookURL(Document):
+	_DOCTYPE_NAME = "Slack Webhook URL"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -33,6 +33,8 @@ class ClientSecretNotSetError(frappe.ValidationError):
 
 
 class SocialLoginKey(Document):
+	_DOCTYPE_NAME = "Social Login Key"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/token_cache/token_cache.py
+++ b/frappe/integrations/doctype/token_cache/token_cache.py
@@ -11,6 +11,8 @@ from frappe.utils import cint, cstr, get_datetime, get_system_timezone
 
 
 class TokenCache(Document):
+	_DOCTYPE_NAME = "Token Cache"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -21,6 +21,8 @@ WEBHOOK_SECRET_HEADER = "X-Frappe-Webhook-Signature"
 
 
 class Webhook(Document):
+	_DOCTYPE_NAME = "Webhook"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/webhook_data/webhook_data.py
+++ b/frappe/integrations/doctype/webhook_data/webhook_data.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebhookData(Document):
+	_DOCTYPE_NAME = "Webhook Data"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/webhook_header/webhook_header.py
+++ b/frappe/integrations/doctype/webhook_header/webhook_header.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebhookHeader(Document):
+	_DOCTYPE_NAME = "Webhook Header"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.py
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebhookRequestLog(Document):
+	_DOCTYPE_NAME = "Webhook Request Log"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -88,11 +88,13 @@ class Document(BaseDocument):
 		self._default_new_docs = {}
 		self.flags = frappe._dict()
 
+		_DOCTYPE_NAME = getattr(self.__class__, "_DOCTYPE_NAME", None)
+
 		if args and args[0] and isinstance(args[0], str):
 			# first arugment is doctype
 			if len(args)==1:
-				if hasattr(self.__class__, "_DOCTYPE_NAME"):
-					self.doctype = self.__class__._DOCTYPE_NAME
+				if _DOCTYPE_NAME:
+					self.doctype = _DOCTYPE_NAME
 					self.name = args[0]
 				else:
 					# single
@@ -120,8 +122,8 @@ class Document(BaseDocument):
 				kwargs = args[0]
 
 			# if doctype is not set, use _DOCTYPE_NAME
-			if hasattr(self.__class__, "_DOCTYPE_NAME"):
-				kwargs.setdefault("doctype", self.__class__._DOCTYPE_NAME)
+			if _DOCTYPE_NAME:
+				kwargs.setdefault("doctype", _DOCTYPE_NAME)
 
 			# init base document
 			super(Document, self).__init__(kwargs)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -131,6 +131,14 @@ class Document(BaseDocument):
 			# incorrect arguments. let's not proceed.
 			raise ValueError('Illegal arguments')
 
+	@classmethod
+	def new(cls):
+		if hasattr(cls, "_DOCTYPE_NAME"):
+			new_doc: cls = frappe.new_doc(cls._DOCTYPE_NAME)
+			return new_doc
+		else:
+			frappe.throw(f"_DOCTYPE_NAME not defined in {cls.__name__}")
+
 	@staticmethod
 	def whitelist(fn):
 		"""Decorator: Whitelist method to be called remotely via REST API."""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -139,6 +139,14 @@ class Document(BaseDocument):
 		else:
 			frappe.throw(f"_DOCTYPE_NAME not defined in {cls.__name__}")
 
+	@classmethod
+	def from_cache(cls, name):
+		if hasattr(cls, "_DOCTYPE_NAME"):
+			doc: cls = frappe.get_cached_doc(cls._DOCTYPE_NAME, name)
+			return doc
+		else:
+			frappe.throw(f"_DOCTYPE_NAME not defined in {cls.__name__}")
+
 	@staticmethod
 	def whitelist(fn):
 		"""Decorator: Whitelist method to be called remotely via REST API."""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -127,6 +127,9 @@ class Document(BaseDocument):
 			if _DOCTYPE_NAME:
 				kwargs.setdefault("doctype", _DOCTYPE_NAME)
 
+			if "doctype" not in kwargs:
+				raise ValueError('"doctype" is a required key')
+
 			# init base document
 			super(Document, self).__init__(kwargs)
 			self.init_valid_columns()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -91,8 +91,12 @@ class Document(BaseDocument):
 		if args and args[0] and isinstance(args[0], str):
 			# first arugment is doctype
 			if len(args)==1:
-				# single
-				self.doctype = self.name = args[0]
+				if hasattr(self.__class__, "_DOCTYPE_NAME"):
+					self.doctype = self.__class__._DOCTYPE_NAME
+					self.name = args[0]
+				else:
+					# single
+					self.doctype = self.name = args[0]
 			else:
 				self.doctype = args[0]
 				if isinstance(args[1], dict):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -112,13 +112,13 @@ class Document(BaseDocument):
 					self.flags.for_update = kwargs.get('for_update')
 
 			self.load_from_db()
-			return
 
-		if args and args[0] and isinstance(args[0], dict):
-			# first argument is a dict
-			kwargs = args[0]
+		# create new doc from dict or kwargs.
+		elif (args and args[0] and isinstance(args[0], dict)) or kwargs:
 
-		if kwargs:
+			if args and args[0] and isinstance(args[0], dict):
+				kwargs = args[0]
+
 			# if doctype is not set, use _DOCTYPE_NAME
 			if hasattr(self.__class__, "_DOCTYPE_NAME"):
 				kwargs.setdefault("doctype", self.__class__._DOCTYPE_NAME)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -84,6 +84,8 @@ class Document(BaseDocument):
 		If DocType name and document name are passed, the object will load
 		all values (including child documents) from the database.
 		"""
+		from frappe.model.meta import is_single
+
 		self.doctype = self.name = None
 		self._default_new_docs = {}
 		self.flags = frappe._dict()
@@ -128,6 +130,10 @@ class Document(BaseDocument):
 			# init base document
 			super(Document, self).__init__(kwargs)
 			self.init_valid_columns()
+
+		elif _DOCTYPE_NAME and is_single(_DOCTYPE_NAME):
+			self.doctype = self.name = _DOCTYPE_NAME
+			self.load_from_db()
 
 		else:
 			# incorrect arguments. let's not proceed.

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -119,6 +119,10 @@ class Document(BaseDocument):
 			kwargs = args[0]
 
 		if kwargs:
+			# if doctype is not set, use _DOCTYPE_NAME
+			if hasattr(self.__class__, "_DOCTYPE_NAME"):
+				kwargs.setdefault("doctype", self.__class__._DOCTYPE_NAME)
+
 			# init base document
 			super(Document, self).__init__(kwargs)
 			self.init_valid_columns()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from typing import TypeVar, Type
 import frappe
 import time
 from frappe import _, msgprint, is_whitelisted
@@ -17,8 +18,7 @@ from frappe.desk.form.document_follow import follow_document
 from frappe.core.doctype.server_script.server_script_utils import run_server_script_for_doc_event
 from frappe.utils.data import get_absolute_url
 
-# once_only validation
-# methods
+D = TypeVar('D', bound='Document')
 
 def get_doc(*args, **kwargs):
 	"""returns a frappe.model.Document object.
@@ -132,18 +132,16 @@ class Document(BaseDocument):
 			raise ValueError('Illegal arguments')
 
 	@classmethod
-	def new(cls):
+	def new(cls: Type[D]) -> D:
 		if hasattr(cls, "_DOCTYPE_NAME"):
-			new_doc: cls = frappe.new_doc(cls._DOCTYPE_NAME)
-			return new_doc
+			return frappe.new_doc(cls._DOCTYPE_NAME)
 		else:
 			frappe.throw(f"_DOCTYPE_NAME not defined in {cls.__name__}")
 
 	@classmethod
-	def from_cache(cls, name):
+	def from_cache(cls: Type[D], name: str) -> D:
 		if hasattr(cls, "_DOCTYPE_NAME"):
-			doc: cls = frappe.get_cached_doc(cls._DOCTYPE_NAME, name)
-			return doc
+			return frappe.get_cached_doc(cls._DOCTYPE_NAME, name)
 		else:
 			frappe.throw(f"_DOCTYPE_NAME not defined in {cls.__name__}")
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -143,7 +143,7 @@ class Document(BaseDocument):
 			raise ValueError('Illegal arguments')
 
 	@classmethod
-	def new(cls: Type[D]) -> D:
+	def new_doc(cls: Type[D]) -> D:
 		if hasattr(cls, "_DOCTYPE_NAME"):
 			return frappe.new_doc(cls._DOCTYPE_NAME)
 		else:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -333,6 +333,8 @@ def get_doc_permission_check(doc: "Document", check_permission: str | bool | Non
 class DocsCollection[T]:
 	"""APIs to manage collections of documents."""
 
+	__slots__ = ("_owner_cls",)
+
 	def __set_name__(self, owner: type, name: str) -> None:
 		self._owner_cls = owner
 
@@ -342,7 +344,7 @@ class DocsCollection[T]:
 		bound._owner_cls = owner or self._owner_cls
 		return bound
 
-	@cached_property
+	@property
 	def _doctype(self) -> str:
 		doctype = getattr(self._owner_cls, "_DOCTYPE_NAME", None)
 		if not doctype:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from collections.abc import Generator, Iterable
 from contextlib import contextmanager
-from functools import wraps
+from functools import cached_property, wraps
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Literal, Optional, Self, TypeAlias, Union, overload, override
 
@@ -347,7 +347,7 @@ class DocsCollection[T]:
 		bound._owner_cls = owner or self._owner_cls
 		return bound
 
-	@property
+	@cached_property
 	def _doctype(self) -> str:
 		doctype = getattr(self._owner_cls, "_DOCTYPE_NAME", None)
 		if not doctype:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -359,7 +359,7 @@ class DocsCollection[T]:
 		cached: bool = False,
 		lazy: bool = False,
 		for_update: bool = False,
-		check_permission: str | bool | None = None,
+		check_permission: str | bool | None = None,  # TODO: Default to true?
 	) -> T:
 		"""Fetch a single document of this DocType by name (or filter dict)."""
 		if cached and lazy:
@@ -368,12 +368,11 @@ class DocsCollection[T]:
 		if not isinstance(name, str | int | None):
 			raise ValueError("`name` has to be a string or integer or None.")
 
-		doctype = self._doctype
 		if lazy:
-			return get_lazy_doc(doctype, name, for_update=for_update, check_permission=check_permission)
+			return get_lazy_doc(self._doctype, name, for_update=for_update, check_permission=check_permission)
 		if cached:
-			return get_cached_doc(doctype, name)
-		return get_doc(doctype, name, for_update=for_update, check_permission=check_permission)
+			return get_cached_doc(self._doctype, name)
+		return get_doc(self._doctype, name, for_update=for_update, check_permission=check_permission)
 
 	def last(
 		self,
@@ -413,25 +412,6 @@ class DocsCollection[T]:
 	def new(self, **kwargs) -> T:
 		"""Create a new (unsaved) document with the given field values."""
 		return new_doc(self._doctype, **kwargs)
-
-	def delete(
-		self,
-		name: str | int,
-		*,
-		force: bool = False,
-		ignore_permissions: bool = False,
-		ignore_missing: bool = True,
-		delete_permanently: bool = False,
-	) -> None:
-		"""Delete a document of this DocType."""
-		frappe.delete_doc(
-			self._doctype,
-			name,
-			force=force,
-			ignore_permissions=ignore_permissions,
-			ignore_missing=ignore_missing,
-			delete_permanently=delete_permanently,
-		)
 
 
 class Document(BaseDocument):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -339,6 +339,10 @@ class DocsCollection[T]:
 		self._owner_cls = owner
 
 	def __get__(self, instance, owner: type | None = None) -> "DocsCollection[T]":
+		if instance is not None:
+			raise AttributeError(
+				f"`docs` isn't accessible via {type(instance).__name__} instances; use the class instead."
+			)
 		# Bind the actual accessing class so subclasses report their own doctype.
 		bound = DocsCollection.__new__(DocsCollection)
 		bound._owner_cls = owner or self._owner_cls

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -9,7 +9,7 @@ from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from functools import cached_property, wraps
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, Optional, Self, TypeAlias, Union, overload, override
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional, Self, TypeAlias, Union, overload, override
 
 from werkzeug.exceptions import NotFound
 
@@ -331,12 +331,7 @@ def get_doc_permission_check(doc: "Document", check_permission: str | bool | Non
 
 
 class DocsCollection[T]:
-	"""Class-level descriptor exposing typed, doctype-scoped document operations.
-
-	Accessed as `MyDocType.docs` on any `Document` subclass. The descriptor reads
-	`_DOCTYPE_NAME` from the owning controller class to determine which DocType
-	to operate on, removing the need to pass the doctype string at every call site.
-	"""
+	"""APIs to manage collections of documents."""
 
 	def __set_name__(self, owner: type, name: str) -> None:
 		self._owner_cls = owner
@@ -359,7 +354,7 @@ class DocsCollection[T]:
 
 	def get(
 		self,
-		name: str | int | dict | None = None,
+		name: str | int | None = None,
 		*,
 		cached: bool = False,
 		lazy: bool = False,
@@ -369,6 +364,9 @@ class DocsCollection[T]:
 		"""Fetch a single document of this DocType by name (or filter dict)."""
 		if cached and lazy:
 			raise ValueError("`cached` and `lazy` are mutually exclusive")
+
+		if not isinstance(name, str | int | None):
+			raise ValueError("`name` has to be a string or integer or None.")
 
 		doctype = self._doctype
 		if lazy:
@@ -439,7 +437,7 @@ class DocsCollection[T]:
 class Document(BaseDocument):
 	"""All controllers inherit from `Document`."""
 
-	_DOCTYPE_NAME: str | None = None
+	_DOCTYPE_NAME: ClassVar[str | None] = None
 	docs: "DocsCollection[Self]" = DocsCollection()
 
 	doctype: DF.Data

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -330,8 +330,117 @@ def get_doc_permission_check(doc: "Document", check_permission: str | bool | Non
 	return doc
 
 
+class DocsCollection[T]:
+	"""Class-level descriptor exposing typed, doctype-scoped document operations.
+
+	Accessed as `MyDocType.docs` on any `Document` subclass. The descriptor reads
+	`_DOCTYPE_NAME` from the owning controller class to determine which DocType
+	to operate on, removing the need to pass the doctype string at every call site.
+	"""
+
+	def __set_name__(self, owner: type, name: str) -> None:
+		self._owner_cls = owner
+
+	def __get__(self, instance, owner: type | None = None) -> "DocsCollection[T]":
+		# Bind the actual accessing class so subclasses report their own doctype.
+		bound = DocsCollection.__new__(DocsCollection)
+		bound._owner_cls = owner or self._owner_cls
+		return bound
+
+	@property
+	def _doctype(self) -> str:
+		doctype = getattr(self._owner_cls, "_DOCTYPE_NAME", None)
+		if not doctype:
+			raise AttributeError(
+				f"{self._owner_cls.__name__} does not define `_DOCTYPE_NAME`; "
+				"controller class must declare its DocType name to use `docs`."
+			)
+		return doctype
+
+	def get(
+		self,
+		name: str | int | dict | None = None,
+		*,
+		cached: bool = False,
+		lazy: bool = False,
+		for_update: bool = False,
+		check_permission: str | bool | None = None,
+	) -> T:
+		"""Fetch a single document of this DocType by name (or filter dict)."""
+		if cached and lazy:
+			raise ValueError("`cached` and `lazy` are mutually exclusive")
+
+		doctype = self._doctype
+		if lazy:
+			return get_lazy_doc(doctype, name, for_update=for_update, check_permission=check_permission)
+		if cached:
+			return get_cached_doc(doctype, name)
+		return get_doc(doctype, name, for_update=for_update, check_permission=check_permission)
+
+	def last(
+		self,
+		filters: FilterSignature | None = None,
+		order_by: str = "creation desc",
+		*,
+		for_update: bool = False,
+	) -> T:
+		"""Return the most recently created document, optionally filtered."""
+		return get_last_doc(self._doctype, filters=filters, order_by=order_by, for_update=for_update)
+
+	def filter(
+		self,
+		filters: dict | None = None,
+		*,
+		chunk_size: int = 1000,
+		limit: int | None = None,
+		limit_start: int = 0,
+		order_by: str = "creation asc",
+		as_iterator: bool = False,
+		for_update: bool = False,
+		distinct: bool = False,
+	) -> list[T] | Generator[T]:
+		"""Return all documents matching `filters`."""
+		return get_docs(
+			self._doctype,
+			filters=filters,
+			chunk_size=chunk_size,
+			limit=limit,
+			limit_start=limit_start,
+			order_by=order_by,
+			as_iterator=as_iterator,
+			for_update=for_update,
+			distinct=distinct,
+		)
+
+	def new(self, **kwargs) -> T:
+		"""Create a new (unsaved) document with the given field values."""
+		return new_doc(self._doctype, **kwargs)
+
+	def delete(
+		self,
+		name: str | int,
+		*,
+		force: bool = False,
+		ignore_permissions: bool = False,
+		ignore_missing: bool = True,
+		delete_permanently: bool = False,
+	) -> None:
+		"""Delete a document of this DocType."""
+		frappe.delete_doc(
+			self._doctype,
+			name,
+			force=force,
+			ignore_permissions=ignore_permissions,
+			ignore_missing=ignore_missing,
+			delete_permanently=delete_permanently,
+		)
+
+
 class Document(BaseDocument):
 	"""All controllers inherit from `Document`."""
+
+	_DOCTYPE_NAME: str | None = None
+	docs: "DocsCollection[Self]" = DocsCollection()
 
 	doctype: DF.Data
 	name: DF.Data | None

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -244,7 +244,8 @@ def make_boilerplate(template, doc, opts=None):
 			base_class = 'NestedSet'
 			base_class_import = 'from frappe.utils.nestedset import NestedSet'
 
-		custom_controller = 'pass'
+		custom_controller = f"""_DOCTYPE_NAME = "{doc.name}"
+	pass"""
 		if doc.get('is_virtual'):
 			custom_controller = """
 	def db_insert(self):

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -375,7 +375,7 @@ def make_boilerplate(template: str, doc: "Document" | "frappe._dict", opts: dict
 	app_publisher = get_app_publisher(doc.module)
 	base_class = "Document"
 	base_class_import = "from frappe.model.document import Document"
-	controller_body = "pass"
+	controller_body = f'_DOCTYPE_NAME = "{doc.name}"'
 
 	if doc.get("is_tree"):
 		base_class = "NestedSet"

--- a/frappe/printing/doctype/letter_head/letter_head.py
+++ b/frappe/printing/doctype/letter_head/letter_head.py
@@ -9,6 +9,8 @@ from frappe.utils import flt, is_image
 
 
 class LetterHead(Document):
+	_DOCTYPE_NAME = "Letter Head"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/printing/doctype/network_printer_settings/network_printer_settings.py
+++ b/frappe/printing/doctype/network_printer_settings/network_printer_settings.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 
 class NetworkPrinterSettings(Document):
+	_DOCTYPE_NAME = "Network Printer Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -12,6 +12,8 @@ from frappe.utils.print_format_generator import download_pdf, get_html
 
 
 class PrintFormat(Document):
+	_DOCTYPE_NAME = "Print Format"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/printing/doctype/print_format_field_template/print_format_field_template.py
+++ b/frappe/printing/doctype/print_format_field_template/print_format_field_template.py
@@ -7,6 +7,8 @@ from frappe.model.document import Document
 
 
 class PrintFormatFieldTemplate(Document):
+	_DOCTYPE_NAME = "Print Format Field Template"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/printing/doctype/print_heading/print_heading.py
+++ b/frappe/printing/doctype/print_heading/print_heading.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class PrintHeading(Document):
+	_DOCTYPE_NAME = "Print Heading"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/printing/doctype/print_settings/print_settings.py
+++ b/frappe/printing/doctype/print_settings/print_settings.py
@@ -8,6 +8,8 @@ from frappe.utils import cint
 
 
 class PrintSettings(Document):
+	_DOCTYPE_NAME = "Print Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/printing/doctype/print_style/print_style.py
+++ b/frappe/printing/doctype/print_style/print_style.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class PrintStyle(Document):
+	_DOCTYPE_NAME = "Print Style"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -911,3 +911,135 @@ class TestGetDocs(IntegrationTestCase):
 	def test_for_update_sets_flag(self):
 		docs = frappe.get_docs(self.parent_dt, limit=1, for_update=True)
 		self.assertTrue(docs[0].flags.for_update)
+
+
+class TestDocsCollection(IntegrationTestCase):
+	"""Tests for the `DocsCollection` descriptor on `Document` subclasses.
+
+	The descriptor exposes typed, doctype-scoped helpers (`.docs.get`,
+	`.docs.last`, `.docs.filter`, `.docs.new`, `.docs.delete`) on any
+	controller class that declares `_DOCTYPE_NAME`.
+	"""
+
+	def test_doctype_resolved_from_controller(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		self.assertEqual(ToDo.docs._doctype, "ToDo")
+
+	def test_get_returns_document(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get test"}).insert()
+		try:
+			fetched = ToDo.docs.get(todo.name)
+			self.assertIsInstance(fetched, ToDo)
+			self.assertEqual(fetched.name, todo.name)
+			self.assertEqual(fetched.description, "docs.get test")
+		finally:
+			todo.delete()
+
+	def test_get_cached(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get cached"}).insert()
+		try:
+			cached = ToDo.docs.get(todo.name, cached=True)
+			self.assertEqual(cached.name, todo.name)
+			# Second call should return the same cached object.
+			cached2 = ToDo.docs.get(todo.name, cached=True)
+			self.assertIs(cached, cached2)
+		finally:
+			todo.delete()
+
+	def test_get_lazy(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get lazy"}).insert()
+		try:
+			lazy = ToDo.docs.get(todo.name, lazy=True)
+			self.assertEqual(lazy.name, todo.name)
+		finally:
+			todo.delete()
+
+	def test_get_cached_and_lazy_are_exclusive(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		with self.assertRaises(ValueError):
+			ToDo.docs.get("dummy", cached=True, lazy=True)
+
+	def test_new_creates_unsaved_document(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		todo = ToDo.docs.new(description="docs.new test")
+		try:
+			self.assertIsInstance(todo, ToDo)
+			self.assertEqual(todo.doctype, "ToDo")
+			self.assertEqual(todo.description, "docs.new test")
+			self.assertTrue(todo.get("__islocal"))
+		finally:
+			if not todo.get("__islocal"):
+				todo.delete()
+
+	def test_last_returns_most_recent(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		marker = f"docs.last marker {frappe.generate_hash(length=8)}"
+		first = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert()
+		second = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert()
+		try:
+			last = ToDo.docs.last({"description": marker})
+			self.assertEqual(last.name, second.name)
+		finally:
+			first.delete()
+			second.delete()
+
+	def test_filter_returns_matching_documents(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		marker = f"docs.filter marker {frappe.generate_hash(length=8)}"
+		created = [frappe.get_doc({"doctype": "ToDo", "description": marker}).insert() for _ in range(3)]
+		try:
+			docs = ToDo.docs.filter({"description": marker})
+			self.assertEqual(len(docs), 3)
+			names = {d.name for d in docs}
+			self.assertEqual(names, {d.name for d in created})
+			self.assertTrue(all(isinstance(d, ToDo) for d in docs))
+		finally:
+			for d in created:
+				d.delete()
+
+	def test_delete_removes_document(self):
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.delete test"}).insert()
+		ToDo.docs.delete(todo.name)
+		self.assertFalse(frappe.db.exists("ToDo", todo.name))
+
+	def test_rename_via_instance(self):
+		from frappe.core.doctype.doctype.test_doctype import new_doctype
+
+		dt = new_doctype(autoname="prompt").insert().name
+		try:
+			doc = frappe.get_doc({"doctype": dt, "name": "ALPHA", "some_fieldname": "x"}).insert()
+			doc.rename("BETA")
+			self.assertTrue(frappe.db.exists(dt, "BETA"))
+			self.assertFalse(frappe.db.exists(dt, "ALPHA"))
+		finally:
+			frappe.delete_doc("DocType", dt, force=True)
+
+	def test_subclass_uses_its_own_doctype(self):
+		"""Subclasses with their own `_DOCTYPE_NAME` resolve independently."""
+		from frappe.desk.doctype.note.note import Note
+		from frappe.desk.doctype.todo.todo import ToDo
+
+		self.assertEqual(ToDo.docs._doctype, "ToDo")
+		self.assertEqual(Note.docs._doctype, "Note")
+
+	def test_missing_doctype_name_raises(self):
+		from frappe.model.document import Document
+
+		class Orphan(Document):
+			pass
+
+		with self.assertRaises(AttributeError):
+			Orphan.docs._doctype

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -987,3 +987,8 @@ class TestDocsCollection(IntegrationTestCase):
 
 		with self.assertRaises(AttributeError):
 			Orphan.docs._doctype
+
+	def test_not_accessible_via_instances(self):
+		todo = ToDo.docs.new(description="docs instance access")
+		with self.assertRaises(AttributeError):
+			todo.docs

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -921,6 +921,10 @@ class TestDocsCollection(IntegrationTestCase):
 	controller class that declares `_DOCTYPE_NAME`.
 	"""
 
+	def tearDown(self):
+		frappe.db.rollback()
+		return super().tearDown()
+
 	def test_doctype_resolved_from_controller(self):
 		from frappe.desk.doctype.todo.todo import ToDo
 
@@ -930,36 +934,27 @@ class TestDocsCollection(IntegrationTestCase):
 		from frappe.desk.doctype.todo.todo import ToDo
 
 		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get test"}).insert()
-		try:
-			fetched = ToDo.docs.get(todo.name)
-			self.assertIsInstance(fetched, ToDo)
-			self.assertEqual(fetched.name, todo.name)
-			self.assertEqual(fetched.description, "docs.get test")
-		finally:
-			todo.delete()
+		fetched = ToDo.docs.get(todo.name)
+		self.assertIsInstance(fetched, ToDo)
+		self.assertEqual(fetched.name, todo.name)
+		self.assertEqual(fetched.description, "docs.get test")
 
 	def test_get_cached(self):
 		from frappe.desk.doctype.todo.todo import ToDo
 
 		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get cached"}).insert()
-		try:
-			cached = ToDo.docs.get(todo.name, cached=True)
-			self.assertEqual(cached.name, todo.name)
-			# Second call should return the same cached object.
-			cached2 = ToDo.docs.get(todo.name, cached=True)
-			self.assertIs(cached, cached2)
-		finally:
-			todo.delete()
+		cached = ToDo.docs.get(todo.name, cached=True)
+		self.assertEqual(cached.name, todo.name)
+		# Second call should return the same cached object.
+		cached2 = ToDo.docs.get(todo.name, cached=True)
+		self.assertIs(cached, cached2)
 
 	def test_get_lazy(self):
 		from frappe.desk.doctype.todo.todo import ToDo
 
 		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get lazy"}).insert()
-		try:
-			lazy = ToDo.docs.get(todo.name, lazy=True)
-			self.assertEqual(lazy.name, todo.name)
-		finally:
-			todo.delete()
+		lazy = ToDo.docs.get(todo.name, lazy=True)
+		self.assertEqual(lazy.name, todo.name)
 
 	def test_get_cached_and_lazy_are_exclusive(self):
 		from frappe.desk.doctype.todo.todo import ToDo
@@ -971,42 +966,30 @@ class TestDocsCollection(IntegrationTestCase):
 		from frappe.desk.doctype.todo.todo import ToDo
 
 		todo = ToDo.docs.new(description="docs.new test")
-		try:
-			self.assertIsInstance(todo, ToDo)
-			self.assertEqual(todo.doctype, "ToDo")
-			self.assertEqual(todo.description, "docs.new test")
-			self.assertTrue(todo.get("__islocal"))
-		finally:
-			if not todo.get("__islocal"):
-				todo.delete()
+		self.assertIsInstance(todo, ToDo)
+		self.assertEqual(todo.doctype, "ToDo")
+		self.assertEqual(todo.description, "docs.new test")
+		self.assertTrue(todo.get("__islocal"))
 
 	def test_last_returns_most_recent(self):
 		from frappe.desk.doctype.todo.todo import ToDo
 
 		marker = f"docs.last marker {frappe.generate_hash(length=8)}"
-		first = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert()
+		_ = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert()
 		second = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert()
-		try:
-			last = ToDo.docs.last({"description": marker})
-			self.assertEqual(last.name, second.name)
-		finally:
-			first.delete()
-			second.delete()
+		last = ToDo.docs.last({"description": marker})
+		self.assertEqual(last.name, second.name)
 
 	def test_filter_returns_matching_documents(self):
 		from frappe.desk.doctype.todo.todo import ToDo
 
 		marker = f"docs.filter marker {frappe.generate_hash(length=8)}"
 		created = [frappe.get_doc({"doctype": "ToDo", "description": marker}).insert() for _ in range(3)]
-		try:
-			docs = ToDo.docs.filter({"description": marker})
-			self.assertEqual(len(docs), 3)
-			names = {d.name for d in docs}
-			self.assertEqual(names, {d.name for d in created})
-			self.assertTrue(all(isinstance(d, ToDo) for d in docs))
-		finally:
-			for d in created:
-				d.delete()
+		docs = ToDo.docs.filter({"description": marker})
+		self.assertEqual(len(docs), 3)
+		names = {d.name for d in docs}
+		self.assertEqual(names, {d.name for d in created})
+		self.assertTrue(all(isinstance(d, ToDo) for d in docs))
 
 	def test_delete_removes_document(self):
 		from frappe.desk.doctype.todo.todo import ToDo
@@ -1019,13 +1002,10 @@ class TestDocsCollection(IntegrationTestCase):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
 		dt = new_doctype(autoname="prompt").insert().name
-		try:
-			doc = frappe.get_doc({"doctype": dt, "name": "ALPHA", "some_fieldname": "x"}).insert()
-			doc.rename("BETA")
-			self.assertTrue(frappe.db.exists(dt, "BETA"))
-			self.assertFalse(frappe.db.exists(dt, "ALPHA"))
-		finally:
-			frappe.delete_doc("DocType", dt, force=True)
+		doc = frappe.get_doc({"doctype": dt, "name": "ALPHA", "some_fieldname": "x"}).insert()
+		doc.rename("BETA")
+		self.assertTrue(frappe.db.exists(dt, "BETA"))
+		self.assertFalse(frappe.db.exists(dt, "ALPHA"))
 
 	def test_subclass_uses_its_own_doctype(self):
 		"""Subclasses with their own `_DOCTYPE_NAME` resolve independently."""

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -11,7 +11,8 @@ from frappe.app import make_form_dict
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.doctype.user.user import User
 from frappe.desk.doctype.note.note import Note
-from frappe.model.document import LazyChildTable
+from frappe.desk.doctype.todo.todo import ToDo
+from frappe.model.document import Document, LazyChildTable
 from frappe.model.naming import make_autoname, parse_naming_series, revert_series_if_last
 from frappe.tests import IntegrationTestCase
 from frappe.utils import cint, now_datetime, set_request
@@ -926,23 +927,17 @@ class TestDocsCollection(IntegrationTestCase):
 		return super().tearDown()
 
 	def test_doctype_resolved_from_controller(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
 		self.assertEqual(ToDo.docs._doctype, "ToDo")
 
 	def test_get_returns_document(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
-		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get test"}).insert()
+		todo = ToDo.docs.new(description="docs.get test").insert()
 		fetched = ToDo.docs.get(todo.name)
 		self.assertIsInstance(fetched, ToDo)
 		self.assertEqual(fetched.name, todo.name)
 		self.assertEqual(fetched.description, "docs.get test")
 
 	def test_get_cached(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
-		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get cached"}).insert()
+		todo = ToDo.docs.new(description="docs.get cached").insert()
 		cached = ToDo.docs.get(todo.name, cached=True)
 		self.assertEqual(cached.name, todo.name)
 		# Second call should return the same cached object.
@@ -950,21 +945,15 @@ class TestDocsCollection(IntegrationTestCase):
 		self.assertIs(cached, cached2)
 
 	def test_get_lazy(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
-		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.get lazy"}).insert()
+		todo = ToDo.docs.new(description="docs.get lazy").insert()
 		lazy = ToDo.docs.get(todo.name, lazy=True)
 		self.assertEqual(lazy.name, todo.name)
 
 	def test_get_cached_and_lazy_are_exclusive(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
 		with self.assertRaises(ValueError):
 			ToDo.docs.get("dummy", cached=True, lazy=True)
 
 	def test_new_creates_unsaved_document(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
 		todo = ToDo.docs.new(description="docs.new test")
 		self.assertIsInstance(todo, ToDo)
 		self.assertEqual(todo.doctype, "ToDo")
@@ -972,52 +961,27 @@ class TestDocsCollection(IntegrationTestCase):
 		self.assertTrue(todo.get("__islocal"))
 
 	def test_last_returns_most_recent(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
 		marker = f"docs.last marker {frappe.generate_hash(length=8)}"
-		_ = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert()
-		second = frappe.get_doc({"doctype": "ToDo", "description": marker}).insert()
+		_ = ToDo.docs.new(description=marker).insert()
+		second = ToDo.docs.new(description=marker).insert()
 		last = ToDo.docs.last({"description": marker})
 		self.assertEqual(last.name, second.name)
 
 	def test_filter_returns_matching_documents(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
 		marker = f"docs.filter marker {frappe.generate_hash(length=8)}"
-		created = [frappe.get_doc({"doctype": "ToDo", "description": marker}).insert() for _ in range(3)]
+		created = [ToDo.docs.new(description=marker).insert() for _ in range(3)]
 		docs = ToDo.docs.filter({"description": marker})
 		self.assertEqual(len(docs), 3)
 		names = {d.name for d in docs}
 		self.assertEqual(names, {d.name for d in created})
 		self.assertTrue(all(isinstance(d, ToDo) for d in docs))
 
-	def test_delete_removes_document(self):
-		from frappe.desk.doctype.todo.todo import ToDo
-
-		todo = frappe.get_doc({"doctype": "ToDo", "description": "docs.delete test"}).insert()
-		ToDo.docs.delete(todo.name)
-		self.assertFalse(frappe.db.exists("ToDo", todo.name))
-
-	def test_rename_via_instance(self):
-		from frappe.core.doctype.doctype.test_doctype import new_doctype
-
-		dt = new_doctype(autoname="prompt").insert().name
-		doc = frappe.get_doc({"doctype": dt, "name": "ALPHA", "some_fieldname": "x"}).insert()
-		doc.rename("BETA")
-		self.assertTrue(frappe.db.exists(dt, "BETA"))
-		self.assertFalse(frappe.db.exists(dt, "ALPHA"))
-
 	def test_subclass_uses_its_own_doctype(self):
 		"""Subclasses with their own `_DOCTYPE_NAME` resolve independently."""
-		from frappe.desk.doctype.note.note import Note
-		from frappe.desk.doctype.todo.todo import ToDo
-
 		self.assertEqual(ToDo.docs._doctype, "ToDo")
 		self.assertEqual(Note.docs._doctype, "Note")
 
 	def test_missing_doctype_name_raises(self):
-		from frappe.model.document import Document
-
 		class Orphan(Document):
 			pass
 

--- a/frappe/website/doctype/about_us_settings/about_us_settings.py
+++ b/frappe/website/doctype/about_us_settings/about_us_settings.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class AboutUsSettings(Document):
+	_DOCTYPE_NAME = "About Us Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/about_us_team_member/about_us_team_member.py
+++ b/frappe/website/doctype/about_us_team_member/about_us_team_member.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class AboutUsTeamMember(Document):
+	_DOCTYPE_NAME = "About Us Team Member"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/color/color.py
+++ b/frappe/website/doctype/color/color.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class Color(Document):
+	_DOCTYPE_NAME = "Color"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/company_history/company_history.py
+++ b/frappe/website/doctype/company_history/company_history.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class CompanyHistory(Document):
+	_DOCTYPE_NAME = "Company History"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/contact_us_settings/contact_us_settings.py
+++ b/frappe/website/doctype/contact_us_settings/contact_us_settings.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class ContactUsSettings(Document):
+	_DOCTYPE_NAME = "Contact Us Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/discussion_reply/discussion_reply.py
+++ b/frappe/website/doctype/discussion_reply/discussion_reply.py
@@ -7,6 +7,8 @@ from frappe.realtime import get_website_room
 
 
 class DiscussionReply(Document):
+	_DOCTYPE_NAME = "Discussion Reply"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/discussion_topic/discussion_topic.py
+++ b/frappe/website/doctype/discussion_topic/discussion_topic.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class DiscussionTopic(Document):
+	_DOCTYPE_NAME = "Discussion Topic"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/help_article/help_article.py
+++ b/frappe/website/doctype/help_article/help_article.py
@@ -10,6 +10,8 @@ from frappe.website.website_generator import WebsiteGenerator
 
 
 class HelpArticle(WebsiteGenerator):
+	_DOCTYPE_NAME = "Help Article"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/help_category/help_category.py
+++ b/frappe/website/doctype/help_category/help_category.py
@@ -7,6 +7,8 @@ from frappe.website.website_generator import WebsiteGenerator
 
 
 class HelpCategory(WebsiteGenerator):
+	_DOCTYPE_NAME = "Help Category"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -15,6 +15,8 @@ from frappe.utils.verified_command import get_signed_params, verify_request
 
 
 class PersonalDataDeletionRequest(Document):
+	_DOCTYPE_NAME = "Personal Data Deletion Request"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/personal_data_deletion_step/personal_data_deletion_step.py
+++ b/frappe/website/doctype/personal_data_deletion_step/personal_data_deletion_step.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class PersonalDataDeletionStep(Document):
+	_DOCTYPE_NAME = "Personal Data Deletion Step"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/personal_data_download_request.py
@@ -10,6 +10,8 @@ from frappe.utils.verified_command import get_signed_params
 
 
 class PersonalDataDownloadRequest(Document):
+	_DOCTYPE_NAME = "Personal Data Download Request"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/portal_menu_item/portal_menu_item.py
+++ b/frappe/website/doctype/portal_menu_item/portal_menu_item.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class PortalMenuItem(Document):
+	_DOCTYPE_NAME = "Portal Menu Item"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/portal_settings/portal_settings.py
+++ b/frappe/website/doctype/portal_settings/portal_settings.py
@@ -7,6 +7,8 @@ from frappe.website.path_resolver import validate_path
 
 
 class PortalSettings(Document):
+	_DOCTYPE_NAME = "Portal Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/social_link_settings/social_link_settings.py
+++ b/frappe/website/doctype/social_link_settings/social_link_settings.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class SocialLinkSettings(Document):
+	_DOCTYPE_NAME = "Social Link Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/top_bar_item/top_bar_item.py
+++ b/frappe/website/doctype/top_bar_item/top_bar_item.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class TopBarItem(Document):
+	_DOCTYPE_NAME = "Top Bar Item"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/utm_campaign/utm_campaign.py
+++ b/frappe/website/doctype/utm_campaign/utm_campaign.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UTMCampaign(Document):
+	_DOCTYPE_NAME = "UTM Campaign"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/utm_medium/utm_medium.py
+++ b/frappe/website/doctype/utm_medium/utm_medium.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UTMMedium(Document):
+	_DOCTYPE_NAME = "UTM Medium"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/utm_source/utm_source.py
+++ b/frappe/website/doctype/utm_source/utm_source.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class UTMSource(Document):
+	_DOCTYPE_NAME = "UTM Source"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -22,6 +22,8 @@ from frappe.website.website_generator import WebsiteGenerator
 
 
 class WebForm(WebsiteGenerator):
+	_DOCTYPE_NAME = "Web Form"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_form_field/web_form_field.py
+++ b/frappe/website/doctype/web_form_field/web_form_field.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebFormField(Document):
+	_DOCTYPE_NAME = "Web Form Field"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_form_list_column/web_form_list_column.py
+++ b/frappe/website/doctype/web_form_list_column/web_form_list_column.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebFormListColumn(Document):
+	_DOCTYPE_NAME = "Web Form List Column"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -25,6 +25,8 @@ H_TAG_PATTERN = re.compile("<h.>")
 
 
 class WebPage(WebsiteGenerator):
+	_DOCTYPE_NAME = "Web Page"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_page_block/web_page_block.py
+++ b/frappe/website/doctype/web_page_block/web_page_block.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebPageBlock(Document):
+	_DOCTYPE_NAME = "Web Page Block"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_page_view/web_page_view.py
+++ b/frappe/website/doctype/web_page_view/web_page_view.py
@@ -10,6 +10,8 @@ from frappe.utils.caching import redis_cache
 
 
 class WebPageView(Document):
+	_DOCTYPE_NAME = "Web Page View"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -12,6 +12,8 @@ from frappe.website.utils import clear_cache
 
 
 class WebTemplate(Document):
+	_DOCTYPE_NAME = "Web Template"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/web_template_field/web_template_field.py
+++ b/frappe/website/doctype/web_template_field/web_template_field.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebTemplateField(Document):
+	_DOCTYPE_NAME = "Web Template Field"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_meta_tag/website_meta_tag.py
+++ b/frappe/website/doctype/website_meta_tag/website_meta_tag.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebsiteMetaTag(Document):
+	_DOCTYPE_NAME = "Website Meta Tag"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_route_meta/website_route_meta.py
+++ b/frappe/website/doctype/website_route_meta/website_route_meta.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class WebsiteRouteMeta(Document):
+	_DOCTYPE_NAME = "Website Route Meta"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_route_redirect/website_route_redirect.py
+++ b/frappe/website/doctype/website_route_redirect/website_route_redirect.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebsiteRouteRedirect(Document):
+	_DOCTYPE_NAME = "Website Route Redirect"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_script/website_script.py
+++ b/frappe/website/doctype/website_script/website_script.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class WebsiteScript(Document):
+	_DOCTYPE_NAME = "Website Script"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -11,6 +11,8 @@ from frappe.website.utils import get_boot_data
 
 
 class WebsiteSettings(Document):
+	_DOCTYPE_NAME = "Website Settings"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_sidebar/website_sidebar.py
+++ b/frappe/website/doctype/website_sidebar/website_sidebar.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebsiteSidebar(Document):
+	_DOCTYPE_NAME = "Website Sidebar"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_sidebar_item/website_sidebar_item.py
+++ b/frappe/website/doctype/website_sidebar_item/website_sidebar_item.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebsiteSidebarItem(Document):
+	_DOCTYPE_NAME = "Website Sidebar Item"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_slideshow/website_slideshow.py
+++ b/frappe/website/doctype/website_slideshow/website_slideshow.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 
 
 class WebsiteSlideshow(Document):
+	_DOCTYPE_NAME = "Website Slideshow"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_slideshow_item/website_slideshow_item.py
+++ b/frappe/website/doctype/website_slideshow_item/website_slideshow_item.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 
 
 class WebsiteSlideshowItem(Document):
+	_DOCTYPE_NAME = "Website Slideshow Item"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -13,6 +13,8 @@ from frappe.model.document import Document
 
 
 class WebsiteTheme(Document):
+	_DOCTYPE_NAME = "Website Theme"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/website/doctype/website_theme_ignore_app/website_theme_ignore_app.py
+++ b/frappe/website/doctype/website_theme_ignore_app/website_theme_ignore_app.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WebsiteThemeIgnoreApp(Document):
+	_DOCTYPE_NAME = "Website Theme Ignore App"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -9,6 +9,8 @@ from frappe.utils import cint
 
 
 class Workflow(Document):
+	_DOCTYPE_NAME = "Workflow"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -26,6 +26,8 @@ from frappe.utils.verified_command import get_signed_params, verify_request
 
 
 class WorkflowAction(Document):
+	_DOCTYPE_NAME = "Workflow Action"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_action_master/workflow_action_master.py
+++ b/frappe/workflow/doctype/workflow_action_master/workflow_action_master.py
@@ -5,6 +5,8 @@ from frappe.model.document import Document
 
 
 class WorkflowActionMaster(Document):
+	_DOCTYPE_NAME = "Workflow Action Master"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_action_permitted_role/workflow_action_permitted_role.py
+++ b/frappe/workflow/doctype/workflow_action_permitted_role/workflow_action_permitted_role.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkflowActionPermittedRole(Document):
+	_DOCTYPE_NAME = "Workflow Action Permitted Role"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkflowDocumentState(Document):
+	_DOCTYPE_NAME = "Workflow Document State"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_state/workflow_state.py
+++ b/frappe/workflow/doctype/workflow_state/workflow_state.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkflowState(Document):
+	_DOCTYPE_NAME = "Workflow State"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.py
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkflowTransition(Document):
+	_DOCTYPE_NAME = "Workflow Transition"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
+++ b/frappe/workflow/doctype/workflow_transition_task/workflow_transition_task.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkflowTransitionTask(Document):
+	_DOCTYPE_NAME = "Workflow Transition Task"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.py
+++ b/frappe/workflow/doctype/workflow_transition_tasks/workflow_transition_tasks.py
@@ -6,6 +6,8 @@ from frappe.model.document import Document
 
 
 class WorkflowTransitionTasks(Document):
+	_DOCTYPE_NAME = "Workflow Transition Tasks"
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 


### PR DESCRIPTION
This PR adds a way to directly initialize a document by using the controller class. Makes some progress towards https://github.com/frappe/frappe/issues/39482.

This won't be ported to v16 as we'd eventually want subtle breaking changes. 



| Old way                                            | New way                                    | Comment                                   |
| ---                                                | ---                                        | ---                                       |
| `frappe.get_doc("ToDo", "T-001")`                  | `ToDo.docs.get("T-001")`                   | Get doc by name                           |
| `frappe.get_last_doc("ToDo")`                      | `ToDo.docs.last()`                         | Get last doc                              |
| `frappe.get_doc("ToDo", {"reference_doc": "ABC"})` | `ToDo.docs.last({"reference_doc": "ABC"})` | Get doc by filter (explicit)              |
| `frappe.get_docs("ToDo", {"status": "Open"})`      | `ToDo.docs.filter({"status": "Open"})`     | Get multiple docs efficiently.            |
| `frappe.new_doc("ToDo", {"status": "Open"})`       | `ToDo.docs.new(status="Open")`             | Create a document explicitly              |
| `frappe.get_cached_doc("ToDo", "T-001")`           | `ToDo.docs.get("T-001", cached=True)`      | Get redis cached version                  |
| `frappe.get_lazy_doc("ToDo", "T-001")`             | `ToDo.docs.get("T-001", lazy=True)`        | Get lazy document                         |
| `frappe.delete_doc("ToDo", "T-001")`               | `ToDo.get("T-001").delete()`                | delete document                           |
| `frappe.rename_doc("ToDo", "T-001", "T-002")`      | `ToDo.docs.get("T-001").rename("T-002")`   | rename document                           |



See commits that migrate `desk` module to evaluate how this change "feels".