### PR TITLE
fix(ux): debounce awesome_bar search

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -50,38 +50,31 @@ frappe.search.AwesomeBar = class AwesomeBar {
 
 		this.awesomplete = awesomplete;
 
-		$input.on("input", function(e) {
+		$input.on("input", frappe.utils.debounce(function(e) {
 			var value = e.target.value;
 			var txt = value.trim().replace(/\s\s+/g, ' ');
 			var last_space = txt.lastIndexOf(' ');
 			me.global_results = [];
-			// if(txt && txt.length > 1) {
-			// 	me.global.get_awesome_bar_options(txt.toLowerCase(), me);
-			// }
 
-			var $this = $(this);
-			clearTimeout($this.data('timeout'));
+			me.options = [];
 
-			$this.data('timeout', setTimeout(function(){
-				me.options = [];
-				if(txt && txt.length > 1) {
-					if(last_space !== -1) {
-						me.set_specifics(txt.slice(0,last_space), txt.slice(last_space+1));
-					}
-					me.add_defaults(txt);
-					me.options = me.options.concat(me.build_options(txt));
-					me.options = me.options.concat(me.global_results);
-				} else {
-					me.options = me.options.concat(
-						me.deduplicate(frappe.search.utils.get_recent_pages(txt || "")));
-					me.options = me.options.concat(frappe.search.utils.get_frequent_links());
+			if (txt && txt.length > 1) {
+				if (last_space !== -1) {
+					me.set_specifics(txt.slice(0, last_space), txt.slice(last_space+1));
 				}
-				me.add_help();
+				me.add_defaults(txt);
+				me.options = me.options.concat(me.build_options(txt));
+				me.options = me.options.concat(me.global_results);
+			} else {
+				me.options = me.options.concat(
+					me.deduplicate(frappe.search.utils.get_recent_pages(txt || "")));
+				me.options = me.options.concat(frappe.search.utils.get_frequent_links());
+			}
+			me.add_help();
 
-				awesomplete.list = me.deduplicate(me.options);
-			}, 100));
+			awesomplete.list = me.deduplicate(me.options);
 
-		});
+		}, 500));
 
 		var open_recent = function() {
 			if (!this.autocomplete_open) {


### PR DESCRIPTION
When the system language is not English each call to search translates all doctypes, report names, etc etc to match them. This is computationally intensive and freezes DOM while typing. 

Root of all evil here is this line:
https://github.com/frappe/frappe/blob/93b7eb64ecf2f521612e40fbfc2eecae75bf5234/frappe/public/js/frappe/ui/toolbar/search_utils.js#L537 

![perf profile](https://user-images.githubusercontent.com/9079960/132017424-2b39cea4-94d6-422c-ab01-125d3539265e.jpg)

Ideal solution: cache translations of standard search results (e.g. doctype, report names)

Proposed change:
- replaced manual implementation of debouncing with frappe.utils.debounce
- increased timeout to 500ms. (previously 100ms)
- assuming ~30 wpm and 5 letter / word ~= 0.4 second / letter.

Tested locally, this feels _more usable_.

refer: https://github.com/frappe/frappe/issues/13914