### PR TITLE
fix: customize same property for multiple rows of DocType Link / DocType Action

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -377,7 +377,7 @@ class CustomizeForm(Document):
 
 	def make_property_setter(self, prop, value, property_type, fieldname=None,
 		apply_on=None, row_name = None):
-		delete_property_setter(self.doc_type, prop, fieldname)
+		delete_property_setter(self.doc_type, prop, fieldname, row_name)
 
 		property_value = self.get_existing_property_value(prop, fieldname)
 

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -19,7 +19,7 @@ class PropertySetter(Document):
 	def validate(self):
 		self.validate_fieldtype_change()
 		if self.is_new():
-			delete_property_setter(self.doc_type, self.property, self.field_name)
+			delete_property_setter(self.doc_type, self.property, self.field_name, self.row_name)
 
 		# clear cache
 		frappe.clear_cache(doctype = self.doc_type)
@@ -91,11 +91,13 @@ def make_property_setter(doctype, fieldname, property, value, property_type, for
 	property_setter.insert()
 	return property_setter
 
-def delete_property_setter(doc_type, property, field_name=None):
+def delete_property_setter(doc_type, property, field_name=None, row_name=None):
 	"""delete other property setters on this, if this is new"""
-	filters = dict(doc_type = doc_type, property=property)
+	filters = dict(doc_type=doc_type, property=property)
 	if field_name:
 		filters['field_name'] = field_name
+	if row_name:
+		filters["row_name"] = row_name
 
 	frappe.db.delete('Property Setter', filters)
 


### PR DESCRIPTION
## Issues Fixed
 #### In `Customize Form` we can not customize the same property (let's say `hidden`) for multiple rows of DocType Link or DocType Action _or_ DocField and DocType Link. 

For example, I want to hide `Customer Details` Field and `Party Specific Item` Link both but I can not, because the property setter gets replaced by the existing ones.

![property-setter-bug](https://user-images.githubusercontent.com/43115036/147845600-4a99c525-6d38-49e0-95d8-0d481ad486c7.gif)


## Changes Made
 - Add `row_name` filter while deleting existing property setter in `delete_property_setter`
