### PR TITLE
fix: pin `@testing-library/dom` to `8.7.2` to make UI tests work

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
   "snyk": true,
   "nyc": {
     "report-dir": ".cypress-coverage"
+  },
+  "resolutions": {
+    "@testing-library/dom": "8.7.2"
   }
 }


### PR DESCRIPTION
Meanwhile, the underlying issue seems to have been fixed here: 
https://github.com/testing-library/dom-testing-library/pull/1055

Once, it is released this can be reverted / closed.