### PR TITLE
fix: wrong website generator import tag

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -381,7 +381,7 @@ class DocType(Document):
 		document_cls_tag = f"class {despaced_name}(Document)"
 		document_import_tag = "from frappe.model.document import Document"
 		website_generator_cls_tag = f"class {despaced_name}(WebsiteGenerator)"
-		website_generator_import_tag = "from frappe.website.generators.website_generator import WebsiteGenerator"
+		website_generator_import_tag = "from frappe.website.website_generator import WebsiteGenerator"
 
 		with open(controller_path) as f:
 			code = f.read()


### PR DESCRIPTION
closes #15347 

This pr fixes the wrong import path for website generator (there is no `frappe.website.generators.website_generator` [[ref](https://github.com/frappe/frappe/blob/develop/frappe/website/website_generator.py)])