### PR TITLE
fix: get_url returns the expected url

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1202,8 +1202,8 @@ class Document(BaseDocument):
 			doc.set(fieldname, flt(doc.get(fieldname), self.precision(fieldname, doc.parentfield)))
 
 	def get_url(self):
-		"""Returns Desk URL for this document. `/app/Form/{doctype}/{name}`"""
-		return "/app/Form/{doctype}/{name}".format(doctype=self.doctype, name=self.name)
+		"""Returns Desk URL for this document. `/app/{doctype}/{name}`"""
+		return "/app/{doctype}/{name}".format(doctype=self.doctype.lower(), name=self.name.lower())
 
 	def add_comment(self, comment_type='Comment', text=None, comment_email=None, link_doctype=None, link_name=None, comment_by=None):
 		"""Add a comment to this document.


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. develop
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

The get_url returned url of the form `/app/Form/{doctype}/{name}`.

After the fix it returns url of the form `/app/{doctype}/{name}`

This fix helps in returning the expected output.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

The pull request solves the problem by returning the right URL `/app/{doctype}/{name}`

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

When created a doctype  list Item with name 302. The get_url was returning '/app/Form/Item/302'

The same function after the fix returns 'app/item/302' (The expected output)

> Screenshots/GIFs

Before:
![onetwo333333333333](https://user-images.githubusercontent.com/47734964/119227387-2d202000-bb2b-11eb-8f99-937f0f1dbddd.PNG)

After:
![Screenshot from 2021-05-22 09-42-36](https://user-images.githubusercontent.com/47734964/119214142-17d2d380-bae2-11eb-9596-044b48912fe0.png)



<!-- Add images/recordings to better visualize the change: expected/current behviour -->


Closes #12820