### PR TITLE
fix: improved sanitization of fields

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -4,7 +4,6 @@
 
 import os
 import logging
-import re
 
 from werkzeug.local import LocalManager
 from werkzeug.wrappers import Request, Response

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -4,6 +4,7 @@
 
 import os
 import logging
+import re
 
 from werkzeug.local import LocalManager
 from werkzeug.wrappers import Request, Response

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -45,7 +45,7 @@ def execute_cmd(cmd, from_async=False):
 
 	from frappe.utils import sanitize_html
 
-	cmd = sanitize_html(cmd)
+	cmd = sanitize_html(cmd, strip=True)
 
 	"""execute a request as python module"""
 	for hook in frappe.get_hooks("override_whitelisted_methods", {}).get(cmd, []):

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -42,12 +42,12 @@ def handle():
 	return build_response("json")
 
 def execute_cmd(cmd, from_async=False):
+	"""execute a request as python module"""
 
 	from frappe.utils import sanitize_html
 
 	cmd = sanitize_html(cmd, strip=True)
 
-	"""execute a request as python module"""
 	for hook in frappe.get_hooks("override_whitelisted_methods", {}).get(cmd, []):
 		# override using the first hook
 		cmd = hook

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -42,6 +42,11 @@ def handle():
 	return build_response("json")
 
 def execute_cmd(cmd, from_async=False):
+
+	from frappe.utils import sanitize_html
+
+	cmd = sanitize_html(cmd)
+
 	"""execute a request as python module"""
 	for hook in frappe.get_hooks("override_whitelisted_methods", {}).get(cmd, []):
 		# override using the first hook

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -813,7 +813,7 @@ class BaseDocument(object):
 				continue
 
 			else:
