### PR TITLE
fix: encode error to add outgoing mail to sent folder

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -8,7 +8,7 @@ import re
 import json
 import socket
 import time
-from frappe import _
+from frappe import _, safe_encode
 from frappe.model.document import Document
 from frappe.utils import validate_email_address, cint, cstr, get_datetime, DATE_FORMAT, strip, comma_or, sanitize_html, add_days
 from frappe.utils.user import is_system_user
@@ -738,7 +738,6 @@ class EmailAccount(Document):
 
 
 	def append_email_to_sent_folder(self, message):
-
 		email_server = None
 		try:
 			email_server = self.get_incoming_server(in_receive=True)
@@ -752,7 +751,8 @@ class EmailAccount(Document):
 
 		if email_server.imap:
 			try:
-				email_server.imap.append("Sent", "\\Seen", imaplib.Time2Internaldate(time.time()), message.encode())
+				message = safe_encode(message)
+				email_server.imap.append("Sent", "\\Seen", imaplib.Time2Internaldate(time.time()), message)
 			except Exception:
 				frappe.log_error()
 


### PR DESCRIPTION
Adding outgoing mail to sent folder is failing because of encoding issue. Fixed it by using safe_encode.

Traceback for the issue
```
Traceback (most recent call last):
 File "/home/dintegra/bench-13/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 732, in append_email_to_sent_folder
 email_server.imap.append("Sent", "\\Seen", imaplib.Time2Internaldate(time.time()), message.encode())
AttributeError: 'bytes' object has no attribute 'encode'


```