### PR TITLE
refactor: Implementing frappe.qb

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -79,7 +79,7 @@ class Database(object):
 		pass
 
 	def sql(self, query, values=(), as_dict = 0, as_list = 0, formatted = 0,
-		debug=0, ignore_ddl=0, as_utf8=0, auto_commit=0, update=None, explain=False):
+		debug=0, ignore_ddl=0, as_utf8=0, auto_commit=0, update=None, explain=False, return_query=False):
 		"""Execute a SQL query and fetch all rows.
 
 		:param query: SQL query.
@@ -92,7 +92,7 @@ class Database(object):
 		:param as_utf8: Encode values as UTF 8.
 		:param auto_commit: Commit after executing the query.
 		:param update: Update this dict to all rows (if returned `as_dict`).
-
+		:param return_query: Returns query with out executing it.
 		Examples:
 
 			# return customer names as dicts
@@ -107,6 +107,8 @@ class Database(object):
 
 		"""
 		query = str(query)
+		if return_query:
+			return query
 		if re.search(r'ifnull\(', query, flags=re.IGNORECASE):
 			# replaces ifnull in query with coalesce
 			query = re.sub(r'ifnull\(', 'coalesce(', query, flags=re.IGNORECASE)
@@ -426,9 +428,8 @@ class Database(object):
 			(doctype, filters, fieldname) in self.value_cache:
 			return self.value_cache[(doctype, filters, fieldname)]
 
-		if not order_by: order_by = 'modified desc'
-
 		if isinstance(filters, list):
+			if not order_by: order_by = 'modified desc'
 			out = self._get_value_for_many_names(doctype, filters, fieldname, debug=debug)
 
 		else:
@@ -441,6 +442,7 @@ class Database(object):
 
 			if (filters is not None) and (filters!=doctype or doctype=="DocType"):
 				try:
+					if not order_by: order_by = 'modified'
 					out = self._get_values_from_table(fields, filters, doctype, as_dict, debug, order_by, update, for_update=for_update)
 				except Exception as e:
 					if ignore and (frappe.db.is_missing_column(e) or frappe.db.is_table_missing(e)):
@@ -570,32 +572,14 @@ class Database(object):
 		return self.get_single_value(*args, **kwargs)
 
 	def _get_values_from_table(self, fields, filters, doctype, as_dict, debug, order_by=None, update=None, for_update=False):
-		fl = []
 		if isinstance(fields, (list, tuple)):
-			for f in fields:
-				if "(" in f or " as " in f: # function
-					fl.append(f)
-				else:
-					fl.append("`" + f + "`")
-			fl = ", ".join(fl)
+			query = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by).select(*fields)
 		else:
-			fl = fields
 			if fields=="*":
+				query = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by).select(fields)
 				as_dict = True
