### PR TITLE
fix: Always show charts even if onboarding enabled

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -361,7 +361,6 @@ class DesktopPage {
 			type: "chart",
 			columns: 1,
 			class_name: "widget-charts",
-			hidden: Boolean(this.onboarding_widget),
 			options: {
 				allow_sorting: this.allow_customization,
 				allow_create: this.allow_customization,


### PR DESCRIPTION
- Show chart in workspace even if onboarding is enabled.
- This behaviour is inline with the latest develop

> no-docs