### PR TITLE
Fix menu button bug (closes #13438)

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1136,8 +1136,9 @@ frappe.ui.form.Form = class FrappeForm {
 			// Add actions as menu item in Mobile View
 			let menu_item_label = group ? `${group} > ${label}` : label;
 			let menu_item = this.page.add_menu_item(menu_item_label, fn, false);
-			menu_item.parent().addClass("hidden-lg");
-
+			if (menu_item) {
+				menu_item.parent().addClass("hidden-lg");
+			}
 			this.custom_buttons[label] = btn;
 		}
 		return btn;


### PR DESCRIPTION
When there's two buttons with the same label error occurs. So to avoid it check if button added successfully before hiding it for web.