### PR TITLE
fix(UI): Duration Filter overlapping issue

### DIFF
--- a/frappe/public/css/bootstrap.css
+++ b/frappe/public/css/bootstrap.css
@@ -5683,7 +5683,9 @@ button.close {
   border: 0;
 }
 .modal-open {
-  overflow: hidden;
+  overflow: scroll !important;
+  position:fixed;
+  width: 100%;
 }
 .modal {
   position: fixed;

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -347,6 +347,7 @@ textarea.form-control {
 	border-radius: var(--border-radius);
 	box-shadow: var(--shadow-sm);
 	background: var(--popover-bg);
+	width: max-content;
 
 	&:after,
 	&:before {


### PR DESCRIPTION
#### Issue :
The Duration filter UI is messed up, it sets the value properly but due to width constraint, the content of the `.duration` class was stacking
<img src="https://frappe.io/files/eq3duDX.png" width="80%" /><br>



#### Simple Solution


Set the `width: max-content` for `.duration` class 
<img src="https://i.postimg.cc/YSQGSLyg/Capture2.png" width="80%" />