### PR TITLE
refactor: minor code cleanup in auto_email_report.py

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -242,13 +242,16 @@ def make_links(columns, data):
 	for row in data:
 		doc_name = row.get('name')
 		for col in columns:
-			if col.fieldtype == "Link" and col.options != "Currency":
-				if col.options and row.get(col.fieldname):
+			if not row.get(col.fieldname):
+				continue
+			
+			if col.fieldtype == "Link":
+				if col.options and col.options != "Currency":
 					row[col.fieldname] = get_link_to_form(col.options, row[col.fieldname])
 			elif col.fieldtype == "Dynamic Link":
-				if col.options and row.get(col.fieldname) and row.get(col.options):
+				if col.options and row.get(col.options):
 					row[col.fieldname] = get_link_to_form(row[col.options], row[col.fieldname])
-			elif col.fieldtype == "Currency" and row.get(col.fieldname):
+			elif col.fieldtype == "Currency":
 				doc = frappe.get_doc(col.parent, doc_name) if doc_name and col.parent else None
 				# Pass the Document to get the currency based on docfield option
 				row[col.fieldname] = frappe.format_value(row[col.fieldname], col, doc=doc)


### PR DESCRIPTION
Minor code cleanup in auto_email_report.py
`row.get(col.fieldname)` needs to be `True` in all cases, so check it only once at the top of the loop and remove the other unnecessary checks.