### PR TITLE
fix(patch): reload property setter for new fields

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -124,6 +124,8 @@ frappe.patches.v12_0.remove_parent_and_parenttype_from_print_formats
 frappe.patches.v12_0.remove_example_email_thread_notify
 execute:from frappe.desk.page.setup_wizard.install_fixtures import update_genders;update_genders()
 frappe.patches.v12_0.set_correct_url_in_files
+execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True)
+execute:frappe.reload_doc('custom', 'doctype', 'property_setter')
 frappe.patches.v13_0.remove_invalid_options_for_data_fields
 frappe.patches.v13_0.website_theme_custom_scss
 frappe.patches.v13_0.make_user_type
@@ -155,7 +157,6 @@ frappe.patches.v13_0.rename_notification_fields
 frappe.patches.v13_0.remove_duplicate_navbar_items
 frappe.patches.v13_0.set_social_icons
 frappe.patches.v12_0.set_default_password_reset_limit
-execute:frappe.reload_doc('core', 'doctype', 'doctype', force=True)
 frappe.patches.v13_0.set_route_for_blog_category
 frappe.patches.v13_0.enable_custom_script
 frappe.patches.v13_0.update_newsletter_content_type
@@ -181,5 +182,4 @@ frappe.patches.v13_0.rename_list_view_setting_to_list_view_settings
 frappe.patches.v13_0.remove_twilio_settings
 frappe.patches.v12_0.rename_uploaded_files_with_proper_name
 frappe.patches.v13_0.queryreport_columns
-execute:frappe.reload_doc('core', 'doctype', 'doctype')
 frappe.patches.v13_0.set_first_day_of_the_week


### PR DESCRIPTION
ERPNext patch test failing:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 27, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/site.py", line 306, in migrate
    migrate(
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 69, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/patches/v13_0/update_deferred_settings.py", line 12, in execute
    accounts_settings.save()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 287, in save
    return self._save(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 324, in _save
    self.run_before_save_methods()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 971, in run_before_save_methods
    self.run_method("validate")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 868, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1161, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1144, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 862, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/accounts_settings/accounts_settings.py", line 28, in validate
    self.enable_payment_schedule_in_print()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/accounts_settings/accounts_settings.py", line 41, in enable_payment_schedule_in_print
    make_property_setter(doctype, "due_date", "print_hide", show_in_print, "Check", validate_fields_for_doctype=False)
  File "/home/runner/frappe-bench/apps/frappe/frappe/custom/doctype/property_setter/property_setter.py", line 84, in make_property_setter
    property_setter.insert()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 240, in insert
    self.run_before_save_methods()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 971, in run_before_save_methods
    self.run_method("validate")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 868, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1161, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1144, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 862, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/custom/doctype/property_setter/property_setter.py", line 23, in validate
    delete_property_setter(self.doc_type, self.property, self.field_name, self.row_name)
AttributeError: 'PropertySetter' object has no attribute 'row_name'
```