### PR TITLE
fix: session clearing query on postgres

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -70,7 +70,7 @@ def get_sessions_to_clear(user=None, keep_current=False, device=None):
 
 	return frappe.db.sql_list("""
 		SELECT `sid` FROM `tabSessions`
-		WHERE user=%(user)s
+		WHERE `tabSessions`.user=%(user)s
 		AND device in %(device)s
 		{condition}
 		ORDER BY `lastupdate` DESC


### PR DESCRIPTION
`user` is a Postgres keyword. To avoid conflict,
use table_name.user

