### PR TITLE
fix: consider parent permissions in `get_list`

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -26,6 +26,8 @@ class DatabaseQuery(object):
 		self.user = user or frappe.session.user
 		self.ignore_ifnull = False
 		self.flags = frappe._dict()
+		self.parent_doctype = None
+		self.permission_doctype = doctype
 		self.reference_doctype = None
 
 	def execute(self, fields=None, filters=None, or_filters=None,

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -42,13 +42,16 @@ def has_permission(doctype, ptype="read", doc=None, verbose=False, user=None, ra
 	"""
 	if not user: user = frappe.session.user
 
+	if user == "Administrator":
+		return True
+
 	if not doc and hasattr(doctype, 'doctype'):
 		# first argument can be doc or doctype
 		doc = doctype
 		doctype = doc.doctype
 
-	if user == "Administrator":
-		return True
+	if isinstance(doc, str):
+		doc = frappe.get_doc(doctype, doc)
 
 	if frappe.is_table(doctype):
 		return has_child_table_permission(doctype, ptype, doc, verbose,
@@ -57,8 +60,6 @@ def has_permission(doctype, ptype="read", doc=None, verbose=False, user=None, ra
 	meta = frappe.get_meta(doctype)
 
 	if doc:
-		if isinstance(doc, str):
-			doc = frappe.get_doc(meta.name, doc)
 		perm = get_doc_permissions(doc, user=user, ptype=ptype).get(ptype)
 		if not perm: push_perm_check_log(_('User {0} does not have access to this document').format(frappe.bold(user)))
 	else:


### PR DESCRIPTION
This PR brings proper parent permission checking to `frappe.get_list`

## Changes Made

### `db_query.py`
- Create a new `permission_doctype` property. It's the `parent_doctype` in case a child table is being accessed. This is because a child table doesn't have permissions of it's own.
- Update `build_match_conditions` to account for `permission_doctype`.
- Append the parent doctype to `self.tables`  if share condition need to be checked. The query is later built based on that.
- As of now, this PR allows a parent document to be accessed when querying a child table. This can be prevented if needed.

### `permissions.py`
- Allow `child_doc` to be string for consistency with existing code for parent doc
- Move up condition for `Administrator`

To be backported like #14610 and #14611 once merged.