### PR TITLE
fix: `set_column_disp` contradicts arguments

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -501,9 +501,9 @@ export default class Grid {
 	}
 
 	set_column_disp(fieldname, show) {
-		if ($.isArray(fieldname)) {
+		if (Array.isArray(fieldname)) {
 			for (let field of fieldname) {
-				this.update_docfield_property(field, "hidden", show);
+				this.update_docfield_property(field, "hidden", show ? 0 : 1);
 				this.set_editable_grid_column_disp(field, show);
 			}
 		} else {


### PR DESCRIPTION
Introduced via https://github.com/frappe/frappe/pull/15380

- `show=1` should set `hidden` as 0 in `set_column_disp()`, but does the opposite.

**Fix:**
- Fix contradictory behaviour of `set_column_disp()`
- Use `Array.isArray()` instead of deprecated usage