### PR TITLE
refactor: use `is None` instead of `== None`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -102,7 +102,7 @@ def as_unicode(text, encoding='utf-8'):
 	'''Convert to unicode if required'''
 	if isinstance(text, str):
 		return text
-	elif text==None:
+	elif text is None:
 		return ''
 	elif isinstance(text, bytes):
 		return str(text, encoding)
@@ -294,7 +294,7 @@ def get_conf(site=None):
 
 class init_site:
 	def __init__(self, site=None):
-		'''If site==None, initialize it for empty site ('') to load common_site_config.json'''
+		'''If site is None, initialize it for empty site ('') to load common_site_config.json'''
 		self.site = site or ''
 
 	def __enter__(self):
@@ -1661,7 +1661,7 @@ def local_cache(namespace, key, generator, regenerate_if_none=False):
 	if key not in local.cache[namespace]:
 		local.cache[namespace][key] = generator()
 
-	elif local.cache[namespace][key]==None and regenerate_if_none:
+	elif local.cache[namespace][key] is None and regenerate_if_none:
 		# if key exists but the previous result was None
 		local.cache[namespace][key] = generator()
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -344,7 +344,7 @@ class User(Document):
 
 		frappe.sendmail(recipients=self.email, sender=sender, subject=subject,
 			template=template, args=args, header=[subject, "green"],
-			delayed=(not now) if now!=None else self.flags.delay_emails, retry=3)
+			delayed=(not now) if now is not None else self.flags.delay_emails, retry=3)
 
 	def a_system_manager_should_exist(self):
 		if not self.get_other_system_managers():

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -126,7 +126,7 @@ def set_default(key, value, parent, parenttype="__default"):
 			"defkey": key,
 			"parent": parent
 		})
-	if value != None:
+	if value is not None:
 		add_default(key, value, parent)
 	else:
 		_clear_cache(parent)
@@ -187,7 +187,7 @@ def get_defaults_for(parent="__default"):
 	"""get all defaults"""
 	defaults = frappe.cache().hget("defaults", parent)
 
