### PR TITLE
fix: issue with collapsible section

### DIFF
--- a/frappe/public/scss/website/page_builder.scss
+++ b/frappe/public/scss/website/page_builder.scss
@@ -481,7 +481,7 @@
 
 .collapsible-item-title {
 	font-weight: 600;
-	color: var(--gray-900);
+	color: var(--text-color);
 	font-size: var(--text-2xl);
 }
 
@@ -522,6 +522,7 @@
 	.section-description, .collapsible-items {
 		margin-left: auto;
 		margin-right: auto;
+		margin-top: 1.5rem;
 	}
 }
 

--- a/frappe/public/scss/website/page_builder.scss
+++ b/frappe/public/scss/website/page_builder.scss
@@ -522,7 +522,7 @@
 	.section-description, .collapsible-items {
 		margin-left: auto;
 		margin-right: auto;
-		margin-top: 1.5rem;
+		margin-top: 3rem;
 	}
 }
 

--- a/frappe/public/scss/website/page_builder.scss
+++ b/frappe/public/scss/website/page_builder.scss
@@ -479,6 +479,12 @@
 	align-items: center;
 }
 
+.collapsible-item-title {
+	font-weight: 600;
+	color: var(--gray-900);
+	font-size: var(--text-2xl);
+}
+
 .collapsible-item a {
 	text-decoration: none;
 }

--- a/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
+++ b/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
@@ -10,7 +10,7 @@
 			{%- set collapse_id = 'id-' + frappe.utils.generate_hash('Collapse', 12) -%}
 			<a class="collapsible-title" data-toggle="collapse" href="#{{ collapse_id }}" role="button"
 				aria-expanded="false" aria-controls="{{ collapse_id }}">
-				<h3>{{ item.title }}</h3>
+				<div class="collapsible-item-title">{{ item.title }}</div>
 				<svg class="collapsible-icon" width="24" height="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 					<path class="vertical" d="M8 4V12" stroke="currentColor" stroke-width="1.5" stroke-miterlimit="10"
 						stroke-linecap="round"


### PR DESCRIPTION
**Issue:** Section with collapsible content is breaking because of changes made in https://github.com/frappe/frappe/pull/16356

**Before:**

This is not zoomed in.

<img width="1433" alt="Screenshot 2022-03-30 at 4 38 16 PM" src="https://user-images.githubusercontent.com/31363128/160893476-873cbe92-f8f1-4db3-a5b2-d66aae0bb706.png">

**After:**

<img width="1440" alt="Screenshot 2022-03-30 at 10 45 28 PM" src="https://user-images.githubusercontent.com/31363128/160893410-6ca88869-33fe-437a-97d8-f54f50d43d03.png">
