### PR TITLE
fix: old style links in global search

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -354,7 +354,7 @@ frappe.search.SearchDialog = class {
 	get_link(result) {
 		let link = "";
 		if (result.route) {
-			link = `href="#${result.route.join("/")}"`;
+			link = `href="/app/${result.route.join("/")}"`;
 		} else if (result.data_path) {
 			link = `data-path=${result.data_path}"`;
 		}


### PR DESCRIPTION
clicking global search result links shows error (routes correctly though 🤷 )



https://user-images.githubusercontent.com/9079960/139467692-0c8fd608-5112-47da-863c-dfdd45ba0183.mov



