### PR TITLE
fix: removed duplicate fields from Customize Form

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -288,16 +288,6 @@
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name"
-  },
-  {
-   "fieldname": "default_email_template",
-   "fieldtype": "Link",
-   "label": "Default Email Template",
-   "options": "Email Template"
-  },
-  {
-   "fieldname": "column_break_26",
-   "fieldtype": "Column Break"
   }
  ],
  "hide_toolbar": 1,
@@ -306,7 +296,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-04-29 21:21:06.476372",
+ "modified": "2021-06-02 06:49:16.782806",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",


### PR DESCRIPTION
Removed two duplicate fields from Customize Form JSON. Probably duplicated while incorrectly fixing a merge conflict.