### PR TITLE
fix: Update webhook.py

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 import json
 from time import sleep
+from jinja2 import Template
 
 import requests
 from urllib.parse import urlparse
@@ -133,6 +134,7 @@ def get_webhook_data(doc, webhook):
 
 def validate_json(string):
 	try:
-		json.loads(string)
+		tmpl = Template(string)
+		json.loads(tmpl.render())
 	except (TypeError, ValueError):
-		frappe.throw(_("Request Body consists of an invalid JSON structure"), title=_("Invalid JSON"))
+		frappe.throw(_("Request Body consists of an invalid JSON structure or invalid jinja structure"), title=_("Invalid JSON"))


### PR DESCRIPTION
I am unable to test this because I don't have access to a non production machine.

The json validation won't allow useful, and arguably vital jinja script.

This use case for being able to use jinja might be the ability to parse through all elements of a table within a doc. 

Example:  Items Doctype (From ERPNext)

{
    "name":"{{doc.name}}",
    "uoms":[
        {
            {% for uom in doc.uoms %}
            "name":"{{uom.name}}"
            {% endfor %}}"
        }
    ]
}

This way we can select names exclusively. There are other functionalities that validation was blocking as well.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
