### PR TITLE
fix: auto_repeat field check while loading customize form

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -115,12 +115,22 @@ class CustomizeForm(Document):
 
 		#If allow_auto_repeat is set, add auto_repeat custom field.
 		if self.allow_auto_repeat:
-			if not frappe.db.exists('Custom Field', {'fieldname': 'auto_repeat', 'dt': self.doc_type}):
-				insert_after = self.fields[len(self.fields) - 1].fieldname
-				df = dict(fieldname='auto_repeat', label='Auto Repeat', fieldtype='Link', options='Auto Repeat', insert_after=insert_after, read_only=1, no_copy=1, print_hide=1)
-				create_custom_field(self.doc_type, df)
+			all_fields = [df.fieldname for df in meta.fields]
+			if "auto_repeat" in all_fields:
+				return
 
-		# NOTE doc is sent to clientside by run_method
+			insert_after = self.fields[len(self.fields) - 1].fieldname
+			create_custom_field(self.doc_type, dict(
+				fieldname='auto_repeat',
+				label='Auto Repeat',
+				fieldtype='Link',
+				options='Auto Repeat',
+				insert_after=insert_after,
+				read_only=1,
+				no_copy=1,
+				print_hide=1
+			))
+
 
 	def get_name_translation(self):
 		'''Get translation object if exists of current doctype name in the default language'''


### PR DESCRIPTION
Customize form breaks with the following error.

![image](https://user-images.githubusercontent.com/36557/119798905-32011d00-bef9-11eb-96d7-f6b4bc2fbb31.png)

We create auto repeat field of a doctype while loading a `customize form`, incase if it does not exist. Instead of checking for `auto_repeat` field in doctype meta, we are currently checking auto_repeat custom field exists or not. This is fixed by changing the check based on meta of doctype.

Note: This got fixed in V13 already.