### PR TITLE
fix: multiple form tour issues

### DIFF
--- a/frappe/desk/doctype/form_tour/form_tour.js
+++ b/frappe/desk/doctype/form_tour/form_tour.js
@@ -15,14 +15,14 @@ frappe.ui.form.on('Form Tour', {
 
 		frm.add_custom_button(__('Show Tour'), async () => {
 			const issingle = await check_if_single(frm.doc.reference_doctype);
+			let route_changed = null;
 
 			if (issingle) {
-				frappe.set_route('Form', frm.doc.reference_doctype);
+				route_changed = frappe.set_route('Form', frm.doc.reference_doctype);
 			} else {
-				const new_name =  'new-' + frappe.scrub(frm.doc.reference_doctype) + '-1';
-				frappe.set_route('Form', frm.doc.reference_doctype, new_name);
+				route_changed = frappe.set_route('Form', frm.doc.reference_doctype, 'new');
 			}
-			frappe.utils.sleep(500).then(() => {
+			route_changed.then(() => {
 				const tour_name = frm.doc.name;
 				cur_frm.tour
 					.init({ tour_name })

--- a/frappe/desk/doctype/form_tour/form_tour.json
+++ b/frappe/desk/doctype/form_tour/form_tour.json
@@ -11,7 +11,6 @@
   "module",
   "is_standard",
   "save_on_complete",
-  "submit_on_complete",
   "section_break_3",
   "steps"
  ],
@@ -63,18 +62,11 @@
    "label": "Module",
    "options": "Module Def",
    "read_only": 1
-  },
-  {
-   "default": "0",
-   "depends_on": "save_on_complete",
-   "fieldname": "submit_on_complete",
-   "fieldtype": "Check",
-   "label": "Submit on Completion"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-06-29 15:23:26.893068",
+ "modified": "2021-06-06 20:32:54.068774",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Form Tour",

--- a/frappe/desk/doctype/form_tour/form_tour.json
+++ b/frappe/desk/doctype/form_tour/form_tour.json
@@ -11,6 +11,7 @@
   "module",
   "is_standard",
   "save_on_complete",
+  "submit_on_complete",
   "section_break_3",
   "steps"
  ],
@@ -62,11 +63,18 @@
    "label": "Module",
    "options": "Module Def",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "save_on_complete",
+   "fieldname": "submit_on_complete",
+   "fieldtype": "Check",
+   "label": "Submit on Completion"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-06-06 20:32:54.068774",
+ "modified": "2021-06-29 15:23:26.893068",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Form Tour",

--- a/frappe/public/js/frappe/form/form_tour.js
+++ b/frappe/public/js/frappe/form/form_tour.js
@@ -15,9 +15,8 @@ frappe.ui.form.FormTour = class FormTour {
 			prevBtnText: 'Previous',
 			opacity: 0.25,
 			onHighlighted: (step) => {
-				// if last step is to save, or if is submit step
-				// then attach a listener on highlighted elem to reset the driver
-				if ((step.options.is_save_step && !this.driver.hasNextStep())|| step.options.is_submit_step) {
+				// if last step is to save, then attach a listener to save button
+				if (step.options.is_save_step) {
 					$(step.options.element).one('click', () => this.driver.reset());
 				}
 
@@ -73,10 +72,6 @@ frappe.ui.form.FormTour = class FormTour {
 
 		if (this.tour.save_on_complete) {
 			this.add_step_to_save();
-		}
-
-		if (this.tour.submit_on_complete) {
-			this.add_step_to_submit();
 		}
 	}
 
@@ -259,37 +254,6 @@ frappe.ui.form.FormTour = class FormTour {
 			}
 		};
 		this.driver_steps.push(save_step);
-
-		let after_save = () => this.on_finish && this.on_finish();
-
-		if (this.tour.submit_on_complete) {
-			after_save = () => {
-				this.update_driver_steps();
-				this.driver.start(this.driver.steps.length - 1);
-			}
-		}
-		frappe.ui.form.on(this.frm.doctype, 'after_save', after_save);
-	}
-
-	add_step_to_submit() {
-		const page_id = `[id="page-${this.frm.doctype}"]`;
-		const $submit_btn = `${page_id} .standard-actions .primary-action`;
-		const submit_step = {
-			element: $submit_btn,
-			is_submit_step: true,
-			allowClose: false,
-			overlayClickNext: false,
-			popover: {
-				title: __("Submit"),
-				description: "",
-				position: "left",
-				doneBtnText: __("Submit")
-			},
-			onNext: () => {
-				this.frm.savesubmit();
-			}
-		};
-		this.driver_steps.push(submit_step);
-		frappe.ui.form.on(this.frm.doctype, 'after_submit', () => this.on_finish && this.on_finish());
+		frappe.ui.form.on(this.frm.doctype, 'after_save', () => this.on_finish && this.on_finish());
 	}
 };

--- a/frappe/public/js/frappe/form/form_tour.js
+++ b/frappe/public/js/frappe/form/form_tour.js
@@ -17,8 +17,9 @@ frappe.ui.form.FormTour = class FormTour {
 			prevBtnText: 'Previous',
 			opacity: 0.25,
 			onHighlighted: (step) => {
-				// if last step is to save, then attach a listener to save button
-				if (step.options.is_save_step) {
+				// if last step is to save, or if is submit step
+				// then attach a listener on highlighted elem to reset the driver
+				if ((step.options.is_save_step && !this.driver.hasNextStep())|| step.options.is_submit_step) {
 					$(step.options.element).one('click', () => this.driver.reset());
 				}
 
@@ -73,6 +74,10 @@ frappe.ui.form.FormTour = class FormTour {
 
 		if (this.tour.save_on_complete) {
 			this.add_step_to_save();
+		}
+
+		if (this.tour.submit_on_complete) {
+			this.add_step_to_submit();
 		}
 	}
 
@@ -249,9 +254,43 @@ frappe.ui.form.FormTour = class FormTour {
 				description: "",
 				position: "left",
 				doneBtnText: __("Save")
+			},
+			onNext: () => {
+				this.frm.save();
 			}
 		};
 		this.driver_steps.push(save_step);
-		frappe.ui.form.on(this.frm.doctype, 'after_save', () => this.on_finish && this.on_finish());
+
+		let after_save = () => this.on_finish && this.on_finish();
+
+		if (this.tour.submit_on_complete) {
+			after_save = () => {
+				this.update_driver_steps();
+				this.driver.start(this.driver.steps.length - 1);
+			}
+		}
+		frappe.ui.form.on(this.frm.doctype, 'after_save', after_save);
+	}
+
+	add_step_to_submit() {
+		const page_id = `[id="page-${this.frm.doctype}"]`;
+		const $submit_btn = `${page_id} .standard-actions .primary-action`;
+		const submit_step = {
+			element: $submit_btn,
+			is_submit_step: true,
+			allowClose: false,
+			overlayClickNext: false,
+			popover: {
+				title: __("Submit"),
+				description: "",
+				position: "left",
+				doneBtnText: __("Submit")
+			},
+			onNext: () => {
+				this.frm.savesubmit();
+			}
+		};
+		this.driver_steps.push(submit_step);
+		frappe.ui.form.on(this.frm.doctype, 'after_submit', () => this.on_finish && this.on_finish());
 	}
 };

--- a/frappe/public/js/frappe/form/form_tour.js
+++ b/frappe/public/js/frappe/form/form_tour.js
@@ -37,7 +37,12 @@ frappe.ui.form.FormTour = class FormTour {
 		if (tour_name) {
 			this.tour = await frappe.db.get_doc('Form Tour', tour_name);
 		} else {
-			this.tour = { steps: frappe.tour[this.frm.doctype] };
+			const doctype_tour_exists = await frappe.db.exists('Form Tour', this.frm.doctype);
+			if (doctype_tour_exists) {
+				this.tour = await frappe.db.get_doc('Form Tour', this.frm.doctype)
+			} else {
+				this.tour = { steps: frappe.tour[this.frm.doctype] };
+			}
 		}
 		
 		if (on_finish) this.on_finish = on_finish;
@@ -232,7 +237,7 @@ frappe.ui.form.FormTour = class FormTour {
 	}
 
 	add_step_to_save() {
-		const page_id = `#page-${this.frm.doctype}`;
+		const page_id = `[id="page-${this.frm.doctype}"]`;
 		const $save_btn = `${page_id} .standard-actions .primary-action`;
 		const save_step = {
 			element: $save_btn,

--- a/frappe/public/js/frappe/form/form_tour.js
+++ b/frappe/public/js/frappe/form/form_tour.js
@@ -38,7 +38,7 @@ frappe.ui.form.FormTour = class FormTour {
 		} else {
 			const doctype_tour_exists = await frappe.db.exists('Form Tour', this.frm.doctype);
 			if (doctype_tour_exists) {
-				this.tour = await frappe.db.get_doc('Form Tour', this.frm.doctype)
+				this.tour = await frappe.db.get_doc('Form Tour', this.frm.doctype);
 			} else {
 				this.tour = { steps: frappe.tour[this.frm.doctype] };
 			}

--- a/frappe/public/js/frappe/form/form_tour.js
+++ b/frappe/public/js/frappe/form/form_tour.js
@@ -2,8 +2,6 @@ frappe.ui.form.FormTour = class FormTour {
 	constructor({ frm }) {
 		this.frm = frm;
 		this.driver_steps = [];
-
-		this.init_driver();
 	}
 
 	init_driver() {
@@ -48,6 +46,7 @@ frappe.ui.form.FormTour = class FormTour {
 		
 		if (on_finish) this.on_finish = on_finish;
 
+		this.init_driver();
 		this.build_steps();
 		this.update_driver_steps();
 	}


### PR DESCRIPTION
- Start Form Tour only when the route is changed & the form is loaded
- Look for standard tours if no tour name is provided
- Initialize driver only if form-tour is initialized
  - Fixes a case, where signature field is not rendered on form load
  - <details><summary>Broken Contract Form</summary><img src="https://user-images.githubusercontent.com/25369014/125035534-8d552c00-e0af-11eb-9d25-d2d2790f2422.png"></details>