### PR TITLE
fix: Use remove_all in file_manager.py

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -729,6 +729,7 @@ def remove_file_by_url(file_url, doctype=None, name=None):
 		fid = frappe.db.get_value("File", {"file_url": file_url})
 
 	if fid:
+		from frappe.utils.file_manager import remove_file
 		return remove_file(fid=fid)
 
 


### PR DESCRIPTION
Use `remove_all` from `file_manager.py`

redundant `remove_all` was removed via https://github.com/frappe/frappe/pull/13996