### PR TITLE
fix: allow custom queues

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -18,12 +18,17 @@ import frappe.monitor
 from frappe import _
 from frappe.utils import cstr
 
+site_config = frappe.get_site_config()
+common_site_config = frappe.get_file_json("common_site_config.json")
+custom_workers_config = site_config.get("workers", common_site_config.get("workers", {}))
 default_timeout = 300
-queue_timeout = {
-	'long': 1500,
-	'default': 300,
-	'short': 300
-}
+queue_timeout = dict(
+	{"default": default_timeout, "short": default_timeout, "long": 1500},
+	**{
+		worker_name: worker_config.get("timeout", default_timeout)
+		for worker_name, worker_config in custom_workers_config.items()
+	},
+)
 
 redis_connection = None
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -21,7 +21,7 @@ from frappe.utils import cstr
 common_site_config = frappe.get_file_json("common_site_config.json")
 custom_workers_config = common_site_config.get("workers", {})
 default_timeout = 300
-queue_timeout = queue_timeout = {
+queue_timeout = {
 	"default": default_timeout,
 	"short": default_timeout,
 	"long": 1500,

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -18,17 +18,18 @@ import frappe.monitor
 from frappe import _
 from frappe.utils import cstr
 
-site_config = frappe.get_site_config()
 common_site_config = frappe.get_file_json("common_site_config.json")
-custom_workers_config = site_config.get("workers", common_site_config.get("workers", {}))
+custom_workers_config = common_site_config.get("workers", {})
 default_timeout = 300
-queue_timeout = dict(
-	{"default": default_timeout, "short": default_timeout, "long": 1500},
+queue_timeout = queue_timeout = {
+	"default": default_timeout,
+	"short": default_timeout,
+	"long": 1500,
 	**{
-		worker_name: worker_config.get("timeout", default_timeout)
-		for worker_name, worker_config in custom_workers_config.items()
-	},
-)
+		worker: config.get("timeout", default_timeout)
+		for worker, config in custom_workers_config.items()
+	}
+}
 
 redis_connection = None
 


### PR DESCRIPTION
Bench v5.7.0 adds new functionality that allows you to define custom queues.

You can see more in the following PR: https://github.com/frappe/bench/pull/1195

Usage example: `bench config set-common-config -c workers "{'example': {'timeout': 18000}}"`. This gives the possibility to run a new queue called `example`.

The problem is that if you now run: `bench worker --queue example`, frappe throws an error:
```python
frappe.throw(_("Queue should be one of {0}").format(', '.join(default_queue_list)))
```
reference: https://github.com/frappe/frappe/blob/develop/frappe/utils/background_jobs.py#L236

This problem occurs because the new queue is not considered in frappe because the queues are hardcoded. In this PR I allow frappe to read custom queues.

## Tests

In the actual branch, executes:
```sh
bench config set-common-config -c workers "{'example': {'timeout': 18000}}" && bench worker --queue example
```

Expected result:
![Screenshot from 2022-01-18 14-33-42](https://user-images.githubusercontent.com/38964964/149988736-3b9dbb00-1d9c-439c-8076-63a26f853c20.png)

