### PR TITLE
fix: correctly compute doctype name from table name

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -148,7 +148,7 @@ def build_table_count_cache():
 	data = (
 		frappe.qb.from_(information_schema.tables).select(table_name, table_rows)
 	).run(as_dict=True)
-	counts = {d.get('name').lstrip('tab'): d.get('count', None) for d in data}
+	counts = {d.get('name').replace('tab', '', 1): d.get('count', None) for d in data}
 	_cache.set_value("information_schema:counts", counts)
 
 	return counts

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -952,7 +952,7 @@ def trim_database(context, dry_run, format, no_backup):
 		doctype_tables = frappe.get_all("DocType", pluck="name")
 
 		for x in database_tables:
-			doctype = x.lstrip("tab")
+			doctype = x.replace("tab", "", 1)
 			if not (doctype in doctype_tables or x.startswith("__") or x in STANDARD_TABLES):
 				TABLES_TO_DROP.append(x)
 
@@ -966,7 +966,7 @@ def trim_database(context, dry_run, format, no_backup):
 
 				odb = scheduled_backup(
 					ignore_conf=False,
-					include_doctypes=",".join(x.lstrip("tab") for x in TABLES_TO_DROP),
+					include_doctypes=",".join(x.replace("tab", "", 1) for x in TABLES_TO_DROP),
 					ignore_files=True,
 					force=True,
 				)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -308,7 +308,7 @@ class Permission:
 			doctype = [doctype]
 
 		for dt in doctype:
-			dt = re.sub("tab", "", dt)
+			dt = re.sub("^tab", "", dt)
 			if not frappe.has_permission(
 				dt,
 				"select",


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/15691 


perhaps there should be a util for this; I saw 3-4 different ways to do this 😆 


```python
def get_doctype_name(table_name):
    return re.sub("^tab", "", table_name.strip())
```

or 

```python
def get_doctype_name(table_name):
    table_name = table_name.strip()
    if table_name.startswith("tab"):
         return table_name[3:]
    return table_name
```