### PR TITLE
fix: Constant fields for documents

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -1,6 +1,7 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) 2019, Frappe Technologies and contributors
+# Copyright (c) 2022, Frappe Technologies and contributors
 # License: MIT. See LICENSE
+
+from typing import Dict, Iterable, List
 
 import frappe
 from frappe import _
@@ -12,17 +13,35 @@ from frappe.model.document import Document
 
 class AssignmentRule(Document):
 	def validate(self):
-		assignment_days = self.get_assignment_days()
-		if not len(set(assignment_days)) == len(assignment_days):
-			repeated_days = get_repeated(assignment_days)
-			frappe.throw(_("Assignment Day {0} has been repeated.").format(frappe.bold(repeated_days)))
-		if self.document_type == 'ToDo':
-			frappe.throw(_('Assignment Rule is not allowed on {0} document type').format(frappe.bold("ToDo")))
+		self.validate_document_types()
+		self.validate_assignment_days()
 
 	def clear_cache(self):
 		super().clear_cache()
 		clear_doctype_map(self.doctype, self.document_type)
 		clear_doctype_map(self.doctype, f"due_date_rules_for_{self.document_type}")
+
+	def validate_document_types(self):
+		if self.document_type == "ToDo":
+			frappe.throw(
+				_('Assignment Rule is not allowed on {0} document type').format(
+					frappe.bold("ToDo")
+				)
+			)
+
+	def validate_assignment_days(self):
+		assignment_days = self.get_assignment_days()
+
+		if len(set(assignment_days)) != len(assignment_days):
+			repeated_days = get_repeated(assignment_days)
+			plural = "s" if len(repeated_days) > 1 else ""
+
+			frappe.throw(
+				_("Assignment Day{0} {1} has been repeated.").format(
+					plural,
+					frappe.bold(", ".join(repeated_days))
+				)
+			)
 
 	def apply_unassign(self, doc, assignments):
 		if (self.unassign_condition and
@@ -136,65 +155,68 @@ class AssignmentRule(Document):
 	def is_rule_not_applicable_today(self):
 		today = frappe.flags.assignment_day or frappe.utils.get_weekday()
 		assignment_days = self.get_assignment_days()
-		if assignment_days and not today in assignment_days:
-			return True
+		return assignment_days and today not in assignment_days
 
-		return False
 
-def get_assignments(doc):
+def get_assignments(doc) -> List[Dict]:
 	return frappe.get_all('ToDo', fields = ['name', 'assignment_rule'], filters = dict(
 		reference_type = doc.get('doctype'),
 		reference_name = doc.get('name'),
 		status = ('!=', 'Cancelled')
-	), limit = 5)
+	), limit=5)
+
 
 @frappe.whitelist()
 def bulk_apply(doctype, docnames):
-	import json
-	docnames = json.loads(docnames)
-
+	docnames = frappe.parse_json(docnames)
 	background = len(docnames) > 5
+
 	for name in docnames:
 		if background:
 			frappe.enqueue('frappe.automation.doctype.assignment_rule.assignment_rule.apply', doc=None, doctype=doctype, name=name)
 		else:
-			apply(None, doctype=doctype, name=name)
+			apply(doctype=doctype, name=name)
+
 
 def reopen_closed_assignment(doc):
-	todo_list = frappe.db.get_all('ToDo', filters = dict(
-		reference_type = doc.doctype,
-		reference_name = doc.name,
-		status = 'Closed'
-	))
-	if not todo_list:
-		return False
+	todo_list = frappe.get_all("ToDo", filters={
+		"reference_type": doc.doctype,
+		"reference_name": doc.name,
+		"status": "Closed",
+	}, pluck="name")
+
 	for todo in todo_list:
-		todo_doc = frappe.get_doc('ToDo', todo.name)
+		todo_doc = frappe.get_doc('ToDo', todo)
 		todo_doc.status = 'Open'
 		todo_doc.save(ignore_permissions=True)
-	return True
 
-def apply(doc, method=None, doctype=None, name=None):
-	if not doctype:
-		doctype = doc.doctype
+	return bool(todo_list)
 
-	if (frappe.flags.in_patch
+
+def apply(doc=None, method=None, doctype=None, name=None):
+	doctype = doctype or doc.doctype
+
+	skip_assignment_rules = (
+		frappe.flags.in_patch
 		or frappe.flags.in_install
 		or frappe.flags.in_setup_wizard
-		or doctype in log_types):
+		or doctype in log_types
+	)
+
+	if skip_assignment_rules:
 		return
 
 	if not doc and doctype and name:
 		doc = frappe.get_doc(doctype, name)
 
