### PR TITLE
fix: consistent button styling in sidebar

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -56,13 +56,8 @@
 		{%= __("Attachments") %}
 	</li>
 	<li class="add-attachment-btn">
-		<button class="data-pill btn">
-			<span class="pill-label ellipsis">
-				{%= __("Attach File") %}
-			</span>
-			<svg class="icon icon-sm">
-				<use href="#icon-add"></use>
-			</svg>
+		<button class="text-muted btn btn-default icon-btn">
+			<svg class="icon icon-sm"><use href="#icon-add"></use></svg>
 		</button>
 	</li>
 </ul>

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -398,7 +398,8 @@ body[data-route^="Module"] .main-menu {
 
 .add-review-btn,
 .share-doc-btn,
-.add-assignment-btn {
+.add-assignment-btn,
+.add-attachment-btn > button {
 	border-radius: 50%;
 }
 


### PR DESCRIPTION


## Before:
<img src="https://user-images.githubusercontent.com/9355208/151542190-01e0632d-d977-4239-b03e-e52990e57cf5.png" height="600">

## After:
<img src="https://user-images.githubusercontent.com/9355208/151541455-c1d87799-baf9-4d49-a745-e743621d390c.png" height="600">