-	if defaults==None:
+	if defaults is None:
 		# sort descending because first default must get precedence
 		table = DocType("DefaultValue")
 		res = frappe.qb.from_(table).where(

--- a/frappe/desk/moduleview.py
+++ b/frappe/desk/moduleview.py
@@ -524,7 +524,7 @@ def get_last_modified(doctype):
 				raise
 
 		# hack: save as -1 so that it is cached
-		if last_modified==None:
+		if last_modified is None:
 			last_modified = -1
 
 		return last_modified

--- a/frappe/desk/page/user_profile/user_profile.py
+++ b/frappe/desk/page/user_profile/user_profile.py
@@ -30,7 +30,7 @@ def get_energy_points_percentage_chart_data(user, field):
 		as_list = True)
 
 	return {
-		"labels": [r[0] for r in result if r[0] != None],
+		"labels": [r[0] for r in result if r[0] is not None],
 		"datasets": [{
 			"values": [r[1] for r in result]
 		}]

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -107,7 +107,7 @@ def search_widget(doctype, txt, query=None, searchfield=None, start=0,
 					else:
 						filters.append([doctype, f[0], "=", f[1]])
 
-			if filters==None:
+			if filters is None:
 				filters = []
 			or_filters = []
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -172,7 +172,7 @@ class BaseDocument(object):
 				...
 			})
 		"""
-		if value==None:
+		if value is None:
 			value={}
 		if isinstance(value, (dict, BaseDocument)):
 			if not self.__dict__.get(key):
@@ -272,7 +272,7 @@ class BaseDocument(object):
 			)):
 				d[fieldname] = str(d[fieldname])
 
-			if d[fieldname] == None and ignore_nulls:
+			if d[fieldname] is None and ignore_nulls:
 				del d[fieldname]
 
 		return d

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -545,7 +545,7 @@ class DatabaseQuery(object):
 
 			elif f.operator.lower() in ("like", "not like") or (isinstance(f.value, str) and
 				(not df or df.fieldtype not in ["Float", "Int", "Currency", "Percent", "Check"])):
-					value = "" if f.value==None else f.value
+					value = "" if f.value is None else f.value
 					fallback = "''"
 
 					if f.operator.lower() in ("like", "not like") and isinstance(value, str):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -211,13 +211,13 @@ class Document(BaseDocument):
 
 		self.flags.notifications_executed = []
 
-		if ignore_permissions!=None:
+		if ignore_permissions is not None:
 			self.flags.ignore_permissions = ignore_permissions
 
-		if ignore_links!=None:
+		if ignore_links is not None:
 			self.flags.ignore_links = ignore_links
 
-		if ignore_mandatory!=None:
+		if ignore_mandatory is not None:
 			self.flags.ignore_mandatory = ignore_mandatory
 
 		self.set("__islocal", True)
@@ -297,7 +297,7 @@ class Document(BaseDocument):
 
 		self.flags.notifications_executed = []
 
-		if ignore_permissions!=None:
+		if ignore_permissions is not None:
 			self.flags.ignore_permissions = ignore_permissions
 
 		self.flags.ignore_version = frappe.flags.in_test if ignore_version is None else ignore_version
@@ -441,7 +441,7 @@ class Document(BaseDocument):
 			values = self.as_dict()
 			# format values
 			for key, value in values.items():
-				if value==None:
+				if value is None:
 					values[key] = ""
 			return values
 
@@ -489,7 +489,7 @@ class Document(BaseDocument):
 		frappe.flags.currently_saving.append((self.doctype, self.name))
 
 	def set_docstatus(self):
-		if self.docstatus==None:
+		if self.docstatus is None:
 			self.docstatus=0
 
 		for d in self.get_all_children():
@@ -887,14 +887,14 @@ class Document(BaseDocument):
 		if (frappe.flags.in_import and frappe.flags.mute_emails) or frappe.flags.in_patch or frappe.flags.in_install:
 			return
 
-		if self.flags.notifications_executed==None:
+		if self.flags.notifications_executed is None:
 			self.flags.notifications_executed = []
 
 		from frappe.email.doctype.notification.notification import evaluate_alert
 
-		if self.flags.notifications == None:
+		if self.flags.notifications is None:
 			alerts = frappe.cache().hget('notifications', self.doctype)
-			if alerts==None:
+			if alerts is None:
 				alerts = frappe.get_all('Notification', fields=['name', 'event', 'method'],
 					filters={'enabled': 1, 'document_type': self.doctype})
 				frappe.cache().hset('notifications', self.doctype, alerts)

--- a/frappe/model/dynamic_links.py
+++ b/frappe/model/dynamic_links.py
@@ -32,7 +32,7 @@ def get_dynamic_link_map(for_delete=False):
 
 	Note: Will not map single doctypes
 	'''
-	if getattr(frappe.local, 'dynamic_link_map', None)==None or frappe.flags.in_test:
+	if getattr(frappe.local, 'dynamic_link_map', None) is None or frappe.flags.in_test:
 		# Build from scratch
 		dynamic_link_map = {}
 		for df in get_dynamic_links():

--- a/frappe/patches/v11_0/remove_skip_for_doctype.py
+++ b/frappe/patches/v11_0/remove_skip_for_doctype.py
@@ -33,7 +33,7 @@ def execute():
 				continue
 			skip_for_doctype = user_permission.skip_for_doctype.split('\n')
 		else: # while migrating from v10 -> v11
-			if skip_for_doctype_map.get((user_permission.allow, user_permission.user)) == None:
+			if skip_for_doctype_map.get((user_permission.allow, user_permission.user)) is None:
 				skip_for_doctype = get_doctypes_to_skip(user_permission.allow, user_permission.user)
 				# cache skip for doctype for same user and doctype
 				skip_for_doctype_map[(user_permission.allow, user_permission.user)] = skip_for_doctype

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -559,7 +559,9 @@ def filter_allowed_docs_for_doctype(user_permissions, doctype, with_default_doc=
 	return (allowed_doc, default_doc) if with_default_doc else allowed_doc
 
 def push_perm_check_log(log):
-	if frappe.flags.get('has_permission_check_logs') == None: return
+	if frappe.flags.get('has_permission_check_logs') is None:
+		return
+
 	frappe.flags.get('has_permission_check_logs').append(_(log))
 
 def has_child_table_permission(child_doctype, ptype="read", child_doc=None,

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -374,7 +374,7 @@ class Session:
 
 		# database persistence is secondary, don't update it too often
 		updated_in_db = False
-		if force or (time_diff==None) or (time_diff > 600):
+		if force or (time_diff is None) or (time_diff > 600):
 			# update sessions table
 			frappe.db.sql("""update `tabSessions` set sessiondata=%s,
 				lastupdate=NOW() where sid=%s""" , (str(self.data['data']),

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -57,7 +57,7 @@ class EnergyPointRule(Document):
 	def rule_condition_satisfied(self, doc):
 		if self.for_doc_event == 'New':
 			# indicates that this was a new doc
-			return doc.get_doc_before_save() == None
+			return doc.get_doc_before_save() is None
 		if self.for_doc_event == 'Submit':
 			return doc.docstatus == 1
 		if self.for_doc_event == 'Cancel':

--- a/frappe/tests/test_twofactor.py
+++ b/frappe/tests/test_twofactor.py
@@ -222,7 +222,7 @@ def disable_2fa():
 def toggle_2fa_all_role(state=None):
 	'''Enable or disable 2fa for 'all' role on the system.'''
 	all_role = frappe.get_doc('Role','All')
-	if state == None:
+	if state is None:
 		state = False if all_role.two_factor_auth == True else False
 	if state not in [True, False]: return
 	all_role.two_factor_auth = cint(state)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -206,7 +206,7 @@ def make_dict_from_messages(messages, full_dict=None, load_user_translation=True
 	:param messages: List of untranslated messages
 	"""
 	out = {}
