### PR TITLE
refactor(minor): Use frappe.db.delete instead of frappe.db.sql queries

### DIFF
--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -76,7 +76,7 @@ class TestAutoAssign(unittest.TestCase):
 		# clear 5 assignments for first user
 		# can't do a limit in "delete" since postgres does not support it
 		for d in frappe.get_all('ToDo', dict(reference_type = 'Note', owner = 'test@example.com'), limit=5):
-			frappe.db.sql("delete from tabToDo where name = %s", d.name)
+			frappe.db.delete("ToDo", {"name": d.name})
 
 		# add 5 more assignments
 		for i in range(5):
@@ -177,7 +177,7 @@ class TestAutoAssign(unittest.TestCase):
 		), 'owner'), 'test@example.com')
 
 	def check_assignment_rule_scheduling(self):
-		frappe.db.sql("DELETE FROM `tabAssignment Rule`")
+		frappe.db.delete("Assignment Rule")
 
 		days_1 = [dict(day = 'Sunday'), dict(day = 'Monday'), dict(day = 'Tuesday')]
 
@@ -204,7 +204,7 @@ class TestAutoAssign(unittest.TestCase):
 		), 'owner'), ['test3@example.com'])
 
 	def test_assignment_rule_condition(self):
-		frappe.db.sql("DELETE FROM `tabAssignment Rule`")
+		frappe.db.delete("Assignment Rule")
 
 		# Add expiry_date custom field
 		from frappe.custom.doctype.custom_field.custom_field import create_custom_field
@@ -253,7 +253,7 @@ class TestAutoAssign(unittest.TestCase):
 		assignment_rule.delete()
 
 def clear_assignments():
-	frappe.db.sql("delete from tabToDo where reference_type = 'Note'")
+	frappe.db.delete("ToDo", {"reference_type": "Note"})
 
 def get_assignment_rule(days, assign=None):
 	frappe.delete_doc_if_exists('Assignment Rule', 'For Note 1')

--- a/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
@@ -7,7 +7,7 @@ import unittest
 
 class TestMilestoneTracker(unittest.TestCase):
 	def test_milestone(self):
-		frappe.db.sql('delete from `tabMilestone Tracker`')
+		frappe.db.delete("Milestone Tracker")
 
 		frappe.cache().delete_key('milestone_tracker_map')
 
@@ -44,5 +44,5 @@ class TestMilestoneTracker(unittest.TestCase):
 		self.assertEqual(milestones[0].value, 'Closed')
 
 		# cleanup
-		frappe.db.sql('delete from tabMilestone')
+		frappe.db.delete("Milestone")
 		milestone_tracker.delete()

--- a/frappe/core/doctype/comment/test_comment.py
+++ b/frappe/core/doctype/comment/test_comment.py
@@ -30,7 +30,7 @@ class TestComment(unittest.TestCase):
 		from frappe.website.doctype.blog_post.test_blog_post import make_test_blog
 		test_blog = make_test_blog()
 
-		frappe.db.sql("delete from `tabComment` where reference_doctype = 'Blog Post'")
+		frappe.db.delete("Comment", {"reference_doctype": "Blog Post"})
 
 		from frappe.templates.includes.comments.comments import add_comment
 		add_comment('Good comment with 10 chars', 'test@test.com', 'Good Tester',
@@ -41,7 +41,7 @@ class TestComment(unittest.TestCase):
 			reference_name = test_blog.name
 		))[0].published, 1)
 
-		frappe.db.sql("delete from `tabComment` where reference_doctype = 'Blog Post'")
+		frappe.db.delete("Comment", {"reference_doctype": "Blog Post"})
 
 		add_comment('pleez vizits my site http://mysite.com', 'test@test.com', 'bad commentor',
 			'Blog Post', test_blog.name, test_blog.route)

--- a/frappe/core/doctype/feedback/test_feedback.py
+++ b/frappe/core/doctype/feedback/test_feedback.py
@@ -9,7 +9,7 @@ class TestFeedback(unittest.TestCase):
 		from frappe.website.doctype.blog_post.test_blog_post import make_test_blog
 		test_blog = make_test_blog()
 
