### PR TITLE
feat: map doctype field to contact/address

### DIFF
--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -3,8 +3,9 @@
 
 frappe.ui.form.on("Address", {
 	refresh: function(frm) {
-		if(frm.doc.__islocal) {
+		if(frm.is_new()) {
 			const last_doc = frappe.contacts.get_last_doc(frm);
+			console.log(last_doc);
 			if(frappe.dynamic_link && frappe.dynamic_link.doc
 					&& frappe.dynamic_link.doc.name == last_doc.docname) {
 				frm.set_value('links', '');
@@ -12,6 +13,10 @@ frappe.ui.form.on("Address", {
 					link_doctype: frappe.dynamic_link.doctype,
 					link_name: frappe.dynamic_link.doc[frappe.dynamic_link.fieldname]
 				});
+
+				for (let row in frappe.address_field_mapping) {
+					frm.set_value(row, frappe.address_field_mapping[row]);
+				}
 			}
 		}
 		frm.set_query('link_doctype', "links", function() {

--- a/frappe/contacts/doctype/address/address.js
+++ b/frappe/contacts/doctype/address/address.js
@@ -3,10 +3,9 @@
 
 frappe.ui.form.on("Address", {
 	refresh: function(frm) {
-		if(frm.is_new()) {
+		if (frm.is_new()) {
 			const last_doc = frappe.contacts.get_last_doc(frm);
-			console.log(last_doc);
-			if(frappe.dynamic_link && frappe.dynamic_link.doc
+			if (frappe.dynamic_link && frappe.dynamic_link.doc
 					&& frappe.dynamic_link.doc.name == last_doc.docname) {
 				frm.set_value('links', '');
 				frm.add_child('links', {

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -6,9 +6,9 @@ frappe.ui.form.on("Contact", {
 		frm.email_field = "email_id";
 	},
 	refresh: function(frm) {
-		if(frm.doc.__islocal) {
+		if (frm.is_new()) {
 			const last_doc = frappe.contacts.get_last_doc(frm);
-			if(frappe.dynamic_link && frappe.dynamic_link.doc
+			if (frappe.dynamic_link && frappe.dynamic_link.doc
 					&& frappe.dynamic_link.doc.name == last_doc.docname) {
 				frm.set_value('links', '');
 				frm.add_child('links', {

--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -15,6 +15,10 @@ frappe.ui.form.on("Contact", {
 					link_doctype: frappe.dynamic_link.doctype,
 					link_name: frappe.dynamic_link.doc[frappe.dynamic_link.fieldname]
 				});
+
+				for (let row in frappe.contact_field_mapping) {
+					frm.set_value(row, frappe.contact_field_mapping[row]);
+				}
 			}
 		}
 


### PR DESCRIPTION
**Issue-** If we add address/contact from the New Address/ New Contact button. We are not able to copy any of the field values from source doc to address/contact doc except dynamic link.

**After-**
![address-contact](https://user-images.githubusercontent.com/20715976/154040525-d196a618-41f9-44c5-9e79-59c052513fd6.gif)

