### PR TITLE
ci: use hotfix branches for patch test

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -106,16 +106,14 @@ jobs:
           source env/bin/activate
           cd apps/frappe/
           git remote set-url upstream https://github.com/frappe/frappe.git
-          git fetch --all --tags
 
-          taglist=$(git tag --sort version:refname | grep -v "beta")
-          last_release=$(echo "$taglist" | tail -1 | cut -d . -f 1 | cut -c 2-)
-
-          for version in $(seq 12 "$last_release")
+          for version in $(seq 12 13)
           do
-              last_tag=$(echo "$taglist" | grep "v$version" | tail -1)
-              echo "Updating to $last_tag"
-              git checkout -q -f "$last_tag"
+              echo "Updating to v$version"
+              branch_name="version-$version-hotfix"
+              git fetch --depth 1 upstream $branch_name:$branch_name
+
+              git checkout -q -f $branch_name
               pip install -q -r requirements.txt
               bench --site test_site migrate
           done


### PR DESCRIPTION
any released patch failure will continue to exist until next release due to the way patch test works... didn't think of this when suggesting https://github.com/frappe/frappe/pull/14251 🥲 