### PR TITLE
fix: Add `xcall` to Frappe's web bundle

### DIFF
--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -46,6 +46,20 @@ $.extend(frappe, {
 	hide_message: function() {
 		$('.message-overlay').remove();
 	},
+	xcall: function(method, params) {
+		return new Promise((resolve, reject) => {
+			frappe.call({
+				method: method,
+				args: params,
+				callback: (r) => {
+					resolve(r.message);
+				},
+				error: (r) => {
+					reject(r.message);
+				}
+			});
+		});
+	},
 	call: function(opts) {
 		// opts = {"method": "PYTHON MODULE STRING", "args": {}, "callback": function(r) {}}
 		if (typeof arguments[0]==='string') {


### PR DESCRIPTION
Added **frappe.xcall** to the web bundle to fix **frappe.xcall is not a function** exception that occurs in Web Form's child tables when choosing a value for a Link field.

closes #15140 
