### PR TITLE
revert: "Revert "fix: Always set `doctype` from `options` for child Document (backport #15957)""

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -223,10 +223,9 @@ class BaseDocument(object):
 			return value
 
 		if not isinstance(value, BaseDocument):
-			if "doctype" not in value or value['doctype'] is None:
-				value["doctype"] = self.get_table_field_doctype(key)
-				if not value["doctype"]:
-					raise AttributeError(key)
+			value["doctype"] = self.get_table_field_doctype(key)
+			if not value["doctype"]:
+				raise AttributeError(key)
 
 			value = get_controller(value["doctype"])(value)
 			value.init_valid_columns()


### PR DESCRIPTION
Reverts frappe/frappe#16047

---

The actual issue got resolved with https://github.com/frappe/frappe/pull/16073