### PR TITLE
fix: minor website styling fixes

### DIFF
--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -99,6 +99,12 @@
 	}
 }
 
+.page-header-wrapper {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
 .breadcrumb-container {
 	margin-top: 1rem;
 	padding-top:  0.25rem;

--- a/frappe/templates/web.html
+++ b/frappe/templates/web.html
@@ -14,7 +14,7 @@
 
 	{% block page_container %}
 	<main class="{% if not full_width %}container my-4{% endif %}">
-		<div class="d-flex justify-content-between align-items-center">
+		<div class="page-header-wrapper">
 			<div class="page-header">
 				{% block header %}{% endblock %}
 			</div>

--- a/frappe/website/doctype/website_theme/website_theme_template.scss
+++ b/frappe/website/doctype/website_theme/website_theme_template.scss
@@ -43,5 +43,12 @@ body {
 	--text-color: #{$body-text-color};
 	--text-light: #{$body-text-color};
 	{% endif -%}
+	{% if not button_rounded_corners %}
+	--border-radius-sm: 0px;
+	--border-radius: 0px;
+	--border-radius-md: 0px;
+	--border-radius-lg: 0px;
+	--border-radius-full: 0px;
+	{% endif -%}
 }
 


### PR DESCRIPTION
### fix: move utility classes from page header wrapper 

So that css is overridable in user stylesheets

### fix(website-theme): obey button rounded corners setting 

When the redesign was merged, the rounded corners setting stopped working. This is a fix for that.

It is fixed by setting all the `--border-radius` css properties to `0px`, but I don't think we should use css variables on the website.