### PR TITLE
build: Bump python_requires to match documentation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,10 @@ setup(
 	{
 		'clean': CleanCommand
 	},
-	python_requires='>=3.6'
+	# python_requires wasn't changed from a while due to an oversight
+	# but Frappe v13 has always been >= PY37
+	# refs:
+	# * https://frappeframework.com/docs/v13/user/en/installation#pre-requisites
+	# * https://github.com/frappe/frappe/blob/version-13/.github/workflows/patch-mariadb-tests.yml#L27
+	python_requires='>=3.7'
 )


### PR DESCRIPTION
Frappe v13 has always been >= `PY37` but this wasn't reflected in `setup.py`'s `python_requires`. This wasn't changed due to an oversight.

This was highlighted when we last bumped iPython to fix a security vulnerability (ref:
https://github.com/frappe/frappe/commit/740db83bd122bd920eb4e285d8525ebdd165cb21#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R33)
when PY36 installs failed. 

The workaround for this is to simply ignore updating this particular dependency while running through pip, but Frappe doesn't have to support it. Another one is to upgrade your env but that may be easier said than done for really old servers :sweat_smile:

---
refs for v13 being PY37+:
* https://frappeframework.com/docs/v13/user/en/installation#pre-requisites
* https://github.com/frappe/frappe/blob/version-13/.github/workflows/patch-mariadb-tests.yml#L27
