### PR TITLE
Revert "fix: Always set `doctype` from `options` for child Document (backport #15957)"

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -223,9 +223,10 @@ class BaseDocument(object):
 			return value
 
 		if not isinstance(value, BaseDocument):
-			value["doctype"] = self.get_table_field_doctype(key)
-			if not value["doctype"]:
-				raise AttributeError(key)
+			if "doctype" not in value or value['doctype'] is None:
+				value["doctype"] = self.get_table_field_doctype(key)
+				if not value["doctype"]:
+					raise AttributeError(key)
 
 			value = get_controller(value["doctype"])(value)
 			value.init_valid_columns()


### PR DESCRIPTION
Reverts frappe/frappe#15994

Reverting this as it causing below error

### App Versions
```
{
	"erpnext": "13.2.0",
	"frappe": "13.1.2"
}
```
### Route
```
List/Purchase Order/List
```
### Trackeback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1213, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/load.py", line 71, in getdoctype
    docs = get_meta_bundle(doctype)
  File "apps/frappe/frappe/desk/form/load.py", line 81, in get_meta_bundle
    bundle = [frappe.desk.form.meta.get_meta(doctype)]
  File "apps/frappe/frappe/desk/form/meta.py", line 24, in get_meta
    meta = FormMeta(meta)
  File "apps/frappe/frappe/desk/form/meta.py", line 38, in __init__
    super(FormMeta, self).__init__(doctype)
  File "apps/frappe/frappe/model/meta.py", line 76, in __init__
    super(Meta, self).__init__(doctype)
  File "apps/frappe/frappe/model/document.py", line 122, in __init__
    super(Document, self).__init__(kwargs)
  File "apps/frappe/frappe/model/base_document.py", line 85, in __init__
    self.update(d)
  File "apps/frappe/frappe/model/base_document.py", line 113, in update
    self.set(key, value)
  File "apps/frappe/frappe/model/base_document.py", line 167, in set
    self.extend(key, value)
  File "apps/frappe/frappe/model/base_document.py", line 214, in extend
    self.append(key, v)
  File "apps/frappe/frappe/model/base_document.py", line 191, in append
    value = self._init_child(value, key)
  File "apps/frappe/frappe/model/base_document.py", line 228, in _init_child
    raise AttributeError(key)
AttributeError: __print_formats

```
### Request Data
```
{
	"type": "GET",
	"args": {
		"doctype": "Purchase Order",
		"with_parent": 1,
		"cached_timestamp": null
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.desk.form.load.getdoctype"
}
```
### Response Data
```
{
	"exception": "AttributeError: __print_formats"
}
```