### PR TITLE
fix(UI): Checked icon not visible in PDF

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -140,6 +140,8 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 			style="width: 12px; height: 12px; margin-top: 5px;">
 			<path d="M2 9.66667L5.33333 13L14 3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 		</svg>
+	{% elif df.fieldtype=="Check" and not doc[df.fieldname] %}
+		<!-- empty -->
 	{% elif df.fieldtype in ("Image", "Attach Image") and frappe.utils.is_image(doc[doc.meta.get_field(df.fieldname).options]) %}
 		<img src="{{ doc[doc.meta.get_field(df.fieldname).options] }}"
 			class="img-responsive"
@@ -178,7 +180,8 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {% macro get_align_class(df, no_of_cols=2) %}
 	{% if no_of_cols >= 3 %}{{ "" }}
 	{%- elif df.align -%}{{ "text-" + df.align }}
-	{%- elif df.fieldtype in ("Int", "Float", "Currency", "Check", "Percent") -%}{{ "text-right" }}
+	{%- elif df.fieldtype in ("Int", "Float", "Currency", "Percent") -%}{{ "text-right" }}
+	{%- elif df.fieldtype in ("Check") -%}{{ "text-center" }}
 	{%- else -%}{{ "" }}
 	{%- endif -%}
 {% endmacro %}

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -135,7 +135,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 	{% elif df.fieldtype=="Check" and doc[df.fieldname] %}
 		<!-- <i class="{{ 'fa fa-check' }}"></i> -->
 		<svg viewBox="0 0 16 16"
-			fill="transparent" stroke="var(--icon-stroke)" stroke-width="2"
+			fill="transparent" stroke="#1F272E" stroke-width="2"
 			xmlns="http://www.w3.org/2000/svg" id="icon-tick"
 			style="width: 12px; height: 12px; margin-top: 5px;">
 			<path d="M2 9.66667L5.33333 13L14 3" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
If you preview any doctype by clicking on the print option, in the print preview of the doctype all check icons are visible but in PDF view they are not visible.

**Print Preview:** Check icons are visible and centered
![image](https://user-images.githubusercontent.com/30859809/132464123-993c4497-61bb-4ad4-8ab1-481af0ee3a30.png)


**Before:** Check icons not visible and not checked is set as `0`
![image](https://user-images.githubusercontent.com/30859809/132168093-abff7e80-8ce7-43e0-9c78-480b7e6de31a.png)


**After:** After fix check icons are visible and not checked cells are empty
![image](https://user-images.githubusercontent.com/30859809/132464360-e2df10e2-d8bd-4a33-bbe7-0a2c5d0436a2.png)

