### PR TITLE
fix: set empty lists for unset meta table fields

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -120,6 +120,11 @@ class Meta(Document):
 					or (not no_nulls and value is None)):
 					out[key] = value
 
+			# set empty lists for unset table fields
+			for table_field in DOCTYPE_TABLE_FIELDS:
+				if not out.get(table_field.fieldname):
+					out[table_field.fieldname] = []
+
 			return out
 
 		return serialize(self)


### PR DESCRIPTION
```py
# Before
m = frappe.get_meta('ToDo').as_dict()
m['states'] // KeyError

# After
m = frappe.get_meta('ToDo').as_dict()
m['states'] // []
```

Fixes:

![image](https://user-images.githubusercontent.com/9355208/146394471-53370156-4fb5-4947-a457-e984b7388eeb.png)
