### PR TITLE
chore: change log for v13.22.0

### DIFF
--- a/frappe/change_log/v13/v13_22_0.md
+++ b/frappe/change_log/v13/v13_22_0.md
@@ -1,0 +1,41 @@
+## Version 13.22.0 Release Notes
+
+### Features & Enhancements
+
+- feat(minor): No Copy attribute for custom fields (backport #15915) ([#15915](https://github.com/frappe/frappe/pull/15915))
+
+### Fixes
+
+- fix: Update df of all grid rows (backport #15380)  ([#15380 ](https://github.com/frappe/frappe/pull/15380 ))
+- fix(Permission Manager): Update client-side permission data ([#15945](https://github.com/frappe/frappe/pull/15945))
+- fix: Update df of all grid rows ([#15380](https://github.com/frappe/frappe/pull/15380))
+- fix: hide fileuploader ([#16180](https://github.com/frappe/frappe/pull/16180))
+- fix: Add freeze message when renaming document ([#15912](https://github.com/frappe/frappe/pull/15912))
+- fix: Use `sort_by` field instead of non-existent `sort_field` (backport #16121) ([#16121](https://github.com/frappe/frappe/pull/16121))
+- fix: update child table row's linked field on creating new connection (backport #15787) ([#15787](https://github.com/frappe/frappe/pull/15787))
+- fix: Ignore `doctype` in setter (backport #15962) ([#15962](https://github.com/frappe/frappe/pull/15962))
+- fix: Totalling for tree view reports ([#15950](https://github.com/frappe/frappe/pull/15950))
+- build: Bump python_requires to match documentation ([#16094](https://github.com/frappe/frappe/pull/16094))
+- fix: load more button loads only 20 records at a time bp v13 ([#15989](https://github.com/frappe/frappe/pull/15989))
+- fix(email_account): Decode uid from bytes before update ([#16061](https://github.com/frappe/frappe/pull/16061))
+- fix: share clickable URLs from List View (backport #16039) ([#16039](https://github.com/frappe/frappe/pull/16039))
+- fix: load more button loads only 20 records at a time ([#15931](https://github.com/frappe/frappe/pull/15931))
+- fix: Merge groups for doctype links ([#15990](https://github.com/frappe/frappe/pull/15990))
+- fix: Always set `doctype` from `options` for child Document (backport #15957) ([#15957](https://github.com/frappe/frappe/pull/15957))
+- fix: Update Translations (backport #15878) ([#15878](https://github.com/frappe/frappe/pull/15878))
+- fix(translation): Add all possible views as comment (backport #16097) ([#16097](https://github.com/frappe/frappe/pull/16097))
+- fix(UI): Fix incorrect dark theme text color in user-wise grid column configuration ([#16106](https://github.com/frappe/frappe/pull/16106))
+- fix: always execute method if found in `__dict__` ([#15958](https://github.com/frappe/frappe/pull/15958))
+- fix(translation): Remove duplicate entry (backport #16091) ([#16091](https://github.com/frappe/frappe/pull/16091))
+- fix: `AttributeError` when initializing `FormMeta` (backport #16069) ([#16069](https://github.com/frappe/frappe/pull/16069))
+- fix: libsass issue with `min()` ([#15982](https://github.com/frappe/frappe/pull/15982))
+- fix: Color picker selected color style (backport #16086) ([#16086](https://github.com/frappe/frappe/pull/16086))
+- fix: broken validation for custom LDAP servers (backport #16016) ([#16016](https://github.com/frappe/frappe/pull/16016))
+- fix: webform mobile view padding (backport #16115) ([#16115](https://github.com/frappe/frappe/pull/16115))
+- fix: Rounding for negative numbers in javascript ([#1082](https://github.com/frappe/frappe/pull/1082))
+- fix(cli): Database agnostic options for root db credentials (backport #15973) ([#15973](https://github.com/frappe/frappe/pull/15973))
+- fix: Check if table_field exists in meta of `link.parent_doctype` (backport #16050) ([#16050](https://github.com/frappe/frappe/pull/16050))
+- fix: limit without filter (backport #15975) ([#15975](https://github.com/frappe/frappe/pull/15975))
+- fix(form-dashboard): Enable `set_open_count` (backport #13664) ([#13664](https://github.com/frappe/frappe/pull/13664))
+- fix: mandatory fields validation on new form (backport #16173) ([#16173](https://github.com/frappe/frappe/pull/16173))
+- fix: Wrap timeout getting for custom queues in function ([#15933](https://github.com/frappe/frappe/pull/15933))


### PR DESCRIPTION
## Version 13.22.0 Release Notes

### Features & Enhancements

- feat(minor): No Copy attribute for custom fields (backport #15915) ([#15915](https://github.com/frappe/frappe/pull/15915))

### Fixes

- fix: Update df of all grid rows (backport #15380)  ([#15380 ](https://github.com/frappe/frappe/pull/15380 ))
- fix(Permission Manager): Update client-side permission data ([#15945](https://github.com/frappe/frappe/pull/15945))
- fix: Update df of all grid rows ([#15380](https://github.com/frappe/frappe/pull/15380))
- fix: hide fileuploader ([#16180](https://github.com/frappe/frappe/pull/16180))
- fix: Add freeze message when renaming document ([#15912](https://github.com/frappe/frappe/pull/15912))
- fix: Use `sort_by` field instead of non-existent `sort_field` (backport #16121) ([#16121](https://github.com/frappe/frappe/pull/16121))
- fix: update child table row's linked field on creating new connection (backport #15787) ([#15787](https://github.com/frappe/frappe/pull/15787))
- fix: Ignore `doctype` in setter (backport #15962) ([#15962](https://github.com/frappe/frappe/pull/15962))
- fix: Totalling for tree view reports ([#15950](https://github.com/frappe/frappe/pull/15950))
- build: Bump python_requires to match documentation ([#16094](https://github.com/frappe/frappe/pull/16094))
- fix: load more button loads only 20 records at a time bp v13 ([#15989](https://github.com/frappe/frappe/pull/15989))
- fix(email_account): Decode uid from bytes before update ([#16061](https://github.com/frappe/frappe/pull/16061))
- fix: share clickable URLs from List View (backport #16039) ([#16039](https://github.com/frappe/frappe/pull/16039))
- fix: load more button loads only 20 records at a time ([#15931](https://github.com/frappe/frappe/pull/15931))
- fix: Merge groups for doctype links ([#15990](https://github.com/frappe/frappe/pull/15990))
- fix: Always set `doctype` from `options` for child Document (backport #15957) ([#15957](https://github.com/frappe/frappe/pull/15957))
- fix: Update Translations (backport #15878) ([#15878](https://github.com/frappe/frappe/pull/15878))
- fix(translation): Add all possible views as comment (backport #16097) ([#16097](https://github.com/frappe/frappe/pull/16097))
- fix(UI): Fix incorrect dark theme text color in user-wise grid column configuration ([#16106](https://github.com/frappe/frappe/pull/16106))
- fix: always execute method if found in `__dict__` ([#15958](https://github.com/frappe/frappe/pull/15958))
- fix(translation): Remove duplicate entry (backport #16091) ([#16091](https://github.com/frappe/frappe/pull/16091))
- fix: `AttributeError` when initializing `FormMeta` (backport #16069) ([#16069](https://github.com/frappe/frappe/pull/16069))
- fix: libsass issue with `min()` ([#15982](https://github.com/frappe/frappe/pull/15982))
- fix: Color picker selected color style (backport #16086) ([#16086](https://github.com/frappe/frappe/pull/16086))
- fix: broken validation for custom LDAP servers (backport #16016) ([#16016](https://github.com/frappe/frappe/pull/16016))
- fix: webform mobile view padding (backport #16115) ([#16115](https://github.com/frappe/frappe/pull/16115))
- fix: Rounding for negative numbers in javascript ([#1082](https://github.com/frappe/frappe/pull/1082))
- fix(cli): Database agnostic options for root db credentials (backport #15973) ([#15973](https://github.com/frappe/frappe/pull/15973))
- fix: Check if table_field exists in meta of `link.parent_doctype` (backport #16050) ([#16050](https://github.com/frappe/frappe/pull/16050))
- fix: limit without filter (backport #15975) ([#15975](https://github.com/frappe/frappe/pull/15975))
- fix(form-dashboard): Enable `set_open_count` (backport #13664) ([#13664](https://github.com/frappe/frappe/pull/13664))
- fix: mandatory fields validation on new form (backport #16173) ([#16173](https://github.com/frappe/frappe/pull/16173))
- fix: Wrap timeout getting for custom queues in function ([#15933](https://github.com/frappe/frappe/pull/15933))