### PR TITLE
fix(listview): Tag count query

### DIFF
--- a/frappe/desk/doctype/tag/test_tag.py
+++ b/frappe/desk/doctype/tag/test_tag.py
@@ -1,8 +1,26 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) 2019, Frappe Technologies and Contributors
-# See license.txt
-# import frappe
 import unittest
+import frappe
+
+from frappe.desk.reportview import get_stats
+from frappe.desk.doctype.tag.tag import add_tag
 
 class TestTag(unittest.TestCase):
-	pass
+	def setUp(self) -> None:
+		frappe.db.sql("DELETE from `tabTag`")
+		frappe.db.sql("UPDATE `tabDocType` set _user_tags=''")
+
+	def test_tag_count_query(self):
+		self.assertDictEqual(get_stats('["_user_tags"]', 'DocType'),
+			{'_user_tags': [['No Tags', frappe.db.count('DocType')]]})
+		add_tag('Standard', 'DocType', 'User')
+		add_tag('Standard', 'DocType', 'ToDo')
+
+		# count with no filter
+		self.assertDictEqual(get_stats('["_user_tags"]', 'DocType'),
+			{'_user_tags': [['Standard', 2], ['No Tags', frappe.db.count('DocType') - 2]]})
+
+		# count with child table field filter
+		self.assertDictEqual(get_stats('["_user_tags"]',
+			'DocType',
+			filters='[["DocField", "fieldname", "like", "%last_name%"], ["DocType", "name", "like", "%use%"]]'),
+			{'_user_tags': [['Standard', 1], ['No Tags', 0]]})

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -450,6 +450,7 @@ def get_stats(stats, doctype, filters=[]):
 				filters=filters + [[tag, '!=', '']],
 				group_by=tag,
 				as_list=True,
+				distinct=1,
 			)
 
 			if tag == '_user_tags':
@@ -458,18 +459,22 @@ def get_stats(stats, doctype, filters=[]):
 					fields=[tag, "count(*)"],
 					filters=filters + [[tag, "in", ('', ',')]],
 					as_list=True,
-				)[0][1]
+					group_by=tag,
+					order_by=tag,
+				)
+
+				no_tag_count = no_tag_count[0][1] if no_tag_count else 0
 
 				stats[tag].append([_("No Tags"), no_tag_count])
 			else:
 				stats[tag] = tag_count
 
 		except frappe.db.SQLError:
-			# does not work for child tables
 			pass
-		except frappe.db.InternalError:
+		except frappe.db.InternalError as e:
 			# raised when _user_tags column is added on the fly
 			pass
+
 	return stats
 
 @frappe.whitelist()

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -445,17 +445,24 @@ def get_stats(stats, doctype, filters=[]):
 	for tag in tags:
 		if not tag in columns: continue
 		try:
-			tagcount = frappe.get_list(doctype, fields=[tag, "count(*)"],
-				#filters=["ifnull(`%s`,'')!=''" % tag], group_by=tag, as_list=True)
-				filters = filters + ["ifnull(`%s`,'')!=''" % tag], group_by = tag, as_list = True)
+			tag_count = frappe.get_list(doctype,
+				fields=[tag, "count(*)"],
+				filters=filters + [[tag, '!=', '']],
+				group_by=tag,
+				as_list=True,
+			)
 
-			if tag=='_user_tags':
-				stats[tag] = scrub_user_tags(tagcount)
-				stats[tag].append([_("No Tags"), frappe.get_list(doctype,
+			if tag == '_user_tags':
+				stats[tag] = scrub_user_tags(tag_count)
+				no_tag_count = frappe.get_list(doctype,
 					fields=[tag, "count(*)"],
-					filters=filters +["({0} = ',' or {0} = '' or {0} is null)".format(tag)], as_list=True)[0][1]])
+					filters=filters + [[tag, "in", ('', ',')]],
+					as_list=True,
+				)[0][1]
+
+				stats[tag].append([_("No Tags"), no_tag_count])
 			else:
-				stats[tag] = tagcount
+				stats[tag] = tag_count
 
 		except frappe.db.SQLError:
 			# does not work for child tables


### PR DESCRIPTION
List view used to fail with the following error when a child field filter is added.

![Screenshot 2021-07-13 at 2 29 53 PM](https://user-images.githubusercontent.com/13928957/125423483-ab0b8040-96c4-4678-9288-a3a9e19e82f2.png)

```
Traceback (most recent call last):
  File "/home/frappe/version13/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/version13/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/version13/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/version13/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 1172, in call
    return fn(*args, **newargs)
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 609, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/version13/apps/frappe/frappe/desk/reportview.py", line 428, in get_sidebar_stats
    return {"stats": get_stats(stats, doctype, filters)}
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 609, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/version13/apps/frappe/frappe/desk/reportview.py", line 452, in get_stats
    filters = filters + ["ifnull(`%s`,'')!=''" % tag], group_by = tag, as_list = True)
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 1406, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/version13/apps/frappe/frappe/model/db_query.py", line 106, in execute
    result = self.build_and_run()
  File "/home/frappe/version13/apps/frappe/frappe/model/db_query.py", line 144, in build_and_run
    update=self.update, ignore_ddl=self.ignore_ddl)
  File "/home/frappe/version13/apps/frappe/frappe/database/database.py", line 152, in sql
    self._cursor.execute(query)
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/version13/env/lib/python3.6/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1052, "Column '_user_tags' in where clause is ambiguous")
```

After fix:
![Screenshot 2021-07-13 at 2 22 02 PM](https://user-images.githubusercontent.com/13928957/125423149-58eb90fa-9d5b-4c33-9e78-49765d082bf5.png)



https://frappe.io/app/issue/ISS-21-22-03962
