### PR TITLE
fix: don't update autoname field when using `Document.save`

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -244,6 +244,7 @@ class Importer:
 		existing_doc = frappe.get_doc(self.doctype, doc.get(id_field.fieldname))
 
 		updated_doc = frappe.get_doc(self.doctype, doc.get(id_field.fieldname))
+
 		updated_doc.update(doc)
 
 		if get_diff(existing_doc, updated_doc):

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -92,11 +92,18 @@ class TestImporter(unittest.TestCase):
 
 		# update child table id in template date
 		i.import_file.raw_data[1][4] = existing_doc.table_field_1[0].name
-		i.import_file.raw_data[1][0] = existing_doc.name
+
+		# uppercase to check if autoname field isn't replaced in mariadb
+		if frappe.db.db_type == "mariadb":
+			i.import_file.raw_data[1][0] = existing_doc.name.upper()
+		else:
+			i.import_file.raw_data[1][0] = existing_doc.name
+
 		i.import_file.parse_data_from_template()
 		i.import_data()
 
 		updated_doc = frappe.get_doc(doctype_name, existing_doc.name)
+		self.assertEqual(existing_doc.title, updated_doc.title)
 		self.assertEqual(updated_doc.description, 'test description')
 		self.assertEqual(updated_doc.table_field_1[0].child_title, 'child title')
 		self.assertEqual(updated_doc.table_field_1[0].name, existing_doc.table_field_1[0].name)

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -817,6 +817,13 @@ class BaseDocument(object):
 			elif language == "PythonExpression":
 				frappe.utils.validate_python_code(code_string, fieldname=field.label)
 
+	def _sync_autoname_field(self):
+		"""Keep autoname field in sync with `name`"""
+		autoname = self.meta.autoname or ""
+		_empty, _field_specifier, fieldname = autoname.partition("field:")
+
+		if fieldname and self.name and self.name != self.get("fieldname"):
+			self.set(fieldname, self.name)
 
 	def throw_length_exceeded_error(self, df, max_length, value):
 		# check if parentfield exists (only applicable for child table doctype)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -500,6 +500,7 @@ class Document(BaseDocument):
 		self._validate_non_negative()
 		self._validate_length()
 		self._validate_code_fields()
+		self._sync_autoname_field()
 		self._extract_images_from_text_editor()
 		self._sanitize_content()
 		self._save_passwords()

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -35,6 +35,17 @@ class TestNaming(unittest.TestCase):
 		title2 = append_number_if_name_exists('Note', 'Test', 'title', '_')
 		self.assertEqual(title2, 'Test_1')
 
+	def test_field_autoname_name_sync(self):
+
+		country = frappe.get_last_doc("Country")
+		original_name = country.name
+		country.country_name = "Not a country"
+		country.save()
+		country.reload()
+
+		self.assertEqual(country.name, original_name)
+		self.assertEqual(country.name, country.country_name)
+
 	def test_format_autoname(self):
 		'''
 		Test if braced params are replaced in format autoname


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/16435 

steps to reproduce:

- Item doctype has autoname `field:item_code` 
- User can download CSV file which won't contain name but `item_code` since both are same. 
- User can now update `item_code` and since it's case-insensitive the update goes through which makes `name` != autoname field.

Simpler example:

```python
item = frappe.get_last_doc("Item")
item.item_code = "garbage"
item.save()

# item.name and item.item_code are now out of sync. This isn't possible from frontend. 
```


Essentially autoname field == `name` always. 

Example: 
<img width="762" alt="Screenshot 2022-03-29 at 11 02 51 AM" src="https://user-images.githubusercontent.com/9079960/160540434-e0a87eb4-160e-429a-b31a-5d1fa62778a0.png">
 