### PR TITLE
fix: always execute method if found in `__dict__`

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -861,8 +861,6 @@ class Document(BaseDocument):
 	def run_method(self, method, *args, **kwargs):
 		"""run standard triggers, plus those in hooks"""
 
-		kwargs.pop("flags", None)
-
 		def fn(self, *args, **kwargs):
 			method_object = getattr(self, method, None)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -863,14 +863,12 @@ class Document(BaseDocument):
 
 		kwargs.pop("flags", None)
 
-		# Cannot have a field with same name as method
-		# Validation for this already exists when saving a DocType
-		if method in self.__dict__ and not callable(self.__dict__[method]):
-			del self.__dict__[method]
-
 		def fn(self, *args, **kwargs):
 			method_object = getattr(self, method, None)
-			if callable(method_object):
+
+			# Cannot have a field with same name as method
+			# If method found in __dict__, expect it to be callable
+			if method in self.__dict__ or callable(method_object):
 				return method_object(*args, **kwargs)
 
 		fn.__name__ = str(method)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -860,8 +860,12 @@ class Document(BaseDocument):
 
 	def run_method(self, method, *args, **kwargs):
 		"""run standard triggers, plus those in hooks"""
-		if "flags" in kwargs:
-			del kwargs["flags"]
+
+		kwargs.pop("flags", None)
+
+		# Cannot have a field with same name as method
+		# Validation for this already exists when saving a DocType
+		self.__dict__.pop(method, None)
 
 		if hasattr(self, method) and hasattr(getattr(self, method), "__call__"):
 			fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -868,12 +868,10 @@ class Document(BaseDocument):
 		if method in self.__dict__ and not callable(self.__dict__[method]):
 			del self.__dict__[method]
 
-		method_object = getattr(self, method, None)
-		if callable(method_object):
-			fn = lambda self, *args, **kwargs: method_object(*args, **kwargs)
-		else:
-			# hack! to run hooks even if method does not exist
-			fn = lambda self, *args, **kwargs: None
+		def fn(self, *args, **kwargs):
+			method_object = getattr(self, method, None)
+			if callable(method_object):
+				return method_object(*args, **kwargs)
 
 		fn.__name__ = str(method)
 		out = Document.hook(fn)(self, *args, **kwargs)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -865,10 +865,12 @@ class Document(BaseDocument):
 
 		# Cannot have a field with same name as method
 		# Validation for this already exists when saving a DocType
-		self.__dict__.pop(method, None)
+		if method in self.__dict__ and not callable(self.__dict__[method]):
+			del self.__dict__[method]
 
-		if hasattr(self, method) and hasattr(getattr(self, method), "__call__"):
-			fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
+		method_object = getattr(self, method, None)
+		if callable(method_object):
+			fn = lambda self, *args, **kwargs: method_object(*args, **kwargs)
 		else:
 			# hack! to run hooks even if method does not exist
 			fn = lambda self, *args, **kwargs: None

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -319,3 +319,22 @@ class TestDocument(unittest.TestCase):
 			self.assertIsInstance(doc, Note)
 			self.assertIsInstance(doc.as_dict().get("age"), timedelta)
 			self.assertIsInstance(doc.get_valid_dict().get("age"), timedelta)
+
+	def test_run_method(self):
+		doc = frappe.get_last_doc("User")
+
+		# Case 1: Override with a string
+		doc.as_dict = ""
+
+		# run_method should still work
+		value = doc.run_method("as_dict")
+		self.assertIsInstance(value, dict)
+
+		# Case 2: Override with a function
+		def my_as_dict(*args, **kwargs):
+			return "success"
+
+		doc.as_dict = my_as_dict
+
+		# run_method should get overridden
+		self.assertEqual(doc.run_method("as_dict"), "success")

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -326,9 +326,8 @@ class TestDocument(unittest.TestCase):
 		# Case 1: Override with a string
 		doc.as_dict = ""
 
-		# run_method should still work
-		value = doc.run_method("as_dict")
-		self.assertIsInstance(value, dict)
+		# run_method should throw TypeError
+		self.assertRaisesRegex(TypeError, "not callable", doc.run_method, "as_dict")
 
 		# Case 2: Override with a function
 		def my_as_dict(*args, **kwargs):


### PR DESCRIPTION
285823