### PR TITLE
fix: Hide inconsequential naming section for child tables

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -203,6 +203,7 @@
    "options": "DocField"
   },
   {
+   "depends_on": "eval: doc.istable == 0",
    "fieldname": "sb1",
    "fieldtype": "Section Break",
    "label": "Naming"
@@ -673,7 +674,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2022-02-15 21:47:16.467217",
+ "modified": "2022-03-29 11:48:04.860868",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",


### PR DESCRIPTION
The Naming section for child tables is inconsequential. It does nothing but sets expectations that a child table record would be named a certain way and then doesn't do it 😄. Hiding the section since it just adds to the confusion.

### Before

![IMAGE 2022-03-29 12:13:20](https://user-images.githubusercontent.com/36654812/160549723-e0e05f2f-cd5b-4643-9723-2009f6377fbd.jpg)

### After

<img width="1433" alt="Screenshot 2022-03-29 at 12 05 34 PM" src="https://user-images.githubusercontent.com/36654812/160549332-2a5c3966-5d26-4f3d-9f73-d205248d4201.png">
