### PR TITLE
fix: use `get_all` instead of `get_list` while fetching linked doctypes

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -133,7 +133,7 @@ class SubmittableDocumentTree:
 		"""Returns list of submittable doctypes.
 		"""
 		if not self._submittable_doctypes:
-			self._submittable_doctypes = frappe.db.get_list('DocType', {'is_submittable': 1}, pluck='name')
+			self._submittable_doctypes = frappe.db.get_all('DocType', {'is_submittable': 1}, pluck='name')
 		return self._submittable_doctypes
 
 


### PR DESCRIPTION
Users who don't have access to DocType are unable to cancel documents since the system uses `get_list` while checking for linked docs

![image](https://user-images.githubusercontent.com/24353136/146304407-41013837-e604-4d60-9d31-3554d132e46c.png)

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1220, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/linked_with.py", line 42, in get_submitted_linked_docs
    visited_documents = tree.get_all_children()
  File "apps/frappe/frappe/desk/form/linked_with.py", line 85, in get_all_children
    child_docs = self.get_next_level_children(parent_dt, parent_docs)
  File "apps/frappe/frappe/desk/form/linked_with.py", line 102, in get_next_level_children
    referencing_fields = self.get_doctype_references(parent_dt)
  File "apps/frappe/frappe/desk/form/linked_with.py", line 116, in get_doctype_references
    get_links_to = self.get_document_sources()
  File "apps/frappe/frappe/desk/form/linked_with.py", line 125, in get_document_sources
    return list(set(self.get_link_sources() + [self.root_doctype]))
  File "apps/frappe/frappe/desk/form/linked_with.py", line 130, in get_link_sources
    return list(set(self.get_submittable_doctypes()) - set(get_exempted_doctypes() or []))
  File "apps/frappe/frappe/desk/form/linked_with.py", line 136, in get_submittable_doctypes
    self._submittable_doctypes = frappe.db.get_list('DocType', {'is_submittable': 1}, pluck='name')
  File "apps/frappe/frappe/database/database.py", line 526, in get_list
    return frappe.get_list(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1453, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "apps/frappe/frappe/model/db_query.py", line 44, in execute
    raise frappe.PermissionError(self.doctype)
frappe.exceptions.PermissionError: DocType
```

Issue introduced via https://github.com/frappe/frappe/pull/14526