### PR TITLE
refactor: API Testing Suite

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -211,7 +211,6 @@ def validate_oauth(authorization_header):
 		pass
 
 
-
 def validate_auth_via_api_keys(authorization_header):
 	"""
 	Authenticate request using API keys and set session user

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -159,7 +159,10 @@ def get_request_form_data():
 	else:
 		data = frappe.local.form_dict.data
 
-	return frappe.parse_json(data)
+	try:
+		return frappe.parse_json(data)
+	except ValueError:
+		return frappe.local.form_dict
 
 
 def validate_auth():

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -1,32 +1,63 @@
+import sys
 import unittest
+from contextlib import contextmanager
 from random import choice
+from typing import Dict, Optional
 
 import requests
 from semantic_version import Version
 
 import frappe
-from frappe.utils import get_site_url
+from frappe.utils import get_site_url, get_test_client
 
 
-def maintain_state(f):
-	def wrapper(*args, **kwargs):
-		frappe.db.rollback()
-		r = f(*args, **kwargs)
-		frappe.db.commit()
-		return r
+@contextmanager
+def suppress_stdout():
+	"""Supress stdout for tests which expectedly make noise
+	but that you don't need in tests"""
+	sys.stdout = None
+	try:
+		yield
+	finally:
+		sys.stdout = sys.__stdout__
 
-	return wrapper
 
-
-class TestResourceAPI(unittest.TestCase):
-	SITE_URL = get_site_url(frappe.local.site)
+class FrappeAPITestCase(unittest.TestCase):
+	SITE = frappe.local.site
+	SITE_URL = get_site_url(SITE)
 	RESOURCE_URL = f"{SITE_URL}/api/resource"
 	DOCTYPE = "ToDo"
 	GENERATED_DOCUMENTS = []
+	TEST_CLIENT = get_test_client()
 
+	@property
+	def sid(self):
+		if not getattr(self, "_sid", None):
+			frappe.conf.admin_password = "root"
+			r = self.TEST_CLIENT.post("/api/method/login", data={
+				"usr": "Administrator",
+				"pwd": frappe.conf.admin_password or "admin",
+			})
+			self._sid = r.headers[2][1].split(";")[0].lstrip("sid=")
+		return self._sid
+
+	def get(self, path: str, params: Optional[Dict] = None):
+		return self.TEST_CLIENT.get(path, data=params)
+
+	def post(self, path, data):
+		return self.TEST_CLIENT.post(path, data=frappe.as_json(data))
+
+	def put(self, path, data):
+		return self.TEST_CLIENT.put(path, data=frappe.as_json(data))
+
+	def delete(self, path):
+		return self.TEST_CLIENT.delete(path)
+
+
+class TestResourceAPI(FrappeAPITestCase):
 	@classmethod
-	@maintain_state
 	def setUpClass(self):
+		frappe.set_user("Administrator")
 		for _ in range(10):
 			doc = frappe.get_doc(
 				{"doctype": "ToDo", "description": frappe.mock("paragraph")}
@@ -34,44 +65,16 @@ class TestResourceAPI(unittest.TestCase):
 			self.GENERATED_DOCUMENTS.append(doc.name)
 
 	@classmethod
-	@maintain_state
 	def tearDownClass(self):
+		frappe.set_user("Administrator")
 		for name in self.GENERATED_DOCUMENTS:
 			frappe.delete_doc_if_exists(self.DOCTYPE, name)
 
 	def setUp(self):
+		frappe.set_user("Administrator")
 		# commit to ensure consistency in session (postgres CI randomly fails)
 		if frappe.conf.db_type == "postgres":
 			frappe.db.commit()
-
-	@property
-	def sid(self):
-		if not getattr(self, "_sid", None):
-			self._sid = requests.post(
-				f"{self.SITE_URL}/api/method/login",
-				data={
-					"usr": "Administrator",
-					"pwd": frappe.conf.admin_password or "admin",
-				},
-			).cookies.get("sid")
-
-		return self._sid
-
-	def get(self, path, params=""):
-		return requests.get(f"{self.RESOURCE_URL}/{path}?sid={self.sid}{params}")
-
-	def post(self, path, data):
-		return requests.post(
-			f"{self.RESOURCE_URL}/{path}?sid={self.sid}", data=frappe.as_json(data)
-		)
-
-	def put(self, path, data):
-		return requests.put(
-			f"{self.RESOURCE_URL}/{path}?sid={self.sid}", data=frappe.as_json(data)
-		)
-
-	def delete(self, path):
-		return requests.delete(f"{self.RESOURCE_URL}/{path}?sid={self.sid}")
 
 	def test_unauthorized_call(self):
 		# test 1: fetch documents without auth
@@ -80,79 +83,81 @@ class TestResourceAPI(unittest.TestCase):
 
 	def test_get_list(self):
 		# test 2: fetch documents without params
-		response = self.get(self.DOCTYPE)
+		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid})
 		self.assertEqual(response.status_code, 200)
