### PR TITLE
chore: change log for v12.23.0

### DIFF
--- a/frappe/change_log/v12/v12_23_0.md
+++ b/frappe/change_log/v12/v12_23_0.md
@@ -1,0 +1,7 @@
+## Frappe Version 12.23.0 Release Notes
+
+### Fixes & Enhancements
+
+- Shift+tab keyboard navigation ([#14243](https://github.com/frappe/frappe/pull/14243))
+- Include space and tab in special characters to match to encode url ([#12632](https://github.com/frappe/frappe/pull/12632))
+- `convert_dates_to_str` converts everything except `date` objects ([#14340](https://github.com/frappe/frappe/pull/14340))


### PR DESCRIPTION
## Frappe Version 12.23.0 Release Notes

### Fixes & Enhancements

- Shift+tab keyboard navigation ([#14243](https://github.com/frappe/frappe/pull/14243))
- Include space and tab in special characters to match to encode url ([#12632](https://github.com/frappe/frappe/pull/12632))
- `convert_dates_to_str` converts everything except `date` objects ([#14340](https://github.com/frappe/frappe/pull/14340))