### PR TITLE
fix(pdf): Fix barcode rendering

### DIFF
--- a/frappe/public/js/frappe/form/controls/barcode.js
+++ b/frappe/public/js/frappe/form/controls/barcode.js
@@ -56,9 +56,6 @@ frappe.ui.form.ControlBarcode = frappe.ui.form.ControlData.extend({
 	get_options(value) {
 		// get JsBarcode options
 		let options = {};
-		options.background = "var(--control-bg)";
-		options.lineColor = "var(--text-color)";
-		options.font = "var(--font-stack)";
 		options.fontSize = "16";
 		options.width = "3";
 		options.height = "50";

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -231,6 +231,16 @@ textarea.form-control {
 	background-color: var(--control-bg);
 	border-radius: var(--border-radius);
 	padding: var(--padding-md);
+
+	svg > rect {
+		fill: var(--control-bg) !important;
+	}
+	svg > g {
+		fill: var(--text-color) !important;
+	}
+	svg > text {
+		font-family: var(--font-stack) !important;
+	}
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
Move barcode style to SCSS file so that the style gets applied only in form view and not in printview (print view uses fallback white and black)

**Before:** (In PDF)
<img width="900" alt="Screenshot 2021-12-15 at 9 19 05 AM" src="https://user-images.githubusercontent.com/13928957/146121104-8122e584-cdc2-4e08-8631-bd4f4696f688.png">

**After:**
<img width="900" alt="Screenshot 2021-12-15 at 9 46 34 AM" src="https://user-images.githubusercontent.com/13928957/146122313-915e1517-834e-492c-a19a-cb139b4b8d94.png">

**Note:** This issue is fixed in develop via https://github.com/frappe/frappe/pull/14134