-		frappe.db.sql("delete from `tabFeedback` where reference_doctype = 'Blog Post'")
+		frappe.db.delete("Feedback", {"reference_doctype": "Blog Post"})
 
 		from frappe.templates.includes.feedback.feedback import add_feedback, update_feedback
 		feedback = add_feedback('Blog Post', test_blog.name, 5, 'New feedback')
@@ -22,6 +22,6 @@ class TestFeedback(unittest.TestCase):
 		self.assertEqual(updated_feedback.feedback, 'Updated feedback')
 		self.assertEqual(updated_feedback.rating, 6)
 
-		frappe.db.sql("delete from `tabFeedback` where reference_doctype = 'Blog Post'")
+		frappe.db.delete("Feedback", {"reference_doctype": "Blog Post"})
 
 		test_blog.delete()

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -8,7 +8,7 @@ from frappe import _
 
 class TestTranslation(unittest.TestCase):
 	def setUp(self):
-		frappe.db.sql('delete from tabTranslation')
+		frappe.db.delete("Translation")
 
 	def tearDown(self):
 		frappe.local.lang = 'en'

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -52,7 +52,7 @@ class TestUser(unittest.TestCase):
 	def test_delete(self):
 		frappe.get_doc("User", "test@example.com").add_roles("_Test Role 2")
 		self.assertRaises(frappe.LinkExistsError, delete_doc, "Role", "_Test Role 2")
-		frappe.db.sql("""delete from `tabHas Role` where role='_Test Role 2'""")
+		frappe.db.delete("Has Role", {"role": "_Test Role 2"})
 		delete_doc("Role","_Test Role 2")
 
 		if frappe.db.exists("User", "_test@example.com"):
@@ -294,5 +294,5 @@ class TestUser(unittest.TestCase):
 	# 	self.assertIsNone(frappe.db.get("User", {"email": email}))
 
 def delete_contact(user):
-	frappe.db.sql("DELETE FROM `tabContact` WHERE `email_id`= %s", user)
-	frappe.db.sql("DELETE FROM `tabContact Email` WHERE `email_id`= %s", user)
+	frappe.db.delete("Contact", {"email_id": user})
+	frappe.db.delete("Contact Email", {"email_id": user})

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -14,7 +14,7 @@ test_records = frappe.get_test_records('Event')
 
 class TestEvent(unittest.TestCase):
 	def setUp(self):
-		frappe.db.sql('delete from tabEvent')
+		frappe.db.delete("Event")
 		make_test_objects('Event', reset=True)
 
 		self.test_records = frappe.get_test_records('Event')

--- a/frappe/desk/doctype/note/test_note.py
+++ b/frappe/desk/doctype/note/test_note.py
@@ -8,9 +8,9 @@ test_records = frappe.get_test_records('Note')
 
 class TestNote(unittest.TestCase):
 	def insert_note(self):
-		frappe.db.sql('delete from tabVersion')
-		frappe.db.sql('delete from tabNote')
-		frappe.db.sql('delete from `tabNote Seen By`')
+		frappe.db.delete("Version")
+		frappe.db.delete("Note")
+		frappe.db.delete("Note Seen By")
 
 		return frappe.get_doc(dict(doctype='Note', title='test note',
 			content='test note content')).insert()

--- a/frappe/desk/doctype/tag/test_tag.py
+++ b/frappe/desk/doctype/tag/test_tag.py
@@ -6,7 +6,7 @@ from frappe.desk.doctype.tag.tag import add_tag
 
 class TestTag(unittest.TestCase):
 	def setUp(self) -> None:
-		frappe.db.sql("DELETE from `tabTag`")
+		frappe.db.delete("Tag")
 		frappe.db.sql("UPDATE `tabDocType` set _user_tags=''")
 
 	def test_tag_count_query(self):

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -122,9 +122,8 @@ class TestToDo(unittest.TestCase):
 		self.assertEqual(todo.assigned_by_full_name, 'Admin')
 
 		# Overwrite user changes
-		todo_meta = frappe.get_doc('DocType', 'ToDo')
-		todo_meta.get('fields', dict(fieldname='assigned_by_full_name'))[0].fetch_if_empty = 0
-		todo_meta.save()
+		todo.meta.get('fields', dict(fieldname='assigned_by_full_name'))[0].fetch_if_empty = 0
+		todo.meta.save()
 
 		todo.reload()
 		todo.save()

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -104,7 +104,7 @@ class TestToDo(unittest.TestCase):
 		clear_permissions_cache('ToDo')
 		frappe.db.rollback()
 
