### PR TITLE
refactor: replacing raw SQL queries with frappe ORM

### DIFF
--- a/frappe/core/doctype/activity_log/activity_log.py
+++ b/frappe/core/doctype/activity_log/activity_log.py
@@ -9,6 +9,7 @@ from frappe.core.utils import set_timeline_doc
 import frappe
 from frappe.query_builder import DocType, Interval
 from frappe.query_builder.functions import Now
+from pypika.terms import PseudoColumn
 
 class ActivityLog(Document):
 	def before_insert(self):
@@ -47,6 +48,6 @@ def clear_activity_logs(days=None):
 	if not days:
 		days = 90
 	doctype = DocType("Activity Log")
-	frappe.qb.from_(doctype).where(
-		doctype.creation < (Now() - Interval(days=days))
-	).delete().run()
+	frappe.db.delete(doctype, filters=(
+		doctype.creation < PseudoColumn(f"({Now() - Interval(days=days)})")
+	))

--- a/frappe/core/doctype/activity_log/activity_log.py
+++ b/frappe/core/doctype/activity_log/activity_log.py
@@ -7,6 +7,8 @@ from frappe.utils import get_fullname, now
 from frappe.model.document import Document
 from frappe.core.utils import set_timeline_doc
 import frappe
+from frappe.query_builder import DocType, Interval
+from frappe.query_builder.functions import Now
 
 class ActivityLog(Document):
 	def before_insert(self):
@@ -44,6 +46,7 @@ def clear_activity_logs(days=None):
 
 	if not days:
 		days = 90
-
-	frappe.db.sql("""delete from `tabActivity Log` where \
-		creation< (NOW() - INTERVAL '{0}' DAY)""".format(days))
+	doctype = DocType("Activity Log")
+	frappe.qb.from_(doctype).where(
+		doctype.creation < (Now() - Interval(days=days))
+	).delete().run()

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -5,6 +5,9 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import DocType, Interval
+from frappe.query_builder.functions import Now
+
 
 class LogSettings(Document):
 	def clear_logs(self):
@@ -13,9 +16,10 @@ class LogSettings(Document):
 		self.clear_email_queue()
 
 	def clear_error_logs(self):
-		frappe.db.sql(""" DELETE FROM `tabError Log`
-			WHERE `creation` < (NOW() - INTERVAL '{0}' DAY)
-		""".format(self.clear_error_log_after))
+		table = DocType("Error Log")
+		frappe.db.delete(table, filters=(
+			table.creation < Now() - Interval(days=self.clear_error_log_after)
+		))
 
 	def clear_activity_logs(self):
 		from frappe.core.doctype.activity_log.activity_log import clear_activity_logs

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -7,6 +7,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import DocType, Interval
 from frappe.query_builder.functions import Now
+from pypika.terms import PseudoColumn
 
 
 class LogSettings(Document):
@@ -18,7 +19,7 @@ class LogSettings(Document):
 	def clear_error_logs(self):
 		table = DocType("Error Log")
 		frappe.db.delete(table, filters=(
-			table.creation < Now() - Interval(days=self.clear_error_log_after)
+			table.creation < PseudoColumn(f"({Now() - Interval(days=self.clear_error_log_after)})")
 		))
 
 	def clear_activity_logs(self):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -16,6 +16,7 @@ from frappe.utils.user import get_system_managers
 from frappe.website.utils import is_signup_disabled
 from frappe.rate_limiter import rate_limit
 from frappe.core.doctype.user_type.user_type import user_linked_with_permission_on_doctype
+from frappe.query_builder import DocType
 
 
 STANDARD_USERS = ("Guest", "Administrator")
@@ -366,15 +367,21 @@ class User(Document):
 		# delete shares
 		frappe.db.delete("DocShare", {"user": self.name})
 		# delete messages
-		frappe.db.sql("""delete from `tabCommunication`
-			where communication_type in ('Chat', 'Notification')
-			and reference_doctype='User'
-			and (reference_name=%s or owner=%s)""", (self.name, self.name))
-
+		table = DocType("Communication")
+		frappe.db.delete(
+			table,
+			filters=(
+				(table.communication_type.isin(["Chat", "Notification"]))
+				& (table.reference_doctype == "User")
+				& ((table.reference_name == self.name) | table.owner == self.name)
+			),
+			run=False,
+		)
 		# unlink contact
