### PR TITLE
Set help links on toolbar_setup event

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -104,7 +104,7 @@ frappe.ui.toolbar.Toolbar = Class.extend({
 			}
 		});
 
-		$(document).on("page-change", function () {
+		$(document).on("page-change toolbar_setup", function () {
 			var $help_links = $(".dropdown-help #help-links");
 			$help_links.html("");
 


### PR DESCRIPTION
Set help links on toolbar_setup event, not only on page-change, because page-change is not triggered when on first load or refreshing the browser.