### PR TITLE
fix: set maxlength property for Link fields

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -15,11 +15,6 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 			.addClass("input-with-feedback form-control")
 			.prependTo(this.input_area);
 
-		if (in_list(['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only', 'Attach', 'Attach Image'],
-			this.df.fieldtype)) {
-			this.$input.attr("maxlength", this.df.length || 140);
-		}
-
 		this.$input.on('paste', (e) => {
 			let pasted_data = frappe.utils.get_clipboard_data(e);
 			let maxlength = this.$input.attr('maxlength');
@@ -199,6 +194,13 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		}
 	}
 	set_input_attributes() {
+		if (in_list(
+			['Data', 'Link', 'Dynamic Link', 'Password', 'Select', 'Read Only'],
+			this.df.fieldtype
+		)) {
+			this.$input.attr("maxlength", this.df.length || 140);
+		}
+
 		this.$input
 			.attr("data-fieldtype", this.df.fieldtype)
 			.attr("data-fieldname", this.df.fieldname)


### PR DESCRIPTION
Solves a weird issue described here:
https://discuss.erpnext.com/t/user-gets-list-view-blank/81531

## Changes Made

- `maxlength` is an input attribute, so it should logically be set in `set_input_attributes`
- As can be seen in earlier code, `maxlength` was always intended to be set for **Link** and **Dynamic Link** fields. But because `make_input` is overridden in `ControlLink`, this doesn't happen as of now.
-  I double-checked the field types **Password**, **Select** and **Read Only** to ensure that this still works as expected.
- **Attach** and **Attach Image** types aren't being considered for `maxlength`. They were already overriding `make_input` so this wasn't working earlier either. And in any case, the input is just a button so this has no impact.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/16315650/138828174-6e0fafe7-14e0-497b-b237-3c8cb5fe5e11.png)


### After

![image](https://user-images.githubusercontent.com/16315650/138827963-bb2f117f-4cc6-4ffe-b47f-2080edaf574d.png)
