### PR TITLE
fix: Erroreneous query building when column exists in matching condition and set field value

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -646,19 +646,17 @@ class Database(object):
 			to_update.update({field: val})
 
 		if dn and dt!=dn:
-			# with table
-			conditions, values = self.build_conditions(dn)
-
-			values.update(to_update)
-
 			set_values = []
 			for key in to_update:
 				set_values.append('`{0}`=%({0})s'.format(key))
 
-			self.sql("""update `tab{0}`
-				set {1} where {2}""".format(dt, ', '.join(set_values), conditions),
-				values, debug=debug)
+			for name in self.get_values(dt, dn, 'name', debug=debug):
+				values = dict(name=name[0])
+				values.update(to_update)
 
+				self.sql("""update `tab{0}`
+					set {1} where name=%(name)s""".format(dt, ', '.join(set_values)),
+					values, debug=debug)
 		else:
 			# for singles
 			keys = list(to_update)


### PR DESCRIPTION
While testing #15460, the related property setter document wasn't being updated. Why? Because the query wasn't being built properly. In this instance, `frappe.db.set_value` was confusing the values of the matching field's value in the condition and the passed `val` kwarg.

Expected Result

```sql
set `value` = 'custom sinv'
where `value` = 'Custom Sales Invoice Print Format'
```

Actual Result

```sql
set `value` = 'Custom Sales Invoice Print Format'
where `value` = 'Custom Sales Invoice Print Format'
```

<img width="720" alt="Screenshot 2021-12-31 at 2 10 52 PM" src="https://user-images.githubusercontent.com/36654812/147820621-8ccd5793-74c4-4593-b672-15345f55f2c7.png">

---

Given how we're still trying to refactor set_value for v14; instead of diverging the fixes for each major version I'd rather change v12 to be more similar to the next two versions instead.

So, I've pasted the changes from v14 as is. Repercussions of this include an extra select query on every set_value call...just as it is in v13 and v14.

Once `frappe.db.set_value` is refactored, I plan to backport the perf improvements to v13 and v12 so that the extra query isn't required.