### PR TITLE
perf: 80% faster `doc.get` for fields with `None` as value [REVERTED]

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -3,7 +3,7 @@
 import datetime
 
 import frappe
-from frappe import _
+from frappe import _, _dict
 from frappe.model import child_table_fields, default_fields, display_fieldtypes, table_fields
 from frappe.model.naming import set_new_name
 from frappe.model.utils.link_count import notify_link_count
@@ -19,6 +19,14 @@ max_positive_value = {
 }
 
 DOCTYPES_FOR_DOCTYPE = ('DocType', 'DocField', 'DocPerm', 'DocType Action', 'DocType Link')
+
+DOCTYPE_TABLE_FIELDS = [
+	_dict({"fieldname": "fields", "options": "DocField"}),
+	_dict({"fieldname": "permissions", "options": "DocPerm"}),
+	_dict({"fieldname": "actions", "options": "DocType Action"}),
+	_dict({"fieldname": "links", "options": "DocType Link"}),
+	_dict({"fieldname": "states", "options": "DocType State"}),
+]
 
 
 def get_controller(doctype):
@@ -146,12 +154,6 @@ class BaseDocument(object):
 			else:
 				value = self.__dict__.get(key, default)
 
-			if value is None and key in (
-				d.fieldname for d in self.meta.get_table_fields()
-			):
-				value = []
-				self.set(key, value)
-
 			if limit and isinstance(value, (list, tuple)) and len(value) > limit:
 				value = value[:limit]
 
@@ -189,7 +191,7 @@ class BaseDocument(object):
 		if value is None:
 			value={}
 		if isinstance(value, (dict, BaseDocument)):
-			if not self.__dict__.get(key):
+			if self.__dict__.get(key) is None:
 				self.__dict__[key] = []
 
 			value = self._init_child(value, key)
@@ -252,8 +254,23 @@ class BaseDocument(object):
 
 		return value
 
+	def _get_table_fields(self):
+		"""
+		To get table fields during Document init
+		Meta.get_table_fields goes into recursion for special doctypes
+		"""
+
+		# child tables don't have child tables
+		if getattr(self, "parentfield", None):
+			return ()
+
+		if self.doctype == "DocType":
+			return DOCTYPE_TABLE_FIELDS
+
+		return self.meta.get_table_fields()
+
 	def get_valid_dict(self, sanitize=True, convert_dates_to_str=False, ignore_nulls=False, ignore_virtual=False):
-		d = frappe._dict()
+		d = _dict()
 		for fieldname in self.meta.get_valid_columns():
 			d[fieldname] = self.get(fieldname)
 
@@ -313,6 +330,16 @@ class BaseDocument(object):
 				del d[fieldname]
 
 		return d
+
+	def init_child_tables(self):
+		"""
+		This is needed so that one can loop over child table properties
+		without worrying about whether or not they have values
+		"""
+
+		for df in self._get_table_fields():
+			if self.__dict__.get(df.fieldname) is None:
+				self.__dict__[df.fieldname] = []
 
 	def init_valid_columns(self):
 		for key in default_fields:
@@ -598,7 +625,7 @@ class BaseDocument(object):
 		if self.meta.istable:
 			for fieldname in ("parent", "parenttype"):
 				if not self.get(fieldname):
-					missing.append((fieldname, get_msg(frappe._dict(label=fieldname))))
+					missing.append((fieldname, get_msg(_dict(label=fieldname))))
 
 		return missing
 
@@ -643,7 +670,7 @@ class BaseDocument(object):
 				if not frappe.get_meta(doctype).get('is_virtual'):
 					if not fields_to_fetch:
 						# cache a single value type
