### PR TITLE
test: Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -382,7 +382,7 @@ class TestFile(unittest.TestCase):
 		}).insert(ignore_permissions=True)
 
 		test_file.make_thumbnail()
-		self.assertEquals(test_file.thumbnail_url, '/files/image_small.jpg')
+		self.assertEqual(test_file.thumbnail_url, '/files/image_small.jpg')
 
 		# test web image without extension
 		test_file = frappe.get_doc({
@@ -399,7 +399,7 @@ class TestFile(unittest.TestCase):
 		test_file.reload()
 		test_file.file_url = "/files/image_small.jpg"
 		test_file.make_thumbnail(suffix="xs", crop=True)
-		self.assertEquals(test_file.thumbnail_url, '/files/image_small_xs.jpg')
+		self.assertEqual(test_file.thumbnail_url, '/files/image_small_xs.jpg')
 
 		frappe.clear_messages()
 		test_file.db_set('thumbnail_url', None)
@@ -407,7 +407,7 @@ class TestFile(unittest.TestCase):
 		test_file.file_url = frappe.utils.get_url('unknown.jpg')
 		test_file.make_thumbnail(suffix="xs")
 		self.assertEqual(json.loads(frappe.message_log[0]).get("message"), f"File '{frappe.utils.get_url('unknown.jpg')}' not found")
-		self.assertEquals(test_file.thumbnail_url, None)
+		self.assertEqual(test_file.thumbnail_url, None)
 
 	def test_file_unzip(self):
 		file_path = frappe.get_app_path('frappe', 'www/_test/assets/file.zip')

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -240,7 +240,7 @@ class TestNotification(unittest.TestCase):
 		self.assertTrue(email_queue)
 
 		# check if description is changed after alert since set_property_after_alert is set
-		self.assertEquals(todo.description, 'Changed by Notification')
+		self.assertEqual(todo.description, 'Changed by Notification')
 
 		recipients = [d.recipient for d in email_queue.recipients]
 		self.assertTrue('test2@example.com' in recipients)

--- a/frappe/tests/test_base_document.py
+++ b/frappe/tests/test_base_document.py
@@ -7,12 +7,12 @@ class TestBaseDocument(unittest.TestCase):
 	def test_docstatus(self):
 		doc = BaseDocument({"docstatus": 0})
 		self.assertTrue(doc.docstatus.is_draft())
-		self.assertEquals(doc.docstatus, 0)
+		self.assertEqual(doc.docstatus, 0)
 
 		doc.docstatus = 1
 		self.assertTrue(doc.docstatus.is_submitted())
-		self.assertEquals(doc.docstatus, 1)
+		self.assertEqual(doc.docstatus, 1)
 
 		doc.docstatus = 2
 		self.assertTrue(doc.docstatus.is_cancelled())
-		self.assertEquals(doc.docstatus, 2)
+		self.assertEqual(doc.docstatus, 2)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -386,7 +386,7 @@ class TestDDLCommandsMaria(unittest.TestCase):
 			WHERE Key_name = '{index_name}';
 			"""
 		)
-		self.assertEquals(len(indexs_in_table), 2)
+		self.assertEqual(len(indexs_in_table), 2)
 
 
 class TestDBSetValue(unittest.TestCase):
@@ -590,7 +590,7 @@ class TestDDLCommandsPost(unittest.TestCase):
 			AND indexname = '{index_name}' ;
 			""",
 		)
-		self.assertEquals(len(indexs_in_table), 1)
+		self.assertEqual(len(indexs_in_table), 1)
 
 	@run_only_if(db_type_is.POSTGRES)
 	def test_modify_query(self):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -260,15 +260,15 @@ class TestDocument(unittest.TestCase):
 			'doctype': 'Test Formatted',
 			'currency': 100000
 		})
-		self.assertEquals(d.get_formatted('currency', currency='INR', format="#,###.##"), '₹ 100,000.00')
+		self.assertEqual(d.get_formatted('currency', currency='INR', format="#,###.##"), '₹ 100,000.00')
 
 	def test_limit_for_get(self):
 		doc = frappe.get_doc("DocType", "DocType")
 		# assuming DocType has more than 3 Data fields
-		self.assertEquals(len(doc.get("fields", limit=3)), 3)
+		self.assertEqual(len(doc.get("fields", limit=3)), 3)
 
 		# limit with filters
-		self.assertEquals(len(doc.get("fields", filters={"fieldtype": "Data"}, limit=3)), 3)
+		self.assertEqual(len(doc.get("fields", filters={"fieldtype": "Data"}, limit=3)), 3)
 
 	def test_virtual_fields(self):
 		"""Virtual fields are accessible via API and Form views, whenever .as_dict is invoked

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -70,10 +70,10 @@ class TestSearch(unittest.TestCase):
 		result = frappe.response['results']
 
 		# Check whether the result is sorted or not
-		self.assertEquals(self.parent_doctype_name, result[0]['value'])
+		self.assertEqual(self.parent_doctype_name, result[0]['value'])
 
 		# Check whether searching for parent also list out children
-		self.assertEquals(len(result), len(self.child_doctypes_names) + 1)
+		self.assertEqual(len(result), len(self.child_doctypes_names) + 1)
 
 	#Search for the word "pay", part of the word "pays" (country) in french.
 	def test_link_search_in_foreign_language(self):


### PR DESCRIPTION
Deprecated aliases have been removed in https://github.com/python/cpython/pull/28268