### PR TITLE
fix(Workflow Action): Pass doc to attach_print to avoid "Not Found"

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -9,9 +9,10 @@ from frappe.desk.form.utils import get_pdf_link
 from frappe.utils.verified_command import get_signed_params, verify_request
 from frappe import _
 from frappe.model.workflow import apply_workflow, get_workflow_name, has_approval_access, \
-	get_workflow_state_field, send_email_alert, get_workflow_field_value, is_transition_condition_satisfied
+	get_workflow_state_field, send_email_alert, is_transition_condition_satisfied
 from frappe.desk.notifications import clear_doctype_notifications
 from frappe.utils.user import get_users_with_role
+from frappe.utils.data import get_link_to_form
 
 class WorkflowAction(Document):
 	pass
@@ -287,7 +288,7 @@ def get_common_email_args(doc):
 		response = frappe.render_template(email_template.response, vars(doc))
 	else:
 		subject = _('Workflow Action')
-		response = _('{0}: {1}').format(doctype, docname)
+		response = get_link_to_form(doctype, docname, f"{doctype}: {docname}")
 
 	common_args = {
 		'template': 'workflow_action',

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -292,7 +292,7 @@ def get_common_email_args(doc):
 	common_args = {
 		'template': 'workflow_action',
 		'header': 'Workflow Action',
-		'attachments': [frappe.attach_print(doctype, docname , file_name=docname)],
+		'attachments': [frappe.attach_print(doctype, docname, file_name=docname, doc=doc)],
 		'subject': subject,
 		'message': response
 	}


### PR DESCRIPTION
- PDFs used to go empty for new documents due to a "Not Found" error in printview because that new document has not been saved in the database while processing workflow action email.

**Before fix:** (in workflow action email for newly created document)
![Screenshot 2021-09-20 at 10 15 00 AM](https://user-images.githubusercontent.com/13928957/133957982-f8e535cc-ffc0-4143-9531-47aebeb8e05d.png)

**After fix:** (in workflow action email for newly created document)
![Screenshot 2021-09-20 at 10 20 03 AM](https://user-images.githubusercontent.com/13928957/133958205-7079436d-cfa1-474f-a6e8-76b6a8095e73.png)

- Also, linked reference document.

**Before:**
![Screenshot 2021-09-20 at 10 38 37 AM](https://user-images.githubusercontent.com/13928957/133959100-34ebb49d-494e-421d-849b-6aaa3c41888d.png)
**After:**
![Screenshot 2021-09-20 at 10 41 09 AM](https://user-images.githubusercontent.com/13928957/133959207-053bd39b-7df0-4159-811b-c0438cb69253.png)

