### PR TITLE
fix: Remove edit icon from quick entry to avoid browser crash

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -267,7 +267,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 	render_edit_in_full_page_link() {
 		var me = this;
 		this.dialog.add_custom_action(
-			`${frappe.utils.icon('edit', 'xs')} ${__("Edit in full page")}`,
+			`${__("Edit in full page")}`,
 			() => me.open_doc(true)
 		);
 	}


### PR DESCRIPTION
**Before:**

https://user-images.githubusercontent.com/13928957/142960923-35345d65-6944-4190-aa2f-1ff4c44dbb12.mov

**After:**

https://user-images.githubusercontent.com/13928957/142960931-00f1dcb5-2c13-4aa5-b449-d2e8718d3af3.mov


Before, the quick entry of ToDo was freezing the browser tab. On debugging I found that removing the edit icon from the **Edit in full page** button in quick entry resolves the issue.

**Root cause:** Spent a lot of time finding but did not get enough information online on this. (guessing that the SVG is triggering some calculation in a loop which is making the browser go crazy)
The issue is only replicable in the chromium browser (on mac laptops I guess).

Made this temporary fix since lots of people use chrome browsers.

--
https://frappe.io/app/issue/ISS-21-22-08257