### PR TITLE
fix(event streaming):  Notify consumers on document cancel

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -164,7 +164,9 @@ doc_events = {
 		"after_rename": "frappe.desk.notifications.clear_doctype_notifications",
 		"on_cancel": [
 			"frappe.desk.notifications.clear_doctype_notifications",
-			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions"
+			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
+			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers"
+
 		],
 		"on_trash": [
 			"frappe.desk.notifications.clear_doctype_notifications",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -166,7 +166,6 @@ doc_events = {
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
 			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers"
-
 		],
 		"on_trash": [
 			"frappe.desk.notifications.clear_doctype_notifications",


### PR DESCRIPTION
fix for https://github.com/frappe/frappe/issues/14141 
event streaming not working on cancel

