### PR TITLE
fix: remove spaces from email placeholders

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -220,9 +220,9 @@ class SendMailContext:
 
 	def message_placeholder(self, placeholder_key):
 		map = {
-			'tracker': '<!--email open check-->',
-			'unsubscribe_url': '<!--unsubscribe url-->',
-			'cc': '<!--cc message-->',
+			'tracker': '<!--email_open_check-->',
+			'unsubscribe_url': '<!--unsubscribe_url-->',
+			'cc': '<!--cc_message-->',
 			'recipient': '<!--recipient-->',
 		}
 		return map.get(placeholder_key)

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -66,25 +66,25 @@ def get_emails_sent_today(email_account=None):
 
 def get_unsubscribe_message(unsubscribe_message, expose_recipients):
 	if unsubscribe_message:
-		unsubscribe_html = '''<a href="<!--unsubscribe url-->"
+		unsubscribe_html = '''<a href="<!--unsubscribe_url-->"
 			target="_blank">{0}</a>'''.format(unsubscribe_message)
 	else:
-		unsubscribe_link = '''<a href="<!--unsubscribe url-->"
+		unsubscribe_link = '''<a href="<!--unsubscribe_url-->"
 			target="_blank">{0}</a>'''.format(_('Unsubscribe'))
 		unsubscribe_html = _("{0} to stop receiving emails of this type").format(unsubscribe_link)
 
 	html = """<div class="email-unsubscribe">
-			<!--cc message-->
+			<!--cc_message-->
 			<div>
 				{0}
 			</div>
 		</div>""".format(unsubscribe_html)
 
 	if expose_recipients == "footer":
-		text = "\n<!--cc message-->"
+		text = "\n<!--cc_message-->"
 	else:
 		text = ""
-	text += "\n\n{unsubscribe_message}: <!--unsubscribe url-->\n".format(unsubscribe_message=unsubscribe_message)
+	text += "\n\n{unsubscribe_message}: <!--unsubscribe_url-->\n".format(unsubscribe_message=unsubscribe_message)
 
 	return frappe._dict({
 		"html": html,

--- a/frappe/templates/emails/email_footer.html
+++ b/frappe/templates/emails/email_footer.html
@@ -18,7 +18,7 @@
 	<!--unsubscribe link here-->
 
 	<div class="email-pixel">
-		<!--email open check-->
+		<!--email_open_check-->
 	</div>
 
 	<!-- default_mail_footer -->

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -27,7 +27,7 @@ class TestEmail(unittest.TestCase):
 		self.assertTrue('test@example.com' in queue_recipients)
 		self.assertTrue('test1@example.com' in queue_recipients)
 		self.assertEqual(len(queue_recipients), 2)
-		self.assertTrue('<!--unsubscribe url-->' in email_queue[0]['message'])
+		self.assertTrue('<!--unsubscribe_url-->' in email_queue[0]['message'])
 
 	def test_send_after(self):
 		self.test_email_queue(send_after=1)


### PR DESCRIPTION
Email placeholders like `<!--unsubscribe url-->` work by replacing the placeholders right before sending the email.
There are some cases where the spaces inside the placeholder get converted to `%20` which breaks text replacement.

**Example**
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/9355208/161536882-306ba2b5-75f0-40d2-8256-f69b9522e595.png">

This PR replaces the spaces inside these placeholders with `_` character.
