### PR TITLE
fix: [Report] - Allow all users to save customized reports

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -3,7 +3,9 @@
 
 """build query for doclistview and return results"""
 
-import frappe, json
+from re import T
+import frappe
+import json
 import frappe.permissions
 from frappe.model.db_query import DatabaseQuery
 from frappe.model import default_fields, optional_fields
@@ -17,576 +19,581 @@ from frappe.model.base_document import get_controller
 @frappe.whitelist()
 @frappe.read_only()
 def get():
-	args = get_form_params()
-	# If virtual doctype get data from controller het_list method
-	if frappe.db.get_value("DocType", filters={"name": args.doctype}, fieldname="is_virtual"):
-		controller = get_controller(args.doctype)
-		data = compress(controller(args.doctype).get_list(args))
-	else:
-		data = compress(execute(**args), args=args)
-	return data
+    args = get_form_params()
+    # If virtual doctype get data from controller het_list method
+    if frappe.db.get_value("DocType", filters={"name": args.doctype}, fieldname="is_virtual"):
+        controller = get_controller(args.doctype)
+        data = compress(controller(args.doctype).get_list(args))
+    else:
+        data = compress(execute(**args), args=args)
+    return data
 
 @frappe.whitelist()
 @frappe.read_only()
 def get_list():
-	# uncompressed (refactored from frappe.model.db_query.get_list)
-	return execute(**get_form_params())
+    # uncompressed (refactored from frappe.model.db_query.get_list)
+    return execute(**get_form_params())
 
 @frappe.whitelist()
 @frappe.read_only()
 def get_count():
-	args = get_form_params()
+    args = get_form_params()
 
-	distinct = 'distinct ' if args.distinct=='true' else ''
-	args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
-	return execute(**args)[0].get('total_count')
+    distinct = 'distinct ' if args.distinct=='true' else ''
+    args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
+    return execute(**args)[0].get('total_count')
 
 def execute(doctype, *args, **kwargs):
-	return DatabaseQuery(doctype).execute(*args, **kwargs)
+    return DatabaseQuery(doctype).execute(*args, **kwargs)
 
 def get_form_params():
-	"""Stringify GET request parameters."""
-	data = frappe._dict(frappe.local.form_dict)
-	clean_params(data)
-	validate_args(data)
-	return data
+    """Stringify GET request parameters."""
+    data = frappe._dict(frappe.local.form_dict)
+    clean_params(data)
+    validate_args(data)
+    return data
 
 def validate_args(data):
-	parse_json(data)
-	setup_group_by(data)
+    parse_json(data)
+    setup_group_by(data)
 
-	validate_fields(data)
-	if data.filters:
-		validate_filters(data, data.filters)
-	if data.or_filters:
-		validate_filters(data, data.or_filters)
+    validate_fields(data)
+    if data.filters:
+        validate_filters(data, data.filters)
+    if data.or_filters:
+        validate_filters(data, data.or_filters)
 
-	data.strict = None
+    data.strict = None
 
-	return data
+    return data
 
 def validate_fields(data):
-	wildcard = update_wildcard_field_param(data)
+    wildcard = update_wildcard_field_param(data)
 
-	for field in data.fields or []:
-		fieldname = extract_fieldname(field)
-		if is_standard(fieldname):
-			continue
+    for field in data.fields or []:
+        fieldname = extract_fieldname(field)
+        if is_standard(fieldname):
+            continue
 
-		meta, df = get_meta_and_docfield(fieldname, data)
+        meta, df = get_meta_and_docfield(fieldname, data)
 
-		if not df:
-			if wildcard:
-				continue
-			else:
-				raise_invalid_field(fieldname)
+        if not df:
+            if wildcard:
+                continue
+            else:
+                raise_invalid_field(fieldname)
 
-		# remove the field from the query if the report hide flag is set and current view is Report
-		if df.report_hide and data.view == 'Report':
-			data.fields.remove(field)
-			continue
+        # remove the field from the query if the report hide flag is set and current view is Report
+        if df.report_hide and data.view == 'Report':
+            data.fields.remove(field)
+            continue
 
-		if df.fieldname in [_df.fieldname for _df in meta.get_high_permlevel_fields()]:
-			if df.get('permlevel') not in meta.get_permlevel_access(parenttype=data.doctype):
-				data.fields.remove(field)
+        if df.fieldname in [_df.fieldname for _df in meta.get_high_permlevel_fields()]:
+            if df.get('permlevel') not in meta.get_permlevel_access(parenttype=data.doctype):
+                data.fields.remove(field)
 
 def validate_filters(data, filters):
-	if isinstance(filters, list):
-		# filters as list
-		for condition in filters:
-			if len(condition)==3:
-				# [fieldname, condition, value]
-				fieldname = condition[0]
-				if is_standard(fieldname):
-					continue
-				meta, df = get_meta_and_docfield(fieldname, data)
-				if not df:
-					raise_invalid_field(condition[0])
-			else:
-				# [doctype, fieldname, condition, value]
-				fieldname = condition[1]
-				if is_standard(fieldname):
-					continue
-				meta = frappe.get_meta(condition[0])
-				if not meta.get_field(fieldname):
-					raise_invalid_field(fieldname)
+    if isinstance(filters, list):
+        # filters as list
+        for condition in filters:
+            if len(condition)==3:
+                # [fieldname, condition, value]
+                fieldname = condition[0]
+                if is_standard(fieldname):
+                    continue
+                meta, df = get_meta_and_docfield(fieldname, data)
+                if not df:
+                    raise_invalid_field(condition[0])
+            else:
+                # [doctype, fieldname, condition, value]
+                fieldname = condition[1]
+                if is_standard(fieldname):
+                    continue
+                meta = frappe.get_meta(condition[0])
+                if not meta.get_field(fieldname):
+                    raise_invalid_field(fieldname)
 
-	else:
-		for fieldname in filters:
-			if is_standard(fieldname):
-				continue
-			meta, df = get_meta_and_docfield(fieldname, data)
-			if not df:
-				raise_invalid_field(fieldname)
+    else:
+        for fieldname in filters:
+            if is_standard(fieldname):
+                continue
+            meta, df = get_meta_and_docfield(fieldname, data)
+            if not df:
+                raise_invalid_field(fieldname)
 
 def setup_group_by(data):
-	'''Add columns for aggregated values e.g. count(name)'''
-	if data.group_by and data.aggregate_function:
-		if data.aggregate_function.lower() not in ('count', 'sum', 'avg'):
-			frappe.throw(_('Invalid aggregate function'))
+    '''Add columns for aggregated values e.g. count(name)'''
+    if data.group_by and data.aggregate_function:
+        if data.aggregate_function.lower() not in ('count', 'sum', 'avg'):
+            frappe.throw(_('Invalid aggregate function'))
 
-		if frappe.db.has_column(data.aggregate_on_doctype, data.aggregate_on_field):
-			data.fields.append('{aggregate_function}(`tab{aggregate_on_doctype}`.`{aggregate_on_field}`) AS _aggregate_column'.format(**data))
-			if data.aggregate_on_field:
-				data.fields.append(f"`tab{data.aggregate_on_doctype}`.`{data.aggregate_on_field}`")
-		else:
-			raise_invalid_field(data.aggregate_on_field)
+        if frappe.db.has_column(data.aggregate_on_doctype, data.aggregate_on_field):
+            data.fields.append('{aggregate_function}(`tab{aggregate_on_doctype}`.`{aggregate_on_field}`) AS _aggregate_column'.format(**data))
+            if data.aggregate_on_field:
+                data.fields.append(f"`tab{data.aggregate_on_doctype}`.`{data.aggregate_on_field}`")
+        else:
+            raise_invalid_field(data.aggregate_on_field)
 
-		data.pop('aggregate_on_doctype')
-		data.pop('aggregate_on_field')
-		data.pop('aggregate_function')
+        data.pop('aggregate_on_doctype')
+        data.pop('aggregate_on_field')
+        data.pop('aggregate_function')
 
 def raise_invalid_field(fieldname):
-	frappe.throw(_('Field not permitted in query') + ': {0}'.format(fieldname), frappe.DataError)
+    frappe.throw(_('Field not permitted in query') + ': {0}'.format(fieldname), frappe.DataError)
 
 def is_standard(fieldname):
-	if '.' in fieldname:
-		parenttype, fieldname = get_parenttype_and_fieldname(fieldname, None)
-	return fieldname in default_fields or fieldname in optional_fields
+    if '.' in fieldname:
+        parenttype, fieldname = get_parenttype_and_fieldname(fieldname, None)
+    return fieldname in default_fields or fieldname in optional_fields
 
 def extract_fieldname(field):
-	for text in (',', '/*', '#'):
-		if text in field:
-			raise_invalid_field(field)
+    for text in (',', '/*', '#'):
+        if text in field:
+            raise_invalid_field(field)
 
-	fieldname = field
-	for sep in (' as ', ' AS '):
-		if sep in fieldname:
-			fieldname = fieldname.split(sep)[0]
+    fieldname = field
+    for sep in (' as ', ' AS '):
+        if sep in fieldname:
+            fieldname = fieldname.split(sep)[0]
 
-	# certain functions allowed, extract the fieldname from the function
-	if (fieldname.startswith('count(')
-		or fieldname.startswith('sum(')
-		or fieldname.startswith('avg(')):
-		if not fieldname.strip().endswith(')'):
-			raise_invalid_field(field)
-		fieldname = fieldname.split('(', 1)[1][:-1]
+    # certain functions allowed, extract the fieldname from the function
+    if (fieldname.startswith('count(')
+            or fieldname.startswith('sum(')
+            or fieldname.startswith('avg(')):
+        if not fieldname.strip().endswith(')'):
+            raise_invalid_field(field)
+        fieldname = fieldname.split('(', 1)[1][:-1]
 
-	return fieldname
+    return fieldname
 
 def get_meta_and_docfield(fieldname, data):
-	parenttype, fieldname = get_parenttype_and_fieldname(fieldname, data)
-	meta = frappe.get_meta(parenttype)
-	df = meta.get_field(fieldname)
-	return meta, df
+    parenttype, fieldname = get_parenttype_and_fieldname(fieldname, data)
+    meta = frappe.get_meta(parenttype)
+    df = meta.get_field(fieldname)
+    return meta, df
 
 def update_wildcard_field_param(data):
-	if ((isinstance(data.fields, str) and data.fields == "*")
-		or (isinstance(data.fields, (list, tuple)) and len(data.fields) == 1 and data.fields[0] == "*")):
-		data.fields = frappe.db.get_table_columns(data.doctype)
-		return True
+    if ((isinstance(data.fields, str) and data.fields == "*")
+            or (isinstance(data.fields, (list, tuple)) and len(data.fields) == 1 and data.fields[0] == "*")):
+        data.fields = frappe.db.get_table_columns(data.doctype)
+        return True
 
-	return False
+    return False
 
 
 def clean_params(data):
-	for param in (
-		"cmd",
-		"data",
-		"ignore_permissions",
-		"view",
-		"user",
-		"csrf_token",
-		"join"
-	):
-		data.pop(param, None)
+    for param in (
+            "cmd",
+            "data",
+            "ignore_permissions",
+            "view",
+            "user",
+            "csrf_token",
+            "join"
+    ):
+        data.pop(param, None)
 
 def parse_json(data):
-	if isinstance(data.get("filters"), str):
-		data["filters"] = json.loads(data["filters"])
-	if isinstance(data.get("or_filters"), str):
-		data["or_filters"] = json.loads(data["or_filters"])
-	if isinstance(data.get("fields"), str):
-		data["fields"] = json.loads(data["fields"])
-	if isinstance(data.get("docstatus"), str):
-		data["docstatus"] = json.loads(data["docstatus"])
-	if isinstance(data.get("save_user_settings"), str):
-		data["save_user_settings"] = json.loads(data["save_user_settings"])
-	else:
-		data["save_user_settings"] = True
+    if isinstance(data.get("filters"), str):
+        data["filters"] = json.loads(data["filters"])
+    if isinstance(data.get("or_filters"), str):
+        data["or_filters"] = json.loads(data["or_filters"])
+    if isinstance(data.get("fields"), str):
+        data["fields"] = json.loads(data["fields"])
+    if isinstance(data.get("docstatus"), str):
+        data["docstatus"] = json.loads(data["docstatus"])
+    if isinstance(data.get("save_user_settings"), str):
+        data["save_user_settings"] = json.loads(data["save_user_settings"])
+    else:
+        data["save_user_settings"] = True
 
 
 def get_parenttype_and_fieldname(field, data):
-	if "." in field:
-		parenttype, fieldname = field.split(".")[0][4:-1], field.split(".")[1].strip("`")
-	else:
-		parenttype = data.doctype
-		fieldname = field.strip("`")
+    if "." in field:
+        parenttype, fieldname = field.split(".")[0][4:-1], field.split(".")[1].strip("`")
+    else:
+        parenttype = data.doctype
+        fieldname = field.strip("`")
 
-	return parenttype, fieldname
+    return parenttype, fieldname
 
 def compress(data, args=None):
-	"""separate keys and values"""
-	from frappe.desk.query_report import add_total_row
+    """separate keys and values"""
+    from frappe.desk.query_report import add_total_row
 
-	if not data: return data
-	if args is None:
-		args = {}
-	values = []
-	keys = list(data[0])
-	for row in data:
-		new_row = []
-		for key in keys:
-			new_row.append(row.get(key))
-		values.append(new_row)
+    if not data:
+        return data
+    if args is None:
+        args = {}
+    values = []
+    keys = list(data[0])
+    for row in data:
+        new_row = []
+        for key in keys:
+            new_row.append(row.get(key))
+        values.append(new_row)
 
-	if args.get("add_total_row"):
-		meta = frappe.get_meta(args.doctype)
-		values = add_total_row(values, keys, meta)
+    if args.get("add_total_row"):
+        meta = frappe.get_meta(args.doctype)
+        values = add_total_row(values, keys, meta)
 
-	return {
-		"keys": keys,
-		"values": values
-	}
+    return {
+            "keys": keys,
+            "values": values
+    }
 
 @frappe.whitelist()
 def save_report():
-	"""save report"""
+    """save report"""
 
-	data = frappe.local.form_dict
-	if frappe.db.exists('Report', data['name']):
-		d = frappe.get_doc('Report', data['name'])
-	else:
-		d = frappe.new_doc('Report')
-		d.report_name = data['name']
-		d.ref_doctype = data['doctype']
+    data = frappe.local.form_dict
+    if frappe.db.exists('Report', data['name']):
+        d = frappe.get_doc('Report', data['name'])
+    else:
+        d = frappe.new_doc('Report')
+        d.report_name = data['name']
+        d.ref_doctype = data['doctype']
 
-	d.report_type = "Report Builder"
-	d.json = data['json']
-	frappe.get_doc(d).save()
-	frappe.msgprint(_("{0} is saved").format(d.name), alert=True)
-	return d.name
+    d.report_type = "Report Builder"
+    d.json = data['json']
+    frappe.get_doc(d).save(ignore_permissions=True)
+    frappe.msgprint(_("{0} is saved").format(d.name), alert=True)
+    return d.name
 
 @frappe.whitelist()
 @frappe.read_only()
 def export_query():
-	"""export from report builder"""
-	title = frappe.form_dict.title
-	frappe.form_dict.pop('title', None)
+    """export from report builder"""
+    title = frappe.form_dict.title
+    frappe.form_dict.pop('title', None)
 
