### PR TITLE
feat: Drop site support for postgres

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -677,7 +677,9 @@ def _drop_site(site, db_root_username=None, db_root_password=None, archived_site
 
 	try:
 		if not no_backup:
-			scheduled_backup(ignore_files=False, force=True)
+			click.secho(f"Taking backup of {site}", fg="green")
+			odb = scheduled_backup(ignore_files=False, force=True, verbose=True)
+			odb.print_summary()
 	except Exception as err:
 		if force:
 			pass
@@ -692,6 +694,7 @@ def _drop_site(site, db_root_username=None, db_root_password=None, archived_site
 			click.echo("\n".join(messages))
 			sys.exit(1)
 
+	click.secho("Dropping site database and user", fg="green")
 	drop_user_and_database(frappe.conf.db_name, db_root_username, db_root_password)
 
 	archived_sites_path = archived_sites_path or os.path.join(frappe.get_app_path('frappe'), '..', '..', '..', 'archived', 'sites')

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -18,7 +18,8 @@ def setup_database(force, source_sql=None, verbose=None, no_mariadb_socket=False
 def drop_user_and_database(db_name, root_login=None, root_password=None):
 	import frappe
 	if frappe.conf.db_type == 'postgres':
-		pass
+		import frappe.database.postgres.setup_db
+		return frappe.database.postgres.setup_db.drop_user_and_database(db_name, root_login, root_password)
 	else:
 		import frappe.database.mariadb.setup_db
 		return frappe.database.mariadb.setup_db.drop_user_and_database(db_name, root_login, root_password)

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -95,3 +95,11 @@ def get_root_connection(root_login=None, root_password=None):
 		frappe.local.flags.root_connection = frappe.database.get_db(user=root_login, password=root_password)
 
 	return frappe.local.flags.root_connection
+
+
+def drop_user_and_database(db_name, root_login, root_password):
+	root_conn = get_root_connection(frappe.flags.root_login or root_login, frappe.flags.root_password or root_password)
+	root_conn.commit()
+	root_conn.sql(f"SELECT pg_terminate_backend (pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = %s", (db_name, ))
+	root_conn.sql(f"DROP DATABASE IF EXISTS {db_name}")
+	root_conn.sql(f"DROP USER IF EXISTS {db_name}")


### PR DESCRIPTION
### Changes

* `drop-site` for Postgres sites just deleted the site folder but left the Database (and stuff) behind. Adding support to drop that (consistent with MariaDB sites).
* Added verbosity for showing Database backup + dropping process.

<!-- no-docs -->