### PR TITLE
patch: set title as label if extends is empty

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -182,4 +182,4 @@ frappe.patches.v13_0.jinja_hook
 frappe.patches.v13_0.update_notification_channel_if_empty
 frappe.patches.v14_0.drop_data_import_legacy
 frappe.patches.v14_0.rename_cancelled_documents
-frappe.patches.v14_0.update_workspace2
+frappe.patches.v14_0.update_workspace2 # 25.08.2021

--- a/frappe/patches/v14_0/update_workspace2.py
+++ b/frappe/patches/v14_0/update_workspace2.py
@@ -54,7 +54,7 @@ def update_wspace(doc, seq, content):
 		doc.sequence_id = seq + 1
 		doc.content = json.dumps(content)
 		doc.public = 0
-		doc.title = doc.extends
+		doc.title = doc.extends or doc.label
 		doc.extends = ''
 		doc.category = ''
 		doc.onboarding = ''

--- a/frappe/patches/v14_0/update_workspace2.py
+++ b/frappe/patches/v14_0/update_workspace2.py
@@ -50,7 +50,7 @@ def create_content(doc):
 	return content
 
 def update_wspace(doc, seq, content):
-	if not doc.title and not content and not doc.is_standard and not doc.public:
+	if not doc.title and not doc.content and not doc.is_standard and not doc.public:
 		doc.sequence_id = seq + 1
 		doc.content = json.dumps(content)
 		doc.public = 0

--- a/frappe/patches/v14_0/update_workspace2.py
+++ b/frappe/patches/v14_0/update_workspace2.py
@@ -50,7 +50,7 @@ def create_content(doc):
 	return content
 
 def update_wspace(doc, seq, content):
-	if not doc.is_standard and not doc.public:
+	if not doc.title and not content and not doc.is_standard and not doc.public:
 		doc.sequence_id = seq + 1
 		doc.content = json.dumps(content)
 		doc.public = 0


### PR DESCRIPTION
Set `title` as `label` if `extends` is empty