### PR TITLE
Revert "test: use `now` instead of `is_async` in tests"

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -115,7 +115,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 				# All the linked docs should be checked beforehand
 				frappe.enqueue('frappe.model.delete_doc.delete_dynamic_links',
 					doctype=doc.doctype, name=doc.name,
-					now=frappe.flags.in_test)
+					is_async=False if frappe.flags.in_test else True)
 
 		# clear cache for Document
 		doc.clear_cache()


### PR DESCRIPTION
Reverts frappe/frappe#15893

reverting till related erpnext tests are fixed