### PR TITLE
fix: misc fixes (integer primary keys)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1925,7 +1925,7 @@ def attach_print(
 
 	if not file_name:
 		file_name = name
-	file_name = file_name.replace(" ", "").replace("/", "-")
+	file_name = cstr(file_name).replace(' ','').replace('/','-')
 
 	print_settings = db.get_singles_dict("Print Settings")
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -232,7 +232,6 @@ def init(site, sites_path=None, new_site=False):
 	local.cache = {}
 	local.document_cache = {}
 	local.meta_cache = {}
-	local.autoincremented_status_map = {site: -1}
 	local.form_dict = _dict()
 	local.session = _dict()
 	local.dev_server = _dev_server

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1925,7 +1925,7 @@ def attach_print(
 
 	if not file_name:
 		file_name = name
-	file_name = cstr(file_name).replace(' ','').replace('/','-')
+	file_name = cstr(file_name).replace(" ", "").replace("/", "-")
 
 	print_settings = db.get_singles_dict("Print Settings")
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -106,6 +106,7 @@ def application(request):
 
 
 def init_request(request):
+	print("boi oh boi im in request")
 	frappe.local.request = request
 	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -106,7 +106,6 @@ def application(request):
 
 
 def init_request(request):
-	print("boi oh boi im in request")
 	frappe.local.request = request
 	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -127,7 +127,7 @@ class DocType(Document):
 		if can_change_name_column_type(self):
 			change_name_column_type(
 				self.name,
-				"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})"
+				"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})",
 			)
 
 	def validate_field_name_conflicts(self):
@@ -903,13 +903,11 @@ def validate_series(dt, autoname=None, name=None):
 			frappe.throw(_("Series {0} already used in {1}").format(prefix, used_in[0][0]))
 
 
-def can_change_name_column_type(dt: DocType, raise_err: bool=True) -> bool:
+def can_change_name_column_type(dt: DocType, raise_err: bool = True) -> bool:
 	def get_autoname_before_save(doctype: str, to_be_customized_dt: str) -> str:
 		if doctype == "Customize Form":
 			property_value = frappe.db.get_value(
-				"Property Setter",
-				{"doc_type": to_be_customized_dt, "property": "autoname"},
-				"value"
+				"Property Setter", {"doc_type": to_be_customized_dt, "property": "autoname"}, "value"
 			)
 
 			# initially no property setter is set,
@@ -927,8 +925,10 @@ def can_change_name_column_type(dt: DocType, raise_err: bool=True) -> bool:
 		autoname_before_save = get_autoname_before_save(dt.doctype, doctype_name)
 		is_autoname_autoincrement = dt.autoname == "autoincrement"
 
-		if is_autoname_autoincrement and autoname_before_save != "autoincrement" or (
-			not is_autoname_autoincrement and autoname_before_save == "autoincrement"
+		if (
+			is_autoname_autoincrement
+			and autoname_before_save != "autoincrement"
+			or (not is_autoname_autoincrement and autoname_before_save == "autoincrement")
 		):
 			if not frappe.get_all(doctype_name, limit=1):
 				# allow changing the column type if there is no data
@@ -944,10 +944,7 @@ def can_change_name_column_type(dt: DocType, raise_err: bool=True) -> bool:
 
 def change_name_column_type(doctype_name: str, type: str) -> None:
 	return frappe.db.change_column_type(
-		doctype_name,
-		"name",
-		type,
-		True if frappe.db.db_type == "mariadb" else False
+		doctype_name, "name", type, True if frappe.db.db_type == "mariadb" else False
 	)
 
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -124,7 +124,7 @@ class DocType(Document):
 		if self.default_print_format and not self.custom:
 			frappe.throw(_("Standard DocType cannot have default print format, use Customize Form"))
 
-		if can_change_name_column_type(self):
+		if check_if_can_change_name_type(self):
 			change_name_column_type(
 				self.name,
 				"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})",
@@ -903,7 +903,7 @@ def validate_series(dt, autoname=None, name=None):
 			frappe.throw(_("Series {0} already used in {1}").format(prefix, used_in[0][0]))
 
 
-def can_change_name_column_type(dt: DocType, raise_err: bool = True) -> bool:
+def check_if_can_change_name_type(dt: DocType, raise_err: bool = True) -> bool:
 	def get_autoname_before_save(doctype: str, to_be_customized_dt: str) -> str:
 		if doctype == "Customize Form":
 			property_value = frappe.db.get_value(

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -92,10 +92,10 @@ class DocType(Document):
 
 		self.check_developer_mode()
 
-		self.validate_autoname()
 		self.validate_name()
 
 		self.set_defaults_for_single_and_table()
+		self.set_defaults_for_autoincremented()
 		self.scrub_field_names()
 		self.set_default_in_list_view()
 		self.set_default_translatable()
@@ -123,6 +123,12 @@ class DocType(Document):
 
 		if self.default_print_format and not self.custom:
 			frappe.throw(_("Standard DocType cannot have default print format, use Customize Form"))
+
+		if can_change_name_column_type(self):
+			change_name_column_type(
+				self.name,
+				"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})"
+			)
 
 	def validate_field_name_conflicts(self):
 		"""Check if field names dont conflict with controller properties and methods"""
@@ -183,6 +189,10 @@ class DocType(Document):
 		elif self.istable:
 			self.allow_import = 0
 			self.permissions = []
+
+	def set_defaults_for_autoincremented(self):
+		if self.autoname and self.autoname == "autoincrement":
+			self.allow_rename = 0
 
 	def set_default_in_list_view(self):
 		"""Set default in-list-view for first 4 mandatory fields"""
@@ -809,28 +819,6 @@ class DocType(Document):
 		max_idx = frappe.db.sql("""select max(idx) from `tabDocField` where parent = %s""", self.name)
 		return max_idx and max_idx[0][0] or 0
 
-	def validate_autoname(self):
-		if not self.is_new():
-			doc_before_save = self.get_doc_before_save()
-			if doc_before_save:
-				if (self.autoname == "autoincrement" and doc_before_save.autoname != "autoincrement") or (
-					self.autoname != "autoincrement" and doc_before_save.autoname == "autoincrement"
-				):
-					if not frappe.get_all(self.name, limit=1):
-						# allow changing the column type if no data is there
-
-						frappe.db.change_column_type(
-							self.name,
-							"name",
-							"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})",
-							True
-						)
-						return
-
-					frappe.throw(_("Cannot change to/from Autoincrement naming rule"))
-		if self.autoname == "autoincrement":
-			self.allow_rename = 0
-
 	def validate_name(self, name=None):
 		if not name:
 			name = self.name
@@ -898,7 +886,7 @@ def validate_series(dt, autoname=None, name=None):
 		autoname
 		and (not autoname.startswith("field:"))
 		and (not autoname.startswith("eval:"))
-		and (not autoname.lower() in ("prompt", "hash"))
+		and (autoname.lower() not in ("prompt", "hash"))
 		and (not autoname.startswith("naming_series:"))
 		and (not autoname.startswith("format:"))
 	):
@@ -913,6 +901,54 @@ def validate_series(dt, autoname=None, name=None):
 		).run()
 		if used_in:
 			frappe.throw(_("Series {0} already used in {1}").format(prefix, used_in[0][0]))
+
+
+def can_change_name_column_type(dt: DocType, raise_err: bool=True) -> bool:
+	def get_autoname_before_save(doctype: str, to_be_customized_dt: str) -> str:
+		if doctype == "Customize Form":
+			property_value = frappe.db.get_value(
+				"Property Setter",
+				{"doc_type": to_be_customized_dt, "property": "autoname"},
+				"value"
+			)
+
+			# initially no property setter is set,
+			# hence getting autoname value from the doctype itself
+			if not property_value:
+				return frappe.db.get_value("DocType", to_be_customized_dt, "autoname") or ""
+
+			return property_value
+
+		return getattr(dt.get_doc_before_save(), "autoname", "")
+
+	doctype_name = dt.doc_type if dt.doctype == "Customize Form" else dt.name
+
+	if not dt.is_new():
+		autoname_before_save = get_autoname_before_save(dt.doctype, doctype_name)
+		is_autoname_autoincrement = dt.autoname == "autoincrement"
+
+		if is_autoname_autoincrement and autoname_before_save != "autoincrement" or (
+			not is_autoname_autoincrement and autoname_before_save == "autoincrement"
+		):
+			if not frappe.get_all(doctype_name, limit=1):
+				# allow changing the column type if there is no data
+				return True
+
+			if raise_err:
+				frappe.throw(
+					_("Can only change to/from Autoincrement naming rule when there is no data in the doctype")
+				)
+
+	return False
+
+
+def change_name_column_type(doctype_name: str, type: str) -> None:
+	return frappe.db.change_column_type(
+		doctype_name,
+		"name",
+		type,
+		True
+	)
 
 
 def validate_links_table_fieldnames(meta):

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -816,6 +816,17 @@ class DocType(Document):
 				if (self.autoname == "autoincrement" and doc_before_save.autoname != "autoincrement") or (
 					self.autoname != "autoincrement" and doc_before_save.autoname == "autoincrement"
 				):
+					if not frappe.get_all(self.name, limit=1):
+						# allow changing the column type if no data is there
+
+						frappe.db.change_column_type(
+							self.name,
+							"name",
+							"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})",
+							True
+						)
+						return
+
 					frappe.throw(_("Cannot change to/from Autoincrement naming rule"))
 		if self.autoname == "autoincrement":
 			self.allow_rename = 0

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -947,7 +947,7 @@ def change_name_column_type(doctype_name: str, type: str) -> None:
 		doctype_name,
 		"name",
 		type,
-		True
+		True if frappe.db.db_type == "mariadb" else False
 	)
 
 

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -530,10 +530,9 @@ class TestDocType(unittest.TestCase):
 
 		dt.save(ignore_permissions=True)
 
-		dt_data = frappe.get_doc({
-			"doctype": dt.name,
-			"some_fieldname": "test data"
-		}).insert(ignore_permissions=True)
+		dt_data = frappe.get_doc({"doctype": dt.name, "some_fieldname": "test data"}).insert(
+			ignore_permissions=True
+		)
 
 		dt.autoname = "autoincrement"
 
@@ -542,7 +541,7 @@ class TestDocType(unittest.TestCase):
 		except frappe.ValidationError as e:
 			self.assertEqual(
 				e.args[0],
-				"Can only change to/from Autoincrement naming rule when there is no data in the doctype"
+				"Can only change to/from Autoincrement naming rule when there is no data in the doctype",
 			)
 		else:
 			self.fail(

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -287,7 +287,7 @@
    "label": "Naming"
   },
   {
-   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
+   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li>\n<li><b>autoincrement</b> - Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name"
@@ -319,7 +319,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-01-07 16:07:06.196534",
+ "modified": "2022-04-21 15:36:16.772277",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -11,9 +11,9 @@ import frappe
 import frappe.translate
 from frappe import _
 from frappe.core.doctype.doctype.doctype import (
-	can_change_name_column_type,
 	change_name_column_type,
 	check_email_append_to,
+	check_if_can_change_name_type,
 	validate_fields_for_doctype,
 	validate_series,
 )
@@ -163,7 +163,7 @@ class CustomizeForm(Document):
 			return
 
 		validate_series(self, self.autoname, self.doc_type)
-		is_name_type_changable = can_change_name_column_type(self)
+		can_change_name_type = check_if_can_change_name_type(self)
 		self.flags.update_db = False
 		self.flags.rebuild_doctype_for_global_search = False
 		self.set_property_setters()
@@ -172,7 +172,7 @@ class CustomizeForm(Document):
 		validate_fields_for_doctype(self.doc_type)
 		check_email_append_to(self)
 
-		if is_name_type_changable:
+		if can_change_name_type:
 			change_name_column_type(
 				self.doc_type,
 				"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -11,11 +11,11 @@ import frappe
 import frappe.translate
 from frappe import _
 from frappe.core.doctype.doctype.doctype import (
+	can_change_name_column_type,
+	change_name_column_type,
 	check_email_append_to,
 	validate_fields_for_doctype,
 	validate_series,
-	can_change_name_column_type,
-	change_name_column_type,
 )
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.custom.doctype.property_setter.property_setter import delete_property_setter
@@ -175,7 +175,7 @@ class CustomizeForm(Document):
 		if is_name_type_changable:
 			change_name_column_type(
 				self.doc_type,
-				"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})"
+				"bigint" if self.autoname == "autoincrement" else f"varchar({frappe.db.VARCHAR_LEN})",
 			)
 
 		if self.flags.update_db:

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1250,11 +1250,11 @@ class Database(object):
 		from frappe.database.sequence import create_sequence
 		return create_sequence(*args, **kwargs)
 
-	def set_next_val(self, *args, **kwargs):
+	def set_next_sequence_val(self, *args, **kwargs):
 		from frappe.database.sequence import set_next_val
 		set_next_val(*args, **kwargs)
 
-	def get_next_val(self, *args, **kwargs):
+	def get_next_sequence_val(self, *args, **kwargs):
 		from frappe.database.sequence import get_next_val
 		return get_next_val(*args, **kwargs)
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1246,6 +1246,18 @@ class Database(object):
 			values_to_insert = values[start_index : start_index + chunk_size]
 			query.columns(fields).insert(*values_to_insert).run()
 
+	def create_sequence(self, *args, **kwargs):
+		from frappe.database.sequence import create_sequence
+		return create_sequence(*args, **kwargs)
+
+	def set_next_val(self, *args, **kwargs):
+		from frappe.database.sequence import set_next_val
+		set_next_val(*args, **kwargs)
+
+	def get_next_val(self, *args, **kwargs):
+		from frappe.database.sequence import get_next_val
+		return get_next_val(*args, **kwargs)
+
 
 def enqueue_jobs_after_commit():
 	from frappe.utils.background_jobs import execute_job, get_queue

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1248,14 +1248,17 @@ class Database(object):
 
 	def create_sequence(self, *args, **kwargs):
 		from frappe.database.sequence import create_sequence
+
 		return create_sequence(*args, **kwargs)
 
 	def set_next_sequence_val(self, *args, **kwargs):
 		from frappe.database.sequence import set_next_val
+
 		set_next_val(*args, **kwargs)
 
 	def get_next_sequence_val(self, *args, **kwargs):
 		from frappe.database.sequence import get_next_val
+
 		return get_next_val(*args, **kwargs)
 
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -149,7 +149,7 @@ class MariaDBDatabase(Database):
 	) -> Union[List, Tuple]:
 		table_name = get_table_name(doctype)
 		null_constraint = "NOT NULL" if not nullable else ""
-		return self.sql(f"ALTER TABLE `{table_name}` MODIFY `{column}` {type} {null_constraint}")
+		return self.sql_ddl(f"ALTER TABLE `{table_name}` MODIFY `{column}` {type} {null_constraint}")
 
 	# exception types
 	@staticmethod

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe import _
 from frappe.database.schema import DBTable
-from frappe.database.sequence import create_sequence
 from frappe.model import log_types
 
 
@@ -48,7 +47,7 @@ class MariaDBTable(DBTable):
 			# By default the cache is 1000 which will mess up the sequence when
 			# using the system after a restore.
 			# issue link: https://jira.mariadb.org/browse/MDEV-21786
-			create_sequence(self.doctype, check_not_exists=True, cache=50)
+			frappe.db.create_sequence(self.doctype, check_not_exists=True, cache=50)
 
 			# NOTE: not used nextval func as default as the ability to restore
 			# database with sequences has bugs in mariadb and gives a scary error.

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -382,12 +382,10 @@ def modify_query(query):
 	# drop .0 from decimals and add quotes around them
 	#
 	# >>> query = "c='abcd' , a >= 45, b = -45.0, c =   40, d=4500.0, e=3500.53, f=40psdfsd, g=9092094312, h=12.00023"
-	# >>> re.sub(r"([=><]+)\s*(?!\d+[a-zA-Z])(?![+-]?\d+\.\d\d+)([+-]?\d+)(\.0)?", r"\1 '\2'", query)
+	# >>> re.sub(r"([=><]+)\s*([+-]?\d+)(\.0)?(?![a-zA-Z\.\d])", r"\1 '\2'", query)
 	# 	"c='abcd' , a >= '45', b = '-45', c = '40', d= '4500', e=3500.53, f=40psdfsd, g= '9092094312', h=12.00023
 
-	query = re.sub(
-		r"([=><]+)\s*(?!\d+[a-zA-Z])(?![+-]?\d+\.\d\d+)([+-]?\d+)(\.0)?", r"\1 '\2'", query
-	)
+	query = re.sub(r"([=><]+)\s*([+-]?\d+)(\.0)?(?![a-zA-Z\.\d])", r"\1 '\2'", query)
 	return query
 
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -213,7 +213,11 @@ class PostgresDatabase(Database):
 	) -> Union[List, Tuple]:
 		table_name = get_table_name(doctype)
 		null_constraint = "SET NOT NULL" if not nullable else "DROP NOT NULL"
-		return self.sql(
+
+		# postgres allows ddl in transactions but since we've currently made
+		# things same as mariadb (raising exception on ddl commands if the transaction has any writes),
+		# hence using sql_ddl here for committing and then moving forward.
+		return self.sql_ddl(
 			f"""ALTER TABLE "{table_name}"
 								ALTER COLUMN "{column}" TYPE {type},
 								ALTER COLUMN "{column}" {null_constraint}"""

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -1,7 +1,6 @@
 import frappe
 from frappe import _
 from frappe.database.schema import DBTable, get_definition
-from frappe.database.sequence import create_sequence
 from frappe.model import log_types
 from frappe.utils import cint, flt
 
@@ -39,7 +38,7 @@ class PostgresTable(DBTable):
 			# Since we're opening and closing connections for every transaction this results in skipping the cache
 			# to the next non-cached value hence not using cache in postgres.
 			# ref: https://stackoverflow.com/questions/21356375/postgres-9-0-4-sequence-skipping-numbers
-			create_sequence(self.doctype, check_not_exists=True)
+			frappe.db.create_sequence(self.doctype, check_not_exists=True)
 			name_column = "name bigint primary key"
 
 		# TODO: set docstatus length

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -56,9 +56,10 @@ def create_sequence(
 
 
 def get_next_val(doctype_name: str, slug: str = "_id_seq") -> int:
-	if db.db_type == "postgres":
-		return db.sql(f"select nextval('\"{scrub(doctype_name + slug)}\"')")[0][0]
-	return db.sql(f"select nextval(`{scrub(doctype_name + slug)}`)")[0][0]
+	return db.multisql({
+		"postgres": f"select nextval(\'\"{scrub(doctype_name + slug)}\"\')",
+		"mariadb": f"select nextval(`{scrub(doctype_name + slug)}`)"
+	})[0][0]
 
 
 def set_next_val(
@@ -67,7 +68,7 @@ def set_next_val(
 
 	is_val_used = "false" if not is_val_used else "true"
 
-	if db.db_type == "postgres":
-		db.sql(f"SELECT SETVAL('\"{scrub(doctype_name + slug)}\"', {next_val}, {is_val_used})")
-	else:
-		db.sql(f"SELECT SETVAL(`{scrub(doctype_name + slug)}`, {next_val}, {is_val_used})")
+	db.multisql({
+		"postgres": f"SELECT SETVAL('\"{scrub(doctype_name + slug)}\"', {next_val}, {is_val_used})",
+		"mariadb": f"SELECT SETVAL(`{scrub(doctype_name + slug)}`, {next_val}, {is_val_used})"
+	})

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -5,6 +5,7 @@ def create_sequence(
 	doctype_name: str,
 	*,
 	slug: str = "_id_seq",
+	temporary = False,
 	check_not_exists: bool = False,
 	cycle: bool = False,
 	cache: int = 0,
@@ -14,7 +15,7 @@ def create_sequence(
 	max_value: int = 0,
 ) -> str:
 
-	query = "create sequence"
+	query = "create sequence" if not temporary else "create temporary sequence"
 	sequence_name = scrub(doctype_name + slug)
 
 	if check_not_exists:

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -57,7 +57,7 @@ def create_sequence(
 
 def get_next_val(doctype_name: str, slug: str = "_id_seq") -> int:
 	return db.multisql({
-		"postgres": f"select nextval(\'\"{scrub(doctype_name + slug)}\"\')",
+		"postgres": f"select nextval('\"{scrub(doctype_name + slug)}\"')",
 		"mariadb": f"select nextval(`{scrub(doctype_name + slug)}`)"
 	})[0][0]
 

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -65,12 +65,9 @@ def set_next_val(
 	doctype_name: str, next_val: int, *, slug: str = "_id_seq", is_val_used: bool = False
 ) -> None:
 
-	if not is_val_used:
-		is_val_used = 0 if db.db_type == "mariadb" else "f"
-	else:
-		is_val_used = 1 if db.db_type == "mariadb" else "t"
+	is_val_used = "false" if not is_val_used else "true"
 
 	if db.db_type == "postgres":
-		db.sql(f"SELECT SETVAL('\"{scrub(doctype_name + slug)}\"', {next_val}, '{is_val_used}')")
+		db.sql(f"SELECT SETVAL('\"{scrub(doctype_name + slug)}\"', {next_val}, {is_val_used})")
 	else:
 		db.sql(f"SELECT SETVAL(`{scrub(doctype_name + slug)}`, {next_val}, {is_val_used})")

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -5,7 +5,7 @@ def create_sequence(
 	doctype_name: str,
 	*,
 	slug: str = "_id_seq",
-	temporary = False,
+	temporary=False,
 	check_not_exists: bool = False,
 	cycle: bool = False,
 	cache: int = 0,
@@ -57,10 +57,12 @@ def create_sequence(
 
 
 def get_next_val(doctype_name: str, slug: str = "_id_seq") -> int:
-	return db.multisql({
-		"postgres": f"select nextval('\"{scrub(doctype_name + slug)}\"')",
-		"mariadb": f"select nextval(`{scrub(doctype_name + slug)}`)"
-	})[0][0]
+	return db.multisql(
+		{
+			"postgres": f"select nextval('\"{scrub(doctype_name + slug)}\"')",
+			"mariadb": f"select nextval(`{scrub(doctype_name + slug)}`)",
+		}
+	)[0][0]
 
 
 def set_next_val(
@@ -69,7 +71,9 @@ def set_next_val(
 
 	is_val_used = "false" if not is_val_used else "true"
 
-	db.multisql({
-		"postgres": f"SELECT SETVAL('\"{scrub(doctype_name + slug)}\"', {next_val}, {is_val_used})",
-		"mariadb": f"SELECT SETVAL(`{scrub(doctype_name + slug)}`, {next_val}, {is_val_used})"
-	})
+	db.multisql(
+		{
+			"postgres": f"SELECT SETVAL('\"{scrub(doctype_name + slug)}\"', {next_val}, {is_val_used})",
+			"mariadb": f"SELECT SETVAL(`{scrub(doctype_name + slug)}`, {next_val}, {is_val_used})",
+		}
+	)

--- a/frappe/database/sequence.py
+++ b/frappe/database/sequence.py
@@ -22,29 +22,29 @@ def create_sequence(
 
 	query += f" {sequence_name}"
 
-	if cache:
-		query += f" cache {cache}"
-	else:
-		# in postgres, the default is cache 1
-		if db.db_type == "mariadb":
-			query += " nocache"
-
-	if start_value:
-		# default is 1
-		query += f" start with {start_value}"
-
 	if increment_by:
 		# default is 1
 		query += f" increment by {increment_by}"
 
 	if min_value:
 		# default is 1
-		query += f" min value {min_value}"
+		query += f" minvalue {min_value}"
 
 	if max_value:
-		query += f" max value {max_value}"
+		query += f" maxvalue {max_value}"
+
+	if start_value:
+		# default is 1
+		query += f" start {start_value}"
+
+	# in postgres, the default is cache 1 / no cache
+	if cache:
+		query += f" cache {cache}"
+	elif db.db_type == "mariadb":
+		query += " nocache"
 
 	if not cycle:
+		# in postgres, default is no cycle
 		if db.db_type == "mariadb":
 			query += " nocycle"
 	else:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -767,7 +767,7 @@ class DatabaseQuery(object):
 			return self.match_filters
 
 	def get_share_condition(self):
-		return self.cast_name(f"`tab{self.doctype}`.name") + " in ({', '.join(frappe.db.escape(s, percent=False) for s in self.shared)})"
+		return self.cast_name(f"`tab{self.doctype}`.name") + f" in ({', '.join(frappe.db.escape(s, percent=False) for s in self.shared)})"
 
 	def add_user_permissions(self, user_permissions):
 		meta = frappe.get_meta(self.doctype)
@@ -816,7 +816,7 @@ class DatabaseQuery(object):
 
 				if docs:
 					values = ", ".join(frappe.db.escape(doc, percent=False) for doc in docs)
-					condition += f"`tab{self.doctype}`.`{df.get('fieldname')}` in ({values})"
+					condition += self.cast_name(f"`tab{self.doctype}`.`{df.get('fieldname')}`") + f" in ({values})"
 					match_conditions.append(f"({condition})")
 					match_filters[df.get("options")] = docs
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -543,9 +543,8 @@ class DatabaseQuery(object):
 		if tname not in self.tables:
 			self.append_table(tname)
 
-		column_name = self.cast_name(f.fieldname) if (
-			'ifnull(' in f.fieldname
-			) else self.cast_name(f"{tname}.`{f.fieldname}`")
+		column_name = f.fieldname if 'ifnull(' in f.fieldname else f"{tname}.`{f.fieldname}`"
+		column_name = self.cast_name(column_name)
 
 		if f.operator.lower() in additional_filters_config:
 			f.update(get_additional_filter_field(additional_filters_config, f, f.value))

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -909,7 +909,11 @@ def cast_name(column: str) -> str:
 	3. ifnull
 	4. coalesce
 
-	Uses regex substitution."""
+	Uses regex substitution.
+
+	Example:
+	input - "ifnull(`tabBlog Post`.`name`, '')=''"
+	output - "ifnull(cast(`tabBlog Post`.`name` as varchar), '')=''" """
 
 	if frappe.db.db_type == "mariadb":
 		return column

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -506,9 +506,7 @@ class DatabaseQuery(object):
 		if tname not in self.tables:
 			self.append_table(tname)
 
-		column_name = cast_name(
-			f.fieldname if 'ifnull(' in f.fieldname else f"{tname}.`{f.fieldname}`"
-		)
+		column_name = cast_name(f.fieldname if "ifnull(" in f.fieldname else f"{tname}.`{f.fieldname}`")
 
 		if f.operator.lower() in additional_filters_config:
 			f.update(get_additional_filter_field(additional_filters_config, f, f.value))
@@ -730,7 +728,10 @@ class DatabaseQuery(object):
 			return self.match_filters
 
 	def get_share_condition(self):
-		return cast_name(f"`tab{self.doctype}`.name") + f" in ({', '.join(frappe.db.escape(s, percent=False) for s in self.shared)})"
+		return (
+			cast_name(f"`tab{self.doctype}`.name")
+			+ f" in ({', '.join(frappe.db.escape(s, percent=False) for s in self.shared)})"
+		)
 
 	def add_user_permissions(self, user_permissions):
 		meta = frappe.get_meta(self.doctype)
@@ -758,7 +759,9 @@ class DatabaseQuery(object):
 				if frappe.get_system_settings("apply_strict_user_permissions"):
 					condition = ""
 				else:
-					empty_value_condition = cast_name(f"ifnull(`tab{self.doctype}`.`{df.get('fieldname')}`, '')=''")
+					empty_value_condition = cast_name(
+						f"ifnull(`tab{self.doctype}`.`{df.get('fieldname')}`, '')=''"
+					)
 					condition = empty_value_condition + " or "
 
 				for permission in user_permission_values:
@@ -895,6 +898,7 @@ class DatabaseQuery(object):
 			user_settings["fields"] = self.user_settings_fields
 
 		update_user_settings(self.doctype, user_settings)
+
 
 def cast_name(column: str) -> str:
 	"""Casts name field to varchar for postgres

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -767,7 +767,7 @@ class DatabaseQuery(object):
 			return self.match_filters
 
 	def get_share_condition(self):
-		return f"`tab{self.doctype}`.name in ({', '.join(frappe.db.escape(s, percent=False) for s in self.shared)})"
+		return self.cast_name(f"`tab{self.doctype}`.name") + " in ({', '.join(frappe.db.escape(s, percent=False) for s in self.shared)})"
 
 	def add_user_permissions(self, user_permissions):
 		meta = frappe.get_meta(self.doctype)

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 	from frappe.model.meta import Meta
 
 
+autoincremented_status_map = {}
+
 def set_new_name(doc):
 	"""
 	Sets the `name` property for the document based on various rules.
@@ -74,23 +76,18 @@ def set_new_name(doc):
 
 def is_autoincremented(doctype: str, meta: "Meta" = None):
 	if doctype in log_types:
-		if (
-			frappe.local.autoincremented_status_map.get(frappe.local.site) is None
-			or frappe.local.autoincremented_status_map[frappe.local.site] == -1
-		):
-			if (
-				frappe.db.sql(
-					f"""select data_type FROM information_schema.columns
+		print(autoincremented_status_map.get(frappe.local.site))
+		if autoincremented_status_map.get(frappe.local.site) is None:
+			if frappe.db.sql(
+				f"""select data_type FROM information_schema.columns
 				where column_name = 'name' and table_name = 'tab{doctype}'"""
-				)[0][0]
-				== "bigint"
-			):
-				frappe.local.autoincremented_status_map[frappe.local.site] = 1
+			)[0][0] == "bigint":
+				autoincremented_status_map[frappe.local.site] = 1
 				return True
 			else:
-				frappe.local.autoincremented_status_map[frappe.local.site] = 0
+				autoincremented_status_map[frappe.local.site] = 0
 
-		elif frappe.local.autoincremented_status_map[frappe.local.site]:
+		elif autoincremented_status_map[frappe.local.site]:
 			return True
 
 	else:

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 # NOTE: This is used to keep track of status of sites
-# whether the `log_types`` have autoincremented naming set for the site or not.
+# whether `log_types` have autoincremented naming set for the site or not.
 autoincremented_site_status_map = {}
 
 
@@ -76,6 +76,8 @@ def set_new_name(doc):
 
 
 def is_autoincremented(doctype: str, meta: Optional["Meta"] = None) -> bool:
+	"""Checks if the doctype has autoincrement autoname set"""
+
 	if doctype in log_types:
 		if autoincremented_site_status_map.get(frappe.local.site) is None:
 			if (

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
 autoincremented_site_status_map = {}
 
+
 def set_new_name(doc):
 	"""
 	Sets the `name` property for the document based on various rules.
@@ -75,10 +76,13 @@ def set_new_name(doc):
 def is_autoincremented(doctype: str, meta: Optional["Meta"] = None) -> bool:
 	if doctype in log_types:
 		if autoincremented_site_status_map.get(frappe.local.site) is None:
-			if frappe.db.sql(
-				f"""select data_type FROM information_schema.columns
+			if (
+				frappe.db.sql(
+					f"""select data_type FROM information_schema.columns
 				where column_name = 'name' and table_name = 'tab{doctype}'"""
-			)[0][0] == "bigint":
+				)[0][0]
+				== "bigint"
+			):
 				autoincremented_site_status_map[frappe.local.site] = 1
 				return True
 			else:

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -37,9 +37,7 @@ def set_new_name(doc):
 		doc.name = None
 
 	if is_autoincremented(doc.doctype, meta):
-		from frappe.database.sequence import get_next_val
-
-		doc.name = get_next_val(doc.doctype)
+		doc.name = frappe.db.get_next_sequence_val(doc.doctype)
 		return
 
 	if getattr(doc, "amended_from", None):
@@ -322,11 +320,9 @@ def validate_name(doctype: str, name: Union[int, str], case: Optional[str] = Non
 
 	if isinstance(name, int):
 		if is_autoincremented(doctype):
-			from frappe.database.sequence import set_next_val
-
-			# this will set the sequence val to be the provided name and set it to be used
-			# so that the sequence will start from the next val of the setted val(name)
-			set_next_val(doctype, name, is_val_used=True)
+			# this will set the sequence value to be the provided name/value and set it to be used
+			# so that the sequence will start from the next value
+			frappe.db.set_next_sequence_val(doctype, name, is_val_used=True)
 			return name
 
 		frappe.throw(_("Invalid name type (integer) for varchar name column"), frappe.NameError)

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -74,7 +74,7 @@ def set_new_name(doc):
 	doc.name = validate_name(doc.doctype, doc.name, meta.get_field("name_case"))
 
 
-def is_autoincremented(doctype: str, meta: "Meta" = None):
+def is_autoincremented(doctype: str, meta: Optional["Meta"] = None) -> bool:
 	if doctype in log_types:
 		if autoincremented_site_status_map.get(frappe.local.site) is None:
 			if frappe.db.sql(
@@ -93,10 +93,7 @@ def is_autoincremented(doctype: str, meta: "Meta" = None):
 		if not meta:
 			meta = frappe.get_meta(doctype)
 
-		if getattr(meta, "issingle", False):
-			return False
-
-		if meta.autoname == "autoincrement":
+		if not getattr(meta, "issingle", False) and meta.autoname == "autoincrement":
 			return True
 
 	return False

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 	from frappe.model.meta import Meta
 
 
+# NOTE: This is used to keep track of status of sites
+# whether the `log_types`` have autoincremented naming set for the site or not.
 autoincremented_site_status_map = {}
 
 

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 	from frappe.model.meta import Meta
 
 
-autoincremented_status_map = {}
+autoincremented_site_status_map = {}
 
 def set_new_name(doc):
 	"""
@@ -76,18 +76,17 @@ def set_new_name(doc):
 
 def is_autoincremented(doctype: str, meta: "Meta" = None):
 	if doctype in log_types:
-		print(autoincremented_status_map.get(frappe.local.site))
-		if autoincremented_status_map.get(frappe.local.site) is None:
+		if autoincremented_site_status_map.get(frappe.local.site) is None:
 			if frappe.db.sql(
 				f"""select data_type FROM information_schema.columns
 				where column_name = 'name' and table_name = 'tab{doctype}'"""
 			)[0][0] == "bigint":
-				autoincremented_status_map[frappe.local.site] = 1
+				autoincremented_site_status_map[frappe.local.site] = 1
 				return True
 			else:
-				autoincremented_status_map[frappe.local.site] = 0
+				autoincremented_site_status_map[frappe.local.site] = 0
 
-		elif autoincremented_status_map[frappe.local.site]:
+		elif autoincremented_site_status_map[frappe.local.site]:
 			return True
 
 	else:

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -65,11 +65,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		};
 
 		var update_input = function() {
-			if (me.doctype && me.docname) {
-				me.set_input(me.value);
-			} else {
-				me.set_input(me.value || null);
-			}
+			me.set_input(me.value);
 		};
 
 		if (me.disp_status != "None") {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -273,7 +273,7 @@ frappe.ui.form.Form = class FrappeForm {
 		// using $.each to preserve df via closure
 		$.each(table_fields, function(i, df) {
 			frappe.model.on(df.options, "*", function(fieldname, value, doc) {
-				if(doc.parent == me.docname && doc.parentfield === df.fieldname) {
+				if (doc.parent == me.docname && doc.parentfield === df.fieldname) {
 					me.dirty();
 					me.fields_dict[df.fieldname].grid.set_value(fieldname, value, doc);
 					return me.script_manager.trigger(fieldname, doc.doctype, doc.name);

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -248,7 +248,7 @@ frappe.ui.form.Form = class FrappeForm {
 		// on main doc
 		frappe.model.on(me.doctype, "*", function(fieldname, value, doc, skip_dirty_trigger=false) {
 			// set input
-			if (cstr(doc.name) === me.docname) {
+			if (doc.name == me.docname) {
 				if (!skip_dirty_trigger) {
 					me.dirty();
 				}
@@ -273,7 +273,7 @@ frappe.ui.form.Form = class FrappeForm {
 		// using $.each to preserve df via closure
 		$.each(table_fields, function(i, df) {
 			frappe.model.on(df.options, "*", function(fieldname, value, doc) {
-				if(doc.parent===me.docname && doc.parentfield===df.fieldname) {
+				if(doc.parent == me.docname && doc.parentfield === df.fieldname) {
 					me.dirty();
 					me.fields_dict[df.fieldname].grid.set_value(fieldname, value, doc);
 					return me.script_manager.trigger(fieldname, doc.doctype, doc.name);
@@ -356,7 +356,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 			// check permissions
 			if (!this.has_read_permission()) {
-				frappe.show_not_permitted(__(this.doctype) + " " + __(this.docname));
+				frappe.show_not_permitted(__(this.doctype) + " " + __(cstr(this.docname)));
 				return;
 			}
 

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -403,8 +403,7 @@ $.extend(frappe.model, {
 				}
 			});
 		} else {
-			typeArr = ["number", "string"]
-			if(typeArr.includes(typeof filters) && locals[doctype] && locals[doctype][filters]) {
+			if(["number", "string"].includes(typeof filters) && locals[doctype] && locals[doctype][filters]) {
 				return locals[doctype][filters][fieldname];
 			} else {
 				var l = frappe.get_list(doctype, filters);

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -403,7 +403,8 @@ $.extend(frappe.model, {
 				}
 			});
 		} else {
-			if(typeof filters==="string" && locals[doctype] && locals[doctype][filters]) {
+			typeArr = ["number", "string"]
+			if(typeArr.includes(typeof filters) && locals[doctype] && locals[doctype][filters]) {
 				return locals[doctype][filters][fieldname];
 			} else {
 				var l = frappe.get_list(doctype, filters);

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -403,7 +403,7 @@ $.extend(frappe.model, {
 				}
 			});
 		} else {
-			if(["number", "string"].includes(typeof filters) && locals[doctype] && locals[doctype][filters]) {
+			if (["number", "string"].includes(typeof filters) && locals[doctype] && locals[doctype][filters]) {
 				return locals[doctype][filters][fieldname];
 			} else {
 				var l = frappe.get_list(doctype, filters);

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -632,11 +632,11 @@ class TestReportview(unittest.TestCase):
 		if frappe.db.db_type == "postgres":
 			self.assertTrue("strpos( cast(\"tabautoinc_dt_test\".\"name\" as varchar), \'1\')" in query)
 			self.assertTrue("strpos(cast(name as varchar), \'1\')" in query)
-			self.assertTrue("where cast(\"tabautoinc_dt_test\".name as varchar) = \'1\'" in query)
+			self.assertTrue("where cast(\"tabautoinc_dt_test\".\"name\" as varchar) = \'1\'" in query)
 		else:
 			self.assertTrue("locate(\'1\', `tabautoinc_dt_test`.`name`)" in query)
 			self.assertTrue("locate(\'1\', name)" in query)
-			self.assertTrue("where `tabautoinc_dt_test`.name = 1" in query)
+			self.assertTrue("where `tabautoinc_dt_test`.`name` = 1" in query)
 
 		dt.delete(ignore_permissions=True)
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -635,8 +635,8 @@ class TestReportview(unittest.TestCase):
 			self.assertTrue("strpos( cast(name as varchar), '1')" in query)
 			self.assertTrue('where cast("tabautoinc_dt_test"."name" as varchar) = \'1\'' in query)
 		else:
-			self.assertTrue("locate(\'1\', `tabautoinc_dt_test`.`name`)" in query)
-			self.assertTrue("locate(\'1\', name)" in query)
+			self.assertTrue("locate('1', `tabautoinc_dt_test`.`name`)" in query)
+			self.assertTrue("locate('1', name)" in query)
 			self.assertTrue("where `tabautoinc_dt_test`.`name` = 1" in query)
 
 		dt.delete(ignore_permissions=True)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -624,17 +624,19 @@ class TestReportview(unittest.TestCase):
 		dt = new_doctype("autoinc_dt_test", autoname="autoincrement").insert(ignore_permissions=True)
 
 		query = DatabaseQuery("autoinc_dt_test").execute(
-			fields=["locate('1', `tabautoinc_dt_test`.`name`)", "`tabautoinc_dt_test`.`name`"],
+			fields=["locate('1', `tabautoinc_dt_test`.`name`)", "name", "locate('1', name)"],
 			filters={"name": 1},
 			run=False,
 		)
 
 		if frappe.db.db_type == "postgres":
-			self.assertTrue('strpos( cast( "tabautoinc_dt_test"."name" as varchar), \'1\')' in query)
-			self.assertTrue('where cast("tabautoinc_dt_test"."name" as varchar) = \'1\'' in query)
+			self.assertTrue("strpos( cast(\"tabautoinc_dt_test\".\"name\" as varchar), \'1\')" in query)
+			self.assertTrue("strpos(cast(name as varchar), \'1\')" in query)
+			self.assertTrue("where cast(\"tabautoinc_dt_test\".name as varchar) = \'1\'" in query)
 		else:
-			self.assertTrue("locate('1', `tabautoinc_dt_test`.`name`)" in query)
-			self.assertTrue("where `tabautoinc_dt_test`.`name` = 1" in query)
+			self.assertTrue("locate(\'1\', `tabautoinc_dt_test`.`name`)" in query)
+			self.assertTrue("locate(\'1\', name)" in query)
+			self.assertTrue("where `tabautoinc_dt_test`.name = 1" in query)
 
 		dt.delete(ignore_permissions=True)
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -621,6 +621,7 @@ class TestReportview(unittest.TestCase):
 	def test_cast_name(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
+		frappe.delete_doc_if_exists("DocType", "autoinc_dt_test")
 		dt = new_doctype("autoinc_dt_test", autoname="autoincrement").insert(ignore_permissions=True)
 
 		query = DatabaseQuery("autoinc_dt_test").execute(
@@ -630,9 +631,9 @@ class TestReportview(unittest.TestCase):
 		)
 
 		if frappe.db.db_type == "postgres":
-			self.assertTrue("strpos( cast(\"tabautoinc_dt_test\".\"name\" as varchar), \'1\')" in query)
-			self.assertTrue("strpos(cast(name as varchar), \'1\')" in query)
-			self.assertTrue("where cast(\"tabautoinc_dt_test\".\"name\" as varchar) = \'1\'" in query)
+			self.assertTrue('strpos( cast("tabautoinc_dt_test"."name" as varchar), \'1\')' in query)
+			self.assertTrue("strpos( cast(name as varchar), '1')" in query)
+			self.assertTrue('where cast("tabautoinc_dt_test"."name" as varchar) = \'1\'' in query)
 		else:
 			self.assertTrue("locate(\'1\', `tabautoinc_dt_test`.`name`)" in query)
 			self.assertTrue("locate(\'1\', name)" in query)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -61,10 +61,12 @@ class TestReportview(unittest.TestCase):
 			in build_match_conditions(as_condition=False)
 		)
 		# get as conditions
-		self.assertEqual(
-			build_match_conditions(as_condition=True),
-			"""(((ifnull(`tabBlog Post`.`name`, '')='' or `tabBlog Post`.`name` in ('-test-blog-post-1', '-test-blog-post'))))""",
-		)
+		if frappe.db.db_type == "mariadb":
+			assertion_string = """(((ifnull(`tabBlog Post`.`name`, '')='' or `tabBlog Post`.`name` in ('-test-blog-post-1', '-test-blog-post'))))"""
+		else:
+			assertion_string = """(((ifnull(cast(`tabBlog Post`.`name` as varchar), '')='' or cast(`tabBlog Post`.`name` as varchar) in ('-test-blog-post-1', '-test-blog-post'))))"""
+
+		self.assertEqual(build_match_conditions(as_condition=True), assertion_string)
 
 		frappe.set_user("Administrator")
 

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -1,0 +1,14 @@
+import frappe
+import unittest
+
+
+class TestSequence(unittest.TestCase):
+	def setUp(self) -> None:
+		pass
+
+	def tearDown(self) -> None:
+		pass
+
+	def test_set_next_val(self):
+		pass
+

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -3,12 +3,11 @@ import unittest
 
 
 class TestSequence(unittest.TestCase):
-	def setUp(self) -> None:
+	def setUpClass(cls) -> None:
 		pass
 
-	def tearDown(self) -> None:
+	def tearDownClass(cls) -> None:
 		pass
 
 	def test_set_next_val(self):
 		pass
-

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -1,13 +1,13 @@
+import psycopg2
+import pymysql
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
-
-import pymysql
-import psycopg2
 
 
 class TestSequence(FrappeTestCase):
 	def generate_sequence_name(self) -> str:
-			return self._testMethodName + "_" + frappe.generate_hash(length=5)
+		return self._testMethodName + "_" + frappe.generate_hash(length=5)
 
 	def test_set_next_val(self):
 		seq_name = self.generate_sequence_name()

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -1,13 +1,44 @@
-import frappe
+from frappe.database.sequence import create_sequence, get_next_val, set_next_val
+
 import unittest
+import pymysql
+import psycopg2
 
 
 class TestSequence(unittest.TestCase):
-	def setUpClass(cls) -> None:
-		pass
-
-	def tearDownClass(cls) -> None:
-		pass
-
 	def test_set_next_val(self):
-		pass
+		seq_name = "test_set_next_val_1"
+		create_sequence(seq_name, check_not_exists=True)
+
+		next_val = get_next_val(seq_name)
+		set_next_val(seq_name, next_val + 1)
+		self.assertEqual(next_val + 1, get_next_val(seq_name))
+
+		next_val = get_next_val(seq_name)
+		set_next_val(seq_name, next_val + 1, is_val_used=True)
+		self.assertEqual(next_val + 2, get_next_val(seq_name))
+
+	def test_create_sequence(self):
+		create_sequence("test_create_sequence_1", max_value=2, cycle=True)
+		get_next_val("test_create_sequence_1")
+		get_next_val("test_create_sequence_1")
+		self.assertEqual(1, get_next_val("test_create_sequence_1"))
+
+		create_sequence("test_create_sequence_2", max_value=2)
+		get_next_val("test_create_sequence_2")
+		get_next_val("test_create_sequence_2")
+
+		try:
+			get_next_val("test_create_sequence_2")
+		except pymysql.err.OperationalError as e:
+			self.assertEqual(e.args[0], 4084)
+		except psycopg2.DataError as e:
+			self.assertEqual("2200H", e.pgcode)
+			print(e)
+		else:
+			self.fail("NEXTVAL didn't raise any error upon sequence's end")
+
+		create_sequence("test_create_sequence_3", min_value=10, max_value=20, increment_by=5)
+		self.assertEqual(10, get_next_val("test_create_sequence_3"))
+		self.assertEqual(15, get_next_val("test_create_sequence_3"))
+		self.assertEqual(20, get_next_val("test_create_sequence_3"))

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -1,7 +1,6 @@
 from frappe.database.sequence import create_sequence, get_next_val, set_next_val
 from frappe.tests.utils import FrappeTestCase
 
-import unittest
 import pymysql
 import psycopg2
 

--- a/frappe/tests/test_sequence.py
+++ b/frappe/tests/test_sequence.py
@@ -1,11 +1,12 @@
 from frappe.database.sequence import create_sequence, get_next_val, set_next_val
+from frappe.tests.utils import FrappeTestCase
 
 import unittest
 import pymysql
 import psycopg2
 
 
-class TestSequence(unittest.TestCase):
+class TestSequence(FrappeTestCase):
 	def test_set_next_val(self):
 		seq_name = "test_set_next_val_1"
 		create_sequence(seq_name, check_not_exists=True)
@@ -34,7 +35,6 @@ class TestSequence(unittest.TestCase):
 			self.assertEqual(e.args[0], 4084)
 		except psycopg2.DataError as e:
 			self.assertEqual("2200H", e.pgcode)
-			print(e)
 		else:
 			self.fail("NEXTVAL didn't raise any error upon sequence's end")
 


### PR DESCRIPTION
Changes:
- `local.autoincremented_status_map` in `frappe.init` get resetted on every request (i think due to `init_request` method? it keeps on triggering `frappe.init` function) so switched to a simple dict
- simplified `is_val_used` in `set_next_val` function for sequences
- use multisql
- fixed fields not being refreshed (ref: https://github.com/frappe/frappe/pull/15964#issuecomment-1070352518)
- refactored `cast_name` method (and made it a simple function as opposed to class method)
- added `cast_name` wherever it was missed (hopefully 🤞)
- added sequence function to Database class - can now be referred/used using `frappe.db.x`
- fixed wrong query strings for `minvalue` and `maxvalue` for sequences
- improved regex in `modify_query` for postgres
- refactored `validate_autoname` method into a simple function
- allowed autoincrement doctype to change name column type if no data is present
- made autoincrement autoname to be set using customize form

TODO:
- [x] add tests related to sequences
- [x] fix tests
- [x] replace all imported sequence functions with `frappe.db.x`
- [x] move out casting from `extract_tables` into a separate function