### PR TITLE
fix: Cypress get_table_field command

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -207,8 +207,8 @@ Cypress.Commands.add('get_table_field', (tablefieldname, row_idx, fieldname, fie
 		selector += ` [data-fieldname="${fieldname}"] .ace_text-input`;
 	} else {
 		selector += ` [data-fieldname="${fieldname}"]`;
+		return cy.get(selector).find('.form-control:visible, .static-area:visible').first();
 	}
-
 	return cy.get(selector);
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -200,14 +200,13 @@ Cypress.Commands.add('fill_table_field', (tablefieldname, row_idx, fieldname, va
 Cypress.Commands.add('get_table_field', (tablefieldname, row_idx, fieldname, fieldtype = 'Data') => {
 	let selector = `.frappe-control[data-fieldname="${tablefieldname}"]`;
 	selector += ` [data-idx="${row_idx}"]`;
-	selector += ` .form-in-grid`;
 
 	if (fieldtype === 'Text Editor') {
 		selector += ` [data-fieldname="${fieldname}"] .ql-editor[contenteditable=true]`;
 	} else if (fieldtype === 'Code') {
 		selector += ` [data-fieldname="${fieldname}"] .ace_text-input`;
 	} else {
-		selector += ` .form-control[data-fieldname="${fieldname}"]`;
+		selector += ` [data-fieldname="${fieldname}"]`;
 	}
 
 	return cy.get(selector);


### PR DESCRIPTION
`get_table_field` should select `.staticarea` of the table field if the field is not editable.