### PR TITLE
fix: add frappe.as_json for safe_exec scripts

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -85,6 +85,7 @@ def get_safe_globals():
 			loads=json.loads,
 			dumps=json.dumps
 		),
+		as_json=frappe.as_json,
 		dict=dict,
 		log=frappe.log,
 		_dict=frappe._dict,


### PR DESCRIPTION
json.dumps does not handle `dict` values that have `datetime` values in them. `frappe.as_json` handles it.

```py
# server scripts

records = frappe.get_all('ToDo', fields='*')
 # this would throw
json.dumps(records)
 # this should work
frappe.as_json(records)
```