### PR TITLE
feat(log): implement `stream_only` to avoid usage of RotatingFileHandler

### DIFF
--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -23,7 +23,7 @@ def get_logger(module=None, with_more_info=False, allow_site=True, filter=None, 
 		filter (function, optional): Add a filter function for your logger. Defaults to None.
 		max_size (int, optional): Max file size of each log file in bytes. Defaults to 100_000.
 		file_count (int, optional): Max count of log files to be retained via Log Rotation. Defaults to 20.
-        stream_nly (bool, optional): Wether to stream logs only to stderr (True) or use log files (False). Defaults to False.
+        stream_only (bool, optional): Whether to stream logs only to stderr (True) or use log files (False). Defaults to False.
 
 	Returns:
 		<class 'logging.Logger'>: Returns a Python logger object with Site and Bench level logging capabilities.

--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -13,7 +13,7 @@ from frappe.utils import get_sites
 default_log_level = logging.DEBUG
 
 
-def get_logger(module=None, with_more_info=False, allow_site=True, filter=None, max_size=100_000, file_count=20):
+def get_logger(module=None, with_more_info=False, allow_site=True, filter=None, max_size=100_000, file_count=20, stream_only=False):
 	"""Application Logger for your given module
 
 	Args:
@@ -23,6 +23,7 @@ def get_logger(module=None, with_more_info=False, allow_site=True, filter=None, 
 		filter (function, optional): Add a filter function for your logger. Defaults to None.
 		max_size (int, optional): Max file size of each log file in bytes. Defaults to 100_000.
 		file_count (int, optional): Max count of log files to be retained via Log Rotation. Defaults to 20.
+        stream_nly (bool, optional): Wether to stream logs only to stderr (True) or use log files (False). Defaults to False.
 
 	Returns:
 		<class 'logging.Logger'>: Returns a Python logger object with Site and Bench level logging capabilities.
@@ -54,65 +55,18 @@ def get_logger(module=None, with_more_info=False, allow_site=True, filter=None, 
 	logger.propagate = False
 
 	formatter = logging.Formatter("%(asctime)s %(levelname)s {0} %(message)s".format(module))
-	handler = RotatingFileHandler(log_filename, maxBytes=max_size, backupCount=file_count)
+	if stream_only:
+		handler = logging.StreamHandler()
+	else:
+		handler = RotatingFileHandler(log_filename, maxBytes=max_size, backupCount=file_count)
 	handler.setFormatter(formatter)
 	logger.addHandler(handler)
 
-	if site:
+	if site and not stream_only:
 		sitelog_filename = os.path.join(site, "logs", logfile)
 		site_handler = RotatingFileHandler(sitelog_filename, maxBytes=max_size, backupCount=file_count)
 		site_handler.setFormatter(formatter)
 		logger.addHandler(site_handler)
-
-	if with_more_info:
-		handler.addFilter(SiteContextFilter())
-
-	if filter:
-		logger.addFilter(filter)
-
-	frappe.loggers[logger_name] = logger
-
-	return logger
-
-
-def get_logger_stderr(module=None, with_more_info=False, allow_site=True, filter=None):
-	"""Application Logger for your given module. This logger don't use the `RotatingFileHandler`,
-	instead use `StreamHandler` in order to avoid the use of log files and outputs everything to stderr.
-	Args:
-		module (str, optional): Name of your logger and consequently your log file. Defaults to None.
-		with_more_info (bool, optional): Will log the form dict using the SiteContextFilter. Defaults to False.
-		allow_site ((str, bool), optional): Pass site name to explicitly log under it's logs. If True and unspecified, guesses which site the logs would be saved under. Defaults to True.
-		filter (function, optional): Add a filter function for your logger. Defaults to None.
-	Returns:
-		<class 'logging.Logger'>: Returns a Python logger object with Site and Bench level logging capabilities.
-	"""
-	if allow_site is True:
-		site = getattr(frappe.local, "site", None)
-	elif allow_site in get_sites():
-		site = allow_site
-	else:
-		site = False
-
-	logger_name = "{0}-{1}".format(module, site or "all")
-
-	try:
-		return frappe.loggers[logger_name]
-	except KeyError:
-		pass
-
-	if not module:
-		module = "frappe"
-		with_more_info = True
-
-
-	logger = logging.getLogger(logger_name)
-	logger.setLevel(frappe.log_level or default_log_level)
-	logger.propagate = False
-
-	formatter = logging.Formatter("%(asctime)s %(levelname)s {0} %(message)s".format(module))
-	handler = logging.StreamHandler()
-	handler.setFormatter(formatter)
-	logger.addHandler(handler)
 
 	if with_more_info:
 		handler.addFilter(SiteContextFilter())


### PR DESCRIPTION
Using rotating logs on NFS-like storage can raise exceptions due to invalid file descriptors. This happens specifically when one process has a file opened and other process move or delete the same file. On NFS filesystems this raises the `NFS4ERR_STALE` error. This use case were found using frappe/erpnext deployed on kubernetes (with several replicas) using AWS EFS as storage filesystem.


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
