### PR TITLE
feat: Hide page head while scrolling down

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -47,13 +47,17 @@ frappe.ui.Page = class Page {
 	}
 
 	setup_scroll_handler() {
-		window.addEventListener('scroll', () => {
-			if (document.documentElement.scrollTop) {
-				$('.page-head').toggleClass('drop-shadow', true);
+		let last_scroll = 0;
+		window.addEventListener('scroll', frappe.utils.throttle(() => {
+			$('.page-head').toggleClass('drop-shadow', !!document.documentElement.scrollTop);
+			let current_scroll = document.documentElement.scrollTop;
+			if (current_scroll > 0 && last_scroll <= current_scroll) {
+				$('.page-head').css("top", "-15px");
 			} else {
-				$('.page-head').removeClass('drop-shadow');
+				$('.page-head').css("top", "var(--navbar-height)");
 			}
-		});
+			last_scroll = current_scroll;
+		}), 500);
 	}
 
 	get_empty_state(title, message, primary_action) {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -88,6 +88,7 @@
 	top: var(--navbar-height);
 	background: var(--bg-color);
 	margin-bottom: 5px;
+	transition: 0.5s top;
 	.page-head-content {
 		height: var(--page-head-height);
 	}


### PR DESCRIPTION
- Hide the page head while scrolling down to create more reading space in the form. Page head re-appears while scrolling up or if the user is at the top of the form

https://user-images.githubusercontent.com/13928957/159404191-d5b247cc-8dad-4bde-838d-19537180df82.mov

(Experimental)

> no-docs