### PR TITLE
fix: make match_filters same as match_conditions

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -650,6 +650,7 @@ class DatabaseQuery(object):
 				else:
 					empty_value_condition = f"ifnull(`tab{self.doctype}`.`{df.get('fieldname')}`, '')=''"
 					condition = empty_value_condition + " or "
+					docs.append("")
 
 				for permission in user_permission_values:
 					if not permission.get('applicable_for'):
@@ -671,7 +672,7 @@ class DatabaseQuery(object):
 					values = ", ".join(frappe.db.escape(doc, percent=False) for doc in docs)
 					condition += f"`tab{self.doctype}`.`{df.get('fieldname')}` in ({values})"
 					match_conditions.append(f"({condition})")
-					match_filters[df.get('options')] = docs
+					match_filters[df.get('fieldname')] = ('in', docs)
 
 		if match_conditions:
 			self.match_conditions.append(" and ".join(match_conditions))

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -54,7 +54,7 @@ class TestReportview(unittest.TestCase):
 
 		# After applying user permission
 		# get as filters
-		self.assertTrue({'Blog Post': ['-test-blog-post-1', '-test-blog-post']} in build_match_conditions(as_condition=False))
+		self.assertTrue({'name': ('in', ['', '-test-blog-post-1', '-test-blog-post'])} in build_match_conditions(as_condition=False))
 		# get as conditions
 		self.assertEqual(build_match_conditions(as_condition=True),
 			"""(((ifnull(`tabBlog Post`.`name`, '')='' or `tabBlog Post`.`name` in ('-test-blog-post-1', '-test-blog-post'))))""")


### PR DESCRIPTION
Problem:
DBQuery user permission conditions and filters are not equivalent. 

conditions -> returning SQL that checks if the link field is empty or in allowed value
match_fitler -> returning list filter that's checking if **DocType** is in allowed values. This doesn't seem to be correct.

![Screenshot 2021-07-28 at 3 37 55 PM](https://user-images.githubusercontent.com/9079960/127306208-6111cfd5-387c-46b4-a849-03ba7ee98441.png)


Solution: change match_filter to be in line with generated conditions.
