### PR TITLE
fix: included company in filters to create a contact

### DIFF
--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -32,11 +32,15 @@ frappe.ui.form.on("Contact", {
 			});
 		}
 		frm.set_query('link_doctype', "links", function() {
+			// company_description to include Company in the filtered options
+
+			let fieldtypes = ["HTML", "Text Editor"];
+			let fieldnames = ["contact_html", "company_description"];
 			return {
 				query: "frappe.contacts.address_and_contact.filter_dynamic_link_doctypes",
 				filters: {
-					fieldtype: "HTML",
-					fieldname: "contact_html",
+					fieldtype: ["in", fieldtypes],
+					fieldname: ["in", fieldnames],
 				}
 			}
 		});


### PR DESCRIPTION
**Before:**
- No company option in filtered options while creating a contact.
- Options were filtered based on doctypes that had the contact_html fieldname which the company doctype does not have.
- Workaround used was to manually set the link field to Company.

![no_company](https://user-images.githubusercontent.com/43572428/122355175-520f8380-cf6f-11eb-951b-7bb12180c7a6.gif)

**Fix:**
- Made the filters include company by making it use company_description (since it's a unique field to the company doctype)

![added_company](https://user-images.githubusercontent.com/43572428/122355442-87b46c80-cf6f-11eb-86d7-09f4f8fcd289.gif)



