### PR TITLE
fix: Fixed get_values

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -20,6 +20,7 @@ from frappe.query_builder.functions import Count
 from frappe.query_builder.functions import Min, Max, Avg, Sum
 from frappe.query_builder.utils import Column
 from .query import Query
+from pypika.terms import PseudoColumn
 
 
 class Database(object):
@@ -521,11 +522,19 @@ class Database(object):
 		return self.get_single_value(*args, **kwargs)
 
 	def _get_values_from_table(self, fields, filters, doctype, as_dict, debug, order_by=None, update=None, for_update=False):
+		field_objects = []
+		for field in fields:
+			if "(" in field or " as " in field:
+				field_objects.append(PseudoColumn(field))
+			else:
+				field_objects.append(field)
+		criterion = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by, for_update=for_update)
+
 		if isinstance(fields, (list, tuple)):
-			query = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by, for_update=for_update).select(*fields)
+			query = criterion.select(*field_objects)
 		else:
 			if fields=="*":
-				query = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by, for_update=for_update).select(fields)
+				query = criterion.select(fields)
 				as_dict = True
 		r = self.sql(query, as_dict=as_dict, debug=debug, update=update)
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -523,11 +523,13 @@ class Database(object):
 
 	def _get_values_from_table(self, fields, filters, doctype, as_dict, debug, order_by=None, update=None, for_update=False):
 		field_objects = []
+
 		for field in fields:
 			if "(" in field or " as " in field:
 				field_objects.append(PseudoColumn(field))
 			else:
 				field_objects.append(field)
+
 		criterion = self.query.build_conditions(table=doctype, filters=filters, orderby=order_by, for_update=for_update)
 
 		if isinstance(fields, (list, tuple)):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -22,6 +22,8 @@ class TestDB(unittest.TestCase):
 		self.assertNotEqual(frappe.db.get_value("User", {"name": ["!=", "Guest"]}), "Guest")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<", "Adn"]}), "Administrator")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<=", "Administrator"]}), "Administrator")
+		self.assertEqual(frappe.db.get_value("User", {}, ["Max(name)"]), "Guest")
+		self.assertEqual(frappe.db.get_value("User", {}, "Max(name)"), "Guest")
 
 		self.assertEqual(frappe.db.sql("""SELECT name FROM `tabUser` WHERE name > 's' ORDER BY MODIFIED DESC""")[0][0],
 			frappe.db.get_value("User", {"name": [">", "s"]}))

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -22,8 +22,8 @@ class TestDB(unittest.TestCase):
 		self.assertNotEqual(frappe.db.get_value("User", {"name": ["!=", "Guest"]}), "Guest")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<", "Adn"]}), "Administrator")
 		self.assertEqual(frappe.db.get_value("User", {"name": ["<=", "Administrator"]}), "Administrator")
-		self.assertEqual(frappe.db.get_value("User", {}, ["Max(name)"]), "Guest")
-		self.assertEqual(frappe.db.get_value("User", {}, "Max(name)"), "Guest")
+		self.assertEqual(frappe.db.get_value("User", {}, ["Max(name)"]), frappe.db.sql("SELECT Max(name) FROM tabUser")[0][0])
+		self.assertEqual(frappe.db.get_value("User", {}, "Min(name)"), frappe.db.sql("SELECT Min(name) FROM tabUser")[0][0])
 
 		self.assertEqual(frappe.db.sql("""SELECT name FROM `tabUser` WHERE name > 's' ORDER BY MODIFIED DESC""")[0][0],
 			frappe.db.get_value("User", {"name": [">", "s"]}))


### PR DESCRIPTION
Fixed ```get_values``` in database.py
Now accepts SQL functions as strings.