### PR TITLE
fix(test): start transaction explicitly before savepoint

### DIFF
--- a/frappe/core/doctype/log_settings/test_log_settings.py
+++ b/frappe/core/doctype/log_settings/test_log_settings.py
@@ -12,8 +12,9 @@ from frappe.core.doctype.log_settings.log_settings import run_log_clean_up
 class TestLogSettings(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
-
 		cls.savepoint = "TestLogSettings"
+		# SAVEPOINT can only be used in transaction blocks and we don't wan't to take chances
+		frappe.db.begin()
 		frappe.db.savepoint(cls.savepoint)
 
 		frappe.db.set_single_value(


### PR DESCRIPTION
Fixes failing _(flaky)_ https://github.com/frappe/frappe/runs/5657459404?check_suite_focus=true

```python
 ERROR  setUpClass (frappe.core.doctype.log_settings.test_log_settings.TestLogSettings)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/log_settings/test_log_settings.py", line 17, in setUpClass
    frappe.db.savepoint(cls.savepoint)
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/database.py", line 845, in savepoint
    self.sql(f"savepoint {save_point}")
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/postgres/database.py", line 103, in sql
    return super(PostgresDatabase, self).sql(
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/database.py", line 159, in sql
    self._cursor.execute(query)
psycopg2.errors.NoActiveSqlTransaction: SAVEPOINT can only be used in transaction blocks
```