### PR TITLE
fix: Filter pop-up overlaps the Notification Window

### DIFF
--- a/frappe/public/scss/desk/filters.scss
+++ b/frappe/public/scss/desk/filters.scss
@@ -8,6 +8,7 @@
 	min-width: 500px;
 	min-height: 50px;
 	font-size: var(--text-md);
+	z-index: 1019;
 }
 
 .filter-area {


### PR DESCRIPTION
**Issue:** 
When you try opening the notification window and filter pop-up window, both of them overlap.

**Before:**
![image](https://user-images.githubusercontent.com/30859809/135879860-6c476fcb-8934-4205-993c-f1fb048f2abb.png)

**After:**
![image](https://user-images.githubusercontent.com/30859809/135879577-2145604c-f1ee-458c-9a61-a1426cc9618e.png)
