### PR TITLE
fix: discussions component datetime format

### DIFF
--- a/frappe/templates/discussions/reply_card.html
+++ b/frappe/templates/discussions/reply_card.html
@@ -8,7 +8,7 @@
 		<a class="button-links {% if loop.index == 1 %} ml-2 {% endif %}" {% if get_profile_url %} href="{{ get_profile_url(member.username) }}" {% endif %}>
 			{{ member.full_name }}
 		</a>
-		<div class="ml-3"> {{ frappe.utils.format_datetime(reply.creation, "dd-mm-yyyy HH:mm") }} </div>
+		<div class="ml-3"> {{ frappe.utils.format_datetime(reply.creation, "medium") }} </div>
 	</div>
 	<div class="reply-text">{{ frappe.utils.md_to_html(reply.reply) }}</div>
 </div>


### PR DESCRIPTION
**Issue:**

The discussions component is showing the wrong DateTime format in v13.

<img width="296" alt="Screenshot 2021-12-27 at 10 18 01 AM" src="https://user-images.githubusercontent.com/31363128/147435547-ec8b8589-c404-4c4f-8602-8276bc1575fa.png">

**After Fix:**

<img width="371" alt="Screenshot 2021-12-27 at 4 33 52 PM" src="https://user-images.githubusercontent.com/31363128/147465735-833720f7-3fdb-47f4-a677-acda3fadd123.png">