### PR TITLE
fix: Remove frappe from boilerplate requirements.txt

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -70,7 +70,7 @@ def make_boilerplate(dest, app_name):
 		f.write(frappe.as_unicode(setup_template.format(**hooks)))
 
 	with open(os.path.join(dest, hooks.app_name, "requirements.txt"), "w") as f:
-		f.write("frappe")
+		f.write("# frappe -- https://github.com/frappe/frappe is installed via 'bench init'")
 
 	with open(os.path.join(dest, hooks.app_name, "README.md"), "w") as f:
 		f.write(frappe.as_unicode("## {0}\n\n{1}\n\n#### License\n\n{2}".format(hooks.app_title,


### PR DESCRIPTION
Remove frappe from new app boilerplates to avoid possible supply chain attacks. Don't make pip fetch frappe from PyPI.