### PR TITLE
fix(website): Minified JS asset load

### DIFF
--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -245,8 +245,9 @@ class TestWebsite(unittest.TestCase):
 		self.assertIn("background-color: var(--bg-color);", content)
 
 	def test_raw_assets_are_loaded(self):
-		content = get_response_content('/_test/assets/js_asset.js')
-		self.assertEqual("console.log('in');", content)
+		content = get_response_content('/_test/assets/js_asset.min.js')
+		# minified js files should not be passed through jinja renderer
+		self.assertEqual("//{% if title %} {{title}} {% endif %}\nconsole.log('in');", content)
 
 		content = get_response_content('/_test/assets/css_asset.css')
 		self.assertEqual("""body{color:red}""", content)

--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -70,7 +70,7 @@ class TemplatePage(BaseTemplatePage):
 
 		self.set_pymodule()
 		self.update_context()
-		self.setup_template()
+		self.setup_template_source()
 		self.load_colocated_files()
 		self.set_properties_from_source()
 		self.post_process_context()
@@ -118,7 +118,7 @@ class TemplatePage(BaseTemplatePage):
 		if os.path.exists(os.path.join(self.app_path, self.pymodule_path)):
 			self.pymodule_name = self.app + "." + self.pymodule_path.replace(os.path.sep, ".")[:-3]
 
-	def setup_template(self):
+	def setup_template_source(self):
 		'''Setup template source, frontmatter and markdown conversion'''
 		self.source = self.get_raw_template()
 		self.extract_frontmatter()
@@ -126,7 +126,6 @@ class TemplatePage(BaseTemplatePage):
 
 	def update_context(self):
 		self.set_page_properties()
-		self.set_properties_from_source()
 		self.context.build_version = frappe.utils.get_build_version()
 
 		if self.pymodule_name:
@@ -202,13 +201,10 @@ class TemplatePage(BaseTemplatePage):
 					frappe.errprint(frappe.utils.get_traceback())
 
 	def render_template(self):
-		if self.source:
+		if self.template_path.endswith('min.js'):
+			html = self.source # static
+		else:
 			html = frappe.render_template(self.source, self.context)
-		elif self.template_path:
-			if self.path.endswith('min.js'):
-				html = self.get_raw_template() # static
-			else:
-				html = frappe.get_template(self.template_path).render(self.context)
 
 		return html
 

--- a/frappe/www/_test/assets/js_asset.js
+++ b/frappe/www/_test/assets/js_asset.js
@@ -1,1 +1,0 @@
-console.log('in');

--- a/frappe/www/_test/assets/js_asset.min.js
+++ b/frappe/www/_test/assets/js_asset.min.js
@@ -1,0 +1,2 @@
+//{% if title %} {{title}} {% endif %}
+console.log('in');


### PR DESCRIPTION
Restores [this fix](https://github.com/frappe/frappe/commit/cca360e8efe84025c0bf04a4ec6b90c2e33e0b26) which broke after [website routing refactor](https://github.com/frappe/frappe/pull/12334)

**Resolves:**

<img width="1440" alt="Screenshot 2021-07-01 at 10 17 16 PM" src="https://user-images.githubusercontent.com/13928957/124161070-972ccd00-daba-11eb-9680-ef61fd67d846.png">

This fix is the continuation of https://github.com/frappe/frappe/pull/13631