### PR TITLE
fix: Added check to validate chat room members

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -23,7 +23,7 @@ if sys.version[0] == '2':
 	reload(sys)
 	sys.setdefaultencoding("utf-8")
 
-__version__ = '12.21.1'
+__version__ = '12.22.0'
 __title__ = "Frappe Framework"
 
 local = Local()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -23,7 +23,7 @@ if sys.version[0] == '2':
 	reload(sys)
 	sys.setdefaultencoding("utf-8")
 
-__version__ = '12.22.0'
+__version__ = 'Release 12.22.1'
 __title__ = "Frappe Framework"
 
 local = Local()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -23,7 +23,7 @@ if sys.version[0] == '2':
 	reload(sys)
 	sys.setdefaultencoding("utf-8")
 
-__version__ = '12.22.2'
+__version__ = '12.23.0'
 __title__ = "Frappe Framework"
 
 local = Local()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -23,7 +23,7 @@ if sys.version[0] == '2':
 	reload(sys)
 	sys.setdefaultencoding("utf-8")
 
-__version__ = 'Release 12.22.1'
+__version__ = '12.22.2'
 __title__ = "Frappe Framework"
 
 local = Local()

--- a/frappe/change_log/v12/v12_22_0.md
+++ b/frappe/change_log/v12/v12_22_0.md
@@ -1,0 +1,8 @@
+## Version 12.22.0 Release Notes
+
+### Fixes & Enhancements
+
+- Switch writes to primary when wrapped with read_only ([#14142](https://github.com/frappe/frappe/pull/14142))
+- Custom database port for read-only replica configuration ([#14159](https://github.com/frappe/frappe/pull/14159))
+- Date or datetime fields disappearing on save ([#14139](https://github.com/frappe/frappe/pull/14139))
+- Accurately cast fieldtype in frappe.db.get_single_value() ([#13655](https://github.com/frappe/frappe/pull/13655))

--- a/frappe/change_log/v12/v12_23_0.md
+++ b/frappe/change_log/v12/v12_23_0.md
@@ -1,0 +1,7 @@
+## Frappe Version 12.23.0 Release Notes
+
+### Fixes & Enhancements
+
+- Shift+tab keyboard navigation ([#14243](https://github.com/frappe/frappe/pull/14243))
+- Include space and tab in special characters to match to encode url ([#12632](https://github.com/frappe/frappe/pull/12632))
+- `convert_dates_to_str` converts everything except `date` objects ([#14340](https://github.com/frappe/frappe/pull/14340))

--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -132,6 +132,9 @@ def get_new_chat_message(user, room, content, type = "Content"):
 
 @frappe.whitelist(allow_guest = True)
 def send(user, room, content, type = "Content"):
+	if user != frappe.session.user:
+		user = frappe.session.user
+
 	mess = get_new_chat_message(user, room, content, type)
 
 	frappe.publish_realtime('frappe.chat.message:create', mess, room = room,
@@ -165,6 +168,9 @@ def history(room, fields = None, limit = 10, start = None, end = None):
 		order_by = 'creation'
 	)
 
+	# validate chat room members
+	validate_members(room)
+
 	if not fields or 'seen' in fields:
 		for m in mess:
 			m['seen'] = json.loads(m._seen) if m._seen else [ ]
@@ -191,6 +197,18 @@ def mark_messages_as_seen(message_names, user):
 		frappe.db.set_value('Chat Message', name, '_seen', seen, update_modified=False)
 
 	frappe.db.commit()
+
+def validate_members(room):
+	user = frappe.session.user
+
+	members = []
+	for d in room.users:
+		members.append(d.user)
+
+	if user in members or user == room.owner:
+		return
+	else:
+		frappe.throw("Chat Room {} not found".format(room))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
### Bug
Earlier anybody can intercept the request and send a message in a group impersonating someone else and by manipulating the chat room from the request body one could see chat messages from another group or someone else's chat box.

### Fix

- Messages can be sent as session users only
- Added check to validate chat room members 
