### PR TITLE
chore: remove unused function `kanban_board.update_doc`

### DIFF
--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -77,26 +77,6 @@ def archive_restore_column(board_name, column_title, status):
 
 
 @frappe.whitelist()
-def update_doc(doc):
-	'''Updates the doc when card is edited'''
-	doc = json.loads(doc)
-
-	try:
-		to_update = doc
-		doctype = doc['doctype']
-		docname = doc['name']
-		doc = frappe.get_doc(doctype, docname)
-		doc.update(to_update)
-		doc.save()
-	except:
-		return {
-			'doc': doc,
-			'exc': frappe.utils.get_traceback()
-		}
-	return doc
-
-
-@frappe.whitelist()
 def update_order(board_name, order):
 	'''Save the order of cards in columns'''
 	board = frappe.get_doc('Kanban Board', board_name)

--- a/frappe/public/js/frappe/views/kanban/kanban_board.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.js
@@ -150,18 +150,6 @@ frappe.provide("frappe.views");
 				}
 				updater.set({ cards: cards });
 			},
-			update_doc: function(updater, doc, card) {
-				var state = this;
-				return frappe.call({
-					method: method_prefix + "update_doc",
-					args: { doc: doc },
-					freeze: true
-				}).then(function(r) {
-					var updated_doc = r.message;
-					var updated_card = prepare_card(card, state, updated_doc);
-					fluxify.doAction('update_card', updated_card);
-				});
-			},
 			update_order_for_single_card: function(updater, card) {
 				// cache original order
 				const _cards = this.cards.slice();


### PR DESCRIPTION
`update_doc` isn't being called elsewhere, just defined in JS and Python.