### PR TITLE
fix: assinging thread locals to global variables

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -15,8 +15,6 @@ from frappe.utils.csvutils import to_csv
 from frappe.utils.xlsxutils import make_xlsx
 from frappe.desk.query_report import build_xlsx_data
 
-max_reports_per_user = frappe.local.conf.max_reports_per_user or 3
-
 
 class AutoEmailReport(Document):
 	def autoname(self):
@@ -46,6 +44,8 @@ class AutoEmailReport(Document):
 	def validate_report_count(self):
 		'''check that there are only 3 enabled reports per user'''
 		count = frappe.db.sql('select count(*) from `tabAuto Email Report` where user=%s and enabled=1', self.user)[0][0]
+		max_reports_per_user = frappe.local.conf.max_reports_per_user or 3
+
 		if count > max_reports_per_user + (-1 if self.flags.in_insert else 0):
 			frappe.throw(_('Only {0} emailed reports are allowed per user').format(max_reports_per_user))
 


### PR DESCRIPTION
added semgrep rule for this: https://github.com/frappe/semgrep-rules/commit/bba70b39b20a0040e756e1d2bc317cb9b020d322 