### PR TITLE
fix!: Execute enqueued method in current thread if no redis worker exists

### DIFF
--- a/frappe/core/doctype/access_log/access_log.py
+++ b/frappe/core/doctype/access_log/access_log.py
@@ -28,7 +28,7 @@ def make_access_log(
 
 @frappe.write_only()
 @retry(
-	stop=stop_after_attempt(3), retry=retry_if_exception_type(frappe.DuplicateEntryError)
+	stop=stop_after_attempt(3), retry=retry_if_exception_type(frappe.DuplicateEntryError), reraise=True,
 )
 def _make_access_log(
 	doctype=None,

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -266,7 +266,8 @@ def validate_queue(queue, default_queue_list=None):
 @retry(
 	retry=retry_if_exception_type(BusyLoadingError) | retry_if_exception_type(ConnectionError),
 	stop=stop_after_attempt(10),
-	wait=wait_fixed(1)
+	wait=wait_fixed(1),
+	reraise=True,
 )
 def get_redis_conn(username=None, password=None):
 	if not hasattr(frappe.local, 'conf'):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -75,7 +75,11 @@ def enqueue(
 	if call_directly:
 		return frappe.call(method, **kwargs)
 
-	q = get_queue(queue, is_async=is_async)
+	try:
+		q = get_queue(queue, is_async=is_async)
+	except redis.exceptions.ConnectionError:
+		return frappe.call(method, **kwargs)
+
 	if not timeout:
 		timeout = get_queues_timeout().get(queue) or 300
 	queue_args = {


### PR DESCRIPTION
This allows making it easier to run Frappe without a Redis worker. I've considered an alternate feature switch approach like adding a separate bench config key to allow this...but doing this by default makes it feel somehow _"lighter"_