### PR TITLE
fix(ux): better message for removal of assignment

### DIFF
--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -28,8 +28,15 @@ class ToDo(Document):
 		else:
 			# NOTE the previous value is only available in validate method
 			if self.get_db_value("status") != self.status:
+				if self.owner == frappe.session.user:
+					removal_message = frappe._("{0} removed their assignment.").format(
+						get_fullname(frappe.session.user))
+				else:
+					removal_message = frappe._("Assignment of {0} removed by {1}").format(
+						get_fullname(self.owner), get_fullname(frappe.session.user))
+
 				self._assignment = {
-					"text": frappe._("Assignment closed by {0}").format(get_fullname(frappe.session.user)),
+					"text": removal_message,
 					"comment_type": "Assignment Completed"
 				}
 
@@ -93,7 +100,7 @@ def get_permission_query_conditions(user):
 	if not user: user = frappe.session.user
 
 	todo_roles = frappe.permissions.get_doctype_roles('ToDo')
-	if 'All' in todo_roles: 
+	if 'All' in todo_roles:
 		todo_roles.remove('All')
 
 	if any(check in todo_roles for check in frappe.get_roles(user)):
@@ -105,7 +112,7 @@ def get_permission_query_conditions(user):
 def has_permission(doc, ptype="read", user=None):
 	user = user or frappe.session.user
 	todo_roles = frappe.permissions.get_doctype_roles('ToDo', ptype)
-	if 'All' in todo_roles: 
+	if 'All' in todo_roles:
 		todo_roles.remove('All')
 
 	if any(check in todo_roles for check in frappe.get_roles(user)):


### PR DESCRIPTION
- Default timeline message is "Assignment closed by {closer}". This doesn't tell whose assignment was closed and also "closed" doesn't seem to be an appropriate word here?
- Changed message to "Assignment of {user} removed by {remover}"


closes: FR-ISS-264112 
![Screenshot 2021-08-16 at 5 03 51 PM](https://user-images.githubusercontent.com/9079960/129557287-4a7c4e4f-3f39-42fa-9507-6f3f149efc30.png)
