### PR TITLE
fix: Use extend_cscript in make to properly extend functions of class

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -149,6 +149,7 @@
 		"before": true,
 		"beforeEach": true,
 		"qz": true,
-		"localforage": true
+		"localforage": true,
+		"extend_cscript": true
 	}
 }

--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -8,6 +8,7 @@ window.extend_cscript = (cscript, controller_object) => {
 	if (cscript && controller_object) {
 		cscript.__proto__ = controller_object.__proto__;
 	}
+	return cscript;
 };
 
 frappe.ui.form.get_event_handler_list = function(doctype, fieldname) {
@@ -81,7 +82,7 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 		$.extend(this, opts);
 	}
 	make(ControllerClass) {
-		this.frm.cscript = $.extend(this.frm.cscript,
+		this.frm.cscript = extend_cscript(this.frm.cscript,
 			new ControllerClass({frm: this.frm}));
 	}
 	trigger(event_name, doctype, name) {


### PR DESCRIPTION
Continuation of https://github.com/frappe/frappe/pull/13300