### PR TITLE
fix: shift+tab keyboard navigation

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -408,7 +408,8 @@ frappe.ui.form.Layout = class Layout {
 					// next row
 					grid_row.grid.grid_rows[grid_row.doc.idx].toggle_view(true);
 				}
-			} else {
+			} else if (!shift) {
+				// End of tab navigation
 				$(this.primary_button).focus();
 			}
 		}


### PR DESCRIPTION
Reverse tab navigation seems to be broken from years, instead of going
back to the previous field, it jumps to the primary button.

Root cause: when all fields are exhausted it's supposed to go to primary
button, however, that's not the case for shift-tab.

Before:

https://user-images.githubusercontent.com/9079960/133797758-d65ea728-c0a7-4601-87f4-cd91ce929fcc.mov


After:


https://user-images.githubusercontent.com/9079960/133797817-3096a77b-ac65-4fe9-85e6-f4079cbaa670.mov



<details>
    <summary>sidenote</summary>
    This convoluted spaghetti needs to be refactored. I thought this was an issue with `tabindex` but only found out that there is a custom tab handler from recorded performance snapshot. 🥲 
</details>


Closes https://github.com/frappe/frappe/issues/14244

discuss: https://discuss.erpnext.com/t/shift-tab-in-forms/9682