### PR TITLE
fix(Print Format): Permission check for default print format

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -36,7 +36,7 @@ frappe.ui.form.on("Print Format", {
 			else if (frm.doc.custom_format && !frm.doc.raw_printing) {
 				frm.set_df_property("html", "reqd", 1);
 			}
-			if (frappe.perm.has_perm('DocType', 0, 'read', frm.doc.doc_type)) {
+			if (frappe.model.can_read(frm.doc.doc_type)) {
 				frappe.db.get_value('DocType', frm.doc.doc_type, 'default_print_format', (r) => {
 					if (r.default_print_format != frm.doc.name) {
 						frm.add_custom_button(__("Set as Default"), function () {


### PR DESCRIPTION
Users even after having required permissions were not able to see "Set As Default" option.

**Before:**
![Screenshot 2021-10-14 at 10 56 54 AM](https://user-images.githubusercontent.com/13928957/137257525-705c851e-53d7-412d-a693-dcdb117475fb.png)

**After:**
![Screenshot 2021-10-14 at 10 57 29 AM](https://user-images.githubusercontent.com/13928957/137257520-98e6112b-bcd8-4050-b607-311558c9bb5b.png)


The bug was introduced via https://github.com/frappe/frappe/pull/14132

---

Fixes: https://frappe.io/app/issue/ISS-21-22-07008
