### PR TITLE
fix: remove/update older whitelist calls

### DIFF
--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -22,7 +22,6 @@ class NavbarSettings(Document):
 		if not frappe.flags.in_patch and (len(before_save_items) > len(after_save_items)):
 			frappe.throw(_("Please hide the standard navbar items instead of deleting them"))
 
-@frappe.whitelist(allow_guest=True)
 def get_app_logo():
 	app_logo = frappe.db.get_single_value('Navbar Settings', 'app_logo', cache=True)
 	if not app_logo:

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -54,7 +54,7 @@ class UserPermission(Document):
 			ref_link = frappe.get_desk_link(self.doctype, overlap_exists[0].name)
 			frappe.throw(_("{0} has already assigned default value for {1}.").format(ref_link, self.allow))
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_user_permissions(user=None):
 	'''Get all users permissions for the user as a dict of doctype'''
 	# if this is called from client-side,

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -13,7 +13,7 @@ from frappe.desk.form.document_follow import is_document_followed
 from frappe import _
 from urllib.parse import quote
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def getdoc(doctype, name, user=None):
 	"""
 	Loads a doclist for a given document. This method is called directly from the client.
@@ -52,7 +52,7 @@ def getdoc(doctype, name, user=None):
 
 	frappe.response.docs.append(doc)
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def getdoctype(doctype, with_parent=False, cached_timestamp=None):
 	"""load doctype"""
 

--- a/frappe/desk/listview.py
+++ b/frappe/desk/listview.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 import frappe
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 def get_list_settings(doctype):
 	try:
 		return frappe.get_cached_doc("List View Settings", doctype)

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -14,7 +14,7 @@ from frappe.utils import cstr, format_duration
 from frappe.model.base_document import get_controller
 
 
-@frappe.whitelist(allow_guest=True)
+@frappe.whitelist()
 @frappe.read_only()
 def get():
 	args = get_form_params()

--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -336,7 +336,6 @@ def dropbox_auth_finish(return_access_token=False):
 		_("Dropbox access is approved!") + close,
 		indicator_color='green')
 
-@frappe.whitelist(allow_guest=True)
 def set_dropbox_access_token(access_token):
 	frappe.db.set_value("Dropbox Settings", None, 'dropbox_access_token', access_token)
 	frappe.db.commit()

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -17,8 +17,8 @@ import redis
 from urllib.parse import unquote
 from frappe.cache_manager import clear_user_cache
 
-@frappe.whitelist(allow_guest=True)
-def clear(user=None):
+@frappe.whitelist()
+def clear():
 	frappe.local.session_obj.update(force=True)
 	frappe.local.db.commit()
 	clear_user_cache(frappe.session.user)


### PR DESCRIPTION
Remove `allow_guest` (methods not being called as `Guest`):
- `frappe.sessions.clear` (remove unused parameter as well)
- `frappe.core.doctype.user_permission.user_permission.get_user_permissions`
- `frappe.desk.listview.get_list_settings`
- `frappe.desk.reportview.get`
- `frappe.desk.form.load.getdoc`
- `frappe.desk.form.load.get_doctype`

Completely remove whitelisting (methods not being called from front-end):
- `frappe.integrations.doctype.dropbox_settings.dropbox_settings.set_dropbox_access_token`
- `frappe.core.doctype.navbar_settings.navbar_settings.get_app_logo`