### PR TITLE
fix: issue with sending emails

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -102,7 +102,7 @@ class EmailQueue(Document):
 
 				message = ctx.build_message(recipient.recipient)
 				if not frappe.flags.in_test:
-					ctx.smtp_session.sendmail(recipient.recipient, self.sender, message)
+					ctx.smtp_session.sendmail(from_addr=self.sender, to_addrs=recipient.recipient, msg=message)
 				ctx.add_to_sent_list(recipient)
 
 			if frappe.flags.in_test:


### PR DESCRIPTION
The sendmail functionality got broken in recent refactoring to the email
module. The call to sendmail was passing `from_addr` and `to_addrs` in the
wrong order. This has been fixed.

Closes #13292

Issue was introduced via https://github.com/frappe/frappe/pull/13122