### PR TITLE
fix: Consider title field only if it's value exists

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -585,7 +585,7 @@ $.extend(frappe.model, {
 				title = `${value} (${docname})`;
 			}
 		}
-		frappe.confirm(__("Permanently delete {0}?", [title]), function() {
+		frappe.confirm(__("Permanently delete {0}?", [title.bold()]), function() {
 			return frappe.call({
 				method: 'frappe.client.delete',
 				args: {

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -577,11 +577,13 @@ $.extend(frappe.model, {
 	},
 
 	delete_doc: function(doctype, docname, callback) {
-		var title = docname;
-		var title_field = frappe.get_meta(doctype).title_field;
+		let title = docname;
+		const title_field = frappe.get_meta(doctype).title_field;
 		if (frappe.get_meta(doctype).autoname == "hash" && title_field) {
-			var title = frappe.model.get_value(doctype, docname, title_field);
-			title += " (" + docname + ")";
+			const value = frappe.model.get_value(doctype, docname, title_field);
+			if (value) {
+				title = `${value} (${docname})`;
+			}
 		}
 		frappe.confirm(__("Permanently delete {0}?", [title]), function() {
 			return frappe.call({


### PR DESCRIPTION
## Issue
When `title_field` value is not set in a doc, while deleting, confirm dialog shows `undefined` in title.

## Change Made
 - Only set title_field value if it is set
 - Make `title` bold for better visuals


## Before
![image](https://user-images.githubusercontent.com/43115036/157595940-eb575f2a-7ec4-4355-b2dc-21722e160216.png)

## After
![image](https://user-images.githubusercontent.com/43115036/157596604-63f7a3c8-8819-4fb6-8d02-c8dc83aa1750.png)

![image](https://user-images.githubusercontent.com/43115036/157596459-0e10d008-fbcc-41fe-8b37-7cd882d43d41.png)
