### PR TITLE
fix: translate fieldname in report dialog and alert

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -340,7 +340,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 								options: columns_in_picker
 							},
 							{
-								label: __('Insert Column Before {0}', [datatabe_col.docfield.label.bold()]),
+								label: __('Insert Column Before {0}', [__(datatabe_col.docfield.label).bold()]),
 								fieldname: 'insert_before',
 								fieldtype: 'Check'
 							}
@@ -789,7 +789,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			} else {
 				this.fields.splice(col_index, 0, field);
 			}
-			frappe.show_alert(__('Also adding the dependent currency field {0}', [field[0].bold()]));
+			const field_label = frappe.meta.get_label(doctype, field[0]);
+			frappe.show_alert(
+				__('Also adding the dependent currency field {0}', [__(field_label).bold()])
+			);
 		}
 	}
 
@@ -799,7 +802,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			const field = [col, doctype];
 			this.fields.push(field);
 			this.refresh();
-			frappe.show_alert(__('Also adding the status dependency field {0}', [field[0].bold()]));
+			const field_label = frappe.meta.get_label(doctype, field[0]);
+			frappe.show_alert(
+				__('Also adding the status dependency field {0}', [__(field_label).bold()])
+			);
 		}
 	}
 


### PR DESCRIPTION
The following places used to show an untranslated field label or name. Now we always show the translated label.

![Bildschirmfoto 2022-01-21 um 17 00 55](https://user-images.githubusercontent.com/14891507/150561243-b6a66944-27b0-4474-810a-6f346d55e545.png)

![Bildschirmfoto 2022-01-21 um 17 01 29](https://user-images.githubusercontent.com/14891507/150561261-954b0c04-908a-48bc-ab58-89395b0fa89c.png)

