### PR TITLE
fix: Hide "Attach File" in form if max limit reached

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -11,7 +11,7 @@ frappe.ui.form.Attachments = class Attachments {
 		this.parent.find(".add-attachment-btn").click(function() {
 			me.new_attachment();
 		});
-		this.add_attachment_wrapper = this.parent.find(".add_attachment").parent();
+		this.add_attachment_wrapper = this.parent.find(".add-attachment-btn");
 		this.attachments_label = this.parent.find(".attachments-label");
 	}
 	max_reached(raise_exception=false) {
@@ -39,7 +39,7 @@ frappe.ui.form.Attachments = class Attachments {
 		this.parent.find(".attachment-row").remove();
 
 		var max_reached = this.max_reached();
-		this.add_attachment_wrapper.toggleClass("hide", !max_reached);
+		this.add_attachment_wrapper.toggle(!max_reached);
 
 		// add attachment objects
 		var attachments = this.get_attachments();


### PR DESCRIPTION
Added a max attachment limit as 1 for Note: 

![Screenshot 2021-06-30 at 5 40 34 PM](https://user-images.githubusercontent.com/36654812/123958204-62414d00-d9ca-11eb-89f2-0316da4d1ef1.png)

![Screenshot 2021-06-30 at 5 40 49 PM](https://user-images.githubusercontent.com/36654812/123958200-61102000-d9ca-11eb-8579-a79398917c49.png)


Rebrand UI Port of https://github.com/frappe/frappe/pull/13618