### PR TITLE
ci: Use node version 14 to avoid node-sass failure in patch testing build

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -32,6 +32,12 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          check-latest: true
+
       - name: Check if build should be run
         id: check-build
         run: |


### PR DESCRIPTION
- Node-sass fails on node v16 so pinning it node to v14 https://stackoverflow.com/a/67337016
- Using node version 14 instead of v15 since we are using v14 in all our other builds


