### PR TITLE
refactor: call getfullargspec only once

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1252,9 +1252,10 @@ def get_newargs(fn, kwargs):
 	if hasattr(fn, 'fnargs'):
 		fnargs = fn.fnargs
 	else:
-		fnargs = inspect.getfullargspec(fn).args
-		fnargs.extend(inspect.getfullargspec(fn).kwonlyargs)
-		varkw = inspect.getfullargspec(fn).varkw
+		fullargspec = inspect.getfullargspec(fn)
+		fnargs = fullargspec.args
+		fnargs.extend(fullargspec.kwonlyargs)
+		varkw = fullargspec.varkw
 
 	newargs = {}
 	for a in kwargs:


### PR DESCRIPTION
Any reason to call `inspect.getfullargspec` 3 times with the same parameter? 🤔