### PR TITLE
fix: Always set `doctype` from `options` for child Document

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -221,10 +221,9 @@ class BaseDocument(object):
 		if not self.doctype:
 			return value
 		if not isinstance(value, BaseDocument):
-			if "doctype" not in value or value['doctype'] is None:
-				value["doctype"] = self.get_table_field_doctype(key)
-				if not value["doctype"]:
-					raise AttributeError(key)
+			value["doctype"] = self.get_table_field_doctype(key)
+			if not value["doctype"]:
+				raise AttributeError(key)
 
 			value = get_controller(value["doctype"])(value)
 			value.init_valid_columns()


### PR DESCRIPTION
285824