### PR TITLE
fix: Grammar of error statement in 404 page

### DIFF
--- a/frappe/www/404.html
+++ b/frappe/www/404.html
@@ -15,7 +15,7 @@
 			{{ _("There's nothing here") }}
 		</h2>
 		<div class="text-muted error-text">
-			{{ _("The page you are looking for have gone missing.") }}
+			{{ _("The page you are looking for has gone missing.") }}
 		</div>
 		<div class="mt-6 back-to-home"><a href='/' class='btn btn-primary'>{{ _("Back to Home") }}</a></div>
 	</div>


### PR DESCRIPTION
Fixed grammar of error statement in 404 page