### PR TITLE
fix: prevent report error for AttachmentLimitReached exceptions

### DIFF
--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -99,8 +99,8 @@ class IncompatibleApp(ValidationError): pass
 class InvalidDates(ValidationError): pass
 class DataTooLongException(ValidationError): pass
 class FileAlreadyAttachedException(Exception): pass
-class DocumentAlreadyRestored(Exception): pass
-class AttachmentLimitReached(Exception): pass
+class DocumentAlreadyRestored(ValidationError): pass
+class AttachmentLimitReached(ValidationError): pass
 # OAuth exceptions
 class InvalidAuthorizationHeader(CSRFTokenError): pass
 class InvalidAuthorizationPrefix(CSRFTokenError): pass


### PR DESCRIPTION
Since `AttachmentLimitReached` extended `Exception`, the `request.js` handled it as a server error and shows the` Report Error` button. 
Since the message `Maximum Attachment Limit of {limit} has been reached for {doctype} {docname}` is already user-friendly, the error need not be reported. 