### PR TITLE
fix: incoming mail handler

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -802,7 +802,7 @@ class InboundMail(Email):
 		except frappe.DuplicateEntryError:
 			# try and find matching parent
 			parent_name = frappe.db.get_value(self.email_account.append_to,
-				{email_fileds.sender_field: email.from_email}
+				{email_fileds.sender_field: self.from_email}
 			)
 			if parent_name:
 				parent.name = parent_name


### PR DESCRIPTION
Creating a communication record from incoming mail is failing in case reference document exists in the system already.
bug raised because of misspelled `self.from_email` as `email.from_email`

**Exception traceback**
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/background_jobs.py", line 97, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 707, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 456, in receive
    raise Exception(frappe.as_json(exceptions))
Exception: [
 "Traceback (most recent call last):\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/email/receive.py\", line 801, in _create_reference_document\n    parent.insert(ignore_permissions=True)\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py\", line 235, in insert\n    self.run_before_save_methods()\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py\", line 958, in run_before_save_methods\n    self.run_method(\"validate\")\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py\", line 856, in run_method\n    out = Document.hook(fn)(self, *args, **kwargs)\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py\", line 1145, in composer\n    return composed(self, method, *args, **kwargs)\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py\", line 1128, in runner\n    add_to_return_value(self, fn(self, *args, **kwargs))\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py\", line 850, in <lambda>\n    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)\n  File \"/home/frappe/frappe-io-bench/apps/erpnext/erpnext/crm/doctype/lead/lead.py\", line 42, in validate\n    self.check_email_id_is_unique()\n  File \"/home/frappe/frappe-io-bench/apps/erpnext/erpnext/crm/doctype/lead/lead.py\", line 84, in check_email_id_is_unique\n    .format(comma_and(duplicate_leads)), frappe.DuplicateEntryError)\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py\", line 430, in throw\n    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py\", line 409, in msgprint\n    _raise_exception()\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py\", line 363, in _raise_exception\n    raise raise_exception(msg)\nfrappe.exceptions.DuplicateEntryError: Email Address must be unique, already exists for Lead-20-21-54608\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 428, in receive\n    communication = mail.process()\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/email/receive.py\", line 605, in process\n    return self._build_communication_doc()\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/email/receive.py\", line 618, in _build_communication_doc\n    reference_doc = self._create_reference_document(self.email_account.append_to)\n  File \"/home/frappe/frappe-io-bench/apps/frappe/frappe/email/receive.py\", line 805, in _create_reference_document\n    {email_fileds.sender_field: email.from_email}\nAttributeError: module 'email' has no attribute 'from_email'\n"
]