-
-		conditions, values = self.build_conditions(filters)
-
-		order_by = ("order by " + order_by) if order_by else ""
-
-		r = self.sql("select {fields} from `tab{doctype}` {where} {conditions} {order_by} {for_update}"
-			.format(
-				for_update = 'for update' if for_update else '',
-				fields = fl,
-				doctype = doctype,
-				where = "where" if conditions else "",
-				conditions = conditions,
-				order_by = order_by),
-			values, as_dict=as_dict, debug=debug, update=update)
+		print(query)
+		r = self.sql(query, as_dict=as_dict, debug=debug, update=update)
 
 		return r
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -515,8 +515,7 @@ class Database(object):
 			# Get coulmn and value of the single doctype Accounts Settings
 			account_settings = frappe.db.get_singles_dict("Accounts Settings")
 		"""
-		query = frappe.qb.from_("Singles").select("field", "value") \
-			.where(frappe.qb.Field("doctype") == doctype)
+		query = self.query.build_conditions("Singles", filters={"doctype": doctype}).select("field", "value")
 		result = self.sql(query, debug=debug)
 		# result = _cast_result(doctype, result)
 
@@ -550,8 +549,8 @@ class Database(object):
 		if fieldname in self.value_cache[doctype]:
 			return self.value_cache[doctype][fieldname]
 
-		val = self.sql("""select `value` from
-			`tabSingles` where `doctype`=%s and `field`=%s""", (doctype, fieldname))
+		query = self.query.build_conditions("Singles", filters={"doctype": doctype, "field": fieldname}).select("value")
+		val = self.sql(query)
 		val = val[0][0] if val else None
 
 		df = frappe.get_meta(doctype).get_field(fieldname)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -571,14 +571,10 @@ class Database(object):
 
 	def _get_values_from_table(self, fields, filters, doctype, as_dict, debug, order_by=None, update=None, for_update=False):
 		if isinstance(fields, (list, tuple)):
-			query = str(self.query.build_conditions(table=doctype, filters=filters, orderby=order_by).select(*fields))
-			if for_update:
-				query += " FOR UPDATE"
+			query = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by, for_update=for_update).select(*fields)
 		else:
 			if fields=="*":
-				query = str(self.query.build_conditions(table=doctype, filters=filters, orderby=order_by).select(fields))
-				if for_update:
-					query += " FOR UPDATE"
+				query = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by, for_update=for_update).select(fields)
 				as_dict = True
 		r = self.sql(query, as_dict=as_dict, debug=debug, update=update)
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -946,11 +946,6 @@ class Database(object):
 		query = self.query.build_conditions(table=doctype, filters=filters).delete()
 		if "debug" not in kwargs:
 			kwargs["debug"] = debug
-
-		if filters:
-			conditions, values = self.build_conditions(filters)
-			query = f"{query} WHERE {conditions}"
-
 		return self.sql(query, values, **kwargs)
 
 	def truncate(self, doctype: str):
@@ -959,7 +954,7 @@ class Database(object):
 
 		Doctype name can be passed directly, it will be pre-pended with `tab`.
 		"""
-		table = doctype if doctype.startswith("__") else f"tab{doctype}"
+		table = get_table_name(doctype)
 		return self.sql_ddl(f"truncate `{table}`")
 
 	def clear_table(self, doctype):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -16,6 +16,7 @@ from frappe import _
 from time import time
 from frappe.utils import now, getdate, cast_fieldtype, get_datetime, get_table_name
 from frappe.model.utils.link_count import flush_local_link_count
+from .query import Query
 
 
 class Database(object):
@@ -55,6 +56,7 @@ class Database(object):
 
 		self.password = password or frappe.conf.db_password
 		self.value_cache = {}
+		self.query = Query()
 
 	def setup_type_map(self):
 		pass
@@ -961,9 +963,7 @@ class Database(object):
 		"""
 		values = ()
 		filters = filters or kwargs.get("conditions")
-		table = get_table_name(doctype)
-		query = f"DELETE FROM `{table}`"
-
+		query = self.query.build_conditions(table=doctype, filters=filters).delete()
 		if "debug" not in kwargs:
 			kwargs["debug"] = debug
 

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -142,7 +142,7 @@ class Query:
 				conditions = conditions.where(_operator(frappe.qb.Field(key), value))
 		if orderby:
 			order = order if order else Order.desc
-			return conditions.orderby(orderby, order)
+			return conditions.orderby(orderby, order=order)
 		return conditions
 
 	def build_conditions(self, table: str, filters: Union[Dict[str, Union[str, int]], str, int] = None,

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1,6 +1,7 @@
-from typing import Tuple, Union, List, Any
-import frappe
 import operator
+from typing import Any, Dict, List, Tuple, Union
+
+import frappe
 
 
 class Query:
@@ -25,7 +26,7 @@ class Query:
 		self.sql_functions = ["sum", "now", "interval"]
 
 	@staticmethod
-	def like(key: str, value: Any):
+	def like(key: str, value: str) -> frappe.qb:
 		"""Wrapper method for `LIKE`
 
 		Args:
@@ -33,61 +34,127 @@ class Query:
 			value (ANy): criterion
 
 		Returns:
