### PR TITLE
fix: Add missing fieldtypes for custom fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,18 @@ install:
     fi
 
   - cd ./frappe-bench
-  - ./env/bin/pip freeze | grep 'urllib'
+
+  - sed -i 's/watch:/# watch:/g' Procfile
+  - sed -i 's/schedule:/# schedule:/g' Procfile
+
+  - if [ $TYPE == "server" ]; then sed -i 's/socketio:/# socketio:/g' Procfile; fi
+  - if [ $TYPE == "server" ]; then sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile; fi
+
+  - if [ $TYPE == "ui" ]; then bench setup requirements --node; fi
+
+  - bench start &
+  - bench --site test_site reinstall --yes
+  - bench build --app frappe
 
 after_script:
   - pip install coverage==4.5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,18 +75,7 @@ install:
     fi
 
   - cd ./frappe-bench
-
-  - sed -i 's/watch:/# watch:/g' Procfile
-  - sed -i 's/schedule:/# schedule:/g' Procfile
-
-  - if [ $TYPE == "server" ]; then sed -i 's/socketio:/# socketio:/g' Procfile; fi
-  - if [ $TYPE == "server" ]; then sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile; fi
-
-  - if [ $TYPE == "ui" ]; then bench setup requirements --node; fi
-
-  - bench start &
-  - bench --site test_site reinstall --yes
-  - bench build --app frappe
+  - ./env/bin/pip freeze | grep 'urllib'
 
 after_script:
   - pip install coverage==4.5.4

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1121,7 +1121,7 @@ def generate_keys(user):
 
 def get_enabled_users():
 	def _get_enabled_users():
-		enabled_users = frappe.get_all("User", filters={"enabled": "1"}, pluck="name")
+		enabled_users = [d.name for d in frappe.get_all("User", filters={"enabled": "1"})]
 		return enabled_users
 
 	return frappe.cache().get_value("enabled_users", _get_enabled_users)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -49,11 +49,7 @@ class User(Document):
 
 	def after_insert(self):
 		create_notification_settings(self.name)
-<<<<<<< HEAD
-=======
-		frappe.cache().delete_key('users_for_mentions')
 		frappe.cache().delete_key('enabled_users')
->>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)
 
 	def validate(self):
 		self.check_demo()
@@ -347,15 +343,7 @@ class User(Document):
 
 		# delete notification settings
 		frappe.delete_doc("Notification Settings", self.name, ignore_permissions=True)
-
-<<<<<<< HEAD
-=======
-		if self.get('allow_in_mentions'):
-			frappe.cache().delete_key('users_for_mentions')
-
 		frappe.cache().delete_key('enabled_users')
-
->>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)
 
 	def before_rename(self, old_name, new_name, merge=False):
 		self.check_demo()
@@ -1130,13 +1118,6 @@ def generate_keys(user):
 
 		return {"api_secret": api_secret}
 	frappe.throw(frappe._("Not Permitted"), frappe.PermissionError)
-<<<<<<< HEAD
-=======
-
-@frappe.whitelist()
-def switch_theme(theme):
-	if theme in ["Dark", "Light"]:
-		frappe.db.set_value("User", frappe.session.user, "desk_theme", theme)
 
 def get_enabled_users():
 	def _get_enabled_users():
@@ -1144,4 +1125,3 @@ def get_enabled_users():
 		return enabled_users
 
 	return frappe.cache().get_value("enabled_users", _get_enabled_users)
->>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -49,6 +49,11 @@ class User(Document):
 
 	def after_insert(self):
 		create_notification_settings(self.name)
+<<<<<<< HEAD
+=======
+		frappe.cache().delete_key('users_for_mentions')
+		frappe.cache().delete_key('enabled_users')
+>>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)
 
 	def validate(self):
 		self.check_demo()
@@ -101,6 +106,9 @@ class User(Document):
 		create_contact(self, ignore_mandatory=True)
 		if self.name not in ('Administrator', 'Guest') and not self.user_image:
 			frappe.enqueue('frappe.core.doctype.user.user.update_gravatar', name=self.name)
