### PR TITLE
test(FrappeTestCase): reset state across test runs

### DIFF
--- a/frappe/core/doctype/log_settings/test_log_settings.py
+++ b/frappe/core/doctype/log_settings/test_log_settings.py
@@ -2,20 +2,17 @@
 # License: MIT. See LICENSE
 
 from datetime import datetime
-import unittest
 
 import frappe
 from frappe.utils import now_datetime, add_to_date
 from frappe.core.doctype.log_settings.log_settings import run_log_clean_up
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestLogSettings(unittest.TestCase):
+class TestLogSettings(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
-		cls.savepoint = "TestLogSettings"
-		# SAVEPOINT can only be used in transaction blocks and we don't wan't to take chances
-		frappe.db.begin()
-		frappe.db.savepoint(cls.savepoint)
+		super().setUpClass()
 
 		frappe.db.set_single_value(
 			"Log Settings",
@@ -25,10 +22,6 @@ class TestLogSettings(unittest.TestCase):
 				"clear_email_queue_after": 1,
 			},
 		)
-
-	@classmethod
-	def tearDownClass(cls):
-		frappe.db.rollback(save_point=cls.savepoint)
 
 	def setUp(self) -> None:
 		if self._testMethodName == "test_delete_logs":

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -11,11 +11,18 @@ class FrappeTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
 		frappe.db.commit()
+		cls.pre_test_flags = copy.deepcopy(frappe.flags)
 		return super().setUpClass()
 
 	@classmethod
 	def tearDownClass(cls) -> None:
 		frappe.db.rollback()
+
+		if hasattr(cls, "pre_test_flags"):
+			frappe.flags  = cls.pre_test_flags
+
+		frappe.db.value_cache = {}
+		frappe.set_user("Administrator")
 		return super().tearDownClass()
 
 


### PR DESCRIPTION
Reset following for each test run to reduce flake:

- frappe.flags
- frappe.db.value_cache
- reset user to `"Administrator"`
- ... more?


example issue: https://github.com/frappe/erpnext/pull/30358 

wait for ERPNext CI run: https://github.com/frappe/erpnext/actions/runs/2022153166 