### PR TITLE
fix: refresh dependencies on `awesomplete-selectcomplete` event

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -40,14 +40,16 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 				this.catch_enter_as_submit();
 			}
 
-			$(this.wrapper).find('input, select').on('change', () => {
-				this.dirty = true;
-
-				frappe.run_serially([
-					() => frappe.timeout(0.1),
-					() => me.refresh_dependency()
-				]);
-			});
+			$(this.wrapper).find('input, select').on(
+				'change awesomplete-selectcomplete',
+				() => {
+					this.dirty = true;
+					frappe.run_serially([
+						() => frappe.timeout(0.1),
+						() => me.refresh_dependency()
+					]);
+				}
+			);
 
 		}
 	}


### PR DESCRIPTION
## Description

The `change` event does not always get called for `Link` fields. This results in dependencies (`depends_on`) not refreshing based on the value set in the field.

Adding `awesomplete-selectcomplete` as an event resolves this issue.

## Screenshots

### Before

![fieldgroup_before](https://user-images.githubusercontent.com/16315650/126607155-e74a3477-a0eb-425f-9c0d-f41856306dba.gif)

### After

![fieldgroup_after](https://user-images.githubusercontent.com/16315650/126607363-0a2d74c6-ff7b-44f1-a29b-1646c4f5298c.gif)

