### PR TITLE
fix: web-image extension

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -663,6 +663,13 @@ def get_web_image(file_url):
 	extn = get_extension(filename, extn, r.content)
 	filename = "/files/" + strip(unquote(filename))
 
+	# Get image extension from response object 'r'
+	if not extn:
+		content_type = r.headers.get("Content-Type") 
+		
+		if content_type:
+			extn = content_type.split("/")[1]
+
 	return image, filename, extn
 
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -668,7 +668,9 @@ def get_web_image(file_url):
 		content_type = r.headers.get("Content-Type") 
 		
 		if content_type:
-			extn = content_type.split("/")[1]
+			from mimetypes import guess_extension
+
+			extn = guess_extension(content_type)[1:]
 
 	return image, filename, extn
 


### PR DESCRIPTION
#### Source/Reference: ISS-21-22-10410

### Issue(s): file.get_web_image()

There are two types of image URLs:
1. with extension: https://m.media-amazon.com/images/I/61AycdVLxzS._AC_SL1500_.jpg
2. without extension: https://store.storeimages.cdn-apple.com/4668/as-images.apple.com/is/iphone-12-family-select-2021?wid=940&hei=1112&fmt=jpeg&qlt=80&.v=1617135051000%5C

_Problem:_
- extension = None, when getting the image from the URL(without extension).

_Proposed Solution:_
- If extension = None, then try to get the extension from the response object.



