### PR TITLE
fix: All all roles to create tags

### DIFF
--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -128,46 +128,35 @@ def delete_tags_for_document(doc):
 	})
 
 def update_tags(doc, tags):
-	"""
-		Adds tags for documents
-		:param doc: Document to be added to global tags
-	"""
+	"""Adds tags for documents
 
+	:param doc: Document to be added to global tags
+	"""
 	new_tags = {tag.strip() for tag in tags.split(",") if tag}
-
-	for tag in new_tags:
-		if not frappe.db.exists("Tag Link", {"parenttype": doc.doctype, "parent": doc.name, "tag": tag}):
-			frappe.get_doc({
-				"doctype": "Tag Link",
-				"document_type": doc.doctype,
-				"document_name": doc.name,
-				"parenttype": doc.doctype,
-				"parent": doc.name,
-				"title": doc.get_title() or '',
-				"tag": tag
-			}).insert(ignore_permissions=True)
-
 	existing_tags = [tag.tag for tag in frappe.get_list("Tag Link", filters={
 			"document_type": doc.doctype,
 			"document_name": doc.name
 		}, fields=["tag"])]
 
-	deleted_tags = get_deleted_tags(new_tags, existing_tags)
+	added_tags = set(new_tags) - set(existing_tags)
+	for tag in added_tags:
+		frappe.get_doc({
+			"doctype": "Tag Link",
+			"document_type": doc.doctype,
+			"document_name": doc.name,
+			"parenttype": doc.doctype,
+			"parent": doc.name,
+			"title": doc.get_title() or '',
+			"tag": tag
+		}).insert(ignore_permissions=True)
 
-	if deleted_tags:
-		for tag in deleted_tags:
-			delete_tag_for_document(doc.doctype, doc.name, tag)
-
-def get_deleted_tags(new_tags, existing_tags):
-
-	return list(set(existing_tags) - set(new_tags))
-
-def delete_tag_for_document(dt, dn, tag):
-	frappe.db.delete("Tag Link", {
-		"document_type": dt,
-		"document_name": dn,
-		"tag": tag
-	})
+	deleted_tags = list(set(existing_tags) - set(new_tags))
+	for tag in deleted_tags:
+		frappe.db.delete("Tag Link", {
+			"document_type": doc.doctype,
+			"document_name": doc.name,
+			"tag": tag
+		})
 
 @frappe.whitelist()
 def get_documents_for_tag(tag):

--- a/frappe/desk/doctype/tag_link/tag_link.json
+++ b/frappe/desk/doctype/tag_link/tag_link.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2019-09-24 13:25:36.435685",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -44,7 +45,8 @@
    "read_only": 1
   }
  ],
- "modified": "2019-10-03 16:42:35.932409",
+ "links": [],
+ "modified": "2021-09-20 16:53:37.217998",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Tag Link",
@@ -59,6 +61,17 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
Currently creating tags for a document by any user other than system
manager throwing below error. Fixed it by giving `Tag Link` read permissions to `ALL` role.

![Screenshot 2021-09-20 at 5 06 12 PM](https://user-images.githubusercontent.com/36557/133995965-5a587bda-5b7a-4405-b4b7-f8f0b8715e5b.png)


