### PR TITLE
refactor(frappe.lang): frappe.translate.get_language [v12 port]

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -154,7 +154,6 @@ class LoginManager:
 		self.get_user_info()
 		self.make_session()
 		self.set_user_info()
-		self.clear_preferred_language()
 
 	def get_user_info(self):
 		self.info = frappe.db.get_value("User", self.user,

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -30,11 +30,12 @@ def guess_language(lang_list=None):
 
 	Order of priority for setting language:
 	1. Form Dict => _lang
-	2. Cookie => preferred_language
-	3. Request Header => Accept-Language
+	2. Cookie => preferred_language (Non authorized user)
+	3. Request Header => Accept-Language (Non authorized user)
 	4. User document => language
 	5. System Settings => language
 	"""
+	is_logged_in = frappe.session.user != "Guest"
 
 	# fetch language from form_dict
 	if frappe.form_dict._lang:
@@ -43,6 +44,10 @@ def guess_language(lang_list=None):
 		)
 		if language:
 			return language
+
+	# use language set in User or System Settings if user is logged in
+	if is_logged_in:
+		return frappe.local.lang
 
 	lang_set = set(lang_list or get_all_languages() or [])
 


### PR DESCRIPTION
> v12 port of https://github.com/frappe/frappe/pull/13820, Update over previous refactor https://github.com/frappe/frappe/pull/13767

`User.language` should be given higher priority in terms of authenticated user since they chose it. Even higher than the browser they're using...even if the system locales aren't set properly and browser isn't configured properly.

New Change in language resolution:
1. Form Dict => _lang
2. Cookie => preferred_language _[Considered only if not logged in / Guest User]_
3. Request Header => Accept-Language _[Considered only if not logged in / Guest User]_
4. User document => language
5. System Settings => language

Change:
* Stop clearing cookie `preferred_language` in _post_login_ introduced in #13703. This means logging out makes you go back to whatever language was set in the Language Picker

Ref: https://github.com/frappe/frappe/pull/13703#issuecomment-888857144