### PR TITLE
fix: Use app name for parsing app name

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -222,7 +222,7 @@ def install_app(name, verbose=False, set_as_patched=True):
 	# install pre-requisites
 	if app_hooks.required_apps:
 		for app in app_hooks.required_apps:
-			name = parse_app_name(name)
+			name = parse_app_name(app)
 			install_app(name, verbose=verbose)
 
 	frappe.flags.in_install = name


### PR DESCRIPTION
When looking for dependencies, use app name for parsing.