### PR TITLE
fix: Use whoosh AsyncWriter to prevent write locks

### DIFF
--- a/frappe/search/full_text_search.py
+++ b/frappe/search/full_text_search.py
@@ -8,6 +8,8 @@ from whoosh.index import create_in, open_dir, EmptyIndexError
 from whoosh.fields import TEXT, ID, Schema
 from whoosh.qparser import MultifieldParser, FieldsPlugin, WildcardPlugin
 from whoosh.query import Prefix
+from whoosh.writing import AsyncWriter
+
 
 class FullTextSearch:
 	""" Frappe Wrapper for Whoosh """
@@ -75,7 +77,7 @@ class FullTextSearch:
 		ix = self.get_index()
 
 		with ix.searcher():
-			writer = ix.writer()
+			writer = AsyncWriter(ix)
 			writer.delete_by_term(self.id, document[self.id])
 			writer.add_document(**document)
 			writer.commit(optimize=True)


### PR DESCRIPTION
When there are concurrent writes, whoosh is failing with lock errors. 

<img width="891" alt="Screenshot 2021-09-15 at 16 47 00" src="https://user-images.githubusercontent.com/4463796/133426248-4c10b812-6081-4bd7-9b5a-e01def6f2a43.png">
