### PR TITLE
fix: Check if table_field exists in meta of `link.parent_doctype`

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -784,10 +784,9 @@ def validate_links_table_fieldnames(meta):
 	if not meta.links or frappe.flags.in_patch or frappe.flags.in_fixtures:
 		return
 
-	fieldnames = tuple(field.fieldname for field in meta.fields)
 	for index, link in enumerate(meta.links, 1):
 		link_meta = frappe.get_meta(link.link_doctype)
-		if not link_meta.get_field(link.link_fieldname):
+		if not frappe.get_meta(link.link_doctype).has_field(link.link_fieldname):
 			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index, frappe.bold(link.link_fieldname), frappe.bold(link.link_doctype))
 			frappe.throw(message, InvalidFieldNameError, _("Invalid Fieldname"))
 
@@ -802,7 +801,7 @@ def validate_links_table_fieldnames(meta):
 			message = _("Document Links Row #{0}: Table Fieldname is mandatory for internal links").format(index)
 			frappe.throw(message, frappe.ValidationError, _("Table Fieldname Missing"))
 
-		if link.table_fieldname not in fieldnames:
+		if not frappe.get_meta(link.parent_doctype).has_field(link.table_fieldname):
 			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index, frappe.bold(link.table_fieldname), frappe.bold(meta.name))
 			frappe.throw(message, frappe.ValidationError, _("Invalid Table Fieldname"))
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -784,10 +784,12 @@ def validate_links_table_fieldnames(meta):
 	if not meta.links or frappe.flags.in_patch or frappe.flags.in_fixtures:
 		return
 
+	fieldnames = tuple(field.fieldname for field in meta.fields)
 	for index, link in enumerate(meta.links, 1):
-		link_meta = frappe.get_meta(link.link_doctype)
 		if not frappe.get_meta(link.link_doctype).has_field(link.link_fieldname):
-			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index, frappe.bold(link.link_fieldname), frappe.bold(link.link_doctype))
+			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(
+				index, frappe.bold(link.link_fieldname), frappe.bold(link.link_doctype)
+			)
 			frappe.throw(message, InvalidFieldNameError, _("Invalid Fieldname"))
 
 		if not link.is_child_table:
@@ -801,8 +803,15 @@ def validate_links_table_fieldnames(meta):
 			message = _("Document Links Row #{0}: Table Fieldname is mandatory for internal links").format(index)
 			frappe.throw(message, frappe.ValidationError, _("Table Fieldname Missing"))
 
-		if not frappe.get_meta(link.parent_doctype).has_field(link.table_fieldname):
-			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(index, frappe.bold(link.table_fieldname), frappe.bold(meta.name))
+		if meta.name == link.parent_doctype:
+			field_exists = link.table_fieldname in fieldnames
+		else:
+			field_exists = frappe.get_meta(link.parent_doctype).has_field(link.table_fieldname)
+
+		if not field_exists:
+			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(
+				index, frappe.bold(link.table_fieldname), frappe.bold(meta.name)
+			)
 			frappe.throw(message, frappe.ValidationError, _("Invalid Table Fieldname"))
 
 def validate_fields_for_doctype(doctype):

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -257,7 +257,7 @@ class TestCustomizeForm(unittest.TestCase):
 		frappe.clear_cache()
 		d = self.get_customize_form("User Group")
 
-		d.append('links', dict(link_doctype='User Group Member', parent_doctype='User',
+		d.append('links', dict(link_doctype='User Group Member', parent_doctype='User Group',
 			link_fieldname='user', table_fieldname='user_group_members', group='Tests', custom=1))
 
 		d.run_method("save_customization")
@@ -267,7 +267,7 @@ class TestCustomizeForm(unittest.TestCase):
 
 		# check links exist
 		self.assertTrue([d.name for d in user_group.links if d.link_doctype == 'User Group Member'])
-		self.assertTrue([d.name for d in user_group.links if d.parent_doctype == 'User'])
+		self.assertTrue([d.name for d in user_group.links if d.parent_doctype == 'User Group'])
 
 		# remove the link
 		d = self.get_customize_form("User Group")


### PR DESCRIPTION
Continuation of https://github.com/frappe/frappe/pull/15832

---

Fixes following issue while setting `table_fieldname` of other doctype
<img width="630" alt="Screenshot 2022-02-21 at 12 41 59 PM" src="https://user-images.githubusercontent.com/13928957/154906121-63df0fda-c4ef-4219-9d9a-72eeec8820ab.png">
```
File "apps/frappe/frappe/model/document.py", line 971, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 869, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1161, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1144, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 863, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "apps/frappe/frappe/core/doctype/doctype/doctype.py", line 82, in validate
    validate_links_table_fieldnames(self)
  File "apps/frappe/frappe/core/doctype/doctype/doctype.py", line 755, in validate_links_table_fieldnames
    frappe.throw(message, frappe.ValidationError, _("Invalid Table Fieldname"))
  File "apps/frappe/frappe/__init__.py", line 444, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "apps/frappe/frappe/__init__.py", line 423, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 378, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Document Links Row #2: Could not find field <b>items</b> in <b>SO</b> DocType
```

fixes: https://github.com/frappe/frappe/issues/16083
fixes: https://frappe.io/app/pre-release-test/PRT-15-02-22-344153

