### PR TITLE
feat: Read Only transactions via @frappe.read_only

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -635,14 +635,11 @@ def read_only():
 				connect_read_only()
 
 			try:
-				flags.read_only = True
 				retval = fn(*args, **get_newargs(fn, kwargs))
 			finally:
 				if local and hasattr(local, 'primary_db'):
 					local.db.close()
 					local.db = local.primary_db
-
-				flags.read_only = False
 
 			return retval
 		return wrapper_fn
@@ -653,24 +650,19 @@ def write_only():
 	def innfn(fn):
 		def wrapper_fn(*args, **kwargs):
 			primary_db = getattr(local, "primary_db", None)
-			replica_db = getattr(local, "replica_db", None)
+			replica_db = getattr(local, "replica_db", None) or getattr(local, "read_only_db", None)
 			in_read_only_conn = getattr(local, "db", None) != primary_db
-			is_read_only_set = flags.read_only
 
 			# switch to primary connection
 			if in_read_only_conn and primary_db:
 				local.db = local.primary_db
 
 			try:
-				flags.read_only = False
 				retval = fn(*args, **get_newargs(fn, kwargs))
 			finally:
 				# switch back to replica connection
 				if in_read_only_conn and replica_db:
 					local.db = replica_db
-
-				# reset read_only flag value
-				flags.read_only = is_read_only_set
 
 			return retval
 		return wrapper_fn

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -619,6 +619,7 @@ def is_whitelisted(method):
 def read_only():
 	def innfn(fn):
 		def wrapper_fn(*args, **kwargs):
+			flags.read_only = True
 			if conf.read_from_replica:
 				connect_replica()
 
@@ -628,6 +629,7 @@ def read_only():
 				if local and hasattr(local, 'primary_db'):
 					local.db.close()
 					local.db = local.primary_db
+				flags.read_only = False
 
 			return retval
 		return wrapper_fn

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -231,6 +231,10 @@ def connect(site=None, db_name=None, set_admin_as_user=True):
 def connect_read_only():
 	"""Connect to database in read only mode."""
 	from frappe.database import get_db
+
+	if hasattr(local, "read_only_db"):
+		return local.read_only_db
+
 	local.read_only_db = get_db()
 	local.read_only_db.begin(read_only=True)
 
@@ -309,6 +313,10 @@ def destroy():
 	"""Closes connection and releases werkzeug local."""
 	if db:
 		db.close()
+	if hasattr(local, "read_only_db"):
+		local.read_only_db.close()
+	if hasattr(local, "replica_db"):
+		local.replica_db.close()
 
 	release_local(local)
 

--- a/frappe/core/doctype/access_log/access_log.json
+++ b/frappe/core/doctype/access_log/access_log.json
@@ -3,7 +3,7 @@
  "creation": "2019-07-25 15:44:44.955496",
  "doctype": "DocType",
  "editable_grid": 1,
