### PR TITLE
feat: translate column names in export of report

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -305,7 +305,7 @@ def export_query():
 	if add_totals_row:
 		ret = append_totals_row(ret)
 
-	data = [['Sr'] + get_labels(db_query.fields, doctype)]
+	data = [[_('Sr')] + get_labels(db_query.fields, doctype)]
 	for i, row in enumerate(ret):
 		data.append([i+1] + list(row))
 
@@ -364,7 +364,8 @@ def get_labels(fields, doctype):
 	for key in fields:
 		key = key.split(" as ")[0]
 
-		if key.startswith(('count(', 'sum(', 'avg(')): continue
+		if key.startswith(('count(', 'sum(', 'avg(')):
+			continue
 
 		if "." in key:
 			parenttype, fieldname = key.split(".")[0][4:-1], key.split(".")[1].strip("`")
@@ -372,10 +373,14 @@ def get_labels(fields, doctype):
 			parenttype = doctype
 			fieldname = fieldname.strip("`")
 
-		df = frappe.get_meta(parenttype).get_field(fieldname)
-		label = df.label if df else fieldname.title()
-		if label in labels:
-			label = doctype + ": " + label
+		if parenttype == doctype and fieldname == "name":
+			label = _("ID", context="Label of name column in report")
+		else:
+			df = frappe.get_meta(parenttype).get_field(fieldname)
+			label = _(df.label if df else fieldname.title())
+			if parenttype != doctype:
+				label += " (" + _(parenttype) + ")"
+
 		labels.append(label)
 
 	return labels

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -379,6 +379,8 @@ def get_labels(fields, doctype):
 			df = frappe.get_meta(parenttype).get_field(fieldname)
 			label = _(df.label if df else fieldname.title())
 			if parenttype != doctype:
+				# If the column is from a child table, append the child doctype.
+				# For example, "Item Code (Sales Invoice Item)".
 				label += " (" + _(parenttype) + ")"
 
 		labels.append(label)

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -381,7 +381,7 @@ def get_labels(fields, doctype):
 			if parenttype != doctype:
 				# If the column is from a child table, append the child doctype.
 				# For example, "Item Code (Sales Invoice Item)".
-				label += " (" + _(parenttype) + ")"
+				label += f" ({ _(parenttype) })"
 
 		labels.append(label)
 

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -860,7 +860,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		}
 
 		doctype_fields = [{
-			label: __('ID'),
+			label: __('ID', null, 'Label of name column in report'),
 			fieldname: 'name',
 			fieldtype: 'Data',
 			reqd: 1


### PR DESCRIPTION
Currently report column labels get translated in the UI:

- The `name` column gets the label `_("ID")`
- Child table columns get the label `f"{ _(field_label) } ({ _(doctype) })"`
- All other columns get the label `_(field_label)`

However, in the CSV/Excel export, none of the above happens. The user gets completely different column labels.

With this PR, column labels in the export become identical to column labels in the UI.

Data Import will still work, since we have #15318.

## Report on User with language set to german (de)

https://user-images.githubusercontent.com/14891507/150524446-123c08f8-e726-46d7-aaab-3d62c8fa90de.mov

Not backporting since it changes an interface.

> no-docs