### PR TITLE
fix: refresh form section while refreshing the field

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -198,6 +198,7 @@ frappe.ui.form.Form = class FrappeForm {
 				field && ["Link", "Dynamic Link"].includes(field.df.fieldtype) && field.validate && field.validate(value);
 
 				me.layout.refresh_dependency();
+				me.layout.refresh_sections();
 				let object = me.script_manager.trigger(fieldname, doc.doctype, doc.name);
 				return object;
 			}
@@ -913,6 +914,7 @@ frappe.ui.form.Form = class FrappeForm {
 		if(this.fields_dict[fname] && this.fields_dict[fname].refresh) {
 			this.fields_dict[fname].refresh();
 			this.layout.refresh_dependency();
+			this.layout.refresh_sections();
 		}
 	}
 


### PR DESCRIPTION
If all the fields with in a section has depends_on property and in such
case section itself stays hidden as all fields with in it are hidden.

Currently when any form field is updated, we are refreshing only the
fields but not the sections. So, field refresh is not affecting the form
because of section being hidden.

Fix is to refresh the sections when ever form fields are refreshed.

You can find this happening for Share Transfer doctype where `Equity/liability Account` and `Asset account` are fields of an `accounts section`  has depends_on property (`account section` won't show up even after company field is populated).
![image](https://user-images.githubusercontent.com/36557/119921284-59082f00-bf8b-11eb-9096-dafe0954400f.png)
