### PR TITLE
fix: Text Editor Height

### DIFF
--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -39,8 +39,7 @@
 
 .ql-snow {
 	.ql-editor {
-		min-height: 400px;
-		max-height: 600px;
+		height: 300px;
 		border-bottom-left-radius: var(--border-radius);
 		border-bottom-right-radius: var(--border-radius);
 	}


### PR DESCRIPTION
**Issue:**

1. Text Editors height increases after a certain number of lines are added. This makes the user scroll down on small screens to see the current cursor location. On scrolling down the toolbar gets out of sight as it's at the top.
2. As we move on to adding more lines, an internal scroll gets added.
3. The height increase is not needed if there is going to be an internal scroll.

**Before:**

User has the text editor in front of them. They start adding text and after certain lines the height increases, causing them to scroll (this is not an internal scroll). When the user scrolls down, the toolbar of the editor gets out of sight as it's at the top. The user proceeds to add some more lines and now there is an internal scroll too. This is even more disturbing on small screen sizes.

https://user-images.githubusercontent.com/31363128/146120955-d46f8819-7fb4-42b6-b887-8e5077d58150.mov



**After:**

https://user-images.githubusercontent.com/31363128/146121458-d5cd6c0a-92b5-4988-834a-cf1d596716d0.mov
