### PR TITLE
fix: Exporting from report builder not exporting all rows

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -106,7 +106,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	get_args() {
 		const args = super.get_args();
-		args.group_by = null;
+		delete args.group_by;
 		this.group_by_control.set_args(args);
 
 		return args;


### PR DESCRIPTION
PR: https://github.com/frappe/frappe/pull/15008 fixed the below issue 
If Sales Order (can be any doctype) has multiple suppose 2 items. If we view it in report view and add an extra item column, we should be able to see 2 records for that Sales Order.

but, if we export the same data to Excel we still do not get 2 records. This PR fixes that issue.
Before:
![image](https://user-images.githubusercontent.com/30859809/142409991-5831e2a1-99bf-420e-a0d8-88479f642a2b.png)

After:
![image](https://user-images.githubusercontent.com/30859809/142410119-1b1158c1-a62f-4327-958d-1ec61a1e32bd.png)
