### PR TITLE
chore: change log for v13.19.0

### DIFF
--- a/frappe/change_log/v13/v13_19_0.md
+++ b/frappe/change_log/v13/v13_19_0.md
@@ -1,0 +1,28 @@
+## Version 13.19.0 Release Notes
+
+### Features & Enhancements
+
+- Setting to configure the day on which a week starts ([#15502](https://github.com/frappe/frappe/pull/15502))
+- Copy link to clipboard ([#15523](https://github.com/frappe/frappe/pull/15523))
+- Added `frappe.enqueue` and `frappe.call` for server scripts ([#15528](https://github.com/frappe/frappe/pull/15528))
+
+### Fixes
+
+- Add unique and index for new columns ([#15484](https://github.com/frappe/frappe/pull/15484))
+- Fixed translations in setup wizard ([#15401](https://github.com/frappe/frappe/pull/15401))
+- Patch for validating options field ([#15565](https://github.com/frappe/frappe/pull/15565))
+- Clear cache for all docs matched with the filters passed as `dn` param in `set_value` ([#15492](https://github.com/frappe/frappe/pull/15492))
+- LDAP Auto-negotiate the highest TLS protocol version supported by client & server ([#15517](https://github.com/frappe/frappe/pull/15517))
+- Handle the exceptions while parsing json on request failure ([#15549](https://github.com/frappe/frappe/pull/15549))
+- Set `first_response_time` only if communication is sent ([#15533](https://github.com/frappe/frappe/pull/15533))
+- Enable languages inserted during setup ([#15588](https://github.com/frappe/frappe/pull/15588))
+- Do not allow rebuilding of tree for doctypes without `lft` & `rgt` fields ([#15504](https://github.com/frappe/frappe/pull/15504))
+- Re-arrange fields in User DocType ([#15498](https://github.com/frappe/frappe/pull/15498))
+- FrappeClient POST api request being redirected to GET request ([#15542](https://github.com/frappe/frappe/pull/15542))
+- Add toggle theme as standard dropdown option ([#15610](https://github.com/frappe/frappe/pull/15610))
+- Route options not getting set while navigating from one report to another ([#15477](https://github.com/frappe/frappe/pull/15477))
+- Set first day of the week for date range ([#15669](https://github.com/frappe/frappe/pull/15669))
+- Fixed limit in `Document.get` ([#15574](https://github.com/frappe/frappe/pull/15574))
+- Use copy of an array while adding new content for proper change trigger ([#15507](https://github.com/frappe/frappe/pull/15507))
+- Email fetch error for imaplib ([#15581](https://github.com/frappe/frappe/pull/15581))
+- Renaming a document updates the modified timestamp ([#15508](https://github.com/frappe/frappe/pull/15508))


### PR DESCRIPTION
## Version 13.19.0 Release Notes

### Features & Enhancements

- Setting to configure the day on which a week starts ([#15502](https://github.com/frappe/frappe/pull/15502))
- Copy link to clipboard ([#15523](https://github.com/frappe/frappe/pull/15523))
- Added `frappe.enqueue` and `frappe.call` for server scripts ([#15528](https://github.com/frappe/frappe/pull/15528))

### Fixes

- Add unique and index for new columns ([#15484](https://github.com/frappe/frappe/pull/15484))
- Fixed translations in setup wizard ([#15401](https://github.com/frappe/frappe/pull/15401))
- Patch for validating options field ([#15565](https://github.com/frappe/frappe/pull/15565))
- Clear cache for all docs matched with the filters passed as `dn` param in `set_value` ([#15492](https://github.com/frappe/frappe/pull/15492))
- LDAP Auto-negotiate the highest TLS protocol version supported by client & server ([#15517](https://github.com/frappe/frappe/pull/15517))
- Handle the exceptions while parsing json on request failure ([#15549](https://github.com/frappe/frappe/pull/15549))
- Set `first_response_time` only if communication is sent ([#15533](https://github.com/frappe/frappe/pull/15533))
- Enable languages inserted during setup ([#15588](https://github.com/frappe/frappe/pull/15588))
- Do not allow rebuilding of tree for doctypes without `lft` & `rgt` fields ([#15504](https://github.com/frappe/frappe/pull/15504))
- Re-arrange fields in User DocType ([#15498](https://github.com/frappe/frappe/pull/15498))
- FrappeClient POST api request being redirected to GET request ([#15542](https://github.com/frappe/frappe/pull/15542))
- Add toggle theme as standard dropdown option ([#15610](https://github.com/frappe/frappe/pull/15610))
- Route options not getting set while navigating from one report to another ([#15477](https://github.com/frappe/frappe/pull/15477))
- Set first day of the week for date range ([#15669](https://github.com/frappe/frappe/pull/15669))
- Fixed limit in `Document.get` ([#15574](https://github.com/frappe/frappe/pull/15574))
- Use copy of an array while adding new content for proper change trigger ([#15507](https://github.com/frappe/frappe/pull/15507))
- Email fetch error for imaplib ([#15581](https://github.com/frappe/frappe/pull/15581))
- Renaming a document updates the modified timestamp ([#15508](https://github.com/frappe/frappe/pull/15508))