### PR TITLE
refactor: `not a in b` -> `a not in b`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,3 +13,6 @@ fe20515c23a3ac41f1092bf0eaf0a0a452ec2e85
 
 # Updating license headers
 34460265554242a8d05fb09f049033b1117e1a2b
+
+# Refactor "not a in b" -> "a not in b"
+745297a49d516e5e3c4bb3e1b0c4235e7d31165d

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -584,7 +584,7 @@ class Database(object):
 			company = frappe.db.get_single_value('Global Defaults', 'default_company')
 		"""
 
-		if not doctype in self.value_cache:
+		if doctype not in self.value_cache:
 			self.value_cache[doctype] = {}
 
 		if cache and fieldname in self.value_cache[doctype]:

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -533,7 +533,8 @@ def get_stats(stats, doctype, filters=None):
 		columns = []
 
 	for tag in tags:
-		if not tag in columns: continue
+		if tag not in columns:
+			continue
 		try:
 			tag_count = frappe.get_list(doctype,
 				fields=[tag, "count(*)"],
@@ -612,7 +613,7 @@ def scrub_user_tags(tagcount):
 		alltags = t.split(',')
 		for tag in alltags:
 			if tag:
-				if not tag in rdict:
+				if tag not in rdict:
 					rdict[tag] = 0
 
 				rdict[tag] += tagdict[t]

--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -15,7 +15,7 @@ def get_all_nodes(doctype, label, parent, tree_method, **filters):
 
 	tree_method = frappe.get_attr(tree_method)
 
-	if not tree_method in frappe.whitelisted:
+	if tree_method not in frappe.whitelisted:
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 
 	data = tree_method(doctype, parent, **filters)

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -184,7 +184,7 @@ def install_app(name, verbose=False, set_as_patched=True):
 
 def add_to_installed_apps(app_name, rebuild_website=True):
 	installed_apps = frappe.get_installed_apps()
-	if not app_name in installed_apps:
+	if app_name not in installed_apps:
 		installed_apps.append(app_name)
 		frappe.db.set_global("installed_apps", json.dumps(installed_apps))
 		frappe.db.commit()

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -330,7 +330,7 @@ class DatabaseQuery(object):
 					table_name = table_name[7:]
 				if not table_name[0]=='`':
 					table_name = f"`{table_name}`"
-				if not table_name in self.tables:
+				if table_name not in self.tables:
 					self.append_table(table_name)
 
 	def append_table(self, table_name):
@@ -428,7 +428,7 @@ class DatabaseQuery(object):
 		f = get_filter(self.doctype, f, additional_filters_config)
 
 		tname = ('`tab' + f.doctype + '`')
-		if not tname in self.tables:
+		if tname not in self.tables:
 			self.append_table(tname)
 
 		if 'ifnull(' in f.fieldname:

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -307,7 +307,7 @@ def get_link_fields(doctype):
 	if not frappe.flags.link_fields:
 		frappe.flags.link_fields = {}
 
-	if not doctype in frappe.flags.link_fields:
+	if doctype not in frappe.flags.link_fields:
 		link_fields = frappe.db.sql("""\
 			select parent, fieldname,
 				(select issingle from tabDocType dt

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -117,7 +117,7 @@ def get_doc_files(files, start_path):
 				if os.path.isdir(os.path.join(doctype_path, docname)):
 					doc_path = os.path.join(doctype_path, docname, docname) + ".json"
 					if os.path.exists(doc_path):
-						if not doc_path in files:
+						if doc_path not in files:
 							files.append(doc_path)
 
 	return files

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -65,7 +65,7 @@ def publish_realtime(event=None, message=None, room=None,
 
 	if after_commit:
 		params = [event, message, room]
-		if not params in frappe.local.realtime_log:
+		if params not in frappe.local.realtime_log:
 			frappe.local.realtime_log.append(params)
 	else:
 		emit_via_redis(event, message, room)

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -285,7 +285,7 @@ def make_test_records(doctype, verbose=0, force=False):
 		if options == "[Select]":
 			continue
 
-		if not options in frappe.local.test_objects:
+		if options not in frappe.local.test_objects:
 			frappe.local.test_objects[options] = []
 			make_test_records(options, verbose, force)
 			make_test_records_for_doctype(options, verbose, force)
@@ -425,7 +425,7 @@ def add_to_test_record_log(doctype):
 	'''Add `doctype` to site/.test_log
 	`.test_log` is a cache of all doctypes for which test records are created'''
 	test_record_log = get_test_record_log()
-	if not doctype in test_record_log:
+	if doctype not in test_record_log:
 		frappe.flags.test_record_log.append(doctype)
 		with open(frappe.get_site_path('.test_log'), 'w') as f:
 			f.write('\n'.join(filter(None, frappe.flags.test_record_log)))

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -135,7 +135,7 @@ def get_dict(fortype, name=None):
 	asset_key = fortype + ":" + (name or "-")
 	translation_assets = cache.hget("translation_assets", frappe.local.lang, shared=True) or {}
 
-	if not asset_key in translation_assets:
+	if asset_key not in translation_assets:
 		messages = []
 		if fortype=="doctype":
 			messages = get_messages_from_doctype(name)

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -154,7 +154,7 @@ class RedisWrapper(redis.Redis):
 		_name = self.make_key(name, shared=shared)
 
 		# set in local
-		if not _name in frappe.local.cache:
+		if _name not in frappe.local.cache:
 			frappe.local.cache[_name] = {}
 		frappe.local.cache[_name][key] = value
 
@@ -173,7 +173,7 @@ class RedisWrapper(redis.Redis):
 
 	def hget(self, name, key, generator=None, shared=False):
 		_name = self.make_key(name, shared=shared)
-		if not _name in frappe.local.cache:
+		if _name not in frappe.local.cache:
 			frappe.local.cache[_name] = {}
 
 		if not key: return None

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -79,7 +79,7 @@ class UserPermissions:
 		for r in get_valid_perms():
 			dt = r['parent']
 
-			if not dt in self.perm_map:
+			if dt not in self.perm_map:
 				self.perm_map[dt] = {}
 
 			for k in frappe.permissions.rights:

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -226,7 +226,7 @@ def get_full_index(route=None, app=None):
 
 			# order as per index if present
 			for route, children in children_map.items():
-				if not route in pages:
+				if route not in pages:
 					# no parent (?)
 					continue
 


### PR DESCRIPTION
In some places `if not a in b` is used. This is hard to read and equivalent to `if not (a in b)`. It can be simplified by using the operator `not in`. We can just write `if a not in b`, without imaginary parentheses.

- [Python docs: Membership test operations](https://docs.python.org/3/reference/expressions.html#membership-test-operations)
- [Flake8: E713](https://www.flake8rules.com/rules/E713.html)


---

Search: `if not ([\w\d]*?) in ([\w\d]*?)`
Replace: `if $1 not in $2`