### PR TITLE
fix(User Type): Select perms not updated for link fields in child table

### DIFF
--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -121,7 +121,7 @@ class UserType(Document):
 
 			for child_table in doc.get_table_fields():
 				child_doc = frappe.get_meta(child_table.options)
-				if not child_doc.istable:
+				if child_doc:
 					self.prepare_select_perm_doctypes(child_doc, user_doctypes, select_doctypes)
 
 		if select_doctypes:


### PR DESCRIPTION
**Problem:**

Select perms not updated for link fields in the child table because this is always false:

https://github.com/frappe/frappe/blob/75245c25dc25bc21a47f6f1328f202562e9a67d2/frappe/core/doctype/user_type/user_type.py#L124-L125

child doc will always have `istable` = 1