### PR TITLE
feat: bind secondary and custom actions to msgprint

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -352,7 +352,7 @@ def log(msg):
 
 	debug_log.append(as_unicode(msg))
 
-def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, indicator=None, alert=False, primary_action=None, is_minimizable=None, wide=None):
+def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, indicator=None, alert=False, primary_action=None, secondary_action=None, custom_action=None, is_minimizable=None, wide=None):
 	"""Print a message to the user (via HTTP response).
 	Messages are sent in the `__server_messages` property in the
 	response JSON and shown in a pop-up / modal.
@@ -415,6 +415,12 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, 
 
 	if primary_action:
 		out.primary_action = primary_action
+
+	if secondary_action:
+		out.secondary_action = secondary_action
+
+	if custom_action:
+		out.custom_action = custom_action
 
 	if wide:
 		out.wide = wide


### PR DESCRIPTION
### Changes
- Can now add secondary and custom action buttons to msgprints.

![image](https://user-images.githubusercontent.com/43572428/153163527-67279c61-15cb-40d7-9554-0dd6ba40d3ee.png)

PR related -> [#29499](https://github.com/frappe/erpnext/pull/29449)