### PR TITLE
revert: "fix: Always set `doctype` from `options` for child Document"

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -226,9 +226,10 @@ class BaseDocument(object):
 			return value
 
 		if not isinstance(value, BaseDocument):
-			value["doctype"] = self.get_table_field_doctype(key)
-			if not value["doctype"]:
-				raise AttributeError(key)
+			if "doctype" not in value or value['doctype'] is None:
+				value["doctype"] = self.get_table_field_doctype(key)
+				if not value["doctype"]:
+					raise AttributeError(key)
 
 			value = get_controller(value["doctype"])(value)
 			value.init_valid_columns()


### PR DESCRIPTION
Reverts frappe/frappe#15957
