### PR TITLE
feat: Conditional doc wise default print format

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -13,6 +13,8 @@
   "standard",
   "custom_format",
   "disabled",
+  "condition_for_default",
+  "priority",
   "section_break_6",
   "print_format_type",
   "raw_printing",
@@ -253,7 +255,22 @@
    "fieldtype": "Select",
    "label": "Page Number",
    "options": "Hide\nTop Left\nTop Center\nTop Right\nBottom Left\nBottom Center\nBottom Right"
-  }
+  },
+  {
+    "fieldname": "condition_for_default",
+    "fieldtype": "Code",
+    "options": "PythonExpression",
+    "label": "Condition for Default",
+    "description": "Context variable: doc and frappe.session.user, function get_roles can be used"
+   },
+   {
+    "fieldname": "priority",
+    "fieldtype": "Int",
+    "insert_after": "condition_for_default",
+    "default": 100,
+    "label": "Priority",
+    "description":"Smaller number higher priority"
+   }
  ],
  "icon": "fa fa-print",
  "idx": 1,

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -192,6 +192,8 @@ frappe.ui.form.PrintView = class {
 		this.frm = frm;
 		this.set_title();
 		this.set_breadcrumbs();
+        this.page && this.page.sidebar && this.page.sidebar.empty();
+        this.setup_sidebar();		
 		this.setup_customize_dialog();
 
 		// print format builder beta
@@ -749,11 +751,22 @@ frappe.ui.form.PrintView = class {
 			&& this.print_sel.val(print_format_select_val);
 	}
 
-	selected_format() {
-		return (
-			this.print_sel.val() || this.frm.meta.default_print_format || 'Standard'
-		);
-	}
+    selected_format() {
+        let current_print_format = this.print_sel.val();
+        if (current_print_format){
+            return current_print_format
+        }
+        else {
+            frappe.call({
+                method: 'frappe.utils.print_format.get_print_format',
+                args: {doc: this.frm.doc}
+            }).then((r) =>{
+                //console.log('r.message=', r.message);
+                this.print_sel.val(r.message || this.frm.meta.default_print_format || 'Standard');
+                this.refresh_print_format();
+            })
+        }
+    }
 
 	is_raw_printing(format) {
 		return this.get_print_format(format).raw_printing === 1;

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -128,3 +128,18 @@ def print_by_server(doctype, name, printer_setting, print_format=None, doc=None,
 		frappe.throw(_("Printing failed"))
 	finally:
 		return
+
+@frappe.whitelist()
+def get_print_format(doc):
+    if isinstance(doc, str):
+        doc = json.loads(doc)
+    doc = frappe.get_doc(doc)
+    print_format_list =  frappe.get_all('Print Format',
+                                        filters = {'doc_type': doc.doctype,
+                                                   'disabled': 0},
+                                        fields = ['name', 'condition_for_default'],
+                                        order_by = 'priority', as_list = 1)
+
+    for (print_format, condition) in print_format_list:
+        if condition and frappe.safe_eval(condition, None, dict(doc=doc, get_roles = frappe.get_roles)):
+            return print_format


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

As of now, system assigns default print format per doctype, even user can define multi print formats for different business types, such as one print format for standard purchase order, another one for sub contract purchase order, only one of the print format can be assigned to Purchase Order doctype, user always need to manually select the non default print format.

this new feature adds two fields in print format form, by which the admin can define python expression as condition to set the print format as default for the corresponding document.

![image](https://user-images.githubusercontent.com/12823863/146558100-e839f3a6-8fd3-49a9-bdee-bc3e99a09bb7.png)


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