-	if full_dict==None:
+	if full_dict is None:
 		if load_user_translation:
 			full_dict = get_full_dict(frappe.local.lang)
 		else:

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -290,7 +290,7 @@ def remove_blanks(d):
 	"""
 	empty_keys = []
 	for key in d:
-		if d[key]=='' or d[key]==None:
+		if d[key] == "" or d[key] is None:
 			# del d[key] raises runtime exception, using a workaround
 			empty_keys.append(key)
 	for key in empty_keys:

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -112,7 +112,7 @@ def check_record(d):
 		docfield = doc.meta.get_field(key)
 		val = d[key]
 		if docfield:
-			if docfield.reqd and (val=='' or val==None):
+			if docfield.reqd and (val=='' or val is None):
 				frappe.msgprint(_("{0} is required").format(docfield.label), raise_exception=1)
 
 			if docfield.fieldtype=='Select' and val and docfield.options:

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -129,7 +129,7 @@ def add_to_date(date, years=0, months=0, weeks=0, days=0, hours=0, minutes=0, se
 	from dateutil.parser._parser import ParserError
 	from dateutil.relativedelta import relativedelta
 
-	if date==None:
+	if date is None:
 		date = now_datetime()
 
 	if hours:

--- a/frappe/utils/minify.py
+++ b/frappe/utils/minify.py
@@ -70,7 +70,7 @@ class JavascriptMinify(object):
 		"""
 		c = self.theLookahead
 		self.theLookahead = None
-		if c == None:
+		if c is None:
 			c = self.instream.read(1)
 		if c >= ' ' or c == '\n':
 			return c

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -305,7 +305,7 @@ def get_context(context):
 				if not section:
 					section = add_section()
 					column = None
-				if column==None:
+				if column is None:
 					column = add_column()
 				column.append(df)
 

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -301,7 +301,7 @@ def get_html_content_based_on_type(doc, fieldname, content_type):
 		elif content_type == 'HTML':
 			content = doc.get(fieldname + '_html')
 
-		if content == None:
+		if content is None:
 			content = ''
 
 		return content


### PR DESCRIPTION
> Comparisons to singletons like `None` should always be done with `is` or `is not`, never the equality operators.

– [PEP 8 - Programming Recommendations](https://www.python.org/dev/peps/pep-0008/#programming-recommendations)