### PR TITLE
fix: Auto email report KeyError

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -250,7 +250,8 @@ def make_links(columns, data):
 				if col.options and row.get(col.fieldname) and row.get(col.options):
 					row[col.fieldname] = get_link_to_form(row[col.options], row[col.fieldname])
 			elif col.fieldtype == "Currency":
-				row[col.fieldname] = frappe.format_value(row[col.fieldname], col)
+				if row.get(col.fieldname):
+					row[col.fieldname] = frappe.format_value(row[col.fieldname], col)
 
 	return columns, data
 


### PR DESCRIPTION
Issue:

- When a report is generated by the auto email report. There are rows that are added with no columns for formatting purposes and the make_links method attempts to change a column that a row doesn't have
- issue at #14816 

Fix:

- Check for the existence of a column first before assignment


