### PR TITLE
feat(integration): Add "mPay" payment gateway integration

### DIFF
--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.js
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('mPay Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.json
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.json
@@ -1,0 +1,73 @@
+{
+ "actions": [],
+ "creation": "2021-09-24 11:35:08.255598",
+ "doctype": "DocType",
+ "document_type": "System",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "merchantid",
+  "merchant_tid",
+  "securekey",
+  "use_sandbox",
+  "redirect_url"
+ ],
+ "fields": [
+  {
+   "fieldname": "merchantid",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Merchant ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "merchant_tid",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Terminal ID",
+   "reqd": 1
+  },
+  {
+   "fieldname": "securekey",
+   "fieldtype": "Password",
+   "in_list_view": 1,
+   "label": "Secure Key",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "use_sandbox",
+   "fieldtype": "Check",
+   "label": "Use Sandbox"
+  },
+  {
+   "fieldname": "redirect_url",
+   "fieldtype": "Data",
+   "label": "Redirect URL"
+  }
+ ],
+ "in_create": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2021-09-24 11:35:08.255598",
+ "modified_by": "Administrator",
+ "module": "Integrations",
+ "name": "mPay Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "read_only": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.json
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.json
@@ -9,8 +9,7 @@
   "merchantid",
   "merchant_tid",
   "securekey",
-  "use_sandbox",
-  "redirect_url"
+  "use_sandbox"
  ],
  "fields": [
   {
@@ -39,17 +38,12 @@
    "fieldname": "use_sandbox",
    "fieldtype": "Check",
    "label": "Use Sandbox"
-  },
-  {
-   "fieldname": "redirect_url",
-   "fieldtype": "Data",
-   "label": "Redirect URL"
   }
  ],
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-24 11:35:08.255598",
+ "modified": "2021-10-15 15:26:18.194756",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "mPay Settings",

--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2021, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+"""
+# Integration for mPay
+https://www.mpay.com.hk/
+"""
+
+import frappe
+import base64
+import hmac
+import hashlib
+from frappe import _
+from frappe.model.document import Document
+from frappe.integrations.utils import create_payment_gateway
+from frappe.utils import get_url, call_hook_method, cint, flt
+from six.moves.urllib.parse import urlencode
+
+
+class mPaySettings(Document):
+	supported_currencies = [
+		'HKD', 'RMB', 'USD'
+	]
+
+	currency_wise_minimum_charge_amount = {
+		'HKD': 10,
+		'RMB': 10,
+		'USD': 2,
+	}
+
+	api_version = '5.0'
+
+	sandbox_url = 'https://demo.mobiletech.com.hk/MPay/MerchantPay.jsp'
+	prod_url = 'https://mobiletech.com.hk/MPay/MerchantPay.jsp'
+
+	def validate(self):
+		if not self.flags.ignore_mandatory:
+			self.validate_mpay_credentails()
+
+	def on_update(self):
+		create_payment_gateway(
+			gateway='mPay',
+		)
+		call_hook_method('payment_gateway_enabled', gateway='mPay')
+
+	def validate_mpay_credentails(self):
+		pass
+
+	def validate_transaction_currency(self, currency):
+		if currency not in self.supported_currencies:
+			frappe.throw(_(
+				"Please select another payment method. mPay does not support transactions in currency '{0}'"
+			).format(currency))
+
+	def validate_minimum_transaction_amount(self, currency, amount):
+		if currency in self.currency_wise_minimum_charge_amount:
+			if flt(amount) < self.currency_wise_minimum_charge_amount.get(currency, 0.0):
+				frappe.throw(_('For currency {0}, the minimum transaction amount should be {1}').format(
+					currency,
+					self.currency_wise_minimum_charge_amount.get(currency, 0.0)
+				))
+
+	def get_payment_url(self, **kwargs):
+		pass
+
+	def construct_text_params(self, **kwargs):
+		"""Combine all params, return as string"""
+		params_dict = {
+			**{
+				'merchantid': self.merchantid,
+				'merchant_tid': self.merchant_tid,
+				'returnurl': self.redirect_url,
+				'securekey': self.securekey,
+				'salt': frappe.generate_hash(length=16),
+			},
+			**kwargs,
+		}
+
+		params_key_list = [
+			'accounttype',
+			'amt',
+			'currency',
+			'customerid',
+			'customizeddata',
+			'datetime',
+			'extrafield1',
+			'extrafield2',
+			'extrafield3',
+			'locale',
+			'merchant_tid',
+			'merchantid',
+			'notifyurl',
+			'ordernum',
+			'paymethod',
+			'returnurl',
+			'storeid',
+			'tokenid',
+		]
+
+		params_list = []
+		for key in params_key_list:
+			if key in params_dict:
+				params_list.append(kwargs.get(key))
+
+		params_text = ''.join(params_list)
+
+		text_params = '{salt};{params_text};{securekey}'.format(
+			salt=params_dict.get('salt'),
+			params_text=params_text,
+			securekey=params_dict.get('securekey'),
+		)
+
+		self.text_params = text_params
+
+	def gen_text_hash(self):
+		m = hashlib.sha256()
+		m.update(self.text_params.encode('utf-8'))
+		self.text_hash = hashlib.sha256(
+			self.text_params.encode('utf-8')
+		).hexdigest()

