### PR TITLE
comment_email field is not selected in get_comments() function

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -13,6 +13,7 @@
   "time_zone",
   "is_first_startup",
   "enable_onboarding",
+  "page_length",
   "setup_complete",
   "date_and_number_format",
   "date_format",
@@ -469,6 +470,12 @@
    "fieldname": "strip_exif_metadata_from_uploaded_images",
    "fieldtype": "Check",
    "label": "Strip EXIF tags from uploaded images"
+  },
+  {
+   "default": "50",
+   "fieldname": "page_length",
+   "fieldtype": "Int",
+   "label": "Page Length"
   }
  ],
  "icon": "fa fa-cog",

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -150,7 +150,7 @@ def get_comments(doctype, name, comment_type='Comment'):
 	elif comment_type == 'attachment':
 		comment_types = ['Attachment', 'Attachment Removed']
 
-	comments = frappe.get_all('Comment', fields = ['name', 'creation', 'content', 'owner', 'comment_type'], filters=dict(
+	comments = frappe.get_all('Comment', fields = ['name', 'creation', 'content', 'owner', 'comment_type','comment_email'], filters=dict(
 		reference_doctype = doctype,
 		reference_name = name,
 		comment_type = ['in', comment_types]

--- a/frappe/public/js/frappe/form/grid_pagination.js
+++ b/frappe/public/js/frappe/form/grid_pagination.js
@@ -6,7 +6,15 @@ export default class GridPagination {
 	}
 
 	setup_pagination() {
-		this.page_length = 50;
+		frappe.db.get_single_value('System Settings', 'page_length')
+			.then((value) => {
+				if(!value){
+					this.page_length = 50;
+				}
+				else{
+					this.page_length = value;
+				}
+		})
 		this.page_index = 1;
 		this.total_pages = Math.ceil(this.grid.data.length/this.page_length);
 


### PR DESCRIPTION
if comment_email not found then Info Comments will show undefined user link in the timelines and it will render session user instead of comment_email user.