### PR TITLE
fix: Problems while using translations via Globe Symbol (v12)

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -114,7 +114,7 @@ frappe.ui.form.Control = Class.extend({
 				if (!this.doc.__islocal) {
 					new frappe.views.TranslationManager({
 						'df': this.df,
-						'source_name': value,
+						'source_name': this.value,
 						'target_language': this.doc.language,
 						'doc': this.doc
 					});

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -766,7 +766,10 @@ def update_translations_for_source(source=None, translation_dict=None):
 		return
 
 	translation_dict = json.loads(translation_dict)
-
+	
+	if is_html(source):
+		source = strip_html_tags(source)
+	
 	# for existing records
 	translation_records = frappe.db.get_values('Translation', { 'source_name': source }, ['name', 'language'],  as_dict=1)
 	for d in translation_records:


### PR DESCRIPTION
closes #14118 for version-12


1. It will solve duplication issue while updating Translations using Globe Symbol - check `screencast- 1`
2. It also solved the issue reloading to get document - (eg item) specific translations  - check `screencast- 2`

### Output Screencast

**Solves Issue - 1 
Screencast- 1**

https://user-images.githubusercontent.com/16986940/132102475-42e9df1d-7f84-401d-b05e-7592e2c74033.mp4



<hr/>

**Solves Issue - 2
Screencast- 2**

https://user-images.githubusercontent.com/16986940/132102485-16d22214-865f-43df-a14d-631de965d55f.mp4



- seanthakur20@gmail.com
- vamagithub@gmail.com


