### PR TITLE
fix: handle JSON content in run_doc_method

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -211,7 +211,10 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 		doc = frappe.get_doc(dt, dn)
 
 	else:
-		doc = frappe.get_doc(json.loads(docs))
+		if isinstance(docs, str):
+			docs = json.loads(docs)
+
+		doc = frappe.get_doc(docs)
 		doc._original_modified = doc.modified
 		doc.check_if_latest()
 


### PR DESCRIPTION
### Problem

Sending a request to `run_doc_method` with a JSON body fails. In this case the `docs` parameter already contains a json object so `json.loads(docs)` throws an error.

### Solution

Check if `docs` is a string before trying to parse it.