### PR TITLE
fix: broken template in password reset

### DIFF
--- a/frappe/templates/emails/password_reset.html
+++ b/frappe/templates/emails/password_reset.html
@@ -3,5 +3,5 @@
 <p><a class="btn btn-primary" href="{{ link }}">{{_("Reset your password")}}</a></p>
 <p>
 	{{_("Thank you")}},<br>
-	{{ user_fullname }}
+	{{ created_by }}
 </p>


### PR DESCRIPTION
Incorrect rendering of html template because of missing context. introduced via https://github.com/frappe/frappe/commit/fbeb71420e798331ffe59026cf939df0c50108d5 https://github.com/frappe/frappe/pull/12277 

Variable name was changed from `full_name` to `created_by`

![telegram-cloud-photo-size-5-6073588368412880049-y](https://user-images.githubusercontent.com/9079960/129711315-08e97e4b-762c-467a-b7a0-a77a5d286e4c.jpg)
