### PR TITLE
test: Fix flaky test of language selection

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -14,7 +14,9 @@ from frappe.utils import set_request
 dirname = os.path.dirname(__file__)
 translation_string_file = os.path.join(dirname, 'translation_test_file.txt')
 first_lang, second_lang, third_lang, fourth_lang, fifth_lang = choices(
-	frappe.get_all("Language", pluck="name"), k=5
+	# skip "en*" since it is a default language
+	frappe.get_all("Language", pluck="name", filters=[["name", "not like", "en%"]]),
+	k=5
 )
 
 class TestTranslate(unittest.TestCase):


### PR DESCRIPTION
Do not use "en" language for testing since "en" is a fallback default language and few tests fail while testing against "en"

Fixes [flaky tests like this](https://github.com/frappe/frappe/runs/4581582406?check_suite_focus=true#step:14:777)
