### PR TITLE
fix: use parent_doctype=... while fetching users from Has Role table

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -61,7 +61,7 @@ class Role(Document):
 
 def get_info_based_on_role(role, field='email'):
 	''' Get information of all users that have been assigned this role '''
-	users = frappe.get_list("Has Role", filters={"role": role, "parenttype": "User"},
+	users = frappe.get_list("Has Role", filters={"role": role}, parent_doctype="User",
 		fields=["parent as user_name"])
 
 	return get_user_info(users, field)


### PR DESCRIPTION
This is needed because of https://github.com/frappe/frappe/pull/14526