### PR TITLE
fix: cannot read property `0` of undefined

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -252,7 +252,7 @@ class DesktopPage {
 				return;
 			}
 			this.refresh();
-		}).finally(this.page.find('.workspace_loading_skeleton').remove);
+		}).finally(() => this.page.find('.workspace_loading_skeleton').remove());
 	}
 
 	refresh() {


### PR DESCRIPTION
Before this fix Desk or workspace load used to throw following error.

```
jquery.js:6144 Uncaught (in promise) TypeError: Cannot read property '0' of undefined
    at remove2 (jquery.js:6144)
    at remove (jquery.js:6248)
    at <anonymous>

remove2 @ jquery.js:6144
remove @ jquery.js:6248
Promise.finally (async)
make @ workspace.js:255
reload @ workspace.js:240
DesktopPage @ workspace.js:220
make_page @ workspace.js:144
show_page @ workspace.js:138
show @ workspace.js:50
(anonymous) @ workspace.js:12
dispatch @ jquery.js:5429
elemData.handle @ jquery.js:5233
trigger @ jquery.js:8715
(anonymous) @ jquery.js:8793
each @ jquery.js:381
each @ jquery.js:203
trigger @ jquery.js:8792
change_to @ container.js:85
(anonymous) @ pageview.js:52
with_page @ pageview.js:13
(anonymous) @ pageview.js:45
with_doctype @ model.js:133
show @ pageview.js:44
render @ router.js:191
route @ router.js:107
set_route @ desk.js:172
startup @ desk.js:71
Application @ desk.js:29
frappe.start_app @ desk.js:13
(anonymous) @ desk.js:24
mightThrow @ jquery.js:3762
process2 @ jquery.js:3830
setTimeout (async)
(anonymous) @ jquery.js:3868
fire @ jquery.js:3496
fireWith @ jquery.js:3626
fire @ jquery.js:3634
fire @ jquery.js:3496
fireWith @ jquery.js:3626
ready @ jquery.js:4106
completed @ jquery.js:4116
```