### PR TITLE
fix: set missing `permlevel` for Role Profile

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -202,7 +202,8 @@
    "fieldname": "role_profile_name",
    "fieldtype": "Link",
    "label": "Role Profile",
-   "options": "Role Profile"
+   "options": "Role Profile",
+   "permlevel": 1
   },
   {
    "fieldname": "roles_html",
@@ -670,7 +671,7 @@
   }
  ],
  "max_attachments": 5,
- "modified": "2021-02-02 16:11:06.037543",
+ "modified": "2021-10-18 16:56:05.578379",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",


### PR DESCRIPTION
set missing `permlevel` for Role Profile