### PR TITLE
fix: Premature commit via notification's `send_an_email`

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -84,8 +84,6 @@ def make(doctype=None, name=None, content=None, subject=None, sent_or_received =
 	if attachments:
 		add_attachments(comm.name, attachments)
 
-	frappe.db.commit()
-
 	if cint(send_email):
 		frappe.flags.print_letterhead = cint(print_letterhead)
 		comm.send(print_html, print_format, attachments, send_me_a_copy=send_me_a_copy)


### PR DESCRIPTION
**Issue:**
- Create a notification on a submittable doctype and set **Send Alert On** as **Save**
- Add a validation (some frappe.throw) on `on_submit`
- Notification gets triggered on Save, all good.
- While submitting the document, `on_update` triggers the notification. Due to a premature commit, it sends mail, adds comment on the document and commits the document.
- Then `on_submit` triggers the validation (some `frappe.throw`), and raises an error
- After this if you reload the document, the document is seen as submitted, without version history. **None of the `on_submit` methods are triggered or run**

**Fix:**
- Remove premature commit, it should be handled as usual after the process is done

> The commit was probably there to make sure that starting a new email sending process before committing the current process does not cause errors (the delayed email task should find the communication. If it runs before the communication is committed it will error). But we don't know if this hypothetical theory will hold true ever, so it's okay to remove this for now. If we ever re-add it, there will be concrete reason to.
