### PR TITLE
fix: Set currency only if df exists

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -743,7 +743,7 @@ class BaseDocument(object):
 			from frappe.model.meta import get_default_df
 			df = get_default_df(fieldname)
 
-		if not currency:
+		if df and not currency:
 			currency = self.get(df.get("options"))
 			if not frappe.db.exists('Currency', currency, cache=True):
 				currency = None


### PR DESCRIPTION
Custom fields that don't exist anymore but are still mentioned in Print Formats break after https://github.com/frappe/frappe/pull/12569. This caused the print view to render and sometimes throw the following traceback.

Traceback:

<details>

```py
In [8]: get_rendered_template(doc, print_format = print_format,
   ...:             meta=meta, trigger_print = frappe.form_dict.trigger_print,
   ...:             no_letterhead=frappe.form_dict.no_letterhead)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/commands/utils.py in <module>()
      1 get_rendered_template(doc, print_format = print_format,
      2             meta=meta, trigger_print = frappe.form_dict.trigger_print,
----> 3             no_letterhead=frappe.form_dict.no_letterhead)

/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/www/printview.py in get_rendered_template(doc, name, print_format, meta, no_letterhead, trigger_print)
    158         }
    159
--> 160         html = template.render(args, filters={"len": len})
    161
    162         if cint(trigger_print):

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/environment.py in render(self, *args, **kwargs)
   1088             return concat(self.root_render_func(self.new_context(vars)))
   1089         except Exception:
-> 1090             self.environment.handle_exception()
   1091
   1092     def render_async(self, *args, **kwargs):

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/environment.py in handle_exception(self, source)
    830         from .debug import rewrite_traceback_stack
    831
--> 832         reraise(*rewrite_traceback_stack(source=source))
    833
    834     def join_path(self, template, parent):

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/_compat.py in reraise(tp, value, tb)
     26     def reraise(tp, value, tb=None):
     27         if value.__traceback__ is not tb:
---> 28             raise value.with_traceback(tb)
     29         raise value
     30

/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/./templates/print_formats/standard.html in top-level template code()
     30                         <div class="col-xs-{{ (12 / section.columns|len)|int }} column-break">
     31             {% for df in column.fields %}
---> 32                 {{ render_field(df, doc) }}
     33             {% endfor %}
     34                         </div>

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/sandbox.py in call(_SandboxedEnvironment__self, _SandboxedEnvironment__context, _SandboxedEnvironment__obj, *args, **kwargs)
    460         if not __self.is_safe_callable(__obj):
    461             raise SecurityError("%r is not safely callable" % (__obj,))
--> 462         return __context.call(__obj, *args, **kwargs)
    463
    464

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/runtime.py in _invoke(self, arguments, autoescape)
    677     def _invoke(self, arguments, autoescape):
    678         """This method is being swapped out by the async implementation."""
--> 679         rv = self._func(*arguments)
    680         if autoescape:
    681             rv = Markup(rv)

/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/./templates/print_formats/standard_macros.html in template()
     24                 {%- endif -%}
     25         {%- else -%}
---> 26                 {{ render_field_with_label(df, doc) }}
     27         {%- endif -%}
     28 {%- endmacro -%}

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/sandbox.py in call(_SandboxedEnvironment__self, _SandboxedEnvironment__context, _SandboxedEnvironment__obj, *args, **kwargs)
    460         if not __self.is_safe_callable(__obj):
    461             raise SecurityError("%r is not safely callable" % (__obj,))
--> 462         return __context.call(__obj, *args, **kwargs)
    463
    464

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/runtime.py in _invoke(self, arguments, autoescape)
    677     def _invoke(self, arguments, autoescape):
    678         """This method is being swapped out by the async implementation."""
--> 679         rv = self._func(*arguments)
    680         if autoescape:
    681             rv = Markup(rv)

/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/./templates/print_formats/standard_macros.html in template()
     91                         {{ get_align_class(df) }} value">
     92                                 {% if doc.get(df.fieldname) != None -%}
---> 93                                         {{ _(print_value(df, doc)) }}{% endif %}
     94                         </div>
     95                 </div>

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/sandbox.py in call(_SandboxedEnvironment__self, _SandboxedEnvironment__context, _SandboxedEnvironment__obj, *args, **kwargs)
    460         if not __self.is_safe_callable(__obj):
    461             raise SecurityError("%r is not safely callable" % (__obj,))
--> 462         return __context.call(__obj, *args, **kwargs)
    463
    464

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/runtime.py in _invoke(self, arguments, autoescape)
    677     def _invoke(self, arguments, autoescape):
    678         """This method is being swapped out by the async implementation."""
--> 679         rv = self._func(*arguments)
    680         if autoescape:
    681             rv = Markup(rv)

/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/./templates/print_formats/standard_macros.html in template()
    147         {% else %}
    148                 {%- set parent = parent_doc or doc -%}
--> 149                 {{ doc.get_formatted(df.fieldname, parent, translated=df.translatable, absolute_value=parent.absolute_value) }}
    150         {% endif %}
    151 {%- endmacro %}

/home/frappe/benches/bench-version-12-2021-06-22/env/lib/python3.6/site-packages/jinja2/sandbox.py in call(_SandboxedEnvironment__self, _SandboxedEnvironment__context, _SandboxedEnvironment__obj, *args, **kwargs)
    460         if not __self.is_safe_callable(__obj):
    461             raise SecurityError("%r is not safely callable" % (__obj,))
--> 462         return __context.call(__obj, *args, **kwargs)
    463
    464

/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/base_document.py in get_formatted(self, fieldname, doc, currency, absolute_value, translated)
    745
    746                 if not currency:
--> 747                         currency = self.get(df.get("options"))
    748                         if not frappe.db.exists('Currency', currency, cache=True):
    749                                 currency = None

AttributeError: 'NoneType' object has no attribute 'get'
```
</details>