### PR TITLE
fix(Permission Manager): Update client-side permission data

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -347,6 +347,7 @@ frappe.PermissionEngine = class PermissionEngine {
 	}
 
 	add_check_events() {
+		let me = this;
 		this.body.on("click", ".show-user-permissions", () => {
 			frappe.route_options = { allow: this.get_doctype() || "" };
 			frappe.set_route('List', 'User Permission');
@@ -373,7 +374,7 @@ frappe.PermissionEngine = class PermissionEngine {
 						// exception: reverse
 						chk.prop("checked", !chk.prop("checked"));
 					} else {
-						this.get_perm(args.role)[args.ptype] = args.value;
+						me.get_perm(args.role)[args.ptype] = args.value;
 					}
 				}
 			});


### PR DESCRIPTION
On updating access from Permission Manager. Permissions are not updated till we do a hard refresh.
![Screenshot from 2022-02-11 12-32-52](https://user-images.githubusercontent.com/53169014/153550692-dc530eec-f44e-497d-9aca-8c10f1819cb0.png)

