### PR TITLE
fix(ldap): Auto-negotiate the highest TLS protocol version supported by client & server

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -58,9 +58,9 @@ class LDAPSettings(Document):
 			import ssl
 
 			if self.require_trusted_certificate == 'Yes':
-				tls_configuration = ldap3.Tls(validate=ssl.CERT_REQUIRED, version=ssl.PROTOCOL_TLSv1)
+				tls_configuration = ldap3.Tls(validate=ssl.CERT_REQUIRED, version=ssl.PROTOCOL_TLS_CLIENT)
 			else:
-				tls_configuration = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1)
+				tls_configuration = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLS_CLIENT)
 
 			if self.local_private_key_file:
 				tls_configuration.private_key_file = self.local_private_key_file

--- a/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
@@ -296,7 +296,7 @@ class LDAP_TestCase():
 
 					if local_doc['require_trusted_certificate'] == 'Yes':
 						tls_validate = ssl.CERT_REQUIRED
-						tls_version = ssl.PROTOCOL_TLSv1
+						tls_version = ssl.PROTOCOL_TLS_CLIENT
 						tls_configuration = ldap3.Tls(validate=tls_validate, version=tls_version)
 
 						self.assertTrue(kwargs['auto_bind'] == ldap3.AUTO_BIND_TLS_BEFORE_BIND,
@@ -304,7 +304,7 @@ class LDAP_TestCase():
 
 					else:
 						tls_validate = ssl.CERT_NONE
-						tls_version = ssl.PROTOCOL_TLSv1
+						tls_version = ssl.PROTOCOL_TLS_CLIENT
 						tls_configuration = ldap3.Tls(validate=tls_validate, version=tls_version)
 
 						self.assertTrue(kwargs['auto_bind'],


### PR DESCRIPTION
fix: offer all (also modern) supported tls versions ([PROTOCOL_TLS_CLIENT](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT) [1]) to LDAP endpoints instead of only (deprecated) [PROTOCOL_TLSv1](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1) [2]

Background: Currently, when connecting to a ldap backend, [ssl.PROTOCOL_TLSv1](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1) [2] is offered as only option to the backend.

```python
if self.require_trusted_certificate == 'Yes':
  tls_configuration = ldap3.Tls(validate=ssl.CERT_REQUIRED, version=ssl.PROTOCOL_TLSv1)
else:
  tls_configuration = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1)
```

This leads to following issues:
- LDAP Backends that do not support TLSv1.0 (because of [security reasons](https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-02.html) [3]) cannot be used in ERPNext
- erpnext can ONLY connect to LDAP Backends offering the insecure [3] TLSv1.0 protocol  (see [ldap_settings.py](https://github.com/frappe/frappe/blob/34460265554242a8d05fb09f049033b1117e1a2b/frappe/integrations/doctype/ldap_settings/ldap_settings.py#L61) ln: 61, 63)

With this change to [ssl.PROTOCOL_TLS_CLIENT](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT)[1] we allow erpnext customers to configure LDAP Backends that also support more modern/secure (TLSv1.2 and up) transport **while still ensure backwards compatibility and allowing TLSv1.0**, since [ssl.PROTOCOL_TLS_CLIENT](https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT) "Auto-negotiates the highest protocol version that both the client and server support" [1]

```python
if self.require_trusted_certificate == 'Yes':
  tls_configuration = ldap3.Tls(validate=ssl.CERT_REQUIRED, version=ssl.PROTOCOL_TLS_CLIENT)
else:
  tls_configuration = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLS_CLIENT)
```

--
[1]: https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLS_CLIENT
[2]: https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1
[3]: https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-02.html