### PR TITLE
fix(File): Handle file_path is None

### DIFF
--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -66,8 +66,8 @@ def get_latest_backup_file(with_files=False):
 
 
 def get_file_size(file_path, unit):
-	if not unit:
-		unit = "MB"
+	if not file_path:
+		return 0
 
 	file_size = os.path.getsize(file_path)
 
@@ -99,7 +99,7 @@ def get_chunk_site(file_size):
 def validate_file_size():
 	frappe.flags.create_new_backup = True
 	latest_file, site_config = get_latest_backup_file()
-	file_size = get_file_size(latest_file, unit="GB")
+	file_size = get_file_size(latest_file, unit="GB") if latest_file else 0
 
 	if file_size > 1:
 		frappe.flags.create_new_backup = False

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -65,7 +65,7 @@ def get_latest_backup_file(with_files=False):
 	return database, config
 
 
-def get_file_size(file_path, unit):
+def get_file_size(file_path, unit='MB'):
 	file_size = os.path.getsize(file_path)
 
 	memory_size_unit_mapper = {"KB": 1, "MB": 2, "GB": 3, "TB": 4}

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -66,9 +66,6 @@ def get_latest_backup_file(with_files=False):
 
 
 def get_file_size(file_path, unit):
-	if not file_path:
-		return 0
-
 	file_size = os.path.getsize(file_path)
 
 	memory_size_unit_mapper = {"KB": 1, "MB": 2, "GB": 3, "TB": 4}


### PR DESCRIPTION
In `validate_file_size`, if `file_path` is invalid i.e `None`,
set `file_size` to 0

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

closes #15550 . Please backport to older versions if PR is accepted as it affects older versions. The bug was detected in version-12

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

This ensures `validate_file_size` does not throw an Exception when there is no backup file to validate i.e when `get_latest_backup_file` returns `None` as the `file_path`. 

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
