### PR TITLE
fix: Use email_account_doc to get track_email_status value

### DIFF
--- a/frappe/email/doctype/email_account/test_records.json
+++ b/frappe/email/doctype/email_account/test_records.json
@@ -19,7 +19,8 @@
 		"unreplied_for_mins": 20,
 		"send_notification_to": "test_unreplied@example.com",
 		"pop3_server": "pop.test.example.com",
-		"no_remaining":"0"
+		"no_remaining":"0",
+		"track_email_status": 1
 	},
 	{
 		"doctype": "ToDo",

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -218,7 +218,7 @@ class SendMailContext:
 			'<img src="https://{}/api/method/frappe.core.doctype.communication.email.mark_email_as_seen?name={}"/>'
 
 		message = ''
-		if frappe.conf.use_ssl and self.queue_doc.track_email_status:
+		if frappe.conf.use_ssl and self.email_account_doc.track_email_status:
 			message = quopri.encodestring(
 				tracker_url_html.format(frappe.local.site, self.queue_doc.communication).encode()
 			).decode()

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -15,6 +15,7 @@ class TestEmail(unittest.TestCase):
 		frappe.db.sql("""delete from `tabEmail Queue Recipient`""")
 
 	def test_email_queue(self, send_after=None):
+		frappe.conf.use_ssl = True
 		frappe.sendmail(recipients=['test@example.com', 'test1@example.com'],
 						sender="admin@example.com",
 						reference_doctype='User', reference_name='Administrator',
@@ -29,6 +30,9 @@ class TestEmail(unittest.TestCase):
 		self.assertTrue('test1@example.com' in queue_recipients)
 		self.assertEqual(len(queue_recipients), 2)
 		self.assertTrue('<!--unsubscribe url-->' in email_queue[0]['message'])
+		# check for email tracker
+		self.assertTrue('frappe.core.doctype.communication.email.mark_email_as_seen' in email_queue[0]['message'])
+		frappe.conf.use_ssl = False
 
 	def test_send_after(self):
 		self.test_email_queue(send_after=1)

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -15,7 +15,6 @@ class TestEmail(unittest.TestCase):
 		frappe.db.sql("""delete from `tabEmail Queue Recipient`""")
 
 	def test_email_queue(self, send_after=None):
-		frappe.conf.use_ssl = True
 		frappe.sendmail(recipients=['test@example.com', 'test1@example.com'],
 						sender="admin@example.com",
 						reference_doctype='User', reference_name='Administrator',
@@ -30,9 +29,6 @@ class TestEmail(unittest.TestCase):
 		self.assertTrue('test1@example.com' in queue_recipients)
 		self.assertEqual(len(queue_recipients), 2)
 		self.assertTrue('<!--unsubscribe url-->' in email_queue[0]['message'])
-		# check for email tracker
-		self.assertTrue('frappe.core.doctype.communication.email.mark_email_as_seen' in email_queue[0]['message'])
-		frappe.conf.use_ssl = False
 
 	def test_send_after(self):
 		self.test_email_queue(send_after=1)
@@ -75,6 +71,7 @@ class TestEmail(unittest.TestCase):
 		self.assertTrue('CC: test1@example.com' in message)
 
 	def test_cc_footer(self):
+		frappe.conf.use_ssl = True
 		# test if sending with cc's makes it into header
 		frappe.sendmail(recipients=['test@example.com'],
 						cc=['test1@example.com'],
@@ -92,7 +89,12 @@ class TestEmail(unittest.TestCase):
 		self.assertTrue('This email was sent to test@example.com and copied to test1@example.com' in frappe.safe_decode(
 			frappe.flags.sent_mail))
 
+		# check for email tracker
+		self.assertTrue('mark_email_as_seen' in frappe.safe_decode(frappe.flags.sent_mail))
+		frappe.conf.use_ssl = False
+
 	def test_expose(self):
+
 		from frappe.utils.verified_command import verify_request
 		frappe.sendmail(recipients=['test@example.com'],
 						cc=['test1@example.com'],


### PR DESCRIPTION
Outgoing email used to fail with following error if `use_ssl` was enabled


```py
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/background_jobs.py", line 100, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 123, in send_mail
    record.send(is_background_task=is_background_task)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 103, in send
    message = ctx.build_message(recipient.recipient)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 207, in build_message
    message = message.replace(self.message_placeholder('tracker'), self.get_tracker_str())
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 221, in get_tracker_str
    if frappe.conf.use_ssl and self.queue_doc.track_email_status:
AttributeError: 'EmailQueue' object has no attribute 'track_email_status'
```

The issue was introduced via https://github.com/frappe/frappe/pull/13122