### PR TITLE
feat: translate connection group label

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_links.html
+++ b/frappe/public/js/frappe/form/templates/form_links.html
@@ -5,7 +5,7 @@
 		{% } %}
 			<div class="col-md-4">
 				<div class="form-link-title">
-					<span>{{ transactions[i].label }}<span>
+					<span>{{ __(transactions[i].label) }}<span>
 				</div>
 				{% for (let j=0; j < transactions[i].items.length; j++) { %}
 					{% let doctype = transactions[i].items[j]; %}

--- a/frappe/public/js/frappe/form/templates/report_links.html
+++ b/frappe/public/js/frappe/form/templates/report_links.html
@@ -5,7 +5,7 @@
 		{% } %}
 			<div class="col-md-4">
 				<div class="form-link-title">
-					<span>{{ reports[i].label }}</span>
+					<span>{{ __(reports[i].label) }}</span>
 				</div>
 				{% for (let j=0; j < reports[i].items.length; j++) { %}
 					{% let report = reports[i].items[j]; %}


### PR DESCRIPTION
In the form dashboard, connections can be grouped under different labels. Let's translate these as well.

> no-docs