### PR TITLE
fix: cache by URL

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -27,7 +27,8 @@ class RedisWrapper(redis.Redis):
 
 			key = "user:{0}:{1}".format(user, key)
 
-		return "{0}|{1}".format(frappe.conf.db_name, key).encode('utf-8')
+		url = frappe.utils.get_url()
+		return "{0}|{1}|{2}".format(url, frappe.conf.db_name, key).encode('utf-8')
 
 	def set_value(self, key, val, user=None, expires_in_sec=None, shared=False):
 		"""Sets cache value.


### PR DESCRIPTION
**Problem Statement**
When a site has alias domains, caching is done on a per-site basis. This means that if you have `siteA.com` with an alias domain `siteB.com` both siteA.com and siteB.com will share the same cache. This could be both useful and a pain depending on what you want to accomplish.

I can think of two different use cases.
1. You have a child company that uses the same site but a different domain, if the site is exactly the same this caching method works great because you will get served the cached content regardless of domain.
2. If you have a child company that doesn't visually share the same theme then this method of caching can cause some problems. For example, if you want to change the `site_logo`, and `site_name` context variables based on the domain being accessed you will get unexpected behavior's because the context will be cached based on the first request since cache cleared.


**Proposed Solution**
Add the domain being accessed to the cache key.
I've been running in production for a few days and I haven't noticed any unexpected behavior's.  

**Comments**
This might be a flag that could be set in the `site_config.json` as I mentioned above, it's possible you may want to retain the same cache across domains.

Discussion: https://discuss.erpnext.com/t/multiple-domains-vs-template-caching/87588