### PR TITLE
fix: properly queue tasks in `frappe.model.trigger`

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -181,8 +181,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 				me.layout.refresh_dependency();
 				me.layout.refresh_sections();
-				let object = me.script_manager.trigger(fieldname, doc.doctype, doc.name);
-				return object;
+				return me.script_manager.trigger(fieldname, doc.doctype, doc.name);
 			}
 		});
 
@@ -197,7 +196,7 @@ frappe.ui.form.Form = class FrappeForm {
 				if(doc.parent===me.docname && doc.parentfield===df.fieldname) {
 					me.dirty();
 					me.fields_dict[df.fieldname].grid.set_value(fieldname, value, doc);
-					me.script_manager.trigger(fieldname, doc.doctype, doc.name);
+					return me.script_manager.trigger(fieldname, doc.doctype, doc.name);
 				}
 			});
 		});

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -465,31 +465,31 @@ $.extend(frappe.model, {
 	},
 
 	trigger: function(fieldname, value, doc) {
-		let tasks = [];
-		var runner = function(events, event_doc) {
-			$.each(events || [], function(i, fn) {
-				if(fn) {
-					let _promise = fn(fieldname, value, event_doc || doc);
+		const tasks = [];
+
+		function enqueue_events(events) {
+			if (!events) return;
+
+			for (const fn of events) {
+				if (!fn) continue;
+
+				tasks.push(() => {
+					const return_value = fn(fieldname, value, doc);
 
 					// if the trigger returns a promise, return it,
 					// or use the default promise frappe.after_ajax
-					if (_promise && _promise.then) {
-						return _promise;
+					if (return_value && return_value.then) {
+						return return_value;
 					} else {
 						return frappe.after_server_call();
 					}
-				}
-			});
+				});
+			}
 		};
 
 		if(frappe.model.events[doc.doctype]) {
-			tasks.push(() => {
-				return runner(frappe.model.events[doc.doctype][fieldname]);
-			});
-
-			tasks.push(() => {
-				return runner(frappe.model.events[doc.doctype]['*']);
-			});
+			enqueue_events(frappe.model.events[doc.doctype][fieldname]);
+			enqueue_events(frappe.model.events[doc.doctype]['*']);
 		}
 
 		return frappe.run_serially(tasks);


### PR DESCRIPTION
## Issue
It is intended to run all events synchronously / serially when a specific field's value is set. However, `frappe.model.trigger` doesn't do this as of now. I think the author intended the `runner` inside `frappe.model.trigger` to return a Promise-like object, but actually, it returns nothing as of now. This is because the `return` statements are connected to the inner anonymous function defined when executing `$.each` and not the `runner` itself.

## Changes Made

### model.js
- `runner` => `enqueue_events`
- push each event to `tasks` instead of pushing the `runner` itself
- `_promise` => `return_value`
- use of `const`

### form.js
- remove unnecessary variable `object`
- return the promise received on triggering a child doc field's event, just like we do for a main doc field's event

## In action

When trying to set `rate` in `Sales Invoice Item` after programatically setting `item_code`

### Before

![rate_before](https://user-images.githubusercontent.com/16315650/133989080-c0d0e17a-229a-4a6f-893c-2c33594fcb0c.gif)

### After

![rate_after](https://user-images.githubusercontent.com/16315650/133988885-d0bb75da-38f3-4f2a-a425-1ea33b044cda.gif)
