### PR TITLE
fix: Make scrollbar thumb rounded

### DIFF
--- a/frappe/public/scss/desk/scrollbar.scss
+++ b/frappe/public/scss/desk/scrollbar.scss
@@ -11,6 +11,7 @@ html {
 /* Works on Chrome, Edge, and Safari */
 *::-webkit-scrollbar-thumb {
 	background: var(--scrollbar-thumb-color);
+	border-radius: 6px;
 }
 
 *::-webkit-scrollbar-track,


### PR DESCRIPTION
Make scrollbar thumb rounded to match the overall design

**Before:** 
![Screenshot 2021-07-12 at 9 11 06 AM](https://user-images.githubusercontent.com/13928957/125227997-87e72400-e2f1-11eb-9318-30160e9a3c63.png)

**After:**
![Screenshot 2021-07-12 at 9 12 48 AM](https://user-images.githubusercontent.com/13928957/125227900-61c18400-e2f1-11eb-81cf-deb396a7303a.png)

continuation of https://github.com/frappe/frappe/pull/12882