### PR TITLE
fix: Image in Comments saved under its Reference Doctype

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -817,8 +817,14 @@ def extract_images_from_html(doc, content):
 			mtype = headers.split(";")[0]
 			filename = get_random_filename(content_type=mtype)
 
-		doctype = doc.parenttype if doc.parent else doc.doctype
-		name = doc.parent or doc.name
+		doctype = doc.doctype
+		name = doc.name
+		if doc.parent: 
+			doctype = doc.parenttype
+			name = doc.parent
+		if doc.doctype == "Comment":
+			doctype = doc.reference_doctype
+			name = doc.reference_name
 
 		_file = frappe.get_doc({
 			"doctype": "File",


### PR DESCRIPTION
https://github.com/frappe/frappe/issues/15901

![save_image_comment](https://user-images.githubusercontent.com/58166671/152942848-41751f08-4f50-4c7c-88c6-6c45b6ca32d3.gif)

