### PR TITLE
feat(REST): OR filters in REST API

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -18,7 +18,7 @@ Requests via FrappeClient are also handled here.
 
 @frappe.whitelist()
 def get_list(doctype, fields=None, filters=None, order_by=None,
-	limit_start=None, limit_page_length=20, parent=None, debug=False, as_dict=True):
+	limit_start=None, limit_page_length=20, parent=None, debug=False, as_dict=True, or_filters=None):
 	'''Returns a list of records by filters, fields, ordering and limit
 
 	:param doctype: DocType of the data to be queried
@@ -34,6 +34,7 @@ def get_list(doctype, fields=None, filters=None, order_by=None,
 		doctype=doctype,
 		fields=fields,
 		filters=filters,
+		or_filters=or_filters,
 		order_by=order_by,
 		limit_start=limit_start,
 		limit_page_length=limit_page_length,


### PR DESCRIPTION
Change:

* Pass `or_filters` from URL to `client.get_list` thus allowing OR filtering while using REST API: `GET /api/resource/DocType?or_filters=[[], []...]`


Ref Discuss post: https://discuss.erpnext.com/t/rest-api-query-filter-multiple-fields-using-or/83001

docs: https://github.com/frappe/frappe_docs/pull/229 


To test:

Try a query with OR filter and confirm if results contain values matching any of the filters. 

example: `http://develop:8000/api/resource/Sales Order?or_filters=[["customer","=","Frappe school"],["customer","=","Frappe Inc"]]`

This can be tested in browser too. No automated tests, this is just using regular `get_list`.