### PR TITLE
fix: Time zone info in web form

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -196,7 +196,7 @@ export default class GridRow {
 			// REDESIGN-TODO: Make translation contextual, this No is Number
 			var txt = (this.doc ? this.doc.idx : __("No."));
 			this.row_index = $(
-				`<div class="row-index sortable-handle col col-xs-1">
+				`<div class="row-index sortable-handle col">
 					${this.row_check_html}
 				<span class="hidden-xs">${txt}</span></div>`)
 				.appendTo(this.row)

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -78,6 +78,10 @@ frappe.boot = {
 	sysdefaults: {
 		float_precision: parseInt("{{ frappe.get_system_settings('float_precision') or 3 }}"),
 		date_format: "{{ frappe.get_system_settings('date_format') or 'yyyy-mm-dd' }}",
+	},
+	time_zone: {
+		system: "{{ frappe.utils.get_time_zone() }}",
+		user: "{{ frappe.db.get_value('User', frappe.session.user, 'time_zone') or frappe.utils.get_time_zone() }}"
 	}
 };
 // for backward compatibility of some libs


### PR DESCRIPTION
**Issue:**
Date field value population was failing in web forms after https://github.com/frappe/frappe/pull/13504

**Error in console**

<img width="1438" alt="Screenshot 2021-12-28 at 3 53 13 PM" src="https://user-images.githubusercontent.com/31363128/147556872-2aed2736-5096-43cd-a7d4-235367494483.png">

**Form fields with Date values were breaking**

<img width="729" alt="Screenshot 2021-12-28 at 3 52 58 PM" src="https://user-images.githubusercontent.com/31363128/147556860-80bbb8f2-1d83-4776-bf88-26831308ca9c.png">

**Fix:**
1. Added time_zone values in frappe.boot for webform

https://user-images.githubusercontent.com/31363128/147557106-8f91f52a-8f64-41eb-b480-49aa14f266ec.mov

2. No. Column alignment issue

<img width="728" alt="Screenshot 2021-12-29 at 10 40 49 PM" src="https://user-images.githubusercontent.com/31363128/147686954-f642e263-042e-4e2b-9e1d-6ed973aa772f.png">
