### PR TITLE
fix(Workspace): Pass doctype info for link item

### DIFF
--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -64,6 +64,7 @@ export default class LinksWidget extends Widget {
 			const opts = {
 				name: item.link_to,
 				type: item.link_type,
+				doctype: item.doctype,
 				is_query_report: item.is_query_report
 			};
 


### PR DESCRIPTION
* Without `item.doctype`, url for non-standard reports in workspace cards doesn't set properly since `doctype` value is unidentified.

![](https://frappe.io/files/NAplJPX.png)

* Sometimes, the relevant section of the workspace won't render because `slug` function breaks while receiving `undefined` object.

![Screenshot 2021-07-01 at 7 18 05 PM](https://user-images.githubusercontent.com/36654812/124135376-612f1f00-daa1-11eb-8a4c-ff07207f9a97.png)

