### PR TITLE
fix(ux): always show scan barcode button

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -122,12 +122,7 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		);
 
 		this.$scan_btn = this.$wrapper.find('.link-btn');
-
-		this.$input.on("focus", () => {
-			setTimeout(() => {
-				this.$scan_btn.toggle(true);
-			}, 500);
-		});
+		this.$scan_btn.toggle(true);
 
 		const me = this;
 		this.$scan_btn.on('click', 'a', () => {
@@ -140,12 +135,6 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 					}
 				}
 			});
-		});
-
-		this.$input.on("blur", () => {
-			setTimeout(() => {
-				this.$scan_btn.toggle(false);
-			}, 500);
 		});
 	}
 


### PR DESCRIPTION
Closes #15295

<img width="1106" alt="Screenshot 2021-12-15 at 12 14 38 PM" src="https://user-images.githubusercontent.com/9079960/146136837-b6c8d176-9188-4a70-bb05-49f9785e7604.png">


Data fields with barcode option show "Scan" button when focused. This adds one extra click and this is hard to discover on mobile version. 

Solution: always show this button regardless of focus. 