### PR TITLE
fix: Check if parent exist in col before getting doc

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -249,7 +249,7 @@ def make_links(columns, data):
 				if col.options and row.get(col.fieldname) and row.get(col.options):
 					row[col.fieldname] = get_link_to_form(row[col.options], row[col.fieldname])
 			elif col.fieldtype == "Currency" and row.get(col.fieldname):
-				doc = frappe.get_doc(col.parent, doc_name) if doc_name else None
+				doc = frappe.get_doc(col.parent, doc_name) if doc_name and col.parent else None
 				# Pass the Document to get the currency based on docfield option
 				row[col.fieldname] = frappe.format_value(row[col.fieldname], col, doc=doc)
 	return columns, data


### PR DESCRIPTION
This fixes the following error while downloading auto email report

```
Traceback (most recent call last):
  File "/Users/sps/benches/develop/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/Users/sps/benches/develop/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 1205, in call
    return fn(*args, **newargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 196, in download
    data = auto_email_report.get_report_content()
  File "/Users/sps/benches/develop/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 98, in get_report_content
    columns, data = make_links(columns, data)
  File "/Users/sps/benches/develop/apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 253, in make_links
    doc = frappe.get_doc(col.parent, doc_name) if doc_name else None
  File "/Users/sps/benches/develop/apps/frappe/frappe/__init__.py", line 883, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/Users/sps/benches/develop/apps/frappe/frappe/model/document.py", line 62, in get_doc
    raise ValueError('First non keyword argument must be a string or dict')
ValueError: First non keyword argument must be a string or dict
```

The issue was introduced via https://github.com/frappe/frappe/pull/13340
