### PR TITLE
fix: unable to delete role permissions

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -325,15 +325,15 @@ frappe.PermissionEngine = class PermissionEngine {
 			.attr("data-doctype", d.parent)
 			.attr("data-role", d.role)
 			.attr("data-permlevel", d.permlevel)
-			.click(function () {
+			.on("click", () => {
 				return frappe.call({
 					module: "frappe.core",
 					page: "permission_manager",
 					method: "remove",
 					args: {
-						doctype: $(this).attr("data-doctype"),
-						role: $(this).attr("data-role"),
-						permlevel: $(this).attr("data-permlevel")
+						doctype: d.parent,
+						role: d.role,
+						permlevel: d.permlevel
 					},
 					callback: (r) => {
 						if (r.exc) {


### PR DESCRIPTION
## Issue

![image](https://user-images.githubusercontent.com/16315650/136538889-f0d99325-cf82-4a95-8106-2cb87ced5bfe.png)


## Changes Made

- `.click()` (deprecated) ➡️  `.on('click')`
- `function () {}` ➡️ `() => {}`
- set arguments for server call using available properties instead of fetching HTML attributes


## Screenshots

### Before

![before_delete](https://user-images.githubusercontent.com/16315650/136538814-ebb7df56-31bf-4a33-86db-be896c29ba98.gif)


### After

![after_delete](https://user-images.githubusercontent.com/16315650/136538830-afbb0982-9e2d-46ba-829e-3b3ee813dcf3.gif)
