### PR TITLE
chore: overriding of modified_by and owner

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -469,6 +469,7 @@ class Document(BaseDocument):
 		self.modified_by = frappe.session.user
 		if not self.creation:
 			self.creation = self.modified
+			self.owner = self.modified_by
 		if not self.owner:
 			self.owner = self.modified_by
 


### PR DESCRIPTION
Updates the owner of the document from the session user if creation is not set.