### PR TITLE
fix: Get timezone in user_info

### DIFF
--- a/cypress/integration/datetime.js
+++ b/cypress/integration/datetime.js
@@ -103,6 +103,7 @@ context('Control Date, Time and DateTime', () => {
 				input_value: '12-02-2019 11:00' // admin timezone (Asia/Kolkata)
 			}
 		];
+
 		datetime_formats.forEach(d => {
 			it(`test datetime format ${d.date_format} ${d.time_format}`, () => {
 				cy.set_value('System Settings', 'System Settings', {

--- a/cypress/integration/timeline_email.js
+++ b/cypress/integration/timeline_email.js
@@ -14,7 +14,7 @@ context('Timeline Email', () => {
 		cy.wait(700);
 	});
 
-	it('Adding email and verifying timeline content for email attachment, deleting attachment and ToDo', () => {
+	it('Adding email and verifying timeline content for email attachment', () => {
 		cy.visit('/app/todo');
 		cy.get('.list-row > .level-left > .list-subject').eq(0).click();
 
@@ -43,7 +43,9 @@ context('Timeline Email', () => {
 		cy.get('#page-Communication > .page-head > .container > .row > .col > .standard-actions > .menu-btn-group > .btn').click();
 		cy.get('#page-Communication > .page-head > .container > .row > .col > .standard-actions > .menu-btn-group > .dropdown-menu > li > .grey-link').eq(9).click();
 		cy.get('.modal.show > .modal-dialog > .modal-content > .modal-footer > .standard-actions > .btn-primary').click();
+	});
 
+	it('Deleting attachment and ToDo', () => {
 		cy.visit('/app/todo');
 		cy.get('.list-row > .level-left > .list-subject > .level-item.ellipsis > .ellipsis').eq(0).click();
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -901,10 +901,11 @@ def dictify(arg):
 def add_user_info(user, user_info):
 	if user not in user_info:
 		info = frappe.db.get_value("User",
-			user, ["full_name", "user_image", "name", 'email'], as_dict=True) or frappe._dict()
+			user, ["full_name", "user_image", "name", 'email', 'time_zone'], as_dict=True) or frappe._dict()
 		user_info[user] = frappe._dict(
 			fullname = info.full_name or user,
 			image = info.user_image,
 			name = user,
-			email = info.email
+			email = info.email,
+			time_zone = info.time_zone
 		)


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/15606

The UI test is failing for datetime.js.
PR: https://github.com/frappe/frappe/pull/13504 introduced a feat that converts DateTime field values to system timezone for which the test was working fine. 
Timezone for the user is set on boot using user_info which used to have time_zone field but PR: https://github.com/frappe/frappe/pull/15606 removed that field which was causing the issue.

This PR also fixes the flaky timeline_email.js UI test