### PR TITLE
fix: format string for formating date

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -324,7 +324,7 @@ def format_date(string_date=None, format_string=None):
 	date = getdate(string_date)
 	if not format_string:
 		format_string = get_user_date_format()
-	format_string = format_string.replace("mm", "MM")
+	format_string = format_string.replace("mm", "MM").replace("Y", "y")
 	try:
 		formatted_date = babel.dates.format_date(
 			date, format_string,


### PR DESCRIPTION
Problem:
![Screenshot 2021-08-06 at 12 37 38 PM](https://user-images.githubusercontent.com/33727827/128471088-51f7fd15-2a3a-4237-9aae-6d2c2d0812ce.png)

Explained better here https://github.com/python-babel/babel/issues/419

In short using `YYYY` in the format gives [ISO year-week calendar](https://en.wikipedia.org/wiki/ISO_week_date) value. Hence occasionally messing up few dates from last week of a year or 1st week of a year.

As explained in the documentation of [Babel](http://babel.pocoo.org/en/latest/dates.html#date-fields)
![Screenshot 2021-08-06 at 12 46 07 PM](https://user-images.githubusercontent.com/33727827/128471740-a85e8e0e-4784-4ae7-8f33-81738bcd901a.png)

Solution:
To replace `Y` with `y` for accurate result.