### PR TITLE
fix: Tunning performance for sales documents with many itens 20+

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -651,25 +651,26 @@ $.extend(frappe.model, {
 	},
 
 	round_floats_childs_in: function(arr, fieldnames) {
-		var cached_precision = [];
-		$.each(arr || [], function(k, item) {
-			if(!fieldnames) {
-				fieldnames = frappe.meta.get_fieldnames(item.doctype, item.parent,
+		var precision_map = [];
+		if (arr && arr.length > 0) {
+			var firstRow = arr[0];
+			if (!fieldnames) {
+				fieldnames = frappe.meta.get_fieldnames(firstRow.doctype, firstRow.parent,
 					{"fieldtype": ["in", ["Currency", "Float"]]});
 			}
 
-			for(var i=0, j=fieldnames.length; i < j; i++) {
-				var fieldname = fieldnames[i];
-				
-				if (k == 0) { // cache precision on first arr position, the precision will be the same for all rows.
-					// precision was cached because it's running many times, and tuning the loop to many itens on sales documents...
-					cached_precision[fieldname] = precision(fieldname, item);
-				}
+			fieldnames.forEach(fieldname => {
+				// precision was cached because it's running many times, and tuning the loop to many itens on sales documents...
+				precision_map[fieldname] = precision(fieldname, firstRow);
+			})
 
-				item[fieldname] = flt(item[fieldname], cached_precision[fieldname]);
-			}
-		});
-	},	
+			arr.forEach(row => {
+				fieldnames.forEach(fieldname => {
+					row[fieldname] = flt(row[fieldname], precision_map[fieldname]);
+				})
+			})			
+		};
+	},
 
 	validate_missing: function(doc, fieldname) {
 		if(!doc[fieldname]) {

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -650,6 +650,27 @@ $.extend(frappe.model, {
 		}
 	},
 
+	round_floats_childs_in: function(arr, fieldnames) {
+		var cached_precision = [];
+		$.each(arr || [], function(k, item) {
+			if(!fieldnames) {
+				fieldnames = frappe.meta.get_fieldnames(item.doctype, item.parent,
+					{"fieldtype": ["in", ["Currency", "Float"]]});
+			}
+
+			for(var i=0, j=fieldnames.length; i < j; i++) {
+				var fieldname = fieldnames[i];
+				
+				if (k == 0) { // cache precision on first arr position, the precision will be the same for all rows.
+					// precision was cached because it's running many times, and tuning the loop to many itens on sales documents...
+					cached_precision[fieldname] = precision(fieldname, item);
+				}
+
+				item[fieldname] = flt(item[fieldname], cached_precision[fieldname]);
+			}
+		});
+	},	
+
 	validate_missing: function(doc, fieldname) {
 		if(!doc[fieldname]) {
 			frappe.throw(__("Please specify") + ": " +


### PR DESCRIPTION
1. Select which branch should this PR be merged in?
 **version-13**

**This change need FRAPPE and ERPNEXT, ERPNext will use IT.**
https://github.com/frappe/erpnext/pull/28332

About the problem

In my test I had a sales order with 49 items and I was inserting the 50th product, just to insert the product was taking 5.4 seconds, freezing the screen (this time varies according to the client's hardware, in my case I have an i7 10700k).

It was identified that the "calculate_taxes_and_totals" method of "taxes_and_totals.js" was being called 4x every time I inserted a product, but I believe this was not the problem, I went deeper and found that each time I ran the "calculate_item_values", it took a long time about 1350 ms.

I went deeper and found that the problem was in the excessive calling of the precision() function, as I know that precision should be applied to the fields, I decided to do a "cache" and get the precision only for the first row of the item list and apply it for all items in the array.

Result: Reduced execution of "calculate_item_values" from 1300ms to 360ms.

But it still wasn't enough, as the "calculate_rates_and_totals" method is called 4x, 360ms * 4 = 1440ms screen freeze.

The second change was to follow the same logic, take the result of precision() from the first line of the item and cache it in a variable and execute it for the other lines of the array, then calling the function "set_in_company_currency" and passing the decimal places of each field.

Result: Reduced from 360ms to 60ms, 4*60 = 240ms to insert an item.

Perfect. 

for more:  https://discuss.erpnext.com/t/sales-documents-is-slowly-when-we-put-many-itens-30-precision-on-js-is-the-problem/82195