### PR TITLE
fix(text-editor): Code block style

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -231,6 +231,10 @@
 
 	--highlight-shadow: 1px 1px 10px var(--blue-50), 0px 0px 4px var(--blue-600);
 
+	// code block
+	--code-block-bg: var(--gray-900);
+	--code-block-text: var(--gray-400);
+
 	// Border Sizes
 	--border-radius-sm: 4px;
 	--border-radius: 6px;

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -85,10 +85,22 @@
 	margin-bottom: 8px;
 }
 
+.ql-code-block-container {
+	background-color: var(--code-block-bg);
+	color: var(--code-block-text);
+	padding: var(--padding-xs) var(--padding-sm) !important;
+	margin-bottom: var(--margin-xs) !important;
+	margin-top: var(--margin-xs)!important;
+	border-radius: var(--border-radius-sm);
+}
+
 .ql-bubble .ql-editor {
 	min-height: 100px;
 	max-height: 300px;
 	border-radius: var(--border-radius-sm);
+	.ql-code-block-container {
+		@extend .ql-code-block-container;
+	}
 }
 
 .ql-mention-list-container {

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -42,6 +42,7 @@
 		height: 300px;
 		border-bottom-left-radius: var(--border-radius);
 		border-bottom-right-radius: var(--border-radius);
+		resize: vertical;
 	}
 	.ql-stroke {
 		stroke: var(--icon-stroke);


### PR DESCRIPTION
- Code block style in email or comment
	**Before:**

	<img width="400" alt="Screenshot 2022-01-27 at 4 35 15 PM" src="https://user-images.githubusercontent.com/13928957/151346866-87e7e800-6eef-4fc8-b8e7-9802f37be855.png">

	**After:**

	<img width="400" alt="Screenshot 2022-01-27 at 4 34 36 PM" src="https://user-images.githubusercontent.com/13928957/151346895-bc6544ea-bc4e-4176-8d2c-a859766b982c.png">


- Made text editor resizable for the ability to view complete content at once.
	**Before:**
	(had to scroll inside that small window to view complete content)

	https://user-images.githubusercontent.com/13928957/151334955-c492d436-642b-4e0c-b4bc-1a1b1469c893.mov

	**After:**

	https://user-images.githubusercontent.com/13928957/151335041-bbb67e48-a9fe-4fc1-b2b0-020497eb863d.mov