- "engine": "InnoDB",
+ "engine": "MyISAM",
  "field_order": [
   "log_data_section",
   "export_from",

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -278,7 +278,8 @@ class Database(object):
 
 		_query = query.lstrip()[:10].lower()
 
-		if not self.transaction_started:
+		# start a transaction if not yet started
+		if not self.transaction_writes and not self.transaction_started:
 			self.begin()
 
 		if self.transaction_writes and _query.startswith(

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -56,7 +56,6 @@ class Database(object):
 		if use_default:
 			self.user = frappe.conf.db_name
 
-		self.transaction_started = False
 		self.transaction_writes = 0
 		self.auto_commit_on_many_writes = 0
 
@@ -288,14 +287,9 @@ class Database(object):
 
 		if _query.startswith(("commit", "rollback")):
 			self.transaction_writes = 0
-			self.transaction_started = False
 
 		if is_read_query(_query):
 			return
-
-		# start a transaction if not yet started
-		if not self.transaction_writes and not self.transaction_started:
-			self.begin()
 
 		if _query.startswith(("insert", "update", "delete")):
 			self.transaction_writes += 1
@@ -730,7 +724,6 @@ class Database(object):
 
 	def begin(self, read_only=False):
 		mode = "READ ONLY" if read_only else ""
-		self.transaction_started = True
 		self.sql(f"START TRANSACTION {mode}")
 
 	def commit(self):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -14,7 +14,7 @@ import frappe.model.meta
 
 from frappe import _
 from time import time
-from frappe.utils import now, getdate, cast, get_datetime
+from frappe.utils import now, getdate, cast, get_datetime, is_read_query, scrub_sql
 from frappe.model.utils.link_count import flush_local_link_count
 from frappe.query_builder.functions import Count
 from frappe.query_builder.functions import Min, Max, Avg, Sum
@@ -261,23 +261,55 @@ class Database(object):
 		self.sql(query, debug=debug)
 
 	def check_transaction_status(self, query):
-		"""Raises exception if more than 20,000 `INSERT`, `UPDATE` queries are
-		executed in one transaction. This is to ensure that writes are always flushed otherwise this
-		could cause the system to hang."""
-		if self.transaction_writes and \
-			query and query.strip().split()[0].lower() in ['start', 'alter', 'drop', 'create', "begin", "truncate"]:
-			raise Exception('This statement can cause implicit commit')
+		"""Raises exceptions if
+		* More than self.MAX_WRITES_PER_TRANSACTION `INSERT`, `UPDATE`
+		or `DELETE` queries are executed in one transaction.
+		* If frappe.flags.read_only is set to True and the query uses an
+		 `INSERT`, `UPDATE` or `DELETE` statement.
+		* If write queries have already been executed and query may cause
+		an implicit commit.
 
-		if query and query.strip().lower() in ('commit', 'rollback'):
+		This is to ensure that writes are always flushed otherwise this
+		could cause the system to hang."""
+
+		if not query:
+			return
+
+		_query = scrub_sql(query)
+		is_write_query = not is_read_query(_query)
+
+		# print(query, frappe.flags.read_only, is_write_query)
+
+		if frappe.flags.read_only and is_write_query:
+			frappe.throw(
+				_("Not allowed in Read Only transactions"),
+				frappe.OperationNotAllowedError
+			)
+
+		if self.transaction_writes and _query.startswith(
+			('start', 'alter', 'drop', 'create', "begin", "truncate")
+		):
+			frappe.throw(
+				_("This statement can cause implicit commit"),
+				frappe.ImplicitCommitError
+			)
+
+		if _query.startswith(("commit", "rollback")):
 			self.transaction_writes = 0
 
-		if query[:6].lower() in ('update', 'insert', 'delete'):
-			self.transaction_writes += 1
-			if self.transaction_writes > self.MAX_WRITES_PER_TRANSACTION:
-				if self.auto_commit_on_many_writes:
-					self.commit()
-				else:
-					frappe.throw(_("Too many writes in one request. Please send smaller requests"), frappe.ValidationError)
+		if not is_write_query:
+			return
+
+		self.transaction_writes += 1
+
+		if self.transaction_writes > self.MAX_WRITES_PER_TRANSACTION:
+			if self.auto_commit_on_many_writes:
+				self.commit()
+			else:
+				frappe.throw(
+					_("Too many writes in one request. Please send smaller requests"),
+					frappe.ValidationError
+				)
 
 	def fetch_as_dict(self, formatted=0, as_utf8=0):
 		"""Internal. Converts results to dict."""

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -216,15 +216,6 @@ class PostgresDatabase(Database):
 			UNIQUE ("user", "doctype")
 			)""")
 
-	def create_help_table(self):
-		self.sql('''CREATE TABLE "help"(
-				"path" varchar(255),
-				"content" text,
-				"title" text,
-				"intro" text,
-				"full_path" text)''')
-		self.sql('''CREATE INDEX IF NOT EXISTS "help_index" ON "help" ("path")''')
-
 	def updatedb(self, doctype, meta=None):
 		"""
 		Syncs a `DocType` to the table

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -103,6 +103,8 @@ class DocumentAlreadyRestored(ValidationError): pass
 class AttachmentLimitReached(ValidationError): pass
 class QueryTimeoutError(Exception): pass
 class QueryDeadlockError(Exception): pass
+class OperationNotAllowedError(ValidationError): pass
+
 # OAuth exceptions
 class InvalidAuthorizationHeader(CSRFTokenError): pass
 class InvalidAuthorizationPrefix(CSRFTokenError): pass

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 import frappe
 import time
-from frappe import _, msgprint, is_whitelisted
+from frappe import _, msgprint, is_whitelisted, DoesNotExistError
 from frappe.utils import flt, cstr, now, get_datetime_str, file_lock, date_diff
 from frappe.model.base_document import BaseDocument, get_controller
 from frappe.model.naming import set_new_name, gen_new_name_for_cancelled_doc
@@ -99,8 +99,7 @@ class Document(BaseDocument):
 					# filter
 					self.name = frappe.db.get_value(args[0], args[1], "name")
 					if self.name is None:
-						frappe.throw(_("{0} {1} not found").format(_(args[0]), args[1]),
-							frappe.DoesNotExistError)
+						frappe.throw(_("{0} {1} not found").format(_(args[0]), args[1]), DoesNotExistError)
 				else:
 					self.name = args[1]
 
@@ -150,7 +149,7 @@ class Document(BaseDocument):
 		else:
 			d = frappe.db.get_value(self.doctype, self.name, "*", as_dict=1, for_update=self.flags.for_update)
 			if not d:
-				frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
+				frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), DoesNotExistError)
 
 			super(Document, self).__init__(d)
 
