### PR TITLE
chore: Use get_absolute_url to doc.get_url

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -14,8 +14,8 @@ from frappe.model.workflow import set_workflow_state_on_action
 from frappe.utils.global_search import update_global_search
 from frappe.integrations.doctype.webhook import run_webhooks
 from frappe.desk.form.document_follow import follow_document
-from frappe.desk.utils import slug
 from frappe.core.doctype.server_script.server_script_utils import run_server_script_for_doc_event
+from frappe.utils.data import get_absolute_url
 
 # once_only validation
 # methods
@@ -1200,8 +1200,8 @@ class Document(BaseDocument):
 			doc.set(fieldname, flt(doc.get(fieldname), self.precision(fieldname, doc.parentfield)))
 
 	def get_url(self):
-		"""Returns Desk URL for this document. `/app/{doctype}/{name}`"""
-		return f"/app/{slug(self.doctype)}/{self.name}"
+		"""Returns Desk URL for this document."""
+		return get_absolute_url(self.doctype, self.name)
 
 	def add_comment(self, comment_type='Comment', text=None, comment_email=None, link_doctype=None, link_name=None, comment_by=None):
 		"""Add a comment to this document.


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/13330 introduced a slight variation to the re-implementation of `frappe.utils.get_absolute_url`

---

The util suggested by @barredterra in the thread, `get_url_to_form` returns the full URL including the site name.  

![Screenshot 2021-06-07 at 12 12 38 PM](https://user-images.githubusercontent.com/36654812/120970985-c5eca780-c789-11eb-81ad-bec0a80e9fd8.png)

To ensure no change in API usage or behaviour, I've interfaced `doc.get_url` with the `get_absolute_url` URL.

#### Before Routing change
 
![Screenshot 2021-06-07 at 12 13 00 PM](https://user-images.githubusercontent.com/36654812/120970983-c4bb7a80-c789-11eb-908c-5fa73c29065a.png)

#### After Routing change

![Screenshot 2021-06-07 at 12 12 28 PM](https://user-images.githubusercontent.com/36654812/120970976-c2f1b700-c789-11eb-8a22-e2cb7c027180.png)
