### PR TITLE
chore: change log for v13.10.0

### DIFF
--- a/frappe/change_log/v13/v13_10_0.md
+++ b/frappe/change_log/v13/v13_10_0.md
@@ -1,0 +1,19 @@
+# Version 13.10.0 Release Notes
+
+### Features & Enhancements
+- Frappe Query Builder ([#13705](https://github.com/frappe/frappe/pull/13705))
+- Improve LDAP implementation to be standards compliant ([#13777](https://github.com/frappe/frappe/pull/13777))
+- Allow duration fields in aggregate function fields ([#13395](https://github.com/frappe/frappe/pull/13395))
+- Promisify frappe.require ([#13925](https://github.com/frappe/frappe/pull/13925))
+
+### Fixes
+- Call `is_rtl` function to get the actual value ([#13899](https://github.com/frappe/frappe/pull/13899))
+- Use IP Address instead of Email field ([#13553](https://github.com/frappe/frappe/pull/13553))
+- Only select active numeric field after layout refresh ([#13987](https://github.com/frappe/frappe/pull/13987))
+- Refactor set amended docname to original docname ([#13910](https://github.com/frappe/frappe/pull/13910))
+- Menu items reappear before inner page buttons disappear ([#13850](https://github.com/frappe/frappe/pull/13850))
+- Multiple issues with Email Inbox ([#13822](https://github.com/frappe/frappe/pull/13822))
+- Broken template in password reset ([#13958](https://github.com/frappe/frappe/pull/13958))
+- Passed failfast flag to unit test runner in all scenarios ([#14033](https://github.com/frappe/frappe/pull/14033))
+- Format string for formating date ([#13878](https://github.com/frappe/frappe/pull/13878))
+- Connected app auto_refresh credentials and mandatory fields ([#13192](https://github.com/frappe/frappe/pull/13192))


### PR DESCRIPTION
# Version 13.10.0 Release Notes

### Features & Enhancements
- Frappe Query Builder ([#13705](https://github.com/frappe/frappe/pull/13705))
- Improve LDAP implementation to be standards compliant ([#13777](https://github.com/frappe/frappe/pull/13777))
- Allow duration fields in aggregate function fields ([#13395](https://github.com/frappe/frappe/pull/13395))
- Promisify frappe.require ([#13925](https://github.com/frappe/frappe/pull/13925))

### Fixes
- Call `is_rtl` function to get the actual value ([#13899](https://github.com/frappe/frappe/pull/13899))
- Use IP Address instead of Email field ([#13553](https://github.com/frappe/frappe/pull/13553))
- Only select active numeric field after layout refresh ([#13987](https://github.com/frappe/frappe/pull/13987))
- Refactor set amended docname to original docname ([#13910](https://github.com/frappe/frappe/pull/13910))
- Menu items reappear before inner page buttons disappear ([#13850](https://github.com/frappe/frappe/pull/13850))
- Multiple issues with Email Inbox ([#13822](https://github.com/frappe/frappe/pull/13822))
- Broken template in password reset ([#13958](https://github.com/frappe/frappe/pull/13958))
- Passed failfast flag to unit test runner in all scenarios ([#14033](https://github.com/frappe/frappe/pull/14033))
- Format string for formating date ([#13878](https://github.com/frappe/frappe/pull/13878))
- Connected app auto_refresh credentials and mandatory fields ([#13192](https://github.com/frappe/frappe/pull/13192))