### PR TITLE
fix: Allow Fetch From for a different link field of the same DocType

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -143,11 +143,10 @@ frappe.ui.form.on("DocField", {
 			curr_value.doctype = doctype;
 			curr_value.fieldname = fieldname;
 		}
-		let curr_df_link_doctype = row.fieldtype == "Link" ? row.options : null;
 
 		let doctypes = frm.doc.fields
 			.filter(df => df.fieldtype == "Link")
-			.filter(df => df.options && df.options != curr_df_link_doctype)
+			.filter(df => df.options && df.fieldname != row.fieldname)
 			.map(df => ({
 				label: `${df.options} (${df.fieldname})`,
 				value: df.fieldname


### PR DESCRIPTION
**Problem**:

If there are 2 Link fields of the same type, fetch from does not allow selecting from the other link field.
For eg: In this doctype, there are 2 Employee Link fields: `employee` and `reports_to` and we need to set the fetch from value for `reports_to` to `employee.reports_to`, the Fetch From select field filters DocTypes of the same type.

![image](https://user-images.githubusercontent.com/24353136/144821295-9233aa96-cdcc-4973-8d9a-6c95676a2c9a.png)

**Fix**:

Filter out selection by `fieldname` instead of Link field options.

![image](https://user-images.githubusercontent.com/24353136/144820546-3c2bef77-4c73-489d-b2ee-1a99aad3e4b6.png)
