### PR TITLE
feat: provision to handle payment authorization event in server script for custom documents

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -49,7 +49,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nOn Payment Authorized"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -109,10 +109,11 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2021-09-04 12:02:43.671240",
+ "modified": "2022-03-08 16:52:49.670074",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -130,5 +131,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -16,7 +16,8 @@ EVENT_MAP = {
 	'on_trash': 'Before Delete',
 	'after_delete': 'After Delete',
 	'before_update_after_submit': 'Before Save (Submitted Document)',
-	'on_update_after_submit': 'After Save (Submitted Document)'
+	'on_update_after_submit': 'After Save (Submitted Document)',
+	'on_payment_authorized': 'On Payment Authorized'
 }
 
 def run_server_script_for_doc_event(doc, event):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -135,6 +135,7 @@ def get_safe_globals():
 			),
 			make_get_request=frappe.integrations.utils.make_get_request,
 			make_post_request=frappe.integrations.utils.make_post_request,
+			get_payment_gateway_controller = frappe.integrations.utils.get_payment_gateway_controller,
 			socketio_port=frappe.conf.socketio_port,
 			get_hooks=get_hooks,
 			enqueue=safe_enqueue,


### PR DESCRIPTION
Currently, there is no provision to handle payment authorization events via server script. So it's not possible if a user wants to link payments against custom documents. 

Thus adding a provision in server script 
- Setup checkout for custom doc 
<img width="1299" alt="Screenshot 2022-03-11 at 2 44 19 PM" src="https://user-images.githubusercontent.com/3784093/157838010-989f6009-83d6-4329-92a6-bb2b6b38438b.png">

- Handle payment callback
<img width="1321" alt="Screenshot 2022-03-11 at 2 44 33 PM" src="https://user-images.githubusercontent.com/3784093/157837953-b7dcfd1f-6d4c-44c1-9fb4-b64c40d0207f.png">

