### PR TITLE
fix: minor fixes to whitelisted methods

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -128,7 +128,6 @@ class LoginManager:
 				self.make_session()
 				self.set_user_info()
 
-	@frappe.whitelist()
 	def login(self):
 		# clear cache
 		frappe.clear_cache(user = frappe.form_dict.get('usr'))

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -27,7 +27,7 @@ def handle():
 	cmd = frappe.local.form_dict.cmd
 	data = None
 
-	if cmd!='login':
+	if cmd != 'login':
 		data = execute_cmd(cmd)
 
 	# data can be an empty string or list which are valid responses


### PR DESCRIPTION
## Changes Made
<!--
 - Deprecated `frappe.ping` in favor of `frappe.handler.ping`. The latter is easier to call from API.
 
![Screenshot-2021-10-25-211117](https://user-images.githubusercontent.com/16315650/138727848-da91cc4f-885f-4160-b57a-b3dd24ef0b9f.png)
-->

- Remove whitelisting from unreachable method: `frappe.auth.LoginManager.login` cannot be called using `frappe.call`.
- Semantic change in `handler.py`