### PR TITLE
fix: Store assets.json directly in assets folder

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -343,12 +343,7 @@ async function write_assets_json(metafile) {
 		}
 	}
 
-	let assets_json_path = path.resolve(
-		assets_path,
-		"frappe",
-		"dist",
-		"assets.json"
-	);
+	let assets_json_path = path.resolve(assets_path, "assets.json");
 	let assets_json;
 	try {
 		assets_json = await fs.promises.readFile(assets_json_path, "utf-8");

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -50,7 +50,7 @@ def build_missing_files():
 	development = frappe.local.conf.developer_mode or frappe.local.dev_server
 	build_mode = "development" if development else "production"
 
-	assets_json = frappe.read_file(frappe.get_app_path('frappe', 'public', 'dist', 'assets.json'))
+	assets_json = frappe.read_file("assets/assets.json")
 	if assets_json:
 		assets_json = frappe.parse_json(assets_json)
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -809,7 +809,7 @@ def get_assets_json():
 			assets_json = None
 
 		if not assets_json:
-			assets_json = frappe.read_file("assets/frappe/dist/assets.json")
+			assets_json = frappe.read_file("assets/assets.json")
 			cache.set_value("assets_json", assets_json, shared=True)
 		frappe.local.assets_json = frappe.safe_decode(assets_json)
 


### PR DESCRIPTION
assets.json stores assets of all apps, so doesn't make sense to put it in frappe folder

This should also fix the issue where `/assets/frappe/dist` is not already created. Ref: https://github.com/frappe/erpnext/pull/22449/checks?check_run_id=2678161622