### PR TITLE
fix: mandatory fields validation on new form

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -148,6 +148,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			});
 
 			if (frm.is_new() && frm.meta.autoname === 'Prompt' && !frm.doc.__newname) {
+				has_errors = true;
 				error_fields = [__('Name'), ...error_fields];
 			}
 


### PR DESCRIPTION
Before, on the creation of a new doctype without a name field (which is mandatory), system was checking backend validations even though `check_mandatory` threw error. This is because `has_errors` was not getting set in this case. This PR fixes that.

**Before**

![save error](https://user-images.githubusercontent.com/54097382/156106244-0c2017cd-f6f5-4d66-966b-fa2f43e18ef0.png)

**After**

![client side validate](https://user-images.githubusercontent.com/54097382/156106291-fa3741d1-39c9-4a63-916d-773f71d8bec9.png)
