### PR TITLE
fix: Use separate API to insert route history

### DIFF
--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -5,7 +5,6 @@ from frappe.utils import cstr
 
 queue_prefix = 'insert_queue_for_'
 
-@frappe.whitelist()
 def deferred_insert(doctype, records):
 	frappe.cache().rpush(queue_prefix + doctype, records)
 

--- a/frappe/desk/doctype/route_history/route_history.py
+++ b/frappe/desk/doctype/route_history/route_history.py
@@ -1,8 +1,12 @@
 # Copyright (c) 2021, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import json
+
 import frappe
+from frappe.deferred_insert import deferred_insert
 from frappe.model.document import Document
+
 
 class RouteHistory(Document):
 	pass
@@ -35,3 +39,19 @@ def flush_old_route_records():
 			"modified": ("<=", last_record_to_keep[0].modified),
 			"user": user
 		})
+
+@frappe.whitelist()
+def deferred_insert_route_history(routes):
+	routes_record = []
+
+	if isinstance(routes, str):
+		routes = json.loads(routes)
+
+	for route_doc in routes:
+		routes_record.append({
+			"user": frappe.session.user,
+			"route": route_doc.get("route"),
+			"creation": route_doc.get("creation")
+		})
+
+	deferred_insert("Route History", json.dumps(routes_record))

--- a/frappe/desk/doctype/route_history/route_history.py
+++ b/frappe/desk/doctype/route_history/route_history.py
@@ -4,7 +4,7 @@
 import json
 
 import frappe
-from frappe.deferred_insert import deferred_insert
+from frappe.deferred_insert import deferred_insert as _deferred_insert
 from frappe.model.document import Document
 
 
@@ -41,7 +41,7 @@ def flush_old_route_records():
 		})
 
 @frappe.whitelist()
-def deferred_insert_route_history(routes):
+def deferred_insert(routes):
 	routes_record = []
 
 	if isinstance(routes, str):
@@ -54,4 +54,4 @@ def deferred_insert_route_history(routes):
 			"creation": route_doc.get("creation")
 		})
 
-	deferred_insert("Route History", json.dumps(routes_record))
+	_deferred_insert("Route History", json.dumps(routes_record))

--- a/frappe/public/js/frappe/router_history.js
+++ b/frappe/public/js/frappe/router_history.js
@@ -8,7 +8,7 @@ const save_routes = frappe.utils.debounce(() => {
 
 	if (!routes.length) return;
 
-	frappe.xcall('frappe.desk.doctype.route_history.route_history.deferred_insert_route_history', {
+	frappe.xcall('frappe.desk.doctype.route_history.route_history.deferred_insert', {
 		'routes': routes
 	}).catch(() => {
 		frappe.route_history_queue.concat(routes);

--- a/frappe/public/js/frappe/router_history.js
+++ b/frappe/public/js/frappe/router_history.js
@@ -5,13 +5,14 @@ const save_routes = frappe.utils.debounce(() => {
 	if (frappe.session.user === 'Guest') return;
 	const routes = frappe.route_history_queue;
 	frappe.route_history_queue = [];
-	
-	frappe.xcall('frappe.deferred_insert.deferred_insert', {
-		'doctype': 'Route History',
-		'records': routes
+
+	if (!routes.length) return;
+
+	frappe.xcall('frappe.desk.doctype.route_history.route_history.deferred_insert_route_history', {
+		'routes': routes
 	}).catch(() => {
 		frappe.route_history_queue.concat(routes);
-	});	
+	});
 
 }, 10000);
 
@@ -19,7 +20,6 @@ frappe.router.on('change', () => {
 	const route = frappe.get_route();
 	if (is_route_useful(route)) {
 		frappe.route_history_queue.push({
-			'user': frappe.session.user,
 			'creation': frappe.datetime.now_datetime(),
 			'route': frappe.get_route_str()
 		});


### PR DESCRIPTION
- Use separate API to insert route history
- Remove whitelisting for `defered_insert`

<!--security-fix-->