### PR TITLE
feat: show link titles in web form link fields

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -166,6 +166,9 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 	}
 
 	parse_options(options) {
+		if (typeof options === 'string' && options[0] === '[') {
+			options = frappe.utils.parse_json(options);
+		}
 		if (typeof options === 'string') {
 			options = options.split('\n');
 		}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -196,6 +196,15 @@ Object.assign(frappe.utils, {
 		}
 		return true;
 	},
+	parse_json: function(str) {
+		let parsed_json = '';
+		try {
+			parsed_json = JSON.parse(str);
+		} catch (e) {
+			return str;
+		}
+		return parsed_json;
+	},
 	strip_whitespace: function(html) {
 		return (html || "").replace(/<p>\s*<\/p>/g, "").replace(/<br>(\s*<br>\s*)+/g, "<br><br>");
 	},

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -598,13 +598,18 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 				break
 
 	if doctype_validated:
-		link_options = []
-		if limited_to_user:
-			link_options = "\n".join([doc.name for doc in frappe.get_all(doctype, filters = {"owner":frappe.session.user})])
-		else:
-			link_options = "\n".join([doc.name for doc in frappe.get_all(doctype)])
+		link_options, filters = [], {}
+		fields = ['name as value']
 
-		return link_options
+		title_field = frappe.db.get_value('DocType', doctype, 'title_field')
+		if title_field:
+			fields.append(f'{title_field} as label')
+
+		if limited_to_user:
+			filters = {"owner":frappe.session.user}
+
+		link_options = frappe.get_all(doctype, filters, fields)
+		return json.dumps(link_options, default=str)
 
 	else:
 		raise frappe.PermissionError('Not Allowed, {0}'.format(doctype))


### PR DESCRIPTION
Show `title` of a Doctype (if exists) in the Link Field dropdown in Web Forms

`no-docs`