### PR TITLE
fix: error in table creation from incorrect scope

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -498,6 +498,13 @@ class TestDocType(unittest.TestCase):
 		self.assertEqual(doc.is_virtual, 1)
 		self.assertFalse(frappe.db.table_exists('Test Virtual Doctype'))
 
+	def test_default_fieldname(self):
+		fields = [{"label": "title", "fieldname": "title", "fieldtype": "Data", "default": "{some_fieldname}"}]
+		dt = new_doctype("DT with default field", fields=fields)
+		dt.insert()
+
+		dt.delete()
+
 def new_doctype(name, unique=0, depends_on='', fields=None):
 	doc = frappe.get_doc({
 		"doctype": "DocType",

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -5,29 +5,29 @@ from frappe.database.schema import DBTable, get_definition
 
 class PostgresTable(DBTable):
 	def create(self):
-		add_text = ""
+		varchar_len = frappe.db.VARCHAR_LEN
 
+		additional_definitions = ""
 		# columns
 		column_defs = self.get_column_definitions()
 		if column_defs:
-			add_text += ",\n".join(column_defs)
+			additional_definitions += ",\n".join(column_defs)
 
 		# child table columns
 		if self.meta.get("istable") or 0:
 			if column_defs:
-				add_text += ",\n"
+				additional_definitions += ",\n"
 
-			add_text += ",\n".join(
+			additional_definitions += ",\n".join(
 				(
-					"parent varchar({varchar_len})".format(varchar_len=frappe.db.VARCHAR_LEN),
-					"parentfield varchar({varchar_len})".format(varchar_len=frappe.db.VARCHAR_LEN),
-					"parenttype varchar({varchar_len})".format(varchar_len=frappe.db.VARCHAR_LEN)
+					f"parent varchar({varchar_len})",
+					f"parentfield varchar({varchar_len})",
+					f"parenttype varchar({varchar_len})",
 				)
 			)
 
-		# TODO: set docstatus length
 		# create table
-		frappe.db.sql("""create table `%s` (
+		frappe.db.sql(f"""create table `{self.table_name}` (
 			name varchar({varchar_len}) not null primary key,
 			creation timestamp(6),
 			modified timestamp(6),
@@ -35,7 +35,9 @@ class PostgresTable(DBTable):
 			owner varchar({varchar_len}),
 			docstatus smallint not null default '0',
 			idx bigint not null default '0',
-			%s)""".format(varchar_len=frappe.db.VARCHAR_LEN) % (self.table_name, add_text))
+			{additional_definitions}
+			)"""
+		)
 
 		self.create_indexes()
 		frappe.db.commit()

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -19,15 +19,15 @@ class PostgresTable(DBTable):
 
 			add_text += ",\n".join(
 				(
-					"parent varchar({varchar_len})",
-					"parentfield varchar({varchar_len})",
-					"parenttype varchar({varchar_len})"
+					"parent varchar({varchar_len})".format(varchar_len=frappe.db.VARCHAR_LEN),
+					"parentfield varchar({varchar_len})".format(varchar_len=frappe.db.VARCHAR_LEN),
+					"parenttype varchar({varchar_len})".format(varchar_len=frappe.db.VARCHAR_LEN)
 				)
 			)
 
 		# TODO: set docstatus length
 		# create table
-		frappe.db.sql(("""create table `%s` (
+		frappe.db.sql("""create table `%s` (
 			name varchar({varchar_len}) not null primary key,
 			creation timestamp(6),
 			modified timestamp(6),
@@ -35,7 +35,7 @@ class PostgresTable(DBTable):
 			owner varchar({varchar_len}),
 			docstatus smallint not null default '0',
 			idx bigint not null default '0',
-			%s)""" % (self.table_name, add_text)).format(varchar_len=frappe.db.VARCHAR_LEN))
+			%s)""".format(varchar_len=frappe.db.VARCHAR_LEN) % (self.table_name, add_text))
 
 		self.create_indexes()
 		frappe.db.commit()


### PR DESCRIPTION
https://github.com/frappe/frappe/commit/b31f3c24f6af2aec39c0c176010ac1297201c82a#diff-966fd83a441fab7f8ac4cf799dae8f178cfb083779029baaa6de746c8efc5039R38 caused the "self" context to no longer be passed into the add_text interpolation. As a result, column names that were referenced as variables in the "add_text" fail when trying to build erpnext with postgres e.g. https://github.com/frappe/erpnext/runs/5278983304?check_suite_focus=true. This change reverts to the old behavior and adds the now-necessary string format to parent fields