### PR TITLE
fix(ux): Images in Markdown

### DIFF
--- a/cypress/integration/control_markdown_editor.js
+++ b/cypress/integration/control_markdown_editor.js
@@ -1,0 +1,22 @@
+context("Control Markdown Editor", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app");
+	});
+
+	it("should allow inserting images by drag and drop", () => {
+		cy.visit("/app/web-page/new");
+		cy.fill_field("content_type", "Markdown", "Select");
+		cy.get_field("main_section_md", "Markdown Editor").attachFile(
+			"sample_image.jpg",
+			{
+				subjectType: "drag-n-drop"
+			}
+		);
+		cy.click_modal_primary_button("Upload");
+		cy.get_field("main_section_md", "Markdown Editor").should(
+			"contain",
+			"![](/files/sample_image.jpg)"
+		);
+	});
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -174,6 +174,9 @@ Cypress.Commands.add('get_field', (fieldname, fieldtype = 'Data') => {
 	if (fieldtype === 'Code') {
 		selector = `[data-fieldname="${fieldname}"] .ace_text-input`;
 	}
+	if (fieldtype === 'Markdown Editor') {
+		selector = `[data-fieldname="${fieldname}"] .ace-editor-target`;
+	}
 
 	return cy.get(selector).first();
 });

--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -10,11 +10,12 @@ export default class FileUploader {
 		fieldname,
 		files,
 		folder,
-		restrictions,
+		restrictions = {},
 		upload_notes,
 		allow_multiple,
 		as_dataurl,
 		disable_file_browser,
+		dialog_title,
 		attach_doc_image,
 		frm
 	} = {}) {
@@ -22,13 +23,9 @@ export default class FileUploader {
 		frm && frm.attachments.max_reached(true);
 
 		if (!wrapper) {
-			this.make_dialog();
+			this.make_dialog(dialog_title);
 		} else {
 			this.wrapper = wrapper.get ? wrapper.get(0) : wrapper;
-		}
-
-		if (attach_doc_image) {
-			restrictions.allowed_file_types = ['image/jpeg', 'image/png'];
 		}
 
 		this.$fileuploader = new Vue({
@@ -53,6 +50,10 @@ export default class FileUploader {
 		});
 
 		this.uploader = this.$fileuploader.$children[0];
+
+		if (!this.dialog) {
+			this.uploader.wrapper_ready = true;
+		}
 
 		this.uploader.$watch('files', (files) => {
 			let all_private = files.every(file => file.private);
@@ -94,14 +95,17 @@ export default class FileUploader {
 		return this.uploader.upload_files();
 	}
 
-	make_dialog() {
+	make_dialog(title) {
 		this.dialog = new frappe.ui.Dialog({
-			title: __('Upload'),
+			title: title || __('Upload'),
 			primary_action_label: __('Upload'),
 			primary_action: () => this.upload_files(),
 			secondary_action_label: __('Set all private'),
 			secondary_action: () => {
 				this.uploader.toggle_all_private();
+			},
+			on_page_show: () => {
+				this.uploader.wrapper_ready = true;
 			}
 		});
 

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -61,7 +61,8 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	}
 	on_attach_doc_image() {
 		this.set_upload_options();
-		this.upload_options["attach_doc_image"] = true;
+		this.upload_options.restrictions.allowed_file_types = ['image/*'];
+		this.upload_options.restrictions.crop_image_aspect_ratio = 1;
 		this.file_uploader = new frappe.ui.FileUploader(this.upload_options);
 	}
 	set_upload_options() {
@@ -70,7 +71,8 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 			on_success: file => {
 				this.on_upload_complete(file);
 				this.toggle_reload_button();
-			}
+			},
+			restrictions: {}
 		};
 
 		if (this.frm) {

--- a/frappe/public/js/frappe/form/controls/attach_image.js
+++ b/frappe/public/js/frappe/form/controls/attach_image.js
@@ -19,7 +19,6 @@ frappe.ui.form.ControlAttachImage = class ControlAttachImage extends frappe.ui.f
 	}
 	set_upload_options() {
 		super.set_upload_options();
-		this.upload_options.restrictions = {};
 		this.upload_options.restrictions.allowed_file_types = ['image/*'];
 	}
 };

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -71,32 +71,20 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 		if (this._autocompletion_setup) return;
 
 		const ace = window.ace;
-		const get_autocompletions = () => {
-			let getters = this._autocompletions || [];
-			let completions = [];
-			for (let getter of getters) {
-				let values = getter()
-				completions.push(...values);
-			}
-			return completions;
-		}
 
-		ace.config.loadModule("ace/ext/language_tools", langTools => {
-			this.editor.setOptions({
-				enableBasicAutocompletion: true,
-				enableLiveAutocompletion: true
-			});
-
-			langTools.addCompleter({
-				getCompletions: customGetCompletions || getCompletions
-			});
-		});
-		this._autocompletion_setup = true;
-
-		function getCompletions(editor, session, pos, prefix, callback) {
+		let getCompletions = (editor, session, pos, prefix, callback) => {
 			if (prefix.length === 0) {
 				callback(null, []);
 				return;
+			}
+			const get_autocompletions = () => {
+				let getters = this._autocompletions || [];
+				let completions = [];
+				for (let getter of getters) {
+					let values = getter({ editor, session, pos, prefix });
+					completions.push(...values);
+				}
+				return completions;
 			}
 			let autocompletions = get_autocompletions();
 			if (autocompletions.length) {
@@ -117,6 +105,18 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 				);
 			}
 		}
+
+		ace.config.loadModule("ace/ext/language_tools", langTools => {
+			this.editor.setOptions({
+				enableBasicAutocompletion: true,
+				enableLiveAutocompletion: true
+			});
+
+			langTools.addCompleter({
+				getCompletions: customGetCompletions || getCompletions
+			});
+		});
+		this._autocompletion_setup = true;
 	}
 
 	refresh_height() {

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -54,9 +54,9 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 				return this._autocompletions || [];
 			},
 			set: (value) => {
-				let getter = value
+				let getter = value;
 				if (typeof getter !== 'function') {
-					getter = () => value
+					getter = () => value;
 				}
 				if (!this._autocompletions) {
 					this._autocompletions = [];
@@ -85,7 +85,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 					completions.push(...values);
 				}
 				return completions;
-			}
+			};
 			let autocompletions = get_autocompletions();
 			if (autocompletions.length) {
 				callback(
@@ -104,7 +104,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 					})
 				);
 			}
