### PR TITLE
fix: Add min-width for dropdown list

### DIFF
--- a/frappe/public/scss/common/awesomeplete.scss
+++ b/frappe/public/scss/common/awesomeplete.scss
@@ -31,6 +31,7 @@
 		margin: 0;
 		padding: var(--padding-xs);
 		z-index: 1;
+		min-width: 250px;
 
 		&> li {
 			cursor: pointer;


### PR DESCRIPTION
**Before:**
<img width="324" alt="Screenshot 2021-06-01 at 6 59 31 PM" src="https://user-images.githubusercontent.com/13928957/120332016-f5279280-c30b-11eb-91a8-be16228db137.png">

**Now:**
<img width="474" alt="Screenshot 2021-06-01 at 6 58 52 PM" src="https://user-images.githubusercontent.com/13928957/120332025-f789ec80-c30b-11eb-94f0-b984752ca7c4.png">
