### PR TITLE
fix!: run synchronous background jobs directly in production

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -57,7 +57,11 @@ def enqueue(method, queue='default', timeout=None, event=None,
 	# To handle older implementations
 	is_async = kwargs.pop('async', is_async)
 
-	if now or frappe.flags.in_migrate:
+	if not is_async and not frappe.flags.in_test:
+		print(_("Using enqueue with is_async=False outside of tests is not recommended, use now=True instead."))
+
+	call_directly = now or frappe.flags.in_migrate or (not is_async and not frappe.flags.in_test)
+	if call_directly:
 		return frappe.call(method, **kwargs)
 
 	q = get_queue(queue, is_async=is_async)


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/15376


Using is_async=False in production is dangerous because it commits/rollsback partial transactions. 

This is only useful for tests, as per RQ docs. 
![telegram-cloud-photo-size-5-6150063735746703633-y](https://user-images.githubusercontent.com/9079960/157849890-493478e5-7914-4662-9886-60e60b7cddc7.jpg)


Note: Don't backport. 