### PR TITLE
fix: dont refresh form dashboard in `layout.refresh_sections`

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -263,9 +263,6 @@ frappe.ui.form.Layout = class Layout {
 				section.addClass("empty-section");
 			}
 		});
-
-		this.frm && this.frm.dashboard.refresh();
-
 	}
 
 	refresh_fields (fields) {


### PR DESCRIPTION
This PR attempts to solve the issue of a custom dashboard section getting removed every time a field gets refreshed.
Previous attempts:
- https://github.com/frappe/erpnext/pull/26273
- https://github.com/frappe/erpnext/pull/26305

<!--
The form dashboard should logically be refreshed only when the form's layout is being refreshed. Earlier `layout.refresh_sections` was being used only when `layout.refresh` was called. But since https://github.com/frappe/frappe/pull/13355, that is not the case.
-->