### PR TITLE
feat: automatically reload web pages whenever JS/CSS assets are rebuilt

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -44,7 +44,7 @@ let argv = yargs
 		type: "boolean",
 		description: "Run in watch mode and rebuild on file changes"
 	})
-	.option("auto-reload", {
+	.option("live-reload", {
 		type: "boolean",
 		description: `Automatically reload webpages when assets are rebuilt.
 			Can only be used with the --watch flag.`
@@ -481,7 +481,7 @@ async function notify_redis({ error, success }) {
 	if (success) {
 		payload = {
 			success: true,
-			autoreload: argv["auto-reload"]
+			live_reload: argv["live-reload"]
 		};
 	}
 

--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -46,7 +46,7 @@ let argv = yargs
 	})
 	.option("live-reload", {
 		type: "boolean",
-		description: `Automatically reload webpages when assets are rebuilt.
+		description: `Automatically reload web pages when assets are rebuilt.
 			Can only be used with the --watch flag.`
 	})
 	.option("production", {

--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -44,6 +44,11 @@ let argv = yargs
 		type: "boolean",
 		description: "Run in watch mode and rebuild on file changes"
 	})
+	.option("auto-reload", {
+		type: "boolean",
+		description: `Automatically reload webpages when assets are rebuilt.
+			Can only be used with the --watch flag.`
+	})
 	.option("production", {
 		type: "boolean",
 		description: "Run build in production mode"
@@ -475,7 +480,8 @@ async function notify_redis({ error, success }) {
 	}
 	if (success) {
 		payload = {
-			success: true
+			success: true,
+			autoreload: argv["auto-reload"]
 		};
 	}
 

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -235,8 +235,12 @@ def watch(apps=None):
 	if apps:
 		command += " --apps {apps}".format(apps=apps)
 
-	if frappe.conf.autoreload_on_build:
-		command += " --auto-reload"
+	live_reload = frappe.conf.live_reload
+	if "LIVE_RELOAD" in os.environ:
+		live_reload = os.environ["LIVE_RELOAD"]
+
+	if live_reload:
+		command += " --live-reload"
 
 	check_node_executable()
 	frappe_app_path = frappe.get_app_path("frappe", "..")

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -235,9 +235,9 @@ def watch(apps=None):
 	if apps:
 		command += " --apps {apps}".format(apps=apps)
 
-	live_reload = frappe.conf.live_reload
-	if "LIVE_RELOAD" in os.environ:
-		live_reload = os.environ["LIVE_RELOAD"]
+	live_reload = frappe.utils.cint(
+		os.environ.get("LIVE_RELOAD", frappe.conf.live_reload)
+	)
 
 	if live_reload:
 		command += " --live-reload"

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -235,6 +235,9 @@ def watch(apps=None):
 	if apps:
 		command += " --apps {apps}".format(apps=apps)
 
+	if frappe.conf.autoreload_on_build:
+		command += " --auto-reload"
+
 	check_node_executable()
 	frappe_app_path = frappe.get_app_path("frappe", "..")
 	frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env())

--- a/frappe/public/js/frappe/build_events/BuildSuccess.vue
+++ b/frappe/public/js/frappe/build_events/BuildSuccess.vue
@@ -3,8 +3,11 @@
 		v-if="is_shown"
 		class="flex justify-between build-success-message align-center"
 	>
-		<div class="mr-4">Compiled successfully</div>
-		<a class="text-white underline" href="/" @click.prevent="reload">
+		Compiled successfully
+		<a
+			v-if="!autoreload"
+			class="ml-4 text-white underline" href="/" @click.prevent="reload"
+		>
 			Refresh
 		</a>
 	</div>
@@ -14,11 +17,17 @@ export default {
 	name: "BuildSuccess",
 	data() {
 		return {
-			is_shown: false
+			is_shown: false,
+			autoreload: false,
 		};
 	},
 	methods: {
-		show() {
+		show(data) {
+			if (data.autoreload) {
+				this.autoreload = true;
+				this.reload();
+			}
+
 			this.is_shown = true;
 			if (this.timeout) {
 				clearTimeout(this.timeout);

--- a/frappe/public/js/frappe/build_events/BuildSuccess.vue
+++ b/frappe/public/js/frappe/build_events/BuildSuccess.vue
@@ -5,7 +5,7 @@
 	>
 		Compiled successfully
 		<a
-			v-if="!autoreload"
+			v-if="!live_reload"
 			class="ml-4 text-white underline" href="/" @click.prevent="reload"
 		>
 			Refresh
@@ -18,13 +18,13 @@ export default {
 	data() {
 		return {
 			is_shown: false,
-			autoreload: false,
+			live_reload: false,
 		};
 	},
 	methods: {
 		show(data) {
-			if (data.autoreload) {
-				this.autoreload = true;
+			if (data.live_reload) {
+				this.live_reload = true;
 				this.reload();
 			}
 

--- a/frappe/public/js/frappe/build_events/build_events.bundle.js
+++ b/frappe/public/js/frappe/build_events/build_events.bundle.js
@@ -13,10 +13,11 @@ frappe.realtime.on("build_event", data => {
 	}
 });
 
-function show_build_success() {
+function show_build_success(data) {
 	if (error) {
 		error.hide();
 	}
+
 	if (!success) {
 		let target = $('<div class="build-success-container">')
 			.appendTo($container)
@@ -27,7 +28,7 @@ function show_build_success() {
 		});
 		success = vm.$children[0];
 	}
-	success.show();
+	success.show(data);
 }
 
 function show_build_error(data) {


### PR DESCRIPTION
This PR makes use of a new config (`live_reload`) defined in `common_site_config.json` to automatically reload webpages whenever esbuild rebuilds JS/CSS assets in watch mode.


## In Action

![autoreload_on_build](https://user-images.githubusercontent.com/16315650/133735533-9bf75141-bc73-459e-a950-f1c1c34a4c21.gif)

---

Documentation PR: https://github.com/frappe/frappe_docs/pull/217
Bench PR: https://github.com/frappe/bench/pull/1205