### PR TITLE
fix(patch): Ignore route conflict validation for Custom to Client Script Rename

### DIFF
--- a/frappe/patches/v13_0/rename_custom_client_script.py
+++ b/frappe/patches/v13_0/rename_custom_client_script.py
@@ -1,9 +1,13 @@
 import frappe
+from frappe.model.rename_doc import rename_doc
 
 
 def execute():
 	if frappe.db.exists("DocType", "Client Script"):
 		return
 
-	frappe.rename_doc("DocType", "Custom Script", "Client Script")
+	frappe.flags.ignore_route_conflict_validation = True
+	rename_doc("DocType", "Custom Script", "Client Script")
+	frappe.flags.ignore_route_conflict_validation = False
+
 	frappe.reload_doctype("Client Script", force=True)


### PR DESCRIPTION
**Issue:** When migrating a v12 site to v13 patch `rename_custom_client_script.py` is breaking.

**Reason:** While renaming doctype `validate_route_conflict` method is called. Also, PR: https://github.com/frappe/frappe/pull/12458 has changed the order of  `rename_custom_client_script.py` and `rename_desk_page_to_workspace.py` so now `rename_custom_client_script.py` is called first and desk page is not yet renamed to workspace hence `validate_route_conflict` method is failing.
![image](https://user-images.githubusercontent.com/30859809/141284796-ba36fc36-b3c1-4615-a75b-c19df2fa0c34.png)

**Solution:** Can change the order(Not implemented) or just avoid calling method `validate_route_conflict`
