### PR TITLE
feat(minor): Add Custom Group Search for custom LDAP servers

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.json
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -38,6 +38,7 @@
   "local_ca_certs_file",
   "ldap_custom_settings_section",
   "ldap_group_objectclass",
+  "ldap_custom_group_search",
   "column_break_33",
   "ldap_group_member_attribute",
   "ldap_group_mappings_section",
@@ -246,6 +247,12 @@
    "fieldname": "ldap_group_objectclass",
    "fieldtype": "Data",
    "label": "Group Object Class"
+  },
+  {
+    "description": "string value, i.e. {0} or uid={0},ou=users,dc=example,dc=com",
+    "fieldname": "ldap_custom_group_search",
+    "fieldtype": "Data",
+    "label": "Custom Group Search"
   },
   {
    "description": "Requires any valid fdn path. i.e. ou=users,dc=example,dc=com",

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -50,8 +50,8 @@ class LDAPSettings(Document):
 						title=_("Misconfigured"))
 
 				if self.ldap_custom_group_search and "{0}" not in self.ldap_custom_group_search:
-						frappe.throw(_("Custom Group Search if filled needs to contain the user placeholder {0}, eg uid={0},ou=users,dc=example,dc=com"),
-						title=_("Misconfigured"))
+					frappe.throw(_("Custom Group Search if filled needs to contain the user placeholder {0}, eg uid={0},ou=users,dc=example,dc=com"),
+					title=_("Misconfigured"))
 
 			else:
 				frappe.throw(_("LDAP Search String must be enclosed in '()' and needs to contian the user placeholder {0}, eg sAMAccountName={0}"))

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -213,9 +213,7 @@ class LDAPSettings(Document):
 
 			ldap_object_class = self.ldap_group_objectclass
 			ldap_group_members_attribute = self.ldap_group_member_attribute
-			ldap_custom_group_search = "{0}"
-			if self.ldap_custom_group_search:
-				ldap_custom_group_search = self.ldap_custom_group_search
+			ldap_custom_group_search = self.ldap_custom_group_search or "{0}"
 			user_search_str = ldap_custom_group_search.format(getattr(user, self.ldap_username_field).value)
 
 		else:

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -49,6 +49,10 @@ class LDAPSettings(Document):
 						frappe.throw(_("Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute' and 'Group Object Class' are entered"),
 						title=_("Misconfigured"))
 
+				if self.ldap_custom_group_search and "{0}" not in self.ldap_custom_group_search:
+						frappe.throw(_("Custom Group Search if filled needs to contain the user placeholder {0}, eg uid={0},ou=users,dc=example,dc=com"),
+						title=_("Misconfigured"))
+
 			else:
 				frappe.throw(_("LDAP Search String must be enclosed in '()' and needs to contian the user placeholder {0}, eg sAMAccountName={0}"))
 
@@ -209,7 +213,10 @@ class LDAPSettings(Document):
 
 			ldap_object_class = self.ldap_group_objectclass
 			ldap_group_members_attribute = self.ldap_group_member_attribute
-			user_search_str = getattr(user, self.ldap_username_field).value
+			ldap_custom_group_search = "{0}"
+			if self.ldap_custom_group_search:
+				ldap_custom_group_search = self.ldap_custom_group_search
+			user_search_str = ldap_custom_group_search.format(getattr(user, self.ldap_username_field).value)
 
 		else:
 			# NOTE: depreciate this else path


### PR DESCRIPTION
When using a custom LDAP server (not AD/OpenLDAP) it may be necessary to specify a custom search group. For example this is the case when using [Okta](https://www.okta.com/).

![148265357-b73c61ec-94c8-4112-8ee9-306ae80b27ec](https://user-images.githubusercontent.com/6875705/154951919-26e8763e-b3a8-4ff1-a38c-8365442d4c50.png)

This configuration is needed for e.g. Okta where the dn is stored like this:
`uniqueMember: uid=andreas,ou=users,dc=example,dc=okta,dc=com.`

Currently the group search query would always look like the following:
`(&(objectClass=groupOfUniqueNames)(uniqueMember=andreas)).`

With the new changes it is possible to adjust the search query to this:
`(&(objectClass=groupOfUniqueNames)(uniqueMember=uid=andreas,ou=users,dc=example,dc=okta,dc=com)).`

If the field is left empty, the behaviour won't change and just the `uid` will be queried.

--

Re of https://github.com/frappe/frappe/pull/15629

[Docs Link](https://frappeframework.com/compare?wiki_page=docs/v13/user/en/integration/ldap-integration&&compare=17a883cf84)
<no-docs>