### PR TITLE
chore: version bump and change log for v13.25.0

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -35,7 +35,7 @@ from frappe.query_builder import get_query_builder, patch_query_execute
 # Lazy imports
 faker = lazy_import('faker')
 
-__version__ = '13.24.0'
+__version__ = '13.25.0'
 
 __title__ = "Frappe Framework"
 

--- a/frappe/change_log/v13/v13_25_0.md
+++ b/frappe/change_log/v13/v13_25_0.md
@@ -1,0 +1,19 @@
+## Version 13.25.0 Release Notes
+
+### Features & Enhancements
+
+- feat: store reference to leaflet's drawControl ([#16407](https://github.com/frappe/frappe/pull/16407))
+- feat(minor): Add Custom Group Search for custom LDAP servers ([#16059](https://github.com/frappe/frappe/pull/16059))
+- feat: allow breaking `_()` function call to different lines ([#16409](https://github.com/frappe/frappe/pull/16409))
+
+### Fixes & Enhancements
+
+- fix: Allow empty webhook data ([#16433](https://github.com/frappe/frappe/pull/16433))
+- fix: set translatable on show alert ([#16427](https://github.com/frappe/frappe/pull/16427))
+- fix: update french translation ([#16444](https://github.com/frappe/frappe/pull/16444))
+- fix: update translation ([#16417](https://github.com/frappe/frappe/pull/16417))
+- fix: don't update autoname field when using `Document.save` ([#16436](https://github.com/frappe/frappe/pull/16436))
+- fix: Fetch only active letter heads for printing ([#16504](https://github.com/frappe/frappe/pull/16504))
+- fix: Follow FIFO while inserting global search record ([#16488](https://github.com/frappe/frappe/pull/16488))
+- fix: incorrect logic for `parenttype` parameter in `get_all_children` ([#16462](https://github.com/frappe/frappe/pull/16462))
+- fix: bad closure on double quote in print.js ([#16420](https://github.com/frappe/frappe/pull/16420))


### PR DESCRIPTION
## Version 13.25.0 Release Notes

### Features & Enhancements

- feat: store reference to leaflet's drawControl ([#16407](https://github.com/frappe/frappe/pull/16407))
- feat(minor): Add Custom Group Search for custom LDAP servers ([#16059](https://github.com/frappe/frappe/pull/16059))
- feat: allow breaking `_()` function call to different lines ([#16409](https://github.com/frappe/frappe/pull/16409))

### Fixes & Enhancements

- fix: Allow empty webhook data ([#16433](https://github.com/frappe/frappe/pull/16433))
- fix: set translatable on show alert ([#16427](https://github.com/frappe/frappe/pull/16427))
- fix: update french translation ([#16444](https://github.com/frappe/frappe/pull/16444))
- fix: update translation ([#16417](https://github.com/frappe/frappe/pull/16417))
- fix: don't update autoname field when using `Document.save` ([#16436](https://github.com/frappe/frappe/pull/16436))
- fix: Fetch only active letter heads for printing ([#16504](https://github.com/frappe/frappe/pull/16504))
- fix: Follow FIFO while inserting global search record ([#16488](https://github.com/frappe/frappe/pull/16488))
- fix: incorrect logic for `parenttype` parameter in `get_all_children` ([#16462](https://github.com/frappe/frappe/pull/16462))
- fix: bad closure on double quote in print.js ([#16420](https://github.com/frappe/frappe/pull/16420))