### PR TITLE
fix: Accurately cast fieldtype in frappe.db.get_single_value()

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -15,7 +15,7 @@ from frappe import _
 from time import time
 from frappe.utils import now, getdate, cast_fieldtype, get_datetime
 from frappe.model.utils.link_count import flush_local_link_count
-from frappe.utils import cint
+from frappe.utils import cint, cast_fieldtype
 
 
 class Database(object):
@@ -556,8 +556,7 @@ class Database(object):
 		if not df:
 			frappe.throw(_('Invalid field name: {0}').format(frappe.bold(fieldname)), self.InvalidColumnName)
 
-		if df.fieldtype in frappe.model.numeric_fieldtypes:
-			val = cint(val)
+		val = cast_fieldtype(df.fieldtype, val)
 
 		self.value_cache[doctype][fieldname] = val
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -15,7 +15,6 @@ from frappe import _
 from time import time
 from frappe.utils import now, getdate, cast_fieldtype, get_datetime
 from frappe.model.utils.link_count import flush_local_link_count
-from frappe.utils import cint, cast_fieldtype
 
 
 class Database(object):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -62,14 +62,14 @@ class TestDB(unittest.TestCase):
 			"value": value} for fieldtype, value in values_dict.items()]
 		for fieldtype in values_dict.keys():
 			create_custom_field("Print Settings", {
-				"fieldname": "test_{0}".format(fieldtype.lower()),
-				"label": "Test {0}".format(fieldtype),
+				"fieldname": f"test_{fieldtype.lower()}",
+				"label": f"Test {fieldtype}",
 				"fieldtype": fieldtype,
 			})
 
 		#test
 		for inp in test_inputs:
-			fieldname = "test_{0}".format(inp["fieldtype"].lower())
+			fieldname = f"test_{inp['fieldtype'].lower()}"
 			frappe.db.set_value("Print Settings", "Print Settings", fieldname, inp["value"])
 			self.assertEqual(frappe.db.get_single_value("Print Settings", fieldname), inp["value"])
 
@@ -157,29 +157,29 @@ class TestDB(unittest.TestCase):
 
 		# Testing read
 		self.assertEqual(list(frappe.get_all("ToDo", fields=[random_field], limit=1)[0])[0], random_field)
-		self.assertEqual(list(frappe.get_all("ToDo", fields=["`{0}` as total".format(random_field)], limit=1)[0])[0], "total")
+		self.assertEqual(list(frappe.get_all("ToDo", fields=[f"`{random_field}` as total"], limit=1)[0])[0], "total")
 
 		# Testing read for distinct and sql functions
 		self.assertEqual(list(
 			frappe.get_all("ToDo",
-				fields=["`{0}` as total".format(random_field)],
+				fields=[f"`{random_field}` as total"],
 				distinct=True,
 				limit=1,
 			)[0]
 		)[0], "total")
 		self.assertEqual(list(
 			frappe.get_all("ToDo",
-			fields=["`{0}`".format(random_field)],
+			fields=[f"`{random_field}`"],
 			distinct=True,
 			limit=1,
 			)[0]
 		)[0], random_field)
 		self.assertEqual(list(
 			frappe.get_all("ToDo",
-				fields=["count(`{0}`)".format(random_field)],
+				fields=[f"count(`{random_field}`)"],
 				limit=1
 			)[0]
-		)[0], "count" if frappe.conf.db_type == "postgres" else "count(`{0}`)".format(random_field))
+		)[0], "count" if frappe.conf.db_type == "postgres" else f"count(`{random_field}`)")
 
 		# Testing update
 		frappe.db.set_value(test_doctype, random_doc, random_field, random_value)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -57,8 +57,8 @@ class TestDB(unittest.TestCase):
 				"fieldname": 'test_'+fieldtype.lower(),
 				"label": 'Test '+fieldtype,
 				"fieldtype": fieldtype,
-		})
-		 
+			})
+
 		#test
 		for inp in test_inputs:
 			fieldname = 'test_'+inp['fieldtype'].lower()

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -47,26 +47,34 @@ class TestDB(unittest.TestCase):
 
 	def test_get_single_value(self):
 		#setup
-		fieldtypes = ['Float', 'Int', 'Percent', 'Currency', 'Data', 'Date', 'Datetime', 'Time']
-		values = [1.5, 1, 55.5, 12.5, 'Test', datetime.datetime.now().date(), datetime.datetime.now(), datetime.timedelta(hours=9, minutes=45, seconds=10)]
+		values_dict = {
+			"Float": 1.5,
+			"Int": 1,
+			"Percent": 55.5,
+			"Currency": 12.5,
+			"Data": "Test",
+			"Date": datetime.datetime.now().date(),
+			"Datetime": datetime.datetime.now(),
+			"Time": datetime.timedelta(hours=9, minutes=45, seconds=10)
+		}
 		test_inputs = [{
-			'fieldtype': fieldtypes[i],
-			'value': values[i]} for i in range(len(fieldtypes))]
-		for fieldtype in fieldtypes:
-			create_custom_field('Print Settings', {
-				"fieldname": 'test_'+fieldtype.lower(),
-				"label": 'Test '+fieldtype,
+			"fieldtype": fieldtype,
+			"value": value} for fieldtype, value in values_dict.items()]
+		for fieldtype in values_dict.keys():
+			create_custom_field("Print Settings", {
+				"fieldname": "test_{0}".format(fieldtype.lower()),
+				"label": "Test {0}".format(fieldtype),
 				"fieldtype": fieldtype,
 			})
 
 		#test
 		for inp in test_inputs:
-			fieldname = 'test_'+inp['fieldtype'].lower()
-			frappe.db.set_value('Print Settings', 'Print Settings', fieldname, inp['value'])
-			self.assertEqual(frappe.db.get_single_value('Print Settings', fieldname), inp['value'])
+			fieldname = "test_{0}".format(inp["fieldtype"].lower())
+			frappe.db.set_value("Print Settings", "Print Settings", fieldname, inp["value"])
+			self.assertEqual(frappe.db.get_single_value("Print Settings", fieldname), inp["value"])
 
 		#teardown 
-		clear_custom_fields('Print Settings')
+		clear_custom_fields("Print Settings")
 
 	def test_log_touched_tables(self):
 		frappe.flags.in_migrate = True


### PR DESCRIPTION
Fixes bug in : https://github.com/frappe/frappe/blob/9fdde15841749ae2faccf2702729350fe7e9e174/frappe/database/database.py#L560

Currently [frappe.db.get_single_value()](https://github.com/frappe/frappe/blob/9fdde15841749ae2faccf2702729350fe7e9e174/frappe/database/database.py#L560) casts values of all [numeric fieldtypes](https://github.com/frappe/frappe/blob/7c5624dd56a4ce4e22b547df6e5de2eef7a568f9/frappe/model/__init__.py#L61) into int. This is not accurate for the following fieldtypes: `Currency`, `Float`, `Percent`

Proposed fix: use [cast_fieldtype](https://github.com/frappe/frappe/blob/9fdde15841749ae2faccf2702729350fe7e9e174/frappe/utils/data.py#L507) from frappe.utils to cast value based on its fieldtype

```diff
- if df.fieldtype in frappe.model.numeric_fieldtypes:
-			val = cint(val)
+ val = cast_fieldtype(df.fieldtype, val)
```
	