### PR TITLE
fix: Handle custom child tables via check_parent_permission

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -740,17 +740,26 @@ def has_permission(doctype=None, ptype="read", doc=None, user=None, verbose=Fals
 	:param doc: [optional] Checks User permissions for given doc.
 	:param user: [optional] Check for given user. Default: current user.
 	:param parent_doctype: Required when checking permission for a child DocType (unless doc is specified)."""
+	import frappe.permissions
+
 	if not doctype and doc:
 		doctype = doc.doctype
 
-	import frappe.permissions
 	out = frappe.permissions.has_permission(doctype, ptype, doc=doc, verbose=verbose, user=user,
 		raise_exception=throw, parent_doctype=parent_doctype)
+
 	if throw and not out:
-		if doc:
-			frappe.throw(_("No permission for {0}").format(doc.doctype + " " + doc.name))
-		else:
-			frappe.throw(_("No permission for {0}").format(doctype))
+		# mimics frappe.throw
+		document_label = f"{doc.doctype} {doc.name}" if doc else doctype
+		msgprint(
+			_("No permission for {0}").format(document_label),
+			raise_exception=ValidationError,
+			title=None,
+			indicator='red',
+			is_minimizable=None,
+			wide=None,
+			as_list=False
+		)
 
 	return out
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -32,6 +32,7 @@ def get_list(doctype, fields=None, filters=None, order_by=None,
 
 	args = frappe._dict(
 		doctype=doctype,
+		parent_doctype=parent,
 		fields=fields,
 		filters=filters,
 		or_filters=or_filters,

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -36,10 +36,12 @@ class DatabaseQuery(object):
 		ignore_ifnull=False, save_user_settings=False, save_user_settings_fields=False,
 		update=None, add_total_row=None, user_settings=None, reference_doctype=None,
 		run=True, strict=True, pluck=None, ignore_ddl=False, parent_doctype=None) -> List:
-		if not ignore_permissions and \
-			not frappe.has_permission(self.doctype, "select", user=user, parent_doctype=parent_doctype) and \
-			not frappe.has_permission(self.doctype, "read", user=user, parent_doctype=parent_doctype):
 
+		if (
+			not ignore_permissions
+			and not frappe.has_permission(self.doctype, "select", user=user, parent_doctype=parent_doctype)
+			and not frappe.has_permission(self.doctype, "read", user=user, parent_doctype=parent_doctype)
+		):
 			frappe.flags.error_message = _('Insufficient Permission for {0}').format(frappe.bold(self.doctype))
 			raise frappe.PermissionError(self.doctype)
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -787,12 +787,15 @@ class DatabaseQuery(object):
 def check_parent_permission(parent, child_doctype):
 	if parent:
 		# User may pass fake parent and get the information from the child table
-		if child_doctype and not frappe.db.exists('DocField',
-			{'parent': parent, 'options': child_doctype}):
+		if child_doctype and not (
+			frappe.db.exists('DocField', {'parent': parent, 'options': child_doctype})
+			or frappe.db.exists('Custom Field', {'dt': parent, 'options': child_doctype})
+		):
 			raise frappe.PermissionError
 
 		if frappe.permissions.has_permission(parent):
 			return
+
 	# Either parent not passed or the user doesn't have permission on parent doctype of child table!
 	raise frappe.PermissionError
 


### PR DESCRIPTION
Check `tabCustom Field` and `tabDocfield` for matching parent existence...And other things that came along after.


### Before

<img width="444" alt="Screenshot 2021-12-24 at 2 06 23 PM" src="https://user-images.githubusercontent.com/36654812/147335425-8d901cdb-e660-4968-ba5e-55fe8c5ee339.png">

<img width="444" alt="Screenshot 2021-12-24 at 2 07 00 PM" src="https://user-images.githubusercontent.com/36654812/147335431-fbc67f2d-b74d-461d-ab55-921f1adc4cda.png">

### After

<img width="444" alt="Screenshot 2021-12-24 at 2 05 22 PM" src="https://user-images.githubusercontent.com/36654812/147335441-b4c7596d-460d-4581-93b7-57c5081fc0e1.png">

