### PR TITLE
feat: Kanban click-drag scroll

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -400,9 +400,16 @@ frappe.provide("frappe.views");
 			let draggable = self.$kanban_board[0];
 
 			draggable.addEventListener('mousedown', (e) => {
-				// don't trigger scroll if one of the ancesstors of the
-				// selected element is a card
-				if (e.target.closest('.kanban-card-wrapper')) return;
+				// don't trigger scroll if one of the ancestors of the
+				// clicked element matches any of these selectors
+				let ignoreEl = [
+					'.kanban-column .kanban-column-header',
+					'.kanban-column .add-card',
+					'.kanban-column .kanban-card.new-card-area',
+					'.kanban-card-wrapper',
+				];
+				if (ignoreEl.some((el) => e.target.closest(el))) return;
+
 				isDown = true;
 				draggable.classList.add('clickdrag-active');
 				startX = e.pageX - draggable.offsetLeft;

--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -337,6 +337,7 @@ frappe.provide("frappe.views");
 
 		function bind_events() {
 			bind_add_column();
+			bind_clickdrag();
 		}
 
 		function setup_sortable() {
@@ -389,6 +390,38 @@ frappe.provide("frappe.views");
 				$(this).val('');
 				$compose_column.show();
 				$compose_column_form.hide();
+			});
+		}
+
+		function bind_clickdrag() {
+			let isDown = false;
+			let startX;
+			let scrollLeft;
+			let draggable = self.$kanban_board[0];
+
+			draggable.addEventListener('mousedown', (e) => {
+				// don't trigger scroll if one of the ancesstors of the
+				// selected element is a card
+				if (e.target.closest('.kanban-card-wrapper')) return;
+				isDown = true;
+				draggable.classList.add('clickdrag-active');
+				startX = e.pageX - draggable.offsetLeft;
+				scrollLeft = draggable.scrollLeft;
+			});
+			draggable.addEventListener('mouseleave', () => {
+				isDown = false;
+				draggable.classList.remove('clickdrag-active');
+			});
+			draggable.addEventListener('mouseup', () => {
+				isDown = false;
+				draggable.classList.remove('clickdrag-active');
+			});
+			draggable.addEventListener('mousemove', (e) => {
+				if(!isDown) return;
+				e.preventDefault();
+				const x = e.pageX - draggable.offsetLeft;
+				const walk = (x - startX);
+				draggable.scrollLeft = scrollLeft - walk;
 			});
 		}
 


### PR DESCRIPTION
Add click-drag scrolling to the kanban view, similar to Trello and other Kanban systems: 

![click-scroll](https://user-images.githubusercontent.com/16672299/149641462-4d321240-8808-44ce-aca7-38c00538ae5a.gif)


**Why:**

- Kanban boards are designed as a tactile interface, and without click-scrolling they feel very confined and artificial
- Usability:
  - None of my users are familiar with using shift+scroll to scroll horizontally
  - Cursor keys are a clumsy way to interact with the kanban view

**Notes:**

I added the click-drag functionality to `frappe.views.KanbanBoard.bind_events()` because similar board-wide events were already set up there. However, I noticed that `bind_events()` runs on each board refresh. This causes the events to bind on each refresh, leading to event triggering once for each reload event. I confirmed this already happens with the pre-existing `bind_add_column()` method. The double-bind doesn't appear to adversely affect functionality (at least under low usage), but it should probably be considered a bug in the current implementation of `bind_events()`.