### PR TITLE
fix: added company to document link options in contacts

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -165,6 +165,10 @@ def filter_dynamic_link_doctypes(doctype, txt, searchfield, start, page_len, fil
 	_doctypes = tuple([d for d in _doctypes if re.search(txt+".*", _(d[0]), re.IGNORECASE)])
 
 	all_doctypes = [d[0] for d in doctypes + _doctypes]
+	# Company does not have a contact_html field.
+	if filters['fieldname'] == 'contact_html':
+		all_doctypes.append('Company')
+
 	allowed_doctypes = frappe.permissions.get_doctypes_with_read()
 
 	valid_doctypes = sorted(set(all_doctypes).intersection(set(allowed_doctypes)))


### PR DESCRIPTION
**Before:**
- No company option in filtered options while creating a contact.
- Options were filtered based on doctypes that had the contact_html fieldname which the company doctype does not have.
- Workaround used was to manually set the link field to Company.

![no_company](https://user-images.githubusercontent.com/43572428/122355175-520f8380-cf6f-11eb-951b-7bb12180c7a6.gif)

**Fix:**
- Hardcoded the company option.

![added_company](https://user-images.githubusercontent.com/43572428/122355442-87b46c80-cf6f-11eb-86d7-09f4f8fcd289.gif)



