### PR TITLE
refactor: Show Document Links

### DIFF
--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -380,8 +380,14 @@ def get_linked_docs(doctype: str, name: str, linkinfo: Dict = None) -> Dict[str,
 	for dt, link in linkinfo.items():
 		filters = []
 		link["doctype"] = dt
-		link_meta_bundle = frappe.desk.form.load.get_meta_bundle(dt)
+		try:
+			link_meta_bundle = frappe.desk.form.load.get_meta_bundle(dt)
+		except Exception:
+			continue
 		linkmeta = link_meta_bundle[0]
+
+		if not linkmeta.has_permission():
+			continue
 
 		if not linkmeta.get("issingle"):
 			fields = [d.fieldname for d in linkmeta.get("fields", {

--- a/frappe/public/js/frappe/form/linked_with.js
+++ b/frappe/public/js/frappe/form/linked_with.js
@@ -1,9 +1,8 @@
-// Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
-// MIT License. See license.txt
+// Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+// MIT License. See LICENSE
 
 
 frappe.ui.form.LinkedWith = class LinkedWith {
-
 	constructor(opts) {
 		$.extend(this, opts);
 	}
@@ -21,29 +20,23 @@ frappe.ui.form.LinkedWith = class LinkedWith {
 	}
 
 	make_dialog() {
-
 		this.dialog = new frappe.ui.Dialog({
 			title: __("Linked With")
 		});
 
 		this.dialog.on_page_show = () => {
-			// execute ajax calls sequentially
-			// 1. get linked doctypes
-			// 2. load all doctypes
-			// 3. load linked docs
-			this.get_linked_doctypes()
-				.then(() => this.load_doctypes())
-				.then(() => this.links_not_permitted_or_missing())
-				.then(() => this.get_linked_docs())
-				.then(() => this.make_html());
+			frappe.xcall(
+				"frappe.desk.form.linked_with.get",
+				{"doctype": cur_frm.doctype, "docname": cur_frm.docname},
+			).then(r => {
+				this.frm.__linked_docs = r;
+			}).then(() => this.make_html());
 		};
 	}
 
 	make_html() {
-		const linked_docs = this.frm.__linked_docs;
-
 		let html = '';
-
+		const linked_docs = this.frm.__linked_docs;
 		const linked_doctypes = Object.keys(linked_docs);
 
 		if (linked_doctypes.length === 0) {
@@ -61,88 +54,6 @@ frappe.ui.form.LinkedWith = class LinkedWith {
 		}
 
 		$(this.dialog.body).html(html);
-	}
-
-	load_doctypes() {
-		const already_loaded = Object.keys(locals.DocType);
-		let doctypes_to_load = [];
-
-		if (this.frm.__linked_doctypes) {
-			doctypes_to_load =
-				Object.keys(this.frm.__linked_doctypes)
-					.filter(doctype => !already_loaded.includes(doctype));
-		}
-
-		// load all doctypes asynchronously using with_doctype
-		const promises = doctypes_to_load.map(dt => {
-			return frappe.model.with_doctype(dt, () => {
-				if(frappe.listview_settings[dt]) {
-					// add additional fields to __linked_doctypes
-					this.frm.__linked_doctypes[dt].add_fields =
-						frappe.listview_settings[dt].add_fields;
-				}
-			});
-		});
-
-		return Promise.all(promises);
-	}
-
-	links_not_permitted_or_missing() {
-		let links = null;
-
-		if (this.frm.__linked_doctypes) {
-			links =
-				Object.keys(this.frm.__linked_doctypes)
-					.filter(frappe.model.can_get_report);
-		}
-
-		let flag;
-		if(!links) {
-			$(this.dialog.body).html(`${this.frm.__linked_doctypes
-				? __("Not enough permission to see links")
-				: __("Not Linked to any record")}`);
-			flag = true;
-		}
-		flag = false;
-
-		// reject Promise if not_permitted or missing
-		return new Promise(
-			(resolve, reject) => flag ? reject() : resolve()
-		);
-	}
-
-	get_linked_doctypes() {
-		return new Promise((resolve) => {
-			if (this.frm.__linked_doctypes) {
-				resolve();
-			}
-
-			frappe.call({
-				method: "frappe.desk.form.linked_with.get_linked_doctypes",
-				args: {
-					doctype: this.frm.doctype
-				},
-				callback: (r) => {
-					this.frm.__linked_doctypes = r.message;
-					resolve();
-				}
-			});
-		});
-	}
-
-	get_linked_docs() {
-		return frappe.call({
-			method: "frappe.desk.form.linked_with.get_linked_docs",
-			args: {
-				doctype: this.frm.doctype,
-				name: this.frm.docname,
-				linkinfo: this.frm.__linked_doctypes,
-				for_doctype: this.for_doctype
-			},
-			callback: (r) => {
-				this.frm.__linked_docs = r.message || {};
-			}
-		});
 	}
 
 	make_doc_head(heading) {


### PR DESCRIPTION
### Before

![linked-with_before](https://user-images.githubusercontent.com/36654812/157024066-0ceaaf68-7311-4564-95c4-41d328dffc7a.gif)

`* le cropped gif because it was more than twice as long`

### After

![linked-with_after](https://user-images.githubusercontent.com/36654812/157024205-fa68d7d6-70a9-4262-8535-6c2d8528d891.gif)

---

~Planning on making a "better" dialog that would be slightly easier to traverse 🤞🏼~