### PR TITLE
fix: Use `get_all` instead of `get_list` for child doctype

### DIFF
--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -191,7 +191,7 @@ class Exporter:
 					[format_column_name(df) for df in self.fields if df.parent == child_table_doctype]
 				)
 			)
-			data = frappe.db.get_list(
+			data = frappe.db.get_all(
 				child_table_doctype,
 				filters={
 					"parent": ("in", parent_names),


### PR DESCRIPTION
This change is required to avoid following permission error

```python
self.csv_array += self.data
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/core/doctype/data_import/exporter.py", line 125, in get_data_to_export
    for doc in data:
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/core/doctype/data_import/exporter.py", line 203, in get_data_as_docs
    as_list=0,
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/database/database.py", line 503, in get_list
    return frappe.get_list(*args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 1446, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/model/db_query.py", line 40, in execute
    not frappe.has_permission(self.doctype, "select", user=user, parent_doctype=parent_doctype) and \
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 743, in has_permission
    raise_exception=throw, parent_doctype=parent_doctype)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/permissions.py", line 24, in inner
    result = func(*args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/permissions.py", line 55, in has_permission
    user, raise_exception, parent_doctype)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/permissions.py", line 585, in has_child_table_permission
    ), title=_("Parent DocType Required"))
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 438, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 417, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/__init__.py", line 371, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Please specify a valid parent DocType for Timesheet Detail
```

to replicate the above error:

1. Go to Project
2. Under Connections click Timesheet

The issue was introduced via https://github.com/frappe/frappe/pull/14526