### PR TITLE
fix: Hide "Attach File" in form if max limit reached

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -13,7 +13,7 @@ frappe.ui.form.Attachments = Class.extend({
 		this.parent.find(".add-attachment").click(function() {
 			me.new_attachment();
 		});
-		this.add_attachment_wrapper = this.parent.find(".add_attachment").parent();
+		this.add_attachment_wrapper = this.parent.find(".add-attachment").parent();
 		this.attachments_label = this.parent.find(".attachments-label");
 	},
 	max_reached: function(raise_exception=false) {
@@ -41,7 +41,7 @@ frappe.ui.form.Attachments = Class.extend({
 		this.parent.find(".attachment-row").remove();
 
 		var max_reached = this.max_reached();
-		this.add_attachment_wrapper.toggleClass("hide", !max_reached);
+		this.add_attachment_wrapper.toggle(!max_reached);
 
 		// add attachment objects
 		var attachments = this.get_attachments();


### PR DESCRIPTION
* Correct element identifier
* Fix visibility toggler

Set max attachment limit as 1 for Note DocType to test this:

![Screenshot 2021-06-30 at 5 04 09 PM](https://user-images.githubusercontent.com/36654812/123953775-3d96a680-d9c5-11eb-993e-8a4bd7ee436e.png)

![Screenshot 2021-06-30 at 5 04 20 PM](https://user-images.githubusercontent.com/36654812/123953771-3c657980-d9c5-11eb-927a-61b9f3b69e3d.png)
