### PR TITLE
chore: Drop deprecated option in command

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -691,16 +691,10 @@ def make_app(destination, app_name):
 @click.argument('value')
 @click.option('-g', '--global', 'global_', is_flag=True, default=False, help='Set value in bench config')
 @click.option('-p', '--parse', is_flag=True, default=False, help='Evaluate as Python Object')
-@click.option('--as-dict', is_flag=True, default=False, help='Legacy: Evaluate as Python Object')
 @pass_context
-def set_config(context, key, value, global_=False, parse=False, as_dict=False):
+def set_config(context, key, value, global_=False, parse=False):
 	"Insert/Update a value in site_config.json"
 	from frappe.installer import update_site_config
-
-	if as_dict:
-		from frappe.utils.commands import warn
-		warn("--as-dict will be deprecated in v14. Use --parse instead", category=PendingDeprecationWarning)
-		parse = as_dict
 
 	if parse:
 		import ast
@@ -710,6 +704,7 @@ def set_config(context, key, value, global_=False, parse=False, as_dict=False):
 		sites_path = os.getcwd()
 		common_site_config_path = os.path.join(sites_path, 'common_site_config.json')
 		update_site_config(key, value, validate=False, site_config_path=common_site_config_path)
+
 	else:
 		for site in context.sites:
 			frappe.init(site=site)


### PR DESCRIPTION
Remove deprecated `--as-dict` from `bench set-config`
Should using this option return a `DeprecationWarning` instead?

Only to be dropped from develop/version-14