### PR TITLE
fix: set title attribute for grid header columns

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -316,6 +316,12 @@ export default class GridRow {
 
 		$col.field_area = $('<div class="field-area"></div>').appendTo($col).toggle(false);
 		$col.static_area = $('<div class="static-area ellipsis"></div>').appendTo($col).html(txt);
+
+		// set title attribute to see full label for columns in the heading row
+		if (!this.doc) {
+			$col.attr("title", txt);
+		}
+
 		$col.df = df;
 		$col.column_index = ci;
 


### PR DESCRIPTION
Resolves #13288

---

![one prototype](https://user-images.githubusercontent.com/16315650/119220421-2f24b780-bb08-11eb-9bd4-fcd197ff7280.gif)

---

Alternate solution: show a Bootstrap tooltip optionally if the label exceeds available width ([Demo](https://codepen.io/avnish002/pen/rxjWzE)) (#13298)

---

Sponsored by @barredterra :tada: 