### PR TITLE
fix: Enable Server Scripts by default

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -30,8 +30,14 @@ class NamespaceDict(frappe._dict):
 
 
 def safe_exec(script, _globals=None, _locals=None):
-	# script reports must be enabled via site_config.json
-	if not frappe.conf.server_script_enabled:
+	# server scripts can be disabled via site_config.json
+	# they are enabled by default
+	if 'server_script_enabled' in frappe.conf:
+		enabled = frappe.conf.server_script_enabled
+	else:
+		enabled = True
+
+	if not enabled:
 		frappe.throw(_('Please Enable Server Scripts'), ServerScriptNotEnabled)
 
 	# build globals


### PR DESCRIPTION
They can still be disabled explicitly from site_config.json

Updated docs: https://github.com/frappe/frappe_docs/pull/190