### PR TITLE
fix: Escape document name

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -194,7 +194,7 @@ def rename_versions(doctype, old, new):
 def rename_eps_records(doctype, old, new):
 	epl = frappe.qb.DocType("Energy Point Log")
 	(frappe.qb.update(epl)
-		.set(epl.reference_name, new)
+		.set(epl.reference_name, frappe.db.escape(new))
 		.where(
 			(epl.reference_doctype == doctype)
 			& (epl.reference_name == old)


### PR DESCRIPTION
Fixes an issue that occurs while renaming a document with "%" sign in it.

```bash
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1208, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/model/rename_doc.py", line 21, in update_document_title
    docname = rename_doc(doctype=doctype, old=docname, new=new_name, merge=merge)
  File "apps/frappe/frappe/model/rename_doc.py", line 90, in rename_doc
    rename_eps_records(doctype, old, new)
  File "apps/frappe/frappe/model/rename_doc.py", line 198, in rename_eps_records
    & (epl.reference_name == old)
  File "apps/frappe/frappe/query_builder/utils.py", line 56, in execute_query
    return frappe.db.sql(query, params, *args, **kwargs) # nosemgrep
  File "apps/frappe/frappe/database/database.py", line 148, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.6/site-packages/pymysql/cursors.py", line 146, in execute
    query = self.mogrify(query, args)
  File "env/lib/python3.6/site-packages/pymysql/cursors.py", line 125, in mogrify
    query = query % self._escape_args(args, conn)
ValueError: unsupported format character ''' (0x27) at index 73
```

The issue was introduced via https://github.com/frappe/frappe/pull/15104

---

Was expecting that Pypika escapes all inputs. Can we do a better fix for this? @gavindsouza, @saxenabhishek?


closes https://github.com/frappe/erpnext/issues/29583