### PR TITLE
 refactor: set amended docname to original docname

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1714,9 +1714,18 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 	eval_globals.update(whitelisted_globals)
 	return eval(code, eval_globals, eval_locals)
 
-def get_system_settings(key):
+def get_system_settings(key, ignore_if_not_exists=False):
+	"""Get a system setting value.
+
+	:param ignore_if_not_exists: Do not raise error if key does not exists.
+	"""
+	doctype = 'System Settings'
+
+	if ignore_if_not_exists and not get_meta(doctype).get_field(key):
+		return
+
 	if key not in local.system_settings:
-		local.system_settings.update({key: db.get_single_value('System Settings', key)})
+		local.system_settings.update({key: db.get_single_value(doctype, key)})
 	return local.system_settings.get(key)
 
 def get_active_domains():

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -373,7 +373,7 @@ class TestDocType(unittest.TestCase):
 		for data in link_doc.get('permissions'):
 			data.submit = 1
 			data.cancel = 1
-		link_doc.insert()
+		link_doc.insert(ignore_if_duplicate=True)
 
 		#create first parent doctype
 		test_doc_1 = new_doctype('Test Doctype 1')
@@ -388,7 +388,7 @@ class TestDocType(unittest.TestCase):
 		for data in test_doc_1.get('permissions'):
 			data.submit = 1
 			data.cancel = 1
-		test_doc_1.insert()
+		test_doc_1.insert(ignore_if_duplicate=True)
 
 		#crete second parent doctype
 		doc = new_doctype('Test Doctype 2')
@@ -403,7 +403,7 @@ class TestDocType(unittest.TestCase):
 		for data in link_doc.get('permissions'):
 			data.submit = 1
 			data.cancel = 1
-		doc.insert()
+		doc.insert(ignore_if_duplicate=True)
 
 		# create doctype data
 		data_link_doc_1 = frappe.new_doc('Test Linked Doctype 1')

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -67,7 +67,9 @@
   "enable_prepared_report_auto_deletion",
   "prepared_report_expiry_period",
   "chat",
