### PR TITLE
fix: Move layout colors to common css_variables.scss

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -179,9 +179,20 @@
 	--text-on-pink: var(--pink-500);
 	--text-on-cyan: var(--cyan-600);
 
+	// Layout Colors
+	--bg-color: var(--gray-50);
+	--fg-color: white;
+	--navbar-bg: white;
+	--fg-hover-color: var(--gray-100);
+	--card-bg: var(--fg-color);
+	--disabled-text-color: var(--gray-700);
 	--disabled-control-bg: var(--gray-50);
 	--control-bg: var(--gray-100);
 	--control-bg-on-gray: var(--gray-200);
+	--awesomebar-focus-bg: var(--fg-color);
+	--modal-bg: white;
+	--toast-bg: var(--modal-bg);
+	--popover-bg: white;
 
 	--awesomplete-hover-bg: var(--control-bg);
 

--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -25,20 +25,7 @@ $input-height: 28px !default;
 
 	--navbar-height: 60px;
 
-	// Layout Colors
-	--bg-color: var(--gray-50);
-	--fg-color: white;
-	--navbar-bg: white;
-	--fg-hover-color: var(--gray-100);
-	--card-bg: var(--fg-color);
-	--disabled-text-color: var(--gray-700);
-	--disabled-control-bg: var(--gray-50);
-	--control-bg: var(--gray-100);
-	--control-bg-on-gray: var(--gray-200);
-	--awesomebar-focus-bg: var(--fg-color);
-	--modal-bg: white;
-	--toast-bg: var(--modal-bg);
-	--popover-bg: white;
+
 
 	--appreciation-color: var(--dark-green-600);
 	--appreciation-bg: var(--dark-green-100);


### PR DESCRIPTION
- Move layout colors to common `css_variables.scss` so that web form pages can use it.

**Before:**
<img width="377" alt="Screenshot 2021-07-20 at 8 40 09 AM" src="https://user-images.githubusercontent.com/13928957/126256573-7aa32c7b-df4a-4dd7-9168-e373afb0b2bf.png">

**Now:**
<img width="366" alt="Screenshot 2021-07-20 at 8 40 51 AM" src="https://user-images.githubusercontent.com/13928957/126256578-46f2b0f7-f048-46f9-97a2-edd44d60f533.png">




