### PR TITLE
fix!: block customizing select field type options

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -600,4 +600,4 @@ ALLOWED_FIELDTYPE_CHANGE = (
 	('Code', 'Geolocation'),
 	('Table', 'Table MultiSelect'))
 
-ALLOWED_OPTIONS_CHANGE = ('Read Only', 'HTML', 'Select', 'Data')
+ALLOWED_OPTIONS_CHANGE = ('Read Only', 'HTML', 'Data')


### PR DESCRIPTION
This change disables the use of "customize form" for modifying "Options" of select fields. 

Select fields are like enumerations and are very often used for writing business logic based on selected value (e.g. status of invoice)

<img width="1317" alt="Screenshot 2022-02-28 at 2 57 57 PM" src="https://user-images.githubusercontent.com/9079960/155958387-e2d74f9d-a7d2-4c4e-95fa-ebe6aedd0ae4.png">



PS: property setters will still be able to override this (hence no patch is written to remove current customization) This change just blocks customization from "Customize Form". 

