### PR TITLE
fix(email_account): Decode uid from bytes before update

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -417,7 +417,13 @@ class EmailAccount(Document):
 			if names:
 				name = names[0].get("name")
 				# email is already available update communication uid instead
-				frappe.db.set_value("Communication", name, "uid", uid, update_modified=False)
+				frappe.db.set_value(
+					"Communication",
+					name,
+					"uid",
+					frappe.safe_decode(uid),
+					update_modified=False,
+				)
 
 				self.flags.notify = False
 


### PR DESCRIPTION
If you have Email Accounts with `enable_incoming` set, Frappe will pull the inbox on the All event which usually means every 4 minutes. Now, in `EmailAccount.receive`, the **uid** type is in bytes it seems (sometimes?), at least the Unhandled Email records claim so:

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/email/doctype/email_account/email_account.py", line 334, in receive
    communication = self.insert_communication(msg, args=args)
  File "apps/frappe/frappe/email/doctype/email_account/email_account.py", line 420, in insert_communication
    frappe.db.set_value("Communication", name, "uid", uid, update_modified=False)
  File "apps/frappe/frappe/database/database.py", line 703, in set_value
    query.run(debug=debug)
  File "apps/frappe/frappe/query_builder/utils.py", line 59, in execute_query
    return frappe.db.sql(query, params, *args, **kwargs) # nosemgrep
  File "apps/frappe/frappe/database/database.py", line 146, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.6/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "env/lib/python3.6/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.6/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.6/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'b'322' WHERE `name` IN ('2fad4d7eb0')' at line 1")
```

This was supported in the previous set_value API perhaps before the slew of recent changes via #15883. But rather than adding support to handle in set_value, I chose to fix it for this particular usage alone because I don't think we should support that, to begin with 😅 

Related Thread: https://discuss.erpnext.com/t/error-after-updating-to-13-20-1/86322