### PR TITLE
fix(restore): Repopulate db_tables cache after database restore

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -837,9 +837,9 @@ class Database(object):
 	def has_table(self, doctype):
 		return self.table_exists(doctype)
 
-	def get_tables(self):
+	def get_tables(self, cached=True):
 		tables = frappe.cache().get_value('db_tables')
-		if not tables:
+		if not tables or not cached:
 			table_rows = self.sql("""
 				SELECT table_name
 				FROM information_schema.tables

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -92,7 +92,7 @@ def bootstrap_database(db_name, verbose, source_sql=None):
 	import_db_from_sql(source_sql, verbose)
 
 	frappe.connect(db_name=db_name)
-	if 'tabDefaultValue' not in frappe.db.get_tables():
+	if 'tabDefaultValue' not in frappe.db.get_tables(cached=False):
 		from click import secho
 
 		secho(


### PR DESCRIPTION
During restore, before `tabDefaultValue` is created if a request/command executes `frappe.db.get_tables`, then the cached value `db_tables` is populated with a partial list of tables.

`bootstrap_database` then checks if this partial list contains `tabDefaultValue` (as a sanity test to see if the restore worked). This check fails even though the database is correctly restored.