### PR TITLE
fix: dont return docinfo as `message`

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -124,7 +124,6 @@ def get_docinfo(doc=None, doctype=None, name=None):
 	update_user_info(docinfo)
 
 	frappe.response["docinfo"] = docinfo
-	return docinfo
 
 def add_comments(doc, docinfo):
 	# divide comments into separate lists

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -168,8 +168,8 @@ class TestFormLoad(unittest.TestCase):
 			"reference_name": note.name,
 		}).insert()
 
-
-		docinfo = get_docinfo(note)
+		get_docinfo(note)
+		docinfo = frappe.response["docinfo"]
 
 		self.assertEqual(len(docinfo.comments), 1)
 		self.assertIn("test", docinfo.comments[0].content)


### PR DESCRIPTION
The return was added for testability but it also becomes part of the response when the whitelisted function is called directly, so response size doubles. :)

Doesn't affect perf much since direct calls to this function are limited, it mostly gets called from `getdoc`.

caused by https://github.com/frappe/frappe/pull/15821 