### PR TITLE
fix(timeline): Custom action alignment

### DIFF
--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -51,11 +51,6 @@
 	}
 }
 
-.custom-actions {
-	display: flex;
-	align-items: center;
-}
-
 .page-actions {
 	align-items: center;
 	.btn {
@@ -71,6 +66,11 @@
 	}
 	.custom-btn-group {
 		display: inline-flex;
+	}
+
+	.custom-actions {
+		display: flex;
+		align-items: center;
 	}
 }
 


### PR DESCRIPTION
- Move `custom-actions` under `page-actions`. Change in `custom-actions` was affecting `custom-actions` of timeline
	**Before:**
	<img width="241" alt="Screenshot 2022-04-05 at 7 55 36 PM" src="https://user-images.githubusercontent.com/13928957/161884230-f0e83666-2e63-43a5-bfec-0ca78abd073e.png">
	**After:**
	<img width="233" alt="Screenshot 2022-04-05 at 7 56 12 PM" src="https://user-images.githubusercontent.com/13928957/161884277-1f146c78-a61a-4f38-b347-424eeb96bf31.png">
	The issue was introduced with https://github.com/frappe/frappe/pull/16470
