### PR TITLE
fix: strip html from blog comments to prevent spam

### DIFF
--- a/frappe/templates/includes/comments/comment.html
+++ b/frappe/templates/includes/comments/comment.html
@@ -13,6 +13,6 @@
 				{{ frappe.utils.pretty_date(comment.creation) }}
 			</span>
 		</div>
-		<div class="content">{{ comment.content | markdown }}</div>
+		<div class="content">{{ frappe.utils.strip_html(comment.content) | markdown }}</div>
 	</div>
 </div>

--- a/frappe/templates/includes/comments/comment.html
+++ b/frappe/templates/includes/comments/comment.html
@@ -1,13 +1,17 @@
 {% from "frappe/templates/includes/avatar_macro.html" import avatar %}
 
-<div class="comment-row media my-5">
+<div class="my-5 comment-row media">
 	<div class="comment-avatar">
-		{{  avatar(user_id=(comment.comment_email or comment.sender), size='avatar-medium') }}
+		{{  avatar(user_id=(frappe.utils.strip_html(comment.comment_email or comment.sender)), size='avatar-medium') }}
 	</div>
 	<div class="comment-content">
-		<div class="head mb-2">
-			<span class="title font-weight-bold mr-2">{{ comment.sender_full_name or comment.comment_by }}</span>
-			<span class="time small text-muted">{{ frappe.utils.pretty_date(comment.creation) }}</span>
+		<div class="mb-2 head">
+			<span class="mr-2 title font-weight-bold">
+				{{ frappe.utils.strip_html(comment.sender_full_name or comment.comment_by) | e }}
+			</span>
+			<span class="time small text-muted">
+				{{ frappe.utils.pretty_date(comment.creation) }}
+			</span>
 		</div>
 		<div class="content">{{ comment.content | markdown }}</div>
 	</div>


### PR DESCRIPTION
If people try to put spam links in blog comments they shouldn't be rendered on the page.

**Before**
<img width="885" alt="image" src="https://user-images.githubusercontent.com/9355208/161957407-dfa91e2b-19e8-4415-80e2-3a4753d38de5.png">

**After**
<img width="860" alt="image" src="https://user-images.githubusercontent.com/9355208/161957342-0ce46219-1662-4789-a223-821931ce0cc3.png">

