### PR TITLE
fix: Add a command to properly extend class methods

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -3,6 +3,13 @@
 
 frappe.provide("frappe.ui.form.handlers");
 
+window.extend_cscript = (cscript, controller_object) => {
+	$.extend(cscript, controller_object);
+	if (controller_object.__proto__) {
+		cscript.__proto__ = controller_object.__proto__;
+	}
+};
+
 frappe.ui.form.get_event_handler_list = function(doctype, fieldname) {
 	if(!frappe.ui.form.handlers[doctype]) {
 		frappe.ui.form.handlers[doctype] = {};

--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -5,7 +5,7 @@ frappe.provide("frappe.ui.form.handlers");
 
 window.extend_cscript = (cscript, controller_object) => {
 	$.extend(cscript, controller_object);
-	if (controller_object.__proto__) {
+	if (cscript && controller_object) {
 		cscript.__proto__ = controller_object.__proto__;
 	}
 };


### PR DESCRIPTION
Inherited functions & properties of a class instance live in `__proto__` in case of ES6 class... 

this is used to properly extend function from an extended class instance to cscript.

**Case:**
Class instance to be extended
<img width="917" alt="Screenshot 2021-05-23 at 1 17 09 PM" src="https://user-images.githubusercontent.com/13928957/119252464-0c5ad780-bbca-11eb-8f62-1f704bb5b351.png">


with `$.extend`: amount and other inherited functions are not extended
<img width="1027" alt="Screenshot 2021-05-23 at 1 20 36 PM" src="https://user-images.githubusercontent.com/13928957/119252422-c998ff80-bbc9-11eb-8ef0-920a42b3633c.png">

with `extend_cscript`: amount and other inherited functions are extended properly
<img width="660" alt="Screenshot 2021-05-23 at 1 19 43 PM" src="https://user-images.githubusercontent.com/13928957/119252447-efbe9f80-bbc9-11eb-89ec-51c054e98e7e.png">


> Note: this is a quick fix to make breaking functionalities work in ERPNext after the [new build system change](https://github.com/frappe/erpnext/pull/25623)