### PR TITLE
feat(ldap): Add Custom Group Search setting for custom ldap systems like okta

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.json
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -38,6 +38,7 @@
   "local_ca_certs_file",
   "ldap_custom_settings_section",
   "ldap_group_objectclass",
+  "ldap_custom_group_search",
   "column_break_33",
   "ldap_group_member_attribute",
   "ldap_group_mappings_section",
@@ -246,6 +247,12 @@
    "fieldname": "ldap_group_objectclass",
    "fieldtype": "Data",
    "label": "Group Object Class"
+  },
+  {
+   "description": "string value, i.e. {0} or uid={0},ou=users,dc=example,dc=com",
+   "fieldname": "ldap_custom_group_search",
+   "fieldtype": "Data",
+   "label": "Custom Group Search"
   },
   {
    "description": "Requires any valid fdn path. i.e. ou=users,dc=example,dc=com",

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -49,6 +49,10 @@ class LDAPSettings(Document):
 						frappe.throw(_("Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute' and 'LDAP Group Mappings' are entered"),
 						title=_("Misconfigured"))
 
+					if self.ldap_custom_group_search and "{0}" not in self.ldap_custom_group_search:
+						frappe.throw(_("Custom Group Search if filled needs to contain the user placeholder {0}, eg uid={0},ou=users,dc=example,dc=com"),
+						title=_("Misconfigured"))
+
 			else:
 				frappe.throw(_("LDAP Search String must be enclosed in '()' and needs to contian the user placeholder {0}, eg sAMAccountName={0}"))
 
@@ -209,7 +213,10 @@ class LDAPSettings(Document):
 
 			ldap_object_class = self.ldap_group_objectclass
 			ldap_group_members_attribute = self.ldap_group_member_attribute
-			user_search_str = getattr(user, self.ldap_username_field).value
+			ldap_custom_group_search = "{0}"
+			if self.ldap_custom_group_search:
+				ldap_custom_group_search = self.ldap_custom_group_search
+			user_search_str = ldap_custom_group_search.format(getattr(user, self.ldap_username_field).value)
 
 		else:
 			# NOTE: depreciate this else path


### PR DESCRIPTION
### Setting to configure Custom Group Search for Custom Directory Server
![LDAP Settings Changes](https://user-images.githubusercontent.com/3177081/148265357-b73c61ec-94c8-4112-8ee9-306ae80b27ec.png)

This configuration is needed for e.g. Okta where the dn is stored like this: 
`uniqueMember: uid=andreas,ou=users,dc=example,dc=okta,dc=com`. 

If the settings stays blank, the behaviour won't change from before and just the uid e.g. andreas will be queried.

Currently the group search query would always look like the following:
`(&(objectClass=groupOfUniqueNames)(uniqueMember=andreas))`.

With the new changes it is possible to adjust the search query to this:
`(&(objectClass=groupOfUniqueNames)(uniqueMember=uid=andreas,ou=users,dc=example,dc=okta,dc=com))`.

