### PR TITLE
Text editor support for align buttons 

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -163,6 +163,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 			['link', 'image'],
 			[{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'list': 'check' }],
 			[{ 'indent': '-1'}, { 'indent': '+1' }],
+			[{ 'align': [] }],
 			[{'table': [
 				'insert-table',
 				'insert-row-above',


### PR DESCRIPTION
The align buttons are not enabled for quill editor by default. Added the code to enable the align buttons