### PR TITLE
fix(form-dashboard): Enable `set_open_count`

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -5,7 +5,6 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	constructor(opts) {
 		$.extend(this, opts);
 		this.setup_dashboard_sections();
-		this.set_open_count = frappe.utils.throttle(this.set_open_count, 500);
 	}
 
 	setup_dashboard_sections() {
@@ -179,7 +178,6 @@ frappe.ui.form.Dashboard = class FormDashboard {
 				return;
 			}
 			this.render_links();
-			// this.set_open_count();
 			show = true;
 		}
 
@@ -206,6 +204,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 				$(this).removeClass('hidden');
 			}
 		});
+		this.set_open_count();
 	}
 
 	init_data() {


### PR DESCRIPTION
- Re-enable [unintentionally commented out](https://github.com/frappe/frappe/commit/a81d4fd4ebf638ada949541359feb68a4a28ee22#diff-0eb237f702fbfee1e71c07e60de668631c1641c745fc4b5b15e0151f79984895R182) `set_open_count`
- Move `set_open_count` inside `after_refresh` to avoid unnecessary calls
---

fixes https://github.com/frappe/frappe/pull/13510#issuecomment-862851307
fixes #13578

**Before:**
<img width="1440" alt="Screenshot 2021-07-07 at 11 04 50 PM" src="https://user-images.githubusercontent.com/13928957/124804317-c8544400-df77-11eb-94f5-de2993241981.png">


**Now:**
Only single query per form load
<img width="1440" alt="Screenshot 2021-07-07 at 10 42 52 PM" src="https://user-images.githubusercontent.com/13928957/124801834-ecfaec80-df74-11eb-83b0-c68dd3a416b1.png">