### PR TITLE
fix: Do not append child table doctype in case of _aggregate_column

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -410,7 +410,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			x_fields.push({
 				label: col.content,
 				fieldname: col.id,
-				value:  col.id,
+				value: col.id,
 			});
 
 			// numeric values in y
@@ -1024,8 +1024,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			return docfield.fieldtype === 'Date' ? 'right' : 'left';
 		})();
 
+		let id = fieldname;
+
 		// child table column
-		const id = doctype !== this.doctype ? `${doctype}:${fieldname}` : fieldname;
+		if (doctype !== this.doctype && fieldname !== '_aggregate_column') {
+			id = `${doctype}:${fieldname}`;
+		}
 
 		let width = (docfield ? cint(docfield.width) : null) || null;
 		if (this.report_doc) {


### PR DESCRIPTION
Chart rendering for report used to fail while applying "Group By" filter based on child table fields. This PR fixes that.

**Before:**
Applied filters
<img width="400" alt="Screenshot 2021-06-15 at 2 09 47 PM" src="https://user-images.githubusercontent.com/13928957/122021584-6aeb2e00-cde3-11eb-8d3d-28640f2a7e04.png">
<img width="500" alt="Screenshot 2021-06-15 at 2 14 40 PM" src="https://user-images.githubusercontent.com/13928957/122022244-0b415280-cde4-11eb-8c8c-eb8752528f3a.png">


**After:**
<img width="500" alt="Screenshot 2021-06-15 at 2 07 15 PM" src="https://user-images.githubusercontent.com/13928957/122021558-645cb680-cde3-11eb-9e7e-348bfc158220.png">

**Note:** `_aggregate_column` is a special column that should not be linked with any doctype
since it is a derived column.