### PR TITLE
test: Fix flaky permission test

### DIFF
--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -14,9 +14,12 @@ from frappe.core.doctype.user_permission.user_permission import clear_user_permi
 from frappe.desk.form.load import getdoc
 from frappe.utils.data import now_datetime
 
+from frappe.tests.test_utils import FrappeTestCase
+
 test_dependencies = ['Blogger', 'Blog Post', "User", "Contact", "Salutation"]
 
-class TestPermissions(unittest.TestCase):
+
+class TestPermissions(FrappeTestCase):
 	def setUp(self):
 		frappe.clear_cache(doctype="Blog Post")
 
@@ -221,7 +224,7 @@ class TestPermissions(unittest.TestCase):
 
 		# check that Document.owner cannot be changed
 		user.reload()
-		user.owner = frappe.db.get_value("User", {"name": ("!=", user.name)})
+		user.owner = "Guest"
 		self.assertRaises(frappe.CannotChangeConstantError, user.save)
 
 	def test_set_only_once(self):
@@ -556,7 +559,6 @@ class TestPermissions(unittest.TestCase):
 
 		# Remove delete perm
 		update('Blog Post', 'Website Manager', 0, 'delete', 0)
-
 
 		frappe.clear_cache(doctype="Blog Post")
 

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -512,3 +512,14 @@ class TestLinkTitle(unittest.TestCase):
 		prop_setter.delete()
 
 
+class FrappeTestCase(unittest.TestCase):
+	"""Base test class for Frappe tests."""
+	@classmethod
+	def setUpClass(cls) -> None:
+		frappe.db.commit()
+		return super().setUpClass()
+
+	@classmethod
+	def tearDownClass(cls) -> None:
+		frappe.db.rollback()
+		return super().tearDownClass()


### PR DESCRIPTION
Added a base class for frappe tests with basic commit/rollback.

In `test_dont_change_standard_constants` test, some times same owner is getting assigned to `user.owner` and assertion is failing. Changed `user.owner` to `Guest`.