### PR TITLE
fix: Invalid Custom Report link on Workspace

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -453,6 +453,7 @@ def get_custom_report_list(module):
 			"type": "Link",
 			"link_type": "report",
 			"doctype": r.ref_doctype,
+			"dependencies": r.ref_doctype,
 			"is_query_report": 1 if r.report_type in ("Query Report", "Script Report", "Custom Report") else 0,
 			"label": _(r.name),
 			"link_to": r.name,

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1200,6 +1200,8 @@ Object.assign(frappe.utils, {
 			} else if (type === "report") {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;
+				} else if (!item.doctype) {
+					route = "/report/" + item.name;
 				} else {
 					route = frappe.router.slug(item.doctype) + "/view/report/" + item.name;
 				}

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -67,7 +67,7 @@ export default class LinksWidget extends Widget {
 				is_query_report: item.is_query_report
 			};
 
-			if (item.link_type == "Report" && !item.is_query_report) {
+			if (item.link_type.toLowerCase() == "report" && !item.is_query_report) {
 				opts.doctype = item.dependencies;
 			}
 


### PR DESCRIPTION
When we create a custom report, a card is added on the workspace with a link to that custom report, this was not working.

This PR is a fix for the above issue.

Before:
![image](https://user-images.githubusercontent.com/30859809/125278941-f4cdde80-e330-11eb-971a-5b0f1a283d98.png)

After:
![image](https://user-images.githubusercontent.com/30859809/125278734-b89a7e00-e330-11eb-8af8-6cbf715cde16.png)
