### PR TITLE
fix: import order Code conventions

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 import base64
 import binascii
 import json
@@ -9,8 +10,8 @@ import frappe
 import frappe.client
 import frappe.handler
 from frappe import _
-from frappe.utils.response import build_response
 from frappe.utils.data import sbool
+from frappe.utils.response import build_response
 
 
 def handle():

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -2,29 +2,30 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import os
 import logging
+import os
 
-from werkzeug.local import LocalManager
-from werkzeug.wrappers import Request, Response
 from werkzeug.exceptions import HTTPException, NotFound
+from werkzeug.local import LocalManager
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.shared_data import SharedDataMiddleware
+from werkzeug.wrappers import Request, Response
 
 import frappe
-import frappe.handler
-import frappe.auth
 import frappe.api
-import frappe.utils.response
-from frappe.utils import get_site_name, sanitize_html
-from frappe.middlewares import StaticDataMiddleware
-from frappe.website.serve import get_response
-from frappe.utils.error import make_error_snapshot
-from frappe.core.doctype.comment.comment import update_comments_in_parent_after_request
-from frappe import _
-import frappe.recorder
+import frappe.auth
+import frappe.handler
 import frappe.monitor
 import frappe.rate_limiter
+import frappe.recorder
+import frappe.utils.response
+from frappe import _
+from frappe.core.doctype.comment.comment import \
+    update_comments_in_parent_after_request
+from frappe.middlewares import StaticDataMiddleware
+from frappe.utils import get_site_name, sanitize_html
+from frappe.utils.error import make_error_snapshot
+from frappe.website.serve import get_response
 
 local_manager = LocalManager([frappe.local])
 

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See LICENSE
+
 from urllib.parse import quote
 
 import frappe
@@ -7,11 +8,13 @@ import frappe.database
 import frappe.utils
 import frappe.utils.user
 from frappe import _, conf
-from frappe.core.doctype.activity_log.activity_log import add_authentication_log
+from frappe.core.doctype.activity_log.activity_log import \
+    add_authentication_log
 from frappe.modules.patch_handler import check_session_stopped
 from frappe.sessions import Session, clear_sessions, delete_session
 from frappe.translate import get_language
-from frappe.twofactor import authenticate_for_2factor, confirm_otp_token, get_cached_user_pass, should_run_2fa
+from frappe.twofactor import (authenticate_for_2factor, confirm_otp_token,
+                              get_cached_user_pass, should_run_2fa)
 from frappe.utils import cint, date_diff, datetime, get_datetime, today
 from frappe.utils.password import check_password
 from frappe.website.utils import get_home_page

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -7,16 +7,21 @@ bootstrap client session
 import frappe
 import frappe.defaults
 import frappe.desk.desk_page
+from frappe.core.doctype.navbar_settings.navbar_settings import (
+    get_app_logo, get_navbar_settings)
 from frappe.desk.form.load import get_meta_bundle
-from frappe.utils.change_log import get_versions
-from frappe.translate import get_lang_dict
 from frappe.email.inbox import get_email_accounts
-from frappe.social.doctype.energy_point_settings.energy_point_settings import is_energy_point_enabled
-from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
-from frappe.social.doctype.energy_point_log.energy_point_log import get_energy_points
 from frappe.model.base_document import get_controller
+from frappe.social.doctype.energy_point_log.energy_point_log import \
+    get_energy_points
+from frappe.social.doctype.energy_point_settings.energy_point_settings import \
+    is_energy_point_enabled
 from frappe.social.doctype.post.post import frequently_visited_links
-from frappe.core.doctype.navbar_settings.navbar_settings import get_navbar_settings, get_app_logo
+from frappe.translate import get_lang_dict
+from frappe.utils.change_log import get_versions
+from frappe.website.doctype.web_page_view.web_page_view import \
+    is_tracking_enabled
+
 
 def get_bootinfo():
 	"""build and return boot info"""

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -1,23 +1,23 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
+import json
 import os
 import re
-import json
 import shutil
 import subprocess
+from distutils.spawn import find_executable
 from io import StringIO
 from tempfile import mkdtemp, mktemp
-from distutils.spawn import find_executable
-
-import frappe
-from frappe.utils.minify import JavascriptMinify
+from urllib.parse import urlparse
 
 import click
 import psutil
-from urllib.parse import urlparse
-from simple_chalk import green
 from semantic_version import Version
+from simple_chalk import green
 
+import frappe
+from frappe.utils.minify import JavascriptMinify
 
 timestamps = {}
 app_paths = None
@@ -72,6 +72,7 @@ def build_missing_files():
 
 def get_assets_link(frappe_head):
 	from subprocess import getoutput
