### PR TITLE
fix(Customize Form): delete translation for renaming only if label is empty

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -109,6 +109,7 @@ class CustomizeForm(Document):
 		current = self.get_name_translation()
 		if not self.label:
 			if current:
+				# clear translation
 				frappe.delete_doc('Translation', current.name)
 			return
 

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -107,20 +107,25 @@ class CustomizeForm(Document):
 	def set_name_translation(self):
 		'''Create, update custom translation for this doctype'''
 		current = self.get_name_translation()
-		if current:
-			if self.label and current.translated_text != self.label:
-				frappe.db.set_value('Translation', current.name, 'translated_text', self.label)
-				frappe.translate.clear_cache()
-			else:
-				# clear translation
+		if not self.label:
+			if current:
 				frappe.delete_doc('Translation', current.name)
+			return
 
-		else:
-			if self.label:
-				frappe.get_doc(dict(doctype='Translation',
-					source_text=self.doc_type,
-					translated_text=self.label,
-					language_code=frappe.local.lang or 'en')).insert()
+		if not current:
+			frappe.get_doc(
+				{
+					"doctype": 'Translation',
+					"source_text": self.doc_type,
+					"translated_text": self.label,
+					"language_code": frappe.local.lang or 'en'
+				}
+			).insert()
+			return
+
+		if self.label != current.translated_text:
+			frappe.db.set_value('Translation', current.name, 'translated_text', self.label)
+			frappe.translate.clear_cache()
 
 	def clear_existing_doc(self):
 		doc_type = self.doc_type

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -304,3 +304,25 @@ class TestCustomizeForm(unittest.TestCase):
 
 		action = [d for d in event.actions if d.label=='Test Action']
 		self.assertEqual(len(action), 0)
+
+	def test_custom_label(self):
+		d = self.get_customize_form("Event")
+
+		# add label
+		d.label = "Test Rename"
+		d.run_method("save_customization")
+		self.assertEqual(d.label, "Test Rename")
+
+		# change label
+		d.label = "Test Rename 2"
+		d.run_method("save_customization")
+		self.assertEqual(d.label, "Test Rename 2")
+
+		# saving again to make sure existing label persists
+		d.run_method("save_customization")
+		self.assertEqual(d.label, "Test Rename 2")
+
+		# clear label
+		d.label = ""
+		d.run_method("save_customization")
+		self.assertEqual(d.label, "")


### PR DESCRIPTION
## Issues Fixed

 In `Customize Form`, If there is already a `Change Label` field set and if we click on `Update` without changing it, It will unset that `Change Label` field.
 
![change-label-bug](https://user-images.githubusercontent.com/43115036/147845371-d2457835-4342-4477-996a-d0267be0972c.gif)

## Changes Made
 - Add check for empty `label` before deleting the Translation in `set_name_translation`
 - Refactor `set_name_translation`

---

Separated PR from #15491 