### PR TITLE
feat: patched frappe email to work with frappecloud mail app

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -18,7 +18,7 @@ from frappe import _, safe_encode, task
 from frappe.model.document import Document
 from frappe.email.queue import get_unsubcribed_url, get_unsubscribe_message
 from frappe.email.email_body import add_attachment, get_formatted_html, get_email
-from frappe.utils import cint, split_emails, add_days, nowdate, cstr
+from frappe.utils import cint, split_emails, add_days, nowdate, cstr, get_hook_method
 from frappe.email.doctype.email_account.email_account import EmailAccount
 
 
@@ -121,9 +121,13 @@ class EmailQueue(Document):
 					continue
 
 				message = ctx.build_message(recipient.recipient)
-				if not frappe.flags.in_test:
-					ctx.smtp_session.sendmail(from_addr=self.sender, to_addrs=recipient.recipient, msg=message)
-				ctx.add_to_sent_list(recipient)
+				method = get_hook_method('send_mime_mail')
+				if method:
+					method(self, recipient.recipient, message)
+				else:
+					if not frappe.flags.in_test:
+						ctx.smtp_session.sendmail(from_addr=self.sender, to_addrs=recipient.recipient, msg=message)
+					ctx.add_to_sent_list(recipient)
 
 			if frappe.flags.in_test:
 				frappe.flags.sent_mail = message

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -121,9 +121,9 @@ class EmailQueue(Document):
 					continue
 
 				message = ctx.build_message(recipient.recipient)
-				method = get_hook_method('send_mime_mail')
+				method = get_hook_method('override_email_send')
 				if method:
-					method(self, recipient.recipient, message)
+					method(self, self.sender, recipient.recipient, message)
 				else:
 					if not frappe.flags.in_test:
 						ctx.smtp_session.sendmail(from_addr=self.sender, to_addrs=recipient.recipient, msg=message)

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -59,7 +59,9 @@ def get_formatted_email(user, mail=None):
 	
 	method = get_hook_method('get_sender_details')
 	if method:
-		fullname, mail = method()
+		sender_name, mail = method()
+		# if method exists but sender_name is ""
+		fullname = sender_name or fullname
 
 	if not mail:
 		mail = get_email_address(user) or validate_email_address(user)

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -56,6 +56,10 @@ def get_email_address(user=None):
 def get_formatted_email(user, mail=None):
 	"""get Email Address of user formatted as: `John Doe <johndoe@example.com>`"""
 	fullname = get_fullname(user)
+	
+	method = get_hook_method('get_sender_details')
+	if method:
+		fullname, mail = method()
 
 	if not mail:
 		mail = get_email_address(user) or validate_email_address(user)


### PR DESCRIPTION
* added two hook methods `get_sender_details` and `override_email_send`
* `get_sender_details` sets the default sender name and address which generated by default from logged in user.
* `override_email_send` overrides `smtp_session.sendmail` and sends the content and email data to any other hooked method.
* both these methods provide a way to set default sender address regardless of the user logged in and sending email content to some third party server/sender.


Docs: https://frappeframework.com/docs/v13/user/en/python-api/hooks#email-hooks