### PR TITLE
fix: Merge groups for doctype links

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -14,16 +14,28 @@ Example:
 
 
 '''
+import json
+import os
 from datetime import datetime
+
 import click
-import frappe, json, os
-from frappe.utils import cstr, cint, cast
-from frappe.model import default_fields, no_value_fields, optional_fields, data_fieldtypes, table_fields, child_table_fields
-from frappe.model.document import Document
-from frappe.model.base_document import BaseDocument
-from frappe.modules import load_doctype_module
-from frappe.model.workflow import get_workflow_name
+
+import frappe
 from frappe import _
+from frappe.model import (
+	child_table_fields,
+	data_fieldtypes,
+	default_fields,
+	no_value_fields,
+	optional_fields,
+	table_fields,
+)
+from frappe.model.base_document import BaseDocument
+from frappe.model.document import Document
+from frappe.model.workflow import get_workflow_name
+from frappe.modules import load_doctype_module
+from frappe.utils import cast, cint, cstr
+
 
 def get_meta(doctype, cached=True):
 	if cached:
@@ -546,7 +558,7 @@ class Meta(Document):
 				# For internal links parent doctype will be the key
 				doctype = link.parent_doctype or link.link_doctype
 				# group found
-				if link.group and group.label == link.group:
+				if link.group and _(group.label) == _(link.group):
 					if doctype not in group.get('items'):
 						group.get('items').append(doctype)
 					link.added = True


### PR DESCRIPTION
- When adding custom DocType Links in doctype, similar groups arent merged.
- Eg. If a user adds a new group as Projekt (de), since Project and Projekt are treated as different groups, the groups arent merged. Project and Projekt in spite being same, are rendered as two different groups.
- Before Fix
    - English
    - ![image](https://user-images.githubusercontent.com/7310479/154090869-ed4e13d5-0010-409f-9684-d3e927ceae3d.png)
    - German
    -![image](https://user-images.githubusercontent.com/7310479/154090726-72e103e7-d611-4a35-9b8c-721dfcab4520.png)

- After Fix
    - English
    - ![image](https://user-images.githubusercontent.com/7310479/154090338-c3fe2489-0293-49b5-aba2-e3a616d542e9.png)
    - German
    - ![image](https://user-images.githubusercontent.com/7310479/154090562-c2aede8e-d98a-465e-8008-18357a900a49.png)
