### PR TITLE
fix: Reload user doctype to avoid patch failure

### DIFF
--- a/frappe/core/doctype/role/patches/v13_set_default_desk_properties.py
+++ b/frappe/core/doctype/role/patches/v13_set_default_desk_properties.py
@@ -2,6 +2,7 @@ import frappe
 from ..role import desk_properties
 
 def execute():
+	frappe.reload_doctype('user')
 	frappe.reload_doctype('role')
 	for role in frappe.get_all('Role', ['name', 'desk_access']):
 		role_doc = frappe.get_doc('Role', role.name)


### PR DESCRIPTION
Reload user doctype to avoid patch failure