-		frappe.db.sql("""update `tabContact`
-			set `user`=null
-			where `user`=%s""", (self.name))
+		table = DocType("Contact")
+		frappe.qb.update(table).where(
+			table.user == self.name
+		).set(table.user, None).run()
 
 		# delete notification settings
 		frappe.delete_doc("Notification Settings", self.name, ignore_permissions=True)
@@ -421,9 +428,10 @@ class User(Document):
 			frappe.rename_doc("Notification Settings", old_name, new_name, force=True, show_alert=False)
 
 		# set email
-		frappe.db.sql("""UPDATE `tabUser`
-			SET email = %s
-			WHERE name = %s""", (new_name, new_name))
+		table = DocType("User")
+		frappe.qb.update(table).where(
+			table.name == new_name
+		).set("email", new_name).run()
 
 	def append_roles(self, *roles):
 		"""Add roles to user"""

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -83,7 +83,8 @@ class Database(object):
 		pass
 
 	def sql(self, query, values=(), as_dict = 0, as_list = 0, formatted = 0,
-		debug=0, ignore_ddl=0, as_utf8=0, auto_commit=0, update=None, explain=False, run=True):
+			debug=0, ignore_ddl=0, as_utf8=0, auto_commit=0, update=None,
+			explain=False, run=True, pluck=False):
 		"""Execute a SQL query and fetch all rows.
 
 		:param query: SQL query.
@@ -178,6 +179,9 @@ class Database(object):
 		if not self._cursor.description:
 			return ()
 
+		if pluck:
+			return [r[0] for r in self._cursor.fetchall()]
+
 		# scrub output if required
 		if as_dict:
 			ret = self.fetch_as_dict(formatted, as_utf8)
@@ -233,7 +237,7 @@ class Database(object):
 		except Exception:
 			frappe.errprint("error in query explain")
 
-	def sql_list(self, query, values=(), debug=False):
+	def sql_list(self, query, values=(), debug=False, **kwargs):
 		"""Return data as list of single elements (first column).
 
 		Example:
@@ -241,7 +245,7 @@ class Database(object):
 			# doctypes = ["DocType", "DocField", "User", ...]
 			doctypes = frappe.db.sql_list("select name from DocType")
 		"""
-		return [r[0] for r in self.sql(query, values, debug=debug)]
+		return [r[0] for r in self.sql(query, values, **kwargs, debug=debug)]
 
 	def sql_ddl(self, query, values=(), debug=False):
 		"""Commit and execute a query. DDL (Data Definition Language) queries that alter schema

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -190,7 +190,7 @@ def get_defaults_for(parent="__default"):
 		# sort descending because first default must get precedence
 		table = frappe.qb.DocType("DefaultValue")
 		res = frappe.qb.from_(table).where(table.parent == parent) \
-			  .select(table.defkey, table.defvalue).orderby("creation").run(as_dict=True)
+ 			  .select(table.defkey, table.defvalue).orderby("creation").run(as_dict=True)
 
 		defaults = frappe._dict({})
 		for d in res:

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.desk.notifications import clear_notifications
 from frappe.cache_manager import clear_defaults_cache, common_default_keys
+from frappe.query_builder import DocType
 
 # Note: DefaultValue records are identified by parenttype
 # __default, __global or 'User Permission'
