### PR TITLE
feat: add breadcrumbs in dashboard view

### DIFF
--- a/frappe/core/page/dashboard_view/dashboard_view.js
+++ b/frappe/core/page/dashboard_view/dashboard_view.js
@@ -77,7 +77,7 @@ class Dashboard {
 	}
 
 	set_breadcrumbs() {
-		frappe.breadcrumbs.add("Desk", "Dashboard")
+		frappe.breadcrumbs.add("Desk", "Dashboard");
 	}
 
 	refresh() {

--- a/frappe/core/page/dashboard_view/dashboard_view.js
+++ b/frappe/core/page/dashboard_view/dashboard_view.js
@@ -30,6 +30,7 @@ class Dashboard {
 
 	show() {
 		this.route = frappe.get_route();
+		this.set_breadcrumbs();
 		if (this.route.length > 1) {
 			// from route
 			this.show_dashboard(this.route.slice(-1)[0]);
@@ -73,6 +74,10 @@ class Dashboard {
 		}
 		this.charts = {};
 		frappe.last_dashboard = current_dashboard_name;
+	}
+
+	set_breadcrumbs() {
+		frappe.breadcrumbs.add("Desk", "Dashboard")
 	}
 
 	refresh() {

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -70,6 +70,9 @@ frappe.breadcrumbs = {
 				this.set_form_breadcrumb(breadcrumbs, view);
 			} else if (breadcrumbs.doctype && view === 'list') {
 				this.set_list_breadcrumb(breadcrumbs);
+			} else if (breadcrumbs.doctype && view == 'dashboard-view') {
+				this.set_list_breadcrumb(breadcrumbs);
+				this.set_dashboard_breadcrumb(breadcrumbs);
 			}
 		}
 
@@ -162,6 +165,14 @@ frappe.breadcrumbs = {
 			});
 		}
 
+	},
+
+	set_dashboard_breadcrumb(breadcrumbs) {
+		const doctype = breadcrumbs.doctype;
+		const docname = frappe.get_route()[1];
+		let dashboard_route = `/app/${frappe.router.slug(doctype)}/${docname}`;
+		$(`<li><a href="${dashboard_route}">${__(docname)}</a></li>`)
+			.appendTo(this.$breadcrumbs);
 	},
 
 	setup_modules() {


### PR DESCRIPTION
***Before***
No breadcrumb to navigate to dashboard doc or dashboard list
<img width="1434" alt="Screenshot 2022-02-02 at 11 51 21 AM" src="https://user-images.githubusercontent.com/58825865/152104248-f312747a-58b1-4f89-b954-0a6d87c880d0.png">

***After***

https://user-images.githubusercontent.com/58825865/152104594-3a253236-fd42-40ee-9d51-b0cb0f3da814.mov


`no-docs`

