### PR TITLE
fix: Enable local file access for wkhtmltopdf

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -25,7 +25,7 @@ def get_pdf(html, options=None, output=None):
 
 	options.update({
 		"disable-javascript": "",
-		"disable-local-file-access": ""
+		"enable-local-file-access": None
 	})
 
 	filedata = ''


### PR DESCRIPTION
Currently, pdf generation is failing as [wkhtmltopdf is not able to access css/js files](https://github.com/frappe/erpnext/runs/2792916281). Enabling localfile access so that pdf is generated correctly.