### PR TITLE
fix: Web Form child table scroll issue

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -316,7 +316,7 @@ Object.assign(frappe.utils, {
 		}
 	},
 	get_scroll_position: function(element, additional_offset) {
-		let header_offset = $(".navbar").height() + $(".page-head:visible").height();
+		let header_offset = $(".navbar").height() + $(".page-head:visible").height() || $(".navbar").height();
 		let scroll_top = $(element).offset().top - header_offset - cint(additional_offset);
 		return scroll_top;
 	},


### PR DESCRIPTION
**Issue:**

If there is a table on the web form, clicking on **Add Row** scrolls to the top of the page.

**Before:**

https://user-images.githubusercontent.com/31363128/145342101-9d77705f-b471-47fd-9f33-a33ca3f2684e.mov

**After:**

https://user-images.githubusercontent.com/31363128/145342150-41d4cc4a-b8b6-4c53-9211-7802542b650c.mov
