### PR TITLE
chore: change log for v12.26.0

### DIFF
--- a/frappe/change_log/v12/v12_26_0.md
+++ b/frappe/change_log/v12/v12_26_0.md
@@ -1,0 +1,9 @@
+## Frappe Version 12.26.0 Release Notes
+
+### Fixes & Enhancements
+
+- Communication method "get_contacts" ([#15564](https://github.com/frappe/frappe/pull/15564))
+- Add more Sort options in List views ([#15709](https://github.com/frappe/frappe/pull/15709))
+- Limit in `Document.get` ([#15574](https://github.com/frappe/frappe/pull/15574))
+- Use Link type instead of Data for parent ([#15715](https://github.com/frappe/frappe/pull/15715))
+- FrappeClient post_api request being redirected to GET request ([#15542](https://github.com/frappe/frappe/pull/15542))


### PR DESCRIPTION
## Frappe Version 12.26.0 Release Notes

### Fixes & Enhancements

- Communication method "get_contacts" ([#15564](https://github.com/frappe/frappe/pull/15564))
- Add more Sort options in List views ([#15709](https://github.com/frappe/frappe/pull/15709))
- Limit in `Document.get` ([#15574](https://github.com/frappe/frappe/pull/15574))
- Use Link type instead of Data for parent ([#15715](https://github.com/frappe/frappe/pull/15715))
- FrappeClient post_api request being redirected to GET request ([#15542](https://github.com/frappe/frappe/pull/15542))