### PR TITLE
fix: primary color for checkbox and radio

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -249,6 +249,7 @@
 	--checkbox-right-margin: var(--margin-xs);
 	--checkbox-size: 14px;
 	--checkbox-focus-shadow: 0 0 0 2px var(--gray-300);
+	--checkbox-gradient: linear-gradient(180deg, #4AC3F8 -124.51%, var(--primary) 100%);
 
 	--right-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1.25 7.5L4.75 4L1.25 0.5' stroke='%231F272E' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 	--left-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M7.5 9.5L4 6l3.5-3.5' stroke='%231F272E' stroke-linecap='round' stroke-linejoin='round'></path></svg>");

--- a/frappe/public/scss/common/global.scss
+++ b/frappe/public/scss/common/global.scss
@@ -54,7 +54,7 @@ input[type="radio"] {
 	}
 
 	&:checked::before {
-		background-color: var(--blue-500);
+		background-color: var(--primary);
 		border-radius: 16px;
 		box-shadow: inset 0 0 0 2px white;
 	}
@@ -85,8 +85,8 @@ input[type="checkbox"] {
 	}
 
 	&:checked {
-		background-color: var(--blue-500);
-		background-image: $check-icon, linear-gradient(180deg, #4AC3F8 -124.51%, #2490EF 100%);
+		background-color: var(--primary);
+		background-image: $check-icon, var(--checkbox-gradient);
 		background-size: 57%, 100%;
 		box-shadow: none;
 		border: none;


### PR DESCRIPTION
## Issue
Currently, checkbox color has absolute values. Due to this, when we override the value of css variable `--primary`, it does not change the checkbox/radio color.

## Changes Made
 - Use `--primary` instead of `--blue-500`.
 - Introduce new variable `--checkbox-gradient`, making it more extensible.

## Screenshots
With the CSS code in the Custom App:
```css
:root {
  --primary: #7a2ef5;
  --checkbox-gradient: linear-gradient(180deg, #cf9dff -124.51%, var(--primary) 100%);
}
```
### Before
![image](https://user-images.githubusercontent.com/43115036/152137080-7abd74ce-506d-49ea-9621-4fdb3878df36.png)

### After
![image](https://user-images.githubusercontent.com/43115036/152137235-d289fb35-2850-4e41-bf6a-b5aceed0fea8.png)


---
similar PR: #15839