### PR TITLE
ci: add rule to check active buttons frappe.call

### DIFF
--- a/.github/helper/semgrep_rules/frappe_correctness.js
+++ b/.github/helper/semgrep_rules/frappe_correctness.js
@@ -1,0 +1,36 @@
+erpnext.stock.move_item = function (item, source, target, actual_qty, rate, callback) {
+	var dialog = new frappe.ui.Dialog();
+
+	dialog.set_primary_action(__('Submit'), function () {
+
+		// ruleid: frappe-disable-button-during-request
+		frappe.call({
+			method: 'erpnext.stock.doctype.stock_entry.stock_entry_utils.make_stock_entry',
+			args: values,
+			callback: function (r) {
+				callback(r);
+			},
+		});
+	});
+};
+
+
+
+erpnext.stock.move_item = function (item, source, target, actual_qty, rate, callback) {
+	var dialog = new frappe.ui.Dialog();
+
+	dialog.set_primary_action(__('Submit'), function () {
+
+		// ok: frappe-disable-button-during-request
+		frappe.call({
+			method: 'erpnext.stock.doctype.stock_entry.stock_entry_utils.make_stock_entry',
+			args: values,
+			btn: dialog.get_primary_btn(),
+			callback: function (r) {
+				callback(r);
+			},
+		});
+	});
+};
+
+

--- a/.github/helper/semgrep_rules/frappe_correctness.yml
+++ b/.github/helper/semgrep_rules/frappe_correctness.yml
@@ -133,3 +133,17 @@ rules:
       key `$X` is uselessly assigned twice. This could be a potential bug.
   languages: [python]
   severity: ERROR
+
+- id: frappe-disable-button-during-request
+  patterns:
+    - pattern: |
+        frappe.call({...}, ...)
+    - pattern-not-inside: |
+        frappe.call({..., btn: $BUTTON, ...}, ...)
+    - pattern-inside: |
+        $DIALOG.set_primary_action(...)
+  message: |
+      Set `btn: $DIALOG.get_primary_btn()` in `frappe.call` to disable button while ajax call is being made.
+      This is required to prevent duplication of requests in case of multiple clicks.
+  severity: ERROR
+  languages: [javascript]


### PR DESCRIPTION
Add a rule to catch ajax calls inside dialogs that do not disable the button. Not doing that can lead to duplicate requests being sent. When such a request is mutating data in any way, it becomes a bug. 

Example: https://github.com/frappe/erpnext/issues/24841

Solution is simple in most flagged issues: add `btn: dialog.get_primary_btn()`

There are ~7 findings in Frappe and ~13 in ERPNext repo. Some of them are not really a bug because the request isn't mutating any data. But still, it's duplicate requests and bad UX (multiple popups/callback actions)  There is no way for me to weed out non-mutating requests, so all of them will have to be flagged. Add `// nosemgrep: frappe-disable-button-during-request` to avoid warnings or just specify the `btn` which is the correct thing to do. 