### PR TITLE
fix: get currency name from DB only if `options` are set and value is truthy

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -969,7 +969,7 @@ class BaseDocument(object):
 			and (currency_field := df.get("options"))
 			and (currency_value := self.get(currency_field))
 		):
-			currency = frappe.db.exists('Currency', currency_value, cache=True)
+			currency = frappe.db.get_value('Currency', currency_value, cache=True)
 
 		val = self.get(fieldname)
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -963,10 +963,13 @@ class BaseDocument(object):
 			from frappe.model.meta import get_default_df
 			df = get_default_df(fieldname)
 
-		if df.fieldtype == "Currency" and not currency:
-			currency = self.get(df.get("options"))
-			if not frappe.db.exists('Currency', currency, cache=True):
-				currency = None
+		if (
+			df.fieldtype == "Currency"
+			and not currency
+			and	(currency_field := df.get("options"))
+			and (currency_value := self.get(currency_field))
+		):
+			currency = frappe.db.exists('Currency', currency_value, cache=True)
 
 		val = self.get(fieldname)
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -966,7 +966,7 @@ class BaseDocument(object):
 		if (
 			df.fieldtype == "Currency"
 			and not currency
-			and	(currency_field := df.get("options"))
+			and (currency_field := df.get("options"))
 			and (currency_value := self.get(currency_field))
 		):
 			currency = frappe.db.exists('Currency', currency_value, cache=True)

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -246,7 +246,7 @@ class TestDocument(unittest.TestCase):
 			'fields': [
 				{'label': 'Currency', 'fieldname': 'currency', 'reqd': 1, 'fieldtype': 'Currency'},
 			]
-		}).insert()
+		}).insert(ignore_if_duplicate=True)
 
 		frappe.delete_doc_if_exists("Currency", "INR", 1)
 
@@ -261,6 +261,10 @@ class TestDocument(unittest.TestCase):
 			'currency': 100000
 		})
 		self.assertEqual(d.get_formatted('currency', currency='INR', format="#,###.##"), '₹ 100,000.00')
+
+		# should work even if options aren't set in df
+		# and currency param is not passed
+		self.assertIn("0", d.get_formatted("currency"))
 
 	def test_limit_for_get(self):
 		doc = frappe.get_doc("DocType", "DocType")


### PR DESCRIPTION
## Issue

```bash
16:27:20 web.1            | Traceback (most recent call last):
16:27:20 web.1            |   File "apps/frappe/frappe/app.py", line 66, in application
16:27:20 web.1            |     response = frappe.api.handle()
16:27:20 web.1            |   File "apps/frappe/frappe/api.py", line 54, in handle
16:27:20 web.1            |     return frappe.handler.handle()
16:27:20 web.1            |   File "apps/frappe/frappe/handler.py", line 31, in handle
16:27:20 web.1            |     data = execute_cmd(cmd)
16:27:20 web.1            |   File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
16:27:20 web.1            |     return frappe.call(method, **frappe.form_dict)
16:27:20 web.1            |   File "apps/frappe/frappe/__init__.py", line 1248, in call
16:27:20 web.1            |     return fn(*args, **newargs)
16:27:20 web.1            |   File "apps/frappe/frappe/desk/form/save.py", line 20, in savedocs
16:27:20 web.1            |     doc.save()
16:27:20 web.1            |   File "apps/frappe/frappe/model/document.py", line 284, in save
16:27:20 web.1            |     return self._save(*args, **kwargs)
16:27:20 web.1            |   File "apps/frappe/frappe/model/document.py", line 335, in _save
16:27:20 web.1            |     self.run_post_save_methods()
16:27:20 web.1            |   File "apps/frappe/frappe/model/document.py", line 1023, in run_post_save_methods
16:27:20 web.1            |     self.save_version()
16:27:20 web.1            |   File "apps/frappe/frappe/model/document.py", line 1124, in save_version
16:27:20 web.1            |     elif version.set_diff(self._doc_before_save, self):
16:27:20 web.1            |   File "apps/frappe/frappe/core/doctype/version/version.py", line 12, in set_diff
16:27:20 web.1            |     diff = get_diff(old, new)
16:27:20 web.1            |   File "apps/frappe/frappe/core/doctype/version/version.py", line 80, in get_diff
16:27:20 web.1            |     diff = get_diff(old_row_by_name[d.name], d, for_child=True)
16:27:20 web.1            |   File "apps/frappe/frappe/core/doctype/version/version.py", line 93, in get_diff
16:27:20 web.1            |     old_value = old.get_formatted(df.fieldname) if old_value else old_value
16:27:20 web.1            |   File "apps/frappe/frappe/model/base_document.py", line 968, in get_formatted
16:27:20 web.1            |     if not frappe.db.exists('Currency', currency, cache=True):
16:27:20 web.1            |   File "apps/frappe/frappe/database/database.py", line 925, in exists
16:27:20 web.1            |     return self.get_value(dt, dn, ignore=True, cache=cache)
16:27:20 web.1            |   File "apps/frappe/frappe/database/database.py", line 389, in get_value
16:27:20 web.1            |     ret = self.get_values(doctype, filters, fieldname, ignore, as_dict, debug,
16:27:20 web.1            |   File "apps/frappe/frappe/database/database.py", line 450, in get_values
16:27:20 web.1            |     out = self._get_values_from_table(
16:27:20 web.1            |   File "apps/frappe/frappe/database/database.py", line 642, in _get_values_from_table
16:27:20 web.1            |     query = self.query.get_sql(
16:27:20 web.1            |   File "apps/frappe/frappe/database/query.py", line 294, in get_sql
16:27:20 web.1            |     criterion = self.build_conditions(table, filters, **kwargs)
16:27:20 web.1            |   File "apps/frappe/frappe/database/query.py", line 283, in build_conditions
16:27:20 web.1            |     criterion = self.dict_query(filters=filters, table=table, **kwargs)
16:27:20 web.1            |   File "apps/frappe/frappe/database/query.py", line 241, in dict_query
16:27:20 web.1            |     if isinstance(value[1], (list, tuple)) or value[0] in list(OPERATOR_MAP.keys())[-4:]:
16:27:20 web.1            | IndexError: list index out of range
```
This issue happens because in `base_document.py` on line 967, the variable `currency` gets set to the document's internal `__dict__` (this is what `doc.get` returns if key is `None`). Ideally, we should look into deprecating this behavior.

## Steps to replicate

1. `options` are not set for a Currency field (for example: `incoming_rate` in **Sales Invoice Item**)
1. Try calling `get_formatted` for that field without setting the `currency` parameter

## Changes Made
- Get value only if currency field is set in `options`
- `frappe.db.exists` => `frappe.db.get_value`
- Call `frappe.db.get_value` only if value is truthy
- Refactor two if conditions into one
- Always set currency from `frappe.db.get_value`. This way, if the value is in lowercase for some reason, it gets converted to uppercase.


**Tested Locally**