### PR TITLE
fix: Focus reset issue due to field refresh

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -250,7 +250,13 @@ frappe.ui.form.Layout = class Layout {
 			// collapse sections
 			this.refresh_section_collapse();
 		}
-	}
+
+		document.activeElement.focus();
+
+		if (document.activeElement.tagName == 'INPUT') {
+			document.activeElement.select();
+		}
+	},
 
 	refresh_sections() {
 		// hide invisible sections

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -251,10 +251,12 @@ frappe.ui.form.Layout = class Layout {
 			this.refresh_section_collapse();
 		}
 
-		document.activeElement.focus();
-
-		if (document.activeElement.tagName == 'INPUT') {
-			document.activeElement.select();
+		if (document.activeElement) {
+			document.activeElement.focus();
+	
+			if (document.activeElement.tagName == 'INPUT') {
+				document.activeElement.select();
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -256,7 +256,7 @@ frappe.ui.form.Layout = class Layout {
 		if (document.activeElement.tagName == 'INPUT') {
 			document.activeElement.select();
 		}
-	},
+	}
 
 	refresh_sections() {
 		// hide invisible sections


### PR DESCRIPTION
**Issue:**

When the user is entering data in a grid by navigating through the grid using the tab key and entering data into the cells the input fields tend to lose focus many times as `refresh_fields` is called in the background and post refresh the input which user is entering gets appended at the end which makes entering data in the form difficult. An example of this can be seen in the below GIF

![3pInRRr](https://user-images.githubusercontent.com/42651287/127637592-cc73973b-368c-4cf5-bfab-f51431778fb7.gif)

After fix:
![Data Entry](https://user-images.githubusercontent.com/42651287/127638025-a19fecd4-55d4-4083-89a4-3f67e24a223f.gif)


 