### PR TITLE
chore: change log for v13.21.0

### DIFF
--- a/frappe/change_log/v13/v13_21_0.md
+++ b/frappe/change_log/v13/v13_21_0.md
@@ -1,0 +1,28 @@
+## Version 13.21.0 Release Notes
+
+### Features & Enhancements
+
+- Add breadcrumbs in dashboard view ([#15835](https://github.com/frappe/frappe/pull/15835))
+- Add Attach Image in Add Fetch feature ([#15799](https://github.com/frappe/frappe/pull/15799))
+- Allow all users to customize reports of type Report Builder ([#15918](https://github.com/frappe/frappe/pull/15918))
+- Additional filter support ([#14102](https://github.com/frappe/frappe/pull/14102))
+
+### Fixes
+
+- Image action not in center of image in mobile view ([#15969](https://github.com/frappe/frappe/pull/15969))
+- Libsass issue with `min()` ([#15982](https://github.com/frappe/frappe/pull/15982))
+- Delete chat message attachments ([#15852](https://github.com/frappe/frappe/pull/15852))
+- Check if valid file instead of path [v13] ([#15936](https://github.com/frappe/frappe/pull/15936))
+- Thumbnail for external images (from URL) [v13] ([#15838](https://github.com/frappe/frappe/pull/15838))
+- Added translation for Yes/No ([#15884](https://github.com/frappe/frappe/pull/15884))
+- Updated translations ([#15879](https://github.com/frappe/frappe/pull/15879))
+- Doctype name/table-name in database is limited to 64 character ([#15826](https://github.com/frappe/frappe/pull/15826))
+- Added regex for alerts ([#15833](https://github.com/frappe/frappe/pull/15833))
+- Primary color for progress bar ([#15839](https://github.com/frappe/frappe/pull/15839))
+- Data exporter throwing exception ([#15561](https://github.com/frappe/frappe/pull/15561))
+- Primary color for checkbox and radio ([#15842](https://github.com/frappe/frappe/pull/15842))
+- Call validate_link only if "value" is passed ([#15856](https://github.com/frappe/frappe/pull/15856))
+- Validate doc naming when set via prompt or by passing `set_name` ([#15746](https://github.com/frappe/frappe/pull/15746))
+- User permission for restricting nested struct ([#14079](https://github.com/frappe/frappe/pull/14079))
+- Translate default msgprint title in backend ([#15769](https://github.com/frappe/frappe/pull/15769))
+- Sync `index` & `unique` constraint changes in DB ([#15680](https://github.com/frappe/frappe/pull/15680))


### PR DESCRIPTION
## Version 13.21.0 Release Notes

### Features & Enhancements

- Add breadcrumbs in dashboard view ([#15835](https://github.com/frappe/frappe/pull/15835))
- Add Attach Image in Add Fetch feature ([#15799](https://github.com/frappe/frappe/pull/15799))
- Allow all users to customize reports of type Report Builder ([#15918](https://github.com/frappe/frappe/pull/15918))
- Additional filter support ([#14102](https://github.com/frappe/frappe/pull/14102))

### Fixes

- Image action not in center of image in mobile view ([#15969](https://github.com/frappe/frappe/pull/15969))
- Libsass issue with `min()` ([#15982](https://github.com/frappe/frappe/pull/15982))
- Delete chat message attachments ([#15852](https://github.com/frappe/frappe/pull/15852))
- Check if valid file instead of path [v13] ([#15936](https://github.com/frappe/frappe/pull/15936))
- Thumbnail for external images (from URL) [v13] ([#15838](https://github.com/frappe/frappe/pull/15838))
- Added translation for Yes/No ([#15884](https://github.com/frappe/frappe/pull/15884))
- Updated translations ([#15879](https://github.com/frappe/frappe/pull/15879))
- Doctype name/table-name in database is limited to 64 character ([#15826](https://github.com/frappe/frappe/pull/15826))
- Added regex for alerts ([#15833](https://github.com/frappe/frappe/pull/15833))
- Primary color for progress bar ([#15839](https://github.com/frappe/frappe/pull/15839))
- Data exporter throwing exception ([#15561](https://github.com/frappe/frappe/pull/15561))
- Primary color for checkbox and radio ([#15842](https://github.com/frappe/frappe/pull/15842))
- Call validate_link only if "value" is passed ([#15856](https://github.com/frappe/frappe/pull/15856))
- Validate doc naming when set via prompt or by passing `set_name` ([#15746](https://github.com/frappe/frappe/pull/15746))
- User permission for restricting nested struct ([#14079](https://github.com/frappe/frappe/pull/14079))
- Translate default msgprint title in backend ([#15769](https://github.com/frappe/frappe/pull/15769))
- Sync `index` & `unique` constraint changes in DB ([#15680](https://github.com/frappe/frappe/pull/15680))