### PR TITLE
fix: Allow navigation to the document with # in the docname

### DIFF
--- a/cypress/integration/navigation.js
+++ b/cypress/integration/navigation.js
@@ -1,0 +1,15 @@
+context('Navigation', () => {
+	before(() => {
+		cy.login();
+		cy.visit('/app/website');
+	});
+	it('Navigate to route with hash in document name', () => {
+		cy.insert_doc('ToDo', {'__newname': 'ABC#123', 'description': 'Test this', 'ignore_duplicate': true});
+		cy.visit('/app/todo/ABC#123');
+		cy.title().should('eq', 'Test this - ABC#123');
+		cy.get_field('description', 'Text Editor').contains('Test this');
+		cy.go('back');
+		cy.title().should('eq', 'Website');
+		cy.remove_doc('ToDo', 'ABC#123');
+	});
+});

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -47,20 +47,18 @@ $('body').on('click', 'a', function(e) {
 		return;
 	}
 
-	if (href==='') {
+	if (href === '') {
 		return override('/app');
+	}
+
+	if (href.startsWith('#')) {
+		// target startswith "#", this is a v1 style route, so remake it.
+		return override(e.currentTarget.hash);
 	}
 
 	if (frappe.router.is_app_route(e.currentTarget.pathname)) {
 		// target has "/app, this is a v2 style route.
-		if (e.currentTarget.pathname) {
-			return override(e.currentTarget.pathname + e.currentTarget.hash);
-		}
-	} else {
-		// target has "#" ,this is a v1 style route, so remake it.
-		if (e.currentTarget.hash) {
-			return override(e.currentTarget.hash);
-		}
+		return override(e.currentTarget.pathname + e.currentTarget.hash);
 	}
 });
 

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -365,7 +365,7 @@ frappe.router = {
 		if (!route) {
 			route = window.location.pathname + window.location.hash + window.location.search;
 			if (route.includes('app#')) {
-				// to supports v1
+				// to support v1
 				route = window.location.hash;
 			}
 		}

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -14,11 +14,10 @@ frappe.view_factories = [];
 frappe.route_options = null;
 frappe.route_hooks = {};
 
-$(window).on('hashchange', function() {
+$(window).on('hashchange', function(e) {
 	// v1 style routing, route is in hash
-	if (window.location.hash) {
+	if (window.location.hash && !frappe.router.is_app_route(e.currentTarget.pathname)) {
 		let sub_path = frappe.router.get_sub_path(window.location.hash);
-		window.location.hash = '';
 		frappe.router.push_state(sub_path);
 		return false;
 	}
@@ -52,14 +51,16 @@ $('body').on('click', 'a', function(e) {
 		return override('/app');
 	}
 
-	// target has "#" ,this is a v1 style route, so remake it.
-	if (e.currentTarget.hash) {
-		return override(e.currentTarget.hash);
-	}
-
-	// target has "/app, this is a v2 style route.
-	if (e.currentTarget.pathname && frappe.router.is_app_route(e.currentTarget.pathname)) {
-		return override(e.currentTarget.pathname);
+	if (frappe.router.is_app_route(e.currentTarget.pathname)) {
+		// target has "/app, this is a v2 style route.
+		if (e.currentTarget.pathname) {
+			return override(e.currentTarget.pathname + e.currentTarget.hash);
+		}
+	} else {
+		// target has "#" ,this is a v1 style route, so remake it.
+		if (e.currentTarget.hash) {
+			return override(e.currentTarget.hash);
+		}
 	}
 });
 
@@ -349,8 +350,6 @@ frappe.router = {
 	push_state(url) {
 		// change the URL and call the router
 		if (window.location.pathname !== url) {
-			// cleanup any remenants of v1 routing
-			window.location.hash = '';
 
 			// push state so the browser looks fine
 			history.pushState(null, null, url);
@@ -364,7 +363,11 @@ frappe.router = {
 		// return clean sub_path from hash or url
 		// supports both v1 and v2 routing
 		if (!route) {
-			route = window.location.hash || (window.location.pathname + window.location.search);
+			route = window.location.pathname + window.location.hash + window.location.search;
+			if (route.includes('app#')) {
+				// to supports v1
+				route = window.location.hash;
+			}
 		}
 
 		return this.strip_prefix(route);


### PR DESCRIPTION
- Allow navigation to the document with "**#**" in the docname
- Fixed external link (with "**#**") navigation

**Before:**

https://user-images.githubusercontent.com/13928957/126257835-18e77d91-7c94-463e-a972-1b06b041588c.mov



**Now:**

https://user-images.githubusercontent.com/13928957/126257881-df90842b-6083-4096-a293-732146fcdc78.mov

---


## Types of URL tested:

**Before:**
⨯ external v1 link with hash: `https://version12test.erpnext.com/desk#Form/Customer/Tom%20H2`
⨯ external link with hash: `https://github.com/frappe/frappe/pull/13728#pullrequestreview-708053874`
✓ internal v1 link: `#List/ToDo/List`
⨯ internal link with hash in docname: `/app/todo/DOOM#100075`
✓ with app prefix: `/app#List/ToDo/List`
✓ v1 with desk prefix: `/desk#List/ToDo/List`
✓ v2 with query parameters: `/app/customize-form?doc_type=Task`

**After:**
✓ external v1 link with hash: `https://version12test.erpnext.com/desk#Form/Customer/Tom%20H2`
✓ external link with hash: `https://github.com/frappe/frappe/pull/13728#pullrequestreview-708053874`
✓ internal v1 link: `#List/ToDo/List`
✓ internal link with hash in docname: `/app/todo/DOOM#100075`
✓ with app prefix: `/app#List/ToDo/List`
✓ v1 with desk prefix: `/desk#List/ToDo/List`
✓ v2 with query parameters: `/app/customize-form?doc_type=Task`

The issue was introduced via https://github.com/frappe/frappe/pull/12277

Resolves: https://frappe.io/app/issue/ISS-21-22-03960

port-of: https://github.com/frappe/frappe/pull/13730