### PR TITLE
test: fix flaky email domain test

### DIFF
--- a/frappe/email/doctype/email_domain/test_email_domain.py
+++ b/frappe/email/doctype/email_domain/test_email_domain.py
@@ -20,11 +20,13 @@ class TestDomain(unittest.TestCase):
 		mail_domain = frappe.get_doc("Email Domain", "test.com")
 		mail_account = frappe.get_doc("Email Account", "Test")
 
-		# Initially, incoming_port is different in domain and account
-		self.assertNotEqual(mail_account.incoming_port, mail_domain.incoming_port)
+		# Ensure a different port
+		mail_account.incoming_port = int(mail_domain.incoming_port) + 5
+		mail_account.save()
 		# Trigger update of accounts using this domain
 		mail_domain.on_update()
-		mail_account = frappe.get_doc("Email Account", "Test")
+
+		mail_account.reload()
 		# After update, incoming_port in account should match the domain
 		self.assertEqual(mail_account.incoming_port, mail_domain.incoming_port)
 


### PR DESCRIPTION
The test was asserting that test records are different but while inserting test records `on_update` might get triggered and they'd be the same. 

fix: Deliberately change values to assert behavior. 