### PR TITLE
refactor: improved design for fetching values using `add_fetch`

### DIFF
--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -77,4 +77,19 @@ context('Control Link', () => {
 			cy.location('pathname').should('eq', `/app/todo/${todos[0]}`);
 		});
 	});
+
+	it('should fetch valid value', () => {
+		cy.get('@todos').then(todos => {
+			cy.visit(`/app/todo/${todos[0]}`);
+			cy.intercept('GET', '/api/method/frappe.client.get_value*').as('get_value');
+
+			cy.get('.frappe-control[data-fieldname=assigned_by] input').focus().as('input');
+			cy.get('@input').type('Administrator', {delay: 100}).blur();
+			cy.wait('@get_value');
+			cy.get('.frappe-control[data-fieldname=assigned_by_full_name] .control-value').should(
+				'contain', 'Administrator'
+			);
+		});
+	});
+
 });

--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -49,19 +49,19 @@ context('Control Link', () => {
 	it('should unset invalid value', () => {
 		get_dialog_with_link().as('dialog');
 
-		cy.intercept('GET', '/api/method/frappe.desk.form.utils.validate_link*').as('validate_link');
+		cy.intercept('GET', '/api/method/frappe.client.get_value*').as('get_value');
 
 		cy.get('.frappe-control[data-fieldname=link] input')
 			.type('invalid value', { delay: 100 })
 			.blur();
-		cy.wait('@validate_link');
+		cy.wait('@get_value');
 		cy.get('.frappe-control[data-fieldname=link] input').should('have.value', '');
 	});
 
 	it('should route to form on arrow click', () => {
 		get_dialog_with_link().as('dialog');
 
-		cy.intercept('GET', '/api/method/frappe.desk.form.utils.validate_link*').as('validate_link');
+		cy.intercept('GET', '/api/method/frappe.client.get_value*').as('get_value');
 		cy.intercept('POST', '/api/method/frappe.desk.search.search_link').as('search_link');
 
 		cy.get('@todos').then(todos => {
@@ -69,7 +69,7 @@ context('Control Link', () => {
 			cy.get('@input').focus();
 			cy.wait('@search_link');
 			cy.get('@input').type(todos[0]).blur();
-			cy.wait('@validate_link');
+			cy.wait('@get_value');
 			cy.get('@input').focus();
 			cy.findByTitle('Open Link')
 				.should('be.visible')

--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -16,44 +16,6 @@ def remove_attach():
 	file_name = frappe.form_dict.get('file_name')
 	frappe.delete_doc('File', fid)
 
-@frappe.whitelist()
-def validate_link():
-	"""validate link when updated by user"""
-	import frappe
-	import frappe.utils
-
-	value, options, fetch = frappe.form_dict.get('value'), frappe.form_dict.get('options'), frappe.form_dict.get('fetch')
-
-	# no options, don't validate
-	if not options or options=='null' or options=='undefined':
-		frappe.response['message'] = 'Ok'
-		return
-
-	valid_value = frappe.db.get_all(options, filters=dict(name=value), as_list=1, limit=1)
-
-	if valid_value:
-		valid_value = valid_value[0][0]
-
-		# get fetch values
-		if fetch:
-			# escape with "`"
-			fetch = ", ".join(("`{0}`".format(f.strip()) for f in fetch.split(",")))
-			fetch_value = None
-			try:
-				fetch_value = frappe.db.sql("select %s from `tab%s` where name=%s"
-					% (fetch, options, '%s'), (value,))[0]
-			except Exception as e:
-				error_message = str(e).split("Unknown column '")
-				fieldname = None if len(error_message)<=1 else error_message[1].split("'")[0]
-				frappe.msgprint(_("Wrong fieldname <b>{0}</b> in add_fetch configuration of custom client script").format(fieldname))
-				frappe.errprint(frappe.get_traceback())
-
-			if fetch_value:
-				frappe.response['fetch_values'] = [frappe.utils.parse_val(c) for c in fetch_value]
-
-		frappe.response['valid_value'] = valid_value
-		frappe.response['message'] = 'Ok'
-
 
 @frappe.whitelist()
 def add_comment(reference_doctype, reference_name, content, comment_email, comment_by):

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1112,12 +1112,24 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	// UTILITIES
-	add_fetch(link_field, src_field, tar_field) {
-		if(!this.fetch_dict[link_field]) {
-			this.fetch_dict[link_field] = {'columns':[], 'fields':[]};
-		}
-		this.fetch_dict[link_field].columns.push(src_field);
-		this.fetch_dict[link_field].fields.push(tar_field);
+	add_fetch(link_field, source_field, target_field, target_doctype) {
+		/*
+		Example fetch dict to get sender_email from email_id field in sender:
+			{
+				"Notification": {
+					"sender": {
+						"sender_email": "email_id"
+					}
+				}
+			}
+		*/
+
+		if (!target_doctype) target_doctype = "*";
+
+		// Target field kept as key because source field could be non-unique
+		this.fetch_dict
+			.setDefault(target_doctype, {})
+			.setDefault(link_field, {})[target_field] = source_field;
 	}
 
 	has_perm(ptype) {

--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -196,7 +196,7 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 				'Text Editor', 'Code', 'Link', 'Float', 'Int', 'Date', 'Select', 'Duration'].includes(df.fieldtype) || df.read_only==1)
 				&& df.fetch_from && df.fetch_from.indexOf(".")!=-1) {
 				var parts = df.fetch_from.split(".");
-				me.frm.add_fetch(parts[0], parts[1], df.fieldname);
+				me.frm.add_fetch(parts[0], parts[1], df.fieldname, df.parent);
 			}
 		}
 


### PR DESCRIPTION
This PR fixes multiple issues and adds minor enhancements to fetching values using `add_fetch`.

## Changes Made
- Redesign `frm.fetch_dict` to allow multiple child tables to have _target_ and _link_ fields of same name. This fixes following bug in ERPNext v13:

    > In New Sales Invoice, add a Customer. Choose an Item with an Item Price set in the Items table. Change that Item. The Rate of previously chosen Item become Discount of currently chosen Item (leading to a negative `rate` being set). This happens because `fetch_from` set for `rate` field in `Packed Item` table interferes with `rate` field in `Sales Invoice Item` table.

    ![fetch_from issue](https://user-images.githubusercontent.com/16315650/137153282-0f2dfefa-7939-4fe3-ae0a-8f80514f7294.gif)

    To solve above issue, a new parameter called `target_doctype` has been introduced. In above, example this would be set to `Packed Item`.
- Remove `frappe.desk.form.utils.validate_link` to use `frappe.client.get_value` instead. The latter accomplishes the task more optimally and securely.
- Remove internal Link methods:
    -  `fetch_and_validate_link`: Could get confused with `validate_link_and_fetch`
    -  `set_fetch_values`: Two lines not used elsewhere.

- Add a getter called `fetch_map` to Link fields.