### PR TITLE
feat(Customize Form): Enable QR Code for Doctypes

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -21,6 +21,7 @@
   "track_views",
   "allow_auto_repeat",
   "allow_import",
+  "enable_qr_code",
   "fields_section_break",
   "fields",
   "naming_section",
@@ -280,6 +281,12 @@
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_qr_code",
+   "fieldtype": "Check",
+   "label": "Enable QR Code"
   }
  ],
  "hide_toolbar": 1,
@@ -288,7 +295,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-06-21 19:01:06.920663",
+ "modified": "2021-07-06 19:54:11.056891",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -171,7 +171,7 @@ doc_events = {
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
 			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers",
-			"frappe.custom.doctype.customize_form.customize_form.genrate_qr_code_file"
+			"frappe.custom.doctype.customize_form.customize_form.delete_qr_code_file"
 		],
 		"on_change": [
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -149,7 +149,8 @@ standard_queries = {
 doc_events = {
 	"*": {
 		"after_insert": [
-			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers"
+			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers",
+			"frappe.custom.doctype.customize_form.customize_form.genrate_qr_code_file"
 		],
 		"on_update": [
 			"frappe.desk.notifications.clear_doctype_notifications",
@@ -169,7 +170,8 @@ doc_events = {
 		"on_trash": [
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
-			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers"
+			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers",
+			"frappe.custom.doctype.customize_form.customize_form.genrate_qr_code_file"
 		],
 		"on_change": [
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",


### PR DESCRIPTION
Enable QR Code for Doctype to make it publicly available. Can be used in the print formats as well.

![2021-07-06 at 20 12 08 - QR Code](https://user-images.githubusercontent.com/7881486/124624945-cc5c6500-de96-11eb-8afa-5f104280f997.gif)


