### PR TITLE
fix: remove duplicate parent when child item option selected

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -325,7 +325,9 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 		let parent_names = this.child_datatable.rowmanager.checkMap.reduce((parent_names, checked, index) => {
 			if (checked == 1) {
 				const parent_name = this.child_results[index].parent;
-				parent_names.push(parent_name);
+				if (!parent_names.includes(parent_name)) {
+					parent_names.push(parent_name);
+				}
 			}
 			return parent_names;
 		}, []);


### PR DESCRIPTION
The issue is when we are creating a purchase order and click on **Get items from** material request we will have checkbox **'Select Material Request Item'** so when the user chooses that checkbox and select multiple items that will add duplicate items in purchase order item table.

![143460340-76faf60a-9c4a-466e-bcaa-af8668c53826](https://user-images.githubusercontent.com/34086262/143733858-8da88c11-99f5-44ab-a71c-de7c233d5224.gif)

I found the problem is duplicate parent_name pass so if we restrict that is any parent_name already exists then we should not that into the parent_names list.

After that condition, it is working fine.

![ezgif com-gif-maker](https://user-images.githubusercontent.com/34086262/143734029-9f5d8da0-deb6-4bfa-bc23-67df9644cbe7.gif)
 




