### PR TITLE
fix: use last_value when refreshing input if the value doesn't exist in `locals`

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -75,7 +75,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		if (me.disp_status != "None") {
 			// refresh value
 			if (me.frm) {
-				me.value = frappe.model.get_value(me.doctype, me.docname, me.df.fieldname);
+				me.value = frappe.model.get_value(me.doctype, me.docname, me.df.fieldname) || me.last_value;
 			} else if (me.doc) {
 				me.value = me.doc[me.df.fieldname];
 			}

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -65,11 +65,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		};
 
 		var update_input = function() {
-			if (me.doctype && me.docname) {
-				me.set_input(me.value);
-			} else {
-				me.set_input(me.value || null);
-			}
+			me.set_input(me.value || null);
 		};
 
 		if (me.disp_status != "None") {


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/16201

explained here https://github.com/frappe/frappe/issues/16201#issuecomment-1065305512