### PR TITLE
fix: Do not encode if route has "/" in it

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -160,7 +160,7 @@ frappe.set_route = function() {
 				return null;
 			} else {
 				a = String(a);
-				if (a && a.match(/[%'"\s\t]/)) {
+				if (a && !a.includes('/') && a.match(/[%'"\s\t]/)) {
 					// if special chars, then encode
 					a = encodeURIComponent(a);
 				}


### PR DESCRIPTION
Fixes following routing issues in the workspace.

```Page #List/Sales Invoice not found```

The bug was introduced after https://github.com/frappe/frappe/pull/14439
