### PR TITLE
refactor: Misc changes in commands

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -447,11 +447,10 @@ def disable_user(context, email):
 @pass_context
 def migrate(context, skip_failing=False, skip_search_index=False):
 	"Run patches, sync schema and rebuild files/translations"
-	import re
 	from frappe.migrate import migrate
 
 	for site in context.sites:
-		print('Migrating', site)
+		click.secho(f"Migrating {site}", fg="green")
 		frappe.init(site=site)
 		frappe.connect()
 		try:
@@ -697,8 +696,7 @@ def _drop_site(site, root_login='root', root_password=None, archived_sites_path=
 
 	drop_user_and_database(frappe.conf.db_name, root_login, root_password)
 
-	if not archived_sites_path:
-		archived_sites_path = os.path.join(frappe.get_app_path('frappe'), '..', '..', '..', 'archived_sites')
+	archived_sites_path = archived_sites_path or os.path.join(frappe.get_app_path('frappe'), '..', '..', '..', 'archived', 'sites')
 
 	if not os.path.exists(archived_sites_path):
 		os.mkdir(archived_sites_path)

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -829,39 +829,37 @@ def publish_realtime(context, event, message, room, user, doctype, docname, afte
 @pass_context
 def browse(context, site, user=None):
 	'''Opens the site on web browser'''
-	from frappe.auth import LoginManager
-	from frappe.auth import CookieManager
-	import webbrowser
+	from frappe.auth import CookieManager, LoginManager
 
-	site = context.sites[0] if context.sites else site
+	site = get_site(context, raise_err=False) or site
 
 	if not site:
-		click.echo('''Please provide site name\n\nUsage:\n\tbench browse [site-name]\nor\n\tbench --site [site-name] browse''')
-		return
+		raise SiteNotSpecifiedError
 
-	site = site.lower()
+	if site not in frappe.utils.get_sites():
+		click.echo(f"\nSite named {click.style(site, bold=True)} doesn't exist\n", err=True)
+		sys.exit(1)
 
-	if site in frappe.utils.get_sites():
-		frappe.init(site=site)
-		frappe.connect()
+	frappe.init(site=site)
+	frappe.connect()
 
-		sid = ''
-		if user:
-			if frappe.conf.developer_mode or user == "Administrator":
-				frappe.utils.set_request(path="/")
-				frappe.local.cookie_manager = CookieManager()
-				frappe.local.login_manager = LoginManager()
-				frappe.local.login_manager.login_as(user)
-				sid = f'/app?sid={frappe.session.sid}'
-			else:
-				print("Please enable developer mode to login as a user")
+	sid = ''
+	if user:
+		if frappe.conf.developer_mode or user == "Administrator":
+			frappe.utils.set_request(path="/")
+			frappe.local.cookie_manager = CookieManager()
+			frappe.local.login_manager = LoginManager()
+			frappe.local.login_manager.login_as(user)
+			sid = f'/app?sid={frappe.session.sid}'
+		else:
+			click.echo("Please enable developer mode to login as a user")
 
-		url = f'{frappe.utils.get_site_url(site)}{sid}'
-		if user == "Administrator":
-			print(f'Login URL: {url}')
-		webbrowser.open(url, new=2)
-	else:
-		click.echo("\nSite named \033[1m{}\033[0m doesn't exist\n".format(site))
+	url = f'{frappe.utils.get_site_url(site)}{sid}'
+
+	if user == "Administrator":
+		click.echo(f'Login URL: {url}')
+
+	click.launch(url)
 
 
 @click.command('start-recording')

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -7,7 +7,7 @@ import os
 import shlex
 import shutil
 import subprocess
-import sys
+from typing import List
 import unittest
 import glob
 
@@ -18,37 +18,11 @@ from frappe.installer import add_to_installed_apps, remove_app
 from frappe.utils import add_to_date, get_bench_relative_path, now
 from frappe.utils.backups import fetch_latest_backups
 
-
-# TODO: check frappe.cli.coloured_output to set coloured output!
-def supports_color():
-	"""
-	Returns True if the running system's terminal supports color, and False
-	otherwise.
-	"""
-	plat = sys.platform
-	supported_platform = plat != 'Pocket PC' and (plat != 'win32' or 'ANSICON' in os.environ)
-	# isatty is not always implemented, #6223.
-	is_a_tty = hasattr(sys.stdout, 'isatty') and sys.stdout.isatty()
-	return supported_platform and is_a_tty
+# imports - third party imports
+import click
 
 
-class color(dict):
-	nc = "\033[0m"
-	blue = "\033[94m"
-	green = "\033[92m"
-	yellow = "\033[93m"
-	red = "\033[91m"
-	silver = "\033[90m"
-
-	def __getattr__(self, key):
-		if supports_color():
-			ret = self.get(key)
-		else:
-			ret = ""
-		return ret
-
-
-def clean(value):
+def clean(value) -> str:
 	"""Strips and converts bytes to str
 
 	Args:
@@ -64,7 +38,7 @@ def clean(value):
 	return value
 
 
-def missing_in_backup(doctypes, file):
+def missing_in_backup(doctypes: List, file: os.PathLike) -> List:
 	"""Returns list of missing doctypes in the backup.
 
 	Args:
@@ -86,7 +60,7 @@ def missing_in_backup(doctypes, file):
 			if predicate.format(doctype).lower() not in content]
 
 
-def exists_in_backup(doctypes, file):
+def exists_in_backup(doctypes: List, file: os.PathLike) -> bool:
 	"""Checks if the list of doctypes exist in the database.sql.gz file supplied
 
 	Args:
@@ -118,7 +92,8 @@ class BaseTestCommands(unittest.TestCase):
 			kwargs = site
 
 		self.command = " ".join(command.split()).format(**kwargs)
-		print("{0}$ {1}{2}".format(color.silver, self.command, color.nc))
+		click.secho(self.command, fg="bright_black")
+
 		command = shlex.split(self.command)
 		self._proc = subprocess.run(command, input=cmd_input, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 		self.stdout = clean(self._proc.stdout)


### PR DESCRIPTION
### Changes

* Refactored browse command via https://github.com/frappe/frappe/commit/1c6691d0b9331b4b169fc17dc658a2c56764792a
* TestCommands - Replaced terminal colour handling using click
* Changed path for archiving sites from `archived_sites` to `archived/sites` - This is for consistency in terms of maintaining a common folder for everything archived: `./archived/apps`, `./archived/sites`, `./archived/envs` (so far) [ref: https://github.com/frappe/bench/pull/1208]

---

I also plan on writing a patch in bench to move all contents of `archived_sites` into `archived/sites` and making `archived_sites` a symbolic link that points to `archived/sites`