-			[frappe.qb]: frappe.qb object with `LIKE`
+			frappe.qb: `frappe.qb object with `LIKE`
 		"""
 		return frappe.qb.Field(key).like(value)
 
 	@staticmethod
-	def func_in(key, value):
+	def func_in(key: str, value: Union[List, Tuple]) -> frappe.qb:
+		"""Wrapper method for `IN`
+
+		Args:
+			key (str): field
+			value (ANy): criterion
+
+		Returns:
+			frappe.qb: `frappe.qb object with `IN`
+		"""
 		return frappe.qb.Field(key).isin(value)
 
 	@staticmethod
-	def not_like(key, value):
+	def not_like(key: str, value: str) -> frappe.qb:
+		"""Wrapper method for `NOT LIKE`
+
+		Args:
+			key (str): field
+			value (ANy): criterion
+
+		Returns:
+			frappe.qb: `frappe.qb object with `NOT LIKE`
+		"""
 		return frappe.qb.Field(key).not_like(value)
 
 	@staticmethod
-	def func_not_in(key, value):
+	def func_not_in(key: str, value: Union[List, Tuple]):
+		"""Wrapper method for `NOT IN`
+
+		Args:
+			key (str): field
+			value (ANy): criterion
+
+		Returns:
+			frappe.qb: `frappe.qb object with `NOT IN`
+		"""
 		return frappe.qb.Field(key).notin(value)
 
 	@staticmethod
-	def func_regex(key, value):
+	def func_regex(key: str, value: str) -> frappe.qb:
+		"""Wrapper method for `REGEX`
+
+		Args:
+			key (str): field
+			value (ANy): criterion
+
+		Returns:
+			frappe.qb: `frappe.qb object with `REGEX`
+		"""
 		return frappe.qb.Field(key).regex(value)
 
 	@staticmethod
-	def func_between(key, value):
+	def func_between(key: str, value: Union[List, Tuple]) -> frappe.qb:
+		"""Wrapper method for `BETWEEN`
+
+		Args:
+			key (str): field
+			value (ANy): criterion
+
+		Returns:
+			frappe.qb: `frappe.qb object with `BETWEEN`
+		"""
 		return frappe.qb.Field(key)[slice(*value)]
 
 	@staticmethod
-	def get_func_obj(func: str):
+	def get_func_obj(func: str) -> frappe.qb.functions:
+		"""Wrapper method for generating custom functions
+
+		Args:
+			key (str): field
+			value (ANy): criterion
+
+		Returns:
+			frappe.qb.functions
+		"""
 		return frappe.qb.functions(func)
 
-	def build_conditions(self, filters, table):
-		"""
-		filters = {columns: condition}
-		frappe.qb.from_(table).where(conditions)
-		"""
+	def make_function(self, key: Any, value: Union[int, str]):
+		return self.operator_map[value[0]](key, value[1])
 
-		conditions = frappe.qb.from_(table)
+	def dict_query(self, filters: Dict[str, Union[str, int]], table: str):
+			conditions = frappe.qb.from_(table)
+			for key in filters:
+				value = filters.get(key)
+				_operator = self.operator_map["="]
 
-		def _query(key):
-			nonlocal conditions
-			value = filters.get(key)
-			_operator = self.operator_map["="]
-			if isinstance(value, (list, tuple)):
-				if isinstance(value[1], (list, tuple)) or value[0] in list(self.operator_map.keys())[-4:]:
-					_operator = self.operator_map[value[0]]
-					conditions = conditions.where(_operator(key, value[1]))
+				if not isinstance(key, str):
+					conditions = conditions.where(self.make_function(key, value))
+					continue
+				if isinstance(value, (list, tuple)):
+					if isinstance(value[1], (list, tuple)) or value[0] in list(self.operator_map.keys())[-4:]:
+						_operator = self.operator_map[value[0]]
+						conditions = conditions.where(_operator(key, value[1]))
+					else:
+						_operator = self.operator_map[value[0]]
+						conditions = conditions.where(_operator(frappe.qb.Field(key), value[1]))
 				else:
-					_operator = self.operator_map[value[0]]
-					conditions = conditions.where(_operator(frappe.qb.Field(key), value[1]))
-			else:
-				conditions = conditions.where(_operator(frappe.qb.Field(key), value))
+					conditions = conditions.where(_operator(frappe.qb.Field(key), value))
+
+			return conditions
+
+	def build_conditions(self, filters: Union[Dict[str, Union[str, int]], str, int], table: str) -> frappe.qb:
+		"""Build conditions for sql query
+
+		Args:
+			filters (Union[Dict[str, Union[str, int]], str, int]): conditions built from filters provided
+			table (str): DocType
+
+		Returns:
+			frappe.qb: frappe.qb conditions object
+		"""
+		if isinstance(filters, list):
+			pass
 
 		if isinstance(filters, int) or isinstance(filters, str):
 			filters = {"name": str(filters)}
 
-		if filters:
-			for f in filters:
-				_query(f)
-
-		return conditions
+		if filters and isinstance(filters, dict):
+			return self.dict_query(filters, table)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -31,11 +31,11 @@ class Query:
 		"""Wrapper method for `LIKE`
 
 		Args:
