### PR TITLE
fix: Switch writes to primary when wrapped with read_only

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -633,11 +633,11 @@ def write_only():
 	# if replica connection exists, we have to replace it momentarily with the primary connection
 	def innfn(fn):
 		def wrapper_fn(*args, **kwargs):
-			# switch to primary connection
 			primary_db = getattr(local, "primary_db", None)
 			replica_db = getattr(local, "replica_db", None)
 			in_read_only = getattr(local, "db", None) != primary_db
 
+			# switch to primary connection
 			if in_read_only and primary_db:
 				local.db = local.primary_db
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -618,8 +618,6 @@ def read_only():
 
 			try:
 				retval = fn(*args, **get_newargs(fn, kwargs))
-			except:
-				raise
 			finally:
 				if local and hasattr(local, 'primary_db'):
 					local.db.close()
@@ -643,8 +641,6 @@ def write_only():
 
 			try:
 				retval = fn(*args, **get_newargs(fn, kwargs))
-			except:
-				raise
 			finally:
 				# switch back to replica connection
 				if in_read_only and replica_db:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -629,6 +629,31 @@ def read_only():
 		return wrapper_fn
 	return innfn
 
+def write_only():
+	# if replica connection exists, we have to replace it momentarily with the primary connection
+	def innfn(fn):
+		def wrapper_fn(*args, **kwargs):
+			# switch to primary connection
+			primary_db = getattr(local, "primary_db", None)
+			replica_db = getattr(local, "replica_db", None)
+			in_read_only = getattr(local, "db", None) != primary_db
+
+			if in_read_only and primary_db:
+				local.db = local.primary_db
+
+			try:
+				retval = fn(*args, **get_newargs(fn, kwargs))
+			except:
+				raise
+			finally:
+				# switch back to replica connection
+				if in_read_only and replica_db:
+					local.db = replica_db
+
+			return retval
+		return wrapper_fn
+	return innfn
+
 def only_for(roles, message=False):
 	"""Raise `frappe.PermissionError` if the user does not have any of the given **Roles**.
 

--- a/frappe/core/doctype/access_log/access_log.py
+++ b/frappe/core/doctype/access_log/access_log.py
@@ -9,6 +9,7 @@ class AccessLog(Document):
 
 
 @frappe.whitelist()
+@frappe.write_only()
 def make_access_log(doctype=None, document=None, method=None, file_type=None,
 		report_name=None, filters=None, page=None, columns=None):
 


### PR DESCRIPTION
**Issue raised by `fnrfarid` on Discuss:**

Setup read operations from slave/secondary mysql system is enabled and everything working fine except: when I'm trying to export something, i.e: Sales Invoice list using the `Report Builder` feature, throwing this error. 

Whereas, other default reports, i.e Sales Register, exporting them is working just fine. Can anyone please point out what went wrong?

![](https://i.imgur.com/etbNgFP.gif)

    Traceback (most recent call last):
      File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 65, in application
        response = frappe.handler.handle()
      File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 31, in handle
        data = execute_cmd(cmd)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 67, in execute_cmd
        return frappe.call(method, **frappe.form_dict)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1177, in call
        return fn(*args, **newargs)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 614, in wrapper_fn
        retval = fn(*args, **get_newargs(fn, kwargs))
      File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/reportview.py", line 289, in export_query
        filters=form_params.filters)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/access_log/access_log.py", line 35, in make_access_log
        doc.insert(ignore_permissions=True)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 233, in insert
        self.set_new_name(set_name=set_name, set_child_names=set_child_names)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 423, in set_new_name
        set_new_name(self)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 61, in set_new_name
        set_name_from_naming_options(autoname, doc)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 96, in set_name_from_naming_options
        doc.name = _format_autoname(autoname, doc)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 353, in _format_autoname
        name = re.sub(r"(\{[\w | #]+\})", get_param_value_for_match, autoname_value)
      File "/usr/local/lib/python3.7/re.py", line 194, in sub
        return _compile(pattern, flags).sub(repl, string, count)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 350, in get_param_value_for_match
        return parse_naming_series([trimmed_param], doc=doc)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 170, in parse_naming_series
        part = getseries(n, digits)
      File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 200, in getseries
        current = frappe.db.sql("SELECT `current` FROM `tabSeries` WHERE `name`=%s FOR UPDATE", (key,))
      File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 147, in sql
        self._cursor.execute(query, values)
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 148, in execute
        result = self._query(query)
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 310, in _query
        conn.query(q)
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 548, in query
        self._affected_rows = self._read_query_result(unbuffered=unbuffered)
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 775, in _read_query_result
        result.read()
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 1156, in read
        first_packet = self.connection._read_packet()
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 725, in _read_packet
        packet.raise_for_error()
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/protocol.py", line 221, in raise_for_error
        err.raise_mysql_exception(self._data)
      File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
        raise errorclass(errno, errval)
    pymysql.err.OperationalError: (1290, 'The MariaDB server is running with the --read-only option so it cannot execute this statement')

---

Ref: https://discuss.erpnext.com/t/mariadb-slave-setup-is-causing-error-while-exporting-csv-with-report-builder/