-		self.assertIsInstance(response.json(), dict)
-		self.assertIn("data", response.json())
+		self.assertIsInstance(response.json, dict)
+		self.assertIn("data", response.json)
 
 	def test_get_list_limit(self):
 		# test 3: fetch data with limit
-		response = self.get(self.DOCTYPE, "&limit=2")
+		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "limit": 2})
 		self.assertEqual(response.status_code, 200)
-		self.assertEqual(len(response.json()["data"]), 2)
+		self.assertEqual(len(response.json["data"]), 2)
 
 	def test_get_list_dict(self):
 		# test 4: fetch response as (not) dict
-		response = self.get(self.DOCTYPE, "&as_dict=True")
-		json = frappe._dict(response.json())
+		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "as_dict": True})
+		json = frappe._dict(response.json)
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(json.data, list)
 		self.assertIsInstance(json.data[0], dict)
 
-		response = self.get(self.DOCTYPE, "&as_dict=False")
-		json = frappe._dict(response.json())
+		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "as_dict": False})
+		json = frappe._dict(response.json)
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(json.data, list)
 		self.assertIsInstance(json.data[0], list)
 
 	def test_get_list_debug(self):
 		# test 5: fetch response with debug
-		response = self.get(self.DOCTYPE, "&debug=true")
+		with suppress_stdout():
+			response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "debug": True})
 		self.assertEqual(response.status_code, 200)
-		self.assertIn("exc", response.json())
-		self.assertIsInstance(response.json()["exc"], str)
-		self.assertIsInstance(eval(response.json()["exc"]), list)
+		self.assertIn("exc", response.json)
+		self.assertIsInstance(response.json["exc"], str)
+		self.assertIsInstance(eval(response.json["exc"]), list)
 
 	def test_get_list_fields(self):
 		# test 6: fetch response with fields
-		response = self.get(self.DOCTYPE, r'&fields=["description"]')
+		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "fields": '["description"]'})
 		self.assertEqual(response.status_code, 200)
-		json = frappe._dict(response.json())
+		json = frappe._dict(response.json)
 		self.assertIn("description", json.data[0])
 
 	def test_create_document(self):
 		# test 7: POST method on /api/resource to create doc
-		data = {"description": frappe.mock("paragraph")}
-		response = self.post(self.DOCTYPE, data)
+		data = {"description": frappe.mock("paragraph"), "sid": self.sid}
+		response = self.post(f"/api/resource/{self.DOCTYPE}", data)
 		self.assertEqual(response.status_code, 200)
-		docname = response.json()["data"]["name"]
+		docname = response.json["data"]["name"]
 		self.assertIsInstance(docname, str)
 		self.GENERATED_DOCUMENTS.append(docname)
 
 	def test_update_document(self):
 		# test 8: PUT method on /api/resource to update doc
 		generated_desc = frappe.mock("paragraph")
-		data = {"description": generated_desc}
+		data = {"description": generated_desc, "sid": self.sid}
 		random_doc = choice(self.GENERATED_DOCUMENTS)
 		desc_before_update = frappe.db.get_value(self.DOCTYPE, random_doc, "description")
 
-		response = self.put(f"{self.DOCTYPE}/{random_doc}", data=data)
+		response = self.put(f"/api/resource/{self.DOCTYPE}/{random_doc}", data=data)
 		self.assertEqual(response.status_code, 200)
