### PR TITLE
feat: Convenience methods for NestedSet {get_parent, get_children}

### DIFF
--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -269,7 +269,7 @@ class NestedSet(Document):
 			return frappe.get_doc(self.doctype, parent_name)
 
 	def get_children(self):
-		"""Return a list of child Documents."""
+		"""Return a generator that yields child Documents."""
 		child_names = frappe.get_list(self.doctype, filters={self.nsm_parent_field: self.name}, pluck="name")
 		for name in child_names:
 			yield frappe.get_doc(self.doctype, name)

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -263,14 +263,14 @@ class NestedSet(Document):
 		return get_ancestors_of(self.doctype, self.name)
 
 	@property
-	def parent(self, **kwargs):
+	def parent(self):
 		"""Return the parent Document."""
 		parent_name = self.get(self.nsm_parent_field)
 		if parent_name:
-			return frappe.get_cached_doc(self.doctype, parent_name, **kwargs)
+			return frappe.get_cached_doc(self.doctype, parent_name)
 
 	@property
-	def children(self, **kwargs):
+	def children(self):
 		"""Return a list of child Documents."""
 		return [
 			frappe.get_cached_doc(self.doctype, name)

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -273,7 +273,7 @@ class NestedSet(Document):
 	def children(self, **kwargs):
 		"""Return a list of child Documents."""
 		return [
-			frappe.get_cached_doc("Organization", name)
+			frappe.get_cached_doc(self.doctype, name)
 			for name in frappe.get_list(
 				self.doctype,
 				filters={

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -262,18 +262,16 @@ class NestedSet(Document):
 	def get_ancestors(self):
 		return get_ancestors_of(self.doctype, self.name)
 
-	@property
-	def parent(self):
+	def get_parent(self):
 		"""Return the parent Document."""
 		parent_name = self.get(self.nsm_parent_field)
 		if parent_name:
-			return frappe.get_cached_doc(self.doctype, parent_name)
+			return frappe.get_doc(self.doctype, parent_name)
 
-	@property
-	def children(self):
+	def get_children(self):
 		"""Return a list of child Documents."""
 		return [
-			frappe.get_cached_doc(self.doctype, name)
+			frappe.get_doc(self.doctype, name)
 			for name in frappe.get_list(
 				self.doctype,
 				filters={

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -262,6 +262,28 @@ class NestedSet(Document):
 	def get_ancestors(self):
 		return get_ancestors_of(self.doctype, self.name)
 
+	@property
+	def parent(self, **kwargs):
+		"""Return the parent Document."""
+		parent_name = self.get(self.nsm_parent_field)
+		if parent_name:
+			return frappe.get_cached_doc(self.doctype, parent_name, **kwargs)
+
+	@property
+	def children(self, **kwargs):
+		"""Return a list of child Documents."""
+		return [
+			frappe.get_cached_doc("Organization", name)
+			for name in frappe.get_list(
+				self.doctype,
+				filters={
+					self.nsm_parent_field: self.name
+				},
+				pluck="name"
+			)
+		]
+
+
 def get_root_of(doctype):
 	"""Get root element of a DocType with a tree structure"""
 	result = frappe.db.sql("""select t1.name from `tab{0}` t1 where

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -270,16 +270,9 @@ class NestedSet(Document):
 
 	def get_children(self):
 		"""Return a list of child Documents."""
-		return [
-			frappe.get_doc(self.doctype, name)
-			for name in frappe.get_list(
-				self.doctype,
-				filters={
-					self.nsm_parent_field: self.name
-				},
-				pluck="name"
-			)
-		]
+		child_names = frappe.get_list(self.doctype, filters={self.nsm_parent_field: self.name}, pluck="name")
+		for name in child_names:
+			yield frappe.get_doc(self.doctype, name)
 
 
 def get_root_of(doctype):

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -262,13 +262,13 @@ class NestedSet(Document):
 	def get_ancestors(self):
 		return get_ancestors_of(self.doctype, self.name)
 
-	def get_parent(self):
+	def get_parent(self) -> NestedSet:
 		"""Return the parent Document."""
 		parent_name = self.get(self.nsm_parent_field)
 		if parent_name:
 			return frappe.get_doc(self.doctype, parent_name)
 
-	def get_children(self):
+	def get_children(self) -> Iterator[NestedSet]:
 		"""Return a generator that yields child Documents."""
 		child_names = frappe.get_list(self.doctype, filters={self.nsm_parent_field: self.name}, pluck="name")
 		for name in child_names:

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -10,7 +10,7 @@
 # 3. call update_nsm(doc_obj) in the on_upate method
 
 # ------------------------------------------
-from collections.abc import Iterator
+from typing import Iterator
 
 import frappe
 from frappe import _

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -262,13 +262,13 @@ class NestedSet(Document):
 	def get_ancestors(self):
 		return get_ancestors_of(self.doctype, self.name)
 
-	def get_parent(self) -> NestedSet:
+	def get_parent(self) -> "NestedSet":
 		"""Return the parent Document."""
 		parent_name = self.get(self.nsm_parent_field)
 		if parent_name:
 			return frappe.get_doc(self.doctype, parent_name)
 
-	def get_children(self) -> Iterator[NestedSet]:
+	def get_children(self) -> Iterator["NestedSet"]:
 		"""Return a generator that yields child Documents."""
 		child_names = frappe.get_list(self.doctype, filters={self.nsm_parent_field: self.name}, pluck="name")
 		for name in child_names:

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -10,6 +10,8 @@
 # 3. call update_nsm(doc_obj) in the on_upate method
 
 # ------------------------------------------
+from collections.abc import Iterator
+
 import frappe
 from frappe import _
 from frappe.model.document import Document


### PR DESCRIPTION
Make working with tree DocTypes easier.

Let's take the ERPNext Chart of Accounts as an example:

- 4000 - Income
    - 4100 - Direct Income
        - 4110 - Sales (<- we start here)
        - 4120 - Service
    - 4200 - Indirect Income

```py
doc = frappe.get_doc("Account", "4110 - Sales")

for child in doc.get_children():
    print(child.name)
# <empty>

doc.get_parent().name
# 4100 - Direct Income

for child in doc.get_parent().get_children():
    print(child.name)
# 4110 - Sales
# 4120 - Service

doc.get_parent().get_parent().name
# 4000 - Income

for child in doc.get_parent().get_parent().get_children():
    print(child.name)
# 4100 - Direct Income
# 4200 - Indirect Income

doc.get_parent().get_parent().get_parent()
# None
```

Docs: https://github.com/frappe/frappe_docs/pull/223