### PR TITLE
fix: record name creating based on naming series and not as per the user input

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -199,7 +199,7 @@ class Importer:
 		new_doc = frappe.new_doc(self.doctype)
 		new_doc.update(doc)
 
-		if (meta.autoname or "").lower() != "prompt":
+		if not doc.name and (meta.autoname or "").lower() != "prompt":
 			# name can only be set directly if autoname is prompt
 			new_doc.set("name", None)
 


### PR DESCRIPTION
**Issue**

User wants to create the multiple opening invoices and for that they are using the Data Import feature. They have tried data import and system has generated invoices properly. But while importing data user has set the ID as per their requirement in the excel and their expectation was system should use same ID but system has generated new id using Naming Series

Imported Excel Sheet
<img width="1160" alt="Screenshot 2021-12-09 at 7 24 15 PM" src="https://user-images.githubusercontent.com/8780500/145409335-b5afd29b-d2b2-4ca0-8bf6-cd85e032d9dc.png">

Id Generated using Naming Series PVR
<img width="1337" alt="Screenshot 2021-12-09 at 7 10 00 PM" src="https://user-images.githubusercontent.com/8780500/145409102-f8f867b5-7a39-4a1a-81b1-ed37b9f4e94a.png">


**After Fix**

<img width="1109" alt="Screenshot 2021-12-09 at 7 14 16 PM" src="https://user-images.githubusercontent.com/8780500/145409127-f0c740b5-f3b6-4d14-ad49-8eccfa705a1c.png">