-				key (str): field
-				value (ANy): criterion
+			key (str): field
+			value (ANy): criterion
 
 		Returns:
-				frappe.qb: `frappe.qb object with `LIKE`
+			frappe.qb: `frappe.qb object with `LIKE`
 		"""
 		return frappe.qb.Field(key).like(value)
 
@@ -44,11 +44,11 @@ class Query:
 		"""Wrapper method for `IN`
 
 		Args:
-				key (str): field
-				value (ANy): criterion
+			key (str): field
+			value (ANy): criterion
 
 		Returns:
-				frappe.qb: `frappe.qb object with `IN`
+			frappe.qb: `frappe.qb object with `IN`
 		"""
 		return frappe.qb.Field(key).isin(value)
 
@@ -57,11 +57,11 @@ class Query:
 		"""Wrapper method for `NOT LIKE`
 
 		Args:
-				key (str): field
-				value (ANy): criterion
+			key (str): field
+			value (ANy): criterion
 
 		Returns:
-				frappe.qb: `frappe.qb object with `NOT LIKE`
+			frappe.qb: `frappe.qb object with `NOT LIKE`
 		"""
 		return frappe.qb.Field(key).not_like(value)
 
@@ -70,11 +70,11 @@ class Query:
 		"""Wrapper method for `NOT IN`
 
 		Args:
-				key (str): field
-				value (ANy): criterion
+			key (str): field
+			value (ANy): criterion
 
 		Returns:
-				frappe.qb: `frappe.qb object with `NOT IN`
+			frappe.qb: `frappe.qb object with `NOT IN`
 		"""
 		return frappe.qb.Field(key).notin(value)
 
@@ -83,11 +83,11 @@ class Query:
 		"""Wrapper method for `REGEX`
 
 		Args:
-				key (str): field
-				value (ANy): criterion
+			key (str): field
+			value (ANy): criterion
 
 		Returns:
-				frappe.qb: `frappe.qb object with `REGEX`
+			frappe.qb: `frappe.qb object with `REGEX`
 		"""
 		return frappe.qb.Field(key).regex(value)
 
@@ -96,16 +96,42 @@ class Query:
 		"""Wrapper method for `BETWEEN`
 
 		Args:
-				key (str): field
-				value (ANy): criterion
+			key (str): field
+			value (ANy): criterion
 
 		Returns:
