### PR TITLE
fix: Allow user to continue as Guest if API key validation fails

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -229,6 +229,8 @@ def validate_auth_via_api_keys(authorization_header):
 		frappe.throw(_("Failed to decode token, please provide a valid base64-encoded token."), frappe.InvalidAuthorizationToken)
 	except (AttributeError, TypeError, ValueError):
 		pass
+	except Exception:
+		pass
 
 
 def validate_api_key_secret(api_key, api_secret, frappe_authorization_source=None):

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -227,9 +227,7 @@ def validate_auth_via_api_keys(authorization_header):
 			validate_api_key_secret(api_key, api_secret, authorization_source)
 	except binascii.Error:
 		frappe.throw(_("Failed to decode token, please provide a valid base64-encoded token."), frappe.InvalidAuthorizationToken)
-	except (AttributeError, TypeError, ValueError):
-		pass
-	except Exception:
+	except (AttributeError, TypeError, ValueError, frappe.AuthenticationError):
 		pass
 
 

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -174,4 +174,4 @@ class TestFrappeClient(unittest.TestCase):
 		api_secret = "ksk&93nxoe3os"
 		header = {"Authorization": "token {}:{}".format(api_key, api_secret)}
 		res = requests.post(get_url() + "/api/method/frappe.auth.get_logged_user", headers=header)
-		self.assertEqual(res.status_code, 401)
+		self.assertEqual(res.status_code, 403)


### PR DESCRIPTION
Allow user to continue as Guest if API key validation fails

Background for change:
* When trying to integrate Frappe as OAuth Provider with Apache Superset, it makes a call to get token from Frappe. During this call, it passes an Authorization Header based on the OAuth ClientId and ClientSecret Generated by Frappe and configured in superset.
* During this call, when trying to validate user via api key, it fails, because, though the Authorization Header is present, it corresponds to OAuth client and not a frappe user, what the code is currently expects.
* So, adding this change, would ignore any exception generated and allow to continue as Guest.

Additional context - https://discuss.erpnext.com/t/oauth-integration-of-frappe-with-apache-superset/83085/15