### PR TITLE
fix(UI): Checkbox hidden in List view in mobile view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -583,7 +583,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		const subject_field = this.columns[0].df;
 		let subject_html = `
-			<input class="level-item list-check-all hidden-xs" type="checkbox"
+			<input class="level-item list-check-all" type="checkbox"
 				title="${__("Select All")}">
 			<span class="level-item list-liked-by-me">
 				<span title="${__("Likes")}">${frappe.utils.icon('heart', 'sm', 'like-icon')}</span>
@@ -622,7 +622,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				</div>
 				<div class="level-left checkbox-actions">
 					<div class="level list-subject">
-						<input class="level-item list-check-all hidden-xs" type="checkbox"
+						<input class="level-item list-check-all" type="checkbox"
 							title="${__("Select All")}">
 						<span class="level-item list-header-meta"></span>
 					</div>
@@ -930,7 +930,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		let subject_html = `
 			<span class="level-item select-like">
-				<input class="list-row-checkbox hidden-xs" type="checkbox"
+				<input class="list-row-checkbox" type="checkbox"
 					data-name="${escape(doc.name)}">
 				<span class="list-row-like style="margin-bottom: 1px;">
 					${this.get_like_html(doc)}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -585,7 +585,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		let subject_html = `
 			<input class="level-item list-check-all" type="checkbox"
 				title="${__("Select All")}">
-			<span class="level-item list-liked-by-me">
+			<span class="level-item list-liked-by-me hidden-xs">
 				<span title="${__("Likes")}">${frappe.utils.icon('heart', 'sm', 'like-icon')}</span>
 			</span>
 			<span class="level-item">${__(subject_field.label)}</span>
@@ -932,7 +932,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			<span class="level-item select-like">
 				<input class="list-row-checkbox" type="checkbox"
 					data-name="${escape(doc.name)}">
-				<span class="list-row-like style="margin-bottom: 1px;">
+				<span class="list-row-like hidden-xs style="margin-bottom: 1px;">
 					${this.get_like_html(doc)}
 				</span>
 			</span>

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -207,6 +207,13 @@ body {
 	}
 
 	// listviews
+	.select-like {
+		margin-right: unset !important;
+	}
+
+	.list-count {
+		display: contents;
+	}
 
 	.doclist-row {
 		position: relative;

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -207,9 +207,6 @@ body {
 	}
 
 	// listviews
-	.list-row {
-		padding: 13px 15px !important;
-	}
 
 	.doclist-row {
 		position: relative;


### PR DESCRIPTION
Checkboxes were not visible in mobile view for list rows.
**Before:**
![image](https://user-images.githubusercontent.com/30859809/132629101-dd3ef181-90e9-43af-bfb3-431b3af312b8.png)

**After:**
![image](https://user-images.githubusercontent.com/30859809/132628585-612c4a1e-9559-49f9-8a14-edd1087c292b.png)

Also, fixes https://github.com/frappe/frappe/issues/11576