-	assignment_rules = frappe.cache_manager.get_doctype_map('Assignment Rule', doc.doctype, dict(
-		document_type = doc.doctype, disabled = 0), order_by = 'priority desc')
-
-	assignment_rule_docs = []
+	assignment_rules = get_doctype_map("Assignment Rule", doc.doctype, filters={
+		"document_type": doc.doctype, "disabled": 0
+	}, order_by="priority desc")
 
 	# multiple auto assigns
-	for d in assignment_rules:
-		assignment_rule_docs.append(frappe.get_cached_doc('Assignment Rule', d.get('name')))
+	assignment_rule_docs: List[AssignmentRule] = [
+		frappe.get_cached_doc("Assignment Rule", d.get('name')) for d in assignment_rules
+	]
 
 	if not assignment_rule_docs:
 		return
@@ -230,6 +252,7 @@ def apply(doc, method=None, doctype=None, name=None):
 
 	# apply close rule only if assignments exists
 	assignments = get_assignments(doc)
+
 	if assignments:
 		for assignment_rule in assignment_rule_docs:
 			if assignment_rule.is_rule_not_applicable_today():
@@ -237,38 +260,74 @@ def apply(doc, method=None, doctype=None, name=None):
 
 			if not new_apply:
 				# only reopen if close condition is not satisfied
-				if not assignment_rule.safe_eval('close_condition', doc):
-					reopen =  reopen_closed_assignment(doc)
-					if reopen:
+				to_close_todos = assignment_rule.safe_eval('close_condition', doc)
+
+				if to_close_todos:
+					# close todo status
+					todos_to_close = frappe.get_all("ToDo", filters={
+						"reference_type": doc.doctype,
+						"reference_name": doc.name,
+					}, pluck="name")
+
+					for todo in todos_to_close:
+						_todo = frappe.get_doc("ToDo", todo)
+						_todo.status = "Closed"
+						_todo.save()
+					break
+
+				else:
+					reopened = reopen_closed_assignment(doc)
+					if reopened:
 						break
+
+				# print(f"Rule:{assignment_rule}\nDoc: {doc}\nReOpened: {reopened}")
+
 			assignment_rule.close_assignments(doc)
 
+
 def update_due_date(doc, state=None):
-	# called from hook
-	if (frappe.flags.in_patch
-		or frappe.flags.in_install
-		or frappe.flags.in_migrate
+	"""Run on_update on every Document (via hooks.py)
+	"""
+	skip_document_update = (
+		frappe.flags.in_migrate
+		or frappe.flags.in_patch
 		or frappe.flags.in_import
-		or frappe.flags.in_setup_wizard):
+		or frappe.flags.in_setup_wizard
+		or frappe.flags.in_install
+	)
+
+	if skip_document_update:
 		return
-	assignment_rules = frappe.cache_manager.get_doctype_map('Assignment Rule', 'due_date_rules_for_' + doc.doctype, dict(
-		document_type = doc.doctype,
-		disabled = 0,
-		due_date_based_on = ['is', 'set']
-	))
+
+	assignment_rules = get_doctype_map(
+		doctype="Assignment Rule",
+		name=f"due_date_rules_for_{doc.doctype}",
+		filters={
+			"due_date_based_on": ["is", "set"],
+			"document_type": doc.doctype,
+			"disabled": 0,
+		}
+	)
+
 	for rule in assignment_rules:
-		rule_doc = frappe.get_cached_doc('Assignment Rule', rule.get('name'))
+		rule_doc = frappe.get_cached_doc("Assignment Rule", rule.get("name"))
 		due_date_field = rule_doc.due_date_based_on
-		if doc.meta.has_field(due_date_field) and \
-			doc.has_value_changed(due_date_field) and rule.get('name'):
-			assignment_todos = frappe.get_all('ToDo', {
-				'assignment_rule': rule.get('name'),
-				'status': 'Open',
-				'reference_type': doc.doctype,
-				'reference_name': doc.name
-			})
+		field_updated = (
+			doc.meta.has_field(due_date_field)
+			and doc.has_value_changed(due_date_field)
+			and rule.get("name")
+		)
+
+		if field_updated:
+			assignment_todos = frappe.get_all("ToDo", filters={
+				"assignment_rule": rule.get("name"),
+				"reference_type": doc.doctype,
+				"reference_name": doc.name,
+				"status": "Open",
+			}, pluck="name")
+
 			for todo in assignment_todos:
-				todo_doc = frappe.get_doc('ToDo', todo.name)
+				todo_doc = frappe.get_doc('ToDo', todo)
 				todo_doc.date = doc.get(due_date_field)
 				todo_doc.flags.updater_reference = {
 					'doctype': 'Assignment Rule',
@@ -277,17 +336,19 @@ def update_due_date(doc, state=None):
 				}
 				todo_doc.save(ignore_permissions=True)
 
-def get_assignment_rules():
-	return [d.document_type for d in frappe.db.get_all('Assignment Rule', fields=['document_type'], filters=dict(disabled = 0))]
 
