### PR TITLE
fix: Allow navigation to folders that are nested inside 2 folders

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -171,8 +171,8 @@ frappe.router = {
 		} else {
 			standard_route = ['List', doctype_route.doctype, frappe.utils.to_title_case(route[2])];
 			if (route[3]) {
-				// calendar / kanban / dashboard name
-				standard_route.push(route[3]);
+				// calendar / kanban / dashboard / folder name
+				standard_route.push(...route.splice(3, route.length));
 			}
 		}
 		return standard_route;
@@ -297,8 +297,8 @@ frappe.router = {
 			if (route[2] && route[2] !== 'list' && !$.isPlainObject(route[2])) {
 				new_route = [this.slug(route[1]), 'view', route[2].toLowerCase()];
 
-				// calendar / inbox
-				if (route[3]) new_route.push(route[3]);
+				// calendar / inbox / file folder
+				if (route[3]) new_route.push(...route.slice(3, route.length));
 			} else {
 				if ($.isPlainObject(route[2])) {
 					frappe.route_options = route[2];

--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -315,7 +315,7 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 						acc += "/" + curr;
 					}
 					return acc;
-				}, "/app/file");
+				}, "/app/file/view");
 
 				return `<a href="${route}">${folder}</a>`;
 			})


### PR DESCRIPTION
- Allowed navigation to folders that are nested inside 2 folders
- Fixed custom file breadcrumb for folder navigation

**Before:**
![file-folder-routing-bug](https://user-images.githubusercontent.com/13928957/124761153-1ef95800-df4f-11eb-9dba-6847c8302c4b.gif)


**After:**
![file-folder-routing-fix](https://user-images.githubusercontent.com/13928957/124760603-882c9b80-df4e-11eb-95a4-47792e2ad598.gif)


The issue was introduced via https://github.com/frappe/frappe/commit/c7cb09bec95c11a931ddcde40eec1735eb9beef0


https://frappe.io/app/issue/ISS-21-22-03651