### PR TITLE
fix: Use calendar name as it is

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -29,7 +29,7 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 			.then(() => {
 				this.page_title = __('{0} Calendar', [this.page_title]);
 				this.calendar_settings = frappe.views.calendar[this.doctype] || {};
-				this.calendar_name = frappe.utils.to_title_case(frappe.get_route()[3] || '');
+				this.calendar_name = frappe.get_route()[3];
 			});
 	}
 
@@ -72,12 +72,17 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 		const calendar_name = this.calendar_name;
 
 		return new Promise(resolve => {
-			if (calendar_name === 'Default') {
+			if (calendar_name === 'default') {
 				Object.assign(options, frappe.views.calendar[this.doctype]);
 				resolve(options);
 			} else {
 				frappe.model.with_doc('Calendar View', calendar_name, () => {
 					const doc = frappe.get_doc('Calendar View', calendar_name);
+					if (!doc) {
+						frappe.show_alert(__("{0} is not a valid Calendar. Redirecting to default Calendar.", [calendar_name.bold()]));
+						frappe.set_route("List", this.doctype, "Calendar", "default");
+						return;
+					}
 					Object.assign(options, {
 						field_map: {
 							id: "name",


### PR DESCRIPTION
Calendar views with names like `POC Plan` (basically names that are not Title Cased) used to break with the following error
```
TypeError: Cannot read properties of null (reading 'start_date_field')
    at calendar.js:84:19
    at Object.callback (model.js:218:19)
    at Object.callback [as success_callback] (request.js:83:16)
    at 200 (request.js:127:34)
    at Object.<anonymous> (request.js:279:6)
    at fire (jquery.js:3500:31)
    at Object.fireWith [as resolveWith] (jquery.js:3630:7)
    at done (jquery.js:9796:14)
    at XMLHttpRequest.<anonymous> (jquery.js:10057:9)
```
The issue was introduced with https://github.com/frappe/frappe/commit/6759966a577ba9e49c824b84549ac15a337fc9c8

---

<img width="1431" alt="Screenshot 2022-03-23 at 9 17 56 AM" src="https://user-images.githubusercontent.com/13928957/159620120-127aecdb-c00e-43cb-b1a6-a2f4129c6e3e.png">

Works after the fix.
