### PR TITLE
fix: datatable column resize in rtl

### DIFF
--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -87,6 +87,11 @@
 		}
 	}
 
+	.dt-cell__resize-handle {
+		right: -3px !important;
+		left: unset !important;
+	}
+
 	.dt-row.dt-row-totalRow {
 		font-weight: bold;
 	}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "express": "^4.17.1",
     "fast-deep-equal": "^2.0.1",
     "frappe-charts": "^2.0.0-rc13",
-    "frappe-datatable": "^1.16.0",
+    "frappe-datatable": "^1.16.1",
     "frappe-gantt": "^0.5.0",
     "fuse.js": "^3.4.6",
     "highlight.js": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,10 +1601,10 @@ frappe-charts@^2.0.0-rc13:
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc13.tgz#fdb251d7ae311c41e38f90a3ae108070ec6b9072"
   integrity sha512-Bv7IfllIrjRbKWHn5b769dOSenqdBixAr6m5kurf8ZUOJSLOgK4HOXItJ7BA8n9PvviH9/k5DaloisjLM2Bm1w==
 
-frappe-datatable@^1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.16.0.tgz#822dbcaaf48e5171f47ce2909da88e9a31bb2cbc"
-  integrity sha512-FkeHcaxxz4+BQLhwiegk94602PlnWNG4LiBPehgKdEL+OpJcwl8oNKWb/wPNw9lgW25u0LaaQwq/11sw7mnEbA==
+frappe-datatable@^1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.16.1.tgz#a5844b7ad8259ef45606608f492ca4b343006818"
+  integrity sha512-TRj3459YWyJdoP9MgHfOAEq7ylyoT3TVkwxLQGEmn5Xj6UAJOFa7F9j4TaWnFXW8tuoy69z/TktDclOurMeT2w==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
In RTL mode, column resizing of datatable headers is buggy. This PR updates frappe-datatable to 1.16.1 which has [fixed this issue](https://github.com/frappe/datatable/commit/95a239963cfd9d75883177a4e627b15fd907ac8c)
![rtl-column-resizing](https://user-images.githubusercontent.com/9355208/149763060-ac8b2bff-a8b7-499c-93c4-57b06b0f347d.gif)

