### PR TITLE
fix: Overwrite Email Content on Selecting Email Template

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -260,9 +260,7 @@ frappe.views.CommunicationComposer = class {
 				const content_field = me.dialog.fields_dict.content;
 				const subject_field = me.dialog.fields_dict.subject;
 
-				let content = content_field.get_value() || "";
-
-				content_field.set_value(`${reply.message}<br>${content}`);
+				content_field.set_value(reply.message);
 				subject_field.set_value(reply.subject);
 
 				me.reply_added = email_template;


### PR DESCRIPTION
### **Details of the Issue:**
When sending an email it allows user to choose an email template. However, when a user already loaded an email template and decides to change the template to another template, It does not overwrite the message with the newly selected template but instead it stacks it one after another.

### **Problem:**
The main issue is this should overwrite the message instead of stacking it one after another when selecting a new template as it is a logical standard behaviour when selecting templates.

**Screenshot of the Problem:**
![email_1](https://user-images.githubusercontent.com/86836253/152750092-64d222be-770b-4b61-909c-006494116a66.gif)

### **Replicate the Issue:**

- Menu > Email
- Choose Email Template
- Choose Another Email Template

### **Solution:**
Removing the line of code that keeps the previous template and adds it to the bottom of the new template.

**Screenshot of the fix:**
![email_fix](https://user-images.githubusercontent.com/86836253/152750133-fa25e486-82da-452b-b6a9-5b0b414e7d97.gif)

