### PR TITLE
feat: Default section before Tabs

### DIFF
--- a/cypress/fixtures/doctype_with_tab_break.js
+++ b/cypress/fixtures/doctype_with_tab_break.js
@@ -12,9 +12,9 @@ export default {
 			options: 'Name'
 		},
 		{
-			fieldname: 'tab',
+			fieldname: 'tab_1',
 			fieldtype: 'Tab Break',
-			label: 'Tab 2',
+			label: 'Tab 1',
 		},
 		{
 			fieldname: 'Phone',
@@ -22,6 +22,16 @@ export default {
 			label: 'Phone',
 			options: 'Phone',
 			reqd: 1
+		},
+		{
+			fieldname: 'tab_2',
+			fieldtype: 'Tab Break',
+			label: 'Tab 2',
+		},
+		{
+			fieldname: 'Address',
+			fieldtype: 'Data',
+			label: 'Address'
 		},
 	],
 	links: [

--- a/cypress/integration/form_tab_break.js
+++ b/cypress/integration/form_tab_break.js
@@ -10,9 +10,9 @@ context("Form Tab Break", () => {
 		cy.new_form(doctype_name);
 		// test tab switch
 		cy.findByRole("tab", {name: "Tab 2"}).click();
+		cy.findByText("Address");
+		cy.findByRole("tab", {name: "Tab 1"}).click();
 		cy.findByText("Phone");
-		cy.findByRole("tab", {name: "Details"}).click();
-		cy.findByText("Name");
 
 		// form should switch to the tab with un-filled mandatory field
 		cy.fill_field("username", "Test");

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -211,12 +211,22 @@ frappe.ui.form.Form = class FrappeForm {
 		this.fields = this.layout.fields_list;
 
 		let dashboard_parent = $('<div class="form-dashboard">');
+		let dashboard_added = false;
 
 		if (this.layout.tabs.length) {
-			this.layout.tabs[0].wrapper.prepend(dashboard_parent);
-		} else {
+			this.layout.tabs.every(tab => {
+				if (tab.df.options === 'Dashboard') {
+					tab.wrapper.prepend(dashboard_parent);
+					dashboard_added = true;
+					return false;
+				}
+				return true;
+			});
+		} 
+		if (!this.layout.tabs.length || !dashboard_added) {
 			dashboard_parent.insertAfter(this.layout.wrapper.find('.form-message'));
 		}
+
 		this.dashboard = new frappe.ui.form.Dashboard(dashboard_parent, this);
 
 		this.tour = new frappe.ui.form.FormTour({

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -26,6 +26,8 @@ frappe.ui.form.Layout = class Layout {
 			this.fields = this.get_doctype_fields();
 		}
 
+		this.untabbed_content = $(`<div class="form-untabbed-content"></div>`).appendTo(this.page);
+
 		if (this.is_tabbed_layout()) {
 			this.setup_tabbed_layout();
 		}
@@ -119,14 +121,6 @@ frappe.ui.form.Layout = class Layout {
 
 		if (this.no_opening_section() && !this.is_tabbed_layout()) {
 			this.fields.unshift({fieldtype: 'Section Break'});
-		}
-
-		if (this.is_tabbed_layout()) {
-			let default_tab = {label: __('Details'), fieldname: 'details', fieldtype: "Tab Break"};
-			let first_tab = this.fields[1].fieldtype === "Tab Break" ? this.fields[1] : null;
-			if (!first_tab) {
-				this.fields.splice(1, 0, default_tab);
-			}
 		}
 
 		fields.forEach(df => {
@@ -245,7 +239,7 @@ frappe.ui.form.Layout = class Layout {
 	}
 
 	make_section(df) {
-		this.section = new Section(this.current_tab ? this.current_tab.wrapper : this.page, df, this.card_layout, this);
+		this.section = new Section(this.current_tab ? this.current_tab.wrapper : this.untabbed_content, df, this.card_layout, this);
 
 		// append to layout fields
 		if (df) {


### PR DESCRIPTION
Show Default Section before Tabs.

![image](https://user-images.githubusercontent.com/30859809/146904304-9f87124b-3147-4163-b0b8-6a77dc2fa71e.png)

To add the dashboard section to any tab add `Dashboard` in the `options` field. 
![image](https://user-images.githubusercontent.com/30859809/146904669-330ee81c-1848-4757-990b-306e5d4555ea.png)

![image](https://user-images.githubusercontent.com/30859809/146905149-ab543a78-1b58-4b8d-b703-6bcdfb12b761.png)

docs: https://frappeframework.com/docs/v13/user/en/basics/doctypes/fieldtypes#tab-break
