### PR TITLE
fix: translate title in msgprint

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -355,7 +355,10 @@ class TestUser(unittest.TestCase):
 			test_user.reload()
 			self.assertEqual(update_password(new_password, key=test_user.reset_password_key), "/")
 			update_password(old_password, old_password=new_password)
-			self.assertEqual(json.loads(frappe.message_log[0]), {"message": "Password reset instructions have been sent to your email"})
+			self.assertEqual(
+				json.loads(frappe.message_log[0]).get("message"), 
+				"Password reset instructions have been sent to your email"
+			)
 		sendmail.assert_called_once()
 		self.assertEqual(sendmail.call_args[1]["recipients"], "test2@example.com")
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -756,7 +756,7 @@ def verify_password(password):
 @frappe.whitelist(allow_guest=True)
 def sign_up(email, full_name, redirect_to):
 	if is_signup_disabled():
-		frappe.throw(_('Sign Up is disabled'), title='Not Allowed')
+		frappe.throw(_("Sign Up is disabled"), title=_("Not Allowed"))
 
 	user = frappe.db.get("User", {"email": email})
 	if user:
@@ -810,8 +810,10 @@ def reset_password(user):
 		user.validate_reset_password()
 		user.reset_password(send_email=True)
 
-		return frappe.msgprint(_("Password reset instructions have been sent to your email"))
-
+		return frappe.msgprint(
+			msg=_("Password reset instructions have been sent to your email"),
+			title=_("Password Email Sent")
+		)
 	except frappe.DoesNotExistError:
 		frappe.local.response['http_status_code'] = 400
 		frappe.clear_messages()


### PR DESCRIPTION
- title in `is_signup_disabled` was not translatable
- title in `reset_password` was not translatable, because it is shown on the website while the user is logged out. Frontend translations don't work in this case.