### PR TITLE
fix: import option in doctype menu when allow import is not selected

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1485,7 +1485,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		const doctype = this.doctype;
 		const items = [];
 		
-		if (frappe.model.can_import(this.meta)) {
+		if (frappe.model.can_import(doctype, null, this.meta)) {
 			items.push({
 				label: __("Import"),
 				action: () =>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1484,8 +1484,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	get_menu_items() {
 		const doctype = this.doctype;
 		const items = [];
-
-		if (frappe.model.can_import(doctype)) {
+		
+		if (frappe.model.can_import(this.meta)) {
 			items.push({
 				label: __("Import"),
 				action: () =>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1484,7 +1484,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	get_menu_items() {
 		const doctype = this.doctype;
 		const items = [];
-		
 		if (frappe.model.can_import(this.meta)) {
 			items.push({
 				label: __("Import"),

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1484,7 +1484,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	get_menu_items() {
 		const doctype = this.doctype;
 		const items = [];
-		
+
 		if (frappe.model.can_import(doctype, null, this.meta)) {
 			items.push({
 				label: __("Import"),

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -318,14 +318,13 @@ $.extend(frappe.model, {
 	},
 
 	can_import: function(doctype, frm) {
-		if(doctype.allow_import) {
-			// system manager can always import
-			if(frappe.user_roles.includes("System Manager")) return true;
+		if (!doctype.allow_import) return false;
 
-			if(frm) return frm.perm[0].import===1;
-			return frappe.boot.user.can_import.indexOf(doctype)!==-1;
-		}
-		else return false;
+		// system manager can always import
+		if (frappe.user_roles.includes("System Manager")) return true;
+
+		if (frm) return frm.perm[0].import===1;
+		return frappe.boot.user.can_import.indexOf(doctype.name)!==-1;
 	},
 
 	can_export: function(doctype, frm) {

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -317,14 +317,14 @@ $.extend(frappe.model, {
 		return doc && doc.__last_sync_on && ((new Date() - doc.__last_sync_on)) < 5000;
 	},
 
-	can_import: function(doctype, frm) {
-		if (!doctype.allow_import) return false;
+	can_import: function(doctype, frm, meta=null) {
+		if (meta && !meta.allow_import) return false;
 
 		// system manager can always import
 		if (frappe.user_roles.includes("System Manager")) return true;
 
 		if (frm) return frm.perm[0].import===1;
-		return frappe.boot.user.can_import.indexOf(doctype.name)!==-1;
+		return frappe.boot.user.can_import.indexOf(doctype)!==-1;
 	},
 
 	can_export: function(doctype, frm) {

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -318,11 +318,14 @@ $.extend(frappe.model, {
 	},
 
 	can_import: function(doctype, frm) {
-		// system manager can always import
-		if(frappe.user_roles.includes("System Manager")) return true;
+		if(doctype.allow_import) {
+			// system manager can always import
+			if(frappe.user_roles.includes("System Manager")) return true;
 
-		if(frm) return frm.perm[0].import===1;
-		return frappe.boot.user.can_import.indexOf(doctype)!==-1;
+			if(frm) return frm.perm[0].import===1;
+			return frappe.boot.user.can_import.indexOf(doctype)!==-1;
+		}
+		else return false;
 	},
 
 	can_export: function(doctype, frm) {


### PR DESCRIPTION
**Issue**
If you uncheck the allow data import in the form settings of doctype, you can still the shortcut 'Import' in the doctype menu

**Example**
In the data import doctype, allow import is unchecked.

<img width="1074" alt="Screenshot 2021-11-25 at 10 25 04 AM" src="https://user-images.githubusercontent.com/58825865/143381866-c7bcd622-3802-44b8-83c1-71b64372f598.png">

Still, you can see the import option in the menu.
 
https://user-images.githubusercontent.com/58825865/143382062-59470ac6-5986-4c7d-8a1c-4bda1ed9929e.mov

**After Fix**

<img width="1396" alt="Screenshot 2021-11-25 at 10 28 22 AM" src="https://user-images.githubusercontent.com/58825865/143382139-becec09b-a877-423f-9720-2f8d993700fe.png">


