### PR TITLE
fix: Set creation dates of standard DocTypes correctly

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -471,7 +471,7 @@ class Document(BaseDocument):
 
 		# We'd probably want the creation and owner to be set via API
 		# or Data import at some point, that'd have to be handled here
-		if self.is_new() and not (frappe.flags.in_patch or frappe.flags.in_migrate):
+		if self.is_new() and not (frappe.flags.in_install or frappe.flags.in_patch or frappe.flags.in_migrate):
 			self.creation = self.modified
 			self.owner = self.modified_by
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -189,6 +189,7 @@ frappe.patches.v14_0.update_workspace2 # 20.09.2021
 frappe.patches.v14_0.save_ratings_in_fraction #23-12-2021
 frappe.patches.v14_0.transform_todo_schema
 frappe.patches.v14_0.remove_post_and_post_comment
+frappe.patches.v14_0.reset_creation_datetime
 
 [post_model_sync]
 frappe.patches.v14_0.drop_data_import_legacy

--- a/frappe/patches/v14_0/reset_creation_datetime.py
+++ b/frappe/patches/v14_0/reset_creation_datetime.py
@@ -1,0 +1,41 @@
+import glob
+import json
+import frappe
+import os
+from frappe.query_builder import DocType as _DocType
+
+
+def execute():
+	"""Resetting creation datetimes for DocTypes"""
+	DocType = _DocType("DocType")
+	doctype_jsons = glob.glob(
+		os.path.join("..", "apps", "frappe", "frappe", "**", "doctype", "**", "*.json")
+	)
+
+	frappe_modules = frappe.get_all(
+		"Module Def", filters={"app_name": "frappe"}, pluck="name"
+	)
+	site_doctypes = frappe.get_all(
+		"DocType",
+		filters={"module": ("in", frappe_modules), "custom": False},
+		fields=["name", "creation"],
+	)
+
+	for dt_path in doctype_jsons:
+		with open(dt_path) as f:
+			try:
+				file_schema = frappe._dict(json.load(f))
+			except Exception:
+				continue
+
+			if not file_schema.name:
+				continue
+
+			_site_schema = [x for x in site_doctypes if x.name == file_schema.name]
+			if not _site_schema:
+				continue
+
+			if file_schema.creation != _site_schema[0].creation:
+				frappe.qb.update(DocType).set(
+					DocType.creation, file_schema.creation
+				).where(DocType.name == file_schema.name).run()


### PR DESCRIPTION
### Changes

* Don't set creation dates `now()` for DocTypes on new sites
* Added patch to fix this issue on existing sites (will be much easier for managing contributions now 🥲)
* Show patch's docstring if exists

<img width="824" alt="Screenshot 2022-02-28 at 5 45 49 PM" src="https://user-images.githubusercontent.com/36654812/155982034-59507138-86c0-47cf-805b-b4d644c44a01.png">
