### PR TITLE
fix: Increase timeout for window close

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -505,8 +505,9 @@ window.print();
 
 // close the window after print
 // NOTE: doesn't close if print is cancelled in Chrome
+// Changed timeout to 5s from 1s because it blocked mobile view rendering
 setTimeout(function() {
 	window.close();
-}, 1000);
+}, 5000);
 </script>
 """


### PR DESCRIPTION
On mobile view, `window.close` would block rendering the print view. Increasing the timeout to 5s from 1s helps.

**Before this fix:**

<img src="https://user-images.githubusercontent.com/36654812/118832297-22248000-b8de-11eb-9106-c6c997261427.jpeg" alt="drawing" width="200"/>

**After this fix:**

<img src="https://user-images.githubusercontent.com/36654812/118832285-205abc80-b8de-11eb-9ac3-0d681d4434a0.jpeg" alt="drawing" width="200"/>

**Other Attempts to fix this:**

* Serially executing the different lines
* Removing the window close call

Both attempts failed

fixes https://github.com/frappe/frappe/issues/12991