### PR TITLE
perf: reduce loop in `doc.update`

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -106,13 +106,9 @@ class BaseDocument(object):
 			})
 		"""
 
-		# QUESTION: why do we need the 1st for loop?
-		# we're essentially setting the values in d, in the 2nd for loop (?)
-
-		# first set default field values of base document
-		for key in default_fields:
-			if key in d:
-				self.set(key, d[key])
+		# set name first, as it is used a reference in child document
+		if "name" in d:
+			self.name = d["name"]
 
 		for key, value in d.items():
 			self.set(key, value)
@@ -189,6 +185,7 @@ class BaseDocument(object):
 		if isinstance(value, (dict, BaseDocument)):
 			if not self.__dict__.get(key):
 				self.__dict__[key] = []
+
 			value = self._init_child(value, key)
 			self.__dict__[key].append(value)
 
@@ -225,6 +222,7 @@ class BaseDocument(object):
 	def _init_child(self, value, key):
 		if not self.doctype:
 			return value
+
 		if not isinstance(value, BaseDocument):
 			if "doctype" not in value or value['doctype'] is None:
 				value["doctype"] = self.get_table_field_doctype(key)


### PR DESCRIPTION
Depends on #15962

## Background

- `doctype` and `name` need to be set first.

## Changes Made

- `doctype` being set before `doc.update` (#15962)
- `name` being set first instead of all default fields