### PR TITLE
fix: Misc fixes

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -137,10 +137,10 @@ lang = local("lang")
 if typing.TYPE_CHECKING:
 	from frappe.database.mariadb.database import MariaDBDatabase
 	from frappe.database.postgres.database import PostgresDatabase
-	from pypika import Query
+	from frappe.query_builder.builder import MariaDB, Postgres
 
 	db: typing.Union[MariaDBDatabase, PostgresDatabase]
-	qb: Query
+	qb: typing.Union[MariaDB, Postgres]
 
 # end: static analysis hack
 

--- a/frappe/core/doctype/access_log/access_log.py
+++ b/frappe/core/doctype/access_log/access_log.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.utils import cstr
 from tenacity import retry, retry_if_exception_type, stop_after_attempt
 from frappe.model.document import Document
 
@@ -24,25 +25,21 @@ def make_access_log(
 	page=None,
 	columns=None,
 ):
-
 	user = frappe.session.user
 	in_request = frappe.request and frappe.request.method == "GET"
 
-	doc = frappe.get_doc(
-		{
-			"doctype": "Access Log",
-			"user": user,
-			"export_from": doctype,
-			"reference_document": document,
-			"file_type": file_type,
-			"report_name": report_name,
-			"page": page,
-			"method": method,
-			"filters": frappe.utils.cstr(filters) if filters else None,
-			"columns": columns,
-		}
-	)
-	doc.insert(ignore_permissions=True)
+	frappe.get_doc({
+		"doctype": "Access Log",
+		"user": user,
+		"export_from": doctype,
+		"reference_document": document,
+		"file_type": file_type,
+		"report_name": report_name,
+		"page": page,
+		"method": method,
+		"filters": cstr(filters) or None,
+		"columns": columns,
+	}).db_insert()
 
 	# `frappe.db.commit` added because insert doesnt `commit` when called in GET requests like `printview`
 	# dont commit in test mode

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -10,7 +10,7 @@ class TestWebsite(unittest.TestCase):
 		frappe.set_user('Guest')
 
 	def tearDown(self):
-		frappe.db.value_cache = {}
+		frappe.db.delete('Access Log')
 		frappe.set_user('Administrator')
 
 	def test_home_page(self):


### PR DESCRIPTION
### Changes

- Show "accurate" type hints for `frappe.qb`
- Use `db_insert` to make Access Logs instead of `insert`
- Clear Access Log table before each `TestWebsite` suite [flaky] 