-  "enable_chat"
+  "enable_chat",
+  "document_naming_section",
+  "use_original_name_for_amended_document"
  ],
  "fields": [
   {
@@ -469,12 +471,25 @@
    "fieldname": "strip_exif_metadata_from_uploaded_images",
    "fieldtype": "Check",
    "label": "Strip EXIF tags from uploaded images"
+  },
+  {
+   "fieldname": "document_naming_section",
+   "fieldtype": "Section Break",
+   "label": "Document Naming"
+  },
+  {
+   "default": "0",
+   "description": "Amended document gets the name of the original document if enabled and will be applicable to all submittable doctypes. This is a nonreversible operation. ",
+   "fieldname": "use_original_name_for_amended_document",
+   "fieldtype": "Check",
+   "label": "Use original name for amended document",
+   "read_only_depends_on": "eval:doc.use_original_name_for_amended_document==1"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2021-03-30 11:47:47.330437",
+ "modified": "2021-08-11 09:04:43.856970",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -55,6 +55,13 @@ class SystemSettings(Document):
 		if frappe.flags.update_last_reset_password_date:
 			update_last_reset_password_date()
 
+		if self.use_original_name_for_amended_document and \
+				self.has_value_changed('use_original_name_for_amended_document'):
+			rename_fun = 'frappe.model.utils.rename_cancelled_docs.rename_cancelled_docs'
+			frappe.enqueue(rename_fun)
+			frappe.msgprint(_("preparing the system to use original names for amended docs."
+				"System might be a little slow for a few seconds as it gets ready."))
+
 def update_last_reset_password_date():
 	frappe.db.sql(""" UPDATE `tabUser`
 		SET

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -7,8 +7,8 @@ import time
 from frappe import _, msgprint, is_whitelisted
 from frappe.utils import flt, cstr, now, get_datetime_str, file_lock, date_diff
 from frappe.model.base_document import BaseDocument, get_controller
-from frappe.model.naming import set_new_name
 from six import iteritems, string_types
+from frappe.model.naming import set_new_name, gen_new_name_for_cancelled_doc
 from werkzeug.exceptions import NotFound, Forbidden
 import hashlib, json
 from frappe.model import optional_fields, table_fields
@@ -710,7 +710,6 @@ class Document(BaseDocument):
 			else:
 				tmp = frappe.db.sql("""select modified, docstatus from `tab{0}`
 					where name = %s for update""".format(self.doctype), self.name, as_dict=True)
-
 				if not tmp:
 					frappe.throw(_("Record does not exist"))
 				else:
@@ -921,8 +920,14 @@ class Document(BaseDocument):
 
 	@whitelist.__func__
 	def _cancel(self):
-		"""Cancel the document. Sets `docstatus` = 2, then saves."""
+		"""Cancel the document. Sets `docstatus` = 2, then saves.
+		"""
 		self.docstatus = 2
+
+		if frappe.get_system_settings('use_original_name_for_amended_document', ignore_if_not_exists=True):
+			new_name = gen_new_name_for_cancelled_doc(self)
+			frappe.rename_doc(self.doctype, self.name, new_name, force=True, show_alert=False)
+			self.name = new_name
 		self.save()
 
 	@whitelist.__func__

--- a/frappe/model/utils/rename_cancelled_docs.py
+++ b/frappe/model/utils/rename_cancelled_docs.py
@@ -1,0 +1,221 @@
+"""Utilities needed to prepare the system to use original names for amended docs.
+
+From Version 14, The naming pattern is changed in a way that amended documents will
+have the original name `orig_name` instead of `orig_name-X`. To make this happen
+the cancelled document naming pattern is changed to 'orig_name-CANC-X'.
+
+In version 13, whenever a submittable document is amended it's name is set to orig_name-X,
+where X is a counter and it increments when amended again and so on. We are backporting
+the version-14 styled naming into version-13 and will be available through system settings.
+"""
+
+import functools
+import traceback
+
+import frappe
+
+def get_submittable_doctypes():
+	"""Returns list of submittable doctypes in the system.
+	"""
+	return frappe.db.get_all('DocType', filters={'is_submittable': 1}, pluck='name')
+
+def get_cancelled_doc_names(doctype):
+	"""Return names of cancelled document names those are in old format.
+	"""
+	docs = frappe.db.get_all(doctype, filters={'docstatus': 2}, pluck='name')
+	return [each for each in docs if not (each.endswith('-CANC') or ('-CANC-' in each))]
+
+@functools.lru_cache()
+def get_linked_doctypes():
+	"""Returns list of doctypes those are linked with given doctype using 'Link' fieldtype.
+	"""
+	filters=[['fieldtype','=', 'Link']]
+	links = frappe.get_all("DocField",
+		fields=["parent", "fieldname", "options as linked_to"],
+		filters=filters,
+		as_list=1)
+
+	links+= frappe.get_all("Custom Field",
+		fields=["dt as parent", "fieldname", "options as linked_to"],
+		filters=filters,
+		as_list=1)
+
+	links_by_doctype = {}
+	for doctype, fieldname, linked_to in links:
+		links_by_doctype.setdefault(linked_to, []).append((doctype, fieldname))
+	return links_by_doctype
+
+@functools.lru_cache()
+def get_single_doctypes():
+	return frappe.get_all("DocType", filters={'issingle': 1}, pluck='name')
+
+@functools.lru_cache()
+def get_dynamic_linked_doctypes():
+	filters=[['fieldtype','=', 'Dynamic Link']]
+
+	# find dynamic links of parents
+	links = frappe.get_all("DocField",
+		fields=["parent as doctype", "fieldname", "options as doctype_fieldname"],
+		filters=filters,
+		as_list=1)
+	links+= frappe.get_all("Custom Field",
+		fields=["dt as doctype", "fieldname", "options as doctype_fieldname"],
+		filters=filters,
+		as_list=1)
+	return links
+
+@functools.lru_cache()
+def get_child_tables():
+	"""
+	"""
+	filters =[['fieldtype', 'in', ('Table', 'Table MultiSelect')]]
+	links = frappe.get_all("DocField",
+		fields=["parent as doctype", "options as child_table"],
+		filters=filters,
+		as_list=1)
+
+	links+= frappe.get_all("Custom Field",
+		fields=["dt as doctype", "options as child_table"],
+		filters=filters,
+		as_list=1)
+
+	map = {}
+	for doctype, child_table in links:
+		map.setdefault(doctype, []).append(child_table)
+	return map
+
+def update_cancelled_document_names(doctype, cancelled_doc_names):
+	return frappe.db.sql("""
+		update
+			`tab{doctype}`
+		set
+			name=CONCAT(name, '-CANC')
+		where
+			docstatus=2
+			and
+			name in %(cancelled_doc_names)s;
+	""".format(doctype=doctype), {'cancelled_doc_names': cancelled_doc_names})
+
+def update_amended_field(doctype, cancelled_doc_names):
+	return frappe.db.sql("""
+		update
+			`tab{doctype}`
+		set
+			amended_from=CONCAT(amended_from, '-CANC')
+		where
+			amended_from in %(cancelled_doc_names)s;
+	""".format(doctype=doctype), {'cancelled_doc_names': cancelled_doc_names})
+
+def update_attachments(doctype, cancelled_doc_names):
+	frappe.db.sql("""
+		update
+			`tabFile`
+		set
+			attached_to_name=CONCAT(attached_to_name, '-CANC')
+		where
+			attached_to_doctype=%(dt)s and attached_to_name in %(cancelled_doc_names)s
+		""", {'cancelled_doc_names': cancelled_doc_names, 'dt': doctype})
+
+def update_versions(doctype, cancelled_doc_names):
+	frappe.db.sql("""
+		UPDATE
+			`tabVersion`
+		SET
+			docname=CONCAT(docname, '-CANC')
+		WHERE
+			ref_doctype=%(dt)s AND docname in %(cancelled_doc_names)s
+		""", {'cancelled_doc_names': cancelled_doc_names, 'dt': doctype})
+
+def update_linked_doctypes(doctype, cancelled_doc_names):
+	single_doctypes = get_single_doctypes()
+
+	for linked_dt, field in get_linked_doctypes().get(doctype, []):
+		if linked_dt not in single_doctypes:
+			frappe.db.sql("""
+				update
+					`tab{linked_dt}`
+				set
+					`{column}`=CONCAT(`{column}`, '-CANC')
+				where
+					`{column}` in %(cancelled_doc_names)s;
+			""".format(linked_dt=linked_dt, column=field),
+				{'cancelled_doc_names': cancelled_doc_names})
+		else:
+			doc = frappe.get_single(linked_dt)
+			if getattr(doc, field) in cancelled_doc_names:
+				setattr(doc, field, getattr(doc, field)+'-CANC')
+				doc.flags.ignore_mandatory=True
+				doc.flags.ignore_validate=True
+				doc.save(ignore_permissions=True)
+
+def update_dynamic_linked_doctypes(doctype, cancelled_doc_names):
+	single_doctypes = get_single_doctypes()
+
+	for linked_dt, fieldname, doctype_fieldname in get_dynamic_linked_doctypes():
+		if linked_dt not in single_doctypes:
+			frappe.db.sql("""
+				update
+					`tab{linked_dt}`
+				set
+					`{column}`=CONCAT(`{column}`, '-CANC')
+				where
+					`{column}` in %(cancelled_doc_names)s and {doctype_fieldname}=%(dt)s;
+			""".format(linked_dt=linked_dt, column=fieldname, doctype_fieldname=doctype_fieldname),
+				{'cancelled_doc_names': cancelled_doc_names, 'dt': doctype})
+		else:
+			doc = frappe.get_single(linked_dt)
+			if getattr(doc, doctype_fieldname) == doctype and getattr(doc, fieldname) in cancelled_doc_names:
+				setattr(doc, fieldname, getattr(doc, fieldname)+'-CANC')
+				doc.flags.ignore_mandatory=True
+				doc.flags.ignore_validate=True
+				doc.save(ignore_permissions=True)
+
+def update_child_tables(doctype, cancelled_doc_names):
+	child_tables = get_child_tables().get(doctype, [])
+	single_doctypes = get_single_doctypes()
+
+	for table in child_tables:
+		if table not in single_doctypes:
+			frappe.db.sql("""
+				update
+					`tab{table}`
+				set
+					parent=CONCAT(parent, '-CANC')
+				where
+					parenttype=%(dt)s and parent in %(cancelled_doc_names)s;
+			""".format(table=table), {'cancelled_doc_names': cancelled_doc_names, 'dt': doctype})
+		else:
+			doc = frappe.get_single(table)
+			if getattr(doc, 'parenttype')==doctype and getattr(doc, 'parent') in cancelled_doc_names:
+				setattr(doc, 'parent', getattr(doc, 'parent')+'-CANC')
+				doc.flags.ignore_mandatory=True
+				doc.flags.ignore_validate=True
+				doc.save(ignore_permissions=True)
+
+def rename_cancelled_docs():
+	submittable_doctypes = get_submittable_doctypes()
+
+	for dt in submittable_doctypes:
+		for retry in range(2):
+			try:
+				cancelled_doc_names = tuple(get_cancelled_doc_names(dt))
+				if not cancelled_doc_names:
+					break
+				update_cancelled_document_names(dt, cancelled_doc_names)
+				update_amended_field(dt, cancelled_doc_names)
+				update_child_tables(dt, cancelled_doc_names)
+				update_linked_doctypes(dt, cancelled_doc_names)
+				update_dynamic_linked_doctypes(dt, cancelled_doc_names)
+				update_attachments(dt, cancelled_doc_names)
+				update_versions(dt, cancelled_doc_names)
+				print(f"Renaming cancelled records of {dt} doctype")
+				frappe.db.commit()
+				break
+			except Exception:
+				if retry == 1:
+					msg = f"Failed to rename the cancelled records of {dt} doctype"
+					frappe.log_error(message=frappe.get_traceback(), title=msg)
+					print(msg + ", moving on!")
+					traceback.print_exc()
+				frappe.db.rollback()
+

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -765,32 +765,36 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	_cancel(btn, callback, on_error, skip_confirm) {
-		const me = this;
 		const cancel_doc = () => {
 			frappe.validated = true;
-			me.script_manager.trigger("before_cancel").then(() => {
+			this.script_manager.trigger("before_cancel").then(() => {
 				if (!frappe.validated) {
-					return me.handle_save_fail(btn, on_error);
+					return this.handle_save_fail(btn, on_error);
 				}
 
-				var after_cancel = function(r) {
+				const original_name = this.docname;
+				const after_cancel = (r) => {
 					if (r.exc) {
-						me.handle_save_fail(btn, on_error);
+						this.handle_save_fail(btn, on_error);
 					} else {
 						frappe.utils.play_sound("cancel");
-						me.refresh();
 						callback && callback();
-						me.script_manager.trigger("after_cancel");
+						this.script_manager.trigger("after_cancel");
+						frappe.run_serially([
+							() => this.rename_notify(this.doctype, original_name, r.docs[0].name),
+							() => frappe.router.clear_re_route(this.doctype, original_name),
+							() => this.refresh(),
+						]);
 					}
 				};
-				frappe.ui.form.save(me, "cancel", after_cancel, btn);
+				frappe.ui.form.save(this, "cancel", after_cancel, btn);
 			});
 		}
 
 		if (skip_confirm) {
 			cancel_doc();
 		} else {
-			frappe.confirm(__("Permanently Cancel {0}?", [this.docname]), cancel_doc, me.handle_save_fail(btn, on_error));
+			frappe.confirm(__("Permanently Cancel {0}?", [this.docname]), cancel_doc, this.handle_save_fail(btn, on_error));
 		}
 	};
 
@@ -812,7 +816,7 @@ frappe.ui.form.Form = class FrappeForm {
 			'docname': this.doc.name
 		}).then(is_amended => {
 			if (is_amended) {
-				frappe.throw(__('This document is already amended, you cannot ammend it again'));
+				frappe.throw(__('This document is already amended, you cannot amend it again'));
 			}
 			this.validate_form_action("Amend");
 			var me = this;

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -232,6 +232,12 @@ frappe.router = {
 		}
 	},
 
+	clear_re_route(doctype, docname) {
+		delete frappe.re_route[
+			`${encodeURIComponent(frappe.router.slug(doctype))}/${encodeURIComponent(docname)}`
+		];
+	},
+
 	set_title(sub_path) {
 		if (frappe.route_titles[sub_path]) {
 			frappe.utils.set_title(frappe.route_titles[sub_path]);

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import unittest
 import frappe
 from frappe.utils import now_datetime
+from frappe.tests import update_system_settings
 
 from frappe.model.naming import getseries
 from frappe.model.naming import append_number_if_name_exists, revert_series_if_last
@@ -95,3 +96,39 @@ class TestNaming(unittest.TestCase):
 
 		self.assertEqual(count.get('current'), 2)
 		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+
+	def test_naming_for_cancelled_and_amended_doc(self):
+		update_system_settings({'use_original_name_for_amended_document': 1})
+
+		submittable_doctype = frappe.get_doc({
+			"doctype": "DocType",
+			"module": "Core",
+			"custom": 1,
+			"is_submittable": 1,
+			"permissions": [{
+				"role": "System Manager",
+				"read": 1
+			}],
+			"name": 'Submittable Doctype'
+		}).insert(ignore_if_duplicate=True)
+
+		doc = frappe.new_doc('Submittable Doctype')
+		doc.save()
+		original_name = doc.name
+
+		doc.submit()
+		doc.cancel()
+		cancelled_name = doc.name
+		self.assertEqual(cancelled_name, "{}-CANC-0".format(original_name))
+
+		amended_doc = frappe.copy_doc(doc)
+		amended_doc.docstatus = 0
+		amended_doc.amended_from = doc.name
+		amended_doc.save()
+		self.assertEqual(amended_doc.name, original_name)
+
+		amended_doc.submit()
+		amended_doc.cancel()
+		self.assertEqual(amended_doc.name, "{}-CANC-1".format(original_name))
+
+		submittable_doctype.delete()


### PR DESCRIPTION
In version 13, whenever a submittable document is amended it's name is set to orig_name-X,
where X is a counter and it increments when amended again and so on. With this PR, we are backporting #13861 (Use original name for amended documents). Current naming style being the default style, new style naming can be enabled through system settings.
