### PR TITLE
fix: Print login url before launching url in browser

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -853,8 +853,7 @@ def browse(context, site, user=None):
 
 	url = f'{frappe.utils.get_site_url(site)}{sid}'
 
-	if user == "Administrator":
-		click.echo(f'Login URL: {url}')
+	click.echo(f'Login URL: {url}')
 
 	click.launch(url)
 


### PR DESCRIPTION
Currently, we are logging url only for `Administator` user. For other users, even though it is opening the url in browser, we are not printing it. 

This is a problem when using a remote machine. Since bench can't launch a browser in remote machine, this command will become useless for other users. 

If we print the url, we can copy the url and use it on system browsers.