### PR TITLE
fix(datetime): Use `last_value` as a fallback if the model value isn't set

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -81,6 +81,9 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 
 	get_model_value() {
 		let value = super.get_model_value();
+		if (!value && !this.doc) {
+			value = this.last_value;
+		}
 		return frappe.datetime.get_datetime_as_string(value);
 	}
 };

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -156,26 +156,29 @@
 		.result, .no-result, .freeze {
 			min-height: #{"calc(100vh - 284px)"};
 		}
+	}
 
-		.msg-box {
-			margin-bottom: 4em;
-			font-size: var(--text-sm);
+	.msg-box {
+		margin-bottom: 4em;
+		font-size: var(--text-sm);
 
-			// To compensate for perceived centering
-			.null-state {
-				height: 85px;
-				width: auto;
-				margin-bottom: var(--margin-md);
-				img {
-					fill: var(--fg-color);
-				}
+		// To compensate for perceived centering
+		.null-state {
+			height: 85px;
+			width: auto;
+			margin-bottom: var(--margin-md);
+			img {
+				fill: var(--fg-color);
 			}
+		}
+		p {
+			font-size: var(--text-md);
+		}
 
-			.meta-description {
-				width: 45%;
-				margin-right: auto;
-				margin-left: auto;
-			}
+		.meta-description {
+			width: 45%;
+			margin-right: auto;
+			margin-left: auto;
 		}
 	}
 }


### PR DESCRIPTION
- Use `last_value` as a fallback if the model value isn't set. Did this to avoid repeated value set of DateTime value which causes the browser to freeze. This happens only with the DateTime control that is used in filters (with a default value) and is not linked with a form.
	**Before:** (Report with a DateTime filter used to freeze the browser)

	https://user-images.githubusercontent.com/13928957/147435814-1c4ed5a6-2ca8-4c63-af57-20b8f7865923.mov

	**Now:**
	
	https://user-images.githubusercontent.com/13928957/147436244-edffa1f1-435e-4e67-ad60-70424ecf10ea.mov

This issue was introduced with https://github.com/frappe/frappe/pull/13504

- Fixed report empty state style
	**Before:**
	<img width="600" alt="Screenshot 2021-12-27 at 10 37 13 AM" src="https://user-images.githubusercontent.com/13928957/147436478-0315c066-ec0d-4e0e-a0c6-48b8459c8287.png">

	**After:**
	<img width="600" alt="Screenshot 2021-12-27 at 10 36 29 AM" src="https://user-images.githubusercontent.com/13928957/147436491-b8b4f26d-15af-4c12-9740-517adfe4964c.png">

