### PR TITLE
fix: Prioritse TemplatePage over ListPage

### DIFF
--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -37,7 +37,7 @@ class PathResolver():
 
 		endpoint = resolve_path(self.path)
 		custom_renderers = self.get_custom_page_renderers()
-		renderers = custom_renderers + [StaticPage, WebFormPage, ListPage, DocumentPage, TemplatePage, PrintPage, NotFoundPage]
+		renderers = custom_renderers + [StaticPage, WebFormPage, DocumentPage, TemplatePage, ListPage, PrintPage, NotFoundPage]
 
 		for renderer in renderers:
 			renderer_instance = renderer(endpoint, 200)


### PR DESCRIPTION
Sites with custom doctype named "App" were not able to load desk page.

issue introduced after: https://github.com/frappe/frappe/pull/13558

fixes https://github.com/frappe/frappe/issues/13571