### PR TITLE
feat: frappe.errprint in the server script for debugging

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -84,6 +84,7 @@ def get_safe_globals():
 			form_dict=getattr(frappe.local, 'form_dict', {}),
 			bold=frappe.bold,
 			copy_doc=frappe.copy_doc,
+			errprint=frappe.errprint,
 
 			get_meta=frappe.get_meta,
 			get_doc=frappe.get_doc,


### PR DESCRIPTION
User can use frappe.errprint to debug the server script

<img width="779" alt="Screenshot 2021-10-01 at 3 36 43 PM" src="https://user-images.githubusercontent.com/8780500/135602877-ac7f61af-b2a4-4fd0-9d64-2f10947b5824.png">
#no-docs