### PR TITLE
fix: Add missing fieldtypes for custom fields (backport #13689)

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -112,7 +112,11 @@
    "label": "Field Type",
    "oldfieldname": "fieldtype",
    "oldfieldtype": "Select",
+<<<<<<< HEAD
    "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nGeolocation\nHTML\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRating\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
+=======
+   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDuration\nDynamic Link\nFloat\nFold\nGeolocation\nHeading\nHTML\nHTML Editor\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRead Only\nRating\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
+>>>>>>> cf67dbce5a (fix: Add missing fieldtypes in for custom fields)
    "reqd": 1
   },
   {
@@ -360,7 +364,13 @@
  ],
  "icon": "fa fa-glass",
  "idx": 1,
+<<<<<<< HEAD
  "modified": "2020-03-17 21:30:18.102333",
+=======
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2021-07-12 04:54:12.042319",
+>>>>>>> cf67dbce5a (fix: Add missing fieldtypes in for custom fields)
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",


### PR DESCRIPTION
This is an automatic backport of pull request #13689 done by [Mergify](https://mergify.io).
Cherry-pick of cf67dbce5abd96687ab3c8a05a74cecf3bf7792b has failed:
```
On branch mergify/bp/v12-pre-release/pr-13689
Your branch is up to date with 'origin/v12-pre-release'.

You are currently cherry-picking commit cf67dbce5a.
  (fix conflicts and run "git cherry-pick --continue")
  (use "git cherry-pick --skip" to skip this patch)
  (use "git cherry-pick --abort" to cancel the cherry-pick operation)

Unmerged paths:
  (use "git add <file>..." to mark resolution)
	both modified:   frappe/custom/doctype/custom_field/custom_field.json

no changes added to commit (use "git add" and/or "git commit -a")
```


To fix up this pull request, you can check it out locally. See documentation: https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally

---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://docs.mergify.io/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR on its base branch
- `@Mergifyio update` will merge the base branch into this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the config editor.

Finally, you can contact us on https://mergify.io/
</details>

port-of: https://github.com/frappe/frappe/pull/13723