### PR TITLE
feat: generic memoizing decorator for redis

### DIFF
--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -1,0 +1,29 @@
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+import frappe
+
+T = TypeVar("T", bound=Callable[..., Any])
+
+
+def memoize(fn: T, ttl: int = 600) -> T:
+	"""A decorator to memoize function results into redis cache."""
+
+	cache = frappe.cache()
+
+	@wraps(fn)
+	def wrapper(*args: Any, **kwargs: Any):
+		key = __create_key(fn, *args, **kwargs)
+		return cache.get_value(key, generator=lambda: fn(*args, **kwargs))
+
+	return wrapper
+
+
+def __create_key(fn, *args, **kwargs):
+	return (
+		fn.__name__
+		+ "|"
+		+ ",".join(str(arg) for arg in args)
+		+ "|"
+		+ ",".join(f"{key}:{value}" for key, value in kwargs.items())
+	)


### PR DESCRIPTION
Decorator to memoize arbitrary function outputs in Redis, like @functools.lru_cache but for redis. 

Keys are generated using function name, args and kwargs.

Usage:

```python
from frappe.utils.caching import memoize

@memoize
def deep_thought(ans=42):
    import time
    time.sleep(7.5)
    return ans

>>> deep_thought()
>>> ....... 42 # takes 7.5 seconds
>>> deep_thought() 
>>>  42 # instant 

```

TODO:
- many possible edge cases. 
- Handle custom objects that don't have decent `__str__` (or don't support this and throw an error when used incorrectly.)
- Test / docs. 
