### PR TITLE
revert: "feat(minor): Implement __getitem__ in Base Document"

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -409,7 +409,7 @@ def build_xlsx_data(columns, data, visible_idx, include_indentation, ignore_visi
 	for column in data.columns:
 		if column.get("hidden"):
 			continue
-		result[0].append(column["label"])
+		result[0].append(column.get("label"))
 		column_width = cint(column.get('width', 0))
 		# to convert into scale accepted by openpyxl
 		column_width /= 10

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -246,7 +246,7 @@ def make_links(columns, data):
 		for col in columns:
 			if not row.get(col.fieldname):
 				continue
-			
+
 			if col.fieldtype == "Link":
 				if col.options and col.options != "Currency":
 					row[col.fieldname] = get_link_to_form(col.options, row[col.fieldname])

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -675,7 +675,7 @@ class BaseDocument(object):
 			if data_field_options == "URL":
 				if not data:
 					continue
-				
+
 				frappe.utils.validate_url(data, throw=True)
 
 	def _validate_constants(self):

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -85,9 +85,6 @@ class BaseDocument(object):
 		if hasattr(self, "__setup__"):
 			self.__setup__()
 
-	def __getitem__(self, key):
-		return self.get(key) if hasattr(self, key) else frappe.throw(msg=key, exc=KeyError)
-
 	@property
 	def meta(self):
 		if not hasattr(self, "_meta"):
@@ -678,7 +675,7 @@ class BaseDocument(object):
 			if data_field_options == "URL":
 				if not data:
 					continue
-
+				
 				frappe.utils.validate_url(data, throw=True)
 
 	def _validate_constants(self):


### PR DESCRIPTION
- Reverts frappe/frappe#14855
- Fix keyerror by replacing subscripting with `.get` in auto email report. 

This is causing https://github.com/frappe/frappe/issues/14944 