### PR TITLE
fix: Use encryption key for document signature generation

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -17,6 +17,8 @@ from frappe.desk.form.document_follow import follow_document
 from frappe.core.doctype.server_script.server_script_utils import run_server_script_for_doc_event
 from frappe.utils.data import get_absolute_url
 
+from frappe.utils.password import get_hash
+
 # once_only validation
 # methods
 
@@ -1261,7 +1263,8 @@ class Document(BaseDocument):
 
 	def get_signature(self):
 		"""Returns signature (hash) for private URL."""
-		return hashlib.sha224(get_datetime_str(self.creation).encode()).hexdigest()
+		# using creation since it is only the immutable value of a doc
+		return get_hash(get_datetime_str(self.creation))
 
 	def get_liked_by(self):
 		liked_by = getattr(self, "_liked_by", None)

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -3,6 +3,9 @@
 
 import string
 import frappe
+import hmac
+import hashlib
+
 from frappe import _
 from frappe.query_builder import Table
 from frappe.utils import cstr, encode
@@ -243,3 +246,11 @@ def get_encryption_key():
 
 def get_password_reset_limit():
 	return frappe.db.get_single_value("System Settings", "password_reset_limit") or 0
+
+def get_hash(txt):
+	hmac_obj = hmac.new(
+		bytes(get_encryption_key(), "utf-8"),
+		msg=frappe.safe_encode(txt),
+		digestmod=hashlib.sha256
+	)
+	return hmac_obj.hexdigest()[-16:]


### PR DESCRIPTION
- Use an encryption key for the document signature generation so that the generated signature
is different in different sites for the same value

**Note:** This will break old links (we cannot do much about it though)

> security fix