### PR TITLE
refactor: add separate padding for top and bottom in the complete signup page.

### DIFF
--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -266,7 +266,8 @@ h5.modal-title {
 
 .login-content.container {
 	background-color: var(--fg-color);
-	padding: 45px 0px;
+	padding-bottom: 45px;
+	padding-top: 45px;
 	box-shadow: var(--shadow-base);
 	border-radius: var(--border-radius-md);
 	max-width: 400px;


### PR DESCRIPTION
**Description**
We can't set left and right padding to 0, or add some value because these paddings are being set in the website bundle for different screens.

**Before**
<img width="741" alt="Screenshot 2021-12-03 at 2 16 17 PM" src="https://user-images.githubusercontent.com/58825865/144572891-82f77ac4-b151-4010-b013-de44528e301d.png">


 
**After**
<img width="846" alt="Screenshot 2021-12-03 at 1 53 30 PM" src="https://user-images.githubusercontent.com/58825865/144569619-fc69c790-d2e0-4877-b855-32092e36fc1b.png">

--

The issue was introduced via: https://github.com/frappe/frappe/pull/14853