### PR TITLE
fix: Combine request args and form data

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -185,7 +185,9 @@ def make_form_dict(request):
 	if 'application/json' in (request.content_type or '') and request_data:
 		args = json.loads(request_data)
 	else:
-		args = request.form or request.args
+		args = {}
+		args.update(request.args or {})
+		args.update(request.form or {})
 
 	if not isinstance(args, dict):
 		frappe.throw(_("Invalid request arguments"))


### PR DESCRIPTION
Combine request "args" and "form data" to accept arguments through both options in a single request

fixes: https://github.com/frappe/frappe/issues/8693