### PR TITLE
fix(grid): Update docfield list while creating new record

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -368,8 +368,6 @@ export default class Grid {
 			if (this.grid_rows[ri] && !append_row) {
 				var grid_row = this.grid_rows[ri];
 				grid_row.doc = d;
-				// reset docfield list for this row
-				grid_row.docfields = this.docfields;
 				grid_row.refresh();
 			} else {
 				var grid_row = new GridRow({

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -368,6 +368,8 @@ export default class Grid {
 			if (this.grid_rows[ri] && !append_row) {
 				var grid_row = this.grid_rows[ri];
 				grid_row.doc = d;
+				// reset docfield list for this row
+				grid_row.docfields = this.docfields;
 				grid_row.refresh();
 			} else {
 				var grid_row = new GridRow({
@@ -972,7 +974,6 @@ export default class Grid {
 
 		// update the parent too (for new rows)
 		this.docfields.find(d => d.fieldname === fieldname)[property] = value;
-		frappe.meta.docfield_map[this.doctype][fieldname][property] = value;
 
 		this.debounced_refresh();
 	}

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -972,6 +972,7 @@ export default class Grid {
 
 		// update the parent too (for new rows)
 		this.docfields.find(d => d.fieldname === fieldname)[property] = value;
+		frappe.meta.docfield_map[this.doctype][fieldname][property] = value;
 
 		this.debounced_refresh();
 	}

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -5,16 +5,13 @@ export default class GridRow {
 		this.on_grid_fields_dict = {};
 		this.on_grid_fields = [];
 		$.extend(this, opts);
-		if (this.doc && this.parent_df.options) {
-			frappe.meta.make_docfield_copy_for(this.parent_df.options, this.doc.name, this.docfields);
-			const docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
-			this.docfields = docfields.length ? docfields : opts.docfields;
-		}
+		this.set_docfields();
 		this.columns = {};
 		this.columns_list = [];
 		this.row_check_html = '<input type="checkbox" class="grid-row-check pull-left">';
 		this.make();
 	}
+
 	make() {
 		var me = this;
 
@@ -41,6 +38,15 @@ export default class GridRow {
 			this.set_data();
 		}
 	}
+
+	set_docfields() {
+		if (this.doc && this.parent_df.options) {
+			frappe.meta.make_docfield_copy_for(this.parent_df.options, this.doc.name, this.docfields);
+			const docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
+			this.docfields = docfields;
+		}
+	}
+
 	set_data() {
 		this.wrapper.data({
 			"doc": this.doc
@@ -152,6 +158,8 @@ export default class GridRow {
 			this.doc = locals[this.doc.doctype][this.doc.name];
 		}
 
+		// update docfield list
+		this.set_docfields();
 		if(this.grid.template && !this.grid.meta.editable_grid) {
 			this.render_template();
 		} else {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -11,7 +11,6 @@ export default class GridRow {
 		this.row_check_html = '<input type="checkbox" class="grid-row-check pull-left">';
 		this.make();
 	}
-
 	make() {
 		var me = this;
 
@@ -39,11 +38,18 @@ export default class GridRow {
 		}
 	}
 
-	set_docfields() {
+	set_docfields(update=false) {
 		if (this.doc && this.parent_df.options) {
 			frappe.meta.make_docfield_copy_for(this.parent_df.options, this.doc.name, this.docfields);
 			const docfields = frappe.meta.get_docfields(this.parent_df.options, this.doc.name);
-			this.docfields = docfields;
+			if (update) {
+				// to maintain references
+				this.docfields.forEach(df => {
+					Object.assign(df, docfields.find(d => d.fieldname === df.fieldname));
+				});
+			} else {
+				this.docfields = docfields;
+			}
 		}
 	}
 
@@ -154,12 +160,15 @@ export default class GridRow {
 		}, __('Move To'), 'Update');
 	}
 	refresh() {
+		// update docfields for new record
+		if (this.frm && this.doc && this.doc.__islocal) {
+			this.set_docfields(true);
+		}
+
 		if(this.frm && this.doc) {
 			this.doc = locals[this.doc.doctype][this.doc.name];
 		}
 
-		// update docfield list
-		this.set_docfields();
 		if(this.grid.template && !this.grid.meta.editable_grid) {
 			this.render_template();
 		} else {


### PR DESCRIPTION
Use grid docfield list while adding new a record from an existing row. 

Previously, we used to create docfield list from doctype meta instead of using docfield list of a grid. Due to this, all changes property changes made on the grid were not available for a new row.

**Issue:**

**Before:**

https://user-images.githubusercontent.com/13928957/154407006-628aa90c-ff0f-4bff-9573-2da15ffaa908.mov

**After:**

https://user-images.githubusercontent.com/13928957/154407060-60cfb79c-530e-4ccb-a8a0-9150dd45f709.mov

---

fixes https://github.com/frappe/frappe/issues/15947