### PR TITLE
feat: allow enqueue at front of Redis Queue

### DIFF
--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -28,6 +28,22 @@ class TestBackgroundJobs(unittest.TestCase):
 				fail_registry = queue.failed_job_registry
 				self.assertEqual(fail_registry.count, 0)
 
+	def test_enqueue_at_front(self):
+		kwargs = {
+			"method": "frappe.handler.ping",
+			"queue": "short",
+		}
+
+		# give worker something to work on first so that get_position doesn't return None
+		frappe.enqueue(**kwargs)
+
+		# test enqueue with at_front=True
+		low_priority_job = frappe.enqueue(**kwargs)
+		high_priority_job = frappe.enqueue(**kwargs, at_front=True)
+
+		# lesser is earlier
+		self.assertTrue(high_priority_job.get_position() < low_priority_job.get_position())
+
 
 def fail_function():
 	return 1 / 0

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -40,8 +40,19 @@ def get_queues_timeout():
 
 redis_connection = None
 
-def enqueue(method, queue='default', timeout=None, event=None,
-	is_async=True, job_name=None, now=False, enqueue_after_commit=False, **kwargs):
+def enqueue(
+	method,
+	queue='default',
+	timeout=None,
+	event=None,
+	is_async=True,
+	job_name=None,
+	now=False,
+	enqueue_after_commit=False,
+	*,
+	at_front=False,
+	**kwargs
+):
 	'''
 		Enqueue method to be executed using a background worker
 
@@ -87,9 +98,8 @@ def enqueue(method, queue='default', timeout=None, event=None,
 			"queue_args":queue_args
 		})
 		return frappe.flags.enqueue_after_commit
-	else:
-		return q.enqueue_call(execute_job, timeout=timeout,
-			kwargs=queue_args)
+
+	return q.enqueue_call(execute_job, timeout=timeout, kwargs=queue_args, at_front=at_front)
 
 def enqueue_doc(doctype, name=None, method=None, queue='default', timeout=300,
 	now=False, **kwargs):


### PR DESCRIPTION
This can be useful for jobs you want to offload from request handler, but still execute on priority.

[Docs](https://frappeframework.com/compare?wiki_page=docs/v13/user/en/guides/app-development/running-background-jobs&&compare=d00556ddbe#)

<!-- no-docs qki tuje link samjh nahi aayi -->