### PR TITLE
fix(UI): Translate preview popover data

### DIFF
--- a/frappe/desk/link_preview.py
+++ b/frappe/desk/link_preview.py
@@ -40,6 +40,10 @@ def get_preview_data(doctype, docname):
 
 	for key, val in preview_data.items():
 		if val and meta.has_field(key) and key not in [image_field, title_field, 'name']:
-			formatted_preview_data[meta.get_field(key).label] = frappe.format(val, meta.get_field(key).fieldtype)
+			formatted_preview_data[meta.get_field(key).label] = frappe.format(
+				val,
+				meta.get_field(key).fieldtype,
+				translated=True,
+			)
 
 	return formatted_preview_data


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Data in preview popover is not translated, but it could be. This PR fixes the bug.

> Screenshots/GIFs

In this example `status` field is not translated before change. Now it is.

Before:

<img width="300" alt="Screenshot 2021-10-31 at 08 07 37" src="https://user-images.githubusercontent.com/75225148/139568773-d9298cca-89c9-4907-86d5-ea7641bf2125.png">

After:

<img width="300" alt="Screenshot 2021-10-31 at 08 07 20" src="https://user-images.githubusercontent.com/75225148/139568769-caf4e225-3877-450f-9ffa-0db9aeeb3d88.png">
