### PR TITLE
feat: keyboard shortcuts for the grid

### DIFF
--- a/cypress/integration/grid_keyboard_shortcut.js
+++ b/cypress/integration/grid_keyboard_shortcut.js
@@ -1,0 +1,52 @@
+context('Grid Keyboard Shortcut', () => {
+    let total_count = 0;
+	beforeEach(() => {
+		cy.login();
+        cy.visit('/app/doctype/User');
+    });
+    before(() => {
+		cy.login();
+		cy.visit('/app/doctype/User');
+		return cy.window().its('frappe').then(frappe => {
+			frappe.db.count('DocField', {
+                filters: {
+                    'parent': 'User', 'parentfield': 'fields', 'parenttype': 'DocType'
+                }
+            }).then((r) => {
+                total_count = r;
+            })
+		});
+	});
+	it('Insert new row at the end', () => {
+        cy.wait(100);
+        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
+        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
+        cy.get('.grid-body .grid-row').find('.col-xs-2')
+            .first().type('{ctrl}{shift}{downarrow}').should('be.visible')
+        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', `${total_count+1}`);
+    });
+    it('Insert new row at the top', () => {
+        cy.wait(100);
+        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
+        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
+        cy.get('.grid-body .grid-row').find('.col-xs-2')
+            .first().type('{ctrl}{shift}{uparrow}').should('be.visible')
+        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '1');
+    });
+    it('Insert new row below', () => {
+        cy.wait(100);
+        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
+        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
+        cy.get('.grid-body .grid-row').find('.col-xs-2')
+            .first().type('{ctrl}{downarrow}').should('be.visible')
+        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '2');
+	});
+    it('Insert new row above', () => {
+        cy.wait(100);
+        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
+        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
+        cy.get('.grid-body .grid-row').find('.col-xs-2')
+            .first().type('{ctrl}{uparrow}').should('be.visible')
+        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '1');
+    });
+});

--- a/cypress/integration/grid_keyboard_shortcut.js
+++ b/cypress/integration/grid_keyboard_shortcut.js
@@ -1,52 +1,49 @@
 context('Grid Keyboard Shortcut', () => {
-    let total_count = 0;
+	let total_count = 0;
 	beforeEach(() => {
 		cy.login();
-        cy.visit('/app/doctype/User');
-    });
-    before(() => {
+		cy.visit('/app/doctype/User');
+	});
+	before(() => {
 		cy.login();
 		cy.visit('/app/doctype/User');
 		return cy.window().its('frappe').then(frappe => {
 			frappe.db.count('DocField', {
-                filters: {
-                    'parent': 'User', 'parentfield': 'fields', 'parenttype': 'DocType'
-                }
-            }).then((r) => {
-                total_count = r;
-            })
+				filters: {
+					'parent': 'User', 'parentfield': 'fields', 'parenttype': 'DocType'
+				}
+			}).then((r) => {
+				total_count = r;
+			});
 		});
 	});
 	it('Insert new row at the end', () => {
-        cy.wait(100);
-        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
-        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
-        cy.get('.grid-body .grid-row').find('.col-xs-2')
-            .first().type('{ctrl}{shift}{downarrow}').should('be.visible')
-        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', `${total_count+1}`);
-    });
-    it('Insert new row at the top', () => {
-        cy.wait(100);
-        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
-        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
-        cy.get('.grid-body .grid-row').find('.col-xs-2')
-            .first().type('{ctrl}{shift}{uparrow}').should('be.visible')
-        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '1');
-    });
-    it('Insert new row below', () => {
-        cy.wait(100);
-        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
-        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
-        cy.get('.grid-body .grid-row').find('.col-xs-2')
-            .first().type('{ctrl}{downarrow}').should('be.visible')
-        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '2');
+		cy.add_new_row_in_grid('{ctrl}{shift}{downarrow}', (cy, total_count) => {
+			cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', `${total_count+1}`);
+		}, total_count);
 	});