+
 	from requests import head
 
 	tag = getoutput(

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe, json
+import json
+
+import frappe
+from frappe.desk.notifications import (clear_notifications,
+                                       delete_notification_count_for)
 from frappe.model.document import Document
-from frappe.desk.notifications import (delete_notification_count_for,
-	clear_notifications)
 
 common_default_keys = ["__default", "__global"]
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
+import json
+import os
+
 import frappe
-from frappe import _
 import frappe.model
 import frappe.utils
-import json, os
-from frappe.utils import get_safe_filters
+from frappe import _
 from frappe.desk.reportview import validate_args
 from frappe.model.db_query import check_parent_permission
-
+from frappe.utils import get_safe_filters
 
 '''
 Handle RESTful requests that are mapped to the `/api/resource` route.

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -2,8 +2,8 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.desk.notifications import clear_notifications
 from frappe.cache_manager import clear_defaults_cache, common_default_keys
+from frappe.desk.notifications import clear_notifications
 
 # Note: DefaultValue records are identified by parenttype
 # __default, __global or 'User Permission'
@@ -67,8 +67,8 @@ def not_in_user_permission(key, value, user=None):
 	return True if user_permission else False
 
 def get_user_permissions(user=None):
-	from frappe.core.doctype.user_permission.user_permission \
-		import get_user_permissions as _get_user_permissions
+	from frappe.core.doctype.user_permission.user_permission import \
+	    get_user_permissions as _get_user_permissions
 	'''Return frappe.core.doctype.user_permissions.user_permissions._get_user_permissions (kept for backward compatibility)'''
 	return _get_user_permissions(user)
 

--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -1,6 +1,6 @@
 import json
-import frappe
 
+import frappe
 from frappe.utils import cstr
 
 queue_prefix = 'insert_queue_for_'

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -1,7 +1,9 @@
-import requests
-import json
-import frappe
 import base64
+import json
+
+import requests
+
+import frappe
 
 '''
 FrappeClient is a library that helps you connect with other frappe systems

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -1,19 +1,20 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+from mimetypes import guess_type
+
 from werkzeug.wrappers import Response
 
 import frappe
-import frappe.utils
 import frappe.sessions
-from frappe.utils import cint
+import frappe.utils
 from frappe import _, is_whitelisted
-from frappe.utils.response import build_response
+from frappe.core.doctype.server_script.server_script_utils import \
+    run_server_script_api
+from frappe.utils import cint
 from frappe.utils.csvutils import build_csv_response
 from frappe.utils.image import optimize_image
-from mimetypes import guess_type
-from frappe.core.doctype.server_script.server_script_utils import run_server_script_api
-
+from frappe.utils.response import build_response
 
 ALLOWED_MIMETYPES = ('image/png', 'image/jpeg', 'application/pdf', 'application/msword',
 			'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -211,8 +212,8 @@ def ping():
 
 def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 	"""run a whitelisted controller method"""
-	import json
 	import inspect
+	import json
 
 	if not args:
 		args = arg or ""

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -117,7 +117,8 @@ def install_db(root_login="root", root_password=None, db_name=None, source_sql=N
 
 
 def install_app(name, verbose=False, set_as_patched=True):
-	from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
+	from frappe.core.doctype.scheduled_job_type.scheduled_job_type import \
+	    sync_jobs
 	from frappe.model.sync import sync_for
 	from frappe.modules.utils import sync_customizations
 	from frappe.utils.fixtures import sync_fixtures
@@ -466,6 +467,7 @@ def extract_sql_gzip(sql_gz_path):
 def extract_files(site_name, file_path):
 	import shutil
 	import subprocess
+
 	from frappe.utils import get_bench_relative_path
 
 	file_path = get_bench_relative_path(file_path)
@@ -549,9 +551,11 @@ def partial_restore(sql_file_path, verbose=False):
 	if frappe.conf.db_type in (None, "mariadb"):
 		from frappe.database.mariadb.setup_db import import_db_from_sql
 	elif frappe.conf.db_type == "postgres":
-		from frappe.database.postgres.setup_db import import_db_from_sql
 		import warnings
+
 		from click import style
+
+		from frappe.database.postgres.setup_db import import_db_from_sql
 		warn = style(
 			"Delete the tables you want to restore manually before attempting"
 			" partial restore operation for PostreSQL databases",

--- a/frappe/middlewares.py
+++ b/frappe/middlewares.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe
 import os
+
 from werkzeug.exceptions import NotFound
 from werkzeug.middleware.shared_data import SharedDataMiddleware
-from frappe.utils import get_site_name, cstr
+
+import frappe
+from frappe.utils import cstr, get_site_name
 
 
 class StaticDataMiddleware(SharedDataMiddleware):

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -4,20 +4,21 @@
 import json
 import os
 import sys
+
 import frappe
-import frappe.translate
-import frappe.modules.patch_handler
 import frappe.model.sync
-from frappe.utils.fixtures import sync_fixtures
+import frappe.modules.patch_handler
+import frappe.translate
+from frappe.cache_manager import clear_global_cache
+from frappe.core.doctype.language.language import sync_languages
+from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
+from frappe.desk.notifications import clear_notifications
+from frappe.modules.utils import sync_customizations
+from frappe.search.website_search import build_index_for_all_routes
 from frappe.utils.connections import check_connection
 from frappe.utils.dashboard import sync_dashboards
-from frappe.cache_manager import clear_global_cache
-from frappe.desk.notifications import clear_notifications
+from frappe.utils.fixtures import sync_fixtures
 from frappe.website.utils import clear_website_cache
-from frappe.core.doctype.language.language import sync_languages
-from frappe.modules.utils import sync_customizations
-from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
-from frappe.search.website_search import build_index_for_all_routes
 
 
 def migrate(verbose=True, skip_failing=False, skip_search_index=False):

--- a/frappe/model/create_new.py
+++ b/frappe/model/create_new.py
@@ -6,12 +6,15 @@ Create a new document with defaults set
 """
 
 import copy
+
 import frappe
 import frappe.defaults
+from frappe.core.doctype.user_permission.user_permission import \
+    get_user_permissions
 from frappe.model import data_fieldtypes
-from frappe.utils import nowdate, nowtime, now_datetime, cstr
-from frappe.core.doctype.user_permission.user_permission import get_user_permissions
 from frappe.permissions import filter_allowed_docs_for_doctype
+from frappe.utils import cstr, now_datetime, nowdate, nowtime
+
 
 def get_new_doc(doctype, parent_doc = None, parentfield = None, as_dict=False):
 	if doctype not in frappe.local.new_doc_templates:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -2,18 +2,26 @@
 # License: MIT. See LICENSE
 """build query for doclistview and return results"""
 
+import copy
+import json
+import re
+from datetime import datetime
 from typing import List
+
+import frappe
 import frappe.defaults
+import frappe.permissions
 import frappe.share
 from frappe import _
-import frappe.permissions
-from datetime import datetime
-import frappe, json, copy, re
+from frappe.core.doctype.server_script.server_script_utils import \
+    get_server_script_map
 from frappe.model import optional_fields
-from frappe.model.utils.user_settings import get_user_settings, update_user_settings
-from frappe.utils import flt, cint, get_time, make_filter_tuple, get_filter, add_to_date, cstr, get_timespan_date_range
 from frappe.model.meta import get_table_columns
-from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
+from frappe.model.utils.user_settings import (get_user_settings,
+                                              update_user_settings)
+from frappe.utils import (add_to_date, cint, cstr, flt, get_filter, get_time,
+                          get_timespan_date_range, make_filter_tuple)
+
 
 class DatabaseQuery(object):
 	def __init__(self, doctype, user=None):

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -7,15 +7,13 @@ import shutil
 import frappe
 import frappe.defaults
 import frappe.model.meta
-from frappe import _
-from frappe import get_module_path
-from frappe.model.dynamic_links import get_dynamic_link_map
-from frappe.utils.file_manager import remove_all
-from frappe.utils.password import delete_all_passwords_for
-from frappe.model.naming import revert_series_if_last
-from frappe.utils.global_search import delete_for_document
+from frappe import _, get_module_path
 from frappe.desk.doctype.tag.tag import delete_tags_for_document
-
+from frappe.model.dynamic_links import get_dynamic_link_map
+from frappe.model.naming import revert_series_if_last
+from frappe.utils.file_manager import remove_all
+from frappe.utils.global_search import delete_for_document
+from frappe.utils.password import delete_all_passwords_for
 
 doctypes_to_skip = ("Communication", "ToDo", "DocShare", "Email Unsubscribe", "Activity Log", "File",
 	"Version", "Document Follow", "Comment" , "View Log", "Tag Link", "Notification Log", "Email Queue")

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1,21 +1,26 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import frappe
+
+import hashlib
+import json
 import time
-from frappe import _, msgprint, is_whitelisted
-from frappe.utils import flt, cstr, now, get_datetime_str, file_lock, date_diff
-from frappe.model.base_document import BaseDocument, get_controller
-from frappe.model.naming import set_new_name, gen_new_name_for_cancelled_doc
-from werkzeug.exceptions import NotFound, Forbidden
-import hashlib, json
-from frappe.model import optional_fields, table_fields
-from frappe.model.workflow import validate_workflow
-from frappe.model.workflow import set_workflow_state_on_action
-from frappe.utils.global_search import update_global_search
-from frappe.integrations.doctype.webhook import run_webhooks
+
+from werkzeug.exceptions import Forbidden, NotFound
+
+import frappe
+from frappe import _, is_whitelisted, msgprint
+from frappe.core.doctype.server_script.server_script_utils import \
+    run_server_script_for_doc_event
 from frappe.desk.form.document_follow import follow_document
-from frappe.core.doctype.server_script.server_script_utils import run_server_script_for_doc_event
+from frappe.integrations.doctype.webhook import run_webhooks
+from frappe.model import optional_fields, table_fields
+from frappe.model.base_document import BaseDocument, get_controller
+from frappe.model.naming import gen_new_name_for_cancelled_doc, set_new_name
+from frappe.model.workflow import (set_workflow_state_on_action,
+                                   validate_workflow)
+from frappe.utils import cstr, date_diff, file_lock, flt, get_datetime_str, now
 from frappe.utils.data import get_absolute_url
+from frappe.utils.global_search import update_global_search
 
 # once_only validation
 # methods
@@ -1092,7 +1097,8 @@ class Document(BaseDocument):
 
 	def check_no_back_links_exist(self):
 		"""Check if document links to any active document before Cancel."""
-		from frappe.model.delete_doc import check_if_doc_is_linked, check_if_doc_is_dynamically_linked
+		from frappe.model.delete_doc import (check_if_doc_is_dynamically_linked,
+		                                     check_if_doc_is_linked)
 		if not self.flags.ignore_links:
 			check_if_doc_is_linked(self, method="Cancel")
 			check_if_doc_is_dynamically_linked(self, method="Cancel")

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 import json
 
 import frappe

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -12,11 +12,12 @@ the cancelled document naming pattern is changed to 'orig_name-CANC-X'.
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import re
+
 import frappe
 from frappe import _
-from frappe.utils import now_datetime, cint, cstr
-import re
 from frappe.model import log_types
+from frappe.utils import cint, cstr, now_datetime
 
 
 def set_new_name(doc):

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 import frappe
 from frappe import _, bold
 from frappe.model.dynamic_links import get_dynamic_link_map
 from frappe.model.naming import validate_name
-from frappe.model.utils.user_settings import sync_user_settings, update_user_settings_data
+from frappe.model.utils.user_settings import (sync_user_settings,
+                                              update_user_settings_data)
 from frappe.utils import cint
 from frappe.utils.password import rename_password
 

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -1,14 +1,18 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 """
-	Sync's doctype and docfields from txt files to database
-	perms will get synced only if none exist
+Sync's doctype and docfields from txt files to database
+perms will get synced only if none exist
 """
-import frappe
+
 import os
+
+import frappe
 from frappe.modules.import_file import import_file_by_path
 from frappe.modules.patch_handler import block_user
 from frappe.utils import update_progress_bar
+
 
 def sync_all(force=0, verbose=False, reset_permissions=False):
 	block_user(True)

--- a/frappe/model/utils/rename_field.py
+++ b/frappe/model/utils/rename_field.py
@@ -1,10 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import frappe
+
 import json
+
+import frappe
 from frappe.model import no_value_fields, table_fields
+from frappe.model.utils.user_settings import (sync_user_settings,
+                                              update_user_settings_data)
 from frappe.utils.password import rename_password_field
-from frappe.model.utils.user_settings import update_user_settings_data, sync_user_settings
 
 
 def rename_field(doctype, old_fieldname, new_fieldname):

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -2,7 +2,9 @@
 # Settings saved per user basis
 # such as page_limit, filters, last_view
 
-import frappe, json
+import json
+
+import frappe
 from frappe import safe_decode
 
 # dict for mapping the index and index type for the filters of different views

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -1,10 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe
-from frappe.utils import cint
-from frappe import _
 import json
+
+import frappe
+from frappe import _
+from frappe.utils import cint
+
 
 class WorkflowStateError(frappe.ValidationError): pass
 class WorkflowTransitionError(frappe.ValidationError): pass

--- a/frappe/modules/export_file.py
+++ b/frappe/modules/export_file.py
@@ -1,9 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe, os
+import os
+
+import frappe
 import frappe.model
-from frappe.modules import scrub, get_module_path, scrub_dt_dn
+from frappe.modules import get_module_path, scrub, scrub_dt_dn
+
 
 def export_doc(doc):
 	write_document_file(doc)

--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import frappe, os, json
+
+import json
+import os
+
+import frappe
+from frappe.model.base_document import get_controller
 from frappe.modules import get_module_path, scrub_dt_dn
 from frappe.utils import get_datetime_str
-from frappe.model.base_document import get_controller
 
 ignore_values = {
 	"Report": ["disabled", "prepared_report", "add_total_row"],

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -1,15 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 """
-	Execute Patch Files
+Execute Patch Files
 
-	To run directly
+To run directly
 
-	python lib/wnf.py patch patch1, patch2 etc
-	python lib/wnf.py patch -f patch1, patch2 etc
+python lib/wnf.py patch patch1, patch2 etc
+python lib/wnf.py patch -f patch1, patch2 etc
 
-	where patch1, patch2 is module name
+where patch1, patch2 is module name
 """
+
 import frappe, frappe.permissions, time
 
 class PatchError(Exception): pass

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -1,12 +1,18 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 """
-	Utilities for using modules
+Utilities for using modules
 """
-import frappe, os, json
+
+import json
+import os
+
+import frappe
 import frappe.utils
 from frappe import _
 from frappe.utils import cint
+
 
 def export_module_json(doc, is_standard, module):
 	"""Make a folder for the given doc and add its json file (make it a standard

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -2,14 +2,15 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-from datetime import datetime
 import json
-import traceback
-import frappe
 import os
+import traceback
 import uuid
+from datetime import datetime
+
 import rq
 
+import frappe
 
 MONITOR_REDIS_KEY = "monitor-transactions"
 MONITOR_MAX_ENTRIES = 1000000

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -4,9 +4,11 @@ import hashlib
 import re
 from http import cookies
 from urllib.parse import unquote, urlparse
+
 import jwt
 import pytz
 from oauthlib.openid import RequestValidator
+
 import frappe
 from frappe.auth import LoginManager
 

--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -4,11 +4,14 @@ import re
 import sys
 import time
 import unittest
+
 import click
-import frappe
 import requests
 
-from .test_runner import (SLOW_TEST_THRESHOLD, make_test_records, set_test_email_config)
+import frappe
+
+from .test_runner import (SLOW_TEST_THRESHOLD, make_test_records,
+                          set_test_email_config)
 
 click_ctx = click.get_current_context(True)
 if click_ctx:

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -7,7 +7,6 @@ import frappe.share
 from frappe import _, msgprint
 from frappe.utils import cint
 
-
 rights = ("select", "read", "write", "create", "delete", "submit", "cancel", "amend",
 	"print", "email", "report", "import", "export", "set_user_permissions", "share")
 
@@ -204,12 +203,14 @@ def get_role_permissions(doctype_meta, user=None, is_owner=None):
 	return frappe.local.role_permissions[cache_key]
 
 def get_user_permissions(user):
-	from frappe.core.doctype.user_permission.user_permission import get_user_permissions
+	from frappe.core.doctype.user_permission.user_permission import \
+	    get_user_permissions
 	return get_user_permissions(user)
 
 def has_user_permission(doc, user=None):
 	'''Returns True if User is allowed to view considering User Permissions'''
-	from frappe.core.doctype.user_permission.user_permission import get_user_permissions
+	from frappe.core.doctype.user_permission.user_permission import \
+	    get_user_permissions
 	user_permissions = get_user_permissions(user)
 
 	if not user_permissions:
@@ -408,7 +409,8 @@ def set_user_permission_if_allowed(doctype, name, user, with_message=False):
 def add_user_permission(doctype, name, user, ignore_permissions=False, applicable_for=None,
 	is_default=0, hide_descendants=0):
 	'''Add user permission'''
-	from frappe.core.doctype.user_permission.user_permission import user_permission_exists
+	from frappe.core.doctype.user_permission.user_permission import \
+	    user_permission_exists
 
 	if not user_permission_exists(user, doctype, name, applicable_for):
 		if not frappe.db.exists(doctype, name):
@@ -458,7 +460,8 @@ def can_export(doctype, raise_exception=False):
 
 def update_permission_property(doctype, role, permlevel, ptype, value=None, validate=True):
 	'''Update a property in Custom Perm'''
-	from frappe.core.doctype.doctype.doctype import validate_permissions_for_doctype
+	from frappe.core.doctype.doctype.doctype import \
+	    validate_permissions_for_doctype
 	out = setup_custom_perms(doctype)
 
 	name = frappe.get_value('Custom DocPerm', dict(parent=doctype, role=role,
@@ -481,7 +484,8 @@ def setup_custom_perms(parent):
 def add_permission(doctype, role, permlevel=0, ptype=None):
 	'''Add a new permission rule to the given doctype
 		for the given Role and Permission Level'''
-	from frappe.core.doctype.doctype.doctype import validate_permissions_for_doctype
+	from frappe.core.doctype.doctype.doctype import \
+	    validate_permissions_for_doctype
 	setup_custom_perms(doctype)
 
 	if frappe.db.get_value('Custom DocPerm', dict(parent=doctype, role=role,

--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -1,5 +1,6 @@
 from pypika import MySQLQuery, Order, PostgreSQLQuery, terms
 from pypika.queries import Schema, Table
+
 from frappe.utils import get_table_name
 
 

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -1,6 +1,8 @@
 from pypika.functions import *
+
+from frappe.query_builder.custom import (GROUP_CONCAT, MATCH, STRING_AGG,
+                                         TO_TSVECTOR)
 from frappe.query_builder.utils import ImportMapper, db_type_is
-from frappe.query_builder.custom import GROUP_CONCAT, STRING_AGG, MATCH, TO_TSVECTOR
 
 GroupConcat = ImportMapper(
 	{

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -1,10 +1,11 @@
 from enum import Enum
-from typing import Any, Callable, Dict, get_type_hints
 from importlib import import_module
+from typing import Any, Callable, Dict, get_type_hints
 
 from pypika import Query
 
 import frappe
+
 from .builder import MariaDB, Postgres
 
 

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -4,7 +4,7 @@
 
 from datetime import datetime
 from functools import wraps
-from typing import Union, Callable
+from typing import Callable, Union
 
 from werkzeug.wrappers import Response
 

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # License: MIT. See LICENSE
 
-import frappe
 import os
+
 import redis
+
+import frappe
 
 redis_server = None
 
@@ -101,8 +103,8 @@ def can_subscribe_doc(doctype, docname):
 	if os.environ.get('CI'):
 		return True
 
-	from frappe.sessions import Session
 	from frappe.exceptions import PermissionError
+	from frappe.sessions import Session
 	session = Session(None, resume=True).get_session_data()
 	if not frappe.has_permission(user=session.user, doctype=doctype, doc=docname, ptype='read'):
 		raise PermissionError()

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-from collections import Counter
 import datetime
 import inspect
 import json
 import re
 import time
-import frappe
+from collections import Counter
+
 import sqlparse
 
+import frappe
 from frappe import _
 
 RECORDER_INTERCEPT_FLAG = "recorder-intercept"

--- a/frappe/search/full_text_search.py
+++ b/frappe/search/full_text_search.py
@@ -1,13 +1,14 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+from whoosh.fields import ID, TEXT, Schema
+from whoosh.index import EmptyIndexError, create_in, open_dir
+from whoosh.qparser import FieldsPlugin, MultifieldParser, WildcardPlugin
+from whoosh.query import Prefix
+
 import frappe
 from frappe.utils import update_progress_bar
 
-from whoosh.index import create_in, open_dir, EmptyIndexError
-from whoosh.fields import TEXT, ID, Schema
-from whoosh.qparser import MultifieldParser, FieldsPlugin, WildcardPlugin
-from whoosh.query import Prefix
 
 class FullTextSearch:
 	""" Frappe Wrapper for Whoosh """

--- a/frappe/search/test_full_text_search.py
+++ b/frappe/search/test_full_text_search.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 import unittest
 from frappe.search.full_text_search import FullTextSearch
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -6,16 +6,20 @@ Boot session from cache or build
 Session bootstraps info needed by common client side activities including
 permission, homepage, default variables, system defaults etc
 """
-import frappe, json
-from frappe import _
-import frappe.utils
-from frappe.utils import cint, cstr, get_assets_json
-import frappe.model.meta
-import frappe.defaults
-import frappe.translate
-import redis
+import json
 from urllib.parse import unquote
+
+import redis
+
+import frappe
+import frappe.defaults
+import frappe.model.meta
+import frappe.translate
+import frappe.utils
+from frappe import _
 from frappe.cache_manager import clear_user_cache
+from frappe.utils import cint, cstr, get_assets_json
+
 
 @frappe.whitelist(allow_guest=True)
 def clear(user=None):

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -3,10 +3,11 @@
 
 import frappe
 from frappe import _
+from frappe.desk.doctype.notification_log.notification_log import (
+    enqueue_create_notification, get_title, get_title_html)
 from frappe.desk.form.document_follow import follow_document
-from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification,\
-	get_title, get_title_html
 from frappe.utils import cint
+
 
 @frappe.whitelist()
 def add(doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, flags=None, notify=0):

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -1,16 +1,22 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import frappe
-import unittest, json, sys, os
-import time
-import xmlrunner
+import cProfile
 import importlib
-from frappe.modules import load_doctype_module, get_module_name
-import frappe.utils.scheduler
-import cProfile, pstats
-from io import StringIO
+import json
+import os
+import pstats
+import sys
+import time
+import unittest
 from importlib import reload
+from io import StringIO
+
+import xmlrunner
+
+import frappe
+import frappe.utils.scheduler
 from frappe.model.naming import revert_series_if_last
+from frappe.modules import get_module_name, load_doctype_module
 
 unittest_runner = unittest.TextTestRunner
 SLOW_TEST_THRESHOLD = 2

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -1,21 +1,21 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 """
-	frappe.translate
-	~~~~~~~~~~~~~~~~
+frappe.translate
+~~~~~~~~~~~~~~~~
 
-	Translation tools for frappe
+Translation tools for frappe
 """
 
+import functools
 import io
 import itertools
 import json
 import operator
-import functools
 import os
 import re
 from csv import reader
-from typing import List, Union, Tuple
+from typing import List, Tuple, Union
 
 import frappe
 from frappe.model.utils import InvalidIncludePath, render_include

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -1,13 +1,17 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import os
+from base64 import b32encode, b64encode
+from io import BytesIO
+
+import pyotp
+from pyqrcode import create as qrcreate
+
 import frappe
 from frappe import _
-import pyotp, os
+from frappe.utils import cint, get_datetime, get_url, time_diff_in_seconds
 from frappe.utils.background_jobs import enqueue
-from pyqrcode import create as qrcreate
-from io import BytesIO
-from base64 import b64encode, b32encode
-from frappe.utils import get_url, get_datetime, time_diff_in_seconds, cint
+
 
 class ExpiredLoginException(Exception): pass
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -1,24 +1,23 @@
 import os
 import socket
 import time
-from uuid import uuid4
 from collections import defaultdict
 from typing import List
-
+from uuid import uuid4
 
 import redis
 from redis.exceptions import BusyLoadingError, ConnectionError
 from rq import Connection, Queue, Worker
 from rq.logutils import setup_loghandlers
-from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
+                      wait_fixed)
 
 import frappe
-from frappe import _
 import frappe.monitor
+from frappe import _
 from frappe.utils import cstr, get_bench_id
-from frappe.utils.rq import RedisQueue
 from frappe.utils.commands import log
-
+from frappe.utils.rq import RedisQueue
 
 default_timeout = 300
 queue_timeout = {

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-# imports - standard imports
 import gzip
 import os
 from calendar import timegm
@@ -9,13 +8,11 @@ from datetime import datetime
 from glob import glob
 from shutil import which
 
-# imports - third party imports
 import click
 
-# imports - module imports
 import frappe
 from frappe import _, conf
-from frappe.utils import get_file_size, get_url, now, now_datetime, cint
+from frappe.utils import cint, get_file_size, get_url, now, now_datetime
 
 # backup variable for backwards compatibility
 verbose = False

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -1,11 +1,13 @@
-import click
-import frappe
-import os
-import json
 import importlib
-import frappe.utils
+import json
+import os
 import traceback
 import warnings
+
+import click
+
+import frappe
+import frappe.utils
 
 click.disable_unicode_literals_warning = True
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -1,7 +1,14 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import frappe, os, re, git
-from frappe.utils import touch_file, cstr
+
+import os
+import re
+
+import git
+
+import frappe
+from frappe.utils import cstr, touch_file
+
 
 def make_boilerplate(dest, app_name):
 	if not os.path.exists(dest):

--- a/frappe/utils/bot.py
+++ b/frappe/utils/bot.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2016, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe, re, frappe.utils
-from frappe.desk.notifications import get_notifications
+import re
+
+import frappe
+import frappe.utils
 from frappe import _
+from frappe.desk.notifications import get_notifications
+
 
 @frappe.whitelist()
 def get_bot_reply(question):

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -1,12 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import frappe
-from frappe import msgprint, _
-import json
+
 import csv
-import requests
+import json
 from io import StringIO
-from frappe.utils import cstr, cint, flt, comma_or
+
+import requests
+
+import frappe
+from frappe import _, msgprint
+from frappe.utils import cint, comma_or, cstr, flt
+
 
 def read_csv_content_from_attached_file(doc):
 	fileid = frappe.get_all("File", fields = ["name"], filters = {"attached_to_doctype": doc.doctype,

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
+import os
+from functools import wraps
+from os.path import join
+
 import frappe
 from frappe import _
-from functools import wraps
-from frappe.utils import add_to_date, cint, get_link_to_form
 from frappe.modules.import_file import import_file_by_path
-import os
-from os.path import join
+from frappe.utils import add_to_date, cint, get_link_to_form
 
 
 def cache_source(function):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1,15 +1,20 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-from typing import Optional
-import frappe
-import operator
+import datetime
 import json
-import re, datetime, math, time
+import math
+import operator
+import re
+import time
 from code import compile_command
+from typing import Optional
 from urllib.parse import quote, urljoin
-from frappe.desk.utils import slug
+
 from click import secho
+
+import frappe
+from frappe.desk.utils import slug
 
 DATE_FORMAT = "%Y-%m-%d"
 TIME_FORMAT = "%H:%M:%S.%f"
@@ -182,7 +187,7 @@ def get_time_zone():
 	return frappe.cache().get_value("time_zone", _get_time_zone)
 
 def convert_utc_to_timezone(utc_timestamp, time_zone):
-	from pytz import timezone, UnknownTimeZoneError
+	from pytz import UnknownTimeZoneError, timezone
 	utcnow = timezone('UTC').localize(utc_timestamp)
 	try:
 		return utcnow.astimezone(timezone(time_zone))
@@ -976,9 +981,11 @@ def is_image(filepath):
 
 def get_thumbnail_base64_for_image(src):
 	from os.path import exists as file_exists
+
 	from PIL import Image
+
+	from frappe import cache, safe_decode
 	from frappe.core.doctype.file.file import get_local_image
-	from frappe import safe_decode, cache
 
 	if not src:
 		frappe.throw('Invalid source for image: {0}'.format(src))
@@ -1369,8 +1376,9 @@ def make_filter_dict(filters):
 	return _filter
 
 def sanitize_column(column_name):
-	from frappe import _
 	import sqlparse
+
+	from frappe import _
 	regex = re.compile("^.*[,'();].*")
 	column_name = sqlparse.format(column_name, strip_comments=True, keyword_case="lower")
 	blacklisted_keywords = ['select', 'create', 'insert', 'delete', 'drop', 'update', 'case', 'and', 'or']
@@ -1446,8 +1454,9 @@ def strip(val, chars=None):
 	return (val or "").replace("\ufeff", "").replace("\u200b", "").strip(chars)
 
 def to_markdown(html):
-	from html2text import html2text
 	from html.parser import HTMLParser
+
+	from html2text import html2text
 
 	text = None
 	try:
@@ -1458,7 +1467,8 @@ def to_markdown(html):
 	return text
 
 def md_to_html(markdown_text):
-	from markdown2 import markdown as _markdown, MarkdownError
+	from markdown2 import MarkdownError
+	from markdown2 import markdown as _markdown
 
 	extras = {
 		'fenced-code-blocks': None,

--- a/frappe/utils/dateutils.py
+++ b/frappe/utils/dateutils.py
@@ -1,12 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import datetime
+
 import frappe
 import frappe.defaults
-import datetime
-from frappe.utils import get_datetime, add_to_date, getdate
-from frappe.utils.data import get_first_day, get_first_day_of_week, get_quarter_start, get_year_start,\
-	get_last_day, get_last_day_of_week, get_quarter_ending, get_year_ending
+from frappe.utils import add_to_date, get_datetime, getdate
+from frappe.utils.data import (get_first_day, get_first_day_of_week,
+                               get_last_day, get_last_day_of_week,
+                               get_quarter_ending, get_quarter_start,
+                               get_year_ending, get_year_start)
 
 # global values -- used for caching
 dateformats = {

--- a/frappe/utils/doctor.py
+++ b/frappe/utils/doctor.py
@@ -1,7 +1,10 @@
-import frappe.utils
 from collections import defaultdict
-from rq import Worker, Connection
-from frappe.utils.background_jobs import get_redis_conn, get_queue, get_queue_list
+
+from rq import Connection, Worker
+
+import frappe.utils
+from frappe.utils.background_jobs import (get_queue, get_queue_list,
+                                          get_redis_conn)
 from frappe.utils.scheduler import is_scheduler_disabled, is_scheduler_inactive
 
 

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -2,19 +2,19 @@
 # Copyright (c) 2015, Maxwell Morais and contributors
 # License: MIT. See LICENSE
 
+import cgitb
+import datetime
+import functools
+import inspect
+import json
+import linecache
 import os
+import pydoc
 import sys
 import traceback
-import functools
 
 import frappe
 from frappe.utils import cstr, encode
-import inspect
-import linecache
-import pydoc
-import cgitb
-import datetime
-import json
 
 
 def make_error_snapshot(exception):

--- a/frappe/utils/file_lock.py
+++ b/frappe/utils/file_lock.py
@@ -7,7 +7,9 @@ File based locking utility
 
 import os
 from time import time
+
 from frappe.utils import get_site_path, touch_file
+
 
 class LockTimeoutError(Exception):
     pass

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -1,17 +1,22 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe
-import os, base64, re, json
+import base64
 import hashlib
-import mimetypes
 import io
-from frappe.utils import get_hook_method, get_files_path, random_string, encode, cstr, call_hook_method, cint
-from frappe import _
-from frappe import conf
+import json
+import mimetypes
+import os
+import re
 from copy import copy
 from urllib.parse import unquote
+
+import frappe
+from frappe import _, conf
+from frappe.utils import (call_hook_method, cint, cstr, encode, get_files_path,
+                          get_hook_method, random_string)
 from frappe.utils.image import optimize_image
+
 
 class MaxFileSizeReachedError(frappe.ValidationError):
 	pass

--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe
 import datetime
-from frappe.utils import formatdate, fmt_money, flt, cstr, cint, format_datetime, format_time, format_duration
-from frappe.model.meta import get_field_currency, get_field_precision
 import re
+
+import frappe
+from frappe.model.meta import get_field_currency, get_field_precision
+from frappe.utils import (cint, cstr, flt, fmt_money, format_datetime,
+                          format_duration, format_time, formatdate)
+
 
 def format_value(value, df=None, doc=None, currency=None, translated=False, format=None):
 	'''Format value based on given fieldtype, document reference, currency reference.

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -1,14 +1,17 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe
-import re
-import redis
 import json
 import os
+import re
+
+import redis
+
+import frappe
+from frappe.model.base_document import get_controller
 from frappe.utils import cint, strip_html_tags
 from frappe.utils.html_utils import unescape_html
-from frappe.model.base_document import get_controller
+
 
 def setup_global_search_table():
 	"""
@@ -302,8 +305,9 @@ def get_routes_to_index():
 
 def add_route_to_global_search(route):
 	from bs4 import BeautifulSoup
-	from frappe.website.serve import get_response_content
+
 	from frappe.utils import set_request
+	from frappe.website.serve import get_response_content
 	frappe.set_user('Guest')
 	frappe.local.no_cache = True
 
@@ -411,9 +415,8 @@ def search(text, start=0, limit=20, doctype=""):
 	:param limit: number of results to return, default 20
 	:return: Array of result objects
 	"""
-	from frappe.desk.doctype.global_search_settings.global_search_settings import (
-		get_doctypes_for_global_search,
-	)
+	from frappe.desk.doctype.global_search_settings.global_search_settings import \
+	    get_doctypes_for_global_search
 	from frappe.query_builder.functions import Match
 
 	results = []

--- a/frappe/utils/identicon.py
+++ b/frappe/utils/identicon.py
@@ -1,9 +1,10 @@
 
-from PIL import Image, ImageDraw
-from hashlib import md5
 import base64
 import random
+from hashlib import md5
 from io import StringIO
+
+from PIL import Image, ImageDraw
 
 GRID_SIZE = 5
 BORDER_SIZE = 20

--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import os
-from PIL import Image
 import io
+import os
+
+from PIL import Image
+
 
 def resize_images(path, maxdim=700):
 	from PIL import Image

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import frappe
+
 import getpass
+
+import frappe
 from frappe.utils.password import update_password
+
 
 def before_install():
 	frappe.reload_doc("core", "doctype", "docfield")

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 def get_jenv():
 	import frappe
 	from frappe.utils.safe_exec import get_safe_globals

--- a/frappe/utils/lazy_loader.py
+++ b/frappe/utils/lazy_loader.py
@@ -1,6 +1,7 @@
 import importlib.util
 import sys
 
+
 def lazy_import(name, package=None):
 	"""Import a module lazily.
 

--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -1,14 +1,9 @@
-# imports - standard imports
 import logging
 import os
 from logging.handlers import RotatingFileHandler
 
-# imports - third party imports
-
-# imports - module imports
 import frappe
 from frappe.utils import get_sites
-
 
 default_log_level = logging.DEBUG
 

--- a/frappe/utils/make_random.py
+++ b/frappe/utils/make_random.py
@@ -1,5 +1,5 @@
-
-import frappe, random
+import random
+import frappe
 
 settings = frappe._dict(
 	prob = {

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -15,6 +15,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now
 
+
 class NestedSetRecursionError(frappe.ValidationError): pass
 class NestedSetMultipleRootsError(frappe.ValidationError): pass
 class NestedSetChildExistsError(frappe.ValidationError): pass

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -1,12 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import base64
+import json
+
+import jwt
+
 import frappe
 import frappe.utils
-import json, jwt
-import base64
 from frappe import _
 from frappe.utils.password import get_decrypted_password
+
 
 class SignupDisabledError(frappe.PermissionError): pass
 

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -2,15 +2,18 @@
 # License: MIT. See LICENSE
 
 import string
+
+from cryptography.fernet import Fernet, InvalidToken
+from passlib.context import CryptContext
+from passlib.hash import mysql41, pbkdf2_sha256
+from passlib.registry import register_crypt_handler
+from psycopg2.errorcodes import STRING_DATA_RIGHT_TRUNCATION
+from pymysql.constants.ER import DATA_TOO_LONG
+
 import frappe
 from frappe import _
 from frappe.utils import cstr, encode
-from cryptography.fernet import Fernet, InvalidToken
-from passlib.hash import pbkdf2_sha256, mysql41
-from passlib.registry import register_crypt_handler
-from passlib.context import CryptContext
-from pymysql.constants.ER import DATA_TOO_LONG
-from psycopg2.errorcodes import STRING_DATA_RIGHT_TRUNCATION
+
 
 class LegacyPassword(pbkdf2_sha256):
 	name = "frappe_legacy"

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -3,8 +3,8 @@
 import io
 import os
 import re
-from distutils.version import LooseVersion
 import subprocess
+from distutils.version import LooseVersion
 
 import pdfkit
 from bs4 import BeautifulSoup

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -1,9 +1,11 @@
-import frappe, os
-from frappe import _
+import os
 
-from frappe.utils.pdf import get_pdf,cleanup
-from frappe.core.doctype.access_log.access_log import make_access_log
 from PyPDF2 import PdfFileWriter
+
+import frappe
+from frappe import _
+from frappe.core.doctype.access_log.access_log import make_access_log
+from frappe.utils.pdf import cleanup, get_pdf
 
 no_cache = 1
 

--- a/frappe/utils/reset_doc.py
+++ b/frappe/utils/reset_doc.py
@@ -1,13 +1,17 @@
+import json
+import os
+from urllib.request import urlopen
 
 import frappe
-import json, os
-from frappe.modules import scrub, get_module_path, utils
-from frappe.custom.doctype.customize_form.customize_form import doctype_properties, docfield_properties
-from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.core.page.permission_manager.permission_manager import \
+    get_standard_permissions
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
-from frappe.core.page.permission_manager.permission_manager import get_standard_permissions
+from frappe.custom.doctype.customize_form.customize_form import (
+    docfield_properties, doctype_properties)
+from frappe.custom.doctype.property_setter.property_setter import \
+    make_property_setter
+from frappe.modules import get_module_path, scrub, utils
 from frappe.permissions import setup_custom_perms
-from urllib.request import urlopen
 
 branch = 'develop'
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -1,24 +1,26 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import json
 import datetime
 import decimal
+import json
 import mimetypes
 import os
-import frappe
-from frappe import _
-import frappe.model.document
-import frappe.utils
-import frappe.sessions
-import werkzeug.utils
-from werkzeug.local import LocalProxy
-from werkzeug.wsgi import wrap_file
-from werkzeug.wrappers import Response
-from werkzeug.exceptions import NotFound, Forbidden
-from frappe.utils import cint
 from urllib.parse import quote
+
+import werkzeug.utils
+from werkzeug.exceptions import Forbidden, NotFound
+from werkzeug.local import LocalProxy
+from werkzeug.wrappers import Response
+from werkzeug.wsgi import wrap_file
+
+import frappe
+import frappe.model.document
+import frappe.sessions
+import frappe.utils
+from frappe import _
 from frappe.core.doctype.access_log.access_log import make_access_log
+from frappe.utils import cint
 
 
 def report_error(status_code):

--- a/frappe/utils/rq.py
+++ b/frappe/utils/rq.py
@@ -3,6 +3,7 @@ import redis
 import frappe
 from frappe.utils import get_bench_id, random_string
 
+
 class RedisQueue:
 	def __init__(self, conn):
 		self.conn = conn

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -1,19 +1,23 @@
-
-import os, json, inspect
+import inspect
+import json
 import mimetypes
+import os
+
+import RestrictedPython.Guards
 from html2text import html2text
 from RestrictedPython import compile_restricted, safe_globals
-import RestrictedPython.Guards
+
 import frappe
-from frappe import _
-import frappe.utils
-import frappe.utils.data
-from frappe.website.utils import (get_shade, get_toc, get_next_link)
-from frappe.modules import scrub
-from frappe.www.printview import get_visible_columns
 import frappe.exceptions
 import frappe.integrations.utils
+import frappe.utils
+import frappe.utils.data
+from frappe import _
 from frappe.frappeclient import FrappeClient
+from frappe.modules import scrub
+from frappe.website.utils import get_next_link, get_shade, get_toc
+from frappe.www.printview import get_visible_columns
+
 
 class ServerScriptNotEnabled(frappe.PermissionError):
 	pass

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -2,26 +2,22 @@
 # License: MIT. See LICENSE
 """
 Events:
-	always
-	daily
-	monthly
-	weekly
+always
+daily
+monthly
+weekly
 """
 
-# imports - standard imports
 import os
 import time
 
-# imports - third party imports
 import schedule
 
-# imports - module imports
 import frappe
 from frappe.core.doctype.user.user import STANDARD_USERS
 from frappe.installer import update_site_config
 from frappe.utils import get_sites, now_datetime
 from frappe.utils.background_jobs import get_jobs
-
 
 DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -1,13 +1,17 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import frappe, json
-from frappe import _dict
+import json
+
+import frappe
 import frappe.share
-from frappe.utils import cint
+from frappe import _dict
 from frappe.boot import get_allowed_reports
+from frappe.core.doctype.domain_settings.domain_settings import \
+    get_active_modules
 from frappe.permissions import get_roles, get_valid_perms
-from frappe.core.doctype.domain_settings.domain_settings import get_active_modules
+from frappe.utils import cint
+
 
 class UserPermissions:
 	"""
@@ -223,6 +227,7 @@ def get_fullname_and_avatar(user):
 def get_system_managers(only_name=False):
 	"""returns all system manager's user details"""
 	import email.utils
+
 	from frappe.core.doctype.user.user import STANDARD_USERS
 	system_managers = frappe.db.sql("""SELECT DISTINCT `name`, `creation`,
 		CONCAT_WS(' ',

--- a/frappe/utils/verified_command.py
+++ b/frappe/utils/verified_command.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import hmac, hashlib
+
+import hashlib
+import hmac
 from urllib.parse import urlencode
-from frappe import _
 
 import frappe
 import frappe.utils
+from frappe import _
+
 
 def get_signed_params(params):
 	"""Sign a url by appending `&_signature=xxxxx` to given params (string or dict).

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 import re
 from io import BytesIO
 

--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -1,6 +1,6 @@
 import re
-import click
 
+import click
 from werkzeug.routing import Rule
 
 import frappe

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -5,9 +5,11 @@ import io
 import os
 import re
 
+from werkzeug.routing import Map, NotFound, Rule
+
 import frappe
 from frappe.website.utils import extract_title
-from werkzeug.routing import Map, Rule, NotFound
+
 
 def get_page_info_from_web_page_with_dynamic_routes(path):
 	'''

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+
 import json
 import mimetypes
 import os

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -3,10 +3,11 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.website.utils import cleanup_page_name
-from frappe.website.utils import clear_cache
 from frappe.modules import get_module_name
-from frappe.search.website_search import update_index_for_path, remove_document_from_index
+from frappe.search.website_search import (remove_document_from_index,
+                                          update_index_for_path)
+from frappe.website.utils import cleanup_page_name, clear_cache
+
 
 class WebsiteGenerator(Document):
 	website = frappe._dict()


### PR DESCRIPTION
## How Python Community Do Imports

System Imports

3rd Party Imports

Code Modules

Each has Spacing Between them