-	form_params = get_form_params()
-	form_params["limit_page_length"] = None
-	form_params["as_list"] = True
-	doctype = form_params.doctype
-	add_totals_row = None
-	file_format_type = form_params["file_format_type"]
-	title = title or doctype
+    form_params = get_form_params()
+    form_params["limit_page_length"] = None
+    form_params["as_list"] = True
+    doctype = form_params.doctype
+    add_totals_row = None
+    file_format_type = form_params["file_format_type"]
+    title = title or doctype
 
-	del form_params["doctype"]
-	del form_params["file_format_type"]
+    del form_params["doctype"]
+    del form_params["file_format_type"]
 
-	if 'add_totals_row' in form_params and form_params['add_totals_row']=='1':
-		add_totals_row = 1
-		del form_params["add_totals_row"]
+    if 'add_totals_row' in form_params and form_params['add_totals_row']=='1':
+        add_totals_row = 1
+        del form_params["add_totals_row"]
 
-	frappe.permissions.can_export(doctype, raise_exception=True)
+    frappe.permissions.can_export(doctype, raise_exception=True)
 
-	if 'selected_items' in form_params:
-		si = json.loads(frappe.form_dict.get('selected_items'))
-		form_params["filters"] = {"name": ("in", si)}
-		del form_params["selected_items"]
+    if 'selected_items' in form_params:
+        si = json.loads(frappe.form_dict.get('selected_items'))
+        form_params["filters"] = {"name": ("in", si)}
+        del form_params["selected_items"]
 
-	make_access_log(doctype=doctype,
-		file_type=file_format_type,
-		report_name=form_params.report_name,
-		filters=form_params.filters)
+    make_access_log(doctype=doctype,
+            file_type=file_format_type,
+            report_name=form_params.report_name,
+            filters=form_params.filters)
 
-	db_query = DatabaseQuery(doctype)
-	ret = db_query.execute(**form_params)
+    db_query = DatabaseQuery(doctype)
+    ret = db_query.execute(**form_params)
 
-	if add_totals_row:
-		ret = append_totals_row(ret)
+    if add_totals_row:
+        ret = append_totals_row(ret)
 
-	data = [['Sr'] + get_labels(db_query.fields, doctype)]
-	for i, row in enumerate(ret):
-		data.append([i+1] + list(row))
+    data = [['Sr'] + get_labels(db_query.fields, doctype)]
+    for i, row in enumerate(ret):
+        data.append([i+1] + list(row))
 
-	data = handle_duration_fieldtype_values(doctype, data, db_query.fields)
+    data = handle_duration_fieldtype_values(doctype, data, db_query.fields)
 
-	if file_format_type == "CSV":
+    if file_format_type == "CSV":
 
-		# convert to csv
-		import csv
-		from frappe.utils.xlsxutils import handle_html
+        # convert to csv
+        import csv
+        from frappe.utils.xlsxutils import handle_html
 
-		f = StringIO()
-		writer = csv.writer(f)
-		for r in data:
-			# encode only unicode type strings and not int, floats etc.
-			writer.writerow([handle_html(frappe.as_unicode(v)) \
-				if isinstance(v, str) else v for v in r])
+        f = StringIO()
+        writer = csv.writer(f)
+        for r in data:
+            # encode only unicode type strings and not int, floats etc.
+            writer.writerow([handle_html(frappe.as_unicode(v))
+                    if isinstance(v, str) else v for v in r])
 
-		f.seek(0)
-		frappe.response['result'] = cstr(f.read())
-		frappe.response['type'] = 'csv'
-		frappe.response['doctype'] = title
+        f.seek(0)
+        frappe.response['result'] = cstr(f.read())
+        frappe.response['type'] = 'csv'
+        frappe.response['doctype'] = title
 
-	elif file_format_type == "Excel":
+    elif file_format_type == "Excel":
 
-		from frappe.utils.xlsxutils import make_xlsx
-		xlsx_file = make_xlsx(data, doctype)
+        from frappe.utils.xlsxutils import make_xlsx
+        xlsx_file = make_xlsx(data, doctype)
 
-		frappe.response['filename'] = title + '.xlsx'
-		frappe.response['filecontent'] = xlsx_file.getvalue()
-		frappe.response['type'] = 'binary'
+        frappe.response['filename'] = title + '.xlsx'
+        frappe.response['filecontent'] = xlsx_file.getvalue()
+        frappe.response['type'] = 'binary'
 
 
 def append_totals_row(data):
-	if not data:
-		return data
-	data = list(data)
-	totals = []
-	totals.extend([""]*len(data[0]))
+    if not data:
+        return data
+    data = list(data)
+    totals = []
+    totals.extend([""]*len(data[0]))
 
-	for row in data:
-		for i in range(len(row)):
-			if isinstance(row[i], (float, int)):
-				totals[i] = (totals[i] or 0) + row[i]
+    for row in data:
+        for i in range(len(row)):
+            if isinstance(row[i], (float, int)):
+                totals[i] = (totals[i] or 0) + row[i]
 
-	if not isinstance(totals[0], (int, float)):
-		totals[0] = 'Total'
+    if not isinstance(totals[0], (int, float)):
+        totals[0] = 'Total'
 
-	data.append(totals)
+    data.append(totals)
 
-	return data
+    return data
 
 def get_labels(fields, doctype):
-	"""get column labels based on column names"""
-	labels = []
-	for key in fields:
-		key = key.split(" as ")[0]
+    """get column labels based on column names"""
+    labels = []
+    for key in fields:
+        key = key.split(" as ")[0]
 
-		if key.startswith(('count(', 'sum(', 'avg(')): continue
+        if key.startswith(('count(', 'sum(', 'avg(')):
+            continue
 
-		if "." in key:
-			parenttype, fieldname = key.split(".")[0][4:-1], key.split(".")[1].strip("`")
-		else:
-			parenttype = doctype
-			fieldname = fieldname.strip("`")
+        if "." in key:
+            parenttype, fieldname = key.split(".")[0][4:-1], key.split(".")[1].strip("`")
+        else:
+            parenttype = doctype
+            fieldname = fieldname.strip("`")
 
-		df = frappe.get_meta(parenttype).get_field(fieldname)
-		label = df.label if df else fieldname.title()
-		if label in labels:
-			label = doctype + ": " + label
-		labels.append(label)
+        df = frappe.get_meta(parenttype).get_field(fieldname)
+        label = df.label if df else fieldname.title()
+        if label in labels:
+            label = doctype + ": " + label
+        labels.append(label)
 
-	return labels
+    return labels
 
 def handle_duration_fieldtype_values(doctype, data, fields):
-	for field in fields:
-		key = field.split(" as ")[0]
+    for field in fields:
+        key = field.split(" as ")[0]
 
-		if key.startswith(('count(', 'sum(', 'avg(')): continue
+        if key.startswith(('count(', 'sum(', 'avg(')):
+            continue
 
-		if "." in key:
-			parenttype, fieldname = key.split(".")[0][4:-1], key.split(".")[1].strip("`")
-		else:
-			parenttype = doctype
-			fieldname = field.strip("`")
+        if "." in key:
+            parenttype, fieldname = key.split(".")[0][4:-1], key.split(".")[1].strip("`")
+        else:
+            parenttype = doctype
+            fieldname = field.strip("`")
 
-		df = frappe.get_meta(parenttype).get_field(fieldname)
+        df = frappe.get_meta(parenttype).get_field(fieldname)
 
-		if df and df.fieldtype == 'Duration':
-			index = fields.index(field) + 1
-			for i in range(1, len(data)):
-				val_in_seconds = data[i][index]
-				if val_in_seconds:
-					duration_val = format_duration(val_in_seconds, df.hide_days)
-					data[i][index] = duration_val
-	return data
+        if df and df.fieldtype == 'Duration':
+            index = fields.index(field) + 1
+            for i in range(1, len(data)):
+                val_in_seconds = data[i][index]
+                if val_in_seconds:
+                    duration_val = format_duration(val_in_seconds, df.hide_days)
+                    data[i][index] = duration_val
+    return data
 
 @frappe.whitelist()
 def delete_items():
-	"""delete selected items"""
-	import json
+    """delete selected items"""
+    import json
 
-	items = sorted(json.loads(frappe.form_dict.get('items')), reverse=True)
-	doctype = frappe.form_dict.get('doctype')
+    items = sorted(json.loads(frappe.form_dict.get('items')), reverse=True)
+    doctype = frappe.form_dict.get('doctype')
 
-	if len(items) > 10:
-		frappe.enqueue('frappe.desk.reportview.delete_bulk',
-			doctype=doctype, items=items)
-	else:
-		delete_bulk(doctype, items)
+    if len(items) > 10:
+        frappe.enqueue('frappe.desk.reportview.delete_bulk',
+                doctype=doctype, items=items)
+    else:
+        delete_bulk(doctype, items)
 
 def delete_bulk(doctype, items):
-	for i, d in enumerate(items):
-		try:
-			frappe.delete_doc(doctype, d)
-			if len(items) >= 5:
-				frappe.publish_realtime("progress",
-					dict(progress=[i+1, len(items)], title=_('Deleting {0}').format(doctype), description=d),
-						user=frappe.session.user)
-			# Commit after successful deletion
-			frappe.db.commit()
-		except Exception:
-			# rollback if any record failed to delete
-			# if not rollbacked, queries get committed on after_request method in app.py
-			frappe.db.rollback()
+    for i, d in enumerate(items):
+        try:
+            frappe.delete_doc(doctype, d)
+            if len(items) >= 5:
+                frappe.publish_realtime("progress",
+                        dict(progress=[i+1, len(items)], title=_('Deleting {0}').format(doctype), description=d),
+                                user=frappe.session.user)
+            # Commit after successful deletion
+            frappe.db.commit()
+        except Exception:
+            # rollback if any record failed to delete
+            # if not rollbacked, queries get committed on after_request method in app.py
+            frappe.db.rollback()
 
 @frappe.whitelist()
 @frappe.read_only()
 def get_sidebar_stats(stats, doctype, filters=None):
-	if filters is None:
-		filters = []
+    if filters is None:
+        filters = []
 
-	return {"stats": get_stats(stats, doctype, filters)}
+    return {"stats": get_stats(stats, doctype, filters)}
 
 @frappe.whitelist()
 @frappe.read_only()
 def get_stats(stats, doctype, filters=None):
-	"""get tag info"""
-	import json
+    """get tag info"""
+    import json
 
-	if filters is None:
-		filters = []
-	tags = json.loads(stats)
-	if filters:
-		filters = json.loads(filters)
-	stats = {}
+    if filters is None:
+        filters = []
+    tags = json.loads(stats)
+    if filters:
+        filters = json.loads(filters)
+    stats = {}
 
-	try:
-		columns = frappe.db.get_table_columns(doctype)
-	except (frappe.db.InternalError, frappe.db.ProgrammingError):
-		# raised when _user_tags column is added on the fly
-		# raised if its a virtual doctype
-		columns = []
+    try:
+        columns = frappe.db.get_table_columns(doctype)
+    except (frappe.db.InternalError, frappe.db.ProgrammingError):
+        # raised when _user_tags column is added on the fly
+        # raised if its a virtual doctype
+        columns = []
 
-	for tag in tags:
-		if not tag in columns: continue
-		try:
-			tag_count = frappe.get_list(doctype,
-				fields=[tag, "count(*)"],
-				filters=filters + [[tag, '!=', '']],
-				group_by=tag,
-				as_list=True,
-				distinct=1,
-			)
+    for tag in tags:
+        if not tag in columns:
+            continue
+        try:
+            tag_count = frappe.get_list(doctype,
+                    fields=[tag, "count(*)"],
+                    filters=filters + [[tag, '!=', '']],
+                    group_by=tag,
+                    as_list=True,
+                    distinct=1,
+            )
 
-			if tag == '_user_tags':
-				stats[tag] = scrub_user_tags(tag_count)
-				no_tag_count = frappe.get_list(doctype,
-					fields=[tag, "count(*)"],
-					filters=filters + [[tag, "in", ('', ',')]],
-					as_list=True,
-					group_by=tag,
-					order_by=tag,
-				)
+            if tag == '_user_tags':
+                stats[tag] = scrub_user_tags(tag_count)
+                no_tag_count = frappe.get_list(doctype,
+                        fields=[tag, "count(*)"],
+                        filters=filters + [[tag, "in", ('', ',')]],
+                        as_list=True,
+                        group_by=tag,
+                        order_by=tag,
+                )
 
-				no_tag_count = no_tag_count[0][1] if no_tag_count else 0
+                no_tag_count = no_tag_count[0][1] if no_tag_count else 0
 
-				stats[tag].append([_("No Tags"), no_tag_count])
-			else:
-				stats[tag] = tag_count
+                stats[tag].append([_("No Tags"), no_tag_count])
+            else:
+                stats[tag] = tag_count
 
-		except frappe.db.SQLError:
-			pass
-		except frappe.db.InternalError as e:
-			# raised when _user_tags column is added on the fly
-			pass
+        except frappe.db.SQLError:
+            pass
+        except frappe.db.InternalError as e:
+            # raised when _user_tags column is added on the fly
+            pass
 
-	return stats
+    return stats
 
 @frappe.whitelist()
 def get_filter_dashboard_data(stats, doctype, filters=None):
-	"""get tags info"""
-	import json
-	tags = json.loads(stats)
-	filters = json.loads(filters or [])
-	stats = {}
+    """get tags info"""
+    import json
+    tags = json.loads(stats)
+    filters = json.loads(filters or [])
+    stats = {}
 
-	columns = frappe.db.get_table_columns(doctype)
-	for tag in tags:
-		if not tag["name"] in columns: continue
-		tagcount = []
-		if tag["type"] not in ['Date', 'Datetime']:
-			tagcount = frappe.get_list(doctype,
-				fields=[tag["name"], "count(*)"],
-				filters = filters + ["ifnull(`%s`,'')!=''" % tag["name"]],
-				group_by = tag["name"],
-				as_list = True)
+    columns = frappe.db.get_table_columns(doctype)
+    for tag in tags:
+        if not tag["name"] in columns:
+            continue
+        tagcount = []
+        if tag["type"] not in ['Date', 'Datetime']:
+            tagcount = frappe.get_list(doctype,
+                    fields=[tag["name"], "count(*)"],
+                    filters = filters + ["ifnull(`%s`,'')!=''" % tag["name"]],
+                    group_by = tag["name"],
+                    as_list = True)
 
-		if tag["type"] not in ['Check','Select','Date','Datetime','Int',
-			'Float','Currency','Percent'] and tag['name'] not in ['docstatus']:
-			stats[tag["name"]] = list(tagcount)
-			if stats[tag["name"]]:
-				data =["No Data", frappe.get_list(doctype,
-					fields=[tag["name"], "count(*)"],
-					filters=filters + ["({0} = '' or {0} is null)".format(tag["name"])],
-					as_list=True)[0][1]]
-				if data and data[1]!=0:
+        if tag["type"] not in ['Check','Select','Date','Datetime','Int',
+                'Float','Currency','Percent'] and tag['name'] not in ['docstatus']:
+            stats[tag["name"]] = list(tagcount)
+            if stats[tag["name"]]:
+                data =["No Data", frappe.get_list(doctype,
+                        fields=[tag["name"], "count(*)"],
+                        filters=filters + ["({0} = '' or {0} is null)".format(tag["name"])],
+                        as_list=True)[0][1]]
+                if data and data[1]!=0:
 
