### PR TITLE
fix: ignore empty `patches.txt` file

### DIFF
--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -109,6 +109,9 @@ def get_patches_from_app(app: str, patch_type: Optional[PatchType] = None) -> Li
 		parser.optionxform = str
 		parser.read(patches_txt)
 
+		# empty file
+		if not parser.sections():
+			return []
 
 		if not patch_type:
 			return [patch for patch in parser[PatchType.pre_model_sync.value]] + \

--- a/frappe/tests/test_patches.py
+++ b/frappe/tests/test_patches.py
@@ -1,6 +1,42 @@
 
-import unittest, frappe
+import unittest
+import frappe
 from frappe.modules import patch_handler
+
+from unittest.mock import mock_open, patch
+
+
+EMTPY_FILE = ""
+EMTPY_SECTION = """
+[pre_model_sync]
+
+[post_model_sync]
+"""
+FILLED_SECTIONS = """
+[pre_model_sync]
+app.module.patch1
+app.module.patch2
+
+[post_model_sync]
+app.module.patch3
+
+"""
+OLD_STYLE_PATCH_TXT = """
+app.module.patch1
+app.module.patch2
+app.module.patch3
+"""
+
+EDGE_CASES = """
+[pre_model_sync]
+App.module.patch1
+app.module.patch2 # rerun
+execute:frappe.db.updatedb("Item")
+execute:frappe.function(arg="1")
+
+[post_model_sync]
+app.module.patch3
+"""
 
 class TestPatches(unittest.TestCase):
 	def test_patch_module_names(self):
@@ -30,3 +66,54 @@ class TestPatches(unittest.TestCase):
 		finished_patches = frappe.db.count("Patch Log")
 
 		self.assertGreaterEqual(finished_patches, len(all_patches))
+
+
+
+class TestPatchReader(unittest.TestCase):
+	@patch("builtins.open", new_callable=mock_open, read_data=EMTPY_FILE)
+	def test_empty_file(self, _file):
+		all_patches = patch_handler.get_patches_from_app("frappe")
+		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
+		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
+		self.assertEqual(all_patches, [])
+		self.assertEqual(pre, [])
+		self.assertEqual(post, [])
+
+
+	@patch("builtins.open", new_callable=mock_open, read_data=EMTPY_SECTION)
+	def test_empty_sections(self, _file):
+		all_patches = patch_handler.get_patches_from_app("frappe")
+		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
+		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
+		self.assertEqual(all_patches, [])
+		self.assertEqual(pre, [])
+		self.assertEqual(post, [])
+
+	@patch("builtins.open", new_callable=mock_open, read_data=FILLED_SECTIONS)
+	def test_new_style(self, _file):
+		all_patches = patch_handler.get_patches_from_app("frappe")
+		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
+		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
+		self.assertEqual(all_patches, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
+		self.assertEqual(pre, ["app.module.patch1", "app.module.patch2"])
+		self.assertEqual(post, ["app.module.patch3",])
+
+	@patch("builtins.open", new_callable=mock_open, read_data=OLD_STYLE_PATCH_TXT)
+	def test_old_style(self, _file):
+		all_patches = patch_handler.get_patches_from_app("frappe")
+		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
+		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
+		self.assertEqual(all_patches, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
+		self.assertEqual(pre, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
+		self.assertEqual(post, [])
+
+
+	@patch("builtins.open", new_callable=mock_open, read_data=EDGE_CASES)
+	def test_new_style_edge_cases(self, _file):
+		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
+		self.assertEqual(pre, [
+			"App.module.patch1",
+			"app.module.patch2 # rerun",
+			'execute:frappe.db.updatedb("Item")',
+			'execute:frappe.function(arg="1")',
+		])


### PR DESCRIPTION
caused by https://github.com/frappe/frappe/pull/15351 

problem: when `patches.txt` is empty it gets parsed correctly as per new format but doesn't find any sections.

```
Installing frappe_tinymce...
An error occurred while installing frappe_tinymce: *pre_model_sync'
Traceback (most recent call last):
File "apps/frappe/frappe/commands/site.py", line 342, in install_app
_install_app(app, verbose=context. verbose)
File "apps/frappe/frappe/installer. py", line 170, in install app
set_all_patches_as_completed (name)
File "apps/frappe/frappe/installer. py", line 351, in set_all_patches_as_completed
patches = get_patches_from_app(app)
File "apps/frappe/frappe/modules/patch_handler.py", line 114, in get_patches_from_app
return [patch for patch in parser (PatchType. pre_model_sync. value]l + \
File "/usr/lib/python3.8/configparser.py", line 960, in _getitem_
raise KeyError(key)
KeyError: 'pre_model_sync'
```

PS: added all known patches.txt fileformat test cases; in hindsight I should've done this in original PR 🥲 