### PR TITLE
fix: Avoid style leak from email or comment

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -190,6 +190,7 @@ class FormTimeline extends BaseTimeline {
 		}
 		doc.owner = doc.sender;
 		doc.user_full_name = doc.sender_full_name;
+		doc.content = frappe.dom.remove_script_and_style(doc.content);
 		let communication_content = $(frappe.render_template('timeline_message_box', { doc }));
 		if (allow_reply) {
 			this.setup_reply(communication_content, doc);
@@ -248,6 +249,7 @@ class FormTimeline extends BaseTimeline {
 	}
 
 	get_comment_timeline_content(doc) {
+		doc.content = frappe.dom.remove_script_and_style(doc.content);
 		const comment_content = $(frappe.render_template('timeline_message_box', { doc }));
 		this.setup_comment_actions(comment_content, doc);
 		return comment_content;


### PR DESCRIPTION
`remove_script_and_style` to avoid style leak from external email or comment content.

**Before:** 
Following is the example of a comment with a style tag. It used to override application styles.
<img width="1439" alt="Screenshot 2021-06-18 at 2 25 25 PM" src="https://user-images.githubusercontent.com/13928957/122535813-86ec0b00-d041-11eb-894e-8a133a8ca80d.png">
  
**Now:**
<img width="1440" alt="Screenshot 2021-06-18 at 2 24 04 PM" src="https://user-images.githubusercontent.com/13928957/122535337-18a74880-d041-11eb-9274-bca710a66627.png">

