### PR TITLE
refactor(frappe.lang): frappe.translate.get_language

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -154,7 +154,6 @@ class LoginManager:
 		self.make_session()
 		self.setup_boot_cache()
 		self.set_user_info()
-		self.clear_preferred_language()
 
 	def get_user_info(self):
 		self.info = frappe.db.get_value("User", self.user,

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -18,8 +18,19 @@ first_lang, second_lang, third_lang, fourth_lang, fifth_lang = choices(
 )
 
 class TestTranslate(unittest.TestCase):
+	guest_sessions_required = [
+		"test_guest_request_language_resolution_with_cookie",
+		"test_guest_request_language_resolution_with_request_header"
+	]
+
+	def setUp(self):
+		if self._testMethodName in self.guest_sessions_required:
+			frappe.set_user("Guest")
+
 	def tearDown(self):
 		frappe.form_dict.pop("_lang", None)
+		if self._testMethodName in self.guest_sessions_required:
+			frappe.set_user("Administrator")
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)
@@ -56,16 +67,40 @@ class TestTranslate(unittest.TestCase):
 			set_request(method="POST", path="/", headers=[("Accept-Language", third_lang)])
 			return_val = get_language()
 
+		self.assertNotIn(return_val, [second_lang, get_parent_language(second_lang)])
+
+	def test_guest_request_language_resolution_with_cookie(self):
+		"""Test for frappe.translate.get_language
+
+		Case 3: frappe.form_dict._lang is not set, but preferred_language cookie is [Guest User]
+		"""
+
+		with patch.object(frappe.translate, "get_preferred_language_cookie", return_value=second_lang):
+			set_request(method="POST", path="/", headers=[("Accept-Language", third_lang)])
+			return_val = get_language()
+
 		self.assertIn(return_val, [second_lang, get_parent_language(second_lang)])
+
+
+	def test_guest_request_language_resolution_with_request_header(self):
+		"""Test for frappe.translate.get_language
+
+		Case 4: frappe.form_dict._lang & preferred_language cookie is not set, but Accept-Language header is [Guest User]
+		"""
+
+		set_request(method="POST", path="/", headers=[("Accept-Language", third_lang)])
+		return_val = get_language()
+		self.assertIn(return_val, [third_lang, get_parent_language(third_lang)])
 
 	def test_request_language_resolution_with_request_header(self):
 		"""Test for frappe.translate.get_language
 
-		Case 3: frappe.form_dict._lang & preferred_language cookie is not set, but Accept-Language header is
+		Case 5: frappe.form_dict._lang & preferred_language cookie is not set, but Accept-Language header is
 		"""
+
 		set_request(method="POST", path="/", headers=[("Accept-Language", third_lang)])
 		return_val = get_language()
-		self.assertIn(return_val, [third_lang, get_parent_language(third_lang)])
+		self.assertNotIn(return_val, [third_lang, get_parent_language(third_lang)])
 
 
 expected_output = [

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -27,11 +27,12 @@ def get_language(lang_list: List = None) -> str:
 
 	Order of priority for setting language:
 	1. Form Dict => _lang
-	2. Cookie => preferred_language
-	3. Request Header => Accept-Language
+	2. Cookie => preferred_language (Non authorized user)
+	3. Request Header => Accept-Language (Non authorized user)
 	4. User document => language
 	5. System Settings => language
 	"""
+	is_logged_in = frappe.session.user != "Guest"
 
 	# fetch language from form_dict
 	if frappe.form_dict._lang:
@@ -40,6 +41,10 @@ def get_language(lang_list: List = None) -> str:
 		)
 		if language:
 			return language
+
+	# use language set in User or System Settings if user is logged in
+	if is_logged_in:
+		return frappe.local.lang
 
 	lang_set = set(lang_list or get_all_languages() or [])
 


### PR DESCRIPTION
`User.language` should be given higher priority in terms of authenticated user since they chose it. Even higher than the browser they're using...even if the system locales aren't set properly and browser isn't configured properly.

New Change in language resolution:
1. Form Dict => _lang
2. Cookie => preferred_language _[Considered only if not logged in / Guest User]_
3. Request Header => Accept-Language _[Considered only if not logged in / Guest User]_
4. User document => language
5. System Settings => language

Change:
* Stop clearing cookie `preferred_language` in _post_login_ introduced in #13703. This means logging out makes you go back to whatever language was set in the Language Picker

Ref: https://github.com/frappe/frappe/pull/13703#issuecomment-888857144

To be ported to v12, v13 (As per last refactored PR)