### PR TITLE
fix: removed red indicator from alert

### DIFF
--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -116,10 +116,7 @@ frappe.ui.Capture = class {
 			})
 			.catch(err => {
 				if (this.options.error) {
-					const alert = `<span class="indicator red"/> ${
-						frappe.ui.Capture.ERR_MESSAGE
-					}`;
-					frappe.show_alert(alert, 3);
+					frappe.show_alert(frappe.ui.Capture.ERR_MESSAGE, 3);
 				}
 
 				throw err;


### PR DESCRIPTION
Removed the red indicator from the alert message when it fails to open the camera.

#### Before:

![image](https://user-images.githubusercontent.com/38958184/124428165-f5db9a80-dd89-11eb-924e-851b07712563.png)

#### After:

![image](https://user-images.githubusercontent.com/38958184/124428344-3509eb80-dd8a-11eb-89b2-4f3fdb771766.png)