-				sanitized_value = sanitize_html(value, linkify=df and df.fieldtype=='Text Editor')
+				sanitized_value = sanitize_html(value, strip=df.get("fieldtype") in ("Data", "Small Text", "Text"))
 
 			self.set(fieldname, sanitized_value)
 

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -230,6 +230,7 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		return val==null ? "" : val;
 	}
 	validate(v) {
+		var field_types = ['Data', 'Small Text', 'Text', 'Long Text'];
 		if (!v) {
 			return '';
 		}
@@ -259,6 +260,9 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		} else if (this.df.options == 'URL') {
 			this.df.invalid = !validate_url(v);
 			return v;
+		} else if (field_types.includes(this.df.fieldtype)  && !this.df.ignore_xss_filter) {
+			var sanitised_value = frappe.utils.xss_sanitise(v);
+			return sanitised_value;
 		} else {
 			return v;
 		}

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -247,6 +247,7 @@ frappe.is_mobile = function () {
 
 frappe.utils.xss_sanitise = function (string, options) {
 	// Reference - https://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet
+	if (!string) return;
 	let sanitised = string; // un-sanitised string.
 	const DEFAULT_OPTIONS = {
 		strategies: ['html', 'js'] // use all strategies.
@@ -261,6 +262,11 @@ frappe.utils.xss_sanitise = function (string, options) {
 	const REGEX_SCRIPT = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi; // used in jQuery 1.7.2 src/ajax.js Line 14
 	options = Object.assign({}, DEFAULT_OPTIONS, options); // don't deep copy, immutable beauty.
 
+	// Rule 3 - TODO: Check event handlers?
+	if (options.strategies.includes('js')) {
+		sanitised = sanitised.replace(REGEX_SCRIPT, "");
+	}
+
 	// Rule 1
 	if (options.strategies.includes('html')) {
 		for (let char in HTML_ESCAPE_MAP) {
@@ -268,11 +274,6 @@ frappe.utils.xss_sanitise = function (string, options) {
 			const regex = new RegExp(char, "g");
 			sanitised = sanitised.replace(regex, escape);
 		}
-	}
-
-	// Rule 3 - TODO: Check event handlers?
-	if (options.strategies.includes('js')) {
-		sanitised = sanitised.replace(REGEX_SCRIPT, "");
 	}
 
 	return sanitised;

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -174,3 +174,19 @@ class TestMethodAPI(unittest.TestCase):
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(response.json(), dict)
 		self.assertEqual(response.json()['message'], "pong")
+
+	def test_xss_filter(self):
+		# test 3: test for /api/method/{method_name_with_xss}
+		response = requests.get(f"{self.METHOD_URL}/frappe.realtime.get_user_info<img src=x onerror=alert(1)")
+		self.assertEqual(response.status_code, 200)
+		self.assertIsInstance(response.json(), dict)
+		self.assertEqual(response.json()['message']['user'], "Guest")
+
+	def test_xss_filter2(self):
+		# test 4: test for /?cmd={method_name_with_xss}
+		response = requests.get(f"{get_site_url(frappe.local.site)}/?cmd=web_logout<img src=x onerror=alert(1)")
+		self.assertEqual(response.status_code, 200)
+
+		# test 5: test for error method
+		from frappe.handler import execute_cmd
+		self.assertRaises(frappe.ValidationError, execute_cmd,"test<img src=x onerror=alert(1)")

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -171,7 +171,7 @@ class TestDocument(unittest.TestCase):
 		d.reload()
 
 		self.assertTrue(xss not in d.subject)
-		self.assertTrue(escaped_xss in d.subject)
+		self.assertTrue(escaped_xss not in d.subject)
 
 		# onload
 		xss = '<div onload="alert("XSS")">Test</div>'

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -165,31 +165,23 @@ class TestDocument(unittest.TestCase):
 		d = self.test_insert()
 
 		# script
-		xss = '<script>alert("XSS")</script>'
-		escaped_xss = xss.replace('<', '&lt;').replace('>', '&gt;')
+		xss = '<script>alert("XSS")</script>test<img src=x onerror=alert(1)'
+		escaped_xss = 'alert("XSS")test'
 		d.subject += xss
 		d.save()
 		d.reload()
 
 		self.assertTrue(xss not in d.subject)
-		self.assertTrue(escaped_xss not in d.subject)
+		self.assertTrue(escaped_xss in d.subject)
 
 		# not allowed tags are stripped only for fieldtype Data, Text, Small Text
-		d.description = xss
-		escaped_xss = xss.replace('<', '&lt;').replace('>', '&gt;')
+		xss_description = 'test<script>alert("XSS")</script>'
+		d.description = xss_description
+		escaped_xss = xss_description.replace('<', '&lt;').replace('>', '&gt;')
 		d.save()
 		d.reload()
 
 		self.assertTrue(escaped_xss in d.description)
-
-		xss2 = 'test;<img src=x onerror=alert(1)'
-		filtered_xss = 'test;'
-		d.subject += xss2
-		d.save()
-		d.reload()
-
-		self.assertTrue(xss2 not in d.subject)
-		self.assertTrue(filtered_xss in d.subject)
 
 		# onload
 		xss = '<div onload="alert("XSS")">Test</div>'

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -6,7 +6,6 @@ import unittest
 import frappe
 from frappe.utils import cint
 from frappe.model.naming import revert_series_if_last, make_autoname, parse_naming_series
-from frappe.utils import sanitize_html
 
 
 class TestDocument(unittest.TestCase):

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -544,7 +544,7 @@ def markdown(text, sanitize=True, linkify=True):
 
 	if sanitize:
 		html = html.replace("<!-- markdown -->", "")
-		html = sanitize_html(html, linkify=linkify)
+		html = sanitize_html(html)
 
 	return html
 

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -68,15 +68,9 @@ def sanitize_html(html, strip=False):
 	elif is_json(html):
 		return html
 
-	# regex for finding unicode characters like %3E, %3c
-	regex = re.compile(r"%[0-9]?[0-9a-zA-Z]?")
-	char_list = set(regex.findall(html))
-
 	if (u"<" not in html and u">" not in html) \
-		and not bool(char_list) and not bool(BeautifulSoup(html, 'html.parser').find()):
+		and not bool(BeautifulSoup(html, 'html.parser').find()):
 		return html
-
-	html = strip_encoded_chars(html, char_list) if bool(char_list) else html
 
 	tags = (acceptable_elements + svg_elements + mathml_elements
 		+ ["html", "head", "meta", "link", "body", "style", "o:p"])
@@ -125,11 +119,6 @@ def get_icon_html(icon, small=False):
 def unescape_html(value):
 	from html import unescape
 	return unescape(value)
-
-def strip_encoded_chars(html, char_list):
-	for d in char_list:
-		html = html.replace(d, '')
-	return html
 
 # adapted from https://raw.githubusercontent.com/html5lib/html5lib-python/4aa79f113e7486c7ec5d15a6e1777bfe546d3259/html5lib/sanitizer.py
 acceptable_elements = [

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -60,7 +60,6 @@ def sanitize_html(html, strip=False):
 	"""
 	import bleach
 	from bs4 import BeautifulSoup
-	import re
 
 	if not isinstance(html, str):
 		return html
@@ -68,6 +67,7 @@ def sanitize_html(html, strip=False):
 	elif is_json(html):
 		return html
 
+	# returns false for cases like `<img src='x' alert(1)`
 	if (u"<" not in html and u">" not in html) \
 		and not bool(BeautifulSoup(html, 'html.parser').find()):
 		return html
@@ -77,7 +77,6 @@ def sanitize_html(html, strip=False):
 	attributes = {"*": acceptable_attributes, 'svg': svg_attributes}
 	styles = bleach_allowlist.all_styles
 	strip_comments = False
-	strip = strip
 
 	# returns html with escaped tags, escaped orphan >, <, etc.
 	escaped_html = bleach.clean(html, tags=tags, attributes=attributes, styles=styles,

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -69,10 +69,10 @@ def sanitize_html(html, strip=False):
 		return html
 
 	# regex for finding unicode characters like %3E, %3c
-	regex = re.compile(r"%[0-9]?[a-zA-Z]?")
-	char_list = regex.findall(html)
+	regex = re.compile(r"%[0-9]?[0-9a-zA-Z]?")
+	char_list = set(regex.findall(html))
 
-	if (u"<" not in html or u">" not in html) \
+	if (u"<" not in html and u">" not in html) \
 		and not bool(char_list) and not bool(BeautifulSoup(html, 'html.parser').find()):
 		return html
 

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -51,7 +51,7 @@ def clean_script_and_style(html):
 		s.decompose()
 	return frappe.as_unicode(soup)
 
-def sanitize_html(html, linkify=False):
+def sanitize_html(html, strip=False):
 	"""
 	Sanitize HTML tags, attributes and style to prevent XSS attacks
 	Based on bleach clean, bleach whitelist and html5lib's Sanitizer defaults
@@ -72,8 +72,8 @@ def sanitize_html(html, linkify=False):
 	regex = re.compile(r"%[0-9]?[a-zA-Z]?")
 	char_list = regex.findall(html)
 
-	if not bool(BeautifulSoup(html, 'html.parser').find()) \
-		and not bool(char_list) and (u"<" not in html and u">" not in html):
+	if (u"<" not in html or u">" not in html) \
+		and not bool(char_list) and not bool(BeautifulSoup(html, 'html.parser').find()):
 		return html
 
 	html = strip_encoded_chars(html, char_list) if bool(char_list) else html
@@ -83,10 +83,11 @@ def sanitize_html(html, linkify=False):
 	attributes = {"*": acceptable_attributes, 'svg': svg_attributes}
 	styles = bleach_allowlist.all_styles
 	strip_comments = False
+	strip = strip
 
 	# returns html with escaped tags, escaped orphan >, <, etc.
 	escaped_html = bleach.clean(html, tags=tags, attributes=attributes, styles=styles,
-		strip_comments=strip_comments, strip=True, protocols=['cid', 'http', 'https', 'mailto'])
+		strip_comments=strip_comments, strip=strip, protocols=['cid', 'http', 'https', 'mailto'])
 
 	return escaped_html
 

--- a/frappe/www/search.py
+++ b/frappe/www/search.py
@@ -14,7 +14,7 @@ def get_context(context):
 		context.title = _('Search Results for')
 		context.query = query
 		context.route = '/search'
-		context.update(get_search_results(query, frappe.utils.sanitize_html(frappe.form_dict.scope)))
+		context.update(get_search_results(query, sanitize_html(frappe.form_dict.scope)))
 	else:
 		context.title = _('Search')
 


### PR DESCRIPTION
### Why?
Due to improper sanitization of data fields, many XSS reports were reported.

### Solution
- Added Client-side filtering for XSS payloads for field type Data, Small Text, Text, Long Text.
![ezgif com-gif-maker](https://user-images.githubusercontent.com/30501401/151100156-55c220a6-1c75-4bd2-aa02-167afb5b7eca.gif)

- Added option to strip the HTML content in `sanitize_html`method if the field type is Data, text, or small text. 
  - This is a kinda breaking change but the previous parameter was never used anywhere in the codebase neither it was used in the method itself.
  - Strip parameter strips the payload entirely from the payload if True. Default is False.
- Added filtering for method payloads injected directly in the URL. such as 
  - `/api/method/<anymethod><script>alert()</script>`
  - `/?cmd=example<script>alert()</script>`

#### ToDo
- Parameter filtering in the request
