### PR TITLE
feat: add format dd.mm.yy to dateutils

### DIFF
--- a/frappe/utils/dateutils.py
+++ b/frappe/utils/dateutils.py
@@ -17,6 +17,7 @@ dateformats = {
 	'dd-mmm-yyyy': '%d-%b-%Y', # numbers app format
 	'dd/mm/yyyy': '%d/%m/%Y',
 	'dd.mm.yyyy': '%d.%m.%Y',
+	'dd.mm.yy': '%d.%m.%y',
 	'dd-mm-yyyy': '%d-%m-%Y',
 	"dd/mm/yy": "%d/%m/%y",
 }


### PR DESCRIPTION
`dd.mm.yy` is a common date format in Germany. Adding it here, so that `parse_date` can recognize dates in this format.

https://github.com/frappe/frappe/blob/b76f79c06c10854fd0751b7916f294fe60c3794f/frappe/utils/dateutils.py#L36-L37

(We could also make it available in **System Settings**, but I didn't know the implications. Therefore this PR is only intended to enhance the capabilities of `dateutils`.)

> no-docs