### PR TITLE
fix: Total Row hidden in query report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -832,7 +832,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if (this.raw_data.add_total_row) {
 			data = data.slice();
 			data.splice(-1, 1);
-			this.$page.find('.layout-main-section').css('--report-total-height', '310px');
+			this.$page.find('.layout-main-section')[0].style.setProperty('--report-total-height', '310px');
 		}
 
 		this.$report.show();


### PR DESCRIPTION
Fixing PR: https://github.com/frappe/frappe/pull/14183

In above PR setting css variable `--report-total-height` using jquery which is not working at some instance

So now setting css variable using javascript `style.setProperty` method.