### PR TITLE
fix: Rollback while exiting console

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -12,10 +12,9 @@ from frappe.exceptions import SiteNotSpecifiedError
 from frappe.utils import update_progress_bar, cint
 from frappe.coverage import CodeCoverage
 
-DATA_IMPORT_DEPRECATION = click.style(
+DATA_IMPORT_DEPRECATION = (
 	"[DEPRECATED] The `import-csv` command used 'Data Import Legacy' which has been deprecated.\n"
-	"Use `data-import` command instead to import data via 'Data Import'.",
-	fg="yellow"
+	"Use `data-import` command instead to import data via 'Data Import'."
 )
 
 
@@ -364,7 +363,7 @@ def import_doc(context, path, force=False):
 @click.option('--no-email', default=True, is_flag=True, help='Send email if applicable')
 @pass_context
 def import_csv(context, path, only_insert=False, submit_after_import=False, ignore_encoding_errors=False, no_email=True):
-	click.secho(DATA_IMPORT_DEPRECATION)
+	click.secho(DATA_IMPORT_DEPRECATION, fg="yellow")
 	sys.exit(1)
 
 

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -504,6 +504,12 @@ frappe.db.connect()
 	])
 
 
+def _console_cleanup():
+	# Execute rollback_observers on console close
+	frappe.db.rollback()
+	frappe.destroy()
+
+
 @click.command('console')
 @click.option(
 	'--autoreload',
@@ -519,6 +525,9 @@ def console(context, autoreload=False):
 	frappe.local.lang = frappe.db.get_default("lang")
 
 	from IPython.terminal.embed import InteractiveShellEmbed
+	from atexit import register
+
+	register(_console_cleanup)
 
 	terminal = InteractiveShellEmbed()
 	if autoreload:


### PR DESCRIPTION
When exiting the console, roll back and destroy the Frappe connection. This rollback is added so that rollback_observers are executed in case methods are run in the console which shouldn't be committed. For instance, running `File.optimize` will make changes to the file on disk but may not update the corresponding data in the DB.

### Other Changes

* Since the character to render NC was cut off due to the char limit, the whole list of following commands and descriptions would also turn yellow. Let's keep it colorless in --help. Only, make it yellow when the command is executed directly.