### PR TITLE
fix: backup utils

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -15,7 +15,7 @@ import click
 
 # imports - module imports
 import frappe
-from frappe import _, conf
+from frappe import conf
 from frappe.utils import get_file_size, get_url, now, now_datetime, cint
 from frappe.utils.password import get_encryption_key
 

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -505,7 +505,7 @@ download only after 24 hours.""" % {
 			datetime_str.strftime("%d/%m/%Y %H:%M:%S") + """ - Backup ready to be downloaded"""
 		)
 
-		frappe.sendmail(recipients=recipient_list, msg=msg, subject=subject)
+		frappe.sendmail(recipients=recipient_list, message=msg, subject=subject)
 		return recipient_list
 
 

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -779,7 +779,7 @@ if __name__ == "__main__":
 			db_type=db_type,
 			db_port=db_port,
 		)
-		odb.send_email("abc.sql.gz")
+		odb.send_email()
 
 	if cmd == "delete_temp_backups":
 		delete_temp_backups()


### PR DESCRIPTION
- remove unused import
- fix parameter name from `msg` to `message`
- fix too many arguments for `send_email`
