### PR TITLE
fix(ci): Don't skip Coverage job unconditionally

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -25,7 +25,7 @@ def is_ci(file):
 	return ".github" in file
 
 def is_frontend_code(file):
-	return file.endswith((".css", ".scss", ".less", ".sass", ".styl", ".js", ".ts"))
+	return file.lower().endswith((".css", ".scss", ".less", ".sass", ".styl", ".js", ".ts", ".vue"))
 
 def is_docs(file):
 	regex = re.compile(r'\.(md|png|jpg|jpeg|csv)$|^.github|LICENSE')

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -131,17 +131,29 @@ jobs:
           COVERALLS_SERVICE_NAME: ${{ github.event_name == 'pull_request' && 'github' || 'github-actions' }}
           COVERALLS_PARALLEL: true
 
+      - run: echo ${{ steps.check-build.outputs.build }} > guess-the-fruit.txt
+      - uses: actions/upload-artifact@v1
+        with:
+          name: fruit
+          path: guess-the-fruit.txt
+
   coveralls:
     name: Coverage Wrap Up
     needs: test
-    if: ${{ needs.test.steps.check-build.build == 'strawberry' }}
     container: python:3-slim
     runs-on: ubuntu-18.04
     steps:
+      - uses: actions/download-artifact@v1
+        with:
+          name: fruit
+      - run: echo "WILDCARD=$(cat fruit/guess-the-fruit.txt)" >> $GITHUB_ENV
+
       - name: Clone
+        if: ${{ env.WILDCARD == 'strawberry' }}
         uses: actions/checkout@v2
 
       - name: Coveralls Finished
+        if: ${{ env.WILDCARD == 'strawberry' }}
         run: |
           cd ${GITHUB_WORKSPACE}
           pip3 install coverage==5.5


### PR DESCRIPTION
So GHA apparently gives a pretty useless `needs` object to the jobs that gives empty outputs object and just one useful "success". So I had to make an artifact and pass it to the coverage job since outputs and envs can't be passed directly.

### other changes:
* Added `.vue` as an acceptable extension for frontend code

Test PR: https://github.com/gavindsouza/frappe/pull/41