### PR TITLE
perf: speed up link validation

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -543,7 +543,7 @@ class Database(object):
 		"""
 
 		if not doctype in self.value_cache:
-			self.value_cache = self.value_cache[doctype] = {}
+			self.value_cache[doctype] = {}
 
 		if fieldname in self.value_cache[doctype]:
 			return self.value_cache[doctype][fieldname]


### PR DESCRIPTION
Problem:
- db.value_cache is erased every time `get_single_value` is called and doctype is not found in cache.
- This causes an endless loop of erasing and recreating it if two different single doctype values are requested in a transaction, which essentially make this cache useless overhead.  

E.g. 
```python
for sle in sles:
    a = frappe.db.get_single_value("Stock Setting", "allow_negative_stock") # this cleared the cache
    b = frappe.db.get_single_value("Account Setting", "frozen_upto") # this cleared the cache again
```


Solution:
- Temp fix: Don't erase the whole cache, just initiate new dictionary for missing doctype. 

Results:

Example: Stock entry with ~100 items submitted twice after full cold restart. 

~20-25% reduction in repeated queries. ~20-25% reduction in query time.

**Before:**
![Screenshot 2021-08-06 at 2 00 13 PM](https://user-images.githubusercontent.com/9079960/128482733-7c4f9bd8-734f-4145-8367-5f951b888183.png)


**After:**
![Screenshot 2021-08-06 at 2 05 54 PM](https://user-images.githubusercontent.com/9079960/128482754-fffdcc97-991e-46ff-98c0-1e7d4abc8710.png)



**repeated queries before** (you can identify that these are all link validation queries):
![Screenshot 2021-08-06 at 2 00 37 PM](https://user-images.githubusercontent.com/9079960/128483161-97dd7c9d-3f13-4779-9722-072b06ce6170.png)



**Repeated queries after:**

(these will be fixed in already open separate PR on ERPNext)
![Screenshot 2021-08-06 at 2 06 22 PM](https://user-images.githubusercontent.com/9079960/128483140-86f653f2-4bb8-4bba-a34a-02ca0c890e4f.png)