-def test_fetch_if_empty(self):
+	def test_fetch_if_empty(self):
 		frappe.db.delete("ToDo")
 
 		# Allow user changes

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -14,7 +14,7 @@ class TestToDo(unittest.TestCase):
 		todo = frappe.get_doc(dict(doctype='ToDo', description='test todo',
 			assigned_by='Administrator')).insert()
 
-		frappe.db.sql('delete from `tabDeleted Document`')
+		frappe.db.delete("Deleted Document")
 		todo.delete()
 
 		deleted = frappe.get_doc('Deleted Document', dict(deleted_doctype=todo.doctype, deleted_name=todo.name))
@@ -27,7 +27,7 @@ class TestToDo(unittest.TestCase):
 			frappe.db.get_value('User', todo.assigned_by, 'full_name'))
 
 	def test_fetch_setup(self):
-		frappe.db.sql('delete from tabToDo')
+		frappe.db.delete("ToDo")
 
 		todo_meta = frappe.get_doc('DocType', 'ToDo')
 		todo_meta.get('fields', dict(fieldname='assigned_by_full_name'))[0].fetch_from = ''
@@ -105,7 +105,7 @@ class TestToDo(unittest.TestCase):
 		frappe.db.rollback()
 
 def test_fetch_if_empty(self):
-		frappe.db.sql('delete from tabToDo')
+		frappe.db.delete("ToDo")
 
 		# Allow user changes
 		todo_meta = frappe.get_doc('DocType', 'ToDo')

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -34,8 +34,8 @@ class TestEmailAccount(unittest.TestCase):
 	def setUp(self):
 		frappe.flags.mute_emails = False
 		frappe.flags.sent_mail = None
-		frappe.db.sql('delete from `tabEmail Queue`')
-		frappe.db.sql('delete from `tabUnhandled Email`')
+		frappe.db.delete("Email Queue")
+		frappe.db.delete("Unhandled Email")
 
 	def get_test_mail(self, fname):
 		with open(os.path.join(os.path.dirname(__file__), "test_mails", fname), "r") as f:
@@ -60,7 +60,7 @@ class TestEmailAccount(unittest.TestCase):
 		comm = frappe.get_doc("Communication", {"sender": "test_sender@example.com"})
 		comm.db_set("creation", datetime.now() - timedelta(seconds = 30 * 60))
 
-		frappe.db.sql("DELETE FROM `tabEmail Queue`")
+		frappe.db.delete("Email Queue")
 		notify_unreplied()
 		self.assertTrue(frappe.db.get_value("Email Queue", {"reference_doctype": comm.reference_doctype,
 			"reference_name": comm.reference_name, "status":"Not Sent"}))
@@ -183,7 +183,7 @@ class TestEmailAccount(unittest.TestCase):
 
 	def test_threading_by_message_id(self):
 		cleanup()
-		frappe.db.sql("""delete from `tabEmail Queue`""")
+		frappe.db.delete("Email Queue")
 
 		# reference document for testing
 		event = frappe.get_doc(dict(doctype='Event', subject='test-message')).insert()
@@ -242,8 +242,8 @@ class TestInboundMail(unittest.TestCase):
 
 	def setUp(self):
 		cleanup()
-		frappe.db.sql('delete from `tabEmail Queue`')
-		frappe.db.sql('delete from `tabToDo`')
+		frappe.db.delete("Email Queue")
+		frappe.db.delete("ToDo")
 
 	def get_test_mail(self, fname):
 		with open(os.path.join(os.path.dirname(__file__), "test_mails", fname), "r") as f:

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -9,7 +9,7 @@ test_dependencies = ["User", "Notification"]
 
 class TestNotification(unittest.TestCase):
 	def setUp(self):
-		frappe.db.sql("""delete from `tabEmail Queue`""")
+		frappe.db.delete("Email Queue")
 		frappe.set_user("test@example.com")
 
 		if not frappe.db.exists('Notification', {'name': 'ToDo Status Update'}, 'name'):
@@ -50,7 +50,7 @@ class TestNotification(unittest.TestCase):
 
 		self.assertTrue(frappe.db.get_value("Email Queue", {"reference_doctype": "Communication",
 			"reference_name": communication.name, "status":"Not Sent"}))
