### PR TITLE
fix(Newsletter): append "open in web" only if enabled

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -159,11 +159,10 @@ class Newsletter(WebsiteGenerator):
 	def send_newsletter(self, emails: List[str]):
 		"""Trigger email generation for `emails` and add it in Email Queue.
 		"""
-		# TODO: get rid of this maybe?
-		message = self.get_message()
 		attachments = self.get_newsletter_attachments()
 		sender = self.send_from or frappe.utils.get_formatted_email(self.owner)
-		args = {"message": message, "name": self.name}
+		args = self.as_dict()
+		args["message"] = self.get_message()
 
 		is_auto_commit_set = bool(frappe.db.auto_commit_on_many_writes)
 		frappe.db.auto_commit_on_many_writes = not frappe.flags.in_test
@@ -172,7 +171,6 @@ class Newsletter(WebsiteGenerator):
 			subject=self.subject,
 			sender=sender,
 			recipients=emails,
-			message=message,
 			attachments=attachments,
 			template="newsletter",
 			add_unsubscribe_link=self.send_unsubscribe_link,

--- a/frappe/templates/emails/newsletter.html
+++ b/frappe/templates/emails/newsletter.html
@@ -3,8 +3,11 @@
         {{ message }}
     </div>
 </div>
+
+{% if published and send_webview_link %}
 <div style="font-size: 12px; line-height: 20px;">
     <div>
         Open in <a style="color: #687178; text-decoration: underline;" href="/newsletters/{{ name }}" target="_blank">web</a>
     </div>
 </div>
+{% endif %}


### PR DESCRIPTION
In Newsletter we can enable or disable "Published" and "Send Web View Link". However, the web view link was sent regardless of whether these were enabled.

<img width="1320" alt="Bildschirmfoto 2021-11-23 um 12 46 32" src="https://user-images.githubusercontent.com/14891507/143018771-84ab339e-03e6-4d10-82fb-8b457e9c2152.png">

Now we append the "Open in [web]()" paragraph only if "Published" and "Send Web View Link" are both enabled.

Further changes:

- pass the whole newsletter doc to the template to enable easier extension in the future or by custom apps
- don't pass `message` to `sendmail()` - It doesn't get used anyways because we pass `template="newsletter"`