### PR TITLE
fix: ensure `Page.add_dropdown_item` returns link even if it already exists

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -409,6 +409,9 @@ frappe.ui.Page = class Page {
 			parent.parent().removeClass("hide");
 		}
 
+		let $link = this.is_in_group_button_dropdown(parent, 'li > a.grey-link', label);
+		if ($link) return $link;
+
 		let $li;
 		let $icon = ``;
 
@@ -440,9 +443,8 @@ frappe.ui.Page = class Page {
 				</li>
 			`);
 		}
-		var $link = $li.find("a").on("click", click);
 
-		if (this.is_in_group_button_dropdown(parent, 'li > a.grey-link', label)) return;
+		$link = $li.find("a").on("click", click);
 
 		if (standard) {
 			$li.appendTo(parent);
@@ -508,7 +510,7 @@ frappe.ui.Page = class Page {
 				let item = $(this).html();
 				return $(item).attr('data-label') === label;
 			});
-		return result.length > 0;
+		return result.length > 0 && result;
 	}
 
 	clear_btn_group(parent) {


### PR DESCRIPTION
Resolves #13411 

If a link with the same label was found in the dropdown, `Page.add_dropdown_item` earlier returned nothing (`undefined`). This created the issue in `Form.add_custom_button` where it would fail to access the `parent` property of undefined (see linked issue). 

## Solution

Since the `is_in_group_button_dropdown` already created the jQuery object to see if the label existed in dropdown, it has been tweaked to return the jQuery object (which is also truthy) if true. This is then being returned from `Page.add_dropdown_item`.

Additionally, the check to see if a button with label already exists in dropdown has been moved to before creating the `$li` object to avoid unnecessary processing.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/16315650/120698005-120ac400-c4cc-11eb-8882-bad0492102ce.png)


### After

![image](https://user-images.githubusercontent.com/16315650/120697956-ff908a80-c4cb-11eb-9c3c-d4bdd6670776.png)
