### PR TITLE
perf: limit rows to 1 for `get_value` and `exists`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -384,7 +384,7 @@ class Database(object):
 		"""
 
 		ret = self.get_values(doctype, filters, fieldname, ignore, as_dict, debug,
-			order_by, cache=cache, for_update=for_update, run=run, pluck=pluck, distinct=distinct)
+			order_by, cache=cache, for_update=for_update, run=run, pluck=pluck, distinct=distinct, limit=1)
 
 		if not run:
 			return ret
@@ -393,7 +393,7 @@ class Database(object):
 
 	def get_values(self, doctype, filters=None, fieldname="name", ignore=None, as_dict=False,
 		debug=False, order_by="KEEP_DEFAULT_ORDERING", update=None, cache=False, for_update=False,
-		run=True, pluck=False, distinct=False):
+		run=True, pluck=False, distinct=False, limit=None):
 		"""Returns multiple document properties.
 
 		:param doctype: DocType name.
@@ -423,14 +423,15 @@ class Database(object):
 
 		if isinstance(filters, list):
 			out = self._get_value_for_many_names(
-				doctype,
-				filters,
-				fieldname,
-				order_by,
+				doctype=doctype,
+				names=filters,
+				field=fieldname,
+				order_by=order_by,
 				debug=debug,
 				run=run,
 				pluck=pluck,
 				distinct=distinct,
+				limit=limit,
 			)
 
 		else:
@@ -444,17 +445,18 @@ class Database(object):
 					if order_by:
 						order_by = "modified" if order_by == "KEEP_DEFAULT_ORDERING" else order_by
 					out = self._get_values_from_table(
-						fields,
-						filters,
-						doctype,
-						as_dict,
-						debug,
-						order_by,
-						update,
+						fields=fields,
+						filters=filters,
+						doctype=doctype,
+						as_dict=as_dict,
+						debug=debug,
+						order_by=order_by,
+						update=update,
 						for_update=for_update,
 						run=run,
 						pluck=pluck,
-						distinct=distinct
+						distinct=distinct,
+						limit=limit,
 					)
 				except Exception as e:
 					if ignore and (frappe.db.is_missing_column(e) or frappe.db.is_table_missing(e)):
@@ -623,6 +625,7 @@ class Database(object):
 		run=True,
 		pluck=False,
 		distinct=False,
+		limit=None,
 	):
 		field_objects = []
 
@@ -641,6 +644,7 @@ class Database(object):
 			field_objects=field_objects,
 			fields=fields,
 			distinct=distinct,
+			limit=limit,
 		)
 		if (
 			fields == "*"
@@ -654,7 +658,7 @@ class Database(object):
 		)
 		return r
 
-	def _get_value_for_many_names(self, doctype, names, field, order_by, debug=False, run=True, pluck=False, distinct=False):
+	def _get_value_for_many_names(self, doctype, names, field, order_by, debug=False, run=True, pluck=False, distinct=False, limit=None):
 		names = list(filter(None, names))
 		if names:
 			return self.get_all(
@@ -667,6 +671,7 @@ class Database(object):
 				as_list=1,
 				run=run,
 				distinct=distinct,
+				limit_page_length=limit
 			)
 		else:
 			return {}


### PR DESCRIPTION
Improve `db.exists` and `db.get_value` when used with filters from `O(N)` to `O(1)` :stonks:

Before: 

```ipython
%timeit frappe.db.exists("Stock Ledger Entry", {"item_code": "_Test Item"})
4 ms ± 1.06 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

This is with JUST 200 matching rows in the database, in reality, SLEs often have millions of rows and all are getting serialized to python objects just to get discarded immediately after. 😄 


After:
```ipython
%timeit frappe.db.exists("Stock Ledger Entry", {"item_code": "_Test Item"})
143 µs ± 349 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

TODO:
- [x] test for ensuring DB doesn't fetch more than the required number of rows. 

ERPNext CI run: https://github.com/frappe/erpnext/actions/runs/2012032706 