### PR TITLE
fix: replace bleach allowlist

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -2,8 +2,9 @@ from __future__ import unicode_literals
 import frappe
 import json
 import re
-import bleach_whitelist.bleach_whitelist as bleach_whitelist
+from bleach_allowlist import bleach_allowlist
 from six import string_types
+
 
 def clean_html(html):
 	import bleach
@@ -72,7 +73,7 @@ def sanitize_html(html, linkify=False):
 	tags = (acceptable_elements + svg_elements + mathml_elements
 		+ ["html", "head", "meta", "link", "body", "style", "o:p"])
 	attributes = {"*": acceptable_attributes, 'svg': svg_attributes}
-	styles = bleach_whitelist.all_styles
+	styles = bleach_allowlist.all_styles
 	strip_comments = False
 
 	# returns html with escaped tags, escaped orphan >, <, etc.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Babel~=2.9.0
 beautifulsoup4~=4.9.3
-bleach-whitelist~=0.0.11
+bleach-allowlist~=1.0.3
 bleach~=3.3.0
 boto3~=1.17.53
 braintree~=4.8.0


### PR DESCRIPTION
Backport of d236a931693fccc0a59852cf18833afe24ce09d9

Fixes this warning:

```
/home/frappe/frappe-bench/env/lib/python3.6/site-packages/bleach_whitelist/bleach_whitelist.py:7:
DeprecationWarning: bleach-whitelist has been renamed bleach-allowlist. It will not receive further
updates under the old name. See https://pypi.org/project/bleach-allowlist
```