### PR TITLE
fix: remove pycups from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,4 +77,3 @@ wrapt~=1.12.1
 xlrd~=2.0.1
 zxcvbn-python~=4.4.24
 tenacity~=8.0.1
-pycups~=2.0.1


### PR DESCRIPTION
This causes installation failure and most people don't need this feature. The documentation for network printing specifies the requirements, so this can be removed from the default installation. 

ref: https://github.com/frappe/frappe/pull/14329#issuecomment-932068924