### PR TITLE
fix: Added regex for alerts

### DIFF
--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -259,7 +259,15 @@ frappe.utils.xss_sanitise = function (string, options) {
 		'/': '&#x2F;'
 	};
 	const REGEX_SCRIPT = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi; // used in jQuery 1.7.2 src/ajax.js Line 14
+	const REGEX_ALERT = /confirm\(.*\)|alert\(.*\)|prompt\(.*\)/gi; // captures alert, confirm, prompt
 	options = Object.assign({}, DEFAULT_OPTIONS, options); // don't deep copy, immutable beauty.
+
+	// Rule 3 - TODO: Check event handlers?
+	// script and alert should be checked first or else it will be escaped
+	if (options.strategies.includes('js')) {
+		sanitised = sanitised.replace(REGEX_SCRIPT, "");
+		sanitised = sanitised.replace(REGEX_ALERT, "");
+	}
 
 	// Rule 1
 	if (options.strategies.includes('html')) {
@@ -268,11 +276,6 @@ frappe.utils.xss_sanitise = function (string, options) {
 			const regex = new RegExp(char, "g");
 			sanitised = sanitised.replace(regex, escape);
 		}
-	}
-
-	// Rule 3 - TODO: Check event handlers?
-	if (options.strategies.includes('js')) {
-		sanitised = sanitised.replace(REGEX_SCRIPT, "");
 	}
 
 	return sanitised;


### PR DESCRIPTION
Added regex for popups such as alert, prompt and confirm on client side. 
Previously only script tags were identified which left many pyloads bypass even after apply sanitization. 

Also, rearranged the strategies to check for payloads since if both strategies are applicable then html escape makes the script tag unidentifiable
![Screenshot 2022-02-02 at 11 28 13 AM](https://user-images.githubusercontent.com/30501401/152100906-45230fcb-d2b6-47a5-97f6-fe02c4981685.png)
.