### PR TITLE
fix: Show assignments based on allocated todo only

### DIFF
--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -72,7 +72,8 @@ class ToDo(Document):
 			assignments = frappe.get_all("ToDo", filters={
 				"reference_type": self.reference_type,
 				"reference_name": self.reference_name,
-				"status": ("!=", "Cancelled")
+				"status": ("!=", "Cancelled"),
+				"allocated_to": ("is", "set")
 			}, pluck="allocated_to")
 			assignments.reverse()
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -312,6 +312,7 @@ def get_assignments(dt, dn):
 			'reference_type': dt,
 			'reference_name': dn,
 			'status': ('!=', 'Cancelled'),
+			'allocated_to': ("is", "set")
 		})
 
 @frappe.whitelist()

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -111,7 +111,6 @@ class EmailQueue(Document):
 		""" Send emails to recipients.
 		"""
 		if not self.can_send_now():
-			frappe.db.rollback()
 			return
 
 		with SendMailContext(self, is_background_task) as ctx:

--- a/frappe/tests/test_assign.py
+++ b/frappe/tests/test_assign.py
@@ -4,6 +4,7 @@ import frappe, unittest
 import frappe.desk.form.assign_to
 from frappe.desk.listview import get_group_by_count
 from frappe.automation.doctype.assignment_rule.test_assignment_rule import make_note
+from frappe.desk.form.load import get_assignments
 
 class TestAssign(unittest.TestCase):
 	def test_assign(self):
@@ -55,6 +56,17 @@ class TestAssign(unittest.TestCase):
 
 		frappe.db.rollback()
 
+	def test_assignment_removal(self):
+		todo = frappe.get_doc({"doctype":"ToDo", "description": "test"}).insert()
+		if not frappe.db.exists("User", "test@example.com"):
+			frappe.get_doc({"doctype":"User", "email":"test@example.com", "first_name":"Test"}).insert()
+
+		new_todo = assign(todo, "test@example.com")
+
+		# remove assignment
+		frappe.db.set_value("ToDo", new_todo[0].name, "allocated_to", "")
+
+		self.assertFalse(get_assignments("ToDo", todo.name))
 
 def assign(doc, user):
 	return frappe.desk.form.assign_to.add({


### PR DESCRIPTION
Issue:
Currently, if you assign a reference document (e.g Issue) to someone, in the backend, the system creates a ToDo record allocated to that person. Now, if you remove the "Allocated To" value from the ToDo record, the system shows the assignment based on the session user on the reference document (Issue).

Fix:
After the fix, the system shows assignments only based on ToDo allocated to someone.