-					stats[tag["name"]].append(data)
-		else:
-			stats[tag["name"]] = tagcount
+                    stats[tag["name"]].append(data)
+        else:
+            stats[tag["name"]] = tagcount
 
-	return stats
+    return stats
 
 def scrub_user_tags(tagcount):
-	"""rebuild tag list for tags"""
-	rdict = {}
-	tagdict = dict(tagcount)
-	for t in tagdict:
-		if not t:
-			continue
-		alltags = t.split(',')
-		for tag in alltags:
-			if tag:
-				if not tag in rdict:
-					rdict[tag] = 0
+    """rebuild tag list for tags"""
+    rdict = {}
+    tagdict = dict(tagcount)
+    for t in tagdict:
+        if not t:
+            continue
+        alltags = t.split(',')
+        for tag in alltags:
+            if tag:
+                if not tag in rdict:
+                    rdict[tag] = 0
 
-				rdict[tag] += tagdict[t]
+                rdict[tag] += tagdict[t]
 
-	rlist = []
-	for tag in rdict:
-		rlist.append([tag, rdict[tag]])
+    rlist = []
+    for tag in rdict:
+        rlist.append([tag, rdict[tag]])
 
-	return rlist
+    return rlist
 
 # used in building query in queries.py
 def get_match_cond(doctype, as_condition=True):
-	cond = DatabaseQuery(doctype).build_match_conditions(as_condition=as_condition)
-	if not as_condition:
-		return cond
+    cond = DatabaseQuery(doctype).build_match_conditions(as_condition=as_condition)
+    if not as_condition:
+        return cond
 
-	return ((' and ' + cond) if cond else "").replace("%", "%%")
+    return ((' and ' + cond) if cond else "").replace("%", "%%")
 
 def build_match_conditions(doctype, user=None, as_condition=True):
-	match_conditions =  DatabaseQuery(doctype, user=user).build_match_conditions(as_condition=as_condition)
-	if as_condition:
-		return match_conditions.replace("%", "%%")
-	else:
-		return match_conditions
+    match_conditions = DatabaseQuery(doctype, user=user).build_match_conditions(as_condition=as_condition)
+    if as_condition:
+        return match_conditions.replace("%", "%%")
+    else:
+        return match_conditions
 
 def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with_match_conditions=False):
-	if isinstance(filters, str):
-		filters = json.loads(filters)
+    if isinstance(filters, str):
+        filters = json.loads(filters)
 
-	if filters:
-		flt = filters
-		if isinstance(filters, dict):
-			filters = filters.items()
-			flt = []
-			for f in filters:
-				if isinstance(f[1], str) and f[1][0] == '!':
-					flt.append([doctype, f[0], '!=', f[1][1:]])
-				elif isinstance(f[1], (list, tuple)) and \
-					f[1][0] in (">", "<", ">=", "<=", "!=", "like", "not like", "in", "not in", "between"):
+    if filters:
+        flt = filters
+        if isinstance(filters, dict):
+            filters = filters.items()
+            flt = []
+            for f in filters:
+                if isinstance(f[1], str) and f[1][0] == '!':
+                    flt.append([doctype, f[0], '!=', f[1][1:]])
+                elif isinstance(f[1], (list, tuple)) and \
+                        f[1][0] in (">", "<", ">=", "<=", "!=", "like", "not like", "in", "not in", "between"):
 
-					flt.append([doctype, f[0], f[1][0], f[1][1]])
-				else:
-					flt.append([doctype, f[0], '=', f[1]])
+                    flt.append([doctype, f[0], f[1][0], f[1][1]])
+                else:
+                    flt.append([doctype, f[0], '=', f[1]])
 
-		query = DatabaseQuery(doctype)
-		query.filters = flt
-		query.conditions = conditions
+        query = DatabaseQuery(doctype)
+        query.filters = flt
+        query.conditions = conditions
 
-		if with_match_conditions:
-			query.build_match_conditions()
+        if with_match_conditions:
+            query.build_match_conditions()
 
-		query.build_filter_conditions(flt, conditions, ignore_permissions)
+        query.build_filter_conditions(flt, conditions, ignore_permissions)
 
