### PR TITLE
refactor: Form.update_in_all_rows

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1708,7 +1708,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 		frappe.model
 			.get_children(this.doc, table_fieldname)
-			.filter(child => !child[fieldname])
+			.filter(child => !frappe.model.has_value(child.doctype, child.name, fieldname))
 			.forEach(child =>
 				frappe.model.set_value(child.doctype, child.name, fieldname, value)
 			);

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1707,7 +1707,7 @@ frappe.ui.form.Form = class FrappeForm {
 		for(var i = 0; i < cl.length; i++){
 			if(!cl[i][fieldname]) cl[i][fieldname] = value;
 		}
-		refresh_field("items");
+		this.refresh_field("items");
 	}
 
 	get_sum(table_fieldname, fieldname) {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1701,13 +1701,17 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	update_in_all_rows(table_fieldname, fieldname, value) {
-		// update the child value in all tables where it is missing
-		if(!value) return;
-		var cl = this.doc[table_fieldname] || [];
-		for(var i = 0; i < cl.length; i++){
-			if(!cl[i][fieldname]) cl[i][fieldname] = value;
-		}
-		this.refresh_field("items");
+		// Update the `value` of the field named `fieldname` in all rows of the
+		// child table named `table_fieldname`.
+		// Do not overwrite existing values.
+		if (!value) return;
+
+		frappe.model
+			.get_children(this.doc, table_fieldname)
+			.filter(child => !child[fieldname])
+			.forEach(child =>
+				frappe.model.set_value(child.doctype, child.name, fieldname, value)
+			);
 	}
 
 	get_sum(table_fieldname, fieldname) {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1704,7 +1704,7 @@ frappe.ui.form.Form = class FrappeForm {
 		// Update the `value` of the field named `fieldname` in all rows of the
 		// child table named `table_fieldname`.
 		// Do not overwrite existing values.
-		if (!value) return;
+		if (value === undefined) return;
 
 		frappe.model
 			.get_children(this.doc, table_fieldname)


### PR DESCRIPTION
Edit: the review lead me to refactor the whole method. What i've written below is not really relevant anymore. Read it as my motivation for this PR.

---

`Form.update_in_all_rows()` called the global method `refresh_field("items")`, which in turn called `cur_frm.refresh_field("items")` (Line 35):

https://github.com/frappe/frappe/blob/abd421fa02fe3a86a65dff82d49865ffaa051c2e/frappe/public/js/frappe/form/script_helpers.js#L14-L37

Probably this was a typo, as we can call `this.refresh_field("items")` directly.