### PR TITLE
fix: change Event subject data type from Data to Text

### DIFF
--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -53,7 +53,7 @@
   },
   {
    "fieldname": "subject",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "in_global_search": 1,
    "in_list_view": 1,
    "label": "Subject",
@@ -277,10 +277,11 @@
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2020-01-14 21:47:15.825287",
+ "modified": "2021-11-18 05:06:24.881742",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -157,7 +157,7 @@ class TestDocument(unittest.TestCase):
 
 	def test_varchar_length(self):
 		d = self.test_insert()
-		d.subject = "abcde"*100
+		d.sender = "abcde"*100 + "@user.com"
 		self.assertRaises(frappe.CharacterLengthExceededError, d.save)
 
 	def test_xss_filter(self):


### PR DESCRIPTION
The subject can be longer than 140 characters. No real reason to restrict
it to an arbitrary length.

PS: This is required because events are often created from other doctypes
automatically and longer subject lines cause a failure where the user can't
do much to recover from it.

