### PR TITLE
Fixed Report boilerplate (js, py) year to current year

### DIFF
--- a/frappe/core/doctype/report/boilerplate/controller.js
+++ b/frappe/core/doctype/report/boilerplate/controller.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, {app_publisher} and contributors
+// Copyright (c) {year}, {app_publisher} and contributors
 // For license information, please see license.txt
 /* eslint-disable */
 

--- a/frappe/core/doctype/report/boilerplate/controller.py
+++ b/frappe/core/doctype/report/boilerplate/controller.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013, {app_publisher} and contributors
+# Copyright (c) {year}, {app_publisher} and contributors
 # For license information, please see license.txt
 
 # import frappe


### PR DESCRIPTION
This PR automatically set the current year in Script Report boilerplate controller (report_name.js and report_name.py).
Currently the year is hard-coded as 2013 and 2016 respectively for example:

// Copyright (c) 2013, me@xmail.com and contributors
// For license information, please see license.txt
/* eslint-disable */

The year will be automatically set during Script Report controller generation.

A local test was executed by creating new report, the year was successfully injected into the boilerplate.