-def get_repeated(values):
-	unique_list = []
-	diff = []
+def get_assignment_rules() -> List[str]:
+	return frappe.get_all("Assignment Rule", filters={"disabled": 0}, pluck="document_type")
+
+
+def get_repeated(values: Iterable) -> List:
+	unique = set()
+	repeated = set()
+
 	for value in values:
-		if value not in unique_list:
-			unique_list.append(str(value))
+		if value in unique:
+			repeated.add(value)
 		else:
-			if value not in diff:
-				diff.append(str(value))
-	return " ".join(diff)
+			unique.add(value)
 
+	return [str(x) for x in repeated]

--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -1,12 +1,22 @@
-# -*- coding: utf-8 -*-
-# Copyright (c) 2019, Frappe Technologies and Contributors
+# Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import frappe
+
 import unittest
-from frappe.utils import random_string
+
+import frappe
 from frappe.test_runner import make_test_records
+from frappe.utils import random_string
+
 
 class TestAutoAssign(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		frappe.db.delete("Assignment Rule")
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.rollback()
+
 	def setUp(self):
 		make_test_records("User")
 		days = [
@@ -129,7 +139,7 @@ class TestAutoAssign(unittest.TestCase):
 			reference_type = 'Note',
 			reference_name = note.name,
 			status = 'Open'
-		))[0]
+		), limit=1)[0]
 
 		todo = frappe.get_doc('ToDo', todo['name'])
 		self.assertEqual(todo.owner, 'test@example.com')
@@ -151,7 +161,7 @@ class TestAutoAssign(unittest.TestCase):
 			reference_type = 'Note',
 			reference_name = note.name,
 			status = 'Open'
-		))[0]
+		), limit=1)[0]
 
 		todo = frappe.get_doc('ToDo', todo['name'])
 		self.assertEqual(todo.owner, 'test@example.com')

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -96,7 +96,15 @@ class AutoRepeat(Document):
 		auto_repeat_days = self.get_auto_repeat_days()
 		if not len(set(auto_repeat_days)) == len(auto_repeat_days):
 			repeated_days = get_repeated(auto_repeat_days)
-			frappe.throw(_('Auto Repeat Day {0} has been repeated.').format(frappe.bold(repeated_days)))
+			plural = "s" if len(repeated_days) > 1 else ""
+
+			frappe.throw(
+				_("Auto Repeat Day{0} {1} has been repeated.").format(
+					plural,
+					frappe.bold(", ".join(repeated_days))
+				)
+			)
+
 
 	def update_auto_repeat_id(self):
 		#check if document is already on auto repeat

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -117,7 +117,8 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 					doctype=doc.doctype, name=doc.name,
 					is_async=False if frappe.flags.in_test else True)
 
-
+		# clear cache for Document
+		doc.clear_cache()
 		# delete global search entry
 		delete_for_document(doc)
 		# delete tag link entry

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -504,7 +504,6 @@ class Document(BaseDocument):
 		self._sanitize_content()
 		self._save_passwords()
 		self.validate_workflow()
-		self.validate_owner()
 
 		children = self.get_all_children()
 		for d in children:
@@ -546,11 +545,6 @@ class Document(BaseDocument):
 			validate_workflow(self)
 			if not self._action == 'save':
 				set_workflow_state_on_action(self, workflow, self._action)
-
-	def validate_owner(self):
-		"""Validate if the owner of the Document has changed"""
-		if not self.is_new() and self.has_value_changed('owner'):
-			frappe.throw(_('Document owner cannot be changed'))
 
 	def validate_set_only_once(self):
 		"""Validate that fields are not changed if not in insert"""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -396,6 +396,7 @@ class Document(BaseDocument):
 				"parenttype": self.doctype,
 				"parentfield": fieldname
 			})
+
 	def get_doc_before_save(self):
 		return getattr(self, '_doc_before_save', None)
 
@@ -468,9 +469,11 @@ class Document(BaseDocument):
 		self._original_modified = self.modified
 		self.modified = now()
 		self.modified_by = frappe.session.user
-		if not self.creation:
+
+		# We'd probably want the creation and owner to be set via API
+		# or Data import at some point, that'd have to be handled here
+		if self.is_new():
 			self.creation = self.modified
-		if not self.owner:
 			self.owner = self.modified_by
 
 		for d in self.get_all_children():

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -562,8 +562,12 @@ class Document(BaseDocument):
 					fail = value != original_value
 
 				if fail:
-					frappe.throw(_("Value cannot be changed for {0}").format(self.meta.get_label(field.fieldname)),
-						frappe.CannotChangeConstantError)
+					frappe.throw(
+						_("Value cannot be changed for {0}").format(
+							frappe.bold(self.meta.get_label(field.fieldname))
+						),
+						exc=frappe.CannotChangeConstantError
+					)
 
 		return False
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -67,6 +67,10 @@ class Meta(Document):
 	_metaclass = True
 	default_fields = list(default_fields)[1:]
 	special_doctypes = ("DocField", "DocPerm", "DocType", "Module Def", 'DocType Action', 'DocType Link', 'DocType State')
