### PR TITLE
perf: strain html before passing to bs4

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -488,11 +488,12 @@ def set_content_type(response, data, path):
 	return data
 
 def add_preload_headers(response):
-	from bs4 import BeautifulSoup
+	from bs4 import BeautifulSoup, SoupStrainer
 
 	try:
 		preload = []
-		soup = BeautifulSoup(response.data, "lxml")
+		strainer = SoupStrainer(re.compile("script|link"))
+		soup = BeautifulSoup(response.data, "lxml", parse_only=strainer)
 		for elem in soup.find_all('script', src=re.compile(".*")):
 			preload.append(("script", elem.get("src")))
 


### PR DESCRIPTION

Beautiful on init creates a tree for all elements in the html
For an Html of 500kb of content-heavy page it takes around 3.5s
We do not need to go through all tags so we can use a strainer 
This brought down the init to 0.6s

The below profiles were made using this [file](https://drive.google.com/file/d/1VkYzCGqSHSjRPJdlPlA7M7j954QuLWXX) 

It is really difficult to create identical conditions, need to set up some benchmarking tools(eg: [asv](https://asv.readthedocs.io/en/stable/writing_benchmarks.html)) - Contributions are welcome (in a separate PR)!

<details>
<summary>improved perf profile</summary>
<p>

```
         506716 function calls (506707 primitive calls) in 0.519 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.519    0.519 /Users/mohammadhasnain/frappe-work/benches/edit-docs/apps/frappe/frappe/website/utils.py:452(build_response)
        1    0.000    0.000    0.518    0.518 /Users/mohammadhasnain/frappe-work/benches/edit-docs/apps/frappe/frappe/website/utils.py:487(add_preload_headers)
        1    0.000    0.000    0.517    0.517 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:115(__init__)
        1    0.000    0.000    0.517    0.517 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:427(_feed)
        1    0.136    0.136    0.517    0.517 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:320(feed)
     9530    0.069    0.000    0.258    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:213(start)
     9530    0.020    0.000    0.159    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:678(handle_starttag)
     9530    0.026    0.000    0.100    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:268(end)
     9562    0.017    0.000    0.099    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:1980(search_tag)
    28595    0.052    0.000    0.081    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:541(endData)
9570/9562    0.025    0.000    0.061    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:2076(_matches)
    86329    0.025    0.000    0.040    0.000 {built-in method builtins.isinstance}
     9530    0.011    0.000    0.040    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:716(handle_endtag)
    28595    0.020    0.000    0.025    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:478(string_container)
    12948    0.012    0.000    0.023    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:289(data)
    19126    0.007    0.000    0.016    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/bin/../lib/python3.8/abc.py:96(__instancecheck__)
    70144    0.015    0.000    0.015    0.000 {built-in method builtins.len}
     9530    0.013    0.000    0.014    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:644(_popToTag)
    39861    0.013    0.000    0.013    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:130(_getNsTag)
    12950    0.008    0.000    0.011    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:726(handle_data)
```

</p>
</details>  



<details>
<summary>old perf profile</summary>
<p>

```
         952495 function calls (952482 primitive calls) in 2.217 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    2.217    2.217 /Users/mohammadhasnain/frappe-work/benches/edit-docs/apps/frappe/frappe/website/utils.py:452(build_response)
        1    0.000    0.000    2.206    2.206 /Users/mohammadhasnain/frappe-work/benches/edit-docs/apps/frappe/frappe/website/utils.py:487(add_preload_headers)
        1    0.000    0.000    2.016    2.016 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:115(__init__)
        1    0.000    0.000    2.016    2.016 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:427(_feed)
        1    0.432    0.432    2.016    2.016 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:320(feed)
     9530    0.195    0.000    1.078    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:213(start)
     9530    0.128    0.000    0.793    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:678(handle_starttag)
    28595    0.124    0.000    0.471    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:541(endData)
     9530    0.095    0.000    0.460    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:268(end)
     9531    0.165    0.000    0.358    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:1068(__init__)
        4    0.000    0.000    0.189    0.047 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:1767(find_all)
        4    0.035    0.009    0.189    0.047 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:738(_find_all)
    12946    0.061    0.000    0.182    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:576(object_was_parsed)
    35423    0.158    0.000    0.158    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:158(setup)
     9530    0.017    0.000    0.149    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:716(handle_endtag)
    44952    0.052    0.000    0.123    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:2043(search)
    12946    0.065    0.000    0.113    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:890(__new__)
     9530    0.056    0.000    0.107    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:644(_popToTag)
     6366    0.041    0.000    0.081    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/__init__.py:284(_replace_cdata_list_attribute_values)
     6141    0.068    0.000    0.071    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:604(_linkage_fixer)
     9531    0.062    0.000    0.067    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:527(pushTag)
    28595    0.041    0.000    0.049    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:478(string_container)
47682/47680    0.048    0.000    0.048    0.000 {built-in method builtins.len}
    12948    0.019    0.000    0.046    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:289(data)
    39861    0.045    0.000    0.045    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/builder/_lxml.py:130(_getNsTag)
   189550    0.041    0.000    0.041    0.000 {built-in method builtins.isinstance}
     9530    0.031    0.000    0.034    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/__init__.py:513(popTag)
    19060    0.024    0.000    0.034    0.000 /Users/mohammadhasnain/frappe-work/benches/edit-docs/env/lib/python3.8/site-packages/bs4/element.py:1980(search_tag)```

</p>
</details>  

