### PR TITLE
ci: Only upload server-side coverage report if `.py` files are changed

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
 	# this is a push build, run all builds
 	if not pr_number:
 		os.system('echo "::set-output name=build::strawberry"')
+		os.system('echo "::set-output name=build-server::strawberry"')
 		sys.exit(0)
 
 	files_list = files_list or get_files_list(pr_number=pr_number, repo=repo)

--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -52,7 +52,8 @@ if __name__ == "__main__":
 	ci_files_changed = any(f for f in files_list if is_ci(f))
 	only_docs_changed = len(list(filter(is_docs, files_list))) == len(files_list)
 	only_frontend_code_changed = len(list(filter(is_frontend_code, files_list))) == len(files_list)
-	only_py_changed = len(list(filter(is_py, files_list))) == len(files_list)
+	updated_py_file_count = len(list(filter(is_py, files_list)))
+	only_py_changed = updated_py_file_count == len(files_list)
 
 	if ci_files_changed:
 		print("CI related files were updated, running all build processes.")
@@ -65,8 +66,12 @@ if __name__ == "__main__":
 		print("Only Frontend code was updated; Stopping Python build process.")
 		sys.exit(0)
 
-	elif only_py_changed and build_type == "ui":
-		print("Only Python code was updated, stopping Cypress build process.")
-		sys.exit(0)
+	elif build_type == "ui":
+		if only_py_changed:
+			print("Only Python code was updated, stopping Cypress build process.")
+			sys.exit(0)
+		elif updated_py_file_count > 0:
+			# both frontend and backend code were updated
+			os.system('echo "::set-output name=build-server::strawberry"')
 
 	os.system('echo "::set-output name=build::strawberry"')

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -142,6 +142,7 @@ jobs:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
 
       - name: Stop server
+        if: ${{ steps.check-build.outputs.build-server == 'strawberry' }}
         run: |
           ps -ef | grep "frappe serve" | awk '{print $2}' | xargs kill -s SIGINT 2> /dev/null || true
           sleep 5
@@ -163,7 +164,7 @@ jobs:
           flags: ui-tests
 
       - name: Upload Server Coverage Data
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
+        if: ${{ steps.check-build.outputs.build-server == 'strawberry' }}
         uses: codecov/codecov-action@v2
         with:
           name: MariaDB


### PR DESCRIPTION
Only upload server-side coverage report if `.py` files are updated to avoid weird coverage drops like [this](https://github.com/frappe/frappe/pull/16039#issuecomment-1044499211) and [this](https://github.com/frappe/frappe/pull/16009#issuecomment-1041340433).

The issue was introduced via https://github.com/frappe/frappe/pull/16012

---

PS: Still have no idea why we have set a fruit as an identifier : p