### PR TITLE
feat: Auto attached documents while replying

### DIFF
--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -168,7 +168,7 @@ frappe.views.InteractionComposer = class InteractionComposer {
 				f.file_url = frappe.urllib.get_full_url(f.file_url);
 
 				$(repl('<p class="checkbox">'
-					+	'<label><span><input type="checkbox" data-file-name="%(name)s"></input></span>'
+					+	'<label><span><input type="checkbox" data-file-name="%(name)s" checked="checked"></input></span>'
 					+		'<span class="small">%(file_name)s</span>'
 					+	' <a href="%(file_url)s" target="_blank" class="text-muted small">'
 					+		'<i class="fa fa-share" style="vertical-align: middle; margin-left: 3px;"></i>'


### PR DESCRIPTION
The attached documents checkbox will already be checked, useful for sending sales invoices and their attachments, in the case of Mexico, the xml files.
![image](https://user-images.githubusercontent.com/41874407/142271719-0f316380-91cb-4d4e-8400-fc047c4c3e0a.png)
