### PR TITLE
fix: cannot uninstall app with virtual doctype

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -324,7 +324,7 @@ def _delete_doctypes(doctypes: List[str], dry_run: bool) -> None:
 		print(f"* dropping Table for '{doctype}'...")
 		if not dry_run:
 			frappe.delete_doc("DocType", doctype, ignore_on_trash=True)
-			frappe.db.sql_ddl(f"drop table `tab{doctype}`")
+			frappe.db.sql_ddl(f"DROP TABLE IF EXISTS `tab{doctype}`")
 
 
 def post_install(rebuild_website=False):

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -260,7 +260,7 @@ def _delete_modules(modules: List[str], dry_run: bool) -> List[str]:
 		print(f"Deleting Module '{module_name}'")
 
 		for doctype in frappe.get_all(
-			"DocType", filters={"module": module_name}, fields=["name", "issingle"]
+			"DocType", filters={"module": module_name, "is_virtual": 0}, fields=["name", "issingle"]
 		):
 			print(f"* removing DocType '{doctype.name}'...")
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -260,7 +260,7 @@ def _delete_modules(modules: List[str], dry_run: bool) -> List[str]:
 		print(f"Deleting Module '{module_name}'")
 
 		for doctype in frappe.get_all(
-			"DocType", filters={"module": module_name, "is_virtual": 0}, fields=["name", "issingle"]
+			"DocType", filters={"module": module_name}, fields=["name", "issingle"]
 		):
 			print(f"* removing DocType '{doctype.name}'...")
 


### PR DESCRIPTION
Trying to uninstall an app with a virtual doctype causes the following error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 27, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 489, in uninstall
    remove_app(app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 238, in remove_app
    _delete_doctypes(drop_doctypes, dry_run=dry_run)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/installer.py", line 324, in _delete_doctypes
    frappe.db.sql_ddl(f"drop table `tab{doctype}`")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 257, in sql_ddl
    self.sql(query, debug=debug)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 154, in sql
    self._cursor.execute(query)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 775, in _read_query_result  
    result.read()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/lib/python3.6/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1051, "Unknown table '_e32e715ab7b42b3f.tabMy Virtual DocType'")
```

Fix: don't attempt to remove database table for virtual doctype.