### PR TITLE
revert: Override link click to avoid page reload

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -56,6 +56,11 @@ $('body').on('click', 'a', function(e) {
 		return override(e.currentTarget.hash);
 	}
 
+	if (frappe.router.is_app_route(e.currentTarget.pathname)) {
+		// target has "/app, this is a v2 style route.
+		return override(e.currentTarget.pathname + e.currentTarget.hash);
+	}
+
 });
 
 frappe.router = {


### PR DESCRIPTION
Without this change, every link click inside the application was reloading the page.

This PR reverts unnecessary change  made in #14394