### PR TITLE
fix: Move site setup into background to fix timeouts

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -197,6 +197,8 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 			callback: (r) => {
 				if (r.message.status === 'ok') {
 					this.post_setup_success();
+				} else if (r.message.status === 'registered') {
+					this.update_setup_message(__("starting the setup..."));
 				} else if (r.message.fail !== undefined) {
 					this.abort_setup(r.message.fail);
 				}
@@ -237,6 +239,9 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 			}
 			if (data.fail_msg) {
 				this.abort_setup(data.fail_msg);
+			}
+			if (data.status === 'ok') {
+				this.post_setup_success();
 			}
 		})
 	}


### PR DESCRIPTION
Currently ERPNext setup wizard request is getting timed out once a while depending on the factors like country, timezone, server speed etc. In this PR providing an option to run setup wizard as a background job.

run below CLI to make site setup run in the background with setup wizard submission.
```
bench set-config trigger_site_setup_in_background 1
```