### PR TITLE
fix: patch failure due to incorrect args in query

### DIFF
--- a/frappe/patches/v11_0/remove_skip_for_doctype.py
+++ b/frappe/patches/v11_0/remove_skip_for_doctype.py
@@ -75,7 +75,7 @@ def execute():
 	if new_user_permissions_list:
 		frappe.qb.into("User Permission").columns(
 			"name", "user", "allow", "for_value", "applicable_for", "apply_to_all_doctypes", "creation", "modified"
-		).insert(tuple(new_user_permissions_list)).run()
+		).insert(*new_user_permissions_list).run()
 
 	if user_permissions_to_delete:
 		frappe.db.delete(


### PR DESCRIPTION
patches failing on ERPNext because of this query, ref: https://github.com/frappe/erpnext/runs/3998361123?check_suite_focus=true 

`insert` expects multiple tuples as `args`: https://pypika.readthedocs.io/en/latest/2_tutorial.html#inserting-data 

after this change: https://github.com/frappe/erpnext/runs/4006039052?check_suite_focus=true