### PR TITLE
fix: `if_owner` constraint being applied wrongly

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -597,8 +597,8 @@ class DatabaseQuery(object):
 				self.conditions.append(self.get_share_condition())
 
 		else:
-			#if has if_owner permission skip user perm check
-			if role_permissions.get("has_if_owner_enabled") and role_permissions.get("if_owner", {}):
+			# skip user perm check if owner constraint is required
+			if requires_owner_constraint(role_permissions):
 				self.match_conditions.append(
 					f"`tab{self.doctype}`.`owner` = {frappe.db.escape(self.user, percent=False)}"
 				)
@@ -895,3 +895,22 @@ def get_date_range(operator, value):
 	timespan = period_map[operator] + ' ' + timespan_map[value] if operator != 'timespan' else value
 
 	return get_timespan_date_range(timespan)
+
+def requires_owner_constraint(role_permissions):
+	"""Returns True if "select" or "read" isn't available without being creator."""
+
+	if not role_permissions.get("has_if_owner_enabled"):
+		return
+
+	if_owner_perms = role_permissions.get("if_owner")
+	if not if_owner_perms:
+		return
+
+	# has select or read without if owner, no need for constraint
+	for perm_type in ("select", "read"):
+		if role_permissions.get(perm_type) and perm_type not in if_owner_perms:
+			return
+
+	# not checking if either select or read if present in if_owner_perms
+	# because either of those is required to perform a query
+	return True

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -107,13 +107,9 @@ def get_doc_permissions(doc, user=None, ptype=None):
 	meta = frappe.get_meta(doc.doctype)
 
 	def is_user_owner():
-		doc_owner = doc.get('owner') or ''
-		doc_owner = doc_owner.lower()
-		session_user = frappe.session.user.lower()
-		return doc_owner == session_user
+		return (doc.get("owner") or "").lower() == frappe.session.user.lower()
 
-
-	if has_controller_permissions(doc, ptype, user=user) == False :
+	if has_controller_permissions(doc, ptype, user=user) is False:
 		push_perm_check_log('Not allowed via controller permission check')
 		return {ptype: 0}
 
@@ -182,22 +178,23 @@ def get_role_permissions(doctype_meta, user=None, is_owner=None):
 
 		applicable_permissions = list(filter(is_perm_applicable, getattr(doctype_meta, 'permissions', [])))
 		has_if_owner_enabled = any(p.get('if_owner', 0) for p in applicable_permissions)
-
 		perms['has_if_owner_enabled'] = has_if_owner_enabled
 
 		for ptype in rights:
 			pvalue = any(p.get(ptype, 0) for p in applicable_permissions)
 			# check if any perm object allows perm type
 			perms[ptype] = cint(pvalue)
-			if (pvalue
-				and has_if_owner_enabled
-				and not has_permission_without_if_owner_enabled(ptype)
-				and ptype != 'create'):
+			if (
+					pvalue
+					and has_if_owner_enabled
+					and not has_permission_without_if_owner_enabled(ptype)
+					and ptype != 'create'
+			):
 				perms['if_owner'][ptype] = cint(pvalue and is_owner)
 				# has no access if not owner
 				# only provide select or read access so that user is able to at-least access list
 				# (and the documents will be filtered based on owner sin further checks)
-				perms[ptype] = 1 if ptype in ['select', 'read'] else 0
+				perms[ptype] = 1 if ptype in ('select', 'read') else 0
 
 		frappe.local.role_permissions[cache_key] = perms
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -493,6 +493,34 @@ class TestPermissions(unittest.TestCase):
 		frappe.set_user("test2@example.com")
 		self.assertRaises(frappe.PermissionError, getdoc, 'Blog Post', doc.name)
 
+	def test_if_owner_permission_on_get_list(self):
+		doc = frappe.get_doc({
+			"doctype": "Blog Post",
+			"blog_category": "-test-blog-category",
+			"blogger": "_Test Blogger 1",
+			"title": "_Test If Owner Permissions on Get List",
+			"content": "_Test Blog Post Content"
+		})
+
+		doc.insert(ignore_if_duplicate=True)
+
+		update('Blog Post', 'Blogger', 0, 'if_owner', 1)
+		update('Blog Post', 'Blogger', 0, 'read', 1)
+		user = frappe.get_doc("User", "test2@example.com")
+		user.add_roles("Website Manager")
+		frappe.clear_cache(doctype="Blog Post")
+
+		frappe.set_user("test2@example.com")
+		self.assertIn(doc.name, frappe.get_list("Blog Post", pluck="name"))
+
+		# Become system manager to remove role
+		frappe.set_user("test1@example.com")
+		user.remove_roles("Website Manager")
+		frappe.clear_cache(doctype="Blog Post")
+
+		frappe.set_user("test2@example.com")
+		self.assertNotIn(doc.name, frappe.get_list("Blog Post", pluck="name"))
+
 	def test_if_owner_permission_on_delete(self):
 		update('Blog Post', 'Blogger', 0, 'if_owner', 1)
 		update('Blog Post', 'Blogger', 0, 'read', 1)


### PR DESCRIPTION
## Issue

If a User has any permission that is applicable only if the user is owner, he cannot **Read** or **Select** a document although he has one of **Read** of **Select** permissions without the `If Owner` constraint.

For example:
X can read **Blog Post** without the `If Owner` constraint because he has the **Website Manager** role. However, X also has **Blogger** with **Share** permission (not present in **Website Manager**) and **If Owner** checked. X will not be able to read or select **Blog Posts** created by another user despite having relevant permissions.

## Changes Made
- Create new function `requires_owner_constraint` to properly test if the owner constraint needs to be set.
- Semantic changes in `permissions.py`.