### PR TITLE
fix: Other user must not able to delete other user's comment except System Manager

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -452,7 +452,7 @@ class FormTimeline extends BaseTimeline {
 		let content_wrapper = comment_wrapper.find('.content');
 
 		let delete_button = $();
-		if (frappe.model.can_delete("Comment")) {
+		if ((frappe.session.user == doc.owner && frappe.model.can_delete("Comment")) || frappe.session.user == 'Administrator') {
 			delete_button = $(`
 				<button class="btn btn-link action-btn">
 					${frappe.utils.icon('close', 'sm')}

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -452,7 +452,7 @@ class FormTimeline extends BaseTimeline {
 		let content_wrapper = comment_wrapper.find('.content');
 
 		let delete_button = $();
-		if (frappe.model.can_delete("Comment") && (frappe.session.user == doc.owner || frappe.user.has_role("System Manager")) {
+		if (frappe.model.can_delete("Comment") && (frappe.session.user == doc.owner || frappe.user.has_role("System Manager"))) {
 			delete_button = $(`
 				<button class="btn btn-link action-btn">
 					${frappe.utils.icon('close', 'sm')}

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -452,7 +452,7 @@ class FormTimeline extends BaseTimeline {
 		let content_wrapper = comment_wrapper.find('.content');
 
 		let delete_button = $();
-		if ((frappe.session.user == doc.owner && frappe.model.can_delete("Comment")) || frappe.session.user == 'Administrator') {
+		if (frappe.model.can_delete("Comment") && (frappe.session.user == doc.owner || frappe.user.has_role("System Manager")) {
 			delete_button = $(`
 				<button class="btn btn-link action-btn">
 					${frappe.utils.icon('close', 'sm')}


### PR DESCRIPTION
### **Details of the Issue:**
Other user must not able to delete other user's comment except Admin.

**Screenshot of the problem:**
Test User:
![user_comment_b](https://user-images.githubusercontent.com/86836253/154019302-9366a362-6c3c-401d-a56d-1b1ae648e576.gif)

Admin:
![admin_comment_b](https://user-images.githubusercontent.com/86836253/154019339-a2ca0003-f1e9-4363-813a-c8a1851e50fa.gif)

**Replicate the issue:**
- Add a comment in any forms in any doctype where we can add a comment.
- See if you can delete other user's comment even if you're not an admin.

### **Solution:**
Adding a few more conditions when deleting the comment, to only the user themselves will only able to delete their own comments.


**Screenshot of the fix:**
Test User:
![user_comment_a](https://user-images.githubusercontent.com/86836253/154019379-1613a1f4-26a9-42f9-8ecc-81d8633503d4.gif)

Test User 2:
![test user 2](https://user-images.githubusercontent.com/86836253/154397840-9eb8db4b-81b2-435d-b53f-02082e3349de.gif)

Admin:
![admin_comment_a](https://user-images.githubusercontent.com/86836253/154019403-d837207a-54b5-43d0-9bda-770ef71a646b.gif)