### PR TITLE
fix(BackupGenerator): set missing attribute for class object

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -181,8 +181,6 @@ class BackupGenerator:
 				False,
 			)
 
-		self.todays_date = now_datetime().strftime("%Y%m%d_%H%M%S")
-
 		if not (
 			self.backup_path_conf
 			and self.backup_path_db
@@ -206,6 +204,7 @@ class BackupGenerator:
 	def set_backup_file_name(self):
 		partial = "-partial" if self.partial else ""
 		ext = "tgz" if self.compress_files else "tar"
+		self.todays_date = now_datetime().strftime("%Y%m%d_%H%M%S")
 
 		for_conf = f"{self.todays_date}-{self.site_slug}-site_config_backup.json"
 		for_db = f"{self.todays_date}-{self.site_slug}{partial}-database.sql.gz"


### PR DESCRIPTION
We are getting this issue when we set s3 backup.

Traceback:
```python
File apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py", line 81, in take_backups_s3 backup_to_s3() 
File "apps/frappe/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py", line 129, in backup_to_s3 generate_files_backup() 
File "apps/frappe/frappe/integrations/offsite_backup_utils.py", line 112, in generate_files_backup backup.set_backup_file_name() 
File "apps/frappe/frappe/utils/backups.py", line 211, in set_backup_file_name for_conf = f"{self.todays_date}-{self.site_slug}-site_config_backup.json" 
AttributeError: 'BackupGenerator' object has no attribute 'todays_date'

