### PR TITLE
fix: Set home workspace as first available for user

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -289,7 +289,7 @@ frappe.Application = Class.extend({
 		}
 		if (!frappe.workspaces['home']) {
 			// default workspace is settings for Frappe
-			frappe.workspaces['home'] = frappe.workspaces['build'];
+			frappe.workspaces['home'] = frappe.workspaces[Object.keys(frappe.workspaces)[0]];
 		}
 	},
 


### PR DESCRIPTION
The default `"Build"` Workspace may not be available for all users depending on Role/Permissions settings. To handle this, instead of assuming everyone gets Build, we'll dynamically pick from the available workspaces instead