### PR TITLE
fix(ux): validate max_attachment count on doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -1,16 +1,6 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
 
-// -------------
-// Menu Display
-// -------------
-
-// $(cur_frm.wrapper).on("grid-row-render", function(e, grid_row) {
-// 	if(grid_row.doc && grid_row.doc.fieldtype=="Section Break") {
-// 		$(grid_row.row).css({"font-weight": "bold"});
-// 	}
-// })
-
 frappe.ui.form.on('DocType', {
 	refresh: function(frm) {
 		frm.set_query('role', 'permissions', function(doc) {
@@ -130,22 +120,6 @@ frappe.ui.form.on('DocType', {
 
 		frm.set_df_property('fields', 'reqd', frm.doc.autoname !== 'Prompt');
 	},
-
-	max_attachments: function(frm) {
-		if (!frm.doc.max_attachments) {
-			return;
-		}
-		const is_attach_field = (f) => ["Attach", "Attach Image"].includes(f.fieldtype);
-		const no_of_attach_fields = frm.doc.fields.filter(is_attach_field).length;
-
-		if (no_of_attach_fields > frm.doc.max_attachments) {
-			frm.set_value("max_attachments", no_of_attach_fields);
-			const label = frm.get_docfield("max_attachments").label;
-			frappe.show_alert(
-				__("Number of attachment fields are more than {}, limit updated to {}.", [label, no_of_attach_fields]));
-		}
-	},
-
 });
 
 frappe.ui.form.on("DocField", {
@@ -239,3 +213,5 @@ frappe.ui.form.on("DocField", {
 		frm.trigger("max_attachments");
 	}
 });
+
+extend_cscript(cur_frm.cscript, new frappe.model.DocTypeController({frm: cur_frm}));

--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -129,7 +129,23 @@ frappe.ui.form.on('DocType', {
 		}
 
 		frm.set_df_property('fields', 'reqd', frm.doc.autoname !== 'Prompt');
-	}
+	},
+
+	max_attachments: function(frm) {
+		if (!frm.doc.max_attachments) {
+			return;
+		}
+		const is_attach_field = (f) => ["Attach", "Attach Image"].includes(f.fieldtype);
+		const no_of_attach_fields = frm.doc.fields.filter(is_attach_field).length;
+
+		if (no_of_attach_fields > frm.doc.max_attachments) {
+			frm.set_value("max_attachments", no_of_attach_fields);
+			const label = frm.get_docfield("max_attachments").label;
+			frappe.show_alert(
+				__("Number of attachment fields are more than {}, limit updated to {}.", [label, no_of_attach_fields]));
+		}
+	},
+
 });
 
 frappe.ui.form.on("DocField", {
@@ -217,5 +233,9 @@ frappe.ui.form.on("DocField", {
 			$doctype_select.val(curr_value.doctype);
 			update_fieldname_options();
 		}
+	},
+
+	fieldtype: function(frm) {
+		frm.trigger("max_attachments");
 	}
 });

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -332,3 +332,4 @@ frappe.customize_form.clear_locals_and_refresh = function(frm) {
 	frm.refresh();
 }
 
+extend_cscript(cur_frm.cscript, new frappe.model.DocTypeController({frm: cur_frm}));

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -38,6 +38,11 @@ data_fieldtypes = (
 	'Icon'
 )
 
+attachment_fieldtypes = (
+	'Attach',
+	'Attach Image',
+)
+
 no_value_fields = (
 	'Section Break',
 	'Column Break',

--- a/frappe/public/js/form.bundle.js
+++ b/frappe/public/js/form.bundle.js
@@ -14,4 +14,4 @@ import "./frappe/form/controls/control.js";
 import "./frappe/views/formview.js";
 import "./frappe/form/form.js";
 import "./frappe/meta_tag.js";
-
+import "./frappe/doctype/"

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -1,0 +1,23 @@
+frappe.provide("frappe.model");
+
+/*
+	Common class for handling client side interactions that
+	apply to both DocType form and customize form.
+*/
+frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.Controller {
+
+	max_attachments() {
+		if (!this.frm.doc.max_attachments) {
+			return;
+		}
+		const is_attach_field = (f) => ["Attach", "Attach Image"].includes(f.fieldtype);
+		const no_of_attach_fields = this.frm.doc.fields.filter(is_attach_field).length;
+
+		if (no_of_attach_fields > this.frm.doc.max_attachments) {
+			this.frm.set_value("max_attachments", no_of_attach_fields);
+			const label = this.frm.get_docfield("max_attachments").label;
+			frappe.show_alert(
+				__("Number of attachment fields are more than {}, limit updated to {}.", [label, no_of_attach_fields]));
+		}
+	}
+}


### PR DESCRIPTION
Long term solution for issues like these: https://github.com/frappe/erpnext/pull/28632 https://github.com/frappe/frappe/pull/14515 

If doctype has 2 attach fields then it makes very little sense to limit max_attachment to a number lower than that. 

Change: If a limit exists then ensure that it's sufficient for at least # of attach fields on doctype. 