-		}
+		};
 
 		ace.config.loadModule("ace/ext/language_tools", langTools => {
 			this.editor.setOptions({

--- a/frappe/public/js/frappe/form/controls/markdown_editor.js
+++ b/frappe/public/js/frappe/form/controls/markdown_editor.js
@@ -29,6 +29,8 @@ frappe.ui.form.ControlMarkdownEditor = class ControlMarkdownEditor extends frapp
 
 		this.markdown_preview = $(`<div class="${editor_class}-preview border rounded">`).hide();
 		this.markdown_container.append(this.markdown_preview);
+
+		this.setup_image_drop();
 	}
 
 	set_language() {
@@ -52,5 +54,46 @@ frappe.ui.form.ControlMarkdownEditor = class ControlMarkdownEditor extends frapp
 
 	set_disp_area(value) {
 		this.disp_area && $(this.disp_area).text(value);
+	}
+
+	setup_image_drop() {
+		this.ace_editor_target.on('drop', e => {
+			e.stopPropagation();
+			e.preventDefault();
+			let { dataTransfer } = e.originalEvent;
+			if (!dataTransfer?.files?.length) {
+				return;
+			}
+			let files = dataTransfer.files;
+			if (!files[0].type.includes('image')) {
+				frappe.show_alert({
+					message: __('You can only insert images in Markdown fields', [files[0].name]),
+					indicator: 'orange'
+				});
+				return;
+			}
+
+			new frappe.ui.FileUploader({
+				dialog_title: __('Insert Image in Markdown'),
+				doctype: this.doctype,
+				docname: this.docname,
+				frm: this.frm,
+				files,
+				folder: 'Home/Attachments',
+				allow_multiple: false,
+				restrictions: {
+					allowed_file_types: ['image/*']
+				},
+				on_success: (file_doc) => {
+					if (this.frm) {
+						this.frm.attachments.attachment_uploaded(file_doc);
+					}
+					this.editor.session.insert(
+						this.editor.getCursorPosition(),
+						`![](${encodeURI(file_doc.file_url)})`
+					);
+				}
+			});
+		});
 	}
 };

--- a/frappe/public/js/frappe/form/controls/markdown_editor.js
+++ b/frappe/public/js/frappe/form/controls/markdown_editor.js
@@ -85,7 +85,7 @@ frappe.ui.form.ControlMarkdownEditor = class ControlMarkdownEditor extends frapp
 					allowed_file_types: ['image/*']
 				},
 				on_success: (file_doc) => {
-					if (this.frm) {
+					if (this.frm && !this.frm.is_new()) {
 						this.frm.attachments.attachment_uploaded(file_doc);
 					}
 					this.editor.session.insert(

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -319,6 +319,25 @@ frappe.ui.form.Form = class FrappeForm {
 			});
 	}
 
+	setup_image_autocompletions_in_markdown() {
+		this.fields.map(field => {
+			if (field.df.fieldtype === 'Markdown Editor') {
+				this.set_df_property(field.df.fieldname, 'autocompletions', () => {
+					let attachments = this.attachments.get_attachments();
+					return attachments
+						.filter(file => frappe.utils.is_image_file(file.file_url))
+						.map(file => {
+							return {
+								caption: 'image: ' + file.file_name,
+								value: `![](${file.file_url})`,
+								meta: 'image'
+							}
+						});
+				});
+			}
+		})
+	}
+
 	// REFRESH
 
 	refresh(docname) {
@@ -533,6 +552,7 @@ frappe.ui.form.Form = class FrappeForm {
 				// call onload post render for callbacks to be fired
 				() => {
 					if(this.cscript.is_onload) {
+						this.onload_post_render();
 						return this.script_manager.trigger("onload_post_render");
 					}
 				},
@@ -558,6 +578,10 @@ frappe.ui.form.Form = class FrappeForm {
 				this.scroll_to_element();
 			});
 		});
+	}
+
+	onload_post_render() {
+		this.setup_image_autocompletions_in_markdown();
 	}
 
 	set_first_tab_as_active() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -331,11 +331,11 @@ frappe.ui.form.Form = class FrappeForm {
 								caption: 'image: ' + file.file_name,
 								value: `![](${file.file_url})`,
 								meta: 'image'
-							}
+							};
 						});
 				});
 			}
