### PR TITLE
feat: frappe.flags.read_only

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -277,7 +277,7 @@ class Database(object):
 		if frappe.flags.read_only:
 			frappe.throw(
 				_("This operation is not allowed in read only transactions"),
-				exc=frappe.OperationNotAllowed
+				exc=frappe.OperationNotAllowedError
 			)
 
 		query = query.lstrip()[:10].lower()

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -103,6 +103,8 @@ class DocumentAlreadyRestored(ValidationError): pass
 class AttachmentLimitReached(ValidationError): pass
 class QueryTimeoutError(Exception): pass
 class QueryDeadlockError(Exception): pass
+class OperationNotAllowed(ValidationError): pass
+
 # OAuth exceptions
 class InvalidAuthorizationHeader(CSRFTokenError): pass
 class InvalidAuthorizationPrefix(CSRFTokenError): pass

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -103,7 +103,7 @@ class DocumentAlreadyRestored(ValidationError): pass
 class AttachmentLimitReached(ValidationError): pass
 class QueryTimeoutError(Exception): pass
 class QueryDeadlockError(Exception): pass
-class OperationNotAllowed(ValidationError): pass
+class OperationNotAllowedError(ValidationError): pass
 
 # OAuth exceptions
 class InvalidAuthorizationHeader(CSRFTokenError): pass

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -15,13 +15,15 @@ from email.utils import formataddr, parseaddr
 from gzip import GzipFile
 from typing import Generator, Iterable
 from urllib.parse import quote, urlparse
-from werkzeug.test import Client
+
+import sqlparse
 from redis.exceptions import ConnectionError
+from werkzeug.test import Client
 
 import frappe
-# utility functions like cint, int, flt, etc.
-from frappe.utils.data import *
+from frappe.utils.data import *  # utility functions like cint, int, flt, etc.
 from frappe.utils.html_utils import sanitize_html
+
 
 default_fields = ['doctype', 'name', 'owner', 'creation', 'modified', 'modified_by',
 	'parent', 'parentfield', 'parenttype', 'idx', 'docstatus']
@@ -861,3 +863,7 @@ def groupby_metric(iterable: typing.Dict[str, list], key: str):
 
 def get_table_name(table_name: str) -> str:
 	return f"tab{table_name}" if not table_name.startswith("__") else table_name
+
+def is_read_query(query):
+	query = sqlparse.format(query, strip_comments=True, strip_whitespace=True)
+	return query.startswith(("select", "with", "explain"))


### PR DESCRIPTION
### Changes

* Raise `OperationNotAllowedError` when write query detected and `frappe.flags.read_only` is set
* Refactored `frappe.db.check_transaction_status`
* Disallowed write queries to be executed via `frappe.render_template`

Alternate fix to https://github.com/frappe/frappe/pull/14870

<!-- no-docs -->