### PR TITLE
fix: user permission for restricting nested struct

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -49,7 +49,6 @@ class UserPermission(Document):
 			}, or_filters={
 				'applicable_for': cstr(self.applicable_for),
 				'apply_to_all_doctypes': 1,
-				'hide_descendants': cstr(self.hide_descendants)
 			}, limit=1)
 		if overlap_exists:
 			ref_link = frappe.get_desk_link(self.doctype, overlap_exists[0].name)


### PR DESCRIPTION
Adding hide descendants to the or_filters is pulling in all records that have hide descendants turned even though they might not be on the same doctype
Hide descendants should not be considered while adding user permissions since a permission with and one without it is not useful.