### PR TITLE
fix: copy to clipboard functionality (on pasting)

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -608,17 +608,15 @@ frappe.Application = class Application {
 					// to avoid abrupt UX
 					// wait for activity feedback
 					sleep(500).then(() => {
-						let res = frappe.model.with_doctype(doc.doctype, () => {
-							let newdoc = frappe.model.copy_doc(doc);
-							newdoc.__newname = doc.name;
+						frappe.model.with_doctype(doc.doctype, () => {
 							delete doc.name;
+							let newdoc = frappe.model.copy_doc(doc);
 							newdoc.idx = null;
 							newdoc.__run_link_triggers = false;
 							frappe.set_route('Form', newdoc.doctype, newdoc.name);
 							frappe.dom.unfreeze();
 						});
-						res && res.fail(frappe.dom.unfreeze);
-					});
+					}, frappe.dom.unfreeze);
 				}
 			} catch (e) {
 				//


### PR DESCRIPTION
So upon pasting a copied doc (by using copy to clipboard) ..we set the new doc's `__newname` property to the old/copied doc's name

https://github.com/frappe/frappe/blob/6163ebf1eb1cc014590dcb572b52a8a9b56193ce/frappe/public/js/frappe/desk.js#L613

This we then use in the backend to set as the name of the new doc

https://github.com/frappe/frappe/blob/6163ebf1eb1cc014590dcb572b52a8a9b56193ce/frappe/model/document.py#L417-L420

This leads to duplicate key error on saving the new doc.

Fix: removing that line automatically sets the name of the new doc


PS: we might need to rename `set_new_name` as it's calling `frappe.naming.set_new_name` in it which seems like recursion at first (but isn't)

https://github.com/frappe/frappe/blob/6163ebf1eb1cc014590dcb572b52a8a9b56193ce/frappe/model/document.py#L410-L432