### PR TITLE
feat: Country and Age during Signup

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -1,4 +1,10 @@
 frappe.ui.form.on('User', {
+
+	setup: function() {
+		console.log(frappe.meta.get_field("User", "country"))
+		frappe.meta.get_field('User', 'country').no_default = true;
+	},
+
 	before_load: function(frm) {
 		var update_tz_select = function(user_language) {
 			frm.set_df_property("time_zone", "options", [""].concat(frappe.all_timezones));

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -1,11 +1,10 @@
 frappe.ui.form.on('User', {
-
-	setup: function() {
-		console.log(frappe.meta.get_field("User", "country"))
-		frappe.meta.get_field('User', 'country').no_default = true;
-	},
-
 	before_load: function(frm) {
+
+		if (frm.is_new()) {
+			frm.set_value("country", "");		// Using default country for every new user created doesn't make sense
+		}
+
 		var update_tz_select = function(user_language) {
 			frm.set_df_property("time_zone", "options", [""].concat(frappe.all_timezones));
 		};

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -39,6 +39,8 @@
   "mute_sounds",
   "column_break_22",
   "mobile_no",
+  "country",
+  "age",
   "change_password",
   "new_password",
   "logout_all_sessions",
@@ -606,6 +608,18 @@
    "fieldtype": "Link",
    "label": "Module Profile",
    "options": "Module Profile"
+  },
+  {
+   "fieldname": "country",
+   "fieldtype": "Link",
+   "label": "Country",
+   "options": "Country"
+  },
+  {
+   "default": "0",
+   "fieldname": "age",
+   "fieldtype": "Check",
+   "label": "Age is 18 years old or above"
   }
  ],
  "icon": "fa fa-user",
@@ -669,7 +683,7 @@
   }
  ],
  "max_attachments": 5,
- "modified": "2021-11-17 17:17:16.098457",
+ "modified": "2021-12-02 20:21:21.873269",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -749,7 +749,7 @@ def verify_password(password):
 	frappe.local.login_manager.check_password(frappe.session.user, password)
 
 @frappe.whitelist(allow_guest=True)
-def sign_up(email, full_name, redirect_to):
+def sign_up(email, full_name, redirect_to, country=None, age=0):
 	if is_signup_disabled():
 		frappe.throw(_('Sign Up is disabled'), title='Not Allowed')
 
@@ -770,6 +770,8 @@ def sign_up(email, full_name, redirect_to):
 			"doctype":"User",
 			"email": email,
 			"first_name": escape_html(full_name),
+			"country": country,
+			"age": age,
 			"enabled": 1,
 			"new_password": random_string(10),
 			"user_type": "Website User"

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -778,6 +778,7 @@ def sign_up(email, full_name, redirect_to, country=None, age=0):
 		})
 		user.flags.ignore_permissions = True
 		user.flags.ignore_password_policy = True
+		user.dont_update_if_missing = ["country"]
 		user.insert()
 
 		# set default signup role as per Portal Settings

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -35,6 +35,8 @@ login.bind_events = function () {
 		args.email = ($("#signup_email").val() || "").trim();
 		args.redirect_to = frappe.utils.sanitise_redirect(frappe.utils.get_url_arg("redirect-to"));
 		args.full_name = frappe.utils.xss_sanitise(($("#signup_fullname").val() || "").trim());
+		args.country = $("#signup-country").val();
+		args.age = $("#signup-age").prop("checked") && 1;
 		if (!args.email || !validate_email(args.email) || !args.full_name) {
 			login.set_status('{{ _("Valid email and name required") }}', 'red');
 			return false;

--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -58,7 +58,10 @@
   "misc_section",
   "app_name",
   "app_logo",
+  "column_break_56",
   "disable_signup",
+  "show_country",
+  "verify_age",
   "section_break_38",
   "subdomain",
   "head_html",
@@ -386,6 +389,22 @@
    "fieldname": "app_logo",
    "fieldtype": "Attach Image",
    "label": "App Logo"
+  },
+  {
+   "fieldname": "column_break_56",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_country",
+   "fieldtype": "Check",
+   "label": "Show Country dropdown during Signup"
+  },
+  {
+   "default": "0",
+   "fieldname": "verify_age",
+   "fieldtype": "Check",
+   "label": "Verify Age during Signup"
   }
  ],
  "icon": "fa fa-cog",
@@ -394,7 +413,7 @@
  "issingle": 1,
  "links": [],
  "max_attachments": 10,
- "modified": "2021-08-23 21:39:51.702248",
+ "modified": "2021-12-02 11:52:15.648720",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -81,7 +81,7 @@
 				<div class="page-card-body">
 					<form class="form-signin form-login" role="form">
 						{{ email_login_body() }}
-					</form>	
+					</form>
 					<div class="social-logins text-center">
 						<p class="text-muted login-divider">{{ _("or") }}</p>
 						<div class="social-login-buttons">
@@ -143,6 +143,35 @@
 						<input type="email" id="signup_email" class="form-control"
 							placeholder="{{ _('jane@example.com') }}" required>
 					</div>
+					{% if show_country %}
+					<div class="form-group">
+						<div class="control-input-wrapper">
+							<div class="control-input flex align-center">
+								<select type="text" autocomplete="off" data-fieldtype="Select" data-fieldname="country"
+									class="input-with-feedback form-control ellipsis bold" id="signup-country" required>
+								<option value="">Your Country</option>
+								{% for country in countries %}
+								<option value="{{ country }}"> {{ country }} </option>
+								{% endfor %}
+								</select>
+							</div>
+						</div>
+					</div>
+					{% endif %}
+					{% if verify_age %}
+					<div class="form-group">
+						<div class="checkbox">
+							<label>
+								<span class="input-area">
+									<input type="checkbox" autocomplete="off" class="input-with-feedback"
+										data-fieldtype="Check" data-fieldname="age" id="signup-age" required>
+									</span>
+								<span class="label-area">I confirm that I am 18 years old or above</span>
+							</label>
+							<p class="help-box small text-muted"></p>
+						</div>
+					</div>
+					{% endif %}
 				</div>
 				<div class="page-card-actions">
 					<button class="btn btn-sm btn-primary btn-block btn-signup"

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -35,6 +35,11 @@ def get_context(context):
 	context["title"] = "Login"
 	context["provider_logins"] = []
 	context["disable_signup"] = frappe.utils.cint(frappe.db.get_single_value("Website Settings", "disable_signup"))
+
+	context["show_country"] = frappe.db.get_single_value("Website Settings", "show_country")
+	context["verify_age"] = frappe.db.get_single_value("Website Settings", "verify_age")
+	context["countries"] = frappe.db.get_all("Country", pluck="name")
+
 	context["logo"] = (frappe.db.get_single_value('Website Settings', 'app_logo') or
 		frappe.get_hooks("app_logo_url")[-1])
 	context["app_name"] = (frappe.db.get_single_value('Website Settings', 'app_name') or


### PR DESCRIPTION
**Asking Country and Verifying Age during Signup:**

1. This can be enabled from Website Settings.

<img width="1111" alt="Screenshot 2021-12-06 at 3 58 25 PM" src="https://user-images.githubusercontent.com/31363128/144830819-879f5d3c-2067-4cac-b2e3-c4950fd6a6bd.png">

2. Once enabled, the signup form will have these fields additionally.

<img width="535" alt="Screenshot 2021-12-06 at 3 43 43 PM" src="https://user-images.githubusercontent.com/31363128/144830833-ac4551f2-3027-4584-959d-5049feb662f5.png">

3. Based on the user's input, values will be stored in User doctype.

<img width="1322" alt="Screenshot 2021-12-06 at 4 00 05 PM" src="https://user-images.githubusercontent.com/31363128/144830856-d8166fd8-0c66-4592-9657-9c9a621659ae.png">

**Steps to test:**

1. From website settings, enable Show Country dropdown during Signup and Verify Age during Signup. Save.
2. Go to the Signup form. Fill in the details and signup.
3. Try the signup form with the settings disabled.