### PR TITLE
fix: do not reset doc_before_save on db_set

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1064,7 +1064,10 @@ class Document(BaseDocument):
 			self.set("modified", now())
 			self.set("modified_by", frappe.session.user)
 
-		self.load_doc_before_save()
+		# load but do not reload doc_before_save because before_change or on_change might expect it
+		if not self.get_doc_before_save():
+			self.load_doc_before_save()
+
 		# to trigger notification on value change
 		self.run_method('before_change')
 


### PR DESCRIPTION
**Consider the case:**

1. User changes and saves a document
2. `_doc_before_save` is loaded in `run_before_save_methods()` first
3. The document controller has a `on_update()` or `on_submit()` that calls `self.db_set()`
4. `db_set()` resets and reloads the `_doc_before_save` after the document has been updated in the database
4. Now `_doc_before_save` is the same as the document after save, therefore no version will be saved

**Fix:**
Load but do not reload `_doc_before_save` in `db_set`