### PR TITLE
feat: add on_get_node event in treeview

### DIFF
--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -39,6 +39,7 @@ frappe.ui.Tree = class {
 				method: this.method,
 				args: args,
 				callback: (r) => {
+					this.on_get_node && this.on_get_node(r.message);
 					resolve(r.message);
 				}
 			});
@@ -58,6 +59,7 @@ frappe.ui.Tree = class {
 				method: 'frappe.desk.treeview.get_all_nodes',
 				args: args,
 				callback: (r) => {
+					this.on_get_node && this.on_get_node(r.message, true);
 					resolve(r.message);
 				}
 			});

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -165,6 +165,7 @@ frappe.views.TreeView = class TreeView {
 
 			get_label: this.opts.get_label,
 			on_render: this.opts.onrender,
+			on_get_node: this.opts.on_get_node,
 			on_click: (node) => { this.select_node(node); },
 		});
 


### PR DESCRIPTION
Trigger an event whenever `get_tree_nodes` is called. Useful if someone wants to do any processing on the nodes fetched.

Docs: https://github.com/frappe/frappe_docs/pull/209