### PR TITLE
fix: Get background jobs info

### DIFF
--- a/frappe/core/page/background_jobs/background_jobs.py
+++ b/frappe/core/page/background_jobs/background_jobs.py
@@ -67,7 +67,8 @@ def get_info(show_failed=False) -> List[Dict]:
 			fail_registry = queue.failed_job_registry
 			for job_id in fail_registry.get_job_ids():
 				job = queue.fetch_job(job_id)
-				add_job(job, queue.name)
+				if job:
+					add_job(job, queue.name)
 
 	return jobs
 


### PR DESCRIPTION
Fixes below error:

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-09-05/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-09-05/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-09-05/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-09-05/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-09-05/apps/frappe/frappe/__init__.py", line 1177, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-09-05/apps/frappe/frappe/core/page/background_jobs/background_jobs.py", line 70, in get_info
    add_job(job, queue.name)
  File "/home/frappe/benches/bench-version-13-2021-09-05/apps/frappe/frappe/core/page/background_jobs/background_jobs.py", line 37, in add_job
    if job.kwargs.get('site') == frappe.local.site:
AttributeError: 'NoneType' object has no attribute 'kwargs'
```