### PR TITLE
fix: Multiple filter in shortcut widget

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -60,16 +60,16 @@ export default class ShortcutWidget extends Widget {
 	}
 
 	get_doctype_filter() {
-		let count_filter = []
+		let count_filter = [];
 
 		if (this.stats_filter) {
 			let filters = this.stats_filter.replace(/]/gi, "]~").split("~,").map(e => e.replace(/([{}~])/gi, "").trim());
 			filters.forEach((arr) => {
 				let filter = `{ ${arr} }`;
 				const filter_json = new Function(`return ${filter}`)();
-				let val = Object.values(filter_json)[0]
+				let val = Object.values(filter_json)[0];
 				count_filter.push([this.link_to, Object.keys(filter_json)[0], val[0], val[1]]);
-			})
+			});
 			return count_filter;
 		}
 

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -63,6 +63,8 @@ export default class ShortcutWidget extends Widget {
 		let count_filter = [];
 
 		if (this.stats_filter) {
+			// converting json string to an array to support multiple filter of same field
+			// e.g status: ['!=', 'Open'], status: ['!=', 'Replied'] 
 			let filters = this.stats_filter.replace(/]/gi, "]~").split("~,").map(e => e.replace(/([{}~])/gi, "").trim());
 			filters.forEach((arr) => {
 				let filter = `{ ${arr} }`;

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -60,8 +60,16 @@ export default class ShortcutWidget extends Widget {
 	}
 
 	get_doctype_filter() {
-		let count_filter = new Function(`return ${this.stats_filter}`)();
-		if (count_filter) {
+		let count_filter = []
+
+		if (this.stats_filter) {
+			let filters = this.stats_filter.replace(/]/gi, "]~").split("~,").map(e => e.replace(/([{}~])/gi, "").trim());
+			filters.forEach((arr) => {
+				let filter = `{ ${arr} }`;
+				const filter_json = new Function(`return ${filter}`)();
+				let val = Object.values(filter_json)[0]
+				count_filter.push([this.link_to, Object.keys(filter_json)[0], val[0], val[1]]);
+			})
 			return count_filter;
 		}
 

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -79,9 +79,9 @@ class WidgetDialog {
 			filters.forEach((arr) => {
 				let filter = `{ ${arr} }`;
 				const filter_json = new Function(`return ${filter}`)();
-				let val = Object.values(filter_json)[0]
+				let val = Object.values(filter_json)[0];
 				this.filters.push([this.values.link_to, Object.keys(filter_json)[0], val[0], val[1], false]);
-			})
+			});
 		}
 
 		this.filter_group = new frappe.ui.FilterGroup({

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -74,6 +74,8 @@ class WidgetDialog {
 
 		this.filters = [];
 
+		// converting json string to an array to support multiple filter of same field
+		// e.g status: ['!=', 'Open'], status: ['!=', 'Replied'] 
 		if (this.values && this.values.stats_filter) {
 			let filters = this.values.stats_filter.replace(/]/gi, "]~").split("~,").map(e => e.replace(/([{}~])/gi, "").trim());
 			filters.forEach((arr) => {


### PR DESCRIPTION
In the Shortcut widget when the user tries to add multiple filters for the same field only one filter is applied the other filters get removed which affects the count.

Before Save:
![image](https://user-images.githubusercontent.com/30859809/127294504-32c5b0c4-eddf-46d0-8746-a85061a03821.png)

After Save:
![image](https://user-images.githubusercontent.com/30859809/127294745-9b14ef25-567d-42e3-950f-a5527e7256d7.png)

