### PR TITLE
style: split qb.table into doctype and table

### DIFF
--- a/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
+++ b/frappe/patches/v12_0/set_correct_assign_value_in_docs.py
@@ -4,7 +4,7 @@ from frappe.query_builder.functions import GroupConcat, Coalesce
 def execute():
 	frappe.reload_doc("desk", "doctype", "todo")
 
-	ToDo = frappe.qb.Table("ToDo")
+	ToDo = frappe.qb.DocType("ToDo")
 	assignees = GroupConcat("owner").distinct().as_("assignees")
 
 	query = (

--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -7,9 +7,10 @@ class Base:
 	terms = terms
 	desc = Order.desc
 	Schema = Schema
+	Table = Table
 
 	@staticmethod
-	def Table(table_name: str, *args, **kwargs) -> Table:
+	def DocType(table_name: str, *args, **kwargs) -> Table:
 		table_name = get_table_name(table_name)
 		return Table(table_name, *args, **kwargs)
 
@@ -20,7 +21,7 @@ class MariaDB(Base, MySQLQuery):
 	@classmethod
 	def from_(cls, table, *args, **kwargs):
 		if isinstance(table, str):
-			table = cls.Table(table)
+			table = cls.DocType(table)
 		return super().from_(table, *args, **kwargs)
 
 
@@ -50,6 +51,6 @@ class Postgres(Base, PostgreSQLQuery):
 					table = cls.schema_translation[table._table_name]
 
 		elif isinstance(table, str):
-			table = cls.Table(table)
+			table = cls.DocType(table)
 
 		return super().from_(table, *args, **kwargs)

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -38,8 +38,9 @@ class TestCustomFunctionsPostgres(unittest.TestCase):
 
 class TestBuilderBase(object):
 	def test_adding_tabs(self):
-		self.assertEqual("tabNotes", frappe.qb.Table("Notes").get_sql())
-		self.assertEqual("__Auth", frappe.qb.Table("__Auth").get_sql())
+		self.assertEqual("tabNotes", frappe.qb.DocType("Notes").get_sql())
+		self.assertEqual("__Auth", frappe.qb.DocType("__Auth").get_sql())
+		self.assertEqual("Notes", frappe.qb.Table("Notes").get_sql())
 
 
 @run_only_if(db_type_is.MARIADB)

--- a/frappe/website/report/website_analytics/website_analytics.py
+++ b/frappe/website/report/website_analytics/website_analytics.py
@@ -59,7 +59,7 @@ class WebsiteAnalytics(object):
 		]
 
 	def get_data(self):
-		WebPageView = frappe.qb.Table("Web Page View")
+		WebPageView = frappe.qb.DocType("Web Page View")
 		count_all = Count("*").as_("count")
 		case = frappe.qb.terms.Case().when(WebPageView.is_unique == "1", "1")
 		count_is_unique = Count(case).as_("unique_count")


### PR DESCRIPTION
# Changes
Adds a `frappe.qb.DocType` function to make pypika tables instead of using `frappe.qb.Table`. Also replaced queries which use `table`.

`frappe.qb.Table`: Used when you want to directly pass table names of your DocTypes, internal tables
`frappe.qb.DocType`: Thin wrapper over the above util that generates the table name internally given DocType name

Update for usage over https://github.com/frappe/frappe/pull/13705

# docs
[frappe_docs/pull/169](https://github.com/frappe/frappe_docs/pull/169#issue-700079045)