### PR TITLE
test(type checking): add standard docfield types

### DIFF
--- a/frappe/types/__init__.py
+++ b/frappe/types/__init__.py
@@ -1,0 +1,3 @@
+
+
+from .docfields import *

--- a/frappe/types/docfields.py
+++ b/frappe/types/docfields.py
@@ -1,0 +1,80 @@
+from typing import List, TypeVar, TYPE_CHECKING
+from typing_extensions import Literal  # Literal is not in stdlib for 3.7
+
+
+if TYPE_CHECKING:
+	from frappe.model.document import Document
+
+
+# List type docfields, actual defined by the docfield but always subclass of `Document`
+# i.e. `Table[int]` isn't allowed but `Table[Item]` is.
+D = TypeVar("D", bound="Document")
+Table = List[D]
+TableMultiSelect = List[D]
+
+Select = Literal  # options to be defined by actual docfield.
+Check = Literal[0, 1]
+Rating = Literal[0, 1, 2, 3, 4, 5]
+
+# Type aliases for standard docfields.
+Link = str
+DynamicLink = str
+Attach = str
+AttachImage = str
+Image = str
+Date = str
+DateTime = str
+Barcode = str
+Code = str
+Html = str
+Color = str
+SmallText = str
+LongText = str
+Text = str
+TextEditor = str
+Markdown = str
+Password = str
+ReadOnly = str
+Time = str
+
+Integer = int
+Duration = int
+
+Currency = float
+Float = float
+Percent = float
+
+
+
+# prevent `import *` from polluting namespace
+__all__ = [
+	"Table",
+	"TableMultiSelect",
+	"Select",
+	"Check",
+	"Rating",
+	"Link",
+	"DynamicLink",
+	"Attach",
+	"AttachImage",
+	"Image",
+	"Date",
+	"DateTime",
+	"Barcode",
+	"Code",
+	"Html",
+	"Color",
+	"SmallText",
+	"LongText",
+	"Text",
+	"TextEditor",
+	"Markdown",
+	"Password",
+	"ReadOnly",
+	"Time",
+	"Integer",
+	"Duration",
+	"Currency",
+	"Float",
+	"Percent",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,7 @@ six~=1.15.0
 sqlparse~=0.4.1
 stripe~=2.56.0
 terminaltables~=3.1.0
+typing-extensions>=3.7.4.3
 unittest-xml-reporting~=3.0.4
 urllib3~=1.26.4
 Werkzeug~=0.16.1


### PR DESCRIPTION
I am working on automating stub generation for existing doctypes, however, I feel main type definitions should live in frappe package itself so anyone can use them. 

- Introduced `frappe.types` module for storing type-related info.
- Added aliases for most standard docfields. Aliases don't do much from type checking perspective, other than offering readability. i.e. while `Data` and `Text` field are `str` to python, it's good to have some idea about what we are dealing with.

Any suggestions are welcome.


---

`typing_extensions` dependency required because we still support 3.7