### PR TITLE
fix: Use github.com as fallback when Github API rate limit is hit

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -142,8 +142,10 @@ def find_org(org_repo: str) -> Tuple[str, str]:
 	import requests
 
 	for org in ["frappe", "erpnext"]:
-		res = requests.head(f"https://api.github.com/repos/{org}/{org_repo}")
-		if res.ok:
+		response = requests.head(f"https://api.github.com/repos/{org}/{org_repo}")
+		if response.status_code == 400:
+			response = requests.head(f"https://github.com/{org}/{org_repo}")
+		if response.ok:
 			return org, org_repo
 
 	raise InvalidRemoteException


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/16402

In cases, where API rate limit is reached, use github.com as a fall back option to fetch org name.