### PR TITLE
fix(report builder): Aggregation based on child table field

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -128,7 +128,7 @@ def setup_group_by(data):
 		if frappe.db.has_column(data.aggregate_on_doctype, data.aggregate_on_field):
 			data.fields.append('{aggregate_function}(`tab{aggregate_on_doctype}`.`{aggregate_on_field}`) AS _aggregate_column'.format(**data))
 			if data.aggregate_on_field:
-				data.fields.append("`tab{aggregate_on_doctype}`.`{aggregate_on_field}`".format(**data))
+				data.fields.append(f"`tab{data.aggregate_on_doctype}`.`{data.aggregate_on_field}`")
 		else:
 			raise_invalid_field(data.aggregate_on_field)
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -127,6 +127,8 @@ def setup_group_by(data):
 
 		if frappe.db.has_column(data.aggregate_on_doctype, data.aggregate_on_field):
 			data.fields.append('{aggregate_function}(`tab{aggregate_on_doctype}`.`{aggregate_on_field}`) AS _aggregate_column'.format(**data))
+			if data.aggregate_on_field:
+				data.fields.append("`tab{aggregate_on_doctype}`.`{aggregate_on_field}`".format(**data))
 		else:
 			raise_invalid_field(data.aggregate_on_field)
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -450,18 +450,21 @@ class TestReportview(unittest.TestCase):
 		# test aggregation based on child table field
 		frappe.local.form_dict = frappe._dict({
 			"doctype": "DocType",
-			"fields": """["`tabDocField`.`hidden` as hidden","sum(`tabDocField`.`columns`) as _aggregate_column","`tabDocField`.`columns`"]""",
+			"fields": """["`tabDocField`.`label` as field_label","`tabDocField`.`name` as field_name"]""",
 			"filters": "[]",
 			"order_by": "_aggregate_column desc",
 			"start": 0,
 			"page_length": 20,
 			"view": "Report",
 			"with_comment_count": 0,
-			"group_by": "`tabDocField`.`hidden`, columns"
+			"group_by": "field_label, field_name",
+			"aggregate_on_field": "columns",
+			"aggregate_on_doctype": "DocField",
+			"aggregate_function": "sum"
 		})
 
 		response = execute_cmd("frappe.desk.reportview.get")
-		self.assertListEqual(response["keys"], ["hidden", "_aggregate_column", "columns"])
+		self.assertListEqual(response["keys"], ["field_label", "field_name", "_aggregate_column"])
 
 def add_child_table_to_blog_post():
 	child_table = frappe.get_doc({

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -464,7 +464,7 @@ class TestReportview(unittest.TestCase):
 		})
 
 		response = execute_cmd("frappe.desk.reportview.get")
-		self.assertListEqual(response["keys"], ["field_label", "field_name", "_aggregate_column"])
+		self.assertListEqual(response["keys"], ["field_label", "field_name", "_aggregate_column", 'columns'])
 
 def add_child_table_to_blog_post():
 	child_table = frappe.get_doc({

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -446,6 +446,22 @@ class TestReportview(unittest.TestCase):
 		user.remove_roles("Blogger", "Website Manager")
 		user.add_roles(*user_roles)
 
+	def test_reportview_get_aggregation(self):
+		# test aggregation based on child table field
+		frappe.local.form_dict = frappe._dict({
+			"doctype": "DocType",
+			"fields": """["`tabDocField`.`hidden` as hidden","sum(`tabDocField`.`columns`) as _aggregate_column","`tabDocField`.`columns`"]""",
+			"filters": "[]",
+			"order_by": "_aggregate_column desc",
+			"start": 0,
+			"page_length": 20,
+			"view": "Report",
+			"with_comment_count": 0,
+			"group_by": "`tabDocField`.`hidden`, columns"
+		})
+
+		response = execute_cmd("frappe.desk.reportview.get")
+		self.assertListEqual(response["keys"], ["hidden", "_aggregate_column", "columns"])
 
 def add_child_table_to_blog_post():
 	child_table = frappe.get_doc({


### PR DESCRIPTION
Aggregation based on the child table field was failing with the following error
```
File "/Users/sps/benches/develop/env/lib/python3.9/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/Users/sps/benches/develop/env/lib/python3.9/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/Users/sps/benches/develop/env/lib/python3.9/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/Users/sps/benches/develop/env/lib/python3.9/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/Users/sps/benches/develop/env/lib/python3.9/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'tabSales Invoice Item.amount' in 'field list'")
```

**Before:**
![Screenshot 2021-10-12 at 10 00 04 AM](https://user-images.githubusercontent.com/13928957/136891687-6895dfef-8f2a-48c3-a47e-860210896332.png)

**After:**
![Screenshot 2021-10-12 at 9 57 31 AM](https://user-images.githubusercontent.com/13928957/136891806-57aade73-edf1-4c15-8d69-ac52c6799dc5.png)

https://frappe.io/app/issue/ISS-21-22-07091