### PR TITLE
fix: Give select permission to 'All' for workflow state

### DIFF
--- a/frappe/workflow/doctype/workflow_state/workflow_state.json
+++ b/frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -112,7 +112,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-02-20 13:33:44.011509", 
+ "modified": "2021-11-22 17:56:40.495232", 
  "modified_by": "Administrator", 
  "module": "Workflow", 
  "name": "Workflow State", 
@@ -137,6 +137,10 @@
    "share": 1, 
    "submit": 0, 
    "write": 1
+  },
+  {
+   "role": "All",
+   "select": 1
   }
  ], 
  "quick_entry": 1, 


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/14943
**Issue:**
If a Workflow is created for any doctype (Purchase Order). If a user without a System Manager role tries to create a Purchase Order he/she will get an error `You do not have Read or Select Permissions for Workflow State`

**Solution:**
Giving select permission to **All** for Workflow State doctype

