### PR TITLE
fix: login as user with browse command

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -659,10 +659,14 @@ def publish_realtime(context, event, message, room, user, doctype, docname, afte
 
 @click.command('browse')
 @click.argument('site', required=False)
+@click.option('--user', required=False)
 @pass_context
-def browse(context, site):
+def browse(context, site, user=None):
 	'''Opens the site on web browser'''
+	from frappe.auth import LoginManager
+	from frappe.auth import CookieManager
 	import webbrowser
+
 	site = context.sites[0] if context.sites else site
 
 	if not site:
@@ -672,7 +676,20 @@ def browse(context, site):
 	site = site.lower()
 
 	if site in frappe.utils.get_sites():
-		webbrowser.open(frappe.utils.get_site_url(site), new=2)
+		frappe.init(site=site)
+		frappe.connect()
+
+		if user:
+			frappe.utils.set_request(path="/")
+			frappe.local.cookie_manager = CookieManager()
+			frappe.local.login_manager = LoginManager()
+			frappe.local.login_manager.login_as(user)
+			sid = f'/app?sid={frappe.session.sid}'
+		else:
+			sid = ''
+
+		url = f'{frappe.utils.get_site_url(site)}{sid}'
+		webbrowser.open(url, new=2)
 	else:
 		click.echo("\nSite named \033[1m{}\033[0m doesn't exist\n".format(site))
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -659,7 +659,7 @@ def publish_realtime(context, event, message, room, user, doctype, docname, afte
 
 @click.command('browse')
 @click.argument('site', required=False)
-@click.option('--user', required=False)
+@click.option('--user', required=False, help='Login as user')
 @pass_context
 def browse(context, site, user=None):
 	'''Opens the site on web browser'''
@@ -679,16 +679,20 @@ def browse(context, site, user=None):
 		frappe.init(site=site)
 		frappe.connect()
 
+		sid = ''
 		if user:
-			frappe.utils.set_request(path="/")
-			frappe.local.cookie_manager = CookieManager()
-			frappe.local.login_manager = LoginManager()
-			frappe.local.login_manager.login_as(user)
-			sid = f'/app?sid={frappe.session.sid}'
-		else:
-			sid = ''
+			if frappe.conf.developer_mode or user == "Administrator":
+				frappe.utils.set_request(path="/")
+				frappe.local.cookie_manager = CookieManager()
+				frappe.local.login_manager = LoginManager()
+				frappe.local.login_manager.login_as(user)
+				sid = f'/app?sid={frappe.session.sid}'
+			else:
+				print("Please enable developer mode to login as a user")
 
 		url = f'{frappe.utils.get_site_url(site)}{sid}'
+		if sid:
+			print(f'Login URL: {url}')
 		webbrowser.open(url, new=2)
 	else:
 		click.echo("\nSite named \033[1m{}\033[0m doesn't exist\n".format(site))

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -691,7 +691,7 @@ def browse(context, site, user=None):
 				print("Please enable developer mode to login as a user")
 
 		url = f'{frappe.utils.get_site_url(site)}{sid}'
-		if sid:
+		if user == "Administrator":
 			print(f'Login URL: {url}')
 		webbrowser.open(url, new=2)
 	else:


### PR DESCRIPTION
```bash
# developer_mode: 1
$ bench --site site.local browse --user Administrator
Login URL: http://site.local:8000/app?sid=69d3007f157e39945c7d9c10c90dfca7a324fdcd82e62a6e0582e9cc

$ bench browse site.local --user test@example.com
Login URL: http://site.local:8000/app?sid=69d300788157e39945c7d9c10c90dfca7a324fdcd82e62a6e058257

# developer_mode: 0
$ bench browse site.local --user Administrator
Login URL: http://site.local:8000/app?sid=69d3007f157e39945c7d9c10c90dfca7a324fdcd82e62a6e0582e9cc

$ bench browse site.local --user test@example.com
Please enable developer mode to login as a user
```

- Allows login as any user including Administrator when developer_mode is set to 1
- Allows login as Administrator when developer_mode is set to 0
- Prints the login URL when user is Administrator

docs: https://github.com/frappe/frappe_docs/pull/222