@@ -710,7 +709,7 @@ class Document(BaseDocument):
 				tmp = frappe.db.sql("""select modified, docstatus from `tab{0}`
 					where name = %s for update""".format(self.doctype), self.name, as_dict=True)
 				if not tmp:
-					frappe.throw(_("Record does not exist"))
+					frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), DoesNotExistError)
 				else:
 					tmp = tmp[0]
 
@@ -980,7 +979,7 @@ class Document(BaseDocument):
 		if not self.is_new():
 			try:
 				self._doc_before_save = frappe.get_doc(self.doctype, self.name)
-			except frappe.DoesNotExistError:
+			except DoesNotExistError:
 				self._doc_before_save = None
 				frappe.clear_last_message()
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -864,4 +864,4 @@ def get_table_name(table_name: str) -> str:
 	return f"tab{table_name}" if not table_name.startswith("__") else table_name
 
 def is_read_query(query):
-	return query.startswith(("select", "with"))
+	return query.startswith(("select", "with", "explain"))

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -864,4 +864,4 @@ def get_table_name(table_name: str) -> str:
 	return f"tab{table_name}" if not table_name.startswith("__") else table_name
 
 def is_read_query(query):
-	return not query.startswith(("update", "insert", "delete"))
+	return query.startswith(("select", "with"))

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -865,7 +865,3 @@ def get_table_name(table_name: str) -> str:
 
 def is_read_query(query):
 	return not query.startswith(("update", "insert", "delete"))
-
-def scrub_sql(query):
-	# get rid of comments etc in queries; anything that looks funny
-	return query

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -859,5 +859,13 @@ def groupby_metric(iterable: typing.Dict[str, list], key: str):
 			records.setdefault(item[key], {}).setdefault(category, []).append(item)
 	return records
 
+
 def get_table_name(table_name: str) -> str:
 	return f"tab{table_name}" if not table_name.startswith("__") else table_name
+
+def is_read_query(query):
+	return not query.startswith(("update", "insert", "delete"))
+
+def scrub_sql(query):
+	# get rid of comments etc in queries; anything that looks funny
+	return query

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -76,7 +76,7 @@ def render_template(template, context, is_path=None, safe_render=True):
 			return get_jenv().get_template(template).render(context)
 
 		if safe_render and ".__" in template:
-				throw(_("Illegal template"))
+			throw(_("Illegal template"))
 
 		try:
 			return get_jenv().from_string(template).render(context)


### PR DESCRIPTION
When you wrap a function with `@frappe.read_only` and if you've done a replica setup, on calling said function a database connection with the replica server will be made in the context of the function's execution. When there's no replica setup, a separate connection will be started with the primary with read-only transactions.

Essentially, functions wrapped with `@frappe.read_only` will only allow reads in the context of the function. To call a function that allows writes from this, you'd have to wrap it with `@frappe.write_only`.


### Other Changes

* "perf" fixes for `frappe.db.check_transaction_status`
* Marked `frappe.render_template` as read only. This will disallow writes through it
