### PR TITLE
fix: remove duplication in `customize_form.json`

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -279,16 +279,6 @@
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name"
-  },
-  {
-   "fieldname": "default_email_template",
-   "fieldtype": "Link",
-   "label": "Default Email Template",
-   "options": "Email Template"
-  },
-  {
-   "fieldname": "column_break_26",
-   "fieldtype": "Column Break"
   }
  ],
  "hide_toolbar": 1,
@@ -297,7 +287,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-06-21 19:01:06.920663",
+ "modified": "2021-10-19 15:20:55.393272",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",


### PR DESCRIPTION
Possibly while merging branches, certain fields were appearing twice in `fields`. Issue not existent in `develop`.

Fixes this error when saving the `Customize Form` DocType:

![image](https://user-images.githubusercontent.com/16315650/137850126-2190f1ac-93da-430d-a659-cd3f3babc070.png)

v13 Port of https://github.com/frappe/frappe/pull/13410
Closes https://github.com/frappe/frappe/issues/14021

![image](https://user-images.githubusercontent.com/16315650/137886645-b2f0415b-ed3f-418c-bc27-33aa53e49a5e.png)
