### PR TITLE
fix: append chart options before render

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -549,14 +549,14 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	render_graph(args) {
 		this.chart_area.show();
 		this.chart_area.body.empty();
-		$.extend({
+		$.extend(args, {
 			type: 'line',
 			colors: ['green'],
 			truncateLegends: 1,
 			axisOptions: {
 				shortenYAxisNumbers: 1
 			}
-		}, args);
+		});
 		this.show();
 
 		this.chart = new frappe.Chart('.form-graph', args);


### PR DESCRIPTION
Steps to replicate:
- Go to a company master (ERPNext) which has some sales transaction against it.
- Check the first chart in the company form dashboard.

**Before:**

![image](https://user-images.githubusercontent.com/13396535/152760428-c2b6b5b6-36db-4a7c-8168-27ad4670ea58.png)

**After:**

![image](https://user-images.githubusercontent.com/13396535/152760371-404a6a1d-150c-4b0d-9871-cfcbfe8a6a68.png)
