### PR TITLE
fix: set correct title in links table

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -179,4 +179,4 @@ def set_link_title(doc):
 	for link in doc.links:
 		if not link.link_title:
 			linked_doc = frappe.get_doc(link.link_doctype, link.link_name)
-			link.link_title = linked_doc.get("title_field") or linked_doc.get("name")
+			link.link_title = linked_doc.get_title() or link.link_name


### PR DESCRIPTION
The links table tries to auto-fill the title of the linked doc.
DocTypes don't usually have a field named "title_field". Use `doc.get_title()` instead.