### PR TITLE
feat: add no-git option in make-app command and boilerplate generation

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -791,10 +791,11 @@ def request(context, args=None, path=None):
 @click.command('make-app')
 @click.argument('destination')
 @click.argument('app_name')
-def make_app(destination, app_name):
+@click.option('--no-git', is_flag=True, default=False, help='Do not initialize git repository for the app')
+def make_app(destination, app_name, no_git=False):
 	"Creates a boilerplate app"
 	from frappe.utils.boilerplate import make_boilerplate
-	make_boilerplate(destination, app_name)
+	make_boilerplate(destination, app_name, no_git=no_git)
 
 
 @click.command('set-config')

--- a/frappe/tests/test_boilerplate.py
+++ b/frappe/tests/test_boilerplate.py
@@ -11,14 +11,7 @@ from frappe.utils.boilerplate import make_boilerplate
 
 class TestBoilerPlate(unittest.TestCase):
 	@classmethod
-	def tearDownClass(cls):
-
-		bench_path = frappe.utils.get_bench_path()
-		test_app_dir = os.path.join(bench_path, "apps", "test_app")
-		if os.path.exists(test_app_dir):
-			shutil.rmtree(test_app_dir)
-
-	def test_create_app(self):
+	def setUpClass(cls):
 		title = "Test App"
 		description = "This app's description contains 'single quotes' and \"double quotes\"."
 		publisher = "Test Publisher"
@@ -27,7 +20,7 @@ class TestBoilerPlate(unittest.TestCase):
 		color = ""
 		app_license = "MIT"
 