-						values = frappe._dict(name=frappe.db.get_value(doctype, docname,
+						values = _dict(name=frappe.db.get_value(doctype, docname,
 							'name', cache=True))
 					else:
 						values_to_fetch = ['name'] + [_df.fetch_from.split('.')[-1]
@@ -938,10 +965,10 @@ class BaseDocument(object):
 		cache_key = parentfield or "main"
 
 		if not hasattr(self, "_precision"):
-			self._precision = frappe._dict()
+			self._precision = _dict()
 
 		if cache_key not in self._precision:
-			self._precision[cache_key] = frappe._dict()
+			self._precision[cache_key] = _dict()
 
 		if fieldname not in self._precision[cache_key]:
 			self._precision[cache_key][fieldname] = None

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -121,6 +121,7 @@ class Document(BaseDocument):
 		if kwargs:
 			# init base document
 			super(Document, self).__init__(kwargs)
+			self.init_child_tables()
 			self.init_valid_columns()
 
 		else:
@@ -158,20 +159,20 @@ class Document(BaseDocument):
 
 			super(Document, self).__init__(d)
 
-		if self.name=="DocType" and self.doctype=="DocType":
-			from frappe.model.meta import DOCTYPE_TABLE_FIELDS
-			table_fields = DOCTYPE_TABLE_FIELDS
-		else:
-			table_fields = self.meta.get_table_fields()
+		for df in self._get_table_fields():
+			children = frappe.db.get_values(
+				df.options,
+				{
+					"parent": self.name,
+					"parenttype": self.doctype,
+					"parentfield": df.fieldname
+				},
+				"*",
+				as_dict=True,
+				order_by="idx asc"
+			) or []
 
-		for df in table_fields:
-			children = frappe.db.get_values(df.options,
-				{"parent": self.name, "parenttype": self.doctype, "parentfield": df.fieldname},
-				"*", as_dict=True, order_by="idx asc")
-			if children:
-				self.set(df.fieldname, children)
-			else:
-				self.set(df.fieldname, [])
+			self.set(df.fieldname, children)
 
 		# sometimes __setup__ can depend on child values, hence calling again at the end
 		if hasattr(self, "__setup__"):
@@ -856,8 +857,7 @@ class Document(BaseDocument):
 			if parenttype and df.options != parenttype:
 				continue
 
-			value = self.get(df.fieldname)
-			if isinstance(value, list):
+			if value := self.get(df.fieldname):
 				children.extend(value)
 
 		return children

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -30,7 +30,7 @@ from frappe.model import (
 	optional_fields,
 	table_fields,
 )
-from frappe.model.base_document import BaseDocument
+from frappe.model.base_document import BaseDocument, DOCTYPE_TABLE_FIELDS
 from frappe.model.document import Document
 from frappe.model.workflow import get_workflow_name
 from frappe.modules import load_doctype_module
@@ -180,7 +180,7 @@ class Meta(Document):
 
 	def get_table_fields(self):
 		if not hasattr(self, "_table_fields"):
-			if self.name!="DocType":
+			if self.name != "DocType":
 				self._table_fields = self.get('fields', {"fieldtype": ['in', table_fields]})
 			else:
 				self._table_fields = DOCTYPE_TABLE_FIELDS
@@ -608,14 +608,6 @@ class Meta(Document):
 
 	def is_nested_set(self):
 		return self.has_field('lft') and self.has_field('rgt')
-
-DOCTYPE_TABLE_FIELDS = [
-	frappe._dict({"fieldname": "fields", "options": "DocField"}),
-	frappe._dict({"fieldname": "permissions", "options": "DocPerm"}),
-	frappe._dict({"fieldname": "actions", "options": "DocType Action"}),
-	frappe._dict({"fieldname": "links", "options": "DocType Link"}),
-	frappe._dict({"fieldname": "states", "options": "DocType State"}),
-]
 
 #######
 


### PR DESCRIPTION
## Issue

`doc.get` wasn't performant for fields with value as `None`. Additionally, it set a value for child table fields if one didn't exist. This is unexpected behavior in a getter function.

The reason why `doc.get` did this is so that one could confidently loop over `doc.get(child_fieldname)` without worrying about the object being non-iterable.

## Solution
- Set all child fieldnames without values to an empty list whenever a Document is initialized.
- Don't do anything special in `doc.get`

## Screenshots

### Before

```python
In [5]: %timeit doc.get("from_date")
1.25 µs ± 182 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

### After (~80% improvement)

```python
In [4]: %timeit doc.get("from_date")
162 ns ± 2.26 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

```

This might not seem like a lot, but it has significant impact on a lot of utilities like `doc.as_dict`

## Other Changes
- Update `doc.append` to only set the value of child field if it is None. Previously, it was doing so for all falsy values, but that includes an empty list (set in `doc.set` or `doc.init_child_tables`), which should not be reset.
- Assume truthy value to be iterable in `get_all_children`
- Define `DOCTYPE_TABLE_FIELDS` in `base_document.py`, import in `meta.py`
- Import and use `_dict` directly instead of `frappe._dict`
- Reformatting for readability

Note: `init_child_tables` isn't needed for Document initialized via `load_from_db` route, that happens already.