### PR TITLE
fix: Don't strip 'app' from doctype route names

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -372,7 +372,8 @@ frappe.router = {
 
 	strip_prefix(route) {
 		if (route.substr(0, 1)=='/') route = route.substr(1); // for /app/sub
-		if (route.startsWith('app')) route = route.substr(4); // for desk/sub
+		if (route.startsWith('app/')) route = route.substr(4); // for desk/sub
+		if (route == 'app') route = route.substr(4); // for /app
 		if (route.substr(0, 1)=='/') route = route.substr(1);
 		if (route.substr(0, 1)=='#') route = route.substr(1);
 		if (route.substr(0, 1)=='!') route = route.substr(1);


### PR DESCRIPTION
After the creation of a new document and going back would break routes for doctypes that start with 'App'. It would clip the “app” portion in the appraisal and appraisal template.

## Before
![2021-05-21 18 59 13](https://user-images.githubusercontent.com/36654812/119145377-334cc880-ba67-11eb-8213-e64ef220afe5.gif)

## After
![2021-05-21 19 01 38](https://user-images.githubusercontent.com/36654812/119145413-3b0c6d00-ba67-11eb-9a13-5a90b5b67564.gif)
