### PR TITLE
fix: Reset `lft` & `rgt` in copy doc

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -178,7 +178,7 @@ $.extend(frappe.model, {
 						user_default = user_defaults[0];
 					}
 				}
-				
+
 				if (!user_default) {
 					user_default = frappe.defaults.get_user_default(df.fieldname);
 				} else if (
@@ -351,6 +351,8 @@ $.extend(frappe.model, {
 		newdoc.creation = "";
 		newdoc.modified_by = user;
 		newdoc.modified = "";
+		newdoc.lft = null;
+		newdoc.rgt = null;
 
 		return newdoc;
 	},


### PR DESCRIPTION
When a doc is duplicated, `lft` and `rgt` fields (NestedSet) are also copied. Reset these fields while copying the doc.