### PR TITLE
fix: dont auto drop manually created index on text types

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -222,7 +222,7 @@ class DbColumn:
 		# unique
 		if ((self.unique and not current_def['unique']) and column_type not in ('text', 'longtext')):
 			self.table.add_unique.append(self)
-		elif (current_def['unique'] and not self.unique):
+		elif (current_def['unique'] and not self.unique) and column_type not in ('text', 'longtext'):
 			self.table.drop_unique.append(self)
 
 		# default
@@ -233,7 +233,7 @@ class DbColumn:
 			self.table.set_default.append(self)
 
 		# index should be applied or dropped irrespective of type change
-		if (current_def['index'] and not self.set_index):
+		if (current_def['index'] and not self.set_index) and column_type not in ('text', 'longtext'):
 			self.table.drop_index.append(self)
 
 		elif (not current_def['index'] and self.set_index) and not (column_type in ('text', 'longtext')):

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -80,6 +80,12 @@ class TestDBUpdate(unittest.TestCase):
 		self.assertFalse(restrict_ip_in_table.index)
 		self.assertTrue(restrict_ip_in_table.unique)
 
+		# explicitly make a text index
+		frappe.db.add_index(doctype, ["email_signature(200)"])
+		frappe.db.updatedb(doctype)
+		email_sig_column = get_table_column("User", "email_signature")
+		self.assertEqual(email_sig_column.index, 1)
+
 def get_fieldtype_from_def(field_def):
 	fieldtuple = frappe.db.type_map.get(field_def.fieldtype, ('', 0))
 	fieldtype = fieldtuple[0]


### PR DESCRIPTION
- TEXT/LONGTEXT fields index can't be created from UI.
- Manually created indexes are dropped by `frappe.db.updatedb` because on doctype index=0 but in database the column has an index. 

caused by https://github.com/frappe/frappe/pull/15680 

Solution: Don't auto drop indexes on text fieldtype. 


ERPNext CI failing because of this:

```
 FAIL  test_index_creation (erpnext.stock.doctype.item.test_item.TestItem)
check if index is getting created in db
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/item/test_item.py", line 544, in test_index_creation
    self.fail(f"Expected db index on these columns: {', '.join(expected_columns)}")
AssertionError: Expected db index on these columns: route
```

Custom field creation is wiping that index:


```
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/utils.py", line 681, in run_parallel_tests
    ParallelTestWithOrchestrator(app, site=site)
  File "/home/runner/frappe-bench/apps/frappe/frappe/parallel_test_runner.py", line 214, in __init__
    ParallelTestRunner.__init__(self, app, site)
  File "/home/runner/frappe-bench/apps/frappe/frappe/parallel_test_runner.py", line 23, in __init__
    self.setup_test_site()
  File "/home/runner/frappe-bench/apps/frappe/frappe/parallel_test_runner.py", line 35, in setup_test_site
    self.before_test_setup()
  File "/home/runner/frappe-bench/apps/frappe/frappe/parallel_test_runner.py", line 46, in before_test_setup
    make_test_records(doctype)
  File "/home/runner/frappe-bench/apps/frappe/frappe/test_runner.py", line 288, in make_test_records
    make_test_records_for_doctype(options, verbose, force)
  File "/home/runner/frappe-bench/apps/frappe/frappe/test_runner.py", line 339, in make_test_records_for_doctype
    frappe.local.test_objects[doctype] += make_test_objects(doctype, test_module.test_records, verbose, force)
  File "/home/runner/frappe-bench/apps/frappe/frappe/test_runner.py", line 392, in make_test_objects
    d.insert()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 267, in insert
    self.run_post_save_methods()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1010, in run_post_save_methods
    self.run_method("on_update")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 874, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1171, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1154, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 868, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 115, in on_update
    install_country_fixtures(self.name, self.country)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 425, in install_country_fixtures
    frappe.get_attr(module_name)(company, False)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 16, in setup
    setup_company_independent_fixtures(patch=patch)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 23, in setup_company_independent_fixtures
    make_custom_fields()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 135, in make_custom_fields
    create_custom_fields(custom_fields, update=update)
  File "/home/runner/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 163, in create_custom_fields
    create_custom_field(doctype, df, ignore_validate=ignore_validate)
  File "/home/runner/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 138, in create_custom_field
    custom_field.insert()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 267, in insert
    self.run_post_save_methods()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1010, in run_post_save_methods
    self.run_method("on_update")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 874, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1171, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1154, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 868, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 80, in on_update
    frappe.db.updatedb(self.dt)
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/mariadb/database.py", line 306, in updatedb
    db_table.sync()
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/schema.py", line 39, in sync
    self.alter()
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/mariadb/schema.py", line 89, in alter
    raise BaseException("Dropping route index") # added for debugging
BaseException: Dropping route index
```