### PR TITLE
refactor: don't assign variable to itself

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -225,11 +225,10 @@ def ping():
 
 def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 	"""run a whitelisted controller method"""
-	import json
-	import inspect
+	from inspect import getfullargspec
 
-	if not args:
-		args = arg or ""
+	if not args and arg:
+		args = arg
 
 	if dt: # not called from a doctype (from a page)
 		if not dn:
@@ -237,9 +236,7 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 		doc = frappe.get_doc(dt, dn)
 
 	else:
-		if isinstance(docs, str):
-			docs = json.loads(docs)
-
+		docs = frappe.parse_json(docs)
 		doc = frappe.get_doc(docs)
 		doc._original_modified = doc.modified
 		doc.check_if_latest()
@@ -248,7 +245,7 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 		throw_permission_error()
 
 	try:
-		args = json.loads(args)
+		args = frappe.parse_json(args)
 	except ValueError:
 		pass
 
@@ -257,7 +254,7 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 	is_whitelisted(fn)
 	is_valid_http_method(fn)
 
-	fnargs = inspect.getfullargspec(method_obj).args
+	fnargs = getfullargspec(method_obj).args
 
 	if not fnargs or (len(fnargs)==1 and fnargs[0]=="self"):
 		response = doc.run_method(method)

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -250,7 +250,7 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 	try:
 		args = json.loads(args)
 	except ValueError:
-		args = args
+		pass
 
 	method_obj = getattr(doc, method)
 	fn = getattr(method_obj, '__func__', method_obj)


### PR DESCRIPTION
https://github.com/frappe/frappe/blob/367e3fdb4ee58867ccbcc596aa47e50a3348c2cf/frappe/handler.py#L253

`args` already has the value of `args`, so there's no point in reassigning it.

> no-docs