### PR TITLE
fix: allow cancelling by PUT docstatus=2

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -306,6 +306,9 @@ class Document(BaseDocument):
 
 		self.check_permission("write", "save")
 
+		if self.docstatus == 2:
+			self._rename_doc_on_cancel()
+
 		self.set_user_and_timestamp()
 		self.set_docstatus()
 		self.check_if_latest()
@@ -922,9 +925,6 @@ class Document(BaseDocument):
 		"""Cancel the document. Sets `docstatus` = 2, then saves.
 		"""
 		self.docstatus = 2
-		new_name = gen_new_name_for_cancelled_doc(self)
-		frappe.rename_doc(self.doctype, self.name, new_name, force=True, show_alert=False)
-		self.name = new_name
 		return self.save()
 
 	@whitelist.__func__
@@ -1354,6 +1354,11 @@ class Document(BaseDocument):
 		"""Return a list of Tags attached to this document"""
 		from frappe.desk.doctype.tag.tag import DocTags
 		return DocTags(self.doctype).get_tags(self.name).split(",")[1:]
+
+	def _rename_doc_on_cancel(self):
+		new_name = gen_new_name_for_cancelled_doc(self)
+		frappe.rename_doc(self.doctype, self.name, new_name, force=True, show_alert=False)
+		self.name = new_name
 
 	def __repr__(self):
 		name = self.name or "unsaved"

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -78,6 +78,8 @@ def rename_doc(doctype, old, new, force=False, merge=False, ignore_permissions=F
 
 	rename_versions(doctype, old, new)
 
+	rename_eps_records(doctype, old, new)
+
 	# call after_rename
 	new_doc = frappe.get_doc(doctype, new)
 
@@ -176,6 +178,16 @@ def update_attachments(doctype, old, new):
 def rename_versions(doctype, old, new):
 	frappe.db.sql("""UPDATE `tabVersion` SET `docname`=%s WHERE `ref_doctype`=%s AND `docname`=%s""",
 		(new, doctype, old))
+
+def rename_eps_records(doctype, old, new):
+	epl = frappe.qb.DocType("Energy Point Log")
+	(frappe.qb.update(epl)
+		.set(epl.reference_name, new)
+		.where(
+			(epl.reference_doctype == doctype)
+			& (epl.reference_name == old)
+		)
+	).run()
 
 def rename_parent_and_child(doctype, old, new, meta):
 	# rename the doc


### PR DESCRIPTION
ref: https://github.com/frappe/frappe/issues/14869

currently cancelling a document via REST API makes it impossible to amend the cancelled document again, this is because doc doesn't get renamed like it does if cancelled from frontend. 

PS: Only affects `develop` branch, on v13 this is a feature toggle hence it will require manual backporting. 