### PR TITLE
feat: SQL savepoints

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -801,14 +801,27 @@ class Database(object):
 
 		frappe.local.realtime_log = []
 
-	def rollback(self):
-		"""`ROLLBACK` current transaction."""
-		self.sql("rollback")
-		self.begin()
-		for obj in frappe.local.rollback_observers:
-			if hasattr(obj, "on_rollback"):
-				obj.on_rollback()
-		frappe.local.rollback_observers = []
+	def savepoint(self, save_point):
+		"""Savepoints work as a nested transaction.
+
+		Changes can be undone to a save point by doing frappe.db.rollback(save_point)
+
+		Note: rollback watchers can not work with save points.
+			so only changes to database are undone when rolling back to a savepoint.
+			Avoid using savepoints when writing to filesystem."""
+		self.sql(f"savepoint {save_point}")
+
+	def rollback(self, *, save_point=None):
+		"""`ROLLBACK` current transaction. Optionally rollback to a known save_point."""
+		if save_point:
+			self.sql(f"rollback to savepoint {save_point}")
+		else:
+			self.sql("rollback")
+			self.begin()
+			for obj in frappe.local.rollback_observers:
+				if hasattr(obj, "on_rollback"):
+					obj.on_rollback()
+			frappe.local.rollback_observers = []
 
 	def field_exists(self, dt, fn):
 		"""Return true of field exists."""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -301,8 +301,7 @@ class Document(BaseDocument):
 		self.flags.ignore_version = frappe.flags.in_test if ignore_version is None else ignore_version
 
 		if self.get("__islocal") or not self.get("name"):
-			self.insert()
-			return
+			return self.insert()
 
 		self.check_permission("write", "save")
 


### PR DESCRIPTION
Use cases:
1. Doing multiple operations on multiple docs, we often need to skip failing ones, this is typically implemented by commit + rollback. This leads to a forceful commit in transactions just to accommodate this use case. Also prone to weird partial commits.
2. Loggin type code that must commit log but rollback everything before that and continue on.  

Savepoints are supported by most DBs and it's part of SQL standard:

- https://mariadb.com/kb/en/savepoint/
- https://www.postgresql.org/docs/14/sql-savepoint.html


Example use case:

```python
for doc in docs:
    try:   
      frappe.db.savepoint("savepoint")
      doc.process_something()          # <-- any changes done to DB by these two lines 
      doc.save()                       #       can be rolled back in case of exception. 
    except Exception:
       frappe.db.rollback(save_point="savepoint")
```

No explicit commits or full rollbacks required 

Caveats:
1. Don't create stupidly long/large transactions. (for reasons regardless of savepoint feature)
2. rollback watchers won't work because sadly filesystems aren't ACID compliant and I don't want to implement a complex system for maintaining savepoint-wise rollback for filesystem changes.
3. savepoint names are programmer-defined and string substituted (so don't use user input, duh (?)). Make sure they're valid identifiers. (should we bother validating this?) 


docs: https://frappeframework.com/docs/v13/user/en/api/database/edit?wiki_page_patch=62588315c3 
