### PR TITLE
fix: minor fixes for API Access section in User

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -263,6 +263,7 @@ frappe.ui.form.on('User', {
 			callback: function(r) {
 				if (r.message) {
 					frappe.msgprint(__("Save API Secret: {0}", [r.message.api_secret]));
+					frm.reload_doc();
 				}
 			}
 		});

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -555,20 +555,22 @@
    "collapsible": 1,
    "fieldname": "api_access",
    "fieldtype": "Section Break",
-   "label": "Api Access"
+   "label": "API Access"
   },
   {
-   "description": "API Key cannot be  regenerated",
+   "description": "API Key cannot be regenerated",
    "fieldname": "api_key",
    "fieldtype": "Data",
    "label": "API Key",
+   "permlevel": 1,
    "read_only": 1,
    "unique": 1
   },
   {
    "fieldname": "generate_keys",
    "fieldtype": "Button",
-   "label": "Generate Keys"
+   "label": "Generate Keys",
+   "permlevel": 1
   },
   {
    "fieldname": "column_break_65",
@@ -578,6 +580,7 @@
    "fieldname": "api_secret",
    "fieldtype": "Password",
    "label": "API Secret",
+   "permlevel": 1,
    "read_only": 1
   },
   {
@@ -671,7 +674,7 @@
   }
  ],
  "max_attachments": 5,
- "modified": "2021-10-18 16:56:05.578379",
+ "modified": "2021-10-27 17:17:16.098457",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",


### PR DESCRIPTION
## Changes Made
- `reload_doc` on successful generation of API key/secret
- Set appropriate `permlevel`: `generate_keys` is only allowed for `System Manager`
- Fix label and description