@@ -116,11 +117,11 @@ def set_default(key, value, parent, parenttype="__default"):
 	:param value: Default value.
 	:param parent: Usually, **User** to whom the default belongs.
 	:param parenttype: [optional] default is `__default`."""
-	table = frappe.qb.DocType("DefaultValue")
-	result = frappe.qb.from_(table).where(table.defkey == key) \
-	.where(table.parent == parent) \
-	.select(table.defkey).for_update().run()
-	if result:
+	table = DocType("DefaultValue")
+	key_exists = frappe.qb.from_(table).where(
+		(table.defkey == key) & (table.parent == parent)
+	).select(table.defkey).for_update().run()
+	if key_exists:
 		frappe.db.delete("DefaultValue", {
 			"defkey": key,
 			"parent": parent
@@ -188,9 +189,12 @@ def get_defaults_for(parent="__default"):
 
 	if defaults==None:
 		# sort descending because first default must get precedence
-		table = frappe.qb.DocType("DefaultValue")
-		res = frappe.qb.from_(table).where(table.parent == parent) \
- 			  .select(table.defkey, table.defvalue).orderby("creation").run(as_dict=True)
+		table = DocType("DefaultValue")
+		res = frappe.qb.from_(table).where(
+			table.parent == parent
+		).select(
+			table.defkey, table.defvalue
+		).orderby("creation").run(as_dict=True)
 
 		defaults = frappe._dict({})
 		for d in res:

--- a/frappe/patches/v11_0/remove_skip_for_doctype.py
+++ b/frappe/patches/v11_0/remove_skip_for_doctype.py
@@ -2,6 +2,7 @@
 import frappe
 from frappe.desk.form.linked_with import get_linked_doctypes
 from frappe.patches.v11_0.replicate_old_user_permissions import get_doctypes_to_skip
+from frappe.query_builder import Field
 
 # `skip_for_doctype` was a un-normalized way of storing for which
 # doctypes the user permission was applicable.
@@ -72,16 +73,12 @@ def execute():
 			frappe.db.set_value('User Permission', user_permission.name, 'apply_to_all_doctypes', 1)
 
 	if new_user_permissions_list:
-		frappe.db.sql('''
-			INSERT INTO `tabUser Permission`
-			(`name`, `user`, `allow`, `for_value`, `applicable_for`, `apply_to_all_doctypes`, `creation`, `modified`)
-			VALUES {}
-		'''.format( # nosec
-			', '.join(['%s'] * len(new_user_permissions_list))
-		), tuple(new_user_permissions_list))
+		frappe.qb.into("User Permission").columns(
+			"name", "user", "allow", "for_value", "applicable_for", "apply_to_all_doctypes", "creation", "modified"
+		).insert(tuple(new_user_permissions_list)).run()
 
 	if user_permissions_to_delete:
-		frappe.db.sql('DELETE FROM `tabUser Permission` WHERE `name` in ({})' # nosec
-			.format(','.join(['%s'] * len(user_permissions_to_delete))),
-			tuple(user_permissions_to_delete)
+		frappe.db.delete(
+			"User Permission",
+			filters=(Field("name").isin(tuple(user_permissions_to_delete)))
 		)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -353,10 +353,10 @@ def get_roles(user=None, with_standard=True):
 			return frappe.get_all("Role", pluck="name") # return all available roles
 		else:
 			table = DocType("Has Role")
-			result = frappe.qb.from_(table).where(
+			roles = frappe.qb.from_(table).where(
 				(table.parent == user) & (table.role.notin(["All", "Guest"]))
-			).select(table.role).run()
-			return [r[0] for r in result] + ['All', 'Guest']
+			).select(table.role).run(pluck=True)
+			return roles + ['All', 'Guest']
 
 	roles = frappe.cache().hget("roles", user, get)
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -354,7 +354,7 @@ def get_roles(user=None, with_standard=True):
 			return [r[0] for r in frappe.qb.from_("Role").select("name").run()] # return all available roles
 		else:
 			table = frappe.qb.DocType("Has Role")
-			result = frappe.qb.form_(table).where(table.parent == user) \
+			result = frappe.qb.from_(table).where(table.parent == user) \
 					.where(table.role.notin(["All", "Guest"])).select(table.role).run()
 			return [r[0] for r in result] + ['All', 'Guest']
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -16,8 +16,8 @@ import frappe.translate
 import redis
 from urllib.parse import unquote
 from frappe.cache_manager import clear_user_cache
-from frappe.query_builder import Order
-from frappe.query_builder import DocType
+from frappe.query_builder import Order, DocType
+
 
 @frappe.whitelist(allow_guest=True)
 def clear(user=None):
@@ -63,12 +63,12 @@ def get_sessions_to_clear(user=None, keep_current=False, device=None):
 		simultaneous_sessions = frappe.db.get_value('User', user, 'simultaneous_sessions') or 1
 		offset = simultaneous_sessions - 1
 
-	table = frappe.qb.DocType("Sessions")
-	criterion = frappe.qb.from_(table).where((table.user == user) & (table.device.isin(device)))
+	session = DocType("Sessions")
+	session_id = frappe.qb.from_(session).where((session.user == user) & (session.device.isin(device)))
 	if keep_current:
-		criterion = criterion.where(table.sid != frappe.db.escape(frappe.session.sid))
+		session_id = session_id.where(session.sid != frappe.db.escape(frappe.session.sid))
 
-	query = criterion.select(table.sid).offset(offset).limit(100).orderby(table.lastupdate, order=Order.desc)
+	query = session_id.select(session.sid).offset(offset).limit(100).orderby(session.lastupdate, order=Order.desc)
 
 	return frappe.db.sql_list(query)
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -64,8 +64,7 @@ def get_sessions_to_clear(user=None, keep_current=False, device=None):
 		offset = simultaneous_sessions - 1
 
 	table = frappe.qb.DocType("Sessions")
-	criterion =  frappe.qb.from_(table).where(table.user == user) \
-		  		.where(table.device.isin(device))
+	criterion = frappe.qb.from_(table).where((table.user == user) & (table.device.isin(device)))
 	if keep_current:
 		criterion = criterion.where(table.sid != frappe.db.escape(frappe.session.sid))
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -70,7 +70,7 @@ def get_sessions_to_clear(user=None, keep_current=False, device=None):
 
 	query = session_id.select(session.sid).offset(offset).limit(100).orderby(session.lastupdate, order=Order.desc)
 
-	return frappe.db.sql_list(query)
+	return query.run(pluck=True)
 
 def delete_session(sid=None, user=None, reason="Session Expired"):
 	from frappe.core.doctype.activity_log.feed import logout_feed
@@ -92,7 +92,7 @@ def clear_all_sessions(reason=None):
 	"""This effectively logs out all users"""
 	frappe.only_for("Administrator")
 	if not reason: reason = "Deleted All Active Session"
-	for sid in [r[0] for r in frappe.qb.from_("Sessions").select("sid").run()]:
+	for sid in frappe.qb.from_("Sessions").select("sid").run(pluck=True):
 		delete_session(sid, reason=reason)
 
 def get_expired_sessions():

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -132,7 +132,7 @@ def get_shared_doctypes(user=None):
 	query = frappe.qb.from_(table).where(
 		(table.user == user) | (table.everyone == 1)
 	).select(table.share_doctype).distinct()
-	return frappe.db.sql_list(query)
+	return query.run(pluck=True)
 
 def get_share_name(doctype, name, user, everyone):
 	if cint(everyone):

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -128,8 +128,10 @@ def get_shared_doctypes(user=None):
 	"""Return list of doctypes in which documents are shared for the given user."""
 	if not user:
 		user = frappe.session.user
-
-	return frappe.db.sql_list("select distinct share_doctype from tabDocShare where (user=%s or everyone=1)", user)
+	table = frappe.qb.DocType("DocShare")
+	query = frappe.qb.from_(table).where(table.user == user | table.everyone == 1) \
+			.select(table.share_doctype).distinct()
+	return frappe.db.sql_list(query)
 
 def get_share_name(doctype, name, user, everyone):
 	if cint(everyone):

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -129,8 +129,9 @@ def get_shared_doctypes(user=None):
 	if not user:
 		user = frappe.session.user
 	table = frappe.qb.DocType("DocShare")
-	query = frappe.qb.from_(table).where(table.user == user | table.everyone == 1) \
-			.select(table.share_doctype).distinct()
+	query = frappe.qb.from_(table).where(
+		(table.user == user) | (table.everyone == 1)
+	).select(table.share_doctype).distinct()
 	return frappe.db.sql_list(query)
 
 def get_share_name(doctype, name, user, everyone):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -121,7 +121,7 @@ def set_default_language(lang):
 
 def get_lang_dict():
 	"""Returns all languages in dict format, full name is the key e.g. `{"english":"en"}`"""
-	result = frappe.get_all("Language", fields=["language_name", "name"], order_by="modified", as_list=True)
+	result = dict(frappe.get_all("Language", fields=["language_name", "name"], order_by="modified", as_list=True))
 	return result
 
 def get_dict(fortype, name=None):
@@ -156,33 +156,23 @@ def get_dict(fortype, name=None):
 			messages += get_messages_from_include_files()
 			messages += (
 				frappe.qb.from_("Print Format")
-				.select(PseudoColumn("'Print Format:'"), "name")
-				.run()
-			)
+				.select(PseudoColumn("'Print Format:'"), "name")).run()
 			messages += (
 				frappe.qb.from_("DocType")
-				.select(PseudoColumn("'DocType:'"), "name")
-				.run()
-			)
+				.select(PseudoColumn("'DocType:'"), "name")).run()
 			messages += (
 				frappe.qb.from_("Role").select(PseudoColumn("'Role:'"), "name").run()
 			)
 			messages += (
 				frappe.qb.from_("Module Def")
-				.select(PseudoColumn("'Module:'"), "name")
-				.run()
-			)
+				.select(PseudoColumn("'Module:'"), "name")).run()
 			messages += (
 				frappe.qb.from_("Workspace Shortcut")
 				.where(Field("format").isnotnull())
-				.select(PseudoColumn("''"), "format")
-				.run()
-			)
+				.select(PseudoColumn("''"), "format")).run()
 			messages += (
 				frappe.qb.from_("Onboarding Step")
-				.select(PseudoColumn("''"), "title")
-				.run()
-			)
+				.select(PseudoColumn("''"), "title")).run()
 
 		messages = deduplicate_messages(messages)
 		message_dict = make_dict_from_messages(messages, load_user_translation=False)
@@ -349,17 +339,17 @@ def get_messages_for_app(app, deduplicate=True):
 
 	# doctypes
 	if modules:
-		names = frappe.qb.from_("DocType").where(
+		filtered_doctypes = frappe.qb.from_("DocType").where(
 			Field("module").isin(modules)
 		).select("name").run()
-		for name in names:
+		for name in filtered_doctypes:
 			messages.extend(get_messages_from_doctype(name))
 
 		# pages
-		result = frappe.qb.from_("Page").where(
+		filtered_pages = frappe.qb.from_("Page").where(
 			Field("module").isin(modules)
 		).select("name", "title").run()
-		for name, title in result:
+		for name, title in filtered_pages:
 			messages.append((None, title or name))
 			messages.extend(get_messages_from_page(name))
 
@@ -928,7 +918,7 @@ def get_translator_url():
 def get_all_languages(with_language_name=False):
 	"""Returns all language codes ar, ch etc"""
 	def get_language_codes():
-		return frappe.get_all("Language", pluck="name", order_by="modified")
+		return frappe.get_all("Language", pluck="name")
 
 	def get_all_language_with_name():
 		return frappe.db.get_all('Language', ['language_code', 'language_name'])

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -119,7 +119,8 @@ def set_default_language(lang):
 
 def get_lang_dict():
 	"""Returns all languages in dict format, full name is the key e.g. `{"english":"en"}`"""
-	return dict(frappe.db.sql('select language_name, name from tabLanguage'))
+	result = dict(frappe.qb.from_("Language").select("language_name", "name").run())
+	return result
 
 def get_dict(fortype, name=None):
 	"""Returns translation dict for a type of object.
