### PR TITLE
fix: show tooltip for grid header columns where label not fully visible

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -316,6 +316,14 @@ export default class GridRow {
 
 		$col.field_area = $('<div class="field-area"></div>').appendTo($col).toggle(false);
 		$col.static_area = $('<div class="static-area ellipsis"></div>').appendTo($col).html(txt);
+
+		if (!this.doc) {
+			const static_area = $col.static_area[0];
+			if (static_area.offsetWidth < static_area.scrollWidth) {
+				$col.tooltip({title: txt});
+			}
+		}
+
 		$col.df = df;
 		$col.column_index = ci;
 


### PR DESCRIPTION
Resolves #13288
Alternate to #13296

---

![p2](https://user-images.githubusercontent.com/16315650/119249805-48d20780-bbb9-11eb-8754-e86cdbd2669f.gif)
