### PR TITLE
fix: Add distinct to sql query

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -445,6 +445,7 @@ frappe.views.BaseList = class BaseList {
 			start: this.start,
 			page_length: this.page_length,
 			view: this.view,
+			distinct: true,
 			group_by: this.get_group_by()
 		};
 	}


### PR DESCRIPTION
add distinct to sql
when filter by field in child table and the value is duplicated eg. Create (Delivery Note from Order)
and delivery note has 20 item so when filter by against order it will fetch one delivery note for all items that have order value
then the `prepare_data` function will execute and show only one delivery note because `uniqBy`