### PR TITLE
fix(print page): additional menu in mobile view print page

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -81,8 +81,9 @@ frappe.ui.form.PrintView = class {
 		);
 
 		this.page.add_button(
-			frappe.utils.icon('refresh'),
-			() => this.refresh_print_format()
+			__('Refresh'),
+			() => this.refresh_print_format(),
+			{ icon: 'refresh' }
 		);
 	}
 

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -52,8 +52,8 @@ frappe.ui.form.PrintView = class {
 			':Print Settings',
 			'Print Settings'
 		);
-		this.setup_toolbar();
 		this.setup_menu();
+		this.setup_toolbar();
 		this.setup_sidebar();
 		this.setup_keyboard_shortcuts();
 	}

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -714,6 +714,10 @@ frappe.ui.Page = class Page {
 				${opts.icon ? frappe.utils.icon(opts.icon): ''}
 				${label}
 		</button>`);
+		// Add actions as menu item in Mobile View (similar to "add_custom_button" in forms.js)
+		let menu_item = this.add_menu_item(label, click, false);
+		menu_item.parent().addClass("hidden-xl");
+
 		button.appendTo(this.custom_actions);
 		button.on('click', click);
 		this.custom_actions.removeClass('hide');


### PR DESCRIPTION
fixes #13416 (Missing PDF print option on Mobile View)

**- before fix**

![print_page_before_fix_mobile](https://user-images.githubusercontent.com/4847317/147317563-985a0bbd-0342-43c9-9727-a04575e0a780.png)
![print_page_before_fix_desktop](https://user-images.githubusercontent.com/4847317/147318331-5dba3212-4bb5-4dc9-b673-c735d7cea6d3.png)



**- after fix**

![print_page_after_fix_mobile](https://user-images.githubusercontent.com/4847317/147318318-d9a95633-f8df-45ac-ba7a-439f8002d7a0.png)
![print_page_after_fix_desktop](https://user-images.githubusercontent.com/4847317/147318338-bbe9ecc2-5296-421f-97ad-d4484ddbe8dc.png)

