### PR TITLE
fix: naming series not working for doctypes with "has web view"

### DIFF
--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -27,7 +27,10 @@ class WebsiteGenerator(Document):
 
 	def autoname(self):
 		if not self.name and self.meta.autoname != "hash":
-			self.name = self.scrubbed_title()
+			if self.meta.autoname == "naming_series:":
+				self.name = cleanup_page_name(self.name)
+			else:
+				self.name = self.scrubbed_title()
 
 	def onload(self):
 		self.get("__onload").update({


### PR DESCRIPTION
## Problem

If in a doctype the Naming Rule is set as Naming Series and the "Has web view" is checked, then expected behavior i.e. names of the doctype entries follow the naming series provided. But this is not the case, the website_generator overrides the name set via the naming series.

## Solution

Check `self.meta.autoname == "naming_series:" `, if true then use the same name.
```py	
def autoname(self):
   if not self.name and self.meta.autoname != "hash":
      if self.meta.autoname == "naming_series:":
         self.name = cleanup_page_name(self.name)
      else:
         self.name = self.scrubbed_title()
```

## Result

Before
![image](https://user-images.githubusercontent.com/22856401/151747729-b30f00d9-4708-4221-b3d7-cda9b2f115c0.png)

Now
![image](https://user-images.githubusercontent.com/22856401/151747779-97ccb72b-728a-4199-bc5d-31790661c0fd.png)
