### PR TITLE
fix:check is_submittable attr exists in meta before accessing

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -730,7 +730,7 @@ class DatabaseQuery(object):
 					args.order_by = "`tab{0}`.`{1}` {2}".format(self.doctype, sort_field or "modified", sort_order or "desc")
 
 				# draft docs always on top
-				if meta.is_submittable:
+				if hasattr(meta, 'is_submittable') and meta.is_submittable:
 					args.order_by = "`tab{0}`.docstatus asc, {1}".format(self.doctype, args.order_by)
 
 	def validate_order_by_and_group_by(self, parameters):


### PR DESCRIPTION
The object 'meta' does not always have the attribute 'is_submittable.'
This extra syntax checks for existence first.