### PR TITLE
fix: avoid cached results for `table_exists` during install

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1283,7 +1283,7 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 		roles = [p.role for p in doc.get("permissions") or []] + default_roles
 
 		for role in list(set(roles)):
-			if frappe.db.table_exists("Role") and not frappe.db.exists("Role", role):
+			if frappe.db.table_exists("Role", cached=False) and not frappe.db.exists("Role", role):
 				r = frappe.get_doc(dict(doctype= "Role", role_name=role, desk_access=1))
 				r.flags.ignore_mandatory = r.flags.ignore_permissions = True
 				r.insert()

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -838,9 +838,9 @@ class Database(object):
 			'parent': dt
 		})
 
-	def table_exists(self, doctype):
+	def table_exists(self, doctype, cached=True):
 		"""Returns True if table for given doctype exists."""
-		return ("tab" + doctype) in self.get_tables()
+		return ("tab" + doctype) in self.get_tables(cached=cached)
 
 	def has_table(self, doctype):
 		return self.table_exists(doctype)

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -103,7 +103,7 @@ class PostgresDatabase(Database):
 
 		return super(PostgresDatabase, self).sql(*args, **kwargs)
 
-	def get_tables(self):
+	def get_tables(self, cached=True):
 		return [d[0] for d in self.sql("""select table_name
 			from information_schema.tables
 			where table_catalog='{0}'


### PR DESCRIPTION
noticed this from https://github.com/frappe/frappe/pull/15495

`get_tables` is cached by default so during install this should be avoided.