### PR TITLE
fix: Website URL parsing function parses absolute telephone/phone tel: URLs as relative

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -164,7 +164,9 @@ def abs_url(path):
 	"""Deconstructs and Reconstructs a URL into an absolute URL or a URL relative from root '/'"""
 	if not path:
 		return
-	if path.startswith('http://') or path.startswith('https://') or path.startswith('tel:'):
+	if path.startswith('http://') or path.startswith('https://'):
+		return path
+	if path.startswith('tel:'):
 		return path
 	if path.startswith('data:'):
 		return path

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -164,7 +164,7 @@ def abs_url(path):
 	"""Deconstructs and Reconstructs a URL into an absolute URL or a URL relative from root '/'"""
 	if not path:
 		return
-	if path.startswith('http://') or path.startswith('https://'):
+	if path.startswith('http://') or path.startswith('https://') or path.startswith('tel:'):
 		return path
 	if path.startswith('data:'):
 		return path


### PR DESCRIPTION
tel: URLs should be parsed as absolute path

Closes frappe#14567