### PR TITLE
fix: Replaced capitalize to to_title_case util method

### DIFF
--- a/frappe/public/js/frappe/utils/user.js
+++ b/frappe/public/js/frappe/utils/user.js
@@ -12,7 +12,7 @@ frappe.user_info = function(uid) {
 
 	if(!(frappe.boot.user_info && frappe.boot.user_info[uid])) {
 		var user_info = {
-			fullname: frappe.utils.capitalize(uid.split("@")[0]) || "Unknown"
+			fullname: frappe.utils.to_title_case(uid.split("@")[0]) || "Unknown"
 		};
 	} else {
 		var user_info = frappe.boot.user_info[uid];


### PR DESCRIPTION
There is no such method named as `frappe.utils.capitalize`, replacing it with `frappe.utils.to_title_case`