### PR TITLE
fix: remove bench path from traceback

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -240,7 +240,9 @@ def get_traceback() -> str:
 		return ""
 
 	trace_list = traceback.format_exception(exc_type, exc_value, exc_tb)
-	return "".join(cstr(t) for t in trace_list)
+	bench_path = get_bench_path()
+
+	return "".join(cstr(t) for t in trace_list).replace(bench_path, "")
 
 def log(event, details):
 	frappe.logger().info(details)

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -240,7 +240,7 @@ def get_traceback() -> str:
 		return ""
 
 	trace_list = traceback.format_exception(exc_type, exc_value, exc_tb)
-	bench_path = get_bench_path()
+	bench_path = get_bench_path() + "/"
 
 	return "".join(cstr(t) for t in trace_list).replace(bench_path, "")
 


### PR DESCRIPTION
This is mostly useless for debugging and clutters the error message. 

before:

```
Traceback (most recent call last):
  File "/Users/ankush/benches/develop/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 1220, in call
    return fn(*args, **newargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/desk/form/load.py", line 35, in getdoc
    run_onload(doc)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/desk/form/load.py", line 278, in run_onload
    doc.run_method("onload")
  File "/Users/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 866, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 1163, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 1146, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 860, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/ankush/benches/develop/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 41, in onload
    1/ 0
ZeroDivisionError: division by zero

```




After:



```
Traceback (most recent call last):
  File "/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/apps/frappe/frappe/__init__.py", line 1220, in call
    return fn(*args, **newargs)
  File "/apps/frappe/frappe/desk/form/load.py", line 35, in getdoc
    run_onload(doc)
  File "/apps/frappe/frappe/desk/form/load.py", line 278, in run_onload
    doc.run_method("onload")
  File "/apps/frappe/frappe/model/document.py", line 866, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/apps/frappe/frappe/model/document.py", line 1163, in composer
    return composed(self, method, *args, **kwargs)
  File "/apps/frappe/frappe/model/document.py", line 1146, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/apps/frappe/frappe/model/document.py", line 860, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 41, in onload
    1/ 0
ZeroDivisionError: division by zero

```
