### PR TITLE
fix: RTL support for text editor

### DIFF
--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -104,8 +104,10 @@ frappe.ui.form.ControlComment = frappe.ui.form.ControlTextEditor.extend({
 		return [
 			['bold', 'italic', 'underline'],
 			['blockquote', 'code-block'],
+			[{ 'direction': "rtl" }],
 			['link', 'image'],
 			[{ 'list': 'ordered' }, { 'list': 'bullet' }],
+			[{ 'align': [] }],
 			['clean']
 		];
 	},

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -160,8 +160,11 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 			['bold', 'italic', 'underline', 'clean'],
 			[{ 'color': [] }, { 'background': [] }],
 			['blockquote', 'code-block'],
+			// Adding Direction tool to give the user the ability to change text direction.
+			[{ 'direction': "rtl" }],
 			['link', 'image'],
 			[{ 'list': 'ordered' }, { 'list': 'bullet' }, { 'list': 'check' }],
+			[{ 'align': [] }],
 			[{ 'indent': '-1'}, { 'indent': '+1' }],
 			[{'table': [
 				'insert-table',


### PR DESCRIPTION
Introduce Direction and alignment to quill editor. Taken from PR https://github.com/frappe/frappe/pull/12271.
