### PR TITLE
use X-Forwarded-Port in get_url()

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1097,7 +1097,9 @@ def get_url(uri=None, full_address=False):
 	if not uri and full_address:
 		uri = frappe.get_request_header("REQUEST_URI", "")
 
-	port = frappe.conf.http_port or frappe.conf.webserver_port
+	port = frappe.get_request_header('X-Forwarded-Port', None)
+	if not port:
+		port = frappe.conf.http_port or frappe.conf.webserver_port
 
 	if not (frappe.conf.restart_supervisor_on_update or frappe.conf.restart_systemd_on_update) and host_name and not url_contains_port(host_name) and port:
 		host_name = host_name + ':' + str(port)


### PR DESCRIPTION
when frappe is behind a reverse proxy/load balancer, the external facing URL will be different from the internal URL.
Therefore it is required to use the external URL information that's passed by the proxy server via the `X-Forwarded-Port` and `X-Forward-Proto` headers.