### PR TITLE
fix: navbar settings validation

### DIFF
--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -13,6 +13,9 @@ class NavbarSettings(Document):
 	def validate_standard_navbar_items(self):
 		doc_before_save = self.get_doc_before_save()
 
+		if not doc_before_save:
+			return
+
 		before_save_items = [item for item in \
 			doc_before_save.help_dropdown + doc_before_save.settings_dropdown if item.is_standard]
 
@@ -32,7 +35,3 @@ def get_app_logo():
 def get_navbar_settings():
 	navbar_settings = frappe.get_single('Navbar Settings')
 	return navbar_settings
-
-
-
-


### PR DESCRIPTION
### Reproduce

1. take a backup
1. change **Navbar Settings** and export to fixtures
1. restore backup
1. run `bench migrate` 

### Error

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 27, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 309, in migrate
    skip_search_index=skip_search_index
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 73, in migrate
    sync_fixtures()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/fixtures.py", line 24, in sync_fixtures
    import_doc(frappe.get_app_path(app, "fixtures", fname))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/data_import/data_import.py", line 191, in import_doc
    reset_permissions=True
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 70, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 152, in import_doc
    doc.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 238, in insert
    self.run_before_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 968, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 860, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1158, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1141, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 854, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/navbar_settings/navbar_settings.py", line 12, in validate
    self.validate_standard_navbar_items()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/navbar_settings/navbar_settings.py", line 18, in validate_standard_navbar_items
    doc_before_save.help_dropdown + doc_before_save.settings_dropdown if item.is_standard]
AttributeError: 'NoneType' object has no attribute 'help_dropdown'
```

### Fix

`return if doc_before_save is None`