### PR TITLE
fix: ability to select email account even if only one account is allowed

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -145,7 +145,7 @@ frappe.views.CommunicationComposer = class {
 			);
 		});
 
-		if (email_accounts.length > 1) {
+		if (email_accounts.length) {
 			fields.unshift({
 				label: __("From"),
 				fieldtype: "Select",


### PR DESCRIPTION
When user has access to only to one email account, they won't able to select 'From', causing the mail to be sent from default outgoing email account.

Closes #13474 
