### PR TITLE
fix: Remove chart from report builder when saved without chart

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -388,6 +388,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			this.$charts_wrapper.addClass('hidden');
 			this.save_view_user_settings(
 				{ chart_args: null });
+			this.chart_args = null;
 		}
 	}
 


### PR DESCRIPTION
**Issue:**
If you have a report saved with a chart enabled, you cannot disable the chart.

**Steps:** 
1. Go to Sales Order report view. **Toggle Chart** from menu button set the fields and **Save** the report with any name from the menu button.
2. Now refresh the report, you will see the chart with the report.
3. Now again **Toggle Chart** from the menu button and save the report.
4. Refresh the report but the chart is still visible. It should be removed.

**Before:**

https://user-images.githubusercontent.com/30859809/143184250-40d365c2-3e00-44b5-a39a-f509fa56a416.mov

**After:**

https://user-images.githubusercontent.com/30859809/143184280-9a5eec40-58c0-4912-8095-012e3f0ef431.mov

