### PR TITLE
fix: Do not set base template for each file / route

### DIFF
--- a/frappe/templates/test/_test_base.html
+++ b/frappe/templates/test/_test_base.html
@@ -1,20 +1,9 @@
 <!-- base template for testing -->
 <html>
 <head>
-	{%- block style %}
-		{% if colocated_css -%}
-			<style>{{ colocated_css }}</style>
-		{%- endif %}
-	{%- endblock -%}
 </head>
 <body>
-	{% include "templates/includes/breadcrumbs.html" %}
 	<h1>This is for testing</h1>
 	{% block content %}{% endblock %}
-	{%- block script %}
-		{% if colocated_js -%}
-			<script>{{ colocated_js }}</script>
-		{%- endif %}
-	{%- endblock %}
 </body>
 </html>

--- a/frappe/templates/test/_test_base_breadcrumbs.html
+++ b/frappe/templates/test/_test_base_breadcrumbs.html
@@ -1,0 +1,20 @@
+<!-- base template for testing -->
+<html>
+<head>
+	{%- block style %}
+		{% if colocated_css -%}
+			<style>{{ colocated_css }}</style>
+		{%- endif %}
+	{%- endblock -%}
+</head>
+<body>
+	{% include "templates/includes/breadcrumbs.html" %}
+	<h1>This is for testing</h1>
+	{% block content %}{% endblock %}
+	{%- block script %}
+		{% if colocated_js -%}
+			<script>{{ colocated_js }}</script>
+		{%- endif %}
+	{%- endblock %}
+</body>
+</html>

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -253,12 +253,12 @@ class TestWebsite(unittest.TestCase):
 
 	def test_breadcrumbs(self):
 		content = get_response_content('/_test/_test_folder/_test_page')
-		self.assertIn('<span itemprop="name">Test TOC</span>', content)
+		self.assertIn('<span itemprop="name">Test Folder</span>', content)
 		self.assertIn('<span itemprop="name"> Test Page</span>', content)
 
 		content = get_response_content('/_test/_test_folder/index')
 		self.assertIn('<span itemprop="name"> Test</span>', content)
-		self.assertIn('<span itemprop="name">Test TOC</span>', content)
+		self.assertIn('<span itemprop="name">Test Folder</span>', content)
 
 	def test_get_context_without_context_object(self):
 		content = get_response_content('/_test/_test_no_context')

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -244,6 +244,13 @@ class TestWebsite(unittest.TestCase):
 		self.assertIn("<script>console.log('test data');</script>", content)
 		self.assertIn("background-color: var(--bg-color);", content)
 
+	def test_raw_assets_are_loaded(self):
+		content = get_response_content('/_test/assets/js_asset.js')
+		self.assertEqual("console.log('in');", content)
+
+		content = get_response_content('/_test/assets/css_asset.css')
+		self.assertEqual("""body{color:red}""", content)
+
 	def test_breadcrumbs(self):
 		content = get_response_content('/_test/_test_folder/_test_page')
 		self.assertIn('<span itemprop="name">Test TOC</span>', content)

--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -150,8 +150,7 @@ class TemplatePage(BaseTemplatePage):
 
 	def set_page_properties(self):
 		self.context.base_template = self.context.base_template \
-			or get_base_template(self.path) \
-			or 'templates/web.html'
+			or get_base_template(self.path)
 		self.context.basepath = self.basepath
 		self.context.basename = self.basename
 		self.context.name = self.name

--- a/frappe/www/_test/_test_folder/_test_page.html
+++ b/frappe/www/_test/_test_folder/_test_page.html
@@ -1,3 +1,4 @@
+{% extends base_template_path %}
 {% block content %}
 {% include "templates/includes/web_sidebar.html" %}
 <p>Test content</p>

--- a/frappe/www/_test/_test_folder/_test_page.py
+++ b/frappe/www/_test/_test_folder/_test_page.py
@@ -1,3 +1,3 @@
 def get_context(context):
-	context.base_template_path = 'frappe/templates/test/_test_base.html'
+	context.base_template_path = 'frappe/templates/test/_test_base_breadcrumbs.html'
 	context.add_breadcrumbs = 1

--- a/frappe/www/_test/_test_folder/index.md
+++ b/frappe/www/_test/_test_folder/index.md
@@ -1,9 +1,9 @@
 ---
-title: Test TOC
+title: Test Folder
 add_breadcrumbs: 1
 show_sidebar: 1
+base_template: templates/web.html
 ---
-
 # Index
 
 {index}

--- a/frappe/www/_test/assets/css_asset.css
+++ b/frappe/www/_test/assets/css_asset.css
@@ -1,0 +1,1 @@
+body{color:red}

--- a/frappe/www/_test/assets/js_asset.js
+++ b/frappe/www/_test/assets/js_asset.js
@@ -1,0 +1,1 @@
+console.log('in');


### PR DESCRIPTION
After [this PR got merged](https://github.com/frappe/frappe/pull/12334), each file was unnecessarily getting extended with `templates/web.html` which was resulting in some asset load failure with random tracebacks like the following.

```
Traceback (most recent call last):
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/serve.py", line 17, in get_response
    response = renderer_instance.render()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/page_renderers/template_page.py", line 61, in render
    html = self.get_html()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/utils.py", line 443, in cache_html_decorator
    html = func(*args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/page_renderers/template_page.py", line 78, in get_html
    html = self.render_template()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/website/page_renderers/template_page.py", line 207, in render_template
    html = frappe.render_template(self.source, self.context)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/utils/jinja.py", line 78, in render_template
    throw(_("Illegal template"))
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 430, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 409, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 363, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Illegal template
```

Resolves:
<img width="1440" alt="Screenshot 2021-07-01 at 10 17 16 PM" src="https://user-images.githubusercontent.com/13928957/124161070-972ccd00-daba-11eb-9680-ef61fd67d846.png">

