### PR TITLE
fix: get_role_permissions for attached files

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -164,7 +164,7 @@ def get_role_permissions(doctype_meta, user=None, is_owner=None):
 	if user == 'Administrator':
 		return allow_everything()
 
-	if not frappe.local.role_permissions.get(cache_key):
+	if not frappe.local.role_permissions.get(cache_key) or is_owner:
 		perms = frappe._dict(
 			if_owner={}
 		)


### PR DESCRIPTION
The problem is tied to trying to delete a file on canceling a document

On Cancel event
When the system check for permissions it checks without passing doc hence  `is owner` is None and sets up `frappe.local.role_permissions[cache_key]` 
The second time system checks for the attached file `frappe.local.role_permissions[cache_key]` because its already setup it does not update even when the doc is passed and the user `is owner`

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/7881486/158790775-70f23f16-397f-4d0f-8115-90289b7cf11f.png">

<img width="1278" alt="image" src="https://user-images.githubusercontent.com/7881486/158790870-c1376fe3-7911-4179-b03f-1b221eefbaaa.png">

This is an issue related to erpnext. When trying to delete the QR code

<img width="685" alt="image" src="https://user-images.githubusercontent.com/7881486/158791041-a1b4a546-28d4-4351-b427-557db766243c.png">

