### PR TITLE
feat: `before_uninstall` and `after_uninstall` hooks

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1203,7 +1203,7 @@ def read_file(path, raise_not_found=False):
 def get_attr(method_string):
 	"""Get python method object from its name."""
 	app_name = method_string.split(".")[0]
-	if not local.flags.in_install and app_name not in get_installed_apps():
+	if not local.flags.in_uninstall and not local.flags.in_install and app_name not in get_installed_apps():
 		throw(_("App {0} is not installed").format(app_name), AppNotInstalledError)
 
 	modulename = '.'.join(method_string.split('.')[:-1])

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -208,6 +208,7 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 	import click
 
 	site = frappe.local.site
+	app_hooks = frappe.get_hooks(app_name=app_name)
 
 	# dont allow uninstall app if not installed unless forced
 	if not force:
@@ -233,6 +234,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 
 	frappe.flags.in_uninstall = True
 
+	for before_uninstall in app_hooks.before_uninstall or []:
+		frappe.get_attr(before_uninstall)()
+
 	modules = frappe.get_all("Module Def", filters={"app_name": app_name}, pluck="name")
 
 	drop_doctypes = _delete_modules(modules, dry_run=dry_run)
@@ -242,6 +246,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 		remove_from_installed_apps(app_name)
 		frappe.get_single('Installed Applications').update_versions()
 		frappe.db.commit()
+
+	for after_uninstall in app_hooks.after_uninstall or []:
+		frappe.get_attr(after_uninstall)()
 
 	click.secho(f"Uninstalled App {app_name} from Site {site}", fg="green")
 	frappe.flags.in_uninstall = False

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -203,6 +203,12 @@ app_license = "{app_license}"
 # before_install = "{app_name}.install.before_install"
 # after_install = "{app_name}.install.after_install"
 
+# Uninstallation
+# ------------
+
+# before_uninstall = "{app_name}.uninstall.before_uninstall"
+# after_uninstall = "{app_name}.uninstall.after_uninstall"
+
 # Desk Notifications
 # ------------------
 # See frappe.core.notifications.get_notification_config


### PR DESCRIPTION
This pr adds 2 new hooks to be used when uninstalling an app - `before_uninstall` and  `after_uninstall`

implements 2/3 hooks proposed in #15338 

edit: Just realised that "after uninstallation" - the previously "installed" app doesn't really exist in the namespace so the `after_uninstall` hook didn't really work 😅

edit2: added a working `after_uninstall` hook 🙄 

docs: https://frappeframework.com/docs/v13/user/en/python-api/hooks/edit?wiki_page_patch=87157e903e