### PR TITLE
feat: Introduce rate-limiting for web forms

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -788,7 +788,7 @@ def sign_up(email, full_name, redirect_to):
 			return 2, _("Please ask your administrator to verify your sign-up")
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(key='user', limit=get_password_reset_limit, seconds = 24*60*60, methods=['POST'])
+@rate_limit(limit=get_password_reset_limit, seconds = 24*60*60, methods=['POST'])
 def reset_password(user):
 	if user=="Administrator":
 		return 'not allowed'

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -469,7 +469,7 @@ class Document(BaseDocument):
 		if not self.creation:
 			self.creation = self.modified
 		if not self.owner:
-			self.owner = self.modified_by
+			self.owner = self.flags.owner or self.modified_by
 
 		for d in self.get_all_children():
 			d.modified = self.modified

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -469,7 +469,7 @@ class Document(BaseDocument):
 		if not self.creation:
 			self.creation = self.modified
 		if not self.owner:
-			self.owner = self.flags.owner or self.modified_by
+			self.owner = self.modified_by
 
 		for d in self.get_all_children():
 			d.modified = self.modified

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -107,8 +107,14 @@ def rate_limit(key: str, limit: Union[int, Callable] = 5, seconds: int= 24*60*60
 
 			_limit = limit() if callable(limit) else limit
 
-			identity = frappe.form_dict[key]
-			cache_key = f"rl:{frappe.form_dict.cmd}:{identity}"
+			cmd = (frappe.form_dict.cmd).split('.')[-1]
+			user_key=frappe.form_dict[key]
+			ip = frappe.local.request_ip
+			
+			# cmd "accept" is used for web-forms only
+			ip_based_key = ":".join([ip, user_key]) if cmd == 'accept' else ip
+
+			cache_key = f"rl:{frappe.form_dict.cmd}:{ip_based_key}"
 
 			value = frappe.cache().get_value(cache_key, expires=True) or 0
 			if not value:

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -109,17 +109,19 @@ def rate_limit(key: str = None, limit: Union[int, Callable] = 5, seconds: int = 
 
 			_limit = limit() if callable(limit) else limit
 
-			ip = frappe.local.request_ip
+			ip = frappe.local.request_ip if ip_based is True else None
 
-			if key is None and ip_based is False:
-				frappe.throw(_('Either key or IP flag is required.'))
-			elif key is None:
-				identity = ip
-			elif ip_based is False:
-				identity = frappe.form_dict[key]
-			else:
-				user_key=frappe.form_dict[key]
+			user_key = frappe.form_dict[key] if key else None
+
+			identity = None
+
+			if key and ip_based:
 				identity = ":".join([ip, user_key])
+
+			identity = identity or ip or user_key
+
+			if not identity:
+				frappe.throw(_('Either key or IP flag is required.'))
 
 			cache_key = f"rl:{frappe.form_dict.cmd}:{identity}"
 

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -104,7 +104,7 @@ def rate_limit(key: str=None, limit: Union[int, Callable] = 5, seconds: int= 24*
 		@wraps(fun)
 		def wrapper(*args, **kwargs):
 			# Do not apply rate limits if method is not opted to check
-			if methods != 'ALL' and frappe.request.method.upper() not in methods:
+			if methods != 'ALL' and frappe.request and frappe.request.method and frappe.request.method.upper() not in methods:
 				return frappe.call(fun, **frappe.form_dict or kwargs)
 
 			_limit = limit() if callable(limit) else limit

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -82,7 +82,7 @@ class RateLimiter:
 		if self.rejected:
 			return Response(_("Too Many Requests"), status=429)
 
-def rate_limit(key: str=None, limit: Union[int, Callable] = 5, seconds: int= 24*60*60, methods: Union[str, list]='ALL', ip_based: bool=True):
+def rate_limit(key: str = None, limit: Union[int, Callable] = 5, seconds: int = 24*60*60, methods: Union[str, list] = 'ALL', ip_based: bool = True):
 	"""Decorator to rate limit an endpoint.
 
 	This will limit Number of requests per endpoint to `limit` within `seconds`.
@@ -111,11 +111,11 @@ def rate_limit(key: str=None, limit: Union[int, Callable] = 5, seconds: int= 24*
 
 			ip = frappe.local.request_ip
 
-			if key == None and ip_based == False:
+			if key is None and ip_based is False:
 				frappe.throw(_('Either key or IP flag is required.'))
-			elif key == None:
+			elif key is None:
 				identity = ip
-			elif ip_based == False:
+			elif ip_based is False:
 				identity = frappe.form_dict[key]
 			else:
 				user_key=frappe.form_dict[key]

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -123,9 +123,9 @@ def rate_limit(key: str=None, limit: Union[int, Callable] = 5, seconds: int= 24*
 
 			cache_key = f"rl:{frappe.form_dict.cmd}:{identity}"
 
-			value = frappe.cache().get_value(cache_key, expires=True) or 0
+			value = frappe.cache().get(cache_key) or 0
 			if not value:
-				frappe.cache().set_value(cache_key, 0, expires_in_sec=seconds)
+				frappe.cache().setex(cache_key, seconds, 0)
 
 			value = frappe.cache().incrby(cache_key, 1)
 			if value > _limit:

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -82,19 +82,21 @@ class RateLimiter:
 		if self.rejected:
 			return Response(_("Too Many Requests"), status=429)
 
-def rate_limit(key: str, limit: Union[int, Callable] = 5, seconds: int= 24*60*60, methods: Union[str, list]='ALL'):
+def rate_limit(key: str=None, limit: Union[int, Callable] = 5, seconds: int= 24*60*60, methods: Union[str, list]='ALL', ip_based: bool=True):
 	"""Decorator to rate limit an endpoint.
 
 	This will limit Number of requests per endpoint to `limit` within `seconds`.
 	Uses redis cache to track request counts.
 
-	:param key: Key is used to identify the requests uniqueness
+	:param key: Key is used to identify the requests uniqueness (Optional)
 	:param limit: Maximum number of requests to allow with in window time
 	:type limit: Callable or Integer
 	:param seconds: window time to allow requests
 	:param methods: Limit the validation for these methods.
 		`ALL` is a wildcard that applies rate limit on all methods.
 	:type methods: string or list or tuple
+	:param ip_based: flag to allow ip based rate-limiting
+	:type ip_based: Boolean
 
 	:returns: a decorator function that limit the number of requests per endpoint
 	"""
@@ -107,14 +109,19 @@ def rate_limit(key: str, limit: Union[int, Callable] = 5, seconds: int= 24*60*60
 
 			_limit = limit() if callable(limit) else limit
 
-			cmd = (frappe.form_dict.cmd).split('.')[-1]
-			user_key=frappe.form_dict[key]
 			ip = frappe.local.request_ip
-			
-			# cmd "accept" is used for web-forms only
-			ip_based_key = ":".join([ip, user_key]) if cmd == 'accept' else ip
 
-			cache_key = f"rl:{frappe.form_dict.cmd}:{ip_based_key}"
+			if key == None and ip_based == False:
+				frappe.throw(_('Either key or IP flag is required.'))
+			elif key == None:
+				identity = ip
+			elif ip_based == False:
+				identity = frappe.form_dict[key]
+			else:
+				user_key=frappe.form_dict[key]
+				identity = ":".join([ip, user_key])
+
+			cache_key = f"rl:{frappe.form_dict.cmd}:{identity}"
 
 			value = frappe.cache().get_value(cache_key, expires=True) or 0
 			if not value:

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -16,15 +16,26 @@ class TestWebForm(unittest.TestCase):
 	def tearDown(self):
 		frappe.conf.disable_website_cache = False
 		frappe.local.path = None
+		frappe.local.request_ip = None
+		frappe.form_dict.web_form = None
+		frappe.form_dict.data = None
+		frappe.form_dict.docname = None
 
 	def test_accept(self):
 		frappe.set_user("Administrator")
-		accept(web_form='manage-events', data=json.dumps({
+
+		doc = {
 			'doctype': 'Event',
 			'subject': '_Test Event Web Form',
 			'description': '_Test Event Description',
 			'starts_on': '2014-09-09'
-		}))
+		}
+
+		frappe.form_dict.web_form = "manage-events"
+		frappe.form_dict.data = json.dumps(doc)
+		frappe.local.request_ip = '127.0.0.1'
+
+		accept(web_form='manage-events', data=json.dumps(doc))
 
 		self.event_name = frappe.db.get_value("Event",
 			{"subject": "_Test Event Web Form"})
@@ -32,6 +43,7 @@ class TestWebForm(unittest.TestCase):
 
 	def test_edit(self):
 		self.test_accept()
+
 		doc={
 			'doctype': 'Event',
 			'subject': '_Test Event Web Form',
@@ -42,6 +54,10 @@ class TestWebForm(unittest.TestCase):
 
 		self.assertNotEqual(frappe.db.get_value("Event",
 			self.event_name, "description"), doc.get('description'))
+
+		frappe.form_dict.web_form = 'manage-events'
+		frappe.form_dict.docname = self.event_name
+		frappe.form_dict.data = json.dumps(doc)
 
 		accept(web_form='manage-events', docname=self.event_name, data=json.dumps(doc))
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -13,7 +13,7 @@ from frappe.modules.utils import export_module_json, get_doc_module
 from frappe.utils import cstr
 from frappe.website.utils import get_comment_list
 from frappe.website.website_generator import WebsiteGenerator
-
+from frappe.rate_limiter import rate_limit
 
 class WebForm(WebsiteGenerator):
 	website = frappe._dict(
@@ -365,6 +365,7 @@ def get_context(context):
 
 
 @frappe.whitelist(allow_guest=True)
+@rate_limit(key='web_form', limit=5, seconds=60, methods=['POST'])
 def accept(web_form, data, docname=None, for_payment=False):
 	'''Save the web form'''
 	data = frappe._dict(json.loads(data))


### PR DESCRIPTION
Added rate-limiting on web forms with a limit of 5 requests in 60 seconds for the same type of web form.

Added IP-based validation in rate-limit decorator since using a different key for each request still bypasses the rate limit. Also, the key is now optional in the decorator.

### For Reset Password: 
1. When the same request is sent 10 times without changing any parameter.
![Screenshot 2021-09-07 at 7 21 15 PM](https://user-images.githubusercontent.com/30501401/132361332-27cbadaa-a6e7-4533-902a-f26f8e63e8c2.png)

2. When the email field is changed with each request.
![Screenshot 2021-09-07 at 7 25 49 PM](https://user-images.githubusercontent.com/30501401/132361639-6239cacc-2f2a-4567-bccb-8b9ec08ff82c.png)
Both the times' rate limit was applied after 3 requests which is set from system settings.

### For Web Forms:
The rate limit is applied after 5 requests for the same web form and IP. 
![Screenshot 2021-09-07 at 7 35 40 PM](https://user-images.githubusercontent.com/30501401/132362172-d6f2915c-ba80-46f6-a81d-889869ad1dc3.png)
Here 409 status is actually from Duplicate data entry.

--
> no-docs