### PR TITLE
fix: Workspace content loading twice

### DIFF
--- a/frappe/public/js/frappe/views/container.js
+++ b/frappe/public/js/frappe/views/container.js
@@ -40,11 +40,6 @@ frappe.views.Container = class Container {
 	}
 	change_to(label) {
 		cur_page = this;
-		if(this.page && this.page.label === label) {
-			$(this.page).trigger('show');
-		}
-
-		var me = this;
 		if(label.tagName) {
 			// if sent the div, get the table
 			var page = label;


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/14981

**Issue:** 
`$(this.page).trigger('show');` in container.js in above mentioned PR  is called twice which renders Workspace Content twice.

**Steps:** 
1. Open Any Workspace (Home).
2. Click on another Workspace (Accounting)
3. Come back to the first Workspace (Home)

![image](https://user-images.githubusercontent.com/30859809/147347650-bf024081-69cf-4c85-896e-89942b738b52.png)
