### PR TITLE
perf: cache single documents

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -850,8 +850,7 @@ def set_value(doctype, docname, fieldname, value=None):
 	return frappe.client.set_value(doctype, docname, fieldname, value)
 
 def get_cached_doc(*args, **kwargs):
-	key = can_cache_doc(args)
-	if key:
+	if key := can_cache_doc(args):
 		# local cache
 		doc = local.document_cache.get(key)
 		if doc:
@@ -930,8 +929,7 @@ def get_doc(*args, **kwargs):
 	doc = frappe.model.document.get_doc(*args, **kwargs)
 
 	# set in cache
-	key = can_cache_doc(args)
-	if key:
+	if key := can_cache_doc(args):
 		local.document_cache[key] = doc
 		cache().hset('document_cache', key, doc.as_dict())
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -870,7 +870,7 @@ def get_cached_doc(*args, **kwargs):
 
 def can_cache_doc(args):
 	"""
-	Function to determine if document should be cached based on get_doc params.
+	Determine if document should be cached based on get_doc params.
 	Returns cache key if doc can be cached, None otherwise.
 	"""
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -878,10 +878,7 @@ def can_cache_doc(args):
 		return
 
 	doctype = args[0]
-	if len(args) == 1:
-		name = doctype # Probably a single DocType
-	else:
-		name = args[1]
+	name = doctype if len(args) == 1 else args[1]
 
 	# Only cache if both doctype and name are strings
 	if isinstance(doctype, str) and isinstance(name, str):


### PR DESCRIPTION
Single DocTypes are generally "settings" of some kind. They are updated rarely, but used regularly. We should cache them better.

### 99.9% improvement 😄 

![Screenshot-2022-03-11-235819](https://user-images.githubusercontent.com/16315650/157931418-82b915c9-0106-413b-b858-f4d8ac89bba3.png)

Disclaimer: this is based on local document cache, which only lasts for the duration of one request (it get re-initialised in `frappe.init` which gets called in every request). A fairer comparison would be if redis cache is considered instead.

## Changes Made
- Refactor logic to decide whether or not to cache doc into a separate function called `can_cache_doc`. This way, there is consistency between what is stored into and retrieved from cache. This function returns the document cache key if the doc is cache-able, `None` otherwise. In addition to what was supported earlier, this function also supports caching single doctypes (where only DocType is passed).
- [Style] Convert `.format()` to f-string in `get_document_cache_key`