### PR TITLE
ci: Track server-side coverage as well while running UI tests

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -50,7 +50,9 @@ if [ "$TYPE" == "server" ]; then sed -i 's/^socketio:/# socketio:/g' Procfile; f
 if [ "$TYPE" == "server" ]; then sed -i 's/^redis_socketio:/# redis_socketio:/g' Procfile; fi
 
 if [ "$TYPE" == "ui" ]; then bench setup requirements --node; fi
-if [ "$TYPE" == "server" ]; then bench setup requirements --dev; fi
+bench setup requirements --dev
+
+if [ "$TYPE" == "ui" ]; then sed -i 's/^web: bench serve/web: bench serve --with-coverage/g' Procfile; fi
 
 # install node-sass which is required for website theme test
 cd ./apps/frappe || exit

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -62,4 +62,4 @@ cd ../..
 bench start &
 bench --site test_site reinstall --yes
 if [ "$TYPE" == "server" ]; then bench --site test_site_producer reinstall --yes; fi
-CI=Yes bench build --app frappe
+if [ "$TYPE" == "server" ]; then CI=Yes bench build --app frappe; fi

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -118,7 +118,9 @@ jobs:
 
       - name: Install
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
+        run: |
+          bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
+          cat ~/frappe-bench/Procfile
         env:
           DB: mariadb
           TYPE: ui
@@ -141,6 +143,11 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
 
+      - name: Stop server
+        run: |
+          ps -ef | grep "frappe serve" | awk '{print $2}' | xargs kill -s SIGINT 2> /dev/null || true
+          sleep 5
+
       - name: Check If Coverage Report Exists
         id: check_coverage
         uses: andstor/file-existence-action@v1
@@ -156,3 +163,13 @@ jobs:
           directory: /home/runner/frappe-bench/apps/frappe/.cypress-coverage/
           verbose: true
           flags: ui-tests
+
+      - name: Upload Server Coverage Data
+        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
+        uses: codecov/codecov-action@v2
+        with:
+          name: MariaDB
+          fail_ci_if_error: true
+          files: /home/runner/frappe-bench/sites/coverage.xml
+          verbose: true
+          flags: server

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -118,9 +118,7 @@ jobs:
 
       - name: Install
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        run: |
-          bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
-          cat ~/frappe-bench/Procfile
+        run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
           DB: mariadb
           TYPE: ui

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -742,8 +742,9 @@ def run_ui_tests(context, app, headless=False, parallel=True, with_coverage=Fals
 @click.option('--profile', is_flag=True, default=False)
 @click.option('--noreload', "no_reload", is_flag=True, default=False)
 @click.option('--nothreading', "no_threading", is_flag=True, default=False)
+@click.option('--with-coverage', is_flag=True, default=False)
 @pass_context
-def serve(context, port=None, profile=False, no_reload=False, no_threading=False, sites_path='.', site=None):
+def serve(context, port=None, profile=False, no_reload=False, no_threading=False, sites_path='.', site=None, with_coverage=False):
 	"Start development web server"
 	import frappe.app
 
@@ -751,8 +752,12 @@ def serve(context, port=None, profile=False, no_reload=False, no_threading=False
 		site = None
 	else:
 		site = context.sites[0]
-
-	frappe.app.serve(port=port, profile=profile, no_reload=no_reload, no_threading=no_threading, site=site, sites_path='.')
+	with CodeCoverage(with_coverage, 'frappe'):
+		if with_coverage:
+			# unable to track coverage with threading enabled
+			no_threading = True
+			no_reload = True
+		frappe.app.serve(port=port, profile=profile, no_reload=no_reload, no_threading=no_threading, site=site, sites_path='.')
 
 
 @click.command('request')

--- a/frappe/coverage.py
+++ b/frappe/coverage.py
@@ -30,7 +30,6 @@ FRAPPE_EXCLUSIONS = [
 	"*/frappe/change_log/*",
 	"*/frappe/exceptions*",
 	"*/frappe/coverage.py",
-	"*/frappe/build.py",
 	"*frappe/setup.py",
 	"*/doctype/*/*_dashboard.py",
 	"*/patches/*",

--- a/frappe/coverage.py
+++ b/frappe/coverage.py
@@ -29,6 +29,8 @@ FRAPPE_EXCLUSIONS = [
 	"*/commands/*",
 	"*/frappe/change_log/*",
 	"*/frappe/exceptions*",
+	"*/frappe/coverage.py",
+	"*/frappe/build.py",
 	"*frappe/setup.py",
 	"*/doctype/*/*_dashboard.py",
 	"*/patches/*",


### PR DESCRIPTION
Server-side code that got executed during UI tests was not getting considered for coverage report.

--

This will be helpful to detect if UI tests are hitting the expected endpoints and if all cases are covered.
