### PR TITLE
fix: Remove unnecessary missing_ok kwarg from unlink

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -507,7 +507,6 @@ def convert_archive_content(sql_file_path):
 		sql_file_path = Path(sql_file_path)
 
 		os.rename(sql_file_path, old_sql_file_path)
-		sql_file_path.unlink()
 		sql_file_path.touch()
 
 		with open(old_sql_file_path) as r, open(sql_file_path, "a") as w:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -507,14 +507,14 @@ def convert_archive_content(sql_file_path):
 		sql_file_path = Path(sql_file_path)
 
 		os.rename(sql_file_path, old_sql_file_path)
-		sql_file_path.unlink(missing_ok=True)
+		sql_file_path.unlink()
 		sql_file_path.touch()
 
 		with open(old_sql_file_path) as r, open(sql_file_path, "a") as w:
 			for line in r:
 				w.write(line.replace("ROW_FORMAT=COMPRESSED", "ROW_FORMAT=DYNAMIC"))
 
-		old_sql_file_path.unlink(missing_ok=True)
+		old_sql_file_path.unlink()
 
 
 def extract_sql_gzip(sql_gz_path):


### PR DESCRIPTION
missing_ok added in PY38, this change breaks installs for PY37. 
ref: https://docs.python.org/3/library/pathlib.html#pathlib.Path.unlink

Introduced via https://github.com/frappe/frappe/pull/14401
Closes https://github.com/frappe/frappe/issues/14467