### PR TITLE
fix: after load more on refresh gets duplicate data

### DIFF
--- a/cypress/integration/report_view.js
+++ b/cypress/integration/report_view.js
@@ -46,7 +46,6 @@ context('Report View', () => {
 	it('test load more with count selection buttons', () => {
 		cy.visit('/app/contact/view/report');
 
-		cy.clear_filters();
 		cy.get('.list-paging-area .list-count').should('contain.text', '20 of');
 		cy.get('.list-paging-area .btn-more').click();
 		cy.get('.list-paging-area .list-count').should('contain.text', '40 of');
@@ -59,6 +58,10 @@ context('Report View', () => {
 		cy.get('.list-paging-area .btn-more').click();
 		cy.get('.list-paging-area .list-count').should('contain.text', '200 of');
 		cy.get('.list-paging-area .btn-more').click();
+		cy.get('.list-paging-area .list-count').should('contain.text', '300 of');
+
+		// check if refresh works after load more
+		cy.get('.page-head .standard-actions [data-original-title="Refresh"]').click();
 		cy.get('.list-paging-area .list-count').should('contain.text', '300 of');
 
 		cy.get('.list-paging-area .btn-group .btn-paging[data-value="500"]').click();

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -391,9 +391,10 @@ frappe.views.BaseList = class BaseList {
 				$this.addClass("btn-info");
 
 				this.start = 0;
-				this.page_length = $this.data().value;
+				this.page_length = this.selected_page_count = $this.data().value;
 			} else if ($this.is(".btn-more")) {
 				this.start = this.start + this.page_length;
+				this.page_length = this.selected_page_count || 20;
 			}
 			this.refresh();
 		});
@@ -474,6 +475,7 @@ frappe.views.BaseList = class BaseList {
 			this.render();
 			this.after_render();
 			this.freeze(false);
+			this.reset_defaults();
 			if (this.settings.refresh) {
 				this.settings.refresh(this);
 			}
@@ -498,6 +500,11 @@ frappe.views.BaseList = class BaseList {
 		}
 
 		this.data = this.data.uniqBy((d) => d.name);
+	}
+
+	reset_defaults() {
+		this.page_length = this.page_length + this.start;
+		this.start = 0;
 	}
 
 	freeze() {


### PR DESCRIPTION
Caused by https://github.com/frappe/frappe/pull/15931

**Issue:** Go to any list view which has more than 20 records, click Load More, now click on the refresh button. The new data that gets loaded is loaded again which also changes the count (It shows children records since there are the same records).

**Before:**

https://user-images.githubusercontent.com/30859809/154091667-df4be5e2-ea62-4c1b-8257-d0e26114d114.mov


**After:**

https://user-images.githubusercontent.com/30859809/154091727-5d3e54ea-17e3-4123-9861-ed949c678bd4.mov

