### PR TITLE
fix: Retry get_redis_conn until Redis is available

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,4 @@ Whoosh~=2.7.4
 wrapt~=1.12.1
 xlrd~=2.0.1
 zxcvbn-python~=4.4.24
+tenacity~=8.0.1


### PR DESCRIPTION
**What:** If `ConnectionError` or `BusyLoadingError` occurs, try every second for up-to 10 times.

**Why:** `bench start` exits just as i run it at times. This happens when the worker's processes each try to fetch a redis conn but redis isn't up yet. The 3 worker processes exit with 1 and our Procman gives up too. I chose 10s since it takes up-to 5 seconds _(or 5 **Please make sure that Redis Queue runs @ redis://localhost:11000** x3)_ errors to show up until it can finally get hold of a connection, on my machine (Macbook Air M1). I assume it could take longer on some others, so 10 is a healthy number IMO.

**Concerns:** This means if there's a `ConnectionError`, this could block up the function call for up-to 10s. Without this, the program would automatically shut just as it's started, but now it would retry for ~10s before giving up.