### PR TITLE
fix: treeview expanding at random

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1910,12 +1910,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (!doctype) return;
 		frappe.provide("frappe.views.trees");
 
-		// refresh tree view
-		if (frappe.views.trees[doctype]) {
-			frappe.views.trees[doctype].tree.refresh();
-			return;
-		}
-
 		// refresh list view
 		const page_name = frappe.get_route_str();
 		const list_view = frappe.views.list_view[page_name];

--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -299,7 +299,6 @@ frappe.ui.Tree = class {
 				.appendTo($toolbar);
 			$link.on('click', () => {
 				obj.click(node);
-				this.refresh();
 			});
 		});
 

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -318,10 +318,7 @@ frappe.views.TreeView = class TreeView {
 				args: args,
 				callback: function(r) {
 					if(!r.exc) {
-						if(node.expanded) {
-							me.tree.toggle_node(node);
-						}
-						me.tree.load_children(node, true);
+						me.tree.load_children(node);
 					}
 				},
 				always: function() {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -242,6 +242,7 @@ frappe.views.TreeView = class TreeView {
 					frappe.model.rename_doc(me.doctype, node.label, function(new_name) {
 						node.$tree_link.find('a').text(new_name);
 						node.label = new_name;
+						me.tree.refresh();
 					});
 				},
 				btnClass: "hidden-xs"


### PR DESCRIPTION
Tree view expands parent node recursively when...
1. You click on any toolbar buttons. (like add item, delete item buttons) 
2. Insert a new item.
3. Someone else inserts a new item (and your view gets refreshed via realtime event)


This change disables all three. 


https://user-images.githubusercontent.com/9079960/145864282-868ade4e-4cfe-4223-8c72-578eb071b7ff.mov


Treeview refresh in the current state is more of a nuisance than help 😅 Maybe it can be added back once we somehow preserve the expanded state of nodes? AFAIK most treeviews are slow-changing records and probably don't need realtime update. 