### PR TITLE
fix: Problems while using translations via Globe Symbol (v13)

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -131,7 +131,7 @@ frappe.ui.form.Control = Class.extend({
 				if (!this.doc.__islocal) {
 					new frappe.views.TranslationManager({
 						'df': this.df,
-						'source_text': value,
+						'source_text': this.value,
 						'target_language': this.doc.language,
 						'doc': this.doc
 					});

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -846,6 +846,9 @@ def update_translations_for_source(source=None, translation_dict=None):
 
 	translation_dict = json.loads(translation_dict)
 
+	if is_html(source):
+		source = strip_html_tags(source)
+
 	# for existing records
 	translation_records = frappe.db.get_values('Translation', {
 		'source_text': source


### PR DESCRIPTION
closes #14118 

1. It will solve duplication issue while updating Translations using Globe Symbol - check `screencast- 1`
2. It also solved the issue reloading to get document - (eg item) specific translations  - check `screencast- 2`

### Output Screencast

**Solves Issue - 1 
Screencast- 1**

https://user-images.githubusercontent.com/16986940/132101576-05def231-83a8-450d-aeb6-80ba9d06893a.mp4

<hr/>

**Solves Issue - 2
Screencast- 2**


https://user-images.githubusercontent.com/16986940/132101607-0406c917-70c7-4f5f-bb01-c073ce6e43ec.mp4


- seanthakur20@gmail.com
- vamagithub@gmail.com


