### PR TITLE
feat: get_count, get_stats for virtual doctype

### DIFF
--- a/frappe/core/doctype/test/test.py
+++ b/frappe/core/doctype/test/test.py
@@ -32,3 +32,14 @@ class test(Document):
 		# return []
 		with open("data_file.json", "r") as read_file:
 			return [json.load(read_file)]
+
+	def get_count(self, args):
+		# return []
+		with open("data_file.json", "r") as read_file:
+			return [json.load(read_file)]
+
+	def get_stats(self, args):
+		# return []
+		with open("data_file.json", "r") as read_file:
+			return [json.load(read_file)]
+

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -19,7 +19,7 @@ from frappe.utils import add_user_info
 def get():
 	args = get_form_params()
 	# If virtual doctype get data from controller het_list method
-	if frappe.db.get_value("DocType", filters={"name": args.doctype}, fieldname="is_virtual"):
+	if is_virtual_doctype(args.doctype):
 		controller = get_controller(args.doctype)
 		data = compress(controller(args.doctype).get_list(args))
 	else:
@@ -31,7 +31,7 @@ def get():
 def get_list():
 	args = get_form_params()
 
-	if frappe.db.get_value("DocType", filters={"name": args.doctype}, fieldname="is_virtual"):
+	if is_virtual_doctype(args.doctype):
 		controller = get_controller(args.doctype)
 		data = controller(args.doctype).get_list(args)
 	else:
@@ -45,7 +45,7 @@ def get_list():
 def get_count():
 	args = get_form_params()
 
-	if frappe.db.get_value("DocType", filters={"name": args.doctype}, fieldname="is_virtual"):
+	if is_virtual_doctype(args.doctype):
 		controller = get_controller(args.doctype)
 		data = controller(args.doctype).get_count(args)
 	else:
@@ -452,7 +452,7 @@ def get_sidebar_stats(stats, doctype, filters=None):
 	if filters is None:
 		filters = []
 
-	if frappe.db.get_value("DocType", filters={"name": doctype}, fieldname="is_virtual"):
+	if is_virtual_doctype(doctype):
 		controller = get_controller(doctype)
 		args = {"stats": stats, "filters": filters}
 		data = controller(doctype).get_stats(args)
@@ -619,3 +619,7 @@ def get_filters_cond(doctype, filters, conditions, ignore_permissions=None, with
 	else:
 		cond = ''
 	return cond
+
+def is_virtual_doctype(doctype):
+	return frappe.db.get_value("DocType", doctype, "is_virtual")
+

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -29,17 +29,31 @@ def get():
 @frappe.whitelist()
 @frappe.read_only()
 def get_list():
-	# uncompressed (refactored from frappe.model.db_query.get_list)
-	return execute(**get_form_params())
+	args = get_form_params()
+
+	if frappe.db.get_value("DocType", filters={"name": args.doctype}, fieldname="is_virtual"):
+		controller = get_controller(args.doctype)
+		data = controller(args.doctype).get_list(args)
+	else:
+		# uncompressed (refactored from frappe.model.db_query.get_list)
+		data = execute(**args)
+
+	return data
 
 @frappe.whitelist()
 @frappe.read_only()
 def get_count():
 	args = get_form_params()
 
-	distinct = 'distinct ' if args.distinct=='true' else ''
-	args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
-	return execute(**args)[0].get('total_count')
+	if frappe.db.get_value("DocType", filters={"name": args.doctype}, fieldname="is_virtual"):
+		controller = get_controller(args.doctype)
+		data = controller(args.doctype).get_count(args)
+	else:
+		distinct = 'distinct ' if args.distinct=='true' else ''
+		args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
+		data = execute(**args)[0].get('total_count')
+
+	return data
 
 def execute(doctype, *args, **kwargs):
 	return DatabaseQuery(doctype).execute(*args, **kwargs)
@@ -438,7 +452,14 @@ def get_sidebar_stats(stats, doctype, filters=None):
 	if filters is None:
 		filters = []
 
-	return {"stats": get_stats(stats, doctype, filters)}
+	if frappe.db.get_value("DocType", filters={"name": doctype}, fieldname="is_virtual"):
+		controller = get_controller(doctype)
+		args = {"stats": stats, "filters": filters}
+		data = controller(doctype).get_stats(args)
+	else:
+		data = get_stats(stats, doctype, filters)
+
+	return {"stats": data}
 
 @frappe.whitelist()
 @frappe.read_only()
@@ -560,7 +581,7 @@ def get_match_cond(doctype, as_condition=True):
 	return ((' and ' + cond) if cond else "").replace("%", "%%")
 
 def build_match_conditions(doctype, user=None, as_condition=True):
-	match_conditions =  DatabaseQuery(doctype, user=user).build_match_conditions(as_condition=as_condition)
+	match_conditions = DatabaseQuery(doctype, user=user).build_match_conditions(as_condition=as_condition)
 	if as_condition:
 		return match_conditions.replace("%", "%%")
 	else:

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -257,6 +257,12 @@ def make_boilerplate(template, doc, opts=None):
 		pass
 
 	def get_list(self, args):
+		pass
+
+	def get_count(self, args):
+		pass
+
+	def get_stats(self, args):
 		pass"""
 
 		with open(target_file_path, 'w') as target:

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -183,7 +183,8 @@ frappe.views.ListSidebar = class ListSidebar {
 				filters: (me.list_view.filter_area ? me.list_view.get_filters_for_args() : me.default_filters) || []
 			},
 			callback: function(r) {
-				me.render_stat((r.message.stats || {})["_user_tags"]);
+				let stats = (r.message.stats || {})["_user_tags"] || [];
+				me.render_stat(stats);
 				let stats_dropdown = me.sidebar.find('.list-stats-dropdown');
 				frappe.utils.setup_search(stats_dropdown, '.stat-link', '.stat-label');
 			}


### PR DESCRIPTION
- Add the get_stats method to virtual doctype boilerplate
- Add get_count method for virtual doctype boilerplate to fix the following issue
```
Traceback (most recent call last):
  File "apps/frappe/frappe/desk/reportview.py", line 42, in get_count
    return execute(**args)[0].get('total_count')
  File "apps/frappe/frappe/desk/reportview.py", line 45, in execute
    return DatabaseQuery(doctype).execute(*args, **kwargs)
  File "apps/frappe/frappe/model/db_query.py", line 103, in execute
    self.columns = self.get_table_columns()
  File "apps/frappe/frappe/model/db_query.py", line 360, in get_table_columns
    return get_table_columns(self.doctype)
  File "apps/frappe/frappe/model/meta.py", line 47, in get_table_columns
    return frappe.db.get_table_columns(doctype)
  File "apps/frappe/frappe/database/database.py", line 950, in get_table_columns
    raise self.TableMissingError('DocType', doctype)
pymysql.err.ProgrammingError: ('DocType', 'Test Virtual DocType')
```

> no-docs