### PR TITLE
fix: missing param_wrapper in recursive calls

### DIFF
--- a/frappe/query_builder/terms.py
+++ b/frappe/query_builder/terms.py
@@ -59,6 +59,7 @@ class ParameterizedValueWrapper(ValueWrapper):
 			sql = self.get_value_sql(
 				quote_char=quote_char,
 				secondary_quote_char=secondary_quote_char,
+				param_wrapper=param_wrapper,
 				**kwargs,
 			)
 		return format_alias_sql(sql, self.alias, quote_char=quote_char, **kwargs)

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -116,6 +116,7 @@ class TestParameterization(unittest.TestCase):
 				Case()
 				.when(DocType.search_fields == "value", "other_value")
 				.when(Coalesce(DocType.search_fields == "subject_in_function"), "true_value")
+				.else_("Overdue")
 			)
 		)
 
@@ -128,6 +129,32 @@ class TestParameterization(unittest.TestCase):
 		self.assertEqual(params["param2"], "other_value")
 		self.assertEqual(params["param3"], "subject_in_function")
 		self.assertEqual(params["param4"], "true_value")
+		self.assertEqual(params["param5"], "Overdue")
+
+	def test_case_in_update(self):
+		DocType = frappe.qb.DocType("DocType")
+		query = (
+			frappe.qb.update(DocType)
+			.set(
+				"parent",
+				Case()
+				.when(DocType.search_fields == "value", "other_value")
+				.when(Coalesce(DocType.search_fields == "subject_in_function"), "true_value")
+				.else_("Overdue")
+			)
+		)
+
+		self.assertTrue("walk" in dir(query))
+		query, params = query.walk()
+
+		self.assertIn("%(param1)s", query)
+		self.assertIn("param1", params)
+		self.assertEqual(params["param1"], "value")
+		self.assertEqual(params["param2"], "other_value")
+		self.assertEqual(params["param3"], "subject_in_function")
+		self.assertEqual(params["param4"], "true_value")
+		self.assertEqual(params["param5"], "Overdue")
+
 
 
 @run_only_if(db_type_is.MARIADB)


### PR DESCRIPTION
`ParamaterisedValueWrapper` only adds parameters for string values if a `param wraper` is present.
When QB objects are passed (which require recursive calls) the `param wraper` isn't passed down in recursive calls because of a missing argument.

# Changes
 - Fixes bug introduced by https://github.com/frappe/frappe/pull/15560
 
 - Added a test to detect this in the future
 
ref - https://github.com/frappe/frappe/pull/15847