### PR TITLE
chore: change log for v13.13.0

### DIFF
--- a/frappe/change_log/v13/v13_13_0.md
+++ b/frappe/change_log/v13/v13_13_0.md
@@ -1,0 +1,16 @@
+# Version 13.13.0 Release Notes
+
+### Features & Enhancements
+
+- User wise configure grid columns ([#14130](https://github.com/frappe/frappe/pull/14130))
+- Enhancements in the Server Script ([#14140](https://github.com/frappe/frappe/pull/14140))
+- Expose frappe.db.exists & frappe.db.count to Server Script ([#14370](https://github.com/frappe/frappe/pull/14370))
+- Added frappe.qb in server script ([#14423](https://github.com/frappe/frappe/pull/14423))
+- Added app_name and app_logo in Website Settings ([#14020](https://github.com/frappe/frappe/pull/14020))
+
+### Fixes
+
+- Heatmap legend color not set when the color theme is set ([#14332](https://github.com/frappe/frappe/pull/14332))
+- Date mismatches while displaying in short form ([#14277](https://github.com/frappe/frappe/pull/14277))
+- Not able to delete the role permissions ([#14397](https://github.com/frappe/frappe/pull/14397))
+- Leaderboard is not loading for user with the language other than English ([#14327](https://github.com/frappe/frappe/pull/14327))


### PR DESCRIPTION
# Version 13.13.0 Release Notes

### Features & Enhancements

- User wise configure grid columns ([#14130](https://github.com/frappe/frappe/pull/14130))
- Enhancements in the Server Script ([#14140](https://github.com/frappe/frappe/pull/14140))
- Expose frappe.db.exists & frappe.db.count to Server Script ([#14370](https://github.com/frappe/frappe/pull/14370))
- Added frappe.qb in server script ([#14423](https://github.com/frappe/frappe/pull/14423))
- Added app_name and app_logo in Website Settings ([#14020](https://github.com/frappe/frappe/pull/14020))

### Fixes

- Heatmap legend color not set when the color theme is set ([#14332](https://github.com/frappe/frappe/pull/14332))
- Date mismatches while displaying in short form ([#14277](https://github.com/frappe/frappe/pull/14277))
- Not able to delete the role permissions ([#14397](https://github.com/frappe/frappe/pull/14397))
- Leaderboard is not loading for user with the language other than English ([#14327](https://github.com/frappe/frappe/pull/14327))
