### PR TITLE
fix: incorrect logic for `parenttype` parameter in `get_all_children`

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -848,16 +848,19 @@ class Document(BaseDocument):
 				frappe.CancelledLinkError)
 
 	def get_all_children(self, parenttype=None):
-		"""Returns all children documents from **Table** type field in a list."""
-		ret = []
-		for df in self.meta.get("fields", {"fieldtype": ['in', table_fields]}):
-			if parenttype:
-				if df.options==parenttype:
-					return self.get(df.fieldname)
+		"""Returns all children documents from **Table** type fields in a list."""
+
+		children = []
+
+		for df in self.meta.get_table_fields():
+			if parenttype and df.options != parenttype:
+				continue
+
 			value = self.get(df.fieldname)
 			if isinstance(value, list):
-				ret.extend(value)
-		return ret
+				children.extend(value)
+
+		return children
 
 	def run_method(self, method, *args, **kwargs):
 		"""run standard triggers, plus those in hooks"""


### PR DESCRIPTION
### Before 

![Screenshot-2022-03-31-101133](https://user-images.githubusercontent.com/16315650/160978220-48cd21ef-86e0-4f4b-90f3-c980b285dce1.png)


### After

![Screenshot-2022-03-31-101037](https://user-images.githubusercontent.com/16315650/160978236-3622be0a-ef46-4d3c-b9b0-bea2a26074e1.png)


Also added minor performance fix: use `meta.get_table_fields`, which implements local caching.