--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.py
@@ -161,6 +161,7 @@ class mPaySettings(PaymentGateway):
 		request_text_params = self.params_dict_to_text(
 			params_dict=request_dict_params,
 			params_key_list=params_key_list,
+			secure_key=request_dict_params.get('securekey')
 		)
 		request_text_hash = self.gen_text_hash(
 			request_text_params
@@ -173,7 +174,7 @@ class mPaySettings(PaymentGateway):
 		return request_dict_params
 
 	@staticmethod
-	def params_dict_to_text(params_dict, params_key_list):
+	def params_dict_to_text(params_dict, params_key_list, secure_key):
 		params_list = []
 		for key in params_key_list:
 			if key in params_dict:
@@ -186,7 +187,7 @@ class mPaySettings(PaymentGateway):
 		params_text = '{salt};{params_text};{securekey}'.format(
 			salt=params_dict.get('salt'),
 			params_text=params_text,
-			securekey=params_dict.get('securekey'),
+			securekey=secure_key,
 		)
 		return params_text
 

--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.py
@@ -60,11 +60,9 @@ class PaymentGateway(Document):
 				))
 
 	def create_payment_request(self, data):
-		self.data = frappe._dict(data)
-
 		try:
 			self.integration_request = create_request_log(
-				self.data, 'Host', self.gateway_name,
+				data, 'Host', self.gateway_name,
 			)
 
 		except Exception:
@@ -94,9 +92,11 @@ class mPaySettings(PaymentGateway):
 	prod_url = 'https://mobiletech.com.hk/MPay/MerchantPay.jsp'
 
 	def get_payment_url(self, **kwargs):
-		self.create_payment_request(self, data=kwargs)
+		self.create_payment_request(data=frappe._dict(kwargs))
 		return get_url('./integrations/mpay_checkout?{0}'.format(
-			urlencode(self.integration_request.name)
+			urlencode({
+				'order_id': self.integration_request.name,
+			})
 		))
 
 	def get_gateway_settings(self):

--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.py
@@ -91,6 +91,47 @@ class mPaySettings(PaymentGateway):
 	sandbox_url = 'https://demo.mobiletech.com.hk/MPay/MerchantPay.jsp'
 	prod_url = 'https://mobiletech.com.hk/MPay/MerchantPay.jsp'
 
+	request_params_list = [
+		'accounttype',
+		'amt',
+		'currency',
+		'customerid',
+		'customizeddata',
+		'datetime',
+		'extrafield1',
+		'extrafield2',
+		'extrafield3',
+		'locale',
+		'merchant_tid',
+		'merchantid',
+		'notifyurl',
+		'ordernum',
+		'paymethod',
+		'returnurl',
+		'storeid',
+		'tokenid',
+	]
+	response_params_list = [
+		"accounttype",
+		"amt",
+		"authcode",
+		"cardnum",
+		"currency",
+		"customerid",
+		"customizeddata",
+		"fi_post_dt",
+		"merchant_tid",
+		"merchantid",
+		"ordernum",
+		"paymethod",
+		"ref",
+		"rspcode",
+		"settledate",
+		"storeid",
+		"sysdatetime",
+		"tokenid",
+	]
+
 	def get_payment_url(self, **kwargs):
 		self.create_payment_request(data=frappe._dict(kwargs))
 		return get_url('./integrations/mpay_checkout?{0}'.format(
@@ -116,6 +157,7 @@ class mPaySettings(PaymentGateway):
 		request_dict_params = {
 			**self.gateway_settings,
 			**{
+				'ordernum': self.integration_request_name,
 				# salt value generated, used for security validation
 				# random alphanumeric values with length 16 (e.g. whi1i7lifa70yhgs)
 				'salt': frappe.generate_hash(length=16),
@@ -137,44 +179,43 @@ class mPaySettings(PaymentGateway):
 			**kwargs,
 		}
 
-		params_key_list = [
-			'accounttype',
-			'amt',
-			'currency',
-			'customerid',
-			'customizeddata',
-			'datetime',
-			'extrafield1',
-			'extrafield2',
-			'extrafield3',
-			'locale',
-			'merchant_tid',
-			'merchantid',
-			'notifyurl',
-			'ordernum',
-			'paymethod',
-			'returnurl',
-			'storeid',
-			'tokenid',
-		]
-
 		request_text_params = self.params_dict_to_text(
 			params_dict=request_dict_params,
-			params_key_list=params_key_list,
-			secure_key=request_dict_params.get('securekey')
+			params_key_list=self.request_params_list,
+		)
+		request_text_params = '{salt};{params_text};{securekey}'.format(
+			salt=request_dict_params.get('salt'),
+			params_text=request_text_params,
+			securekey=request_dict_params.get('securekey'),
 		)
 		request_text_hash = self.gen_text_hash(
 			request_text_params
 		)
 
-		request_dict_params.pop('securekey')
+		request_dict_params = self.select_params(
+			params_dict=request_dict_params,
+			params_key_list=self.request_params_list,
+		)
 		request_dict_params['version'] = self.api_version
 		request_dict_params['hash'] = request_text_hash
 
 		return request_dict_params
 
 	@staticmethod
-	def params_dict_to_text(params_dict, params_key_list, secure_key):
+	def select_params(params_dict, params_key_list):
+		_params_key_list = params_key_list.copy()
+		_params_key_list.append('salt')
+		selected_params_dict = {}
+		for key in _params_key_list:
+			if key in params_dict:
+				val = params_dict.get(key, None)
+				if val is not None:
+					selected_params_dict[key] = params_dict[key]
+
+		return selected_params_dict
+
+	@staticmethod
+	def params_dict_to_text(params_dict, params_key_list):
 		params_list = []
 		for key in params_key_list:
 			if key in params_dict:
@@ -184,11 +225,6 @@ class mPaySettings(PaymentGateway):
 
 		params_text = ''.join(params_list)
 
-		params_text = '{salt};{params_text};{securekey}'.format(
-			salt=params_dict.get('salt'),
-			params_text=params_text,
-			securekey=secure_key,
-		)
 		return params_text
 
 	@staticmethod
@@ -206,7 +242,6 @@ class mPaySettings(PaymentGateway):
 			# 'frappe_key': 'mpay_key',
 			'amount': 'amt',
 			'currency': 'currency',
-			'reference_docname': 'ordernum',
 			'payer_name': 'customerid',
 		}
 
@@ -221,6 +256,7 @@ class mPaySettings(PaymentGateway):
 			'Integration Request',
 			integration_request_id
 		).as_dict()
+		self.integration_request_name = integration_request_id
 
 		integration_request_data = json.loads(integration_request.data)
 		request_data = self.map_payment_key(integration_request_data)
@@ -238,3 +274,145 @@ class mPaySettings(PaymentGateway):
 		}
 
 		return context
