### PR TITLE
test: restore scheduler state after running tests

### DIFF
--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -60,7 +60,10 @@ def main(app=None, module=None, doctype=None, verbose=False, tests=(),
 
 		# workaround! since there is no separate test db
 		frappe.clear_cache()
-		frappe.utils.scheduler.disable_scheduler()
+		scheduler_disabled_by_user = frappe.utils.scheduler.is_scheduler_disabled()
+		if not scheduler_disabled_by_user:
+			frappe.utils.scheduler.disable_scheduler()
+
 		set_test_email_config()
 		frappe.conf.update({'bench_id': 'test_bench', 'use_rq_auth': False})
 
@@ -77,7 +80,9 @@ def main(app=None, module=None, doctype=None, verbose=False, tests=(),
 		else:
 			ret = run_all_tests(app, verbose, profile, ui_tests, failfast=failfast, junit_xml_output=junit_xml_output)
 
-		frappe.utils.scheduler.enable_scheduler()
+		if not scheduler_disabled_by_user:
+			frappe.utils.scheduler.enable_scheduler()
+
 		if frappe.db: frappe.db.commit()
 
 		# workaround! since there is no separate test db


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/14798 enabled scheduler after running tests. However, the user might have intentionally disabled it. So for better dx, just respect the state it was before running the test. 