### PR TITLE
fix: incorrect depends on evalutation with parent variables

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -543,7 +543,7 @@ frappe.ui.form.Layout = class Layout {
 
 		} else if (expression.substr(0, 5)=='eval:') {
 			try {
-				out = frappe.utils.eval(expression.substr(5), { doc });
+				out = frappe.utils.eval(expression.substr(5), { doc, parent });
 				if (parent && parent.istable && expression.includes('is_submittable')) {
 					out = true;
 				}


### PR DESCRIPTION
Depends on conditions like `parent.doctype == 'Asset'` were not working

Following case should work after the fix:
- If Doctype ToDo is linked with a child table ToDo Item
- A field in ToDo Item let's say, `completed` has a `depends_on` condition to make it visible only if the parent i.e ToDo is marked as completed
- Depends on condition for the child table field would be `depends_on: parent.status == 'completed'`