### PR TITLE
perf: Grid rendering

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -37,6 +37,8 @@ export default class Grid {
 		}
 
 		this.is_grid = true;
+		this.debounced_refresh = this.refresh.bind(this);
+		this.debounced_refresh = frappe.utils.debounce(this.debounced_refresh, 500);
 	}
 
 	allow_on_grid_editing() {
@@ -675,6 +677,7 @@ export default class Grid {
 		if (!idx) {
 			idx = this.grid_rows.length - 1;
 		}
+
 		setTimeout(() => {
 			this.grid_rows[idx].row
 				.find('input[type="Text"],textarea,select').filter(':visible:first').focus();
@@ -934,6 +937,6 @@ export default class Grid {
 		// update the parent too (for new rows)
 		this.docfields.find(d => d.fieldname === fieldname)[property] = value;
 
-		this.refresh();
+		this.debounced_refresh();
 	}
 }


### PR DESCRIPTION
### Issue
Recently we found that while adding a new row in the child table or rendering multiple rows in the form, the system was taking a lot of time. Also whenever we create the purchase receipt from the purchase order, the grid was frozen for 5 to 10 seconds and not able to edit the field in the grid. To debug the issue we checked the performance and we found that the latest added [fix](https://github.com/frappe/frappe/pull/12974) has a problem. This code system renders the same grid multiple times based on the number of rows added to the table.

**Performance Monitor**


<img width="1154" alt="Screenshot 2021-08-12 at 12 52 35 PM" src="https://user-images.githubusercontent.com/8780500/129187082-fe4bed8a-84b7-4f08-8530-f76b99c20a2e.png">

### After Fix
To fix this issue we have debounced the grid class refresh method, to execute the method a single time for each grid

![image](https://user-images.githubusercontent.com/8780500/129192321-86a89526-f120-4582-adf4-31a5393ceb19.png)