-		cond = ' and ' + ' and '.join(query.conditions)
-	else:
-		cond = ''
-	return cond
+        cond = ' and ' + ' and '.join(query.conditions)
+    else:
+        cond = ''
+    return cond

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -7,1479 +7,1477 @@ window.DataTable = DataTable;
 frappe.provide('frappe.views');
 
 frappe.views.ReportView = class ReportView extends frappe.views.ListView {
-	get view_name() {
-		return 'Report';
-	}
+    get view_name() {
+        return 'Report';
+    }
 
-	render_header() {
-		// Override List View Header
-	}
+    render_header() {
+        // Override List View Header
+    }
 
-	setup_defaults() {
-		super.setup_defaults();
-		this.page_title = __('Report:') + ' ' + this.page_title;
-		this.menu_items = this.report_menu_items();
-		this.view = 'Report';
+    setup_defaults() {
+        super.setup_defaults();
+        this.page_title = __('Report:') + ' ' + this.page_title;
+        this.menu_items = this.report_menu_items();
+        this.view = 'Report';
 
-		const route = frappe.get_route();
-		if (route.length === 4) {
-			this.report_name = route[3];
-		}
+        const route = frappe.get_route();
+        if (route.length === 4) {
+            this.report_name = route[3];
+        }
 
-		if (this.report_name) {
-			return this.get_report_doc()
-				.then(doc => {
-					this.report_doc = doc;
-					this.report_doc.json = JSON.parse(this.report_doc.json);
+        if (this.report_name) {
+            return this.get_report_doc()
+                .then(doc => {
+                    this.report_doc = doc;
+                    this.report_doc.json = JSON.parse(this.report_doc.json);
 
-					this.filters = this.report_doc.json.filters;
-					this.order_by = this.report_doc.json.order_by;
-					this.add_totals_row = this.report_doc.json.add_totals_row;
-					this.page_title = this.report_name;
-					this.page_length = this.report_doc.json.page_length || 20;
-					this.order_by = this.report_doc.json.order_by || 'modified desc';
-					this.chart_args = this.report_doc.json.chart_args;
-				});
-		} else {
-			this.add_totals_row = this.view_user_settings.add_totals_row || 0;
-			this.chart_args = this.view_user_settings.chart_args;
-		}
-	}
+                    this.filters = this.report_doc.json.filters;
+                    this.order_by = this.report_doc.json.order_by;
+                    this.add_totals_row = this.report_doc.json.add_totals_row;
+                    this.page_title = this.report_name;
+                    this.page_length = this.report_doc.json.page_length || 20;
+                    this.order_by = this.report_doc.json.order_by || 'modified desc';
+                    this.chart_args = this.report_doc.json.chart_args;
+                });
+        } else {
+            this.add_totals_row = this.view_user_settings.add_totals_row || 0;
+            this.chart_args = this.view_user_settings.chart_args;
+        }
+    }
 
-	setup_view() {
-		this.setup_columns();
-		super.setup_new_doc_event();
-		this.page.main.addClass('report-view');
-	}
+    setup_view() {
+        this.setup_columns();
+        super.setup_new_doc_event();
+        this.page.main.addClass('report-view');
+    }
 
-	toggle_side_bar() {
-		super.toggle_side_bar();
-		// refresh datatable when sidebar is toggled to accomodate extra space
-		this.render(true);
-	}
+    toggle_side_bar() {
+        super.toggle_side_bar();
+        // refresh datatable when sidebar is toggled to accomodate extra space
+        this.render(true);
+    }
 
-	setup_result_area() {
-		super.setup_result_area();
-		this.setup_charts_area();
-		this.$datatable_wrapper = $('<div class="datatable-wrapper">');
-		this.$result.append(this.$datatable_wrapper);
-	}
+    setup_result_area() {
+        super.setup_result_area();
+        this.setup_charts_area();
+        this.$datatable_wrapper = $('<div class="datatable-wrapper">');
+        this.$result.append(this.$datatable_wrapper);
+    }
 
-	setup_charts_area() {
-		this.$charts_wrapper = $(`<div class="charts-wrapper hidden">
+    setup_charts_area() {
+        this.$charts_wrapper = $(`<div class="charts-wrapper hidden">
 			<div class="text-right"><button class="btn btn-default btn-xs btn-chart-configure"
 				style="margin-right: 15px; margin-top: 15px">Configure</button></div>
 			<div class="charts-inner-wrapper"></div>
 		</div>`);
-		this.$result.append(this.$charts_wrapper);
-		this.$charts_wrapper.find('.btn-chart-configure').on('click', () => {
-			this.setup_charts();
-		});
-	}
-
-	setup_paging_area() {
-		super.setup_paging_area();
-		const message = __('For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 & 10).');
-		this.$paging_area.find('.level-left').append(
-			`<span class="comparison-message text-muted">${message}</span>`
-		)
-	}
-
-	setup_sort_selector() {
-		this.sort_selector = new frappe.ui.SortSelector({
-			parent: this.filter_area.$filter_list_wrapper,
-			doctype: this.doctype,
-			args: this.order_by,
-			onchange: this.on_sort_change.bind(this)
-		});
-
-		//Setup groupby for reports
-		this.group_by_control = new frappe.ui.GroupBy(this);
-		if (this.report_doc && this.report_doc.json.group_by) {
-			this.group_by_control.apply_settings(this.report_doc.json.group_by);
-		}
-		if (this.view_user_settings && this.view_user_settings.group_by) {
-			this.group_by_control.apply_settings(this.view_user_settings.group_by);
-		}
-
-	}
-
-	get_args() {
-		const args = super.get_args();
-		delete args.group_by;
-		this.group_by_control.set_args(args);
-
-		return args;
-	}
-
-	before_refresh() {
-		if (this.report_doc) {
-			// don't parse frappe.route_options if this is a Custom Report
-			return Promise.resolve();
-		}
-		return super.before_refresh();
-	}
-
-	after_render() {
-		if (this.report_doc) {
-			this.set_dirty_state_for_custom_report();
-		} else {
-			this.save_report_settings();
-		}
-		if (!this.group_by) {
-			this.init_chart();
-		}
-	}
-
-	set_dirty_state_for_custom_report() {
-		let current_settings = {
-			filters: this.filter_area.get(),
-			fields: this.fields,
-			order_by: this.sort_selector.get_sql_string(),
-			add_totals_row: this.add_totals_row,
-			page_length: this.page_length,
-			column_widths: this.get_column_widths(),
-			group_by: this.group_by_control.get_settings(),
-			chart_args: this.get_chart_settings()
-		};
-
-		let report_settings = {
-			filters: this.report_doc.json.filters,
-			fields: this.report_doc.json.fields,
-			order_by: this.report_doc.json.order_by,
-			add_totals_row: this.report_doc.json.add_totals_row,
-			page_length: this.report_doc.json.page_length,
-			column_widths: this.report_doc.json.column_widths,
-			group_by: this.report_doc.json.group_by,
-			chart_args: this.report_doc.json.chart_args
-		};
-
-		if (!frappe.utils.deep_equal(current_settings, report_settings)) {
-			this.page.set_indicator(__('Not Saved'), 'orange');
-		} else {
-			this.page.clear_indicator();
-		}
-	}
-
-	save_report_settings() {
-		frappe.model.user_settings.save(this.doctype, 'last_view', this.view_name);
-
-		if (!this.report_name) {
-			this.save_view_user_settings({
-				fields: this.fields,
-				filters: this.filter_area.get(),
-				order_by: this.sort_selector.get_sql_string(),
-				group_by: this.group_by_control.get_settings(),
-				chart_args: this.get_chart_settings(),
-				add_totals_row: this.add_totals_row
-			});
-		}
-	}
-
-	prepare_data(r) {
-		let data = r.message || {};
-		data = frappe.utils.dict(data.keys, data.values);
-
-		if (this.start === 0) {
-			this.data = data;
-		} else {
-			this.data = this.data.concat(data);
-		}
-	}
-
-	render(force) {
-		if (this.data.length === 0) return;
-		this.render_count();
-		this.setup_columns();
-
-		if (this.group_by) {
-			this.$charts_wrapper.addClass('hidden');
-		} else if (this.chart) {
-			this.refresh_charts();
-		}
-
-		if (this.datatable && !force) {
-			this.datatable.refresh(this.get_data(this.data), this.columns);
-			return;
-		}
-		this.setup_datatable(this.data);
-	}
-
-	render_count() {
-		let $list_count = this.$paging_area.find('.list-count');
-		if (!$list_count.length) {
-			$list_count = $('<span>')
-				.addClass('text-muted list-count')
-				.prependTo(this.$paging_area.find('.level-right'));
-		}
-		this.get_count_str()
-			.then(str => {
-				$list_count.text(str);
-			});
-	}
-
-	on_update(data) {
-		if (this.doctype === data.doctype && data.name) {
-			// flash row when doc is updated by some other user
-			const flash_row = data.user !== frappe.session.user;
-			if (this.data.find(d => d.name === data.name)) {
-				// update existing
-				frappe.db.get_doc(data.doctype, data.name)
-					.then(doc => this.update_row(doc, flash_row));
-			} else {
-				// refresh
-				this.refresh();
-			}
-		}
-	}
-
-	update_row(doc, flash_row) {
-		const to_refresh = [];
-
-		this.data = this.data.map((d, i) => {
-			if (d.name === doc.name) {
-				for (let fieldname in d) {
-					if (fieldname.includes(':')) {
-						// child table field
-						const [cdt, _field] = fieldname.split(':');
-						const cdt_row = Object.keys(doc)
-							.filter(key =>
-								Array.isArray(doc[key])
-								&& doc[key].length
-								&& doc[key][0].doctype === cdt
-							)
-							.map(key => doc[key])
-							.map(a => a[0])
-							.filter(cdoc => cdoc.name === d[cdt + ':name'])[0];
-						if (cdt_row) {
-							d[fieldname] = cdt_row[_field];
-						}
-					} else {
-						d[fieldname] = doc[fieldname];
-					}
-				}
-				to_refresh.push([d, i]);
-			}
-			return d;
-		});
-
-		// indicate row update
-		const _flash_row = (rowIndex) => {
-			if (!flash_row) return;
-			const $row = this.$result.find(`.dt-row[data-row-index="${rowIndex}"]`);
-			$row.addClass('row-update');
-			setTimeout(() => $row.removeClass('row-update'), 500);
-		};
-
-		to_refresh.forEach(([data, rowIndex]) => {
-			const new_row = this.build_row(data);
-			this.datatable.refreshRow(new_row, rowIndex);
-			_flash_row(rowIndex);
-		});
-	}
-
-	setup_datatable(values) {
-		this.$datatable_wrapper.empty();
-		this.datatable = new DataTable(this.$datatable_wrapper[0], {
-			columns: this.columns,
-			data: this.get_data(values),
-			getEditor: this.get_editing_object.bind(this),
-			checkboxColumn: true,
-			inlineFilters: true,
-			cellHeight: 35,
-			direction: frappe.utils.is_rtl() ? 'rtl' : 'ltr',
-			events: {
-				onRemoveColumn: (column) => {
-					this.remove_column_from_datatable(column);
-				},
-				onSwitchColumn: (column1, column2) => {
-					this.switch_column(column1, column2);
-				},
-				onCheckRow: () => {
-					const checked_items = this.get_checked_items();
-					this.toggle_actions_menu_button(checked_items.length > 0);
-				}
-			},
-			hooks: {
-				columnTotal: frappe.utils.report_column_total
-			},
-			headerDropdown: [{
-				label: __('Add Column'),
-				action: (datatabe_col) => {
-					let columns_in_picker = [];
-					const columns = this.get_columns_for_picker();
-
-					columns_in_picker = columns[this.doctype]
-						.filter(df => !this.is_column_added(df))
-						.map(df => ({
-							label: __(df.label),
-							value: df.fieldname
-						}));
-
-					delete columns[this.doctype];
-
-					for (let cdt in columns) {
-						columns[cdt]
-							.filter(df => !this.is_column_added(df))
-							.map(df => ({
-								label: __(df.label) + ` (${cdt})`,
-								value: df.fieldname + ',' + cdt
-							}))
-							.forEach(df => columns_in_picker.push(df));
-					}
-
-					const d = new frappe.ui.Dialog({
-						title: __('Add Column'),
-						fields: [
-							{
-								label: __('Select Column'),
-								fieldname: 'column',
-								fieldtype: 'Autocomplete',
-								options: columns_in_picker
-							},
-							{
-								label: __('Insert Column Before {0}', [datatabe_col.docfield.label.bold()]),
-								fieldname: 'insert_before',
-								fieldtype: 'Check'
-							}
-						],
-						primary_action: ({ column, insert_before }) => {
-							if (!columns_in_picker.map(col => col.value).includes(column)) {
-								frappe.show_alert({message: __('Invalid column'), indicator: 'orange'});
-								d.hide();
-								return;
-							}
-
-							let doctype = this.doctype;
-							if (column.includes(',')) {
-								[column, doctype] = column.split(',');
-							}
-
-
-							let index = datatabe_col.colIndex;
-							if (insert_before) {
-								index = index - 1;
-							}
-
-							this.add_column_to_datatable(column, doctype, index);
-							d.hide();
-						}
-					});
-
-					d.show();
-				}
-			}]
-		});
-	}
-
-	toggle_charts() {
-		// add
-		if (!this.chart) {
-			this.setup_charts();
-			return;
-		}
-
-		if (this.$charts_wrapper.hasClass('hidden')) {
-			// reload chart
-			this.$charts_wrapper.removeClass('hidden');
-			this.refresh_charts();
-		} else {
-			// remove chart
-			this.$charts_wrapper.addClass('hidden');
-			this.save_view_user_settings(
-				{ chart_args: null });
-			this.chart_args = null;
-		}
-	}
-
-	init_chart() {
-		// show chart if saved via report or user settings
-		if (!this.chart) {
-			if (this.chart_args) {
-				this.build_chart_args(this.chart_args.x_axis,
-					this.chart_args.y_axes,
-					this.chart_args.chart_type);
-
-				this.make_chart();
-			}
-		}
-	}
-
-	setup_charts() {
-		// get fields from columns
-		let x_fields = [], y_fields = [];
-		for (let col of this.columns) {
-			// all options in x
-			x_fields.push({
-				label: col.content,
-				fieldname: col.id,
-				value: col.id,
-			});
-
-			// numeric values in y
-			if (col.docfield && frappe.model.numeric_fieldtypes.includes(col.docfield.fieldtype)) {
-				y_fields.push({
-					label: col.content,
-					fieldname: col.id,
-					value: col.id
-				});
-			}
-		}
-
-		const defaults = this.chart_args || {};
-
-		const dialog = new frappe.ui.Dialog({
-			title: __('Configure Chart'),
-			fields: [
-				{
-					label: __('X Axis Field'),
-					fieldtype: 'Select',
-					fieldname: 'x_axis',
-					options: x_fields,
-					default: defaults.x_axis
-				},
-				{
-					label: __('Y Axis Fields'),
-					fieldtype: 'MultiSelect',
-					fieldname: 'y_axes',
-					options: y_fields,
-					description: __('Showing only Numeric fields from Report'),
-					default: defaults.y_axes ? defaults.y_axes.join(', ') : null
-				},
-				{
-					label: __('Chart Type'),
-					fieldtype: 'Select',
-					options: ['Bar', 'Line', 'Pie', 'Percentage', 'Donut'],
-					fieldname: 'chart_type',
-					default: defaults.chart_type ?
-						frappe.utils.to_title_case(defaults.chart_type) :
-						'Bar'
-				}
-			],
-			primary_action: (data) => {
-				data.y_axes = data.y_axes.split(',').map(d => d.trim()).filter(Boolean);
-
-				this.build_chart_args(data.x_axis, data.y_axes, data.chart_type);
-				this.make_chart();
-				dialog.hide();
-			}
-		});
-
-		dialog.show();
-	}
-
-	build_chart_args(x_axis, y_axes, chart_type) {
-		let datasets = y_axes.map(y_axis => ({
-			name: this.columns_map[y_axis].content,
-			values: this.data.map(d => d[y_axis])
-		}));
-
-		this.chart_args = {
-			chart_type: chart_type.toLowerCase(),
-			x_axis: x_axis,
-			y_axes: y_axes,
-			labels: this.data.map(d => d[x_axis]),
-			datasets: datasets
-		};
-
-		this.save_view_user_settings(
-			{ chart_args: this.get_chart_settings() });
-	}
-
-	get_chart_settings() {
-		if (this.chart_args) {
-			return {
-				chart_type: this.chart_args.chart_type,
-				x_axis: this.chart_args.x_axis,
-				y_axes: this.chart_args.y_axes,
-			};
-		}
-	}
-
-	make_chart() {
-		const args = this.chart_args;
-		let data = {
-			labels: args.labels,
-			datasets: args.datasets
-		};
-
-		this.last_chart_type = args.chart_type;
-
-		const get_df = (field) => this.columns_map[field].docfield;
-		const get_doc = (value, field) => this.data.find(d => d[field] === value);
-
-		this.$charts_wrapper.removeClass('hidden');
-
-		this.chart = new frappe.Chart(this.$charts_wrapper.find('.charts-inner-wrapper')[0], {
-			title: __("{0} Chart", [this.doctype]),
-			data: data,
-			type: args.chart_type,
-			truncateLegends: 1,
-			colors: ['#70E078', 'light-blue', 'orange', 'red'],
-			axisOptions: {
-				shortenYAxisNumbers: 1
-			},
-			tooltipOptions: {
-				formatTooltipY: value => frappe.format(value, get_df(this.chart_args.y_axes[0]), { always_show_decimals: true, inline: true }, get_doc(value.doc))
-			}
-		});
-	}
-
-	refresh_charts() {
-		if (!this.chart || !this.chart_args) return;
-		this.$charts_wrapper.removeClass('hidden');
-		const { x_axis, y_axes, chart_type } = this.chart_args;
-		this.build_chart_args(x_axis, y_axes, chart_type);
-		this.chart.update(this.chart_args);
-	}
-
-	get_editing_object(colIndex, rowIndex, value, parent) {
-		const control = this.render_editing_input(colIndex, value, parent);
-		if (!control) return false;
-
-		control.df.change = () => control.set_focus();
-
-		return {
-			initValue: (value) => {
-				return control.set_value(value);
-			},
-			setValue: (value) => {
-				const cell = this.datatable.getCell(colIndex, rowIndex);
-				let fieldname = this.datatable.getColumn(colIndex).docfield.fieldname;
-				let docname = cell.name;
-				let doctype = cell.doctype;
-
-				control.set_value(value);
-				return this.set_control_value(doctype, docname, fieldname, value)
-					.then((updated_doc) => {
-						const _data = this.data
-							.filter(b => b.name === updated_doc.name)
-							.find(a =>
-								// child table cell
-								(doctype != updated_doc.doctype && a[doctype + ":name"] == docname)
-								|| doctype == updated_doc.doctype
-							);
-
-						for (let field in _data) {
-							if (field.includes(':')) {
-								// child table field
-								const [cdt, _field] = field.split(':');
-								const cdt_row = Object.keys(updated_doc)
-									.filter(key =>
-										Array.isArray(updated_doc[key])
-										&& updated_doc[key].length
-										&& updated_doc[key][0].doctype === cdt
-									)
-									.map(key => updated_doc[key])[0]
-									.filter(cdoc => cdoc.name === _data[cdt + ':name'])[0];
-								if (cdt_row) {
-									_data[field] = cdt_row[_field];
-								}
-							} else {
-								_data[field] = updated_doc[field];
-							}
-						}
-					})
-					.then(() => this.refresh_charts());
-			},
-			getValue: () => {
-				return control.get_value();
-			}
-		};
-	}
-
-	set_control_value(doctype, docname, fieldname, value) {
-		this.last_updated_doc = docname;
-		return new Promise((resolve, reject) => {
-			frappe.db.set_value(doctype, docname, {[fieldname]: value})
-				.then(r => {
-					if (r.message) {
-						resolve(r.message);
-					} else {
-						reject();
-					}
-				})
-				.fail(reject);
-		});
-	}
-
-	render_editing_input(colIndex, value, parent) {
-		const col = this.datatable.getColumn(colIndex);
-		let control = null;
-
-		if (col.docfield.fieldtype === 'Text Editor') {
-			const d = new frappe.ui.Dialog({
-				title: __('Edit {0}', [col.docfield.label]),
-				fields: [col.docfield],
-				primary_action: () => {
-					this.datatable.cellmanager.submitEditing();
-					this.datatable.cellmanager.deactivateEditing();
-					d.hide();
-				}
-			});
-			d.show();
-			control = d.fields_dict[col.docfield.fieldname];
-		} else {
-			// make control
-			control = frappe.ui.form.make_control({
-				df: col.docfield,
-				parent: parent,
-				render_input: true
-			});
-			control.set_value(value);
-			control.toggle_label(false);
-			control.toggle_description(false);
-		}
-
-		return control;
-	}
-
-	is_editable(df, data) {
-		if (df
-			&& frappe.model.can_write(this.doctype)
-			// not a submitted doc or field is allowed to edit after submit
-			&& (data.docstatus !== 1 || df.allow_on_submit)
-			// not a cancelled doc
-			&& data.docstatus !== 2
-			&& !df.read_only
-			&& !df.hidden
-			// not a standard field i.e., owner, modified_by, etc.
-			&& !frappe.model.std_fields_list.includes(df.fieldname))
-			return true;
-		return false;
-	}
-
-	get_data(values) {
-		return this.build_rows(values);
-	}
-
-	set_fields() {
-		// default fields
-		['name', 'docstatus'].map((f) => this._add_field(f));
-
-		if (this.report_name && this.report_doc.json.fields) {
-			let fields = this.report_doc.json.fields.slice();
-			fields.forEach(f => this._add_field(f[0], f[1]));
-			return;
-		} else if (this.view_user_settings.fields) {
-			// get from user_settings
-			let fields = this.view_user_settings.fields;
-			fields.forEach(f => this._add_field(f[0], f[1]));
-			return;
-		}
-
-		this.set_default_fields();
-	}
-
-	set_default_fields() {
-		// get fields from meta
-		this.fields = this.fields || [];
-		const add_field = f => this._add_field(f);
-
-		// default fields
-		[
-			this.meta.title_field,
-			this.meta.image_field
-		].map(add_field);
-
-		// fields in_list_view or in_standard_filter
-		const fields = this.meta.fields.filter(df => {
-			return (df.in_list_view || df.in_standard_filter)
-				&& frappe.perm.has_perm(this.doctype, df.permlevel, 'read')
-				&& frappe.model.is_value_type(df.fieldtype)
-				&& !df.report_hide;
-		});
-
-		fields.map(add_field);
-
-		// currency fields
-		fields.filter(
-			df => df.fieldtype === 'Currency' && df.options
-		).map(df => {
-			if (df.options.includes(':')) {
-				add_field(df.options.split(':')[1]);
-			} else {
-				add_field(df.options);
-			}
-		});
-
-		// fields in listview_settings
-		(this.settings.add_fields || []).map(add_field);
-	}
-
-	build_fields() {
-		super.build_fields();
-	}
-
-	reorder_fields() {
-		// generate table fields in the required format ["name", "DocType"]
-		// these are fields in the column before adding new fields
-		let table_fields = this.columns.map(df => [df.field, df.docfield.parent]);
-
-		// filter fields that are already in table
-		// iterate over table_fields to preserve the existing order of fields
-		// The filter will ensure the unchecked fields are removed
-		let fields_already_in_table = table_fields.filter(df => {
-			return this.fields.find((field) => {
-				return df[0] == field[0] && df[1] == field[1]
-			})
-		})
-
-		// find new fields that didn't already exists
-		// This will be appended to the end of the table
-		let fields_to_add = this.fields.filter(df => {
-			return !table_fields.find((field) => {
-				return df[0] == field[0] && df[1] == field[1];
-			});
-		});
-
-		// rebuild fields
-		this.fields = [...fields_already_in_table, ...fields_to_add];
-	}
-
-	get_fields() {
-		let fields = this.fields.map(f => {
-			let column_name = frappe.model.get_full_column_name(f[0], f[1]);
-			if (f[1] !== this.doctype) {
-				// child table field
-				column_name = column_name + ' as ' + `'${f[1]}:${f[0]}'`;
-			}
-			return column_name;
-		});
-		const cdt_name_fields =
-			this.get_unique_cdt_in_view()
-				.map(cdt => frappe.model.get_full_column_name('name', cdt) + ' as ' + `'${cdt}:name'`);
-		fields = fields.concat(cdt_name_fields);
-
-		return fields;
-	}
-
-	get_unique_cdt_in_view() {
-		return this.fields
-			.filter(f => f[1] !== this.doctype)
-			.map(f => f[1])
-			.uniqBy(d => d);
-	}
-
-	add_column_to_datatable(fieldname, doctype, col_index) {
-		const field = [fieldname, doctype];
-		this.fields.splice(col_index, 0, field);
-
-		this.add_currency_column(fieldname, doctype, col_index);
-
-		this.build_fields();
-		this.setup_columns();
-
-		if (this.datatable) this.datatable.destroy();
-		this.datatable = null;
-		this.refresh();
-	}
-
-	add_currency_column(fieldname, doctype, col_index) {
-		// Adds dependent currency field if required
-		const df = frappe.meta.get_docfield(doctype, fieldname);
-		if (df && df.fieldtype === 'Currency' && df.options &&
-			!df.options.includes(':') && frappe.meta.has_field(doctype, df.options)
-		) {
-			const field = [df.options, doctype];
-			if (col_index === undefined) {
-				this.fields.push(field);
-			} else {
-				this.fields.splice(col_index, 0, field);
-			}
-			frappe.show_alert(__('Also adding the dependent currency field {0}', [field[0].bold()]));
-		}
-	}
-
-	add_status_dependency_column(col, doctype) {
-		// Adds dependent column from which status is derived if required
-		if (!this.fields.find(f => f[0] === col)) {
-			const field = [col, doctype];
-			this.fields.push(field);
-			this.refresh();
-			frappe.show_alert(__('Also adding the status dependency field {0}', [field[0].bold()]));
-		}
-	}
-
-	remove_column_from_datatable(column) {
-		const index = this.fields.findIndex(f => column.field === f[0]);
-		if (index === -1) return;
-		const field = this.fields[index];
-
-		if (field[0] === 'name') {
-			this.refresh();
-			frappe.throw(__('Cannot remove ID field'));
-		}
-
-		this.fields.splice(index, 1);
-		this.build_fields();
-		this.setup_columns();
-		this.refresh();
-	}
-
-	switch_column(col1, col2) {
-		const index1 = this.fields.findIndex(f => col1.field === f[0]);
-		const index2 = this.fields.findIndex(f => col2.field === f[0]);
-		const _fields = this.fields.slice();
-
-		let temp = _fields[index1];
-		_fields[index1] = _fields[index2];
-		_fields[index2] = temp;
-
-		this.fields = _fields;
-		this.build_fields();
-		this.setup_columns();
-		this.refresh();
-	}
-
-	get_columns_for_picker() {
-		let out = {};
-
-		const standard_fields_filter = df => !in_list(frappe.model.no_value_type, df.fieldtype);
-
-		let doctype_fields = frappe.meta.get_docfields(this.doctype).filter(standard_fields_filter);
-
-		// filter out docstatus field from picker
-		let std_fields = frappe.model.std_fields.filter( df => df.fieldname !== 'docstatus');
-
-		// add status field derived from docstatus, if status is not a standard field
-		let has_status_values = false;
-
-		if (this.data) {
-			has_status_values = frappe.get_indicator(this.data[0], this.doctype);
-		}
-
-		if (!frappe.meta.has_field(this.doctype, 'status') && has_status_values) {
-			doctype_fields = [{
-				label: __('Status'),
-				fieldname: 'docstatus',
-				fieldtype: 'Data'
-			}].concat(doctype_fields);
-		}
-
-		doctype_fields = [{
-			label: __('ID'),
-			fieldname: 'name',
-			fieldtype: 'Data',
-			reqd: 1
-		}].concat(doctype_fields, std_fields);
-
-		out[this.doctype] = doctype_fields;
-
-		const table_fields = frappe.meta.get_table_fields(this.doctype);
-
-		table_fields.forEach(df => {
-			const cdt = df.options;
-			const child_table_fields = frappe.meta.get_docfields(cdt).filter(standard_fields_filter);
-
-			out[cdt] = child_table_fields;
-
-			// add index column for child tables
-			out[cdt].push({
-				label: __('Index'),
-				fieldname: 'idx',
-				fieldtype: 'Int',
-				parent: cdt
-			});
-		});
-		return out;
-	}
-
-	get_dialog_fields() {
-		const dialog_fields = [];
-		const columns = this.get_columns_for_picker();
-
-		dialog_fields.push({
-			label: __(this.doctype),
-			fieldname: this.doctype,
-			fieldtype: 'MultiCheck',
-			columns: 2,
-			options: columns[this.doctype]
-				.filter(df => {
-					return !df.hidden && df.fieldname !== 'name';
-				})
-				.map(df => ({
-					label: __(df.label),
-					value: df.fieldname,
-					checked: this.fields.find(f => f[0] === df.fieldname && f[1] === this.doctype)
-				}))
-		});
-
-		delete columns[this.doctype];
-
-		const table_fields = frappe.meta.get_table_fields(this.doctype)
-			.filter(df => !df.hidden);
-
-		table_fields.forEach(df => {
-			const cdt = df.options;
-
-			dialog_fields.push({
-				label: __(df.label) + ` (${__(cdt)})`,
-				fieldname: df.options,
-				fieldtype: 'MultiCheck',
-				columns: 2,
-				options: columns[cdt]
-					.filter(df => {
-						return !df.hidden;
-					})
-					.map(df => ({
-						label: __(df.label),
-						value: df.fieldname,
-						checked: this.fields.find(f => f[0] === df.fieldname && f[1] === cdt)
-					}))
-			});
-		});
-
-		return dialog_fields;
-	}
-
-	is_column_added(df) {
-		return Boolean(
-			this.fields.find(f => f[0] === df.fieldname && df.parent === f[1])
-		);
-	}
-
-	setup_columns() {
-		// apply previous column width
-		let column_widths = null;
-		if (this.columns) {
-			column_widths = this.get_column_widths();
-		}
-
-		this.columns = [];
-		this.columns_map = {};
-
-		for (let f of this.fields) {
-			let column;
-			if (f[0]!=='docstatus') {
-				column = this.build_column(f);
-			} else {
-				// if status is not in fields append status column derived from docstatus
-				if (!this.fields.includes(['status', this.doctype]) && !frappe.meta.has_field(this.doctype, 'status')) {
-					column = this.build_column(['docstatus', this.doctype]);
-				}
-			}
-
-			if (column) {
-				if (column_widths) {
-					column.width = column_widths[column.id] || column.width || 120;
-				}
-				this.columns.push(column);
-				this.columns_map[column.id] = column;
-			}
-		}
-	}
-
-	build_column(c) {
-
-		let [fieldname, doctype] = c;
-		let docfield = frappe.meta.docfield_map[doctype || this.doctype][fieldname];
-
-		// group by column
-		if (fieldname === '_aggregate_column') {
-			docfield = this.group_by_control.get_group_by_docfield();
-		}
-
-		// child table index column
-		if (fieldname === 'idx' && doctype !== this.doctype) {
-			docfield = {
-				label: "Index",
-				fieldtype: "Int",
-				parent: doctype,
-			};
-		}
-
-		if (!docfield) {
-			docfield = frappe.model.get_std_field(fieldname, true);
-
-			if (docfield) {
-				if(!docfield.label) {
-					docfield.label = toTitle(fieldname);
-					if(docfield.label.includes('_')) {
-						docfield.label = docfield.label.replace('_',' ');
-					}
-				}
-				docfield.parent = this.doctype;
-				if (fieldname == 'name') {
-					docfield.options = this.doctype;
-				}
-				if (fieldname == 'docstatus' && !frappe.meta.has_field(this.doctype, 'status')) {
-					docfield.label = 'Status';
-					docfield.fieldtype = 'Data';
-					docfield.name = 'status';
-				}
-			}
-		}
-		if (!docfield || docfield.report_hide) return;
-
-		let title = __(docfield ? docfield.label : toTitle(fieldname));
-		if (doctype !== this.doctype) {
-			title += ` (${__(doctype)})`;
-		}
-
-		const editable = frappe.model.is_non_std_field(fieldname) && !docfield.read_only;
-
-		const align = (() => {
-			const is_numeric = frappe.model.is_numeric_field(docfield);
-			if (is_numeric) {
-				return 'right';
-			}
-			return docfield.fieldtype === 'Date' ? 'right' : 'left';
-		})();
-
-		let id = fieldname;
-
-		// child table column
-		if (doctype !== this.doctype && fieldname !== '_aggregate_column') {
-			id = `${doctype}:${fieldname}`;
-		}
-
-		let width = (docfield ? cint(docfield.width) : null) || null;
-		if (this.report_doc) {
-			// load the user saved column width
-			let saved_column_widths = this.report_doc.json.column_widths || {};
-			width = saved_column_widths[id] || width;
-		}
-
-		let compareFn = null;
-		if (docfield.fieldtype === 'Date') {
-			compareFn = (cell, keyword) => {
-				if (!cell.content) return null;
-				if (keyword.length !== 'YYYY-MM-DD'.length) return null;
-
-				const keywordValue = frappe.datetime.user_to_obj(keyword);
-				const cellValue = frappe.datetime.str_to_obj(cell.content);
-				return [+cellValue, +keywordValue];
-			}
-		}
-
-
-		return {
-			id: id,
-			field: fieldname,
-			name: title,
-			content: title,
-			docfield,
-			width,
-			editable,
-			align,
-			compareValue: compareFn,
-			format: (value, row, column, data) => {
-				let doc = null;
-				if (Array.isArray(row)) {
-					doc = row.reduce((acc, curr) => {
-						if (!curr.column.docfield) return acc;
-						acc[curr.column.docfield.fieldname] = curr.content;
-						return acc;
-					}, {});
-				} else {
-					doc = row;
-				}
-
-				return frappe.format(value, column.docfield, { always_show_decimals: true }, doc);
-			}
-		};
-	}
-
-	build_rows(data) {
-		const out = data.map(d => this.build_row(d));
-
-		if (this.add_totals_row) {
-			const totals = this.get_columns_totals(data);
-			const totals_row = this.columns.map((col, i) => {
-				return {
-					name: __('Totals Row'),
-					content: totals[col.id],
-					format: value => {
-						let formatted_value = frappe.format(value, col.docfield, {
-							always_show_decimals: true
-						}, data[0]);
-						if (i === 0) {
-							return this.format_total_cell(formatted_value, col);
-						}
-						return formatted_value;
-					}
-				};
-			});
-
-			out.push(totals_row);
-		}
-		return out;
-	}
-
-	format_total_cell(formatted_value, df) {
-		let cell_value = __('Totals').bold();
-		if (frappe.model.is_numeric_field(df.docfield)) {
-			cell_value = `<span class="flex justify-between">
+        this.$result.append(this.$charts_wrapper);
+        this.$charts_wrapper.find('.btn-chart-configure').on('click', () => {
+            this.setup_charts();
+        });
+    }
+
+    setup_paging_area() {
+        super.setup_paging_area();
+        const message = __('For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 & 10).');
+        this.$paging_area.find('.level-left').append(
+            `<span class="comparison-message text-muted">${message}</span>`
+        )
+    }
+
+    setup_sort_selector() {
+        this.sort_selector = new frappe.ui.SortSelector({
+            parent: this.filter_area.$filter_list_wrapper,
+            doctype: this.doctype,
+            args: this.order_by,
+            onchange: this.on_sort_change.bind(this)
+        });
+
+        //Setup groupby for reports
+        this.group_by_control = new frappe.ui.GroupBy(this);
+        if (this.report_doc && this.report_doc.json.group_by) {
+            this.group_by_control.apply_settings(this.report_doc.json.group_by);
+        }
+        if (this.view_user_settings && this.view_user_settings.group_by) {
+            this.group_by_control.apply_settings(this.view_user_settings.group_by);
+        }
+
+    }
+
+    get_args() {
+        const args = super.get_args();
+        delete args.group_by;
+        this.group_by_control.set_args(args);
+
+        return args;
+    }
+
+    before_refresh() {
+        if (this.report_doc) {
+            // don't parse frappe.route_options if this is a Custom Report
+            return Promise.resolve();
+        }
+        return super.before_refresh();
+    }
+
+    after_render() {
+        if (this.report_doc) {
+            this.set_dirty_state_for_custom_report();
+        } else {
+            this.save_report_settings();
+        }
+        if (!this.group_by) {
+            this.init_chart();
+        }
+    }
+
+    set_dirty_state_for_custom_report() {
+        let current_settings = {
+            filters: this.filter_area.get(),
+            fields: this.fields,
+            order_by: this.sort_selector.get_sql_string(),
+            add_totals_row: this.add_totals_row,
+            page_length: this.page_length,
+            column_widths: this.get_column_widths(),
+            group_by: this.group_by_control.get_settings(),
+            chart_args: this.get_chart_settings()
+        };
+
+        let report_settings = {
+            filters: this.report_doc.json.filters,
+            fields: this.report_doc.json.fields,
+            order_by: this.report_doc.json.order_by,
+            add_totals_row: this.report_doc.json.add_totals_row,
+            page_length: this.report_doc.json.page_length,
+            column_widths: this.report_doc.json.column_widths,
+            group_by: this.report_doc.json.group_by,
+            chart_args: this.report_doc.json.chart_args
+        };
+
+        if (!frappe.utils.deep_equal(current_settings, report_settings)) {
+            this.page.set_indicator(__('Not Saved'), 'orange');
+        } else {
+            this.page.clear_indicator();
+        }
+    }
+
+    save_report_settings() {
+        frappe.model.user_settings.save(this.doctype, 'last_view', this.view_name);
+
+        if (!this.report_name) {
+            this.save_view_user_settings({
+                fields: this.fields,
+                filters: this.filter_area.get(),
+                order_by: this.sort_selector.get_sql_string(),
+                group_by: this.group_by_control.get_settings(),
+                chart_args: this.get_chart_settings(),
+                add_totals_row: this.add_totals_row
+            });
+        }
+    }
+
+    prepare_data(r) {
+        let data = r.message || {};
+        data = frappe.utils.dict(data.keys, data.values);
+
+        if (this.start === 0) {
+            this.data = data;
+        } else {
+            this.data = this.data.concat(data);
+        }
+    }
+
+    render(force) {
+        if (this.data.length === 0) return;
+        this.render_count();
+        this.setup_columns();
+
+        if (this.group_by) {
+            this.$charts_wrapper.addClass('hidden');
+        } else if (this.chart) {
+            this.refresh_charts();
+        }
+
+        if (this.datatable && !force) {
+            this.datatable.refresh(this.get_data(this.data), this.columns);
+            return;
+        }
+        this.setup_datatable(this.data);
+    }
+
+    render_count() {
+        let $list_count = this.$paging_area.find('.list-count');
+        if (!$list_count.length) {
+            $list_count = $('<span>')
+                .addClass('text-muted list-count')
+                .prependTo(this.$paging_area.find('.level-right'));
+        }
+        this.get_count_str()
+            .then(str => {
+                $list_count.text(str);
+            });
+    }
+
+    on_update(data) {
+        if (this.doctype === data.doctype && data.name) {
+            // flash row when doc is updated by some other user
+            const flash_row = data.user !== frappe.session.user;
+            if (this.data.find(d => d.name === data.name)) {
+                // update existing
+                frappe.db.get_doc(data.doctype, data.name)
+                    .then(doc => this.update_row(doc, flash_row));
+            } else {
+                // refresh
+                this.refresh();
+            }
+        }
+    }
+
+    update_row(doc, flash_row) {
+        const to_refresh = [];
+
+        this.data = this.data.map((d, i) => {
+            if (d.name === doc.name) {
+                for (let fieldname in d) {
+                    if (fieldname.includes(':')) {
+                        // child table field
+                        const [cdt, _field] = fieldname.split(':');
+                        const cdt_row = Object.keys(doc)
+                            .filter(key =>
+                                Array.isArray(doc[key])
+                                && doc[key].length
+                                && doc[key][0].doctype === cdt
+                            )
+                            .map(key => doc[key])
+                            .map(a => a[0])
+                            .filter(cdoc => cdoc.name === d[cdt + ':name'])[0];
+                        if (cdt_row) {
+                            d[fieldname] = cdt_row[_field];
+                        }
+                    } else {
+                        d[fieldname] = doc[fieldname];
+                    }
+                }
+                to_refresh.push([d, i]);
+            }
+            return d;
+        });
+
+        // indicate row update
+        const _flash_row = (rowIndex) => {
+            if (!flash_row) return;
+            const $row = this.$result.find(`.dt-row[data-row-index="${rowIndex}"]`);
+            $row.addClass('row-update');
+            setTimeout(() => $row.removeClass('row-update'), 500);
+        };
+
+        to_refresh.forEach(([data, rowIndex]) => {
+            const new_row = this.build_row(data);
+            this.datatable.refreshRow(new_row, rowIndex);
+            _flash_row(rowIndex);
+        });
+    }
+
+    setup_datatable(values) {
+        this.$datatable_wrapper.empty();
+        this.datatable = new DataTable(this.$datatable_wrapper[0], {
+            columns: this.columns,
+            data: this.get_data(values),
+            getEditor: this.get_editing_object.bind(this),
+            checkboxColumn: true,
+            inlineFilters: true,
+            cellHeight: 35,
+            direction: frappe.utils.is_rtl() ? 'rtl' : 'ltr',
+            events: {
+                onRemoveColumn: (column) => {
+                    this.remove_column_from_datatable(column);
+                },
+                onSwitchColumn: (column1, column2) => {
+                    this.switch_column(column1, column2);
+                },
+                onCheckRow: () => {
+                    const checked_items = this.get_checked_items();
+                    this.toggle_actions_menu_button(checked_items.length > 0);
+                }
+            },
+            hooks: {
+                columnTotal: frappe.utils.report_column_total
+            },
+            headerDropdown: [{
+                label: __('Add Column'),
+                action: (datatabe_col) => {
+                    let columns_in_picker = [];
+                    const columns = this.get_columns_for_picker();
+
+                    columns_in_picker = columns[this.doctype]
+                        .filter(df => !this.is_column_added(df))
+                        .map(df => ({
+                            label: __(df.label),
+                            value: df.fieldname
+                        }));
+
+                    delete columns[this.doctype];
+
+                    for (let cdt in columns) {
+                        columns[cdt]
+                            .filter(df => !this.is_column_added(df))
+                            .map(df => ({
+                                label: __(df.label) + ` (${cdt})`,
+                                value: df.fieldname + ',' + cdt
+                            }))
+                            .forEach(df => columns_in_picker.push(df));
+                    }
+
+                    const d = new frappe.ui.Dialog({
+                        title: __('Add Column'),
+                        fields: [
+                            {
+                                label: __('Select Column'),
+                                fieldname: 'column',
+                                fieldtype: 'Autocomplete',
+                                options: columns_in_picker
+                            },
+                            {
+                                label: __('Insert Column Before {0}', [datatabe_col.docfield.label.bold()]),
+                                fieldname: 'insert_before',
+                                fieldtype: 'Check'
+                            }
+                        ],
+                        primary_action: ({ column, insert_before }) => {
+                            if (!columns_in_picker.map(col => col.value).includes(column)) {
+                                frappe.show_alert({ message: __('Invalid column'), indicator: 'orange' });
+                                d.hide();
+                                return;
+                            }
+
+                            let doctype = this.doctype;
+                            if (column.includes(',')) {
+                                [column, doctype] = column.split(',');
+                            }
+
+
+                            let index = datatabe_col.colIndex;
+                            if (insert_before) {
+                                index = index - 1;
+                            }
+
+                            this.add_column_to_datatable(column, doctype, index);
+                            d.hide();
+                        }
+                    });
+
+                    d.show();
+                }
+            }]
+        });
+    }
+
+    toggle_charts() {
+        // add
+        if (!this.chart) {
+            this.setup_charts();
+            return;
+        }
+
+        if (this.$charts_wrapper.hasClass('hidden')) {
+            // reload chart
+            this.$charts_wrapper.removeClass('hidden');
+            this.refresh_charts();
+        } else {
+            // remove chart
+            this.$charts_wrapper.addClass('hidden');
+            this.save_view_user_settings(
+                { chart_args: null });
+            this.chart_args = null;
+        }
+    }
+
+    init_chart() {
+        // show chart if saved via report or user settings
+        if (!this.chart) {
+            if (this.chart_args) {
+                this.build_chart_args(this.chart_args.x_axis,
+                    this.chart_args.y_axes,
+                    this.chart_args.chart_type);
+
+                this.make_chart();
+            }
+        }
+    }
+
+    setup_charts() {
+        // get fields from columns
+        let x_fields = [], y_fields = [];
+        for (let col of this.columns) {
+            // all options in x
+            x_fields.push({
+                label: col.content,
+                fieldname: col.id,
+                value: col.id,
+            });
+
+            // numeric values in y
+            if (col.docfield && frappe.model.numeric_fieldtypes.includes(col.docfield.fieldtype)) {
+                y_fields.push({
+                    label: col.content,
+                    fieldname: col.id,
+                    value: col.id
+                });
+            }
+        }
+
+        const defaults = this.chart_args || {};
+
+        const dialog = new frappe.ui.Dialog({
+            title: __('Configure Chart'),
+            fields: [
+                {
+                    label: __('X Axis Field'),
+                    fieldtype: 'Select',
+                    fieldname: 'x_axis',
+                    options: x_fields,
+                    default: defaults.x_axis
+                },
+                {
+                    label: __('Y Axis Fields'),
+                    fieldtype: 'MultiSelect',
+                    fieldname: 'y_axes',
+                    options: y_fields,
+                    description: __('Showing only Numeric fields from Report'),
+                    default: defaults.y_axes ? defaults.y_axes.join(', ') : null
+                },
+                {
+                    label: __('Chart Type'),
+                    fieldtype: 'Select',
+                    options: ['Bar', 'Line', 'Pie', 'Percentage', 'Donut'],
+                    fieldname: 'chart_type',
+                    default: defaults.chart_type ?
+                        frappe.utils.to_title_case(defaults.chart_type) :
+                        'Bar'
+                }
+            ],
+            primary_action: (data) => {
+                data.y_axes = data.y_axes.split(',').map(d => d.trim()).filter(Boolean);
+
+                this.build_chart_args(data.x_axis, data.y_axes, data.chart_type);
+                this.make_chart();
+                dialog.hide();
+            }
+        });
+
+        dialog.show();
+    }
+
+    build_chart_args(x_axis, y_axes, chart_type) {
+        let datasets = y_axes.map(y_axis => ({
+            name: this.columns_map[y_axis].content,
+            values: this.data.map(d => d[y_axis])
+        }));
+
+        this.chart_args = {
+            chart_type: chart_type.toLowerCase(),
+            x_axis: x_axis,
+            y_axes: y_axes,
+            labels: this.data.map(d => d[x_axis]),
+            datasets: datasets
+        };
+
+        this.save_view_user_settings(
+            { chart_args: this.get_chart_settings() });
+    }
+
+    get_chart_settings() {
+        if (this.chart_args) {
+            return {
+                chart_type: this.chart_args.chart_type,
+                x_axis: this.chart_args.x_axis,
+                y_axes: this.chart_args.y_axes,
+            };
+        }
+    }
+
+    make_chart() {
+        const args = this.chart_args;
+        let data = {
+            labels: args.labels,
+            datasets: args.datasets
+        };
+
+        this.last_chart_type = args.chart_type;
+
+        const get_df = (field) => this.columns_map[field].docfield;
+        const get_doc = (value, field) => this.data.find(d => d[field] === value);
+
+        this.$charts_wrapper.removeClass('hidden');
+
+        this.chart = new frappe.Chart(this.$charts_wrapper.find('.charts-inner-wrapper')[0], {
+            title: __("{0} Chart", [this.doctype]),
+            data: data,
+            type: args.chart_type,
+            truncateLegends: 1,
+            colors: ['#70E078', 'light-blue', 'orange', 'red'],
+            axisOptions: {
+                shortenYAxisNumbers: 1
+            },
+            tooltipOptions: {
+                formatTooltipY: value => frappe.format(value, get_df(this.chart_args.y_axes[0]), { always_show_decimals: true, inline: true }, get_doc(value.doc))
+            }
+        });
+    }
+
+    refresh_charts() {
+        if (!this.chart || !this.chart_args) return;
+        this.$charts_wrapper.removeClass('hidden');
+        const { x_axis, y_axes, chart_type } = this.chart_args;
+        this.build_chart_args(x_axis, y_axes, chart_type);
+        this.chart.update(this.chart_args);
+    }
+
+    get_editing_object(colIndex, rowIndex, value, parent) {
+        const control = this.render_editing_input(colIndex, value, parent);
+        if (!control) return false;
+
+        control.df.change = () => control.set_focus();
+
+        return {
+            initValue: (value) => {
+                return control.set_value(value);
+            },
+            setValue: (value) => {
+                const cell = this.datatable.getCell(colIndex, rowIndex);
+                let fieldname = this.datatable.getColumn(colIndex).docfield.fieldname;
+                let docname = cell.name;
+                let doctype = cell.doctype;
+
+                control.set_value(value);
+                return this.set_control_value(doctype, docname, fieldname, value)
+                    .then((updated_doc) => {
+                        const _data = this.data
+                            .filter(b => b.name === updated_doc.name)
+                            .find(a =>
+                                // child table cell
+                                (doctype != updated_doc.doctype && a[doctype + ":name"] == docname)
+                                || doctype == updated_doc.doctype
+                            );
+
+                        for (let field in _data) {
+                            if (field.includes(':')) {
+                                // child table field
+                                const [cdt, _field] = field.split(':');
+                                const cdt_row = Object.keys(updated_doc)
+                                    .filter(key =>
+                                        Array.isArray(updated_doc[key])
+                                        && updated_doc[key].length
+                                        && updated_doc[key][0].doctype === cdt
+                                    )
+                                    .map(key => updated_doc[key])[0]
+                                    .filter(cdoc => cdoc.name === _data[cdt + ':name'])[0];
+                                if (cdt_row) {
+                                    _data[field] = cdt_row[_field];
+                                }
+                            } else {
+                                _data[field] = updated_doc[field];
+                            }
+                        }
+                    })
+                    .then(() => this.refresh_charts());
+            },
+            getValue: () => {
+                return control.get_value();
+            }
+        };
+    }
+
+    set_control_value(doctype, docname, fieldname, value) {
+        this.last_updated_doc = docname;
+        return new Promise((resolve, reject) => {
+            frappe.db.set_value(doctype, docname, { [fieldname]: value })
+                .then(r => {
+                    if (r.message) {
+                        resolve(r.message);
+                    } else {
+                        reject();
+                    }
+                })
+                .fail(reject);
+        });
+    }
+
+    render_editing_input(colIndex, value, parent) {
+        const col = this.datatable.getColumn(colIndex);
+        let control = null;
+
+        if (col.docfield.fieldtype === 'Text Editor') {
+            const d = new frappe.ui.Dialog({
+                title: __('Edit {0}', [col.docfield.label]),
+                fields: [col.docfield],
+                primary_action: () => {
+                    this.datatable.cellmanager.submitEditing();
+                    this.datatable.cellmanager.deactivateEditing();
+                    d.hide();
+                }
+            });
+            d.show();
+            control = d.fields_dict[col.docfield.fieldname];
+        } else {
+            // make control
+            control = frappe.ui.form.make_control({
+                df: col.docfield,
+                parent: parent,
+                render_input: true
+            });
+            control.set_value(value);
+            control.toggle_label(false);
+            control.toggle_description(false);
+        }
+
+        return control;
+    }
+
+    is_editable(df, data) {
+        if (df
+            && frappe.model.can_write(this.doctype)
+            // not a submitted doc or field is allowed to edit after submit
+            && (data.docstatus !== 1 || df.allow_on_submit)
+            // not a cancelled doc
+            && data.docstatus !== 2
+            && !df.read_only
+            && !df.hidden
+            // not a standard field i.e., owner, modified_by, etc.
+            && !frappe.model.std_fields_list.includes(df.fieldname))
+            return true;
+        return false;
+    }
+
+    get_data(values) {
+        return this.build_rows(values);
+    }
+
+    set_fields() {
+        // default fields
+        ['name', 'docstatus'].map((f) => this._add_field(f));
+
+        if (this.report_name && this.report_doc.json.fields) {
+            let fields = this.report_doc.json.fields.slice();
+            fields.forEach(f => this._add_field(f[0], f[1]));
+            return;
+        } else if (this.view_user_settings.fields) {
+            // get from user_settings
+            let fields = this.view_user_settings.fields;
+            fields.forEach(f => this._add_field(f[0], f[1]));
+            return;
+        }
+
+        this.set_default_fields();
+    }
+
+    set_default_fields() {
+        // get fields from meta
+        this.fields = this.fields || [];
+        const add_field = f => this._add_field(f);
+
+        // default fields
+        [
+            this.meta.title_field,
+            this.meta.image_field
+        ].map(add_field);
+
+        // fields in_list_view or in_standard_filter
+        const fields = this.meta.fields.filter(df => {
+            return (df.in_list_view || df.in_standard_filter)
+                && frappe.perm.has_perm(this.doctype, df.permlevel, 'read')
+                && frappe.model.is_value_type(df.fieldtype)
+                && !df.report_hide;
+        });
+
+        fields.map(add_field);
+
+        // currency fields
+        fields.filter(
+            df => df.fieldtype === 'Currency' && df.options
+        ).map(df => {
+            if (df.options.includes(':')) {
+                add_field(df.options.split(':')[1]);
+            } else {
+                add_field(df.options);
+            }
+        });
+
+        // fields in listview_settings
+        (this.settings.add_fields || []).map(add_field);
+    }
+
+    build_fields() {
+        super.build_fields();
+    }
+
+    reorder_fields() {
+        // generate table fields in the required format ["name", "DocType"]
+        // these are fields in the column before adding new fields
+        let table_fields = this.columns.map(df => [df.field, df.docfield.parent]);
+
+        // filter fields that are already in table
+        // iterate over table_fields to preserve the existing order of fields
+        // The filter will ensure the unchecked fields are removed
+        let fields_already_in_table = table_fields.filter(df => {
+            return this.fields.find((field) => {
+                return df[0] == field[0] && df[1] == field[1]
+            })
+        })
+
+        // find new fields that didn't already exists
+        // This will be appended to the end of the table
+        let fields_to_add = this.fields.filter(df => {
+            return !table_fields.find((field) => {
+                return df[0] == field[0] && df[1] == field[1];
+            });
+        });
+
+        // rebuild fields
+        this.fields = [...fields_already_in_table, ...fields_to_add];
+    }
+
+    get_fields() {
+        let fields = this.fields.map(f => {
+            let column_name = frappe.model.get_full_column_name(f[0], f[1]);
+            if (f[1] !== this.doctype) {
+                // child table field
+                column_name = column_name + ' as ' + `'${f[1]}:${f[0]}'`;
+            }
+            return column_name;
+        });
+        const cdt_name_fields =
+            this.get_unique_cdt_in_view()
+                .map(cdt => frappe.model.get_full_column_name('name', cdt) + ' as ' + `'${cdt}:name'`);
+        fields = fields.concat(cdt_name_fields);
+
+        return fields;
+    }
+
+    get_unique_cdt_in_view() {
+        return this.fields
+            .filter(f => f[1] !== this.doctype)
+            .map(f => f[1])
+            .uniqBy(d => d);
+    }
+
+    add_column_to_datatable(fieldname, doctype, col_index) {
+        const field = [fieldname, doctype];
+        this.fields.splice(col_index, 0, field);
+
+        this.add_currency_column(fieldname, doctype, col_index);
+
+        this.build_fields();
+        this.setup_columns();
+
+        if (this.datatable) this.datatable.destroy();
+        this.datatable = null;
+        this.refresh();
+    }
+
+    add_currency_column(fieldname, doctype, col_index) {
+        // Adds dependent currency field if required
+        const df = frappe.meta.get_docfield(doctype, fieldname);
+        if (df && df.fieldtype === 'Currency' && df.options &&
+            !df.options.includes(':') && frappe.meta.has_field(doctype, df.options)
+        ) {
+            const field = [df.options, doctype];
+            if (col_index === undefined) {
+                this.fields.push(field);
+            } else {
+                this.fields.splice(col_index, 0, field);
+            }
+            frappe.show_alert(__('Also adding the dependent currency field {0}', [field[0].bold()]));
+        }
+    }
+
+    add_status_dependency_column(col, doctype) {
+        // Adds dependent column from which status is derived if required
+        if (!this.fields.find(f => f[0] === col)) {
+            const field = [col, doctype];
+            this.fields.push(field);
+            this.refresh();
+            frappe.show_alert(__('Also adding the status dependency field {0}', [field[0].bold()]));
+        }
+    }
+
+    remove_column_from_datatable(column) {
+        const index = this.fields.findIndex(f => column.field === f[0]);
+        if (index === -1) return;
+        const field = this.fields[index];
+
+        if (field[0] === 'name') {
+            this.refresh();
+            frappe.throw(__('Cannot remove ID field'));
+        }
+
+        this.fields.splice(index, 1);
+        this.build_fields();
+        this.setup_columns();
+        this.refresh();
+    }
+
+    switch_column(col1, col2) {
+        const index1 = this.fields.findIndex(f => col1.field === f[0]);
+        const index2 = this.fields.findIndex(f => col2.field === f[0]);
+        const _fields = this.fields.slice();
+
+        let temp = _fields[index1];
+        _fields[index1] = _fields[index2];
+        _fields[index2] = temp;
+
+        this.fields = _fields;
+        this.build_fields();
+        this.setup_columns();
+        this.refresh();
+    }
+
+    get_columns_for_picker() {
+        let out = {};
+
+        const standard_fields_filter = df => !in_list(frappe.model.no_value_type, df.fieldtype);
+
+        let doctype_fields = frappe.meta.get_docfields(this.doctype).filter(standard_fields_filter);
+
+        // filter out docstatus field from picker
+        let std_fields = frappe.model.std_fields.filter(df => df.fieldname !== 'docstatus');
+
+        // add status field derived from docstatus, if status is not a standard field
+        let has_status_values = false;
+
+        if (this.data) {
+            has_status_values = frappe.get_indicator(this.data[0], this.doctype);
+        }
+
+        if (!frappe.meta.has_field(this.doctype, 'status') && has_status_values) {
+            doctype_fields = [{
+                label: __('Status'),
+                fieldname: 'docstatus',
+                fieldtype: 'Data'
+            }].concat(doctype_fields);
+        }
+
+        doctype_fields = [{
+            label: __('ID'),
+            fieldname: 'name',
+            fieldtype: 'Data',
+            reqd: 1
+        }].concat(doctype_fields, std_fields);
+
+        out[this.doctype] = doctype_fields;
+
+        const table_fields = frappe.meta.get_table_fields(this.doctype);
+
+        table_fields.forEach(df => {
+            const cdt = df.options;
+            const child_table_fields = frappe.meta.get_docfields(cdt).filter(standard_fields_filter);
+
+            out[cdt] = child_table_fields;
+
+            // add index column for child tables
+            out[cdt].push({
+                label: __('Index'),
+                fieldname: 'idx',
+                fieldtype: 'Int',
+                parent: cdt
+            });
+        });
+        return out;
+    }
+
+    get_dialog_fields() {
+        const dialog_fields = [];
+        const columns = this.get_columns_for_picker();
+
+        dialog_fields.push({
+            label: __(this.doctype),
+            fieldname: this.doctype,
+            fieldtype: 'MultiCheck',
+            columns: 2,
+            options: columns[this.doctype]
+                .filter(df => {
+                    return !df.hidden && df.fieldname !== 'name';
+                })
+                .map(df => ({
+                    label: __(df.label),
+                    value: df.fieldname,
+                    checked: this.fields.find(f => f[0] === df.fieldname && f[1] === this.doctype)
+                }))
+        });
+
+        delete columns[this.doctype];
+
+        const table_fields = frappe.meta.get_table_fields(this.doctype)
+            .filter(df => !df.hidden);
+
+        table_fields.forEach(df => {
+            const cdt = df.options;
+
+            dialog_fields.push({
+                label: __(df.label) + ` (${__(cdt)})`,
+                fieldname: df.options,
+                fieldtype: 'MultiCheck',
+                columns: 2,
+                options: columns[cdt]
+                    .filter(df => {
+                        return !df.hidden;
+                    })
+                    .map(df => ({
+                        label: __(df.label),
+                        value: df.fieldname,
+                        checked: this.fields.find(f => f[0] === df.fieldname && f[1] === cdt)
+                    }))
+            });
+        });
+
+        return dialog_fields;
+    }
+
+    is_column_added(df) {
+        return Boolean(
+            this.fields.find(f => f[0] === df.fieldname && df.parent === f[1])
+        );
+    }
+
+    setup_columns() {
+        // apply previous column width
+        let column_widths = null;
+        if (this.columns) {
+            column_widths = this.get_column_widths();
+        }
+
+        this.columns = [];
+        this.columns_map = {};
+
+        for (let f of this.fields) {
+            let column;
+            if (f[0] !== 'docstatus') {
+                column = this.build_column(f);
+            } else {
+                // if status is not in fields append status column derived from docstatus
+                if (!this.fields.includes(['status', this.doctype]) && !frappe.meta.has_field(this.doctype, 'status')) {
+                    column = this.build_column(['docstatus', this.doctype]);
+                }
+            }
+
+            if (column) {
+                if (column_widths) {
+                    column.width = column_widths[column.id] || column.width || 120;
+                }
+                this.columns.push(column);
+                this.columns_map[column.id] = column;
+            }
+        }
+    }
+
+    build_column(c) {
+
+        let [fieldname, doctype] = c;
+        let docfield = frappe.meta.docfield_map[doctype || this.doctype][fieldname];
+
+        // group by column
+        if (fieldname === '_aggregate_column') {
+            docfield = this.group_by_control.get_group_by_docfield();
+        }
+
+        // child table index column
+        if (fieldname === 'idx' && doctype !== this.doctype) {
+            docfield = {
+                label: "Index",
+                fieldtype: "Int",
+                parent: doctype,
+            };
+        }
+
+        if (!docfield) {
+            docfield = frappe.model.get_std_field(fieldname, true);
+
+            if (docfield) {
+                if (!docfield.label) {
+                    docfield.label = toTitle(fieldname);
+                    if (docfield.label.includes('_')) {
+                        docfield.label = docfield.label.replace('_', ' ');
+                    }
+                }
+                docfield.parent = this.doctype;
+                if (fieldname == 'name') {
+                    docfield.options = this.doctype;
+                }
+                if (fieldname == 'docstatus' && !frappe.meta.has_field(this.doctype, 'status')) {
+                    docfield.label = 'Status';
+                    docfield.fieldtype = 'Data';
+                    docfield.name = 'status';
+                }
+            }
+        }
+        if (!docfield || docfield.report_hide) return;
+
+        let title = __(docfield ? docfield.label : toTitle(fieldname));
+        if (doctype !== this.doctype) {
+            title += ` (${__(doctype)})`;
+        }
+
+        const editable = frappe.model.is_non_std_field(fieldname) && !docfield.read_only;
+
+        const align = (() => {
+            const is_numeric = frappe.model.is_numeric_field(docfield);
+            if (is_numeric) {
+                return 'right';
+            }
+            return docfield.fieldtype === 'Date' ? 'right' : 'left';
+        })();
+
+        let id = fieldname;
+
+        // child table column
+        if (doctype !== this.doctype && fieldname !== '_aggregate_column') {
+            id = `${doctype}:${fieldname}`;
+        }
+
+        let width = (docfield ? cint(docfield.width) : null) || null;
+        if (this.report_doc) {
+            // load the user saved column width
+            let saved_column_widths = this.report_doc.json.column_widths || {};
+            width = saved_column_widths[id] || width;
+        }
+
+        let compareFn = null;
+        if (docfield.fieldtype === 'Date') {
+            compareFn = (cell, keyword) => {
+                if (!cell.content) return null;
+                if (keyword.length !== 'YYYY-MM-DD'.length) return null;
+
+                const keywordValue = frappe.datetime.user_to_obj(keyword);
+                const cellValue = frappe.datetime.str_to_obj(cell.content);
+                return [+cellValue, +keywordValue];
+            }
+        }
+
+
+        return {
+            id: id,
+            field: fieldname,
+            name: title,
+            content: title,
+            docfield,
+            width,
+            editable,
+            align,
+            compareValue: compareFn,
+            format: (value, row, column, data) => {
+                let doc = null;
+                if (Array.isArray(row)) {
+                    doc = row.reduce((acc, curr) => {
+                        if (!curr.column.docfield) return acc;
+                        acc[curr.column.docfield.fieldname] = curr.content;
+                        return acc;
+                    }, {});
+                } else {
+                    doc = row;
+                }
+
+                return frappe.format(value, column.docfield, { always_show_decimals: true }, doc);
+            }
+        };
+    }
+
+    build_rows(data) {
+        const out = data.map(d => this.build_row(d));
+
+        if (this.add_totals_row) {
+            const totals = this.get_columns_totals(data);
+            const totals_row = this.columns.map((col, i) => {
+                return {
+                    name: __('Totals Row'),
+                    content: totals[col.id],
+                    format: value => {
+                        let formatted_value = frappe.format(value, col.docfield, {
+                            always_show_decimals: true
+                        }, data[0]);
+                        if (i === 0) {
+                            return this.format_total_cell(formatted_value, col);
+                        }
+                        return formatted_value;
+                    }
+                };
+            });
+
+            out.push(totals_row);
+        }
+        return out;
+    }
+
+    format_total_cell(formatted_value, df) {
+        let cell_value = __('Totals').bold();
+        if (frappe.model.is_numeric_field(df.docfield)) {
+            cell_value = `<span class="flex justify-between">
 				${cell_value} ${$(formatted_value).text()}
 			</span>`;
-		}
-		return cell_value;
-	}
+        }
+        return cell_value;
+    }
 