-		})
+		});
 	}
 
 	// REFRESH

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -62,7 +62,7 @@ frappe.ui.form.Attachments = class Attachments {
 
 	}
 	get_attachments() {
-		return this.frm.get_docinfo().attachments;
+		return this.frm.get_docinfo().attachments || [];
 	}
 	add_attachment(attachment) {
 		var file_name = attachment.file_name;


### PR DESCRIPTION
## Drop images into Markdown fields

Bonus: Aspect Ratio buttons during image cropping

![markdown-image-drop](https://user-images.githubusercontent.com/9355208/163170963-e63eb03f-81c5-4b32-b06c-7466e1f305d1.gif)

## Show image suggestions in Markdown fields

![markdown-image-autocompletion](https://user-images.githubusercontent.com/9355208/154232885-27672a7f-d303-43c6-90a2-c64df5f10ede.gif)

## `df.autocompletions` is now a getter

The current Autocompletions API only allows you to set an array of values. This change will allow you to also pass a function that returns an array.

```js
// add dynamic autocompletion in any code field
frm.set_df_property("markdown_content", "autocompletions", ({ pos, prefix, editor, session }) => {
  // use pos (position), prefix (typed word), editor and session values to dynamically generate suggestions
  return [
    {
      value: "lorem ipsum", // the value that is inserted
      caption: "add filler text", // (optional) the value that is displayed
      score: 0.5, // (optional) for sorting
      meta: "variable", // (optional) additional info about the completion, shown at the end of the suggestion
    },
    ...
  ];
});
```