### PR TITLE
fix: do not delete user permissions for all the user

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -17,11 +17,11 @@ class UserPermission(Document):
 		self.validate_default_permission()
 
 	def on_update(self):
-		frappe.cache().delete_value('user_permissions')
+		frappe.cache().hdel('user_permissions', self.user)
 		frappe.publish_realtime('update_user_permissions')
 
 	def on_trash(self): # pylint: disable=no-self-use
-		frappe.cache().delete_value('user_permissions')
+		frappe.cache().hdel('user_permissions', self.user)
 		frappe.publish_realtime('update_user_permissions')
 
 	def validate_user_permission(self):


### PR DESCRIPTION
Current behaviour

On creation / update of user permission, system delete the cached user permissions of all the user

After fix
On creation / update of user permission, system delete the cached user permissions of the respective user