### PR TITLE
fix: update schedule date on drag and drop

### DIFF
--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 import json
+from datetime import datetime
 
 @frappe.whitelist()
 def update_event(args, field_map):
@@ -13,6 +14,8 @@ def update_event(args, field_map):
 	w = frappe.get_doc(args.doctype, args.name)
 	w.set(field_map.start, args[field_map.start])
 	w.set(field_map.end, args.get(field_map.end))
+	date_obj = datetime.strptime(args.get(field_map.schedule_date), "%Y-%m-%d %H:%M:%S")
+	w.set(field_map.schedule_date, date_obj)
 	w.save()
 
 def get_event_conditions(doctype, filters=None):

--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -4,7 +4,6 @@
 import frappe
 from frappe import _
 import json
-from datetime import datetime
 
 @frappe.whitelist()
 def update_event(args, field_map):
@@ -14,8 +13,7 @@ def update_event(args, field_map):
 	w = frappe.get_doc(args.doctype, args.name)
 	w.set(field_map.start, args[field_map.start])
 	w.set(field_map.end, args.get(field_map.end))
-	date_obj = datetime.strptime(args.get(field_map.schedule_date), "%Y-%m-%d %H:%M:%S")
-	w.set(field_map.schedule_date, date_obj)
+	w.set(field_map.schedule_date, args.get(field_map.schedule_date))
 	w.save()
 
 def get_event_conditions(doctype, filters=None):

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -422,6 +422,7 @@ frappe.views.Calendar = class Calendar {
 			name: event[this.field_map.id]
 		};
 
+		args[this.field_map.schedule_date] = me.get_system_datetime(event.start);
 		args[this.field_map.start] = me.get_system_datetime(event.start);
 
 		if(this.field_map.allDay)


### PR DESCRIPTION
Before Fix :

The bug was identified from the following [Issue](https://github.com/frappe/erpnext/issues/28727).
On dragging and dropping a calendar event to a different date it did not update the **schedule date.**
![drag_and_drop_in_date_slots](https://user-images.githubusercontent.com/49878143/147933349-0fc48984-68d9-4f60-ab86-b7f2d189a122.gif)

After Fix :

Dragging and dropping events to a different date updates the **schedule date**

![drag_and_drop_in_date_slots_fix](https://user-images.githubusercontent.com/49878143/147933697-b07cd502-88f0-4639-8ded-306b8d94a2f2.gif)

