### PR TITLE
perf: insert all children of same doctype in one query

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -249,10 +249,7 @@ class Document(BaseDocument):
 				if not ignore_if_duplicate:
 					raise e
 
-		# children
-		for d in self.get_all_children():
-			d.db_insert()
-
+		self.insert_children()
 		self.run_method("after_insert")
 		self.flags.in_insert = True
 
@@ -356,6 +353,25 @@ class Document(BaseDocument):
 				"folder": "Home/Attachments"})
 			_file.save()
 
+	def insert_children(self):
+		all_children = self.get_all_children()
+
+		if not all_children:
+			return
+
+		if self.doctype == "DocType":
+			for d in all_children:
+				d.db_insert()
+
+			return
+
+		doctype_wise_children = {}
+		for child in all_children:
+			children = doctype_wise_children.setdefault(child.doctype, [])
+			children.append(child)
+
+		for doctype, children in doctype_wise_children.items():
+			self.db_insert(children, doctype)
 
 	def update_children(self):
 		"""update child tables"""


### PR DESCRIPTION
## Changes Made
- Move logic for inserting children to `Document.insert_children`
- Redesign `BaseDocument.db_insert` to accept multiple documents

## Screenshots (for 200 child items)

### Before

![image](https://user-images.githubusercontent.com/16315650/124921234-cf319400-e015-11eb-8d38-8bb6a4c59d60.png)

### After (30% reduction)

![Screenshot-2021-07-08-175512](https://user-images.githubusercontent.com/16315650/124921266-d6f13880-e015-11eb-852d-fca1df6ce304.png)


