### PR TITLE
fix: set invalid link fields to `null` instead `''`

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -471,7 +471,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			docname: value,
 			fields: columns_to_fetch,
 		}).then((response) => {
-			if (!response || !response.name) return "";
+			if (!response || !response.name) return undefined;
 			if (!docname || !columns_to_fetch.length) return response.name;
 
 			for (const [target_field, source_field] of Object.entries(fetch_map)) {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -471,7 +471,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			docname: value,
 			fields: columns_to_fetch,
 		}).then((response) => {
-			if (!response || !response.name) return undefined;
+			if (!response || !response.name) return null;
 			if (!docname || !columns_to_fetch.length) return response.name;
 
 			for (const [target_field, source_field] of Object.entries(fetch_map)) {


### PR DESCRIPTION
This breaks other code where undefined values are removed, technically
invalid value for link field => unset link field so it should be
undefined

closes: https://github.com/frappe/frappe/issues/15319 


steps to reproduce:

1. Open sales order
2. Add some gibberish in the customer field, it will get erased and become `''` empty string
3. Try to add item in items table. You'll get error from invalid filters that are passed on `customer: ''`