### PR TITLE
fix: Escape matching pattern for substitution

### DIFF
--- a/frappe/patches/v14_0/remove_db_aggregation.py
+++ b/frappe/patches/v14_0/remove_db_aggregation.py
@@ -27,6 +27,6 @@ def execute():
 		name, script = server_script["name"], server_script["script"]
 
 		for agg in ["avg", "max", "min", "sum"]:
-			script = re.sub(f"frappe.db.{agg}(", f"frappe.qb.{agg}(", script)
+			script = re.sub(f"frappe.db.{agg}\(", f"frappe.qb.{agg}(", script)
 
 		frappe.db.update("Server Script", name, "script", script)


### PR DESCRIPTION
Tested on PY3.9.7 and PY3.9.9

Fixes #15359 