### PR TITLE
test(fix): Cypress test form.js

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -29,10 +29,12 @@ context('Form', () => {
 		cy.get('.standard-filter-section [data-fieldname="name"] input').type('Test Form Contact 3').blur();
 		cy.click_listview_row_item(0);
 
+		cy.get('#page-Contact .page-head').findByTitle('Test Form Contact 3').should('exist');
 		cy.get('.prev-doc').should('be.visible').click();
 		cy.get('.msgprint-dialog .modal-body').contains('No further records').should('be.visible');
 		cy.hide_dialog();
 
+		cy.get('#page-Contact .page-head').findByTitle('Test Form Contact 3').should('exist');
 		cy.get('.next-doc').should('be.visible').click();
 		cy.get('.msgprint-dialog .modal-body').contains('No further records').should('be.visible');
 		cy.hide_dialog();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -290,6 +290,7 @@ Cypress.Commands.add('add_filter', () => {
 });
 
 Cypress.Commands.add('clear_filters', () => {
+	let has_filter = false;
 	cy.intercept({
 		method: 'POST',
 		url: 'api/method/frappe.model.utils.user_settings.save'
@@ -297,12 +298,17 @@ Cypress.Commands.add('clear_filters', () => {
 	cy.get('.filter-section .filter-button').click({force: true});
 	cy.wait(300);
 	cy.get('.filter-popover').should('exist');
+	cy.get('.filter-popover').then(popover => {
+		if (popover.find('input.input-with-feedback')[0].value != '') {
+			has_filter = true;
+		}
+	});
 	cy.get('.filter-popover').find('.clear-filters').click();
 	cy.get('.filter-section .filter-button').click();
 	cy.window().its('cur_list').then(cur_list => {
 		cur_list && cur_list.filter_area && cur_list.filter_area.clear();
+		has_filter && cy.wait('@filter-saved');
 	});
-	cy.wait('@filter-saved');
 });
 
 Cypress.Commands.add('click_modal_primary_button', (btn_name) => {


### PR DESCRIPTION
Failing form.js Cypress test

**Finding/Cause:**
1. Because of header scrolling [feat](https://github.com/frappe/frappe/pull/16364) next-doc button in header is not getting clicked properly (flaky)
2. `cy.clear_filter` custom cypress command wait for filter-saved request. But the request is only called if filter exist. When filter is empty test fails because it waits for the filter-saved request to complete which was never called. This will also fix the flaky test for `dashboard_links.js`
```
cy.intercept({
		method: 'POST',
		url: 'api/method/frappe.model.utils.user_settings.save'
	}).as('filter-saved');
```