### PR TITLE
fix: CSV upload failure

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -835,10 +835,11 @@ export default class Grid {
 									$.each(row, (ci, value) => {
 										var fieldname = fieldnames[ci];
 										var df = frappe.meta.get_docfield(me.df.options, fieldname);
-
-										d[fieldnames[ci]] = value_formatter_map[df.fieldtype]
-											? value_formatter_map[df.fieldtype](value)
-											: value;
+										if (df) {
+											d[fieldnames[ci]] = value_formatter_map[df.fieldtype]
+												? value_formatter_map[df.fieldtype](value)
+												: value;
+										}
 									});
 								}
 							}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -927,7 +927,16 @@ Object.assign(frappe.utils, {
 		// decodes base64 to string
 		let parts = dataURI.split(',');
 		const encoded_data = parts[1];
-		return decodeURIComponent(escape(atob(encoded_data)));
+		let decoded = atob(encoded_data);
+		try {
+			const escaped = escape(decoded);
+			decoded = decodeURIComponent(escaped);
+
+		} catch (e) {
+			// pass decodeURIComponent failure
+			// just return atob response
+		}
+		return decoded;
 	},
 	copy_to_clipboard(string) {
 		let input = $("<input>");


### PR DESCRIPTION
Fixes the following failure while uploading CSV from the grid.

Happen if CSV has extra unknown columns
```js
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'fieldtype')
    at String.<anonymous> (grid.js:839)
    at Function.each (jquery.js:381)
    at Array.<anonymous> (grid.js:835)
    at Function.each (jquery.js:381)
    at VueComponent.on_success (grid.js:823)
    at FileUploader.vue:384
    at async Promise.all (index 0)
```

Happens if csv has `%` in CSV 
```js
Uncaught (in promise) URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at Object.get_decoded_string (utils.js:930)
    at VueComponent.on_success (grid.js:819)
    at FileUploader.vue:384
    at async Promise.all (index 0)
```

https://frappe.io/app/issue/ISS-21-22-05970