### PR TITLE
fix(session): Do not logout on restarting bench

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -112,7 +112,7 @@ def get_expired_sessions():
 			frappe.db.get_values(
 				sessions,
 				filters=(
-					PseudoColumn(f"({Now() - sessions.lastupdate})")
+					PseudoColumn(f"({Now()} - {sessions.lastupdate.get_sql()})")
 					> get_expiry_period_for_query(device)
 				)
 				& (sessions.device == device),
@@ -334,7 +334,7 @@ class Session:
 			sessions,
 			filters=(sessions.sid == self.sid)
 			& (
-				PseudoColumn(f"({Now() - sessions.lastupdate})")
+				PseudoColumn(f"({Now()} - {sessions.lastupdate.get_sql()})")
 				< get_expiry_period_for_query(self.device)
 			),
 			fieldname=["user", "sessiondata"],


### PR DESCRIPTION
**Issue:**
On restarting the bench, the cache resets. Due to this, the application has to look in the database for existing sessions. The query to check the existing session was not working as expected which is why on every bench restart user sessions were getting logged out.

**Fix:**
- Normal string of pypika field has additional quotes which create an invalid query
- Used `get_sql` since it returns column name without additional quotes
	<img width="288" alt="Screenshot 2022-01-16 at 9 59 55 PM" src="https://user-images.githubusercontent.com/13928957/149708643-dd11fdbb-ed38-45dc-bcd3-3edb40a23d5a.png">
	  **Before: (Invalid query to retrieve valid session)**
		Note: `lastupdate` was wrapped with quotes which makes it a constant.
	  <img width="1067" alt="Screenshot 2022-01-16 at 9 57 05 PM" src="https://user-images.githubusercontent.com/13928957/149708696-200b33ff-7598-4b99-b20d-8382b4219f78.png">
	  **After:**
	  <img width="1053" alt="Screenshot 2022-01-17 at 10 01 06 AM" src="https://user-images.githubusercontent.com/13928957/149708721-1c0736d0-834a-4591-9207-96402a5e303b.png">

--
the issue was introduced via https://github.com/frappe/frappe/pull/14987