### PR TITLE
feat: Internal Sections using Line Break

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -595,13 +595,21 @@ frappe.ui.form.Section = class FormSection {
 		if (!this.layout.page) {
 			this.layout.page = $('<div class="form-page"></div>').appendTo(this.layout.wrapper);
 		}
-		let make_card = this.layout.card_layout;
-		this.wrapper = $(`<div class="row form-section ${ make_card ? "card-section" : "" }">`)
-			.appendTo(this.layout.page);
+
+		let is_internal_section = this.df.hide_border;
+		if (is_internal_section && this.layout.section) {
+			this.wrapper = $(`<div class="row form-section internal-section">`);
+			this.wrapper.appendTo(this.layout.section.wrapper);
+		} else {
+			let make_card = this.layout.card_layout;
+			this.wrapper = $(`<div class="row form-section ${ make_card ? "card-section" : "" }">`);
+			this.wrapper.appendTo(this.layout.page);
+		}
+
 		this.layout.sections.push(this);
 
 		if (this.df) {
-			if (this.df.label) {
+			if (!is_internal_section && this.df.label) {
 				this.make_head();
 			}
 			if (this.df.description) {

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -305,6 +305,10 @@
 		}
 	}
 
+	.internal-section {
+		flex: 1;
+	}
+
 	.grid-delete-row {
 		.icon use {
 			stroke: var(--fg-color);

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -144,6 +144,10 @@ body.modal-open[style^="padding-right"] {
 		}
 	}
 
+	.internal-section {
+		flex: 1;
+	}
+
 	.hasDatepicker {
 		z-index: 1140;
 	}

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -40,6 +40,10 @@
 	}
 }
 
+.internal-section {
+	flex: 1;
+}
+
 .empty-section {
 	display: none !important;
 	border: 0 !important;

--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -205,6 +205,10 @@ h5.modal-title {
 	margin: 0px;
 }
 
+.internal-section {
+	flex: 1;
+}
+
 .form-section .section-body {
 	width: 100%;
 	margin: 0;


### PR DESCRIPTION
Before the version-13 redesign, since sections were divided by a border, a `hide_border` property was used to create sections within sections just by removing the border. 

This PR uses the same `hide_border` (temporarily) property to append a section within the previous section.

Without Hide Border:

<img width="1081" alt="CleanShot 2021-09-19 at 15 35 21@2x" src="https://user-images.githubusercontent.com/25369014/133923602-7e353b86-b8c8-4d55-99f5-0f46566e6c53.png">

With Hide Border:

<img width="1090" alt="CleanShot 2021-09-19 at 15 38 10@2x" src="https://user-images.githubusercontent.com/25369014/133923589-f6bed219-f8d0-42f9-b0ee-5fed7a50a24a.png">

Caveats:
- For a case when:
  - Section A (Visible)
  - Section B (Hidden for any reason)
  - Section C (with `hide_border` checked)
- Then Section C is appended and hidden inside the Section B

---

- [ ] Modify 'Hide Border' label & fieldname