### PR TITLE
fix: consistent behaviour of `ignore_if_duplicate` on postgres and mariadb

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -177,6 +177,8 @@ class Database(object):
 				raise frappe.QueryTimeoutError(e)
 
 			elif frappe.conf.db_type == 'postgres':
+				# TODO: added temporarily
+				print(e)
 				raise
 
 			if ignore_ddl and (self.is_missing_column(e) or self.is_missing_table(e) or self.cant_drop_field_or_key(e)):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -249,11 +249,7 @@ class Document(BaseDocument):
 		if getattr(self.meta, "issingle", 0):
 			self.update_single(self.get_valid_dict())
 		else:
-			try:
-				self.db_insert()
-			except frappe.DuplicateEntryError as e:
-				if not ignore_if_duplicate:
-					raise e
+			self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
 
 		# children
 		for d in self.get_all_children():

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -291,6 +291,16 @@ class TestDB(unittest.TestCase):
 
 		frappe.db.MAX_WRITES_PER_TRANSACTION = Database.MAX_WRITES_PER_TRANSACTION
 
+	def test_pk_collision_ignoring(self):
+		# note has `name` generated from title
+		for _ in range(3):
+			frappe.get_doc(doctype="Note", title="duplicate name").insert(ignore_if_duplicate=True)
+
+		with savepoint():
+			self.assertRaises(frappe.DuplicateEntryError, frappe.get_doc(doctype="Note", title="duplicate name").insert)
+			# recover transaction to continue other tests
+			raise Exception
+
 
 @run_only_if(db_type_is.MARIADB)
 class TestDDLCommandsMaria(unittest.TestCase):


### PR DESCRIPTION
On Postgres inserting a duplicate row aborts the transaction and only partial/full rollback can be used to recover from it.

`ignore_if_duplicate` flag exists on `Document.insert` method, this is actually harmful in Postgres because it ignores the error instead of letting it bubble up where it can be handled.

The only way to make this flag work with Postgres is to ignore pk collisions at the database level using `ON CONFLICT` statement. 


Note about MariaDB: MariaDB has no equivalent functionality, similar functionality exists but it's dangerous:
1. `insert ignore` will ignore more than primary key collisions
2. "upsert" or `insert ... on duplicate key update name=name` will also get triggered on non-pk violations (e.g. unique violation)

Since MariaDB has no need to ignore it at DB level anyway we can ignore this I think?


`no-docs`



After this on both DB `Document.insert(ignore_if_duplicate=True)` will give equivalent behavior from ORM/dev perspective. No need to do savepoint dance just to get this basic functionality 😬 