### PR TITLE
fix: Add patch to remove chat related doctypes

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -175,6 +175,7 @@ execute:frappe.delete_doc_if_exists('Page', 'workspace')
 execute:frappe.delete_doc_if_exists('Page', 'dashboard', force=1)
 frappe.core.doctype.page.patches.drop_unused_pages
 execute:frappe.get_doc('Role', 'Guest').save() # remove desk access
+frappe.patches.v13_0.remove_chat
 frappe.patches.v13_0.rename_desk_page_to_workspace # 02.02.2021
 frappe.patches.v13_0.delete_package_publish_tool
 frappe.patches.v13_0.rename_list_view_setting_to_list_view_settings

--- a/frappe/patches/v13_0/remove_chat.py
+++ b/frappe/patches/v13_0/remove_chat.py
@@ -1,0 +1,16 @@
+import frappe
+import click
+
+def execute():
+	frappe.delete_doc_if_exists("DocType", "Chat Message")
+	frappe.delete_doc_if_exists("DocType", "Chat Profile")
+	frappe.delete_doc_if_exists("DocType", "Chat Token")
+	frappe.delete_doc_if_exists("DocType", "Chat Room User")
+	frappe.delete_doc_if_exists("DocType", "Chat Room")
+	frappe.delete_doc_if_exists("Module Def", "Chat")
+
+	click.secho(
+		"Chat Module is moved to a separate app and is removed from Frappe in version-13.\n"
+		"Please install the app to continue using the chat feature: https://github.com/frappe/chat",
+		fg="yellow",
+	)


### PR DESCRIPTION
Added a patch to remove chat related doctypes 
> Should have been part of https://github.com/frappe/frappe/pull/14926

**Fixes:**

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1208, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/load.py", line 71, in getdoctype
    docs = get_meta_bundle(doctype)
  File "apps/frappe/frappe/desk/form/load.py", line 81, in get_meta_bundle
    bundle = [frappe.desk.form.meta.get_meta(doctype)]
  File "apps/frappe/frappe/desk/form/meta.py", line 26, in get_meta
    meta = FormMeta(doctype)
  File "apps/frappe/frappe/desk/form/meta.py", line 39, in __init__
    self.load_assets()
  File "apps/frappe/frappe/desk/form/meta.py", line 49, in load_assets
    self.add_code()
  File "apps/frappe/frappe/desk/form/meta.py", line 81, in add_code
    path = os.path.join(get_module_path(self.module), 'doctype', scrub(self.name))
  File "apps/frappe/frappe/modules/utils.py", line 167, in get_module_path
    return frappe.get_module_path(module)
  File "apps/frappe/frappe/__init__.py", line 991, in get_module_path
    return get_pymodule_path(local.module_app[module] + "." + module, *joins)
KeyError: 'chat'
```