+
+		if self.has_value_changed('enabled'):
+			frappe.cache().delete_key('enabled_users')
 
 	def has_website_permission(self, ptype, user, verbose=False):
 		"""Returns true if current user is the session user"""
@@ -340,6 +348,14 @@ class User(Document):
 		# delete notification settings
 		frappe.delete_doc("Notification Settings", self.name, ignore_permissions=True)
 
+<<<<<<< HEAD
+=======
+		if self.get('allow_in_mentions'):
+			frappe.cache().delete_key('users_for_mentions')
+
+		frappe.cache().delete_key('enabled_users')
+
+>>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)
 
 	def before_rename(self, old_name, new_name, merge=False):
 		self.check_demo()
@@ -1114,3 +1130,18 @@ def generate_keys(user):
 
 		return {"api_secret": api_secret}
 	frappe.throw(frappe._("Not Permitted"), frappe.PermissionError)
+<<<<<<< HEAD
+=======
+
+@frappe.whitelist()
+def switch_theme(theme):
+	if theme in ["Dark", "Light"]:
+		frappe.db.set_value("User", frappe.session.user, "desk_theme", theme)
+
+def get_enabled_users():
+	def _get_enabled_users():
+		enabled_users = frappe.get_all("User", filters={"enabled": "1"}, pluck="name")
+		return enabled_users
+
+	return frappe.cache().get_value("enabled_users", _get_enabled_users)
+>>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -112,7 +112,7 @@
    "label": "Field Type",
    "oldfieldname": "fieldtype",
    "oldfieldtype": "Select",
-   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nGeolocation\nHTML\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRating\nRead Only\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
+   "options": "Attach\nAttach Image\nBarcode\nButton\nCheck\nCode\nColor\nColumn Break\nCurrency\nData\nDate\nDatetime\nDynamic Link\nFloat\nFold\nGeolocation\nHTML\nHTML Editor\nImage\nInt\nLink\nLong Text\nMarkdown Editor\nPassword\nPercent\nRead Only\nRating\nSection Break\nSelect\nSmall Text\nTable\nTable MultiSelect\nText\nText Editor\nTime\nSignature",
    "reqd": 1
   },
   {
@@ -360,7 +360,7 @@
  ],
  "icon": "fa fa-glass",
  "idx": 1,
- "modified": "2020-03-17 21:30:18.102333",
+ "modified": "2021-07-12 04:54:12.042319",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -18,7 +18,7 @@ from time import time
 from frappe.utils import now, getdate, cast_fieldtype
 from frappe.utils.background_jobs import execute_job, get_queue
 from frappe.model.utils.link_count import flush_local_link_count
