### PR TITLE
feat(UI): checkbox for custom actions in dialog

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -259,6 +259,27 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 
 		action && action_button.click(action);
 	}
+
+	add_custom_checkbox(label) {
+		this.footer.removeClass('hide');
+		let checkbox = $(`<div class="form-group frappe-control">
+			<div class="checkbox">
+				<label>
+					<span class="input-area"></span>
+					<span class="disp-area"></span>
+					<span class="label-area">${label}</span>
+				</label>
+				<p class="help-box small text-muted"></p>
+			</div>
+		</div>`).appendTo(this.custom_actions);
+		this.input_area = checkbox.find(".input-area").get(0);
+		this.$input = $("<input>")
+			.attr("type", "checkbox")
+			.attr("autocomplete", "off")
+			.addClass("input-with-feedback")
+			.prependTo(this.input_area);
+		this.$custom_input = this.$input.get(0)
+	}
 };
 
 frappe.ui.hide_open_dialog = () => {

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -278,7 +278,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 			.attr("autocomplete", "off")
 			.addClass("input-with-feedback")
 			.prependTo(this.input_area);
-		this.$custom_input = this.$input.get(0)
+		this.$custom_input = this.$input.get(0);
 	}
 };
 

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -115,6 +115,9 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			});
 			return null;
 		}
+		if (this.$custom_input) {
+			ret["save_setting"] = this.$custom_input.checked;
+		}
 		return ret;
 	}
 

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -108,6 +108,10 @@ body.modal-open[style^="padding-right"] {
 			}
 		}
 
+		.checkbox {
+			display: flex;
+		}
+
 		& > * {
 			margin: 0;
 		}


### PR DESCRIPTION
### Changes
- Added a function to create a checkbox under custom actions in dialog. Currently we could only add custom buttons.

![image](https://user-images.githubusercontent.com/43572428/150947384-914c7942-6c2e-4304-b465-dc7e2aed45d2.png)

- PR related -> [#29499](https://github.com/frappe/erpnext/pull/29449)