### PR TITLE
fix: delete chat message attachments

### DIFF
--- a/frappe/patches/v13_0/remove_chat.py
+++ b/frappe/patches/v13_0/remove_chat.py
@@ -3,6 +3,7 @@ import click
 
 def execute():
 	frappe.delete_doc_if_exists("DocType", "Chat Message")
+	frappe.delete_doc_if_exists("DocType", "Chat Message Attachment")
 	frappe.delete_doc_if_exists("DocType", "Chat Profile")
 	frappe.delete_doc_if_exists("DocType", "Chat Token")
 	frappe.delete_doc_if_exists("DocType", "Chat Room User")


### PR DESCRIPTION
Issue:
![2022-02-03 12 15 37](https://user-images.githubusercontent.com/836784/152294162-46b683d8-6e8d-4a75-b2ad-408d48ba0edd.jpg)


Solution:
Delete "Chat Message Attachment" before deleting Chat doctype

