### PR TITLE
feat: Allow all users to customize Query Reports

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -72,8 +72,16 @@ def get_report_result(report, filters):
 
 	return res
 
+
 @frappe.read_only()
-def generate_report_result(report, filters=None, user=None, custom_columns=None, is_tree=False, parent_field=None):
+def generate_report_result(
+	report,
+	filters=None,
+	user=None,
+	custom_columns=None,
+	is_tree=False,
+	parent_field=None,
+):
 	user = user or frappe.session.user
 	filters = filters or []
 
@@ -99,7 +107,9 @@ def generate_report_result(report, filters=None, user=None, custom_columns=None,
 			columns.insert(custom_column["insert_after_index"] + 1, custom_column)
 
 	# all columns which are not in original report
-	report_custom_columns = [column for column in columns if column["fieldname"] not in report_column_names]
+	report_custom_columns = [
+		column for column in columns if column["fieldname"] not in report_column_names
+	]
 
 	if report_custom_columns:
 		result = add_custom_column_data(report_custom_columns, result)
@@ -108,7 +118,9 @@ def generate_report_result(report, filters=None, user=None, custom_columns=None,
 		result = get_filtered_data(report.ref_doctype, columns, result, user)
 
 	if cint(report.add_total_row) and result and not skip_total_row:
-		result = add_total_row(result, columns, is_tree=is_tree, parent_field=parent_field)
+		result = add_total_row(
+			result, columns, is_tree=is_tree, parent_field=parent_field
+		)
 
 	return {
 		"result": result,
@@ -121,6 +133,7 @@ def generate_report_result(report, filters=None, user=None, custom_columns=None,
 		"execution_time": frappe.cache().hget("report_execution_time", report.name)
 		or 0,
 	}
+
 
 def normalize_result(result, columns):
 	# Converts to list of dicts from list of lists/tuples
@@ -136,6 +149,7 @@ def normalize_result(result, columns):
 		data = result
 
 	return data
+
 
 @frappe.whitelist()
 def background_enqueue_run(report_name, filters=None, user=None):
@@ -176,10 +190,16 @@ def get_script(report_name):
 	is_custom_module = frappe.get_cached_value("Module Def", module, "custom")
 
 	# custom modules are virtual modules those exists in DB but not in disk.
-	module_path = '' if is_custom_module else get_module_path(module)
-	report_folder = module_path and os.path.join(module_path, "report", scrub(report.name))
-	script_path = report_folder and os.path.join(report_folder, scrub(report.name) + ".js")
-	print_path = report_folder and os.path.join(report_folder, scrub(report.name) + ".html")
+	module_path = "" if is_custom_module else get_module_path(module)
+	report_folder = module_path and os.path.join(
+		module_path, "report", scrub(report.name)
+	)
+	script_path = report_folder and os.path.join(
+		report_folder, scrub(report.name) + ".js"
+	)
+	print_path = report_folder and os.path.join(
+		report_folder, scrub(report.name) + ".html"
+	)
 
 	script = None
 	if os.path.exists(script_path):
@@ -210,7 +230,15 @@ def get_script(report_name):
 
 @frappe.whitelist()
 @frappe.read_only()
-def run(report_name, filters=None, user=None, ignore_prepared_report=False, custom_columns=None, is_tree=False, parent_field=None):
+def run(
+	report_name,
+	filters=None,
+	user=None,
+	ignore_prepared_report=False,
+	custom_columns=None,
+	is_tree=False,
+	parent_field=None,
+):
 	report = get_report_doc(report_name)
 	if not user:
 		user = frappe.session.user
@@ -238,7 +266,9 @@ def run(report_name, filters=None, user=None, ignore_prepared_report=False, cust
 			dn = ""
 		result = get_prepared_report_result(report, filters, dn, user)
 	else:
-		result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
+		result = generate_report_result(
+			report, filters, user, custom_columns, is_tree, parent_field
+		)
 
 	result["add_total_row"] = report.add_total_row and not result.get(
 		"skip_total_row", False
@@ -251,14 +281,16 @@ def add_custom_column_data(custom_columns, result):
 	custom_column_data = get_data_for_custom_report(custom_columns)
 
 	for column in custom_columns:
-		key = (column.get('doctype'), column.get('fieldname'))
+		key = (column.get("doctype"), column.get("fieldname"))
 		if key in custom_column_data:
 			for row in result:
-				row_reference = row.get(column.get('link_field'))
+				row_reference = row.get(column.get("link_field"))
 				# possible if the row is empty
 				if not row_reference:
 					continue
-				row[column.get('fieldname')] = custom_column_data.get(key).get(row_reference)
+				row[column.get("fieldname")] = custom_column_data.get(key).get(
+					row_reference
+				)
 
 	return result
 
@@ -359,7 +391,9 @@ def export_query():
 		data["result"] = handle_duration_fieldtype_values(
 			data.get("result"), data.get("columns")
 		)
-		xlsx_data, column_widths = build_xlsx_data(columns, data, visible_idx, include_indentation)
+		xlsx_data, column_widths = build_xlsx_data(
+			columns, data, visible_idx, include_indentation
+		)
 		xlsx_file = make_xlsx(xlsx_data, "Query Report", column_widths=column_widths)
 
 		frappe.response["filename"] = report_name + ".xlsx"
@@ -399,7 +433,9 @@ def handle_duration_fieldtype_values(result, columns):
 	return result
 
 
-def build_xlsx_data(columns, data, visible_idx, include_indentation, ignore_visible_idx=False):
+def build_xlsx_data(
+	columns, data, visible_idx, include_indentation, ignore_visible_idx=False
+):
 	result = [[]]
 	column_widths = []
 
@@ -407,7 +443,7 @@ def build_xlsx_data(columns, data, visible_idx, include_indentation, ignore_visi
 		if column.get("hidden"):
 			continue
 		result[0].append(_(column.get("label")))
-		column_width = cint(column.get('width', 0))
+		column_width = cint(column.get("width", 0))
 		# to convert into scale accepted by openpyxl
 		column_width /= 10
 		column_widths.append(column_width)
@@ -545,9 +581,23 @@ def save_report(reference_report, report_name, columns):
 
 	if docname:
 		report = frappe.get_doc("Report", docname)
+
+		if report.is_standard == "Yes":
+			frappe.throw(_("Standard Reports cannot be edited"))
+
+		if report.report_type not in ("Query Report", "Script Report", "Custom Report"):
+			frappe.throw(_("Reports of type Report Builder can not be edited"))
+
+		if report.owner != frappe.session.user and not frappe.has_permission(
+			"Report", "write"
+		):
+			frappe.throw(
+				_("Insufficient Permissions for editing Report"), frappe.PermissionError
+			)
+
 		existing_jd = json.loads(report.json)
 		existing_jd["columns"] = json.loads(columns)
-		report.update({"json": json.dumps(existing_jd, separators=(',', ':'))})
+		report.update({"json": json.dumps(existing_jd, separators=(",", ":"))})
 		report.save()
 		frappe.msgprint(_("Report updated successfully"))
 
@@ -566,6 +616,32 @@ def save_report(reference_report, report_name, columns):
 		).insert(ignore_permissions=True)
 		frappe.msgprint(_("{0} saved successfully").format(new_report.name))
 		return new_report.name
+
+
+@frappe.whitelist()
+def delete_report(name):
+	"""Delete reports of type Query / Script/ Custom Report from Report View"""
+
+	report = frappe.get_doc("Report", name)
+	if report.is_standard == "Yes":
+		frappe.throw(_("Standard Reports cannot be deleted"))
+
+	if report.report_type not in ("Query Report", "Script Report", "Custom Report"):
+		frappe.throw(_("Reports of type Report Builder can not be deleted"))
+
+	if report.owner != frappe.session.user and not frappe.has_permission(
+		"Report", "delete"
+	):
+		frappe.throw(
+			_("Insufficient Permissions for deleting Report"), frappe.PermissionError
+		)
+
+	report.delete(ignore_permissions=True)
+	frappe.msgprint(
+		_("Report {0} deleted").format(frappe.bold(report.name)),
+		indicator="green",
+		alert=True,
+	)
 
 
 def get_filtered_data(ref_doctype, columns, data, user):


### PR DESCRIPTION
Resolves https://github.com/frappe/frappe/issues/16208

This PR allows a report of type Query, Script or Custom Reports to be created / edited / deleted by any user. This is accomplished without changing permissions for the Report DocType, since this PR only allows non-standard reports of type Query/Script Report to be saved. They can then be edited / deleted by owner or someone else with requisite permissions.

Delete button in Report View:

![image](https://user-images.githubusercontent.com/54097382/158017326-9f64f0d8-aa74-4779-99dd-21e9f7c86377.png)
