### PR TITLE
fix(rename_doc): Re-link Custom DocPerm records

### DIFF
--- a/frappe/core/doctype/custom_docperm/custom_docperm.json
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.json
@@ -210,7 +210,7 @@
   },
   {
    "fieldname": "parent",
-   "fieldtype": "Link",
+   "fieldtype": "Data",
    "label": "Reference Document Type",
    "read_only": 1
   },
@@ -222,7 +222,7 @@
   }
  ],
  "links": [],
- "modified": "2022-01-25 15:20:48.296730",
+ "modified": "2020-12-03 15:20:48.296730",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Custom DocPerm",

--- a/frappe/core/doctype/custom_docperm/custom_docperm.json
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.json
@@ -210,7 +210,7 @@
   },
   {
    "fieldname": "parent",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Reference Document Type",
    "read_only": 1
   },
@@ -222,7 +222,7 @@
   }
  ],
  "links": [],
- "modified": "2020-12-03 15:20:48.296730",
+ "modified": "2022-01-25 15:20:48.296730",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Custom DocPerm",

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -80,6 +80,7 @@ def rename_doc(
 
 	if doctype=='DocType':
 		rename_doctype(doctype, old, new, force)
+		update_customizations(old, new)
 
 	update_attachments(doctype, old, new)
 
@@ -174,6 +175,8 @@ def update_user_settings(old, new, link_fields):
 		else:
 			continue
 
+def update_customizations(old: str, new: str) -> None:
+	frappe.db.set_value("Custom DocPerm", {"parent": old}, "parent", new, update_modified=False)
 
 def update_attachments(doctype, old, new):
 	try:


### PR DESCRIPTION
This makes sure `frappe.rename_doc` updates linked doctype records

Ref: https://github.com/frappe/erpnext/pull/21179#issuecomment-1020921520