### PR TITLE
fix: Set `assigned_by` to interaction_values for ToDos

### DIFF
--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -224,7 +224,7 @@ frappe.views.InteractionComposer = class InteractionComposer {
 		if (!("owner" in interaction_values)){
 			interaction_values["owner"] = frappe.session.user;
 		}
-		if (!("assigned_by" in interaction_values) && interaction_values["doctype"] == "ToDo"){
+		if (!("assigned_by" in interaction_values) && interaction_values["doctype"] == "ToDo") {
 			interaction_values["assigned_by"] = frappe.session.user;
 		}
 		return frappe.call({

--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -224,6 +224,9 @@ frappe.views.InteractionComposer = class InteractionComposer {
 		if (!("owner" in interaction_values)){
 			interaction_values["owner"] = frappe.session.user;
 		}
+		if (!("assigned_by" in interaction_values) && interaction_values["doctype"] == "ToDo"){
+			interaction_values["assigned_by"] = frappe.session.user;
+		}
 		return frappe.call({
 			method:"frappe.client.insert",
 			args: { doc: interaction_values},


### PR DESCRIPTION
The key "assigned_by" is needed in interaction_values when creating a ToDo for another user, otherwise, a PermissionError will be raised.

"Not allowed via controller permission check"
