### PR TITLE
fix: publish realtime to work with localhost

### DIFF
--- a/socketio.js
+++ b/socketio.js
@@ -260,9 +260,11 @@ function get_chat_room(socket, room) {
 }
 
 function get_site_name(socket) {
+	var hostname_from_host = get_hostname(socket.request.headers.host);
+
 	if (socket.request.headers['x-frappe-site-name']) {
 		return get_hostname(socket.request.headers['x-frappe-site-name']);
-	} else if (['localhost', '127.0.0.1'].indexOf(socket.request.headers.host) !== -1 &&
+	} else if (['localhost', '127.0.0.1'].indexOf(hostname_from_host) !== -1 &&
 		conf.default_site) {
 		// from currentsite.txt since host is localhost
 		return conf.default_site;


### PR DESCRIPTION
Currently, Publish realtime does not work in development environment until and unless the site gets opened in the browser with the site name (You do not see setup-wizard getting updated with real time publish messages if opened as localhost:port).

Fixed it by using default site(from currentsite.txt file) incase of host is localhost (by ignoring port).
