### PR TITLE
fix: dont animate "Jump to field"

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1722,7 +1722,11 @@ frappe.ui.form.Form = class FrappeForm {
 		return sum;
 	}
 
-	scroll_to_field(fieldname) {
+	scroll_to_field(fieldname, animate) {
+		if (animate == null) {
+			animate = true;
+		}
+
 		let field = this.get_field(fieldname);
 		if (!field) return;
 
@@ -1739,7 +1743,7 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 
 		// scroll to input
-		frappe.utils.scroll_to($el, true, 15);
+		frappe.utils.scroll_to($el, animate, 15);
 
 		// highlight input
 		$el.addClass('has-error');

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1722,11 +1722,7 @@ frappe.ui.form.Form = class FrappeForm {
 		return sum;
 	}
 
-	scroll_to_field(fieldname, animate) {
-		if (animate == null) {
-			animate = true;
-		}
-
+	scroll_to_field(fieldname, animate = true) {
 		let field = this.get_field(fieldname);
 		if (!field) return;
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -568,8 +568,9 @@ frappe.ui.form.Toolbar = class Toolbar {
 			primary_action_label: __('Go'),
 			primary_action: ({ fieldname }) => {
 				dialog.hide();
-				this.frm.scroll_to_field(fieldname);
-			}
+				this.frm.scroll_to_field(fieldname, false);
+			},
+			animate: false,
 		});
 
 		dialog.show();


### PR DESCRIPTION
It's supposed to be keyboard-driven, but currently wasting 500 ms for animating modal and 500 ms more for scrolling to the field.


**before**


https://user-images.githubusercontent.com/9079960/160793159-c0bb6d32-6942-416c-99f3-9cdef3e49d55.mov


**after**



https://user-images.githubusercontent.com/9079960/160793214-9056f9ea-559a-4cd1-8aec-f8416e2475c4.mov




