### PR TITLE
feat: Add document actions in mobile view

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1125,9 +1125,16 @@ frappe.ui.form.Form = class FrappeForm {
 
 	add_custom_button(label, fn, group) {
 		// temp! old parameter used to be icon
-		if(group && group.indexOf("fa fa-")!==-1) group = null;
-		var btn = this.page.add_inner_button(label, fn, group);
-		if(btn) {
+		if (group && group.indexOf("fa fa-") !== -1)
+			group = null;
+
+		let btn = this.page.add_inner_button(label, fn, group);
+
+		if (btn) {
+			// Add actions as menu item in Mobile View
+			let menu_item = this.page.add_menu_item(label, fn, false);
+			menu_item.parent().addClass("hidden-lg");
+
 			this.custom_buttons[label] = btn;
 		}
 		return btn;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1132,7 +1132,8 @@ frappe.ui.form.Form = class FrappeForm {
 
 		if (btn) {
 			// Add actions as menu item in Mobile View
-			let menu_item = this.page.add_menu_item(label, fn, false);
+			let menu_item_label = group ? `${group} > ${label}` : label;
+			let menu_item = this.page.add_menu_item(menu_item_label, fn, false);
 			menu_item.parent().addClass("hidden-lg");
 
 			this.custom_buttons[label] = btn;

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -120,6 +120,12 @@ pre {
 	}
 }
 
+.hidden-lg {
+	@include media-breakpoint-up(md) {
+		display: none !important;
+	}
+}
+
 .visible-xs {
 	@include media-breakpoint-up(sm) {
 		display: none !important;


### PR DESCRIPTION
Added custom buttons added via `frm.add_custom_buttons` as a menu item available for mobile views. This PR adds the missing doc actions functionality in mobile form view.

![Screenshot 2021-05-18 at 11 43 36 AM](https://user-images.githubusercontent.com/36654812/118600205-4ee97200-b7ce-11eb-9b67-8b1b1129f2d5.png "Desktop View")

![Screenshot 2021-05-18 at 11 50 31 AM](https://user-images.githubusercontent.com/36654812/118600973-4cd3e300-b7cf-11eb-8da9-19742ce953ee.png "Mobile View")

no-docs