### PR TITLE
chore: change log for v12.24

### DIFF
--- a/frappe/change_log/v12/v12_24_0.md
+++ b/frappe/change_log/v12/v12_24_0.md
@@ -1,0 +1,11 @@
+## Frappe Version 12.24.0 Release Notes
+
+### Fixes & Enhancements
+
+- Prepared report read from replica database ([#14883](https://github.com/frappe/frappe/pull/14883))
+- Handled timeout and deadlocks in db.sql ([#15092](https://github.com/frappe/frappe/pull/15092))
+- The method get_mapping_module doesn't need to access to instance ([#15095](https://github.com/frappe/frappe/pull/15095))
+- Multi level custom report fix ([#14489](https://github.com/frappe/frappe/pull/14489))
+- clean `join` param when executing `reportview.get` ([#14845](https://github.com/frappe/frappe/pull/14845))
+- Remove chart from report builder when saved without chart ([#15064](https://github.com/frappe/frappe/pull/15064))
+- Return doc object after submit/cancel document ([#15105](https://github.com/frappe/frappe/pull/15105))


### PR DESCRIPTION
## Frappe Version 12.24.0 Release Notes

### Fixes & Enhancements

- Prepared report read from replica database ([#14883](https://github.com/frappe/frappe/pull/14883))
- Handled timeout and deadlocks in db.sql ([#15092](https://github.com/frappe/frappe/pull/15092))
- The method get_mapping_module doesn't need to access to instance ([#15095](https://github.com/frappe/frappe/pull/15095))
- Multi level custom report fix ([#14489](https://github.com/frappe/frappe/pull/14489))
- clean `join` param when executing `reportview.get` ([#14845](https://github.com/frappe/frappe/pull/14845))
- Remove chart from report builder when saved without chart ([#15064](https://github.com/frappe/frappe/pull/15064))
- Return doc object after submit/cancel document ([#15105](https://github.com/frappe/frappe/pull/15105))