### PR TITLE
fix: Use capital M in `max` to avoid libsass compatibility issue

### DIFF
--- a/frappe/public/scss/login.scss
+++ b/frappe/public/scss/login.scss
@@ -14,7 +14,8 @@ body {
 .for-forgot,
 .for-signup,
 .for-email-login {
-	padding: max(15vh, 70px) 0;
+	// max with capital M to avoid libsass compatibility issue
+	padding: Max(15vh, 70px) 0;
 
 	@include media-breakpoint-up(sm) {
 		.page-card {


### PR DESCRIPTION
https://github.com/sass/sass/issues/2849#issuecomment-820538086

**Before:**
![Screenshot 2021-10-04 at 3 00 10 PM](https://user-images.githubusercontent.com/13928957/135828053-8338cab1-970b-4c7b-809d-aa2dd10da365.png)

**After:**
![Screenshot 2021-10-04 at 3 00 24 PM](https://user-images.githubusercontent.com/13928957/135828083-b2c451a0-eb7e-4a09-b600-9a343d05f3a7.png)

