### PR TITLE
fix: not able to go back from user profile page

### DIFF
--- a/frappe/desk/page/user_profile/user_profile_controller.js
+++ b/frappe/desk/page/user_profile/user_profile_controller.js
@@ -68,8 +68,7 @@ class UserProfile {
 			primary_action_label: __('Go'),
 			primary_action: ({ user }) => {
 				dialog.hide();
-				this.user_id = user;
-				this.make_user_profile();
+				frappe.set_route('user-profile', user);
 			}
 		});
 		dialog.show();

--- a/frappe/desk/page/user_profile/user_profile_controller.js
+++ b/frappe/desk/page/user_profile/user_profile_controller.js
@@ -17,21 +17,15 @@ class UserProfile {
 	show() {
 		let route = frappe.get_route();
 		this.user_id = route[1] || frappe.session.user;
-
-		//validate if user
-		if (route.length > 1) {
-			frappe.dom.freeze(__('Loading user profile') + '...');
-			frappe.db.exists('User', this.user_id).then(exists => {
-				frappe.dom.unfreeze();
-				if (exists) {
-					this.make_user_profile();
-				} else {
-					frappe.msgprint(__('User does not exist'));
-				}
-			});
-		} else {
-			frappe.set_route('user-profile', frappe.session.user);
-		}
+		frappe.dom.freeze(__('Loading user profile') + '...');
+		frappe.db.exists('User', this.user_id).then(exists => {
+			frappe.dom.unfreeze();
+			if (exists) {
+				this.make_user_profile();
+			} else {
+				frappe.msgprint(__('User does not exist'));
+			}
+		});
 	}
 
 	make_user_profile() {

--- a/frappe/desk/page/user_profile/user_profile_sidebar.html
+++ b/frappe/desk/page/user_profile/user_profile_sidebar.html
@@ -51,7 +51,7 @@
 			<p><a class="edit-profile-link">{%=__("Edit Profile") %}</a></p>
 			<p><a class="user-settings-link">{%=__("User Settings") %}</a></p>
 			<p>
-				<a class="leaderboard-link" href="#leaderboard/User"
+				<a class="leaderboard-link" href="/app/leaderboard/User"
 					>{%=__("Leaderboard") %}</a
 				>
 			</p>


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/15141 

The problem was i was stuck on my user profile page on frappe.io. at first i thought i was not hitting the back button and repeatedly hitting reload or something happened to my mouse which finally led me to reach a conclusion that i've lost it - but then i saw there was a same issue https://github.com/frappe/frappe/issues/15141 open and where @ankush had already highlighted the problem (which was the fix), hence all the credit goes to him :)