### PR TITLE
ci: fix mariadb-client install in CI

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -17,7 +17,7 @@ if [ "$TYPE" == "server" ]; then
 fi
 
 if [ "$DB" == "mariadb" ];then
-      sudo apt install mariadb-client-10.3
+      sudo apt update && sudo apt install mariadb-client-10.3
       mysql --host 127.0.0.1 --port 3306 -u root -e "SET GLOBAL character_set_server = 'utf8mb4'";
       mysql --host 127.0.0.1 --port 3306 -u root -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'";
 


### PR DESCRIPTION
Installing mariadb client is required for some capabilities (backup): https://github.com/frappe/frappe/pull/14085#issuecomment-917629236 

This is failing right now because of stale apt cache. 🙄 