-		self.assertNotEqual(response.json()["data"]["description"], desc_before_update)
-		self.assertEqual(response.json()["data"]["description"], generated_desc)
+		self.assertNotEqual(response.json["data"]["description"], desc_before_update)
+		self.assertEqual(response.json["data"]["description"], generated_desc)
 
 	def test_delete_document(self):
 		# test 9: DELETE method on /api/resource
 		doc_to_delete = choice(self.GENERATED_DOCUMENTS)
-		response = self.delete(f"{self.DOCTYPE}/{doc_to_delete}")
+		response = self.delete(f"/api/resource/{self.DOCTYPE}/{doc_to_delete}")
 		self.assertEqual(response.status_code, 202)
-		self.assertDictEqual(response.json(), {"message": "ok"})
+		self.assertDictEqual(response.json, {"message": "ok"})
 		self.GENERATED_DOCUMENTS.remove(doc_to_delete)
 
 		non_existent_doc = frappe.generate_hash(length=12)
-		response = self.delete(f"{self.DOCTYPE}/{non_existent_doc}")
+		with suppress_stdout():
+			response = self.delete(f"/api/resource/{self.DOCTYPE}/{non_existent_doc}")
 		self.assertEqual(response.status_code, 404)
-		self.assertDictEqual(response.json(), {})
+		self.assertDictEqual(response.json, {})
 
 
 class TestMethodAPI(unittest.TestCase):
@@ -161,7 +166,7 @@ class TestMethodAPI(unittest.TestCase):
 	def test_version(self):
 		# test 1: test for /api/method/version
 		response = requests.get(f"{self.METHOD_URL}/version")
-		json = frappe._dict(response.json())
+		json = frappe._dict(response.json)
 
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(json, dict)
@@ -172,5 +177,5 @@ class TestMethodAPI(unittest.TestCase):
 		# test 2: test for /api/method/ping
 		response = requests.get(f"{self.METHOD_URL}/ping")
 		self.assertEqual(response.status_code, 200)
-		self.assertIsInstance(response.json(), dict)
-		self.assertEqual(response.json()['message'], "pong")
+		self.assertIsInstance(response.json, dict)
+		self.assertEqual(response.json['message'], "pong")

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -33,7 +33,6 @@ class FrappeAPITestCase(unittest.TestCase):
 	@property
 	def sid(self):
 		if not getattr(self, "_sid", None):
