### PR TITLE
chore: unnecessary JS warning if options are not defined in date field

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -158,10 +158,10 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		return value;
 	}
 	get_df_options() {
-		if(!this.df.options) return {};
-
-		let options = {};
 		let df_options = this.df.options;
+		if (!df_options) return {};
+	
+		let options = {};
 		if (typeof df_options === 'string') {
 			try {
 				options = JSON.parse(df_options);

--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -158,8 +158,10 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		return value;
 	}
 	get_df_options() {
+		if(!this.df.options) return {};
+
 		let options = {};
-		let df_options = this.df.options || '';
+		let df_options = this.df.options;
 		if (typeof df_options === 'string') {
 			try {
 				options = JSON.parse(df_options);


### PR DESCRIPTION
# Issue

Unnecessary JS warning cluttering  console due to parsing of empty string in ```date.js```.

This occurs when the options field for datefield is left empty.

## Fix:

```
if(!this.df.options) return {};
```
Empty string no longer raises any warning :

### Before:
![image](https://user-images.githubusercontent.com/84378369/155099693-9d99ae81-612b-4bc9-87ff-a3cb8fd3debd.png)

### After:
![Image](https://user-images.githubusercontent.com/84378369/155099805-5d8ff2a1-2d07-4114-be87-5699b1446613.png)





