### PR TITLE
fix: Lost connection to MySQL server during query - bench restore

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -43,6 +43,8 @@ def install_db(root_login="root", root_password=None, db_name=None, source_sql=N
 	frappe.connect(db_name=db_name)
 	check_if_ready_for_barracuda()
 	import_db_from_sql(source_sql, verbose)
+	# Long imports cause the connection to time out on the server, so close and reconnect.
+	frappe.db.close()
 	if not 'tabDefaultValue' in frappe.db.get_tables():
 		print('''Database not installed, this can due to lack of permission, or that the database name exists.
 Check your mysql root password, or use --force to reinstall''')


### PR DESCRIPTION
## Needs forward-porting to **all versions**

Long-running db bench restores causing server db connection timeout

Reproduce: restore a 7GB .sql db file using bench restore on 2 core 4GB RAM server

Other things tried: adding `-B 32M` to the `pv` pipe command -> no change

Client (error happens **AFTER** restore completes):
`Error number: 2013; Symbol: CR_SERVER_LOST; Message: Lost connection to MySQL server during query`

Server `/var/lib/mysql/mysql-error.log`
```log
2022-03-10 13:02:12 140702333904640 [Warning] Aborted connection 438 to db: '37011ea640019af9' user: '37011ea640019af9' host: 'localhost' (Got an error reading communication packets)
2022-03-10 13:02:19 140702333904640 [Warning] Aborted connection 444 to db: 'd957997b291796bc' user: 'd957997b291796bc' host: 'localhost' (Got an error reading communication packets)
2022-03-10 13:03:49 140702333904640 [Warning] Aborted connection 460 to db: 'b5101527484f559b' user: 'b5101527484f559b' host: 'localhost' (Got an error reading communication packets)
2022-03-10 13:04:07 140702334211840 [Warning] Aborted connection 465 to db: '0ffca28726536b58' user: '0ffca28726536b58' host: 'localhost' (Got an error reading communication packets)
2022-03-10 13:35:38 140702333597440 [Warning] Aborted connection 1011 to db: 'd957997b291796bc' user: 'd957997b291796bc' host: 'localhost' (Got an error reading communication packets)
2022-03-10 13:35:42 140702333597440 [Warning] Aborted connection 1014 to db: '37011ea640019af9' user: '37011ea640019af9' host: 'localhost' (Got an error reading communication packets)
2022-03-10 14:45:42 140702333904640 [Warning] Aborted connection 2206 to db: 'b88dfb9de4f294d4' user: 'b88dfb9de4f294d4' host: 'localhost' (Got an error reading communication packets)
```

PS I have also noticed this on some unittest test case scenarios requiring:

```python
def tearDown(self):
    frappe.db.close()
```