### PR TITLE
fix: load default company for users from user permission and set to s…

### DIFF
--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -209,6 +209,14 @@ def get_defaults_for(parent="__default"):
 			elif d.defvalue is not None:
 				defaults[d.defkey] = d.defvalue
 
+		# load company from user permission
+		if parent not in ['__default', 'Guest', '__global']:
+			user_permission = get_user_permissions(parent).get(frappe.unscrub('company')) or []
+
+			for d in user_permission:
+				if d.is_default:
+					defaults['company'] = d.doc
+
 		frappe.cache().hset("defaults", parent, defaults)
 
 	return defaults


### PR DESCRIPTION
When we have more than one company we have where users can access both companies but they are "Default" for only one.

Example:
Company A
John
marie
Louis

Company B
John
marie
Louis

They have access to both companies, but only one is standard.

**Problem 1** - Currently we have in the Globals Defaults a field to define the default company of the system, where it generates a conflict with the User Permissions configuration.

Example: Let's suppose that in the Global Defaults Company A is defined as Default and Louis only has permission for Company B, when he logs into the system, he will not load the Session Defaults, but the filters of all the screens are loaded based on the default company from Global Defaults.
All Dashboards will show an error message and will not load because the user does not have access to company A.

**Problem 2** - User always logs in and has to change company
in the session defaults, and it is already defined that he must have access to company B and is marked as Default.

With this change considering the User Permission to load the default company, the system will be less subject to user errors because they will no longer launch sales in the wrong company.

I didn't find it necessary to consider other fields in the session, only the company must be loaded. 