### PR TITLE
fix(DX): sourceURL to debug report and page JS

### DIFF
--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -109,6 +109,7 @@ class Page(Document):
 		if os.path.exists(fpath):
 			with open(fpath, 'r') as f:
 				self.script = render_include(f.read())
+				self.script += f"\n\n//# sourceURL={page_name}.js"
 
 		# css
 		fpath = os.path.join(path, page_name + '.css')

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -177,11 +177,13 @@ def get_script(report_name):
 	if os.path.exists(script_path):
 		with open(script_path, "r") as f:
 			script = f.read()
+			script += f"\n\n//# sourceURL={scrub(report.name)}.js"
 
 	html_format = get_html_format(print_path)
 
 	if not script and report.javascript:
 		script = report.javascript
+		script += f"\n\n//# sourceURL={scrub(report.name)}__custom"
 
 	if not script:
 		script = "frappe.query_reports['%s']={}" % report_name


### PR DESCRIPTION
Add sourceURL to report and page javascript to enable debugging without fiddling with the source.  

More info in previous similar PR:  https://github.com/frappe/frappe/pull/12999 