@@ -151,12 +152,12 @@ def get_dict(fortype, name=None):
 
 			messages += get_messages_from_navbar()
 			messages += get_messages_from_include_files()
-			messages += frappe.db.sql("select 'Print Format:', name from `tabPrint Format`")
-			messages += frappe.db.sql("select 'DocType:', name from tabDocType")
-			messages += frappe.db.sql("select 'Role:', name from tabRole")
-			messages += frappe.db.sql("select 'Module:', name from `tabModule Def`")
-			messages += frappe.db.sql("select '', format from `tabWorkspace Shortcut` where format is not null")
-			messages += frappe.db.sql("select '', title from `tabOnboarding Step`")
+			messages += frappe.qb.from_("Print Format").select("Print Format:", "name").run()
+			messages += frappe.qb.from_("DocType").select("DocType:", "name").run()
+			messages += frappe.qb.from_("Role").select("Role:", "name").run()
+			messages += frappe.qb.from_("Module Def").select("Module:", "name").run()
+			messages += frappe.qb.from_("Workspace Shortcut").where(frappe.qb.Field("format" != None)).select("").run()
+			messages += frappe.qb.from_("Onboarding Step").select("", "title").run()
 
 		messages = deduplicate_messages(messages)
 		message_dict = make_dict_from_messages(messages, load_user_translation=False)
