### PR TITLE
fix: limit without filter

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -149,6 +149,9 @@ class BaseDocument(object):
 				self.set(key, [])
 				value = self.__dict__.get(key)
 
+			if limit and isinstance(value, (list, tuple)) and len(value) > limit:
+				value = value[:limit]
+
 			return value
 		else:
 			return self.__dict__

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -264,7 +264,10 @@ class TestDocument(unittest.TestCase):
 
 	def test_limit_for_get(self):
 		doc = frappe.get_doc("DocType", "DocType")
-		# assuming DocType has more that 3 Data fields
+		# assuming DocType has more than 3 Data fields
+		self.assertEquals(len(doc.get("fields", limit=3)), 3)
+
+		# limit with filters
 		self.assertEquals(len(doc.get("fields", filters={"fieldtype": "Data"}, limit=3)), 3)
 
 	def test_virtual_fields(self):


### PR DESCRIPTION
related PR: #15574 

## Issue Fixed
`limit` param is ignored if no `filters` passed in `doc.get`

## Changes Made
 - Apply limit if value is `list` or `tuple`
 - Add test case