### PR TITLE
fix: Add frappe.rename_doc to Server Scripts

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -85,6 +85,7 @@ def get_safe_globals():
 			get_list=frappe.get_list,
 			get_all=frappe.get_all,
 			get_system_settings=frappe.get_system_settings,
+			rename_doc=frappe.rename_doc,
 
 			utils=datautils,
 			get_url=frappe.utils.get_url,


### PR DESCRIPTION
This PR allows the use of `frappe.rename_doc` method in server script environments.