### PR TITLE
fix: only run `get_email_template` if a template is selected

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -172,6 +172,7 @@ frappe.views.CommunicationComposer = Class.extend({
 
 		this.dialog.fields_dict["email_template"].df.onchange = () => {
 			var email_template = me.dialog.fields_dict.email_template.get_value();
+			if (!email_template) return;
 
 			var prepend_reply = function(reply) {
 				if(me.reply_added===email_template) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -198,19 +198,17 @@ frappe.views.CommunicationComposer = Class.extend({
 				me.reply_added = email_template;
 			}
 
-			if (email_template && email_template !== '') {
-				frappe.call({
-					method: 'frappe.email.doctype.email_template.email_template.get_email_template',
-					args: {
-						template_name: email_template,
-						doc: me.frm.doc,
-						_lang: me.dialog.get_value("language_sel")
-					},
-					callback: function(r) {
-						prepend_reply(r.message);
-					},
-				});
-			}
+			frappe.call({
+				method: 'frappe.email.doctype.email_template.email_template.get_email_template',
+				args: {
+					template_name: email_template,
+					doc: me.frm.doc,
+					_lang: me.dialog.get_value("language_sel")
+				},
+				callback: function(r) {
+					prepend_reply(r.message);
+				},
+			});
 		}
 	},
 

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -197,17 +197,19 @@ frappe.views.CommunicationComposer = Class.extend({
 				me.reply_added = email_template;
 			}
 
-			frappe.call({
-				method: 'frappe.email.doctype.email_template.email_template.get_email_template',
-				args: {
-					template_name: email_template,
-					doc: me.frm.doc,
-					_lang: me.dialog.get_value("language_sel")
-				},
-				callback: function(r) {
-					prepend_reply(r.message);
-				},
-			});
+			if (email_template && email_template !== '') {
+				frappe.call({
+					method: 'frappe.email.doctype.email_template.email_template.get_email_template',
+					args: {
+						template_name: email_template,
+						doc: me.frm.doc,
+						_lang: me.dialog.get_value("language_sel")
+					},
+					callback: function(r) {
+						prepend_reply(r.message);
+					},
+				});
+			}
 		}
 	},
 


### PR DESCRIPTION
Before leaving the email_template field without a selection, there has been an error, that the email template (without a name) can not be found.

Now the ajax call will only be done when a selection has been done.