### PR TITLE
chore: change log for v13.18.0

### DIFF
--- a/frappe/change_log/v13/v13_18_0.md
+++ b/frappe/change_log/v13/v13_18_0.md
@@ -1,0 +1,29 @@
+# Version 13.18.0 Release Notes
+
+### Features & Enhancements
+
+- Added `before_uninstall` and `after_uninstall` events in the hooks ([#15339](https://github.com/frappe/frappe/pull/15339))
+- Consecutive calendar week (WW) for naming series ([#14514](https://github.com/frappe/frappe/pull/14514))
+- Sanitise frappe.qb ([#15180](https://github.com/frappe/frappe/pull/15180))
+- SQL savepoints ([#15379](https://github.com/frappe/frappe/pull/15379))
+- Keyboard shortcuts for the grid ([#14438](https://github.com/frappe/frappe/pull/14438))
+
+### Fixes
+
+- Date fix in Discussions Component ([#15314](https://github.com/frappe/frappe/pull/15314))
+- Barcode rendering in server side printing ([#15383](https://github.com/frappe/frappe/pull/15383))
+- Default Print Format not updated in the property setter after rename ([#15458](https://github.com/frappe/frappe/pull/15458))
+- Default language code set to 'en' if no language in System Settings ([#15381](https://github.com/frappe/frappe/pull/15381))
+- Pagination issue with multi-select dialog ([#15312](https://github.com/frappe/frappe/pull/15312))
+- Repopulate db_tables cache after database restore ([#15404](https://github.com/frappe/frappe/pull/15404))
+- Improved translation speed ([#15337](https://github.com/frappe/frappe/pull/15337))
+- Make "Use original name for amended document" field read-only in System Settings ([#15278](https://github.com/frappe/frappe/pull/15278))
+- Always show scan barcode icon in the scan barcode field ([#15309](https://github.com/frappe/frappe/pull/15309))
+- Show unique records in list view ([#15175](https://github.com/frappe/frappe/pull/15175))
+- Additional menu in mobile view print page ([#15435](https://github.com/frappe/frappe/pull/15435))
+- Improved document permission validation message ([#15467](https://github.com/frappe/frappe/pull/15467))
+- Check if value for `applicable_for` exists before setting it null ([#15497](https://github.com/frappe/frappe/pull/15497))
+- The Sr.No column not showing for the child table in a web form view ([#15279](https://github.com/frappe/frappe/pull/15279))
+- Different icons for different events in the timeline ([#15284](https://github.com/frappe/frappe/pull/15284))
+- Set year to current year in Script Report boilerplate ([#15428](https://github.com/frappe/frappe/pull/15428))
+- Select permission not visible in role permission summary dialog ([#15300](https://github.com/frappe/frappe/pull/15300))


### PR DESCRIPTION
# Version 13.18.0 Release Notes

### Features & Enhancements

- Added `before_uninstall` and `after_uninstall` events in the hooks ([#15339](https://github.com/frappe/frappe/pull/15339))
- Consecutive calendar week (WW) for naming series ([#14514](https://github.com/frappe/frappe/pull/14514))
- Sanitise frappe.qb ([#15180](https://github.com/frappe/frappe/pull/15180))
- SQL savepoints ([#15379](https://github.com/frappe/frappe/pull/15379))
- Keyboard shortcuts for the grid ([#14438](https://github.com/frappe/frappe/pull/14438))

### Fixes

- Date fix in Discussions Component ([#15314](https://github.com/frappe/frappe/pull/15314))
- Barcode rendering in server side printing ([#15383](https://github.com/frappe/frappe/pull/15383))
- Default Print Format not updated in the property setter after rename ([#15458](https://github.com/frappe/frappe/pull/15458))
- Default language code set to 'en' if no language in System Settings ([#15381](https://github.com/frappe/frappe/pull/15381))
- Pagination issue with multi-select dialog ([#15312](https://github.com/frappe/frappe/pull/15312))
- Repopulate db_tables cache after database restore ([#15404](https://github.com/frappe/frappe/pull/15404))
- Improved translation speed ([#15337](https://github.com/frappe/frappe/pull/15337))
- Make "Use original name for amended document" field read-only in System Settings ([#15278](https://github.com/frappe/frappe/pull/15278))
- Always show scan barcode icon in the scan barcode field ([#15309](https://github.com/frappe/frappe/pull/15309))
- Show unique records in list view ([#15175](https://github.com/frappe/frappe/pull/15175))
- Additional menu in mobile view print page ([#15435](https://github.com/frappe/frappe/pull/15435))
- Improved document permission validation message ([#15467](https://github.com/frappe/frappe/pull/15467))
- Check if value for `applicable_for` exists before setting it null ([#15497](https://github.com/frappe/frappe/pull/15497))
- The Sr.No column not showing for the child table in a web form view ([#15279](https://github.com/frappe/frappe/pull/15279))
- Different icons for different events in the timeline ([#15284](https://github.com/frappe/frappe/pull/15284))
- Set year to current year in Script Report boilerplate ([#15428](https://github.com/frappe/frappe/pull/15428))
- Select permission not visible in role permission summary dialog ([#15300](https://github.com/frappe/frappe/pull/15300))