### PR TITLE
fix: propergate no_default_fields in documents as_dict to childtable …

### DIFF
--- a/frappe/data_migration/doctype/testx/test_testx.py
+++ b/frappe/data_migration/doctype/testx/test_testx.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class Testtestx(unittest.TestCase):
+	pass

--- a/frappe/data_migration/doctype/testx/testx.js
+++ b/frappe/data_migration/doctype/testx/testx.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('testx', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe/data_migration/doctype/testx/testx.json
+++ b/frappe/data_migration/doctype/testx/testx.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "creation": "2021-09-09 09:02:31.208454",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "ok"
+ ],
+ "fields": [
+  {
+   "fieldname": "ok",
+   "fieldtype": "Data",
+   "label": "ok"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2021-09-09 09:02:31.208454",
+ "modified_by": "Administrator",
+ "module": "Data Migration",
+ "name": "testx",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/data_migration/doctype/testx/testx.py
+++ b/frappe/data_migration/doctype/testx/testx.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class testx(Document):
+	pass

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -307,7 +307,7 @@ class BaseDocument(object):
 		doc["doctype"] = self.doctype
 		for df in self.meta.get_table_fields():
 			children = self.get(df.fieldname) or []
-			doc[df.fieldname] = [d.as_dict(convert_dates_to_str=convert_dates_to_str, no_nulls=no_nulls) for d in children]
+			doc[df.fieldname] = [d.as_dict(convert_dates_to_str=convert_dates_to_str, no_nulls=no_nulls, no_default_fields=no_default_fields) for d in children]
 
 		if no_nulls:
 			for k in list(doc):


### PR DESCRIPTION
I want to export the non frappe relevant information of my document via json.
The code calls `as_dict` and this `as_dict` will be called again for the childdocuments of the document I want to export.
The problem was, that I set the `no_default_fields` parameter to `True` but this will not be handed further down to the recursive call `as_dict` on the childtable documents.

This leads to the stupid combination, that I get a dictionary with all my non-frappe relevant document attributes, but then the childtable documents have all those attributes.

This patch fixes this and it is easy to see, that it is correct
