### PR TITLE
fix: section with collapsible content jerk issue

### DIFF
--- a/frappe/public/scss/website/page_builder.scss
+++ b/frappe/public/scss/website/page_builder.scss
@@ -486,9 +486,12 @@
 }
 
 .collapsible-content {
+	color: $gray-700;
+}
+
+.collapsible-content p {
 	margin-top: 1rem;
 	margin-bottom: 0;
-	color: $gray-700;
 }
 
 .section-with-collapsible-content.align-center {

--- a/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
+++ b/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
@@ -21,7 +21,9 @@
 				</svg>
 			</a>
 			<div class="collapse collapsible-content from-markdown" id="{{ collapse_id }}">
-				{{ frappe.utils.md_to_html(item.content) }}
+				<div>
+					{{ frappe.utils.md_to_html(item.content) }}
+				</div>
 			</div>
 		</div>
 		{%- endfor -%}


### PR DESCRIPTION
### Issue:

1. A jerk affect is observed on closing the section with collapsible content.

##### Before

https://user-images.githubusercontent.com/31363128/133258797-8f92bf16-5f17-4e16-989c-b95a5f37101a.mov

##### After

https://user-images.githubusercontent.com/31363128/133259012-ff3a4dd4-bbf0-43b9-bc60-6eed0e548c54.mov

