### PR TITLE
fix: awesomeplete line wrapping

### DIFF
--- a/frappe/public/scss/common/awesomeplete.scss
+++ b/frappe/public/scss/common/awesomeplete.scss
@@ -39,6 +39,7 @@
 			padding: var(--padding-sm);
 			color: var(--text-color);
 			border-radius: var(--border-radius);
+			white-space: unset;
 			@extend .ellipsis;
 			&:not(:last-child) {
 				margin-bottom: var(--margin-xs);


### PR DESCRIPTION
### Before

![Bildschirmfoto 2022-01-05 um 17 52 10](https://user-images.githubusercontent.com/14891507/148260079-b7e25cb2-24f2-4eef-964a-45aa3df5e358.png)


### After

![Bildschirmfoto 2022-01-05 um 17 50 03](https://user-images.githubusercontent.com/14891507/148260060-429c7c32-5b1c-4b76-9232-55306f7a1b2c.png)

Closes https://github.com/frappe/frappe/issues/15534