### PR TITLE
fix: set correct default redis async broker in node_utils

### DIFF
--- a/node_utils.js
+++ b/node_utils.js
@@ -6,7 +6,7 @@ const bench_path = path.resolve(__dirname, '..', '..');
 function get_conf() {
 	// defaults
 	var conf = {
-		redis_async_broker_port: 12311,
+		redis_async_broker_port: 'redis://localhost:12311',
 		socketio_port: 3000
 	};
 


### PR DESCRIPTION
Fix for https://github.com/frappe/frappe/issues/13281