### PR TITLE
fix(ux)!: when error messages are present, supress non-error messages

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -136,8 +136,8 @@ frappe.msgprint = function(msg, title, is_minimizable) {
 	if(data.message instanceof Array) {
 		let messages = data.message;
 		const exceptions = messages
-							.map(m => JSON.parse(m))
-							.filter(m => m.raise_exception);
+			.map(m => JSON.parse(m))
+			.filter(m => m.raise_exception);
 
 		// only show exceptions if any exceptions exist
 		if (exceptions.length) {

--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -134,7 +134,17 @@ frappe.msgprint = function(msg, title, is_minimizable) {
 	}
 
 	if(data.message instanceof Array) {
-		data.message.forEach(function(m) {
+		let messages = data.message;
+		const exceptions = messages
+							.map(m => JSON.parse(m))
+							.filter(m => m.raise_exception);
+
+		// only show exceptions if any exceptions exist
+		if (exceptions.length) {
+			messages = exceptions;
+		}
+
+		messages.forEach(function(m) {
 			frappe.msgprint(m);
 		});
 		return;


### PR DESCRIPTION
Problem: During network request handling we often print several messages to help users... however during the course of handling such requests a single `frappe.throw` usually means full rollback of everything that happened in the request. Hence previous messages make no sense.

Summary of change: if there are any messages with `raise_exception` then only show errors. 


Minimal reproducible example:

```python
def onload(self):
    frappe.msgprint("success")
    frappe.throw("failure")
```

This will show up as:
<img width="598" alt="Screenshot 2022-03-15 at 1 52 48 PM" src="https://user-images.githubusercontent.com/9079960/158342579-c1b4904a-bc26-4167-b1e8-4ee5429c6063.png">



Another real example when serial no generation fails:

<img width="598" alt="Screenshot 2022-03-15 at 2 49 47 PM" src="https://user-images.githubusercontent.com/9079960/158346104-8da53c37-8b99-49d6-ad57-874b931c42fd.png">




XP vibes.

<img width="598" alt="EEXPEEE" src="https://user-images.githubusercontent.com/9079960/158342860-cb905267-244f-48ce-aee5-b7e961b7ad61.png">




After this change:
<img width="598" alt="Screenshot 2022-03-15 at 2 31 26 PM" src="https://user-images.githubusercontent.com/9079960/158342630-7ae67bcc-ef76-4037-996c-28c0e76f97e3.png">

<img width="598" alt="Screenshot 2022-03-15 at 2 49 58 PM" src="https://user-images.githubusercontent.com/9079960/158346164-5a7f98c2-d02f-4bbf-83c5-ef165ccc424b.png">




closes https://github.com/frappe/frappe/issues/15674