### PR TITLE
fix: new-doc-2 not found error while duplicating record.

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -204,7 +204,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 				$(this).removeClass('hidden');
 			}
 		});
-		this.set_open_count();
+		!this.frm.is_new() && this.set_open_count();
 	}
 
 	init_data() {


### PR DESCRIPTION
While creating a duplicate of any doc a new doc is created and an error pops up. 
E.g While Duplicating Lead record.
`Lead new-lead-2 not found` error is popping up.
![image](https://user-images.githubusercontent.com/30859809/127491575-fb05799e-6fb0-4422-92d4-0f6aa84e8ea3.png)
