### PR TITLE
fix: Use IP Address instead of Email field

### DIFF
--- a/frappe/core/doctype/feedback/feedback.json
+++ b/frappe/core/doctype/feedback/feedback.json
@@ -8,8 +8,8 @@
   "reference_doctype",
   "reference_name",
   "column_break_3",
-  "email",
   "rating",
+  "ip_address",
   "section_break_6",
   "feedback"
  ],
@@ -17,12 +17,6 @@
   {
    "fieldname": "column_break_3",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "email",
-   "fieldtype": "Data",
-   "label": "Email",
-   "reqd": 1
   },
   {
    "fieldname": "rating",
@@ -56,11 +50,18 @@
    "label": "Reference Name",
    "options": "reference_doctype",
    "reqd": 1
+  },
+  {
+   "fieldname": "ip_address",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "IP Address",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-06-14 15:11:26.005805",
+ "modified": "2021-06-23 12:45:42.045696",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Feedback",

--- a/frappe/core/doctype/feedback/test_feedback.py
+++ b/frappe/core/doctype/feedback/test_feedback.py
@@ -12,12 +12,12 @@ class TestFeedback(unittest.TestCase):
 		frappe.db.sql("delete from `tabFeedback` where reference_doctype = 'Blog Post'")
 
 		from frappe.templates.includes.feedback.feedback import add_feedback, update_feedback
-		feedback = add_feedback('Blog Post', test_blog.name, 5, 'New feedback','test@test.com')
+		feedback = add_feedback('Blog Post', test_blog.name, 5, 'New feedback')
 
 		self.assertEqual(feedback.feedback, 'New feedback')
 		self.assertEqual(feedback.rating, 5)
 
-		updated_feedback = update_feedback('Blog Post', test_blog.name, 6, 'Updated feedback', 'test@test.com')
+		updated_feedback = update_feedback('Blog Post', test_blog.name, 6, 'Updated feedback')
 
 		self.assertEqual(updated_feedback.feedback, 'Updated feedback')
 		self.assertEqual(updated_feedback.rating, 6)

--- a/frappe/templates/includes/feedback/feedback.html
+++ b/frappe/templates/includes/feedback/feedback.html
@@ -8,9 +8,6 @@
 				<fieldset>
 					<div class="row" style="margin-bottom: 15px;">
 						<div class="col-sm-6">
-							<input class="form-control feedback_email" name="feedback_email" placeholder="{{ _("Your Email Address") }}" type="email">
-						</div>
-						<div class="col-sm-6">
 							<div class="rating">
 								{% for rating in [1, 2, 3, 4, 5 ,6, 7, 8, 9, 10] %}
 									<div class="icon rating-box" data-rating="{{ rating }}">{{ rating }}</div>
@@ -41,7 +38,6 @@
 		feedback && $("#submit-feedback").html(__("Update"));
 
 		if (frappe.is_user_logged_in()) {
-			$(".feedback_email").parent().toggleClass("hidden");
 			if (feedback) {
 				$("[name='feedback']").val(feedback);
 				toggle_feedback();
@@ -83,12 +79,12 @@
 
 		$('#submit-feedback').click((ev) => {
 			let update = ev.target.innerText !== __("Submit");
+			let rating = $('.rating').find('.rating-click').length;
 			let args = {
 				reference_doctype: "{{ reference_doctype or doctype }}",
 				reference_name: "{{ reference_name or name }}",
 				rating: rating,
-				feedback: $("[name='feedback']").val(),
-				feedback_email: $("[name='feedback_email']").val() || frappe.user_id
+				feedback: $("[name='feedback']").val()
 			}
 
 			if (args.rating == 0) {
@@ -101,16 +97,14 @@
 				return false;
 			}
 
-			if (args.feedback_email!=='Administrator' && !validate_email(args.feedback_email)) {
-				frappe.msgprint("{{ _("Please enter a valid email address.") }}");
-				return false;
-			}
-
 			if (!update) {
 				frappe.call({
 					method: "frappe.templates.includes.feedback.feedback.add_feedback",
 					args: args,
 					callback: function(r) {
+						if (!r.message) {
+							return
+						}
 						toggle_feedback();
 						if (!frappe.is_user_logged_in()) {
 							$("[name='feedback']").val('');

--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -147,12 +147,15 @@ class BlogPost(WebsiteGenerator):
 				context.comment_text = _('{0} comments').format(len(context.comment_list))
 
 	def load_feedback(self, context):
+		user = frappe.session.user
+		if user == 'Guest':
+			user = ''
 		feedback = frappe.get_all('Feedback',
-			fields=['email', 'feedback', 'rating'],
+			fields=['feedback', 'rating'],
 			filters=dict(
 				reference_doctype=self.doctype,
 				reference_name=self.name,
-				email=frappe.session.user
+				owner=user
 			)
 		)
 		context.user_feedback = feedback[0] if feedback else ''


### PR DESCRIPTION
Removed Email field from Feedback.
Now using IP Address to keep track of the feedback of Guest User and added a limit of 20 feedback in 1 hour based on IP Address

Before:
![image](https://user-images.githubusercontent.com/30859809/123054456-80cfa300-d422-11eb-8b35-c48c29415f7b.png)

After:
![image](https://user-images.githubusercontent.com/30859809/123054242-4d8d1400-d422-11eb-8690-5733f5790029.png)
