### PR TITLE
fix: return self after submit/cancel

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -915,7 +915,7 @@ class Document(BaseDocument):
 	def _submit(self):
 		"""Submit the document. Sets `docstatus` = 1, then saves."""
 		self.docstatus = 1
-		self.save()
+		return self.save()
 
 	@whitelist.__func__
 	def _cancel(self):
@@ -925,17 +925,17 @@ class Document(BaseDocument):
 		new_name = gen_new_name_for_cancelled_doc(self)
 		frappe.rename_doc(self.doctype, self.name, new_name, force=True, show_alert=False)
 		self.name = new_name
-		self.save()
+		return self.save()
 
 	@whitelist.__func__
 	def submit(self):
 		"""Submit the document. Sets `docstatus` = 1, then saves."""
-		self._submit()
+		return self._submit()
 
 	@whitelist.__func__
 	def cancel(self):
 		"""Cancel the document. Sets `docstatus` = 2, then saves."""
-		self._cancel()
+		return self._cancel()
 
 	def delete(self, ignore_permissions=False):
 		"""Delete document."""


### PR DESCRIPTION
`Document.save` returns `self` but `submit` and `cancel` don't.

change:
For sake of consistency and better support for `run_method` via REST API, return the document.

ref: https://github.com/frappe/frappe/issues/14869