### PR TITLE
feat: allow breaking `_()` function call to different lines

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -36,7 +36,18 @@ class TestTranslate(unittest.TestCase):
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)
-		self.assertListEqual(data, expected_output)
+		exp_filename = "apps/frappe/frappe/tests/translation_test_file.txt"
+
+		self.assertEqual(len(data), len(expected_output),
+				msg=f"Mismatched output:\nExpected: {expected_output}\nFound: {data}")
+
+		for extracted, expected in zip(data, expected_output):
+			ext_filename, ext_message, ext_context, ext_line  = extracted
+			exp_message, exp_context, exp_line  = expected
+			self.assertEqual(ext_filename, exp_filename)
+			self.assertEqual(ext_message, exp_message)
+			self.assertEqual(ext_context, exp_context)
+			self.assertEqual(ext_line, exp_line)
 
 	def test_translation_with_context(self):
 		try:
@@ -107,13 +118,13 @@ class TestTranslate(unittest.TestCase):
 
 
 expected_output = [
-	('apps/frappe/frappe/tests/translation_test_file.txt', 'Warning: Unable to find {0} in any table related to {1}', 'This is some context', 2),
-	('apps/frappe/frappe/tests/translation_test_file.txt', 'Warning: Unable to find {0} in any table related to {1}', None, 4),
-	('apps/frappe/frappe/tests/translation_test_file.txt', "You don't have any messages yet.", None, 6),
-	('apps/frappe/frappe/tests/translation_test_file.txt', 'Submit', 'Some DocType', 8),
-	('apps/frappe/frappe/tests/translation_test_file.txt', 'Warning: Unable to find {0} in any table related to {1}', 'This is some context', 15),
-	('apps/frappe/frappe/tests/translation_test_file.txt', 'Submit', 'Some DocType', 17),
-	('apps/frappe/frappe/tests/translation_test_file.txt', "You don't have any messages yet.", None, 19),
-	('apps/frappe/frappe/tests/translation_test_file.txt', "You don't have any messages yet.", None, 21)
+	('Warning: Unable to find {0} in any table related to {1}', 'This is some context', 2),
+	('Warning: Unable to find {0} in any table related to {1}', None, 4),
+	("You don't have any messages yet.", None, 6),
+	('Submit', 'Some DocType', 8),
+	('Warning: Unable to find {0} in any table related to {1}', 'This is some context', 15),
+	('Submit', 'Some DocType', 17),
+	("You don't have any messages yet.", None, 19),
+	("You don't have any messages yet.", None, 21)
 ]
 

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -125,6 +125,9 @@ expected_output = [
 	('Warning: Unable to find {0} in any table related to {1}', 'This is some context', 15),
 	('Submit', 'Some DocType', 17),
 	("You don't have any messages yet.", None, 19),
-	("You don't have any messages yet.", None, 21)
+	("You don't have any messages yet.", None, 21),
+	("Long string that needs its own line because of black formatting.", None, 24),
+	("Long string with", "context", 28),
+	("Long string with", "context on newline", 32),
 ]
 

--- a/frappe/tests/translation_test_file.txt
+++ b/frappe/tests/translation_test_file.txt
@@ -19,3 +19,17 @@ _('Submit', context="Some DocType")
 _("""You don't have any messages yet.""")
 
 _('''You don't have any messages yet.''')