-				frappe.qb: `frappe.qb object with `BETWEEN`
+			frappe.qb: `frappe.qb object with `BETWEEN`
 		"""
 		return frappe.qb.Field(key)[slice(*value)]
 
 	def make_function(self, key: Any, value: Union[int, str]):
+		"""returns fucntion query
+
+		Args:
+			key (Any): field
+			value (Union[int, str]): criterion
+
+		Returns:
+			[type]: [description]
+		"""
 		return self.operator_map[value[0]](key, value[1])
+
+	@staticmethod
+	def change_orderby(order: str):
+		"""Convert orderby to standart Order object
+
+		Args:
+			order (str): Field, order
+
+		Returns:
+			tuple: field, order
+		"""
+		order = order.split()
+		if order[1].lower() == "asc":
+			orderby, order = order[0], Order.asc
+			return orderby, order
+		orderby, order = order[0], Order.desc
+		return orderby, order
 
 	def dict_query(self, table: str, filters: Dict[str, Union[str, int]] = None,
 				   orderby:str = None, order:Order = None):
@@ -141,6 +167,9 @@ class Query:
 			else:
 				conditions = conditions.where(_operator(frappe.qb.Field(key), value))
 		if orderby:
+			if isinstance(orderby, str) and len(orderby.split()) > 1:
+				orderby, order = self.change_orderby(orderby)
+
 			order = order if order else Order.desc
 			return conditions.orderby(orderby, order=order)
 		return conditions

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1,6 +1,8 @@
 import operator
 from typing import Any, Dict, List, Tuple, Union
 
+from frappe.query_builder import Order
+
 import frappe
 
 
@@ -105,7 +107,19 @@ class Query:
 	def make_function(self, key: Any, value: Union[int, str]):
 		return self.operator_map[value[0]](key, value[1])
 
-	def dict_query(self, table: str, filters: Dict[str, Union[str, int]]=None):
+	def dict_query(self, table: str, filters: Dict[str, Union[str, int]] = None,
+				   orderby:str = None, order:Order = None):
+		"""Generate condition object using filters
+
+		Args:
+			table (str): DocType
+			filters (Dict[str, Union[str, int]], optional): Conditions. Defaults to None.
+			orderby (str, optional): field to order by. Defaults to None.
+			order (Order, optional): order. Defaults to None.
+
+		Returns:
+			condition: conditions object
+		"""
 		conditions = frappe.qb.from_(table)
 		if not filters:
 			return conditions
@@ -126,10 +140,13 @@ class Query:
 					conditions = conditions.where(_operator(frappe.qb.Field(key), value[1]))
 			else:
 				conditions = conditions.where(_operator(frappe.qb.Field(key), value))
-
+		if orderby:
+			order = order if order else Order.desc
+			return conditions.orderby(orderby, order)
 		return conditions
 
-	def build_conditions(self, table: str, filters: Union[Dict[str, Union[str, int]], str, int]=None) -> frappe.qb:
+	def build_conditions(self, table: str, filters: Union[Dict[str, Union[str, int]], str, int] = None,
+						 orderby: str = None, order: Order = None) -> frappe.qb:
 		"""Build conditions for sql query
 
 		Args:
@@ -142,4 +159,4 @@ class Query:
 		if isinstance(filters, int) or isinstance(filters, str):
 			filters = {"name": str(filters)}
 
-		return self.dict_query(filters=filters, table=table)
+		return self.dict_query(filters=filters, table=table, orderby=orderby, order=order)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -7,34 +7,33 @@ import frappe
 class Query:
 	def __init__(self):
 		self.operator_map = {
-						"+": operator.add,
-						"=": operator.eq,
-						"-": operator.sub,
-						"!=": operator.ne,
-						"<": operator.lt,
-						">": operator.gt,
-						"<=": operator.le,
-						">=": operator.ge,
-						"in": self.func_in,
-						"not in": self.func_not_in,
-						"like": self.like,
-						"not like": self.not_like,
-						"regex": self.func_regex,
-						"between": self.func_between
+			"+": operator.add,
+			"=": operator.eq,
+			"-": operator.sub,
+			"!=": operator.ne,
+			"<": operator.lt,
+			">": operator.gt,
+			"<=": operator.le,
+			">=": operator.ge,
+			"in": self.func_in,
+			"not in": self.func_not_in,
+			"like": self.like,
+			"not like": self.not_like,
+			"regex": self.func_regex,
+			"between": self.func_between
 		}
 
-		self.sql_functions = ["sum", "now", "interval"]
 
 	@staticmethod
 	def like(key: str, value: str) -> frappe.qb:
 		"""Wrapper method for `LIKE`
 
 		Args:
-			key (str): field
-			value (ANy): criterion
+				key (str): field
+				value (ANy): criterion
 
 		Returns:
-			frappe.qb: `frappe.qb object with `LIKE`
+				frappe.qb: `frappe.qb object with `LIKE`
 		"""
 		return frappe.qb.Field(key).like(value)
 
