### PR TITLE
fix: Add fallback option for time format when system defaults are not set

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -172,7 +172,7 @@ frappe.form.formatters = {
 				m = m.tz(frappe.boot.sysdefaults.time_zone);
 			}
 			return m.format(frappe.boot.sysdefaults.date_format.toUpperCase()
-				+  ' ' + frappe.boot.sysdefaults.time_format);
+				+  ' ' + (frappe.boot.sysdefaults.time_format || 'HH:mm:ss'));
 		} else {
 			return "";
 		}


### PR DESCRIPTION
If **Time Format** is not set in System Settings Datetime fields don't show up correctly:

![image](https://user-images.githubusercontent.com/24353136/144358181-55f8b20d-717d-47d7-bf49-a5547568c2e5.png)

Added fallback option ('HH:mm:ss') for Time Format in Datetime formatter.