### PR TITLE
feat: Option to disable Event Reminders in Notification Settings

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -11,6 +11,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils.user import get_enabled_system_users
 from frappe.desk.reportview import get_filters_cond
+from frappe.desk.doctype.notification_settings.notification_settings import is_email_notifications_enabled_for_type
 
 weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
 communication_mapping = {"": "Event", "Event": "Event", "Meeting": "Meeting", "Call": "Phone", "Sent/Received Email": "Email", "Other": "Other"}
@@ -141,7 +142,12 @@ def has_permission(doc, user):
 
 def send_event_digest():
 	today = nowdate()
-	for user in get_enabled_system_users():
+
+	# select only those users that have event reminder email notifications enabled
+	users = [user for user in get_enabled_system_users() if
+		is_email_notifications_enabled_for_type(user.name, 'Event Reminders')]
+
+	for user in users:
 		events = get_events(today, today, user.name, for_reminder=True)
 		if events:
 			frappe.set_user_lang(user.name, user.language)

--- a/frappe/desk/doctype/notification_settings/notification_settings.json
+++ b/frappe/desk/doctype/notification_settings/notification_settings.json
@@ -14,6 +14,7 @@
   "enable_email_assignment",
   "enable_email_energy_point",
   "enable_email_share",
+  "enable_email_event_reminders",
   "user",
   "seen",
   "system_notifications_section",
@@ -97,12 +98,19 @@
    "fieldname": "energy_points_system_notifications",
    "fieldtype": "Check",
    "label": "Energy Points"
+  },
+  {
+   "default": "1",
+   "depends_on": "enable_email_notifications",
+   "fieldname": "enable_email_event_reminders",
+   "fieldtype": "Check",
+   "label": "Event Reminders"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-11-16 12:18:46.955501",
+ "modified": "2021-11-24 14:45:31.931154",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Settings",

--- a/frappe/desk/doctype/notification_settings/test_notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/test_notification_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestNotificationSettings(unittest.TestCase):
+	pass


### PR DESCRIPTION
There is an option to "_Send an Email Reminder in the Morning_" in the Event document:

<img width="1299" alt="email-reminder" src="https://user-images.githubusercontent.com/24353136/143212793-2e24dd8b-1a53-49ac-aaef-a56b53195145.png">

This email is sent to all the active System Users and there is no option to unsubscribe.

Added an option in Notification Settings to make this configurable:
<img width="1299" alt="event-reminders-config" src="https://user-images.githubusercontent.com/24353136/143212821-fd60216a-d9d6-4459-b634-fab905919fc6.png">

`no-docs`