### PR TITLE
fix: set fetch from values before checking permissions

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -220,13 +220,13 @@ class Document(BaseDocument):
 
 		self.set("__islocal", True)
 
-		self.check_permission("create")
 		self._set_defaults()
 		self.set_user_and_timestamp()
 		self.set_docstatus()
 		self.check_if_latest()
-		self.run_method("before_insert")
 		self._validate_links()
+		self.check_permission("create")
+		self.run_method("before_insert")
 		self.set_new_name(set_name=set_name, set_child_names=set_child_names)
 		self.set_parent_in_children()
 		self.validate_higher_perm_levels()


### PR DESCRIPTION
## Problem:

In `document.py`:

- Fetch from values are set in `_validate_links`
- Permissions are checked in `check_permissions` which is called before `_validate_links`

### Use Case

In the Task doctype:

- User permissions are applied on a field, for eg: Company field
- Company is fetched from Project
- **Apply Strict User Permissions** is checked in System Settings
- User tries to create a Project from Project Template (which creates the tasks). But before setting the company (via fetch from), permissions are checked by the system and it raises "Insufficient Permissions for Task" since the company is not set.

## Fix:

Permissions should be checked after:

- Setting defaults (`_set_defaults`)
- Setting fetch from values and validating links (`_validate_links`)
- Setting user and timestamp (`set_user_and_timestamp `)