### PR TITLE
fix: unknown method unescape on html2text

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -329,3 +329,12 @@ class TestDateUtils(unittest.TestCase):
 			frappe.utils.getdate("2020-12-26"))
 		self.assertEqual(frappe.utils.get_last_day_of_week("2020-12-28"),
 			frappe.utils.getdate("2021-01-02"))
+
+class TestXlsxUtils(unittest.TestCase):
+
+	def test_unescape(self):
+		from frappe.utils.xlsxutils import handle_html
+
+		val = handle_html("<p>html data &gt;</p>")
+		self.assertIn("html data >", val)
+		self.assertEqual("abc", handle_html("abc"))

--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -10,6 +10,7 @@ from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 
 import frappe
+from frappe.utils.html_utils import unescape_html
 
 ILLEGAL_CHARACTERS_RE = re.compile(r'[\000-\010]|[\013-\014]|[\016-\037]')
 
@@ -51,19 +52,15 @@ def make_xlsx(data, sheet_name, wb=None, column_widths=None):
 
 
 def handle_html(data):
+	from html2text import HTML2Text
+
 	# return if no html tags found
 	data = frappe.as_unicode(data)
 
-	if '<' not in data:
-		return data
-	if '>' not in data:
+	if '<' not in data or '>' not in data:
 		return data
 
-	from html2text import HTML2Text
-
-	h = HTML2Text()
-	h.unicode_snob = True
-	h = h.unescape(data or "")
+	h = unescape_html(data or "")
 
 	obj = HTML2Text()
 	obj.ignore_links = True


### PR DESCRIPTION
this method was removed from the library (internal method technically 🤷 )

use stdlib [unescape](https://docs.python.org/3/library/html.html#html.unescape) instead. 



Backport not required, v13 has pinned old version; `develop` had to upgrade to manage compatibility with other packages. 

closes https://github.com/frappe/frappe/issues/15779 