### PR TITLE
fix: Remove no_copy condition for route options.

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -69,8 +69,7 @@ $.extend(frappe.model, {
 					in_list(
 						["Link", "Data", "Select", "Dynamic Link"],
 						df.fieldtype
-					) &&
-					!df.no_copy
+					)
 				) {
 					doc[fieldname] = value;
 				}


### PR DESCRIPTION
I am facing an issue in creating Vital Signs from Patient Encounter Doctype. In Vital Signs, we have the 'encounter' (This field no_copy property set true) field which is set through route options when we create Vital Signs from Patient Encounter but due to this condition 'encounter' field not set through route_options, and Vital Signs not linked with Patient Encounter.

This is an issue that also can be resolved if I set no_copy=false but that will give a problem when any user duplicates any Vital Signs so that is copy Patient Encounter id in duplicate Vital SIgns as well.


