### PR TITLE
fix: disable data import legacy on v13

### DIFF
--- a/frappe/core/doctype/data_import_legacy/data_import_legacy.js
+++ b/frappe/core/doctype/data_import_legacy/data_import_legacy.js
@@ -85,25 +85,14 @@ frappe.ui.form.on('Data Import Legacy', {
 				frappe.data_import.download_dialog(frm).show();
 			});
 		}
-
-		if (frm.doc.reference_doctype && frm.doc.import_file && frm.doc.total_rows &&
-			frm.doc.docstatus === 0 && (!frm.doc.import_status || frm.doc.import_status == "Failed")) {
-			frm.page.set_primary_action(__("Start Import"), function() {
-				frappe.call({
-					btn: frm.page.btn_primary,
-					method: "frappe.core.doctype.data_import_legacy.data_import_legacy.import_data",
-					args: {
-						data_import: frm.doc.name
-					}
-				});
-			}).addClass('btn btn-primary');
-		}
-
 		if (frm.doc.log_details) {
 			frm.events.create_log_table(frm);
 		} else {
 			$(frm.fields_dict.import_log.wrapper).empty();
 		}
+
+		const data_import_link = "<a href='/app/data-import'>Data Import</a>";
+		frm.dashboard.add_comment(__("This data importer utility is deprecated and will be removed, use {} instead.", [data_import_link]), "yellow", true);
 	},
 
 	action: function(frm) {


### PR DESCRIPTION
Disable import from client-side and suggest using the new Data Importer. 

<img width="1327" alt="Screenshot 2021-12-09 at 3 08 35 PM" src="https://user-images.githubusercontent.com/9079960/145371677-cab92238-6d52-47b7-ade7-b79922ad9e63.png">
