### PR TITLE
fix: Remove meta from pickling overhead

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -83,10 +83,14 @@ class BaseDocument(object):
 
 	@property
 	def meta(self):
-		if not hasattr(self, "_meta"):
+		if not getattr(self, "_meta", None):
 			self._meta = frappe.get_meta(self.doctype)
 
 		return self._meta
+
+	def __getstate__(self):
+		self._meta = None
+		return self.__dict__
 
 	def update(self, d):
 		""" Update multiple fields of a doctype using a dictionary of key-value pairs.


### PR DESCRIPTION
1. Pickling a document pickles the dict, as well as the meta object.
2. Unpickling a document with meta causes a new meta object to be created instead from a global cache. 
3. Since meta is not needed as part of each document, removing it from the pickling (using pickle __getstate__ instruction) saves loads of ram and cache usage (99% per document in cache and 75% per document in memory).

To test this hypothesis, run following commands
```
import pickle
doc = frappe.get_doc('System Settings')
doc.meta
print('With meta', len(pickle.dumps(doc)))
doc._meta = None
print('Without meta', len(pickle.dumps(doc)))
```

Without and with fix optimisation
![Screenshot from 2021-06-15 17-27-30](https://user-images.githubusercontent.com/14350421/122048618-240b3180-cdff-11eb-8f2a-f0f8c097a43d.png)
