### PR TITLE
refactor: move max_writes constant to a class var

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -37,6 +37,7 @@ class Database(object):
 	STANDARD_VARCHAR_COLUMNS = ('name', 'owner', 'modified_by', 'parent', 'parentfield', 'parenttype')
 	DEFAULT_COLUMNS = ['name', 'creation', 'modified', 'modified_by', 'owner', 'docstatus', 'parent',
 		'parentfield', 'parenttype', 'idx']
+	MAX_WRITES_PER_TRANSACTION = 200_000
 
 	class InvalidColumnName(frappe.ValidationError): pass
 
@@ -262,7 +263,7 @@ class Database(object):
 
 		if query[:6].lower() in ('update', 'insert', 'delete'):
 			self.transaction_writes += 1
-			if self.transaction_writes > 200000:
+			if self.transaction_writes > self.MAX_WRITES_PER_TRANSACTION:
 				if self.auto_commit_on_many_writes:
 					self.commit()
 				else:


### PR DESCRIPTION
- move hardcoded constant to the class variable.
- Allows changing it dynamically if required where `auto_commit_on_many_writes` is not a good alternative.  (ACID wat? 😏 )