### PR TITLE
fix: Customize is not listed in menu item [Print]

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -171,7 +171,7 @@ frappe.ui.form.PrintView = class {
 			});
 		}
 
-		if (frappe.perm.has_perm('Print Format', 0, 'create')) {
+		if (frappe.model.can_create('Print Format')) {
 			this.page.add_menu_item(__('Customize'), () =>
 				this.edit_print_format()
 			);


### PR DESCRIPTION
Issue- 
![telegram-cloud-photo-size-5-6280297782795415144-x](https://user-images.githubusercontent.com/20715976/136908240-743c1332-8fb0-40ea-b46d-9b4e4156c21f.jpg)

-Customize button is not visible even user have permission to create Print Format
![image](https://user-images.githubusercontent.com/20715976/136908934-b156a4d8-64b1-4793-bbe0-f7feb5c5584f.png)
