### PR TITLE
feat: Consensus Workflow issue 14655

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -103,7 +103,8 @@ def apply_workflow(doc, action):
 	if uom == 'Percent':
 		num_members = get_role_member_count(transition.allowed)
 		# this is instead of a conditional check in JavaScript
-		if quantity > 100: quantity = 100
+		if quantity > 100: 
+            quantity = 100
 	
 	# update workflow state field
 	if uom == 'Individual' and quantity == 1:
@@ -263,7 +264,7 @@ def add_workflow_vote_and_return_count(doc, workflow, state, action, user):
 			, 'reference_name': doc.name, 'reference_doctype': doc.doctype
 			, 'workflow': workflow, 'workflow_state': state
 			, 'workflow_action': action, 'user': user
-			, 'vote_datetime': frappe.utils.now_datetime() #datetime.datetime.now() 
+			, 'vote_datetime': frappe.utils.now_datetime() 
 		}).insert(ignore_permissions=True)
 	# existing votes plus new vote.  We won't get here if user already voted b/c of frappe.throw()
 	vote_count = len(current_votes_this_action) + 1 

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -241,7 +241,7 @@ def get_workflow_field_value(workflow_name, field):
 	return value
 
 def get_role_member_count(role_name):
-	counts = frappe.db.get_list('Has Role'
+	counts = frappe.db.get_all('Has Role'
 			, filters = {'parenttype' : 'User', 'parentfield': 'roles', 'role': role_name}
 			, fields = ['count(name) as count'])
 	return counts[0]['count']

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -104,7 +104,7 @@ def apply_workflow(doc, action):
 		num_members = get_role_member_count(transition.allowed)
 		# this is instead of a conditional check in JavaScript
 		if quantity > 100: 
-            quantity = 100
+			quantity = 100
 	
 	# update workflow state field
 	if uom == 'Individual' and quantity == 1:

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -221,3 +221,139 @@ def create_todo_workflow():
 
 def create_new_todo():
 	return frappe.get_doc(dict(doctype='ToDo', description='workflow ' + random_string(10))).insert()
+
+class TestVotingWorkflow(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		make_test_records("User")
+		create_extra_states()		
+
+	def setUp(self):
+		self.workflow = create_voting_workflow()
+		frappe.set_user('Administrator')
+
+	def tearDown(self):
+		frappe.delete_doc('Workflow', 'Test Voting')
+		pass
+	
+
+	def test_voting_progress(self):
+		doc = create_new_voting()
+		
+		# somehow, when running tests for this DocType, you can end up with 
+		# the "Administrator" account showing up twice in the 'Test Voter' 
+		# Role.  This shouldn't be possible, but it is happening.  So fix it.
+		# these two lines don't seem work to get rid of Administrator being in the group:
+		#user = frappe.get_doc('User', 'Administrator')
+		#user.remove_roles('Test Voter')
+		# so use a bigger hammer:
+		#frappe.db.sql("delete from `tabHas Role` where parent = 'Administrator' and parentfield = 'roles' and parenttype = 'User' and role = 'Test Voter'")
+		frappe.db.delete('Has Role', {'parent': 'Administrator'
+			, 'parentfield': 'roles'
+			, 'parenttype': 'User'
+			, 'role': 'Test Voter'})
+		user1 = frappe.get_doc('User', 'test1@example.com')
+		user1.add_roles('Test Voter')
+		user2 = frappe.get_doc('User', 'test2@example.com')
+		user2.add_roles('Test Voter')
+		user3 = frappe.get_doc('User', 'test3@example.com')
+		user3.add_roles('Test Voter')
+		user4 = frappe.get_doc('User', 'test4@example.com')
+		user4.add_roles('Test Voter')
+		
+		# two votes (50% of 4 members) to get from "Pending" to "In Process"
+		frappe.set_user('test1@example.com')
+		apply_workflow(doc, 'Approve')
+		self.assertEqual(doc.workflow_state, "Pending")
+		# voting twice shouldn't change things
+		frappe.set_user('test1@example.com')
+		#apply_workflow(doc, 'Approve')
+		self.assertRaises(WorkflowTransitionError, apply_workflow, doc, 'Approve')
+		self.assertEqual(doc.workflow_state, "Pending")
+		# second vote
+		frappe.set_user('test2@example.com')
+		apply_workflow(doc, 'Approve')
+		self.assertEqual(doc.workflow_state, "In Process")
+		# three votes to get from "In Process" to "Approved"
+		frappe.set_user('test1@example.com')
+		apply_workflow(doc, 'Approve')
+		self.assertEqual(doc.workflow_state, "In Process")
+		# voting twice shouldn't change things
+		frappe.set_user('test1@example.com')
+		#apply_workflow(doc, 'Approve')
+		self.assertRaises(WorkflowTransitionError, apply_workflow, doc, 'Approve')
+		self.assertEqual(doc.workflow_state, "In Process")
+		# second vote
+		frappe.set_user('test2@example.com')
+		apply_workflow(doc, 'Approve')
+		self.assertEqual(doc.workflow_state, "In Process")
+		# third vote
+		frappe.set_user('test3@example.com')
+		apply_workflow(doc, 'Approve')
+		self.assertEqual(doc.workflow_state, "Approved")
+		frappe.set_user('Administrator')
+
+
+def create_voting_workflow():
+	# designed for a group of 4.  Administrator was showing up in the group, but I used the
+	# big hammer to remove it.
+	# starts at "Pending", goes to "In Process" with 50%, goes to "Approved" with 3 individuals
+	if frappe.db.exists('Workflow', 'Test Tag'):
+		frappe.db.delete('Workflow Action Vote', {'workflow': 'Test Tag'})
+		frappe.delete_doc('Workflow', 'Test Tag')
+
+	if not frappe.db.exists('Role', 'Test Voter'):
+		frappe.get_doc(dict(doctype='Role',
+			role_name='Test Voter')).insert(ignore_if_duplicate=True)
+	workflow = frappe.new_doc('Workflow')
+	workflow.workflow_name = 'Test Tag'
+	workflow.document_type = 'Tag'
+	workflow.workflow_state_field = 'workflow_state'
+	workflow.is_active = 1
+	workflow.send_email_alert = 0
+	workflow.append('states', dict(
+		state = 'Pending', allow_edit = 'All'
+	))
+	workflow.append('states', dict(
+		state = 'In Process', allow_edit = 'Test Voter'
+	))
+	workflow.append('states', dict(
+		state = 'Approved', allow_edit = 'Test Voter',
+		update_field = 'status', update_value = 'Closed'
+	))
+	workflow.append('states', dict(
+		state = 'Rejected', allow_edit = 'Test Voter'
+	))
+	workflow.append('transitions', dict(
+		state = 'Pending', action='Approve', next_state = 'In Process',
+		allowed='Test Voter', allow_self_approval= 1, quantity = 50, unit_of_measure = 'Percent'
+	))
+	workflow.append('transitions', dict(
+		state = 'In Process', action='Approve', next_state = 'Approved',
+		allowed='Test Voter', allow_self_approval= 1, quantity = 3, unit_of_measure = 'Individual'
+	))
+	workflow.append('transitions', dict(
+		state = 'Pending', action='Reject', next_state = 'Rejected',
+		allowed='Test Voter', allow_self_approval= 1
+	))
+	workflow.append('transitions', dict(
+		state = 'In Process', action='Reject', next_state = 'Rejected',
+		allowed='Test Voter', allow_self_approval= 1
+	))
+	workflow.append('transitions', dict(
+		state = 'Rejected', action='Review', next_state = 'Pending',
+		allowed='Test Voter', allow_self_approval= 1
+	))
+	workflow.insert(ignore_permissions=True)
+
+	return workflow
+
+def create_new_voting():
+	rnd_str = random_string(10)
+	return frappe.get_doc(dict(doctype='Tag', description='workflow ' + rnd_str, name = rnd_str)).insert()
+
+def create_extra_states():
+	if not frappe.db.exists('Workflow State', 'In Process'):
+		frappe.get_doc(dict(doctype='Workflow State'
+			, workflow_state_name='In Process')).insert(ignore_if_duplicate=True)
+	

--- a/frappe/workflow/doctype/workflow_action_vote/test_workflow_action_vote.py
+++ b/frappe/workflow/doctype/workflow_action_vote/test_workflow_action_vote.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+import unittest
+
+class TestWorkflowActionVote(unittest.TestCase):
+	pass

--- a/frappe/workflow/doctype/workflow_action_vote/workflow_action_vote.js
+++ b/frappe/workflow/doctype/workflow_action_vote/workflow_action_vote.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Workflow Action Vote', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe/workflow/doctype/workflow_action_vote/workflow_action_vote.json
+++ b/frappe/workflow/doctype/workflow_action_vote/workflow_action_vote.json
@@ -1,0 +1,91 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-03-18 17:21:56.529911",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "reference_name",
+  "reference_doctype",
+  "workflow",
+  "workflow_state",
+  "workflow_action",
+  "user",
+  "vote_datetime"
+ ],
+ "fields": [
+  {
+   "fieldname": "reference_name",
+   "fieldtype": "Dynamic Link",
+   "in_list_view": 1,
+   "label": "Reference Name",
+   "options": "reference_doctype",
+   "reqd": 1
+  },
+  {
+   "fieldname": "reference_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Reference Document Type",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "workflow",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Workflow",
+   "options": "Workflow",
+   "reqd": 1
+  },
+  {
+   "fieldname": "workflow_state",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Workflow State",
+   "options": "Workflow State",
+   "reqd": 1
+  },
+  {
+   "fieldname": "workflow_action",
+   "fieldtype": "Link",
+   "label": "Workflow Action",
+   "options": "Workflow Action Master",
+   "reqd": 1
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  },
+  {
+   "fieldname": "vote_datetime",
+   "fieldtype": "Datetime",
+   "label": "Vote Date and Time",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2022-03-18 17:21:56.529911",
+ "modified_by": "Administrator",
+ "module": "Workflow",
+ "name": "Workflow Action Vote",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
+   "share": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/frappe/workflow/doctype/workflow_action_vote/workflow_action_vote.py
+++ b/frappe/workflow/doctype/workflow_action_vote/workflow_action_vote.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class WorkflowActionVote(Document):
+	pass

--- a/frappe/workflow/doctype/workflow_transition/workflow_transition.json
+++ b/frappe/workflow/doctype/workflow_transition/workflow_transition.json
@@ -14,7 +14,9 @@
   "conditions",
   "condition",
   "column_break_7",
-  "example"
+  "example",
+  "quantity",
+  "unit_of_measure"
  ],
  "fields": [
   {
@@ -84,12 +86,29 @@
    "fieldtype": "HTML",
    "label": "Example",
    "options": "<pre><code>doc.grand_total &gt; 0</code></pre>\n\n<p>Conditions should be written in simple Python. Please use properties available in the form only.</p>\n<p>Allowed functions: \n</p><ul>\n<li>frappe.db.get_value</li>\n<li>frappe.db.get_list</li>\n<li>frappe.session</li>\n<li>frappe.utils.now_datetime</li>\n<li>frappe.utils.get_datetime</li>\n<li>frappe.utils.add_to_date</li>\n<li>frappe.utils.now</li>\n</ul>\n<p>Example: </p><pre><code>doc.creation &gt; frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-5, as_string=True, as_datetime=True) </code></pre><p></p>"
+  },
+  {
+   "default": "1",
+   "description": "The number required in order to change to the next state.",
+   "fieldname": "quantity",
+   "fieldtype": "Int",
+   "label": "Quantity",
+   "reqd": 1
+  },
+  {
+   "default": "Individual",
+   "description": "How the number in 'Quantity' should be interpreted.  \"Individual\" means individual user accounts.  \"Percent\" means a percent of the members in the group.",
+   "fieldname": "unit_of_measure",
+   "fieldtype": "Select",
+   "label": "Basis",
+   "options": "Individual\nPercent",
+   "reqd": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-07-21 13:24:59.084836",
+ "modified": "2022-03-18 16:31:51.669071",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Transition",


### PR DESCRIPTION
feat: Consensus Workflow for Frappe issue #14655.

This adds code and DocType changes to provide the functionality to implement issue 14655 Multiple Approvers for a Workflow State.

Two fields are added to the DocType Workflow Transition: Quantity and Basis.

Basis is a Select field type that indicates whether the consensus should be measured in individual user accounts ('Individual') or as a percentage of the number of people in the Role specified by the 'Allowed' field. This field defaults to 'Individual' so that the behavior of existing workflows will not be affected.

Quantity is an Int field type that indicates the number required to achieve consensus. If Basis is Individual then this is the number of individual user accounts that must have selected a single transition in order for it to be transitioned to. If Basis is Percent then this is a percentage. It should be a number between 1 and 100, inclusive. It indicates the percentage of individual user accounts that are in the Role specified by the 'Allowed' field that must have selected a single transition in order for it to be transitioned to. This field defaults to 1 so that the behavior of existing workflows will not be affected. All comparisons are "greater than or equal to".

To facilitate consensus, each person's selection is shown as a comment on the target Document. A User may only select one Action. If the user tries to select another Action, then the user will receive a notice that he or she has already made a selection and cannot make another.

Examples:

Role: "Allowed Deny" contains 10 users.
Basis: Is set to Individual
Quantity: Is set to 3

The document will transition to the Denied state once 3 members of the group selected the Deny Action.

Role: "Allowed to Approve" contains 5 users
Basis: Is set to Percentage
Quantity: Is set to 50

The workflow will transition to "Approved" once 3 users select the Approve Action

No attempt is made to prevent a Workflow creator from creating a Workflow that cannot advance. This is considered a feature. For example if a Workflow is created with one Transition that looks like this:

State: "Ready"
Action: "Approve"
Next State: "Approved"
Allowed: "My Group"
Basis: Percent
Quantity: 75

Another Transition that looks like this:

State: "Ready"
Action: "Deny"
Allowed: "My Group"
Next State: "Denied"
Basis: Percent
Quantity: 75

If there are ten people in the Role "My Group" then as soon as there are three people that have selected "Approve" and three people that have selected "Deny" for a particular Document then there is no way that the Document can successfully reach either the "Approved" or the "Denied" state. The Workflow Consensus is designed to record consensus reached, not provide tools to assist in reaching consensus because that is outside the scope.

The choice made by each individual account is recorded in the DocType Workflow
Action Vote. Documents of this DocType are what is counted in order to determine if the condition represented by "Basis" and "Quantity" have been reached.

I am having an issue updating documentation on Workflow.

The following DocType has been changed:
Workflow Transition
Changed fields: none
Deleted fields: none
Added fields:
Quantity/quantity Type:Int Mandatory:checked Default: 1
Basis/unit_of_measure type:Select Mandatory:checked Default:Individual

The following DocType has been added:
Workflow Action Vote:
All fields are mandatory:checked
reference_name type:Link options:reference_doctype
reference_doctype type:Link options:DocType
workflow type:Link options:Workflow
workflow_state type:Link options:Workflow State
workflow_action type:Link options:Workflow Action Master
user type:Link options:User
vote_datetime type:Datetime

Note: there is one test that did not pass before this PR. I have not made any changes to affect that.