### PR TITLE
fix: copy dict before popping keys

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -919,8 +919,8 @@ class Database(object):
 			return dn
 
 		if isinstance(dt, dict):
-			_dt = dt.pop("doctype")
-			dt, dn = _dt, dt
+			dt = dt.copy() # don't modify the original dict
+			dt, dn = dt.pop("doctype"), dt
 
 		return self.get_value(dt, dn, ignore=True, cache=cache)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -327,7 +327,13 @@ class TestDB(unittest.TestCase):
 		self.assertEqual(frappe.db.exists(dt, dn, cache=True), dn)
 		self.assertEqual(frappe.db.exists(dt, dn), dn)
 		self.assertEqual(frappe.db.exists(dt, {"name": ("=", dn)}), dn)
-		self.assertEqual(frappe.db.exists({"doctype": dt, "name": ("like", "Admin%")}), dn)
+
+		filters = {"doctype": dt, "name": ("like", "Admin%")}
+		self.assertEqual(frappe.db.exists(filters), dn)
+		self.assertEqual(
+			filters["doctype"], dt
+		)  # make sure that doctype was not removed from filters
+
 		self.assertEqual(frappe.db.exists(dt, [["name", "=", dn]]), dn)
 
 


### PR DESCRIPTION
### Problem

```py
filters = {"doctype": "User", "full_name": "Jane Doe"}
frappe.db.exists(filters)
filters.get("doctype") # doesn't exist anymore 😭
```

Introduced by #16200

### Solution

`frappe.db.exists` copies filters for internal use.