### PR TITLE
fix: Throttle set_open_count

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -5,6 +5,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	constructor(opts) {
 		$.extend(this, opts);
 		this.setup_dashboard_sections();
+		this.set_open_count = frappe.utils.throttle(this.set_open_count, 500);
 	}
 
 	setup_dashboard_sections() {


### PR DESCRIPTION
set_open_count is called every time form refresh is called.
Form links don't update that frequently, so this can be throttled.


Steps to test:

1. Open a saved sales invoice
2. go to console > network tab
3. get_open_count should not be called for each field like in the image below

![image](https://user-images.githubusercontent.com/28212972/122230282-1f19b100-ced7-11eb-9c7c-170532862b6e.png)
