### PR TITLE
feat: reset user-wise grid config to default

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -368,8 +368,13 @@ export default class GridRow {
 	prepare_columns_for_dialog(selected_fields) {
 		let fields = [];
 
+		const blocked_fields = frappe.model.no_value_type;
+		const always_allow = ["Button"];
+
+		const show_field = (f) => always_allow.includes(f) || !blocked_fields.includes(f);
+
 		this.docfields.forEach(column => {
-			if (!column.hidden && !in_list(frappe.model.no_value_type, column.fieldtype)) {
+			if (!column.hidden && show_field(column.fieldtype)) {
 				fields.push({
 					label: column.label,
 					value: column.fieldname,

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -291,6 +291,11 @@ export default class GridRow {
 			this.grid_settings_dialog.hide();
 		});
 
+		this.grid_settings_dialog.set_secondary_action_label(__("Reset to default"));
+		this.grid_settings_dialog.set_secondary_action(() => {
+			this.reset_user_settings_for_grid();
+			this.grid_settings_dialog.hide();
+		});
 	}
 
 	setup_columns_for_dialog() {
@@ -509,6 +514,14 @@ export default class GridRow {
 		let value = {};
 		value[this.grid.doctype] = this.selected_columns_for_grid;
 		frappe.model.user_settings.save(this.frm.doctype, 'GridView', value)
+			.then((r) => {
+				frappe.model.user_settings[this.frm.doctype] = r.message || r;
+				this.grid.reset_grid();
+			});
+	}
+
+	reset_user_settings_for_grid() {
+		frappe.model.user_settings.save(this.frm.doctype, 'GridView', null)
 			.then((r) => {
 				frappe.model.user_settings[this.frm.doctype] = r.message || r;
 				this.grid.reset_grid();


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/14936 

Changes:
1. Show "Button" type fields in selection box for grid config. These were ignored before because a button is "no value type" but it's helpful on list view.  (to test: add a custom field with Button type and see if it pops up in config dialog box)

2. Option to clear user-wise grid config in case user messes up things and wants to back to default. 


https://user-images.githubusercontent.com/9079960/144408465-de532123-dab5-4dd8-adda-dfbd40056587.mov


<!-- no-docs -->