### PR TITLE
fix: renaming a document updates the modified timestamp

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -284,7 +284,7 @@ def update_link_field_values(link_fields, old, new, doctype):
 			if parent == new and doctype == "DocType":
 				parent = old
 
-			frappe.db.set_value(parent, {docfield: old}, docfield, new)
+			frappe.db.set_value(parent, {docfield: old}, docfield, new, update_modified=False)
 
 		# update cached link_fields as per new
 		if doctype=='DocType' and field['parent'] == old:


### PR DESCRIPTION
I am not sure if this is the intended behavior
But,
If a Document is renamed, all the Documents which has a Link to it will have their modified timestamp updated

Edit:

To test the fix:
- Rename a Document that has been linked to any other Document via the Link field
- Once renamed, check the modified timestamp of the other Document
- Check if Timestamp is modified (it shouldn't be)