### PR TITLE
fix: stabilize leaflet map

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -58,7 +58,7 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 				}));
 			this.add_non_group_layers(data_layers, this.editableLayers);
 			try {
-				this.map.flyToBounds(this.editableLayers.getBounds(), {
+				this.map.fitBounds(this.editableLayers.getBounds(), {
 					padding: [50,50]
 				});
 			}
@@ -66,10 +66,10 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 				// suppress error if layer has a point.
 			}
 			this.editableLayers.addTo(this.map);
-			this.map._onResize();
-		} else if ((value===undefined) || (value == JSON.stringify(new L.FeatureGroup().toGeoJSON()))) {
-			this.locate_control.start();
+		} else {
+			this.map.setView(frappe.utils.map_defaults.center, frappe.utils.map_defaults.zoom);
 		}
+		this.map.invalidateSize();
 	}
 
 	bind_leaflet_map() {
@@ -97,8 +97,7 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 		});
 
 		L.Icon.Default.imagePath = '/assets/frappe/images/leaflet/';
-		this.map = L.map(this.map_id).setView(frappe.utils.map_defaults.center,
-			frappe.utils.map_defaults.zoom);
+		this.map = L.map(this.map_id);
 
 		L.tileLayer(frappe.utils.map_defaults.tiles,
 			frappe.utils.map_defaults.options).addTo(this.map);


### PR DESCRIPTION
### Before

1. Start at the default location
2. "Fly" to the stored location, if any 

    Very annoying to see hundreds of "flights" while clicking through multiple records.

    https://user-images.githubusercontent.com/14891507/161961432-2f40e86e-2f22-4b5b-8f83-f5d212d31285.mov

3. Else: try to geolocate the user (See video above)

    This causes annoying browser pop-ups on every form load. Also, who says that I want to map something at the user's location?

5. Shows largely gray tiles

    I guess because the size of the control has changed since initialization. To reproduce, add some fields and a collapsible section break.

    https://user-images.githubusercontent.com/14891507/161965836-148dfcd0-8833-4b95-96d5-320424e509dd.mov




### After

1. Start at the stored location, or, if None, at the default location

    https://user-images.githubusercontent.com/14891507/161962793-bda9846a-858c-4e98-80b5-3cca2f1e00d9.mov

3. Don't proactively try to locate users. Who wants to be located can click the "locate" button. (See video above)
4. Call `map.invalidateSize()` to make leaflet check the current size of the control and adjust accordingly - no more gray tiles!

    https://user-images.githubusercontent.com/14891507/161965466-a325aaa6-f723-46d5-bc74-e44f86c04b83.mov


