### PR TITLE
fix!: drop py3.7 support for v14

### DIFF
--- a/.github/workflows/docs-checker.yml
+++ b/.github/workflows/docs-checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'Setup Environment'
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: 'Clone repo'
         uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,5 @@ setup(
 	{
 		'clean': CleanCommand
 	},
-	python_requires='>=3.7'
+	python_requires='>=3.8'
 )


### PR DESCRIPTION
- Py3.6 is EOL
- Py3.7 will be EOL in less than a year after V14's first release. Hence bumping the minimum required version to Py3.8.

Support range could be 3.8-3.10/11 ish