### PR TITLE
fix: clear filters before setting them

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -315,7 +315,9 @@ frappe.views.BaseList = class BaseList {
 		this.filter_area = new FilterArea(this);
 
 		if (this.filters && this.filters.length > 0) {
-			return this.filter_area.set(this.filters);
+			return this.filter_area
+				.clear(false)
+				.then(() => this.filter_area.set(this.filters));
 		}
 	}
 

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -760,6 +760,10 @@ class FilterArea {
 
 		const doctype_fields = this.list_view.meta.fields;
 		const title_field = this.list_view.meta.title_field;
+		const has_existing_filters = (
+			this.list_view.filters
+			&& this.list_view.filters.length > 0
+		);
 
 		fields = fields.concat(
 			doctype_fields
@@ -797,10 +801,7 @@ class FilterArea {
 
 					let default_value;
 
-					if (
-						fieldtype === "Link" &&
-						!(this.list_view.filters && this.list_view.filters.length > 0)
-					) {
+					if (fieldtype === "Link" && !has_existing_filters) {
 						default_value = frappe.defaults.get_user_default(options);
 					}
 

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -315,9 +315,7 @@ frappe.views.BaseList = class BaseList {
 		this.filter_area = new FilterArea(this);
 
 		if (this.filters && this.filters.length > 0) {
-			return this.filter_area
-				.clear(false)
-				.then(() => this.filter_area.set(this.filters));
+			return this.filter_area.set(this.filters);
 		}
 	}
 
@@ -796,13 +794,20 @@ class FilterArea {
 							options = options.join("\n");
 						}
 					}
-					let default_value =
-						fieldtype === "Link"
-							? frappe.defaults.get_user_default(options)
-							: null;
+
+					let default_value;
+
+					if (
+						fieldtype === "Link" &&
+						!(this.list_view.filters && this.list_view.filters.length > 0)
+					) {
+						default_value = frappe.defaults.get_user_default(options);
+					}
+
 					if (["__default", "__global"].includes(default_value)) {
 						default_value = null;
 					}
+
 					return {
 						fieldtype: fieldtype,
 						label: __(df.label),

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -83,32 +83,15 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		this.sort_by = this.view_user_settings.sort_by || "modified";
 		this.sort_order = this.view_user_settings.sort_order || "desc";
 
-		// set filters from user_settings or list_settings
-		if (
-			this.view_user_settings.filters &&
-			this.view_user_settings.filters.length
-		) {
-			// Priority 1: user_settings
-			const saved_filters = this.view_user_settings.filters;
-			this.filters = this.validate_filters(saved_filters);
-		} else {
-			// Priority 2: filters in listview_settings
-			this.filters = (this.settings.filters || []).map((f) => {
-				if (f.length === 3) {
-					f = [this.doctype, f[0], f[1], f[2]];
-				}
-				return f;
-			});
-		}
-
 		// build menu items
 		this.menu_items = this.menu_items.concat(this.get_menu_items());
 
+		// set filters from view_user_settings or list_settings
 		if (
 			this.view_user_settings.filters &&
 			this.view_user_settings.filters.length
 		) {
-			// Priority 1: saved filters
+			// Priority 1: view_user_settings
 			const saved_filters = this.view_user_settings.filters;
 			this.filters = this.validate_filters(saved_filters);
 		} else {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -125,7 +125,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	after_render() {
-		if (this.report_doc) {
+		if (this.report_doc && !$.isEmptyObject(this.report_doc.json)) {
 			this.set_dirty_state_for_custom_report();
 		} else {
 			this.save_report_settings();

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -125,11 +125,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	}
 
 	after_render() {
-		if (this.report_doc && !$.isEmptyObject(this.report_doc.json)) {
-			this.set_dirty_state_for_custom_report();
-		} else {
+		if (!this.report_doc) {
 			this.save_report_settings();
+		} else if (!$.isEmptyObject(this.report_doc.json)) {
+			this.set_dirty_state_for_custom_report();
 		}
+
 		if (!this.group_by) {
 			this.init_chart();
 		}


### PR DESCRIPTION
Possible fix for https://github.com/frappe/frappe/issues/16031

## Issue

Standard filters get set with a default value when `FilterArea` is initialised. This PR prevents them from getting set if filters are already defined for List/Report View.

> <s>Alternate fix: don't set default value if `this.list_view.filters > 0` (possibly better for perf)</s>

## Other Changes
- Remove duplicate code and improve comments in `list_view.js`. The removed code is executed again right below it in same function.

## Screenshots

### Before (default company gets set)

![image](https://user-images.githubusercontent.com/16315650/155118732-c8ca98a9-3cf0-4e8b-bbc4-3dc21ddd3942.png)


### After (not unsaved)

![image](https://user-images.githubusercontent.com/16315650/155118547-69868601-241d-4e21-8640-b02878f8418e.png)

