### PR TITLE
feat: custom database port for read-only replica configuration

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -235,14 +235,11 @@ def connect_replica():
 	from frappe.database import get_db
 	user = local.conf.db_name
 	password = local.conf.db_password
-	port = None
+	port = local.conf.replica_db_port
 
 	if local.conf.different_credentials_for_replica:
 		user = local.conf.replica_db_name
 		password = local.conf.replica_db_password
-		
-	if local.conf.replica_db_port:
-		port = local.conf.replica_db_port
 
 	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -235,12 +235,16 @@ def connect_replica():
 	from frappe.database import get_db
 	user = local.conf.db_name
 	password = local.conf.db_password
+	port = None
 
 	if local.conf.different_credentials_for_replica:
 		user = local.conf.replica_db_name
 		password = local.conf.replica_db_password
+		
+	if local.conf.replica_db_port:
+		port = local.conf.replica_db_port
 
-	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password)
+	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)
 
 	# swap db connections
 	local.primary_db = local.db


### PR DESCRIPTION
Able to use custom port for database load balancers (e.g., Maxscale, ProxySQL and HAProxy).
By adding following key to site_config.json
`"replica_db_port": "Replica DB port"`

Docs: https://github.com/frappe/frappe_docs/pull/205