### PR TITLE
feat: translate column names in export of query report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -406,7 +406,7 @@ def build_xlsx_data(columns, data, visible_idx, include_indentation, ignore_visi
 	for column in data.columns:
 		if column.get("hidden"):
 			continue
-		result[0].append(column.get("label"))
+		result[0].append(_(column.get("label")))
 		column_width = cint(column.get('width', 0))
 		# to convert into scale accepted by openpyxl
 		column_width /= 10

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1343,7 +1343,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			if (file_format === 'CSV') {
 				const column_row = this.columns.reduce((acc, col) => {
 					if (!col.hidden) {
-						acc.push(col.label);
+						acc.push(__(col.label));
 					}
 					return acc;
 				}, []);


### PR DESCRIPTION
#15679 took care of translating column names in exports from report builder.

This PR continues the work to also translate column names in exports from query report.

> no-docs