+
+	def update_integration_request(self):
+		response_data = self.response_data
+		request_id = response_data.get('ordernum')
+		response_code = response_data.get('rspcode')
+		request_doc = frappe.get_doc('Integration Request', request_id)
+
+		if response_code == '100':
+			request_doc.db_set('status', 'Completed')
+		else:
+			request_doc.db_set('status', 'Failed')
+
+		# pop private info from kwargs
+		response_data.pop('hash')
+		response_data.pop('salt')
+
+		# append response to request data
+		request_data = json.loads(request_doc.data)
+		request_data['response_data'] = response_data
+		request_data_str = json.dumps(request_data)
+
+		request_doc.db_set('data', request_data_str)
+
+		self.response_code = response_code
+		self.ref_doctype = request_data.get('reference_doctype')
+		self.ref_docname = request_data.get('reference_docname')
+
+		return response_code
+
+	def run_payment_authorized(self):
+		redirect_to = None
+		if self.ref_doctype and self.ref_docname and self.response_code == '100':
+			try:
+				ref_doc = frappe.get_doc(self.ref_doctype, self.ref_docname)
+				redirect_to = ref_doc.run_method(
+					'on_payment_authorized', 'Completed'
+				)
+			except Exception:
+				frappe.log_error(frappe.get_traceback())
+
+		return redirect_to
+
+	def verify_return_data(self):
+		return_text_params = self.params_dict_to_text(
+			params_dict=self.response_data,
+			params_key_list=self.response_params_list,
+		)
+		return_text_params = '{securekey};{params_text};{salt}'.format(
+			salt=self.response_data.get('salt'),
+			params_text=return_text_params,
+			securekey=get_decrypted_password(
+				doctype='mPay Settings',
+				name='mPay Settings',
+				fieldname='securekey'
+			),
+		)
+		return_text_hash = self.gen_text_hash(
+			return_text_params
+		)
+
+		if return_text_hash.upper() != self.response_data.get('hash').upper():
+			frappe.log_error(
+				title=_('Invalid mPay return data'),
+				message=self.response_data,
+			)
+			frappe.throw(_('Invalid mPay return data'))
+
+	def handle_return(self, response_data):
+		self.response_data = response_data
+		self.verify_return_data()
+		response_code = self.update_integration_request()
+		redirect_to = self.run_payment_authorized()
+		return {
+			'response_code': response_code,
+			'redirect_to': redirect_to,
+		}
+
+
+"""
+# [FROM mPay MANUAL]
+# Merchant Client Response Message (mPay to Merchant)
+
+The following parameters are returned from mPay to merchant for BOTH return URL(successful and fail transaction)
+and notify URL (successful transaction only by default).
+
+For Return URL, the response parameters are returned as Name Value Pair with POST method by default.
+Merchant can request to change to GET method.
+
+For Notify URL, the response parameters are returned as Name Value Pair by default. Merchant can request
+to change to JSON format.
+"""
+
+
+@frappe.whitelist(allow_guest=True, xss_safe=True)
+def notify_url(**response_kwargs):
+	"""Notify url will be call **ONLY IF TRANSACTION IS SUCCESSFUL**
+
+	This method is somewhat repetitive with return_url method,
+	but it might be useful for somecase such as
+	user close browser exactly when payment successful then return url don't get call
+	and status didn't get update
+
+	So for this method we'll check if Integration Request is still in pending
+	if it is then update success status
+	"""
+	request_status = frappe.get_value(
+		doctype='Integration Request',
+		filters=response_kwargs.get('ordernum'),
+		fieldname='status'
+	)
+	if (request_status != 'Queued'):
+		return
+
+	mPay = frappe.get_doc('mPay Settings')
+	mPay.handle_return(response_kwargs)
+
+
+@frappe.whitelist(allow_guest=True, xss_safe=True)
+def return_url(**response_kwargs):
+	"""Determine if payment is successful or not,
+	update Integration Request then redirect to
+	payment success or failed accordingly
+	"""
+	mPay = frappe.get_doc('mPay Settings')
+	m = mPay.handle_return(response_kwargs)
+	response_code = m.get('response_code')
+	redirect_to = m.get('redirect_to')
+
+	redirect_msg = None
+	if response_code == '100':
+		redirect_url = '/integrations/payment-success'
+	else:
+		redirect_url = '/integrations/payment-failed'
+		redirect_msg = 'mPay Error Code: {}'.format(response_code)
+
+	if redirect_to:
+		redirect_url += '?' + urlencode({'redirect_to': redirect_to})
+	if redirect_msg:
+		redirect_url += '&' + urlencode({'redirect_message': redirect_msg})
+
+	frappe.local.response['type'] = 'redirect'
+	frappe.local.response['location'] = redirect_url

