### PR TITLE
fix: web form link title doctype issue

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -325,6 +325,7 @@ def get_desk_settings():
 def get_notification_settings():
 	return frappe.get_cached_doc('Notification Settings', frappe.session.user)
 
+@frappe.whitelist()
 def get_link_title_doctypes():
 	dts = frappe.get_all("DocType", {"show_title_field_in_link": 1})
 	custom_dts = frappe.get_all(

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -83,8 +83,7 @@ frappe.boot = {
 		system: "{{ frappe.utils.get_time_zone() }}",
 		user: "{{ frappe.db.get_value('User', frappe.session.user, 'time_zone') or frappe.utils.get_time_zone() }}"
 	},
-	link_title_doctypes: `{{ frappe.get_all('DocType', {'show_title_field_in_link': 1}, pluck='name') +
-		frappe.get_all('Property Setter', {'property': 'show_title_field_in_link', 'value': '1'},pluck='doc_type') }}`
+	link_title_doctypes: `{{ frappe.call('frappe.boot.get_link_title_doctypes') }}`
 };
 // for backward compatibility of some libs
 frappe.sys_defaults = frappe.boot.sysdefaults;

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -82,7 +82,9 @@ frappe.boot = {
 	time_zone: {
 		system: "{{ frappe.utils.get_time_zone() }}",
 		user: "{{ frappe.db.get_value('User', frappe.session.user, 'time_zone') or frappe.utils.get_time_zone() }}"
-	}
+	},
+	link_title_doctypes: `{{ frappe.get_all('DocType', {'show_title_field_in_link': 1}, pluck='name') +
+		frappe.get_all('Property Setter', {'property': 'show_title_field_in_link', 'value': '1'},pluck='doc_type') }}`
 };
 // for backward compatibility of some libs
 frappe.sys_defaults = frappe.boot.sysdefaults;


### PR DESCRIPTION
**Issue:** An error appears in the console while trying to select a link field from a child table in web form. This prevents the user from selecting the value in the table.

The error is regarding "Show Title Field in Link" info not being present at boot for web forms.

**Before:**

https://user-images.githubusercontent.com/31363128/158178321-2aa6314a-0ff5-4316-89a1-362b072b3fa8.mov

**After:**
 
https://user-images.githubusercontent.com/31363128/158178351-ba142d4c-3dcb-415e-82d6-067a1613b7a6.mov
