### PR TITLE
fix: Ability to disable standard notification

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -61,7 +61,7 @@ def get_context(context):
 """)
 
 	def validate_standard(self):
-		if self.is_standard and not frappe.conf.developer_mode:
+		if self.is_standard and self.enabled and not frappe.conf.developer_mode:
 			frappe.throw(_('Cannot edit Standard Notification. To edit, please disable this and duplicate it'))
 
 	def validate_condition(self):


### PR DESCRIPTION
To avoid following warning while disabling standard Notification

<img width="1438" alt="Screenshot 2022-02-28 at 9 03 23 PM" src="https://user-images.githubusercontent.com/13928957/156011057-34beacc5-3429-492b-8ac8-9414278ab12c.png">


https://frappe.io/app/issue/ISS-21-22-12836