@@ -898,7 +899,8 @@ def get_translator_url():
 def get_all_languages(with_language_name=False):
 	"""Returns all language codes ar, ch etc"""
 	def get_language_codes():
-		return frappe.db.sql_list('select name from tabLanguage')
+		query = frappe.qb.from_("Language").select("name")
+		return frappe.db.sql_list(query)
 
 	def get_all_language_with_name():
 		return frappe.db.get_all('Language', ['language_code', 'language_name'])

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -120,7 +120,7 @@ def set_default_language(lang):
 
 def get_lang_dict():
 	"""Returns all languages in dict format, full name is the key e.g. `{"english":"en"}`"""
-	result = dict(frappe.qb.from_("Language").select("language_name", "name").run())
+	result = frappe.get_all("Language", fields=["language_name", "name"], order_by="modified", as_list=True)
 	return result
 
 def get_dict(fortype, name=None):
@@ -904,8 +904,7 @@ def get_translator_url():
 def get_all_languages(with_language_name=False):
 	"""Returns all language codes ar, ch etc"""
 	def get_language_codes():
-		query = frappe.qb.from_("Language").select("name")
-		return frappe.db.sql_list(query)
+		return frappe.get_all("Language", pluck="name", order_by="modified")
 
 	def get_all_language_with_name():
 		return frappe.db.get_all('Language', ['language_code', 'language_name'])

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -21,6 +21,7 @@ import frappe
 from frappe.model.utils import InvalidIncludePath, render_include
 from frappe.utils import get_bench_path, is_html, strip, strip_html_tags
 from frappe.query_builder import Field
