### PR TITLE
fix: user profile not loading

### DIFF
--- a/frappe/desk/page/user_profile/user_profile.js
+++ b/frappe/desk/page/user_profile/user_profile.js
@@ -1,5 +1,5 @@
 frappe.pages['user-profile'].on_page_load = function (wrapper) {
-	frappe.require('assets/js/user_profile_controller.min.js', () => {
+	frappe.require('user_profile_controller.bundle.js', () => {
 		let user_profile = new frappe.ui.UserProfile(wrapper);
 		user_profile.show();
 	});


### PR DESCRIPTION
fix an issue caused during the implementation of the new build system.

Following is the error that is coming: 
![image](https://user-images.githubusercontent.com/5052568/119271415-03e0bc00-bc1f-11eb-9533-2009f0971184.png)

Fixed:
![image](https://user-images.githubusercontent.com/5052568/119271438-270b6b80-bc1f-11eb-89c4-207c00abc794.png)



Documentation: Not required.