### PR TITLE
ci: ignore js only changes while running unittests (bp #13932)

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -1,6 +1,11 @@
 name: Patch
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths-ignore:
+      - '**.js'
+      - '**.md'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -2,6 +2,9 @@ name: Server
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.js'
+      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -2,6 +2,9 @@ name: Server
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.js'
+      - '**.md'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -2,6 +2,8 @@ name: UI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
manual port of #13932 as mergify isn't allowed to edit workflows. 