### PR TITLE
fix: escape quotes before declaring variables when making a new app

### DIFF
--- a/frappe/tests/test_boilerplate.py
+++ b/frappe/tests/test_boilerplate.py
@@ -20,7 +20,7 @@ class TestBoilerPlate(unittest.TestCase):
 
 	def test_create_app(self):
 		title = "Test App"
-		description = "Test app for unit testing"
+		description = "This app's description contains 'single quotes' and \"double quotes\"."
 		publisher = "Test Publisher"
 		email = "example@example.org"
 		icon = ""  # empty -> default

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -66,9 +66,6 @@ def make_boilerplate(dest, app_name):
 	with open(os.path.join(dest, hooks.app_name, ".gitignore"), "w") as f:
 		f.write(frappe.as_unicode(gitignore_template.format(app_name = hooks.app_name)))
 
-	with open(os.path.join(dest, hooks.app_name, "setup.py"), "w") as f:
-		f.write(frappe.as_unicode(setup_template.format(**hooks)))
-
 	with open(os.path.join(dest, hooks.app_name, "requirements.txt"), "w") as f:
 		f.write("# frappe -- https://github.com/frappe/frappe is installed via 'bench init'")
 
@@ -81,6 +78,14 @@ def make_boilerplate(dest, app_name):
 
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "modules.txt"), "w") as f:
 		f.write(frappe.as_unicode(hooks.app_title))
+
+	# These values could contain quotes and can break string declarations
+	# So escaping them before setting variables in setup.py and hooks.py
+	for key in ("app_publisher", "app_description", "app_license"):
+		hooks[key] = hooks[key].replace("\\", "\\\\").replace("'", "\\'").replace("\"", "\\\"")
+
+	with open(os.path.join(dest, hooks.app_name, "setup.py"), "w") as f:
+		f.write(frappe.as_unicode(setup_template.format(**hooks)))
 
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "hooks.py"), "w") as f:
 		f.write(frappe.as_unicode(hooks_template.format(**hooks)))
@@ -328,18 +333,18 @@ def get_data():
 
 setup_template = """from setuptools import setup, find_packages
 
-with open('requirements.txt') as f:
-	install_requires = f.read().strip().split('\\n')
+with open("requirements.txt") as f:
+	install_requires = f.read().strip().split("\\n")
 
 # get version from __version__ variable in {app_name}/__init__.py
 from {app_name} import __version__ as version
 
 setup(
-	name='{app_name}',
+	name="{app_name}",
 	version=version,
-	description='{app_description}',
-	author='{app_publisher}',
-	author_email='{app_email}',
+	description="{app_description}",
+	author="{app_publisher}",
+	author_email="{app_email}",
 	packages=find_packages(),
 	zip_safe=False,
 	include_package_data=True,


### PR DESCRIPTION
## Changes Made

- Escape quotes before setting `app_publisher`, `app_description` and `app_license` in auto-generated Python files (`hooks.py` and `setup.py`)
- Minor: Use double quotes consistently

## Screenshots 

### Before

![Screenshot-2021-07-13-175524](https://user-images.githubusercontent.com/16315650/125451401-0c67c976-f5a5-485f-9b64-82424e14506c.png)


### After

![Screenshot-2021-07-13-174814](https://user-images.githubusercontent.com/16315650/125451428-eaac6779-dc02-4068-8a01-cece560758bb.png)
