### PR TITLE
fix: Clarified docstatus transition exceptions

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -750,8 +750,10 @@ class Document(BaseDocument):
 			elif self.docstatus==1:
 				self._action = "submit"
 				self.check_permission("submit")
-			else:
+			elif self.docstatus==2:
 				raise frappe.DocstatusTransitionError(_("Cannot change docstatus from 0 to 2"))
+			else:
+				raise frappe.ValidationError(_("Invalid docstatus"), self.docstatus)
 
 		elif docstatus==1:
 			if self.docstatus==1:
@@ -760,8 +762,10 @@ class Document(BaseDocument):
 			elif self.docstatus==2:
 				self._action = "cancel"
 				self.check_permission("cancel")
-			else:
+			elif self.docstatus==0:
 				raise frappe.DocstatusTransitionError(_("Cannot change docstatus from 1 to 0"))
+			else:
+				raise frappe.ValidationError(_("Invalid docstatus"), self.docstatus)
 
 		elif docstatus==2:
 			raise frappe.ValidationError(_("Cannot edit cancelled document"))

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -751,7 +751,7 @@ class Document(BaseDocument):
 				self._action = "submit"
 				self.check_permission("submit")
 			elif self.docstatus==2:
-				raise frappe.DocstatusTransitionError(_("Cannot change docstatus from 0 to 2"))
+				raise frappe.DocstatusTransitionError(_("Cannot change docstatus from 0 (Draft) to 2 (Cancelled)"))
 			else:
 				raise frappe.ValidationError(_("Invalid docstatus"), self.docstatus)
 
@@ -763,7 +763,7 @@ class Document(BaseDocument):
 				self._action = "cancel"
 				self.check_permission("cancel")
 			elif self.docstatus==0:
-				raise frappe.DocstatusTransitionError(_("Cannot change docstatus from 1 to 0"))
+				raise frappe.DocstatusTransitionError(_("Cannot change docstatus from 1 (Submitted) to 0 (Draft)"))
 			else:
 				raise frappe.ValidationError(_("Invalid docstatus"), self.docstatus)
 


### PR DESCRIPTION
Exceptions issued by the document.py `check_docstatus_transition` method are potentially very misleading. In cases where an invalid docstatus is used, users receive an confusing exception stating "Cannot change docstatus from 0 to 2" or "Cannot change docstatus from 1 to 0". 

This PR adds an additional exception message when an invalid docstatus is used.

See discussion here: https://discuss.erpnext.com/t/php-frappe-exceptions-docstatustransitionerror-cannot-change-docstatus-from-0-to-2/83292