### PR TITLE
fix: Loading state for query reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -555,7 +555,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	refresh() {
 		this.toggle_message(true);
 		this.toggle_report(false);
-		this.show_loading_indicator();
+		this.show_loading_screen();
 		let filters = this.get_filter_values(true);
 
 		// only one refresh at a time
@@ -646,7 +646,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.show_footer_message();
 			frappe.hide_progress();
 		}).finally(() => {
-			this.hide_loading_indicator();
+			this.hide_loading_screen();
 		});
 	}
 
@@ -871,18 +871,20 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 	}
 
-	show_loading_indicator() {
-		this.$loading.find('div').html(`<div class="msg-box no-border">
+	show_loading_screen() {
+		const loading_state = `<div class="msg-box no-border">
 			<div>
 				<img src="/assets/frappe/images/ui-states/list-empty-state.svg" alt="Generic Empty State" class="null-state">
 			</div>
 			<p>${__('Loading')}...</p>
-		</div>`);
+		</div>`;
+
+		this.$loading.find('div').html(loading_state);
 		this.$report.hide();
 		this.$loading.show();
 	}
 
-	hide_loading_indicator() {
+	hide_loading_screen() {
 		this.$loading.hide();
 		this.$report.show();
 	}
@@ -1699,7 +1701,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.$chart = $('<div class="chart-wrapper">').hide().appendTo(this.page.main);
 
 		this.$loading = $(this.message_div('')).hide().appendTo(this.page.main);
-
 		this.$report = $('<div class="report-wrapper">').appendTo(this.page.main);
 		this.$message = $(this.message_div('')).hide().appendTo(this.page.main);
 	}

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -107,7 +107,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 
 		if (this.report_name !== frappe.get_route()[1]) {
-			// this.toggle_loading(true);
 			// different report
 			this.load_report();
 		}
@@ -556,6 +555,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	refresh() {
 		this.toggle_message(true);
 		this.toggle_report(false);
+		this.show_loading_indicator();
 		let filters = this.get_filter_values(true);
 
 		// only one refresh at a time
@@ -645,6 +645,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 			this.show_footer_message();
 			frappe.hide_progress();
+		}).finally(() => {
+			this.hide_loading_indicator();
 		});
 	}
 
@@ -867,6 +869,22 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		if (this.report_settings.after_datatable_render) {
 			this.report_settings.after_datatable_render(this.datatable);
 		}
+	}
+
+	show_loading_indicator() {
+		this.$loading.find('div').html(`<div class="msg-box no-border">
+			<div>
+				<img src="/assets/frappe/images/ui-states/list-empty-state.svg" alt="Generic Empty State" class="null-state">
+			</div>
+			<p>${__('Loading')}...</p>
+		</div>`);
+		this.$report.hide();
+		this.$loading.show();
+	}
+
+	hide_loading_indicator() {
+		this.$loading.hide();
+		this.$report.show();
 	}
 
 	get_chart_options(data) {
@@ -1679,6 +1697,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			.hide().appendTo(this.page.main);
 
 		this.$chart = $('<div class="chart-wrapper">').hide().appendTo(this.page.main);
+
+		this.$loading = $(this.message_div('')).hide().appendTo(this.page.main);
+
 		this.$report = $('<div class="report-wrapper">').appendTo(this.page.main);
 		this.$message = $(this.message_div('')).hide().appendTo(this.page.main);
 	}
@@ -1737,11 +1758,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.toggle_nothing_to_show(true);
 		this.refresh();
 	}
-
-	toggle_loading(flag) {
-		this.toggle_message(flag, __('Loading') + '...');
-	}
-
 
 	toggle_nothing_to_show(flag) {
 		let message = this.prepared_report


### PR DESCRIPTION
The threshold for a script report to get converted to a prepared report is 30 seconds

Let's say a report takes 10-20 seconds to load, meanwhile, the user sees a blank screen and doesn't come to know whether the report is getting generated or not. To give better feedback to the user added a loading state to query reports

<img width="1338" alt="Screenshot 2021-10-12 at 7 07 56 PM" src="https://user-images.githubusercontent.com/42651287/136967650-902b83e8-89ad-453d-8628-c76ab0464bb0.png">

We can replace this with a better icon once we have one


