### PR TITLE
fix(UI): Image action not in center of image in mobile view

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -104,10 +104,10 @@ body[data-route^="Module"] .main-menu {
 	}
 
 	.sidebar-image-section {
+		width: min(100%, 170px);
 		cursor: pointer;
 
 		.sidebar-image {
-			width: min(100%, 170px);
 			height: auto;
 			max-height: 170px;
 			object-fit: cover;


### PR DESCRIPTION
**Before:** Image action **Change** is not in centre of image
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30859809/153865850-f40fc728-793b-4a19-a7ff-f999ec9051d5.png">

**After:** Image action **Change** is in centre of image
<img width="400" alt="image" src="https://user-images.githubusercontent.com/30859809/153866066-05fec1f2-7eb0-4d99-b533-319d69f79748.png">

fixes: https://github.com/frappe/frappe/issues/15905