### PR TITLE
fix: ignore `flags` in `frappe.client.bulk_update`

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -276,18 +276,17 @@ def bulk_update(docs):
 	docs = json.loads(docs)
 	failed_docs = []
 	for doc in docs:
+		doc.pop("flags", None)
 		try:
-			ddoc = {key: val for key, val in doc.items() if key not in ['doctype', 'docname']}
-			doctype = doc['doctype']
-			docname = doc['docname']
-			doc = frappe.get_doc(doctype, docname)
-			doc.update(ddoc)
-			doc.save()
-		except:
+			existing_doc = frappe.get_doc(doc.pop("doctype"), doc.pop("docname"))
+			existing_doc.update(doc)
+			existing_doc.save()
+		except Exception:
 			failed_docs.append({
 				'doc': doc,
 				'exc': frappe.utils.get_traceback()
 			})
+
 	return {'failed_docs': failed_docs}
 
 @frappe.whitelist()


### PR DESCRIPTION
Changes to `frappe.client.bulk_update`
- Ignore `flags`
- Skip re-iteration and filtration. Just pop it 😆 
- Semantic changes