### PR TITLE
fix(postgres)!: transactions implementation for PostgreSQL

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1283,7 +1283,7 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 		roles = [p.role for p in doc.get("permissions") or []] + default_roles
 
 		for role in list(set(roles)):
-			if not frappe.db.exists("Role", role):
+			if frappe.db.table_exists("Role") and not frappe.db.exists("Role", role):
 				r = frappe.get_doc(dict(doctype= "Role", role_name=role, desk_access=1))
 				r.flags.ignore_mandatory = r.flags.ignore_permissions = True
 				r.insert()

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -15,6 +15,10 @@ from frappe.core.doctype.doctype.doctype import (UniqueFieldnameError,
 # test_records = frappe.get_test_records('DocType')
 
 class TestDocType(unittest.TestCase):
+
+	def tearDown(self):
+		frappe.db.rollback()
+
 	def test_validate_name(self):
 		self.assertRaises(frappe.NameError, new_doctype("_Some DocType").insert)
 		self.assertRaises(frappe.NameError, new_doctype("8Some DocType").insert)
@@ -42,6 +46,7 @@ class TestDocType(unittest.TestCase):
 
 		doc1.insert()
 		self.assertRaises(frappe.UniqueValidationError, doc2.insert)
+		frappe.db.rollback()
 
 		dt.fields[0].unique = 0
 		dt.save()

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -267,9 +267,7 @@ class Database(object):
 		"""Raises exception if more than 20,000 `INSERT`, `UPDATE` queries are
 		executed in one transaction. This is to ensure that writes are always flushed otherwise this
 		could cause the system to hang."""
-		if self.transaction_writes and \
-			query and query.strip().split()[0].lower() in ['start', 'alter', 'drop', 'create', "begin", "truncate"]:
-			raise Exception('This statement can cause implicit commit')
+		self.check_implicit_commit(query)
 
 		if query and query.strip().lower() in ('commit', 'rollback'):
 			self.transaction_writes = 0
@@ -281,6 +279,11 @@ class Database(object):
 					self.commit()
 				else:
 					frappe.throw(_("Too many writes in one request. Please send smaller requests"), frappe.ValidationError)
+
+	def check_implicit_commit(self, query):
+		if self.transaction_writes and \
+			query and query.strip().split()[0].lower() in ['start', 'alter', 'drop', 'create', "begin", "truncate"]:
+			raise Exception('This statement can cause implicit commit')
 
 	def fetch_as_dict(self, formatted=0, as_utf8=0):
 		"""Internal. Converts results to dict."""

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -164,10 +164,7 @@ class Database(object):
 				frappe.errprint(("Execution time: {0} sec").format(round(time_end - time_start, 2)))
 
 		except Exception as e:
-			if frappe.conf.db_type == 'postgres':
-				self.rollback()
-
-			elif self.is_syntax_error(e):
+			if self.is_syntax_error(e):
 				# only for mariadb
 				frappe.errprint('Syntax error in query:')
 				frappe.errprint(query)
@@ -177,6 +174,9 @@ class Database(object):
 
 			elif self.is_timedout(e):
 				raise frappe.QueryTimeoutError(e)
+
+			elif frappe.conf.db_type == 'postgres':
+				raise
 
 			if ignore_ddl and (self.is_missing_column(e) or self.is_missing_table(e) or self.cant_drop_field_or_key(e)):
 				pass

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -3,7 +3,7 @@ from typing import List, Tuple, Union
 
 import psycopg2
 import psycopg2.extensions
-from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
 from psycopg2.errorcodes import STRING_DATA_RIGHT_TRUNCATION
 
 import frappe
@@ -69,7 +69,7 @@ class PostgresDatabase(Database):
 		conn = psycopg2.connect("host='{}' dbname='{}' user='{}' password='{}' port={}".format(
 			self.host, self.user, self.user, self.password, self.port
 		))
-		conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT) # TODO: Remove this
+		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
 
 		return conn
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -139,6 +139,10 @@ class PostgresDatabase(Database):
 		return isinstance(e, psycopg2.extensions.QueryCanceledError)
 
 	@staticmethod
+	def is_syntax_error(e):
+		return isinstance(e, psycopg2.errors.SyntaxError)
+
+	@staticmethod
 	def is_table_missing(e):
 		return getattr(e, 'pgcode', None) == '42P01'
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -259,8 +259,8 @@ class PostgresDatabase(Database):
 			key=key
 		)
 
