### PR TITLE
fix: sanitize the input before saving

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -8,6 +8,7 @@ from frappe.model.utils.user_settings import sync_user_settings, update_user_set
 from frappe.utils import cint
 from frappe.utils.password import rename_password
 from frappe.query_builder import Field
+from frappe.utils import sanitize_html
 
 
 @frappe.whitelist()
@@ -18,9 +19,10 @@ def update_document_title(doctype, docname, title_field=None, old_title=None, ne
 	if docname and new_name and not docname == new_name:
 		docname = rename_doc(doctype=doctype, old=docname, new=new_name, merge=merge)
 
-	if old_title and new_title and not old_title == new_title:
+	_new_title = sanitize_html(new_title)
+	if old_title and _new_title and not old_title == _new_title:
 		try:
-			frappe.db.set_value(doctype, docname, title_field, new_title)
+			frappe.db.set_value(doctype, docname, title_field, _new_title)
 			frappe.msgprint(_('Saved'), alert=True, indicator='green')
 		except Exception as e:
 			if frappe.db.is_duplicate_entry(e):

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -78,7 +78,7 @@ def sanitize_html(html, linkify=False):
 
 	# returns html with escaped tags, escaped orphan >, <, etc.
 	escaped_html = bleach.clean(html, tags=tags, attributes=attributes, styles=styles,
-		strip_comments=strip_comments, protocols=['cid', 'http', 'https', 'mailto'])
+		strip=True, strip_comments=strip_comments, protocols=['cid', 'http', 'https', 'mailto'])
 
 	return escaped_html
 

--- a/frappe/website/doctype/blogger/blogger.py
+++ b/frappe/website/doctype/blogger/blogger.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 
 from frappe.model.document import Document
+from frappe.utils import sanitize_html
 
 class Blogger(Document):
 	def validate(self):
@@ -17,6 +18,9 @@ class Blogger(Document):
 				"email": self.user,
 				"first_name": self.user.split("@")[0]
 			}).insert()
+
+		self.short_name = sanitize_html(self.short_name)
+		self.full_name = sanitize_html(self.full_name)
 
 	def on_update(self):
 		"if user is set, then update all older blogs"


### PR DESCRIPTION
### Changes:
- Sanitizing the input for blogger full name and short name. 
- Also, sanitize input from the rename dialog box.
- Added strip parameter to remove unsafe attributes or tags from the input.

### Before
![Untitled design](https://user-images.githubusercontent.com/30501401/156347654-7ff2dace-dcaf-49d4-a110-5153f280c3ac.gif)

### After
![Untitled design(3)](https://user-images.githubusercontent.com/30501401/156348321-e67f03d9-51f8-4366-9cae-dc7a96073575.gif)

