### PR TITLE
fix: add check to validate chat room members

### DIFF
--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -209,7 +209,7 @@ def validate_members(room):
 	if user_in_room:
 		return
 
-	frappe.throw("Chat Room {} not found".format(room))
+	frappe.throw(_("Chat Room {} not found").format(room))
 
 
 @frappe.whitelist()

--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -132,6 +132,9 @@ def get_new_chat_message(user, room, content, type = "Content"):
 
 @frappe.whitelist(allow_guest = True)
 def send(user, room, content, type = "Content"):
+	if user != frappe.session.user:
+		user = frappe.session.user
+
 	mess = get_new_chat_message(user, room, content, type)
 
 	frappe.publish_realtime('frappe.chat.message:create', mess, room = room,
@@ -165,6 +168,9 @@ def history(room, fields = None, limit = 10, start = None, end = None):
 		order_by = 'creation'
 	)
 
+	# validate chat room members
+	validate_members(room)
+
 	if not fields or 'seen' in fields:
 		for m in mess:
 			m['seen'] = json.loads(m._seen) if m._seen else [ ]
@@ -191,6 +197,18 @@ def mark_messages_as_seen(message_names, user):
 		frappe.db.set_value('Chat Message', name, '_seen', seen, update_modified=False)
 
 	frappe.db.commit()
+
+def validate_members(room):
+	user = frappe.session.user
+
+	members = []
+	for d in room.users:
+		members.append(d.user)
+
+	if user in members or user == room.owner:
+		return
+	else:
+		frappe.throw("Chat Room {} not found".format(room))
 
 
 @frappe.whitelist()

--- a/frappe/chat/doctype/chat_message/chat_message.py
+++ b/frappe/chat/doctype/chat_message/chat_message.py
@@ -132,8 +132,8 @@ def get_new_chat_message(user, room, content, type = "Content"):
 
 @frappe.whitelist(allow_guest = True)
 def send(user, room, content, type = "Content"):
-	if user != frappe.session.user:
-		user = frappe.session.user
+	# user should not be other than session user
+	user = frappe.session.user
 
 	mess = get_new_chat_message(user, room, content, type)
 
@@ -201,14 +201,15 @@ def mark_messages_as_seen(message_names, user):
 def validate_members(room):
 	user = frappe.session.user
 
-	members = []
-	for d in room.users:
-		members.append(d.user)
-
-	if user in members or user == room.owner:
+	if user == room.owner:
 		return
-	else:
-		frappe.throw("Chat Room {} not found".format(room))
+
+	user_in_room = [member for member in room.users if member.user == user]
+
+	if user_in_room:
+		return
+
+	frappe.throw("Chat Room {} not found".format(room))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
### Bug
Earlier anybody can intercept the request and send a message in a group impersonating someone else and by manipulating the chat room from the request body one could see chat messages from another group or someone else's chatbox.

### Fix

- Messages can be sent as session users only
- Added check to validate chat room members 