### PR TITLE
fix: different icons for different events in the timeline.

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -172,9 +172,11 @@ class FormTimeline extends BaseTimeline {
 
 	get_communication_timeline_contents() {
 		let communication_timeline_contents = [];
+		let icon_set = {Email: "mail", Phone: "call", Meeting: "calendar", Other: "dot-horizontal"};
 		(this.doc_info.communications|| []).forEach(communication => {
+			let medium = communication.communication_medium;
 			communication_timeline_contents.push({
-				icon: 'mail',
+				icon: icon_set[medium],
 				icon_size: 'sm',
 				creation: communication.creation,
 				is_card: true,


### PR DESCRIPTION
***Issue***
For every event type, we have the same 'mail' icon in the timeline.

***Before***
<img width="910" alt="Screenshot 2021-12-13 at 9 20 40 PM" src="https://user-images.githubusercontent.com/58825865/145844944-c0ae97e1-e3c5-4424-89b9-71eeff1e09ba.png">

***After***

Event Categories created in  order - Other, Sent/Received mail, Meeting, Call.

<img width="900" alt="Screenshot 2021-12-13 at 9 23 39 PM" src="https://user-images.githubusercontent.com/58825865/145845013-4dd0a2d6-ded7-494e-80fa-c5ffd7527d02.png">

***Steps to reproduce***
1. Go to any doctype which has event in the timeline enabled.
2. For any doc, create events of different categories.
3. You will notice every event type has 'mail' icon.
