### PR TITLE
fix: limit in `Document.get`

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1008,15 +1008,12 @@ def _filter(data, filters, limit=None):
 			_filters[f] = fval
 
 	for d in data:
-		add = True
 		for f, fval in _filters.items():
 			if not frappe.compare(getattr(d, f, None), fval[0], fval[1]):
-				add = False
 				break
-
-		if add:
+		else:
 			out.append(d)
-			if limit and (len(out)-1)==limit:
+			if limit and len(out) >= limit:
 				break
 
 	return out

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -252,3 +252,8 @@ class TestDocument(unittest.TestCase):
 			'currency': 100000
 		})
 		self.assertEquals(d.get_formatted('currency', currency='INR', format="#,###.##"), '₹ 100,000.00')
+
+	def test_limit_for_get(self):
+		doc = frappe.get_doc("DocType", "DocType")
+		# assuming DocType has more that 3 Data fields
+		self.assertEquals(len(doc.get("fields", filters={"fieldtype": "Data"}, limit=3)), 3)


### PR DESCRIPTION
## Issue Fixed
`limit` parameter for `Document.get` is not working as expected. It always returns `limit + 1` (e.g 6 results for `limit=5`) results.

![image](https://user-images.githubusercontent.com/43115036/148752367-b4e4c7e5-e01e-4ef3-a451-614f5bb19342.png)


## Changes Made
 - correct the condition for limit in `_filter` function
 - refactor: use [for...else](https://docs.python.org/3/tutorial/controlflow.html#break-and-continue-statements-and-else-clauses-on-loops) instead of flag

![image](https://user-images.githubusercontent.com/43115036/148752810-0cda29b2-c166-4b69-ad08-54321533ba86.png)
