### PR TITLE
fix: Exporting from report builder not exporting all rows bp v13

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -105,7 +105,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	get_args() {
 		const args = super.get_args();
-		args.group_by = null;
+		delete args.group_by;
 		this.group_by_control.set_args(args);
 
 		return args;


### PR DESCRIPTION
Backport of #15020