### PR TITLE
fix(translation): Set translated text as html to get unescaped output

### DIFF
--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -317,7 +317,7 @@ var continue_otp_app = function (setup, qrcode) {
 		qrcode_div.append(direction);
 		$('#otp_div').prepend(qrcode_div);
 	} else {
-		direction = $('<div>').attr('id', 'qr_info').text('{{ _("OTP setup using OTP App was not completed. Please contact Administrator.") }}');
+		direction = $('<div>').attr('id', 'qr_info').html('{{ _("OTP setup using OTP App was not completed. Please contact Administrator.") }}');
 		qrcode_div.append(direction);
 		$('#otp_div').prepend(qrcode_div);
 	}
@@ -331,7 +331,7 @@ var continue_sms = function (setup, prompt) {
 		sms_div.append(prompt)
 		$('#otp_div').prepend(sms_div);
 	} else {
-		direction = $('<div>').attr('id', 'qr_info').text(prompt || '{{ _("SMS was not sent. Please contact Administrator.") }}');
+		direction = $('<div>').attr('id', 'qr_info').html(prompt || '{{ _("SMS was not sent. Please contact Administrator.") }}');
 		sms_div.append(direction);
 		$('#otp_div').prepend(sms_div)
 	}
@@ -345,7 +345,7 @@ var continue_email = function (setup, prompt) {
 		email_div.append(prompt)
 		$('#otp_div').prepend(email_div);
 	} else {
-		var direction = $('<div>').attr('id', 'qr_info').text(prompt || '{{ _("Verification code email not sent. Please contact Administrator.") }}');
+		var direction = $('<div>').attr('id', 'qr_info').html(prompt || '{{ _("Verification code email not sent. Please contact Administrator.") }}');
 		email_div.append(direction);
 		$('#otp_div').prepend(email_div);
 	}


### PR DESCRIPTION
**Before:** (Verification code box translated in `Français`)

<img width="418" alt="Screenshot 2021-09-15 at 2 07 19 PM" src="https://user-images.githubusercontent.com/13928957/133400537-dc68d226-6163-4a40-8341-871614094e65.png">

**After:**
<img width="427" alt="Screenshot 2021-09-15 at 2 06 02 PM" src="https://user-images.githubusercontent.com/13928957/133400529-bfd92fbb-a707-4dbb-9609-48a0dead98de.png">

