### PR TITLE
fix: Handle fieldname conflicts in Custom Reports

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -498,12 +498,17 @@ def add_total_row(result, columns, meta=None):
 
 
 @frappe.whitelist()
-def get_data_for_custom_field(doctype, field):
+def get_data_for_custom_field(doctype, fieldname, field=None):
 
 	if not frappe.has_permission(doctype, "read"):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 
-	value_map = frappe._dict(frappe.get_all(doctype, fields=["name", field], as_list=1))
+	if field:
+		custom_field = field + " as " + fieldname
+	else:
+		custom_field = fieldname
+
+	value_map = frappe._dict(frappe.get_all(doctype, fields=["name", custom_field], as_list=1))
 
 	return value_map
 
@@ -515,8 +520,9 @@ def get_data_for_custom_report(columns):
 		if column.get("link_field"):
 			fieldname = column.get("fieldname")
 			doctype = column.get("doctype")
+			field = column.get("field")
 			doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(
-				doctype, fieldname
+				doctype, fieldname, field
 			)
 
 	return doc_field_value_map

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1507,7 +1507,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							const insert_after_index = this.columns
 								.findIndex(column => column.label === values.insert_after);
 
-							let fieldname = this.get_fieldname_for_column(df.fieldname);
+							let fieldname = this.get_fieldname_for_column(df.fieldname, values.doctype);
 
 							custom_columns.push({
 								fieldname: fieldname,
@@ -1607,16 +1607,16 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 	}
 
-	get_fieldname_for_column(fieldname) {
+	get_fieldname_for_column(fieldname, doctype) {
 		// check if fieldname already used for any other column
 		let existing_fieldnames = [];
 		this.columns.forEach(column => {
 			existing_fieldnames.push(column.fieldname);
 		});
 
-		// Append random string after fieldname to avoid conflict
+		// Append doctype after fieldname to avoid conflict
 		if (existing_fieldnames.includes(fieldname)) {
-			fieldname = fieldname + Math.random().toString(36).substring(2, 15);
+			fieldname = fieldname + cstr(doctype);
 		}
 
 		return fieldname;

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1506,8 +1506,12 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							let df = frappe.meta.get_docfield(values.doctype, values.field);
 							const insert_after_index = this.columns
 								.findIndex(column => column.label === values.insert_after);
+
+							let fieldname = this.get_fieldname_for_column(df.fieldname)
+
 							custom_columns.push({
-								fieldname: df.fieldname,
+								fieldname: fieldname,
+								field: values.field,
 								fieldtype: df.fieldtype,
 								label: df.label,
 								insert_after_index: insert_after_index,
@@ -1521,14 +1525,14 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							frappe.call({
 								method: 'frappe.desk.query_report.get_data_for_custom_field',
 								args: {
-									field: values.field,
-									doctype: values.doctype
+									doctype: values.doctype,
+									fieldname: fieldname,
+									field: values.field
 								},
 								callback: (r) => {
 									const custom_data = r.message;
 									const link_field = this.doctype_field_map[values.doctype];
-
-									this.add_custom_column(custom_columns, custom_data, link_field, values.field, insert_after_index);
+									this.add_custom_column(custom_columns, custom_data, link_field, fieldname, insert_after_index);
 									d.hide();
 								}
 							});
@@ -1601,6 +1605,21 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				dialog.set_df_property('orientation', 'description', description);
 			});
 		}
+	}
+
+	get_fieldname_for_column(fieldname) {
+		// check if fieldname already used for any other column
+		let existing_fieldnames = [];
+		this.columns.forEach(column => {
+			existing_fieldnames.push(column.fieldname);
+		});
+
+		// Append random string after fieldname to avoid conflict
+		if (existing_fieldnames.includes(fieldname)) {
+			fieldname = fieldname + Math.random().toString(36).substring(2, 15);
+		}
+
+		return fieldname;
 	}
 
 	add_custom_column(custom_column, custom_data, link_field, column_field, insert_after_index) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1616,7 +1616,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 		// Append doctype after fieldname to avoid conflict
 		if (existing_fieldnames.includes(fieldname)) {
-			fieldname = fieldname + cstr(doctype);
+			fieldname = frappe.model.scrub(fieldname + " " + doctype);
 		}
 
 		return fieldname;

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1507,7 +1507,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							const insert_after_index = this.columns
 								.findIndex(column => column.label === values.insert_after);
 
-							let fieldname = this.get_fieldname_for_column(df.fieldname)
+							let fieldname = this.get_fieldname_for_column(df.fieldname);
 
 							custom_columns.push({
 								fieldname: fieldname,


### PR DESCRIPTION
**Issue Description:**
Consider a report contains a fieldname `test`. Now suppose this same report contains a doctype link which also has fieldname `test`, now on adding this `test` column from this doctype using add column feature it will create a fieldname conflict in the report between already existing column and the added custom column and both the columns will display same data even though they are from different doctypes

This PR handles this column fieldname conflicts