### PR TITLE
feat: add context for "is (not) set" filter translations

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -536,8 +536,8 @@ frappe.ui.filter_utils = {
 		if (condition === 'is') {
 			df.fieldtype = 'Select';
 			df.options = [
-				{ label: __('Set'), value: 'set' },
-				{ label: __('Not Set'), value: 'not set' },
+				{ label: __('Set', null, 'Field value is set'), value: 'set' },
+				{ label: __('Not Set', null, 'Field value is not set'), value: 'not set' },
 			];
 		}
 		return;


### PR DESCRIPTION
I noticed german translations were in the wrong context for "Set" and "Is Set" in filter options. 

Added context according to https://frappeframework.com/docs/user/en/translations#6-adding-context-for-a-string

> no-docs