### PR TITLE
fix: cannot set shortcut for actions menu item

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -377,11 +377,12 @@ frappe.ui.Page = class Page {
 		});
 	}
 
-	add_actions_menu_item(label, click, standard) {
+	add_actions_menu_item(label, click, standard, shortcut) {
 		return this.add_dropdown_item({
 			label,
 			click,
 			standard,
+			shortcut,
 			parent: this.actions,
 			show_parent: false
 		});


### PR DESCRIPTION
Allow setting shortcuts for action menu items. Useful in List View & Report View