### PR TITLE
chore: change log for v13.20.0

### DIFF
--- a/frappe/change_log/v13/v13_20_0.md
+++ b/frappe/change_log/v13/v13_20_0.md
@@ -1,0 +1,33 @@
+## Version 13.20.0 Release Notes
+
+### Features & Enhancements
+
+- Add click-drag scrolling to kanban boards ([#15641](https://github.com/frappe/frappe/pull/15641))
+- Time field in webform ([#15703](https://github.com/frappe/frappe/pull/15703))
+- Query Builder: additional filter support ([#14102](https://github.com/frappe/frappe/pull/14102))
+- Added more Sort options in list views ([#15709](https://github.com/frappe/frappe/pull/15709))
+- Added translations to datatable ([#15551](https://github.com/frappe/frappe/pull/15551))
+- Query Building & Data Handling ([#15883](https://github.com/frappe/frappe/pull/15883))
+- Allow custom queues ([#15653](https://github.com/frappe/frappe/pull/15653))
+
+### Fixes
+
+- Updated colors of standard alert classes ([#15663](https://github.com/frappe/frappe/pull/15663))
+- Use Link data type instead of Data for parent field ([#15715](https://github.com/frappe/frappe/pull/15715))
+- Code block style ([#15759](https://github.com/frappe/frappe/pull/15759))
+- Thumbnail for external images  ([#15838](https://github.com/frappe/frappe/pull/15838))
+- Set first day of the week for date range ([#15669](https://github.com/frappe/frappe/pull/15669))
+- Show image in sidebar in mobile view ([#15752](https://github.com/frappe/frappe/pull/15752))
+- Recursive routing for Form route ([#15539](https://github.com/frappe/frappe/pull/15539))
+- Datatable column resize in rtl ([#15636](https://github.com/frappe/frappe/pull/15636))
+- Remove salutation from email composer ([#15740](https://github.com/frappe/frappe/pull/15740))
+- Show sidebar in nav for md and sm screen size ([#15783](https://github.com/frappe/frappe/pull/15783))
+- Is Custom field placement in Role form ([#15601](https://github.com/frappe/frappe/pull/15601))
+- Document email in timeline ([#15592](https://github.com/frappe/frappe/pull/15592))
+- Set toast's background color based on alert type ([#15659](https://github.com/frappe/frappe/pull/15659))
+- The YYYY.MM.DD format not working for the document naming rule ([#15634](https://github.com/frappe/frappe/pull/15634))
+- Customize same property for multiple rows of DocType Link / DocType Action ([#15491](https://github.com/frappe/frappe/pull/15491))
+- Delete translation for renaming only if label is empty ([#15568](https://github.com/frappe/frappe/pull/15568))
+- Select perms not updated for link fields in child table ([#15707](https://github.com/frappe/frappe/pull/15707))
+- Translate title in msgprint method ([#15768](https://github.com/frappe/frappe/pull/15768))
+- Call validate_link only if "value" is passed ([#15856](https://github.com/frappe/frappe/pull/15856))


### PR DESCRIPTION
## Version 13.20.0 Release Notes

### Features & Enhancements

- Add click-drag scrolling to kanban boards ([#15641](https://github.com/frappe/frappe/pull/15641))
- Time field in webform ([#15703](https://github.com/frappe/frappe/pull/15703))
- Query Builder: additional filter support ([#14102](https://github.com/frappe/frappe/pull/14102))
- Added more Sort options in list views ([#15709](https://github.com/frappe/frappe/pull/15709))
- Added translations to datatable ([#15551](https://github.com/frappe/frappe/pull/15551))
- Query Building & Data Handling ([#15883](https://github.com/frappe/frappe/pull/15883))
- Allow custom queues ([#15653](https://github.com/frappe/frappe/pull/15653))

### Fixes

- Updated colors of standard alert classes ([#15663](https://github.com/frappe/frappe/pull/15663))
- Use Link data type instead of Data for parent field ([#15715](https://github.com/frappe/frappe/pull/15715))
- Code block style ([#15759](https://github.com/frappe/frappe/pull/15759))
- Thumbnail for external images  ([#15838](https://github.com/frappe/frappe/pull/15838))
- Set first day of the week for date range ([#15669](https://github.com/frappe/frappe/pull/15669))
- Show image in sidebar in mobile view ([#15752](https://github.com/frappe/frappe/pull/15752))
- Recursive routing for Form route ([#15539](https://github.com/frappe/frappe/pull/15539))
- Datatable column resize in rtl ([#15636](https://github.com/frappe/frappe/pull/15636))
- Remove salutation from email composer ([#15740](https://github.com/frappe/frappe/pull/15740))
- Show sidebar in nav for md and sm screen size ([#15783](https://github.com/frappe/frappe/pull/15783))
- Is Custom field placement in Role form ([#15601](https://github.com/frappe/frappe/pull/15601))
- Document email in timeline ([#15592](https://github.com/frappe/frappe/pull/15592))
- Set toast's background color based on alert type ([#15659](https://github.com/frappe/frappe/pull/15659))
- The YYYY.MM.DD format not working for the document naming rule ([#15634](https://github.com/frappe/frappe/pull/15634))
- Customize same property for multiple rows of DocType Link / DocType Action ([#15491](https://github.com/frappe/frappe/pull/15491))
- Delete translation for renaming only if label is empty ([#15568](https://github.com/frappe/frappe/pull/15568))
- Select perms not updated for link fields in child table ([#15707](https://github.com/frappe/frappe/pull/15707))
- Translate title in msgprint method ([#15768](https://github.com/frappe/frappe/pull/15768))
- Call validate_link only if "value" is passed ([#15856](https://github.com/frappe/frappe/pull/15856))