### PR TITLE
fix: bad closure on double quote in print.js

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -37,7 +37,7 @@ frappe.ui.form.PrintView = class {
 		this.print_wrapper = this.page.main.empty().html(
 			`<div class="print-preview-wrapper"><div class="print-preview">
 				${frappe.render_template('print_skeleton_loading')}
-				<iframe class="print-format-container" width="100%" height="0" frameBorder="0" scrolling="no"">
+				<iframe class="print-format-container" width="100%" height="0" frameBorder="0" scrolling="no">
 				</iframe>
 			</div>
 			<div class="page-break-message text-muted text-center text-medium margin-top"></div>


### PR DESCRIPTION
fix: bad closure on double quote in print.js

closes #16425 