### PR TITLE
fix: handle case if position is not defined

### DIFF
--- a/frappe/public/js/frappe/form/form_tour.js
+++ b/frappe/public/js/frappe/form/form_tour.js
@@ -88,7 +88,7 @@ frappe.ui.form.FormTour = class FormTour {
 		return {
 			element,
 			name,
-			popover: { title, description, position: frappe.router.slug(position) },
+			popover: { title, description, position: frappe.router.slug(position || 'Bottom') },
 			onNext: on_next
 		};
 	}


### PR DESCRIPTION
If Form Tours are defined as before (in JS files) and position is not set, then form tour breaks with following error

<img width="606" alt="CleanShot 2021-07-30 at 13 59 25@2x" src="https://user-images.githubusercontent.com/25369014/127625085-b410208f-b594-4a4b-9922-682c7554b22b.png">
