### PR TITLE
fix: Rename Property Setter on Print Format Rename

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -71,8 +71,19 @@ class PrintFormat(Document):
 
 		self.export_doc()
 
+	def after_rename(self, old: str, new: str, *args, **kwargs):
+		if self.doc_type:
+			frappe.clear_cache(doctype=self.doc_type)
+
+		# update property setter default_print_format if set
+		frappe.db.set_value("Property Setter", {
+			"doctype_or_field": "DocType",
+			"doc_type": self.doc_type,
+			"property": "default_print_format",
+			"value": old,
+		}, "value", new)
+
 	def export_doc(self):
-		# export
 		from frappe.modules.utils import export_module_json
 		export_module_json(self, self.standard == 'Yes', self.module)
 


### PR DESCRIPTION
This fixes the default print format set when Custom Print Formats are renamed

### After

<img width="1424" alt="Screenshot 2021-12-27 at 3 04 48 PM" src="https://user-images.githubusercontent.com/36654812/147458198-ced6dd8f-5a5a-469b-bfb3-9594c9ba9955.png">
<img width="1424" alt="Screenshot 2021-12-27 at 3 05 20 PM" src="https://user-images.githubusercontent.com/36654812/147458207-d73aecf5-6bdd-4c7d-9071-d0764a034fd8.png">

