### PR TITLE
fix: clear cache for all docs matched with the filters passed as `dn` param in `set_value`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -699,6 +699,8 @@ class Database(object):
 				self.sql("""update `tab{0}`
 					set {1} where name=%(name)s""".format(dt, ', '.join(set_values)),
 					values, debug=debug)
+
+				frappe.clear_document_cache(dt, values['name'])
 		else:
 			# for singles
 			keys = list(to_update)
@@ -711,10 +713,11 @@ class Database(object):
 				self.sql('''insert into `tabSingles` (doctype, field, value) values (%s, %s, %s)''',
 					(dt, key, value), debug=debug)
 
+			frappe.clear_document_cache(dt, dn)
+
 		if dt in self.value_cache:
 			del self.value_cache[dt]
 
-		frappe.clear_document_cache(dt, dn)
 
 	@staticmethod
 	def set(doc, field, val):


### PR DESCRIPTION
## Issue
When `dict`(filters) is passed as `dn` param in `frappe.db.set_value`, cache is not being cleared as expected.

## Changes Made
called `frappe.clear_document_cache` for each document matched with the filters.
