### PR TITLE
fix: fetching hooks with sorted apps

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1106,7 +1106,7 @@ def get_hooks(hook=None, default=None, app_name=None):
 	:param app_name: Filter by app."""
 	def load_app_hooks(app_name=None):
 		hooks = {}
-		for app in [app_name] if app_name else get_installed_apps(sort=True):
+		for app in [app_name] if app_name else get_installed_apps(sort=False):
 			app = "frappe" if app=="webnotes" else app
 			try:
 				app_hooks = get_module(app + ".hooks")

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -99,7 +99,7 @@ def get_jloader():
 
 		apps = frappe.get_hooks('template_apps')
 		if not apps:
-			apps = frappe.local.flags.web_pages_apps or frappe.get_installed_apps(sort=True)
+			apps = frappe.local.flags.web_pages_apps or frappe.get_installed_apps(sort=False)
 			apps.reverse()
 
 		if "frappe" not in apps:


### PR DESCRIPTION
While fetching hooks. The system fetches the apps sorted and not in the order they were installed, causing unwanted behaviour

Same issue for jinja templates