### PR TITLE
fix: Show traceback if custom app installation fails with exception

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -193,7 +193,7 @@ def install_app(context, apps):
 				print("App {} is Incompatible with Site {}{}".format(app, site, err_msg))
 				exit_code = 1
 			except Exception as err:
-				err_msg = ":\n{}".format(err if str(err) else frappe.get_traceback())
+				err_msg = ": {}\n{}".format(str(err), frappe.get_traceback())
 				print("An error occurred while installing {}{}".format(app, err_msg))
 				exit_code = 1
 


### PR DESCRIPTION
When custom app installation fails, frappe shows a single line error message like this. 

```
Installing healthcare...
Updating DocTypes for healthcare : [===============                         ]
An error occurred while installing healthcare:
expected str, bytes or os.PathLike object, not NoneType
```
Instead if full traceback is shown, it would be useful to identify the problem.

Ref: https://discuss.erpnext.com/t/error-nonetype-when-install-custom-app/65324