### PR TITLE
fix: system notifications without email

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -15,7 +15,7 @@ class NotificationLog(Document):
 			try:
 				send_notification_email(self)
 			except frappe.OutgoingEmailError:
-				frappe.log_error(message = frappe.get_traceback(), title=_("Error Sending Notification Email(System Notification sent)."))
+				frappe.log_error(message = frappe.get_traceback(), title=_("Error Sending Notification Email."))
 
 
 def get_permission_query_conditions(for_user):

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -15,7 +15,7 @@ class NotificationLog(Document):
 			try:
 				send_notification_email(self)
 			except frappe.OutgoingEmailError:
-				frappe.log_error(message = frappe.get_traceback(), title=_("Error Sending Notification Email."))
+				frappe.log_error(message=frappe.get_traceback(), title=_("Failed to send notification email"))
 
 
 def get_permission_query_conditions(for_user):

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -12,7 +12,10 @@ class NotificationLog(Document):
 		frappe.publish_realtime('notification', after_commit=True, user=self.for_user)
 		set_notifications_as_unseen(self.for_user)
 		if is_email_notifications_enabled_for_type(self.for_user, self.type):
-			send_notification_email(self)
+			try:
+				send_notification_email(self)
+			except frappe.OutgoingEmailError:
+				frappe.log_error(message = frappe.get_traceback(), title=_("Error Sending Notification Email(System Notification sent)."))
 
 
 def get_permission_query_conditions(for_user):


### PR DESCRIPTION
Problem
If Outgoing email is not set OutgoingEmailError is raised which does not let the system notification to be sent too
![image](https://user-images.githubusercontent.com/28212972/124552987-d5771300-de51-11eb-805f-dafedc03d1c5.png)

Solution:
Create an error log but silence the exception

Error Log:
![image](https://user-images.githubusercontent.com/28212972/124553152-07887500-de52-11eb-80af-32b984473150.png)
