### PR TITLE
fix: form tour field in onboarding step

### DIFF
--- a/frappe/desk/doctype/onboarding_step/onboarding_step.js
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.js
@@ -2,6 +2,17 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Onboarding Step", {
+
+	setup: function(frm) {
+		frm.set_query("form_tour", function() {
+			return {
+				filters: {
+					reference_doctype: frm.doc.reference_document
+				}
+			};
+		});
+	},
+
 	refresh: function(frm) {
 		frappe.boot.developer_mode &&
 			frm.set_intro(

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.json
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.json
@@ -20,6 +20,7 @@
   "reference_document",
   "show_full_form",
   "show_form_tour",
+  "form_tour",
   "is_single",
   "reference_report",
   "report_reference_doctype",
@@ -206,13 +207,21 @@
    "fieldname": "show_form_tour",
    "fieldtype": "Check",
    "label": "Show Form Tour"
+  },
+  {
+   "depends_on": "show_form_tour",
+   "fieldname": "form_tour",
+   "fieldtype": "Link",
+   "label": "Form Tour",
+   "options": "Form Tour"
   }
  ],
  "links": [],
- "modified": "2020-10-30 14:54:06.646513",
+ "modified": "2021-12-02 10:56:04.448580",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Onboarding Step",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -329,7 +329,7 @@ export default class OnboardingWidget extends Widget {
 					this.mark_complete(step);
 				};
 			};
-			const tour_name = step.form_tour
+			const tour_name = step.form_tour;
 			frm.tour
 				.init({ tour_name, on_finish })
 				.then(() => frm.tour.start());

--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -234,8 +234,9 @@ export default class OnboardingWidget extends Widget {
 					},
 				});
 			};
+			const tour_name = step.form_tour;
 			frm.tour
-				.init({ on_finish })
+				.init({ tour_name, on_finish })
 				.then(() => frm.tour.start());
 		};
 
@@ -328,8 +329,9 @@ export default class OnboardingWidget extends Widget {
 					this.mark_complete(step);
 				};
 			};
+			const tour_name = step.form_tour
 			frm.tour
-				.init({ on_finish })
+				.init({ tour_name, on_finish })
 				.then(() => frm.tour.start());
 		};
 


### PR DESCRIPTION
**Issue:**

1. A doctype can have multiple form tours highlighting different sections of that doctype.
2. When creating an onboarding step for a doctype, there is no way to mention which form tour we want the step to have.

**Fix:**

1. Onboarding step will now have a form tour field. We can link a relevant form tour of this doctype here.

<img width="1077" alt="Screenshot 2021-12-02 at 11 30 49 AM" src="https://user-images.githubusercontent.com/31363128/144366480-16e491b6-c6e8-4a30-b3fb-ae08624c2cb6.png">
