### PR TITLE
fix: Use makedirs instead of mkdir to create archived sites path

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -698,8 +698,7 @@ def _drop_site(site, root_login='root', root_password=None, archived_sites_path=
 
 	archived_sites_path = archived_sites_path or os.path.join(frappe.get_app_path('frappe'), '..', '..', '..', 'archived', 'sites')
 
-	if not os.path.exists(archived_sites_path):
-		os.mkdir(archived_sites_path)
+	os.makedirs(archived_sites_path, exist_ok=True)
 
 	move(archived_sites_path, site)
 


### PR DESCRIPTION
When a new bench is created, there is no `archived` directory in the bench directory.

When users drop a site, bench is failing to create `bench/archived/site` directory as the parent is not present. If `makedirs` is used, it will create parent directories also.