### PR TITLE
fix: Make symbols translatable

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -129,7 +129,7 @@ function format_currency(v, currency, decimals) {
 	}
 
 	if (symbol)
-		return symbol + " " + format_number(v, format, decimals);
+		return __(symbol) + " " + format_number(v, format, decimals);
 	else
 		return format_number(v, format, decimals);
 }

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -211,7 +211,7 @@ export default class NumberCardWidget extends Widget {
 		const symbol = number_parts[1] || '';
 		const formatted_number = $(frappe.format(number_parts[0], df)).text();
 
-		this.formatted_number = formatted_number + ' ' + symbol;
+		this.formatted_number = formatted_number + ' ' + __(symbol);
 	}
 
 	render_number() {

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -868,7 +868,7 @@ def fmt_money(amount, precision=None, currency=None, format=None):
 
 	if currency and frappe.defaults.get_global_default("hide_currency_symbol") != "Yes":
 		symbol = frappe.db.get_value("Currency", currency, "symbol", cache=True) or currency
-		amount = symbol + " " + amount
+		amount = frappe._(symbol) + " " + amount
 
 	return amount
 


### PR DESCRIPTION
Some currencies have characters values in symbols and these values changes from one language to another
eg. KWD (en) and د.ك (ar) so in print format and when format currency it depends on system language!