### PR TITLE
fix: Make "Use original name for amended document" setting read-only

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -471,7 +471,7 @@
    "fieldname": "use_original_name_for_amended_document",
    "fieldtype": "Check",
    "label": "Use original name for amended document",
-   "read_only_depends_on": "eval:doc.use_original_name_for_amended_document==1"
+   "read_only": 1
   },
   {
    "collapsible": 1,
@@ -489,7 +489,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2021-11-29 18:09:53.601629",
+ "modified": "2021-12-13 12:07:26.860735",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",


### PR DESCRIPTION
This PR will not allow turning on "Use original name for amended document" setting in System Settings for sites that do not have turned it on yet.

![image](https://user-images.githubusercontent.com/28212972/145766230-d2e14e26-d561-4452-8f66-363052aea313.png)

This PR should be followed by another pr which will remove this functionality entirely with a patch to revert changes.
