### PR TITLE
fix(NotFoundPage): Set default value for http_status_code

### DIFF
--- a/frappe/website/page_renderers/not_found_page.py
+++ b/frappe/website/page_renderers/not_found_page.py
@@ -8,11 +8,11 @@ from frappe.website.utils import can_cache
 HOMEPAGE_PATHS = ('/', '/index', 'index')
 
 class NotFoundPage(TemplatePage):
-	def __init__(self, path, http_status_code):
+	def __init__(self, path, http_status_code=None):
 		self.request_path = path
 		self.request_url = frappe.local.request.url if hasattr(frappe.local, 'request') else ''
 		path = '404'
-		http_status_code = 404
+		http_status_code = http_status_code or 404
 		super().__init__(path=path, http_status_code=http_status_code)
 
 	def can_render(self):


### PR DESCRIPTION
![Screenshot 2021-07-16 at 12 03 06 PM](https://user-images.githubusercontent.com/36654812/125903038-5114cd62-fdbc-45b3-be17-bd11e999e897.png)

refs: 
- https://frappeframework.com/docs/v13/user/en/guides/reports-and-printing/how-to-make-script-reports
- https://frappeframework.com/docs/user/en/python-api/router
---

The issue was introduced via https://github.com/frappe/frappe/pull/12334
Closes https://github.com/frappe/frappe/issues/13677