### PR TITLE
revert: server script errors

### DIFF
--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -34,19 +34,7 @@ def run_server_script_for_doc_event(doc, event):
 	if scripts:
 		# run all scripts for this doctype + event
 		for script_name in scripts:
-			try:
-				frappe.get_doc('Server Script', script_name).execute_doc(doc)
-			except Exception as e:
-				message = frappe._('Error executing Server Script {0}. Open Browser Console to see traceback.').format(
-					frappe.utils.get_link_to_form('Server Script', script_name)
-				)
-				exception = type(e)
-				if getattr(frappe, 'request', None):
-					# all exceptions throw 500 which is internal server error
-					# however server script error is a user error
-					# so we should throw 417 which is expectation failed
-					exception.http_status_code = 417
-				frappe.throw(title=frappe._('Server Script Error'), msg=message, exc=exception)
+			frappe.get_doc('Server Script', script_name).execute_doc(doc)
 
 def get_server_script_map():
 	# fetch cached server script methods


### PR DESCRIPTION
#15334 added a change where all exceptions are caught when a server
script is executed, which makes validation errors useless. reverting this
for now, until we find a better solution.

fixes: #15755 