### PR TITLE
fix KeyError on auto_email_report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -250,7 +250,8 @@ def make_links(columns, data):
 				if col.options and row.get(col.fieldname) and row.get(col.options):
 					row[col.fieldname] = get_link_to_form(row[col.options], row[col.fieldname])
 			elif col.fieldtype == "Currency":
-				row[col.fieldname] = frappe.format_value(row[col.fieldname], col)
+				if row.get(col.fieldname):
+					row[col.fieldname] = frappe.format_value(row[col.fieldname], col)
 
 	return columns, data
 


### PR DESCRIPTION
fixes issues #14816 

rows are some items added for formatting so it won't necessarily have the columns from the configuration. Checks if a row has the column before editing the value.