### PR TITLE
chore: change log for v13.17.0

### DIFF
--- a/frappe/change_log/v13/v13_17_0.md
+++ b/frappe/change_log/v13/v13_17_0.md
@@ -1,0 +1,19 @@
+# Version 13.17.0 Release Notes
+
+### Features & Enhancements
+
+- Provision to disable new updates notification ([#15102](https://github.com/frappe/frappe/pull/15102))
+- Deferred insert for route history ([#15120](https://github.com/frappe/frappe/pull/15120))
+- Discussions component for the website ([#14226](https://github.com/frappe/frappe/pull/14226))
+- Copy error info to clipboard ([#15225](https://github.com/frappe/frappe/pull/15225))
+
+### Fixes
+- Cannot uninstall app with virtual doctype ([#15136](https://github.com/frappe/frappe/pull/15136))
+- Add `xcall` to Frappe's web bundle ([#15146](https://github.com/frappe/frappe/pull/15146))
+- Scrolling issues after minimize global search ([#15127](https://github.com/frappe/frappe/pull/15127))
+- Record name creating based on naming series and not as per the user input during data import ([#15238](https://github.com/frappe/frappe/pull/15238))
+- Barcode not showing in the pdf during print ([#15307](https://github.com/frappe/frappe/pull/15307))
+- Allow cancelling document using API with docstatus 2 ([#15104](https://github.com/frappe/frappe/pull/15104))
+- Add fallback option for time format when system defaults are not set ([#15150](https://github.com/frappe/frappe/pull/15150))
+- Sales invoice cancellation error due to get_list ([#15243](https://github.com/frappe/frappe/pull/15243))
+- Make query Postgres compatible ([#15239](https://github.com/frappe/frappe/pull/15239))


### PR DESCRIPTION
# Version 13.17.0 Release Notes

### Features & Enhancements

- Provision to disable new updates notification ([#15102](https://github.com/frappe/frappe/pull/15102))
- Deferred insert for route history ([#15120](https://github.com/frappe/frappe/pull/15120))
- Discussions component for the website ([#14226](https://github.com/frappe/frappe/pull/14226))
- Copy error info to clipboard ([#15225](https://github.com/frappe/frappe/pull/15225))

### Fixes
- Cannot uninstall app with virtual doctype ([#15136](https://github.com/frappe/frappe/pull/15136))
- Add `xcall` to Frappe's web bundle ([#15146](https://github.com/frappe/frappe/pull/15146))
- Scrolling issues after minimize global search ([#15127](https://github.com/frappe/frappe/pull/15127))
- Record name creating based on naming series and not as per the user input during data import ([#15238](https://github.com/frappe/frappe/pull/15238))
- Barcode not showing in the pdf during print ([#15307](https://github.com/frappe/frappe/pull/15307))
- Allow cancelling document using API with docstatus 2 ([#15104](https://github.com/frappe/frappe/pull/15104))
- Add fallback option for time format when system defaults are not set ([#15150](https://github.com/frappe/frappe/pull/15150))
- Sales invoice cancellation error due to get_list ([#15243](https://github.com/frappe/frappe/pull/15243))
- Make query Postgres compatible ([#15239](https://github.com/frappe/frappe/pull/15239))