### PR TITLE
fix: Footer overlapping with total row for query and script reports

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -95,7 +95,7 @@
 		height: calc(100vh - var(--report-filter-height) - 205px);
 
 		.dt-scrollable {
-			height: calc(100vh - var(--report-filter-height) - 275px);
+			height: calc(100vh - var(--report-filter-height) - 310px);
 		}
 	}
 }


### PR DESCRIPTION
Before:
<img width="1332" alt="Screenshot 2021-08-20 at 11 20 07 AM" src="https://user-images.githubusercontent.com/42651287/130186075-da195d3a-c1a1-4e8e-888c-93d7799d7234.png">

After:
<img width="1302" alt="Screenshot 2021-08-20 at 11 19 13 AM" src="https://user-images.githubusercontent.com/42651287/130186111-237eb4a1-a2e2-48a8-be14-c0e19e71cd4f.png">
