### PR TITLE
fix: Show assignments based on allocated todo only

### DIFF
--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -72,7 +72,8 @@ class ToDo(Document):
 			assignments = frappe.get_all("ToDo", filters={
 				"reference_type": self.reference_type,
 				"reference_name": self.reference_name,
-				"status": ("!=", "Cancelled")
+				"status": ("!=", "Cancelled"),
+				"allocated_to": ("is", "set")
 			}, pluck="allocated_to")
 			assignments.reverse()
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -307,6 +307,7 @@ def get_assignments(dt, dn):
 			'reference_type': dt,
 			'reference_name': dn,
 			'status': ('!=', 'Cancelled'),
+			'allocated_to': ("is", "set")
 		})
 
 @frappe.whitelist()


### PR DESCRIPTION
### Issue:

Currently, if you assign a reference document (e.g Issue) to someone, in the backend, the system creates a ToDo record allocated to that person. Now, if you remove the "Allocated To" value from the ToDo record, the system shows the assignment based on the **session user** on the reference document (Issue).

### Fix:

After the fix, the system shows assignments only based on ToDo allocated to someone.

