### PR TITLE
refactor: remove unused fallback value

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1026,7 +1026,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		}
 		if (!docfield || docfield.report_hide) return;
 
-		let title = __(docfield ? docfield.label : toTitle(fieldname));
+		let title = __(docfield.label);
 		if (doctype !== this.doctype) {
 			title += ` (${__(doctype)})`;
 		}


### PR DESCRIPTION
Because of the line above, `docfield` always evaluates to `true`. Thus, the fallback value `toTitle(fieldname)` will never get used. We might as well remove it.