-			frappe.conf.admin_password = "root"
 			r = self.TEST_CLIENT.post("/api/method/login", data={
 				"usr": "Administrator",
 				"pwd": frappe.conf.admin_password or "admin",
@@ -160,12 +159,13 @@ class TestResourceAPI(FrappeAPITestCase):
 		self.assertDictEqual(response.json, {})
 
 
-class TestMethodAPI(unittest.TestCase):
-	METHOD_URL = f"{get_site_url(frappe.local.site)}/api/method"
+class TestMethodAPI(FrappeAPITestCase):
+	SITE_URL = get_site_url(frappe.local.site)
+	METHOD_PATH = f"/api/method"
 
 	def test_version(self):
 		# test 1: test for /api/method/version
-		response = requests.get(f"{self.METHOD_URL}/version")
+		response = self.get(f"{self.METHOD_PATH}/version")
 		json = frappe._dict(response.json)
 
 		self.assertEqual(response.status_code, 200)
@@ -175,7 +175,7 @@ class TestMethodAPI(unittest.TestCase):
 
 	def test_ping(self):
 		# test 2: test for /api/method/ping
-		response = requests.get(f"{self.METHOD_URL}/ping")
+		response = self.get(f"{self.METHOD_PATH}/ping")
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(response.json, dict)
 		self.assertEqual(response.json['message'], "pong")

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -26,8 +26,6 @@ class FrappeAPITestCase(unittest.TestCase):
 	SITE = frappe.local.site
 	SITE_URL = get_site_url(SITE)
 	RESOURCE_URL = f"{SITE_URL}/api/resource"
-	DOCTYPE = "ToDo"
-	GENERATED_DOCUMENTS = []
 	TEST_CLIENT = get_test_client()
 
 	@property
@@ -54,20 +52,23 @@ class FrappeAPITestCase(unittest.TestCase):
 
 
 class TestResourceAPI(FrappeAPITestCase):
+	DOCTYPE = "ToDo"
+	GENERATED_DOCUMENTS = []
+
 	@classmethod
-	def setUpClass(self):
+	def setUpClass(cls):
 		frappe.set_user("Administrator")
 		for _ in range(10):
 			doc = frappe.get_doc(
 				{"doctype": "ToDo", "description": frappe.mock("paragraph")}
 			).insert()
-			self.GENERATED_DOCUMENTS.append(doc.name)
+			cls.GENERATED_DOCUMENTS.append(doc.name)
 
 	@classmethod
-	def tearDownClass(self):
+	def tearDownClass(cls):
 		frappe.set_user("Administrator")
-		for name in self.GENERATED_DOCUMENTS:
-			frappe.delete_doc_if_exists(self.DOCTYPE, name)
+		for name in cls.GENERATED_DOCUMENTS:
+			frappe.delete_doc_if_exists(cls.DOCTYPE, name)
 
 	def setUp(self):
 		frappe.set_user("Administrator")
@@ -160,8 +161,7 @@ class TestResourceAPI(FrappeAPITestCase):
 
 
 class TestMethodAPI(FrappeAPITestCase):
-	SITE_URL = get_site_url(frappe.local.site)
-	METHOD_PATH = f"/api/method"
+	METHOD_PATH = "/api/method"
 
 	def test_version(self):
 		# test 1: test for /api/method/version

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -63,12 +63,14 @@ class TestResourceAPI(FrappeAPITestCase):
 				{"doctype": "ToDo", "description": frappe.mock("paragraph")}
 			).insert()
 			cls.GENERATED_DOCUMENTS.append(doc.name)
+		frappe.db.commit()
 
 	@classmethod
 	def tearDownClass(cls):
 		frappe.set_user("Administrator")
 		for name in cls.GENERATED_DOCUMENTS:
 			frappe.delete_doc_if_exists(cls.DOCTYPE, name)
+		frappe.db.commit()
 
 	def setUp(self):
 		frappe.set_user("Administrator")

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -2,19 +2,22 @@ import sys
 import unittest
 from contextlib import contextmanager
 from random import choice
-from typing import Dict, Optional, Tuple
 from threading import Thread
+from typing import Dict, Optional, Tuple
+from unittest.mock import patch
 
 import requests
 from semantic_version import Version
+from werkzeug.test import TestResponse
 
 import frappe
-from frappe.utils import get_site_url
+from frappe.utils import get_site_url, get_test_client
 
 try:
 	_site = frappe.local.site
 except Exception:
 	_site = None
+
 
 @contextmanager
 def suppress_stdout():
@@ -26,36 +29,28 @@ def suppress_stdout():
 	finally:
 		sys.stdout = sys.__stdout__
 
+
+def make_request(target: str, args: Optional[Tuple] = None, kwargs: Optional[Dict] = None) -> TestResponse:
+	t = ThreadWithReturnValue(target=target, args=args, kwargs=kwargs)
+	t.start()
+	t.join()
+	return t._return
+
+
 class ThreadWithReturnValue(Thread):
-	def __init__(self, group=None, target=None, name=None,
-				args=(), kwargs={}, Verbose=None):
+	def __init__(self, group=None, target=None, name=None, args=(), kwargs={}):
 		Thread.__init__(self, group, target, name, args, kwargs)
 		self._return = None
 
 	def run(self):
-		from unittest.mock import patch
 		if self._target is not None:
 			with patch("frappe.app.get_site_name", return_value=_site):
-				# print(self._args, self._kwargs)
 				self._return = self._target(*self._args, **self._kwargs)
 
 	def join(self, *args):
 		Thread.join(self, *args)
 		return self._return
 
-
-def get_test_client():
-	from frappe.app import application
-	from werkzeug.test import Client
-
-	return Client(application)
-
-
-def make_request(target: str, args: Optional[Tuple] = None, kwargs: Optional[Dict] = None):
-	t = ThreadWithReturnValue(target=target, args=args, kwargs=kwargs)
-	t.start()
-	t.join()
-	return t._return
 
 class FrappeAPITestCase(unittest.TestCase):
 	SITE = frappe.local.site
@@ -64,7 +59,7 @@ class FrappeAPITestCase(unittest.TestCase):
 	TEST_CLIENT = get_test_client()
 
 	@property
-	def sid(self):
+	def sid(self) -> str:
 		if not getattr(self, "_sid", None):
 			r = self.post("/api/method/login", {
 				"usr": "Administrator",
@@ -74,16 +69,16 @@ class FrappeAPITestCase(unittest.TestCase):
 
 		return self._sid
 
-	def get(self, path: str, params: Optional[Dict] = None):
+	def get(self, path: str, params: Optional[Dict] = None) -> TestResponse:
 		return make_request(target=self.TEST_CLIENT.get, args=(path, ), kwargs={"data": params})
 
-	def post(self, path, data):
+	def post(self, path, data) -> TestResponse:
 		return make_request(target=self.TEST_CLIENT.post, args=(path, ), kwargs={"data": data})
 
-	def put(self, path, data):
+	def put(self, path, data) -> TestResponse:
 		return make_request(target=self.TEST_CLIENT.put, args=(path, ), kwargs={"data": data})
 
-	def delete(self, path):
+	def delete(self, path) -> TestResponse:
 		return make_request(target=self.TEST_CLIENT.delete, args=(path, ))
 
 

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -145,8 +145,7 @@ class TestResourceAPI(FrappeAPITestCase):
 
 	def test_get_list_debug(self):
 		# test 5: fetch response with debug
-		with suppress_stdout():
-			response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "debug": True})
+		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "debug": True})
 		self.assertEqual(response.status_code, 200)
 		self.assertIn("exc", response.json)
 		self.assertIsInstance(response.json["exc"], str)

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -10,7 +10,8 @@ import requests
 import base64
 
 class TestFrappeClient(unittest.TestCase):
