### PR TITLE
fix: Resolved redefine object issue on webform load

### DIFF
--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -242,18 +242,21 @@ Object.defineProperties(window, {
 		get: function() {
 			console.warn('Please use `frappe.datetime` instead of `dateutil`. It will be deprecated soon.');
 			return frappe.datetime;
-		}
+		},
+		configurable: true
 	},
 	'date': {
 		get: function() {
 			console.warn('Please use `frappe.datetime` instead of `date`. It will be deprecated soon.');
 			return frappe.datetime;
-		}
+		},
+		configurable: true
 	},
 	'get_today': {
 		get: function() {
 			console.warn('Please use `frappe.datetime.get_today` instead of `get_today`. It will be deprecated soon.');
 			return frappe.datetime.get_today;
-		}
+		},
+		configurable: true
 	}
 });


### PR DESCRIPTION
In https://github.com/frappe/frappe/pull/14226 `datetime.js` was added to `frappe-web.bundle.js`.
In `datetime.js` `Object.defineProperties` method is used and since `datetime.js` is called twice from two different places `frappe-web.bundle.js` and `web_form.bundle.js` the properties are defined twice which caused the issue.
![image](https://user-images.githubusercontent.com/30859809/136167868-40973d89-d30a-4122-a159-a8f1996acae7.png)