### PR TITLE
fix: Call `is_rtl` function to get the actual value

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -179,7 +179,7 @@ def prepare_header_footer(soup):
 				"html_id": html_id,
 				"css": css,
 				"lang": frappe.local.lang,
-				"layout_direction": "rtl" if is_rtl else "ltr"
+				"layout_direction": "rtl" if is_rtl() else "ltr"
 			})
 
 			# create temp file


### PR DESCRIPTION
Previously, since `is_rtl` was not called, the value of `layout_direction` was always "rtl".

---

Fixes following issue in PDF

**Before:**
![Screenshot 2021-08-10 at 10 05 34 AM](https://user-images.githubusercontent.com/13928957/128810015-c8bf1080-aa5e-460a-bc1d-d391a4684ecb.png)
(Notice that the full stop has been moved to the start)

**After:**
![Screenshot 2021-08-10 at 10 04 42 AM](https://user-images.githubusercontent.com/13928957/128810021-c6be2b56-a45c-4354-858f-346651e29a77.png)

---
Fixes https://frappe.io/app/issue/ISS-21-22-04820
This issue was introduced via https://github.com/frappe/frappe/pull/13573
