### PR TITLE
fix: error on empty grid

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -912,6 +912,9 @@ export default class Grid {
 	}
 
 	update_docfield_property(fieldname, property, value) {
+		// grid might not have any rows
+		if (this.grid_rows === undefined) return;
+
 		// update the docfield of each row
 		for (let row of this.grid_rows) {
 			let docfield = row.docfields.find(d => d.fieldname === fieldname);


### PR DESCRIPTION
Closes https://github.com/barredterra/connection_test/issues/1
Closes https://github.com/frappe/frappe/issues/13411

Grid can be hidden through customization and not get any rows added. Still, the client side script (on Sales Order, for example) might try to modify the rows. This throws an error causing the linked issues.

Solution: If there are no rows, don't attempt to update them.