### PR TITLE
fix(print): Added properties page-width, page-height

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -155,7 +155,7 @@ def read_options_from_html(html):
 	toggle_visible_pdf(soup)
 
 	# use regex instead of soup-parser
-	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size", "header-spacing", "orientation"):
+	for attr in ("margin-top", "margin-bottom", "margin-left", "margin-right", "page-size", "header-spacing", "orientation", "page-width", "page-height"):
 		try:
 			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
 			match = pattern.findall(html)


### PR DESCRIPTION
When we save a print template as a PDF, we can't control the size of the sheet we're going to generate, for that we've added two properties:
- page-width
- page height 

Result: 
![image](https://user-images.githubusercontent.com/25017988/154802028-c1a1c97a-8503-43c5-bf6d-e71ed42b91bd.png)

We can print this on a label printer, or we can print several on a single A4 sheet. 

![image](https://user-images.githubusercontent.com/25017988/154802079-0ff123f2-659e-4a72-a016-b9bd99db303f.png)
Selected in red is "Pages per sheet" in English. 

This change brings more flexibility for customizations, just set **page-width, page height**  on CSS from ur Print Format

![image](https://user-images.githubusercontent.com/25017988/154802198-59ecebfa-d929-48ef-b182-50851bb92743.png)
