### PR TITLE
feat(minor): Implement __getitem__ in Base Document

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -86,7 +86,7 @@ class BaseDocument(object):
 			self.__setup__()
 
 	def __getitem__(self, key):
-		return self.get(key, frappe.throw(msg=key, exc=KeyError))
+		return self.get(key) if hasattr(self, key) else frappe.throw(msg=key, exc=KeyError)
 
 	@property
 	def meta(self):

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -86,7 +86,7 @@ class BaseDocument(object):
 			self.__setup__()
 
 	def __getitem__(self, key):
-		return getattr(self, key)
+		return self.get(key, frappe.throw(msg=key, exc=KeyError))
 
 	@property
 	def meta(self):
@@ -678,7 +678,7 @@ class BaseDocument(object):
 			if data_field_options == "URL":
 				if not data:
 					continue
-				
+
 				frappe.utils.validate_url(data, throw=True)
 
 	def _validate_constants(self):

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -86,7 +86,7 @@ class BaseDocument(object):
 			self.__setup__()
 
 	def __getitem__(self, key):
-		return self.get(key)
+		return getattr(self, key)
 
 	@property
 	def meta(self):

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -85,6 +85,9 @@ class BaseDocument(object):
 		if hasattr(self, "__setup__"):
 			self.__setup__()
 
+	def __getitem__(self, key):
+		return self.get(key)
+
 	@property
 	def meta(self):
 		if not hasattr(self, "_meta"):


### PR DESCRIPTION
This addition allows for syntactic sugars like writing `doc["name"]` to access document name. This addition is solely for the sake of code simplicity. Since dictionaries in Python follow this standard, we can write code that works for both Vanilla Dicts, Frappe Dicts & all Document objects.

This allows for accessing the document attributes in one more way now.

<img width="453" alt="Screenshot 2021-11-01 at 12 47 18 PM" src="https://user-images.githubusercontent.com/36654812/139636245-24ab3e42-b01e-4af9-89fd-9c89fc3374a8.png">


### Motivation

Plainly, this change is driven by the following error that comes up when you try downloading/sending Auto Email Report with XLSX or CSV formats.

<img width="1552" alt="Screenshot 2021-11-01 at 12 47 36 PM" src="https://user-images.githubusercontent.com/36654812/139636250-cc0ff655-c943-4b05-8d09-53fae73060d5.png">

<!-- no-docs -->