### PR TITLE
fix: filter on `HTML Editor` and `Markdown Editor` field types

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -490,6 +490,8 @@ frappe.ui.filter_utils = {
 				'Small Text',
 				'Text Editor',
 				'Code',
+				'Markdown Editor',
+				'HTML Editor',
 				'Tag',
 				'Comments',
 				'Dynamic Link',


### PR DESCRIPTION
## Issue
If a filter is added to a field of type `HTML Editor` or `Markdown Editor` and we Refresh the page, List View doesn't load.

## Changes Made
 - Convert `HTML Editor` and `Markdown Editor` to `Data` for filtering purposes (Already being done for `Code` fields).

## Screenshots
### Before
![Kapture 2021-10-04 at 16 27 48](https://user-images.githubusercontent.com/43115036/135839884-9511f84f-34bd-453d-8a30-0faf7bea41e7.gif)

### After
![Kapture 2021-10-04 at 16 23 47](https://user-images.githubusercontent.com/43115036/135839570-1883130c-8c6f-47b9-ab86-8981648ba7dc.gif)
