### PR TITLE
fix: Email issues

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -140,7 +140,7 @@ def notify(doc, print_html=None, print_format=None, attachments=None,
 			recipients=recipients, cc=cc, bcc=None)
 	else:
 		enqueue(sendmail, queue="default", timeout=300, event="sendmail",
-			communication_name=doc.name,
+			enqueue_after_commit=True, communication_name=doc.name,
 			print_html=print_html, print_format=print_format, attachments=attachments,
 			recipients=recipients, cc=cc, bcc=bcc, lang=frappe.local.lang,
 			session=frappe.local.session, print_letterhead=frappe.flags.print_letterhead)

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -85,6 +85,8 @@ def make(doctype=None, name=None, content=None, subject=None, sent_or_received =
 		add_attachments(comm.name, attachments)
 
 	if cint(send_email):
+		# Raise error if outgoing email account is missing
+		_ = frappe.email.smtp.get_outgoing_email_account(append_to=comm.doctype, sender=comm.sender)
 		frappe.flags.print_letterhead = cint(print_letterhead)
 		comm.send(print_html, print_format, attachments, send_me_a_copy=send_me_a_copy)
 

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -227,7 +227,7 @@
   },
   {
    "default": "UNSEEN",
-   "depends_on": "eval: doc.enable_incoming",
+   "depends_on": "eval: doc.enable_incoming && doc.use_imap",
    "fieldname": "email_sync_option",
    "fieldtype": "Select",
    "hide_days": 1,
@@ -237,6 +237,7 @@
   },
   {
    "default": "250",
+   "depends_on": "eval: doc.enable_incoming && doc.use_imap",
    "description": "Total number of emails to sync in initial sync process ",
    "fieldname": "initial_sync_count",
    "fieldtype": "Select",
@@ -532,7 +533,7 @@
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-01-21 10:05:24.820597",
+ "modified": "2021-09-22 11:09:15.603556",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",


### PR DESCRIPTION
Fixing the below issues
1. We currently enqueue the sendmail jobs without checking sender email account exists in the system. Fixed this by adding the outgoing email account check.
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 100, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 460, in sendmail
    recipients=recipients, cc=cc, bcc=bcc)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/communication.py", line 211, in _notify
    _notify(self, print_html, print_format, attachments, recipients, cc, bcc)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 149, in _notify
    prepare_to_notify(doc, print_html, print_format, attachments)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 231, in prepare_to_notify
    set_incoming_outgoing_accounts(doc)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/communication/email.py", line 291, in set_incoming_outgoing_accounts
    doc.db_set("email_account", doc.outgoing_email_account.name)
AttributeError: 'NoneType' object has no attribute 'name'
```
2. POP3 protocol does not provide a way of accessing unseen mails from POP servers. It does not make sense to display sync related options if the protocol chosen is not IMAP while configuring the email account.

3. Fixed #14116 , by enqueuing a sendmail job after the current transaction is committed.
