### PR TITLE
fix(blog): Load more with category filter

### DIFF
--- a/frappe/website/doctype/blog_post/templates/blog_post_list.html
+++ b/frappe/website/doctype/blog_post/templates/blog_post_list.html
@@ -52,5 +52,39 @@
 {% endblock %}
 
 {% block script %}
-<script>{% include "templates/includes/list/list.js" %}</script>
+<script>
+	frappe.ready(() => {
+		let result_wrapper = $(".website-list .result");
+		let next_start = {{ next_start or 0 }};
+
+		$(".website-list .btn-more").on("click", function() {
+			let $btn = $(this);
+			let args = $.extend(frappe.utils.get_query_params(), {
+				doctype: "Blog Post",
+				category: "{{ frappe.form_dict.category or '' }}",
+				limit_start: next_start,
+				pathname: location.pathname,
+			});
+			$btn.prop("disabled", true);
+			frappe.call('frappe.www.list.get', args)
+				.then(r => {
+					var data = r.message;
+					next_start = data.next_start;
+					$.each(data.result, function(i, d) {
+						$(d).appendTo(result_wrapper);
+					});
+					toggle_more(data.show_more);
+				})
+				.always(() => {
+					$btn.prop("disabled", false);
+				});
+		});
+
+		function toggle_more(show) {
+			if (!show) {
+				$(".website-list .more-block").addClass("hide");
+			}
+		}
+	});
+</script>
 {% endblock %}


### PR DESCRIPTION
When you click "Load more" on a blog category page, it used to fetch blog posts without filtering by category. It will now fetch blog posts for the selected category.

