### PR TITLE
fix: Add toggle theme as standard dropdown option

### DIFF
--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -220,6 +220,12 @@ def add_standard_navbar_items():
 			'is_standard': 1
 		},
 		{
+			'item_label': 'Toggle Theme',
+			'item_type': 'Action',
+			'action': 'new frappe.ui.ThemeSwitcher().show()',
+			'is_standard': 1
+		},
+		{
 			'item_label': 'Background Jobs',
 			'item_type': 'Route',
 			'route': '/app/background_jobs',


### PR DESCRIPTION
- For new sites toggle theme was not available. It was added via a patch for old sites.

Resolves issue mentioned in: https://frappe.io/app/pre-release-test/PRT-10-01-22-333597 
