### PR TITLE
chore: remove unused variable `doc_before_save`

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1003,8 +1003,6 @@ class Document(BaseDocument):
 		- `on_cancel` for **Cancel**
 		- `update_after_submit` for **Update after Submit**"""
 
-		doc_before_save = self.get_doc_before_save()
-
 		if self._action=="save":
 			self.run_method("on_update")
 		elif self._action=="submit":


### PR DESCRIPTION
`doc_before_save` is defined, but not used. Even call to `get_doc_before_save` not required, as it doesn't change any value and is simply a getter.