### PR TITLE
fix: Workspace 2.0 minor fixes

### DIFF
--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -14,7 +14,7 @@ context('Workspace 2.0', () => {
 
 	it('Create Private Page', () => {
 		cy.get('.codex-editor__redactor .ce-block');
-		cy.get('.custom-actions button[data-label="Create%20Page"]').click();
+		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
 		cy.fill_field('title', 'Test Private Page', 'Data');
 		cy.fill_field('icon', 'edit', 'Icon');
 		cy.get_open_dialog().find('.modal-header').click();
@@ -29,7 +29,7 @@ context('Workspace 2.0', () => {
 
 		cy.wait(500);
 		cy.get('.codex-editor__redactor .ce-block');
-		cy.get('.standard-actions .btn-secondary[data-label=Customize]').click();
+		cy.get('.standard-actions .btn-secondary[data-label=Edit]').click();
 	});
 
 	it('Add New Block', () => {
@@ -77,7 +77,7 @@ context('Workspace 2.0', () => {
 
 	it('Delete Private Page', () => {
 		cy.get('.codex-editor__redactor .ce-block');
-		cy.get('.standard-actions .btn-secondary[data-label=Customize]').click();
+		cy.get('.standard-actions .btn-secondary[data-label=Edit]').click();
 
 		cy.get('.sidebar-item-container[item-name="Test Private Page"]').find('.sidebar-item-control .delete-page').click();
 		cy.wait(300);

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -368,7 +368,7 @@ def get_desktop_page(page):
 	on desk.
 
 	Args:
-		page (string): page name
+		page (json): page data
 
 	Returns:
 		dict: dictionary of cards, charts and shortcuts to be displayed on website

--- a/frappe/public/js/frappe/views/workspace/blocks/card.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/card.js
@@ -14,7 +14,7 @@ export default class Card extends Block {
 	constructor({ data, api, config, readOnly, block }) {
 		super({ data, api, config, readOnly, block });
 		this.sections = {};
-		this.col = this.data.col ? this.data.col : "12";
+		this.col = this.data.col ? this.data.col : "4";
 		this.allow_customization = !this.readOnly;
 		this.options = {
 			allow_sorting: this.allow_customization,

--- a/frappe/public/js/frappe/views/workspace/blocks/paragraph.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/paragraph.js
@@ -123,10 +123,10 @@ export default class Paragraph extends Block {
 		return true;
 	}
 
-	save(toolsContent) {
+	save() {
 		this.wrapper = this._element;
 		return {
-			text: toolsContent.innerText,
+			text: this.wrapper.innerHTML,
 			col: this.get_col(),
 		};
 	}
@@ -155,6 +155,9 @@ export default class Paragraph extends Block {
 		return {
 			text: {
 				br: true,
+				b: true,
+				i: true,
+				a: true
 			}
 		};
 	}

--- a/frappe/public/js/frappe/views/workspace/blocks/shortcut.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/shortcut.js
@@ -13,7 +13,7 @@ export default class Shortcut extends Block {
 
 	constructor({ data, api, config, readOnly, block }) {
 		super({ data, api, config, readOnly, block });
-		this.col = this.data.col ? this.data.col : "12";
+		this.col = this.data.col ? this.data.col : "4";
 		this.allow_customization = !this.readOnly;
 		this.options = {
 			allow_sorting: this.allow_customization,

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -946,7 +946,11 @@ body {
 						&.new-widget {
 							align-items: inherit;
 						}
-	
+
+						&.ce-paragraph {
+							display: block;
+						}
+
 						.paragraph-control {
 							display: flex;
 							flex-direction: row-reverse;


### PR DESCRIPTION
1. Enabled paragraph styling for e.g. **Bold**, _Italic_, line break, [link](URL).
![image](https://user-images.githubusercontent.com/30859809/129686858-94e4891e-d390-4c38-844a-a279ea2f6f1c.png)

2. Made default size of Shortcuts & Cards to col-4.
![DefaultShortcutSize](https://user-images.githubusercontent.com/30859809/129686237-9ec68334-9ba0-47dc-ac85-1bfd62be353f.gif)

3. Switched `Public` and `Private` in Sidebar.
![image](https://user-images.githubusercontent.com/30859809/129684295-68e67205-6c7c-4c13-b795-069b1d2e2a1c.png)

4. Added `Settings` button in Edit Mode to navigate to workspace document.
![image](https://user-images.githubusercontent.com/30859809/129685406-86b79035-2d9f-4dba-9f99-c0148454dfbe.png)
5. Renamed `Customize` to `Edit` & `PRIVATE` to `MY WORKSPACES` 
6. When we click on public pages we get the message `Only Workspace Manager can edit or sort this page`