### PR TITLE
fix: Delete Event Producer Last Update on trash event of Event Producer

### DIFF
--- a/frappe/event_streaming/doctype/event_producer/event_producer.py
+++ b/frappe/event_streaming/doctype/event_producer/event_producer.py
@@ -54,6 +54,11 @@ class EventProducer(Document):
 			self.db_set('incoming_change', 0)
 			self.reload()
 
+	def on_trash(self):
+		last_update = frappe.db.get_value('Event Producer Last Update', dict(event_producer=self.name))
+		if last_update:
+			frappe.delete_doc('Event Producer Last Update', last_update)
+
 	def check_url(self):
 		valid_url_schemes = ("http", "https")
 		frappe.utils.validate_url(self.producer_url, throw=True, valid_schemes=valid_url_schemes)


### PR DESCRIPTION
**Steps to Replicate:**

1. Create an Event Producer
2. Delete Event Consumer created on the remote site. Delete Event Producer on the current site.
3. Try creating an Event Producer again. It will throw a duplicate name error while creating **Event Producer Last Update**

![image](https://user-images.githubusercontent.com/24353136/144371926-3e2f1731-1ac2-4f6e-b0b8-52c61c1b5883.png)

**Fix**:

Event Producer Last Update is a pointer maintained internally to store the last time of sync. Earlier this was part of the Event Producer doctype but later on, separated into a separate doctype via this [commit](https://github.com/frappe/frappe/commit/625ab74883b914b5b7781be2fdccd6f50cc4a01c)
 
It's an internal document created without the user's knowledge and it cannot be searched from the awesome bar too since these configurations have been enabled for this doctype:

![image](https://user-images.githubusercontent.com/24353136/144549230-369f5923-4eba-4abe-b566-7c7f0940ccbf.png)

Hence, it should be deleted on the trash event of the Event Producer.
