### PR TITLE
feat: patched frappe email to work with frappecloud mail app

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -11,7 +11,6 @@ from frappe.utils import now_datetime
 
 
 class EmailQueue(Document):
-	DOCTYPE = "Email Queue"
 	def set_recipients(self, recipients):
 		self.set("recipients", [])
 		for r in recipients:
@@ -30,17 +29,6 @@ class EmailQueue(Document):
 		duplicate = frappe.get_doc(values)
 		duplicate.set_recipients(recipients)
 		return duplicate
-
-	def update_db(self, commit=False, **kwargs):
-		frappe.db.set_value(self.DOCTYPE, self.name, kwargs)
-		if commit:
-			frappe.db.commit()
-
-	def update_status(self, status, commit=False, **kwargs):
-		self.update_db(status = status, commit = commit, **kwargs)
-		if self.communication:
-			communication_doc = frappe.get_doc('Communication', self.communication)
-			communication_doc.set_delivery_status(commit=commit)
 
 @frappe.whitelist()
 def retry_sending(name):

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -11,6 +11,7 @@ from frappe.utils import now_datetime
 
 
 class EmailQueue(Document):
+	DOCTYPE = "Email Queue"
 	def set_recipients(self, recipients):
 		self.set("recipients", [])
 		for r in recipients:
@@ -29,6 +30,17 @@ class EmailQueue(Document):
 		duplicate = frappe.get_doc(values)
 		duplicate.set_recipients(recipients)
 		return duplicate
+
+	def update_db(self, commit=False, **kwargs):
+		frappe.db.set_value(self.DOCTYPE, self.name, kwargs)
+		if commit:
+			frappe.db.commit()
+
+	def update_status(self, status, commit=False, **kwargs):
+		self.update_db(status = status, commit = commit, **kwargs)
+		if self.communication:
+			communication_doc = frappe.get_doc('Communication', self.communication)
+			communication_doc.set_delivery_status(commit=commit)
 
 @frappe.whitelist()
 def retry_sending(name):

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -60,6 +60,12 @@ def get_formatted_email(user, mail=None):
 	"""get Email Address of user formatted as: `John Doe <johndoe@example.com>`"""
 	fullname = get_fullname(user)
 
+	method = get_hook_method('get_sender_details')
+	if method:
+		sender_name, mail = method()
+		# if method exists but sender_name is ""
+		fullname = sender_name or fullname
+
 	if not mail:
 		mail = get_email_address(user) or validate_email_address(user)
 


### PR DESCRIPTION
* added two hook methods `get_sender_details` and `override_email_send`
* `get_sender_details` sets the default sender name and address which generated by default from logged in user.
* `override_email_send` overrides `smtp.session.sendmail` and sends the content and email data to any other hooked method.
* both these methods provide a way to set default sender name or address regardless of the user logged in and sending email content to some third party server/sender.

Backport for this [PR](https://github.com/frappe/frappe/pull/15248). Had to create separate pr because most of the email module of v13 is missing functionality from nightly
docs: https://frappeframework.com/docs/v13/user/en/python-api/hooks#email-hooks