### PR TITLE
chore: change log for v13.23.0

### DIFF
--- a/frappe/change_log/v13/v13_23_0.md
+++ b/frappe/change_log/v13/v13_23_0.md
@@ -1,0 +1,20 @@
+## Version 13.23.0 Release Notes
+
+### Features & Enhancements
+- feat: MySQL TIMESTAMP functionality for QB ([#16295](https://github.com/frappe/frappe/pull/16295))
+
+### Fixes
+
+- fix: Consider title field only if it's value exists ([#16236](https://github.com/frappe/frappe/pull/16236))
+- fix: `set_column_disp` contradicts arguments (backport #16255) ([#16255](https://github.com/frappe/frappe/pull/16255))
+- fix(BackupGenerator): set missing attribute for class object ([#16273](https://github.com/frappe/frappe/pull/16273))
+- fix(rename_doc): Allow updating only document title or name (backport #16225) ([#16225](https://github.com/frappe/frappe/pull/16225))
+- fix(ux): remove attachment limits ([#16222](https://github.com/frappe/frappe/pull/16222))
+- fix: Dashboard report link (backport #14052) ([#14052](https://github.com/frappe/frappe/pull/14052))
+- fix: Double signature in composed Email (backport #16178) ([#16178](https://github.com/frappe/frappe/pull/16178))
+- fix: Number Card to support child table doctype for filters (backport #16243) ([#16243](https://github.com/frappe/frappe/pull/16243))
+- fix: Print for tree view is broken (backport #16137) ([#16137](https://github.com/frappe/frappe/pull/16137))
+- fix: Routing with hash in URL [v13] ([#16298](https://github.com/frappe/frappe/pull/16298))
+- fix: Typo in is_downgrade's user warning (backport #16313) ([#16313](https://github.com/frappe/frappe/pull/16313))
+- fix: typo in database file for v12 - latest ([#16250](https://github.com/frappe/frappe/pull/16250))
+- chore: add German translations (backport #16292) ([#16292](https://github.com/frappe/frappe/pull/16292))


### PR DESCRIPTION
## Version 13.23.0 Release Notes

### Features & Enhancements
- feat: MySQL TIMESTAMP functionality for QB ([#16295](https://github.com/frappe/frappe/pull/16295))

### Fixes

- fix: Consider title field only if it's value exists ([#16236](https://github.com/frappe/frappe/pull/16236))
- fix: `set_column_disp` contradicts arguments (backport #16255) ([#16255](https://github.com/frappe/frappe/pull/16255))
- fix(BackupGenerator): set missing attribute for class object ([#16273](https://github.com/frappe/frappe/pull/16273))
- fix(rename_doc): Allow updating only document title or name (backport #16225) ([#16225](https://github.com/frappe/frappe/pull/16225))
- fix(ux): remove attachment limits ([#16222](https://github.com/frappe/frappe/pull/16222))
- fix: Dashboard report link (backport #14052) ([#14052](https://github.com/frappe/frappe/pull/14052))
- fix: Double signature in composed Email (backport #16178) ([#16178](https://github.com/frappe/frappe/pull/16178))
- fix: Number Card to support child table doctype for filters (backport #16243) ([#16243](https://github.com/frappe/frappe/pull/16243))
- fix: Print for tree view is broken (backport #16137) ([#16137](https://github.com/frappe/frappe/pull/16137))
- fix: Routing with hash in URL [v13] ([#16298](https://github.com/frappe/frappe/pull/16298))
- fix: Typo in is_downgrade's user warning (backport #16313) ([#16313](https://github.com/frappe/frappe/pull/16313))
- fix: typo in database file for v12 - latest ([#16250](https://github.com/frappe/frappe/pull/16250))
- chore: add German translations (backport #16292) ([#16292](https://github.com/frappe/frappe/pull/16292))
