### PR TITLE
fix: markdown support for section with features

### DIFF
--- a/frappe/website/web_template/section_with_features/section_with_features.html
+++ b/frappe/website/web_template/section_with_features/section_with_features.html
@@ -17,12 +17,12 @@
 				<h3 class="feature-title">{{ feature.title }}</h3>
 				{%- endif -%}
 				{%- if feature.content -%}
-				<p class="feature-content">{{ feature.content }}</p>
+				<p class="feature-content">{{ frappe.utils.md_to_html(feature.content) }}</p>
 				{%- endif -%}
 			</div>
 			<div>
 				{%- if feature.url -%}
-				<a href="{{ feature.url }}" class="feature-url stretched-link">Learn more →</a>
+				<a href="{{ feature.url }}" class="feature-url stretched-link"> {{ _("Learn more") }} →</a>
 				{%- endif -%}
 			</div>
 		</div>


### PR DESCRIPTION
Markdown support for Section with Features web template.

<img width="1440" alt="Screenshot 2022-04-01 at 9 38 16 AM" src="https://user-images.githubusercontent.com/31363128/161193588-49ad6a9f-11ec-46a9-8ccc-8a77344f4e2c.png">

