### PR TITLE
feat: custom columns for `MultiSelectDialog`

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -1,6 +1,6 @@
 frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	constructor(opts) {
-		/* Options: doctype, target, setters, get_query, action, add_filters_group, data_fields, primary_action_label */
+		/* Options: doctype, target, setters, get_query, action, add_filters_group, data_fields, primary_action_label, columns */
 		Object.assign(this, opts);
 		this.for_select = this.doctype == "[Select]";
 		if (!this.for_select) {
@@ -384,23 +384,22 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 		return this.results.filter(res => checked_values.includes(res.name));
 	}
 
+	get_datatable_columns() {
+		if(this.get_query && this.get_query().query && this.columns) return this.columns;
+
+		if(Array.isArray(this.setters))
+			return ["name", ...this.setters.map(df => df.fieldname)]
+
+		return ["name", ...Object.keys(this.setters)]
+	}
+
 	make_list_row(result = {}) {
 		var me = this;
 		// Make a head row by default (if result not passed)
 		let head = Object.keys(result).length === 0;
 
 		let contents = ``;
-		let columns = ["name"];
-
-		if ($.isArray(this.setters)) {
-			for (let df of this.setters) {
-				columns.push(df.fieldname);
-			}
-		} else {
-			columns = columns.concat(Object.keys(this.setters));
-		}
-
-		columns.forEach(function (column) {
+		this.get_datatable_columns().forEach(function (column) {
 			contents += `<div class="list-item__content ellipsis">
 				${
 	head ? `<span class="ellipsis text-muted" title="${__(frappe.model.unscrub(column))}">${__(frappe.model.unscrub(column))}</span>`
@@ -470,7 +469,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 
 	get_filters_from_setters() {
 		let me = this;
-		let filters = this.get_query ? this.get_query().filters : {} || {};
+		let filters = (this.get_query ? this.get_query().filters : {}) || {};
 		let filter_fields = [];
 
 		if ($.isArray(this.setters)) {

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -385,12 +385,12 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	}
 
 	get_datatable_columns() {
-		if(this.get_query && this.get_query().query && this.columns) return this.columns;
+		if (this.get_query && this.get_query().query && this.columns) return this.columns;
 
-		if(Array.isArray(this.setters))
-			return ["name", ...this.setters.map(df => df.fieldname)]
+		if (Array.isArray(this.setters))
+			return ["name", ...this.setters.map(df => df.fieldname)];
 
-		return ["name", ...Object.keys(this.setters)]
+		return ["name", ...Object.keys(this.setters)];
 	}
 
 	make_list_row(result = {}) {


### PR DESCRIPTION
## Use case
As per the current behaviour of `MultiSelectDialog`, columns of the result datatable will be automatically set from the filter fields. However, sometimes we need custom columns to be shown when we use custom query (by passing `get_query` option).

this PR adds an option `columns` which accepts the array of `field name` returned by the custom query.

Note: `columns` args will only work with the `get_query` option returning a `query`.

## Usage
pass `columns` args along with other options while creating a dialog.

```js
new MultiSelectDialog({
    ...
    columns: ['time_sheet', 'activity_type', 'from_time', 'project_name'],
    ...
});
```
![image](https://user-images.githubusercontent.com/43115036/151146156-5e48c362-be40-4af8-adc5-2ea417cb6b06.png)

## docs
https://frappeframework.com/docs/v13/user/en/api/dialog#frappeuiformmultiselectdialog

![image](https://user-images.githubusercontent.com/43115036/154030382-8f1dfda1-2403-4dc6-a3e4-147985b95240.png)

 