### PR TITLE
fix: do not validate if options is undefined

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -456,6 +456,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			this.docname, value);
 	}
 	validate_link_and_fetch(df, options, docname, value) {
+		if (!options) return;
+
 		let field_value = "";
 		const fetch_map = this.fetch_map;
 		const columns_to_fetch = Object.values(fetch_map);


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/15343

**Issue:**
When we create **Payment Entry** and change **Payment Type** from `Recieve` to `Internal Transfer` error occurs.

**Before:**

https://user-images.githubusercontent.com/30859809/147572866-409c2ab1-ef28-460f-a121-077da4cf5957.mov

**After:**

https://user-images.githubusercontent.com/30859809/147572848-ee0545a8-278c-41a8-a795-f0a4a3508a53.mov