--- a/frappe/integrations/doctype/mpay_settings/mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/mpay_settings.py
@@ -117,7 +117,20 @@ class mPaySettings(PaymentGateway):
 		dict_params = {
 			**self.gateway_settings,
 			**{
+				# salt value generated, used for security validation
+				# random alphanumeric values with length 16 (e.g. whi1i7lifa70yhgs)
+				'salt': frappe.generate_hash(length=16),
+				# choose payment method at mPay side
 				'paymethod': 0,
+				# datetime in "yyyyMMddHHmmss" format
+				'datetime': frappe.utils.data.now_datetime().strftime('%Y%m%d%H%M%S'),
+				# store ID of this transaction take place
+				# if not used, just put in "1" as default
+				'storeid': 1,
+				# the notify URL of merchant which receive payment response from mPay server
+				'notifyurl': 'https://dummy.com',
+				# language used in mPay side
+				'locale': 'en_US',
 			},
 			**kwargs,
 		}
@@ -146,7 +159,9 @@ class mPaySettings(PaymentGateway):
 		params_list = []
 		for key in params_key_list:
 			if key in dict_params:
-				params_list.append(kwargs.get(key))
+				val = dict_params.get(key, None)
+				if val is not None:
+					params_list.append(str(val))
 
 		params_text = ''.join(params_list)
 

--- a/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
@@ -23,9 +23,35 @@ class TestmPaySettings(unittest.TestCase):
 		)
 		self.mpay.insert()
 
+		self.ref_doc = frappe.get_doc({
+			'doctype': 'Note',
+			'title': 'Note title',
+			'content': """
+				Use note as reference doc for Payment Request doctype,
+				since note doesn't have any other doctype dependencies
+				such as company or customer, so we don't have to set those up
+			"""
+		})
+
 	def tearDown(self):
 		self.mpay.delete()
 		frappe.db.rollback()
+
+	def test_get_payment_url(self):
+		self.assertRegex(
+			self.mpay.get_payment_url(**{
+				'amount': 100,
+				'title': 'mPay testing',
+				'description': 'mPay unittest',
+				'reference_doctype': self.ref_doc.doctype,
+				'reference_docname': self.ref_doc.name,
+				'payer_email': 'someone@mpaytest.com',
+				'payer_name': 'someonetest',
+				'order_id': 'orderid0124',
+				'currency': 'HKD'
+			}),
+			r'^http.*\/integrations\/mpay_checkout\?order_id=[\w\d]*$'
+		)
 
 	def test_create_payment_request(self):
 		data = dict(

--- a/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
@@ -5,6 +5,8 @@ import frappe
 import json
 import unittest
 
+from frappe.exceptions import ValidationError
+
 
 class TestmPaySettings(unittest.TestCase):
 	def setUp(self):
@@ -97,6 +99,7 @@ class TestmPaySettings(unittest.TestCase):
 
 	def test_construct_request_params(self):
 		with self.subTest('Text params from mpay Manual'):
+			self.mpay.integration_request_name = 'asd7lifa7'
 			params = dict(
 				salt="whi1i7lifa70yhgs",
 				securekey="ABCDEFG123456789",
@@ -139,28 +142,8 @@ class TestmPaySettings(unittest.TestCase):
 				},
 			)
 
