### PR TITLE
fix: property to hide grid Delete button

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -236,6 +236,10 @@ export default class Grid {
 	}
 
 	refresh_remove_rows_button() {
+		if (this.df.cannot_delete_rows) {
+			return;
+		}
+
 		this.remove_rows_button.toggleClass('hidden',
 			this.wrapper.find('.grid-body .grid-row-check:checked:first').length ? false : true);
 		this.remove_all_rows_button.toggleClass('hidden',

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -563,6 +563,9 @@ export default class GridRow {
 			.find('.grid-insert-row-below, .grid-insert-row, .grid-duplicate-row, .grid-append-row')
 			.toggle(!cannot_add_rows);
 
+		this.wrapper.find('.grid-delete-row')
+			.toggle(!(this.grid.df && this.grid.df.cannot_delete_rows));
+
 		frappe.dom.freeze("", "dark");
 		if (cur_frm) cur_frm.cur_grid = this;
 		this.wrapper.addClass("grid-row-open");


### PR DESCRIPTION
Normal

<img width="495" alt="Screenshot 2021-06-07 at 9 28 37 PM" src="https://user-images.githubusercontent.com/8780500/121051866-76cd6380-c7d7-11eb-9fd0-f2303c03536b.png">


**With cannot_delete_rows property**
frm.set_df_property('supplied_items', 'cannot_delete_rows', 1);

<img width="1045" alt="Screenshot 2021-06-07 at 9 27 15 PM" src="https://user-images.githubusercontent.com/8780500/121051966-8c428d80-c7d7-11eb-9117-fa5f61bd4f08.png">


