### PR TITLE
fix: Descendants of including self

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -766,6 +766,9 @@ class FilterArea {
 							options = options.join("\n");
 						}
 					}
+					if (df.fieldtype == "Link" && df.options && frappe.boot.treeviews.includes(df.options)) {
+						condition = "descendants of including self";
+					}
 					let default_value =
 						fieldtype === "Link"
 							? frappe.defaults.get_user_default(options)

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -30,6 +30,7 @@ frappe.ui.Filter = class {
 
 		this.nested_set_conditions = [
 			['descendants of', __('Descendants Of')],
+			['descendants of including self', __('Descendants Of Including Self')],
 			['not descendants of', __('Not Descendants Of')],
 			['ancestors of', __('Ancestors Of')],
 			['not ancestors of', __('Not Ancestors Of')],
@@ -508,6 +509,7 @@ frappe.ui.filter_utils = {
 				'=',
 				'!=',
 				'descendants of',
+				'descendants of including self',
 				'ancestors of',
 				'not descendants of',
 				'not ancestors of',

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1333,7 +1333,7 @@ def get_filter(doctype, f, filters_config=None):
 		f.operator = "="
 
 	valid_operators = ("=", "!=", ">", "<", ">=", "<=", "like", "not like", "in", "not in", "is",
-		"between", "descendants of", "ancestors of", "not descendants of", "not ancestors of",
+		"between", "descendants of", "descendants of including self", "ancestors of", "not descendants of", "not ancestors of",
 		"timespan", "previous", "next")
 
 	if filters_config:


### PR DESCRIPTION
In list view, if you apply a filter on a link field whose doctype is a tree structure, you would expect all the children of that field to show up.

For e.g., in Item list, you apply a filter on Item Group to be All Item Groups. Now, All Item Groups is the parent of all Item Groups (duh), but you only see records that have All Item Groups set as the item group.

This is the job of the `descendants of` operator. However, it leaves out the node itself. This PR introduces a new operator `descendants of including self`. I am not happy with this naming, need better suggestions.

TODO:

Find a better name for nested set operators
- `descendants of`
- `descendants of including self`
- `not descendants of`
- etc