### PR TITLE
fix: double checkboxes in editable grid

### DIFF
--- a/frappe/public/js/frappe/form/controls/check.js
+++ b/frappe/public/js/frappe/form/controls/check.js
@@ -14,8 +14,10 @@ frappe.ui.form.ControlCheck = class ControlCheck extends frappe.ui.form.ControlD
 		</div>`).appendTo(this.parent);
 	}
 	set_input_areas() {
-		this.label_area = this.label_span = this.$wrapper.find(".label-area").get(0);
 		this.input_area = this.$wrapper.find(".input-area").get(0);
+		if (this.only_input) return;
+
+		this.label_area = this.label_span = this.$wrapper.find(".label-area").get(0);
 		this.disp_area = this.$wrapper.find(".disp-area").get(0);
 	}
 	make_input() {

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -140,7 +140,7 @@
 		.checkbox {
 			margin: 0px;
 			text-align: center;
-			margin-top: 9px;
+			margin-top: var(--padding-sm);
 		}
 
 		textarea {


### PR DESCRIPTION
Resolves #13287 

## Screenshots

### Before

![before cb fix](https://user-images.githubusercontent.com/16315650/119513436-d6684f80-bd91-11eb-8b13-addf12533a5d.gif)


### After

![after cb fix](https://user-images.githubusercontent.com/16315650/119513295-b89aea80-bd91-11eb-9201-fcd6c0ed60f4.gif)


## Changes Made

- Set `disp_area` and `label_area` if `only_input` is not set
- A CSS fix to ensure that the checkbox margin looks same whether or not the row is in focus. (`--padding-sm` used since that's the padding applied to grid cells)


Sponsored by @barredterra :tada:

---

**Note:** The elements `disp-area`, `label-area` can be optionally removed from the `$wrapper` itself if `only_input` is specified.