-	def test_params_dict_to_text(self):
-		params_key_list = [
-			'accounttype',
-			'amt',
-			'currency',
-			'customerid',
-			'customizeddata',
-			'datetime',
-			'extrafield1',
-			'extrafield2',
-			'extrafield3',
-			'locale',
-			'merchant_tid',
-			'merchantid',
-			'notifyurl',
-			'ordernum',
-			'paymethod',
-			'returnurl',
-			'storeid',
-			'tokenid',
-		]
-		params_dict = dict(
+	def test_select_params(self):
+		params = dict(
 			salt="whi1i7lifa70yhgs",
 			accounttype="V",
 			amt="30.0",
@@ -176,24 +159,110 @@ class TestmPaySettings(unittest.TestCase):
 			returnurl="https://demo.mpay.com.hk/return.jsp",
 			storeid="001",
 			tokenid="101",
-		)
-		params_text = self.mpay.params_dict_to_text(
-			params_dict=params_dict,
-			params_key_list=params_key_list,
-			secure_key='ABCDEFG123456789'
-		)
-		self.assertEqual(
-			params_text,
-			'whi1i7lifa70yhgs;V30.0HKD1257984115649643163420180701010100zh_TW0011100000https://demo.mpay.com.hk/mpay/notify.jspHK2018070101010037https://demo.mpay.com.hk/return.jsp001101;ABCDEFG123456789',
+			reference_doctype="Some Doctype",
+			reference_docname="Some Docname",
 		)
 
+		self.assertDictEqual(
+			self.mpay.select_params(
+				params_dict=params,
+				params_key_list=self.mpay.request_params_list,
+			),
+			dict(
+				salt="whi1i7lifa70yhgs",
+				accounttype="V",
+				amt="30.0",
+				currency="HKD",
+				customerid="12579841156496431634",
+				datetime="20180701010100",
+				locale="zh_TW",
+				merchant_tid="001",
+				merchantid="1100000",
+				notifyurl="https://demo.mpay.com.hk/mpay/notify.jsp",
+				ordernum="HK20180701010100",
+				paymethod="37",
+				returnurl="https://demo.mpay.com.hk/return.jsp",
+				storeid="001",
+				tokenid="101",
+			)
+		)
+
+	def test_params_dict_to_text(self):
+		with self.subTest('request_data'):
+			params_dict = dict(
+				salt="whi1i7lifa70yhgs",
+				accounttype="V",
+				amt="30.0",
+				currency="HKD",
+				customerid="12579841156496431634",
+				datetime="20180701010100",
+				locale="zh_TW",
+				merchant_tid="001",
+				merchantid="1100000",
+				notifyurl="https://demo.mpay.com.hk/mpay/notify.jsp",
+				ordernum="HK20180701010100",
+				paymethod="37",
+				returnurl="https://demo.mpay.com.hk/return.jsp",
+				storeid="001",
+				tokenid="101",
+			)
+			params_text = self.mpay.params_dict_to_text(
+				params_dict=params_dict,
+				params_key_list=self.mpay.request_params_list,
+			)
+			self.assertEqual(
+				params_text,
+				'V30.0HKD1257984115649643163420180701010100zh_TW0011100000https://demo.mpay.com.hk/mpay/notify.jspHK2018070101010037https://demo.mpay.com.hk/return.jsp001101',
+			)
+
+		with self.subTest('with return data'):
+			return_data = dict(
+				version="5.0",
+				salt="whi1i7lifa70yhgs",
+				accounttype="V",
+				amt="30.0",
+				authcode="",
+				cardnum="456789xxxxxx6789",
+				currency="HKD",
+				customerid="12579841156496431634",
+				customizeddata="",
+				fi_post_dt="20180701010100",
+				merchant_tid="001",
+				merchantid="1100000",
+				ordernum="HK20180701010100",
+				paymethod="37",
+				ref="370000111111",
+				rspcode="100",
+				settledate="20180701010100",
+				storeid="001",
+				sysdatetime="20180701010100",
+				tokenid="101",
+				hash="D4ED49F985972DAE258439DC57ADA1C20BD3D797C1510DEC54ACF2CC8B9B4988",
+			)
+			params_text = self.mpay.params_dict_to_text(
+				params_dict=return_data,
+				params_key_list=self.mpay.response_params_list,
+			)
+			self.assertEqual(
+				params_text,
+				'V30.0456789xxxxxx6789HKD12579841156496431634201807010101000011100000HK20180701010100373700001111111002018070101010000120180701010100101',
+			)
+
 	def test_gen_text_hash(self):
-		with self.subTest('Text params from mpay Manual'):
+		with self.subTest('Text params from mpay Manual, request data'):
 			text_params = 'whi1i7lifa70yhgs;V30.0HKD1257984115649643163420180701010100zh_TW0011100000https://demo.mpay.com.hk/mpay/notify.jspHK2018070101010037https://demo.mpay.com.hk/return.jsp001101;ABCDEFG123456789'
 			text_hash = self.mpay.gen_text_hash(text_params)
 			self.assertEqual(
 				text_hash.upper(),
 				'0D959AA4CCBF2844B1DB7A3777772203712F31E04BAD9E208CB52BCA11FAF72B'
+			)
+
+		with self.subTest('Text params from mpay Manual, response data'):
+			text_params = 'ABCDEFG123456789;V30.0456789xxxxxx6789HKD12579841156496431634201807010101000011100000HK20180701010100373700001111111002018070101010000120180701010100101;whi1i7lifa70yhgs'
+			text_hash = self.mpay.gen_text_hash(text_params)
+			self.assertEqual(
+				text_hash.upper(),
+				'D4ED49F985972DAE258439DC57ADA1C20BD3D797C1510DEC54ACF2CC8B9B4988'
 			)
 
 	def test_map_payment_key(self):
@@ -214,15 +283,16 @@ class TestmPaySettings(unittest.TestCase):
 				"title": "mPay testing",
 				"description": "mPay unittest",
 				"reference_doctype": "Note",
-				"ordernum": "04fb9bd3",
+				"reference_docname": "04fb9bd3",
+				"order_id": "orderid0124",
 				"payer_email": "someone@mpaytest.com",
 				"customerid": "someonetest",
-				"order_id": "orderid0124",
 				"currency": "HKD"
 			},
 		)
 
 	def test_get_payment_context(self):
+		self.maxDiff = None
 		data = dict(
 			salt="whi1i7lifa70yhgs",
 			securekey="ABCDEFG123456789",
@@ -271,3 +341,75 @@ class TestmPaySettings(unittest.TestCase):
 				)
 			}
 		)
