### PR TITLE
fix(ci): Run all builds on github push events

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -38,8 +38,12 @@ if __name__ == "__main__":
 	pr_number = os.environ.get("PR_NUMBER")
 	repo = os.environ.get("REPO_NAME")
 
-	if not files_list and pr_number:
-		files_list = get_files_list(pr_number=pr_number, repo=repo)
+	# this is a push build, run all builds
+	if not pr_number:
+		os.system('echo "::set-output name=build::strawberry"')
+		sys.exit(0)
+
+	files_list = files_list or get_files_list(pr_number=pr_number, repo=repo)
 
 	if not files_list:
 		print("No files' changes detected. Build is shutting")


### PR DESCRIPTION
**Issue:** No PR number is detected on Push events and all builds are skipped (since https://github.com/frappe/frappe/pull/14030). We want the opposite to be true, so we're running all builds on merges in hopes of testing better.

**Before:**

<img width="1440" alt="Screenshot 2021-08-30 at 1 06 21 PM" src="https://user-images.githubusercontent.com/36654812/131303608-feb0d897-8f8c-49b5-9c95-5038cca9d74b.png">

Via https://github.com/frappe/frappe/runs/3458984556

**After:**

<img width="1440" alt="Screenshot 2021-08-30 at 1 09 27 PM" src="https://user-images.githubusercontent.com/36654812/131303713-c7e6514d-8a2a-4890-b51e-560be1d5530c.png">

Via https://github.com/gavindsouza/frappe/runs/3459243602