### PR TITLE
fix: Set limit_page_length to get all letterhead

### DIFF
--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -78,7 +78,7 @@ export default class BulkOperations {
 			args: {
 				doctype: 'Letter Head',
 				fields: ['name', 'is_default'],
-				limit: 0
+				limit_page_length: 0
 			},
 			async: false,
 			callback (r) {


### PR DESCRIPTION
`limit` is not a valid argument for `frappe.client.get_list`

port-of: https://github.com/frappe/frappe/pull/14478