@@ -43,11 +42,11 @@ class Query:
 		"""Wrapper method for `IN`
 
 		Args:
-			key (str): field
-			value (ANy): criterion
+				key (str): field
+				value (ANy): criterion
 
 		Returns:
-			frappe.qb: `frappe.qb object with `IN`
+				frappe.qb: `frappe.qb object with `IN`
 		"""
 		return frappe.qb.Field(key).isin(value)
 
@@ -56,11 +55,11 @@ class Query:
 		"""Wrapper method for `NOT LIKE`
 
 		Args:
-			key (str): field
-			value (ANy): criterion
+				key (str): field
+				value (ANy): criterion
 
 		Returns:
-			frappe.qb: `frappe.qb object with `NOT LIKE`
+				frappe.qb: `frappe.qb object with `NOT LIKE`
 		"""
 		return frappe.qb.Field(key).not_like(value)
 
@@ -69,11 +68,11 @@ class Query:
 		"""Wrapper method for `NOT IN`
 
 		Args:
-			key (str): field
-			value (ANy): criterion
+				key (str): field
+				value (ANy): criterion
 
 		Returns:
-			frappe.qb: `frappe.qb object with `NOT IN`
+				frappe.qb: `frappe.qb object with `NOT IN`
 		"""
 		return frappe.qb.Field(key).notin(value)
 
@@ -82,11 +81,11 @@ class Query:
 		"""Wrapper method for `REGEX`
 
 		Args:
-			key (str): field
-			value (ANy): criterion
+				key (str): field
+				value (ANy): criterion
 
 		Returns:
-			frappe.qb: `frappe.qb object with `REGEX`
+				frappe.qb: `frappe.qb object with `REGEX`
 		"""
 		return frappe.qb.Field(key).regex(value)
 
@@ -95,66 +94,52 @@ class Query:
 		"""Wrapper method for `BETWEEN`
 
 		Args:
-			key (str): field
-			value (ANy): criterion
+				key (str): field
+				value (ANy): criterion
 
 		Returns:
-			frappe.qb: `frappe.qb object with `BETWEEN`
+				frappe.qb: `frappe.qb object with `BETWEEN`
 		"""
 		return frappe.qb.Field(key)[slice(*value)]
-
-	@staticmethod
-	def get_func_obj(func: str) -> frappe.qb.functions:
-		"""Wrapper method for generating custom functions
-
-		Args:
-			key (str): field
-			value (ANy): criterion
-
-		Returns:
-			frappe.qb.functions
-		"""
-		return frappe.qb.functions(func)
 
 	def make_function(self, key: Any, value: Union[int, str]):
 		return self.operator_map[value[0]](key, value[1])
 
-	def dict_query(self, filters: Dict[str, Union[str, int]], table: str):
-			conditions = frappe.qb.from_(table)
-			for key in filters:
-				value = filters.get(key)
-				_operator = self.operator_map["="]
-
-				if not isinstance(key, str):
-					conditions = conditions.where(self.make_function(key, value))
-					continue
-				if isinstance(value, (list, tuple)):
-					if isinstance(value[1], (list, tuple)) or value[0] in list(self.operator_map.keys())[-4:]:
-						_operator = self.operator_map[value[0]]
-						conditions = conditions.where(_operator(key, value[1]))
-					else:
-						_operator = self.operator_map[value[0]]
-						conditions = conditions.where(_operator(frappe.qb.Field(key), value[1]))
-				else:
-					conditions = conditions.where(_operator(frappe.qb.Field(key), value))
-
+	def dict_query(self, table: str, filters: Dict[str, Union[str, int]]=None):
+		conditions = frappe.qb.from_(table)
+		if not filters:
 			return conditions
 
