### PR TITLE
fix: empty ControlFloat field displayed NaN as its value

### DIFF
--- a/frappe/public/js/frappe/form/controls/float.js
+++ b/frappe/public/js/frappe/form/controls/float.js
@@ -10,7 +10,7 @@ frappe.ui.form.ControlFloat = class ControlFloat extends frappe.ui.form.ControlI
 			number_format = this.get_number_format();
 		}
 		var formatted_value = format_number(value, number_format, this.get_precision());
-		return isNaN(Number(value)) ? "" : formatted_value;
+		return (isNaN(Number(value)) || value === null) ? "" : formatted_value;
 	}
 
 	get_number_format() {


### PR DESCRIPTION
A ControlFloat field with an empty input has a value of `null`, which is displayed as `NaN` in the UI, instead of being displayed as empty.

Indeed, looking at line 13 we see that, when `value` equals `null`, `Number(value)` equals `0`, which means `isNaN(Number(value))` is `false`, which causes `formatted_value` to be returned in the ternary expression (and `formatted_value` equals `"NaN"`).

**Buggy behaviour:**


https://user-images.githubusercontent.com/10946971/129758942-8f21c8a1-9b77-468e-93f0-6cc9c76528f0.mp4

<img width="930" alt="screencap" src="https://user-images.githubusercontent.com/10946971/129760514-87c2cf70-61fb-419b-b0c9-a79d6f0ab324.png">
