### PR TITLE
fix: Make images in comments private

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -813,7 +813,7 @@ def extract_images_from_doc(doc, fieldname):
 		doc.set(fieldname, content)
 
 
-def extract_images_from_html(doc, content):
+def extract_images_from_html(doc, content, is_private=False):
 	frappe.flags.has_dataurl = False
 
 	def _save_file(match):
@@ -839,7 +839,6 @@ def extract_images_from_html(doc, content):
 
 		doctype = doc.parenttype if doc.parent else doc.doctype
 		name = doc.parent or doc.name
-		is_private = True if doctype == "Comment" else False
 
 		_file = frappe.get_doc({
 			"doctype": "File",

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -839,6 +839,7 @@ def extract_images_from_html(doc, content):
 
 		doctype = doc.parenttype if doc.parent else doc.doctype
 		name = doc.parent or doc.name
+		is_private = True if doctype == "Comment" else False
 
 		_file = frappe.get_doc({
 			"doctype": "File",
@@ -846,7 +847,8 @@ def extract_images_from_html(doc, content):
 			"attached_to_doctype": doctype,
 			"attached_to_name": name,
 			"content": content,
-			"decode": False
+			"decode": False,
+			"is_private": is_private
 		})
 		_file.save(ignore_permissions=True)
 		file_url = _file.file_url

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -66,7 +66,7 @@ def add_comment(reference_doctype, reference_name, content, comment_email, comme
 		comment_type='Comment',
 		comment_by=comment_by
 	))
-	doc.content = extract_images_from_html(doc, content)
+	doc.content = extract_images_from_html(doc, content, is_private=True)
 	doc.insert(ignore_permissions=True)
 
 	follow_document(doc.reference_doctype, doc.reference_name, frappe.session.user)


### PR DESCRIPTION
Currently images added in comments are stored as public files. This PR fixes this so that images added in comments, in the future, will be stored as private files.