### PR TITLE
chore: change log for v13.16.0

### DIFF
--- a/frappe/change_log/v13/v13_16_0.md
+++ b/frappe/change_log/v13/v13_16_0.md
@@ -1,0 +1,27 @@
+# Version 13.16.0 Release Notes
+
+### Features & Enhancements
+
+- Added more print page size options ([#14577](https://github.com/frappe/frappe/pull/14577))
+- Provision to reset user-wise grid config to default ([#15162](https://github.com/frappe/frappe/pull/15162))
+- Editable grid/table pagination ([#14935](https://github.com/frappe/frappe/pull/14935))
+- Icon Picker control ([#13676](https://github.com/frappe/frappe/pull/13676))
+- OR filters in REST API ([#15103](https://github.com/frappe/frappe/pull/15103))
+
+### Fixes
+
+- Reset `lft` & `rgt` in copy doc ([#15128](https://github.com/frappe/frappe/pull/15128))
+- Give select permission to 'All' for workflow state ([#15044](https://github.com/frappe/frappe/pull/15044))
+- Change Event's subject data type from Data to Text ([#15017](https://github.com/frappe/frappe/pull/15017))
+- Refactored 404 page ([#15039](https://github.com/frappe/frappe/pull/15039))
+- Return object after submit/cancel ([#15105](https://github.com/frappe/frappe/pull/15105))
+- Add separate padding for top and bottom in the complete signup page. ([#15178](https://github.com/frappe/frappe/pull/15178))
+- Remove the uninstall app from the Installed Applications list ([#15027](https://github.com/frappe/frappe/pull/15027))
+- Delete prepared reports on deleting reports ([#15069](https://github.com/frappe/frappe/pull/15069))
+- Fixed Last Step Page style  ([#14853](https://github.com/frappe/frappe/pull/14853))
+- Fixed Dark mode style ([#15099](https://github.com/frappe/frappe/pull/15099))
+- Remove edit icon from quick entry to avoid browser crash ([#15049](https://github.com/frappe/frappe/pull/15049))
+- Don't pass kwargs that make_access_log can't handle ([#15084](https://github.com/frappe/frappe/pull/15084))
+- Remove duplicate parent when child item option selected ([#15101](https://github.com/frappe/frappe/pull/15101))
+- Only show report when there is data ([#15016](https://github.com/frappe/frappe/pull/15016))
+- Ignore route conflict validation for Custom to Client Script Rename ([#14953](https://github.com/frappe/frappe/pull/14953))


### PR DESCRIPTION
# Version 13.16.0 Release Notes

### Features & Enhancements

- Added more print page size options ([#14577](https://github.com/frappe/frappe/pull/14577))
- Provision to reset user-wise grid config to default ([#15162](https://github.com/frappe/frappe/pull/15162))
- Editable grid/table pagination ([#14935](https://github.com/frappe/frappe/pull/14935))
- Icon Picker control ([#13676](https://github.com/frappe/frappe/pull/13676))
- OR filters in REST API ([#15103](https://github.com/frappe/frappe/pull/15103))

### Fixes

- Reset `lft` & `rgt` in copy doc ([#15128](https://github.com/frappe/frappe/pull/15128))
- Give select permission to 'All' for workflow state ([#15044](https://github.com/frappe/frappe/pull/15044))
- Change Event's subject data type from Data to Text ([#15017](https://github.com/frappe/frappe/pull/15017))
- Refactored 404 page ([#15039](https://github.com/frappe/frappe/pull/15039))
- Return object after submit/cancel ([#15105](https://github.com/frappe/frappe/pull/15105))
- Add separate padding for top and bottom in the complete signup page. ([#15178](https://github.com/frappe/frappe/pull/15178))
- Remove the uninstall app from the Installed Applications list ([#15027](https://github.com/frappe/frappe/pull/15027))
- Delete prepared reports on deleting reports ([#15069](https://github.com/frappe/frappe/pull/15069))
- Fixed Last Step Page style  ([#14853](https://github.com/frappe/frappe/pull/14853))
- Fixed Dark mode style ([#15099](https://github.com/frappe/frappe/pull/15099))
- Remove edit icon from quick entry to avoid browser crash ([#15049](https://github.com/frappe/frappe/pull/15049))
- Don't pass kwargs that make_access_log can't handle ([#15084](https://github.com/frappe/frappe/pull/15084))
- Remove duplicate parent when child item option selected ([#15101](https://github.com/frappe/frappe/pull/15101))
- Only show report when there is data ([#15016](https://github.com/frappe/frappe/pull/15016))
- Ignore route conflict validation for Custom to Client Script Rename ([#14953](https://github.com/frappe/frappe/pull/14953))