### PR TITLE
fix: html mode for ace editor

### DIFF
--- a/frappe/public/js/frappe/form/controls/markdown_editor.js
+++ b/frappe/public/js/frappe/form/controls/markdown_editor.js
@@ -32,7 +32,9 @@ frappe.ui.form.ControlMarkdownEditor = class ControlMarkdownEditor extends frapp
 	}
 
 	set_language() {
-		this.df.options = 'Markdown';
+		if (!this.df.options) {
+			this.df.options = 'Markdown';
+		}
 		super.set_language();
 	}
 


### PR DESCRIPTION
**Issue**
the language is always set to markdown and so the HTML editor does not have HTML features like autocomplete, etc.

***Before***

https://user-images.githubusercontent.com/58825865/148959054-6e51a806-a098-4269-b2a9-3f567450318e.mov

***After***

https://user-images.githubusercontent.com/58825865/148959164-733ad68a-4619-4632-b7cf-f6ba6ea8c37a.mov

