### PR TITLE
fix: Allow empty webhook data

### DIFF
--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -48,7 +48,8 @@ def validate_template(html):
 	"""Throws exception if there is a syntax error in the Jinja Template"""
 	import frappe
 	from jinja2 import TemplateSyntaxError
-
+	if not html:
+		return
 	jenv = get_jenv()
 	try:
 		jenv.from_string(html)


### PR DESCRIPTION
The system used to throw the following error when someone tried to save a webhook doc with no webhook data.

![Screenshot 2022-03-29 at 8 47 28 AM](https://user-images.githubusercontent.com/13928957/160526197-8d8a969c-a4e9-49a2-a6aa-b9906622e0ba.png)


```bash
Traceback (most recent call last):
  File "apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 287, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 309, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 240, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 971, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 869, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1161, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1144, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 866, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 31, in validate
    self.validate_request_body()
  File "apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 64, in validate_request_body
    validate_template(self.webhook_json)
  File "apps/frappe/frappe/utils/jinja.py", line 60, in validate_template
    jenv.from_string(html)
  File "env/lib/python3.7/site-packages/jinja2/environment.py", line 1092, in from_string
    return cls.from_code(self, self.compile(source), gs, None)
  File "env/lib/python3.7/site-packages/jinja2/environment.py", line 750, in compile
    source = self._generate(source, name, filename, defer_init=defer_init)
  File "env/lib/python3.7/site-packages/jinja2/environment.py", line 684, in _generate
    optimized=self.optimized,
  File "env/lib/python3.7/site-packages/jinja2/compiler.py", line 112, in generate
    raise TypeError("Can't compile non template nodes")
TypeError: Can't compile non template nodes
```
