### PR TITLE
feat: Document workflow

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -12,7 +12,7 @@ from frappe.model.base_document import BaseDocument, get_controller
 from frappe.model.naming import set_new_name, validate_name
 from frappe.model.docstatus import DocStatus
 from frappe.model import optional_fields, table_fields
-from frappe.model.workflow import validate_workflow
+from frappe.model.workflow import validate_workflow, get_workflow_name  # workflow change
 from frappe.model.workflow import set_workflow_state_on_action
 from frappe.utils.global_search import update_global_search
 from frappe.integrations.doctype.webhook import run_webhooks
@@ -543,7 +543,9 @@ class Document(BaseDocument):
 	def validate_workflow(self):
 		"""Validate if the workflow transition is valid"""
 		if frappe.flags.in_install == 'frappe': return
-		workflow = self.meta.get_workflow()
+		# workflow change
+		
+		workflow = get_workflow_name(self)
 		if workflow:
 			validate_workflow(self)
 			if not self._action == 'save':

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -544,7 +544,6 @@ class Document(BaseDocument):
 		"""Validate if the workflow transition is valid"""
 		if frappe.flags.in_install == 'frappe': return
 		# workflow change
-		
 		workflow = get_workflow_name(self)
 		if workflow:
 			validate_workflow(self)

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -12,7 +12,6 @@ class WorkflowTransitionError(frappe.ValidationError): pass
 class WorkflowPermissionError(frappe.ValidationError): pass
 
 # workflow change
-
 def get_workflow_name(doc_or_doctype):
 	if type(doc_or_doctype) is str:
 		workflow_name = frappe.db.get_value("Workflow", {"document_type": doc_or_doctype,

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -484,7 +484,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 			};
 			if (this.has_workflow()) {
 				frappe.xcall('frappe.model.workflow.can_cancel_document', {
-					'doctype': this.frm.doc.doctype,
+					// Workflow change 
+					'doc': this.frm.doc, 
 				}).then((can_cancel) => {
 					if (can_cancel) {
 						add_cancel_button();

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -484,7 +484,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 			};
 			if (this.has_workflow()) {
 				frappe.xcall('frappe.model.workflow.can_cancel_document', {
-					// Workflow change 
+					// Workflow change
 					'doc': this.frm.doc, 
 				}).then((can_cancel) => {
 					if (can_cancel) {

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -33,7 +33,8 @@ def has_permission(doc, user):
 		return False
 
 def process_workflow_actions(doc, state):
-	workflow = get_workflow_name(doc.get('doctype'))
+	# workflow change
+	workflow = get_workflow_name(doc)
 	if not workflow: return
 
 	if state == "on_trash":
@@ -262,7 +263,8 @@ def clear_workflow_actions(doctype, name):
 		"reference_name": name
 	})
 def get_doc_workflow_state(doc):
-	workflow_name = get_workflow_name(doc.get('doctype'))
+	# workflow change
+	workflow_name = get_workflow_name(doc)
 	workflow_state_field = get_workflow_state_field(workflow_name)
 	return doc.get(workflow_state_field)
 

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -263,7 +263,7 @@ def clear_workflow_actions(doctype, name):
 		"reference_name": name
 	})
 def get_doc_workflow_state(doc):
-	# workflow change
+	# workflow change 
 	workflow_name = get_workflow_name(doc)
 	workflow_state_field = get_workflow_state_field(workflow_name)
 	return doc.get(workflow_state_field)


### PR DESCRIPTION
**Scenario**
Workflows in Frappe assigned at the DocType level. There are scenarios in which the workflow is to be managed at the document level. Frappe suggests to create conditions in the transition rules to manage the same, however the workflow get difficult to maintain with time.

**Objective**
The objective is to have the ability to assign workflows at document level.

**Changes**
The changes done in the pull request caters to select an existing workflow for a document. Below are the changes:
1. get_workflow_name in workflow.py accepted the name of doctype as an argument. This has been updated to doc_or_doctype
If the argument doc_or_doctype is a string, it would result in default functionality to ensure backward compatibility.
If the argument doc_or_doctype is doc, then we will use the workflow field in the doctype to identify the workflow.
**Limitation:** Custom field 'workflow' cannot be created for any other purpose other than for document level workflow assignment. This can be improved by allowing user to set his own field name for document level workflow in settings.

2. Default argument of doctype has been updated to doc in function call of get_workflow_name in document.py, workflow.py, workflow_action.py 

3. toolbar.js that calls frappe.model.workflow.can_cancel_document also have been updated to send doc instead of doctype

**Backward Compatibility**
The changes are built with backward compatibility.

**How the feature will be used?**
Use case: 
A company has 5 different approval workflows that can be assigned to the purchase order.
The assignment of the workflow is not logical and it requires user input to select the workflow
The user can select the Approval Workflow 1 for PO/00001 and Approval Workflow 2 for PO/00002

Steps:
1. Create a custom field 'Workflow' in Purchase Order
2. Create the approval workflows
3. Create the first record in Purchase Order and select Approval Workflow 1
4. Create the second record in Purchase Order and select Approval Workflow 2
5. On submission of the Purchase Orders the respective workflow will be applied.