### PR TITLE
fix: delete prepared reports on deleting reports

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -51,6 +51,14 @@ class Report(Document):
 			and not frappe.flags.in_patch):
 			frappe.throw(_("You are not allowed to delete Standard Report"))
 		delete_custom_role('report', self.name)
+		self.delete_prepared_reports()
+
+	def delete_prepared_reports(self):
+		prepared_reports = frappe.get_all("Prepared Report", filters={'ref_report_doctype': self.name}, pluck='name')
+
+		for report in prepared_reports:
+			frappe.delete_doc("Prepared Report", report, ignore_missing=True, force=True,
+					delete_permanently=True)
 
 	def get_columns(self):
 		return [d.as_dict(no_default_fields = True) for d in self.columns]


### PR DESCRIPTION
closes https://github.com/frappe/erpnext/issues/25319 

Fix sent by @rtdany10 on ERPNext repo but this is a generic solution that can just be added to report doctype. 

To test: 

1. Create a new test report. Something as basic as query report `select name from tabToDo`.
2. Toggle prepared reports from db/system console. `r = frappe.get_doc("Report", name); r.prepared_report = 1`. Not doable from frontend. 
3. Run the report twice so prepared report are there
4. Delete the Report, linked prepared reports should be auto deleted. 