### PR TITLE
fix: allow submitting comment with images only

### DIFF
--- a/frappe/public/js/frappe/form/footer/footer.js
+++ b/frappe/public/js/frappe/form/footer/footer.js
@@ -30,7 +30,7 @@ frappe.ui.form.Footer = class FormFooter {
 				fieldname: 'comment'
 			},
 			on_submit: (comment) => {
-				if (strip_html(comment).trim() != "") {
+				if (strip_html(comment).trim() != "" || comment.includes('img')) {
 					this.frm.comment_box.disable();
 					frappe.xcall("frappe.desk.form.utils.add_comment", {
 						reference_doctype: this.frm.doctype,


### PR DESCRIPTION
If you just add a comment with image, there is no text left after stripping HTML. 

Changed condition to consider img tags while submitting comment. 