### PR TITLE
feat: Custom signup form hook

### DIFF
--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,0 +1,22 @@
+<form class="form-signin form-signup hide" role="form">
+    <div class="page-card-body">
+        <div class="form-group">
+            <label class="form-label sr-only" for="signup_fullname">Full Name</label>
+            <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"
+                required autofocus>
+        </div>
+        <div class="form-group">
+            <label class="form-label sr-only" for="signup_email">Email</label>
+            <input type="email" id="signup_email" class="form-control"
+                placeholder="{{ _('jane@example.com') }}" required>
+        </div>
+    </div>
+    <div class="page-card-actions">
+        <button class="btn btn-sm btn-primary btn-block btn-signup"
+            type="submit">{{ _("Sign up") }}</button>
+
+        <p class="text-center sign-up-message">
+            <a href="#login" class="blue">{{ _("Have an account? Login") }}</a>
+        </p>
+    </div>
+</form>

--- a/frappe/templates/signup.html
+++ b/frappe/templates/signup.html
@@ -1,12 +1,12 @@
 <form class="form-signin form-signup hide" role="form">
     <div class="page-card-body">
         <div class="form-group">
-            <label class="form-label sr-only" for="signup_fullname">Full Name</label>
+            <label class="form-label sr-only" for="signup_fullname">{{ _("Full Name") }}</label>
             <input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"
                 required autofocus>
         </div>
         <div class="form-group">
-            <label class="form-label sr-only" for="signup_email">Email</label>
+            <label class="form-label sr-only" for="signup_email">{{ _("Email") }}</label>
             <input type="email" id="signup_email" class="form-control"
                 placeholder="{{ _('jane@example.com') }}" required>
         </div>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -81,7 +81,7 @@
 				<div class="page-card-body">
 					<form class="form-signin form-login" role="form">
 						{{ email_login_body() }}
-					</form>	
+					</form>
 					<div class="social-logins text-center">
 						<p class="text-muted login-divider">{{ _("or") }}</p>
 						<div class="social-login-buttons">
@@ -131,6 +131,10 @@
 		<div class="login-content page-card">
 			{{ logo_section() }}
 			{%- if not disable_signup -%}
+
+			{% if custom_signup_form %}
+			{{ custom_signup_form }}
+			{% else %}
 			<form class="form-signin form-signup hide" role="form">
 				<div class="page-card-body">
 					<div class="form-group">
@@ -153,6 +157,8 @@
 					</p>
 				</div>
 			</form>
+			{% endif %}
+
 			{%- else -%}
 			<div class='page-card-head mb-2'>
 				<span class='indicator gray'>{{_("Signup Disabled")}}</span>

--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -131,34 +131,7 @@
 		<div class="login-content page-card">
 			{{ logo_section() }}
 			{%- if not disable_signup -%}
-
-			{% if custom_signup_form %}
-			{{ custom_signup_form }}
-			{% else %}
-			<form class="form-signin form-signup hide" role="form">
-				<div class="page-card-body">
-					<div class="form-group">
-						<label class="form-label sr-only" for="signup_fullname">Full Name</label>
-						<input type="text" id="signup_fullname" class="form-control" placeholder="{{ _('Jane Doe') }}"
-							required autofocus>
-					</div>
-					<div class="form-group">
-						<label class="form-label sr-only" for="signup_email">Email</label>
-						<input type="email" id="signup_email" class="form-control"
-							placeholder="{{ _('jane@example.com') }}" required>
-					</div>
-				</div>
-				<div class="page-card-actions">
-					<button class="btn btn-sm btn-primary btn-block btn-signup"
-						type="submit">{{ _("Sign up") }}</button>
-
-					<p class="text-center sign-up-message">
-						<a href="#login" class="blue">{{ _("Have an account? Login") }}</a>
-					</p>
-				</div>
-			</form>
-			{% endif %}
-
+			{{ signup_form_template }}
 			{%- else -%}
 			<div class='page-card-head mb-2'>
 				<span class='indicator gray'>{{_("Signup Disabled")}}</span>

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -39,6 +39,13 @@ def get_context(context):
 		frappe.get_hooks("app_logo_url")[-1])
 	context["app_name"] = (frappe.db.get_single_value('Website Settings', 'app_name') or
 		frappe.get_system_settings("app_name") or _("Frappe"))
+
+	custom_signup = frappe.get_hooks("custom_signup_form")
+	if custom_signup:
+		path = frappe.get_attr(custom_signup[0])()
+		if path:
+			context["custom_signup_form"] = frappe.get_template(path).render()
+
 	providers = [i.name for i in frappe.get_all("Social Login Key", filters={"enable_social_login":1}, order_by="name")]
 	for provider in providers:
 		client_id, base_url = frappe.get_value("Social Login Key", provider, ["client_id", "base_url"])

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -41,10 +41,8 @@ def get_context(context):
 		frappe.get_system_settings("app_name") or _("Frappe"))
 
 	custom_signup = frappe.get_hooks("custom_signup_form")
-	if custom_signup:
-		path = frappe.get_attr(custom_signup[0])()
-		if path:
-			context["custom_signup_form"] = frappe.get_template(path).render()
+	if custom_signup and len(custom_signup) and custom_signup[0]:
+		context["custom_signup_form"] = frappe.get_template(custom_signup[0]).render()
 
 	providers = [i.name for i in frappe.get_all("Social Login Key", filters={"enable_social_login":1}, order_by="name")]
 	for provider in providers:


### PR DESCRIPTION
1. A new hook called **signup_form_template** through which we can pass the path of the template file for a custom signup form.

2. If a custom signup form is passed through the hook, it will be rendered. Else the original signup form will render.

<img width="462" alt="Screenshot 2021-12-20 at 9 49 40 AM" src="https://user-images.githubusercontent.com/31363128/146712596-6374512a-769d-4fe1-8498-2102d4ea4fd4.png">

**Documentation Draft:** https://frappeframework.com/docs/v13/user/en/python-api/hooks/edit?wiki_page_patch=d5654b5ac7