### PR TITLE
test: commented out lines in patches.txt

### DIFF
--- a/frappe/tests/test_patches.py
+++ b/frappe/tests/test_patches.py
@@ -38,6 +38,16 @@ execute:frappe.function(arg="1")
 app.module.patch3
 """
 
+COMMENTED_OUT = """
+[pre_model_sync]
+app.module.patch1
+# app.module.patch2 # rerun
+app.module.patch3
+
+[post_model_sync]
+app.module.patch4
+"""
+
 class TestPatches(unittest.TestCase):
 	def test_patch_module_names(self):
 		frappe.flags.final_patches = []
@@ -70,50 +80,55 @@ class TestPatches(unittest.TestCase):
 
 
 class TestPatchReader(unittest.TestCase):
+
+	def get_patches(self):
+		return (
+			patch_handler.get_patches_from_app("frappe"),
+			patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync),
+			patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
+		)
+
 	@patch("builtins.open", new_callable=mock_open, read_data=EMTPY_FILE)
 	def test_empty_file(self, _file):
-		all_patches = patch_handler.get_patches_from_app("frappe")
-		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
-		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
-		self.assertEqual(all_patches, [])
+		all, pre, post = self.get_patches()
+		self.assertEqual(all, [])
 		self.assertEqual(pre, [])
 		self.assertEqual(post, [])
 
 
 	@patch("builtins.open", new_callable=mock_open, read_data=EMTPY_SECTION)
 	def test_empty_sections(self, _file):
-		all_patches = patch_handler.get_patches_from_app("frappe")
-		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
-		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
-		self.assertEqual(all_patches, [])
+		all, pre, post = self.get_patches()
+		self.assertEqual(all, [])
 		self.assertEqual(pre, [])
 		self.assertEqual(post, [])
 
 	@patch("builtins.open", new_callable=mock_open, read_data=FILLED_SECTIONS)
 	def test_new_style(self, _file):
-		all_patches = patch_handler.get_patches_from_app("frappe")
-		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
-		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
-		self.assertEqual(all_patches, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
+		all, pre, post = self.get_patches()
+		self.assertEqual(all, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
 		self.assertEqual(pre, ["app.module.patch1", "app.module.patch2"])
 		self.assertEqual(post, ["app.module.patch3",])
 
 	@patch("builtins.open", new_callable=mock_open, read_data=OLD_STYLE_PATCH_TXT)
 	def test_old_style(self, _file):
-		all_patches = patch_handler.get_patches_from_app("frappe")
-		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
-		post = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.post_model_sync)
-		self.assertEqual(all_patches, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
+		all, pre, post = self.get_patches()
+		self.assertEqual(all, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
 		self.assertEqual(pre, ["app.module.patch1", "app.module.patch2", "app.module.patch3"])
 		self.assertEqual(post, [])
 
 
 	@patch("builtins.open", new_callable=mock_open, read_data=EDGE_CASES)
 	def test_new_style_edge_cases(self, _file):
-		pre = patch_handler.get_patches_from_app("frappe", patch_handler.PatchType.pre_model_sync)
+		all, pre, post = self.get_patches()
 		self.assertEqual(pre, [
 			"App.module.patch1",
 			"app.module.patch2 # rerun",
 			'execute:frappe.db.updatedb("Item")',
 			'execute:frappe.function(arg="1")',
 		])
+
+	@patch("builtins.open", new_callable=mock_open, read_data=COMMENTED_OUT)
+	def test_ignore_comments(self, _file):
+		all, pre, post = self.get_patches()
+		self.assertEqual(pre, ["app.module.patch1", "app.module.patch3"])


### PR DESCRIPTION
test for confirming this old behaviour with new ini-like format

https://github.com/frappe/frappe/blob/7d5465b2e36af6719f2650a47a5fb68ee295d998/frappe/__init__.py#L1192 