### PR TITLE
feat: copy error info to clipbaord + misc. fixes

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -481,6 +481,24 @@ frappe.request.report_error = function(xhr, request_opts) {
 		exc = "";
 	}
 
+	const copy_markdown_to_clipboard = () => {
+		const code_block = snippet => '```\n' + snippet + '\n```';
+		const traceback_info = [
+			'### App Versions',
+			code_block(JSON.stringify(frappe.boot.versions, null, "\t")),
+			'### Route',
+			code_block(frappe.get_route_str()),
+			'### Trackeback',
+			code_block(exc),
+			'### Request Data',
+			code_block(JSON.stringify(request_opts, null, "\t")),
+			'### Response Data',
+			code_block(JSON.stringify(data, null, '\t')),
+		].join("\n");
+		frappe.utils.copy_to_clipboard(traceback_info);
+	};
+
+
 	var show_communication = function() {
 		var error_report_message = [
 			'<h5>Please type some additional information that could help us reproduce this issue:</h5>',
@@ -531,6 +549,11 @@ frappe.request.report_error = function(xhr, request_opts) {
 					} else {
 						frappe.msgprint(__('Support Email Address Not Specified'));
 					}
+					frappe.error_dialog.hide();
+				},
+				secondary_action_label: __('Copy error to clipboard'),
+				secondary_action: () => {
+					copy_markdown_to_clipboard();
 					frappe.error_dialog.hide();
 				}
 			});

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -957,17 +957,24 @@ Object.assign(frappe.utils, {
 		return decoded;
 	},
 	copy_to_clipboard(string) {
-		let input = $("<textarea>");
-		$("body").append(input);
-		input.val(string).select();
+		const show_success_alert = () => {
+			frappe.show_alert({
+				indicator: 'green',
+				message: __('Copied to clipboard.')
+			});
+		};
+		if (navigator.clipboard && window.isSecureContext) {
+			navigator.clipboard.writeText(string).then(show_success_alert);
+		} else {
+			let input = $("<textarea>");
+			$("body").append(input);
+			input.val(string).select();
 
-		document.execCommand("copy");
-		input.remove();
+			document.execCommand("copy");
+			show_success_alert();
+			input.remove();
+		}
 
-		frappe.show_alert({
-			indicator: 'green',
-			message: __('Copied to clipboard.')
-		});
 	},
 	is_rtl(lang=null) {
 		return ["ar", "he", "fa", "ps"].includes(lang || frappe.boot.lang);

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -957,7 +957,7 @@ Object.assign(frappe.utils, {
 		return decoded;
 	},
 	copy_to_clipboard(string) {
-		let input = $("<input>");
+		let input = $("<textarea>");
 		$("body").append(input);
 		input.val(string).select();
 

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -351,7 +351,7 @@ frappe.views.CommunicationComposer = class {
 	}
 
 	async set_values_from_last_edited_communication() {
-		if (this.txt) return;
+		if (this.txt || this.message) return;
 
 		const last_edited = this.get_last_edited_communication();
 		if (!last_edited.content) return;
@@ -713,7 +713,7 @@ frappe.views.CommunicationComposer = class {
 	async set_content() {
 		if (this.content_set) return;
 
-		let message = this.txt || "";
+		let message = this.txt || this.message || "";
 		if (!message && this.frm) {
 			const { doctype, docname } = this.frm;
 			message = await localforage.getItem(doctype + docname) || "";
@@ -727,7 +727,7 @@ frappe.views.CommunicationComposer = class {
 
 		const SALUTATION_END_COMMENT = "<!-- salutation-ends -->";
 		if (this.real_name && !message.includes(SALUTATION_END_COMMENT)) {
-			this.message = `
+			message = `
 				<p>${__('Dear {0},', [this.real_name], 'Salutation in new email')},</p>
 				${SALUTATION_END_COMMENT}<br>
 				${message}


### PR DESCRIPTION
Changes:
1. Fix: email window not populating content from `message` argument. closes  https://github.com/frappe/frappe/issues/15224
2. Feature: copy error traceback info in markdown format to clipboard. closes https://github.com/frappe/frappe/issues/15210 
3. Fix: Use `textarea` instead of `input` so clipboard can now support newline characters too. 
4. Refactor: Use `navigator.clipboard` for setting text in clipboard over deprecated methods and DOM hacks.

https://user-images.githubusercontent.com/9079960/145258844-94e287c7-492d-40aa-9419-b7b9cc1083b4.mov


`no-docs`