### PR TITLE
fix: display currency in auto email report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -245,6 +245,7 @@ def send_monthly():
 
 def make_links(columns, data):
 	for row in data:
+		doc_name = row.get('name')
 		for col in columns:
 			if col.fieldtype == "Link" and col.options != "Currency":
 				if col.options and row.get(col.fieldname):
@@ -253,8 +254,9 @@ def make_links(columns, data):
 				if col.options and row.get(col.fieldname) and row.get(col.options):
 					row[col.fieldname] = get_link_to_form(row[col.options], row[col.fieldname])
 			elif col.fieldtype == "Currency" and row.get(col.fieldname):
-				row[col.fieldname] = frappe.format_value(row[col.fieldname], col)
-
+				doc = frappe.get_doc(col.parent, doc_name) if doc_name else None
+				# Pass the Document to get the currency based on docfield option
+				row[col.fieldname] = frappe.format_value(row[col.fieldname], col, doc=doc)
 	return columns, data
 
 def update_field_types(columns):


### PR DESCRIPTION
In auto email reports, currency is always showed as INR(default) irrespective of what currency it is.

In current implementation, whole document is required to find the specific fields currency and that is missed to pass. Fixed it by passing the whole document while finding currency of a specific field.