### PR TITLE
fix: Show image in sidebar in mobile view

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -1,5 +1,5 @@
 <ul class="list-unstyled sidebar-menu user-actions hidden"></ul>
-<ul class="list-unstyled sidebar-menu sidebar-image-section hidden-xs hidden-sm hide">
+<ul class="list-unstyled sidebar-menu sidebar-image-section hide">
 	<li class="sidebar-image-wrapper">
 		<img class="sidebar-image">
 		<div class="sidebar-standard-image">

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -107,7 +107,7 @@ body[data-route^="Module"] .main-menu {
 		cursor: pointer;
 
 		.sidebar-image {
-			width: 100%;
+			width: min(100%, 170px);
 			height: auto;
 			max-height: 170px;
 			object-fit: cover;


### PR DESCRIPTION
Show image in the sidebar in mobile view.

| Before | After |
|:---:|:---:|
| <img src="https://user-images.githubusercontent.com/30859809/151320257-5722b1df-13ad-4b5f-8563-1486634ba8f1.png" width="300" height="auto">  | <img src="https://user-images.githubusercontent.com/30859809/151318979-36d06a4c-599b-4fad-ae9f-5147db9bb5fe.png" width="300" height="auto"> |