### PR TITLE
fix: typo in database file for v12 - latest

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -181,7 +181,7 @@ class Database(object):
 				print(e)
 				raise
 
-			if ignore_ddl and (self.is_missing_column(e) or self.is_missing_table(e) or self.cant_drop_field_or_key(e)):
+			if ignore_ddl and (self.is_missing_column(e) or self.is_table_missing(e) or self.cant_drop_field_or_key(e)):
 				pass
 			else:
 				raise
@@ -1028,7 +1028,7 @@ class Database(object):
 			return []
 
 	def is_missing_table_or_column(self, e):
-		return self.is_missing_column(e) or self.is_missing_table(e)
+		return self.is_missing_column(e) or self.is_table_missing(e)
 
 	def multisql(self, sql_dict, values=(), **kwargs):
 		current_dialect = frappe.db.db_type or 'mariadb'


### PR DESCRIPTION
## Simple typo in ```database.py``` 🤦
> Exists for all versions from atleast v12 to lastest AFAIK

