### PR TITLE
Fix translations for customizations in "public" folder

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -117,6 +117,7 @@ def get_dict(fortype, name=None):
 
 			messages += frappe.db.sql("""select 'navbar', item_label from `tabNavbar Item` where item_label is not null""")
 			messages = get_messages_from_include_files()
+			messages += get_all_messages_from_js_files()
 			messages += frappe.db.sql("select 'Print Format:', name from `tabPrint Format`")
 			messages += frappe.db.sql("select 'DocType:', name from tabDocType")
 			messages += frappe.db.sql("select 'Role:', name from tabRole")

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -10,6 +10,9 @@ import os, re
 import frappe
 from frappe import _
 import frappe.sessions
+import json
+from frappe.utils.response import json_handler
+
 
 def get_context(context):
 	if frappe.session.user == "Guest":
@@ -31,7 +34,8 @@ def get_context(context):
 
 	desk_theme = frappe.db.get_value("User", frappe.session.user, "desk_theme")
 
-	boot_json = frappe.as_json(boot)
+	# Fix login with account with Russian language set
+	boot_json = json.dumps(boot, indent=1, default=json_handler, separators=(',', ': '))
 
 	# remove script tags from boot
 	boot_json = re.sub("\<script[^<]*\</script\>", "", boot_json)

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -10,9 +10,6 @@ import os, re
 import frappe
 from frappe import _
 import frappe.sessions
-import json
-from frappe.utils.response import json_handler
-
 
 def get_context(context):
 	if frappe.session.user == "Guest":
@@ -34,8 +31,7 @@ def get_context(context):
 
 	desk_theme = frappe.db.get_value("User", frappe.session.user, "desk_theme")
 
-	# Fix login with account with Russian language set
-	boot_json = json.dumps(boot, indent=1, default=json_handler, separators=(',', ': '))
+	boot_json = frappe.as_json(boot)
 
 	# remove script tags from boot
 	boot_json = re.sub("\<script[^<]*\</script\>", "", boot_json)


### PR DESCRIPTION
This PR fixes translation issue I noticed making customizations for ERPNext doctypes with hooks. These translations wasn't loading in boot. 

Tree
> <img width="335" alt="Screenshot 2021-06-08 at 13 17 08" src="https://user-images.githubusercontent.com/75225148/121168686-e7b65f00-c85b-11eb-8d82-70b292807872.png">

In `public/js/sales_order.js`
```js
frm.add_custom_button(__('Check Availability'), () => {...
```

In `translations/ru.csv`
```
Check Availability,Проверить наличие
```

**Before (in user with Russian language)**
> <img width="143" alt="Screenshot 2021-06-08 at 13 17 15" src="https://user-images.githubusercontent.com/75225148/121168864-146a7680-c85c-11eb-9113-97241fcb1732.png">

**After**
> <img width="169" alt="Screenshot 2021-06-08 at 13 17 18" src="https://user-images.githubusercontent.com/75225148/121168875-16ccd080-c85c-11eb-8b59-0486a1498f16.png">
