### PR TITLE
fix: outstanding amount not visible in number card

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -156,11 +156,6 @@ frappe.ui.form.on('Number Card', {
 			frappe.model.with_doctype(doctype, () => {
 				frappe.get_meta(doctype).fields.map(df => {
 					if (frappe.model.numeric_fieldtypes.includes(df.fieldtype)) {
-						if (df.fieldtype == 'Currency') {
-							if (!df.options || df.options !== 'Company:company:default_currency') {
-								return;
-							}
-						}
 						aggregate_based_on_fields.push({label: df.label, value: df.fieldname});
 					}
 				});


### PR DESCRIPTION
Outstanding amount not visible since it does not have the company currency set
The chart works perfectly when those fields are used
![image](https://user-images.githubusercontent.com/28212972/121059093-b21f6080-c7de-11eb-8b03-002528601fee.png)
