### PR TITLE
refactor: Rename options for db credentials in drop-site command

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -660,16 +660,16 @@ def uninstall(context, app, dry_run, yes, no_backup, force):
 
 @click.command('drop-site')
 @click.argument('site')
-@click.option('--root-login', default='root')
-@click.option('--root-password')
+@click.option('--mariadb-root-username', default='root', help='Root username for MariaDB')
+@click.option('--mariadb-root-password', help='Root password for MariaDB')
 @click.option('--archived-sites-path')
 @click.option('--no-backup', is_flag=True, default=False)
 @click.option('--force', help='Force drop-site even if an error is encountered', is_flag=True, default=False)
-def drop_site(site, root_login='root', root_password=None, archived_sites_path=None, force=False, no_backup=False):
-	_drop_site(site, root_login, root_password, archived_sites_path, force, no_backup)
+def drop_site(site, mariadb_root_username='root', mariadb_root_password=None, archived_sites_path=None, force=False, no_backup=False):
+	_drop_site(site, mariadb_root_username, mariadb_root_username, archived_sites_path, force, no_backup)
 
 
-def _drop_site(site, root_login='root', root_password=None, archived_sites_path=None, force=False, no_backup=False):
+def _drop_site(site, mariadb_root_username='root', mariadb_root_password=None, archived_sites_path=None, force=False, no_backup=False):
 	"Remove site from database and filesystem"
 	from frappe.database import drop_user_and_database
 	from frappe.utils.backups import scheduled_backup
@@ -694,7 +694,7 @@ def _drop_site(site, root_login='root', root_password=None, archived_sites_path=
 			click.echo("\n".join(messages))
 			sys.exit(1)
 
-	drop_user_and_database(frappe.conf.db_name, root_login, root_password)
+	drop_user_and_database(frappe.conf.db_name, mariadb_root_username, mariadb_root_password)
 
 	archived_sites_path = archived_sites_path or os.path.join(frappe.get_app_path('frappe'), '..', '..', '..', 'archived', 'sites')
 

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -13,13 +13,13 @@ def setup_database(force, source_sql=None, verbose=None, no_mariadb_socket=False
 		import frappe.database.mariadb.setup_db
 		return frappe.database.mariadb.setup_db.setup_database(force, source_sql, verbose, no_mariadb_socket=no_mariadb_socket)
 
-def drop_user_and_database(db_name, root_login=None, root_password=None):
+def drop_user_and_database(db_name, mariadb_root_username=None, mariadb_root_password=None):
 	import frappe
 	if frappe.conf.db_type == 'postgres':
 		pass
 	else:
 		import frappe.database.mariadb.setup_db
-		return frappe.database.mariadb.setup_db.drop_user_and_database(db_name, root_login, root_password)
+		return frappe.database.mariadb.setup_db.drop_user_and_database(db_name, mariadb_root_username, mariadb_root_password)
 
 def get_db(host=None, user=None, password=None, port=None):
 	import frappe


### PR DESCRIPTION
For `new-site`, `restore`, `reinstall` commands, `--mariadb-root-username` & `--mariadb-root-password` options are used for db credentials. 

For `drop-site` command, changing the options to the same so that the CLI options remain consistent across all the commands.