### PR TITLE
fix: remove hyphen from class name while creating boilerplate

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -272,7 +272,7 @@ def make_boilerplate(template, doc, opts=None):
 					frappe.utils.cstr(source.read()).format(
 						app_publisher=app_publisher,
 						year=frappe.utils.nowdate()[:4],
-						classname=doc.name.replace(" ", ""),
+						classname=doc.name.replace(" ", "").replace("-", ""),
 						base_class_import=base_class_import,
 						base_class=base_class,
 						doctype=doc.name, **opts,


### PR DESCRIPTION
Continues #16188

Hyphen already being removed when retrieving controller [here](https://github.com/frappe/frappe/blob/4bb5ea609cd83c92e8d7b170cb8f899440a1f4f8/frappe/model/base_document.py#L53).