### PR TITLE
perf: remove "track changes" from log-like doctypes

### DIFF
--- a/frappe/core/doctype/activity_log/activity_log.json
+++ b/frappe/core/doctype/activity_log/activity_log.json
@@ -154,7 +154,7 @@
  "icon": "fa fa-comment",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-08-28 11:43:57.504565",
+ "modified": "2021-10-25 11:43:57.504565",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Activity Log",
@@ -182,6 +182,5 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "title_field": "subject",
- "track_changes": 1,
  "track_seen": 1
 }

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -150,7 +150,7 @@
       "fieldtype": "Column Break"
     },
     {
-      "default": "1",
+      "default": "0",
       "depends_on": "eval:!doc.istable",
       "description": "If enabled, changes to the document are tracked and shown in timeline",
       "fieldname": "track_changes",
@@ -649,7 +649,7 @@
       "link_fieldname": "reference_doctype"
     }
   ],
-  "modified": "2021-09-05 15:39:13.233403",
+  "modified": "2021-10-29 11:39:13.233403",
   "modified_by": "Administrator",
   "module": "Core",
   "name": "DocType",

--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -112,7 +112,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-03-14 12:21:44.292471", 
+ "modified": "2021-10-25 12:21:44.292471", 
  "modified_by": "Administrator", 
  "module": "Core", 
  "name": "Error Log", 
@@ -144,6 +144,5 @@
  "read_only_onload": 0, 
  "show_name_in_global_search": 0, 
  "sort_order": "ASC", 
- "track_changes": 1, 
  "track_seen": 0
 }

--- a/frappe/core/doctype/error_snapshot/error_snapshot.json
+++ b/frappe/core/doctype/error_snapshot/error_snapshot.json
@@ -359,7 +359,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2016-12-29 14:40:38.619106", 
+ "modified": "2021-10-25 14:40:38.619106", 
  "modified_by": "Administrator", 
  "module": "Core", 
  "name": "Error Snapshot", 
@@ -394,6 +394,5 @@
  "sort_field": "timestamp", 
  "sort_order": "DESC", 
  "title_field": "evalue", 
- "track_changes": 1, 
  "track_seen": 0
 }

--- a/frappe/core/doctype/scheduled_job_log/scheduled_job_log.json
+++ b/frappe/core/doctype/scheduled_job_log/scheduled_job_log.json
@@ -38,7 +38,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-22 00:00:00.000000",
+ "modified": "2021-10-25 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Log",
@@ -59,6 +59,5 @@
  ],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "DESC",
- "track_changes": 1
+ "sort_order": "DESC"
 }

--- a/frappe/core/doctype/view_log/view_log.json
+++ b/frappe/core/doctype/view_log/view_log.json
@@ -125,7 +125,7 @@
  "issingle": 0,
  "istable": 0,
  "max_attachments": 0,
- "modified": "2019-09-05 14:22:27.664645",
+ "modified": "2021-10-25 14:22:27.664645",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "View Log",
@@ -158,7 +158,6 @@
  "show_name_in_global_search": 0,
  "sort_field": "modified",
  "sort_order": "DESC",
- "track_changes": 1,
  "track_seen": 0,
  "track_views": 0
 }

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -120,7 +120,7 @@
  "hide_toolbar": 1,
  "in_create": 1,
  "links": [],
- "modified": "2020-09-18 17:26:09.703215",
+ "modified": "2021-10-25 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Log",
@@ -139,6 +139,5 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "title_field": "subject",
- "track_changes": 1,
  "track_seen": 1
 }

--- a/frappe/desk/doctype/route_history/route_history.json
+++ b/frappe/desk/doctype/route_history/route_history.json
@@ -88,7 +88,7 @@
  "issingle": 0,
  "istable": 0,
  "max_attachments": 0,
- "modified": "2018-10-05 13:26:03.106050",
+ "modified": "2021-10-25 13:26:03.106050",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Route History",
@@ -121,7 +121,6 @@
  "show_name_in_global_search": 0,
  "sort_field": "modified",
  "sort_order": "DESC",
- "track_changes": 1,
  "track_seen": 0,
  "track_views": 0
 }

--- a/frappe/social/doctype/energy_point_log/energy_point_log.json
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.json
@@ -112,7 +112,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-06 17:25:40.477044",
+ "modified": "2021-10-25 17:25:40.477044",
  "modified_by": "Administrator",
  "module": "Social",
  "name": "Energy Point Log",
@@ -131,6 +131,5 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "title_field": "user",
- "track_changes": 1
+ "title_field": "user"
 }

--- a/frappe/website/doctype/web_page_view/web_page_view.json
+++ b/frappe/website/doctype/web_page_view/web_page_view.json
@@ -59,7 +59,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-05-05 14:11:24.718770",
+ "modified": "2021-10-25 14:11:24.718770",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Page View",
@@ -82,6 +82,5 @@
  "read_only": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "title_field": "path",
- "track_changes": 1
+ "title_field": "path"
 }


### PR DESCRIPTION
These documents don't change and even if they did it's useless to keep track of it IMO. Removing this speeds up insertion and saves storage.

Removed "Track Changes" from:

- Activity Log
- Error Log
- Error Snapshot
- Scheduled Job Log
- View Log
- Notification Log
- Route History
- Energy Point Log
- Web Page View

Anecdotal numbers: on one site, there are ~20 million version records for these logging doctypes. Assuming ~50 bytes per row (new version record without changes) this consumes ~1 gigabyte of storage.