### PR TITLE
fix: value associated with property may be changed

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -28,7 +28,8 @@ Object.defineProperty(Object.prototype, "setDefault", {
 	value: function(key, default_value) {
 		if (!(key in this)) this[key] = default_value;
 		return this[key];
-	}
+	},
+	writable: true
 });
 
 // Pluralize


### PR DESCRIPTION
- seems like this issue was introduced with #14532, but dunno why it started breaking now especially in `moment-timezone-with-data.min.js`
- define setDefault as writable when defining the new property [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties)
```
moment-timezone-with-data.min.js:1 Uncaught TypeError: Cannot assign to read only property 'setDefault' of function 'function R(c){var M=Array.prototype.slice.call(arguments,0,-1),A=arguments[arguments.length-1],o=s(A),z=b.utc.a...<omitted>...z}'
    at VM1661 moment-timezone-with-data.min.js:1
    at VM1661 moment-timezone-with-data.min.js:1
    at VM1661 moment-timezone-with-data.min.js:1
```