### PR TITLE
fix(`get_value`): make `as_dict` work for list-style filters

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -446,6 +446,7 @@ class Database(object):
 				pluck=pluck,
 				distinct=distinct,
 				limit=limit,
+				as_dict=as_dict,
 			)
 
 		else:
@@ -674,7 +675,20 @@ class Database(object):
 		)
 		return r
 
-	def _get_value_for_many_names(self, doctype, names, field, order_by, *, debug=False, run=True, pluck=False, distinct=False, limit=None):
+	def _get_value_for_many_names(
+		self,
+		doctype,
+		names,
+		field,
+		order_by,
+		*,
+		debug=False,
+		run=True,
+		pluck=False,
+		distinct=False,
+		limit=None,
+		as_dict=False
+	):
 		names = list(filter(None, names))
 		if names:
 			return self.get_all(
@@ -684,7 +698,7 @@ class Database(object):
 				order_by=order_by,
 				pluck=pluck,
 				debug=debug,
-				as_list=1,
+				as_list=not as_dict,
 				run=run,
 				distinct=distinct,
 				limit_page_length=limit


### PR DESCRIPTION
### Before

```python
In [1]: frappe.db.get_value("UOM", [["UOM", "name", "!=", ""]], as_dict=True)
Out[1]: ('Unit',)
```

### After

```python
In [1]: frappe.db.get_value("UOM", [["UOM", "name", "!=", ""]], as_dict=True)
Out[1]: {'name': 'Unit'}
```