### PR TITLE
fix(translation): Set translated text as html to get unescaped output

### DIFF
--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -313,7 +313,7 @@ var continue_otp_app = function (setup, qrcode) {
 	var qrcode_div = $('<div class="text-muted" style="padding-bottom: 15px;"></div>');
 
 	if (setup) {
-		direction = $('<div>').attr('id', 'qr_info').text('{{ _("Enter Code displayed in OTP App.") }}');
+		direction = $('<div>').attr('id', 'qr_info').html('{{ _("Enter Code displayed in OTP App.") }}');
 		qrcode_div.append(direction);
 		$('#otp_div').prepend(qrcode_div);
 	} else {


### PR DESCRIPTION
Before 
<img width="429" alt="image" src="https://user-images.githubusercontent.com/28212972/159986388-57d52fda-da11-454e-972c-681e92cbd552.png">


After
<img width="431" alt="image" src="https://user-images.githubusercontent.com/28212972/159986261-6365722e-8811-4029-b0fd-e753463042eb.png">