-from frappe.utils import cint
+from frappe.utils import cint, cast_fieldtype
 
 # imports - compatibility imports
 from six import (
@@ -558,8 +558,7 @@ class Database(object):
 		if not df:
 			frappe.throw(_('Invalid field name: {0}').format(frappe.bold(fieldname)), self.InvalidColumnName)
 
-		if df.fieldtype in frappe.model.numeric_fieldtypes:
-			val = cint(val)
+		val = cast_fieldtype(df.fieldtype, val)
 
 		self.value_cache[doctype][fieldname] = val
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -18,7 +18,6 @@ from time import time
 from frappe.utils import now, getdate, cast_fieldtype
 from frappe.utils.background_jobs import execute_job, get_queue
 from frappe.model.utils.link_count import flush_local_link_count
-from frappe.utils import cint, cast_fieldtype
 
 # imports - compatibility imports
 from six import (

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -385,6 +385,11 @@ class Document(BaseDocument):
 	def get_doc_before_save(self):
 		return getattr(self, '_doc_before_save', None)
 
+	def has_value_changed(self, fieldname):
+		'''Returns true if value is changed before and after saving'''
+		previous = self.get_doc_before_save()
+		return previous.get(fieldname)!=self.get(fieldname) if previous else True
+
 	def set_new_name(self, force=False):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""
 		if self.flags.name_set and not force:

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -271,6 +271,31 @@ class TestEnergyPointLog(unittest.TestCase):
 		self.assertEqual(points_after_reverting_todo, points_after_closing_todo - rule_points)
 		self.assertEqual(points_after_saving_todo_again, points_after_reverting_todo + rule_points)
 
+	def test_energy_points_disabled_user(self):
+		frappe.set_user('test@example.com')
+		user = frappe.get_doc('User', 'test@example.com')
+		user.enabled = 0
+		user.save()
+		todo_point_rule = create_energy_point_rule_for_todo()
+		energy_point_of_user = get_points('test@example.com')
+
+		created_todo = create_a_todo()
+
+		created_todo.status = 'Closed'
+		created_todo.save()
+		points_after_closing_todo = get_points('test@example.com')
+
+		# do not update energy points for disabled user
+		self.assertEqual(points_after_closing_todo, energy_point_of_user)
+
+		user.enabled = 1
+		user.save()
+
+		created_todo.save()
+		points_after_re_saving_todo = get_points('test@example.com')
+		self.assertEqual(points_after_re_saving_todo, energy_point_of_user + todo_point_rule.points)
+
+
 def create_energy_point_rule_for_todo(multiplier_field=None, for_doc_event='Custom', max_points=None,
 	for_assigned_users=0, field_to_check=None, apply_once=False, user_field='owner'):
 	name = 'ToDo Closed'

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -6,11 +6,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 import frappe.cache_manager
-<<<<<<< HEAD
-=======
 from frappe.core.doctype.user.user import get_enabled_users
-from frappe.model import log_types
->>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)
 from frappe.model.document import Document
 from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 from frappe.social.doctype.energy_point_log.energy_point_log import \

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -6,6 +6,11 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 import frappe.cache_manager
+<<<<<<< HEAD
+=======
+from frappe.core.doctype.user.user import get_enabled_users
+from frappe.model import log_types
+>>>>>>> bd854bb368 (fix: Do not create energy points for disabled users)
 from frappe.model.document import Document
 from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
 from frappe.social.doctype.energy_point_log.energy_point_log import \
@@ -44,7 +49,7 @@ class EnergyPointRule(Document):
 
 			try:
 				for user in users:
-					if not user or user == 'Administrator': continue
+					if not is_eligible_user(user): continue
 					create_energy_points_log(reference_doctype, reference_name, {
 						'points': points,
 						'user': user,
@@ -118,3 +123,8 @@ def get_energy_point_doctypes():
 		d.reference_doctype for d in frappe.get_all('Energy Point Rule',
 			['reference_doctype'], {'enabled': 1})
 	]
+
+def is_eligible_user(user):
+	'''Checks if user is eligible to get energy points'''
+	enabled_users = get_enabled_users()
+	return user and user in enabled_users and user != 'Administrator'

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -43,8 +43,8 @@ class TestDB(unittest.TestCase):
 				"fieldname": 'test_'+fieldtype.lower(),
 				"label": 'Test '+fieldtype,
 				"fieldtype": fieldtype,
-		})
-		 
+			})
+
 		#test
 		for inp in test_inputs:
 			fieldname = 'test_'+inp['fieldtype'].lower()

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -33,26 +33,34 @@ class TestDB(unittest.TestCase):
 
 	def test_get_single_value(self):
 		#setup
