### PR TITLE
fix: Grid delete all should trigger form change

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -210,9 +210,9 @@ export default class Grid {
 
 	delete_all_rows() {
 		frappe.confirm(__("Are you sure you want to delete all rows?"), () => {
-			this.frm.doc[this.df.fieldname] = [];
-			$(this.parent).find('.rows').empty();
-			this.grid_rows = [];
+			this.grid_rows.forEach(row => {
+				row.remove();
+			});
 			this.frm.script_manager.trigger(this.df.fieldname + "_delete", this.doctype);
 
 			this.wrapper.find('.grid-heading-row .grid-row-check:checked:first').prop('checked', 0);


### PR DESCRIPTION
Previously, "Delete All" button was not triggering a form's change event... this PR fixes that.

**Before:**
![2021-06-14 09 34 16](https://user-images.githubusercontent.com/13928957/121837670-cfc75b00-ccf3-11eb-8da8-bef6b1e28a0f.gif)



**After:**
![2021-06-14 09 33 33](https://user-images.githubusercontent.com/13928957/121837667-cd650100-ccf3-11eb-8498-e446624a95e1.gif)