### PR TITLE
fix: `get_doc` owner permission

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -108,7 +108,7 @@ def get_doc_permissions(doc, user=None, ptype=None):
 	meta = frappe.get_meta(doc.doctype)
 
 	def is_user_owner():
-		return (doc.get("owner") or "").lower() == frappe.session.user.lower()
+		return (doc.get("owner") or "").lower() == user
 
 	if has_controller_permissions(doc, ptype, user=user) is False:
 		push_perm_check_log('Not allowed via controller permission check')

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -108,7 +108,7 @@ def get_doc_permissions(doc, user=None, ptype=None):
 	meta = frappe.get_meta(doc.doctype)
 
 	def is_user_owner():
-		return (doc.get("owner") or "").lower() == user
+		return (doc.get("owner") or "").lower() == user.lower()
 
 	if has_controller_permissions(doc, ptype, user=user) is False:
 		push_perm_check_log('Not allowed via controller permission check')

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -284,7 +284,7 @@ def filter_allowed_users(users, doc, transition):
 	perms.extend(custom_docperms)
 	for permission in perms:
 		if permission.parent == doc.doctype and permission.if_owner == 1:
-			return [doc.get('owner') or '']
+			return [doc.get('owner').lower() or '']
 	return filtered_users
 
 def get_common_email_args(doc):

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -271,12 +271,6 @@ def filter_allowed_users(users, doc, transition):
 	if the user satisfies 'workflow transision self approval' condition
 	"""
 	from frappe.permissions import has_permission, get_perms_for
-	filtered_users = []
-	for user in users:
-		if (has_approval_access(user, doc, transition)
-			and has_permission(doctype=doc, user=user)):
-			filtered_users.append(user)
-
 	# Filtering results based on if owner enabled
 	allowed_role = transition.allowed
 	perms = get_perms_for([allowed_role])
@@ -285,6 +279,13 @@ def filter_allowed_users(users, doc, transition):
 	for permission in perms:
 		if permission.parent == doc.doctype and permission.if_owner == 1:
 			return [doc.get('owner').lower() or '']
+			
+	filtered_users = []
+	for user in users:
+		if (has_approval_access(user, doc, transition)
+			and has_permission(doctype=doc, user=user)):
+			filtered_users.append(user)
+
 	return filtered_users
 
 def get_common_email_args(doc):


### PR DESCRIPTION
In the case If creator is selected in the role permission manager. This check fails while checking for doc permissions for sending out emails for next workflow actions.

Case: Creator has the role for the Next Workflow state. Many other users share the same role. Role permissions is applied for only if creator only

Required result. The owner should only get emails for the next workflow state

Problem: Currently all users with the shared role get the email notification for the next workflow state irrespective of "only if creator"

As the logged in user is same as the owner at the time of the creation or any next workflow actions. The validation fails.