### PR TITLE
fix: Grid navigation with keyboard on multiple pages

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -523,7 +523,7 @@ export default class GridRow {
 		// hide other
 		var open_row = this.get_open_form();
 
-		if (show===undefined) show = !!!open_row;
+		if (show === undefined) show = !open_row;
 
 		// call blur
 		document.activeElement && document.activeElement.blur();
@@ -588,17 +588,40 @@ export default class GridRow {
 		this.wrapper.removeClass("grid-row-open");
 	}
 	open_prev() {
-		const row_index = this.wrapper.index();
-		if (this.grid.grid_rows[row_index - 1]) {
-			this.grid.grid_rows[row_index - 1].toggle_view(true);
-		}
+		if (!this.doc) return;
+		this.open_row_at_index(this.doc.idx - 2);
 	}
 	open_next() {
-		const row_index = this.wrapper.index();
-		if (this.grid.grid_rows[row_index + 1]) {
-			this.grid.grid_rows[row_index + 1].toggle_view(true);
-		} else {
+		if (!this.doc) return;
+
+		if (!this.open_row_at_index(this.doc.idx)) {
 			this.grid.add_new_row(null, null, true);
+		}
+	}
+	open_row_at_index(row_index) {
+		if (!this.grid.data[row_index]) return;
+
+		this.change_page_if_reqd(row_index);
+		this.grid.grid_rows[row_index].toggle_view(true);
+		return true;
+	}
+	change_page_if_reqd(row_index) {
+		const {
+			page_index,
+			page_length
+		} = this.grid.grid_pagination;
+
+		row_index++;
+		let new_page;
+
+		if (row_index <= (page_index - 1) * page_length) {
+			new_page = page_index - 1;
+		} else if (row_index > page_index * page_length) {
+			new_page = page_index + 1;
+		}
+
+		if (new_page) {
+			this.grid.grid_pagination.go_to_page(new_page);
 		}
 	}
 	refresh_field(fieldname, txt) {


### PR DESCRIPTION
## Issue

Ever since grid pagination was implemented, the keyboard shortcuts <kbd>Ctrl + &uparrow; </kbd> and <kbd>Ctrl + &downarrow; </kbd> didn't work as expected.

One couldn't navigate on pages 2+ with these shortcuts:

![page2](https://user-images.githubusercontent.com/16315650/119252513-5d6acb80-bbca-11eb-8c01-f4a3bfcaba86.gif)


Trying to go to the row on next page added a new row instead:

![new_row](https://user-images.githubusercontent.com/16315650/119252530-78d5d680-bbca-11eb-84db-e4ddf3a6723e.gif)


Trying to go to a row on the previous page didn't work:

![prev page](https://user-images.githubusercontent.com/16315650/119252553-9d31b300-bbca-11eb-952e-79e712f751a4.gif)


## Solution

### In action

![grid row after](https://user-images.githubusercontent.com/16315650/119252339-4a0b3080-bbc9-11eb-8935-571202205a5c.gif)


### Summary of changes made

- Use `doc.idx` instead of `wrapper.index()` as the latter again starts at `1` for a new page.
- Commonify code in `open_prev` and `open_next` as `open_row_at_index`
- Check if row exists in `this.grid.data` rather than `this.grid.grid_rows` as `grid_rows` are rendered as required.
- Add code to change grid page if required when switching rows.
- (Minor) `!!!` ==> `!`