### PR TITLE
fix: route to orignal form after creating a new document

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -446,6 +446,8 @@ frappe.ui.form.Form = class FrappeForm {
 				() => this.refresh_fields(),
 				// call trigger
 				() => this.script_manager.trigger("refresh"),
+				// route back to the parent document
+				() => frappe.router.route(),
 				// call onload post render for callbacks to be fired
 				() => {
 					if(this.cscript.is_onload) {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -446,8 +446,6 @@ frappe.ui.form.Form = class FrappeForm {
 				() => this.refresh_fields(),
 				// call trigger
 				() => this.script_manager.trigger("refresh"),
-				// route back to the parent document
-				() => frappe.router.route(),
 				// call onload post render for callbacks to be fired
 				() => {
 					if(this.cscript.is_onload) {
@@ -989,7 +987,7 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 
 		frappe.re_route[frappe.router.get_sub_path()] = `${encodeURIComponent(frappe.router.slug(this.doctype))}/${encodeURIComponent(name)}`;
-		frappe.set_route('Form', this.doctype, name);
+		!frappe._from_link && frappe.set_route('Form', this.doctype, name);
 	}
 
 	// ACTIONS


### PR DESCRIPTION
steps to reproduce:
1. go to a form with link field
2. click on create new document from the link field
3. open full view and add details
4. the content on the page will not change to the orignal document

Reason:
rename notify reroutes to the saved document
this may happen after our route to the new link creator document has happened

Solution:
In case of documents that are created from some other document they do not need to be redirected to the saved document

Before:
![Kapture 2021-06-28 at 17 09 08](https://user-images.githubusercontent.com/28212972/123630821-9afaee00-d833-11eb-9d0c-e11920d229e7.gif)


After
![Kapture 2021-06-28 at 17 02 01](https://user-images.githubusercontent.com/28212972/123630000-a0a40400-d832-11eb-8c2e-f285fad7fbc0.gif)
