### PR TITLE
perf: ~90% faster `get_cached_value` from Redis cache

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -851,18 +851,25 @@ def set_value(doctype, docname, fieldname, value=None):
 	return frappe.client.set_value(doctype, docname, fieldname, value)
 
 def get_cached_doc(*args, **kwargs):
+	allow_dict = kwargs.pop("_allow_dict", False)
+
+	def _respond(doc, from_redis=False):
+		if not allow_dict and isinstance(doc, dict):
+			local.document_cache[key] = doc = get_doc(doc)
+
+		elif from_redis:
+			local.document_cache[key] = doc
+
+		return doc
+
 	if key := can_cache_doc(args):
 		# local cache
-		doc = local.document_cache.get(key)
-		if doc:
-			return doc
+		if doc := local.document_cache.get(key):
+			return _respond(doc)
 
 		# redis cache
-		doc = cache().hget('document_cache', key)
-		if doc:
-			doc = get_doc(doc)
-			local.document_cache[key] = doc
-			return doc
+		if doc := cache().hget('document_cache', key):
+			return _respond(doc, True)
 
 	# database
 	doc = get_doc(*args, **kwargs)
@@ -895,9 +902,9 @@ def clear_document_cache(doctype, name):
 		del local.document_cache[key]
 	cache().hdel('document_cache', key)
 
-def get_cached_value(doctype, name, fieldname, as_dict=False):
+def get_cached_value(doctype, name, fieldname="name", as_dict=False):
 	try:
-		doc = get_cached_doc(doctype, name)
+		doc = get_cached_doc(doctype, name, _allow_dict=True)
 	except DoesNotExistError:
 		clear_last_message()
 		return


### PR DESCRIPTION
Don't convert `_dict` to `Document` based on new keyword argument `_allow_dict` in `get_cached_doc`
(prefixed with underscore to prevent clash with actual fieldname)

This change impacts performance only when retrieving document from Redis Cache, but this is almost all the time because `document_cache` is only for specific request. Local cache code was commented for below tests.

### Before

```python
In [2]: %timeit frappe.get_cached_value("Sales Invoice", "SINV-21-00070", "name")
214 µs ± 779 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

### After (99% improvement for Sales Invoice)

```python
In [2]: %timeit frappe.get_cached_value("Sales Invoice", "SINV-21-00070", "name")
1.39 µs ± 17.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```



---

Minor new feature:  `fieldname` in `get_cached_value` defaults to `name`, just like `db.get_value`