### PR TITLE
fix(grid): Select All checkbox not visible

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -166,16 +166,16 @@ export default class GridRow {
 	render_template() {
 		this.set_row_index();
 
-		if(this.row_display) {
+		if (this.row_display) {
 			this.row_display.remove();
 		}
 
 		// row index
-		if(!this.row_index) {
-			this.row_index = $(`<div class="grid-header-check">${this.row_check_html}<span></span></div>`).appendTo(this.row);
+		if (!this.row_index) {
+			this.row_index = $(`<div class="template-row-index">${this.row_check_html}<span></span></div>`).appendTo(this.row);
 		}
 
-		if(this.doc) {
+		if (this.doc) {
 			this.row_index.find('span').html(this.doc.idx);
 		}
 

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -172,15 +172,14 @@ export default class GridRow {
 
 		// row index
 		if(!this.row_index) {
-			this.row_index = $('<div class="grid-header-check">'+this.row_check_html+' <span></span></div>').appendTo(this.row);
+			this.row_index = $(`<div class="grid-header-check">${this.row_check_html}<span></span></div>`).appendTo(this.row);
 		}
 
 		if(this.doc) {
 			this.row_index.find('span').html(this.doc.idx);
 		}
 
-		this.row_display = $('<div class="row-data sortable-handle template-row">'+
-			+'</div>').appendTo(this.row)
+		this.row_display = $('<div class="row-data sortable-handle template-row"></div>').appendTo(this.row)
 			.html(frappe.render(this.grid.template, {
 				doc: this.doc ? frappe.get_format_helper(this.doc) : null,
 				frm: this.frm,

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -171,11 +171,11 @@ export default class GridRow {
 		}
 
 		// row index
+		if(!this.row_index) {
+			this.row_index = $('<div class="grid-header-check">'+this.row_check_html+' <span></span></div>').appendTo(this.row);
+		}
+
 		if(this.doc) {
-			if(!this.row_index) {
-				this.row_index = $('<div style="float: left; margin-left: 15px; margin-top: 8px; \
-					margin-right: -20px;">'+this.row_check_html+' <span></span></div>').appendTo(this.row);
-			}
 			this.row_index.find('span').html(this.doc.idx);
 		}
 

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -54,7 +54,7 @@
 }
 
 .form-grid .grid-heading-row .template-row {
-	margin-left: 20px;
+	margin-left: 8px;
 }
 
 .form-grid .template-row {
@@ -88,11 +88,15 @@
 	margin-top: 2px;
 }
 
-.grid-header-check {
-	float: left; 
-	margin-left: 10px; 
+.template-row-index {
+	float: left;
+	margin-left: 15px;
 	margin-top: 8px;
 	margin-right: -20px;
+
+	span {
+		margin-left: 5px;
+	}
 }
 
 .editable-form .grid-static-col.bold {

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -88,6 +88,13 @@
 	margin-top: 2px;
 }
 
+.grid-header-check {
+	float: left; 
+	margin-left: 10px; 
+	margin-top: 8px;
+	margin-right: -20px;
+}
+
 .editable-form .grid-static-col.bold {
 	font-weight: bold;
 }


### PR DESCRIPTION
In Child Tables such as Stock Entry Detail, Sales Invoice Item (wherever `grid.template` applies) non-editable grid doesn't let users select all rows of the child table.

![image](https://user-images.githubusercontent.com/54097382/153049801-26f2ca38-4892-4aff-9fe5-238a3fa58f5e.png)

This fix will let users select all rows using a checkbox in the header row of the child table.

## Screenshots

**Before**

![image](https://user-images.githubusercontent.com/16315650/153127765-1e575096-b7da-41f1-bed4-e5d1c48cb98e.png)

**After**

![image](https://user-images.githubusercontent.com/16315650/153127672-9054014d-fbc2-4fff-9c7b-6dd0c7c6cc1c.png)
