### PR TITLE
perf: remove duplicate call to `ListView.show`

### DIFF
--- a/frappe/public/js/frappe/list/list_factory.js
+++ b/frappe/public/js/frappe/list/list_factory.js
@@ -30,13 +30,12 @@ frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
 		me.set_cur_list();
 	}
 
-	show() {
+	before_show() {
 		if (this.re_route_to_view()) {
-			return;
+			return false;
 		}
 
 		this.set_module_breadcrumb();
-		super.show();
 	}
 
 	on_show() {

--- a/frappe/public/js/frappe/list/list_factory.js
+++ b/frappe/public/js/frappe/list/list_factory.js
@@ -6,8 +6,8 @@ frappe.provide('frappe.views.list_view');
 window.cur_list = null;
 frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
 	make (route) {
-		var me = this;
-		var doctype = route[1];
+		const me = this;
+		const doctype = route[1];
 
 		// List / Gantt / Kanban / etc
 		// File is a special view
@@ -21,60 +21,59 @@ frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
 		}
 
 		frappe.provide('frappe.views.list_view.' + doctype);
-		const page_name = frappe.get_route_str();
 
-		if (!frappe.views.list_view[page_name]) {
-			frappe.views.list_view[page_name] = new view_class({
-				doctype: doctype,
-				parent: me.make_page(true, page_name)
-			});
-		} else {
-			frappe.container.change_to(page_name);
-		}
+		frappe.views.list_view[me.page_name] = new view_class({
+			doctype: doctype,
+			parent: me.make_page(true, me.page_name)
+		});
+
 		me.set_cur_list();
-
-
 	}
 
 	show() {
 		if (this.re_route_to_view()) {
 			return;
 		}
+
 		this.set_module_breadcrumb();
 		super.show();
+	}
+
+	on_show() {
 		this.set_cur_list();
-		cur_list && cur_list.show();
+		if (cur_list) cur_list.show();
 	}
 
 	re_route_to_view() {
-		var route = frappe.get_route();
-		var doctype = route[1];
-		var last_route = frappe.route_history.slice(-2)[0];
-		if (route[0] === 'List' && route.length === 2 && frappe.views.list_view[doctype]) {
-			if(last_route && last_route[0]==='List' && last_route[1]===doctype) {
-				// last route same as this route, so going back.
-				// this happens because /app/List/Item will redirect to /app/List/Item/List
-				// while coming from back button, the last 2 routes will be same, so
-				// we know user is coming in the reverse direction (via back button)
+		const doctype = this.route[1];
+		const last_route = frappe.route_history.slice(-2)[0];
+		if (
+			this.route[0] === 'List' &&
+			this.route.length === 2	&&
+			frappe.views.list_view[doctype] &&
+			last_route &&
+			last_route[0] === 'List' &&
+			last_route[1] === doctype
+		) {
+			// last route same as this route, so going back.
+			// this happens because /app/List/Item will redirect to /app/List/Item/List
+			// while coming from back button, the last 2 routes will be same, so
+			// we know user is coming in the reverse direction (via back button)
 
-				// example:
-				// Step 1: /app/List/Item redirects to /app/List/Item/List
-				// Step 2: User hits "back" comes back to /app/List/Item
-				// Step 3: Now we cannot send the user back to /app/List/Item/List so go back one more step
-				window.history.go(-1);
-				return true;
-			} else {
-				return false;
-			}
+			// example:
+			// Step 1: /app/List/Item redirects to /app/List/Item/List
+			// Step 2: User hits "back" comes back to /app/List/Item
+			// Step 3: Now we cannot send the user back to /app/List/Item/List so go back one more step
+			window.history.go(-1);
+			return true;
 		}
 	}
 
 	set_module_breadcrumb() {
 		if (frappe.route_history.length > 1) {
-			var prev_route = frappe.route_history[frappe.route_history.length - 2];
+			const prev_route = frappe.route_history[frappe.route_history.length - 2];
 			if (prev_route[0] === 'modules') {
-				var doctype = frappe.get_route()[1],
-					module = prev_route[1];
+				const doctype = this.route[1], module = prev_route[1];
 				if (frappe.module_links[module] && frappe.module_links[module].includes(doctype)) {
 					// save the last page from the breadcrumb was accessed
 					frappe.breadcrumbs.set_doctype_module(doctype, module);
@@ -84,10 +83,8 @@ frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
 	}
 
 	set_cur_list() {
-		var route = frappe.get_route();
-		var page_name = frappe.get_route_str();
-		cur_list = frappe.views.list_view[page_name];
-		if (cur_list && cur_list.doctype !== route[1]) {
+		cur_list = frappe.views.list_view[this.page_name];
+		if (cur_list && cur_list.doctype !== this.route[1]) {
 			// changing...
 			window.cur_list = null;
 		}

--- a/frappe/public/js/frappe/views/factory.js
+++ b/frappe/public/js/frappe/views/factory.js
@@ -13,6 +13,8 @@ frappe.views.Factory = class Factory {
 		this.route = frappe.get_route();
 		this.page_name = frappe.get_route_str();
 
+		if (this.before_show && this.before_show() === false) return;
+
 		if (frappe.pages[this.page_name]) {
 			frappe.container.change_to(this.page_name);
 			if (this.on_show) {

--- a/frappe/public/js/frappe/views/factory.js
+++ b/frappe/public/js/frappe/views/factory.js
@@ -10,20 +10,19 @@ frappe.views.Factory = class Factory {
 	}
 
 	show() {
-		var page_name = frappe.get_route_str(),
-			me = this;
+		this.route = frappe.get_route();
+		this.page_name = frappe.get_route_str();
 
-		if (frappe.pages[page_name]) {
-			frappe.container.change_to(page_name);
-			if(me.on_show) {
-				me.on_show();
+		if (frappe.pages[this.page_name]) {
+			frappe.container.change_to(this.page_name);
+			if (this.on_show) {
+				this.on_show();
 			}
 		} else {
-			var route = frappe.get_route();
-			if(route[1]) {
-				me.make(route);
+			if (this.route[1]) {
+				this.make(this.route);
 			} else {
-				frappe.show_not_found(route);
+				frappe.show_not_found(this.route);
 			}
 		}
 	}
@@ -34,15 +33,17 @@ frappe.views.Factory = class Factory {
 }
 
 frappe.make_page = function(double_column, page_name) {
-	if(!page_name) {
-		var page_name = frappe.get_route_str();
+	if (!page_name) {
+		page_name = frappe.get_route_str();
 	}
-	var page = frappe.container.add_page(page_name);
+
+	const page = frappe.container.add_page(page_name);
 
 	frappe.ui.make_app_page({
 		parent: page,
 		single_column: !double_column
 	});
+
 	frappe.container.change_to(page_name);
 	return page;
 }


### PR DESCRIPTION
## Issue

If a list view is opened for the first time, it's `show` method gets called twice in following places:
- In `ListView` constructor, when called in `ListFactory.make`
- In `ListFactory.show` (immediately after)

The reason why `ListView.show` needs to be called in `ListFactory.show` is because it also needs to be called in subsequent requests when routing to the view.

This leads to the expensive `load.getdoctype` being called twice, causing performance issue.

## Changes Made

### `frappe.views.Factory`
- Create `route` and `page_name` properties in `show()`
- Create optional `before_show` method (can be implemented by child classes) and stop further execution if this returns `false`.
- Remove unnecessary re-declaration
- Use `const` instead of `var`

### `frappe.views.ListFactory`
 - Use `before_show()` method instead of overriding `show()`. Alternatively, we can split `Factory.show` into `set_properties` and `_show` and call these methods instead.
 - Move `set_cur_list` and `cur_list.show` to `on_show`. This way, it only gets called in subsequent requests, but not when `make` is called.
 - Remove unnecessary if-else block from `ListFactory.make`. This function only gets called if the page doesn't already exist. If the page does exist, it gets shown in `Factory.show` itself.
 - Remove unnecessary nesting in `re_route_to_view` method.
 - Use new properties defined in `Factory`
 - Use `const` instead of `var`




## Screenshots

### Before

![Screenshot-2022-03-05-134402](https://user-images.githubusercontent.com/16315650/156874909-bb45b3af-484c-4b90-adc0-db6be07e0ab3.png)

![image](https://user-images.githubusercontent.com/16315650/156875033-d7226625-1c17-4c9d-8cfc-2684b488399c.png)


### After (~19% improvement)

![image](https://user-images.githubusercontent.com/16315650/156874788-81890778-c726-489a-b3b7-6be851ab00bc.png)

![Screenshot-2022-03-05-133931](https://user-images.githubusercontent.com/16315650/156875060-ab41b35f-8a24-4da5-b0aa-a53614f35887.png)

