### PR TITLE
feat: user wise configure grid columns

### DIFF
--- a/cypress/integration/grid_configuration.js
+++ b/cypress/integration/grid_configuration.js
@@ -1,0 +1,23 @@
+context('Grid Configuration', () => {
+	beforeEach(() => {
+		cy.login();
+		cy.visit('/app/doctype/User');
+	});
+	it('Set user wise grid settings', () => {
+		cy.wait(100);
+		cy.get('.frappe-control[data-fieldname="fields"]').as('table');
+		cy.get('@table').find('.icon-sm').click();
+		cy.wait(100);
+		cy.get('.frappe-control[data-fieldname="fields_html"]').as('modal');
+		cy.get('@modal').find('.add-new-fields').click();
+		cy.wait(100);
+		cy.get('[type="checkbox"][data-unit="read_only"]').check();
+		cy.findByRole('button', {name: 'Add'}).click();
+		cy.wait(100);
+		cy.get('[data-fieldname="options"]').invoke('attr', 'value', '1');
+		cy.get('.form-control.column-width[data-fieldname="options"]').trigger('change');
+		cy.findByRole('button', {name: 'Update'}).click();
+		cy.wait(200);
+		cy.get('[title="Read Only"').should('be.visible');
+	});
+});

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -265,6 +265,14 @@ export default class Grid {
 		});
 	}
 
+	reset_grid() {
+		this.visible_columns = [];
+		this.grid_rows = [];
+
+		$(this.parent).find(".grid-body .grid-row").remove();
+		this.refresh();
+	}
+
 	make_head() {
 		// labels
 		if (this.header_row) {
@@ -275,7 +283,8 @@ export default class Grid {
 			parent_df: this.df,
 			docfields: this.docfields,
 			frm: this.frm,
-			grid: this
+			grid: this,
+			configure_columns: true
 		});
 	}
 
