### PR TITLE
ci(Mergify): Configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -48,3 +48,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+        commit_message_template: |
+            {{ title }} (#{{ number }})
+
+            {{ body }}


### PR DESCRIPTION
Reference doc: https://docs.mergify.com/actions/merge

---

To forcefully use PR title while squashing a PR [instead of picking the first commit](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#merge-message-for-a-squash-merge) in case of only one commit in the PR.
Example: https://github.com/frappe/frappe/commit/954b932c10f5448810a33b447468522777ad3084