### PR TITLE
fix: multi select filters in query report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -481,17 +481,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			df.onchange = () => {
 				this.refresh_filters_dependency();
 
-				let current_filters = this.get_filter_values();
-				if (this.previous_filters
-					&& (JSON.stringify(this.previous_filters) === JSON.stringify(current_filters))) {
-					// filter values have not changed
-					return;
-				}
-
-				// clear previous_filters after 10 seconds, to allow refresh for new data
-				this.previous_filters = current_filters;
-				setTimeout(() => this.previous_filters = null, 10000);
-
 				if (f.on_change) {
 					f.on_change(this);
 				} else {


### PR DESCRIPTION
**Issue**
In the query report, if the filter is a multi-select field, selecting the values doesn't refresh the report. The report refreshes when you unselect the value.

***Example: General Ledger report***

https://user-images.githubusercontent.com/58825865/143015558-ce329fb1-0658-494f-9482-b59c39c22e07.mov

**After Fix**


https://user-images.githubusercontent.com/58825865/143015634-5848d0a6-e045-41d4-b848-2dad86770674.mov


