### PR TITLE
chore: change log for v13.15.0

### DIFF
--- a/frappe/change_log/v13/v13_15_0.md
+++ b/frappe/change_log/v13/v13_15_0.md
@@ -1,0 +1,20 @@
+# Version 13.15.0 Release Notes
+
+### Features & Enhancements
+
+- Add format dd.mm.yy to dateutils ([#14879](https://github.com/frappe/frappe/pull/14879))
+- Prepared report read from replica ([#14883](https://github.com/frappe/frappe/pull/14883))
+- API to change the custom button type ([#14074](https://github.com/frappe/frappe/pull/14074))
+
+### Fixes
+
+- Multi level custom report fix ([#14489](https://github.com/frappe/frappe/pull/14489))
+- Dashboard Chart to support Child Table Doctype ([#13995](https://github.com/frappe/frappe/pull/13995))
+- Exporting from report builder not exporting all rows ([#15020](https://github.com/frappe/frappe/pull/15020))
+- CSS for Primary navbar template ([#14356](https://github.com/frappe/frappe/pull/14356))
+- Hide 'Show Saved' filter button if there is no saved filters ([#14309](https://github.com/frappe/frappe/pull/14309))
+- Give select permission to 'All' for workflow state ([#15044](https://github.com/frappe/frappe/pull/15044))
+- Filter pop-up overlaps the Notification Window ([#14355](https://github.com/frappe/frappe/pull/14355))
+- Translate preview popover data ([#14842](https://github.com/frappe/frappe/pull/14842))
+- Clean `join` param when executing `reportview.get` ([#14845](https://github.com/frappe/frappe/pull/14845))
+- Fixes for API Access section in User ([#14594](https://github.com/frappe/frappe/pull/14594))


### PR DESCRIPTION
# Version 13.15.0 Release Notes

### Features & Enhancements

- Add format dd.mm.yy to dateutils ([#14879](https://github.com/frappe/frappe/pull/14879))
- Prepared report read from replica ([#14883](https://github.com/frappe/frappe/pull/14883))
- API to change the custom button type ([#14074](https://github.com/frappe/frappe/pull/14074))

### Fixes

- Multi level custom report fix ([#14489](https://github.com/frappe/frappe/pull/14489))
- Dashboard Chart to support Child Table Doctype ([#13995](https://github.com/frappe/frappe/pull/13995))
- Exporting from report builder not exporting all rows ([#15020](https://github.com/frappe/frappe/pull/15020))
- CSS for Primary navbar template ([#14356](https://github.com/frappe/frappe/pull/14356))
- Hide 'Show Saved' filter button if there is no saved filters ([#14309](https://github.com/frappe/frappe/pull/14309))
- Give select permission to 'All' for workflow state ([#15044](https://github.com/frappe/frappe/pull/15044))
- Filter pop-up overlaps the Notification Window ([#14355](https://github.com/frappe/frappe/pull/14355))
- Translate preview popover data ([#14842](https://github.com/frappe/frappe/pull/14842))
- Clean `join` param when executing `reportview.get` ([#14845](https://github.com/frappe/frappe/pull/14845))
- Fixes for API Access section in User ([#14594](https://github.com/frappe/frappe/pull/14594))