### PR TITLE
ci: concurrency control for CI jobs

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -2,6 +2,11 @@ name: Patch
 
 on: [pull_request, workflow_dispatch]
 
+
+concurrency:
+  group: patch-mariadb-develop-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -6,6 +6,11 @@ on:
   push:
     branches: [ develop ]
 
+concurrency:
+  group: server-mariadb-${{ github.event.number }}
+  cancel-in-progress: true
+
+
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [ develop ]
 
 concurrency:
-  group: server-mariadb-${{ github.event.number }}
+  group: server-mariadb-develop-${{ github.event.number }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: server-postgres-develop-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [ develop ]
 
+concurrency:
+  group: ui-develop-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
When the same PR causes multiple CI triggers due to the rapid addition of new commits, this change will cancel previous CI jobs to save resources. Many hosted services like Sider already do this, as it's of little use to test commits that are superseded with other changes. 

Test PR: check first commit on this PR: https://github.com/frappe/frappe/pull/14061 

Multiple PRs:
https://github.com/ankush/frappe/pull/2
https://github.com/ankush/frappe/pull/3 


reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency 

~~q: Not sure whether `github.ref` should be used or `github.event.id` as a unique identifier for this.~~

PR events: `github.event.id` is okay as all PRs have a unique number.
Push Events:  `github.event.id` will be null, hence the concurrency group will be a "branch" in this case `develop`. 