### PR TITLE
feat: diffview for client/server scripts

### DIFF
--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -10,6 +10,13 @@ frappe.ui.form.on('Server Script', {
 			frm.dashboard.hide();
 		}
 
+		if (!frm.is_new()) {
+			frm.add_custom_button(__('Compare Versions'), () => {
+				let diff = new frappe.ui.DiffView("Server Script", "script", frm.doc.name);
+			});
+		}
+
+
 		frm.call('get_autocompletion_items')
 			.then(r => r.message)
 			.then(items => {

--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -12,7 +12,7 @@ frappe.ui.form.on('Server Script', {
 
 		if (!frm.is_new()) {
 			frm.add_custom_button(__('Compare Versions'), () => {
-				let diff = new frappe.ui.DiffView("Server Script", "script", frm.doc.name);
+				new frappe.ui.DiffView("Server Script", "script", frm.doc.name);
 			});
 		}
 

--- a/frappe/custom/doctype/client_script/client_script.js
+++ b/frappe/custom/doctype/client_script/client_script.js
@@ -46,7 +46,7 @@ frappe.ui.form.on('Client Script', {
 
 			if (!frm.is_new()) {
 				frm.add_custom_button(__('Compare Versions'), () => {
-					let diff = new frappe.ui.DiffView("Client Script", "script", frm.doc.name);
+					new frappe.ui.DiffView("Client Script", "script", frm.doc.name);
 				});
 			}
 		}

--- a/frappe/custom/doctype/client_script/client_script.js
+++ b/frappe/custom/doctype/client_script/client_script.js
@@ -43,6 +43,12 @@ frappe.ui.form.on('Client Script', {
 					d.show();
 				});
 			});
+
+			if (!frm.is_new()) {
+				frm.add_custom_button(__('Compare Versions'), () => {
+					let diff = new frappe.ui.DiffView("Client Script", "script", frm.doc.name);
+				});
+			}
 		}
 
 		frm.set_query('dt', {

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -62,6 +62,7 @@ import "./frappe/utils/help_links.js";
 import "./frappe/utils/address_and_contact.js";
 import "./frappe/utils/preview_email.js";
 import "./frappe/utils/file_manager.js";
+import "./frappe/utils/diffview";
 
 import "./frappe/upload.js";
 import "./frappe/ui/tree.js";

--- a/frappe/public/js/frappe/utils/diffview.js
+++ b/frappe/public/js/frappe/utils/diffview.js
@@ -79,6 +79,32 @@ frappe.ui.DiffView = class DiffView {
 	}
 
 	prettify_diff(diff) {
-		return `<pre>${diff.join("<br>")}</pre>`;
+		let html = `
+		<style type="text/css">
+			.diffview {
+				font-family: monospace;
+				white-space: pre;
+				word-wrap: break-word;
+				color: #000000;
+			}
+		.diffview .insert {
+			background-color: #ddffdd;
+		}
+		.diffview .delete {
+			background-color: #ffdddd;
+		}
+		</style>
+		`;
+
+		diff.forEach((line) => {
+			let line_class = "";
+			if (line.startsWith("+")) {
+				line_class = "insert";
+			} else if (line.startsWith("-")) {
+				line_class = "delete";
+			}
+			html += `<div class=${line_class}>${line}</div>`;
+		});
+		return `<div class='diffview'>${html}</div>`;
 	}
 };

--- a/frappe/public/js/frappe/utils/diffview.js
+++ b/frappe/public/js/frappe/utils/diffview.js
@@ -1,0 +1,84 @@
+frappe.provide("frappe.ui");
+
+frappe.ui.DiffView = class DiffView {
+	constructor(doctype, fieldname, docname) {
+		this.dialog = null;
+		this.handler = null;
+		this.doctype = doctype;
+		this.fieldname = fieldname;
+		this.docname = docname;
+
+		this.dialog = this.make_dialog();
+		this.dialog.show();
+	}
+
+	make_dialog() {
+		const get_query = () => ({
+			query: "frappe.utils.diff.version_query",
+			filters: { docname: this.docname, ref_doctype: this.doctype },
+		});
+		const onchange = () => this.compute_diff();
+		let dialog = new frappe.ui.Dialog({
+			title: __("Compare Versions"),
+			fields: [
+				{
+					label: __("From version"),
+					fieldtype: "Link",
+					fieldname: "from_version",
+					options: "Version",
+					reqd: 1,
+					get_query,
+					onchange,
+				},
+				{
+					fieldtype: "Column Break",
+					fieldname: "cb",
+				},
+				{
+					label: __("To version"),
+					fieldtype: "Link",
+					fieldname: "to_version",
+					options: "Version",
+					reqd: 1,
+					get_query,
+					onchange,
+				},
+				{
+					fieldtype: "Section Break",
+					fieldname: "sb",
+				},
+				{
+					label: __("Diff"),
+					fieldtype: "HTML",
+					fieldname: "diff",
+				},
+			],
+			size: "large",
+		});
+		return dialog;
+	}
+
+	compute_diff() {
+		const from_version = this.dialog.get_value("from_version");
+		const to_version = this.dialog.get_value("to_version");
+		const fieldname = this.fieldname;
+
+		if (from_version && to_version) {
+			frappe
+				.xcall("frappe.utils.diff.get_version_diff", {
+					from_version,
+					to_version,
+					fieldname,
+				})
+				.then((data) => {
+					this.dialog.set_value("diff", this.prettify_diff(data));
+				});
+		} else {
+			this.dialog.set_value("diff", " ");
+		}
+	}
+
+	prettify_diff(diff) {
+		return `<pre>${diff.join("<br>")}</pre>`;
+	}
+};

--- a/frappe/public/js/frappe/utils/diffview.js
+++ b/frappe/public/js/frappe/utils/diffview.js
@@ -9,6 +9,7 @@ frappe.ui.DiffView = class DiffView {
 		this.docname = docname;
 
 		this.dialog = this.make_dialog();
+		this.set_empty_state();
 		this.dialog.show();
 	}
 
@@ -74,7 +75,7 @@ frappe.ui.DiffView = class DiffView {
 					this.dialog.set_value("diff", this.prettify_diff(data));
 				});
 		} else {
-			this.dialog.set_value("diff", " ");
+			this.set_empty_state();
 		}
 	}
 
@@ -106,5 +107,9 @@ frappe.ui.DiffView = class DiffView {
 			html += `<div class=${line_class}>${line}</div>`;
 		});
 		return `<div class='diffview'>${html}</div>`;
