### PR TITLE
fix: primary color for progress bar

### DIFF
--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -54,4 +54,6 @@ $input-height: 28px !default;
 	// skeleton
 	--skeleton-bg: var(--gray-100);
 
+	// progress bar
+	--progress-bar-bg: var(--primary);
 }

--- a/frappe/public/scss/desk/variables.scss
+++ b/frappe/public/scss/desk/variables.scss
@@ -118,6 +118,9 @@ $custom-control-label-color: var(--text-color);
 $custom-switch-indicator-size: 8px;
 $custom-control-indicator-border-width: 2px;
 
+// progress bar
+$progress-bar-bg: var(--progress-bar-bg);
+
 $navbar-nav-link-padding-x: 1rem !default;
 $navbar-padding-y: 1rem !default;
 $card-border-radius: 0.75rem !default;


### PR DESCRIPTION
## Issue
Currently, progress-bar color has absolute value of `$primary`. Due to this, when we override the value of css variable 
`--primary`, it does not set to the progress bar color and there is no other way we can set it **dynamically**. 

## Changes Made
 - Introduced new css variable `--progress-bar-bg`, which makes it more extensible.
 - Aligned the progress-bar color with the css variable (`--primary`).

## Screenshorts
With the CSS code in the Custom App:
```css
:root {
  --primary: #7a2ef5;
}
```
### Before
![image](https://user-images.githubusercontent.com/43115036/152120936-d231c177-c1b0-4918-8381-baa897536853.png)

### After
![Screenshot 2022-02-02 at 2 07 44 PM](https://user-images.githubusercontent.com/43115036/152121118-1cdd8e62-e87f-40e6-9616-8f8e038a6744.png)

