### PR TITLE
feat: change custom button type

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1152,6 +1152,10 @@ frappe.ui.form.Form = class FrappeForm {
 		return btn;
 	}
 
+	change_custom_button_type(label, group, type) {
+		this.page.change_inner_button_type(label, group, type);
+	}
+
 	clear_custom_buttons() {
 		this.page.clear_inner_toolbar();
 		this.page.clear_user_actions();

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -624,10 +624,10 @@ frappe.ui.Page = class Page {
 		if (group) {
 			var $group = this.get_inner_group_button(__(group));
 			if ($group.length) {
-				btn = $group.find(`.dropdown-item[data-label="${encodeURIComponent(label)}"]`)
+				btn = $group.find(`.dropdown-item[data-label="${encodeURIComponent(label)}"]`);
 			}
 		} else {
-			btn = this.inner_toolbar.find(`button[data-label="${encodeURIComponent(label)}"]`)
+			btn = this.inner_toolbar.find(`button[data-label="${encodeURIComponent(label)}"]`);
 		}
 
 		if (btn) {

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -618,6 +618,23 @@ frappe.ui.Page = class Page {
 		}
 	}
 
+	change_inner_button_type(label, group, type) {
+		let btn;
+
+		if (group) {
+			var $group = this.get_inner_group_button(__(group));
+			if ($group.length) {
+				btn = $group.find(`.dropdown-item[data-label="${encodeURIComponent(label)}"]`)
+			}
+		} else {
+			btn = this.inner_toolbar.find(`button[data-label="${encodeURIComponent(label)}"]`)
+		}
+
+		if (btn) {
+			btn.removeClass().addClass(`btn btn-${type} ellipsis`);
+		}
+	}
+
 	add_inner_message(message) {
 		let $message = $(`<span class='inner-page-message text-muted small'>${message}</div>`);
 		this.inner_toolbar.find('.inner-page-message').remove();


### PR DESCRIPTION
Adds a method to change the custom button type on a `page`. 

To make a custom button `primary` you can just do
```JS
frm.change_custom_button_type("Allocate", null, "primary");
```


Docs: https://github.com/frappe/frappe_docs/pull/192