### PR TITLE
fix: Sr. No/ row number in the data import preview table

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -522,7 +522,7 @@ class Row:
 
 	def __init__(self, index, row, doctype, header, import_type):
 		self.index = index
-		self.row_number = index + 1
+		self.row_number = index
 		self.doctype = doctype
 		self.data = row
 		self.header = header

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -67,7 +67,7 @@ class TestImporter(unittest.TestCase):
 		expected_error = "Error: <strong>Child 1 of DocType for Import</strong> Row #2: Value missing for: Child Title"
 		self.assertEqual(frappe.parse_json(import_log[0]['messages'][1])['message'], expected_error)
 
-		self.assertEqual(import_log[1]['row_indexes'], [4])
+		self.assertEqual(import_log[1]['row_indexes'], [3])
 		self.assertEqual(frappe.parse_json(import_log[1]['messages'][0])['message'], "Title is required")
 
 	def test_data_import_update(self):

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -61,7 +61,7 @@ class TestImporter(unittest.TestCase):
 		data_import.start_import()
 		data_import.reload()
 		import_log = frappe.parse_json(data_import.import_log)
-		self.assertEqual(import_log[0]['row_indexes'], [2,3])
+		self.assertEqual(import_log[0]['row_indexes'], [1,2])
 		expected_error = "Error: <strong>Child 1 of DocType for Import</strong> Row #1: Value missing for: Child Title"
 		self.assertEqual(frappe.parse_json(import_log[0]['messages'][0])['message'], expected_error)
 		expected_error = "Error: <strong>Child 1 of DocType for Import</strong> Row #2: Value missing for: Child Title"


### PR DESCRIPTION
**Issue**

The serial number in the preview table doesnot start from 1, but  from 2
<img width="1265" alt="Screenshot 2021-11-25 at 11 30 53 AM" src="https://user-images.githubusercontent.com/58825865/143388054-6a64e1ba-1cad-4d78-8ff5-b30f3293dfd2.png">

**After Fix**

<img width="1308" alt="Screenshot 2021-11-25 at 11 30 34 AM" src="https://user-images.githubusercontent.com/58825865/143388161-ea8aee38-c1b0-4db8-8b91-b266ce671cc3.png">

***Steps to reproduce***

1. Go to data import and click on new.
2. Attach a file to import there.
3. See the preview of the same. You will notice that the Sr.no starts from 2 and not 1.



