### PR TITLE
fix: TextEditor - Text editor will now save unordered list

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -212,7 +212,21 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 		} catch(e) {
 			value = `<div class="ql-editor read-mode">${value}</div>`;
 		}
-
+	
+		// quill keeps ol as a common container for both type of lists
+		// and uses css for appearances, this is not semantic
+		// so we convert ol to ul if it is unordered
+		const $value = $(`<div>${value}</div>`);
+		$value.find('ol li[data-list=bullet]:first-child').each((i, li) => {
+			let $li = $(li);
+			let $parent = $li.parent();
+			let $children = $parent.children();
+			let $ul = $('<ul>').append($children);
+			$parent.replaceWith($ul);
+		});
+	
+		value = $value.html();
+	
 		return value;
 	},
 


### PR DESCRIPTION
closes #14104

Works correctly on earlier versions, so added that part of the code in v13 

> Screenshots/GIFs - OUTPUT

https://user-images.githubusercontent.com/16986940/132960573-f530b50a-6496-4540-bb93-929338bed1c6.mp4

