### PR TITLE
fix: Use capital M in min to avoid libsass compatibility issue

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -107,7 +107,7 @@ body[data-route^="Module"] .main-menu {
 		cursor: pointer;
 
 		.sidebar-image {
-			width: min(100%, 170px);
+			width: Min(100%, 170px);
 			height: auto;
 			max-height: 170px;
 			object-fit: cover;


### PR DESCRIPTION
Similar to https://github.com/frappe/frappe/pull/14348

Fixes broken build
<img width="328" alt="Screenshot 2022-01-28 at 5 04 12 PM" src="https://user-images.githubusercontent.com/13928957/151540052-cfd1761a-bcda-426c-81d9-9c8c42a632d0.png">

Issue introduced via: https://github.com/frappe/frappe/pull/15761

