### PR TITLE
refactor!: improved `frappe._dict`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -55,20 +55,19 @@ controllers = {}
 class _dict(dict):
 	"""dict like object that exposes keys as attributes"""
 
+	__slots__ = ()
 	__getattr__ = dict.get
 	__setattr__ = dict.__setitem__
 	__delattr__ = dict.__delitem__
+	__setstate__ = dict.update
 
 	def __getstate__(self):
 		return self
 
-	def __setstate__(self, d):
-		self.update(d)
-
-	def update(self, d):
+	def update(self, *args, **kwargs):
 		"""update and return self -- the missing dict feature in python"""
 
-		super().update(d)
+		super().update(*args, **kwargs)
 		return self
 
 	def copy(self):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -55,15 +55,9 @@ controllers = {}
 class _dict(dict):
 	"""dict like object that exposes keys as attributes"""
 
-	def __getattr__(self, key):
-		ret = self.get(key)
-		# "__deepcopy__" exception added to fix frappe#14833 via DFP
-		if not ret and key.startswith("__") and key != "__deepcopy__":
-			raise AttributeError()
-		return ret
-
-	def __setattr__(self, key, value):
-		self[key] = value
+	__getattr__ = dict.get
+	__setattr__ = dict.__setitem__
+	__delattr__ = dict.__delitem__
 
 	def __getstate__(self):
 		return self
@@ -73,11 +67,12 @@ class _dict(dict):
 
 	def update(self, d):
 		"""update and return self -- the missing dict feature in python"""
-		super(_dict, self).update(d)
+
+		super().update(d)
 		return self
 
 	def copy(self):
-		return _dict(dict(self).copy())
+		return _dict(self)
 
 
 def _(msg, lang=None, context=None):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -143,8 +143,8 @@ class Meta(Document):
 					value = [serialize(d) for d in value]
 
 				if (
-					isinstance(value, (str, int, float, datetime, list, tuple))
-					or (not no_nulls and value is None)
+					(not no_nulls and value is None)
+					or isinstance(value, (str, int, float, datetime, list, tuple))
 				):
 					out[key] = value
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -134,24 +134,23 @@ class Meta(Document):
 	def as_dict(self, no_nulls=False):
 		def serialize(doc):
 			out = {}
-			for key in doc.__dict__:
-				value = doc.__dict__.get(key)
-
+			for key, value in doc.__dict__.items():
 				if isinstance(value, (list, tuple)):
-					if len(value) > 0 and hasattr(value[0], "__dict__"):
-						value = [serialize(d) for d in value]
-					else:
+					if not value or not isinstance(value[0], BaseDocument):
 						# non standard list object, skip
 						continue
 
-				if isinstance(value, (str, int, float, datetime, list, tuple)) or (
-					not no_nulls and value is None
+					value = [serialize(d) for d in value]
+
+				if (
+					isinstance(value, (str, int, float, datetime, list, tuple))
+					or (not no_nulls and value is None)
 				):
 					out[key] = value
 
 			# set empty lists for unset table fields
 			for table_field in DOCTYPE_TABLE_FIELDS:
-				if not out.get(table_field.fieldname):
+				if out.get(table_field.fieldname) is None:
 					out[table_field.fieldname] = []
 
 			return out

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -142,9 +142,8 @@ class Meta(Document):
 
 					value = [serialize(d) for d in value]
 
-				if (
-					(not no_nulls and value is None)
-					or isinstance(value, (str, int, float, datetime, list, tuple))
+				if (not no_nulls and value is None) or isinstance(
+					value, (str, int, float, datetime, list, tuple)
 				):
 					out[key] = value
 


### PR DESCRIPTION
## Changes Made

- Use `dict` methods directly instead of overwriting. ([inspiration](https://stackoverflow.com/a/23689767/4767738))
- Using `dict.get` method led to change in how `__getattr__` works. But I think that's okay because:
  -  The[ code to raise `AttributeError`](https://github.com/frappe/frappe/commit/19c6dc2d57d93ec9fe280f2e9628f70bd484a509) doesn't seem relevant anymore. It was probably added to make `_dict` pickle-able, which it still is (tested locally).
  - The behaviour wasn't consistent. `_dict.__key` worked only if `__key` is truthy. It should ideally work even if key is falsy.
  - If one wants to explicitly disallow keys starting with `__`, they can do something like `safe_exec.NamespaceDict`.
- Added `__delattr__` because.. why not 😄 
- Simplify `_dict.copy`. Earlier, it would create two new objects. One when calling `dict(self).copy()` and another when calling `_dict`. `_dict` alone is sufficient.


---

### `_dict.__getattr__` before

```python
In [3]: %timeit x.new_site
1.31 µs ± 4.19 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

### `_dict.__getattr__` after (~10% better)

```python
In [3]: %timeit x.new_site
1.15 µs ± 8.53 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

### `_dict.copy` before

```python
In [4]: %timeit x.copy()
1.73 µs ± 14.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

### `_dict.copy` after (~20% better)

```python
In [4]: %timeit x.copy()
1.36 µs ± 9.44 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```


### `copy.deepcopy` still works

![image](https://user-images.githubusercontent.com/16315650/160754363-d24e26ea-3766-4a1c-8991-894ffbfb4815.png)

---

[Tested with ERPNext](https://github.com/frappe/erpnext/actions/runs/2111489473)