### PR TITLE
fix: Set first day of the week for date range

### DIFF
--- a/frappe/public/js/frappe/form/controls/date_range.js
+++ b/frappe/public/js/frappe/form/controls/date_range.js
@@ -11,7 +11,8 @@ frappe.ui.form.ControlDateRange = class ControlDateRange extends frappe.ui.form.
 			language: "en",
 			range: true,
 			autoClose: true,
-			toggleSelected: false
+			toggleSelected: false,
+			firstDay: frappe.datetime.get_first_day_of_the_week_index()
 		};
 		this.datepicker_options.dateFormat =
 			(frappe.boot.sysdefaults.date_format || 'yyyy-mm-dd');


### PR DESCRIPTION
"Date Range" control was not obeying "[First Day Of The Week](https://github.com/frappe/frappe/pull/15502)" set in system settings.

This PR fixes that.

**Before:**
<img width="1440" alt="Screenshot 2022-01-20 at 3 39 38 PM" src="https://user-images.githubusercontent.com/13928957/150318328-78e1adf3-6720-41ec-b925-b373fd6f4850.png">

**After:**
<img width="1440" alt="Screenshot 2022-01-20 at 3 37 59 PM" src="https://user-images.githubusercontent.com/13928957/150318334-41c3fc73-a8e6-4067-bf4d-0f30bc460f1d.png">


---
fixes https://github.com/frappe/frappe/issues/15668