### PR TITLE
fix: misc setup_wizard region slide

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -595,6 +595,7 @@ frappe.setup.utils = {
 
 			$timezone.empty();
 
+			if (!country) return;
 			// add country specific timezones first
 			const timezone_list = data.country_info[country].timezones || [];
 			$timezone.add_options(timezone_list.sort());
@@ -612,6 +613,7 @@ frappe.setup.utils = {
 
 		slide.get_input("currency").on("change", function () {
 			var currency = slide.get_input("currency").val();
+			if (!currency) return;
 			frappe.model.with_doc("Currency", currency, function () {
 				frappe.provide("locals.:Currency." + currency);
 				var currency_doc = frappe.model.get_doc("Currency", currency);

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -392,12 +392,14 @@ frappe.setup.slides_settings = [
 		fields: [
 			{
 				fieldname: "country", label: __("Your Country"), reqd: 1,
-				fieldtype: "Select"
+				fieldtype: "Autocomplete",
+				placeholder: __('Select Country')
 			},
 			{ fieldtype: "Section Break" },
 			{
 				fieldname: "timezone", label: __("Time Zone"), reqd: 1,
-				fieldtype: "Select"
+				fieldtype: "Select",
+
 			},
 			{ fieldtype: "Column Break" },
 			{
@@ -529,16 +531,19 @@ frappe.setup.utils = {
 
 		var country_field = slide.get_field('country');
 
-		slide.get_input("country").empty()
-			.add_options([""].concat(Object.keys(data.country_info).sort()));
 
-		slide.get_input("currency").empty()
-			.add_options(frappe.utils.unique([""].concat(
-				$.map(data.country_info, opts => opts.currency)
-			)).sort());
+		country_field.set_data(Object.keys(data.country_info).sort());
+
+		slide.get_input("currency")
+			.empty()
+			.add_options(
+				frappe.utils.unique(
+					["Select Currency"].concat($.map(data.country_info, opts => opts.currency).sort())
+				)
+			);
 
 		slide.get_input("timezone").empty()
-			.add_options([""].concat(data.all_timezones));
+			.add_options(["Select Timezone"].concat(data.all_timezones));
 
 		// set values if present
 		if (frappe.wizard.values.country) {
@@ -590,7 +595,7 @@ frappe.setup.utils = {
 			$timezone.empty();
 
 			// add country specific timezones first
-			if (country) {
+			if (country !== "Select Country" ) {
 				var timezone_list = data.country_info[country].timezones || [];
 				$timezone.add_options(timezone_list.sort());
 				slide.get_field("currency").set_input(data.country_info[country].currency);
@@ -598,7 +603,7 @@ frappe.setup.utils = {
 			}
 
 			// add all timezones at the end, so that user has the option to change it to any timezone
-			$timezone.add_options([""].concat(data.all_timezones));
+			$timezone.add_options(["Select Timezone"].concat(data.all_timezones));
 
 			slide.get_field("timezone").set_input($timezone.val());
 
@@ -609,7 +614,7 @@ frappe.setup.utils = {
 
 		slide.get_input("currency").on("change", function () {
 			var currency = slide.get_input("currency").val();
-			if (!currency) return;
+			if (currency === "Select Currency") return;
 			frappe.model.with_doc("Currency", currency, function () {
 				frappe.provide("locals.:Currency." + currency);
 				var currency_doc = frappe.model.get_doc("Currency", currency);

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -397,14 +397,19 @@ frappe.setup.slides_settings = [
 			},
 			{ fieldtype: "Section Break" },
 			{
-				fieldname: "timezone", label: __("Time Zone"), reqd: 1,
+				fieldname: "timezone",
+				label: __("Time Zone"),
+				placeholder: __('Select Time Zone'),
+				reqd: 1,
 				fieldtype: "Select",
-
 			},
 			{ fieldtype: "Column Break" },
 			{
-				fieldname: "currency", label: __("Currency"), reqd: 1,
-				fieldtype: "Select"
+				fieldname: "currency",
+				label: __("Currency"),
+				placeholder: __('Select Currency'),
+				reqd: 1,
+				fieldtype: "Select",
 			}
 		],
 
@@ -514,7 +519,7 @@ frappe.setup.utils = {
 				frappe.setup.data.email = r.message.email;
 				callback(slide);
 			}
-		})
+		});
 	},
 
 	setup_language_field: function (slide) {
@@ -538,12 +543,12 @@ frappe.setup.utils = {
 			.empty()
 			.add_options(
 				frappe.utils.unique(
-					["Select Currency"].concat($.map(data.country_info, opts => opts.currency).sort())
+					$.map(data.country_info, opts => opts.currency).sort()
 				)
 			);
 
 		slide.get_input("timezone").empty()
-			.add_options(["Select Timezone"].concat(data.all_timezones));
+			.add_options(data.all_timezones);
 
 		// set values if present
 		if (frappe.wizard.values.country) {
@@ -552,13 +557,9 @@ frappe.setup.utils = {
 			country_field.set_input(data.default_country);
 		}
 
-		if (frappe.wizard.values.currency) {
-			slide.get_field("currency").set_input(frappe.wizard.values.currency);
-		}
+		slide.get_field("currency").set_input(frappe.wizard.values.currency);
 
-		if (frappe.wizard.values.timezone) {
-			slide.get_field("timezone").set_input(frappe.wizard.values.timezone);
-		}
+		slide.get_field("timezone").set_input(frappe.wizard.values.timezone);
 
 	},
 
@@ -595,16 +596,13 @@ frappe.setup.utils = {
 			$timezone.empty();
 
 			// add country specific timezones first
-			if (country !== "Select Country" ) {
-				var timezone_list = data.country_info[country].timezones || [];
-				$timezone.add_options(timezone_list.sort());
-				slide.get_field("currency").set_input(data.country_info[country].currency);
-				slide.get_field("currency").$input.trigger("change");
-			}
+			const timezone_list = data.country_info[country].timezones || [];
+			$timezone.add_options(timezone_list.sort());
+			slide.get_field("currency").set_input(data.country_info[country].currency);
+			slide.get_field("currency").$input.trigger("change");
 
 			// add all timezones at the end, so that user has the option to change it to any timezone
-			$timezone.add_options(["Select Timezone"].concat(data.all_timezones));
-
+			$timezone.add_options(data.all_timezones);
 			slide.get_field("timezone").set_input($timezone.val());
 
 			// temporarily set date format
@@ -614,7 +612,6 @@ frappe.setup.utils = {
 
 		slide.get_input("currency").on("change", function () {
 			var currency = slide.get_input("currency").val();
-			if (currency === "Select Currency") return;
 			frappe.model.with_doc("Currency", currency, function () {
 				frappe.provide("locals.:Currency." + currency);
 				var currency_doc = frappe.model.get_doc("Currency", currency);
@@ -622,7 +619,7 @@ frappe.setup.utils = {
 				if (number_format === "#.###") {
 					number_format = "#.###,##";
 				} else if (number_format === "#,###") {
-					number_format = "#,###.##"
+					number_format = "#,###.##";
 				}
 
 				frappe.boot.sysdefaults.number_format = number_format;


### PR DESCRIPTION
# Before 

<div align="center">
    <img src="https://user-images.githubusercontent.com/33656173/146039388-003108ba-adbe-48dd-ac14-b5d3cd6d49b0.png" height = "500">

<p>
    <i>
         Long list of countries, default text is empty, no placeholder
    </i>
</p>

</div>




# Changes

- placeholder on all fields of region slides
- autocomplete on the country input field
- default selected values on inputs instead of blank values


# After
<div align="center">
    <div align="center">
        <img src="https://user-images.githubusercontent.com/33656173/146396734-849f7a84-bd86-4242-ab26-977df764358c.png" height = "350"/>
        <img src="https://user-images.githubusercontent.com/33656173/146039455-5ec19e04-51a3-42d5-8486-feb74ded0a73.jpg" height = "350"/>
 <img src="https://user-images.githubusercontent.com/33656173/146396747-d7a19be3-e37c-4f0b-a824-a252c3a9082d.png" height = "350"/>
    </div>
    <p>
        <i>
            `select county` is the placeholder, country field now has autocomplete
        </i>
    </p>
</div>
