### PR TITLE
fix: validate code fields of children too

### DIFF
--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -109,3 +109,13 @@ class TestServerScript(unittest.TestCase):
 		"""Raise AttributeError if method not found in Namespace"""
 		note = frappe.get_doc({"doctype": "Note", "title": "Test Note: Server Script"})
 		self.assertRaises(AttributeError, note.insert)
+
+	def test_syntax_validation(self):
+		server_script = scripts[0]
+		server_script["script"] = "js || code.?"
+
+		with self.assertRaises(frappe.ValidationError) as se:
+			frappe.get_doc(doctype="Server Script", **server_script).insert()
+
+		self.assertTrue("invalid python code" in str(se.exception).lower(),
+				msg="Python code validation not working")

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -507,6 +507,7 @@ class Document(BaseDocument):
 			d._validate_selects()
 			d._validate_non_negative()
 			d._validate_length()
+			d._validate_code_fields()
 			d._extract_images_from_text_editor()
 			d._sanitize_content()
 			d._save_passwords()

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -121,6 +121,16 @@ class TestWorkflow(unittest.TestCase):
 		self.workflow.states[1].doc_status = 0
 		self.workflow.save()
 
+	def test_syntax_error_in_transition_rule(self):
+		self.workflow.transitions[0].condition = 'doc.status =! "Closed"'
+
+		with self.assertRaises(frappe.ValidationError) as se:
+			self.workflow.save()
+
+		self.assertTrue("invalid python code" in str(se.exception).lower(),
+				msg="Python code validation not working")
+
+
 def create_todo_workflow():
 	if frappe.db.exists('Workflow', 'Test ToDo'):
 		frappe.delete_doc('Workflow', 'Test ToDo')


### PR DESCRIPTION
This validation is also applicable on child table fields. 

Missed out in PR that introduced this validation: https://github.com/frappe/frappe/pull/13707 