### PR TITLE
fix: `show Report` button in report view

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -172,7 +172,7 @@ frappe.router = {
 			standard_route = ['List', doctype_route.doctype, frappe.utils.to_title_case(route[2])];
 			if (route[3]) {
 				// calendar / kanban / dashboard / folder name
-				standard_route.push(...route.splice(3, route.length));
+				standard_route.push([...route].splice(3, route.length));
 			}
 		}
 		return standard_route;
@@ -298,7 +298,7 @@ frappe.router = {
 				new_route = [this.slug(route[1]), 'view', route[2].toLowerCase()];
 
 				// calendar / inbox / file folder
-				if (route[3]) new_route.push(...route.slice(3, route.length));
+				if (route[3]) new_route.push([...route].slice(3, route.length));
 			} else {
 				if ($.isPlainObject(route[2])) {
 					frappe.route_options = route[2];


### PR DESCRIPTION
Fix the below error that is triggered while trying to access the report using `Show Report` button.

![Screenshot 2021-07-20 at 7 12 41 PM](https://user-images.githubusercontent.com/36557/126334508-4cdb330e-b1a7-4404-a45b-0acde1808ea2.png)

This is happening because, type argument to type array conversion is not done correctly.