### PR TITLE
refactor: remove useless pass, log error

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -253,8 +253,8 @@ class User(Document):
 				self.email_new_password(new_password)
 
 		except frappe.OutgoingEmailError:
-			print(frappe.get_traceback())
-			pass # email server not set, don't send email
+			# email server not set, don't send email
+			frappe.log_error(frappe.get_traceback())
 
 	@Document.hook
 	def validate_reset_password(self):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -650,8 +650,6 @@ def extract_messages_from_code(code):
 		if isinstance(e, InvalidIncludePath):
 			frappe.clear_last_message()
 
-		pass
-
 	messages = []
 	pattern = r"_\(([\"']{,3})(?P<message>((?!\1).)*)\1(\s*,\s*context\s*=\s*([\"'])(?P<py_context>((?!\5).)*)\5)*(\s*,\s*(.)*?\s*(,\s*([\"'])(?P<js_context>((?!\11).)*)\11)*)*\)"
 

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -227,7 +227,6 @@ class NestedSet(Document):
 			update_nsm(self)
 		except frappe.DoesNotExistError:
 			if self.flags.on_rollback:
-				pass
 				frappe.message_log.pop()
 			else:
 				raise


### PR DESCRIPTION
`pass` is often used as a line-filler, but it really does nothing. For example:

```py
try:
    # ...
except Exception:
    pass
```

We _have to_ write something in the `except` block, but we don't want to do anything, so we write `pass`. But if we do something anyways, `pass` is useless and we can safely remove it:

```py
try:
    # ...
except Exception:
    log_error()
    # no `pass` needed
```

---

Also, in `user.py` we printed the traceback. Not sure if that was on purpose, but it doesn't seem very useful at first glance. I took the liberty to replace it with `frappe.log_error()`