### PR TITLE
fix: Import css files without extension for raw imports

### DIFF
--- a/frappe/public/scss/common/datepicker.scss
+++ b/frappe/public/scss/common/datepicker.scss
@@ -1,4 +1,4 @@
-@import "~air-datepicker/dist/css/datepicker.min.css";
+@import "~air-datepicker/dist/css/datepicker.min";
 
 .datepicker {
 

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -1,5 +1,5 @@
-@import '~quill/dist/quill.snow.css';
-@import '~quill/dist/quill.bubble.css';
+@import '~quill/dist/quill.snow';
+@import '~quill/dist/quill.bubble';
 
 .ql-toolbar.ql-snow,
 .ql-container.ql-snow {


### PR DESCRIPTION
Import CSS files without extension for raw imports

Refer: https://stackoverflow.com/a/36166487

Fixes the following issue while loading website or webform with the custom website theme
![Screenshot 2021-07-07 at 11 47 37 AM](https://user-images.githubusercontent.com/13928957/124709667-5f3de380-df19-11eb-9092-846eb3794ccf.png)

This was issue introduced via https://github.com/frappe/frappe/pull/12277
