### PR TITLE
fix: the YYYY.MM.DD format not working for the document naming rule

### DIFF
--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -5,6 +5,7 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils.data import evaluate_filters
+from frappe.model.naming import parse_naming_series
 from frappe import _
 
 class DocumentNamingRule(Document):
@@ -27,7 +28,9 @@ class DocumentNamingRule(Document):
 				return
 
 		counter = frappe.db.get_value(self.doctype, self.name, 'counter', for_update=True) or 0
-		doc.name = self.prefix + ('%0'+str(self.prefix_digits)+'d') % (counter + 1)
+		naming_series = parse_naming_series(self.prefix, doc=doc)
+
+		doc.name = naming_series + ('%0'+str(self.prefix_digits)+'d') % (counter + 1)
 		frappe.db.set_value(self.doctype, self.name, 'counter', counter + 1)
 
 @frappe.whitelist()


### PR DESCRIPTION
### **Issue**

Created document naming rule for the purchase invoice and set the prefix as YYYY.MM.DD.-

<img width="675" alt="Screenshot 2022-01-17 at 3 57 06 PM" src="https://user-images.githubusercontent.com/8780500/149753404-dcf59d92-69df-49c1-8231-92320969bc89.png">


Created new Purchase Invoice and system has set the name as 'YYYY.MM.DD-00004' which is incorrect
<img width="548" alt="Screenshot 2022-01-17 at 3 54 06 PM" src="https://user-images.githubusercontent.com/8780500/149753581-0fdda2d6-2b70-461e-a94d-f5a5035fa733.png">


### **After Fix**

Created new Purchase Invoice and system has set the correct name as '20220117-00005'

<img width="421" alt="Screenshot 2022-01-17 at 3 56 53 PM" src="https://user-images.githubusercontent.com/8780500/149753640-574c3e67-af7c-4181-a0d1-7fb51a475890.png">

