### PR TITLE
fix: Use `frappe.permissions.has_permission` for proper error message

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -190,7 +190,7 @@ class Document(BaseDocument):
 		:param permtype: one of `read`, `write`, `submit`, `cancel`, `delete`"""
 		if self.flags.ignore_permissions:
 			return True
-		return frappe.has_permission(self.doctype, permtype, self, verbose=verbose)
+		return frappe.permissions.has_permission(self.doctype, permtype, self, verbose=verbose)
 
 	def raise_no_permission_to(self, perm_type):
 		"""Raise `frappe.PermissionError`."""


### PR DESCRIPTION
`frappe.has_permission` does not have proper wiring for `raise_exception` and fixing that could be breaking. Hence using `frappe.permissions.has_permission` which has `raise_exception` enabled by default.

**Before:**
![Screenshot 2021-12-28 at 3 42 16 PM](https://user-images.githubusercontent.com/13928957/147556118-97260f6e-1d2d-4423-a369-f67d9f37300b.png)

**After:**
![Screenshot 2021-12-28 at 3 41 38 PM](https://user-images.githubusercontent.com/13928957/147556131-b37eb5a9-4e44-44fd-a4e1-8944cab91f98.png)

The issue was introduced via https://github.com/frappe/frappe/commit/8f307f612350ce35534c7d23d75a9a4c77350b7a

