### PR TITLE
fix: Inherit from FrappeTestCase in template

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/test_controller._py
+++ b/frappe/core/doctype/doctype/boilerplate/test_controller._py
@@ -2,7 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
-class Test{classname}(unittest.TestCase):
+
+class Test{classname}(FrappeTestCase):
 	pass


### PR DESCRIPTION
Now that we have FrappeTestCase, all new controller tests should inherit from it.