+	standard_set_once_fields = [
+		frappe._dict(fieldname="creation", fieldtype="Datetime"),
+		frappe._dict(fieldname="owner", fieldtype="Data"),
+	]
 
 	def __init__(self, doctype):
 		self._fields = {}
@@ -154,6 +158,12 @@ class Meta(Document):
 		'''Return fields with `set_only_once` set'''
 		if not hasattr(self, "_set_only_once_fields"):
 			self._set_only_once_fields = self.get("fields", {"set_only_once": 1})
+			fieldnames = [d.fieldname for d in self._set_only_once_fields]
+
+			for df in self.standard_set_once_fields:
+				if df.fieldname not in fieldnames:
+					self._set_only_once_fields.append(df)
+
 		return self._set_only_once_fields
 
 	def get_table_fields(self):

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -110,6 +110,7 @@ def rename_doc(
 	if merge:
 		frappe.delete_doc(doctype, old)
 
+	new_doc.clear_cache()
 	frappe.clear_cache()
 	if rebuild_search:
 		frappe.enqueue('frappe.utils.global_search.rebuild_for_doctype', doctype=doctype)

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -252,22 +252,3 @@ class TestDocument(unittest.TestCase):
 			'currency': 100000
 		})
 		self.assertEquals(d.get_formatted('currency', currency='INR', format="#,###.##"), '₹ 100,000.00')
-
-	def test_owner_changed(self):
-		frappe.delete_doc_if_exists("User", "hello@example.com")
-		frappe.set_user("Administrator")
-
-		d = frappe.get_doc({
-			"doctype": "User",
-			"email": "hello@example.com",
-			"first_name": "John"
-		})
-		d.insert()
-		self.assertEqual(frappe.db.get_value("User", d.owner), d.owner)
-
-		d.set("owner", "johndoe@gmail.com")
-		self.assertRaises(frappe.ValidationError, d.save)
-
-		d.reload()
-		d.save()
-		self.assertEqual(frappe.db.get_value("User", d.owner), d.owner)

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -198,6 +198,21 @@ class TestPermissions(unittest.TestCase):
 		doc = frappe.get_doc("Blog Post", "-test-blog-post")
 		self.assertTrue(doc.has_permission("read"))
 
+	def test_set_standard_fields_manually(self):
+		# check that creation and owner cannot be set manually
+		from datetime import timedelta
+
+		fake_creation = now_datetime() + timedelta(days=-7)
+		fake_owner = frappe.db.get_value("User", {"name": ("!=", frappe.session.user)})
+
+		d = frappe.new_doc("ToDo")
+		d.description = "ToDo created via test_set_standard_fields_manually"
+		d.creation = fake_creation
+		d.owner = fake_owner
+		d.save()
+		self.assertNotEqual(d.creation, fake_creation)
+		self.assertNotEqual(d.owner, fake_owner)
+
 	def test_dont_change_standard_constants(self):
 		# check that Document.creation cannot be changed
 		user = frappe.get_doc("User", frappe.session.user)

--- a/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
@@ -50,11 +50,10 @@ class TestPersonalDataDeletionRequest(unittest.TestCase):
 	def test_unverified_record_removal(self):
 		date_time_obj = datetime.strptime(
 			self.delete_request.creation, "%Y-%m-%d %H:%M:%S.%f"
-		)
-		date_time_obj += timedelta(days=-7)
-		self.delete_request.creation = date_time_obj
-		self.status = "Pending Verification"
-		self.delete_request.save()
+		) + timedelta(days=-7)
+		self.delete_request.db_set("creation", date_time_obj)
+		self.delete_request.db_set("status", "Pending Verification")
+
 		remove_unverified_record()
 		self.assertFalse(
 			frappe.db.exists("Personal Data Deletion Request", self.delete_request.name)

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,9 +554,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001219:
-  version "1.0.30001272"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001272.tgz"
-  integrity sha512-DV1j9Oot5dydyH1v28g25KoVm7l8MTxazwuiH3utWiAS6iL/9Nh//TGwqFEeqqN8nnWYQ8HHhUq+o4QPt9kvYw==
+  version "1.0.30001296"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz"
+  integrity sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
### Changes:
- Mark `owner`, `creation` as constant fields for all documents.
- Make the field label bold in user message.
- Disallow setting standard fields like `creation`, `owner`. These fields will only be set on Document insert.
- Added 2 tests for the above changes.
- Refactor Assignment Rule
- Clear Document cache on Document updates/trashing
- Updated caniuse-lite package

Depends on https://github.com/frappe/frappe/pull/15521