### PR TITLE
fix: Added company info in the about dialog

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -1,9 +1,12 @@
 frappe.provide('frappe.ui.misc');
 frappe.ui.misc.about = function() {
 	if(!frappe.ui.misc.about_dialog) {
-		var d = new frappe.ui.Dialog({title: __('Frappe Framework')});
+		var d = new frappe.ui.Dialog({title: __('About Frappe Technologies Pvt. Ltd')});
 
 		$(d.body).html(repl("<div>\
+		<p>"+__("Frappe Framework is an open source project started and maintained by Frappe Technolgies Pvt. Ltd., Mumbai, India. It's a meta data driven framework, which helps in rapid application development. ERPNext is most well known and open source developed using Frappe Framework, driven by the community.")+"</p>  \
+		<p><a href='https://frappe.io/story' target='_blank'>Learn more</a> about the history of Frappe and ERPNext history.</p>\
+		<hr>\
 		<p>"+__("Open Source Applications for the Web")+"</p>  \
 		<p><i class='fa fa-globe fa-fw'></i>\
 			Website: <a href='https://frappeframework.com' target='_blank'>https://frappeframework.com</a></p>\


### PR DESCRIPTION
Added some more information about the company in the about dialog box. Also, changed the title of the dialog box, so that it can be common for both Frappe and ERPNext instances.

Before:
![Screenshot 2021-12-21 at 4 46 46 PM](https://user-images.githubusercontent.com/81952590/146921335-1f8d75fd-ff2e-4d63-a81a-3fb0b35126d9.png)

After:
![image](https://user-images.githubusercontent.com/81952590/146921076-4cc1a960-4807-4e84-a9c6-93fa371c30f6.png)
