### PR TITLE
test: use `now` instead of `is_async` in tests

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -115,7 +115,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 				# All the linked docs should be checked beforehand
 				frappe.enqueue('frappe.model.delete_doc.delete_dynamic_links',
 					doctype=doc.doctype, name=doc.name,
-					is_async=False if frappe.flags.in_test else True)
+					now=frappe.flags.in_test)
 
 		# clear cache for Document
 		doc.clear_cache()


### PR DESCRIPTION
`is_async=False` causes transaction commit even though it's not running as separate background job as documented here: https://github.com/frappe/frappe/issues/15376 


While that core issue still needs more time to fix, this is the only place where it's being used and hence fixing this first.

PS: this doesn't change any behavior in production. Only in tests. 
PS2: I am not really sure what's the point of doing is_async=False vs now=True? is_async flag makes a round trip to `rq` while `now` executes it immediately. 
PS3: this is introducing flake in tests because of partial data commits. 