-		frappe.db.sql("""delete from `tabEmail Queue`""")
+		frappe.db.delete("Email Queue")
 
 		communication.reload()
 		communication.content = "test 2"
@@ -189,9 +189,9 @@ class TestNotification(unittest.TestCase):
 
 	def test_cc_jinja(self):
 
-		frappe.db.sql("""delete from `tabUser` where email='test_jinja@example.com'""")
-		frappe.db.sql("""delete from `tabEmail Queue`""")
-		frappe.db.sql("""delete from `tabEmail Queue Recipient`""")
+		frappe.db.delete("User", {"email": "test_jinja@example.com"})
+		frappe.db.delete("Email Queue")
+		frappe.db.delete("Email Queue Recipient")
 
 		test_user = frappe.new_doc("User")
 		test_user.name = 'test_jinja'
@@ -205,9 +205,9 @@ class TestNotification(unittest.TestCase):
 
 		self.assertTrue(frappe.db.get_value("Email Queue Recipient", {"recipient": "test_jinja@example.com"}))
 
-		frappe.db.sql("""delete from `tabUser` where email='test_jinja@example.com'""")
-		frappe.db.sql("""delete from `tabEmail Queue`""")
-		frappe.db.sql("""delete from `tabEmail Queue Recipient`""")
+		frappe.db.delete("User", {"email": "test_jinja@example.com"})
+		frappe.db.delete("Email Queue")
+		frappe.db.delete("Email Queue Recipient")
 
 	def test_notification_to_assignee(self):
 		todo = frappe.new_doc('ToDo')

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -11,9 +11,9 @@ class TestWebhook(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
 		# delete any existing webhooks
-		frappe.db.sql("DELETE FROM tabWebhook")
+		frappe.db.delete("Webhook")
 		# Delete existing logs if any
-		frappe.db.sql("DELETE FROM `tabWebhook Request Log`")
+		frappe.db.delete("Webhook Request Log")
 		# create test webhooks
 		cls.create_sample_webhooks()
 
@@ -46,7 +46,7 @@ class TestWebhook(unittest.TestCase):
 	@classmethod
 	def tearDownClass(cls):
 		# delete any existing webhooks
-		frappe.db.sql("DELETE FROM tabWebhook")
+		frappe.db.delete("Webhook")
 
 	def setUp(self):
 		# retrieve or create a User webhook for `after_insert`
@@ -168,7 +168,7 @@ class TestWebhook(unittest.TestCase):
 	def test_webhook_req_log_creation(self):
 		if not frappe.db.get_value('User', 'user2@integration.webhooks.test.com'):
 			user = frappe.get_doc({
-				'doctype': 'User', 
+				'doctype': 'User',
 				'email': 'user2@integration.webhooks.test.com',
 				'first_name': 'user2'
 			}).insert()

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -190,7 +190,7 @@ def delete_from_table(doctype, name, ignore_doctypes, doc):
 	# delete from child tables
 	for t in list(set(tables)):
 		if t not in ignore_doctypes:
-			frappe.db.sql("delete from `tab%s` where parenttype=%s and parent = %s" % (t, '%s', '%s'), (doctype, name))
+			frappe.db.delete(t, {"parenttype": doctype, "parent": name})
 
 def update_flags(doc, flags=None, ignore_permissions=False):
 	if ignore_permissions:
@@ -323,9 +323,10 @@ def delete_dynamic_links(doctype, name):
 
 def delete_references(doctype, reference_doctype, reference_name,
 		reference_doctype_field = 'reference_doctype', reference_name_field = 'reference_name'):
-	frappe.db.sql('''delete from `tab{0}`
-		where {1}=%s and {2}=%s'''.format(doctype, reference_doctype_field, reference_name_field), # nosec
-		(reference_doctype, reference_name))
+	frappe.db.delete(doctype, {
+		reference_doctype_field: reference_doctype,
+		reference_name_field: reference_name
+	})
 
 def clear_references(doctype, reference_doctype, reference_name,
 		reference_doctype_field = 'reference_doctype', reference_name_field = 'reference_name'):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -385,8 +385,7 @@ class Document(BaseDocument):
 					[self.name, self.doctype, fieldname] + rows)
 			if len(deleted_rows) > 0:
 				# delete rows that do not match the ones in the document
