### PR TITLE
perf: reduce query when calling `get_doc` with filters

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -549,7 +549,7 @@ class Database(object):
 				return r and [[i[1] for i in r]] or []
 
 
-	def get_singles_dict(self, doctype, debug = False):
+	def get_singles_dict(self, doctype, debug=False, *, for_update=False):
 		"""Get Single DocType as dict.
 
 		:param doctype: DocType of the single object whose value is requested
@@ -560,10 +560,13 @@ class Database(object):
 			account_settings = frappe.db.get_singles_dict("Accounts Settings")
 		"""
 		result = self.query.get_sql(
-			"Singles", filters={"doctype": doctype}, fields=["field", "value"]
+			"Singles",
+			filters={"doctype": doctype},
+			fields=["field", "value"],
+			for_update=for_update,
 		).run()
-		dict_  = frappe._dict(result)
-		return dict_
+
+		return frappe._dict(result)
 
 	@staticmethod
 	def get_all(*args, **kwargs):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -92,25 +92,24 @@ class Document(BaseDocument):
 		self.name = None
 		self.flags = frappe._dict()
 
-		if args and args[0] and isinstance(args[0], str):
-			# first arugment is doctype
-			self.doctype = args[0]
+		if args and args[0]:
+			if isinstance(args[0], str):
+				# first arugment is doctype
+				self.doctype = args[0]
 
-			if len(args)==1:
-				# single
-				self.name = self.doctype
-			else:
-				self.name = args[1]
+				if len(args) == 1:
+					# single
+					self.name = self.doctype
+				else:
+					self.name = args[1]
+					self.flags.for_update = kwargs.get("for_update")
 
-				if 'for_update' in kwargs:
-					self.flags.for_update = kwargs.get('for_update')
+				self.load_from_db()
+				return
 
-			self.load_from_db()
-			return
-
-		if args and args[0] and isinstance(args[0], dict):
-			# first argument is a dict
-			kwargs = args[0]
+			if isinstance(args[0], dict):
+				# first argument is a dict
+				kwargs = args[0]
 
 		if kwargs:
 			# init base document
@@ -126,10 +125,6 @@ class Document(BaseDocument):
 		"""Decorator: Whitelist method to be called remotely via REST API."""
 		frappe.whitelist()(fn)
 		return fn
-
-	def reload(self):
-		"""Reload document from database"""
-		self.load_from_db()
 
 	def load_from_db(self):
 		"""Load document and children from database and create properties
@@ -170,6 +165,8 @@ class Document(BaseDocument):
 		# sometimes __setup__ can depend on child values, hence calling again at the end
 		if hasattr(self, "__setup__"):
 			self.__setup__()
+
+	reload = load_from_db
 
 	def get_latest(self):
 		if not getattr(self, "latest", None):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -96,6 +96,8 @@ class Document(BaseDocument):
 			if isinstance(args[0], str):
 				# first arugment is doctype
 				self.doctype = args[0]
+
+				# doctype for singles, string value or filters for other documents
 				self.name = self.doctype if len(args) == 1 else args[1]
 
 				# for_update is set in flags to avoid changing load_from_db signature

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -88,25 +88,19 @@ class Document(BaseDocument):
 		If DocType name and document name are passed, the object will load
 		all values (including child documents) from the database.
 		"""
-		self.doctype = self.name = None
-		self._default_new_docs = {}
+		self.doctype = None
+		self.name = None
 		self.flags = frappe._dict()
 
 		if args and args[0] and isinstance(args[0], str):
 			# first arugment is doctype
+			self.doctype = args[0]
+
 			if len(args)==1:
 				# single
-				self.doctype = self.name = args[0]
+				self.name = self.doctype
 			else:
-				self.doctype = args[0]
-				if isinstance(args[1], dict):
-					# filter
-					self.name = frappe.db.get_value(args[0], args[1], "name")
-					if self.name is None:
-						frappe.throw(_("{0} {1} not found").format(_(args[0]), args[1]),
-							frappe.DoesNotExistError)
-				else:
-					self.name = args[1]
+				self.name = args[1]
 
 				if 'for_update' in kwargs:
 					self.flags.for_update = kwargs.get('for_update')

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -132,7 +132,7 @@ class Document(BaseDocument):
 		if not getattr(self, "_metaclass", False) and self.meta.issingle:
 			single_doc = frappe.db.get_singles_dict(self.doctype)
 			if not single_doc:
-				single_doc = frappe.new_doc(self.doctype).as_dict()
+				single_doc = frappe.new_doc(self.doctype, as_dict=True)
 				single_doc["name"] = self.doctype
 				del single_doc["__islocal"]
 


### PR DESCRIPTION
When calling `get_doc` in the format `get_doc(doctype, filters)`, an additional query was run to ascertain the name of the document. This query is unnecessary because the query run in `load_from_db` immediately after accomplishes the same result.

### Other Changes
- Remove unused property `_default_new_docs`
- Move `self.doctype = args[0]` outside if-else block for readability

---

### Before

```python

In [1]: %timeit frappe.get_doc("UOM", {})
456 µs ± 41.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

### After (30% improvement)

```python
In [1]: %timeit frappe.get_doc("UOM", {})
311 µs ± 10.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```