### PR TITLE
fix: Return consistent time types

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -335,7 +335,6 @@ class TestDateUtils(unittest.TestCase):
 			frappe.utils.getdate("2021-01-02"))
 
 	def test_get_time(self):
-		from dateutil.parser import ParserError
 		datetime_input = now_datetime()
 		timedelta_input = get_timedelta()
 		time_input = nowtime()
@@ -343,11 +342,10 @@ class TestDateUtils(unittest.TestCase):
 		self.assertIsInstance(get_time(datetime_input), time)
 		self.assertIsInstance(get_time(timedelta_input), time)
 		self.assertIsInstance(get_time(time_input), time)
+		self.assertIsInstance(get_time("100:2:12"), time)
 		self.assertIsInstance(get_time(str(datetime_input)), time)
 		self.assertIsInstance(get_time(str(timedelta_input)), time)
 		self.assertIsInstance(get_time(str(time_input)), time)
-		with self.assertRaises(ParserError):
-			get_time("100:0:0")
 
 	def test_get_timedelta(self):
 		datetime_input = now_datetime()

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -17,7 +17,7 @@ import frappe
 from frappe.utils import ceil, evaluate_filters, floor, format_timedelta
 from frappe.utils import get_url, money_in_words, parse_timedelta, scrub_urls
 from frappe.utils import validate_email_address, validate_url
-from frappe.utils.data import cast, validate_python_code
+from frappe.utils.data import cast, get_time, get_timedelta, nowtime, now_datetime, validate_python_code
 from frappe.utils.diff import _get_value_from_version, get_version_diff, version_query
 from frappe.utils.image import optimize_image, strip_exif_data
 from frappe.utils.response import json_handler
@@ -333,6 +333,34 @@ class TestDateUtils(unittest.TestCase):
 			frappe.utils.getdate("2020-12-26"))
 		self.assertEqual(frappe.utils.get_last_day_of_week("2020-12-28"),
 			frappe.utils.getdate("2021-01-02"))
+
+	def test_get_time(self):
+		from dateutil.parser import ParserError
+		datetime_input = now_datetime()
+		timedelta_input = get_timedelta()
+		time_input = nowtime()
+
+		self.assertIsInstance(get_time(datetime_input), time)
+		self.assertIsInstance(get_time(timedelta_input), time)
+		self.assertIsInstance(get_time(time_input), time)
+		self.assertIsInstance(get_time(str(datetime_input)), time)
+		self.assertIsInstance(get_time(str(timedelta_input)), time)
+		self.assertIsInstance(get_time(str(time_input)), time)
+		with self.assertRaises(ParserError):
+			get_time("100:0:0")
+
+	def test_get_timedelta(self):
+		datetime_input = now_datetime()
+		timedelta_input = get_timedelta()
+		time_input = nowtime()
+
+		self.assertIsInstance(get_timedelta(), timedelta)
+		self.assertIsInstance(get_timedelta("100:2:12"), timedelta)
+		self.assertIsInstance(get_timedelta("17:21:00"), timedelta)
+		self.assertIsInstance(get_timedelta("2012-01-19 17:21:00"), timedelta)
+		self.assertIsInstance(get_timedelta(str(datetime_input)), timedelta)
+		self.assertIsInstance(get_timedelta(str(timedelta_input)), timedelta)
+		self.assertIsInstance(get_timedelta(str(time_input)), timedelta)
 
 class TestResponse(unittest.TestCase):
 	def test_json_handler(self):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -112,9 +112,9 @@ def get_timedelta(time: Optional[str] = None) -> Optional[datetime.timedelta]:
 		try:
 			t = parser.parse(time)
 		except ParserError as e:
-			if "day" in e.args[1]:
-				from frappe.utils import parse_timedelta
+			if "day" in e.args[1] or "hour must be in" in e.args[0]:
 				return parse_timedelta(time)
+			raise e
 		return datetime.timedelta(
 			hours=t.hour, minutes=t.minute, seconds=t.second, microseconds=t.microsecond
 		)
@@ -329,17 +329,24 @@ def get_year_ending(date):
 	# last day of this month
 	return add_to_date(date, days=-1)
 
-def get_time(time_str):
+def get_time(time_str: str) -> datetime.time:
 	from dateutil import parser
+	from dateutil.parser import ParserError
 
 	if isinstance(time_str, datetime.datetime):
 		return time_str.time()
 	elif isinstance(time_str, datetime.time):
 		return time_str
-	else:
-		if isinstance(time_str, datetime.timedelta):
-			return format_timedelta(time_str)
+	elif isinstance(time_str, datetime.timedelta):
+		return (datetime.datetime.min + time_str).time()
+	try:
 		return parser.parse(time_str).time()
+	except ParserError as e:
+		if "day" in e.args[1] or "hour must be in" in e.args[0]:
+			return (
+				datetime.datetime.min + parse_timedelta(time_str)
+			).time()
+		raise e
 
 def get_datetime_str(datetime_obj):
 	if isinstance(datetime_obj, str):


### PR DESCRIPTION
Fixes bug introduced by #15560 and noticed on ERPNext CI (ref: https://github.com/frappe/erpnext/runs/5036077046?check_suite_focus=true).

Added corresponding tests.