### PR TITLE
fix: jinja in report pdf

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -776,3 +776,9 @@ def get_user_match_filters(doctypes, user):
 			match_filters[dt] = filter_list
 
 	return match_filters
+
+
+@frappe.whitelist()
+def render_letterhead(data, report_doc):
+	report_doc = json.loads(report_doc)
+	return frappe.utils.jinja.render_template(data, {"doc": report_doc})

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1284,6 +1284,22 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			report: this
 		});
 
+		//get rendered letterhead
+		if (print_settings.letter_head.footer) {
+			
+			frappe.call({
+				method: "frappe.desk.query_report.render_letterhead",
+				async: false,
+				args: {
+					data: print_settings.letter_head.footer,
+					report_doc: this.report_doc
+				},
+				callback: r => {
+					print_settings.letter_head["footer"] = r.message;
+				}
+			});
+		}
+
 		// Render Report in HTML
 		const html = frappe.render_template('print_template', {
 			title: __(this.report_name),


### PR DESCRIPTION
**Issue**

The letterhead's footer(jinja) is not rendered in the report pdf

_Letter Head Footer:_

<img width="559" alt="Screenshot 2022-02-27 at 1 19 41 PM" src="https://user-images.githubusercontent.com/58825865/155873530-c26701df-4787-44ab-89f4-82698b0178b0.png">

**_Bug_**:
<img width="1067" alt="Screenshot 2022-02-27 at 1 20 22 PM" src="https://user-images.githubusercontent.com/58825865/155873579-7eea1953-698a-490c-bc21-49f59cdb8fde.png">

**_Fix_**
<img width="1072" alt="Screenshot 2022-02-27 at 1 21 07 PM" src="https://user-images.githubusercontent.com/58825865/155873572-0ee9fbd4-bb42-4591-ac8b-e7b3c1073c01.png">

