### PR TITLE
chore: Clean up requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
+coverage==5.5
 Faker~=8.1.0
 pyngrok~=5.0.5
 unittest-xml-reporting~=3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ boto3~=1.17.53
 braintree~=4.8.0
 chardet~=4.0.0
 Click~=7.1.2
-colorama~=0.4.4
-coverage==5.5
 croniter~=1.0.11
 cryptography~=3.4.7
 dropbox~=11.7.0
@@ -28,7 +26,6 @@ Jinja2~=3.0.1
 ldap3~=2.9
 markdown2~=2.4.0
 maxminddb-geolite2==2018.703
-ndg-httpsclient~=0.5.1
 num2words~=0.5.10
 oauthlib~=3.1.0
 openpyxl~=3.0.7


### PR DESCRIPTION
- `coverage` is needed only for development/tests and colorama is not being used now.
- `httpsclient` was pinned before to fix some issue, it's not necessary right now. 
- `colorama` is only required by click on windows. 