### PR TITLE
fix(ui): Make user-wise grid customization translatable

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -320,7 +320,7 @@ export default class GridRow {
 				</div>
 				<p class='help-box small text-muted hidden-xs'>
 					<a class='add-new-fields text-muted'>
-						+ Add / Remove Columns
+						+ ${__('Add / Remove Columns')}
 					</a>
 				</p>
 			</div>
@@ -397,7 +397,7 @@ export default class GridRow {
 								<a style='cursor: grabbing;'>${frappe.utils.icon('drag', 'xs')}</a>
 							</div>
 							<div class='col-md-7' style='padding-left:0px;'>
-								${docfield.label}
+								${__(docfield.label)}
 							</div>
 							<div class='col-md-3' style='padding-left:0px;margin-top:-2px;' title='${__('Columns')}'>
 								<input class='form-control column-width input-xs text-right'


### PR DESCRIPTION
> Explain the **details** for making this change. What existing problem does the pull request solve?

https://github.com/frappe/frappe/pull/14130 introduced user-wise grid configuration. This PR fixes untranslatable things in this dialog.

> Screenshots/GIFs

Before

<img width="500" alt="Screenshot 2021-10-25 at 20 26 01" src="https://user-images.githubusercontent.com/75225148/138742028-d4338bd9-21ab-45ab-8fa5-a6b42e99022f.png">

After

<img width="500" alt="Screenshot 2021-10-25 at 20 24 59" src="https://user-images.githubusercontent.com/75225148/138742046-fef9da41-45a9-4175-a814-b094dfa0aee9.png">

> no-docs