### PR TITLE
ci: Use codecov for coverage reporting

### DIFF
--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -120,7 +120,8 @@ jobs:
           CI_BUILD_ID: ${{ github.run_id }}
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
 
-      - uses: codecov/codecov-action@v2
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v2
         with:
           name: MariaDB
           fail_ci_if_error: true

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -120,49 +120,9 @@ jobs:
           CI_BUILD_ID: ${{ github.run_id }}
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
 
-      - name: Upload Coverage Data
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        id: upload-coverage-data
-        run: |
-          cp ~/frappe-bench/sites/.coverage ${GITHUB_WORKSPACE}
-          cd ${GITHUB_WORKSPACE}
-          pip3 install coverage==5.5
-          pip3 install coveralls==3.0.1
-          coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          COVERALLS_FLAG_NAME: run-${{ matrix.container }}
-          COVERALLS_SERVICE_NAME: ${{ github.event_name == 'pull_request' && 'github' || 'github-actions' }}
-          COVERALLS_PARALLEL: true
-
-      - run: echo ${{ steps.check-build.outputs.build }} > guess-the-fruit.txt
-      - uses: actions/upload-artifact@v1
+      - uses: codecov/codecov-action@v2
         with:
-          name: fruit
-          path: guess-the-fruit.txt
-
-  coveralls:
-    name: Coverage Wrap Up
-    needs: test
-    container: python:3-slim
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/download-artifact@v1
-        with:
-          name: fruit
-      - run: echo "WILDCARD=$(cat fruit/guess-the-fruit.txt)" >> $GITHUB_ENV
-
-      - name: Clone
-        if: ${{ env.WILDCARD == 'strawberry' }}
-        uses: actions/checkout@v2
-
-      - name: Coveralls Finished
-        if: ${{ env.WILDCARD == 'strawberry' }}
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          pip3 install coverage==5.5
-          pip3 install coveralls==3.0.1
-          coveralls --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          name: MariaDB
+          fail_ci_if_error: true
+          files: /home/runner/frappe-bench/sites/coverage.xml
+          verbose: true

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -121,7 +121,8 @@ jobs:
           CI_BUILD_ID: ${{ github.run_id }}
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
 
-      - uses: codecov/codecov-action@v2
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v2
         with:
           name: Postgres
           fail_ci_if_error: true

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -116,7 +116,14 @@ jobs:
 
       - name: Run Tests
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --use-orchestrator
+        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --use-orchestrator --with-coverage
         env:
           CI_BUILD_ID: ${{ github.run_id }}
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
+
+      - uses: codecov/codecov-action@v2
+        with:
+          name: Postgres
+          fail_ci_if_error: true
+          files: /home/runner/frappe-bench/sites/coverage.xml
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+codecov:
+  require_ci_to_pass: yes
+comment:
+  layout: "diff, flags, files"
+  require_changes: true

--- a/frappe/coverage.py
+++ b/frappe/coverage.py
@@ -59,3 +59,4 @@ class CodeCoverage():
 		if self.with_coverage:
 			self.coverage.stop()
 			self.coverage.save()
+			self.coverage.xml_report()


### PR DESCRIPTION
Why [codecov](https://about.codecov.io/)?
- Coveralls had login issues (too many requests/redirect) and we were not able to view files to find the actual uncovered lines
- Codecov has better reporting (status checks & [commit diff](https://codecov.io/gh/surajshetty3416/frappe/commit/55f37971bee920a2ae2682e5fb0c7e9c5664571d)), UX ([better folder/file navigation](https://codecov.io/gh/surajshetty3416/frappe/tree/55f37971bee920a2ae2682e5fb0c7e9c5664571d/frappe), faster page loads), [browser extension](https://docs.codecov.com/docs/browser-extension) and [graphs](https://codecov.io/gh/surajshetty3416/frappe/commit/55f37971bee920a2ae2682e5fb0c7e9c5664571d/graphs).
- Codecov will not require the additional step of coverage wrap-up for parallel builds ([it manages internally](https://docs.codecov.com/docs/merging-reports))

**Note:** One drawback of this will be we have to let go the [coverage history](https://coveralls.io/github/frappe/frappe)

---
- Enabled coverage for Postgres builds as well