### PR TITLE
fix: patch failure due to new field in doctype

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -178,6 +178,7 @@ frappe.patches.v13_0.rename_list_view_setting_to_list_view_settings
 frappe.patches.v13_0.remove_twilio_settings
 frappe.patches.v12_0.rename_uploaded_files_with_proper_name
 frappe.patches.v13_0.queryreport_columns
+execute:frappe.reload_doc('core', 'doctype', 'doctype')
 frappe.patches.v13_0.jinja_hook
 frappe.patches.v13_0.update_notification_channel_if_empty
 frappe.patches.v14_0.drop_data_import_legacy


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/14245 
introduced via https://github.com/frappe/frappe/pull/13786 