### PR TITLE
fix(develop): Drop support for Python 3.6

### DIFF
--- a/.github/workflows/docs-checker.yml
+++ b/.github/workflows/docs-checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'Setup Environment'
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
 
       - name: 'Clone repo'
         uses: actions/checkout@v2

--- a/.github/workflows/publish-assets-develop.yml
+++ b/.github/workflows/publish-assets-develop.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 14
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.7'
       - name: Set up bench and build assets
         run: |
           npm install -g yarn

--- a/.github/workflows/publish-assets-releases.yml
+++ b/.github/workflows/publish-assets-releases.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '12.x'
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.7'
       - name: Set up bench and build assets
         run: |
           npm install -g yarn

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,5 @@ setup(
 	{
 		'clean': CleanCommand
 	},
-	python_requires='>=3.6'
+	python_requires='>=3.7'
 )


### PR DESCRIPTION
* Bumping iPython by a minor version broke 3.6 installs for us via https://github.com/frappe/frappe/pull/14192 (See assets' actions)
* We could just add another line in requirements.txt to solve this, but
  since PY36 is reaching end of life by end of this year and release of
  3.10 is just around the corner, might as well just drop it now than
    later
* Frappe v14 would probably have the support range of 3.7-3.10/11 given
  when we release it. Maintaining dependencies for such a large range
  can become cumbersome