### PR TITLE
fix: Allow to remove filters from shortcut completely

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -323,6 +323,7 @@ frappe.ui.FilterGroup = class {
 	}
 
 	add_filters_to_filter_group(filters) {
+		this.toggle_empty_filters(false);
 		filters.forEach((filter) => {
 			this.add_filter(filter[0], filter[1], filter[2], filter[3]);
 		});

--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -323,10 +323,12 @@ frappe.ui.FilterGroup = class {
 	}
 
 	add_filters_to_filter_group(filters) {
-		this.toggle_empty_filters(false);
-		filters.forEach((filter) => {
-			this.add_filter(filter[0], filter[1], filter[2], filter[3]);
-		});
+		if (filters.length) {
+			this.toggle_empty_filters(false);
+			filters.forEach((filter) => {
+				this.add_filter(filter[0], filter[1], filter[2], filter[3]);
+			});
+		}
 	}
 
 	add(filters, refresh = true) {

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -271,18 +271,19 @@ class ShortcutDialog extends WidgetDialog {
 	}
 
 	process_data(data) {
-		let stats_filter = {};
 
 		if (this.dialog.get_value("type") == "DocType" && this.filter_group) {
 			let filters = this.filter_group.get_filters();
+			let stats_filter = null;
 
 			if (filters.length) {
+				stats_filter = {};
 				filters.forEach((arr) => {
 					stats_filter[arr[1]] = [arr[2], arr[3]];
 				});
-
-				data.stats_filter = JSON.stringify(stats_filter);
+				stats_filter = JSON.stringify(stats_filter);
 			}
+			data.stats_filter = stats_filter;
 		}
 
 		data.label = data.label


### PR DESCRIPTION
Previously, a user was not able to remove added filters completely from a shortcut. This PR resolves that.

**Before:** 

https://user-images.githubusercontent.com/13928957/121848172-4752b580-cd07-11eb-9dac-ff0899a969fa.mov

**Now:**

https://user-images.githubusercontent.com/13928957/121848383-94cf2280-cd07-11eb-903f-d1074d7be263.mov







