### PR TITLE
feat: Allow WITH ... SELECT (CTE) SQL in query reports.

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -11,7 +11,7 @@ from frappe.modules import make_boilerplate
 from frappe.core.doctype.page.page import delete_custom_role
 from frappe.core.doctype.custom_role.custom_role import get_custom_allowed_roles
 from frappe.desk.reportview import append_totals_row
-from frappe.utils.safe_exec import safe_exec
+from frappe.utils.safe_exec import safe_exec, check_safe_sql_query
 
 
 class Report(Document):
@@ -110,15 +110,7 @@ class Report(Document):
 		if not self.query:
 			frappe.throw(_("Must specify a Query to run"), title=_('Report Document Error'))
 
-		# Disallow SQL that writes to the database.
-		if (not self.query.lower().startswith("select") and
-		    not self.query.lower().startswith("with")):
-			frappe.throw(_("Query must be a SELECT or WITH"), title=_('Report Document Error'))
-
-		# As of MariaDB 10.9, CTE WITH statements can only be combined with a SELECT clause and
-		# therefore are read-only. Postgres allows WITH ... INSERT INTO statements.
-		if (self.query.lower().startswith("with") and frappe.db.db_type != "mariadb"):
-			frappe.throw(_("WITH queries are only allowed for MariaDB databases"), title=_('Report Document Error'))
+		check_safe_sql_query(self.query)
 
 		result = [list(t) for t in frappe.db.sql(self.query, filters)]
 		columns = self.get_columns() or [cstr(c[0]) for c in frappe.db.get_description()]

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -1,17 +1,19 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import textwrap
+
 import frappe, json, os
-import unittest
 from frappe.desk.query_report import run, save_report, add_total_row
 from frappe.desk.reportview import delete_report, save_report as _save_report
 from frappe.custom.doctype.customize_form.customize_form import reset_customization
 from frappe.core.doctype.user_permission.test_user_permission import create_user
+from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records('Report')
 test_dependencies = ['User']
 
-class TestReport(unittest.TestCase):
+class TestReport(FrappeTestCase):
 	def test_report_builder(self):
 		if frappe.db.exists('Report', 'User Activity Report'):
 			frappe.delete_doc('Report', 'User Activity Report')
@@ -335,3 +337,29 @@ result = [
 		self.assertEqual(result[-1][0], "Total")
 		self.assertEqual(result[-1][1], 200)
 		self.assertEqual(result[-1][2], 150.50)
+
+	def test_cte_in_query_report(self):
+		cte_query = textwrap.dedent("""
+			with enabled_users as (
+				select name
+				from `tabUser`
+				where enabled = 1
+			)
+			select * from enabled_users;
+		""")
+
+		report = frappe.get_doc({
+			"doctype": "Report",
+			"ref_doctype": "User",
+			"report_name": "Enabled Users List",
+			"report_type": "Query Report",
+			"is_standard": "No",
+			"query": cte_query,
+		}).insert()
+
+		if frappe.db.db_type == "mariadb":
+			col, rows = report.execute_query_report(filters={})
+			self.assertEqual(col[0], "name")
+			self.assertGreaterEqual(len(rows), 1)
+		elif frappe.db.db_type == "postgres":
+			self.assertRaises(frappe.PermissionError, report.execute_query_report, filters={})


### PR DESCRIPTION
Implements WITH ... SELECT statements for query reports as discussed in #16329.

CTEs can be very useful for reports, the issue shows an example of a report that will show the summed amount of open sales orders per day.

I believe the restriction to SELECT clauses is a security feature, however I am not sure if this
- is sufficient (e.g. postgres allows using SETVAL() even in an SELECT clause)
- will therefore give users a wrong feeling of safety
- is necessary, because even full read-access to the database, bypassing any rights management, should be highly restricted anyways

`no-docs`