### PR TITLE
fix: Fix flaky tests

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -11,7 +11,9 @@ from frappe.model.utils.user_settings import get_user_settings
 from frappe.permissions import get_doc_permissions
 from frappe.desk.form.document_follow import is_document_followed
 from frappe import _
+from frappe import _dict
 from urllib.parse import quote
+
 
 @frappe.whitelist()
 def getdoc(doctype, name, user=None):
@@ -50,7 +52,10 @@ def getdoc(doctype, name, user=None):
 
 	doc.add_seen()
 	set_link_titles(doc)
+	if frappe.response.docs is None:
+		frappe.response = _dict({"docs": []})
 	frappe.response.docs.append(doc)
+
 
 @frappe.whitelist()
 def getdoctype(doctype, with_parent=False, cached_timestamp=None):

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -164,6 +164,7 @@ def get_alert_dict(doc):
 
 	return alert_dict
 
+
 def create_energy_points_log(ref_doctype, ref_name, doc, apply_only_once=False):
 	doc = frappe._dict(doc)
 
@@ -171,7 +172,7 @@ def create_energy_points_log(ref_doctype, ref_name, doc, apply_only_once=False):
 		ref_name, doc.rule, None if apply_only_once else doc.user)
 
 	if log_exists:
-		return
+		return frappe.get_doc('Energy Point Log', log_exists)
 
 	new_log = frappe.new_doc('Energy Point Log')
 	new_log.reference_doctype = ref_doctype

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -510,5 +510,3 @@ class TestLinkTitle(unittest.TestCase):
 		todo.delete()
 		user.delete()
 		prop_setter.delete()
-
-


### PR DESCRIPTION
Test Fixes:
1. Return energy point log if exists.
2. Set empty list for docs when `reponse.docs` is not yet initialized.