-	def check_transaction_status(self, query):
-		pass
+	def check_implicit_commit(self, query):
+		pass # postgres can run DDL in transactions without implicit commits
 
 	def has_index(self, table_name, index_name):
 		return self.sql("""SELECT 1 FROM pg_indexes WHERE tablename='{table_name}'

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -10,8 +10,9 @@ import requests
 import base64
 
 class TestFrappeClient(unittest.TestCase):
+	PASSWORD = "admin"
 	def test_insert_many(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Note", {"title": ("in", ('Sing','a','song','of','sixpence'))})
 		frappe.db.commit()
 
@@ -30,7 +31,7 @@ class TestFrappeClient(unittest.TestCase):
 		self.assertTrue(frappe.db.get_value('Note', {'title': 'sixpence'}))
 
 	def test_create_doc(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Note", {"title": "test_create"})
 		frappe.db.commit()
 
@@ -39,13 +40,13 @@ class TestFrappeClient(unittest.TestCase):
 		self.assertTrue(frappe.db.get_value('Note', {'title': 'test_create'}))
 
 	def test_list_docs(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		doc_list = server.get_list("Note")
 
 		self.assertTrue(len(doc_list))
 
 	def test_get_doc(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Note", {"title": "get_this"})
 		frappe.db.commit()
 
@@ -56,7 +57,7 @@ class TestFrappeClient(unittest.TestCase):
 		self.assertTrue(doc)
 
 	def test_get_value(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Note", {"title": "get_value"})
 		frappe.db.commit()
 
@@ -74,14 +75,14 @@ class TestFrappeClient(unittest.TestCase):
 		self.assertRaises(FrappeException, server.get_value, "Note", "(select (password) from(__Auth) order by name desc limit 1)", {"title": "get_value"})
 
 	def test_get_single(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		server.set_value('Website Settings', 'Website Settings', 'title_prefix', 'test-prefix')
 		self.assertEqual(server.get_value('Website Settings', 'title_prefix', 'Website Settings').get('title_prefix'), 'test-prefix')
 		self.assertEqual(server.get_value('Website Settings', 'title_prefix').get('title_prefix'), 'test-prefix')
 		frappe.db.set_value('Website Settings', None, 'title_prefix', '')
 
 	def test_update_doc(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Note", {"title": ("in", ("Sing", "sing"))})
 		frappe.db.commit()
 
@@ -93,7 +94,7 @@ class TestFrappeClient(unittest.TestCase):
 		self.assertTrue(doc["title"] == changed_title)
 
 	def test_update_child_doc(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Contact", {"first_name": "George", "last_name": "Steevens"})
 		frappe.db.delete("Contact", {"first_name": "William", "last_name": "Shakespeare"})
 		frappe.db.delete("Communication", {"reference_doctype": "Event"})
@@ -130,7 +131,7 @@ class TestFrappeClient(unittest.TestCase):
 		self.assertTrue(frappe.db.exists("Communication Link", {"link_name": "William Shakespeare"}))
 
 	def test_delete_doc(self):
-		server = FrappeClient(get_url(), "Administrator", "admin", verify=False)
+		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Note", {"title": "delete"})
 		frappe.db.commit()
 

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -5,11 +5,11 @@ import getpass
 from frappe.utils.password import update_password
 
 def before_install():
+	frappe.reload_doc("core", "doctype", "doctype_state")
 	frappe.reload_doc("core", "doctype", "docfield")
 	frappe.reload_doc("core", "doctype", "docperm")
 	frappe.reload_doc("core", "doctype", "doctype_action")
 	frappe.reload_doc("core", "doctype", "doctype_link")
-	frappe.reload_doc("core", "doctype", "doctype_state")
 	frappe.reload_doc("desk", "doctype", "form_tour_step")
 	frappe.reload_doc("desk", "doctype", "form_tour")
 	frappe.reload_doc("core", "doctype", "doctype")


### PR DESCRIPTION
changes:
- [x] don't implicitly rollback on DB exception instead let it be propagated to application.
- [x] Define `is_syntax_error` for Postgres too. 
- [x] Enable proper transactions for postgres (repeatable read isolation instead of autocommits) closes https://github.com/frappe/frappe/issues/15218  
- [x] savepoint wrapper for dealing with DB exceptions.  https://github.com/frappe/frappe/pull/15516 
- [x] find and wrap/fix exception handling that aborts the transaction

Suggestion for future changes:
- Make `Database` abstract class so common methods are forcibly defined for all databases. 

BREAKING CHANGES: 
- When `db.sql` throws an exception that aborts a transaction users now need to write code to handle it, this can be done by either full rollback or savepoints (https://github.com/frappe/frappe/pull/15379) 
- Frappe on Postgres now doesn't autocommit and instead uses isolation level of "repeatable read" (same as mariadb)

Required for ERPNext on Postgres https://github.com/frappe/erpnext/pull/28359

