### PR TITLE
fix: attribute error when initialising Meta

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -225,12 +225,15 @@ class BaseDocument(object):
 		if not self.doctype:
 			return value
 
-		if not isinstance(value, BaseDocument):
-			value["doctype"] = self.get_table_field_doctype(key)
-			if not value["doctype"]:
-				raise AttributeError(key)
+		child_doctype = self.get_table_field_doctype(key)
+		if not child_doctype:
+			# probably just a list of values like __print_formats, don't init
+			# this should ideally be tested in set() above
+			return value
 
-			value = get_controller(value["doctype"])(value)
+		if not isinstance(value, BaseDocument):
+			value["doctype"] = child_doctype
+			value = get_controller(child_doctype)(value)
 			value.init_valid_columns()
 
 		value.parent = self.name


### PR DESCRIPTION
Proper fix to 

https://github.com/frappe/erpnext/issues/29882
https://github.com/frappe/erpnext/issues/29930

![image](https://user-images.githubusercontent.com/16315650/154967399-cfc4d3a2-7253-427d-87da-8094fcb980e9.png)

Need to enable cache by modifying `frappe.desk.form.meta.get_meta` to test locally.