### PR TITLE
fix(UI): Editor link popover & datepicker style 

### DIFF
--- a/frappe/public/scss/common/datepicker.scss
+++ b/frappe/public/scss/common/datepicker.scss
@@ -15,6 +15,10 @@
 
 	&--time-current-hours, &--time-current-minutes, &--time-current-seconds {
 		font-family: inherit;
+		&:after {
+			color: var(--text-color);
+			background-color: var(--fg-hover-color);
+		}
 	}
 
 	&--day-name {
@@ -47,10 +51,13 @@
 			background: fade(#0089FF, 10%);
 		}
 
+		&.-focus- {
+			background-color: var(--fg-hover-color);
+		}
+
 		&.-selected-.-focus- {
 			background: fade(#0089FF, 90%);
 		}
-
 	}
 
 	&--time, &--buttons {
@@ -67,8 +74,20 @@
 	&--time-row:first-child {
 		margin: 0;
 	}
+
+	&--pointer {
+		background: var(--fg-color);
+		border-top-right-radius: 2px;
+		border: 1px var(--border-color);
+		border-style: solid solid hidden hidden;
+	}
+
+	&--button {
+		color: var(--brand-color);
+		&:hover {
+			color: var(--text-color);
+			background-color: var(--fg-hover-color);
+		}
+	}
 }
 
-.datepicker--button {
-	color: var(--brand-color);
-}

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -35,13 +35,14 @@
 .ql-container.ql-snow {
 	border-bottom-left-radius: var(--border-radius);
 	border-bottom-right-radius: var(--border-radius);
-	overflow: hidden;
 }
 
 .ql-snow {
 	.ql-editor {
 		min-height: 400px;
 		max-height: 600px;
+		border-bottom-left-radius: var(--border-radius);
+		border-bottom-right-radius: var(--border-radius);
 	}
 	.ql-stroke {
 		stroke: var(--icon-stroke);


### PR DESCRIPTION
Link popover in Text Editor

**Before:**
<img width="300" alt="Screenshot 2021-06-27 at 11 12 51 AM" src="https://user-images.githubusercontent.com/13928957/123534147-a0274280-d738-11eb-9ba9-01d6c4a6a04b.png">


**After:**
<img width="300" alt="Screenshot 2021-06-27 at 11 11 24 AM" src="https://user-images.githubusercontent.com/13928957/123534130-7c63fc80-d738-11eb-90f1-da4254d9b711.png">


---
Datepicker style in Dark Mode

**Before:**
<img width="200" alt="Screenshot 2021-06-27 at 9 34 46 AM" src="https://user-images.githubusercontent.com/13928957/123533880-96044480-d736-11eb-8f5c-b51b93627804.png">

**After:**
<img width="200" alt="Screenshot 2021-06-27 at 11 09 10 AM" src="https://user-images.githubusercontent.com/13928957/123534106-373fca80-d738-11eb-94d6-ecdbb71ea97c.png">

