### PR TITLE
fix: refresh table after add child row

### DIFF
--- a/frappe/custom/doctype/doctype_layout/doctype_layout.js
+++ b/frappe/custom/doctype/doctype_layout/doctype_layout.js
@@ -15,6 +15,7 @@ frappe.ui.form.on('DocType Layout', {
 					for (let f of frappe.get_doc('DocType', frm.doc.document_type).fields) {
 						frm.add_child('fields', { fieldname: f.fieldname, label: f.label });
 					}
+					refresh_field("fields");
 				}
 			}
 		});


### PR DESCRIPTION
Sometimes child table does not refresh after select document type.