### PR TITLE
fix: set `Script Manager` as a standard role

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -2,15 +2,22 @@
 # License: MIT. See LICENSE
 
 import frappe
-
 from frappe.model.document import Document
 
 desk_properties = ("search_bar", "notifications", "list_sidebar",
 	"bulk_actions", "view_switcher", "form_sidebar", "timeline", "dashboard")
 
+STANDARD_ROLES = (
+	"Administrator",
+	"System Manager",
+	"Script Manager",
+	"All",
+	"Guest"
+)
+
 class Role(Document):
 	def before_rename(self, old, new, merge=False):
-		if old in ("Guest", "Administrator", "System Manager", "All"):
+		if old in STANDARD_ROLES:
 			frappe.throw(frappe._("Standard roles cannot be renamed"))
 
 	def after_insert(self):
@@ -23,7 +30,7 @@ class Role(Document):
 			self.set_desk_properties()
 
 	def disable_role(self):
-		if self.name in ("Guest", "Administrator", "System Manager", "All"):
+		if self.name in STANDARD_ROLES:
 			frappe.throw(frappe._("Standard roles cannot be disabled"))
 		else:
 			self.remove_roles()


### PR DESCRIPTION
**Script Manager** has been hardcoded in some places when executing `frappe.only_for`. Consequently, it should be treated as standard.

Also includes minor refactoring.