-	build_row(d) {
-		return this.columns.map(col => {
-			if (col.docfield.parent !== this.doctype) {
-				// child table field
-				const cdt_field = f => `${col.docfield.parent}:${f}`;
-				const name = d[cdt_field('name')];
+    build_row(d) {
+        return this.columns.map(col => {
+            if (col.docfield.parent !== this.doctype) {
+                // child table field
+                const cdt_field = f => `${col.docfield.parent}:${f}`;
+                const name = d[cdt_field('name')];
 
-				return {
-					name: name,
-					doctype: col.docfield.parent,
-					content: d[cdt_field(col.field)] || d[col.field],
-					editable: Boolean(name && this.is_editable(col.docfield, d)),
-					format: value => {
-						return frappe.format(value, col.docfield, { always_show_decimals: true }, d);
-					}
-				};
-			}
-			if (col.field === 'docstatus' && !frappe.meta.has_field(this.doctype, 'status')) {
-				// get status from docstatus
-				let status = frappe.get_indicator(d, this.doctype);
-				if (status) {
-					if (!status[0]) {
-						// get_indicator returns the dependent field's condition as the 3rd parameter
-						let dependent_col = status[2].split(',')[0];
-						// add status dependency column
-						this.add_status_dependency_column(dependent_col, this.doctype);
-					}
-					return {
-						name: d.name,
-						doctype: col.docfield.parent,
-						content: status[0],
-						editable: false
-					};
-				} else {
-					// no status values found
-					this.remove_column_from_datatable(col);
-				}
-			} else if (col.field in d) {
-				const value = d[col.field];
-				return {
-					name: d.name,
-					doctype: col.docfield.parent,
-					content: value,
-					editable: this.is_editable(col.docfield, d)
-				};
-			}
-			return {
-				content: ''
-			};
-		});
-	}
+                return {
+                    name: name,
+                    doctype: col.docfield.parent,
+                    content: d[cdt_field(col.field)] || d[col.field],
+                    editable: Boolean(name && this.is_editable(col.docfield, d)),
+                    format: value => {
+                        return frappe.format(value, col.docfield, { always_show_decimals: true }, d);
+                    }
+                };
+            }
+            if (col.field === 'docstatus' && !frappe.meta.has_field(this.doctype, 'status')) {
+                // get status from docstatus
+                let status = frappe.get_indicator(d, this.doctype);
+                if (status) {
+                    if (!status[0]) {
+                        // get_indicator returns the dependent field's condition as the 3rd parameter
+                        let dependent_col = status[2].split(',')[0];
+                        // add status dependency column
+                        this.add_status_dependency_column(dependent_col, this.doctype);
+                    }
+                    return {
+                        name: d.name,
+                        doctype: col.docfield.parent,
+                        content: status[0],
+                        editable: false
+                    };
+                } else {
+                    // no status values found
+                    this.remove_column_from_datatable(col);
+                }
+            } else if (col.field in d) {
+                const value = d[col.field];
+                return {
+                    name: d.name,
+                    doctype: col.docfield.parent,
+                    content: value,
+                    editable: this.is_editable(col.docfield, d)
+                };
+            }
+            return {
+                content: ''
+            };
+        });
+    }
 
