### PR TITLE
fix(ux): increase modal dialog size for diffview

### DIFF
--- a/frappe/public/js/frappe/utils/diffview.js
+++ b/frappe/public/js/frappe/utils/diffview.js
@@ -54,7 +54,7 @@ frappe.ui.DiffView = class DiffView {
 					fieldname: "diff",
 				},
 			],
-			size: "large",
+			size: "extra-large",
 		});
 		return dialog;
 	}


### PR DESCRIPTION
Large size isn't enough for some scripts that go beyond 90ish characters. Changed width to extra-large. 

Thought of text wrapping, but feels overkill for this, the editor doesn't do it either.  😅 

<img width="1187" alt="Screenshot 2022-01-20 at 2 45 26 PM" src="https://user-images.githubusercontent.com/9079960/150309413-17515759-d7d8-4e22-be31-3dd0b9524c64.png">
