### PR TITLE
fix(rename_doc): Allow updating only document title or name

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -43,8 +43,8 @@ def update_document_title(
 
 	title_field = doc.meta.get_title_field()
 
-	title_updated = (title_field != "name") and (updated_title != doc.get(title_field))
-	name_updated = updated_name != doc.name
+	title_updated = updated_title and (title_field != "name") and (updated_title != doc.get(title_field))
+	name_updated = updated_name and (updated_name != doc.name)
 
 	if name_updated:
 		docname = rename_doc(doctype=doctype, old=docname, new=updated_name, merge=merge)


### PR DESCRIPTION
Introduced by https://github.com/frappe/frappe/pull/16041
Fixes https://github.com/frappe/frappe/issues/16223