### PR TITLE
chore: change log for v12.25.0

### DIFF
--- a/frappe/change_log/v12/v12_25_0.md
+++ b/frappe/change_log/v12/v12_25_0.md
@@ -1,0 +1,9 @@
+## Frappe Version 12.25.0 Release Notes
+
+### Fixes & Enhancements
+
+- Rename Property Setter on Print Format Rename ([#15458](https://github.com/frappe/frappe/pull/15458))
+- Rendering forms created by disabled users ([#15371](https://github.com/frappe/frappe/pull/15371))
+- Erroneous query building when column exists in matching condition and set field value ([#15486](https://github.com/frappe/frappe/pull/15486))
+- Any user can view any other user's ToDo ([#12374](https://github.com/frappe/frappe/pull/12374))
+- IndexError while handling sql timeout error ([#15179](https://github.com/frappe/frappe/pull/15179))


### PR DESCRIPTION
## Frappe Version 12.25.0 Release Notes

### Fixes & Enhancements

- Rename Property Setter on Print Format Rename ([#15458](https://github.com/frappe/frappe/pull/15458))
- Rendering forms created by disabled users ([#15371](https://github.com/frappe/frappe/pull/15371))
- Erroneous query building when column exists in matching condition and set field value ([#15486](https://github.com/frappe/frappe/pull/15486))
- Any user can view any other user's ToDo ([#12374](https://github.com/frappe/frappe/pull/12374))
- IndexError while handling sql timeout error ([#15179](https://github.com/frappe/frappe/pull/15179))