### PR TITLE
fix: upload file to dropbox was failing

### DIFF
--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -135,7 +135,7 @@ def upload_from_folder(path, is_private, dropbox_folder, dropbox_client, did_not
 
 	for f in frappe.get_all("File", filters={"is_folder": 0, "is_private": is_private,
 		"uploaded_to_dropbox": 0}, fields=['file_url', 'name', 'file_name']):
-		if not f.file_url:
+		if not f.file_url or not f.file_name:
 			continue
 		filename = f.file_url.rsplit('/', 1)[-1]
 


### PR DESCRIPTION
#### Upload to dropbox fails if the file provided is just a URL for a website and not a file link.
It throws `IsADirectoryError: [Errno 21] Is a directory: b'./thousandsunny.erpnext.com/public/files/` error.

for example: 
![Screenshot 2022-01-07 at 10 23 26 PM](https://user-images.githubusercontent.com/30501401/148578689-4cdd895a-fa67-4002-89eb-c62c4179884f.png)

