### PR TITLE
fix: Total Row in query report still hidden

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -832,6 +832,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if (this.raw_data.add_total_row) {
 			data = data.slice();
 			data.splice(-1, 1);
+			this.$page.find('.layout-main-section').css('--report-total-height', '310px');
 		}
 
 		this.$report.show();
@@ -853,10 +854,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					columnTotal: frappe.utils.report_column_total
 				}
 			};
-
-			if (this.raw_data.add_total_row) {
-				this.$page.find('.layout-main-section').css('--report-total-height', '310px');
-			}
 
 			if (this.report_settings.get_datatable_options) {
 				datatable_options = this.report_settings.get_datatable_options(datatable_options);


### PR DESCRIPTION
Total Row is missing in Query Report if `add_total_row` is set.
Fixing PR: https://github.com/frappe/frappe/pull/14041