+
+	def test_verify_return_data(self):
+		with self.subTest('validation, pass'):
+			self.mpay.securekey = "ABCDEFG123456789"
+			self.mpay.save()
+
+			return_data = dict(
+				version="5.0",
+				salt="whi1i7lifa70yhgs",
+				accounttype="V",
+				amt="30.0",
+				authcode="",
+				cardnum="456789xxxxxx6789",
+				currency="HKD",
+				customerid="12579841156496431634",
+				customizeddata="",
+				fi_post_dt="20180701010100",
+				merchant_tid="001",
+				merchantid="1100000",
+				ordernum="HK20180701010100",
+				paymethod="37",
+				ref="370000111111",
+				rspcode="100",
+				settledate="20180701010100",
+				storeid="001",
+				sysdatetime="20180701010100",
+				tokenid="101",
+				hash="D4ED49F985972DAE258439DC57ADA1C20BD3D797C1510DEC54ACF2CC8B9B4988",
+			)
+
+			self.mpay.response_data = return_data
+			self.mpay.verify_return_data()
+
+		with self.subTest('validation throw error'):
+			self.mpay.securekey = "ABCDEFG123456789"
+			self.mpay.save()
+
+			return_data = dict(
+				version="5.0",
+				salt="whi1i7lifa70yhgs",
+				accounttype="V",
+				amt="30.0",
+				authcode="",
+				cardnum="456789xxxxxx6789",
+				currency="HKD",
+				customerid="12579841156496431634",
+				customizeddata="",
+				fi_post_dt="20180701010100",
+				merchant_tid="001",
+				merchantid="1100000",
+				ordernum="HK20180701010100",
+				paymethod="37",
+				ref="370000111111",
+				rspcode="100",
+				settledate="20180701010100",
+				storeid="001",
+				sysdatetime="20180701010100",
+				tokenid="101",
+				hash="INVALID_HASH_E258439DC57ADA1C20BD3D797C1510DEC54ACF2CC8B9B4988",
+			)
+
+			self.mpay.response_data = return_data
+			self.assertRaises(
+				ValidationError,
+				self.mpay.verify_return_data,
+			)
+
+	def test_update_integration_request(self):
+		pass
+
+	def test_run_payment_authorized(self):
+		pass

