### PR TITLE
fix: Show command and error message when an exception is raised

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -53,7 +53,7 @@ def execute_cmd(cmd, from_async=False):
 	try:
 		method = get_attr(cmd)
 	except Exception as e:
-		frappe.throw(_('Invalid Method'))
+		frappe.throw(_('Failed to get method for command {0} with {1}').format(cmd, e))
 
 	if from_async:
 		method = method.queue


### PR DESCRIPTION
Currently, when an incorrect/invalid command is sent to Frappe, it simply throws `Invalid Method` message which is not quite useful. If Frappe shows command and error message when an exception is raised, it will be helpful for developers.