### PR TITLE
feat: allow hyphens in DocType name (again)

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -732,9 +732,12 @@ class DocType(Document):
 			frappe.throw(_("DocType's name should not start or end with whitespace"), frappe.NameError)
 
 		# a DocType's name should not start with a number or underscore
-		# and should only contain letters, numbers and underscore
-		if not re.match(r"^(?![\W])[^\d_\s][\w ]+$", name, **flags):
-			frappe.throw(_("DocType's name should start with a letter and it can only consist of letters, numbers, spaces and underscores"), frappe.NameError)
+		# and should only contain letters, numbers, underscore, and hyphen
+		if not re.match(r"^(?![\W])[^\d_\s][\w -]+$", name, **flags):
+			frappe.throw(_(
+				"A DocType's name should start with a letter and can only "
+				"consist of letters, numbers, spaces, underscores and hyphens"
+			), frappe.NameError, title="Invalid Name")
 
 		validate_route_conflict(self.doctype, self.name)
 

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -24,7 +24,7 @@ class TestDocType(unittest.TestCase):
 		self.assertRaises(frappe.NameError, new_doctype("8Some DocType").insert)
 		self.assertRaises(frappe.NameError, new_doctype("Some (DocType)").insert)
 		self.assertRaises(frappe.NameError, new_doctype("Some Doctype with a name whose length is more than 61 characters").insert)
-		for name in ("Some DocType", "Some_DocType"):
+		for name in ("Some DocType", "Some_DocType", "Some-DocType"):
 			if frappe.db.exists("DocType", name):
 				frappe.delete_doc("DocType", name)
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -99,16 +99,8 @@ class PostgresDatabase(Database):
 		return db_size[0].get('database_size')
 
 	# pylint: disable=W0221
-	def sql(self, *args, **kwargs):
-		if args:
-			# since tuple is immutable
-			args = list(args)
-			args[0] = modify_query(args[0])
-			args = tuple(args)
-		elif kwargs.get('query'):
-			kwargs['query'] = modify_query(kwargs.get('query'))
-
-		return super(PostgresDatabase, self).sql(*args, **kwargs)
+	def sql(self, query, *args, **kwargs):
+		return super(PostgresDatabase, self).sql(modify_query(query), *args, **kwargs)
 
 	def get_tables(self, cached=True):
 		return [d[0] for d in self.sql("""select table_name
@@ -335,7 +327,7 @@ def modify_query(query):
 	query = replace_locate_with_strpos(query)
 	# select from requires ""
 	if re.search('from tab', query, flags=re.IGNORECASE):
-		query = re.sub('from tab([a-zA-Z]*)', r'from "tab\1"', query, flags=re.IGNORECASE)
+		query = re.sub('from tab([\w-]*)', r'from "tab\1"', query, flags=re.IGNORECASE)
 
 	return query
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -327,7 +327,7 @@ def modify_query(query):
 	query = replace_locate_with_strpos(query)
 	# select from requires ""
 	if re.search('from tab', query, flags=re.IGNORECASE):
-		query = re.sub('from tab([\w-]*)', r'from "tab\1"', query, flags=re.IGNORECASE)
+		query = re.sub(r'from tab([\w-]*)', r'from "tab\1"', query, flags=re.IGNORECASE)
 
 	return query
 


### PR DESCRIPTION
This PR proposes reverting #5934 to allow using hyphens in DocType name.

- Hyphens are useful in DocType names (e.g. **e-Invoice Settings**).
- They are currently being used in DocTypes in ERPNext (e.g. **C-Form**).
- They are supported in MariaDB and Postgres.

### Error Message Screenshot

![Screenshot-2022-03-02-201924](https://user-images.githubusercontent.com/16315650/156386566-7eb48962-51f8-4b1f-a6d3-3b50b437b034.png)

#### Changes
- Mention hyphens in error message
- Add title

`no-docs`