+
+// allow newline in beginning
+_(
+"""Long string that needs its own line because of black formatting."""
+).format("blah")
+
+_(
+"Long string with", context="context"
+).format("blah")
+
+_(
+    "Long string with",
+    context="context on newline"
+).format("blah")

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -24,7 +24,7 @@ from frappe.query_builder import Field, DocType
 from pypika.terms import PseudoColumn
 
 TRANSLATE_PATTERN = re.compile(
-	r"_\("  # starts with literal `_(` work with both python / JS
+	r"_\([\s\n]*"  # starts with literal `_(`, ignore following whitespace/newlines
 
 	# BEGIN: message search
 	r"([\"']{,3})"  # start of message string identifier - allows: ', ", """, '''; 1st capture group
@@ -33,7 +33,7 @@ TRANSLATE_PATTERN = re.compile(
 	# END: message search
 
 	# BEGIN: python context search
-	r"(\s*,\s*context\s*=\s*"  # capture `context=` with ignoring whitespace
+	r"([\s\n]*,[\s\n]*context\s*=\s*"  # capture `context=` with ignoring whitespace
 		r"([\"'])"  # start of context string identifier; 5th capture group
 		r"(?P<py_context>((?!\5).)*)" # capture context string till closing id is found
 		r"\5"  # match context string closure
@@ -49,7 +49,7 @@ TRANSLATE_PATTERN = re.compile(
 	r")*"  # match one or more context string
 	# END: JS context search
 
-	r"\)"  # Closing function call
+	r"[\s\n]*\)"  # Closing function call ignore leading whitespace/newlines
 )
 
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -23,6 +23,35 @@ from frappe.utils import get_bench_path, is_html, strip, strip_html_tags
 from frappe.query_builder import Field, DocType
 from pypika.terms import PseudoColumn
 
+TRANSLATE_PATTERN = re.compile(
+	r"_\("  # starts with literal `_(` work with both python / JS
+
+	# BEGIN: message search
+	r"([\"']{,3})"  # start of message string identifier - allows: ', ", """, '''; 1st capture group
+		r"(?P<message>((?!\1).)*)" # Keep matching until string closing identifier is met which is same as 1st capture group
+	r"\1" # match exact string closing identifier
+	# END: message search
+
+	# BEGIN: python context search
+	r"(\s*,\s*context\s*=\s*"  # capture `context=` with ignoring whitespace
+		r"([\"'])"  # start of context string identifier; 5th capture group
+		r"(?P<py_context>((?!\5).)*)" # capture context string till closing id is found
+		r"\5"  # match context string closure
+	r")*"  # match one or more context string (?wat this should be 0 or 1)
+	# END: python context search
+
+	# BEGIN: JS context search
+	r"(\s*,\s*(.)*?\s*(,\s*" # skip message format replacements: ["format", ...] | null | []
+		r"([\"'])"  # start of context string; 11th capture group
+		r"(?P<js_context>((?!\11).)*)" # capture context string till closing id is found
+		r"\11"  # match context string closure
+		r")*"
+	r")*"  # match one or more context string
+	# END: JS context search
+
+	r"\)"  # Closing function call
+)
+
 
 def get_language(lang_list: List = None) -> str:
 	"""Set `frappe.local.lang` from HTTP headers at beginning of request
@@ -651,9 +680,8 @@ def extract_messages_from_code(code):
 			frappe.clear_last_message()
 
 	messages = []
-	pattern = r"_\(([\"']{,3})(?P<message>((?!\1).)*)\1(\s*,\s*context\s*=\s*([\"'])(?P<py_context>((?!\5).)*)\5)*(\s*,\s*(.)*?\s*(,\s*([\"'])(?P<js_context>((?!\11).)*)\11)*)*\)"
 
-	for m in re.compile(pattern).finditer(code):
+	for m in TRANSLATE_PATTERN.finditer(code):
 		message = m.group('message')
 		context = m.group('py_context') or m.group('js_context')
 		pos = m.start()

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -37,7 +37,7 @@ TRANSLATE_PATTERN = re.compile(
 		r"([\"'])"  # start of context string identifier; 5th capture group
 		r"(?P<py_context>((?!\5).)*)" # capture context string till closing id is found
 		r"\5"  # match context string closure
-	r")*"  # match one or more context string (?wat this should be 0 or 1)
+	r")?"  # match 0 or 1 context strings
 	# END: python context search
 
 	# BEGIN: JS context search


### PR DESCRIPTION
This is to allow use of black for auto-formatting. Long lines are split by black like this:

```python
_(
"a really long long long long long long long long long long long long long long long long line"
)
```

This is not captured by the current translation extraction regex and hence makes it difficult to introduce bulk formatting in the codebase. 


Other changes:
1. Refactor regex and add an explanation for all the magic.

**Before**: Only readable by a finite automaton. Sadly we don't have any on our team.
<img width="1440" alt="Screenshot 2022-03-26 at 3 22 47 PM" src="https://user-images.githubusercontent.com/9079960/160234339-d6a80876-dee6-4129-b4b9-ed6cf109ac3e.png">


**After**: kinda readable by human programmers. 
<img width="1183" alt="Screenshot 2022-03-26 at 4 14 50 PM" src="https://user-images.githubusercontent.com/9079960/160235972-6a6b9612-1ba2-4e2d-b843-3370559af01b.png">

2. limit context string matches to 0 or 1 (doesn't make sense to have `*` there)




TODO:
- [x] `no-docs` none of the example advise against usage like this. 
- [x] update this semgrep rule: https://github.com/frappe/semgrep-rules/pull/10



Before/After on ERPNext (formatted with black), did a set difference to make sure nothing already matching is getting excluded after this change.

<img width="549" alt="Screenshot 2022-03-26 at 4 32 30 PM" src="https://user-images.githubusercontent.com/9079960/160236534-85dbcc99-af5f-42b6-89d1-52f1a972ea3b.png">



Note: @sagarvora pointed out that black will start splitting strings into separate parts in new releases: https://black.readthedocs.io/en/stable/change_log.html?highlight=--experimental-string-processing#id25 I'll rewrite python extractor to AST based one when this actually becomes a problem. Alternatively, we should probably move towards integrating babel or gettext for translations.