### PR TITLE
fix: diffview styles

### DIFF
--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -591,9 +591,11 @@ details > summary:focus {
 }
 
 [data-theme="dark"] {
-	.diffview .insert,.delete  {
-		color: var(--gray-900);
-
+	.diffview .insert {
+		background-color: var(--green-800);
+	}
+	.diffview .delete {
+		background-color: var(--red-800);
 	}
 }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/28212972/143213689-680ea4cf-b03b-4124-a8f0-f98fcacf3f07.png)


After:
![image](https://user-images.githubusercontent.com/28212972/143213440-29120bcd-3eab-488d-ac3e-9f3cf65fd3ea.png)

Steps to test:
1. create a server script
2. Make two changes
3. Switch to dark mode
3. Click on Compare Version
4. Choose two versions
5. Check if it looks good in dark mode

Caused by: https://github.com/frappe/frappe/pull/14555