### PR TITLE
fix: parent doctype freezes

### DIFF
--- a/frappe/public/js/frappe/views/container.js
+++ b/frappe/public/js/frappe/views/container.js
@@ -42,7 +42,6 @@ frappe.views.Container = class Container {
 		cur_page = this;
 		if(this.page && this.page.label === label) {
 			$(this.page).trigger('show');
-			return;
 		}
 
 		var me = this;


### PR DESCRIPTION
**Issue:**
Parent doctype freezes whenever it's been redirected from its child table.

***Before***

https://user-images.githubusercontent.com/58825865/142565439-1fb0c8ba-5f84-4d2a-9084-d334445307f5.mov

***After***

https://user-images.githubusercontent.com/58825865/142562939-b228b27c-62d0-4d60-ae6b-ab21ec597743.mov

***Steps to reproduce***
1. make a journal entry(or any other entry where you can add reference number in child table).
2. make a reverse journal entry of the 1st one(so that the reference number is automatically added).
3. In the second entry, open one row of child table and click on the link to parent doctype
4. You will see your screen freezes(this only happens when you link the same document type in the child table)
