### PR TITLE
feat: prepared report read from replica (backport to develop)

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -72,6 +72,7 @@ def get_report_result(report, filters):
 
 	return res
 
+@frappe.read_only()
 def generate_report_result(report, filters=None, user=None, custom_columns=None):
 	user = user or frappe.session.user
 	filters = filters or []


### PR DESCRIPTION
added `@frappe.read_only()` to `generate_report_result` function so prepared report also read from replica database.

no-docs