### PR TITLE
feat(minor): add number format parameter in fmt_money

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -706,11 +706,11 @@ def parse_val(v):
 		v = int(v)
 	return v
 
-def fmt_money(amount, precision=None, currency=None):
+def fmt_money(amount, format=None, precision=None, currency=None):
 	"""
 	Convert to string with commas for thousands, millions etc
 	"""
-	number_format = frappe.db.get_default("number_format") or "#,###.##"
+	number_format = format or frappe.db.get_default("number_format") or "#,###.##"
 	if precision is None:
 		precision = cint(frappe.db.get_default('currency_precision')) or None
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -706,7 +706,7 @@ def parse_val(v):
 		v = int(v)
 	return v
 
-def fmt_money(amount, format=None, precision=None, currency=None):
+def fmt_money(amount, precision=None, currency=None, format=None):
 	"""
 	Convert to string with commas for thousands, millions etc
 	"""


### PR DESCRIPTION
Allows for explicitly defining a number format when using fmt_money especially for print format purposes. 

Use Case:
When sending quotes cross country (eg: India to US) the format varies. In India we separate every 2 digits after a thousand vs separation every 3 digits internationally. 

Eg: USD 100,000 will be formatted as USD 1,00,000. The only way to manage this is by changing the system settings. 

Use in Print Formats:
```
{{ frappe.utils.fmt_money(doc.price_list_rate,,currency=doc.currency, format = frappe.db.get_value('Currency',
doc.currency,'number_format')) }}
```
or
```
frappe.utils.fmt_money(doc.price_list_rate,currency=doc.currency, format="#,###.##") }}
```

Output:

![image](https://user-images.githubusercontent.com/33246109/118692330-8b958780-b827-11eb-9bd2-cc65d77c3892.png)

no-docs