-	get_checked_items(only_docnames) {
-		const indexes = this.datatable.rowmanager.getCheckedRows();
-		const items = indexes.map(i => this.data[i]).filter(i => i != undefined);
+    get_checked_items(only_docnames) {
+        const indexes = this.datatable.rowmanager.getCheckedRows();
+        const items = indexes.map(i => this.data[i]).filter(i => i != undefined);
 
-		if (only_docnames) {
-			return items.map(d => d.name);
-		}
+        if (only_docnames) {
+            return items.map(d => d.name);
+        }
 
-		return items;
-	}
+        return items;
+    }
 
-	save_report(save_type) {
-		const _save_report = (name) => {
-			// callback
-			const report_settings = {
-				filters: this.filter_area.get(),
-				fields: this.fields,
-				order_by: this.sort_selector.get_sql_string(),
-				add_totals_row: this.add_totals_row,
-				page_length: this.page_length,
-				column_widths: this.get_column_widths(),
-				group_by: this.group_by_control.get_settings(),
-				chart_args: this.get_chart_settings()
-			};
+    save_report(save_type) {
+        const _save_report = (name) => {
+            // callback
+            const report_settings = {
+                filters: this.filter_area.get(),
+                fields: this.fields,
+                order_by: this.sort_selector.get_sql_string(),
+                add_totals_row: this.add_totals_row,
+                page_length: this.page_length,
+                column_widths: this.get_column_widths(),
+                group_by: this.group_by_control.get_settings(),
+                chart_args: this.get_chart_settings()
+            };
 
-			return frappe.call({
-				method: 'frappe.desk.reportview.save_report',
-				args: {
-					name: name,
-					doctype: this.doctype,
-					json: JSON.stringify(report_settings)
-				},
-				callback:(r) => {
-					if(r.exc) {
-						frappe.msgprint(__("Report was not saved (there were errors)"));
-						return;
-					}
-					if(r.message != this.report_name) {
-						// Rerender the reports dropdown,
-						// so that this report is included in the dropdown as well.
-						frappe.boot.user.all_reports[r.message] = {
-							ref_doctype: this.doctype,
-							report_type: "Report Builder",
-							title: r.message,
-						};
+            return frappe.call({
+                method: 'frappe.desk.reportview.save_report',
+                args: {
+                    name: name,
+                    doctype: this.doctype,
+                    json: JSON.stringify(report_settings)
+                },
+                callback: (r) => {
+                    if (r.exc) {
+                        frappe.msgprint(__("Report was not saved (there were errors)"));
+                        return;
+                    }
+                    if (r.message != this.report_name) {
+                        // Rerender the reports dropdown,
+                        // so that this report is included in the dropdown as well.
+                        frappe.boot.user.all_reports[r.message] = {
+                            ref_doctype: this.doctype,
+                            report_type: "Report Builder",
+                            title: r.message,
+                        };
 
-						frappe.set_route('List', this.doctype, 'Report', r.message);
-						return;
-					}
+                        frappe.set_route('List', this.doctype, 'Report', r.message);
+                        return;
+                    }
 
-					// update state
-					this.report_doc.json = report_settings;
-					this.set_dirty_state_for_custom_report();
-				}
-			});
+                    // update state
+                    this.report_doc.json = report_settings;
+                    this.set_dirty_state_for_custom_report();
+                }
+            });
 
-		};
+        };
 
-		if(this.report_name && save_type == "save") {
-			_save_report(this.report_name);
-		} else {
-			frappe.prompt({fieldname: 'name', label: __('New Report name'), reqd: 1, fieldtype: 'Data'}, (data) => {
-				_save_report(data.name);
-			}, __('Save As'));
-		}
-	}
+        if (this.report_name && save_type == "save") {
+            _save_report(this.report_name);
+        } else {
+            frappe.prompt({ fieldname: 'name', label: __('New Report name'), reqd: 1, fieldtype: 'Data' }, (data) => {
+                _save_report(data.name);
+            }, __('Save As'));
+        }
+    }
 
