### PR TITLE
feat: translations in Data Import

### DIFF
--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -369,7 +369,7 @@ class DataExporter:
 		self.append_field_column(frappe._dict({
 			"fieldname": "name" if dt else self.name_field,
 			"parent": dt or "",
-			"label": "ID",
+			"label": _("ID"),
 			"fieldtype": "Data",
 			"reqd": 1,
 		}), True)

--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -369,7 +369,7 @@ class DataExporter:
 		self.append_field_column(frappe._dict({
 			"fieldname": "name" if dt else self.name_field,
 			"parent": dt or "",
-			"label": _("ID"),
+			"label": "ID",
 			"fieldtype": "Data",
 			"reqd": 1,
 		}), True)

--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -5,6 +5,7 @@
 import typing
 
 import frappe
+from frappe import _
 from frappe.model import (
 	display_fieldtypes,
 	no_value_fields,
@@ -215,9 +216,9 @@ class Exporter:
 		for df in self.fields:
 			is_parent = not df.is_child_table_field
 			if is_parent:
-				label = df.label
+				label = _(df.label)
 			else:
-				label = "{0} ({1})".format(df.label, df.child_table_df.label)
+				label = "{0} ({1})".format(_(df.label), _(df.child_table_df.label))
 
 			if label in header:
 				# this label is already in the header,
@@ -227,6 +228,7 @@ class Exporter:
 					label = "{0}".format(df.fieldname)
 				else:
 					label = "{0}.{1}".format(df.child_table_df.fieldname, df.fieldname)
+
 			header.append(label)
 
 		self.csv_array.append(header)
@@ -253,10 +255,10 @@ class Exporter:
 			self.build_xlsx_response()
 
 	def build_csv_response(self):
-		build_csv_response(self.get_csv_array_for_export(), self.doctype)
+		build_csv_response(self.get_csv_array_for_export(), _(self.doctype))
 
 	def build_xlsx_response(self):
-		build_xlsx_response(self.get_csv_array_for_export(), self.doctype)
+		build_xlsx_response(self.get_csv_array_for_export(), _(self.doctype))
 
 	def group_children_data_by_parent(self, children_data: typing.Dict[str, list]):
 		return groupby_metric(children_data, key='parent')

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -262,7 +262,7 @@ class Importer:
 		rows = [header_row]
 		rows += [row.data for row in self.import_file.data if row.row_number in row_indexes]
 
-		build_csv_response(rows, self.doctype)
+		build_csv_response(rows, _(self.doctype))
 
 	def print_import_log(self, import_log):
 		failed_records = [log for log in import_log if not log.success]
@@ -1009,18 +1009,12 @@ def build_fields_dict_for_column_matching(parent_doctype):
 	out = {}
 
 	# doctypes and fieldname if it is a child doctype
-	doctypes = [[parent_doctype, None]] + [
-		[df.options, df] for df in parent_meta.get_table_fields()
+	doctypes = [(parent_doctype, None)] + [
+		(df.options, df) for df in parent_meta.get_table_fields()
 	]
 
 	for doctype, table_df in doctypes:
 		# name field
-		name_by_label = (
-			"ID" if doctype == parent_doctype else "ID ({0})".format(table_df.label)
-		)
-		name_by_fieldname = (
-			"name" if doctype == parent_doctype else "{0}.name".format(table_df.fieldname)
-		)
 		name_df = frappe._dict(
 			{
 				"fieldtype": "Data",
@@ -1031,63 +1025,104 @@ def build_fields_dict_for_column_matching(parent_doctype):
 			}
 		)
 
-		if doctype != parent_doctype:
+		if doctype == parent_doctype:
+			name_headers = (
+				"name", # fieldname
+				"ID", # label
+				_("ID"), # translated label
+			)
+		else:
+			name_headers = (
+				"{0}.name".format(table_df.fieldname), # fieldname
+				"ID ({0})".format(table_df.label), # label
+				"{0} ({1})".format(_("ID"), _(table_df.label)), # translated label
+			)
+
 			name_df.is_child_table_field = True
 			name_df.child_table_df = table_df
 
-		out[name_by_label] = name_df
-		out[name_by_fieldname] = name_df
+		for header in name_headers:
+			out[header] = name_df
 
 		# other fields
+		table_fields = parent_meta.get(
+			"fields", {"fieldtype": ["in", table_fieldtypes]}
+		)
+
+		for table_field in table_fields:
+			table_field.translated_label = _(table_field.label)
+
 		fields = get_standard_fields(doctype) + frappe.get_meta(doctype).fields
 		for df in fields:
-			label = (df.label or "").strip()
 			fieldtype = df.fieldtype or "Data"
+			if fieldtype in no_value_fields:
+				continue
+
+			label = (df.label or "").strip()
+			translated_label = _(label)
 			parent = df.parent or parent_doctype
-			if fieldtype not in no_value_fields:
-				if parent_doctype == doctype:
-					# for parent doctypes keys will be
-					# Label
-					# label
-					# Label (label)
-					if not out.get(label):
-						# if Label is already set, don't set it again
-						# in case of duplicate column headers
-						out[label] = df
-					out[df.fieldname] = df
-					label_with_fieldname = "{0} ({1})".format(label, df.fieldname)
-					out[label_with_fieldname] = df
-				else:
-					# in case there are multiple table fields with the same doctype
-					# for child doctypes keys will be
-					# Label (Table Field Label)
-					# table_field.fieldname
-					table_fields = parent_meta.get(
-						"fields", {"fieldtype": ["in", table_fieldtypes], "options": parent}
-					)
-					for table_field in table_fields:
-						by_label = "{0} ({1})".format(label, table_field.label)
-						by_fieldname = "{0}.{1}".format(table_field.fieldname, df.fieldname)
 
-						# create a new df object to avoid mutation problems
-						if isinstance(df, dict):
-							new_df = frappe._dict(df.copy())
-						else:
-							new_df = df.as_dict()
+			if parent_doctype == doctype:
+				# for parent doctypes keys will be
+				# Label, fielname, Label (fieldname)
 
-						new_df.is_child_table_field = True
-						new_df.child_table_df = table_field
-						out[by_label] = new_df
-						out[by_fieldname] = new_df
+				for header in (label, translated_label):
+					# if Label is already set, don't set it again
+					# in case of duplicate column headers
+					if header not in out:
+						out[header] = df
+
+				for header in (
+					df.fieldname,
+					f"{label} ({df.fieldname})",
+					f"{translated_label} ({df.fieldname})"
+				):
+					out[header] = df
+
+			else:
+				# in case there are multiple table fields with the same doctype
+				# for child doctypes keys will be
+				# Label (Table Field Label)
+				# table_field.fieldname
+
+
+				for table_field in table_fields:
+					if table_field.options != parent:
+						continue
+
+					# create a new df object to avoid mutation problems
+					if isinstance(df, dict):
+						new_df = frappe._dict(df.copy())
+					else:
+						new_df = df.as_dict()
+
+					new_df.is_child_table_field = True
+					new_df.child_table_df = table_field
+
+					for header in (
+						# fieldname
+						"{0}.{1}".format(table_field.fieldname, df.fieldname),
+						# label
+						"{0} ({1})".format(label, table_field.label),
+						# translated label
+						"{0} ({1})".format(translated_label, table_field.translated_label),
+					):
+						out[header] = new_df
 
 	# if autoname is based on field
 	# add an entry for "ID (Autoname Field)"
 	autoname_field = get_autoname_field(parent_doctype)
 	if autoname_field:
-		out["ID ({})".format(autoname_field.label)] = autoname_field
-		# ID field should also map to the autoname field
-		out["ID"] = autoname_field
-		out["name"] = autoname_field
+		for header in (
+			"ID ({})".format(autoname_field.label), # label
+			"{0} ({1})".format(_("ID"), _(autoname_field.label)), # translated label
+
+			# ID field should also map to the autoname field
+			"ID",
+			_("ID"),
+			"name",
+		):
+			out[header] = autoname_field
 
 	return out
 

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1014,6 +1014,8 @@ def build_fields_dict_for_column_matching(parent_doctype):
 	]
 
 	for doctype, table_df in doctypes:
+		translated_table_label = _(table_df.label) if table_df else None
+
 		# name field
 		name_df = frappe._dict(
 			{
@@ -1035,7 +1037,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 			name_headers = (
 				"{0}.name".format(table_df.fieldname), # fieldname
 				"ID ({0})".format(table_df.label), # label
-				"{0} ({1})".format(_("ID"), _(table_df.label)), # translated label
+				"{0} ({1})".format(_("ID"), translated_table_label), # translated label
 			)
 
 			name_df.is_child_table_field = True
@@ -1043,14 +1045,6 @@ def build_fields_dict_for_column_matching(parent_doctype):
 
 		for header in name_headers:
 			out[header] = name_df
-
-		# other fields
-		table_fields = parent_meta.get(
-			"fields", {"fieldtype": ["in", table_fieldtypes]}
-		)
-
-		for table_field in table_fields:
-			table_field.translated_label = _(table_field.label)
 
 		fields = get_standard_fields(doctype) + frappe.get_meta(doctype).fields
 		for df in fields:
@@ -1085,29 +1079,24 @@ def build_fields_dict_for_column_matching(parent_doctype):
 				# Label (Table Field Label)
 				# table_field.fieldname
 
+				# create a new df object to avoid mutation problems
+				if isinstance(df, dict):
+					new_df = frappe._dict(df.copy())
+				else:
+					new_df = df.as_dict()
 
-				for table_field in table_fields:
-					if table_field.options != parent:
-						continue
+				new_df.is_child_table_field = True
+				new_df.child_table_df = table_df
 
-					# create a new df object to avoid mutation problems
-					if isinstance(df, dict):
-						new_df = frappe._dict(df.copy())
-					else:
-						new_df = df.as_dict()
-
-					new_df.is_child_table_field = True
-					new_df.child_table_df = table_field
-
-					for header in (
-						# fieldname
-						"{0}.{1}".format(table_field.fieldname, df.fieldname),
-						# label
-						"{0} ({1})".format(label, table_field.label),
-						# translated label
-						"{0} ({1})".format(translated_label, table_field.translated_label),
-					):
-						out[header] = new_df
+				for header in (
+					# fieldname
+					"{0}.{1}".format(table_df.fieldname, df.fieldname),
+					# label
+					"{0} ({1})".format(label, table_df.label),
+					# translated label
+					"{0} ({1})".format(translated_label, translated_table_label),
+				):
+					out[header] = new_df
 
 	# if autoname is based on field
 	# add an entry for "ID (Autoname Field)"

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1074,7 +1074,6 @@ def build_fields_dict_for_column_matching(parent_doctype):
 					out[header] = df
 
 			else:
-				# in case there are multiple table fields with the same doctype
 				# for child doctypes keys will be
 				# Label (Table Field Label)
 				# table_field.fieldname

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -1058,7 +1058,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 
 			if parent_doctype == doctype:
 				# for parent doctypes keys will be
-				# Label, fielname, Label (fieldname)
+				# Label, fieldname, Label (fieldname)
 
 				for header in (label, translated_label):
 					# if Label is already set, don't set it again

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -260,7 +260,7 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 
 	# build output as csv
 	if cint(frappe.form_dict.get('as_csv')):
-		build_csv_response(response, doc.doctype.replace(' ', ''))
+		build_csv_response(response, _(doc.doctype).replace(' ', ''))
 		return
 
 	frappe.response['message'] = response

--- a/frappe/public/js/frappe/data_import/import_preview.js
+++ b/frappe/public/js/frappe/data_import/import_preview.js
@@ -343,11 +343,11 @@ function get_fields_as_options(doctype, column_map) {
 	return [].concat(
 		...keys.map(key => {
 			return column_map[key].map(df => {
-				let label = df.label;
+				let label = __(df.label);
 				let value = df.fieldname;
 				if (doctype !== key) {
 					let table_field = frappe.meta.get_docfield(doctype, key);
-					label = `${df.label} (${table_field.label})`;
+					label = `${__(df.label)} (${__(table_field.label)})`;
 					value = `${table_field.fieldname}.${df.fieldname}`;
 				}
 				return {


### PR DESCRIPTION
Resolves https://github.com/frappe/frappe/issues/13801
Resolves https://github.com/frappe/frappe/issues/13209

## Changes Made
- Translate column headers in exported CSV files

**Before:**

![image](https://user-images.githubusercontent.com/16315650/146315003-a9f7ee69-093e-48ab-a7c5-8287263dd85d.png)

**After:**

![image](https://user-images.githubusercontent.com/16315650/146314822-24cc8ad5-2cee-4eba-a564-7be59f7be7c0.png)


- Translate `doctype` wherever it is being used for CSV filename

**Before:**

![image](https://user-images.githubusercontent.com/16315650/146315103-51a222f6-b6ef-4585-bc1a-7adb8174e3f7.png)

**After:**

![Screenshot-2021-12-16-111413](https://user-images.githubusercontent.com/16315650/146315157-5becd720-42ed-4268-a9c5-c9965f09baff.png)



- Allow translated columns to auto-match when data is imported (only for user language)


**Before:**

![Screenshot-2021-12-16-111017](https://user-images.githubusercontent.com/16315650/146314729-f5822343-6212-499a-9a94-cf3dfe3252d2.png)


**After:**
![Screenshot-2021-12-16-110428](https://user-images.githubusercontent.com/16315650/146314739-e1fc066a-4fd7-4b72-9417-daa238487d41.png)

- Remove unnecessary loop in `importer.py`. All table fields of current `parenttype` were being looped over, but that happens already in the outermost loop. (Tested with Crop DocType)

**Before / After** (No Change):

![Screenshot-2021-12-16-105225](https://user-images.githubusercontent.com/16315650/146313651-4c55f4d7-1eaa-44e4-8149-03ff7b7af41e.png)


- Translate the options available when matching column headers with the corresponding fieldname manually.

**Before:**

![image](https://user-images.githubusercontent.com/16315650/146315261-9b337bdf-8644-4e53-81fd-9cdbd75827b7.png)

**After:**

![image](https://user-images.githubusercontent.com/16315650/146315349-7812c975-328f-4484-a78f-308bbda656c4.png)

<!-- no-docs -->