### PR TITLE
fix: Pass no_default_fields parameter further down to recursive calls

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -307,7 +307,7 @@ class BaseDocument(object):
 		doc["doctype"] = self.doctype
 		for df in self.meta.get_table_fields():
 			children = self.get(df.fieldname) or []
-			doc[df.fieldname] = [d.as_dict(convert_dates_to_str=convert_dates_to_str, no_nulls=no_nulls) for d in children]
+			doc[df.fieldname] = [d.as_dict(convert_dates_to_str=convert_dates_to_str, no_nulls=no_nulls, no_default_fields=no_default_fields) for d in children]
 
 		if no_nulls:
 			for k in list(doc):


### PR DESCRIPTION
I want to export the non frappe relevant information of my document via JSON.
The code calls `as_dict` method on the document and this `as_dict` will be called again recursively for the childdocuments of the document I want to export.
The problem was, that I set the `no_default_fields` parameter to `True` but this will not be handed further down to the recursive call of `as_dict` on the childtable documents.

This leads to the stupid combination, that I get a dictionary with all my non-frappe relevant document attributes, but then the child table documents have all those attributes.

This patch fixes this and it is easy to see, that it is correct.