@@ -686,10 +695,13 @@ export default class Grid {
 	}
 
 	setup_visible_columns() {
-		if (this.visible_columns) return;
+		if (this.visible_columns && this.visible_columns.length > 0) return;
 
+		this.user_defined_columns = [];
+		this.setup_user_defined_columns();
 		var total_colsize = 1,
-			fields = this.editable_fields || this.docfields;
+			fields = (this.user_defined_columns && this.user_defined_columns.length > 0)
+				? this.user_defined_columns : this.editable_fields || this.docfields;
 
 		this.visible_columns = [];
 
@@ -697,9 +709,9 @@ export default class Grid {
 			var _df = fields[ci];
 
 			// get docfield if from fieldname
-			df = this.fields_map[_df.fieldname];
+			df = (this.user_defined_columns && this.user_defined_columns.length > 0) ? _df : this.fields_map[_df.fieldname];
 
-			if (!df.hidden
+			if (df && !df.hidden
 				&& (this.editable_fields || df.in_list_view)
 				&& (this.frm && this.frm.get_perm(df.permlevel, "read") || !this.frm)
 				&& !in_list(frappe.model.layout_fields, df.fieldtype)) {
@@ -707,13 +719,7 @@ export default class Grid {
 				if (df.columns) {
 					df.colsize = df.columns;
 				} else {
-					var colsize = 2;
-					switch (df.fieldtype) {
-						case "Text": break;
-						case "Small Text": colsize = 3; break;
-						case "Check": colsize = 1;
-					}
-					df.colsize = colsize;
+					this.update_default_colsize(df);
 				}
 
 				// attach formatter on refresh
@@ -756,6 +762,29 @@ export default class Grid {
 		}
 	}
 
+	update_default_colsize(df) {
+		var colsize = 2;
+		switch (df.fieldtype) {
+			case "Text": break;
+			case "Small Text": colsize = 3; break;
+			case "Check": colsize = 1;
+		}
+		df.colsize = colsize;
+	}
+
+	setup_user_defined_columns() {
+		let user_settings = frappe.get_user_settings(this.frm.doctype, 'GridView');
+		if (user_settings && user_settings[this.doctype] && user_settings[this.doctype].length) {
+			this.user_defined_columns = user_settings[this.doctype].map(row => {
+				let column = frappe.meta.get_docfield(this.doctype, row.fieldname);
+				if (column) {
+					column.in_list_view = 1;
+					column.columns = row.columns;
+					return column;
+				}
+			});
+		}
+	}
 
 	is_editable() {
 		return this.display_status == "Write" && !this.static_rows;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -285,9 +285,10 @@ export default class GridRow {
 		});
 
 		this.grid_settings_dialog.set_primary_action(__('Update'), () => {
+			this.validate_column_width();
 			this.columns = {};
-			this.grid_settings_dialog.hide();
 			this.update_user_settings_for_grid();
+			this.grid_settings_dialog.hide();
 		});
 
 	}
@@ -413,9 +414,7 @@ export default class GridRow {
 			});
 		}
 
-		if (fields) {
-			$(this.fields_html_wrapper).find('.selected-fields').html(fields);
-		}
+		$(this.fields_html_wrapper).find('.selected-fields').html(fields);
 
 		this.prepare_handler_for_sort();
 		this.select_on_focus();
@@ -453,7 +452,10 @@ export default class GridRow {
 
 	update_column_width() {
 		$(this.fields_html_wrapper).find('.column-width').change((event) => {
-			this.validate_column_width(event);
+			if (cint(event.target.value) === 0) {
+				event.target.value = cint(event.target.defaultValue);
+				frappe.throw(__('Column width cannot be zero.'));
+			}
 
 			this.selected_columns_for_grid.forEach(row => {
 				if (row.fieldname === event.target.dataset.fieldname) {
@@ -464,25 +466,17 @@ export default class GridRow {
 		});
 	}
 
-	validate_column_width(event) {
-		if (cint(event.target.value) === 0) {
-			event.target.value = cint(event.target.defaultValue);
-			frappe.throw(__('Column width cannot be zero.'));
-		} else {
-			let fieldname = event.target.dataset.fieldname;
-			let total_column_width = 0.0;
+	validate_column_width() {
+		let total_column_width = 0.0;
 
-			this.selected_columns_for_grid.forEach(row => {
-				if (row.columns && row.columns > 0) {
-					total_column_width += (fieldname === row.fieldname
-						? cint(event.target.value) : row.columns);
-				}
-			});
-
-			if (total_column_width && total_column_width > 10) {
-				event.target.value = cint(event.target.defaultValue);
-				frappe.throw(__('The total column width cannot be more than 10.'));
+		this.selected_columns_for_grid.forEach(row => {
+			if (row.columns && row.columns > 0) {
+				total_column_width += cint(row.columns);
 			}
+		});
+
+		if (total_column_width && total_column_width > 10) {
+			frappe.throw(__('The total column width cannot be more than 10.'));
 		}
 	}
 

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -285,7 +285,7 @@ export default class GridRow {
 		});
 
 		this.grid_settings_dialog.set_primary_action(__('Update'), () => {
-			this.validate_column_width();
+			this.validate_columns_width();
 			this.columns = {};
 			this.update_user_settings_for_grid();
 			this.grid_settings_dialog.hide();
@@ -466,7 +466,7 @@ export default class GridRow {
 		});
 	}
 
-	validate_column_width() {
+	validate_columns_width() {
 		let total_column_width = 0.0;
 
 		this.selected_columns_for_grid.forEach(row => {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -211,6 +211,7 @@ export default class GridRow {
 
 		this.setup_columns();
 		this.add_open_form_button();
+		this.add_column_configure_button();
 		this.refresh_check();
 
 		if(this.frm && this.doc) {
@@ -250,10 +251,275 @@ export default class GridRow {
 		}
 	}
 
+	add_column_configure_button() {
+		if (this.configure_columns) {
+			this.configure_columns_button = $(`
+				<div class="col grid-static-col col-xs-1 d-flex justify-content-center" style="cursor: pointer;">
+					<a>${frappe.utils.icon('setting-gear', 'sm', '', 'filter: opacity(0.5)')}</a>
+				</div>
+			`)
+				.appendTo(this.row)
+				.on('click', () => {
+					this.configure_dialog_for_columns_selector();
+				});
+		}
+	}
+
+	configure_dialog_for_columns_selector() {
+		this.grid_settings_dialog = new frappe.ui.Dialog({
+			title: __("Configure Columns"),
+			fields: [{
+				'fieldtype': 'HTML',
+				'fieldname': 'fields_html'
+			}]
+		});
+
+		this.grid.setup_visible_columns();
+		this.setup_columns_for_dialog();
+		this.prepare_wrapper_for_columns();
+		this.render_selected_columns();
+		this.grid_settings_dialog.show();
+
+		$(this.fields_html_wrapper).find('.add-new-fields').click(() => {
+			this.column_selector_for_dialog();
+		});
+
+		this.grid_settings_dialog.set_primary_action(__('Update'), () => {
+			this.columns = {};
+			this.grid_settings_dialog.hide();
+			this.update_user_settings_for_grid();
+		});
+
+	}
+
+	setup_columns_for_dialog() {
+		this.selected_columns_for_grid = [];
+		this.grid.visible_columns.forEach(row => {
+			this.selected_columns_for_grid.push({
+				fieldname: row[0].fieldname,
+				columns: row[0].columns || row[0].colsize
+			});
+		});
+	}
+
+	prepare_wrapper_for_columns() {
+		this.fields_html_wrapper = this.grid_settings_dialog.get_field("fields_html").$wrapper[0];
+
+		$(`
+			<div class='form-group'>
+				<div class='row' style='margin:0px; margin-bottom:10px'>
+					<div class='col-md-8'>
+						${__('Fieldname').bold()}
+					</div>
+					<div class='col-md-4' style='padding-left:5px;'>
+						${__('Column Width').bold()}
+					</div>
+				</div>
+				<div class='control-input-wrapper selected-fields'>
+				</div>
+				<p class='help-box small text-muted hidden-xs'>
+					<a class='add-new-fields text-muted'>
+						+ Add / Remove Columns
+					</a>
+				</p>
+			</div>
+		`).appendTo(this.fields_html_wrapper);
+	}
+
+	column_selector_for_dialog() {
+		let docfields = this.prepare_columns_for_dialog(this.selected_columns_for_grid.map(field => field.fieldname));
+
+		let d = new frappe.ui.Dialog({
+			title: __("{0} Fields", [__(this.grid.doctype)]),
+			fields: [
+				{
+					label: __("Select Fields"),
+					fieldtype: "MultiCheck",
+					fieldname: "fields",
+					options: docfields,
+					columns: 2
+				}
+			]
+		});
+
+		d.set_primary_action(__('Save'), () => {
+			let selected_fields = d.get_values().fields;
+			this.selected_columns_for_grid = [];
+			if (selected_fields) {
+				selected_fields.forEach(selected_column => {
+					let docfield = frappe.meta.get_docfield(this.grid.doctype, selected_column);
+					this.grid.update_default_colsize(docfield);
+
+					this.selected_columns_for_grid.push({
+						fieldname: selected_column,
+						columns: docfield.columns || docfield.colsize
+					});
+				});
+
+				this.render_selected_columns();
+				d.hide();
+			}
+		});
+
+		d.show();
+	}
+
+	prepare_columns_for_dialog(selected_fields) {
+		let fields = [];
+
+		this.docfields.forEach(column => {
+			if (!column.hidden && !in_list(frappe.model.no_value_type, column.fieldtype)) {
+				fields.push({
+					label: column.label,
+					value: column.fieldname,
+					checked: selected_fields ? in_list(selected_fields, column.fieldname) : false
+				});
+			}
+		});
+
+		return fields;
+	}
+
+	render_selected_columns() {
+		let fields = '';
+		if (this.selected_columns_for_grid) {
+			this.selected_columns_for_grid.forEach(d => {
+				let docfield = frappe.meta.get_docfield(this.grid.doctype, d.fieldname);
+
+				fields += `
+					<div class='control-input flex align-center form-control fields_order sortable-handle sortable'
+						style='display: block; margin-bottom: 5px; cursor: pointer;' data-fieldname='${docfield.fieldname}'
+						data-label='${docfield.label}' data-type='${docfield.fieldtype}'>
+
+						<div class='row'>
+							<div class='col-md-1'>
+								<a style='cursor: grabbing;'>${frappe.utils.icon('drag', 'xs')}</a>
+							</div>
+							<div class='col-md-7' style='padding-left:0px;'>
+								${docfield.label}
+							</div>
+							<div class='col-md-3' style='padding-left:0px;margin-top:-2px;' title='${__('Columns')}'>
+								<input class='form-control column-width input-xs text-right'
+									value='${docfield.columns || cint(d.columns)}'
+									data-fieldname='${docfield.fieldname}' style='background-color: #ffff; display: inline'>
+							</div>
+							<div class='col-md-1'>
+								<a class='text-muted remove-field' data-fieldname='${docfield.fieldname}'>
+									<i class='fa fa-trash-o' aria-hidden='true'></i>
+								</a>
+							</div>
+						</div>
+					</div>`;
+			});
+		}
+
+		if (fields) {
+			$(this.fields_html_wrapper).find('.selected-fields').html(fields);
+		}
+
+		this.prepare_handler_for_sort();
+		this.select_on_focus();
+		this.update_column_width();
+		this.remove_selected_column();
+	}
+
+	prepare_handler_for_sort() {
+		new Sortable($(this.fields_html_wrapper).find('.selected-fields')[0], {
+			handle: '.sortable-handle',
+			draggable: '.sortable',
+			onUpdate: () => {
+				this.sort_columns();
+			}
+		});
+	}
+
+	sort_columns() {
+		this.selected_columns_for_grid = [];
+
+		let columns = $(this.fields_html_wrapper).find('.fields_order') || [];
+		columns.each(idx => {
+			this.selected_columns_for_grid.push({
+				fieldname: $(columns[idx]).attr('data-fieldname'),
+				columns: cint($(columns[idx]).find('.column-width').attr('value'))
+			});
+		});
+	}
+
+	select_on_focus() {
+		$(this.fields_html_wrapper).find('.column-width').click((event) => {
+			$(event.target).select();
+		});
+	}
+
+	update_column_width() {
+		$(this.fields_html_wrapper).find('.column-width').change((event) => {
+			this.validate_column_width(event);
+
+			this.selected_columns_for_grid.forEach(row => {
+				if (row.fieldname === event.target.dataset.fieldname) {
+					row.columns = cint(event.target.value);
+					event.target.defaultValue = cint(event.target.value);
+				}
+			});
+		});
+	}
+
+	validate_column_width(event) {
+		if (cint(event.target.value) === 0) {
+			event.target.value = cint(event.target.defaultValue);
+			frappe.throw(__('Column width cannot be zero.'));
+		} else {
+			let fieldname = event.target.dataset.fieldname;
+			let total_column_width = 0.0;
+
+			this.selected_columns_for_grid.forEach(row => {
+				if (row.columns && row.columns > 0) {
+					total_column_width += (fieldname === row.fieldname
+						? cint(event.target.value) : row.columns);
+				}
+			});
+
+			if (total_column_width && total_column_width > 10) {
+				event.target.value = cint(event.target.defaultValue);
+				frappe.throw(__('The total column width cannot be more than 10.'));
+			}
+		}
+	}
+
+	remove_selected_column() {
+		$(this.fields_html_wrapper).find('.remove-field').click((event) => {
+			let fieldname = event.currentTarget.dataset.fieldname;
+			let selected_columns_for_grid = this.selected_columns_for_grid.filter(row => {
+				return (row.fieldname !== fieldname);
+			});
+
+			if (selected_columns_for_grid && selected_columns_for_grid.length === 0) {
+				frappe.throw(__('At least one column is required to show in the grid.'));
+			}
+
+			this.selected_columns_for_grid = selected_columns_for_grid;
+			$(this.fields_html_wrapper).find(`[data-fieldname="${fieldname}"]`).remove();
+		});
+	}
+
+	update_user_settings_for_grid() {
+		if (!this.selected_columns_for_grid) {
+			return;
+		}
+
+		let value = {};
+		value[this.grid.doctype] = this.selected_columns_for_grid;
+		frappe.model.user_settings.save(this.frm.doctype, 'GridView', value)
+			.then((r) => {
+				frappe.model.user_settings[this.frm.doctype] = r.message || r;
+				this.grid.reset_grid();
+			});
+	}
+
 	setup_columns() {
 		this.focus_set = false;
-		this.grid.setup_visible_columns();
 
+		this.grid.setup_visible_columns();
 		this.grid.visible_columns.forEach((col, ci) => {
 			// to get update df for the row
 			let df = this.docfields.find(field => field.fieldname === col[0].fieldname);

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -343,7 +343,7 @@ export default class GridRow {
 			]
 		});
 
-		d.set_primary_action(__('Save'), () => {
+		d.set_primary_action(__('Add'), () => {
 			let selected_fields = d.get_values().fields;
 			this.selected_columns_for_grid = [];
 			if (selected_fields) {

--- a/frappe/public/js/frappe/model/user_settings.js
+++ b/frappe/public/js/frappe/model/user_settings.js
@@ -7,7 +7,7 @@ $.extend(frappe.model.user_settings, {
 	},
 	save: function(doctype, key, value) {
 		if (frappe.session.user === 'Guest') return Promise.resolve();
-		
+
 		const old_user_settings = frappe.model.user_settings[doctype] || {};
 		const new_user_settings = $.extend(true, {}, old_user_settings); // deep copy
 
@@ -24,7 +24,7 @@ $.extend(frappe.model.user_settings, {
 			// update if changed
 			return this.update(doctype, new_user_settings);
 		}
-		return Promise.resolve();
+		return Promise.resolve(new_user_settings);
 	},
 	remove: function(doctype, key) {
 		var user_settings = frappe.model.user_settings[doctype] || {};

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1123,11 +1123,11 @@ Object.assign(frappe.utils, {
 		}
 	},
 
-	icon(icon_name, size="sm", icon_class="") {
+	icon(icon_name, size="sm", icon_class="", icon_style="") {
 		let size_class = "";
-		let icon_style = "";
+
 		if (typeof size == "object") {
-			icon_style = `width: ${size.width}; height: ${size.height}`;
+			icon_style += ` width: ${size.width}; height: ${size.height}`;
 		} else {
 			size_class = `icon-${size}`;
 		}


### PR DESCRIPTION
Use Case :- Customer wants to show different grid columns of sales order item to the different users. For that they have initially used the permlevel feature and it was worked. But with permlevel, user can't set the value using custom script either the value change it to the old value or change it to the zero.

Solution: To fix this issue added provision to configure user-wise grid columns

### Configure user-wise grid columns
![sales_order_configure_grid_columns](https://user-images.githubusercontent.com/8780500/132255381-67cdea41-0697-4d3c-a17b-6405eee5d2bf.gif)

###  Sorting of Grid Columns

![sales_order_sort_grid_columns](https://user-images.githubusercontent.com/8780500/132255412-74fe7126-7372-44f2-99d9-287b998d8196.gif)

###  Deleting columns

![sales_order_remove_grid_columns](https://user-images.githubusercontent.com/8780500/132256521-cf8a172e-3076-4016-800a-fd89ce82e8ea.gif)


**User settings**

<img width="933" alt="Screenshot 2021-09-07 at 1 09 49 AM" src="https://user-images.githubusercontent.com/8780500/132256489-1e25347f-b3d8-4ba8-afca-149a51b0a48e.png">

#docs https://github.com/frappe/frappe_docs/pull/193