### PR TITLE
fix: Use 1em margin for p outside container

### DIFF
--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -127,7 +127,7 @@ w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 '''
 		transformed_html = '''
 <h3>Hi John</h3>
-<p style="margin:5px 0 !important">This is a test email</p>
+<p style="margin:1em 0 !important">This is a test email</p>
 '''
 		self.assertTrue(transformed_html in inline_style_in_html(html))
 

--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -36,7 +36,13 @@ a {
 }
 
 p {
-	margin: 5px 0 !important;
+	margin: 1em 0 !important;
+}
+
+.with-container {
+	p {
+		margin: 5px 0 !important;
+	}
 }
 
 .ql-editor {


### PR DESCRIPTION
Revert https://github.com/frappe/frappe/commit/397848f9f7f692c3b8ac43efbc85b231ac32cb08#diff-cad6d40df66d9378e252342fe4148d3f8114a3c361dffd048fc3b09d5d9024b3R39

**Before:** (check spacing)

![Screenshot 2021-07-20 at 3 02 12 PM](https://user-images.githubusercontent.com/13928957/126298801-d1944a56-7271-46d0-a80f-eb006c141efc.png)

**After:**

![Screenshot 2021-07-20 at 3 02 36 PM](https://user-images.githubusercontent.com/13928957/126298866-3867d360-2a06-4dc2-aa40-d386d0b110ee.png)

