### PR TITLE
feat: Make url's clickable in text editor when typed/copied

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -4,7 +4,7 @@ import MagicUrl from 'quill-magic-url';
 
 
 Quill.register('modules/imageResize', ImageResize);
-Quill.register('modules/magicUrl', MagicUrl)
+Quill.register('modules/magicUrl', MagicUrl);
 const CodeBlockContainer = Quill.import('formats/code-block-container');
 CodeBlockContainer.tagName = 'PRE';
 Quill.register(CodeBlockContainer, true);

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -1,7 +1,10 @@
 import Quill from 'quill';
 import ImageResize from 'quill-image-resize';
+import MagicUrl from 'quill-magic-url';
+
 
 Quill.register('modules/imageResize', ImageResize);
+Quill.register('modules/magicUrl', MagicUrl)
 const CodeBlockContainer = Quill.import('formats/code-block-container');
 CodeBlockContainer.tagName = 'PRE';
 Quill.register(CodeBlockContainer, true);
@@ -148,7 +151,8 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 			modules: {
 				toolbar: this.get_toolbar_options(),
 				table: true,
-				imageResize: {}
+				imageResize: {},
+				magicUrl: true
 			},
 			theme: 'snow'
 		};

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "quagga": "^0.12.1",
     "quill": "2.0.0-dev.4",
     "quill-image-resize": "^3.0.9",
+    "quill-magic-url": "^3.0.0",
     "qz-tray": "^2.0.8",
     "redis": "^3.1.1",
     "showdown": "^1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4515,6 +4515,11 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
+normalize-url@^4.5.0:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.1.tgz#0dd90cf1288ee1d1313b87081c9a5932ee48518a"
+  integrity sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -5625,6 +5630,14 @@ quill-image-resize@^3.0.9:
     lodash "^4.17.4"
     quill "^1.2.2"
     raw-loader "^0.5.1"
+
+quill-magic-url@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/quill-magic-url/-/quill-magic-url-3.0.2.tgz#84654c749650e006250cbaf905295cb87796f3a7"
+  integrity sha512-kLPDwjNExGJZyCLGxbaiTFD/OYHagNLRvsdKRV+2d946I8cxaXaB7IT9wbrB49jC8z1X5cwI+pzZzHZeV0orFw==
+  dependencies:
+    normalize-url "^4.5.0"
+    quill-delta "^3.6.2"
 
 quill@2.0.0-dev.4:
   version "2.0.0-dev.4"


### PR DESCRIPTION
Use Quill module named `quill-magic-url` to automatically convert
typed/copied urls into links.

https://user-images.githubusercontent.com/36557/121561358-0a9c6b00-ca36-11eb-93c1-a32114510018.mov

> no-docs