### PR TITLE
fix: Route options not getting set while navigating from one report to another

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -105,15 +105,18 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			this.toggle_nothing_to_show(true);
 			return;
 		}
+		
+		let route_options = {}
+		route_options = Object.assign(route_options, frappe.route_options);
 
 		if (this.report_name !== frappe.get_route()[1]) {
 			// different report
-			this.load_report();
+			this.load_report(route_options);
 		}
 		else if (frappe.has_route_options()) {
 			// filters passed through routes
 			// so refresh report again
-			this.refresh_report();
+			this.refresh_report(route_options);
 		} else {
 			// same report
 			// don't do anything to preserve state
@@ -121,7 +124,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 	}
 
-	load_report() {
+	load_report(route_options) {
 		this.page.clear_inner_toolbar();
 		this.route = frappe.get_route();
 		this.page_name = frappe.get_route_str();
@@ -137,7 +140,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			() => this.get_report_settings(),
 			() => this.setup_progress_bar(),
 			() => this.setup_page_head(),
-			() => this.refresh_report(),
+			() => this.refresh_report(route_options),
 			() => this.add_chart_buttons_to_toolbar(true),
 			() => this.add_card_button_to_toolbar(true),
 		]);
@@ -343,13 +346,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		});
 	}
 
-	refresh_report() {
+	refresh_report(route_options) {
 		this.toggle_message(true);
 		this.toggle_report(false);
 
 		return frappe.run_serially([
 			() => this.setup_filters(),
-			() => this.set_route_filters(),
+			() => this.set_route_filters(route_options),
 			() => this.page.clear_custom_actions(),
 			() => this.report_settings.onload && this.report_settings.onload(this),
 			() => this.refresh()
@@ -525,15 +528,17 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		});
 	}
 
-	set_route_filters() {
-		if(frappe.route_options) {
-			const fields = Object.keys(frappe.route_options);
+	set_route_filters(route_options) {
+		if (!route_options) route_options = frappe.route_options;
+
+		if(route_options) {
+			const fields = Object.keys(route_options);
 
 			const filters_to_set = this.filters.filter(f => fields.includes(f.df.fieldname));
 
 			const promises = filters_to_set.map(f => {
 				return () => {
-					const value = frappe.route_options[f.df.fieldname];
+					const value = route_options[f.df.fieldname];
 					f.set_value(value);
 				};
 			});

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -106,7 +106,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			return;
 		}
 		
-		let route_options = {}
+		let route_options = {};
 		route_options = Object.assign(route_options, frappe.route_options);
 
 		if (this.report_name !== frappe.get_route()[1]) {
@@ -531,7 +531,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	set_route_filters(route_options) {
 		if (!route_options) route_options = frappe.route_options;
 
-		if(route_options) {
+		if (route_options) {
 			const fields = Object.keys(route_options);
 
 			const filters_to_set = this.filters.filter(f => fields.includes(f.df.fieldname));


### PR DESCRIPTION
 Fixed an issue where route options not getting set while navigating from one report to another

Before:
![GL Filters Before](https://user-images.githubusercontent.com/42651287/147906584-17033ae8-88e0-4259-8246-1f0af3f17b42.gif)

After:
![GL Filters](https://user-images.githubusercontent.com/42651287/147906721-8f0ad929-7886-4e5d-82bc-a29b9689a231.gif)