### PR TITLE
fix: Load assets required for geolocation control

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -3,6 +3,11 @@ frappe.provide('frappe.utils.utils');
 frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.form.ControlData {
 	static horizontal = false
 
+	async make() {
+		await frappe.require(this.required_libs);
+		super.make();
+	}
+
 	make_wrapper() {
 		// Create the elements for map area
 		super.make_wrapper();
@@ -195,5 +200,18 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 		this.editableLayers.eachLayer((l)=>{
 			this.editableLayers.removeLayer(l);
 		});
+	}
+
+	get required_libs() {
+		return [
+			"assets/frappe/js/lib/leaflet/easy-button.css",
+			"assets/frappe/js/lib/leaflet/L.Control.Locate.css",
+			"assets/frappe/js/lib/leaflet/leaflet.draw.css",
+			"assets/frappe/js/lib/leaflet/leaflet.css",
+			"assets/frappe/js/lib/leaflet/leaflet.js",
+			"assets/frappe/js/lib/leaflet/easy-button.js",
+			"assets/frappe/js/lib/leaflet/leaflet.draw.js",
+			"assets/frappe/js/lib/leaflet/L.Control.Locate.js",
+		];
 	}
 };


### PR DESCRIPTION
**Before** (form with geolocation control):
<img width="1440" alt="Screenshot 2021-11-22 at 2 35 27 PM" src="https://user-images.githubusercontent.com/13928957/142833453-5cafb194-b8ed-4749-b00a-7eaaea02c17b.png">

**After:**
<img width="1440" alt="Screenshot 2021-11-22 at 2 37 25 PM" src="https://user-images.githubusercontent.com/13928957/142833492-0ab36d67-a3da-46d5-b3e5-359d184d57d0.png">

