### PR TITLE
fix: Allow renaming Email Groups

### DIFF
--- a/frappe/email/doctype/email_group/email_group.json
+++ b/frappe/email/doctype/email_group/email_group.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_import": 1,
+ "allow_rename": 1,
  "autoname": "field:title",
  "creation": "2015-03-18 06:08:32.729800",
  "doctype": "DocType",
@@ -50,7 +51,7 @@
    "link_fieldname": "email_group"
   }
  ],
- "modified": "2020-09-24 16:41:55.286377",
+ "modified": "2021-06-15 11:25:13.556201",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Group",


### PR DESCRIPTION
Currently, you can't rename records created in Email Group doctype.

One email group can be repurposed or changed or lists can be used for different goals, or simple mistakes can be made in names, hence renaming is necessary.