### PR TITLE
fix(ux): instructions/warning for doctype edits in developer mode

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -33,9 +33,16 @@ frappe.ui.form.on('DocType', {
 			}
 		}
 
+		const customize_form_link = "<a href='/app/customize-form'>Customize Form</a>";
 		if(!frappe.boot.developer_mode && !frm.doc.custom) {
 			// make the document read-only
 			frm.set_read_only();
+			frm.dashboard.add_comment(__("DocTypes can not be modified, please use {0} instead", [customize_form_link]), "blue", true);
+		} else if (frappe.boot.developer_mode) {
+			let msg = __("This site is running in developer mode. Any change made here will be updated in code.");
+			msg += "<br>";
+			msg += __("If you just want to customize for your site, use {0} instead.", [customize_form_link]);
+			frm.dashboard.add_comment(msg, "yellow");
 		}
 
 		if(frm.is_new()) {

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -98,7 +98,7 @@ frappe.ui.form.Layout = class Layout {
 			// remove previous color
 			this.message.removeClass(this.message_color);
 		}
-		this.message_color = (color && ['yellow', 'blue'].includes(color)) ? color : 'blue';
+		this.message_color = (color && ['yellow', 'blue', 'red'].includes(color)) ? color : 'blue';
 		if (html) {
 			if (html.substr(0, 1)!=='<') {
 				// wrap in a block


### PR DESCRIPTION

<img width="1297" alt="Screenshot 2022-02-23 at 1 20 13 PM" src="https://user-images.githubusercontent.com/9079960/155279413-21324bf9-56c5-4535-a841-debdfc6ff53a.png">



![image](https://user-images.githubusercontent.com/9079960/155273028-0624fb89-855a-4f54-b322-b3c008d7ac5a.png)
