### PR TITLE
fix: DeprecationWarning: invalid escape sequence \<

### DIFF
--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -34,10 +34,10 @@ def get_context(context):
 	boot_json = frappe.as_json(boot)
 
 	# remove script tags from boot
-	boot_json = re.sub("\<script[^<]*\</script\>", "", boot_json)
+	boot_json = re.sub(r"\<script[^<]*\</script\>", "", boot_json)
 
 	# TODO: Find better fix
-	boot_json = re.sub("</script\>", "", boot_json)
+	boot_json = re.sub(r"</script\>", "", boot_json)
 
 	context.update({
 		"no_cache": 1,


### PR DESCRIPTION
Python 3 interprets string literals as Unicode strings, and therefore your \< and \> are treated as an escaped Unicode character.

Declare your RegEx pattern as a raw string instead by prepending r

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