-    it('Insert new row above', () => {
-        cy.wait(100);
-        cy.get('.frappe-control[data-fieldname="fields"]').as('table');
-        cy.get('.grid-body .grid-row').find('.col-xs-2').first().click()
-        cy.get('.grid-body .grid-row').find('.col-xs-2')
-            .first().type('{ctrl}{uparrow}').should('be.visible')
-        cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '1');
-    });
+	it('Insert new row at the top', () => {
+		cy.add_new_row_in_grid('{ctrl}{shift}{uparrow}', (cy) => {
+			cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '1');
+		});
+	});
+	it('Insert new row below', () => {
+		cy.add_new_row_in_grid('{ctrl}{downarrow}', (cy) => {
+			cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '2');
+		});
+	});
+	it('Insert new row above', () => {
+		cy.add_new_row_in_grid('{ctrl}{uparrow}', (cy) => {
+			cy.get('[data-name="new-docfield-1"]').should('have.attr', 'data-idx', '1');
+		});
+	});
+});
+
+Cypress.Commands.add('add_new_row_in_grid', (shortcut_keys, callbackFn, total_count) => {
+	cy.get('.frappe-control[data-fieldname="fields"]').as('table');
+	cy.get('@table').find('.grid-body .col-xs-2').first().click();
+	cy.get('@table').find('.grid-body .col-xs-2')
+		.first().type(shortcut_keys);
+
+	callbackFn(cy, total_count);
 });

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -140,39 +140,39 @@ frappe.ui.form.Form = class FrappeForm {
 		let grid_shortcut_keys = [
 			{
 				'shortcut': 'Up Arrow',
-				'description': 'Move cursor to above row'
+				'description': __('Move cursor to above row')
 			},
 			{
 				'shortcut': 'Down Arrow',
-				'description': 'Move cursor to below row'
+				'description': __('Move cursor to below row')
 			},
 			{
 				'shortcut': 'tab',
-				'description': 'Move cursor to next column'
+				'description': __('Move cursor to next column')
 			},
 			{
 				'shortcut': 'shift+tab',
-				'description': 'Move cursor to previous column'
+				'description': __('Move cursor to previous column')
 			},
 			{
 				'shortcut': 'Ctrl+up',
-				'description': 'Add a row at above the current row'
+				'description': __('Add a row at above the current row')
 			},
 			{
 				'shortcut': 'Ctrl+down',
-				'description': 'Add a row at below the current row'
+				'description': __('Add a row at below the current row')
 			},
 			{
 				'shortcut': 'Ctrl+shift+up',
-				'description': 'Add a row on top of the table'
+				'description': __('Add a row on top of the table')
 			},
 			{
 				'shortcut': 'Ctrl+shift+down',
-				'description': 'Add a row on bottom of the table'
+				'description': __('Add a row on bottom of the table')
 			},
 			{
 				'shortcut': 'shift+alt+down',
-				'description': 'To duplcate current row'
+				'description': __('To duplcate current row')
 			}
 		];
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -156,19 +156,19 @@ frappe.ui.form.Form = class FrappeForm {
 			},
 			{
 				'shortcut': 'Ctrl+up',
-				'description': __('Add a row at above the current row')
+				'description': __('Add a row above the current row')
 			},
 			{
 				'shortcut': 'Ctrl+down',
-				'description': __('Add a row at below the current row')
+				'description': __('Add a row below the current row')
 			},
 			{
 				'shortcut': 'Ctrl+shift+up',
-				'description': __('Add a row on top of the table')
+				'description': __('Add a row at the top')
 			},
 			{
 				'shortcut': 'Ctrl+shift+down',
-				'description': __('Add a row on bottom of the table')
+				'description': __('Add a row at the bottom')
 			},
 			{
 				'shortcut': 'shift+alt+down',

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -85,7 +85,7 @@ frappe.ui.form.Form = class FrappeForm {
 		});
 
 		// navigate records keyboard shortcuts
-		this.add_nav_keyboard_shortcuts();
+		this.add_form_keyboard_shortcuts();
 
 		// 2 column layout
 		this.setup_std_layout();
@@ -116,7 +116,8 @@ frappe.ui.form.Form = class FrappeForm {
 		this.setup_done = true;
 	}
 
-	add_nav_keyboard_shortcuts() {
+	add_form_keyboard_shortcuts() {
+		// Navigate to next record
 		frappe.ui.keys.add_shortcut({
 			shortcut: 'shift+ctrl+>',
 			action: () => this.navigate_records(0),
@@ -126,6 +127,7 @@ frappe.ui.form.Form = class FrappeForm {
 			condition: () => !this.is_new()
 		});
 
+		// Navigate to previous record
 		frappe.ui.keys.add_shortcut({
 			shortcut: 'shift+ctrl+<',
 			action: () => this.navigate_records(1),
@@ -134,6 +136,56 @@ frappe.ui.form.Form = class FrappeForm {
 			ignore_inputs: true,
 			condition: () => !this.is_new()
 		});
+
+		let grid_shortcut_keys = [
+			{
+				'shortcut': 'Up Arrow',
+				'description': 'Move cursor to above row'
+			},
+			{
+				'shortcut': 'Down Arrow',
+				'description': 'Move cursor to below row'
+			},
+			{
+				'shortcut': 'tab',
+				'description': 'Move cursor to next column'
+			},
+			{
+				'shortcut': 'shift+tab',
+				'description': 'Move cursor to previous column'
+			},
+			{
+				'shortcut': 'Ctrl+up',
+				'description': 'Add a row at above the current row'
+			},
+			{
+				'shortcut': 'Ctrl+down',
+				'description': 'Add a row at below the current row'
+			},
+			{
+				'shortcut': 'Ctrl+shift+up',
+				'description': 'Add a row on top of the table'
+			},
+			{
+				'shortcut': 'Ctrl+shift+down',
+				'description': 'Add a row on bottom of the table'
+			},
+			{
+				'shortcut': 'shift+alt+down',
+				'description': 'To duplcate current row'
+			}
+		];
+
+		grid_shortcut_keys.forEach(row => {
+			frappe.ui.keys.add_shortcut({
+				shortcut: row.shortcut,
+				page: this,
+				description: __(row.description),
+				ignore_inputs: true,
+				condition: () => !this.is_new()
+			});
+		});
+
 	}
 
 	setup_std_layout() {

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -687,7 +687,7 @@ export default class Grid {
 	}
 
 	set_focus_on_row(idx) {
-		if (!idx && idx!=0) {
+		if (!idx && idx !== 0) {
 			idx = this.grid_rows.length - 1;
 		}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -684,7 +684,7 @@ export default class Grid {
 	}
 
 	set_focus_on_row(idx) {
-		if (!idx) {
+		if (!idx && idx!=0) {
 			idx = this.grid_rows.length - 1;
 		}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -616,11 +616,14 @@ export default class Grid {
 		});
 	}
 
-	add_new_row(idx, callback, show, copy_doc, go_to_last_page = false) {
+	add_new_row(idx, callback, show, copy_doc, go_to_last_page = false, go_to_first_page = false) {
 		if (this.is_editable()) {
 			if (go_to_last_page) {
 				this.grid_pagination.go_to_last_page_to_add_row();
+			} else if (go_to_first_page) {
+				this.grid_pagination.go_to_page(1);
 			}
+
 			if (this.frm) {
 				var d = frappe.model.add_child(this.frm.doc, this.df.options, this.df.fieldname, idx);
 				if (copy_doc) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -821,9 +821,10 @@ export default class GridRow {
 		if (ctrl_key && e.shiftKey)  {
 			let show = (e.which === DOWN_ARROW) ? true : false;
 			idx = (e.which === DOWN_ARROW) ? null : 1;
+			let goto_last_page = (e.which === DOWN_ARROW) ? true : false;
 
 			setTimeout(() => {
-				this.grid.add_new_row(idx, null, show);
+				this.grid.add_new_row(idx, null, show, false, goto_last_page, !goto_last_page);
 
 				idx = (e.which === DOWN_ARROW) ? this.grid.grid_rows.length : 1;
 				this.grid.grid_rows[(idx - 1)].toggle_editable_row();

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -812,31 +812,25 @@ export default class GridRow {
 	}
 
 	add_new_row_using_keys(e) {
-		let me = this;
 		let idx = '';
 
 		let ctrl_key = e.metaKey || e.ctrlKey;
-		let { DOWN: DOWN_ARROW } = frappe.ui.keyCode;
+		let is_down_arrow_key_press = (e.which === 40);
 
+		// Add new row at the end or start of the table
 		if (ctrl_key && e.shiftKey)  {
-			let show = (e.which === DOWN_ARROW) ? true : false;
-			idx = (e.which === DOWN_ARROW) ? null : 1;
-			let goto_last_page = (e.which === DOWN_ARROW) ? true : false;
-
-			setTimeout(() => {
-				this.grid.add_new_row(idx, null, show, false, goto_last_page, !goto_last_page);
-
-				idx = (e.which === DOWN_ARROW) ? this.grid.grid_rows.length : 1;
-				this.grid.grid_rows[(idx - 1)].toggle_editable_row();
-				this.grid.set_focus_on_row((idx - 1));
-			}, 100);
+			idx = is_down_arrow_key_press ? null : 1;
+			this.grid.add_new_row(idx, null, is_down_arrow_key_press,
+				false, is_down_arrow_key_press, !is_down_arrow_key_press);
+			idx = is_down_arrow_key_press ? (cint(this.grid.grid_rows.length) - 1) : 0;
 
 		} else if (ctrl_key) {
-			let below = (e.which === DOWN_ARROW) ? true : false;
-			idx = (e.which === DOWN_ARROW) ? me.doc.idx : (me.doc.idx - 1);
+			idx = is_down_arrow_key_press ? this.doc.idx : (this.doc.idx - 1);
+			this.insert(false, is_down_arrow_key_press);
+		}
 
+		if (idx !== '') {
 			setTimeout(() => {
-				this.insert(false, below);
 				this.grid.grid_rows[idx].toggle_editable_row();
 				this.grid.set_focus_on_row(idx);
 			}, 100);

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -72,6 +72,9 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 	let current_page_shortcuts = standard_shortcuts.filter(
 		shortcut => shortcut.page && shortcut.page === window.cur_page.page.page);
 
+	let grid_shortcuts = standard_shortcuts.filter(
+		shortcut => shortcut.page && shortcut.page === window.cur_page.page.frm);
+
 	function generate_shortcuts_html(shortcuts, heading) {
 		if (!shortcuts.length) {
 			return '';
@@ -100,6 +103,7 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 
 	let global_shortcuts_html = generate_shortcuts_html(global_shortcuts, __('Global Shortcuts'));
 	let current_page_shortcuts_html = generate_shortcuts_html(current_page_shortcuts, __('Page Shortcuts'));
+	let grid_shortcuts_html = generate_shortcuts_html(grid_shortcuts, __('Grid Shortcuts'));
 
 	let dialog = new frappe.ui.Dialog({
 		title: __('Keyboard Shortcuts'),
@@ -110,6 +114,7 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 
 	dialog.$body.append(global_shortcuts_html);
 	dialog.$body.append(current_page_shortcuts_html);
+	dialog.$body.append(grid_shortcuts_html);
 	dialog.$body.append(`
 		<div class="text-muted">
 			${__('Press Alt Key to trigger additional shortcuts in Menu and Sidebar')}


### PR DESCRIPTION
Keyboard shortcuts description for the Grid

<img width="558" alt="Screenshot 2021-10-14 at 4 10 25 PM" src="https://user-images.githubusercontent.com/8780500/137302416-62980cb9-7d5e-457c-b8c5-a6bd164bfdd3.png">

<hr>

- Shift + Alt + Down Arrow -> Duplicate Row

![duplicate_row_using_keys](https://user-images.githubusercontent.com/8780500/137118781-fcfc0aa3-28d1-4e84-9716-429946265e40.gif)


<hr>

- Command + Shift + UP Arrow -> Add new row in the top

- Command + Shift + Down Arrow -> Add new row in the Bottom

![add_row_at_top_and_bottom](https://user-images.githubusercontent.com/8780500/137119388-87e9832c-0055-455b-99c7-2c3497ce1497.gif)


<hr>

- Command + UP Arrow -> Insert Above

- Command + Down Arrow -> Insert Below
![insert_above_below](https://user-images.githubusercontent.com/8780500/137119049-c8f4e684-6e0f-4fe6-9a4d-a316b646a105.gif)


> In-app docs included
<no-docs>