### PR TITLE
fix: use result of `Array.concat()`

### DIFF
--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -375,7 +375,7 @@ export default class ListSettings {
 		let me = this;
 
 		if (me.removed_fields) {
-			me.removed_fields.concat(fields);
+			me.removed_fields = me.removed_fields.concat(fields);
 		} else {
 			me.removed_fields = fields;
 		}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -231,7 +231,7 @@ Object.assign(frappe.utils, {
 			if (tt && (tt.substr(0, 1)===">" || tt.substr(0, 4)==="&gt;")) {
 				part.push(t);
 			} else {
-				out.concat(part);
+				out = out.concat(part);
 				out.push(t);
 				part = [];
 			}


### PR DESCRIPTION
The `concat` method is pure and does not modify any of the inputs or the array the method is called on. - https://lgtm.com/rules/1510745846115/

We have to assign the return value to achieve any effect.