+from pypika.terms import PseudoColumn
 
 
 def get_language(lang_list: List = None) -> str:
@@ -153,12 +154,35 @@ def get_dict(fortype, name=None):
 
 			messages += get_messages_from_navbar()
 			messages += get_messages_from_include_files()
-			messages += frappe.qb.from_("Print Format").select("Print Format:", "name").run()
-			messages += frappe.qb.from_("DocType").select("DocType:", "name").run()
-			messages += frappe.qb.from_("Role").select("Role:", "name").run()
-			messages += frappe.qb.from_("Module Def").select("Module:", "name").run()
-			messages += frappe.qb.from_("Workspace Shortcut").where(Field("format").isnotnull()).select("").run()
-			messages += frappe.qb.from_("Onboarding Step").select("", "title").run()
+			messages += (
+				frappe.qb.from_("Print Format")
+				.select(PseudoColumn("'Print Format:'"), "name")
+				.run()
+			)
+			messages += (
+				frappe.qb.from_("DocType")
+				.select(PseudoColumn("'DocType:'"), "name")
+				.run()
+			)
+			messages += (
+				frappe.qb.from_("Role").select(PseudoColumn("'Role:'"), "name").run()
+			)
+			messages += (
+				frappe.qb.from_("Module Def")
+				.select(PseudoColumn("'Module:'"), "name")
+				.run()
+			)
+			messages += (
+				frappe.qb.from_("Workspace Shortcut")
+				.where(Field("format").isnotnull())
+				.select(PseudoColumn("''"), "format")
+				.run()
+			)
+			messages += (
+				frappe.qb.from_("Onboarding Step")
+				.select(PseudoColumn("''"), "title")
+				.run()
+			)
 
 		messages = deduplicate_messages(messages)
 		message_dict = make_dict_from_messages(messages, load_user_translation=False)


### PR DESCRIPTION
Replacing raw SQL queries with Frappe ORM

Converted ~29 queries
Added `pluck` to `frappe.db.sql` to mimic `frappe.db.sql_list`