### PR TITLE
refactor(minor): Newsletter

### DIFF
--- a/frappe/email/doctype/newsletter/exceptions.py
+++ b/frappe/email/doctype/newsletter/exceptions.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See LICENSE
+
+from frappe.exceptions import ValidationError
+
+class NewsletterAlreadySentError(ValidationError):
+	pass
+
+class NoRecipientFoundError(ValidationError):
+	pass
+
+class NewsletterNotSavedError(ValidationError):
+	pass

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -204,7 +204,10 @@ class Newsletter(WebsiteGenerator):
 		return list(set(emails))
 
 	def get_email_groups(self) -> List[str]:
-		return frappe.db.get_all(
+		# wondering why the 'or'? i can't figure out why both aren't equivalent - @gavin
+		return [
+			x.email_group for x in self.email_group
+		] or frappe.get_all(
 			"Newsletter Email Group",
 			filters={"parent": self.name, "parenttype": "Newsletter"},
 			pluck="email_group",
@@ -376,4 +379,5 @@ def send_scheduled_email():
 			)
 			frappe.log_error(title="Send Newsletter", message=message)
 
-		frappe.db.commit()
+		if not frappe.flags.in_test:
+			frappe.db.commit()

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -1,241 +1,309 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from typing import Dict, List
+
 import frappe
 import frappe.utils
-from frappe import throw, _
+
+from frappe import _
 from frappe.website.website_generator import WebsiteGenerator
 from frappe.utils.verified_command import get_signed_params, verify_request
 from frappe.email.doctype.email_group.email_group import add_subscribers
-from frappe.utils import parse_addr, now_datetime, markdown, validate_email_address
+
 
 class Newsletter(WebsiteGenerator):
 	def onload(self):
-		if self.email_sent:
-			self.get("__onload").status_count = dict(frappe.db.sql("""select status, count(name)
-				from `tabEmail Queue` where reference_doctype=%s and reference_name=%s
-				group by status""", (self.doctype, self.name))) or None
+		self.setup_newsletter_status()
 
 	def validate(self):
-		self.route = "newsletters/" + self.name
-		if self.send_from:
-			validate_email_address(self.send_from, True)
+		self.route = f"newsletters/{self.name}"
+		self.validate_sender_address()
+		self.validate_recipient_address()
+
+	@property
+	def newsletter_recipients(self) -> List[str]:
+		if getattr(self, "_recipients", None) == None:
+			self._recipients = self.get_recipients()
+		return self._recipients
 
 	@frappe.whitelist()
-	def test_send(self, doctype="Lead"):
-		self.recipients = frappe.utils.split_emails(self.test_email_id)
-		self.queue_all(test_email=True)
+	def test_send(self):
+		test_emails = frappe.utils.split_emails(self.test_email_id)
+		self.queue_all(test_email=test_emails)
 		frappe.msgprint(_("Test email sent to {0}").format(self.test_email_id))
 
 	@frappe.whitelist()
 	def send_emails(self):
 		"""send emails to leads and customers"""
 		if self.email_sent:
-			throw(_("Newsletter has already been sent"))
+			frappe.throw(_("Newsletter has already been sent"))
 
-		self.recipients = self.get_recipients()
+		if not self.newsletter_recipients:
+			frappe.throw(_("Newsletter should have atleast one recipient"))
 
-		if self.recipients:
-			self.queue_all()
-			frappe.msgprint(_("Email queued to {0} recipients").format(len(self.recipients)))
+		self.queue_all()
+		frappe.msgprint(_("Email queued to {0} recipients").format(len(self.newsletter_recipients)))
 
-		else:
-			frappe.msgprint(_("Newsletter should have atleast one recipient"))
+	def setup_newsletter_status(self):
+		"""Setup analytical status for current Newsletter. Can be accessible from desk.
+		"""
+		if self.email_sent:
+			status_count = frappe.get_all("Email Queue",
+				filters={"reference_doctype": self.doctype, "reference_name": self.name},
+				fields=["status", "count(name)"],
+				group_by="status",
+				as_list=True,
+			)
+			self.get("__onload").status_count = dict(status_count)
 
-	def queue_all(self, test_email=False):
-		if not self.get("recipients"):
-			# in case it is called via worker
-			self.recipients = self.get_recipients()
+	def validate_sender_address(self):
+		"""Validate self.send_from is a valid email address or not.
+		"""
+		if self.send_from:
+			frappe.utils.validate_email_address(self.send_from, throw=True)
 
-		self.validate_send()
-
-		sender = self.send_from or frappe.utils.get_formatted_email(self.owner)
-
-		if not frappe.flags.in_test:
-			frappe.db.auto_commit_on_many_writes = True
-
-		attachments = []
-		if self.send_attachments:
-			files = frappe.get_all("File", fields=["name"], filters={"attached_to_doctype": "Newsletter",
-				"attached_to_name": self.name}, order_by="creation desc")
-
-			for file in files:
-				try:
-					# these attachments will be attached on-demand
-					# and won't be stored in the message
-					attachments.append({"fid": file.name})
-				except IOError:
-					frappe.throw(_("Unable to find attachment {0}").format(file.name))
-
-		args = {
-			"message": self.get_message(),
-			"name": self.name
-		}
-		frappe.sendmail(recipients=self.recipients, sender=sender,
-			subject=self.subject, message=self.get_message(), template="newsletter",
-			reference_doctype=self.doctype, reference_name=self.name,
-			add_unsubscribe_link=self.send_unsubscribe_link, attachments=attachments,
-			unsubscribe_method="/unsubscribe",
-			unsubscribe_params={"name": self.name},
-			send_priority=0, queue_separately=True, args=args)
-
-		if not frappe.flags.in_test:
-			frappe.db.auto_commit_on_many_writes = False
-
-		if not test_email:
-			self.db_set("email_sent", 1)
-			self.db_set("schedule_send", now_datetime())
-			self.db_set("scheduled_to_send", len(self.recipients))
-
-	def get_message(self):
-		if self.content_type == "HTML":
-			return frappe.render_template(self.message_html, {"doc": self.as_dict()})
-		return {
-			'Rich Text': self.message,
-			'Markdown': markdown(self.message_md)
-		}[self.content_type or 'Rich Text']
-
-	def get_recipients(self):
-		"""Get recipients from Email Group"""
-		recipients_list = []
-		for email_group in get_email_groups(self.name):
-			for d in frappe.db.get_all("Email Group Member", ["email"],
-				{"unsubscribed": 0, "email_group": email_group.email_group}):
-					recipients_list.append(d.email)
-		return list(set(recipients_list))
+	def validate_recipient_address(self):
+		"""Validate if self.newsletter_recipients are all valid email addresses or not.
+		"""
+		for recipient in self.newsletter_recipients:
+			frappe.utils.validate_email_address(recipient, throw=True)
 
 	def validate_send(self):
+		"""Validate if Newsletter can be sent.
+		"""
 		if self.get("__islocal"):
-			throw(_("Please save the Newsletter before sending"))
+			frappe.throw(_("Please save the Newsletter before sending"))
 
-		if not self.recipients:
+		if not self.newsletter_recipients:
 			frappe.throw(_("Newsletter should have at least one recipient"))
+
+	def get_linked_email_queue(self) -> List[str]:
+		"""Get list of email queue linked to this newsletter.
+		"""
+		return frappe.get_all("Email Queue",
+			filters={
+				"reference_doctype": self.doctype,
+				"reference_name": self.name,
+			},
+			pluck="name",
+		)
+
+	def get_success_recipients(self) -> List[str]:
+		"""Recipients who have already recieved the newsletter.
+
+		Couldn't think of a better name ;)
+		"""
+		return frappe.get_all("Email Queue Recipient",
+			filters={
+				"status": ("in", ["Not Sent", "Sending", "Sent"]),
+				"parentfield": ("in", self.get_linked_email_queue()),
+			},
+			pluck="recipient",
+		)
+
+	def get_pending_recipients(self) -> List[str]:
+		"""Get list of pending recipients of the newsletter. These
+		recipients may not have receive the newsletter in the previous iteration.
+		"""
+		return [
+			x for x in self.newsletter_recipients if x not in self.get_success_recipients()
+		]
+
+	def queue_all(self, test_email: str = None):
+		"""Queue Newsletter to all the recipients generated from the `Email Group`
+		table
+
+		Args:
+			test_email (str, optional): Send test Newsletter to set email. Defaults to None.
+		"""
+		if test_email:
+			frappe.utils.validate_email_address(test_email, throw=True)
+		else:
+			self.validate()
+			self.validate_send()
+
+		newsletter_recipients = test_email or self.get_pending_recipients()
+		self.send_newsletter(emails=newsletter_recipients)
+
+		if not test_email:
+			self.email_sent = True
+			self.schedule_send = frappe.utils.now_datetime()
+			self.scheduled_to_send = len(newsletter_recipients)
+			self.save()
+
+	def get_attachments(self) -> List[Dict[str, str]]:
+		"""Get list of attachments on current Newsletter
+		"""
+		attachments = []
+
+		if self.send_attachments:
+			files = frappe.get_all(
+				"File",
+				filters={"attached_to_doctype": "Newsletter", "attached_to_name": self.name},
+				order_by="creation desc",
+				pluck="name",
+			)
+			attachments.extend({"fid": file} for file in files)
+
+		return attachments
+
+	def send_newsletter(self, emails: List[str]):
+		# TODO: get rid of this maybe?
+		message = self.get_message()
+		attachments = self.get_attachments()
+		sender = self.send_from or frappe.utils.get_formatted_email(self.owner)
+		args = {"message": message, "name": self.name}
+
+		frappe.db.auto_commit_on_many_writes = not frappe.flags.in_test
+
+		frappe.sendmail(
+			subject=self.subject,
+			sender=sender,
+			recipients=emails,
+			message=message,
+			attachments=attachments,
+			template="newsletter",
+			add_unsubscribe_link=self.send_unsubscribe_link,
+			unsubscribe_method="/unsubscribe",
+			unsubscribe_params={"name": self.name},
+			reference_doctype=self.doctype,
+			reference_name=self.name,
+			queue_separately=True,
+			send_priority=0,
+			args=args,
+		)
+
+		frappe.db.auto_commit_on_many_writes = not frappe.flags.in_test
+
+	def get_message(self) -> str:
+		if self.content_type == "HTML":
+			return frappe.render_template(self.message_html, {"doc": self.as_dict()})
+		if self.content_type == "Markdown":
+			return frappe.utils.markdown(self.message_md)
+		# fallback to Rich Text
+		return self.message
+
+	def get_recipients(self) -> List[str]:
+		"""Get recipients from Email Group"""
+		emails = frappe.get_all(
+			"Email Group Member",
+			filters={"unsubscribed": 0, "email_group": ("in", self.get_email_groups())},
+			pluck="email",
+		)
+		return list(set(emails))
+
+	def get_email_groups(self) -> List[str]:
+		return frappe.db.get_all(
+			"Newsletter Email Group",
+			filters={"parent": self.name, "parenttype": "Newsletter"},
+			pluck="email_group",
+		)
+
+	def get_attachments(self) -> List[Dict]:
+		return frappe.get_all(
+			"File",
+			fields=["name", "file_name", "file_url", "is_private"],
+			filters={
+				"attached_to_name": self.name,
+				"attached_to_doctype": "Newsletter",
+				"is_private": 0,
+			},
+		)
 
 	def get_context(self, context):
 		newsletters = get_newsletter_list("Newsletter", None, None, 0)
 		if newsletters:
 			newsletter_list = [d.name for d in newsletters]
 			if self.name not in newsletter_list:
-				frappe.redirect_to_message(_('Permission Error'),
-					_("You are not permitted to view the newsletter."))
+				frappe.redirect_to_message(
+					_("Permission Error"), _("You are not permitted to view the newsletter.")
+				)
 				frappe.local.flags.redirect_location = frappe.local.response.location
 				raise frappe.Redirect
 			else:
-				context.attachments = get_attachments(self.name)
+				context.attachments = self.get_attachments()
 		context.no_cache = 1
 		context.show_sidebar = True
-
-
-def get_attachments(name):
-	return frappe.get_all("File",
-			fields=["name", "file_name", "file_url", "is_private"],
-			filters = {"attached_to_name": name, "attached_to_doctype": "Newsletter", "is_private":0})
-
-
-def get_email_groups(name):
-	return frappe.db.get_all("Newsletter Email Group", ["email_group"],{"parent":name, "parenttype":"Newsletter"})
 
 
 @frappe.whitelist(allow_guest=True)
 def confirmed_unsubscribe(email, group):
 	""" unsubscribe the email(user) from the mailing list(email_group) """
-	frappe.flags.ignore_permissions=True
+	frappe.flags.ignore_permissions = True
 	doc = frappe.get_doc("Email Group Member", {"email": email, "email_group": group})
 	if not doc.unsubscribed:
 		doc.unsubscribed = 1
-		doc.save(ignore_permissions = True)
-
-def create_lead(email_id):
-	"""create a lead if it does not exist"""
-	from frappe.model.naming import get_default_naming_series
-	full_name, email_id = parse_addr(email_id)
-	if frappe.db.get_value("Lead", {"email_id": email_id}):
-		return
-
-	lead = frappe.get_doc({
-		"doctype": "Lead",
-		"email_id": email_id,
-		"lead_name": full_name or email_id,
-		"status": "Lead",
-		"naming_series": get_default_naming_series("Lead"),
-		"company": frappe.db.get_default("Company"),
-		"source": "Email"
-	})
-	lead.insert()
+		doc.save(ignore_permissions=True)
 
 
 @frappe.whitelist(allow_guest=True)
-def subscribe(email, email_group=_('Website')):
-	url = frappe.utils.get_url("/api/method/frappe.email.doctype.newsletter.newsletter.confirm_subscription") +\
-		"?" + get_signed_params({"email": email, "email_group": email_group})
+def subscribe(email, email_group=_("Website")):
+	"""API endpoint to subscribe an email to a particular email group. Triggers a confirmation email.
+	"""
 
-	email_template = frappe.db.get_value('Email Group', email_group, ['confirmation_email_template'])
+	# build subscription confirmation URL
+	api_endpoint = frappe.utils.get_url(
+		"/api/method/frappe.email.doctype.newsletter.newsletter.confirm_subscription"
+	)
+	signed_params = get_signed_params({"email": email, "email_group": email_group})
+	confirm_subscription_url = f"{api_endpoint}?{signed_params}"
 
-	content=''
-	if email_template:
-		args = dict(
-			email=email,
-			confirmation_url=url,
-			email_group=email_group
-		)
+	# fetch custom template if available
+	email_confirmation_template = frappe.db.get_value(
+		"Email Group", email_group, "confirmation_email_template"
+	)
 
-		email_template = frappe.get_doc("Email Template", email_template)
+	# build email and send
+	if email_confirmation_template:
+		args = {"email": email, "confirmation_url": confirm_subscription_url, "email_group": email_group}
+		email_template = frappe.get_doc("Email Template", email_confirmation_template)
+		email_subject = email_template.subject
 		content = frappe.render_template(email_template.response, args)
-
-	if not content:
-		messages = (
+	else:
+		email_subject = _("Confirm Your Email")
+		translatable_content = (
 			_("Thank you for your interest in subscribing to our updates"),
 			_("Please verify your Email Address"),
-			url,
-			_("Click here to verify")
+			confirm_subscription_url,
+			_("Click here to verify"),
 		)
-
 		content = """
-		<p>{0}. {1}.</p>
-		<p><a href="{2}">{3}</a></p>
-		""".format(*messages)
+			<p>{0}. {1}.</p>
+			<p><a href="{2}">{3}</a></p>
+		""".format(*translatable_content)
 
-	frappe.sendmail(email, subject=getattr('email_template', 'subject', '') or _("Confirm Your Email"), content=content, now=True)
+	frappe.sendmail(
+		email,
+		subject=email_subject,
+		content=content,
+		now=True,
+	)
+
 
 @frappe.whitelist(allow_guest=True)
-def confirm_subscription(email, email_group=_('Website')):
+def confirm_subscription(email, email_group=_("Website")):
+	"""API endpoint to confirm email subscription.
+	This endpoint is called when user clicks on the link sent to their mail.
+	"""
 	if not verify_request():
 		return
 
 	if not frappe.db.exists("Email Group", email_group):
-		frappe.get_doc({
-			"doctype": "Email Group",
-			"title": email_group
-		}).insert(ignore_permissions=True)
+		frappe.get_doc({"doctype": "Email Group", "title": email_group}).insert(
+			ignore_permissions=True
+		)
 
 	frappe.flags.ignore_permissions = True
 
 	add_subscribers(email_group, email)
 	frappe.db.commit()
 
-	frappe.respond_as_web_page(_("Confirmed"),
+	frappe.respond_as_web_page(
+		_("Confirmed"),
 		_("{0} has been successfully added to the Email Group.").format(email),
-		indicator_color='green')
-
-
-def send_newsletter(newsletter):
-	try:
-		doc = frappe.get_doc("Newsletter", newsletter)
-		doc.queue_all()
-
-	except:
-		frappe.db.rollback()
-
-		# wasn't able to send emails :(
-		doc.db_set("email_sent", 0)
-		frappe.db.commit()
-
-		frappe.log_error(title='Send Newsletter')
-
-		raise
-
-	else:
-		frappe.db.commit()
+		indicator_color="green",
+	)
 
 
 def get_list_context(context=None):

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -38,9 +38,6 @@ class Newsletter(WebsiteGenerator):
 	@frappe.whitelist()
 	def send_emails(self):
 		"""send emails to leads and customers"""
-		self.validate_newsletter_status()
-		self.validate_newsletter_recipients()
-
 		self.queue_all()
 		frappe.msgprint(_("Email queued to {0} recipients").format(len(self.newsletter_recipients)))
 

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -23,7 +23,7 @@ class Newsletter(WebsiteGenerator):
 
 	@property
 	def newsletter_recipients(self) -> List[str]:
-		if getattr(self, "_recipients", None) == None:
+		if getattr(self, "_recipients", None) is None:
 			self._recipients = self.get_recipients()
 		return self._recipients
 
@@ -132,7 +132,7 @@ class Newsletter(WebsiteGenerator):
 			self.scheduled_to_send = len(newsletter_recipients)
 			self.save()
 
-	def get_attachments(self) -> List[Dict[str, str]]:
+	def get_newsletter_attachments(self) -> List[Dict[str, str]]:
 		"""Get list of attachments on current Newsletter
 		"""
 		attachments = []
@@ -149,9 +149,11 @@ class Newsletter(WebsiteGenerator):
 		return attachments
 
 	def send_newsletter(self, emails: List[str]):
+		"""Trigger email generation for `emails` and add it in Email Queue.
+		"""
 		# TODO: get rid of this maybe?
 		message = self.get_message()
-		attachments = self.get_attachments()
+		attachments = self.get_newsletter_attachments()
 		sender = self.send_from or frappe.utils.get_formatted_email(self.owner)
 		args = {"message": message, "name": self.name}
 
@@ -200,7 +202,7 @@ class Newsletter(WebsiteGenerator):
 			pluck="email_group",
 		)
 
-	def get_attachments(self) -> List[Dict]:
+	def get_attachments(self) -> List[Dict[str, str]]:
 		return frappe.get_all(
 			"File",
 			fields=["name", "file_name", "file_url", "is_private"],

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -336,12 +336,34 @@ def get_newsletter_list(doctype, txt, filters, limit_start, limit_page_length=20
 			'''.format(','.join(['%s'] * len(email_group_list)),
 					limit_page_length, limit_start), email_group_list, as_dict=1)
 
+
 def send_scheduled_email():
 	"""Send scheduled newsletter to the recipients."""
-	scheduled_newsletter = frappe.get_all('Newsletter', filters = {
-		'schedule_send': ('<=', now_datetime()),
-		'email_sent': 0,
-		'schedule_sending': 1
-	}, fields = ['name'], ignore_ifnull=True)
+	scheduled_newsletter = frappe.get_all(
+		"Newsletter",
+		filters={
+			"schedule_send": ("<=", frappe.utils.now_datetime()),
+			"email_sent": False,
+			"schedule_sending": True,
+		},
+		ignore_ifnull=True,
+		pluck="name",
+	)
+
 	for newsletter in scheduled_newsletter:
-		send_newsletter(newsletter.name)
+		try:
+			frappe.get_doc("Newsletter", newsletter).queue_all()
+
+		except Exception:
+			frappe.db.rollback()
+
+			# wasn't able to send emails :(
+			frappe.db.set_value("Newsletter", newsletter, "email_sent", 0)
+			message = (
+				f"Newsletter {newsletter} failed to send"
+				"\n\n"
+				f"Traceback: {frappe.get_traceback()}"
+			)
+			frappe.log_error(title="Send Newsletter", message=message)
+
+		frappe.db.commit()

--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -28,6 +28,8 @@ emails = [
 	"test_subscriber3@example.com",
 	"test1@example.com",
 ]
+newsletters = []
+
 
 def get_dotted_path(obj: type) -> str:
 	klass = obj.__class__
@@ -46,7 +48,14 @@ class TestNewsletterMixin:
 		frappe.set_user("Administrator")
 
 	def tearDown(self):
-		frappe.db.delete("Newsletter")
+		frappe.set_user("Administrator")
+		for newsletter in newsletters:
+			frappe.db.delete("Email Queue", {
+				"reference_doctype": "Newsletter",
+				"reference_name": newsletter,
+			})
+			frappe.delete_doc("Newsletter", newsletter)
+			newsletters.remove(newsletter)
 
 	def setup_email_group(self):
 		if not frappe.db.exists("Email Group", "_Test Email Group"):
@@ -63,9 +72,6 @@ class TestNewsletterMixin:
 			}).insert()
 
 	def send_newsletter(self, published=0, schedule_send=None) -> Union[str, None]:
-		frappe.db.delete("Email Queue")
-		frappe.db.delete("Email Queue Recipient")
-		frappe.db.delete("Newsletter")
 		newsletter_options = {
 			"published": published,
 			"schedule_sending": bool(schedule_send),
@@ -96,6 +102,7 @@ class TestNewsletterMixin:
 		newsletter.insert(ignore_permissions=True)
 		newsletter.save()
 		newsletter.reload()
+		newsletters.add(newsletter.name)
 
 		attached_files = frappe.get_all("File", {
 				"attached_to_doctype": newsletter.doctype,

--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -38,10 +38,12 @@ def get_dotted_path(obj: type) -> str:
 
 
 class TestNewsletterMixin:
+	@classmethod
+	def setUpClass(cls):
+		cls.setup_email_group()
+
 	def setUp(self):
 		frappe.set_user("Administrator")
-		frappe.db.delete("Email Group Member")
-		self.setup_email_group()
 
 	def tearDown(self):
 		frappe.db.delete("Newsletter")

--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -1,16 +1,25 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
-# License: GNU General Public License v3. See license.txt
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See LICENSE
+
 import unittest
 from random import choice
+from typing import Union
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import frappe
-from frappe.email.doctype.newsletter.newsletter import (
-	confirmed_unsubscribe,
-	send_scheduled_email,
+from frappe.desk.form.load import run_onload
+from frappe.email.doctype.newsletter.exceptions import (
+	NewsletterAlreadySentError, NoRecipientFoundError
 )
-from frappe.email.doctype.newsletter.newsletter import get_newsletter_list
+from frappe.email.doctype.newsletter.newsletter import (
+	Newsletter,
+	confirmed_unsubscribe,
+	get_newsletter_list,
+	send_scheduled_email
+)
 from frappe.email.queue import flush
 from frappe.utils import add_days, getdate
+
 
 test_dependencies = ["Email Group"]
 emails = [
@@ -20,14 +29,33 @@ emails = [
 	"test1@example.com",
 ]
 
+def get_dotted_path(obj: type) -> str:
+	klass = obj.__class__
+	module = klass.__module__
+	if module == 'builtins':
+		return klass.__qualname__ # avoid outputs like 'builtins.str'
+	return f"{module}.{klass.__qualname__}"
 
-class TestNewsletter(unittest.TestCase):
+
+class TestNewsletterMixin:
+	@classmethod
+	def setUpclass(self):
+		frappe.db.delete("Newsletter")
+
 	def setUp(self):
 		frappe.set_user("Administrator")
 		frappe.db.delete("Email Group Member")
+		self.setup_email_group()
 
+	def tearDown(self):
+		frappe.db.delete("Newsletter")
+
+	def setup_email_group(self):
 		if not frappe.db.exists("Email Group", "_Test Email Group"):
-			frappe.get_doc({"doctype": "Email Group", "title": "_Test Email Group"}).insert()
+			frappe.get_doc({
+				"doctype": "Email Group",
+				"title": "_Test Email Group"
+			}).insert()
 
 		for email in emails:
 			frappe.get_doc({
@@ -36,6 +64,54 @@ class TestNewsletter(unittest.TestCase):
 				"email_group": "_Test Email Group"
 			}).insert()
 
+	def send_newsletter(self, published=0, schedule_send=None) -> Union[str, None]:
+		frappe.db.delete("Email Queue")
+		frappe.db.delete("Email Queue Recipient")
+		frappe.db.delete("Newsletter")
+		newsletter_options = {
+			"published": published,
+			"schedule_sending": bool(schedule_send),
+			"schedule_send": schedule_send
+		}
+		newsletter = self.get_newsletter(**newsletter_options)
+
+		if schedule_send:
+			send_scheduled_email()
+		else:
+			newsletter.send_emails()
+			return newsletter.name
+
+	@staticmethod
+	def get_newsletter(**kwargs) -> "Newsletter":
+		"""Generate and return Newsletter object
+		"""
+		newsletter_content = {
+			"doctype": "Newsletter",
+			"subject": "_Test Newsletter",
+			"send_from": "Test Sender <test_sender@example.com>",
+			"content_type": "Rich Text",
+			"message": "Testing my news.",
+		}
+		newsletter = frappe.get_doc({**newsletter_content, **kwargs})
+		newsletter.append("email_group", {"email_group": "_Test Email Group"})
+
+		newsletter.insert(ignore_permissions=True)
+		newsletter.save()
+		newsletter.reload()
+
+		attached_files = frappe.get_all("File", {
+				"attached_to_doctype": newsletter.doctype,
+				"attached_to_name": newsletter.name,
+			},
+			pluck="name",
+		)
+		for file in attached_files:
+			frappe.delete_doc("File", file)
+
+		return newsletter
+
+
+class TestNewsletter(TestNewsletterMixin, unittest.TestCase):
 	def test_send(self):
 		self.send_newsletter()
 
@@ -64,32 +140,6 @@ class TestNewsletter(unittest.TestCase):
 			if email != to_unsubscribe:
 				self.assertTrue(email in recipients)
 
-	@staticmethod
-	def send_newsletter(published=0, schedule_send=None):
-		frappe.db.delete("Email Queue")
-		frappe.db.delete("Email Queue Recipient")
-		frappe.db.delete("Newsletter")
-
-		newsletter = frappe.get_doc({
-			"doctype": "Newsletter",
-			"subject": "_Test Newsletter",
-			"send_from": "Test Sender <test_sender@example.com>",
-			"content_type": "Rich Text",
-			"message": "Testing my news.",
-			"published": published,
-			"schedule_sending": bool(schedule_send),
-			"schedule_send": schedule_send
-		})
-		newsletter.insert(ignore_permissions=True)
-		newsletter.append("email_group", {"email_group": "_Test Email Group"})
-		newsletter.save()
-
-		if schedule_send:
-			send_scheduled_email()
-		else:
-			newsletter.send_emails()
-			return newsletter.name
-
 	def test_portal(self):
 		self.send_newsletter(published=1)
 		frappe.set_user("test1@example.com")
@@ -113,3 +163,68 @@ class TestNewsletter(unittest.TestCase):
 		recipients = [e.recipients[0].recipient for e in email_queue_list]
 		for email in emails:
 			self.assertTrue(email in recipients)
+
+	def test_newsletter_test_send(self):
+		"""Test "Test Send" functionality of Newsletter
+		"""
+		newsletter = self.get_newsletter()
+		newsletter.test_email_id = choice(emails)
+		newsletter.test_send()
+
+		self.assertFalse(newsletter.email_sent)
+		newsletter.save = MagicMock()
+		self.assertFalse(newsletter.save.called)
+
+	def test_newsletter_status(self):
+		"""Test for Newsletter's stats on onload event
+		"""
+		newsletter = self.get_newsletter()
+		newsletter.email_sent = True
+		# had to use run_onload as calling .onload directly bought weird errors
+		# like TestNewsletter has no attribute "_TestNewsletter__onload"
+		run_onload(newsletter)
+		self.assertIsInstance(newsletter.get("__onload").status_count, dict)
+
+	def test_already_sent_newsletter(self):
+		newsletter = self.get_newsletter()
+		newsletter.send_emails()
+
+		with self.assertRaises(NewsletterAlreadySentError):
+			newsletter.send_emails()
+
+	def test_newsletter_with_no_recipient(self):
+		newsletter = self.get_newsletter()
+		property_path = f"{get_dotted_path(newsletter)}.newsletter_recipients"
+
+		with patch(property_path, new_callable=PropertyMock) as mock_newsletter_recipients:
+			mock_newsletter_recipients.return_value = []
+			with self.assertRaises(NoRecipientFoundError):
+				newsletter.send_emails()
+
+	def test_send_newsletter_with_attachments(self):
+		newsletter = self.get_newsletter()
+		newsletter.reload()
+		file_attachment = frappe.get_doc({
+			"doctype": "File",
+			"file_name": "test1.txt",
+			"attached_to_doctype": newsletter.doctype,
+			"attached_to_name": newsletter.name,
+			"content": frappe.mock("paragraph")
+		})
+		file_attachment.save()
+		newsletter.send_attachments = True
+		newsletter_attachments = newsletter.get_newsletter_attachments()
+		self.assertEqual(len(newsletter_attachments), 1)
+		self.assertEqual(newsletter_attachments[0]["fid"], file_attachment.name)
+
+	def test_send_scheduled_email_error_handling(self):
+		newsletter = self.get_newsletter(schedule_send=add_days(getdate(), -1))
+		job_path = "frappe.email.doctype.newsletter.newsletter.Newsletter.queue_all"
+		m = MagicMock(side_effect=frappe.OutgoingEmailError)
+
+		with self.assertRaises(frappe.OutgoingEmailError):
+			with patch(job_path, new_callable=m):
+				send_scheduled_email()
+
+		newsletter.reload()
+		self.assertEqual(newsletter.email_sent, 0)

--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -38,10 +38,6 @@ def get_dotted_path(obj: type) -> str:
 
 
 class TestNewsletterMixin:
-	@classmethod
-	def setUpclass(self):
-		frappe.db.delete("Newsletter")
-
 	def setUp(self):
 		frappe.set_user("Administrator")
 		frappe.db.delete("Email Group Member")


### PR DESCRIPTION
### Changes

* Re-send Newsletter only to the recipients who haven't received it yet (Check Email Queue before setting email recipients)
* Re-structured code, broken larger methods to "byte" sized "bits" (hehe)
* Added validations for recipients list
* Added `Newsletter.newsletter_recipients` property
* Used newer APIs and Fixed namespaces for usages/imports
* Added convenience methods for Newsletter APIs
* Added type annotations for all(?) methods
* Don't raise after handling generic Exception class. Just log error and go on. This way, other newsletters will continue to loop instead of breaking after one failure
* Added more context (`doc.name`) to logged error