### PR TITLE
fix: force keyword arguments in new ORM args

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -119,8 +119,8 @@ class Database(object):
 		if not run:
 			return query
 
-		# remove \n \t from start and end of query
-		query = re.sub(r'^\s*|\s*$', '', query)
+		# remove whitespace / indentation from start and end of query
+		query = query.strip()
 
 		if re.search(r'ifnull\(', query, flags=re.IGNORECASE):
 			# replaces ifnull in query with coalesce

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -387,13 +387,23 @@ class Database(object):
 			frappe.db.get_value("System Settings", None, "date_format")
 		"""
 
-		ret = self.get_values(doctype, filters, fieldname, ignore, as_dict, debug,
+		result = self.get_values(doctype, filters, fieldname, ignore, as_dict, debug,
 			order_by, cache=cache, for_update=for_update, run=run, pluck=pluck, distinct=distinct, limit=1)
 
 		if not run:
-			return ret
+			return result
 
-		return ((len(ret[0]) > 1 or as_dict) and ret[0] or ret[0][0]) if ret else None
+		if not result:
+			return None
+
+		row = result[0]
+
+		if len(row) > 1 or as_dict:
+			return row
+		else:
+			# single field is requested, send it without wrapping in containers
+			return row[0]
+
 
 	def get_values(self, doctype, filters=None, fieldname="name", ignore=None, as_dict=False,
 		debug=False, order_by="KEEP_DEFAULT_ORDERING", update=None, cache=False, for_update=False,

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -357,6 +357,7 @@ class Database(object):
 		order_by="KEEP_DEFAULT_ORDERING",
 		cache=False,
 		for_update=False,
+		*,
 		run=True,
 		pluck=False,
 		distinct=False,
@@ -396,7 +397,7 @@ class Database(object):
 
 	def get_values(self, doctype, filters=None, fieldname="name", ignore=None, as_dict=False,
 		debug=False, order_by="KEEP_DEFAULT_ORDERING", update=None, cache=False, for_update=False,
-		run=True, pluck=False, distinct=False, limit=None):
+		*, run=True, pluck=False, distinct=False, limit=None):
 		"""Returns multiple document properties.
 
 		:param doctype: DocType name.
@@ -487,6 +488,7 @@ class Database(object):
 		as_dict=False,
 		debug=False,
 		update=None,
+		*,
 		run=True,
 		pluck=False,
 		distinct=False,
@@ -621,7 +623,8 @@ class Database(object):
 		filters,
 		doctype,
 		as_dict,
-		debug,
+		*,
+		debug=False,
 		order_by=None,
 		update=None,
 		for_update=False,
@@ -661,7 +664,7 @@ class Database(object):
 		)
 		return r
 
-	def _get_value_for_many_names(self, doctype, names, field, order_by, debug=False, run=True, pluck=False, distinct=False, limit=None):
+	def _get_value_for_many_names(self, doctype, names, field, order_by, *, debug=False, run=True, pluck=False, distinct=False, limit=None):
 		names = list(filter(None, names))
 		if names:
 			return self.get_all(

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -312,6 +312,21 @@ class TestDB(unittest.TestCase):
 
 		frappe.db.MAX_WRITES_PER_TRANSACTION = Database.MAX_WRITES_PER_TRANSACTION
 
+	def test_transaction_write_counting(self):
+		note = frappe.get_doc(doctype="Note", title="transaction counting").insert()
+
+		writes = frappe.db.transaction_writes
+		frappe.db.set_value("Note", note.name, "content", "abc")
+		self.assertEqual(1, frappe.db.transaction_writes - writes)
+		writes = frappe.db.transaction_writes
+
+		frappe.db.sql("""
+			update `tabNote`
+			set content = 'abc'
+			where name = %s
+			""", note.name)
+		self.assertEqual(1, frappe.db.transaction_writes - writes)
+
 	def test_pk_collision_ignoring(self):
 		# note has `name` generated from title
 		for _ in range(3):


### PR DESCRIPTION
problem: when positional args differ between two versions backporting new args is prone to errors (example: https://github.com/frappe/frappe/pull/16334)

fix: Force kwargs for newly added args to ORM / DB methods. 


TODO: 
- [x] check if there are more such instances that can be changed without breaking any existing functionality


other changes:
- simpler query stripping
- simplified get_value one-liner return. 