### PR TITLE
fix(Workspace): broken links for reports created with Report Builder

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1197,10 +1197,12 @@ Object.assign(frappe.utils, {
 							route = "";
 					}
 				}
-			} else if (type === "report" && item.is_query_report) {
-				route = "query-report/" + item.name;
 			} else if (type === "report") {
-				route = frappe.router.slug(item.name) + "/view/report";
+				if (item.is_query_report) {
+					route = "query-report/" + item.name;
+				} else {
+					route = frappe.router.slug(item.doctype) + "/view/report/" + item.name;
+				}
 			} else if (type === "page") {
 				route = item.name;
 			} else if (type === "dashboard") {

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -61,11 +61,17 @@ export default class LinksWidget extends Widget {
 		};
 
 		this.link_list = this.links.map(item => {
-			const route = frappe.utils.generate_route({
+			const opts = {
 				name: item.link_to,
 				type: item.link_type,
 				is_query_report: item.is_query_report
-			});
+			}
+
+			if (item.link_type == "Report" && !item.is_query_report) {
+				opts.doctype = item.dependencies;
+			}
+
+			const route = frappe.utils.generate_route(opts);
 
 			return $(`<a href="${route}" class="link-item ellipsis ${
 				item.onboard ? "onboard-spotlight" : ""

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -65,7 +65,7 @@ export default class LinksWidget extends Widget {
 				name: item.link_to,
 				type: item.link_type,
 				is_query_report: item.is_query_report
-			}
+			};
 
 			if (item.link_type == "Report" && !item.is_query_report) {
 				opts.doctype = item.dependencies;

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -157,9 +157,7 @@ export default class OnboardingWidget extends Widget {
 		let route = frappe.utils.generate_route({
 			name: step.reference_report,
 			type: "report",
-			is_query_report: ["Query Report", "Script Report"].includes(
-				step.report_type
-			),
+			is_query_report: step.report_type !== "Report Builder",
 			doctype: step.report_reference_doctype,
 		});
 


### PR DESCRIPTION
Resolves #13039 

## Changes Made
 - Fix route for reports of type **Report Builder** in `frappe.utils.generate_route`. Also checked all places this function is being used to ensure that other functionality doesn't break.
 - Set `doctype` when generating route for report of type **Report Builder** in the Links widget.
 - Fix condition to decide `is_query_report` in Onboarding Widget (Previously, a report of type **Custom Report** would have been falsely identified as not a query report for route generation purposes)

## Screenshots

### Before 

See #13039

### After

![report links after](https://user-images.githubusercontent.com/16315650/119219372-e8808e80-bb02-11eb-9a58-790c4ff00500.gif)


---

Reverts behaviour changed here: https://github.com/frappe/frappe/commit/54cee87826ce1d592f6683f88c945c9a37ae968b#diff-438b625d2cede80cc1665598f2da35a4c0001491a6a20ebd8138ea872eee9e37L1158

Sponsored by @barredterra :tada: 