### PR TITLE
fix(Event Streaming): Doctype dependencies sync

### DIFF
--- a/frappe/event_streaming/doctype/event_producer/event_producer.py
+++ b/frappe/event_streaming/doctype/event_producer/event_producer.py
@@ -408,8 +408,9 @@ def sync_dependencies(document, producer_site):
 			child_table = doc.get(df.fieldname)
 			for entry in child_table:
 				child_doc = producer_site.get_doc(entry.doctype, entry.name)
-				child_doc = frappe._dict(child_doc)
-				set_dependencies(child_doc, frappe.get_meta(entry.doctype).get_link_fields(), producer_site)
+				if child_doc:
+					child_doc = frappe._dict(child_doc)
+					set_dependencies(child_doc, frappe.get_meta(entry.doctype).get_link_fields(), producer_site)
 
 	def sync_link_dependencies(doc, link_fields, producer_site):
 		set_dependencies(doc, link_fields, producer_site)


### PR DESCRIPTION
Fixes the following error while syncing doctype dependencies
```py
 File "/home/mai/Workspace/V13/v13_online/apps/frappe/frappe/event_streaming/doctype/event_producer/event_producer.py", line 414, in sync_child_table_dependencies
    child_doc = frappe._dict(child_doc)
TypeError: 'NoneType' object is not iterable
```