### PR TITLE
chore: Added change log for v13.8.0

### DIFF
--- a/frappe/change_log/v13/v13_8_0.md
+++ b/frappe/change_log/v13/v13_8_0.md
@@ -1,0 +1,17 @@
+# Version 13.8.0 Release Notes
+
+### Features & Enhancements
+- Different output formats for `bench version` ([#13693](https://github.com/frappe/frappe/pull/13693))
+
+### Fixes
+- Add missing fieldtypes for custom fields  ([#13690](https://github.com/frappe/frappe/pull/13690))
+- Invalid Custom Report link on Workspace  ([#13678](https://github.com/frappe/frappe/pull/13678))
+- Auto generate RTL styles using rtlcss ([#13669](https://github.com/frappe/frappe/pull/13669))
+- Trigger workflow action on update_after_submit event ([#13736](https://github.com/frappe/frappe/pull/13736))
+- Allow navigation to the document with # in the docname ([#13755](https://github.com/frappe/frappe/pull/13755))
+- Do not create Energy Points for disabled users ([#13716](https://github.com/frappe/frappe/pull/13716))
+- Accurately cast fieldtype in frappe.db.get_single_value() ([#13682](https://github.com/frappe/frappe/pull/13682))
+- Code Editor scrollbar glitch ([#13718](https://github.com/frappe/frappe/pull/13718))
+- Tag count query ([#13712](https://github.com/frappe/frappe/pull/13712))
+- Escape quotes before declaring variables when making a new app ([#13699](https://github.com/frappe/frappe/pull/13699))
+- Custom Script to duplicate row not working in v13 ([#13667](https://github.com/frappe/frappe/pull/13667))


### PR DESCRIPTION
# Version 13.8.0 Release Notes

### Features & Enhancements
- Different output formats for `bench version` ([#13693](https://github.com/frappe/frappe/pull/13693))

### Fixes
- Add missing fieldtypes for custom fields  ([#13690](https://github.com/frappe/frappe/pull/13690))
- Invalid Custom Report link on Workspace  ([#13678](https://github.com/frappe/frappe/pull/13678))
- Auto generate RTL styles using rtlcss ([#13669](https://github.com/frappe/frappe/pull/13669))
- Trigger workflow action on update_after_submit event ([#13736](https://github.com/frappe/frappe/pull/13736))
- Allow navigation to the document with # in the docname ([#13755](https://github.com/frappe/frappe/pull/13755))
- Do not create Energy Points for disabled users ([#13716](https://github.com/frappe/frappe/pull/13716))
- Accurately cast fieldtype in frappe.db.get_single_value() ([#13682](https://github.com/frappe/frappe/pull/13682))
- Code Editor scrollbar glitch ([#13718](https://github.com/frappe/frappe/pull/13718))
- Tag count query ([#13712](https://github.com/frappe/frappe/pull/13712))
- Escape quotes before declaring variables when making a new app ([#13699](https://github.com/frappe/frappe/pull/13699))
- Custom Script to duplicate row not working in v13 ([#13667](https://github.com/frappe/frappe/pull/13667))