### PR TITLE
fix: Set message in Document.raise_no_permission_to

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -39,7 +39,7 @@ def update_document_title(
 			frappe.throw(f"{obj=} must be of type str or None")
 
 	doc = frappe.get_doc(doctype, docname)
-	doc.has_permission(permtype="write")
+	doc.check_permission(permtype="write")
 
 	title_field = doc.meta.get_title_field()
 


### PR DESCRIPTION
Also, fix bug that caused no raising PermissionError in #16041 