### PR TITLE
fix: Barcode rendering in server side printing

### DIFF
--- a/frappe/public/scss/print.scss
+++ b/frappe/public/scss/print.scss
@@ -1,13 +1,13 @@
-// @import "~bootstrap/scss/bootstrap";
 @import './common/quill';
-@import "./desk/css_variables";
+@import './desk/css_variables';
 
-
-// .print-format {
-// 	.ql-snow .ql-editor {
-// 		height: auto;
-// 		min-height: 0;
-// 		// max-height: 0;
-// 	}
-// }
-
+// !! PDF Barcode hack !!
+// Workaround for rendering barcodes prior to https://github.com/frappe/frappe/pull/15307
+@media print {
+	svg[data-barcode-value] > rect {
+		fill: white !important;
+	}
+	svg[data-barcode-value] > g {
+		fill: black !important;
+	}
+}


### PR DESCRIPTION
**Before:** (In PDF)

All barcodes created before #15307 would be visible as blocks:

<img width="900" alt="Screenshot 2021-12-15 at 9 19 05 AM" src="https://user-images.githubusercontent.com/13928957/146121104-8122e584-cdc2-4e08-8631-bd4f4696f688.png">

**After:**

Workaround for rendering barcodes prior to #15307:

<img width="900" alt="Screenshot 2021-12-15 at 9 46 34 AM" src="https://user-images.githubusercontent.com/13928957/146122313-915e1517-834e-492c-a19a-cb139b4b8d94.png">
