### PR TITLE
fix(minor): add classes for rtl for proper layout 

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -55,6 +55,10 @@ Quill.register(FontStyle, true);
 Quill.register(AlignStyle, true);
 Quill.register(DirectionStyle, true);
 
+// direction class
+const DirectionClass = Quill.import('attributors/class/direction');
+Quill.register(DirectionClass,true);
+
 // replace font tag with span
 const Inline = Quill.import('blots/inline');
 

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -57,7 +57,7 @@ Quill.register(DirectionStyle, true);
 
 // direction class
 const DirectionClass = Quill.import('attributors/class/direction');
-Quill.register(DirectionClass,true);
+Quill.register(DirectionClass, true);
 
 // replace font tag with span
 const Inline = Quill.import('blots/inline');


### PR DESCRIPTION
**Issue**
When we use RTL(from the tools) direction for LTR languages, the list layout is broken.

*****Steps to reproduce*****
1. create a test doctype/use an existing one with text editor field.
2. make a list of item 
3. use the RTL tool to make it align right
4. you can observe the layout of the list items as:

<img width="999" alt="Screenshot 2021-11-01 at 10 43 37 AM" src="https://user-images.githubusercontent.com/58825865/139624706-3bd0aeaf-c82a-483a-bbab-0b99985768e7.png">


**After Fix**
<img width="781" alt="Screenshot 2021-10-31 at 8 01 09 PM" src="https://user-images.githubusercontent.com/58825865/139588463-689bdb10-49cc-4131-af45-86ddbc6c9bda.png">