-	get_column_widths() {
-		if (this.datatable) {
-			return this.datatable
-				.datamanager
-				.getColumns(true)
-				.reduce((acc, curr) => {
-					acc[curr.id] = parseInt(curr.width);
-					return acc;
-				}, {});
-		}
+    get_column_widths() {
+        if (this.datatable) {
+            return this.datatable
+                .datamanager
+                .getColumns(true)
+                .reduce((acc, curr) => {
+                    acc[curr.id] = parseInt(curr.width);
+                    return acc;
+                }, {});
+        }
 
-		return {};
-	}
+        return {};
+    }
 
-	get_report_doc() {
-		return new Promise(resolve => {
-			frappe.model.with_doc('Report', this.report_name, () => {
-				resolve(frappe.get_doc('Report', this.report_name));
-			});
-		});
-	}
+    get_report_doc() {
+        return new Promise(resolve => {
+            frappe.model.with_doc('Report', this.report_name, () => {
+                resolve(frappe.get_doc('Report', this.report_name));
+            });
+        });
+    }
 
-	get_filters_html_for_print() {
-		const filters = this.filter_area.get();
+    get_filters_html_for_print() {
+        const filters = this.filter_area.get();
 
-		return filters.map(f => {
-			const [doctype, fieldname, condition, value] = f;
-			if (condition !== '=') return '';
+        return filters.map(f => {
+            const [doctype, fieldname, condition, value] = f;
+            if (condition !== '=') return '';
 
-			const label = frappe.meta.get_label(doctype, fieldname);
-			return `<h6>${__(label)}: ${value}</h6>`;
-		}).join('');
-	}
+            const label = frappe.meta.get_label(doctype, fieldname);
+            return `<h6>${__(label)}: ${value}</h6>`;
+        }).join('');
+    }
 
