### PR TITLE
feat: add Attach Image in add_fetch

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -192,7 +192,7 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 		}
 
 		function setup_add_fetch(df) {
-			if ((['Data', 'Read Only', 'Text', 'Small Text', 'Currency', 'Check',
+			if ((['Data', 'Read Only', 'Text', 'Small Text', 'Currency', 'Check', 'Attach Image',
 				'Text Editor', 'Code', 'Link', 'Float', 'Int', 'Date', 'Select', 'Duration'].includes(df.fieldtype) || df.read_only==1)
 				&& df.fetch_from && df.fetch_from.indexOf(".")!=-1) {
 				var parts = df.fetch_from.split(".");


### PR DESCRIPTION
#### Now, "Fetch From" functionality will work for "Attach Image" fields as well.

<img width="964" alt="Screenshot 2022-02-17 at 6 37 57 PM" src="https://user-images.githubusercontent.com/13928957/154488225-b4af50f0-c573-4b14-a790-9caca25c839e.png">


https://user-images.githubusercontent.com/13928957/154487798-f1b58cf3-7da3-4832-8854-bf6c1b6a4327.mov




> no-docs