### PR TITLE
chore: change log for v12.22.0

### DIFF
--- a/frappe/change_log/v12/v12_22_0.md
+++ b/frappe/change_log/v12/v12_22_0.md
@@ -1,0 +1,8 @@
+## Version 12.22.0 Release Notes
+
+### Fixes & Enhancements
+
+- Switch writes to primary when wrapped with read_only ([#14142](https://github.com/frappe/frappe/pull/14142))
+- Custom database port for read-only replica configuration ([#14159](https://github.com/frappe/frappe/pull/14159))
+- Date or datetime fields disappearing on save ([#14139](https://github.com/frappe/frappe/pull/14139))
+- Accurately cast fieldtype in frappe.db.get_single_value() ([#13655](https://github.com/frappe/frappe/pull/13655))


### PR DESCRIPTION
## Version 12.22.0 Release Notes

### Fixes & Enhancements

- Switch writes to primary when wrapped with read_only ([#14142](https://github.com/frappe/frappe/pull/14142))
- Custom database port for read-only replica configuration ([#14159](https://github.com/frappe/frappe/pull/14159))
- Date or datetime fields disappearing on save ([#14139](https://github.com/frappe/frappe/pull/14139))
- Accurately cast fieldtype in frappe.db.get_single_value() ([#13655](https://github.com/frappe/frappe/pull/13655))