### PR TITLE
fix: `get_doc` owner permission

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -108,7 +108,7 @@ def get_doc_permissions(doc, user=None, ptype=None):
 	meta = frappe.get_meta(doc.doctype)
 
 	def is_user_owner():
-		return (doc.get("owner") or "").lower() == frappe.session.user.lower()
+		return (doc.get("owner") or "").lower() == user
 
 	if has_controller_permissions(doc, ptype, user=user) is False:
 		push_perm_check_log('Not allowed via controller permission check')

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -108,7 +108,7 @@ def get_doc_permissions(doc, user=None, ptype=None):
 	meta = frappe.get_meta(doc.doctype)
 
 	def is_user_owner():
-		return (doc.get("owner") or "").lower() == user
+		return (doc.get("owner") or "").lower() == user.lower()
 
 	if has_controller_permissions(doc, ptype, user=user) is False:
 		push_perm_check_log('Not allowed via controller permission check')


### PR DESCRIPTION
Picking a part of https://github.com/frappe/frappe/pull/15171

Equate with the passed user instead of equating always with `frappe.session.user` to get the correct result for `is_owner` permission check.