### PR TITLE
fix: remove custom-fields too on reset-to-default

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -134,7 +134,7 @@ frappe.ui.form.on("Customize Form", {
 			);
 
 			frm.add_custom_button(
-				__("Reset Property Setters"),
+				__("Reset to defaults"),
 				function() {
 					frappe.customize_form.confirm(
 						__("Remove all customizations?"),
@@ -315,9 +315,9 @@ frappe.customize_form.confirm = function(msg, frm) {
 	if (!frm.doc.doc_type) return;
 
 	var d = new frappe.ui.Dialog({
-		title: 'Reset Property Setters',
+		title: 'Reset To Defaults',
 		fields: [
-			{fieldtype:"HTML", options:__("All property setters will be removed. Please confirm.")},
+			{fieldtype:"HTML", options:__("All customizations will be removed. Please confirm.")},
 		],
 		primary_action: function() {
 			return frm.call({
@@ -328,7 +328,7 @@ frappe.customize_form.confirm = function(msg, frm) {
 						frappe.msgprint(r.exc);
 					} else {
 						d.hide();
-						frappe.show_alert({message:__('Property Setters Reset'), indicator:'green'});
+						frappe.show_alert({message:__('Customizations Reset'), indicator:'green'});
 						frappe.customize_form.clear_locals_and_refresh(frm);
 					}
 				}

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -134,7 +134,7 @@ frappe.ui.form.on("Customize Form", {
 			);
 
 			frm.add_custom_button(
-				__("Reset to defaults"),
+				__("Reset Property Setters"),
 				function() {
 					frappe.customize_form.confirm(
 						__("Remove all customizations?"),
@@ -315,9 +315,9 @@ frappe.customize_form.confirm = function(msg, frm) {
 	if (!frm.doc.doc_type) return;
 
 	var d = new frappe.ui.Dialog({
-		title: 'Reset To Defaults',
+		title: 'Reset Property Setters',
 		fields: [
-			{fieldtype:"HTML", options:__("All customizations will be removed. Please confirm.")},
+			{fieldtype:"HTML", options:__("All property setters will be removed. Please confirm.")},
 		],
 		primary_action: function() {
 			return frm.call({
@@ -328,7 +328,7 @@ frappe.customize_form.confirm = function(msg, frm) {
 						frappe.msgprint(r.exc);
 					} else {
 						d.hide();
-						frappe.show_alert({message:__('Customizations Reset'), indicator:'green'});
+						frappe.show_alert({message:__('Property Setters Reset'), indicator:'green'});
 						frappe.customize_form.clear_locals_and_refresh(frm);
 					}
 				}

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -487,11 +487,20 @@ def reset_customization(doctype):
 	setters = frappe.get_all("Property Setter", filters={
 		'doc_type': doctype,
 		'field_name': ['!=', 'naming_series'],
-		'property': ['!=', 'options']
+		'property': ['!=', 'options'],
+		'owner': ['!=', 'Administrator']
 	}, pluck='name')
 
 	for setter in setters:
 		frappe.delete_doc("Property Setter", setter)
+
+	custom_fields = frappe.get_all("Custom Field", filters={
+		'dt': doctype,
+		'owner': ['!=', 'Administrator']
+	}, pluck='name')
+
+	for field in custom_fields:
+		frappe.delete_doc("Custom Field", field)
 
 	frappe.clear_cache(doctype=doctype)
 

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -488,7 +488,7 @@ def reset_customization(doctype):
 		'doc_type': doctype,
 		'field_name': ['!=', 'naming_series'],
 		'property': ['!=', 'options'],
-		'owner': ['!=', 'Administrator']
+		'is_system_generated': False
 	}, pluck='name')
 
 	for setter in setters:
@@ -496,7 +496,7 @@ def reset_customization(doctype):
 
 	custom_fields = frappe.get_all("Custom Field", filters={
 		'dt': doctype,
-		'owner': ['!=', 'Administrator']
+		'is_system_generated': False
 	}, pluck='name')
 
 	for field in custom_fields:


### PR DESCRIPTION
### Changes:
Have added functionality to remove custom fields not added by the admin user on reset-to-default.

Resolves https://github.com/frappe/frappe/issues/15959