### PR TITLE
feat: prepending `tab` to doctypes in query builder

### DIFF
--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -28,6 +28,17 @@ class MariaDB(Base, MySQLQuery):
 			table = cls.DocType(table)
 		return super().from_(table, *args, **kwargs)
 
+	@classmethod
+	def into(cls, table, *args, **kwargs):
+		if isinstance(table, str):
+			table = cls.DocType(table)
+		return super().into(table, *args, **kwargs)
+
+	@classmethod
+	def update(cls, table, *args, **kwargs):
+		if isinstance(table, str):
+			table = cls.DocType(table)
+		return super().update(table, *args, **kwargs)
 
 class Postgres(Base, PostgreSQLQuery):
 	field_translation = {"table_name": "relname", "table_rows": "n_tup_ins"}
@@ -58,3 +69,15 @@ class Postgres(Base, PostgreSQLQuery):
 			table = cls.DocType(table)
 
 		return super().from_(table, *args, **kwargs)
+
+	@classmethod
+	def into(cls, table, *args, **kwargs):
+		if isinstance(table, str):
+			table = cls.DocType(table)
+		return super().into(table, *args, **kwargs)
+
+	@classmethod
+	def update(cls, table, *args, **kwargs):
+		if isinstance(table, str):
+			table = cls.DocType(table)
+		return super().update(table, *args, **kwargs)


### PR DESCRIPTION
Prepend tab to table name for  `INSERT` and `UPDATE` queries

<!-- no-docs -->