### PR TITLE
test: enable scheduler back after running the test

### DIFF
--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -77,6 +77,7 @@ def main(app=None, module=None, doctype=None, verbose=False, tests=(),
 		else:
 			ret = run_all_tests(app, verbose, profile, ui_tests, failfast=failfast, junit_xml_output=junit_xml_output)
 
+		frappe.utils.scheduler.enable_scheduler()
 		if frappe.db: frappe.db.commit()
 
 		# workaround! since there is no separate test db


### PR DESCRIPTION
- Running test locally disables the scheduler. Many critical operations depend on the scheduler.
- Addded `enable_scheduler` after running the tests