### PR TITLE
fix: Allow guest to comment on Web Page & Blog Post

### DIFF
--- a/frappe/templates/includes/comments/comments.html
+++ b/frappe/templates/includes/comments/comments.html
@@ -49,8 +49,10 @@
 {% endif %}
 <script>
 	frappe.ready(function() {
+		let guest_allowed = "{{ guest_allowed or ''}}";
+
 		if (!frappe.is_user_logged_in()) {
-			$(".login-required, .comment-form-wrapper").toggleClass("hidden");
+			!guest_allowed && $(".login-required, .comment-form-wrapper").toggleClass("hidden");
 		} else {
 			$('input.comment_by').prop("disabled", true);
 			$('input.comment_email').prop("disabled", true);
@@ -89,6 +91,16 @@
 				reference_name: "{{ reference_name or name }}",
 				comment_type: "Comment",
 				route: "{{ pathname }}",
+			}
+
+			if(!args.comment_by || !args.comment_email || !args.comment) {
+				frappe.msgprint("{{ _("All fields are necessary to submit the comment.") }}");
+				return false;
+			}
+
+			if (args.comment_email!=='Administrator' && !validate_email(args.comment_email)) {
+				frappe.msgprint("{{ _("Please enter a valid email address.") }}");
+				return false;
 			}
 
 			if(!args.comment || !args.comment.trim()) {

--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -13,6 +13,9 @@ from frappe import _
 def add_comment(comment, comment_email, comment_by, reference_doctype, reference_name, route):
 	doc = frappe.get_doc(reference_doctype, reference_name)
 
+	if not doc.doctype in ['Blog Post', 'Web Page']:
+		return
+
 	if not comment.strip():
 		frappe.msgprint(_('The comment cannot be empty'))
 		return False

--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -13,7 +13,7 @@ from frappe import _
 def add_comment(comment, comment_email, comment_by, reference_doctype, reference_name, route):
 	doc = frappe.get_doc(reference_doctype, reference_name)
 
-	if doc.doctype not in ['Blog Post', 'Web Page']:
+	if frappe.session.user == 'Guest' and doc.doctype not in ['Blog Post', 'Web Page']:
 		return
 
 	if not comment.strip():

--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -9,7 +9,7 @@ from frappe.utils import add_to_date, now
 
 from frappe import _
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def add_comment(comment, comment_email, comment_by, reference_doctype, reference_name, route):
 	doc = frappe.get_doc(reference_doctype, reference_name)
 
@@ -24,17 +24,14 @@ def add_comment(comment, comment_email, comment_by, reference_doctype, reference
 		frappe.msgprint(_('Comments cannot have links or email addresses'))
 		return False
 
-	if not comment_email == frappe.session.user:
-		comment_email = frappe.session.user
-
 	comments_count = frappe.db.count("Comment", {
 		"comment_type": "Comment",
-		"comment_email": frappe.session.user,
+		"comment_email": comment_email,
 		"creation": (">", add_to_date(now(), hours=-1))
 	})
 
 	if comments_count > 20:
-		frappe.msgprint(_('Hourly comment limit reached for: {0}').format(frappe.bold(frappe.session.user)))
+		frappe.msgprint(_('Hourly comment limit reached for: {0}').format(frappe.bold(comment_email)))
 		return False
 
 	comment = doc.add_comment(

--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -13,7 +13,7 @@ from frappe import _
 def add_comment(comment, comment_email, comment_by, reference_doctype, reference_name, route):
 	doc = frappe.get_doc(reference_doctype, reference_name)
 
-	if not doc.doctype in ['Blog Post', 'Web Page']:
+	if doc.doctype not in ['Blog Post', 'Web Page']:
 		return
 
 	if not comment.strip():

--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -110,6 +110,7 @@ class BlogPost(WebsiteGenerator):
 		context.parents = [{"name": _("Home"), "route":"/"},
 			{"name": "Blog", "route": "/blog"},
 			{"label": context.category.title, "route":context.category.route}]
+		context.guest_allowed = True
 
 	def fetch_cta(self):
 		if frappe.db.get_single_value("Blog Settings", "show_cta_in_blog", cache=True):

--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -55,6 +55,7 @@ class WebPage(WebsiteGenerator):
 
 		if self.enable_comments:
 			context.comment_list = get_comment_list(self.doctype, self.name)
+			context.guest_allowed = True
 
 		context.update({
 			"style": self.css or "",


### PR DESCRIPTION
PR: https://github.com/frappe/frappe/pull/10906 has blocked the comment feature from everywhere for the guest users since there was a security issue (#10884).

But, Blog Post & Web Page will require comment feature for guest users also.

This PR fixes this issue.