### PR TITLE
fix(minor): Is Custom field placement in Role form

### DIFF
--- a/frappe/core/doctype/role/role.json
+++ b/frappe/core/doctype/role/role.json
@@ -12,6 +12,7 @@
   "restrict_to_domain",
   "column_break_4",
   "disabled",
+  "is_custom",
   "desk_access",
   "two_factor_auth",
   "navigation_settings_section",
@@ -24,8 +25,7 @@
   "form_settings_section",
   "form_sidebar",
   "timeline",
-  "dashboard",
-  "is_custom"
+  "dashboard"
  ],
  "fields": [
   {
@@ -148,7 +148,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-10-08 14:06:55.729364",
+ "modified": "2022-01-12 20:18:18.496230",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Role",
@@ -170,5 +170,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
The **Is Custom** checkbox is placed under Form Settings but its meant for flagging the Role as custom (eg: ESS Role) which is confusing:

<img width="1304" alt="custom" src="https://user-images.githubusercontent.com/24353136/149165145-9776ba70-8fce-4399-8025-0988db03b189.png">

Move it to the first section:

![image](https://user-images.githubusercontent.com/24353136/149165876-70a746c2-310a-42d7-95c3-4bf317e9b539.png)
