### PR TITLE
fix(minor): Don't allow frappe.cache() methods in server scripts

### DIFF
--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -70,16 +70,6 @@ frappe.method_that_doesnt_exist("do some magic")
 		script = '''
 frappe.db.commit()
 '''
-	),
-	dict(
-		name='test_cache_methods',
-		script_type = 'DocType Event',
-		doctype_event = 'Before Save',
-		reference_doctype = 'ToDo',
-		disabled = 1,
-		script = '''
-frappe.cache().set_value('test_key', doc.name)
-'''
 	)
 ]
 class TestServerScript(unittest.TestCase):
@@ -146,17 +136,6 @@ class TestServerScript(unittest.TestCase):
 		server_script.save()
 
 		self.assertRaises(AttributeError, frappe.get_doc(dict(doctype='ToDo', description='test me')).insert)
-
-		server_script.disabled = 1
-		server_script.save()
-
-	def test_cache_methods_in_server_script(self):
-		server_script = frappe.get_doc('Server Script', 'test_cache_methods')
-		server_script.disabled = 0
-		server_script.save()
-
-		todo = frappe.get_doc(dict(doctype='ToDo', description='test me')).insert()
-		self.assertEqual(todo.name, frappe.cache().get_value('test_key'))
 
 		server_script.disabled = 1
 		server_script.save()

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -174,8 +174,6 @@ def get_safe_globals():
 			rollback=frappe.db.rollback,
 		)
 
-		out.frappe.cache = cache
-
 	if frappe.response:
 		out.frappe.response = frappe.response
 
@@ -192,14 +190,6 @@ def get_safe_globals():
 	out.sorted = sorted
 
 	return out
-
-def cache():
-	return NamespaceDict(
-		get_value = frappe.cache().get_value,
-		set_value = frappe.cache().set_value,
-		hset = frappe.cache().hset,
-		hget = frappe.cache().hget
-	)
 
 def get_hooks(hook=None, default=None, app_name=None):
 	hooks = frappe.get_hooks(hook=hook, default=default, app_name=app_name)


### PR DESCRIPTION
This was introduced via https://github.com/frappe/frappe/pull/14140