+	}
+
+	set_empty_state() {
+		this.dialog.set_value("diff", __("Select two versions to view the diff."));
 	}
 };

--- a/frappe/public/js/frappe/utils/diffview.js
+++ b/frappe/public/js/frappe/utils/diffview.js
@@ -80,22 +80,7 @@ frappe.ui.DiffView = class DiffView {
 	}
 
 	prettify_diff(diff) {
-		let html = `
-		<style type="text/css">
-			.diffview {
-				font-family: monospace;
-				white-space: pre;
-				word-wrap: break-word;
-				color: #000000;
-			}
-		.diffview .insert {
-			background-color: #ddffdd;
-		}
-		.diffview .delete {
-			background-color: #ffdddd;
-		}
-		</style>
-		`;
+		let html = ``;
 
 		diff.forEach((line) => {
 			let line_class = "";

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -574,6 +574,29 @@ details > summary:focus {
 	}
 }
 
+.diffview {
+	font-family: monospace;
+	white-space: pre;
+	word-wrap: break-word;
+	color: var(--text-color);
+}
+
+
+.diffview .insert {
+	background-color: var(--green-100);
+}
+
+.diffview .delete {
+	background-color: var(--red-100);
+}
+
+[data-theme="dark"] {
+	.diffview .insert,.delete  {
+		color: var(--gray-900);
+
+	}
+}
+
 // REDESIGN TODO: Handling of broken images?
 // img.no-image:before {
 // 	.img-background();

--- a/frappe/utils/diff.py
+++ b/frappe/utils/diff.py
@@ -1,6 +1,6 @@
 import json
 from difflib import unified_diff
-from typing import List, Tuple
+from typing import List
 
 import frappe
 

--- a/frappe/utils/diff.py
+++ b/frappe/utils/diff.py
@@ -1,0 +1,55 @@
+import json
+from difflib import unified_diff
+from typing import List, Tuple
+
+import frappe
+
+
+@frappe.whitelist()
+def get_version_diff(
+	from_version: str, to_version: str, fieldname: str = "script"
+) -> List[str]:
+
+	before, before_timestamp = _get_value_from_version(from_version, fieldname)
+	after, after_timestamp = _get_value_from_version(to_version, fieldname)
+
+	if not (before and after):
+		return ["Values not available for diff"]
+
+	before = before.split("\n")
+	after = after.split("\n")
+
+	diff = unified_diff(
+		before, after, fromfiledate=before_timestamp, tofiledate=after_timestamp
+	)
+	return list(diff)
+
+
+def _get_value_from_version(version_name: str, fieldname: str):
+	version = frappe.get_list(
+		"Version", fields=["data", "modified"], filters={"name": version_name}
+	)
+	if version:
+		data = json.loads(version[0].data)
+		changed_fields = data.get("changed", [])
+
+		# data structure of field: [fieldname, before_save, after_save]
+		for field in changed_fields:
+			if field[0] == fieldname:
+				return field[2], str(version[0].modified)
+
+	return None, None
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def version_query(doctype, txt, searchfield, start, page_len, filters):
+	return frappe.get_list(
+		"Version",
+		fields=["name", "modified"],
+		filters=filters,
+		limit_start=start,
+		limit_page_length=page_len,
+		as_list=1,
+		order_by="modified desc",
+	)

--- a/frappe/utils/diff.py
+++ b/frappe/utils/diff.py
@@ -3,6 +3,7 @@ from difflib import unified_diff
 from typing import List
 
 import frappe
+from frappe.utils import pretty_date
 
 
 @frappe.whitelist()
@@ -20,7 +21,12 @@ def get_version_diff(
 	after = after.split("\n")
 
 	diff = unified_diff(
-		before, after, fromfiledate=before_timestamp, tofiledate=after_timestamp
+		before,
+		after,
+		fromfile=from_version,
+		tofile=to_version,
+		fromfiledate=before_timestamp,
+		tofiledate=after_timestamp,
 	)
 	return list(diff)
 
@@ -44,12 +50,12 @@ def _get_value_from_version(version_name: str, fieldname: str):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def version_query(doctype, txt, searchfield, start, page_len, filters):
-	return frappe.get_list(
+	results = frappe.get_list(
 		"Version",
 		fields=["name", "modified"],
 		filters=filters,
 		limit_start=start,
 		limit_page_length=page_len,
-		as_list=1,
 		order_by="modified desc",
 	)
+	return [(d.name, pretty_date(d.modified), d.modified) for d in results]


### PR DESCRIPTION
Why do we need this?

Version Log's diff table is useless for long text. 

Common pattern is to either copy those values locally and use a difftool. A simple line-wise diff is good enough to understand the change in most cases.

<details>
  <summary>Why not add this in version log's table?</summary>
 
This is only useful for diffing code. Doing it via a dialog lets me select two arbitrary versions for diffing and not just two sequential versions. 
DiffView Component can be changed to use an arbitrary field with a small change. Feel free to do so if there's any use-case for that. 
</details> 

 <details>
  <summary>full git integration?</summary>
 lolno. 
</details>
 
---

Changes:
- [x] generic `frappe.ui.DiffView` component for diffing a field of document.
- [X] Server-side diff generation using standard library's `difflib.unified_diff`
- [x] Add button on server scripts and client scripts to show diff dialog.
- [x] Show date while selecting the version
- [x] Add background color on changed lines. [This library](https://github.com/kilink/ghdiff) exists but it's last updated in 2014. Also, don't want to add a new dependency for this. 😅 
- [x] respects permission (`get_list` queries only)
- [x] Unit tests
- [x] docs (after initial approval, just need to add screenshot and a note. Usage is mostly _self explanatory_.)


Select versions (constructor allows filtering doctype & docname):
<img width="815" alt="Screenshot 2021-10" src="https://user-images.githubusercontent.com/9079960/138586279-fea8f726-5016-4e65-926c-a1a7e710e24f.png">


Diff view:

<img width="1357" alt="Screenshot" src="https://user-images.githubusercontent.com/9079960/138549752-21cfb17e-8e6e-4a58-b943-cd4dd5ba01ce.png">


Docs: https://github.com/frappe/frappe_docs/pull/220