### PR TITLE
fix(UI): Fix incorrect dark theme text color in user-wise grid column configuration

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -412,7 +412,7 @@ export default class GridRow {
 							<div class='col-md-3' style='padding-left:0px;margin-top:-2px;' title='${__('Columns')}'>
 								<input class='form-control column-width input-xs text-right'
 									value='${docfield.columns || cint(d.columns)}'
-									data-fieldname='${docfield.fieldname}' style='background-color: #ffff; display: inline'>
+									data-fieldname='${docfield.fieldname}' style='background-color: var(--modal-bg); display: inline'>
 							</div>
 							<div class='col-md-1'>
 								<a class='text-muted remove-field' data-fieldname='${docfield.fieldname}'>


### PR DESCRIPTION
Before:
<img width="400" alt="Screenshot 2022-02-23 at 12 46 42" src="https://user-images.githubusercontent.com/75225148/155295406-503b85c2-fc2d-47d1-900f-ffea8b0005be.png">
<img width="400" alt="Screenshot 2022-02-23 at 12 46 47" src="https://user-images.githubusercontent.com/75225148/155295425-8b97dc8d-3eb0-4bc1-8b6d-91b970dd894f.png">


After:
<img width="400" alt="Screenshot 2022-02-23 at 12 45 51" src="https://user-images.githubusercontent.com/75225148/155295458-fa855d5e-37a9-4199-837f-8c35120b1f13.png">
<img width="400" alt="Screenshot 2022-02-23 at 12 46 00" src="https://user-images.githubusercontent.com/75225148/155295475-ef266dff-304e-40ed-8686-a5e2782a7724.png">


Closes #14572.