### PR TITLE
fix: Don't pass kwargs that make_access_log can't handle

### DIFF
--- a/frappe/core/doctype/access_log/access_log.py
+++ b/frappe/core/doctype/access_log/access_log.py
@@ -11,11 +11,26 @@ class AccessLog(Document):
 
 
 @frappe.whitelist()
+def make_access_log(
+	doctype=None,
+	document=None,
+	method=None,
+	file_type=None,
+	report_name=None,
+	filters=None,
+	page=None,
+	columns=None,
+):
+	_make_access_log(
+		doctype, document, method, file_type, report_name, filters, page, columns,
+	)
+
+
 @frappe.write_only()
 @retry(
 	stop=stop_after_attempt(3), retry=retry_if_exception_type(frappe.DuplicateEntryError)
 )
-def make_access_log(
+def _make_access_log(
 	doctype=None,
 	document=None,
 	method=None,
@@ -42,6 +57,7 @@ def make_access_log(
 	}).db_insert()
 
 	# `frappe.db.commit` added because insert doesnt `commit` when called in GET requests like `printview`
-	# dont commit in test mode
+	# dont commit in test mode. It must be tempting to put this block along with the in_request in the
+	# whitelisted method...yeah, don't do it. That part would be executed possibly on a read only DB conn
 	if not frappe.flags.in_test or in_request:
 		frappe.db.commit()


### PR DESCRIPTION
When people try to export reports, sometimes a `cmd` kwarg is passed across the three wrapped functions right to make_access_log. This happens because of the order and way we had to wrap the write_only, retry, and whitelist.

### Traceback

```python
Traceback (most recent call last):
  File "/home/frappe/production-bench/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "/home/frappe/production-bench/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/home/frappe/production-bench/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/production-bench/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/production-bench/apps/frappe/frappe/__init__.py", line 1213, in call
    return fn(*args, **newargs)
  File "/home/frappe/production-bench/apps/frappe/frappe/__init__.py", line 650, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/production-bench/env/lib/python3.6/site-packages/tenacity/__init__.py", line 329, in wrapped_f
    return self.call(f, *args, **kw)
  File "/home/frappe/production-bench/env/lib/python3.6/site-packages/tenacity/__init__.py", line 409, in call
    do = self.iter(retry_state=retry_state)
  File "/home/frappe/production-bench/env/lib/python3.6/site-packages/tenacity/__init__.py", line 356, in iter
    return fut.result()
  File "/usr/lib64/python3.6/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/usr/lib64/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/frappe/production-bench/env/lib/python3.6/site-packages/tenacity/__init__.py", line 412, in call
    result = fn(*args, **kwargs)
TypeError: make_access_log() got an unexpected keyword argument 'cmd'
```

### Request Data

```json
{
	"type": "POST",
	"args": {
  "doctype": "",
  "report_name": "GST Purchase Register",
  "filters": "{\"from_date\":\"2021-10-01\",\"to_date\":\"2021-10-31\",\"company\":\"MonkeyPatch Bois Pvt Ltd\"}",
  "file_type": "Excel",
  "method": "Export"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.core.doctype.access_log.access_log.make_access_log"
}
```