### PR TITLE
fix(ui): Rendering forms created by disabled users

### DIFF
--- a/frappe/public/js/frappe/utils/user.js
+++ b/frappe/public/js/frappe/utils/user.js
@@ -11,9 +11,7 @@ frappe.user_info = function(uid) {
 	}
 
 	if(!(frappe.boot.user_info && frappe.boot.user_info[uid])) {
-		var user_info = {
-			fullname: frappe.utils.capitalize(uid.split("@")[0]) || "Unknown"
-		};
+		var user_info = {fullname: uid || "Unknown"};
 	} else {
 		var user_info = frappe.boot.user_info[uid];
 	}


### PR DESCRIPTION
`frappe.utils.capitalize` doesn't exist anymore (has been very long). And it didn't do that good of a job for setting full names anyway.

Some alternate solutions included: 
1. Fetching all user's info while fetching boot instead of just enabled users - doesn't scale
2. Re-do the capitalization logic - leads to "full names" like "Gavin18d", "Varun.codes" or similar based on the email ID

Just the email/username alone feels like a cleaner solution and it doesn't break any hearts.

<img width="1439" alt="Screenshot 2021-12-20 at 6 06 50 PM" src="https://user-images.githubusercontent.com/36654812/146768503-626179b7-46d6-41bf-8da9-7317fe0436f9.png">

Now, forms render and for disabled users' documents it'll say `"gavin@example.com modified this"` instead of `"Gavin D'souza modified this"`

Edit: This is required for disabled & deleted User documents 