### PR TITLE
fix: remove not needed six import

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -6,7 +6,6 @@ from frappe import _, msgprint, is_whitelisted
 from frappe.utils import flt, cstr, now, get_datetime_str, file_lock, date_diff
 from frappe.model.base_document import BaseDocument, get_controller
 from frappe.model.naming import set_new_name, rename_cancelled_doc
-from six import iteritems, string_types
 from werkzeug.exceptions import NotFound, Forbidden
 import hashlib, json
 from frappe.model import optional_fields, table_fields


### PR DESCRIPTION
Remove unnecessary six import