### PR TITLE
fix: Only select active numeric field after layout refresh

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -163,7 +163,7 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 			}
 		};
 		this.$input.on("change", change_handler);
-		if (this.constructor.trigger_change_on_input_event) {
+		if (this.constructor.trigger_change_on_input_event && !this.in_grid()) {
 			// debounce to avoid repeated validations on value change
 			this.$input.on("input", frappe.utils.debounce(change_handler, 500));
 		}
@@ -266,5 +266,8 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 	toggle_container_scroll(el_class, scroll_class, add=false) {
 		let el = this.$input.parents(el_class)[0];
 		if (el) $(el).toggleClass(scroll_class, add);
+	}
+	in_grid() {
+		return this.grid || this.layout && this.layout.grid;
 	}
 };

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -38,7 +38,7 @@ export default class Grid {
 
 		this.is_grid = true;
 		this.debounced_refresh = this.refresh.bind(this);
-		this.debounced_refresh = frappe.utils.debounce(this.debounced_refresh, 500);
+		this.debounced_refresh = frappe.utils.debounce(this.debounced_refresh, 100);
 	}
 
 	allow_on_grid_editing() {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -260,7 +260,7 @@ frappe.ui.form.Layout = class Layout {
 
 	is_numeric_field_active() {
 		const control = $(document.activeElement).closest(".frappe-control");
-		const fieldtype = control.data().fieldtype;
+		const fieldtype = (control.data() || {}).fieldtype;
 		return frappe.model.numeric_fieldtypes.includes(fieldtype);
 	}
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -259,9 +259,9 @@ frappe.ui.form.Layout = class Layout {
 	}
 
 	is_numeric_field_active() {
-		const control = $(document.activeElement).closest(".frappe-control")
+		const control = $(document.activeElement).closest(".frappe-control");
 		const fieldtype = control.data().fieldtype;
-		return frappe.model.numeric_fieldtypes.includes(fieldtype)
+		return frappe.model.numeric_fieldtypes.includes(fieldtype);
 	}
 
 	refresh_sections() {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -252,12 +252,16 @@ frappe.ui.form.Layout = class Layout {
 		}
 
 		if (document.activeElement) {
-			document.activeElement.focus();
-	
-			if (document.activeElement.tagName == 'INPUT') {
+			if (document.activeElement.tagName == 'INPUT' && this.is_numeric_field_active()) {
 				document.activeElement.select();
 			}
 		}
+	}
+
+	is_numeric_field_active() {
+		const control = $(document.activeElement).closest(".frappe-control")
+		const fieldtype = control.data().fieldtype;
+		return frappe.model.numeric_fieldtypes.includes(fieldtype)
 	}
 
 	refresh_sections() {


### PR DESCRIPTION
- Only select active numeric field after layout refresh
- Avoid input events for controls in the grid
- Reduce grid refresh debounce delay

---

This PR tries to resolve the following issue while entering data in the grid input.

https://user-images.githubusercontent.com/13928957/130171645-312978f2-4e5f-46d4-b390-98f4a4ce3178.mov

**After fix**

https://user-images.githubusercontent.com/13928957/130180731-217efeed-c579-4893-b34c-69c4bcb1b5f7.mov


Continuation of following PRs:
https://github.com/frappe/frappe/pull/13828
https://github.com/frappe/frappe/pull/13926
https://github.com/frappe/frappe/pull/13939