-	def build_conditions(self, filters: Union[Dict[str, Union[str, int]], str, int], table: str) -> frappe.qb:
+		for key in filters:
+			value = filters.get(key)
+			_operator = self.operator_map["="]
+
+			if not isinstance(key, str):
+				conditions = conditions.where(self.make_function(key, value))
+				continue
+			if isinstance(value, (list, tuple)):
+				if isinstance(value[1], (list, tuple)) or value[0] in list(self.operator_map.keys())[-4:]:
+					_operator = self.operator_map[value[0]]
+					conditions = conditions.where(_operator(key, value[1]))
+				else:
+					_operator = self.operator_map[value[0]]
+					conditions = conditions.where(_operator(frappe.qb.Field(key), value[1]))
+			else:
+				conditions = conditions.where(_operator(frappe.qb.Field(key), value))
+
+		return conditions
+
+	def build_conditions(self, table: str, filters: Union[Dict[str, Union[str, int]], str, int]=None) -> frappe.qb:
 		"""Build conditions for sql query
 
 		Args:
-			filters (Union[Dict[str, Union[str, int]], str, int]): conditions built from filters provided
-			table (str): DocType
+				filters (Union[Dict[str, Union[str, int]], str, int]): conditions built from filters provided
+				table (str): DocType
 
 		Returns:
-			frappe.qb: frappe.qb conditions object
+				frappe.qb: frappe.qb conditions object
 		"""
-		if isinstance(filters, list):
-			pass
-
 		if isinstance(filters, int) or isinstance(filters, str):
 			filters = {"name": str(filters)}
 
-		if filters and isinstance(filters, dict):
-			return self.dict_query(filters, table)
+		return self.dict_query(filters=filters, table=table)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -133,7 +133,7 @@ class Query:
 		orderby, order = order[0], Order.desc
 		return orderby, order
 
