### PR TITLE
fix: add "0.0.0.0" in server.listen(), socketio.js

### DIFF
--- a/socketio.js
+++ b/socketio.js
@@ -11,7 +11,9 @@ var conf = get_conf();
 var subscriber = get_redis_subscriber();
 
 // serve socketio
-server.listen(conf.socketio_port, function () {
+
+// add "0.0.0.0", node ip will be ipv4 and not ipv6
+server.listen(conf.socketio_port, "0.0.0.0", function () {
 	log('listening on *:', conf.socketio_port); //eslint-disable-line
 });
 


### PR DESCRIPTION
## add "0.0.0.0", node ip will be ipv4 and not ipv6
Actually, I don't know if it's really useful, but when node is with an ipv6 (see with netstat -nplt), it creates a bug with socketio.