### PR TITLE
fix(routing): Check if href exists for a link

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -51,7 +51,7 @@ $('body').on('click', 'a', function(e) {
 		return override('/app');
 	}
 
-	if (href.startsWith('#')) {
+	if (href && href.startsWith('#')) {
 		// target startswith "#", this is a v1 style route, so remake it.
 		return override(e.currentTarget.hash);
 	}


### PR DESCRIPTION
- Some links may not have `href` attribute which can cause the following failure.
     `Uncaught TypeError: Cannot read property 'startsWith' of undefined`.
- Fixes the flaky [file uploader test](https://dashboard.cypress.io/projects/92odwv/runs/22396/test-results/d92e70c5-dbb6-4d20-ae70-90c78c871422?statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D)

The issue was introduced via https://github.com/frappe/frappe/pull/13730