### PR TITLE
perf: only cache docs that are fetched from cache

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -807,6 +807,11 @@ def get_cached_doc(*args, **kwargs):
 
 	# database
 	doc = get_doc(*args, **kwargs)
+	# set in cache
+	if args and len(args) > 1:
+		key = get_document_cache_key(args[0], args[1])
+		local.document_cache[key] = doc
+		cache().hset('document_cache', key, doc.as_dict())
 
 	return doc
 
@@ -849,15 +854,7 @@ def get_doc(*args, **kwargs):
 
 	"""
 	import frappe.model.document
-	doc = frappe.model.document.get_doc(*args, **kwargs)
-
-	# set in cache
-	if args and len(args) > 1:
-		key = get_document_cache_key(args[0], args[1])
-		local.document_cache[key] = doc
-		cache().hset('document_cache', key, doc.as_dict())
-
-	return doc
+	return frappe.model.document.get_doc(*args, **kwargs)
 
 def get_last_doc(doctype, filters=None, order_by="creation desc"):
 	"""Get last created document of this type."""


### PR DESCRIPTION
As per current implementation whenever `get_doc` is called, document is cached. However, this cache is only ever used by `get_cached_doc`. Going through the codebase of both FF/ERPNext you'll find that `get_doc` is used a lot more than `get_cached_doc`. So in many places, all this caching overhead is unnecessary.

Pros: faster `get_doc`, slightly lower memory usage. Correctness i.e. caching only what gets used from cache. 
Con: After this change. First call to `get_cached_doc` will always be a cache miss.

```
# Before
%timeit frappe.get_doc("Sales Order", "SAL-ORD-2021-00009")
22.1 ms ± 195 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

# After
%timeit frappe.get_doc("Sales Order", "SAL-ORD-2021-00009")
16.9 ms ± 18.5 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```


---

PS: Any better ideas for benchmarking are welcome. 