### PR TITLE
fix: Only show report when there is data

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -634,6 +634,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				this.render_datatable();
 				this.add_chart_buttons_to_toolbar(true);
 				this.add_card_button_to_toolbar();
+				this.$report.show();
 			} else {
 				this.data = [];
 				this.toggle_nothing_to_show(true);
@@ -882,7 +883,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	hide_loading_screen() {
 		this.$loading.hide();
-		this.$report.show();
 	}
 
 	get_chart_options(data) {


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/14434

**Issue:** 
If we use the filter in query_report (Stock Balance) suppose set item as `item 7` there is no `item 7` record in the selected time frame but the result still shows previous data and `Nothing to show` message is also displayed.

**Before:**
![image](https://user-images.githubusercontent.com/30859809/142382554-7d607766-49e7-4574-a0dc-026461cc8dc2.png)

**After:**
![image](https://user-images.githubusercontent.com/30859809/142382850-d3c91db8-2793-491f-a1b8-110ee61536bc.png)
