### PR TITLE
ci: ignore js only changes while running unittests

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -1,6 +1,10 @@
 name: Patch
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths-ignore:
+      - '**.js'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.js'
+      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths-ignore:
       - '**.js'
+      - '**.md'
   workflow_dispatch:
   push:
     branches: [ develop ]
     paths-ignore:
       - '**.js'
+      - '**.md'
 
 jobs:
   test:

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -2,9 +2,13 @@ name: Server
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.js'
   workflow_dispatch:
   push:
     branches: [ develop ]
+    paths-ignore:
+      - '**.js'
 
 jobs:
   test:

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.js'
+      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -2,6 +2,8 @@ name: Server
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.js'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -2,6 +2,8 @@ name: UI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
   push:
     branches: [ develop ]


### PR DESCRIPTION
- If PR only changes JS files then unittests / patch tests won't run.
- Change done to save resources / concurrent builds.


This partially brings back pre-GHA behaviour, haven't done similar changes in cypress tests because python code can alter that behaviour.

https://github.com/frappe/frappe/blob/66924817ca9923df11fd8cdbdbcdc12513fad3e6/.github/helper/roulette.py#L48-L49 