### PR TITLE
fix: Workspace 2.0 Miscellaneous Fixes

### DIFF
--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -36,12 +36,12 @@ context('Workspace 2.0', () => {
 		cy.get('.codex-editor__redactor .ce-block');
 		cy.get('.custom-actions .inner-group-button[data-label="Add%20Block"]').click();
 		cy.get('.custom-actions .inner-group-button .dropdown-menu .block-menu-item-label').contains('Heading').click();
-		cy.get(".ce-block:last").find('h2').click({force: true}).type('Header');
+		cy.get(":focus").type('Header');
 		cy.get(".ce-block:last").find('.ce-header').should('exist');
 
 		cy.get('.custom-actions .inner-group-button[data-label="Add%20Block"]').click();
 		cy.get('.custom-actions .inner-group-button .dropdown-menu .block-menu-item-label').contains('Text').click();
-		cy.get(".ce-block:last").find('.ce-paragraph').click({force: true}).type('Paragraph text');
+		cy.get(":focus").type('Paragraph text');
 		cy.get(".ce-block:last").find('.ce-paragraph').should('exist');
 	});
 

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -28,7 +28,6 @@
   "pin_to_bottom",
   "hide_custom",
   "public",
-  "content_section",
   "content",
   "section_break_2",
   "charts_label",
@@ -39,6 +38,7 @@
   "section_break_18",
   "cards_label",
   "links",
+  "roles_section",
   "roles"
  ],
  "fields": [
@@ -240,13 +240,9 @@
    "label": "Parent Page"
   },
   {
-   "fieldname": "content_section",
-   "fieldtype": "Section Break",
-   "label": "Content"
-  },
-  {
    "fieldname": "content",
    "fieldtype": "Long Text",
+   "hidden": 1,
    "label": "Content"
   },
   {
@@ -259,10 +255,15 @@
    "fieldtype": "Table",
    "label": "Roles",
    "options": "Has Role"
+  },
+  {
+   "fieldname": "roles_section",
+   "fieldtype": "Section Break",
+   "label": "Roles"
   }
  ],
  "links": [],
- "modified": "2021-08-05 11:49:09.028243",
+ "modified": "2021-08-19 12:36:29.825169",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -46,6 +46,7 @@
    "fieldname": "label",
    "fieldtype": "Data",
    "label": "Name",
+   "reqd": 1,
    "unique": 1
   },
   {
@@ -232,7 +233,8 @@
   {
    "fieldname": "title",
    "fieldtype": "Data",
-   "label": "Title"
+   "label": "Title",
+   "reqd": 1
   },
   {
    "fieldname": "parent_page",
@@ -263,7 +265,7 @@
   }
  ],
  "links": [],
- "modified": "2021-08-19 12:36:29.825169",
+ "modified": "2021-08-19 12:51:00.233017",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -20,7 +20,7 @@ class Workspace(Document):
 		try:
 			if not isinstance(loads(self.content), list):
 				raise
-		except:
+		except Exception:
 			frappe.throw(_("Content data shoud be a list"))
 
 		duplicate_exists = frappe.db.exists("Workspace", {

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -17,7 +17,10 @@ class Workspace(Document):
 			frappe.throw(_("You need to be in developer mode to edit this document"))
 		validate_route_conflict(self.doctype, self.name)
 
-		if isinstance(self.content, list):
+		try:
+			if not isinstance(loads(self.content), list):
+				raise
+		except:
 			frappe.throw(_("Content data shoud be a list"))
 
 		duplicate_exists = frappe.db.exists("Workspace", {

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -17,6 +17,9 @@ class Workspace(Document):
 			frappe.throw(_("You need to be in developer mode to edit this document"))
 		validate_route_conflict(self.doctype, self.name)
 
+		if isinstance(self.content, list):
+			frappe.throw(_("Content data shoud be a list"))
+
 		duplicate_exists = frappe.db.exists("Workspace", {
 			"name": ["!=", self.name], 'is_default': 1, 'extends': self.extends
 		})

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -354,8 +354,8 @@ frappe.router = {
 				return a;
 			}
 		}).join('/');
-
-		return '/app/' + (path_string || 'home');
+		let default_page = frappe.workspaces['home'] ? 'home' : Object.keys(frappe.workspaces)[0];
+		return '/app/' + (path_string || default_page);
 	},
 
 	push_state(url) {

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -129,7 +129,7 @@ frappe.router = {
 		if (frappe.workspaces[route[0]]) {
 			// public workspace
 			route = ['Workspaces', frappe.workspaces[route[0]].title];
-		} else if (frappe.workspaces[route[1]]) {
+		} else if (route[0] == 'private' && frappe.workspaces[route[1]]) {
 			// private workspace
 			route = ['Workspaces', 'private', frappe.workspaces[route[1]].title];
 		} else if (this.routes[route[0]]) {

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -174,10 +174,6 @@ frappe.views.Workspace = class Workspace {
 			$(e.target).parent().find('.sidebar-item-container').toggleClass('hidden');
 		});
 
-		if (!this.current_page.name) {
-			$title.trigger("click");
-		}
-
 		if (Object.keys(root_pages).length === 0) {
 			sidebar_section.addClass('hidden');
 		}


### PR DESCRIPTION
1. App without home page gives error when navigating to home
2. Can't navigate to the webpage with name same as a private workspace
3. Make Content hidden and added validation
4. Removed default collapsing sidebar section
5. Make title and label field mandatory
6. Cypress Test Case breaking in Firefox.