### PR TITLE
fix: validate_link calls via Edit Shortcut in Dashboard

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -458,6 +458,8 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	},
 
 	validate_link_and_fetch(df, options, docname, value) {
+		if (!options) return;
+
 		let field_value = "";
 		const fetch_map = this.get_fetch_map();
 		const columns_to_fetch = Object.values(fetch_map);

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -458,8 +458,7 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 	},
 
 	validate_link_and_fetch(df, options, docname, value) {
-		if (!value) return;
-
+		let field_value = "";
 		const fetch_map = this.get_fetch_map();
 		const columns_to_fetch = Object.values(fetch_map);
 
@@ -473,15 +472,16 @@ frappe.ui.form.ControlLink = frappe.ui.form.ControlData.extend({
 			docname: value,
 			fields: columns_to_fetch,
 		}).then((response) => {
-			if (!response || !response.name) return null;
 			if (!docname || !columns_to_fetch.length) return response.name;
 
 			for (const [target_field, source_field] of Object.entries(fetch_map)) {
+				if(value) field_value = response[source_field];
+
 				frappe.model.set_value(
 					df.parent,
 					docname,
 					target_field,
-					response[source_field],
+					field_value,
 					df.fieldtype,
 				);
 			}


### PR DESCRIPTION
This error pops up every time one clicks on an "Edit Shortcut" action via the Dashboard. Seems like this was fixed earlier but not backported for unknown reasons. (cc: @surajshetty3416 @sumaiya2908 @shariquerik)

Backported https://github.com/frappe/frappe/pull/15470, https://github.com/frappe/frappe/pull/15343

![](https://frappe.io/files/od6tfeO.jpg)