-	PASSWORD = "admin"
+	PASSWORD = frappe.conf.admin_password or "admin"
+
 	def test_insert_many(self):
 		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)
 		frappe.db.delete("Note", {"title": ("in", ('Sing','a','song','of','sixpence'))})

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -170,7 +170,6 @@ class TestFrappeClient(unittest.TestCase):
 		res = requests.post(get_url() + "/api/method/frappe.auth.get_logged_user", headers=header)
 		self.assertEqual(res.status_code, 403)
 
-
 		# random api key and api secret
 		api_key = "@3djdk3kld"
 		api_secret = "ksk&93nxoe3os"

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -438,17 +438,10 @@ def touch_file(path):
 		os.utime(path, None)
 	return path
 
-def get_test_client():
+def get_test_client() -> Client:
+	"""Returns an test instance of the Frappe WSGI"""
 	from frappe.app import application
-
-	class TestClient(Client):
-		def open(self, *args, **kwargs):
-			site = frappe.local.site
-			ret = super().open(*args, **kwargs)
-			frappe.connect(site=site)
-			return ret
-
-	return TestClient(application)
+	return Client(application)
 
 def get_hook_method(hook_name, fallback=None):
 	method = frappe.get_hooks().get(hook_name)

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -440,7 +440,15 @@ def touch_file(path):
 
 def get_test_client():
 	from frappe.app import application
-	return Client(application)
+
+	class TestClient(Client):
+		def open(self, *args, **kwargs):
+			site = frappe.local.site
+			ret = super().open(*args, **kwargs)
+			frappe.connect(site=site)
+			return ret
+
+	return TestClient(application)
 
 def get_hook_method(hook_name, fallback=None):
 	method = frappe.get_hooks().get(hook_name)


### PR DESCRIPTION
### Changes

* `get_request_form_data` to return `frappe.form_dict` if parse_json fails
* Added typing & tests for resource and method API endpoints
* Add tests to cover more of `api.py` ;)
* Added new suite `FrappeAPITestCase` to make_request in different threads - coverage++
* Increased server coverage by 0.7% 😄 