--- a/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
@@ -162,7 +162,6 @@ class TestmPaySettings(unittest.TestCase):
 		]
 		params_dict = dict(
 			salt="whi1i7lifa70yhgs",
-			securekey="ABCDEFG123456789",
 			accounttype="V",
 			amt="30.0",
 			currency="HKD",
@@ -181,6 +180,7 @@ class TestmPaySettings(unittest.TestCase):
 		params_text = self.mpay.params_dict_to_text(
 			params_dict=params_dict,
 			params_key_list=params_key_list,
+			secure_key='ABCDEFG123456789'
 		)
 		self.assertEqual(
 			params_text,

--- a/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
@@ -25,7 +25,7 @@ class TestmPaySettings(unittest.TestCase):
 
 		self.ref_doc = frappe.get_doc({
 			'doctype': 'Note',
-			'title': frappe.generate_hash(),
+			'title': frappe.generate_hash(length=5),
 			'content': """
 				Use note as reference doc for Payment Request doctype,
 				since note doesn't have any other doctype dependencies

--- a/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
@@ -25,13 +25,14 @@ class TestmPaySettings(unittest.TestCase):
 
 		self.ref_doc = frappe.get_doc({
 			'doctype': 'Note',
-			'title': 'Note title',
+			'title': frappe.generate_hash(),
 			'content': """
 				Use note as reference doc for Payment Request doctype,
 				since note doesn't have any other doctype dependencies
 				such as company or customer, so we don't have to set those up
 			"""
 		})
+		self.ref_doc.insert()
 
 	def tearDown(self):
 		self.mpay.delete()
@@ -135,6 +136,32 @@ class TestmPaySettings(unittest.TestCase):
 				self.mpay.text_hash.upper(),
 				'0D959AA4CCBF2844B1DB7A3777772203712F31E04BAD9E208CB52BCA11FAF72B'
 			)
+
+	def test_map_payment_key(self):
+		self.assertDictEqual(
+			self.mpay.map_payment_key({
+				"amount": 100,
+				"title": "mPay testing",
+				"description": "mPay unittest",
+				"reference_doctype": "Note",
+				"reference_docname": "04fb9bd3",
+				"payer_email": "someone@mpaytest.com",
+				"payer_name": "someonetest",
+				"order_id": "orderid0124",
+				"currency": "HKD"
+			}),
+			{
+				"amt": 100,
+				"title": "mPay testing",
+				"description": "mPay unittest",
+				"reference_doctype": "Note",
+				"ordernum": "04fb9bd3",
+				"payer_email": "someone@mpaytest.com",
+				"customerid": "someonetest",
+				"order_id": "orderid0124",
+				"currency": "HKD"
+			},
+		)
 
 	def test_get_payment_context(self):
 		data = dict(

--- a/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021, Frappe Technologies and Contributors
+# See license.txt
+
+import frappe
+import unittest
+
+
+class TestmPaySettings(unittest.TestCase):
+	def setUp(self):
+		self.mpay = frappe.get_doc({
+			'doctype': 'mPay Settings',
+			'merchantid': '1234567',
+			'merchant_tid': '999',
+			'securekey': 'ABCDEFG00GFEDCBA',
+			'use_sandbox': 1,
+			'redirect_url': 'https://redirect-url.com',
+		})
+
+	def tearDown(self):
+		self.mpay.delete()
+
+	def test_construct_text_params(self):
+		with self.subTest('Text params from mpay Manual'):
+			self.mpay.construct_text_params(
+				salt="whi1i7lifa70yhgs",
+				securekey="ABCDEFG123456789",
+				accounttype="V",
+				amt="30.0",
+				currency="HKD",
+				customerid="12579841156496431634",
+				datetime="20180701010100",
+				locale="zh_TW",
+				merchant_tid="001",
+				merchantid="1100000",
+				notifyurl="https://demo.mpay.com.hk/mpay/notify.jsp",
+				ordernum="HK20180701010100",
+				paymethod="37",
+				returnurl="https://demo.mpay.com.hk/return.jsp",
+				storeid="001",
+				tokenid="101",
+			)
+			self.assertEqual(
+				self.mpay.text_params,
+				'whi1i7lifa70yhgs;V30.0HKD1257984115649643163420180701010100zh_TW0011100000https://demo.mpay.com.hk/mpay/notify.jspHK2018070101010037https://demo.mpay.com.hk/return.jsp001101;ABCDEFG123456789',
+			)
+
+	def test_gen_text_hash(self):
+		with self.subTest('Text params from mpay Manual'):
+			self.mpay.text_params = 'whi1i7lifa70yhgs;V30.0HKD1257984115649643163420180701010100zh_TW0011100000https://demo.mpay.com.hk/mpay/notify.jspHK2018070101010037https://demo.mpay.com.hk/return.jsp001101;ABCDEFG123456789'
+			self.mpay.gen_text_hash()
+			self.assertEqual(
+				self.mpay.text_hash.upper(),
+				'0D959AA4CCBF2844B1DB7A3777772203712F31E04BAD9E208CB52BCA11FAF72B'
+			)

--- a/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
+++ b/frappe/integrations/doctype/mpay_settings/test_mpay_settings.py
@@ -2,26 +2,77 @@
 # See license.txt
 
 import frappe
+import json
 import unittest
 
 
 class TestmPaySettings(unittest.TestCase):
 	def setUp(self):
-		self.mpay = frappe.get_doc({
-			'doctype': 'mPay Settings',
+		self.mpay_settings = {
 			'merchantid': '1234567',
 			'merchant_tid': '999',
 			'securekey': 'ABCDEFG00GFEDCBA',
 			'use_sandbox': 1,
 			'redirect_url': 'https://redirect-url.com',
-		})
+		}
+		self.mpay = frappe.get_doc(
+			**{
+				'doctype': 'mPay Settings',
+			},
+			**self.mpay_settings
+		)
+		self.mpay.insert()
 
 	def tearDown(self):
 		self.mpay.delete()
+		frappe.db.rollback()
+
+	def test_create_payment_request(self):
+		data = dict(
+			salt="whi1i7lifa70yhgs",
+			securekey="ABCDEFG123456789",
+			accounttype="V",
+			amt="30.0",
+			currency="HKD",
+			customerid="12579841156496431634",
+			datetime="20180701010100",
+			locale="zh_TW",
+			merchant_tid="001",
+			merchantid="1100000",
+			notifyurl="https://demo.mpay.com.hk/mpay/notify.jsp",
+			ordernum="HK20180701010100",
+			paymethod="37",
+			returnurl="https://demo.mpay.com.hk/return.jsp",
+			storeid="001",
+			tokenid="101",
+		)
+		self.mpay.create_payment_request(
+			data=data
+		)
+
+		self.assertTrue(
+			hasattr(self.mpay.integration_request, 'name')
+		)
+		self.assertEqual(
+			data,
+			json.loads(self.mpay.integration_request.data),
+		)
+
+	def test_get_gateway_settings(self):
+		self.mpay.get_gateway_settings()
+		self.assertEqual(
+			self.mpay.gateway_settings,
+			{
+				'merchant_tid': '999',
+				'merchantid': '1234567',
+				'returnurl': 'https://redirect-url.com',
+				'securekey': 'ABCDEFG00GFEDCBA',
+			},
+		)
 
 	def test_construct_text_params(self):
 		with self.subTest('Text params from mpay Manual'):
-			self.mpay.construct_text_params(
+			params = dict(
 				salt="whi1i7lifa70yhgs",
 				securekey="ABCDEFG123456789",
 				accounttype="V",
@@ -39,9 +90,15 @@ class TestmPaySettings(unittest.TestCase):
 				storeid="001",
 				tokenid="101",
 			)
+			self.mpay.construct_text_params(**params)
 			self.assertEqual(
 				self.mpay.text_params,
 				'whi1i7lifa70yhgs;V30.0HKD1257984115649643163420180701010100zh_TW0011100000https://demo.mpay.com.hk/mpay/notify.jspHK2018070101010037https://demo.mpay.com.hk/return.jsp001101;ABCDEFG123456789',
+			)
+
+			self.assertEqual(
+				self.mpay.dict_params,
+				params,
 			)
 
 	def test_gen_text_hash(self):
@@ -52,3 +109,53 @@ class TestmPaySettings(unittest.TestCase):
 				self.mpay.text_hash.upper(),
 				'0D959AA4CCBF2844B1DB7A3777772203712F31E04BAD9E208CB52BCA11FAF72B'
 			)
+
+	def test_get_payment_context(self):
+		data = dict(
+			salt="whi1i7lifa70yhgs",
+			securekey="ABCDEFG123456789",
+			accounttype="V",
+			amt="30.0",
+			currency="HKD",
+			customerid="12579841156496431634",
+			datetime="20180701010100",
+			locale="zh_TW",
+			merchant_tid="001",
+			merchantid="1100000",
+			notifyurl="https://demo.mpay.com.hk/mpay/notify.jsp",
+			ordernum="HK20180701010100",
+			paymethod="37",
+			returnurl="https://demo.mpay.com.hk/return.jsp",
+			storeid="001",
+			tokenid="101",
+		)
+		self.mpay.create_payment_request(data=data)
+		payment_context = self.mpay.get_payment_context(
+			integration_request_id=self.mpay.integration_request.name,
+		)
+
+		self.assertEqual(
+			payment_context,
+			{
+				'url': 'https://demo.mobiletech.com.hk/MPay/MerchantPay.jsp',
+				'data': dict(
+					version="5.0",
+					salt="whi1i7lifa70yhgs",
+					accounttype="V",
+					amt="30.0",
+					currency="HKD",
+					customerid="12579841156496431634",
+					datetime="20180701010100",
+					locale="zh_TW",
+					merchant_tid="001",
+					merchantid="1100000",
+					notifyurl="https://demo.mpay.com.hk/mpay/notify.jsp",
+					ordernum="HK20180701010100",
+					paymethod="37",
+					returnurl="https://demo.mpay.com.hk/return.jsp",
+					storeid="001",
+					tokenid="101",
+					hash="0d959aa4ccbf2844b1db7a3777772203712f31e04bad9e208cb52bca11faf72b"
+				)
+			}
+		)

--- a/frappe/integrations/workspace/integrations/integrations.json
+++ b/frappe/integrations/workspace/integrations/integrations.json
@@ -228,6 +228,15 @@
   {
    "hidden": 0,
    "is_query_report": 0,
+   "label": "mPay Settings",
+   "link_to": "mPay Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
    "label": "Settings",
    "link_count": 0,
    "onboard": 0,

--- a/frappe/templates/pages/integrations/mpay_checkout.html
+++ b/frappe/templates/pages/integrations/mpay_checkout.html
@@ -1,0 +1,50 @@
+{% extends "templates/web.html" %}
+
+{% block title %}Payment{% endblock %}
+
+{%- block header -%}
+<head>
+  <title>Checkout Page</title>
+</head>
+{% endblock %}
+
+{% block script %}
+<script defer type="text/javascript">
+  document.payment_form.submit();
+</script>
+{% endblock %}
+
+{%- block page_content -%}
+<body>
+  <div class="centered">
+    <h2>Please do not refresh this page...</h2>
+  </div>
+
+  <!-- To debug you could remove `display: none` from 'mpay_form'
+  and comment out `document.payment_form.submit();` -->
+  <div id="mpay_form" style="display: none">
+    <form method="post" action="{{ gateway_url }}" name="payment_form">
+      {% for key, val in payment_details.items() %}
+      <label>{{ key }}</label>
+      <input name="{{ key }}" value="{{ val }}" />
+      <br/>
+      {% endfor %}
+      <button type="submit" value="Submit">Submit</button>
+    </form>
+  </div>
+</body>
+{% endblock %}
+
+{% block style %}
+<style>
+  .centered {
+  	position: absolute;
+  	top: 50%;
+  	left: 50%;
+  	transform: translate(-50%, -50%);
+  }
+  .web-footer {
+  	display: none;
+  }
+</style>
+{% endblock %}

--- a/frappe/templates/pages/integrations/mpay_checkout.py
+++ b/frappe/templates/pages/integrations/mpay_checkout.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+import frappe
+
+from frappe import _
+
+
+def get_context(context):
+    context.no_cache = 1
+    try:
+        controller = frappe.get_doc('mPay Settings')
+        payment_context = controller.get_payment_context(
+            integration_request_id=frappe.form_dict['order_id']
+        )
+        context.payment_details = payment_context.get('data')
+        context.gateway_url = payment_context.get('url')
+
+    except Exception:
+        frappe.log_error()
+        frappe.redirect_to_message(
+            _(
+                'Invalid Token'
+                'Seems token you are using is invalid!'
+            ),
+            http_status_code=400,
+            indicator_color='red'
+        )
+
+        frappe.local.flags.redirect_location = frappe.local.response.location
+        raise frappe.Redirect

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -201,8 +201,6 @@ def get_context(context):
 
 	def get_payment_gateway_url(self, doc):
 		if self.accept_payment:
-			controller = get_payment_gateway_controller(self.payment_gateway)
-
 			title = "Payment for {0} {1}".format(doc.doctype, doc.name)
 			amount = self.amount
 			if self.amount_based_on_field:
@@ -224,6 +222,13 @@ def get_context(context):
 				"currency": self.currency,
 				"redirect_to": frappe.utils.get_url(self.success_url or self.route)
 			}
+
+			controller = get_payment_gateway_controller(self.payment_gateway)
+
+			controller.validate_transaction_currency(self.currency)
+
+			if hasattr(controller, 'validate_minimum_transaction_amount'):
+				controller.validate_minimum_transaction_amount(self.currency, amount)
 
 			# Redirect the user to this url
 			return controller.get_payment_url(**payment_details)


### PR DESCRIPTION
Add Payment Gateway Integration for mPay.

https://www.mpay.com.hk
mPay is a online payment gateway solution in Hong Kong.

## Details

This pull request add mPay payment gateway to frappe integration modules.

Diagrams of the payment process as attach.

![Payment_Gateway_Diagram](https://user-images.githubusercontent.com/24489363/137633081-a98b279b-ab8c-43e0-8426-5d6e9d52c941.png)

## Screenshot / GIFs

Payment Success

![mPay_payment_success](https://user-images.githubusercontent.com/24489363/137632309-dc9fd406-d164-41c3-8a77-4e482652907e.gif)

Payment Failed

![mPayIntegration_failed](https://user-images.githubusercontent.com/24489363/137632295-9c8c1396-543f-40d4-ad5d-d65868a2a362.gif)

Integration Request Detail

![integration_request](https://user-images.githubusercontent.com/24489363/137632349-1715c7bd-2db8-4603-a81d-3ba849c55c7a.png)

mPay Settings DocType

![mPay_settings](https://user-images.githubusercontent.com/24489363/137632346-91fe5b96-498f-47ef-b855-4c7c086f9fe9.png)