### PR TITLE
fix: return docs from `frappe.model.sync`

### DIFF
--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -39,7 +39,7 @@ Object.assign(frappe.model, {
 		}
 
 		frappe.model.sync_docinfo(r);
-
+		return r.docs;
 	},
 
 	rename_after_save: (d, i) => {


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/15732

root cause: function signature changed; earlier this function returned docs but after https://github.com/frappe/frappe/pull/15606 nothing is returned so any code that operates on returned docs is failing

mostly only reproducible on ERPNext where the result value is used to open the document from the response. 

Steps to reproduce:
- Create a BOM (erpnext)
- click on create > work order
- nothing happens. 

Another simpler case for testing: 
- create template item
- try to create a single variant