### PR TITLE
feat: add "After Insert" doctype event to server script

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -49,7 +49,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -109,10 +109,11 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2021-09-04 12:02:43.671240",
+ "modified": "2022-04-07 19:41:23.178772",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -130,5 +131,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
The event is handled in the [code](https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/server_script/server_script_utils.py)
https://github.com/frappe/frappe/blob/096110e14d9f3d6f1fe613bc53ec6e30deafc2a1/frappe/core/doctype/server_script/server_script_utils.py#L6-L20

but the "After Insert" option was missing in "Doctype Event" options in [server_script.json](https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/server_script/server_script.json#L52) file
https://github.com/frappe/frappe/blob/096110e14d9f3d6f1fe613bc53ec6e30deafc2a1/frappe/core/doctype/server_script/server_script.json#L52

[Docs](https://frappeframework.com/compare?wiki_page=docs/v13/user/en/desk/scripting/server-script&&compare=83330c3321)
<no-docs>