### PR TITLE
feat: allow tuple of DocTypes as key

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -131,7 +131,7 @@ def create_custom_field(doctype, df, ignore_validate=False):
 			"permlevel": 0,
 			"fieldtype": 'Data',
 			"hidden": 0,
-			# Looks like we always  use this programatically?
+			# Looks like we always	use this programatically?
 			# "is_standard": 1
 		})
 		custom_field.update(df)
@@ -146,24 +146,29 @@ def create_custom_fields(custom_fields, ignore_validate = False, update=True):
 	if not ignore_validate and frappe.flags.in_setup_wizard:
 		ignore_validate = True
 
-	for doctype, fields in custom_fields.items():
+	for doctypes, fields in custom_fields.items():
 		if isinstance(fields, dict):
 			# only one field
 			fields = [fields]
 
-		for df in fields:
-			field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": df["fieldname"]})
-			if not field:
-				try:
-					df["owner"] = "Administrator"
-					create_custom_field(doctype, df, ignore_validate=ignore_validate)
-				except frappe.exceptions.DuplicateEntryError:
-					pass
-			elif update:
-				custom_field = frappe.get_doc("Custom Field", field)
-				custom_field.flags.ignore_validate = ignore_validate
-				custom_field.update(df)
-				custom_field.save()
+		if isinstance(doctypes, str):
+			# only one doctype
+			doctypes = (doctypes,)
+
+		for doctype in doctypes:
+			for df in fields:
+				field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": df["fieldname"]})
+				if not field:
+					try:
+						df["owner"] = "Administrator"
+						create_custom_field(doctype, df, ignore_validate=ignore_validate)
+					except frappe.exceptions.DuplicateEntryError:
+						pass
+				elif update:
+					custom_field = frappe.get_doc("Custom Field", field)
+					custom_field.flags.ignore_validate = ignore_validate
+					custom_field.update(df)
+					custom_field.save()
 
 		frappe.clear_cache(doctype=doctype)
 		frappe.db.updatedb(doctype)

--- a/frappe/custom/doctype/custom_field/test_custom_field.py
+++ b/frappe/custom/doctype/custom_field/test_custom_field.py
@@ -6,7 +6,42 @@
 import frappe
 import unittest
 
-test_records = frappe.get_test_records('Custom Field')
+test_records = frappe.get_test_records("Custom Field")
+
 
 class TestCustomField(unittest.TestCase):
-	pass
+	def test_create_custom_fields(self):
+		from .custom_field import create_custom_fields
+
+		create_custom_fields(
+			{
+				"Address": [
+					{
+						"fieldname": "_test_custom_field_1",
+						"label": "_Test Custom Field 1",
+						"fieldtype": "Data",
+						"insert_after": "phone",
+					},
+				],
+				("Address", "Contact"): [
+					{
+						"fieldname": "_test_custom_field_2",
+						"label": "_Test Custom Field 2",
+						"fieldtype": "Data",
+						"insert_after": "phone",
+					},
+				],
+			}
+		)
+
+		frappe.db.commit()
+
+		self.assertTrue(
+			frappe.db.exists("Custom Field", "Address-_test_custom_field_1")
+		)
+		self.assertTrue(
+			frappe.db.exists("Custom Field", "Address-_test_custom_field_2")
+		)
+		self.assertTrue(
+			frappe.db.exists("Custom Field", "Contact-_test_custom_field_2")
+		)


### PR DESCRIPTION
Previously, `create_custom_fields` accepted a dict of DocTypes and custom fields like this:

```py
{
    "Quotation Item": [dict(fieldname='hide_item_in_print')],
    "Sales Oder Item": [dict(fieldname='hide_item_in_print')],
    "Sales Invoice Item": [dict(fieldname='hide_item_in_print')]
}
```

Now we can add the same fields to _multiple DocTypes at once_, by passing

```py
{
    ("Quotation Item", "Sales Order Item", "Sales Invoice Item"): [dict(fieldname='hide_item_in_print')]
}
```

This is useful for transaction DocTypes that many times all need the same fields. For example, you might want to add a "Hide Item In Print" checkbox to all item tables of all sales transactions (Quotation, Sales Order, Sales Invoice).

> no-docs