### PR TITLE
fix: Unable to open query report

### DIFF
--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -330,7 +330,8 @@ result = [
 			}
 		]
 
-		result = add_total_row(result, columns, meta=None, report_settings=report_settings)
+		result = add_total_row(result, columns, meta=None, is_tree=report_settings['tree'],
+			parent_field=report_settings['parent_field'])
 		self.assertEqual(result[-1][0], "Total")
 		self.assertEqual(result[-1][1], 200)
 		self.assertEqual(result[-1][2], 150.50)

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -578,7 +578,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				args: {
 					report_name: this.report_name,
 					filters: filters,
-					report_settings: this.report_settings
+					is_tree: this.report_settings.tree,
+					parent_field: this.report_settings.parent_field
 				},
 				callback: resolve,
 				always: () => this.page.btn_secondary.prop('disabled', false)


### PR DESCRIPTION
Introduced via: https://github.com/frappe/frappe/pull/15950

Report settings also have the formatter info defined in them so passing entire report settings inside the requests increases the allowed URL length and causes the request to fail. Passes only the required parameters now. An example of such a request can be seen below.

```
api/method/frappe.desk.query_report.run?report_name=General+Ledger&filters=%7B%22company%22%3A%22Swastik+Infralogics+Private+Limited%22%2C%22from_date%22%3A%222022-01-25%22%2C%22to_date%22%3A%222022-02-25%22%2C%22account%22%3A%5B%5D%2C%22party%22%3A%5B%5D%2C%22group_by%22%3A%22Group+by+Voucher+(Consolidated)%22%2C%22cost_center%22%3A%5B%5D%2C%22project%22%3A%5B%5D%2C%22include_dimensions%22%3A1%7D&report_settings=%7B%22filters%22%3A%5B%7B%22fieldname%22%3A%22company%22%2C%22label%22%3A%22Company%22%2C%22fieldtype%22%3A%22Link%22%2C%22options%22%3A%22Company%22%2C%22default%22%3A%22Swastik+Infralogics+Private+Limited%22%2C%22reqd%22%3A1%2C%22placeholder%22%3A%22Company%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22finance_book%22%2C%22label%22%3A%22Finance+Book%22%2C%22fieldtype%22%3A%22Link%22%2C%22options%22%3A%22Finance+Book%22%2C%22placeholder%22%3A%22Finance+Book%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22from_date%22%2C%22label%22%3A%22From+Date%22%2C%22fieldtype%22%3A%22Date%22%2C%22default%22%3A%222022-01-25%22%2C%22reqd%22%3A1%2C%22width%22%3A%2260px%22%2C%22placeholder%22%3A%22From+Date%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22to_date%22%2C%22label%22%3A%22To+Date%22%2C%22fieldtype%22%3A%22Date%22%2C%22default%22%3A%222022-02-25%22%2C%22reqd%22%3A1%2C%22width%22%3A%2260px%22%2C%22placeholder%22%3A%22To+Date%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22account%22%2C%22label%22%3A%22Account%22%2C%22fieldtype%22%3A%22MultiSelectList%22%2C%22options%22%3A%22Account%22%2C%22placeholder%22%3A%22Account%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22voucher_no%22%2C%22label%22%3A%22Voucher+No%22%2C%22fieldtype%22%3A%22Data%22%2C%22placeholder%22%3A%22Voucher+No%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldtype%22%3A%22Break%22%7D%2C%7B%22fieldname%22%3A%22party_type%22%2C%22label%22%3A%22Party+Type%22%2C%22fieldtype%22%3A%22Link%22%2C%22options%22%3A%22Party+Type%22%2C%22default%22%3A%22%22%2C%22placeholder%22%3A%22Party+Type%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22party%22%2C%22label%22%3A%22Party%22%2C%22fieldtype%22%3A%22MultiSelectList%22%2C%22placeholder%22%3A%22Party%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22party_name%22%2C%22label%22%3A%22Party+Name%22%2C%22fieldtype%22%3A%22Data%22%2C%22hidden%22%3A1%2C%22placeholder%22%3A%22Party+Name%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22group_by%22%2C%22label%22%3A%22Group+by%22%2C%22fieldtype%22%3A%22Select%22%2C%22options%22%3A%5B%22%22%2C%7B%22label%22%3A%22Group+by+Voucher%22%2C%22value%22%3A%22Group+by+Voucher%22%7D%2C%7B%22label%22%3A%22Group+by+Voucher+(Consolidated)%22%2C%22value%22%3A%22Group+by+Voucher+(Consolidated)%22%7D%2C%7B%22label%22%3A%22Group+by+Account%22%2C%22value%22%3A%22Group+by+Account%22%7D%2C%7B%22label%22%3A%22Group+by+Party%22%2C%22value%22%3A%22Group+by+Party%22%7D%5D%2C%22default%22%3A%22Group+by+Voucher+(Consolidated)%22%2C%22placeholder%22%3A%22Group+by%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22tax_id%22%2C%22label%22%3A%22Tax+Id%22%2C%22fieldtype%22%3A%22Data%22%2C%22hidden%22%3A1%2C%22placeholder%22%3A%22Tax+Id%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22presentation_currency%22%2C%22label%22%3A%22Currency%22%2C%22fieldtype%22%3A%22Select%22%2C%22options%22%3A%5B%22%22%2C%22AED%22%2C%22AUD%22%2C%22CHF%22%2C%22CNY%22%2C%22EUR%22%2C%22GBP%22%2C%22INR%22%2C%22JPY%22%2C%22USD%22%5D%2C%22placeholder%22%3A%22Currency%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22cost_center%22%2C%22label%22%3A%22Cost+Center%22%2C%22fieldtype%22%3A%22MultiSelectList%22%2C%22placeholder%22%3A%22Cost+Center%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22project%22%2C%22label%22%3A%22Project%22%2C%22fieldtype%22%3A%22MultiSelectList%22%2C%22placeholder%22%3A%22Project%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22department%22%2C%22label%22%3A%22Department%22%2C%22fieldtype%22%3A%22Link%22%2C%22options%22%3A%22Department%22%2C%22placeholder%22%3A%22Department%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22include_dimensions%22%2C%22label%22%3A%22Consider+Accounting+Dimensions%22%2C%22fieldtype%22%3A%22Check%22%2C%22default%22%3A1%2C%22placeholder%22%3A%22Consider+Accounting+Dimensions%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22show_opening_entries%22%2C%22label%22%3A%22Show+Opening+Entries%22%2C%22fieldtype%22%3A%22Check%22%2C%22placeholder%22%3A%22Show+Opening+Entries%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22include_default_book_entries%22%2C%22label%22%3A%22Include+Default+Book+Entries%22%2C%22fieldtype%22%3A%22Check%22%2C%22placeholder%22%3A%22Include+Default+Book+Entries%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22show_cancelled_entries%22%2C%22label%22%3A%22Show+Cancelled+Entries%22%2C%22fieldtype%22%3A%22Check%22%2C%22placeholder%22%3A%22Show+Cancelled+Entries%22%2C%22input_class%22%3A%22input-xs%22%7D%2C%7B%22fieldname%22%3A%22show_net_values_in_party_account%22%2C%22label%22%3A%22Show+Net+Values+in+Party+Account%22%2C%22fieldtype%22%3A%22Check%22%2C%22placeholder%22%3A%22Show+Net+Values+in+Party+Account%22%2C%22input_class%22%3A%22input-xs%22%7D%5D%2C%22html_format%22%3A%22%3Ch2+class%3D%5C%22text-center%5C%22%3E%7B%25%3D+__(%5C%22Statement+of+Account%5C%22)+%25%7D%3C%2Fh2%3E%5Cn%3Ch4+class%3D%5C%22text-center%5C%22%3E%5Cn%5Ct%7B%25+if+(filters.party_name)+%7B+%25%7D%5Cn%5Ct%5Ct%7B%25%3D+filters.party_name+%25%7D%5Cn%5Ct%7B%25+%7D+else+if+(filters.party+%26%26+filters.party.length)+%7B+%25%7D%5Cn%5Ct%5Ct%7B%25%3D+filters.party+%25%7D%5Cn%5Ct%7B%25+%7D+else+if+(filters.account)+%7B+%25%7D%5Cn%5Ct%5Ct%7B%25%3D+filters.account+%25%7D%5Cn%5Ct%7B%25+%7D+%25%7D%5Cn%3C%2Fh4%3E%5Cn%5Cn%3Ch6+class%3D%5C%22text-center%5C%22%3E%5Cn%5Ct%7B%25+if+(filters.tax_id)+%7B+%25%7D%5Cn%5Ct%7B%25%3D+__(%5C%22Tax+Id%3A+%5C%22)%25%7D%5Ct%7B%25%3D+filters.tax_id+%25%7D%5Cn%5Ct%7B%25+%7D+%25%7D%5Cn%3C%2Fh6%3E%5Cn%5Cn%3Ch5+class%3D%5C%22text-center%5C%22%3E%5Cn%5Ct%7B%25%3D+frappe.datetime.str_to_user(filters.from_date)+%25%7D%5Cn%5Ct%7B%25%3D+__(%5C%22to%5C%22)+%25%7D%5Cn%5Ct%7B%25%3D+frappe.datetime.str_to_user(filters.to_date)+%25%7D%5Cn%3C%2Fh5%3E%5Cn%3Chr%3E%5Cn%3Ctable+class%3D%5C%22table+table-bordered%5C%22%3E%5Cn%5Ct%3Cthead%3E%5Cn%5Ct%5Ct%3Ctr%3E%5Cn%5Ct%5Ct%5Ct%3Cth+style%3D%5C%22width%3A+12%25%5C%22%3E%7B%25%3D+__(%5C%22Date%5C%22)+%25%7D%3C%2Fth%3E%5Cn%5Ct%5Ct%5Ct%3Cth+style%3D%5C%22width%3A+15%25%5C%22%3E%7B%25%3D+__(%5C%22Ref%5C%22)+%25%7D%3C%2Fth%3E%5Cn%5Ct%5Ct%5Ct%3Cth+style%3D%5C%22width%3A+25%25%5C%22%3E%7B%25%3D+__(%5C%22Party%5C%22)+%25%7D%3C%2Fth%3E%5Cn%5Ct%5Ct%5Ct%3Cth+style%3D%5C%22width%3A+15%25%5C%22%3E%7B%25%3D+__(%5C%22Debit%5C%22)+%25%7D%3C%2Fth%3E%5Cn%5Ct%5Ct%5Ct%3Cth+style%3D%5C%22width%3A+15%25%5C%22%3E%7B%25%3D+__(%5C%22Credit%5C%22)+%25%7D%3C%2Fth%3E%5Cn%5Ct%5Ct%5Ct%3Cth+style%3D%5C%22width%3A+18%25%5C%22%3E%7B%25%3D+__(%5C%22Balance+(Dr+-+Cr)%5C%22)+%25%7D%3C%2Fth%3E%5Cn%5Ct%5Ct%3C%2Ftr%3E%5Cn%5Ct%3C%2Fthead%3E%5Cn%5Ct%3Ctbody%3E%5Cn%5Ct%5Ct%7B%25+for(var+i%3D0%2C+l%3Ddata.length%3B+i%3Cl%3B+i%2B%2B)+%7B+%25%7D%5Cn%5Ct%5Ct%5Ct%3Ctr%3E%5Cn%5Ct%5Ct%5Ct%7B%25+if(data%5Bi%5D.posting_date)+%7B+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd%3E%7B%25%3D+frappe.datetime.str_to_user(data%5Bi%5D.posting_date)+%25%7D%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd%3E%7B%25%3D+data%5Bi%5D.voucher_type+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%3Cbr%3E%7B%25%3D+data%5Bi%5D.voucher_no+%25%7D%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25+if(\u0021(filters.party+%7C%7C+filters.account))+%7B+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25%3D+data%5Bi%5D.party+%7C%7C+data%5Bi%5D.account+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%3Cbr%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25+%7D+%25%7D%5Cn%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%7B+__(%5C%22Against%5C%22)+%7D%7D%3A+%7B%25%3D+data%5Bi%5D.against+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%3Cbr%3E%7B%25%3D+__(%5C%22Remarks%5C%22)+%25%7D%3A+%7B%25%3D+data%5Bi%5D.remarks+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25+if(data%5Bi%5D.bill_no)+%7B+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%3Cbr%3E%7B%25%3D+__(%5C%22Supplier+Invoice+No%5C%22)+%25%7D%3A+%7B%25%3D+data%5Bi%5D.bill_no+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25+%7D+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%3Ctd+style%3D%5C%22text-align%3A+right%5C%22%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25%3D+format_currency(data%5Bi%5D.debit%2C+filters.presentation_currency)+%25%7D%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%3Ctd+style%3D%5C%22text-align%3A+right%5C%22%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25%3D+format_currency(data%5Bi%5D.credit%2C+filters.presentation_currency)+%25%7D%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%7B%25+%7D+else+%7B+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd%3E%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd%3E%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd%3E%3Cb%3E%7B%25%3D+frappe.format(data%5Bi%5D.account%2C+%7Bfieldtype%3A+%5C%22Link%5C%22%7D)+%7C%7C+%5C%22%26nbsp%3B%5C%22+%25%7D%3C%2Fb%3E%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd+style%3D%5C%22text-align%3A+right%5C%22%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25%3D+data%5Bi%5D.account+%26%26+format_currency(data%5Bi%5D.debit%2C+filters.presentation_currency)+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd+style%3D%5C%22text-align%3A+right%5C%22%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25%3D+data%5Bi%5D.account+%26%26+format_currency(data%5Bi%5D.credit%2C+filters.presentation_currency)+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%7B%25+%7D+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%3Ctd+style%3D%5C%22text-align%3A+right%5C%22%3E%5Cn%5Ct%5Ct%5Ct%5Ct%5Ct%7B%25%3D+format_currency(data%5Bi%5D.balance%2C+filters.presentation_currency)+%25%7D%5Cn%5Ct%5Ct%5Ct%5Ct%3C%2Ftd%3E%5Cn%5Ct%5Ct%5Ct%3C%2Ftr%3E%5Cn%5Ct%5Ct%7B%25+%7D+%25%7D%5Cn%5Ct%3C%2Ftbody%3E%5Cn%3C%2Ftable%3E%5Cn%3Cp+class%3D%5C%22text-right+text-muted%5C%22%3EPrinted+On+%7B%25%3D+frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string())+%25%7D%3C%2Fp%3E%5Cn%22%2C%22execution_time%22%3A0%7D&_=1645795186171
````