### PR TITLE
fix: AttributeError when calling frappe.permissions.$function

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -188,6 +188,8 @@ class Document(BaseDocument):
 		is not set.
 
 		:param permtype: one of `read`, `write`, `submit`, `cancel`, `delete`"""
+		import frappe.permissions
+
 		if self.flags.ignore_permissions:
 			return True
 		return frappe.permissions.has_permission(self.doctype, permtype, self, verbose=verbose)


### PR DESCRIPTION
For some reason not importing this is causing an error shared below; specifically when running from a **background job.**

ps: not fully sure about why this happens yet! will update it once I do. The PR does fix the issue though. 

My guess currently:
1. Somehow this is becoming a circular import (the error message is the same as the one you'd get from circular imports)
2. Some other import system shenanigans. 

```
Traceback (most recent call last):
  File "apps/frappe/frappe/utils/background_jobs.py", line 104, in execute_job
    method(**kwargs)
  File "apps/ecommerce_integrations/ecommerce_integrations/unicommerce/order.py", line 47, in sync_new_orders
    client = UnicommerceAPIClient()
  File "apps/ecommerce_integrations/ecommerce_integrations/unicommerce/api_client.py", line 28, in __init__
    self.__initialize_auth()
  File "apps/ecommerce_integrations/ecommerce_integrations/unicommerce/api_client.py", line 33, in __initialize_auth
    self.settings.renew_tokens()
  File "apps/ecommerce_integrations/ecommerce_integrations/unicommerce/doctype/unicommerce_settings/unicommerce_settings.py", line 81, in renew_tokens
    self.save()
  File "apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 309, in _save
    self.check_permission("write", "save")
  File "apps/frappe/frappe/model/document.py", line 186, in check_permission
    if not self.has_permission(permtype):
  File "apps/frappe/frappe/model/document.py", line 196, in has_permission
    return frappe.permissions.has_permission(self.doctype, permtype, self, verbose=verbose)
AttributeError: module 'frappe' has no attribute 'permissions'
```