### PR TITLE
fix: Changed default for Email Log from 90 to 30 days

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.json
+++ b/frappe/core/doctype/log_settings/log_settings.json
@@ -49,7 +49,7 @@
    "label": "Clear Activity Log After"
   },
   {
-   "default": "90",
+   "default": "30",
    "description": "In Days",
    "fieldname": "clear_email_queue_after",
    "fieldtype": "Int",


### PR DESCRIPTION
Ref: https://frappe.io/app/feature-request/Server%20space%20occupied%20due%20to%20Email%20Queue

To ensure email logs doesn't occupy lots of space in the database.