### PR TITLE
test: flaky sidebar test due to msgprint

### DIFF
--- a/cypress/integration/sidebar.js
+++ b/cypress/integration/sidebar.js
@@ -17,7 +17,7 @@ context('Sidebar', () => {
 		cy.get('.group-by-item > .dropdown-item').should('contain', 'Me');
 
 		//Assigning a doctype to a user
-		cy.click_listview_row_item(0);
+		cy.visit('/app/doctype/ToDo');
 		cy.get('.form-assignments > .flex > .text-muted').click();
 		cy.get_field('assign_to_me', 'Check').click();
 		cy.get('.modal-footer > .standard-actions > .btn-primary').click();
@@ -44,8 +44,7 @@ context('Sidebar', () => {
 		cy.clear_filters();
 
 		//To remove the assignment
-		cy.visit('/app/doctype');
-		cy.click_listview_row_item(0);
+		cy.visit('/app/doctype/ToDo');
 		cy.get('.assignments > .avatar-group > .avatar > .avatar-frame').click();
 		cy.get('.remove-btn').click({force: true});
 		cy.hide_dialog();


### PR DESCRIPTION
sidebar.js is flaky when last updated doctype is `DocType`, this is because it shows a msgprint with a warning about editing [DocType DocType]. 

<img width="1387" alt="Screenshot 2021-11-01 at 2 25 23 PM" src="https://user-images.githubusercontent.com/9079960/139649357-48121eff-98f8-4f94-b9bc-be830ffca113.png">
 

Solution: use a specific doctype instead of last updated one. 

Noticed here: https://github.com/frappe/frappe/pull/14558#issuecomment-956049453