### PR TITLE
fix(minor): Hover on card link indicator color fix

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -578,7 +578,7 @@ body {
 				background-color: var(--fg-hover-color);
 
 				.indicator-pill {
-					background-color: var(--fg-color);
+					background-color: var(--fg-hover-color);
 				}
 			}
 


### PR DESCRIPTION
**Before:**

<img width="348" alt="image" src="https://user-images.githubusercontent.com/30859809/162693954-b814238e-9d3d-400b-be5d-c2bb92cb75a3.png">


**After:**

<img width="346" alt="image" src="https://user-images.githubusercontent.com/30859809/162693575-24ba5b3e-100c-4d77-ba10-ada62081fba4.png">