### PR TITLE
fix(signature): Make pad only after the DOM is ready

### DIFF
--- a/frappe/public/js/frappe/form/controls/signature.js
+++ b/frappe/public/js/frappe/form/controls/signature.js
@@ -53,13 +53,15 @@ frappe.ui.form.ControlSignature = class ControlSignature extends frappe.ui.form.
 		this.img = $("<img class='img-responsive attach-image-display'>")
 			.appendTo(this.img_wrapper).toggle(false);
 	}
-	refresh_input(e) {
+	refresh_input() {
+		// signature dom is not ready
+		if (!this.body) return;
 		// prevent to load the second time
 		this.make_pad();
 		this.$wrapper.find(".control-input").toggle(false);
 		this.set_editable(this.get_status()=="Write");
 		this.load_pad();
-		if(this.get_status()=="Read") {
+		if (this.get_status() == "Read") {
 			$(this.disp_area).toggle(false);
 		}
 	}


### PR DESCRIPTION
**Issue:** The form which had a signature field used to fail with the following error.

```js
request.js:251 TypeError: Cannot read property 'width' of undefined
    at ControlSignature.make_pad (signature.js:22)
    at ControlSignature.refresh_input (signature.js:58)
    at ControlSignature.refresh (base_control.js:102)
    at layout.js:663
    at Array.forEach (<anonymous>)
    at FormSection.collapse (layout.js:661)
    at form_tour.js:33
    at Array.forEach (<anonymous>)
    at FormTour.init_driver (form_tour.js:33)
    at new FormTour (form_tour.js:6)
```
**Before:**
<img width="1440" alt="Screenshot 2021-07-20 at 11 30 58 AM" src="https://user-images.githubusercontent.com/13928957/126269563-fef3050c-0f4f-49a6-bbb2-2a2b5f7c8082.png">

**After:**
<img width="1312" alt="Screenshot 2021-07-20 at 11 33 00 AM" src="https://user-images.githubusercontent.com/13928957/126269842-7abf4bde-6198-4e89-b1cc-cf0d8f3cfaf5.png">



