### PR TITLE
fix: revert gateway_settings and gateway_controller to be non mandatory fields in payment gateway doctype

### DIFF
--- a/frappe/core/doctype/payment_gateway/payment_gateway.json
+++ b/frappe/core/doctype/payment_gateway/payment_gateway.json
@@ -23,15 +23,13 @@
    "fieldname": "gateway_settings",
    "fieldtype": "Link",
    "label": "Gateway Settings",
-   "options": "DocType",
-   "reqd": 1
+   "options": "DocType"
   },
   {
    "fieldname": "gateway_controller",
    "fieldtype": "Dynamic Link",
    "label": "Gateway Controller",
-   "options": "gateway_settings",
-   "reqd": 1
+   "options": "gateway_settings"
   }
  ],
  "links": [],


### PR DESCRIPTION
Reverting the mandatory fields set in #15699 as they're currently being used as non-mandatory in many places (and erpnext as well)