### PR TITLE
fix: test failure due to uncommited transaction

### DIFF
--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -175,6 +175,7 @@ def run_tests_for_module(module, verbose=False, tests=(), profile=False, junit_x
 		for doctype in module.test_dependencies:
 			make_test_records(doctype, verbose=verbose)
 
+	frappe.db.commit()
 	return _run_unittest(module, verbose=verbose, tests=tests, profile=profile, junit_xml_output=junit_xml_output)
 
 def _run_unittest(modules, verbose=False, tests=(), profile=False, junit_xml_output=False):


### PR DESCRIPTION
Steps to reproduce:
- Create a fresh new site with Frappe
- Add and install a new app.
- Add basic test_file.py anywhere in module.
- Run the single using test with bench command:
`bench --site sitename run-tests --module module.dotted.path --test testname`

The test will not run and complain about the implicit commit.

- root cause: test runner makes changes to DB but does not commit. e.g.
disabling of scheduler on L57.

Note: this is not reproducible in FF or when ERPNext is installed because in many places of "test process" something else commits the changes like the `before_tests` hook, which usually isn't present in new apps.

Full traceback for reference:
```
bench --site testrun run-tests --module test_app.test_testtsss --test test_dummy
Traceback (most recent call last):
  File "/Users/ankush/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/Users/ankush/.pyenv/versions/3.7.9/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/ankush/benches/develop/env/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ankush/benches/develop/env/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/ankush/benches/develop/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ankush/benches/develop/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ankush/benches/develop/env/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ankush/benches/develop/env/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/ankush/benches/develop/env/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/commands/utils.py", line 602, in run_tests
    ui_tests=ui_tests, doctype_list_path=doctype_list_path, failfast=failfast)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/test_runner.py", line 69, in main
    ret = run_tests_for_module(module, verbose, tests, profile, junit_xml_output=junit_xml_output)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/test_runner.py", line 178, in run_tests_for_module
    return _run_unittest(module, verbose=verbose, tests=tests, profile=profile, junit_xml_output=junit_xml_output)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/test_runner.py", line 181, in _run_unittest
    frappe.db.begin()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 737, in begin
    self.sql("START TRANSACTION")
  File "/Users/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 115, in sql
    self.check_transaction_status(query)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 248, in check_transaction_status
    raise Exception('This statement can cause implicit commit')
Exception: This statement can cause implicit commit
```