### PR TITLE
fix(Migrate): add unique and index for new columns

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -206,6 +206,12 @@ class DbColumn:
 		if not current_def:
 			self.fieldname = validate_column_name(self.fieldname)
 			self.table.add_column.append(self)
+
+			if column_type not in ('text', 'longtext'):
+				if self.unique:
+					self.table.add_unique.append(self)
+				if self.set_index:
+					self.table.add_index.append(self)
 			return
 
 		# type


### PR DESCRIPTION
Issue: When new columns are added, indexes and unique are ignored
Solution: Add to `self.table.add_index` and `self.table.add_unique` before returning from build