### PR TITLE
fix: use python _ instead of __

### DIFF
--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -12,21 +12,21 @@
 		<form id="reset-password">
 			<div class="form-group">
 				<input id="old_password" type="password"
-					class="form-control" placeholder="{{ _("Old Password") }}">
+					class="form-control" placeholder="{{ _('Old Password') }}">
 			</div>
 			<div class="form-group">
 				<input id="new_password" type="password"
-					class="form-control" placeholder="{{ _("New Password") }}">
+					class="form-control" placeholder="{{ _('New Password') }}">
 				<span class="password-strength-indicator indicator"></span>
 			</div>
 			<div class="form-group">
 				<input id="confirm_password" type="password"
-					class="form-control" placeholder="{{ _("Confirm Password") }}">
-					
+					class="form-control" placeholder="{{ _('Confirm Password') }}">
+
 				<p class="password-mismatch-message text-muted small hidden mt-2"></p>
 			</div>
 			<p class='password-strength-message text-muted small hidden'></p>
-			<button type="submit" id="update" 
+			<button type="submit" id="update"
 				class="btn btn-primary btn-block btn-update">{{_("Confirm")}}</button>
 		</form>
 		{%- if not disable_signup -%}
@@ -36,7 +36,6 @@
 			</div>
 		{%- endif -%}
 	</div>
-	
 </section>
 <style>
 </style>
@@ -49,7 +48,7 @@ frappe.ready(function() {
 	}
 
 	if(frappe.utils.get_url_arg("password_expired")) {
-		$(".password-box").html(__('The password of your account has expired.'));
+		$(".password-box").html("{{ _('The password of your account has expired.') }}");
 	}
 
 	$("#reset-password").on("submit", function() {
@@ -69,15 +68,23 @@ frappe.ready(function() {
 		}
 		const confirm_password = $('#confirm_password').val()
 		if (!args.old_password && !args.key) {
-			frappe.msgprint(__("Old Password Required."));
+			frappe.msgprint({
+				title: "{{ _('Message') }}",
+				message: "{{ _('Old Password Required.') }}",
+				clear: true
+			});
 		}
 		if (!args.new_password) {
-			frappe.msgprint(__("New Password Required."));
+			frappe.msgprint({
+				title: "{{ _('Message') }}",
+				message: "{{ _('New Password Required.') }}",
+				clear: true
+			});
 		}
 		if (args.new_password !== confirm_password) {
-			$('.password-mismatch-message').text(__("Passwords do not match"))
+			$('.password-mismatch-message').text("{{ _('Passwords do not match') }}")
 				.removeClass('hidden text-muted').addClass('text-danger');
-			return false
+			return false;
 		}
 
 		frappe.call({
@@ -87,10 +94,10 @@ frappe.ready(function() {
 			args: args,
 			statusCode: {
 				401: function() {
-					$(".page-card-head .reset-password-heading").text(__("Invalid Password"));
+					$(".page-card-head .reset-password-heading").text("{{ _('Invalid Password') }}");
 				},
 				410: function({ responseJSON }) {
-					const title = __("Invalid Link");
+					const title = "{{ _('Invalid Link') }}";
 					const message = responseJSON.message;
 					$(".page-card-head .reset-password-heading").text(title);
 					frappe.msgprint({ title: title, message: message, clear: true });
@@ -100,10 +107,11 @@ frappe.ready(function() {
 					strength_indicator.addClass("hidden");
 					strength_message.addClass("hidden");
 					$(".page-card-head .reset-password-heading")
-						.html(__("Status Updated"));
+						.html("{{ _('Status Updated') }}");
 					if(r.message) {
 						frappe.msgprint({
-							message: __("Password Updated"),
+							title: "{{ _('Message') }}",
+							message: "{{ _('Password Updated') }}",
 							// password is updated successfully
 							// clear any server message
 							clear: true
@@ -176,7 +184,7 @@ frappe.ready(function() {
 		var message = [];
 		feedback.help_msg = "";
 		if(!feedback.password_policy_validation_passed){
-			feedback.help_msg = "<br>" + "{{ _("Hint: Include symbols, numbers and capital letters in the password") }}";
+			feedback.help_msg = "<br>" + "{{ _('Hint: Include symbols, numbers and capital letters in the password') }}";
 		}
 		if (feedback) {
 			if(!feedback.password_policy_validation_passed){


### PR DESCRIPTION
- Closes [Issue/15189](https://github.com/frappe/frappe/issues/15189)
- Use Jinja to translate text in update-password HTML page since frappe._messages are not populated.
- ![image](https://user-images.githubusercontent.com/7310479/146972273-03d934c8-1e60-4e11-be8a-a641d6152f81.png)
