### PR TITLE
fix: enable languages inserted during setup

### DIFF
--- a/frappe/core/doctype/language/language.py
+++ b/frappe/core/doctype/language/language.py
@@ -39,7 +39,8 @@ def sync_languages():
 			frappe.get_doc({
 				'doctype': 'Language',
 				'language_code': l['code'],
-				'language_name': l['name']
+				'language_name': l['name'],
+				'enabled': 1,
 			}).insert()
 
 def update_language_names():


### PR DESCRIPTION
PS: Nothing is broken right now, but if someone converts that `insert` into `db_insert` in future to get pEfOrmAnCe benefits, then all language might become disabled by default. Similar to https://github.com/frappe/erpnext/pull/29242 