### PR TITLE
feat: pass filename as argument to print_by_server

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -98,7 +98,7 @@ def report_to_pdf(html, orientation="Landscape"):
 	frappe.local.response.type = "pdf"
 
 @frappe.whitelist()
-def print_by_server(doctype, name, printer_setting, print_format=None, doc=None, file=None,no_letterhead=0):
+def print_by_server(doctype, name, printer_setting, print_format=None, doc=None, file_path=None,no_letterhead=0):
 	print_settings = frappe.get_doc("Network Printer Settings", printer_setting)
 	try:
 		import cups
@@ -111,10 +111,10 @@ def print_by_server(doctype, name, printer_setting, print_format=None, doc=None,
 		conn = cups.Connection()
 		output = PdfFileWriter()
 		output = frappe.get_print(doctype, name, print_format, doc=doc, no_letterhead=no_letterhead, as_pdf = True, output = output)
-		if not file:
-			file = os.path.join("/", "tmp", "frappe-pdf-{0}.pdf".format(frappe.generate_hash()))
-		output.write(open(file,"wb"))
-		conn.printFile(print_settings.printer_name,file , name, {})
+		if not file_path:
+			file_path = os.path.join("/", "tmp", "frappe-pdf-{0}.pdf".format(frappe.generate_hash()))
+		output.write(open(file_path,"wb"))
+		conn.printFile(print_settings.printer_name,file_path , name, {})
 	except IOError as e:
 		if ("ContentNotFoundError" in e.message
 			or "ContentOperationNotPermittedError" in e.message

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -98,7 +98,7 @@ def report_to_pdf(html, orientation="Landscape"):
 	frappe.local.response.type = "pdf"
 
 @frappe.whitelist()
-def print_by_server(doctype, name, printer_setting, print_format=None, doc=None, no_letterhead=0):
+def print_by_server(doctype, name, printer_setting, print_format=None, doc=None, file=None,no_letterhead=0):
 	print_settings = frappe.get_doc("Network Printer Settings", printer_setting)
 	try:
 		import cups
@@ -111,7 +111,8 @@ def print_by_server(doctype, name, printer_setting, print_format=None, doc=None,
 		conn = cups.Connection()
 		output = PdfFileWriter()
 		output = frappe.get_print(doctype, name, print_format, doc=doc, no_letterhead=no_letterhead, as_pdf = True, output = output)
-		file = os.path.join("/", "tmp", "frappe-pdf-{0}.pdf".format(frappe.generate_hash()))
+		if not file:
+			file = os.path.join("/", "tmp", "frappe-pdf-{0}.pdf".format(frappe.generate_hash()))
 		output.write(open(file,"wb"))
 		conn.printFile(print_settings.printer_name,file , name, {})
 	except IOError as e:

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -98,7 +98,7 @@ def report_to_pdf(html, orientation="Landscape"):
 	frappe.local.response.type = "pdf"
 
 @frappe.whitelist()
-def print_by_server(doctype, name, printer_setting, print_format=None, doc=None, file_path=None,no_letterhead=0):
+def print_by_server(doctype, name, printer_setting, print_format=None, doc=None, no_letterhead=0, file_path=None):
 	print_settings = frappe.get_doc("Network Printer Settings", printer_setting)
 	try:
 		import cups

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,4 @@ wrapt~=1.12.1
 xlrd~=2.0.1
 zxcvbn-python~=4.4.24
 tenacity~=8.0.1
+pycups

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,4 +77,4 @@ wrapt~=1.12.1
 xlrd~=2.0.1
 zxcvbn-python~=4.4.24
 tenacity~=8.0.1
-pycups
+pycups~=2.0.1


### PR DESCRIPTION
To print attached files(pdf or others) from click of a button in the doctype, we need to pass the filename. So added additional argument "file".  Hash will be generated if file is None.


`no-docs`