### PR TITLE
fix!: remove unnecessary array transformation in request args

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -192,12 +192,7 @@ def make_form_dict(request):
 	if not isinstance(args, dict):
 		frappe.throw(_("Invalid request arguments"))
 
-	try:
-		frappe.local.form_dict = frappe._dict({
-			k: v[0] if isinstance(v, (list, tuple)) else v for k, v in args.items()
-		})
-	except IndexError:
-		frappe.local.form_dict = frappe._dict(args)
+	frappe.local.form_dict = frappe._dict(args)
 
 	if "_" in frappe.local.form_dict:
 		# _ is passed by $.ajax so that the request is not cached by the browser. So, remove _ from form_dict

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -101,3 +101,33 @@ class TestClient(unittest.TestCase):
 			execute_cmd,
 			frappe.local.form_dict.cmd
 		)
+
+	def test_array_values_in_request_args(self):
+		import requests
+		from frappe.auth import CookieManager, LoginManager
+
+		frappe.utils.set_request(path="/")
+		frappe.local.cookie_manager = CookieManager()
+		frappe.local.login_manager = LoginManager()
+		frappe.local.login_manager.login_as('Administrator')
+		params = {
+			'doctype': 'DocType',
+			'fields': ['name', 'modified'],
+			'sid': frappe.session.sid,
+		}
+		headers = {
+			'accept': 'application/json',
+			'content-type': 'application/json',
+		}
+		url = f'http://{frappe.local.site}:{frappe.conf.webserver_port}/api/method/frappe.client.get_list'
+		res = requests.post(
+			url,
+			json=params,
+			headers=headers
+		)
+		self.assertEqual(res.status_code, 200)
+		data = res.json()
+		first_item = data['message'][0]
+		self.assertTrue('name' in first_item)
+		self.assertTrue('modified' in first_item)
+		frappe.local.login_manager.logout()


### PR DESCRIPTION
`key: ['value', 'value2']` is turned into `key: 'value'` for no reason

This is potentially a breaking change. But it is **wrong** behaviour. How should we handle this? @surajshetty3416 @gavindsouza @ankush 

Edit: I think there is no harm in introducing this in v14 only as breaking change.