### PR TITLE
fix: Report print option

### DIFF
--- a/frappe/public/html/print_template.html
+++ b/frappe/public/html/print_template.html
@@ -7,7 +7,7 @@
 	<meta name="description" content="">
 	<meta name="author" content="">
 	<title>{{ title }}</title>
-	<link href="{{ base_url }}{{ frappe.assets.bundled_asset('print.bundle.css') }}" rel="stylesheet">
+	<link href="{{ base_url }}{{ frappe.assets.bundled_asset('print.bundle.css', frappe.utils.is_rtl(lang)) }}" rel="stylesheet">
 	<style>
 		{{ print_css }}
 	</style>

--- a/frappe/public/js/frappe/microtemplate.js
+++ b/frappe/public/js/frappe/microtemplate.js
@@ -119,6 +119,10 @@ frappe.render_grid = function(opts) {
 	// render HTML wrapper page
 	opts.base_url = frappe.urllib.get_base_url();
 	opts.print_css = frappe.boot.print_css;
+
+	opts.lang = opts.lang || frappe.boot.lang,
+	opts.layout_direction = opts.layout_direction || frappe.utils.is_rtl() ? "rtl" : "ltr";
+
 	var html = frappe.render_template("print_template", opts);
 
 	var w = window.open();


### PR DESCRIPTION
Fixes the following issue while generating print view for Report.
<img width="1439" alt="Screenshot 2021-07-28 at 11 33 47 AM" src="https://user-images.githubusercontent.com/13928957/127271953-7a7b17a5-4e89-4b4f-9552-2e9d6a0f6f58.png">


**After fix:**
For LTR layout
<img width="1428" alt="Screenshot 2021-07-28 at 11 35 24 AM" src="https://user-images.githubusercontent.com/13928957/127272069-b8ad7c5d-2344-4fc0-978e-a8e9e844b496.png">

For RTL layout
<img width="1427" alt="Screenshot 2021-07-28 at 11 35 14 AM" src="https://user-images.githubusercontent.com/13928957/127272075-4724f0df-4b48-4709-bcf8-b20029885185.png">

The bug was introduced via: https://github.com/frappe/frappe/pull/13573