### PR TITLE
fix: show parent in `__repr__` only if available

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1378,11 +1378,9 @@ class Document(BaseDocument):
 		doctype = self.__class__.__name__
 
 		docstatus = f" docstatus={self.docstatus}" if self.docstatus else ""
-		repr_str = f"<{doctype}: {name}{docstatus}"
+		parent = f" parent={self.parent}" if getattr(self, "parent", None) else ""
 
-		if not hasattr(self, "parent"):
-			return repr_str + ">"
-		return f"{repr_str} parent={self.parent}>"
+		return f"<{doctype}: {name}{docstatus}{parent}>"
 
 	def __str__(self):
 		name = self.name or "unsaved"


### PR DESCRIPTION
### Before

```python

In [1]: frappe.get_doc("DocType")
Out[1]: <DocType: DocType parent=None>

```


### After

```python

In [3]: frappe.get_doc("DocType")
Out[3]: <DocType: DocType>

In [4]: frappe.get_doc("DocType").fields[0]
Out[4]: <DocField: f2598f2ba2 parent=DocType>

```