### PR TITLE
revert: Logic to route if link with /app is clicked

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -56,6 +56,11 @@ $('body').on('click', 'a', function(e) {
 		return override(e.currentTarget.hash);
 	}
 
+	if (frappe.router.is_app_route(e.currentTarget.pathname)) {
+		// target has "/app, this is a v2 style route.
+		return override(e.currentTarget.pathname + e.currentTarget.hash);
+	}
+
 });
 
 frappe.router = {


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/16298

Reverting the accidentally deleted code.
**Deleted Code:** 
Logic to set route to link if any link (with anchor tag) is click which has `/app` in it.

**Issue:** 
If you click on any link it goes to that document but if you go back it again reloads the previous page, rather it should load it from cache.

**Before:**

https://user-images.githubusercontent.com/30859809/160430408-d8e5bec0-8743-4c4b-ba10-e86625de93a6.mov

**After:**

https://user-images.githubusercontent.com/30859809/160430448-368f88a7-ba92-4aeb-83d5-d239e96b82aa.mov
