### PR TITLE
fix: Import `moment` in `datetime.js` for web portal

### DIFF
--- a/frappe/public/js/frappe-web.bundle.js
+++ b/frappe/public/js/frappe-web.bundle.js
@@ -2,6 +2,7 @@ import "./jquery-bootstrap";
 import "./frappe/class.js";
 import "./frappe/polyfill.js";
 import "./lib/md5.min.js";
+import "./lib/moment.js";
 import "./frappe/provide.js";
 import "./frappe/format.js";
 import "./frappe/utils/number_format.js";

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -1,6 +1,8 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
 
+import moment from "moment/min/moment-with-locales.js";
+
 frappe.provide('frappe.datetime');
 
 frappe.defaultDateFormat = "YYYY-MM-DD";

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -1,8 +1,6 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // MIT License. See license.txt
 
-import moment from "moment/min/moment-with-locales.js";
-
 frappe.provide('frappe.datetime');
 
 frappe.defaultDateFormat = "YYYY-MM-DD";

--- a/frappe/public/js/lib/moment.js
+++ b/frappe/public/js/lib/moment.js
@@ -1,0 +1,5 @@
+// This file is used to make sure that `moment` is bound to the window
+// before the bundle finishes loading, due to imports (datetime.js) in the bundle
+// that depend on `moment`.
+import momentTimezone from "moment-timezone/builds/moment-timezone-with-data.js";
+window.moment = momentTimezone;

--- a/frappe/public/js/libs.bundle.js
+++ b/frappe/public/js/libs.bundle.js
@@ -1,15 +1,12 @@
 import "./jquery-bootstrap";
 import Vue from "vue/dist/vue.esm.js";
-import moment from "moment/min/moment-with-locales.js";
-import momentTimezone from "moment-timezone/builds/moment-timezone-with-data.js";
+import "./lib/moment";
 import io from "socket.io-client/dist/socket.io.slim.js";
 import Sortable from "./lib/Sortable.min.js";
 // TODO: esbuild
 // Don't think jquery.hotkeys is being used anywhere. Will remove this after being sure.
 // import "./lib/jquery/jquery.hotkeys.js";
 
-window.moment = moment;
-window.moment = momentTimezone;
 window.Vue = Vue;
 window.Sortable = Sortable;
 window.io = io;

--- a/frappe/public/js/web_form.bundle.js
+++ b/frappe/public/js/web_form.bundle.js
@@ -1,2 +1,3 @@
+import "./lib/moment.js";
 import "./frappe/utils/datetime.js";
 import "./frappe/web_form/webform_script.js";

--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -105,8 +105,6 @@
 		// for backward compatibility of some libs
 		frappe.sys_defaults = frappe.boot.sysdefaults;
 	</script>
-	<script type="text/javascript" src="/assets/frappe/node_modules/moment/min/moment-with-locales.min.js"></script>
-	<script type="text/javascript" src="/assets/frappe/node_modules/moment-timezone/builds/moment-timezone-with-data.min.js"></script>
 	{{ include_script('frappe-web.bundle.js') }}
 	{% endblock %}
 

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -92,18 +92,12 @@ $(".file-size").each(function() {
 });
 </script>
 {{ include_script("controls.bundle.js") }}
-{% if is_list %}
-{# web form list #}
-<script type="text/javascript" src="/assets/frappe/node_modules/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="/assets/frappe/node_modules/moment-timezone/builds/moment-timezone-with-data.min.js"></script>
+{% if is_list %} <!-- web form list -->
 {{ include_script("dialog.bundle.js") }}
 {{ include_script("web_form.bundle.js") }}
 {{ include_script("bootstrap-4-web.bundle.js") }}
-{% else %}
-{# web form #}
+{% else %} <!-- web form -->
 {{ include_script("dialog.bundle.js") }}
-<script type="text/javascript" src="/assets/frappe/node_modules/moment/min/moment-with-locales.min.js"></script>
-<script type="text/javascript" src="/assets/frappe/node_modules/moment-timezone/builds/moment-timezone-with-data.min.js"></script>
 <script type="text/javascript" src="/assets/frappe/node_modules/vue/dist/vue.js"></script>
 <script>
 	Vue.prototype.__ = window.__;


### PR DESCRIPTION
## **Issue:**
> **TLDR: Web bundle needs moment imported in it, before datetime.js**
- On certain pages due to `moment` being undefined, it stops loading further js assets
- In this example, due to the error: frappe has no method `is_user_logged_in()` bound to it (`website.js not loaded due to error halting the process`)
- **Login** is visible even though the user is already logged in (works on some other pages)
   <img width="1419" alt="Screenshot 2022-02-02 at 10 23 27 AM" src="https://user-images.githubusercontent.com/25857446/152095413-cc0a147d-855c-45b5-84be-85851d5f3ef9.png">
- This breaks assets from other apps as well (erpnext js assets here)
- `moment` is imported via  > `libs.bundle.js` > which is used in **desk** views
- frappe's web bundle does not contain moment due to which, `moment is not undefined` breaks loading other js assets
- for some odd reason, importing moment in the web bundle does not work, so this is a temporary fix for that

## **Fix**:
- Add a new lib file `moment.js` which handles importing moment and binding it to the window
- Replaced all moment imports by this file
- Moment was imported and then momentTimezone (which eventually overwrites moment). Import only **momentTimezone** since **i think** it imports and uses **moment** internally.
- After fix:
  <img width="1329" alt="Screenshot 2022-02-02 at 10 30 16 AM" src="https://user-images.githubusercontent.com/25857446/152095736-97ee3664-5625-4f26-a64e-08eb445d8323.png">

## **(TIL) Today I Learned:**
- Imports in `frappe-web.bundle.js` execute sequentially. 
- So since `datetime.js` needed `moment` we tried importing and binding `moment` to the window before `datetime.js`, hoping it would work
- It still broke though, because the window binding [`window.moment = moment`] **will not execute until the entire set of imports in the bundle is completed**.
- `datetime.js` was imported before that, due to which the obvious missing moment
- Although during the imports if a file is loaded, since that file is being imported, the contents of that file will execute

So if we put some console.log in the **web bundle**, **datetime.js**  and **moment.js** (new file), this is how it will execute:
<img width="147" alt="Screenshot 2022-02-02 at 9 01 35 PM" src="https://user-images.githubusercontent.com/25857446/152184906-fc200540-5843-442a-ab8c-3346582b8c3b.png">
> **Bundle is logged last because it will execute console.log once the entire bundle finishes loading**