### PR TITLE
fix: Removed verbose flag for gzip

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -529,10 +529,9 @@ def extract_sql_gzip(sql_gz_path):
 	import subprocess
 
 	try:
-		# dvf - decompress, verbose, force
 		original_file = sql_gz_path
 		decompressed_file = original_file.rstrip(".gz")
-		cmd = 'gzip -dvf < {0} > {1}'.format(original_file, decompressed_file)
+		cmd = 'gzip --decompress --force < {0} > {1}'.format(original_file, decompressed_file)
 		subprocess.check_call(cmd, shell=True)
 	except Exception:
 		raise


### PR DESCRIPTION

<img width="678" alt="Screenshot 2022-02-17 at 15 44 19" src="https://user-images.githubusercontent.com/4463796/154455393-ac612ad8-f1db-40ea-bf02-f892bd1b5612.png">


When users run `restore` command, an unknown % gets printed on the terminal as shown above. Turns out this output is logged by `gzip` command. If `-v` flag is enabled, gzip will show compression ratio.

This blank % causes confusion for users. Hence disabling the verbose flag.