### PR TITLE
fix: select perm not visible in role permission summary dialog

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -15,7 +15,7 @@ Object.assign(window, {
 });
 
 $.extend(frappe.perm, {
-	rights: ["read", "write", "create", "delete", "submit", "cancel", "amend",
+	rights: ["select", "read", "write", "create", "delete", "submit", "cancel", "amend",
 		"report", "import", "export", "print", "email", "share", "set_user_permissions"],
 
 	doctype_perm: {},


### PR DESCRIPTION
**Before**:

Select permissions not visible in role permission summary

![image](https://user-images.githubusercontent.com/24353136/146039249-8f35adf1-65a5-4d76-adc4-7e7a292f5cba.png)


**After:**

Added select perm to `frappe.perm.rights`

![image](https://user-images.githubusercontent.com/24353136/146039077-7931b16f-dc56-4132-a1cf-e937b1e0d7cc.png)
