### PR TITLE
feat: patch conditions and document reload list

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -103,3 +103,5 @@ jobs:
           wget https://frappeframework.com/files/v10-frappe.sql.gz
           bench --site test_site --force restore ~/frappe-bench/v10-frappe.sql.gz
           bench --site test_site migrate
+        env:
+          PATCH_TEST: mariadb

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -10,6 +10,7 @@
 
 	where patch1, patch2 is module name
 """
+import os
 import click
 import frappe, frappe.permissions, time
 
@@ -20,6 +21,7 @@ def run_all(skip_failing=False):
 	executed = [p[0] for p in frappe.db.sql("""select patch from `tabPatch Log`""")]
 
 	frappe.flags.final_patches = []
+	frappe.flags.in_patch_test = bool(os.environ.get("PATCH_TEST"))
 
 	def run_patch(patch):
 		try:
@@ -107,7 +109,7 @@ def _execute_patch_file(patch_module_path):
 	patch_module = frappe.get_module(dotted_path)
 
 	patch_required = True
-	if hasattr(patch_module, "condition"):
+	if not frappe.flags.in_patch_test and hasattr(patch_module, "condition"):
 		patch_required = bool(patch_module.condition())
 
 	if not patch_required:

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -183,3 +183,4 @@ frappe.patches.v13_0.update_notification_channel_if_empty
 frappe.patches.v14_0.drop_data_import_legacy
 frappe.patches.v14_0.rename_cancelled_documents
 frappe.patches.v14_0.update_workspace2 # 25.08.2021
+frappe.patches.v14_0.template

--- a/frappe/patches/v14_0/template.py
+++ b/frappe/patches/v14_0/template.py
@@ -1,0 +1,33 @@
+from typing import List, Tuple
+
+import click
+
+# list of documents to reload with frappe.reload_doc
+# example: ("core", "doctype", "doctype")
+documents_to_reload: List[Tuple[str, str, str]] = [
+	("core", "doctype", "doctype"),
+]
+
+
+def condition() -> bool:
+	"""return value of this function determines whether patch will run or not.
+
+	Patches are meant to repair data or change schema based on certain conditions, this function should capture them.
+
+	Example:
+	        A patch that should only execute if there are any Indian companies in database.
+
+	        ```python
+	        def condition:
+	                return bool(frappe.db.exists("Company", {"country": "India"}))
+	        ```
+
+	Note:
+	        1. This condition is ignored in patch tests.
+	        2. If this function is removed from patch file, `execute` function is executed unconditionally.
+	"""
+	return True
+
+
+def execute() -> None:
+	click.secho(f"Executed patch {__file__}", fg="yellow")

--- a/frappe/patches/v14_0/template.py
+++ b/frappe/patches/v14_0/template.py
@@ -15,18 +15,18 @@ def condition() -> bool:
 	Patches are meant to repair data or change schema based on certain conditions, this function should capture them.
 
 	Example:
-	        A patch that should only execute if there are any Indian companies in database.
+		A patch that should only execute if there are any Indian companies in database.
 
-	        ```python
-	        def condition:
-	                return bool(frappe.db.exists("Company", {"country": "India"}))
-	        ```
+		```python
+		def condition:
+				return bool(frappe.db.exists("Company", {"country": "India"}))
+		```
 
 	Note:
-	        1. This condition is ignored in patch tests.
-	        2. If this function is removed from patch file, `execute` function is executed unconditionally.
+		1. This condition is ignored in patch tests.
+		2. If this function is removed from patch file, `execute` function is executed unconditionally.
 	"""
-	return True
+	return False
 
 
 def execute() -> None:


### PR DESCRIPTION
why?

![Screenshot 2021-09-18 at 12 43 14 PM](https://user-images.githubusercontent.com/9079960/133879987-aad3094f-25a0-48c4-a6e0-45a61ceeb429.png)

Why this change?

Most patches I've read can be broken down in 3 steps:
1. Check whether patch should be applied -> Condition
2. Reload relevant schema before patch (_optional_)
3. Apply the patch changes to DB.

This should be somehow broken into 3 distinct parts, either by different functions or by making patches OO; Otherwise patches are a bunch of scripts without any structure to them. 

change:
1. Add `condition` function to patches that will get ignored in patch test, so patches will actually run (a little bit more), thus revealing missing bits like missing required "reload_doc".
2. Add list of docs to reload at top. Doesn't offer much benefit than a reminder to list down affected schemas that should be reloaded before running patch.

Template for writing a new patch:

```python


# list of documents to reload with frappe.reload_doc
# example: ("core", "doctype", "doctype")
documents_to_reload: List[Tuple[str, str, str]] = [
	("core", "doctype", "doctype"),
]


def condition() -> bool:
	"""return value of this function determines whether patch will run or not.
	Patches are meant to repair data or change schema based on certain conditions, 
	this function should capture them.
	
	Example:
	        A patch that should only execute if there are any Indian companies in database.
	        ```python
	        def condition:
	                return bool(frappe.db.exists("Company", {"country": "India"}))
	        ```
	Note:
	        1. This condition is ignored in patch tests.
	        2. If this function is removed from patch file, `execute` function is executed unconditionally.
	"""
	return True


def execute() -> None:
	click.secho(f"Executed patch {__file__}", fg="yellow")
	# your magic here

 


```


TODO:
- [x] rewrite some patches to see how well/badly this performs 😄  https://github.com/frappe/erpnext/pull/27607
- [ ] docs

Observation from https://github.com/frappe/erpnext/pull/27607:
- Some conditions can't be ignored in the patch tests. E.g. `table_exists` as these are a test against DB directly. 😐 
