### PR TITLE
feat: `setDefault` for JS Objects

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -23,6 +23,14 @@ if (!Array.prototype.uniqBy) {
 	});
 }
 
+// Python's dict.setdefault ported for JS objects
+Object.defineProperty(Object.prototype, "setDefault", {
+	value: function(key, default_value) {
+		if (!(key in this)) this[key] = default_value;
+		return this[key];
+	}
+});
+
 // Pluralize
 String.prototype.plural = function(revert) {
 	const plural = {


### PR DESCRIPTION
I have named it in camel case, following the convention of default `Object` methods. But I don't mind `setdefault` either. 

[Example](https://github.com/frappe/frappe/pull/14445/files#diff-61fd09d5028929a4ae2811e4af5c6d46f5d4eb2548944bef0d76666efaad4f13R1130-R1132)

<!-- no-docs -->