### PR TITLE
refactor(BaseDocument)!: don't return `__dict__` if `key` is falsy

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -132,7 +132,7 @@ class BaseDocument(object):
 	def get_db_value(self, key):
 		return frappe.db.get_value(self.doctype, self.name, key)
 
-	def get(self, key=None, filters=None, limit=None, default=None):
+	def get(self, key, filters=None, limit=None, default=None):
 		if isinstance(key, dict):
 			return _filter(self.get_all_children(), key, limit=limit)
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -133,31 +133,29 @@ class BaseDocument(object):
 		return frappe.db.get_value(self.doctype, self.name, key)
 
 	def get(self, key=None, filters=None, limit=None, default=None):
-		if key:
-			if isinstance(key, dict):
-				return _filter(self.get_all_children(), key, limit=limit)
-			if filters:
-				if isinstance(filters, dict):
-					value = _filter(self.__dict__.get(key, []), filters, limit=limit)
-				else:
-					default = filters
-					filters = None
-					value = self.__dict__.get(key, default)
+		if isinstance(key, dict):
+			return _filter(self.get_all_children(), key, limit=limit)
+
+		if filters:
+			if isinstance(filters, dict):
+				value = _filter(self.__dict__.get(key, []), filters, limit=limit)
 			else:
+				default = filters
+				filters = None
 				value = self.__dict__.get(key, default)
-
-			if value is None and key in (
-				d.fieldname for d in self.meta.get_table_fields()
-			):
-				value = []
-				self.set(key, value)
-
-			if limit and isinstance(value, (list, tuple)) and len(value) > limit:
-				value = value[:limit]
-
-			return value
 		else:
-			return self.__dict__
+			value = self.__dict__.get(key, default)
+
+		if value is None and key in (
+			d.fieldname for d in self.meta.get_table_fields()
+		):
+			value = []
+			self.set(key, value)
+
+		if limit and isinstance(value, (list, tuple)) and len(value) > limit:
+			value = value[:limit]
+
+		return value
 
 	def getone(self, key, filters=None):
 		return self.get(key, filters=filters, limit=1)[0]


### PR DESCRIPTION
This PR proposes a breaking change in `doc.get`

If a key is not passed to this function, it returns the `doc`'s internal `__dict__`. This is not intuitive and causes hard to debug issues like https://github.com/frappe/frappe/pull/16382. Ideally, one expects `doc.get` to work like `dict.get`.

After this PR, if `key` is `None`, it will return either the value in `doc.__dict__` for key `None` or the `default` value.