### PR TITLE
fix: ability to disable safe_render for template pages

### DIFF
--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -280,6 +280,16 @@ class TestWebsite(unittest.TestCase):
 
 		frappe.flags.force_website_cache = False
 
+	def test_safe_render(self):
+		content = get_response_content('/_test/_test_safe_render_on')
+		self.assertNotIn("Safe Render On", content)
+		self.assertIn("frappe.exceptions.ValidationError: Illegal template", content)
+
+		content = get_response_content('/_test/_test_safe_render_off')
+		self.assertIn("Safe Render Off", content)
+		self.assertIn("test.__test", content)
+		self.assertNotIn("frappe.exceptions.ValidationError: Illegal template", content)
+
 
 def set_home_page_hook(key, value):
 	from frappe import hooks

--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -204,7 +204,12 @@ class TemplatePage(BaseTemplatePage):
 		if self.template_path.endswith('min.js'):
 			html = self.source # static
 		else:
-			html = frappe.render_template(self.source, self.context)
+			if self.context.safe_render is not None:
+				safe_render = self.context.safe_render
+			else:
+				safe_render = True
+
+			html = frappe.render_template(self.source, self.context, safe_render=safe_render)
 
 		return html
 

--- a/frappe/www/_test/_test_safe_render_off.html
+++ b/frappe/www/_test/_test_safe_render_off.html
@@ -1,0 +1,7 @@
+---
+title: Safe Render Off
+safe_render: false
+---
+
+<div>{{ title }}</div>
+<div>test.__test</div>

--- a/frappe/www/_test/_test_safe_render_on.html
+++ b/frappe/www/_test/_test_safe_render_on.html
@@ -1,0 +1,6 @@
+---
+title: Safe Render On
+---
+
+<div>{{ title }}</div>
+<div>test.__test</div>


### PR DESCRIPTION
There are cases where you want to show some code example in a template page. frappe.render_template blocks all templates that contain `.__`. This PR allows you to turn off safe render per page.

![image](https://user-images.githubusercontent.com/9355208/127968340-6925d340-d2c4-4aa0-93a1-7bd9c3756b4b.png)

Docs: https://github.com/frappe/frappe_docs/pull/177