### PR TITLE
fix: Only allow group_by for list view data

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -408,7 +408,6 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	get_group_by() {
-		if (this.view && this.view !== 'List') return;
 		let name_field = this.fields && this.fields.find(f => f[0] == 'name');
 		if (name_field) {
 			return frappe.model.get_full_column_name(name_field[0], name_field[1]);

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -408,6 +408,7 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	get_group_by() {
+		if (this.view && this.view !== 'List') return;
 		let name_field = this.fields && this.fields.find(f => f[0] == 'name');
 		if (name_field) {
 			return frappe.model.get_full_column_name(name_field[0], name_field[1]);

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -106,6 +106,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	get_args() {
 		const args = super.get_args();
+		args.group_by = null;
 		this.group_by_control.set_args(args);
 
 		return args;


### PR DESCRIPTION
Issue:
If Sales Order (can be any doctype) has multiple suppose 2 items. If we view it in report view and add an extra item column, we should be able to see 2 records for that Sales Order.

Before: Only able to see 1 record
![image](https://user-images.githubusercontent.com/30859809/142222012-09a47167-c15f-470f-a663-e3bd7df62458.png)

After: Can see 2 records
![image](https://user-images.githubusercontent.com/30859809/142221841-706acc18-861a-4e01-885e-4e81fbd0dd2c.png)

caused by: https://github.com/frappe/frappe/pull/13849