### PR TITLE
fix: type hints not supported in py2.7

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -144,7 +144,7 @@ def update_user_settings(old, new, link_fields):
 		else:
 			continue
 
-def update_customizations(old: str, new: str) -> None:
+def update_customizations(old, new) -> None:
 	frappe.db.set_value("Custom DocPerm", {"parent": old}, "parent", new, update_modified=False)
 
 def update_attachments(doctype, old, new):

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -144,7 +144,7 @@ def update_user_settings(old, new, link_fields):
 		else:
 			continue
 
-def update_customizations(old, new) -> None:
+def update_customizations(old, new):
 	frappe.db.set_value("Custom DocPerm", {"parent": old}, "parent", new, update_modified=False)
 
 def update_attachments(doctype, old, new):


### PR DESCRIPTION
caused by
https://github.com/frappe/frappe/pull/15726