### PR TITLE
fix: Duplicate attachments in sidebar

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -44,8 +44,14 @@ frappe.ui.form.Attachments = class Attachments {
 		// add attachment objects
 		var attachments = this.get_attachments();
 		if(attachments.length) {
-			attachments.forEach(function(attachment) {
-				me.add_attachment(attachment)
+			let exists = {};
+			let unique_attachments = attachments.filter(attachment => {
+				return exists.hasOwnProperty(attachment.file_name)
+					? false
+					: (exists[attachment.file_name] = true);
+			});
+			unique_attachments.forEach(attachment => {
+				me.add_attachment(attachment);
 			});
 		} else {
 			this.attachments_label.removeClass("has-attachments");
@@ -75,7 +81,19 @@ frappe.ui.form.Attachments = class Attachments {
 			remove_action = function(target_id) {
 				frappe.confirm(__("Are you sure you want to delete the attachment?"),
 					function() {
-						me.remove_attachment(target_id);
+						let target_attachment = me
+							.get_attachments()
+							.find(attachment => attachment.name === target_id);
+						let to_be_removed = me
+							.get_attachments()
+							.filter(
+								attachment =>
+									attachment.file_name ===
+									target_attachment.file_name
+							);
+						to_be_removed.forEach(attachment =>
+							me.remove_attachment(attachment.name)
+						);
 					}
 				);
 				return false;

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -46,7 +46,10 @@ frappe.ui.form.Attachments = class Attachments {
 		if(attachments.length) {
 			let exists = {};
 			let unique_attachments = attachments.filter(attachment => {
-				return exists.hasOwnProperty(attachment.file_name)
+				return Object.prototype.hasOwnProperty.call(
+					exists,
+					attachment.file_name
+				)
 					? false
 					: (exists[attachment.file_name] = true);
 			});


### PR DESCRIPTION
### Issue
When a file that is already attached to a document is re-selected in another field, it is shown twice in the list of attachments on the sidebar. ([ISS-21-22-12964](https://frappe.io/app/issue/ISS-21-22-12964))

![AttachmentIssue](https://user-images.githubusercontent.com/49085834/157011959-3d78f843-d46a-4cb2-a7fb-89a86a6bb689.gif)

### Before
![Screenshot 2022-03-07 at 3 33 25 PM](https://user-images.githubusercontent.com/49085834/157012041-ac97ab21-a820-4712-b138-949f0f88b851.png)

### After
![Screenshot 2022-03-07 at 3 33 48 PM](https://user-images.githubusercontent.com/49085834/157012098-bc9d1f4f-41d9-4460-bb00-0258f3c2789e.png)

