### PR TITLE
fix: Make .bundle. files compatible with v13

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "driver.js": "^0.9.8",
     "express": "^4.17.1",
     "fast-deep-equal": "^2.0.1",
+    "fast-glob": "^3.2.5",
     "frappe-charts": "^2.0.0-rc13",
     "frappe-datatable": "^1.15.3",
     "frappe-gantt": "^0.5.0",

--- a/rollup/config.js
+++ b/rollup/config.js
@@ -183,9 +183,9 @@ function get_options(file, app = "frappe") {
 						return path.resolve(prefix, input_file);
 					});
 				return Object.assign(
-					get_rollup_options(output_file, input_files), {
-					output_file
-				});
+					get_rollup_options(output_file, input_files),
+					{ output_file }
+				);
 			}
 		})
 		.filter(Boolean);
@@ -204,7 +204,7 @@ function get_options_for(app) {
 					public_path,
 					"**",
 					"*.bundle.{js,css,sass,scss,less}"
-				)
+				);
 			let ignore_pattern = path.resolve(public_path, "node_modules");
 			let files = glob.sync(include_pattern, { ignore: ignore_pattern });
 
@@ -218,7 +218,7 @@ function get_options_for(app) {
 		} else {
 			build_json = {};
 		}
-	};
+	}
 
 	return Object.keys(build_json)
 		.map(output_file => {
@@ -237,9 +237,9 @@ function get_options_for(app) {
 					return path.resolve(prefix, input_file);
 				});
 			return Object.assign(
-				get_rollup_options(output_file, input_files), {
-				output_file
-			});
+				get_rollup_options(output_file, input_files),
+				{ output_file }
+			);
 		})
 		.filter(Boolean);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2562,6 +2562,18 @@ fast-diff@1.2.0:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-glob@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
+  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.0"
+    merge2 "^1.3.0"
+    micromatch "^4.0.2"
+    picomatch "^2.2.1"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -2869,6 +2881,13 @@ gl-vec3@^1.0.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/gl-vec3/-/gl-vec3-1.1.3.tgz#a47c62f918774a06cbed1b65bcd0288ecbb03826"
   integrity sha512-jduKUqT0SGH02l8Yl+mV1yVsDfYgQAJyXGxkJQGyxPLHRiW25DwVIRPt6uvhrEMHftJfqhqKthRcyZqNEl9Xdw==
+
+glob-parent@^5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob@7.1.2:
   version "7.1.2"


### PR DESCRIPTION
Custom Apps that use .bundle. files won't work correctly on v13. This PR enables a compatibility change so that you don't need to maintain multiple versions of custom apps.

For e.g., the ERPNext Support App now uses the new bundle files. But the app doesn't work on v13. This PR will make it work.

Note: This PR should NOT be front ported to `develop` as this is a temporary compatibility change.