### PR TITLE
fix: communication missing from form timeline

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -42,7 +42,8 @@ def getdoc(doctype, name, user=None):
 
 		# add file list
 		doc.add_viewed()
-		get_docinfo(doc)
+		frappe.response["docinfo"] = get_docinfo(doc)
+
 
 	except Exception:
 		frappe.errprint(frappe.utils.get_traceback())
@@ -118,7 +119,7 @@ def get_docinfo(doc=None, doctype=None, name=None):
 
 	update_user_info(docinfo)
 
-	frappe.response["docinfo"] = docinfo
+	return docinfo
 
 def add_comments(doc, docinfo):
 	# divide comments into separate lists

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -91,8 +91,8 @@ def get_docinfo(doc=None, doctype=None, name=None):
 			raise frappe.PermissionError
 
 	all_communications = _get_communications(doc.doctype, doc.name)
-	automated_messages = filter(lambda x: x['communication_type'] == 'Automated Message', all_communications)
-	communications_except_auto_messages = filter(lambda x: x['communication_type'] != 'Automated Message', all_communications)
+	automated_messages = [msg for msg in all_communications if msg['communication_type'] == 'Automated Message']
+	communications_except_auto_messages = [msg for msg in all_communications if msg['communication_type'] != 'Automated Message']
 
 	docinfo = frappe._dict(user_info = {})
 

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import frappe, unittest
-from frappe.desk.form.load import getdoctype, getdoc
+from frappe.desk.form.load import getdoctype, getdoc, get_docinfo
 from frappe.core.page.permission_manager.permission_manager import update, reset, add
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.utils.file_manager import save_file
 
 test_dependencies = ['Blog Category', 'Blogger']
 
@@ -140,6 +141,49 @@ class TestFormLoad(unittest.TestCase):
 		user.add_roles(*user_roles)
 
 		contact.delete()
+
+	def test_get_doc_info(self):
+		note = frappe.new_doc("Note")
+		note.content = "some content"
+		note.title = frappe.generate_hash(length=20)
+		note.insert()
+
+		note.content = "new content"
+		# trigger a version
+		note.save(ignore_version=False)
+
+		note.add_comment(text="test")
+
+		note.add_tag("test_tag")
+		note.add_tag("more_tag")
+
+		# empty attachment
+		save_file("test_file", b"", note.doctype, note.name, decode=True)
+
+		frappe.get_doc({
+			"doctype": "Communication",
+			"communication_type": "Communication",
+			"content": "test email",
+			"reference_doctype": note.doctype,
+			"reference_name": note.name,
+		}).insert()
+
+
+		docinfo = get_docinfo(note)
+
+		self.assertEqual(len(docinfo.comments), 1)
+		self.assertIn("test", docinfo.comments[0].content)
+
+		self.assertGreaterEqual(len(docinfo.versions), 2)
+
+		self.assertEqual(set(docinfo.tags.split(",")), {"more_tag", "test_tag"})
+
+		self.assertEqual(len(docinfo.attachments), 1)
+		self.assertIn("test_file", docinfo.attachments[0].file_name)
+
+		self.assertEqual(len(docinfo.communications), 1)
+		self.assertIn("email", docinfo.communications[0].content)
+		note.delete()
 
 
 def get_blog(blog_name):


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/15819 

root cause: `communications_except_auto_messages` was a filter object which means it can only be iterated upon once. While preprocessing this filtered iterator gets consumed and nothing is sent in response. 

https://github.com/frappe/frappe/blob/d2b9fc89ed1001f5f507d19767904e43d2d054cc/frappe/desk/form/load.py#L95-L103

https://github.com/frappe/frappe/blob/2f239dbe4ffb9f4477dd55de347b8eaecc6dc6fd/frappe/desk/form/load.py#L369-L371


Basically this:

<img width="460" alt="Screenshot 2022-02-01 at 10 20 21 AM" src="https://user-images.githubusercontent.com/9079960/151914440-a922fdca-0e96-4136-a1b4-cd219076c604.png">


Introduced by #15606 and #12693