### PR TITLE
chore(deps): bump ipython to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,7 @@ googlemaps~=4.4.5
 gunicorn~=20.1.0
 html2text==2020.1.16
 html5lib~=1.1
-ipython~=7.16.1
-jedi==0.17.2  # not directly required. Pinned to fix upstream IPython issue (https://github.com/ipython/ipython/issues/12740)
+ipython~=7.27.0
 Jinja2~=3.0.1
 ldap3~=2.9
 markdown2~=2.4.0


### PR DESCRIPTION
- unpin jedi (revert https://github.com/frappe/frappe/pull/12497 )
- Bump ipython to the latest version. This means dropping support for python 3.6 (which will be [EOL by end of this year](https://www.python.org/dev/peps/pep-0494/#and-beyond-schedule), so 🤷 )

BREAKING CHANGE. Do not backport. 