### PR TITLE
refactor: (slightly) better whitelisting

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -668,7 +668,7 @@ def only_for(roles, message=False):
 
 	:param roles (list / tuple / str): Permitted role(s)
 	"""
-	if local.flags.in_test:
+	if local.flags.in_test or session.user == "Administrator":
 		return
 
 	if not isinstance(roles, (tuple, list)):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -669,7 +669,7 @@ def only_for(roles, message=False):
 
 	:param roles (list / tuple / str): Permitted role(s)
 	"""
-	if local.flags.in_test or session.user == "Administrator":
+	if flags.in_test or session.user == "Administrator":
 		return
 
 	if not isinstance(roles, (tuple, list)):

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -780,8 +780,7 @@ def request(context, args=None, path=None):
 
 				frappe.local.form_dict = frappe._dict(args)
 
-			frappe.handler.execute_cmd(frappe.form_dict.cmd)
-
+			frappe.handler.handle()
 			print(frappe.response)
 		finally:
 			frappe.destroy()

--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -4,14 +4,13 @@
 import frappe
 from frappe import _, throw
 import frappe.utils.user
-from frappe.permissions import check_admin_or_system_manager, rights
+from frappe.permissions import rights
 from frappe.model import data_fieldtypes
 
 def execute(filters=None):
+	frappe.only_for("System Manager")
+
 	user, doctype, show_permissions = filters.get("user"), filters.get("doctype"), filters.get("show_permissions")
-
-	if not validate(user, doctype): return [], []
-
 	columns, fields = get_columns_and_fields(doctype)
 	data = frappe.get_list(doctype, fields=fields, as_list=True, user=user)
 
@@ -23,11 +22,6 @@ def execute(filters=None):
 			data[i] = doc + tuple(permission.get(right) for right in rights)
 
 	return columns, data
-
-def validate(user, doctype):
-	# check if current user is System Manager
-	check_admin_or_system_manager()
-	return user and doctype
 
 def get_columns_and_fields(doctype):
 	columns = ["Name:Link/{}:200".format(doctype)]

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -1,13 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-# Search
-import frappe, json
+import re
+import json
+import wrapt
+
+import frappe
+from frappe import _
 from frappe.utils import cstr, unique, cint
 from frappe.permissions import has_permission
-from frappe import _, is_whitelisted
-import re
-import wrapt
+from frappe.handler import get_whitelisted_method
+
 
 UNTRANSLATED_DOCTYPES = ["DocType", "Role"]
 
@@ -74,7 +77,7 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 	if query and query.split()[0].lower()!="select":
 		# by method
 		try:
-			is_whitelisted(frappe.get_attr(query))
+			query = get_whitelisted_method(query)
 			frappe.response["values"] = frappe.call(query, doctype, txt,
 				searchfield, start, page_length, filters, as_dict=as_dict)
 		except frappe.exceptions.PermissionError as e:

--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -3,21 +3,16 @@
 
 import frappe
 from frappe import _
+from frappe.handler import get_whitelisted_method
 
 @frappe.whitelist()
 def get_all_nodes(doctype, label, parent, tree_method, **filters):
 	'''Recursively gets all data from tree nodes'''
 
-	if 'cmd' in filters:
-		del filters['cmd']
-	filters.pop('data', None)
+	for filter_ in ("cmd", "data"):
+		filters.pop(filter_, None)
 
-	tree_method = frappe.get_attr(tree_method)
-
-	if not tree_method in frappe.whitelisted:
-		frappe.throw(_("Not Permitted"), frappe.PermissionError)
-
-	data = tree_method(doctype, parent, **filters)
+	data = get_whitelisted_method(tree_method)(doctype, parent, **filters)
 	out = [dict(parent=label, data=data)]
 
 	if 'is_root' in filters:

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -25,7 +25,7 @@ def handle():
 	"""handle request"""
 
 	data = execute_cmd()
-  
+
 	# data can be an empty string or list which are valid responses
 	if data is not None:
 		if isinstance(data, Response):

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -4,6 +4,7 @@ import json
 
 import frappe
 from frappe import _
+from frappe.handler import get_whitelisted_method
 from frappe.model import default_fields, table_fields
 from frappe.utils import cstr
 
@@ -15,15 +16,7 @@ def make_mapped_doc(method, source_name, selected_children=None, args=None):
 
 	Called from `open_mapped_doc` from create_new.js'''
 
-	for hook in frappe.get_hooks("override_whitelisted_methods", {}).get(method, []):
-		# override using the first hook
-		method = hook
-		break
-
-	method = frappe.get_attr(method)
-
-	if method not in frappe.whitelisted:
-		raise frappe.PermissionError
+	method = get_whitelisted_method(method)
 
 	if selected_children:
 		selected_children = json.loads(selected_children)
@@ -43,9 +36,7 @@ def map_docs(method, source_names, target_doc, args=None):
 	:param args: Args as string to pass to the mapper method
 	E.g. args: "{ 'supplier': 'XYZ' }" '''
 
-	method = frappe.get_attr(method)
-	if method not in frappe.whitelisted:
-		raise frappe.PermissionError
+	method = get_whitelisted_method(method)
 
 	for src in json.loads(source_names):
 		_args = (src, target_doc, json.loads(args)) if args else (src, target_doc)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -11,13 +11,6 @@ from frappe.query_builder import DocType
 rights = ("select", "read", "write", "create", "delete", "submit", "cancel", "amend",
 	"print", "email", "report", "import", "export", "set_user_permissions", "share")
 
-
-def check_admin_or_system_manager(user=None):
-	if not user: user = frappe.session.user
-
-	if ("System Manager" not in frappe.get_roles(user)) and (user!="Administrator"):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
-
 def print_has_permission_check_logs(func):
 	def inner(*args, **kwargs):
 		frappe.flags['has_permission_check_logs'] = []


### PR DESCRIPTION
## Changes Made
- `frappe.whitelisted` is now a dict with conditions of whitelisting as value (backwards compatible)
- Removed:
  -  `frappe.guest_methods`
  -  `frappe.xss_safe_methods`
  -  `frappe.allowed_http_methods_for_whitelisted_func`
- Add `roles` parameter to `frappe.whitelist` (syntactic sugar replacement of `frappe.only_for`)
- Standardised use of `get_whitelisted_method`: this allows `override_whitelisted_methods` hook to always work 🎉 
- Trying to run a sever script method has been moved up in precedence over trying to find a method overwritten using `overrride_whitelisted_methods`. Logically, if someone is using `override_whitelist_methods`, it's very unlikely they want to override the method using a Server Script. It'd be easier for them to just continue coding the new method in the app itself.
- I've not been able to detect use of the `from_async` parameter in `execute_cmd`. Perhaps it's dead code, so removed.
- Running `execute_cmd` in backend always failed previously because it would fail trying to validate the HTTP method. Now the HTTP method is validated only if `frappe.request` is truthy.

## Better Error Handling

### Before

![image](https://user-images.githubusercontent.com/16315650/139529335-825a4250-01b7-4a49-afcd-55fa20684dd5.png)

### After

![Screenshot-2021-10-30-160003](https://user-images.githubusercontent.com/16315650/139529343-d5b34d25-6d9a-4dba-a5ff-fa9bb53cfe59.png)

