### PR TITLE
test: Remove focus to avoid double focus

### DIFF
--- a/cypress/integration/control_barcode.js
+++ b/cypress/integration/control_barcode.js
@@ -21,7 +21,6 @@ context('Control Barcode', () => {
 		get_dialog_with_barcode().as('dialog');
 
 		cy.get('.frappe-control[data-fieldname=barcode]').findByRole('textbox')
-			.focus()
 			.type('123456789')
 			.blur();
 		cy.get('.frappe-control[data-fieldname=barcode] svg[data-barcode-value="123456789"]')
@@ -38,7 +37,6 @@ context('Control Barcode', () => {
 		get_dialog_with_barcode().as('dialog');
 
 		cy.get('.frappe-control[data-fieldname=barcode]').findByRole('textbox')
-			.focus()
 			.type('123456789')
 			.blur();
 		cy.get('.frappe-control[data-fieldname=barcode]').findByRole('textbox')


### PR DESCRIPTION
- Modal always [focuses first input](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/ui/dialog.js#L102). Hence focus in test is not necessary.
- Due to double focus barcode tests fails randomly
ref: https://dashboard.cypress.io/projects/92odwv/runs/25831/overview/067a8ebf-eed7-4caa-9719-59cc1b7ce5bf/video

