### PR TITLE
fix: upload jpeg image with alpha channel

### DIFF
--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -30,6 +30,9 @@ def strip_exif_data(content, content_type):
 
 	original_image = Image.open(io.BytesIO(content))
 	output = io.BytesIO()
+	# ref: https://stackoverflow.com/a/48248432
+	if content_type == "image/jpeg" and original_image.mode in ("RGBA", "P"):
+		original_image = original_image.convert("RGB")
 
 	new_image = Image.new(original_image.mode, original_image.size)
 	new_image.putdata(list(original_image.getdata()))


### PR DESCRIPTION
if you try to upload a jpeg image with alpha channel(RGBA), an error is thrown

This pr fixes that behaviour by converting/flattening the jpeg RGBA image to jpeg RGB image

(Though i do have a question - why does a jpeg image have an alpha channel? due to software/user settings? 🤷‍♂️ )

I've attached an example image to this pr to test out.

Steps to reproduce:
1. go to file list doctype
2. try to upload the image attached in this pr

The traceback received:
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1220, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/handler.py", line 194, in upload_file
    ret.save(ignore_permissions=ignore_permissions)
  File "apps/frappe/frappe/model/document.py", line 282, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 304, in _save
    self.insert()
  File "apps/frappe/frappe/model/document.py", line 228, in insert
    self.run_method("before_insert")
  File "apps/frappe/frappe/model/document.py", line 866, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1163, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1146, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 860, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "apps/frappe/frappe/core/doctype/file/file.py", line 54, in before_insert
    self.save_file(content=self.content, decode=self.decode)
  File "apps/frappe/frappe/core/doctype/file/file.py", line 452, in save_file
    self.content = strip_exif_data(self.content, self.content_type)
  File "apps/frappe/frappe/utils/image.py", line 39, in strip_exif_data
    new_image.save(output, format=content_type.split('/')[1])
  File "env/lib/python3.9/site-packages/PIL/Image.py", line 2172, in save
    save_handler(self, fp, filename)
  File "env/lib/python3.9/site-packages/PIL/JpegImagePlugin.py", line 635, in _save
    raise OSError(f"cannot write mode {im.mode} as JPEG") from e
OSError: cannot write mode RGBA as JPEG
```

![rick-and-morty-20-1920×1080](https://user-images.githubusercontent.com/32034600/145780162-626294e2-98c0-48e7-bc5f-dc4969396d6f.jpg)

(Not sure if github will do any conversions or not after uploading)
