### PR TITLE
fix: Add checkbox css variables to common/css_variables

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -204,4 +204,9 @@
 	--primary-color: #2490EF;
 	--btn-height: 28px;
 
+	// Checkbox
+	--checkbox-right-margin: var(--margin-xs);
+	--checkbox-size: 14px;
+	--checkbox-focus-shadow: 0 0 0 2px var(--gray-300);
+	
 }


### PR DESCRIPTION
Checkbox CSS variables not getting loaded after PR https://github.com/frappe/frappe/pull/13019

Checkboxes were not working properly in websites after [this PR](https://github.com/frappe/frappe/pull/13019)
**Before:**
<img width="95" alt="Screenshot 2021-06-22 at 9 49 06 AM" src="https://user-images.githubusercontent.com/13928957/122862656-18f45c00-d33f-11eb-8f56-c8ec23c3f363.png">

**After:**
<img width="100" alt="Screenshot 2021-06-22 at 9 50 40 AM" src="https://user-images.githubusercontent.com/13928957/122862815-5eb12480-d33f-11eb-83f4-fb517e1a1cc9.png">

