### PR TITLE
fix: use decimal digits precision 9 instead of 6 while creating schema

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -22,11 +22,11 @@ class MariaDBDatabase(Database):
 	def setup_type_map(self):
 		self.db_type = 'mariadb'
 		self.type_map = {
-			'Currency':		('decimal', '18,6'),
+			'Currency':		('decimal', '21,9'),
 			'Int':			('int', '11'),
 			'Long Int':		('bigint', '20'),
-			'Float':		('decimal', '18,6'),
-			'Percent':		('decimal', '18,6'),
+			'Float':		('decimal', '21,9'),
+			'Percent':		('decimal', '21,9'),
 			'Check':		('int', '1'),
 			'Small Text':	('text', ''),
 			'Long Text':	('longtext', ''),
@@ -51,7 +51,7 @@ class MariaDBDatabase(Database):
 			'Color':		('varchar', self.VARCHAR_LEN),
 			'Barcode':		('longtext', ''),
 			'Geolocation':	('longtext', ''),
-			'Duration':		('decimal', '18,6'),
+			'Duration':		('decimal', '21,9'),
 			'Icon':			('varchar', self.VARCHAR_LEN)
 		}
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -32,11 +32,11 @@ class PostgresDatabase(Database):
 	def setup_type_map(self):
 		self.db_type = 'postgres'
 		self.type_map = {
-			'Currency':		('decimal', '18,6'),
+			'Currency':		('decimal', '21,9'),
 			'Int':			('bigint', None),
 			'Long Int':		('bigint', None),
-			'Float':		('decimal', '18,6'),
-			'Percent':		('decimal', '18,6'),
+			'Float':		('decimal', '21,9'),
+			'Percent':		('decimal', '21,9'),
 			'Check':		('smallint', None),
 			'Small Text':	('text', ''),
 			'Long Text':	('text', ''),
@@ -61,7 +61,7 @@ class PostgresDatabase(Database):
 			'Color':		('varchar', self.VARCHAR_LEN),
 			'Barcode':		('text', ''),
 			'Geolocation':	('text', ''),
-			'Duration':		('decimal', '18,6'),
+			'Duration':		('decimal', '21,9'),
 			'Icon':			('varchar', self.VARCHAR_LEN)
 		}
 

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -303,6 +303,8 @@ def get_definition(fieldtype, precision=None, length=None):
 	size = d[1] if d[1] else None
 
 	if size:
+		# This check needs to exist for backward compatibility.
+		# Till V13, default size used for float, currency and percent are (18, 6).
 		if fieldtype in ["Float", "Currency", "Percent"] and cint(precision) > 6:
 			size = '21,9'
 


### PR DESCRIPTION
Fixes #12060. 

Currently we use DECIMAL(18, 6) datatype for float, currency and
percent while creating schema. But in the system settings we provide a configuration to change the
precision up to 9 digits. This obviously does not work because we do not
store 9 digit precision in the database. Fixed by changing the decimal
data type scale.

