### PR TITLE
feat: prepared report read from replica database

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -49,6 +49,7 @@ def get_report_doc(report_name):
 	return doc
 
 
+@frappe.read_only()
 def generate_report_result(report, filters=None, user=None, custom_columns=None):
 	user = user or frappe.session.user
 	filters = filters or []


### PR DESCRIPTION
added `@frappe.read_only()` to `generate_report_result` function so prepared report also read from replica database.

no-docs