### PR TITLE
fix: `AttributeError` in `validate_links_table_fieldnames`

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -759,25 +759,25 @@ def validate_links_table_fieldnames(meta):
 		return
 
 	fieldnames = tuple(field.fieldname for field in meta.fields)
-	for index, link in enumerate(meta.links):
+	for index, link in enumerate(meta.links, 1):
 		link_meta = frappe.get_meta(link.link_doctype)
 		if not link_meta.get_field(link.link_fieldname):
-			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index+1, frappe.bold(link.link_fieldname), frappe.bold(link.link_doctype))
+			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index, frappe.bold(link.link_fieldname), frappe.bold(link.link_doctype))
 			frappe.throw(message, InvalidFieldNameError, _("Invalid Fieldname"))
 
 		if not link.is_child_table:
 			continue
 
 		if not link.parent_doctype:
-			message = _("Document Links Row #{0}: Parent DocType is mandatory for internal links").format(index+1)
+			message = _("Document Links Row #{0}: Parent DocType is mandatory for internal links").format(index)
 			frappe.throw(message, frappe.ValidationError, _("Parent Missing"))
 
 		if not link.table_fieldname:
-			message = _("Document Links Row #{0}: Table Fieldname is mandatory for internal links").format(index+1)
+			message = _("Document Links Row #{0}: Table Fieldname is mandatory for internal links").format(index)
 			frappe.throw(message, frappe.ValidationError, _("Table Fieldname Missing"))
 
 		if link.table_fieldname not in fieldnames:
-			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index+1, frappe.bold(link.table_fieldname), frappe.bold(meta.name))
+			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index, frappe.bold(link.table_fieldname), frappe.bold(meta.name))
 			frappe.throw(message, frappe.ValidationError, _("Invalid Table Fieldname"))
 
 def validate_fields_for_doctype(doctype):

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -755,28 +755,30 @@ def validate_series(dt, autoname=None, name=None):
 
 def validate_links_table_fieldnames(meta):
 	"""Validate fieldnames in Links table"""
-	if frappe.flags.in_patch: return
-	if frappe.flags.in_fixtures: return
-	if not meta.links: return
+	if not meta.links or frappe.flags.in_patch or frappe.flags.in_fixtures:
+		return
 
+	fieldnames = tuple(field.fieldname for field in meta.fields)
 	for index, link in enumerate(meta.links):
 		link_meta = frappe.get_meta(link.link_doctype)
 		if not link_meta.get_field(link.link_fieldname):
 			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index+1, frappe.bold(link.link_fieldname), frappe.bold(link.link_doctype))
 			frappe.throw(message, InvalidFieldNameError, _("Invalid Fieldname"))
 
-		if link.is_child_table and not meta.get_field(link.table_fieldname):
+		if not link.is_child_table:
+			continue
+
+		if not link.parent_doctype:
+			message = _("Document Links Row #{0}: Parent DocType is mandatory for internal links").format(index+1)
+			frappe.throw(message, frappe.ValidationError, _("Parent Missing"))
+
+		if not link.table_fieldname:
+			message = _("Document Links Row #{0}: Table Fieldname is mandatory for internal links").format(index+1)
+			frappe.throw(message, frappe.ValidationError, _("Table Fieldname Missing"))
+
+		if link.table_fieldname not in fieldnames:
 			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index+1, frappe.bold(link.table_fieldname), frappe.bold(meta.name))
 			frappe.throw(message, frappe.ValidationError, _("Invalid Table Fieldname"))
-
-		if link.is_child_table:
-			if not link.parent_doctype:
-				message = _("Document Links Row #{0}: Parent DocType is mandatory for internal links").format(index+1)
-				frappe.throw(message, frappe.ValidationError, _("Parent Missing"))
-
-			if not link.table_fieldname:
-				message = _("Document Links Row #{0}: Table Fieldname is mandatory for internal links").format(index+1)
-				frappe.throw(message, frappe.ValidationError, _("Table Fieldname Missing"))
 
 def validate_fields_for_doctype(doctype):
 	meta = frappe.get_meta(doctype, cached=False)


### PR DESCRIPTION
Resolves #14420 

## Cause
The main cause of this issue is the ambiguous parameter name (`meta`) of `validate_links_table_fieldnames`. When this function is called, arguments are not always passed as `Meta` but also  passed as `DocType` (which does not have method `get_field`) in: https://github.com/frappe/frappe/blob/300031aa36941ea17292852f1ec2bc1a45fc67e8/frappe/core/doctype/doctype/doctype.py#L79

The quick fix (which is implemented in this PR) is to just not use `get_field` method at all. But a better fix would be to remove the ambiguity of the parameter `meta` itself.
## Changes Made
 - use `fields` attribute instead of `get_field` method since meta parameter is ambiguous.
 - refactor `validate_links_table_fieldnames`.