-		user_input = [
+		cls.user_input = [
 			title,
 			description,
 			publisher,
@@ -37,22 +30,21 @@ class TestBoilerPlate(unittest.TestCase):
 			app_license,
 		]
 
-		bench_path = frappe.utils.get_bench_path()
-		apps_dir = os.path.join(bench_path, "apps")
-		app_name = "test_app"
+		cls.bench_path = frappe.utils.get_bench_path()
+		cls.apps_dir = os.path.join(cls.bench_path, "apps")
+		cls.app_names = ("test_app", "test_app_no_git")
+		cls.gitignore_file = ".gitignore"
+		cls.git_folder = ".git"
 
-		with patch("builtins.input", side_effect=user_input):
-			make_boilerplate(apps_dir, app_name)
-
-		root_paths = [
-			app_name,
+		cls.root_paths = [
 			"requirements.txt",
 			"README.md",
 			"setup.py",
 			"license.txt",
-			".git",
+			cls.git_folder,
+			cls.gitignore_file
 		]
-		paths_inside_app = [
+		cls.paths_inside_app = [
 			"__init__.py",
 			"hooks.py",
 			"patches.txt",
@@ -60,25 +52,68 @@ class TestBoilerPlate(unittest.TestCase):
 			"www",
 			"config",
 			"modules.txt",
-			"public",
-			app_name,
+			"public"
 		]
 
-		new_app_dir = os.path.join(bench_path, apps_dir, app_name)
+	@classmethod
+	def tearDownClass(cls):
+		test_app_dirs = (os.path.join(cls.bench_path, "apps", app_name) for app_name in cls.app_names)
+		for test_app_dir in test_app_dirs:
+			if os.path.exists(test_app_dir):
+				shutil.rmtree(test_app_dir)
 
+	def test_create_app(self):
+		with patch("builtins.input", side_effect=self.user_input):
+			make_boilerplate(self.apps_dir, self.app_names[0])
+
+		new_app_dir = os.path.join(self.bench_path, self.apps_dir, self.app_names[0])
+
+		paths = self.get_paths(new_app_dir, self.app_names[0])
+		for path in paths:
+			self.assertTrue(
+				os.path.exists(path),
+				msg=f"{path} should exist in {self.app_names[0]} app"
+			)
+
+		self.check_parsable_python_files(new_app_dir)
+
+	def test_create_app_without_git_init(self):
+		with patch("builtins.input", side_effect=self.user_input):
+			make_boilerplate(self.apps_dir, self.app_names[1], no_git=True)
+
+		new_app_dir = os.path.join(self.apps_dir, self.app_names[1])
+
+		paths = self.get_paths(new_app_dir, self.app_names[1])
+		for path in paths:
+			if os.path.basename(path) in (self.git_folder, self.gitignore_file):
+				self.assertFalse(
+					os.path.exists(path),
+					msg=f"{path} shouldn't exist in {self.app_names[1]} app"
+				)
+			else:
+				self.assertTrue(
+					os.path.exists(path),
+					msg=f"{path} should exist in {self.app_names[1]} app"
+				)
+
+		self.check_parsable_python_files(new_app_dir)
+
+	def get_paths(self, app_dir, app_name):
 		all_paths = list()
 
-		for path in root_paths:
-			all_paths.append(os.path.join(new_app_dir, path))
+		for path in self.root_paths:
+			all_paths.append(os.path.join(app_dir, path))
 
-		for path in paths_inside_app:
-			all_paths.append(os.path.join(new_app_dir, app_name, path))
+		all_paths.append(os.path.join(app_dir, app_name))
 
-		for path in all_paths:
-			self.assertTrue(os.path.exists(path), msg=f"{path} should exist in new app")
+		for path in self.paths_inside_app:
+			all_paths.append(os.path.join(app_dir, app_name, path))
 
+		return all_paths
+
+	def check_parsable_python_files(self, app_dir):
 		# check if python files are parsable
-		python_files = glob.glob(new_app_dir + "**/*.py", recursive=True)
+		python_files = glob.glob(app_dir + "**/*.py", recursive=True)
 
 		for python_file in python_files:
 			with open(python_file) as p:

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -3,7 +3,7 @@
 import frappe, os, re, git
 from frappe.utils import touch_file, cstr
 
-def make_boilerplate(dest, app_name):
+def make_boilerplate(dest, app_name, no_git=False):
 	if not os.path.exists(dest):
 		print("Destination directory does not exist")
 		return
@@ -63,9 +63,6 @@ def make_boilerplate(dest, app_name):
 	with open(os.path.join(dest, hooks.app_name, "MANIFEST.in"), "w") as f:
 		f.write(frappe.as_unicode(manifest_template.format(**hooks)))
 
-	with open(os.path.join(dest, hooks.app_name, ".gitignore"), "w") as f:
-		f.write(frappe.as_unicode(gitignore_template.format(app_name = hooks.app_name)))
-
 	with open(os.path.join(dest, hooks.app_name, "requirements.txt"), "w") as f:
 		f.write("# frappe -- https://github.com/frappe/frappe is installed via 'bench init'")
 
@@ -98,11 +95,16 @@ def make_boilerplate(dest, app_name):
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "config", "docs.py"), "w") as f:
 		f.write(frappe.as_unicode(docs_template.format(**hooks)))
 
-	# initialize git repository
 	app_directory = os.path.join(dest, hooks.app_name)
-	app_repo = git.Repo.init(app_directory)
-	app_repo.git.add(A=True)
-	app_repo.index.commit("feat: Initialize App")
+
+	if not no_git:
+		with open(os.path.join(dest, hooks.app_name, ".gitignore"), "w") as f:
+			f.write(frappe.as_unicode(gitignore_template.format(app_name = hooks.app_name)))
+
+		# initialize git repository
+		app_repo = git.Repo.init(app_directory)
+		app_repo.git.add(A=True)
+		app_repo.index.commit("feat: Initialize App")
 
 	print("'{app}' created at {path}".format(app=app_name, path=app_directory))
 


### PR DESCRIPTION
Allowing non git initialisation of apps when using frappe's `make-app` command and/or when using bench's `new-app` command

This pr is in conjunction with https://github.com/frappe/bench/pull/1218
docs: https://github.com/frappe/frappe_docs/pull/226


TODO:
- [x] Add test(s)

PS: This pr (accidentally) introduces a (kind of) feature in taking input value when testing commands using `execute` method of `BaseTestCommands` class - [here](https://github.com/frappe/frappe/pull/15028/files#diff-502d69e82ab1b5ed9489a4eda4c1fe42362643aa03c348fe9b08fba8b5cd61cbR123) :P