### PR TITLE
fix(ldap): using `ldap_group_objectclass` instead of `ldap_group_mappings_section` field for validating custom config

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -45,8 +45,8 @@ class LDAPSettings(Document):
 						title=_("Misconfigured"))
 
 				if self.ldap_directory_server.lower() == 'custom':
-					if not self.ldap_group_member_attribute or not self.ldap_group_mappings_section:
-						frappe.throw(_("Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute' and 'LDAP Group Mappings' are entered"),
+					if not self.ldap_group_member_attribute or not self.ldap_group_objectclass:
+						frappe.throw(_("Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute' and 'Group Object Class' are entered"),
 						title=_("Misconfigured"))
 
 			else:


### PR DESCRIPTION
Bug introduced by #13777.

Causing the LDAP Settings using Custom Directory Server to not save successfully.
Because the ldap_group_mappings_section variable will never be set and the validate function will fail.