### PR TITLE
fix: Read Only fields visible despite no value

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -44,6 +44,8 @@ frappe.ui.form.Control = class BaseControl {
 		}
 
 		if ((!this.doctype && !this.docname) || this.df.parenttype === 'Web Form' || this.df.is_web_form) {
+			let status = "Write";
+
 			// like in case of a dialog box
 			if (cint(this.df.hidden)) {
 				// eslint-disable-next-line
@@ -55,10 +57,10 @@ frappe.ui.form.Control = class BaseControl {
 				if(explain) console.log("By Hidden Dependency: None"); // eslint-disable-line no-console
 				return "None";
 
-			} else if (cint(this.df.read_only || this.df.is_virtual)) {
+			} else if (cint(this.df.read_only || this.df.is_virtual || this.df.fieldtype === "Read Only")) {
 				// eslint-disable-next-line
 				if (explain) console.log("By Read Only: Read"); // eslint-disable-line no-console
-				return "Read";
+				status = "Read";
 
 			} else if ((this.grid &&
 						this.grid.display_status == 'Read') ||
@@ -67,10 +69,16 @@ frappe.ui.form.Control = class BaseControl {
 						this.layout.grid.display_status == 'Read')) {
 				// parent grid is read
 				if (explain) console.log("By Parent Grid Read-only: Read"); // eslint-disable-line no-console
-				return "Read";
+				status = "Read";
 			}
 
-			return "Write";
+			if (
+				status === "Read" &&
+				is_null(this.value) &&
+				!in_list(["HTML", "Image", "Button"], this.df.fieldtype)
+			) status = "None";
+
+			return status;
 		}
 
 		var status = frappe.perm.get_field_display_status(this.df,

--- a/frappe/public/js/frappe/form/controls/control.js
+++ b/frappe/public/js/frappe/form/controls/control.js
@@ -23,7 +23,6 @@ import './table';
 import './color';
 import './signature';
 import './password';
-import './read_only';
 import './button';
 import './html';
 import './markdown_editor';

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -262,3 +262,5 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 		return this.grid || this.layout && this.layout.grid;
 	}
 };
+
+frappe.ui.form.ControlReadOnly = frappe.ui.form.ControlData;

--- a/frappe/public/js/frappe/form/controls/read_only.js
+++ b/frappe/public/js/frappe/form/controls/read_only.js
@@ -1,8 +1,0 @@
-frappe.ui.form.ControlReadOnly = class ControlReadOnly extends frappe.ui.form.ControlData {
-	get_status(explain) {
-		var status = super.get_status(explain);
-		if(status==="Write")
-			status = "Read";
-		return;
-	}
-};

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -225,7 +225,10 @@ $.extend(frappe.perm, {
 		if (explain) console.log("By Workflow:" + status);
 
 		// read only field is checked
-		if (status === "Write" && cint(df.read_only)) {
+		if (status === "Write" && (
+			cint(df.read_only) ||
+			df.fieldtype === "Read Only"
+		)) {
 			status = "Read";
 		}
 		if (explain) console.log("By Read Only:" + status);

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -22,17 +22,15 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			super.make();
 			this.refresh();
 			// set default
-			$.each(this.fields_list, function(i, field) {
-				if (field.df["default"]) {
-					let def_value = field.df["default"];
+			$.each(this.fields_list, (_, field) => {
+				if (!is_null(field.df.default)) {
+					let def_value = field.df.default;
 
-					if (def_value == 'Today' && field.df["fieldtype"] == 'Date') {
+					if (def_value === "Today" && field.df.fieldtype === "Date") {
 						def_value = frappe.datetime.get_today();
 					}
 
-					field.set_input(def_value);
-					// if default and has depends_on, render its fields.
-					me.refresh_dependency();
+					this.set_value(field.df.fieldname, def_value);
 				}
 			})
 
@@ -129,6 +127,7 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			if (f) {
 				f.set_value(val).then(() => {
 					f.set_input(val);
+					f.refresh();
 					this.refresh_dependency();
 					resolve();
 				});


### PR DESCRIPTION
This PR fixes two issues:
## **Read Only** type fields visible in form despite no value

### Before

![image](https://user-images.githubusercontent.com/16315650/162142607-52a2eba9-5154-4b1b-8214-65b6c2982df5.png)


### After

#### Without Value

![Screenshot-2022-04-07-124344](https://user-images.githubusercontent.com/16315650/162142024-b8e76ec0-cdd4-4627-957c-ed3489fac529.png)


#### With Value

![image](https://user-images.githubusercontent.com/16315650/162142191-bff453d2-804c-4a25-9edf-b0a854b61816.png)





## All **Read Only** fields showing `undefined` value in dialog if default is not set


### Before

![image](https://user-images.githubusercontent.com/16315650/162142727-29029f7c-6bac-456c-9ff9-9f3f91e98807.png)


### After


#### Without Value

![Screenshot-2022-04-07-124416](https://user-images.githubusercontent.com/16315650/162142295-25475bc0-773e-4da8-a790-d41fae5571cf.png)


#### With Value

![Screenshot-2022-04-07-124430](https://user-images.githubusercontent.com/16315650/162142321-1f653b7d-d2f8-42a7-9f97-65f4b6627d82.png)


## Changes Made

### `FieldGroup` (inherited by `Dialog`)
- Add field `refresh` event to `set_value`. Required to show / hide field based on value.
- Use `set_value` when setting default instead of `field.set_input`.
- (Minor) use `is_null` to check if default needs to be set.

### Other files
- Remove class definition for **Read Only** type fields. Alias to **ControlData**.
- Move logic for **Read Only** fields to **BaseControl** (for Dialog) and **frappe.perm** (for Form)
- Add logic to hide **Read Only** fields for dialog based on value 

---

`BaseControl.get_status` needs refactor, but focusing on issues for now.