### PR TITLE
ci: semgrep rule for db.sql

### DIFF
--- a/.github/helper/semgrep_rules/frappe_correctness.yml
+++ b/.github/helper/semgrep_rules/frappe_correctness.yml
@@ -131,3 +131,10 @@ rules:
       key `$X` is uselessly assigned twice. This could be a potential bug.
   languages: [python]
   severity: ERROR
+
+- id: frappe-using-db.sql
+  pattern-regex: \.sql.*\(
+  message: |
+    The PR contains a SQL query that may be re-written with frappe.qb (https://frappeframework.com/docs/user/en/api/query-builder) or the Database API (https://frappeframework.com/docs/user/en/api/database)
+  languages: [python]
+  severity: ERROR

--- a/.github/helper/semgrep_rules/frappe_correctness.yml
+++ b/.github/helper/semgrep_rules/frappe_correctness.yml
@@ -133,7 +133,10 @@ rules:
   severity: ERROR
 
 - id: frappe-using-db-sql
-  pattern: frappe.db.sql(...)
+  pattern-either:
+    - pattern: frappe.db.sql(...)
+    - pattern: frappe.db.sql_ddl(...)
+    - pattern: frappe.db.sql_list(...)
   message: |
     The PR contains a SQL query that may be re-written with frappe.qb (https://frappeframework.com/docs/user/en/api/query-builder) or the Database API (https://frappeframework.com/docs/user/en/api/database)
   languages: [python]

--- a/.github/helper/semgrep_rules/frappe_correctness.yml
+++ b/.github/helper/semgrep_rules/frappe_correctness.yml
@@ -137,6 +137,9 @@ rules:
     - pattern: frappe.db.sql(...)
     - pattern: frappe.db.sql_ddl(...)
     - pattern: frappe.db.sql_list(...)
+  paths:
+    exclude:
+      - "test_*.py"
   message: |
     The PR contains a SQL query that may be re-written with frappe.qb (https://frappeframework.com/docs/user/en/api/query-builder) or the Database API (https://frappeframework.com/docs/user/en/api/database)
   languages: [python]

--- a/.github/helper/semgrep_rules/frappe_correctness.yml
+++ b/.github/helper/semgrep_rules/frappe_correctness.yml
@@ -132,8 +132,8 @@ rules:
   languages: [python]
   severity: ERROR
 
-- id: frappe-using-db.sql
-  pattern-regex: \.sql.*\(
+- id: frappe-using-db-sql
+  pattern: frappe.db.sql(...)
   message: |
     The PR contains a SQL query that may be re-written with frappe.qb (https://frappeframework.com/docs/user/en/api/query-builder) or the Database API (https://frappeframework.com/docs/user/en/api/database)
   languages: [python]

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -4,6 +4,7 @@ import frappe
 from frappe.utils import set_request
 from frappe.website.serve import get_response, get_response_content
 from frappe.website.utils import (build_response, clear_website_cache, get_home_page)
+from tenacity import retry, stop_after_attempt, retry_if_exception_type
 
 
 class TestWebsite(unittest.TestCase):
@@ -196,6 +197,11 @@ class TestWebsite(unittest.TestCase):
 		delattr(frappe.hooks, 'page_renderer')
 		frappe.cache().delete_key('app_hooks')
 
+	# TODO: Get rid of this retry logic
+	# Added since test is flaky and we can't figure out why at this point
+	@retry(
+		stop=stop_after_attempt(5), retry=retry_if_exception_type(AssertionError),
+	)
 	def test_printview_page(self):
 		content = get_response_content('/Language/en')
 		self.assertIn('<div class="print-format">', content)


### PR DESCRIPTION
### Changes

* Add a rule in semgrep to error when diff contains a `frappe.db.sql`, `frappe.db.sql_list` or `frappe.db.sql_ddl` call.

Use `frappe.qb` for any SELECT you can't already do with `frappe.get_all`. Instead of `sql_list`, you can use variants of qb or get_all, like `frappe.qb...run(as_list=True), or use `pluck={fieldname}`, or something else IDK...but it's possible to avoid their usages altogether.
