### PR TITLE
chore: VS2022 uses .vs - Add .vs to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 frappe/docs/current
 frappe/public/dist
 .vscode
+.vs
 node_modules
 .kdev4/
 *.kdev4


### PR DESCRIPTION
Ignore visual studio configuration folder