### PR TITLE
fix: corrected the function get_url

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1202,8 +1202,8 @@ class Document(BaseDocument):
 			doc.set(fieldname, flt(doc.get(fieldname), self.precision(fieldname, doc.parentfield)))
 
 	def get_url(self):
-		"""Returns Desk URL for this document. `/app/Form/{doctype}/{name}`"""
-		return "/app/Form/{doctype}/{name}".format(doctype=self.doctype, name=self.name)
+		"""Returns Desk URL for this document. `/app/{doctype}/{name}`"""
+		return "/app/{doctype}/{name}".format(doctype=self.doctype, name=self.name)
 
 	def add_comment(self, comment_type='Comment', text=None, comment_email=None, link_doctype=None, link_name=None, comment_by=None):
 		"""Add a comment to this document.


### PR DESCRIPTION
fixes get_url : As per issue #12820, The get_url function returned '/app/Form/Item/302' (/app/Form/doctype/name), when the expected result should have been '/app/item/302' (/app/doctype/name).
