### PR TITLE
fix(date): Pass date object instead of string for selectDate to work

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -10,14 +10,16 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		this.set_t_for_today();
 	}
 	set_formatted_input(value) {
+		if (value === "Today") {
+			value = this.get_now_date();
+		}
+
 		super.set_formatted_input(value);
 		if (this.timepicker_only) return;
 		if (!this.datepicker) return;
 		if (!value) {
 			this.datepicker.clear();
 			return;
-		} else if (value === "Today") {
-			value = this.get_now_date();
 		}
 
 		let should_refresh = this.last_value && this.last_value !== value;
@@ -78,7 +80,7 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 	}
 
 	get_start_date() {
-		return new Date(this.get_now_date());
+		return this.get_now_date();
 	}
 
 	set_datepicker() {
@@ -117,7 +119,7 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		this.datepicker.update('position', position);
 	}
 	get_now_date() {
-		return frappe.datetime.convert_to_system_tz(frappe.datetime.now_date(true));
+		return frappe.datetime.convert_to_system_tz(frappe.datetime.now_date(true), false).toDate();
 	}
 	set_t_for_today() {
 		var me = this;


### PR DESCRIPTION
**Today** button was not working because `get_now_date` was returning the date string instead of the date object.

**Before:**

https://user-images.githubusercontent.com/13928957/148906293-05577323-3cc2-4817-a774-347a397d0eaa.mov


**Now:** 

https://user-images.githubusercontent.com/13928957/148906317-f9b69b0f-6feb-467c-ba64-fa36df4f972c.mov

The issue introduced via https://github.com/frappe/frappe/pull/13504


