### PR TITLE
feat: update the status of todo doc when reference doc status changes

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -198,3 +198,18 @@ def notify_assignment(assigned_by, owner, doc_type, doc_name, action='CLOSE',
 
 def format_message_for_assign_to(users):
 	return "<br><br>" + "<br>".join(users)
+
+def update_todo_status(doctype, doc):
+	'''update todo doc status when reference's status changes''''
+	if hasattr(doctype, 'status') and doctype.status in ['Completed', 'Closed']:
+		todo_list = frappe.get_all('ToDo', ['name', 'status'], {'reference_name': doctype.name})
+
+		for todo in todo_list:
+			if todo.status == doctype.status:
+				return
+		
+			else:
+				frappe.db.set_value('ToDo', {'name': todo.name}, 'status', 'Closed')
+
+
+

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -200,7 +200,7 @@ def format_message_for_assign_to(users):
 	return "<br><br>" + "<br>".join(users)
 
 def update_todo_status(doctype, doc):
-	'''update todo doc status when reference's status changes''''
+	'''update todo doc status when reference's status changes'''
 	if hasattr(doctype, 'status') and doctype.status in ['Completed', 'Closed']:
 		todo_list = frappe.get_all('ToDo', ['name', 'status'], {'reference_name': doctype.name})
 

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -157,7 +157,8 @@ doc_events = {
 			"frappe.core.doctype.file.file.attach_files_to_document",
 			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
-			"frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type"
+			"frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type",
+			"frappe.desk.form.assign_to.update_todo_status"
 		],
 		"after_rename": "frappe.desk.notifications.clear_doctype_notifications",
 		"on_cancel": [

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -158,7 +158,7 @@ doc_events = {
 			"frappe.event_streaming.doctype.event_update_log.event_update_log.notify_consumers",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 			"frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type",
-			"frappe.desk.form.assign_to.update_todo_status"
+			"frappe.desk.form.assign_to.update_todo_status",
 		],
 		"after_rename": "frappe.desk.notifications.clear_doctype_notifications",
 		"on_cancel": [


### PR DESCRIPTION
**Issue**
When a doc is marked as completed/closed, the todo for the doc remains open unless closed manually.

**Before**

https://user-images.githubusercontent.com/58825865/147036206-c602553b-3ca7-479c-9995-48efa9089911.mov

**After**

https://user-images.githubusercontent.com/58825865/147036223-d1892001-b49e-430f-9643-08f0727cf5a2.mov

**Steps to Reproduce**
1. Create an assignment for a doc
2. A todo doc is created for the assignment and the status is open
3. Mark the doc staus as completed/closed (if status field exists)
4. The todo doc will remain open until manually closed.

