### PR TITLE
fix: Do not allow rebuilding of tree for doctypes without `lft` & `rgt`

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -409,7 +409,9 @@ frappe.views.TreeView = class TreeView {
 			},
 		];
 
-		if (frappe.user.has_role('System Manager')) {
+		if (frappe.user.has_role('System Manager') &&
+			frappe.meta.has_field(me.doctype, "lft") &&
+			frappe.meta.has_field(me.doctype, "rgt")) {
 			this.menu_items.push(
 				{
 					label: __('Rebuild Tree'),

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -144,6 +144,11 @@ def rebuild_tree(doctype, parent_field):
 	if frappe.request and frappe.local.form_dict.cmd == 'rebuild_tree':
 		frappe.only_for('System Manager')
 
+	meta = frappe.get_meta(doctype)
+	if not meta.has_field("lft") or not meta.has_field("rgt"):
+		frappe.throw(_("Rebuilding of tree is not supported for {}").format(frappe.bold(doctype)),
+			title=_("Invalid Action"))
+
 	# get all roots
 	right = 1
 	table = DocType(doctype)


### PR DESCRIPTION
Hide "Rebuild Tree" option if the treeview is loaded for Non-NestedSet doctype

fixes https://github.com/frappe/frappe/issues/15505
