### PR TITLE
fix: consistent description for Live Reload

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -46,7 +46,7 @@ let argv = yargs
 	})
 	.option("live-reload", {
 		type: "boolean",
-		description: `Automatically reload web pages when assets are rebuilt.
+		description: `Automatically reload Desk when assets are rebuilt.
 			Can only be used with the --watch flag.`
 	})
 	.option("production", {


### PR DESCRIPTION
As discussed in https://github.com/frappe/frappe_docs/pull/217, the description for `live-reload` esbuild argument has been updated for consistency.