### PR TITLE
fix: show sidebar in nav for md and sm screen size

### DIFF
--- a/frappe/templates/includes/navbar/navbar_items.html
+++ b/frappe/templates/includes/navbar/navbar_items.html
@@ -70,7 +70,7 @@
 	{% endif %}
 
 	{% if show_sidebar and sidebar_items %}
-	<div class="d-block d-sm-none">
+	<div class="d-block d-lg-none">
 		<hr>
 		{% for item in sidebar_items -%}
 		<li class="nav-item">


### PR DESCRIPTION
- show the sidebar for small and medium screen size devices.
- the original [PR](https://github.com/frappe/frappe/pull/9941)
- The PR for some reason hid the sidebar for small devices 
- ![image](https://user-images.githubusercontent.com/7310479/151549439-431b32a0-0e67-48c3-a4d4-773a07fe9015.png)
