### PR TITLE
test: run patch test for each major release and then to PR

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -102,4 +102,13 @@ jobs:
           cd ~/frappe-bench/
           wget https://frappeframework.com/files/v10-frappe.sql.gz
           bench --site test_site --force restore ~/frappe-bench/v10-frappe.sql.gz
+          cd apps/frappe && git remote set-url upstream https://github.com/frappe/frappe.git && git fetch --all --tags
+          git tag --sort version:refname \
+            | grep -v "beta" \
+            | tail -1 \
+            | xargs -L 1 git checkout -f
+          bench setup requirements --python
+          bench --site test_site migrate --skip-search-index
+          git checkout -f "$GITHUB_SHA"
+          bench setup requirements --python
           bench --site test_site migrate

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -102,7 +102,11 @@ jobs:
           cd ~/frappe-bench/
           wget https://frappeframework.com/files/v10-frappe.sql.gz
           bench --site test_site --force restore ~/frappe-bench/v10-frappe.sql.gz
-          cd apps/frappe && git remote set-url upstream https://github.com/frappe/frappe.git && git fetch --all --tags
+
+          source env/bin/activate
+          cd apps/frappe/
+          git remote set-url upstream https://github.com/frappe/frappe.git
+          git fetch --all --tags
 
           taglist=$(git tag --sort version:refname | grep -v "beta")
           last_release=$(echo "$taglist" | tail -1 | cut -d . -f 1 | cut -c 2-)
@@ -111,11 +115,12 @@ jobs:
           do
               last_tag=$(echo "$taglist" | grep "v$version" | tail -1)
               echo "Updating to $last_tag"
-              git checkout -f "$last_tag"
-              bench setup requirements --python
+              git checkout -q -f "$last_tag"
+              pip install -q -r requirements.txt
               bench --site test_site migrate
           done
 
-          git checkout -f "$GITHUB_SHA"
+          echo "Updating to last commit"
+          git checkout -q -f "$GITHUB_SHA"
           bench setup requirements --python
           bench --site test_site migrate

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -103,12 +103,19 @@ jobs:
           wget https://frappeframework.com/files/v10-frappe.sql.gz
           bench --site test_site --force restore ~/frappe-bench/v10-frappe.sql.gz
           cd apps/frappe && git remote set-url upstream https://github.com/frappe/frappe.git && git fetch --all --tags
-          git tag --sort version:refname \
-            | grep -v "beta" \
-            | tail -1 \
-            | xargs -L 1 git checkout -f
-          bench setup requirements --python
-          bench --site test_site migrate --skip-search-index
+
+          taglist=$(git tag --sort version:refname | grep -v "beta")
+          last_release=$(echo "$taglist" | tail -1 | cut -d . -f 1 | cut -c 2-)
+
+          for version in $(seq 12 "$last_release")
+          do
+              last_tag=$(echo "$taglist" | grep "v$version" | tail -1)
+              echo "Updating to $last_tag"
+              git checkout -f "$last_tag"
+              bench setup requirements --python
+              bench --site test_site migrate
+          done
+
           git checkout -f "$GITHUB_SHA"
           bench setup requirements --python
           bench --site test_site migrate


### PR DESCRIPTION
Change:

- In the patch test, instead of migrating to the current SHA directly. Migrate to the each major releases one at a time (checking out code at the time of release) and then finally migrate to last commit in PR. 
- Why? When directly migrating, the previous patches will have access to latest code and patches won't run as they'd run on IRL installations, hence missing failures. This change brings it a little bit closer to reality. 

Example migration: 

V10 database -> V12 latest release -> v13 latest release -> ... -> last commit in PR. 

Only the first version is hard coded to v12, this should continue to work for all future major releases as long as they follow tagging convention. 

PS: will update the ERPNext test once this is accepted. 

Depends on https://github.com/frappe/frappe/pull/14293 (with a tagged release)