### PR TITLE
fix: custom script to duplicate row not working in v13

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1259,7 +1259,7 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 		if (df && df[property] != value) {
 			df[property] = value;
-			if (table_field && table_row_name) {
+			if (table_field && table_row_name && this.fields_dict[fieldname].grid.grid_rows_by_docname[table_row_name]) {
 				this.fields_dict[fieldname].grid.grid_rows_by_docname[table_row_name].refresh_field(fieldname);
 			} else {
 				this.refresh_field(fieldname);

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1259,8 +1259,10 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 		if (df && df[property] != value) {
 			df[property] = value;
-			if (table_field && table_row_name && this.fields_dict[fieldname].grid.grid_rows_by_docname[table_row_name]) {
-				this.fields_dict[fieldname].grid.grid_rows_by_docname[table_row_name].refresh_field(fieldname);
+			if (table_field && table_row_name) {
+				if (this.fields_dict[fieldname].grid.grid_rows_by_docname[table_row_name]) {
+					this.fields_dict[fieldname].grid.grid_rows_by_docname[table_row_name].refresh_field(fieldname);
+				}
 			} else {
 				this.refresh_field(fieldname);
 			}


### PR DESCRIPTION
**Issue**

frm.fields_dict['items'].grid.add_new_row(idx, null, null, row) not working sometimes

<img width="1433" alt="Screenshot 2021-07-08 at 3 36 36 PM" src="https://user-images.githubusercontent.com/8780500/124905260-7eb13b00-e003-11eb-9326-b10d6dccb26c.png">


