### PR TITLE
fix(google-drive-picker): Trigger form attach on callback

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -534,22 +534,21 @@ export default {
 			});
 		},
 		show_google_drive_picker() {
-			let dialog = cur_dialog;
-			dialog.hide();
+			this.close_dialog = true;
 			let google_drive = new GoogleDrivePicker({
-				pickerCallback: data => this.google_drive_callback(data, dialog),
+				pickerCallback: data => this.google_drive_callback(data),
 				...this.google_drive_settings
 			});
 			google_drive.loadPicker();
 		},
-		google_drive_callback(data, dialog) {
+		google_drive_callback(data) {
 			if (data.action == google.picker.Action.PICKED) {
 				this.upload_file({
 					file_url: data.docs[0].url,
 					file_name: data.docs[0].name
 				});
 			} else if (data.action == google.picker.Action.CANCEL) {
-				dialog.show();
+				cur_frm.attachments.new_attachment()
 			}
 		},
 		url_to_file(url, filename, mime_type) {


### PR DESCRIPTION
- Add an event listener for google dialog to hide when clicked outside.
- Show Error when authentication fails.
- Trigger form file upload.
- The PR fixes the following issues:
    - When you click outside the google uploader, the google uploader dialog didn't close, which is what people are inclined to do
    - When you upload the file to google drive and the file uploader dialog is shown again, the google drive icon is not responsive again
   
- Before Fix
![Peek 2022-02-03 22-27](https://user-images.githubusercontent.com/7310479/152439704-73779cfb-17ea-4d28-b3a7-8544757a3471.gif)

- After Fix
![Peek 2022-02-01 08-38](https://user-images.githubusercontent.com/7310479/152438591-dcb0dc48-21b9-4764-9c7b-75e0966849af.gif)
