### PR TITLE
fix: Calendar view of a doctype

### DIFF
--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -25,7 +25,6 @@ def get_event_conditions(doctype, filters=None):
 
 @frappe.whitelist()
 def get_events(doctype, start, end, field_map, filters=None, fields=None):
-
 	field_map = frappe._dict(json.loads(field_map))
 	fields = frappe.parse_json(fields)
 
@@ -36,8 +35,7 @@ def get_events(doctype, start, end, field_map, filters=None, fields=None):
 				"color": d.fieldname
 			})
 
-	if filters:
-		filters = json.loads(filters or '')
+	filters = json.loads(filters) if filters else []
 
 	if not fields:
 		fields = [field_map.start, field_map.end, field_map.title, 'name']
@@ -52,5 +50,5 @@ def get_events(doctype, start, end, field_map, filters=None, fields=None):
 		[doctype, start_date, '<=', end],
 		[doctype, end_date, '>=', start],
 	]
-
+	fields = list({field for field in fields if field})
 	return frappe.get_list(doctype, fields=fields, filters=filters)

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -109,7 +109,7 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 frappe.views.Calendar = class Calendar {
 	constructor(options) {
 		$.extend(this, options);
-		this.field_map = {
+		this.field_map = this.field_map || {
 			"id": "name",
 			"start": "start",
 			"end": "end",


### PR DESCRIPTION
Calendar view is failing with the below error as default field map is always sent instead of doctype related field map while getting calendar events.

![Screenshot 2021-06-26 at 8 29 43 PM](https://user-images.githubusercontent.com/36557/123517192-403f8600-d6bd-11eb-80fe-e435b4a44eef.png)
