### PR TITLE
feat(ux): Option to disable EPS notifications

### DIFF
--- a/frappe/desk/doctype/notification_settings/notification_settings.json
+++ b/frappe/desk/doctype/notification_settings/notification_settings.json
@@ -15,7 +15,9 @@
   "enable_email_energy_point",
   "enable_email_share",
   "user",
-  "seen"
+  "seen",
+  "system_notifications_section",
+  "energy_points_system_notifications"
  ],
  "fields": [
   {
@@ -84,15 +86,27 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Seen"
+  },
+  {
+   "fieldname": "system_notifications_section",
+   "fieldtype": "Section Break",
+   "label": "System Notifications"
+  },
+  {
+   "default": "1",
+   "fieldname": "energy_points_system_notifications",
+   "fieldtype": "Check",
+   "label": "Energy Points"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-11-04 12:54:57.989317",
+ "modified": "2021-11-16 12:18:46.955501",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Settings",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -32,7 +32,9 @@ class EnergyPointLog(Document):
 		frappe.cache().hdel('energy_points', self.user)
 		frappe.publish_realtime('update_points', after_commit=True)
 
-		if self.type != 'Review':
+		if self.type != 'Review' and \
+			frappe.get_cached_value('Notification Settings', self.user, 'energy_points_system_notifications'):
+
 			reference_user = self.user if self.type == 'Auto' else self.owner
 			notification_doc = {
 				'type': 'Energy Point',


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/14595 

simple checkbox in notification settings to disable receiving EPS notifications. 

<img width="539" alt="Screenshot 2021-11-16 at 11 11 12 PM" src="https://user-images.githubusercontent.com/9079960/142037806-53e4c526-153c-45a0-bc3f-1ceeae1396ec.png">


`no-docs` (self explanatory) 