### PR TITLE
chore: change log for version 13.11.0

### DIFF
--- a/frappe/change_log/v13/v13_11_0.md
+++ b/frappe/change_log/v13/v13_11_0.md
@@ -1,0 +1,24 @@
+# Version 13.11.0 Release Notes
+
+### Features & Enhancements
+
+- Ability to select a child in multi-select dialog ([#12471](https://github.com/frappe/frappe/pull/12471))
+- Choose Letter Head when printing multiple documents from List / Report ([#14099](https://github.com/frappe/frappe/pull/14099))
+- Add number format parameter in fmt_money ([#13255](https://github.com/frappe/frappe/pull/13255))
+
+
+### Fixes
+
+- Total Row is hidden in Query Report & Script Report ([#14041](https://github.com/frappe/frappe/pull/14041))
+- Multi-select dialog child table filtering ([#14181](https://github.com/frappe/frappe/pull/14181))
+- RTL support for text editor ([#14113](https://github.com/frappe/frappe/pull/14113))
+- Incorrect text color on version document in dark mode ([#14147](https://github.com/frappe/frappe/pull/14147))
+- Notify consumers on document cancel ([#14160](https://github.com/frappe/frappe/pull/14160))
+- Customizing print formats ([#14132](https://github.com/frappe/frappe/pull/14132))
+- Report View single vertical scrollbar ([#13497](https://github.com/frappe/frappe/pull/13497))
+- Switch writes to primary when wrapped with read_only ([#14142](https://github.com/frappe/frappe/pull/14142))
+- Bring back the missing Comments ([#14129](https://github.com/frappe/frappe/pull/14129))
+- Only enabled users in mentions ([#14017](https://github.com/frappe/frappe/pull/14017))
+- Length change for docfield not updated in Database ([#13965](https://github.com/frappe/frappe/pull/13965))
+- Deprecate `cast_fieldtype` to use `cast` for consistent return types ([#13989](https://github.com/frappe/frappe/pull/13989))
+- Node creation from tree view ([#14114](https://github.com/frappe/frappe/pull/14114))


### PR DESCRIPTION
# Version 13.11.0 Release Notes

### Features & Enhancements

- Ability to select a child in multi-select dialog ([#12471](https://github.com/frappe/frappe/pull/12471))
- Choose Letter Head when printing multiple documents from List / Report ([#14099](https://github.com/frappe/frappe/pull/14099))
- Add number format parameter in fmt_money ([#13255](https://github.com/frappe/frappe/pull/13255))


### Fixes

- Total Row is hidden in Query Report & Script Report ([#14041](https://github.com/frappe/frappe/pull/14041))
- Multi-select dialog child table filtering ([#14181](https://github.com/frappe/frappe/pull/14181))
- RTL support for text editor ([#14113](https://github.com/frappe/frappe/pull/14113))
- Incorrect text color on version document in dark mode ([#14147](https://github.com/frappe/frappe/pull/14147))
- Notify consumers on document cancel ([#14160](https://github.com/frappe/frappe/pull/14160))
- Customizing print formats ([#14132](https://github.com/frappe/frappe/pull/14132))
- Report View single vertical scrollbar ([#13497](https://github.com/frappe/frappe/pull/13497))
- Switch writes to primary when wrapped with read_only ([#14142](https://github.com/frappe/frappe/pull/14142))
- Bring back the missing Comments ([#14129](https://github.com/frappe/frappe/pull/14129))
- Only enabled users in mentions ([#14017](https://github.com/frappe/frappe/pull/14017))
- Length change for docfield not updated in Database ([#13965](https://github.com/frappe/frappe/pull/13965))
- Deprecate `cast_fieldtype` to use `cast` for consistent return types ([#13989](https://github.com/frappe/frappe/pull/13989))
- Node creation from tree view ([#14114](https://github.com/frappe/frappe/pull/14114))