### PR TITLE
fix: cleaner implementation for link validation

### DIFF
--- a/cypress/integration/control_link.js
+++ b/cypress/integration/control_link.js
@@ -49,7 +49,7 @@ context('Control Link', () => {
 	it('should unset invalid value', () => {
 		get_dialog_with_link().as('dialog');
 
-		cy.intercept('POST', '/api/method/frappe.client.validate_link*').as('validate_link');
+		cy.intercept('POST', '/api/method/frappe.client.validate_link').as('validate_link');
 
 		cy.get('.frappe-control[data-fieldname=link] input')
 			.type('invalid value', { delay: 100 })
@@ -61,7 +61,7 @@ context('Control Link', () => {
 	it('should route to form on arrow click', () => {
 		get_dialog_with_link().as('dialog');
 
-		cy.intercept('POST', '/api/method/frappe.client.validate_link*').as('validate_link');
+		cy.intercept('POST', '/api/method/frappe.client.validate_link').as('validate_link');
 		cy.intercept('POST', '/api/method/frappe.desk.search.search_link').as('search_link');
 
 		cy.get('@todos').then(todos => {
@@ -81,11 +81,11 @@ context('Control Link', () => {
 	it('should fetch valid value', () => {
 		cy.get('@todos').then(todos => {
 			cy.visit(`/app/todo/${todos[0]}`);
-			cy.intercept('GET', '/api/method/frappe.client.get_value*').as('get_value');
+			cy.intercept('POST', '/api/method/frappe.client.validate_link').as('validate_link');
 
 			cy.get('.frappe-control[data-fieldname=assigned_by] input').focus().as('input');
 			cy.get('@input').type('Administrator', {delay: 100}).blur();
-			cy.wait('@get_value');
+			cy.wait('@validate_link');
 			cy.get('.frappe-control[data-fieldname=assigned_by_full_name] .control-value').should(
 				'contain', 'Administrator'
 			);

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -87,7 +87,7 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 		filters = {"name": filters}
 
 	try:
-		fields = json.loads(fieldname)
+		fields = frappe.parse_json(fieldname)
 	except (TypeError, ValueError):
 		# name passed, not json
 		fields = [fieldname]
@@ -407,7 +407,7 @@ def is_document_amended(doctype, docname):
 	return False
 
 @frappe.whitelist()
-def validate_link(doctype: str, docname: str):
+def validate_link(doctype: str, docname: str, fields=None):
 	if not isinstance(doctype, str):
 		frappe.throw(_("DocType must be a string"))
 
@@ -424,4 +424,26 @@ def validate_link(doctype: str, docname: str):
 			frappe.PermissionError
 		)
 
-	return frappe.db.get_value(doctype, docname, cache=True)
+	values = frappe._dict()
+	values.name = frappe.db.get_value(doctype, docname, cache=True)
+
+	fields = frappe.parse_json(fields)
+	if not values.name or not fields:
+		return values
+
+	try:
+		values.update(get_value(doctype, fields, docname))
+	except frappe.PermissionError:
+		frappe.clear_last_message()
+		frappe.msgprint(
+			_("You need {0} permission to fetch values from {1} {2}")
+			.format(
+				frappe.bold(_("Read")),
+				frappe.bold(doctype),
+				frappe.bold(docname)
+			),
+			title=_("Cannot Fetch Values"),
+			indicator="orange"
+		)
+
+	return values

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -167,10 +167,12 @@ frappe.ui.form.Control = class BaseControl {
 		}
 
 		this.inside_change_event = true;
-		var set = function(value) {
+		function set(value) {
 			me.inside_change_event = false;
 			return frappe.run_serially([
+				() => me._validated = true,
 				() => me.set_model_value(value),
+				() => delete me._validated,
 				() => {
 					me.set_mandatory && me.set_mandatory(value);
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -444,7 +444,11 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	}
 	validate(value) {
 		// validate the value just entered
-		if(this.df.options=="[Select]" || this.df.ignore_link_validation) {
+		if (
+			this._validated
+			|| this.df.options=="[Select]"
+			|| this.df.ignore_link_validation
+		) {
 			return value;
 		}
 
@@ -454,39 +458,33 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	validate_link_and_fetch(df, options, docname, value) {
 		if (!value) return;
 
-		return new Promise(async (resolve) => {
-			const fetch_map = this.fetch_map;
-			const columns_to_fetch = Object.values(fetch_map);
+		const fetch_map = this.fetch_map;
+		const columns_to_fetch = Object.values(fetch_map);
 
-			// if default and no fetch, no need to validate
-			if (!columns_to_fetch.length && df.__default_value === value) {
-				return resolve(value);
+		// if default and no fetch, no need to validate
+		if (!columns_to_fetch.length && df.__default_value === value) {
+			return value;
+		}
+
+		return frappe.xcall("frappe.client.validate_link", {
+			doctype: options,
+			docname: value,
+			fields: columns_to_fetch,
+		}).then((response) => {
+			if (!response || !response.name) return "";
+			if (!docname || !columns_to_fetch.length) return response.name;
+
+			for (const [target_field, source_field] of Object.entries(fetch_map)) {
+				frappe.model.set_value(
+					df.parent,
+					docname,
+					target_field,
+					response[source_field],
+					df.fieldtype,
+				);
 			}
 
-			const name = await frappe.xcall("frappe.client.validate_link", {
-				doctype: options,
-				docname: value
-			});
-
-			if (!name) return resolve("");
-			if (!docname || !columns_to_fetch.length) return resolve(name);
-
-			frappe.db.get_value(
-				options,
-				value,
-				columns_to_fetch,
-				(response) => {
-					for (const [target_field, source_field] of Object.entries(fetch_map)) {
-						frappe.model.set_value(
-							df.parent,
-							docname,
-							target_field,
-							response[source_field],
-							df.fieldtype,
-						);
-					}
-				}
-			).always(() => resolve(name));
+			return response.name;
 		});
 	}
 


### PR DESCRIPTION
## Changes Made
- Single API Call: A new flag called `_validated` has been introduced in `BaseControl` to achieve this. The reason why multiple calls were happening is because of [this code](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/form.js#L187).

![image](https://user-images.githubusercontent.com/16315650/141318767-69adc42d-3f93-4dd1-8323-4372fdc23f92.png)



- Use `get_value` inside `validate_link` if fields need to be fetched. `msgprint` for insufficient permissions.

![Screenshot-2021-11-11-195750](https://user-images.githubusercontent.com/16315650/141315762-45bdbec4-bfb3-495a-a1df-46aaac2fd6ab.png)
