### PR TITLE
chore: Added change log for version 13.14.0

### DIFF
--- a/frappe/change_log/v13/v13_14_0.md
+++ b/frappe/change_log/v13/v13_14_0.md
@@ -1,0 +1,28 @@
+# Version 13.14.0 Release Notes
+
+### Features & Enhancements
+
+- Google Drive Picker ([#12715](https://github.com/frappe/frappe/pull/12715))
+    - User can select files from the Google Drive
+    - The selected file is added as an attachment to the doc
+
+- Allow fuzzy search in website search ([#14463](https://github.com/frappe/frappe/pull/14463))
+- Introduced rate-limiting for web forms ([#14087](https://github.com/frappe/frappe/pull/14087))
+- Improved design for fetching values using `add_fetch` ([#14445](https://github.com/frappe/frappe/pull/14445))
+- Handle timeout and deadlocks in db.sql ([#14305](https://github.com/frappe/frappe/pull/14305))
+- allow tuple of DocTypes as key to make custom fields using create_custom_fields ([#14419](https://github.com/frappe/frappe/pull/14419))
+
+### Fixes
+
+- Debounce awesome bar search ([#14538](https://github.com/frappe/frappe/pull/14538))
+
+- Changed default for Email Log from 90 to 30 days ([#14543](https://github.com/frappe/frappe/pull/14543))
+- Include Theme for Apps section rendered twice ([#14510](https://github.com/frappe/frappe/pull/14510))
+- PDF to base64 convert ([#14602](https://github.com/frappe/frappe/pull/14602))
+- Info Timeline always shows current logged in user. ([#14519](https://github.com/frappe/frappe/pull/14519))
+- `if_owner` constraint being applied wrongly ([#14471](https://github.com/frappe/frappe/pull/14471))
+- Get unique records from backend for list ([#13849](https://github.com/frappe/frappe/pull/13849))
+- Use whoosh AsyncWriter to prevent write locks ([#14215](https://github.com/frappe/frappe/pull/14215))
+- File not attached in attachments, if file is uploaded from webform. ([#14328](https://github.com/frappe/frappe/pull/14328))
+- Allow submitting comment with images only ([#14588](https://github.com/frappe/frappe/pull/14588))
+- Removed frappe.cache() methods in server scripts ([#14609](https://github.com/frappe/frappe/pull/14609))


### PR DESCRIPTION
# Version 13.14.0 Release Notes

### Features & Enhancements

- Google Drive Picker ([#12715](https://github.com/frappe/frappe/pull/12715))
    - User can select files from Google Drive
    - The selected file is added as an attachment to the doc

- Allow fuzzy search in website search ([#14463](https://github.com/frappe/frappe/pull/14463))
- Introduced rate-limiting for web forms ([#14087](https://github.com/frappe/frappe/pull/14087))
- Improved design for fetching values using `add_fetch` ([#14445](https://github.com/frappe/frappe/pull/14445))
- Handle timeout and deadlocks in db.sql ([#14305](https://github.com/frappe/frappe/pull/14305))
- allow tuple of DocTypes as key to make custom fields using create_custom_fields ([#14419](https://github.com/frappe/frappe/pull/14419))

### Fixes

- Debounce awesome bar search ([#14538](https://github.com/frappe/frappe/pull/14538))

- Changed default for Email Log from 90 to 30 days ([#14543](https://github.com/frappe/frappe/pull/14543))
- Include Theme for Apps section rendered twice ([#14510](https://github.com/frappe/frappe/pull/14510))
- PDF to base64 convert ([#14602](https://github.com/frappe/frappe/pull/14602))
- Info Timeline always shows current logged in user. ([#14519](https://github.com/frappe/frappe/pull/14519))
- `if_owner` constraint being applied wrongly ([#14471](https://github.com/frappe/frappe/pull/14471))
- Get unique records from backend for list ([#13849](https://github.com/frappe/frappe/pull/13849))
- Use whoosh AsyncWriter to prevent write locks ([#14215](https://github.com/frappe/frappe/pull/14215))
- File not attached in attachments, if file is uploaded from webform. ([#14328](https://github.com/frappe/frappe/pull/14328))
- Allow submitting comment with images only ([#14588](https://github.com/frappe/frappe/pull/14588))
- Removed frappe.cache() methods in server scripts ([#14609](https://github.com/frappe/frappe/pull/14609))