### PR TITLE
fix: readonly in dialog

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -34,6 +34,10 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 					// if default and has depends_on, render its fields.
 					me.refresh_dependency();
 				}
+
+				if (field.df["read_only"] && in_list(["undefined", "", null, undefined], field.df["default"])) {
+					field.set_input("");
+				}
 			})
 
 			if(!this.no_submit_on_enter) {


### PR DESCRIPTION
**Actual Behaviour**
Issue is If Dialog box has field as `read_only:1` and default value is empty string field value has been set as **undefined**

![image](https://user-images.githubusercontent.com/54097382/161984489-ab30ff80-3425-4706-9f3a-826cfd7617e0.png)


**Solution**

This PR fixed the issue.

If default value is empty, undefined or null, the field will be set hidden.

![image](https://user-images.githubusercontent.com/54097382/162039313-d88a2736-a6b0-4c2b-a121-be6190ad9721.png)

**Expected Behaviour**

If the value is undefined or empty string it should set hidden.
![image](https://user-images.githubusercontent.com/54097382/162039448-c9031e15-0861-405b-b36a-167bd1d09269.png)


