### PR TITLE
fix: drag and drop for kanban board

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -180,7 +180,7 @@ frappe.provide("frappe.views");
 					method_name = "update_order_for_single_card";
 					args = {
 						board_name: this.board.name,
-						docname: unescape(card.name),
+						docname: card.name,
 						from_colname: card.from_colname,
 						to_colname: card.to_colname,
 						old_index: card.old_index,
@@ -222,7 +222,7 @@ frappe.provide("frappe.views");
 						var col_name = $(this).data().columnValue;
 						order[col_name] = [];
 						$(this).find('.kanban-card-wrapper').each(function() {
-							var card_name = unescape($(this).data().name);
+							var card_name = decodeURIComponent($(this).data().name);
 							order[col_name].push(card_name);
 						});
 					});
@@ -514,7 +514,7 @@ frappe.provide("frappe.views");
 					wrapper.find('.kanban-cards').height('auto');
 					// update order
 					const args = {
-						name: $(e.item).attr('data-name'),
+						name: decodeURIComponent($(e.item).attr('data-name')),
 						from_colname: $(e.from).parents('.kanban-column').attr('data-column-value'),
 						to_colname: $(e.to).parents('.kanban-column').attr('data-column-value'),
 						old_index: e.oldIndex,

--- a/frappe/public/js/frappe/views/kanban/kanban_card.html
+++ b/frappe/public/js/frappe/views/kanban/kanban_card.html
@@ -1,4 +1,4 @@
-<div class="kanban-card-wrapper {{ disable_click }}" data-name="{{escape(name)}}">
+<div class="kanban-card-wrapper {{ disable_click }}" data-name="{{encodeURIComponent(name)}}">
 	<a class="kanban-card-redirect" href="#">
 		<div class="kanban-card content">
 			{% if(image_url) { %}


### PR DESCRIPTION
## Issue
If the `name` of a document has spaces or any special characters, the drag and drop functionality of kanban board doesn't work.

## Fixes
 * Decode `card.name` before using it.
 * Remove redundant decoding.
 * Use `encodeURIComponent/decodeURIComponent` since it is [preferred over `escape/unescape`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape).

## Screenshots
### Before:

![kanaban_not_dragging_issue_before](https://user-images.githubusercontent.com/43115036/123218151-0027aa00-d4e9-11eb-8bc9-05147983bf0e.gif)

### After:
![kanaban_not_dragging_issue_after](https://user-images.githubusercontent.com/43115036/123235588-a380bb00-d4f9-11eb-926a-a9b472e33559.gif)
