### PR TITLE
fix: fixed width for template row index

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -173,8 +173,7 @@ export default class GridRow {
 		// row index
 		if(this.doc) {
 			if(!this.row_index) {
-				this.row_index = $('<div style="float: left; margin-left: 15px; margin-top: 8px; \
-					margin-right: -20px;">'+this.row_check_html+' <span></span></div>').appendTo(this.row);
+				this.row_index = $(`<div class="template-row-index">${this.row_check_html}<span></span></div>`).appendTo(this.row);
 			}
 			this.row_index.find('span').html(this.doc.idx);
 		}

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -58,8 +58,15 @@
 }
 
 .form-grid .template-row {
-	width: calc(100% - 30px);
+	width: calc(100% - 20px);
 	padding: 8px 15px;
+}
+
+.template-row-index {
+	text-align: left;
+	margin-right: -50px;
+	padding: 8px 10px 0 15px;
+	width: 70px;
 }
 
 .grid-body .data-row {


### PR DESCRIPTION
Extends: #13489 
Requires: [#26059](https://github.com/frappe/erpnext/pull/26059)

- Set a fixed width for template row indexes
- Removed inline CSS

![image](https://user-images.githubusercontent.com/38958184/122022706-7a1eab80-cde4-11eb-9489-338653d922df.png) 

![image](https://user-images.githubusercontent.com/38958184/122023255-ff09c500-cde4-11eb-993a-8ed2e2f5bda5.png)

![image](https://user-images.githubusercontent.com/38958184/122023436-2a8caf80-cde5-11eb-9507-fdb72c6f78a0.png)

<!--![image](https://user-images.githubusercontent.com/38958184/122023122-dd104280-cde4-11eb-9c28-c58e9cfd6ba7.png)-->
<!--![image](https://user-images.githubusercontent.com/38958184/122022997-c2d66480-cde4-11eb-89f5-6023d85bf3b4.png)-->
<!--![image](https://user-images.githubusercontent.com/38958184/121904292-af74bc00-cd46-11eb-898d-da961d1aaae3.png)-->
<!--![image](https://user-images.githubusercontent.com/38958184/121904390-c4514f80-cd46-11eb-8439-f4bc5790f28b.png)-->
