### PR TITLE
fix: TypeError on session expiration

### DIFF
--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -271,15 +271,13 @@ class Session:
 		"""non-login request: load a session"""
 		import frappe
 		from frappe.auth import validate_ip_address
+		self.start_as_guest()
 		data = self.get_session_record()
-
 		if data:
 			self.data.update({'data': data, 'user':data.user, 'sid': self.sid})
 			self.user = data.user
 			validate_ip_address(self.user)
 			self.device = data.device
-		else:
-			self.start_as_guest()
 
 		if self.sid != "Guest":
 			frappe.local.user_lang = frappe.translate.get_user_lang(self.data.user)


### PR DESCRIPTION
## Issue
After merge of #16030, whenever session expires, it shows error page with message `TypeError: cannot unpack non- iterable NoneType object`

Note: The problem is not with the mentioned PR. I referenced it because this bug was identified from it.

## Traceback
```bash
Traceback (most recent call last):
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/app.py", line 52, in application
    init_request(request)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/app.py", line 128, in init_request
    frappe.local.http_request = frappe.auth.HTTPRequest()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/auth.py", line 32, in __init__
    self.set_session()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/auth.py", line 69, in set_session
    frappe.local.login_manager = LoginManager()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/auth.py", line 123, in __init__
    self.make_session(resume=True)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/auth.py", line 205, in make_session
    frappe.local.session_obj = Session(user=self.user, resume=resume,
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/sessions.py", line 214, in __init__
    self.resume()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/sessions.py", line 278, in resume
    data = self.get_session_record()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/sessions.py", line 295, in get_session_record
    r = self.get_session_data()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/sessions.py", line 309, in get_session_data
    data = self.get_session_data_from_cache()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/sessions.py", line 326, in get_session_data_from_cache
    self._delete_session()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/sessions.py", line 358, in _delete_session
    delete_session(self.sid, reason="Session Expired")
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/sessions.py", line 95, in delete_session
    logout_feed(user, reason)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/core/doctype/activity_log/feed.py", line 57, in logout_feed
    add_authentication_log(subject, user, operation="Logout")
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/core/doctype/activity_log/activity_log.py", line 36, in add_authentication_log
    frappe.get_doc({
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/model/document.py", line 279, in insert
    if frappe.get_cached_value("User", frappe.session.user, "follow_created_documents"):
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/__init__.py", line 899, in get_cached_value
    doc = get_cached_doc(doctype, name)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/__init__.py", line 868, in get_cached_doc
    doc = get_doc(*args, **kwargs)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/__init__.py", line 927, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/model/document.py", line 76, in get_doc
    return controller(*args, **kwargs)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/model/document.py", line 114, in __init__
    self.load_from_db()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/model/document.py", line 157, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/__init__.py", line 448, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/__init__.py", line 427, in msgprint
    _raise_exception()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/__init__.py", line 382, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: User None not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/serve.py", line 17, in get_response
    response = renderer_instance.render()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 61, in render
    html = self.get_html()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/utils.py", line 445, in cache_html_decorator
    html = func(*args, **kwargs)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 76, in get_html
    self.post_process_context()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 84, in post_process_context
    self.set_user_info()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 281, in set_user_info
    info = get_fullname_and_avatar(frappe.session.user)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/utils/user.py", line 222, in get_fullname_and_avatar
    first_name, last_name, avatar, name = frappe.db.get_value("User",
TypeError: cannot unpack non-iterable NoneType object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/middlewares.py", line 14, in __call__
    return super(StaticDataMiddleware, self).__call__(environ, start_response)
  File "/Users/pruthvi/development/resilient/bench/dev/env/lib/python3.9/site-packages/werkzeug/middleware/shared_data.py", line 287, in __call__
    return self.app(environ, start_response)
  File "/Users/pruthvi/development/resilient/bench/dev/env/lib/python3.9/site-packages/werkzeug/middleware/shared_data.py", line 287, in __call__
    return self.app(environ, start_response)
  File "/Users/pruthvi/development/resilient/bench/dev/env/lib/python3.9/site-packages/werkzeug/local.py", line 354, in application
    return ClosingIterator(app(environ, start_response), self.cleanup)
  File "/Users/pruthvi/development/resilient/bench/dev/env/lib/python3.9/site-packages/werkzeug/wrappers/request.py", line 206, in application
    resp = f(*args[:-2] + (request,))
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/app.py", line 87, in application
    response = handle_exception(e)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/app.py", line 268, in handle_exception
    response = get_response("message", http_status_code=http_status_code)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/serve.py", line 23, in get_response
    response = ErrorPage(exception=e).render()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 61, in render
    html = self.get_html()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/utils.py", line 445, in cache_html_decorator
    html = func(*args, **kwargs)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 76, in get_html
    self.post_process_context()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 84, in post_process_context
    self.set_user_info()
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/website/page_renderers/template_page.py", line 281, in set_user_info
    info = get_fullname_and_avatar(frappe.session.user)
  File "/Users/pruthvi/development/resilient/bench/dev/apps/frappe/frappe/utils/user.py", line 222, in get_fullname_and_avatar
    first_name, last_name, avatar, name = frappe.db.get_value("User",
TypeError: cannot unpack non-iterable NoneType object
```

The problem is that, when session expires, it deletes the current session which makes logout_log. Document creation internally uses `frappe.session.user` which will be `None` at the time of logging the logout_log.

By default `frappe.session.user` should be `Guest` instead of `None`.

## Changes Made
 - call `start_as_guest` first and then `get_session_record`. This will ensure that `frappe.session.user` will not be None.

