### PR TITLE
fix: Workspace 2.0 issues

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -242,6 +242,7 @@
    "label": "Parent Page"
   },
   {
+   "default": "[]",
    "fieldname": "content",
    "fieldtype": "Long Text",
    "hidden": 1,
@@ -265,7 +266,7 @@
   }
  ],
  "links": [],
- "modified": "2021-08-19 12:51:00.233017",
+ "modified": "2021-08-30 18:47:18.227154",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -62,7 +62,7 @@ class Workspace(Document):
 		for link in self.links:
 			link = link.as_dict()
 			if link.type == "Card Break":
-				if card_links and (not current_card['only_for'] or current_card['only_for'] == frappe.get_system_settings('country')): 
+				if card_links and (not current_card.get('only_for') or current_card.get('only_for') == frappe.get_system_settings('country')): 
 					current_card['links'] = card_links
 					cards.append(current_card)
 

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -285,10 +285,6 @@ frappe.Application = class Application {
 			frappe.modules[page.module]=page;
 			frappe.workspaces[frappe.router.slug(page.title)] = page;
 		}
-		if (!frappe.workspaces['home']) {
-			// default workspace is settings for Frappe
-			frappe.workspaces['home'] = frappe.workspaces[Object.keys(frappe.workspaces)[0]];
-		}
 	}
 
 	load_user_permissions() {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -66,7 +66,7 @@
 		padding: 4px 10px;
 	}
 	.btn-primary, .btn-secondary {
-		min-width: 70px;
+		min-width: 35px;
 	}
 	.custom-btn-group {
 		display: inline-flex;


### PR DESCRIPTION
1. Redirect to the first available workspace page if the home page doesn't exist.
2. Made default content field as [].
3. Deleting links from card gives error