### PR TITLE
fix: encode error to add outgoing mail to sent folder

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -12,7 +12,7 @@ import functools
 
 import email.utils
 
-from frappe import _, are_emails_muted
+from frappe import _, are_emails_muted, safe_encode
 from frappe.model.document import Document
 from frappe.utils import (validate_email_address, cint, cstr, get_datetime,
 	DATE_FORMAT, strip, comma_or, sanitize_html, add_days, parse_addr)
@@ -882,7 +882,6 @@ class EmailAccount(Document):
 
 
 	def append_email_to_sent_folder(self, message):
-
 		email_server = None
 		try:
 			email_server = self.get_incoming_server(in_receive=True)
@@ -896,7 +895,8 @@ class EmailAccount(Document):
 
 		if email_server.imap:
 			try:
-				email_server.imap.append("Sent", "\\Seen", imaplib.Time2Internaldate(time.time()), message.encode())
+				message = safe_encode(message)
+				email_server.imap.append("Sent", "\\Seen", imaplib.Time2Internaldate(time.time()), message)
 			except Exception:
 				frappe.log_error()
 


### PR DESCRIPTION
Failed to add outgoing mail to sent folder because of encoding issue.
fixed it by using safe_encode method.