-		fieldtypes = ['Float', 'Int', 'Percent', 'Currency', 'Data', 'Date', 'Datetime', 'Time']
-		values = [1.5, 1, 55.5, 12.5, 'Test', datetime.datetime.now().date(), datetime.datetime.now(), datetime.timedelta(hours=9, minutes=45, seconds=10)]
+		values_dict = {
+			"Float": 1.5,
+			"Int": 1,
+			"Percent": 55.5,
+			"Currency": 12.5,
+			"Data": "Test",
+			"Date": datetime.datetime.now().date(),
+			"Datetime": datetime.datetime.now(),
+			"Time": datetime.timedelta(hours=9, minutes=45, seconds=10)
+		}
 		test_inputs = [{
-			'fieldtype': fieldtypes[i],
-			'value': values[i]} for i in range(len(fieldtypes))]
-		for fieldtype in fieldtypes:
-			create_custom_field('Print Settings', {
-				"fieldname": 'test_'+fieldtype.lower(),
-				"label": 'Test '+fieldtype,
+			"fieldtype": fieldtype,
+			"value": value} for fieldtype, value in values_dict.items()]
+		for fieldtype in values_dict.keys():
+			create_custom_field("Print Settings", {
+				"fieldname": "test_{0}".format(fieldtype.lower()),
+				"label": "Test {0}".format(fieldtype),
 				"fieldtype": fieldtype,
 			})
 
 		#test
 		for inp in test_inputs:
-			fieldname = 'test_'+inp['fieldtype'].lower()
-			frappe.db.set_value('Print Settings', 'Print Settings', fieldname, inp['value'])
-			self.assertEqual(frappe.db.get_single_value('Print Settings', fieldname), inp['value'])
+			fieldname = "test_{0}".format(inp["fieldtype"].lower())
+			frappe.db.set_value("Print Settings", "Print Settings", fieldname, inp["value"])
+			self.assertEqual(frappe.db.get_single_value("Print Settings", fieldname), inp["value"])
 
 		#teardown 
-		clear_custom_fields('Print Settings')
+		clear_custom_fields("Print Settings")
 
 	def test_log_touched_tables(self):
 		frappe.flags.in_migrate = True

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -4,15 +4,14 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-import unittest
-<<<<<<< HEAD
-=======
-from random import choice
-import datetime
 
->>>>>>> 1e839f0ab1 (test: Add test for frappe.db.get_single_value)
+import datetime
+import unittest
+
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+from frappe.utils.testutils import clear_custom_fields
+
 
 class TestDB(unittest.TestCase):
 	def test_get_value(self):
@@ -59,7 +58,7 @@ class TestDB(unittest.TestCase):
 			frappe.db.set_value("Print Settings", "Print Settings", fieldname, inp["value"])
 			self.assertEqual(frappe.db.get_single_value("Print Settings", fieldname), inp["value"])
 
-		#teardown 
+		#teardown
 		clear_custom_fields("Print Settings")
 
 	def test_log_touched_tables(self):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -5,6 +5,12 @@
 
 from __future__ import unicode_literals
 import unittest
+<<<<<<< HEAD
+=======
+from random import choice
+import datetime
+
+>>>>>>> 1e839f0ab1 (test: Add test for frappe.db.get_single_value)
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
@@ -26,11 +32,27 @@ class TestDB(unittest.TestCase):
 		frappe.db.escape("香港濟生堂製藥有限公司 - IT".encode("utf-8"))
 
 	def test_get_single_value(self):
-		frappe.db.set_value('System Settings', 'System Settings', 'backup_limit', 5)
-		frappe.db.commit()
+		#setup
+		fieldtypes = ['Float', 'Int', 'Percent', 'Currency', 'Data', 'Date', 'Datetime', 'Time']
+		values = [1.5, 1, 55.5, 12.5, 'Test', datetime.datetime.now().date(), datetime.datetime.now(), datetime.timedelta(hours=9, minutes=45, seconds=10)]
+		test_inputs = [{
+			'fieldtype': fieldtypes[i],
+			'value': values[i]} for i in range(len(fieldtypes))]
+		for fieldtype in fieldtypes:
+			create_custom_field('Print Settings', {
+				"fieldname": 'test_'+fieldtype.lower(),
+				"label": 'Test '+fieldtype,
+				"fieldtype": fieldtype,
+		})
+		 
+		#test
+		for inp in test_inputs:
+			fieldname = 'test_'+inp['fieldtype'].lower()
+			frappe.db.set_value('Print Settings', 'Print Settings', fieldname, inp['value'])
+			self.assertEqual(frappe.db.get_single_value('Print Settings', fieldname), inp['value'])
 