-				frappe.db.sql("""delete from `tab{0}` where name in ({1})""".format(df.options,
-					','.join(['%s'] * len(deleted_rows))), tuple(row[0] for row in deleted_rows))
+				frappe.db.delete(df.options, {"name": ("in", tuple(row[0] for row in deleted_rows))})
 
 		else:
 			# no rows found, delete all rows

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -114,8 +114,7 @@ def sync_customizations_for_doctype(data, folder):
 					doc.db_insert()
 
 			if custom_doctype != 'Custom Field':
-				frappe.db.sql('delete from `tab{0}` where `{1}` =%s'.format(
-					custom_doctype, doctype_fieldname), doc_type)
+				frappe.db.delete(custom_doctype, {doctype_fieldname: doc_type})
 
 				for d in data[key]:
 					_insert(d)

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -13,8 +13,8 @@ class TestEnergyPointLog(unittest.TestCase):
 
 	def tearDown(self):
 		frappe.set_user('Administrator')
-		frappe.db.sql('DELETE FROM `tabEnergy Point Log`')
-		frappe.db.sql('DELETE FROM `tabEnergy Point Rule`')
+		frappe.db.delete("Energy Point Log")
+		frappe.db.delete("Energy Point Rule")
 		frappe.cache().delete_value('energy_point_rule_map')
 
 	def test_user_energy_point(self):

--- a/frappe/tests/test_assign.py
+++ b/frappe/tests/test_assign.py
@@ -22,7 +22,7 @@ class TestAssign(unittest.TestCase):
 		self.assertEqual(len(assignments), 0)
 
 	def test_assignment_count(self):
-		frappe.db.sql('delete from tabToDo')
+		frappe.db.delete("ToDo")
 
 		if not frappe.db.exists("User", "test_assign1@example.com"):
 			frappe.get_doc({"doctype":"User", "email":"test_assign1@example.com", "first_name":"Test", "roles": [{"role": "System Manager"}]}).insert()

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -105,7 +105,7 @@ class TestReportview(unittest.TestCase):
 
 	def test_between_filters(self):
 		""" test case to check between filter for date fields """
-		frappe.db.sql("delete from tabEvent")
+		frappe.db.delete("Event")
 
 		# create events to test the between operator filter
 		todays_event = create_event()

--- a/frappe/tests/test_domainification.py
+++ b/frappe/tests/test_domainification.py
@@ -17,9 +17,9 @@ class TestDomainification(unittest.TestCase):
 		self.add_active_domain("_Test Domain 1")
 
 	def tearDown(self):
-		frappe.db.sql("delete from tabRole where name='_Test Role'")
-		frappe.db.sql("delete from `tabHas Role` where role='_Test Role'")
-		frappe.db.sql("delete from tabDomain where name in ('_Test Domain 1', '_Test Domain 2')")
+		frappe.db.delete("Role", {"name": "_Test Role"})
+		frappe.db.delete("Has Role", {"role": "_Test Role"})
+		frappe.db.delete("Domain", {"name": ("in", ("_Test Domain 1", "_Test Domain 2"))})
 		frappe.delete_doc('DocType', 'Test Domainification')
 		self.remove_from_active_domains(remove_all=True)
 

--- a/frappe/tests/test_dynamic_links.py
+++ b/frappe/tests/test_dynamic_links.py
@@ -4,7 +4,7 @@ import frappe, unittest
 
 class TestDynamicLinks(unittest.TestCase):
 	def setUp(self):