-	def dict_query(self, table: str, filters: Dict[str, Union[str, int]] = None,
+	def dict_query(self, table: str, for_update: bool, filters: Dict[str, Union[str, int]] = None,
 				   orderby:str = None, order:Order = None):
 		"""Generate condition object using filters
 
@@ -142,6 +142,7 @@ class Query:
 			filters (Dict[str, Union[str, int]], optional): Conditions. Defaults to None.
 			orderby (str, optional): field to order by. Defaults to None.
 			order (Order, optional): order. Defaults to None.
+			for_update (bool): add `FOR UPDATE`
 
 		Returns:
 			condition: conditions object
@@ -172,20 +173,23 @@ class Query:
 
 			order = order if order else Order.desc
 			return conditions.orderby(orderby, order=order)
+		if for_update:
+			return conditions.for_update()
 		return conditions
 
 	def build_conditions(self, table: str, filters: Union[Dict[str, Union[str, int]], str, int] = None,
-						 orderby: str = None, order: Order = None) -> frappe.qb:
+						 orderby: str = None, order: Order = None, for_update: bool = False) -> frappe.qb:
 		"""Build conditions for sql query
 
 		Args:
-				filters (Union[Dict[str, Union[str, int]], str, int]): conditions built from filters provided
-				table (str): DocType
-
+			filters (Union[Dict[str, Union[str, int]], str, int]): conditions built from filters provided
+			table (str): DocType
+			for_update (bool): add `FOR UPDATE`
 		Returns:
 				frappe.qb: frappe.qb conditions object
 		"""
 		if isinstance(filters, int) or isinstance(filters, str):
 			filters = {"name": str(filters)}
 
-		return self.dict_query(filters=filters, table=table, orderby=orderby, order=order)
+		return self.dict_query(filters=filters, table=table, orderby=orderby,
+						 	   order=order, for_update=for_update)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1,0 +1,93 @@
+from typing import Tuple, Union, List, Any
+import frappe
+import operator
+
+
+class Query:
+	def __init__(self):
+		self.operator_map = {
+						"+": operator.add,
+						"=": operator.eq,
+						"-": operator.sub,
+						"!=": operator.ne,
+						"<": operator.lt,
+						">": operator.gt,
+						"<=": operator.le,
+						">=": operator.ge,
+						"in": self.func_in,
+						"not in": self.func_not_in,
+						"like": self.like,
+						"not like": self.not_like,
+						"regex": self.func_regex,
+						"between": self.func_between
+		}
+
+		self.sql_functions = ["sum", "now", "interval"]
+
+	@staticmethod
+	def like(key: str, value: Any):
+		"""Wrapper method for `LIKE`
+
+		Args:
+			key (str): field
+			value (ANy): criterion
+
+		Returns:
+			[frappe.qb]: frappe.qb object with `LIKE`
+		"""
+		return frappe.qb.Field(key).like(value)
+
+	@staticmethod
+	def func_in(key, value):
+		return frappe.qb.Field(key).isin(value)
+
+	@staticmethod
+	def not_like(key, value):
+		return frappe.qb.Field(key).not_like(value)
+
+	@staticmethod
+	def func_not_in(key, value):
+		return frappe.qb.Field(key).notin(value)
+
+	@staticmethod
+	def func_regex(key, value):
+		return frappe.qb.Field(key).regex(value)
+
+	@staticmethod
+	def func_between(key, value):
+		return frappe.qb.Field(key)[slice(*value)]
+
+	@staticmethod
+	def get_func_obj(func: str):
+		return frappe.qb.functions(func)
+
+	def build_conditions(self, filters, table):
+		"""
+		filters = {columns: condition}
+		frappe.qb.from_(table).where(conditions)
+		"""
+
+		conditions = frappe.qb.from_(table)
+
+		def _query(key):
+			nonlocal conditions
+			value = filters.get(key)
+			_operator = self.operator_map["="]
+			if isinstance(value, (list, tuple)):
+				if isinstance(value[1], (list, tuple)) or value[0] in list(self.operator_map.keys())[-4:]:
+					_operator = self.operator_map[value[0]]
+					conditions = conditions.where(_operator(key, value[1]))
+				else:
+					_operator = self.operator_map[value[0]]
+					conditions = conditions.where(_operator(frappe.qb.Field(key), value[1]))
+			else:
+				conditions = conditions.where(_operator(frappe.qb.Field(key), value))
+
+		if isinstance(filters, int) or isinstance(filters, str):
+			filters = {"name": str(filters)}
+
+		if filters:
+			for f in filters:
+				_query(f)
+
+		return conditions

--- a/frappe/query_builder/__init__.py
+++ b/frappe/query_builder/__init__.py
@@ -1,1 +1,2 @@
+from pypika import *
 from frappe.query_builder.utils import get_query_builder, patch_query_execute

--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -1,13 +1,16 @@
 from pypika import MySQLQuery, Order, PostgreSQLQuery, terms
 from pypika.queries import Schema, Table
 from frappe.utils import get_table_name
-
-
+from pypika.terms import Function
 class Base:
 	terms = terms
 	desc = Order.desc
 	Schema = Schema
 	Table = Table
+
+	@staticmethod
+	def functions(name: str, *args, **kwargs) -> Function:
+		return Function(name, *args, **kwargs)
 
 	@staticmethod
 	def DocType(table_name: str, *args, **kwargs) -> Table:

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -1,5 +1,4 @@
 from pypika.functions import *
-from pypika import Interval, Index
 from frappe.query_builder.utils import ImportMapper, db_type_is
 from frappe.query_builder.custom import GROUP_CONCAT, STRING_AGG, MATCH, TO_TSVECTOR
 

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -1,4 +1,5 @@
 from pypika.functions import *
+from pypika import Interval, Index
 from frappe.query_builder.utils import ImportMapper, db_type_is
 from frappe.query_builder.custom import GROUP_CONCAT, STRING_AGG, MATCH, TO_TSVECTOR
 

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -1,8 +1,6 @@
 from enum import Enum
-from typing import Any, Callable, Dict, get_type_hints
+from typing import Any, Callable, Dict, Union, get_type_hints
 from importlib import import_module
-
-from pypika import Query
 
 import frappe
 from .builder import MariaDB, Postgres
@@ -24,7 +22,7 @@ class BuilderIdentificationFailed(Exception):
 	def __init__(self):
 		super().__init__("Couldn't guess builder")
 
-def get_query_builder(type_of_db: str) -> Query:
+def get_query_builder(type_of_db: str) -> Union[Postgres, MariaDB]:
 	"""[return the query builder object]
 
 	Args:


### PR DESCRIPTION
Problem: ```frappe.db.sql``` relies on functions like ```frappe.db.build_conditions``` in order to build a query which is a very tedious process and does not have support SQL functions. 

Solution: Implementing ```frappe.qb``` under to hood to do all the heavy lifting in order to make queries.

Superseded by https://github.com/frappe/frappe/pull/14102