### PR TITLE
fix: improved execution logic for `has_permission` hook

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -301,7 +301,7 @@ def has_controller_permissions(doc, ptype, user=None):
 	if not methods:
 		return None
 
-	for method in methods:
+	for method in reversed(methods):
 		controller_permission = frappe.call(frappe.get_attr(method), doc=doc, ptype=ptype, user=user)
 		if controller_permission is not None:
 			return controller_permission

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -31,6 +31,44 @@ class TestHooks(unittest.TestCase):
 		todo = frappe.get_doc(doctype='ToDo', description='asdf')
 		self.assertTrue(isinstance(todo, CustomToDo))
 
+	def test_has_permission(self):
+		from frappe import hooks
+
+		# Set hook
+		address_has_permission_hook = hooks.has_permission.get('Address', [])
+		if isinstance(address_has_permission_hook, str):
+			address_has_permission_hook = [address_has_permission_hook]
+
+		address_has_permission_hook.append(
+			'frappe.tests.test_hooks.custom_has_permission'
+		)
+
+		hooks.has_permission['Address'] = address_has_permission_hook
+
+		# Clear cache
+		frappe.cache().delete_value('app_hooks')
+
+		# Init User and Address
+		username = "test@example.com"
+		user = frappe.get_doc("User", username)
+		user.add_roles("System Manager")
+		address = frappe.new_doc("Address")
+
+		# Test!
+		self.assertTrue(
+			frappe.has_permission("Address", doc=address, user=username)
+		)
+
+		address.flags.dont_touch_me = True
+		self.assertFalse(
+			frappe.has_permission("Address", doc=address, user=username)
+		)
+
+
+def custom_has_permission(doc, ptype, user):
+	if doc.flags.dont_touch_me:
+		return False
+
 
 class CustomToDo(ToDo):
 	pass


### PR DESCRIPTION
## Current behavior

The hook `has_permission` is designed to return a value from the first of available methods for that DocType provided it is not None. This means, a `has_permssion` hook in another app for the `Address` doctype will have no effect since that hook is returning a value in the Frappe app itself.

## New behavior

Reversing the `methods` allows the last installed app's hook to be executed first, hence permitting customisation using `has_permission` hook.

## Alternate approach

The `has_controller_permissions` function can be redesigned to return `True` only if all the methods return `True`.