### PR TITLE
fix: Dark mode style

### DIFF
--- a/frappe/desk/doctype/note/note.css
+++ b/frappe/desk/doctype/note/note.css
@@ -1,3 +1,0 @@
-.like-disabled-input{
-    background-color: #fff;
-}

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -161,4 +161,9 @@
 	--right-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1.25 7.5L4.75 4L1.25 0.5' stroke='white' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 
 	--left-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M7.5 9.5L4 6l3.5-3.5' stroke='white' stroke-linecap='round' stroke-linejoin='round'></path></svg>");
+
+	::selection {
+		color: var(--text-color);
+		background: var(--gray-500);
+	}
 }


### PR DESCRIPTION
- Remove unnecessary style file for note... it was causing the following issue
	**Before:**
	<img width="600" alt="Screenshot 2021-11-25 at 8 38 09 PM" src="https://user-images.githubusercontent.com/13928957/143600044-01427afc-fa64-46ab-b275-189016e59e2e.png">
	**After:**
	<img width="600" alt="Screenshot 2021-11-25 at 8 37 47 PM" src="https://user-images.githubusercontent.com/13928957/143600104-627c73b4-d255-479a-8cd3-8f9eb31903a5.png">

- Fixed text selection color
	**Before:**
	<img width="352" alt="Screenshot 2021-11-26 at 8 24 22 PM" src="https://user-images.githubusercontent.com/13928957/143600239-fc107179-db22-40d9-80b7-8a3f4a2656c1.png">
	**After:**	
	<img width="359" alt="Screenshot 2021-11-26 at 8 18 30 PM" src="https://user-images.githubusercontent.com/13928957/143600302-723e9244-2874-499f-85b0-3a54a62cce05.png">
	
	--
	<img width="369" alt="Screenshot 2021-11-26 at 8 38 28 PM" src="https://user-images.githubusercontent.com/13928957/143600509-a065cc88-c48c-4b9c-9a89-06d11c6c7000.png">

	We are better than Github now 🤷🏻‍♂️