-		frappe.db.sql('delete from `tabEmail Unsubscribe`')
+		frappe.db.delete("Email Unsubscribe")
 
 	def test_delete_normal(self):
 		event = frappe.get_doc({

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -7,9 +7,9 @@ test_dependencies = ['Email Account']
 
 class TestEmail(unittest.TestCase):
 	def setUp(self):
-		frappe.db.sql("""delete from `tabEmail Unsubscribe`""")
-		frappe.db.sql("""delete from `tabEmail Queue`""")
-		frappe.db.sql("""delete from `tabEmail Queue Recipient`""")
+		frappe.db.delete("Email Unsubscribe")
+		frappe.db.delete("Email Queue")
+		frappe.db.delete("Email Queue Recipient")
 
 	def test_email_queue(self, send_after=None):
 		frappe.sendmail(recipients=['test@example.com', 'test1@example.com'],
@@ -170,7 +170,7 @@ class TestEmail(unittest.TestCase):
 		import re
 		email_account = frappe.get_doc('Email Account', '_Test Email Account 1')
 
-		frappe.db.sql('''delete from `tabCommunication` where sender = 'sukh@yyy.com' ''')
+		frappe.db.delete("Communication", {"sender": "sukh@yyy.com"})
 
 		with open(frappe.get_app_path('frappe', 'tests', 'data', 'email_with_image.txt'), 'r') as raw:
 			mails = email_account.get_inbound_mails(test_mails=[raw.read()])

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -82,7 +82,7 @@ class TestFrappeClient(unittest.TestCase):
 
 	def test_update_doc(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.delete("Note", {"title": ("in" ("Sing", "sing"))})
+		frappe.db.delete("Note", {"title": ("in", ("Sing", "sing"))})
 		frappe.db.commit()
 
 		server.insert({"doctype":"Note", "public": True, "title": "Sing"})

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -12,7 +12,7 @@ import base64
 class TestFrappeClient(unittest.TestCase):
 	def test_insert_many(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabNote` where title in ('Sing','a','song','of','sixpence')")
+		frappe.db.delete("Note", {"title": ("in", ('Sing','a','song','of','sixpence'))})
 		frappe.db.commit()
 
 		server.insert_many([
@@ -31,7 +31,7 @@ class TestFrappeClient(unittest.TestCase):
 
 	def test_create_doc(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabNote` where title = 'test_create'")
+		frappe.db.delete("Note", {"title": "test_create"})
 		frappe.db.commit()
 
 		server.insert({"doctype": "Note", "public": True, "title": "test_create"})
@@ -46,7 +46,7 @@ class TestFrappeClient(unittest.TestCase):
 
 	def test_get_doc(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabNote` where title = 'get_this'")
+		frappe.db.delete("Note", {"title": "get_this"})
 		frappe.db.commit()
 
 		server.insert_many([
@@ -57,7 +57,7 @@ class TestFrappeClient(unittest.TestCase):
 
 	def test_get_value(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabNote` where title = 'get_value'")
+		frappe.db.delete("Note", {"title": "get_value"})
 		frappe.db.commit()
 
 		test_content = "test get value"
@@ -82,7 +82,7 @@ class TestFrappeClient(unittest.TestCase):
 
 	def test_update_doc(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabNote` where title in ('Sing','sing')")
+		frappe.db.delete("Note", {"title": ("in" ("Sing", "sing"))})
 		frappe.db.commit()
 
 		server.insert({"doctype":"Note", "public": True, "title": "Sing"})
@@ -94,12 +94,12 @@ class TestFrappeClient(unittest.TestCase):
 
 	def test_update_child_doc(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabContact` where first_name = 'George' and last_name = 'Steevens'")
-		frappe.db.sql("delete from `tabContact` where first_name = 'William' and last_name = 'Shakespeare'")
-		frappe.db.sql("delete from `tabCommunication` where reference_doctype = 'Event'")
-		frappe.db.sql("delete from `tabCommunication Link` where link_doctype = 'Contact'")
-		frappe.db.sql("delete from `tabEvent` where subject = 'Sing a song of sixpence'")
-		frappe.db.sql("delete from `tabEvent Participants` where reference_doctype = 'Contact'")
+		frappe.db.delete("Contact", {"first_name": "George", "last_name": "Steevens"})
+		frappe.db.delete("Contact", {"first_name": "William", "last_name": "Shakespeare"})
+		frappe.db.delete("Communication", {"reference_doctype": "Event"})
+		frappe.db.delete("Communication Link", {"link_doctype": "Contact"})
+		frappe.db.delete("Event", {"subject": "Sing a song of sixpence"})
+		frappe.db.delete("Event Participants", {"reference_doctype": "Contact"})
 		frappe.db.commit()
 
 		# create multiple contacts
@@ -131,7 +131,7 @@ class TestFrappeClient(unittest.TestCase):
 
 	def test_delete_doc(self):
 		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
-		frappe.db.sql("delete from `tabNote` where title = 'delete'")
+		frappe.db.delete("Note", {"title": "delete"})
 		frappe.db.commit()
 
 		server.insert_many([

--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -24,15 +24,15 @@ class TestGlobalSearch(unittest.TestCase):
 		make_property_setter(doctype, "repeat_on", "in_global_search", 0, "Int")
 
 	def tearDown(self):
-		frappe.db.sql("DELETE FROM `tabProperty Setter` WHERE `doc_type`='Event'")
+		frappe.db.delete("Property Setter", {"doc_type": "Event"})
 		frappe.clear_cache(doctype='Event')
-		frappe.db.sql('DELETE FROM `tabEvent`')
-		frappe.db.sql('DELETE FROM `__global_search`')
+		frappe.db.delete("Event")
+		frappe.db.delete("__global_search")
 		make_test_objects('Event')
 		frappe.db.commit()
 
 	def insert_test_events(self):
-		frappe.db.sql('DELETE FROM `tabEvent`')
+		frappe.db.delete("Event")
 		phrases = ['"The Sixth Extinction II: Amor Fati" is the second episode of the seventh season of the American science fiction.',
 		'After Mulder awakens from his coma, he realizes his duty to prevent alien colonization. ',
 		'Carter explored themes of extraterrestrial involvement in ancient mass extinctions in this episode, the third in a trilogy.']
@@ -97,7 +97,7 @@ class TestGlobalSearch(unittest.TestCase):
 		self.assertEqual(len(results), 0)
 
 	def test_insert_child_table(self):
-		frappe.db.sql('delete from tabEvent')
+		frappe.db.delete("Event")
 		phrases = ['Hydrus is a small constellation in the deep southern sky. ',
 		'It was first depicted on a celestial atlas by Johann Bayer in his 1603 Uranometria. ',
 		'The French explorer and astronomer Nicolas Louis de Lacaille charted the brighter stars and gave their Bayer designations in 1756. ',

--- a/frappe/tests/test_goal.py
+++ b/frappe/tests/test_goal.py
@@ -13,7 +13,7 @@ class TestGoal(unittest.TestCase):
 		make_test_objects('Event', reset=True)
 
 	def tearDown(self):
-		frappe.db.sql('delete from `tabEvent`')
+		frappe.db.delete("Event")
 		# make_test_objects('Event', reset=True)
 		frappe.db.commit()
 

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -72,7 +72,7 @@ class TestNaming(unittest.TestCase):
 		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
 		self.assertEqual(current_index.get('current'), 0)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+		frappe.db.delete("Series", {"name": series})
 
 		series = 'TEST-{}-'.format(year)
 		key = 'TEST-.YYYY.-.#####'
@@ -82,40 +82,40 @@ class TestNaming(unittest.TestCase):
 		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
 		self.assertEqual(current_index.get('current'), 1)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+		frappe.db.delete("Series", {"name": series})
 
 		series = 'TEST-'
 		key = 'TEST-'
 		name = 'TEST-00003'
-		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
+		frappe.db.delete("Series", {"name": series})
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)
 		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
 		self.assertEqual(current_index.get('current'), 2)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+		frappe.db.delete("Series", {"name": series})
 
 		series = 'TEST1-'
 		key = 'TEST1-.#####.-2021-22'
 		name = 'TEST1-00003-2021-22'
-		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
+		frappe.db.delete("Series", {"name": series})
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)
 		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
 		self.assertEqual(current_index.get('current'), 2)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+		frappe.db.delete("Series", {"name": series})
 
 		series = ''
 		key = '.#####.-2021-22'
 		name = '00003-2021-22'
-		frappe.db.sql("DELETE FROM `tabSeries` WHERE `name`=%s", series)
+		frappe.db.delete("Series", {"name": series})
 		frappe.db.sql("""INSERT INTO `tabSeries` (name, current) values (%s, 3)""", (series,))
 		revert_series_if_last(key, name)
 		current_index = frappe.db.sql("""SELECT current from `tabSeries` where name = %s""", series, as_dict=True)[0]
 
 		self.assertEqual(current_index.get('current'), 2)
-		frappe.db.sql("""delete from `tabSeries` where name = %s""", series)
+		frappe.db.delete("Series", {"name": series})
 
 	def test_naming_for_cancelled_and_amended_doc(self):
 		submittable_doctype = frappe.get_doc({

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -38,7 +38,7 @@ class TestPermissions(unittest.TestCase):
 		reset('Blogger')
 		reset('Blog Post')
 
-		frappe.db.sql('delete from `tabUser Permission`')
+		frappe.db.delete("User Permission")
 
 		frappe.set_user("test1@example.com")
 
@@ -334,9 +334,9 @@ class TestPermissions(unittest.TestCase):
 			doctype"""
 
 		frappe.set_user('Administrator')
-		frappe.db.sql('DELETE FROM `tabContact`')
-		frappe.db.sql('DELETE FROM `tabContact Email`')
-		frappe.db.sql('DELETE FROM `tabContact Phone`')
+		frappe.db.delete("Contact")
+		frappe.db.delete("Contact Email")
+		frappe.db.delete("Contact Phone")
 
 		reset('Salutation')
 		reset('Contact')

--- a/frappe/tests/test_scheduler.py
+++ b/frappe/tests/test_scheduler.py
@@ -45,7 +45,7 @@ class TestScheduler(TestCase):
 
 		# 1st job is in the queue (or running), don't enqueue it again
 		self.assertFalse(job.enqueue())
-		frappe.db.sql('DELETE FROM `tabScheduled Job Log` WHERE `scheduled_job_type`=%s', job.name)
+		frappe.db.delete("Scheduled Job Log", {"scheduled_job_type": job.name})
 
 	def test_is_dormant(self):
 		self.assertTrue(is_dormant(check_time= get_datetime('2100-01-01 00:00:00')))

--- a/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
+++ b/frappe/website/doctype/personal_data_download_request/test_personal_data_download_request.py
@@ -13,7 +13,7 @@ class TestRequestPersonalData(unittest.TestCase):
 		create_user_if_not_exists(email='test_privacy@example.com')
 
 	def tearDown(self):
-		frappe.db.sql("""DELETE FROM `tabPersonal Data Download Request`""")
+		frappe.db.delete("Personal Data Download Request")
 
 	def test_user_data_creation(self):
 		user_data = json.loads(get_user_data('test_privacy@example.com'))
@@ -45,7 +45,7 @@ class TestRequestPersonalData(unittest.TestCase):
 			limit=1)
 		self.assertTrue("Subject: Download Your Data" in email_queue[0].message)
 
-		frappe.db.sql("delete from `tabEmail Queue`")
+		frappe.db.delete("Email Queue")
 
 def create_user_if_not_exists(email, first_name = None):
 	frappe.delete_doc_if_exists("User", email)

--- a/frappe/website/doctype/web_page/test_web_page.py
+++ b/frappe/website/doctype/web_page/test_web_page.py
@@ -8,7 +8,7 @@ test_records = frappe.get_test_records('Web Page')
 
 class TestWebPage(unittest.TestCase):
 	def setUp(self):
-		frappe.db.sql("delete from `tabWeb Page`")
+		frappe.db.delete("Web Page")
 		for t in test_records:
 			frappe.get_doc(t).insert()
 

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -76,7 +76,7 @@ class TestWorkflow(unittest.TestCase):
 		self.assertListEqual(actions, ['Review'])
 
 	def test_if_workflow_actions_were_processed(self):
-		frappe.db.sql('delete from `tabWorkflow Action`')
+		frappe.db.delete("Workflow Action")
 		user = frappe.get_doc('User', 'test2@example.com')
 		user.add_roles('Test Approver', 'System Manager')
 		frappe.set_user('test2@example.com')


### PR DESCRIPTION
Just replaced whatever `DELETE FROM` queries I could to use `frappe.db.delete` throughout Frappe. Converted some 90 queries. ~430 instances of `frappe.db.sql*` to go 🌝 

### Before

![Screenshot 2021-08-19 at 7 57 48 PM](https://user-images.githubusercontent.com/36654812/130086606-204fdb63-ba3b-4e00-ab8d-ebfea0a31e0c.png)

### After

![Screenshot 2021-08-19 at 7 57 02 PM](https://user-images.githubusercontent.com/36654812/130086596-54613988-85d4-482a-9495-d175e7b84c07.png)

---

`test_fetch_if_empty`: So, an old test wasn't running, and was broken...so fixed that