### PR TITLE
fix: Follow FIFO while inserting global search record

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -355,7 +355,9 @@ def sync_global_search():
 	:return:
 	"""
 	while frappe.cache().llen('global_search_queue') > 0:
-		value = json.loads(frappe.cache().lpop('global_search_queue').decode('utf-8'))
+		# rpop to follow FIFO
+		# Last one should override all previous contents of same document
+		value = json.loads(frappe.cache().rpop('global_search_queue').decode('utf-8'))
 		sync_value(value)
 
 def sync_value_in_queue(value):

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -138,6 +138,9 @@ class RedisWrapper(redis.Redis):
 	def lpop(self, key):
 		return super(RedisWrapper, self).lpop(self.make_key(key))
 
+	def rpop(self, key):
+		return super(RedisWrapper, self).rpop(self.make_key(key))
+
 	def llen(self, key):
 		return super(RedisWrapper, self).llen(self.make_key(key))
 


### PR DESCRIPTION
Global search records used to stay in [`global_search_queue`](https://github.com/frappe/frappe/blob/develop/frappe/utils/global_search.py#L364) (till we sync them to DB) even for documents that we sometimes directly deleted from DB ([during tests](https://github.com/frappe/frappe/blob/develop/frappe/email/doctype/document_follow/test_document_follow.py#L187)). 

While syncing for [global search](https://github.com/frappe/frappe/blob/develop/frappe/tests/test_global_search.py#L47), the old doc value (of deleted doc) used to override the new doc (that reused the name of the deleted doc) value because we use the [LIFO approach](https://github.com/frappe/frappe/blob/develop/frappe/utils/global_search.py#L358) while dumping global search records to the database from "global_search_queue". 

This is why while searching for the new value, the global search system used to return an empty array which causes [this test failure](https://github.com/frappe/frappe/runs/5787681496?check_suite_focus=true#step:14:1269).

To resolve this, follow [FIFO](https://github.com/frappe/frappe/compare/develop...surajshetty3416:fix-flaky-test#diff-2df9e640d5d5f2f19851093522f542bbdceea96852667ee33042ad22caa95ac5R360) while inserting global search record.