### PR TITLE
fix: Safe decode base64 data in case of incorrect padding

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -29,6 +29,7 @@ from frappe import _, conf, safe_decode
 from frappe.model.document import Document
 from frappe.utils import call_hook_method, cint, cstr, encode, get_files_path, get_hook_method, random_string, strip
 from frappe.utils.image import strip_exif_data, optimize_image
+from frappe.utils.file_manager import safe_b64decode
 
 class MaxFileSizeReachedError(frappe.ValidationError):
 	pass
@@ -436,7 +437,7 @@ class File(Document):
 
 			if b"," in self.content:
 				self.content = self.content.split(b",")[1]
-			self.content = base64.b64decode(self.content)
+			self.content = safe_b64decode(self.content)
 
 		if not self.is_private:
 			self.is_private = 0
@@ -852,7 +853,7 @@ def extract_images_from_html(doc, content, is_private=False):
 			content = content.encode("utf-8")
 		if b"," in content:
 			content = content.split(b",")[1]
-		content = base64.b64decode(content)
+		content = safe_b64decode(content)
 
 		content = optimize_image(content, mtype)
 


### PR DESCRIPTION
This happens sometimes, generally when the files we're dealing with are not completely downloaded, or shared partially. Luckily, if your file is just missing a trailing `=` or two, we can just append some so that the base64 parser knows when to stop.

<img width="719" alt="Screenshot 2021-12-21 at 1 46 10 PM" src="https://user-images.githubusercontent.com/36654812/146906193-2a83e651-2b0b-49a7-b273-3ead681fe57f.png">

#### Relevant Links:

* https://en.wikipedia.org/wiki/Base64
* https://stackoverflow.com/questions/2941995/python-ignore-incorrect-padding-error-when-base64-decoding

#### Traceback:

```bash
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1208, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 307, in _save
    self.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 239, in insert
    self._validate()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 499, in _validate
    self._extract_images_from_text_editor()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 983, in _extract_images_from_text_editor
    extract_images_from_doc(self, df.fieldname)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 779, in extract_images_from_doc
    content = extract_images_from_html(doc, content)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 822, in extract_images_from_html
    content = re.sub(r']*src\s*=\s*["\'](?=data:)(.*?)["\']', _save_file, content)
  File "/home/frappe/frappe-bench/env/lib/python3.6/re.py", line 191, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 814, in _save_file
    _file.save(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 307, in _save
    self.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 231, in insert
    self.run_method("before_insert")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 860, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1158, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1141, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 854, in
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 56, in before_insert
    self.save_file(content=self.content, decode=self.decode)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/file/file.py", line 436, in save_file
    self.content = base64.b64decode(self.content)
  File "/home/frappe/frappe-bench/env/lib/python3.6/base64.py", line 87, in b64decode
    return binascii.a2b_base64(s)
binascii.Error: Incorrect padding
```