### PR TITLE
fix: Better error message while uploading web image

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -705,8 +705,8 @@ def get_web_image(file_url):
 
 	try:
 		image = Image.open(StringIO(frappe.safe_decode(r.content)))
-	except ValueError:
-		frappe.throw(_("Image link '{0}' is not valid").format(file_url), IOError)
+	except Exception as e:
+		frappe.msgprint(_("Image link '{0}' is not valid").format(file_url), raise_exception=e)
 
 	try:
 		filename, extn = file_url.rsplit("/", 1)[1].rsplit(".", 1)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -706,7 +706,7 @@ def get_web_image(file_url):
 	try:
 		image = Image.open(StringIO(frappe.safe_decode(r.content)))
 	except:
-		frappe.throw(_("Image link {0} is not valid").format(file_url), IOError)
+		frappe.throw(_("Image link '{0}' is not valid").format(file_url), IOError)
 
 	try:
 		filename, extn = file_url.rsplit("/", 1)[1].rsplit(".", 1)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -705,7 +705,7 @@ def get_web_image(file_url):
 
 	try:
 		image = Image.open(StringIO(frappe.safe_decode(r.content)))
-	except:
+	except ValueError:
 		frappe.throw(_("Image link '{0}' is not valid").format(file_url), IOError)
 
 	try:

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -703,7 +703,10 @@ def get_web_image(file_url):
 			frappe.msgprint(_("Unable to read file format for {0}").format(file_url))
 		raise
 
-	image = Image.open(StringIO(frappe.safe_decode(r.content)))
+	try:
+		image = Image.open(StringIO(frappe.safe_decode(r.content)))
+	except:
+		frappe.throw(_("Image link {0} is not valid").format(file_url), IOError)
 
 	try:
 		filename, extn = file_url.rsplit("/", 1)[1].rsplit(".", 1)


### PR DESCRIPTION
An error occurs while we upload an invalid image link (e.g. Current PR link) to the image field by using the Web URL upload method. The Error message is not highlighting the issue correctly.

Before:
![ImageError](https://user-images.githubusercontent.com/30859809/128293983-23e64cb8-67ad-44ba-b92e-3bfff9bd59e7.gif)

After:
![image](https://user-images.githubusercontent.com/30859809/127811069-e85a2b3d-2e05-46e2-b41c-89189d3849e2.png)

