### PR TITLE
ci: fail the build if asset bundling fails

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -58,4 +58,4 @@ cd ../..
 bench start &
 bench --site test_site reinstall --yes
 if [ "$TYPE" == "server" ]; then bench --site test_site_producer reinstall --yes; fi
-bench build --app frappe
+CI=Yes bench build --app frappe

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -245,7 +245,7 @@ def bundle(no_compress, app=None, hard_link=False, verbose=False, skip_frappe=Fa
 
 	frappe_app_path = os.path.abspath(os.path.join(app_paths[0], ".."))
 	check_yarn()
-	frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env())
+	frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env(), raise_err=True)
 
 
 def watch(no_compress):


### PR DESCRIPTION
- Currently, CI just ignores asset build failure. Change this behaviour to stop the build on asset bundling failure.
- No changes for end-users. 

This functionality already existed, maybe stopped working at some point: 

https://github.com/frappe/frappe/blob/35bc3f6df98a8b339c4b7036ee60b1b2083f4f40/rollup/build.js#L107-L110

Before:
![Screenshot 2021-09-29 at 3 35 30 PM](https://user-images.githubusercontent.com/9079960/135250490-79c1b510-868d-42d5-8a0b-926273a97668.png)

After:
![Screenshot 2021-09-29 at 3 51 46 PM](https://user-images.githubusercontent.com/9079960/135250909-c527524d-de03-4e37-b899-08f844913ced.png)
