### PR TITLE
fix: Router issue

### DIFF
--- a/frappe/custom/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/custom/doctype/doctype_layout/doctype_layout.js
@@ -23,7 +23,7 @@ frappe.ui.form.on('DocType Layout', {
 	set_button(frm) {
 		if (!frm.is_new()) {
 			frm.add_custom_button(__('Go to {0} List', [frm.doc.name]), () => {
-				window.open(`/app/list/${frappe.router.slug(frm.doc.name)}/list`);
+				window.open(`/app/${frappe.router.slug(frm.doc.name)}`);
 			});
 		}
 	}

--- a/frappe/custom/doctype/doctype_layout_field/doctype_layout_field.json
+++ b/frappe/custom/doctype/doctype_layout_field/doctype_layout_field.json
@@ -20,14 +20,13 @@
    "fieldname": "label",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Label",
-   "reqd": 1
+   "label": "Label"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-11-16 17:13:01.892345",
+ "modified": "2021-05-19 16:27:40.585865",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "DocType Layout Field",


### PR DESCRIPTION
Doctype route path was wrong so it was given this below error so I changed route.
![image](https://user-images.githubusercontent.com/34086262/119554057-df6d1700-bdb9-11eb-97ce-f5e3da44262f.png)

Also, the Label field was mandatory in the Doctype Layout Fields child table that not make sense if we are trying to make doctype layout for that doctype which has numbers of fields so go each field that has no label to assign label is a big activity. So I make the label field non-mandatory as we already have Web Form and Customize Form.