-	get_columns_totals(data) {
-		if (!this.add_totals_row) {
-			return [];
-		}
+    get_columns_totals(data) {
+        if (!this.add_totals_row) {
+            return [];
+        }
 
-		const row_totals = {};
+        const row_totals = {};
 
-		this.columns.forEach((col, i) => {
-			const totals = data.reduce((totals, d) => {
-				if (col.id in d && frappe.model.is_numeric_field(col.docfield)) {
-					totals += flt(d[col.id]);
-					return totals;
-				}
-			}, 0);
+        this.columns.forEach((col, i) => {
+            const totals = data.reduce((totals, d) => {
+                if (col.id in d && frappe.model.is_numeric_field(col.docfield)) {
+                    totals += flt(d[col.id]);
+                    return totals;
+                }
+            }, 0);
 
-			row_totals[col.id] = totals;
-		});
+            row_totals[col.id] = totals;
+        });
 
-		return row_totals;
-	}
+        return row_totals;
+    }
 
-	report_menu_items() {
-		let items = [
-			{
-				label: __('Show Totals'),
-				action: () => {
-					this.add_totals_row = !this.add_totals_row;
-					this.save_view_user_settings({
-						add_totals_row: this.add_totals_row
-					});
-					this.datatable.refresh(this.get_data(this.data));
-				}
-			},
-			{
-				label: __('Print'),
-				action: () => {
-					// prepare rows in their current state, sorted and filtered
-					const rows_in_order = this.datatable.datamanager.rowViewOrder.map(index => {
-						if (this.datatable.bodyRenderer.visibleRowIndices.includes(index)) {
-							return this.data[index];
-						}
-					}).filter(Boolean);
+    report_menu_items() {
+        let items = [
+            {
+                label: __('Show Totals'),
+                action: () => {
+                    this.add_totals_row = !this.add_totals_row;
+                    this.save_view_user_settings({
+                        add_totals_row: this.add_totals_row
+                    });
+                    this.datatable.refresh(this.get_data(this.data));
+                }
+            },
+            {
+                label: __('Print'),
+                action: () => {
+                    // prepare rows in their current state, sorted and filtered
+                    const rows_in_order = this.datatable.datamanager.rowViewOrder.map(index => {
+                        if (this.datatable.bodyRenderer.visibleRowIndices.includes(index)) {
+                            return this.data[index];
+                        }
+                    }).filter(Boolean);
 
-					if (this.add_totals_row) {
-						const total_data = this.get_columns_totals(this.data);
+                    if (this.add_totals_row) {
+                        const total_data = this.get_columns_totals(this.data);
 
-						total_data['name'] = __('Totals').bold();
-						rows_in_order.push(total_data);
-					}
+                        total_data['name'] = __('Totals').bold();
+                        rows_in_order.push(total_data);
+                    }
 
-					frappe.ui.get_print_settings(false, (print_settings) => {
-						var title =  this.report_name || __(this.doctype);
-						frappe.render_grid({
-							title: title,
-							subtitle: this.get_filters_html_for_print(),
-							print_settings: print_settings,
-							columns: this.columns,
-							data: rows_in_order
-						});
-					});
-				}
-			},
-			{
-				label: __('Toggle Chart'),
-				action: () => this.toggle_charts()
-			},
-			{
-				label: __('Toggle Sidebar'),
-				action: () => this.toggle_side_bar(),
-				shortcut: 'Ctrl+K',
-			},
-			{
-				label: __('Pick Columns'),
-				action: () => {
-					const d = new frappe.ui.Dialog({
-						title: __('Pick Columns'),
-						fields: this.get_dialog_fields(),
-						primary_action: (values) => {
-							// doctype fields
-							let fields = values[this.doctype].map(f => [f, this.doctype]);
-							delete values[this.doctype];
+                    frappe.ui.get_print_settings(false, (print_settings) => {
+                        var title = this.report_name || __(this.doctype);
+                        frappe.render_grid({
+                            title: title,
+                            subtitle: this.get_filters_html_for_print(),
+                            print_settings: print_settings,
+                            columns: this.columns,
+                            data: rows_in_order
+                        });
+                    });
+                }
+            },
+            {
+                label: __('Toggle Chart'),
+                action: () => this.toggle_charts()
+            },
+            {
+                label: __('Toggle Sidebar'),
+                action: () => this.toggle_side_bar(),
+                shortcut: 'Ctrl+K',
+            },
+            {
+                label: __('Pick Columns'),
+                action: () => {
+                    const d = new frappe.ui.Dialog({
+                        title: __('Pick Columns'),
+                        fields: this.get_dialog_fields(),
+                        primary_action: (values) => {
+                            // doctype fields
+                            let fields = values[this.doctype].map(f => [f, this.doctype]);
+                            delete values[this.doctype];
 
-							// child table fields
-							for (let cdt in values) {
-								fields = fields.concat(values[cdt].map(f => [f, cdt]));
-							}
+                            // child table fields
+                            for (let cdt in values) {
+                                fields = fields.concat(values[cdt].map(f => [f, cdt]));
+                            }
 
-							// always keep name (ID) column
-							this.fields = [["name", this.doctype], ...fields];
+                            // always keep name (ID) column
+                            this.fields = [["name", this.doctype], ...fields];
 
-							this.fields.map(f => this.add_currency_column(f[0], f[1]));
+                            this.fields.map(f => this.add_currency_column(f[0], f[1]));
 
-							this.reorder_fields();
-							this.build_fields();
-							this.setup_columns();
+                            this.reorder_fields();
+                            this.build_fields();
+                            this.setup_columns();
 
-							this.datatable.destroy();
-							this.datatable = null;
-							this.refresh();
+                            this.datatable.destroy();
+                            this.datatable = null;
+                            this.refresh();
 
-							d.hide();
-						}
-					});
+                            d.hide();
+                        }
+                    });
 
-					d.$body.prepend(`
+                    d.$body.prepend(`
 						<div class="columns-search">
 							<input type="text" placeholder="${__('Search')}" data-element="search" class="form-control input-xs">
 						</div>
 					`);
 
-					frappe.utils.setup_search(d.$body, '.unit-checkbox', '.label-area');
-					d.show();
-				}
-			}
-		];
+                    frappe.utils.setup_search(d.$body, '.unit-checkbox', '.label-area');
+                    d.show();
+                }
+            }
+        ];
 
-		if (frappe.model.can_export(this.doctype)) {
-			items.push({
-				label: __('Export'),
-				action: () => {
-					const args = this.get_args();
-					const selected_items = this.get_checked_items(true);
-					let fields = [
-						{
-							fieldtype: 'Select',
-							label: __('Select File Type'),
-							fieldname:'file_format_type',
-							options: ['Excel', 'CSV'],
-							default: 'Excel'
-						}
-					];
+        if (frappe.model.can_export(this.doctype)) {
+            items.push({
+                label: __('Export'),
+                action: () => {
+                    const args = this.get_args();
+                    const selected_items = this.get_checked_items(true);
+                    let fields = [
+                        {
+                            fieldtype: 'Select',
+                            label: __('Select File Type'),
+                            fieldname: 'file_format_type',
+                            options: ['Excel', 'CSV'],
+                            default: 'Excel'
+                        }
+                    ];
 
-					if (this.total_count > this.count_without_children || args.page_length) {
-						fields.push({
-							fieldtype: 'Check',
-							fieldname: 'export_all_rows',
-							label: __('Export All {0} rows?', [(this.total_count + "").bold()])
-						});
-					}
+                    if (this.total_count > this.count_without_children || args.page_length) {
+                        fields.push({
+                            fieldtype: 'Check',
+                            fieldname: 'export_all_rows',
+                            label: __('Export All {0} rows?', [(this.total_count + "").bold()])
+                        });
+                    }
 
-					const d = new frappe.ui.Dialog({
-						title: __("Export Report: {0}",[__(this.doctype)]),
-						fields: fields,
-						primary_action_label: __('Download'),
-						primary_action: (data) => {
-							args.cmd = 'frappe.desk.reportview.export_query';
-							args.file_format_type = data.file_format_type;
-							args.title = this.report_name || this.doctype;
+                    const d = new frappe.ui.Dialog({
+                        title: __("Export Report: {0}", [__(this.doctype)]),
+                        fields: fields,
+                        primary_action_label: __('Download'),
+                        primary_action: (data) => {
+                            args.cmd = 'frappe.desk.reportview.export_query';
+                            args.file_format_type = data.file_format_type;
+                            args.title = this.report_name || this.doctype;
 
-							if(this.add_totals_row) {
-								args.add_totals_row = 1;
-							}
+                            if (this.add_totals_row) {
+                                args.add_totals_row = 1;
+                            }
 
-							if(selected_items.length > 0) {
-								args.selected_items = selected_items;
-							}
+                            if (selected_items.length > 0) {
+                                args.selected_items = selected_items;
+                            }
 
-							if (!data.export_all_rows) {
-								args.start = 0;
-								args.page_length = this.data.length;
-							} else {
-								delete args.start;
-								delete args.page_length;
-							}
+                            if (!data.export_all_rows) {
+                                args.start = 0;
+                                args.page_length = this.data.length;
+                            } else {
+                                delete args.start;
+                                delete args.page_length;
+                            }
 
-							open_url_post(frappe.request.url, args);
+                            open_url_post(frappe.request.url, args);
 
-							d.hide();
-						},
-					});
+                            d.hide();
+                        },
+                    });
 
-					d.show();
-				}
-			});
-		}
+                    d.show();
+                }
+            });
+        }
 
-		items.push({
-			label: __("Setup Auto Email"),
-			action: () => {
-				if(this.report_name) {
-					frappe.set_route('List', 'Auto Email Report', {'report' : this.report_name});
-				} else {
-					frappe.msgprint(__('Please save the report first'));
-				}
-			}
-		});
+        items.push({
+            label: __("Setup Auto Email"),
+            action: () => {
+                if (this.report_name) {
+                    frappe.set_route('List', 'Auto Email Report', { 'report': this.report_name });
+                } else {
+                    frappe.msgprint(__('Please save the report first'));
+                }
+            }
+        });
 
-		// save buttons
-		if(frappe.user.is_report_manager()) {
-			items = items.concat([
-				{ label: __('Save'), action: () => this.save_report('save') },
-				{ label: __('Save As'), action: () => this.save_report('save_as') }
-			]);
-		}
+        // save buttons
+        items = items.concat([
+            { label: __('Save'), action: () => this.save_report('save') },
+            { label: __('Save As'), action: () => this.save_report('save_as') }
+        ]);
 
-		// user permissions
-		if(this.report_name && frappe.model.can_set_user_permissions("Report")) {
-			items.push({
-				label: __("User Permissions"),
-				action: () => {
-					const args = {
-						doctype: "Report",
-						name: this.report_name
-					};
-					frappe.set_route('List', 'User Permission', args);
-				}
-			});
-		}
+        // user permissions
+        if (this.report_name && frappe.model.can_set_user_permissions("Report")) {
+            items.push({
+                label: __("User Permissions"),
+                action: () => {
+                    const args = {
+                        doctype: "Report",
+                        name: this.report_name
+                    };
+                    frappe.set_route('List', 'User Permission', args);
+                }
+            });
+        }
 
-		return items.map(i => Object.assign(i, { standard: true }));
-	}
+        return items.map(i => Object.assign(i, { standard: true }));
+    }
 
 };


### PR DESCRIPTION
Fixed Permissions for all users to save and create their own customized reports using report builder. 

**Before:**
![no_perm_save_customize_report](https://user-images.githubusercontent.com/54097382/147871662-1c629e80-6efd-477b-a2b2-1458b84e897d.jpg)

![report_without_save](https://user-images.githubusercontent.com/54097382/147871435-2420479a-b21c-4091-9dbb-5ca32e6cec82.png)

**After**

![saved](https://user-images.githubusercontent.com/54097382/147871449-10f02a52-42bf-4898-8730-1b68d733b3c8.png)
![save_perm_report](https://user-images.githubusercontent.com/54097382/147871451-c2ea5f28-f53e-4ed2-8fc6-94edef7f8211.png)

**Details**
Before, Only users with Role Report Manager can create or customize and save the reports. This pull request let allow all users to customize their own reports and can save reports using report builder.

closes #15074