-		limit = frappe.db.get_single_value('System Settings', 'backup_limit')
-		self.assertEqual(limit, 5)
+		#teardown 
+		clear_custom_fields('Print Settings')
 
 	def test_log_touched_tables(self):
 		frappe.flags.in_migrate = True

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -71,9 +71,6 @@ def make_boilerplate(dest, app_name):
 	with open(os.path.join(dest, hooks.app_name, ".gitignore"), "w") as f:
 		f.write(frappe.as_unicode(gitignore_template.format(app_name = hooks.app_name)))
 
-	with open(os.path.join(dest, hooks.app_name, "setup.py"), "w") as f:
-		f.write(frappe.as_unicode(setup_template.format(**hooks)))
-
 	with open(os.path.join(dest, hooks.app_name, "requirements.txt"), "w") as f:
 		f.write("frappe")
 
@@ -86,6 +83,14 @@ def make_boilerplate(dest, app_name):
 
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "modules.txt"), "w") as f:
 		f.write(frappe.as_unicode(hooks.app_title))
+
+	# These values could contain quotes and can break string declarations
+	# So escaping them before setting variables in setup.py and hooks.py
+	for key in ("app_publisher", "app_description", "app_license"):
+		hooks[key] = hooks[key].replace("\\", "\\\\").replace("'", "\\'").replace("\"", "\\\"")
+
+	with open(os.path.join(dest, hooks.app_name, "setup.py"), "w") as f:
+		f.write(frappe.as_unicode(setup_template.format(**hooks)))
 
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "hooks.py"), "w") as f:
 		f.write(frappe.as_unicode(hooks_template.format(**hooks)))
@@ -277,18 +282,18 @@ def get_data():
 setup_template = """# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
-with open('requirements.txt') as f:
-	install_requires = f.read().strip().split('\\n')
+with open("requirements.txt") as f:
+	install_requires = f.read().strip().split("\\n")
 
 # get version from __version__ variable in {app_name}/__init__.py
 from {app_name} import __version__ as version
 
 setup(
-	name='{app_name}',
+	name="{app_name}",
 	version=version,
-	description='{app_description}',
-	author='{app_publisher}',
-	author_email='{app_email}',
+	description="{app_description}",
+	author="{app_publisher}",
+	author_email="{app_email}",
 	packages=find_packages(),
 	zip_safe=False,
 	include_package_data=True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ stripe==2.40.0
 terminaltables==3.1.0
 Unidecode==1.1.1
 unittest-xml-reporting==2.5.2
-urllib3==1.25.9
+urllib3==1.26.5
 watchdog==0.8.0
 Werkzeug==0.16.1
 xlrd==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ stripe==2.40.0
 terminaltables==3.1.0
 Unidecode==1.1.1
 unittest-xml-reporting==2.5.2
-urllib3==1.26.5
+urllib3==1.25.11
 watchdog==0.8.0
 Werkzeug==0.16.1
 xlrd==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ stripe==2.40.0
 terminaltables==3.1.0
 Unidecode==1.1.1
 unittest-xml-reporting==2.5.2
-urllib3==1.26.5
+urllib3
 watchdog==0.8.0
 Werkzeug==0.16.1
 xlrd==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ stripe==2.40.0
 terminaltables==3.1.0
 Unidecode==1.1.1
 unittest-xml-reporting==2.5.2
-urllib3
+urllib3==1.26.5
 watchdog==0.8.0
 Werkzeug==0.16.1
 xlrd==1.2.0


### PR DESCRIPTION
Resolves the following issue while adding custom field via Customize Form

![](https://frappe.io/files/sLPNTJn.gif)

https://frappe.io/app/issue/ISS-21-22-03931

port-of: https://github.com/frappe/frappe/pull/13689

port-of: https://github.com/frappe/frappe/pull/13725