### PR TITLE
fix(datetime): Side effect due to `__run_link_triggers`

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -148,8 +148,9 @@ frappe.ui.form.Control = class BaseControl {
 			return this.doc[this.df.fieldname];
 		}
 	}
-	set_value(value) {
-		return this.validate_and_set_in_model(value);
+
+	set_value(value, force_set_value=false) {
+		return this.validate_and_set_in_model(value, null, force_set_value);
 	}
 	parse_validate_and_set_in_model(value, e) {
 		if(this.parse) {
@@ -157,12 +158,11 @@ frappe.ui.form.Control = class BaseControl {
 		}
 		return this.validate_and_set_in_model(value, e);
 	}
-	validate_and_set_in_model(value, e) {
-		var me = this;
-		let force_value_set = (this.doc && this.doc.__run_link_triggers);
-		let is_value_same = (this.get_model_value() === value);
+	validate_and_set_in_model(value, e, force_set_value=false) {
+		const me = this;
+		const is_value_same = (this.get_model_value() === value);
 
-		if (this.inside_change_event || (!force_value_set && is_value_same)) {
+		if (this.inside_change_event || (is_value_same && !force_set_value)) {
 			return Promise.resolve();
 		}
 

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -983,7 +983,7 @@ frappe.ui.form.Form = class FrappeForm {
 			$.each(this.fields_dict, function(fieldname, field) {
 				if (field.df.fieldtype=="Link" && this.doc[fieldname]) {
 					// triggers add fetch, sets value in model and runs triggers
-					field.set_value(this.doc[fieldname]);
+					field.set_value(this.doc[fieldname], true);
 				}
 			});
 


### PR DESCRIPTION
### Issue:
**Before:** (While creating a new document from the dashboard `__run_link_triggers` is set which was causing recursive DateTime value set which ultimately freezes the browser) 

https://user-images.githubusercontent.com/13928957/148883090-a055164a-07cb-49c7-935b-a26182e87150.mov


**After:**

https://user-images.githubusercontent.com/13928957/148883115-23d3a312-9922-4b14-9a80-5bdf83e45e4b.mov



---
**Changes:**
- `__run_link_triggers` should only affect link fields so removed usage of `__run_link_triggers` from base control and introduced `force_set_value` for more explicit action.

> Deeper analysis can be done to see if `__run_link_triggers` can be removed completely -- not in the scope of this fix.

The issue was introduced via: https://github.com/frappe/frappe/pull/13504 and https://github.com/frappe/frappe/pull/12975

