### PR TITLE
Revert "fix: Accurately cast fieldtype in frappe.db.get_single_value() (backport #13655)"

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -18,6 +18,7 @@ from time import time
 from frappe.utils import now, getdate, cast_fieldtype
 from frappe.utils.background_jobs import execute_job, get_queue
 from frappe.model.utils.link_count import flush_local_link_count
+from frappe.utils import cint
 
 # imports - compatibility imports
 from six import (
@@ -557,7 +558,8 @@ class Database(object):
 		if not df:
 			frappe.throw(_('Invalid field name: {0}').format(frappe.bold(fieldname)), self.InvalidColumnName)
 
-		val = cast_fieldtype(df.fieldtype, val)
+		if df.fieldtype in frappe.model.numeric_fieldtypes:
+			val = cint(val)
 
 		self.value_cache[doctype][fieldname] = val
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -4,14 +4,9 @@
 # MIT License. See license.txt
 
 from __future__ import unicode_literals
-
-import datetime
 import unittest
-
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
-from frappe.utils.testutils import clear_custom_fields
-
 
 class TestDB(unittest.TestCase):
 	def test_get_value(self):
@@ -31,35 +26,11 @@ class TestDB(unittest.TestCase):
 		frappe.db.escape("香港濟生堂製藥有限公司 - IT".encode("utf-8"))
 
 	def test_get_single_value(self):
-		#setup
-		values_dict = {
-			"Float": 1.5,
-			"Int": 1,
-			"Percent": 55.5,
-			"Currency": 12.5,
-			"Data": "Test",
-			"Date": datetime.datetime.now().date(),
-			"Datetime": datetime.datetime.now(),
-			"Time": datetime.timedelta(hours=9, minutes=45, seconds=10)
-		}
-		test_inputs = [{
-			"fieldtype": fieldtype,
-			"value": value} for fieldtype, value in values_dict.items()]
-		for fieldtype in values_dict.keys():
-			create_custom_field("Print Settings", {
-				"fieldname": "test_{0}".format(fieldtype.lower()),
-				"label": "Test {0}".format(fieldtype),
-				"fieldtype": fieldtype,
-			})
+		frappe.db.set_value('System Settings', 'System Settings', 'backup_limit', 5)
+		frappe.db.commit()
 
-		#test
-		for inp in test_inputs:
-			fieldname = "test_{0}".format(inp["fieldtype"].lower())
-			frappe.db.set_value("Print Settings", "Print Settings", fieldname, inp["value"])
-			self.assertEqual(frappe.db.get_single_value("Print Settings", fieldname), inp["value"])
-
-		#teardown
-		clear_custom_fields("Print Settings")
+		limit = frappe.db.get_single_value('System Settings', 'backup_limit')
+		self.assertEqual(limit, 5)
 
 	def test_log_touched_tables(self):
 		frappe.flags.in_migrate = True


### PR DESCRIPTION
Reverts frappe/frappe#13683
This is an alternative fix to https://github.com/frappe/frappe/pull/14098