### PR TITLE
fix: new route syntax for Logs in System Console

### DIFF
--- a/frappe/desk/doctype/system_console/system_console.json
+++ b/frappe/desk/doctype/system_console/system_console.json
@@ -1,7 +1,7 @@
 {
  "actions": [
   {
-   "action": "#List/Console Log/List",
+   "action": "app/console-log",
    "action_type": "Route",
    "label": "Logs"
   },
@@ -86,7 +86,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-15 17:17:44.844767",
+ "modified": "2022-04-09 16:35:32.345542",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "System Console",
@@ -104,5 +104,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
**Before**
![system-console-logs-fix-1](https://user-images.githubusercontent.com/9355208/162569318-eb87c6ac-8eb8-49c5-9eef-e24a52446955.gif)

**After**
![system-console-logs-fix-2](https://user-images.githubusercontent.com/9355208/162569321-f4b8cb74-492e-49e0-9d68-9f3e444db797.gif)
