### PR TITLE
fix: Color picker selected color style

### DIFF
--- a/frappe/public/scss/common/color_picker.scss
+++ b/frappe/public/scss/common/color_picker.scss
@@ -94,7 +94,10 @@
 
 .frappe-control[data-fieldtype='Color'] {
 	input {
-		padding-left: 40px;
+		padding-left: 38px;
+	}
+	.control-input {
+		position: relative;
 	}
 	.selected-color {
 		cursor: pointer;
@@ -103,7 +106,7 @@
 		border-radius: 5px;
 		background-color: red;
 		position: absolute;
-		top: calc(50% + 1px);
+		top: 5px;
 		left: 8px;
 		content: ' ';
 		&.no-value {
@@ -113,10 +116,9 @@
 	}
 	.like-disabled-input {
 		.color-value {
-			padding-left: 25px;
+			padding-left: 26px;
 		}
 		.selected-color {
-			top: 20%;
 			cursor: default;
 		}
 	}


### PR DESCRIPTION
**Before:**
<img width="250" alt="Screenshot 2022-02-23 at 8 52 49 AM" src="https://user-images.githubusercontent.com/13928957/155257000-b0ca1d2d-bebb-4eaa-a8b1-e66adf055695.png">

**After:**
<img width="250" alt="Screenshot 2022-02-23 at 8 49 40 AM" src="https://user-images.githubusercontent.com/13928957/155257007-fd7cf4be-3487-47fc-9fad-8a2f0e0acbb3.png">

---

fixes https://github.com/frappe/frappe/issues/16076
