### PR TITLE
fix: use site path instead of site name to generate DB name

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -45,7 +45,7 @@ def _new_site(
 
 	if not db_name:
 		import hashlib
-		db_name = "_" + hashlib.sha1(get_site_path().encode()).hexdigest()[:16]
+		db_name = "_" + hashlib.sha1(os.path.realpath(frappe.get_site_path()).encode()).hexdigest()[:16]
 
 	try:
 		# enable scheduler post install?

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -29,6 +29,10 @@ def _new_site(
 ):
 	"""Install a new Frappe site"""
 
+	from frappe.commands.scheduler import _is_scheduler_enabled
+	from frappe.utils import get_site_path, scheduler, touch_file
+
+
 	if not force and os.path.exists(site):
 		print("Site {0} already exists".format(site))
 		sys.exit(1)
@@ -37,14 +41,11 @@ def _new_site(
 		print("--no-mariadb-socket requires db_type to be set to mariadb.")
 		sys.exit(1)
 
-	if not db_name:
-		import hashlib
-		db_name = "_" + hashlib.sha1(site.encode()).hexdigest()[:16]
-
 	frappe.init(site=site)
 
-	from frappe.commands.scheduler import _is_scheduler_enabled
-	from frappe.utils import get_site_path, scheduler, touch_file
+	if not db_name:
+		import hashlib
+		db_name = "_" + hashlib.sha1(get_site_path().encode()).hexdigest()[:16]
 
 	try:
 		# enable scheduler post install?


### PR DESCRIPTION
## Issue
Currently, when we create a new site, the database name associated with that site is generated from the site name. So, whenever system has multiple bench instances, and when someone try to create site with the same name on multiple benches, it creates database conflicts and all sites refer to the same database even though the sites are different.

## Changes Made
 - use absolute path of site to generate database name


## Alternate Solution
use `frappe.generate_hash` by passing `site_name`
