### PR TITLE
fix(translation): Add all possible views as comment

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -204,6 +204,11 @@ frappe.views.BaseList = class BaseList {
 		};
 
 		if (frappe.boot.desk_settings.view_switcher) {
+			/* @preserve
+			for translation, don't remove
+			__("List View") __("Report View") __("Dashboard View") __("Gantt View"),
+			__("Kanban View") __("Calendar View") __("Image View") __("Inbox View"),
+			__("Tree View") __("Map View") */
 			this.views_menu = this.page.add_custom_button_group(__('{0} View', [this.view_name]),
 				icon_map[this.view_name] || 'list');
 			this.views_list = new frappe.views.ListViewSelect({


### PR DESCRIPTION
Add all possible views as comments so that they'll be picked for translation

Continuation of https://github.com/frappe/frappe/pull/15873
cc: @barredterra, @wojosc 

**Before:**
<img width="376" alt="Screenshot 2022-02-23 at 1 08 24 PM" src="https://user-images.githubusercontent.com/13928957/155279085-46f8406e-109d-4fb1-b597-5895f70519e3.png">

**After:**
<img width="402" alt="Screenshot 2022-02-23 at 1 18 27 PM" src="https://user-images.githubusercontent.com/13928957/155279162-9679953a-d0f2-4f1a-b190-3c2ecc88fe86.png">


---

**Note:** Adding `@preseve` in the comment to retain that comment after the build process
