### PR TITLE
fix: reload doctype state early to fix patch

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -2,6 +2,7 @@ frappe.patches.v12_0.remove_deprecated_fields_from_doctype #3
 execute:frappe.utils.global_search.setup_global_search_table()
 execute:frappe.reload_doc('core', 'doctype', 'doctype_action', force=True) #2019-09-23
 execute:frappe.reload_doc('core', 'doctype', 'doctype_link', force=True) #2020-10-17
+execute:frappe.reload_doc('core', 'doctype', 'doctype_state', force=True) #2021-12-15
 execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True) #2017-09-22
 execute:frappe.reload_doc('core', 'doctype', 'docfield', force=True) #2018-02-20
 frappe.patches.v11_0.drop_column_apply_user_permissions


### PR DESCRIPTION
Attempt to fix erpnext patch CI: https://github.com/frappe/erpnext/runs/4529933190?check_suite_focus=true