### PR TITLE
fix(database): Fixed sql convention inconsistency

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -332,7 +332,7 @@ class Database(object):
 			values[key] = value
 			if isinstance(value, (list, tuple)):
 				# value is a tuple like ("!=", 0)
-				_operator = value[0]
+				_operator = value[0].lower()
 				values[key] = value[1]
 				if isinstance(value[1], (tuple, list)):
 					# value is a list in tuple ("in", ("A", "B"))


### PR DESCRIPTION
There was an annoying bug where sql operators written in capital case were causing invalid SQL syntax. frappe.get_list and frappe.get_all are working correctly: You can add a filter like 
```python
# This works fine 
frappe.get_list("Employee", filters={
    "name": ("IN", ("Employee1", "Employee2"))
})
```

But frappe.db.count doesn't work with capital case (like the default convention for SQL syntax):
```python
# This doesn't work
frappe.db.count("Employee", filters={
    "status": ("IN", ("Passive", "Active"))
})
```

The working solution would be (but this can cause problems easily if someone doesn't know that):
```python
# This works fine 
frappe.db.count("Employee", filters={
    "status": ("in", ("Passive", "Active"))
})
```

```python
# This is how it should work too
frappe.db.count("Employee", filters={
    "status": ("IN", ("Passive", "Active"))
})
```
