### PR TITLE
perf: exists is already checked in delete_doc

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -978,8 +978,7 @@ def delete_doc(doctype=None, name=None, force=0, ignore_doctypes=None, for_reloa
 
 def delete_doc_if_exists(doctype, name, force=0):
 	"""Delete document if exists."""
-	if db.exists(doctype, name):
-		delete_doc(doctype, name, force=force)
+	delete_doc(doctype, name, force=force, ignore_missing=True)
 
 def reload_doctype(doctype, force=False, reset_permissions=False):
 	"""Reload DocType from model (`[module]/[doctype]/[name]/[name].json`) files."""


### PR DESCRIPTION
`exists` is already checked in `delete_doc`, no need to do it again.

https://github.com/frappe/frappe/blob/6dfd2798631bbdde14417842aa464c5ff5f75f96/frappe/model/delete_doc.py#L41-L46