### PR TITLE
fix: do not pop `doctype` and `docname`

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -278,7 +278,7 @@ def bulk_update(docs):
 	for doc in docs:
 		doc.pop("flags", None)
 		try:
-			existing_doc = frappe.get_doc(doc.pop("doctype"), doc.pop("docname"))
+			existing_doc = frappe.get_doc(doc["doctype"], doc["docname"])
 			existing_doc.update(doc)
 			existing_doc.save()
 		except Exception:


### PR DESCRIPTION
These will not go into `failed_docs` (where they might be useful for debugging) if popped.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/16315650/138552700-e17017b2-8f45-462a-8313-74e1617307a8.png)

### After

![image](https://user-images.githubusercontent.com/16315650/138552745-bc1decec-c7c3-448d-9f29-3072c5bb8f5e.png)
