### PR TITLE
fix: Fix toolbar drop-down menu in DocType list view if form sidebar is disabled

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -203,11 +203,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 	make_menu() {
 		this.page.clear_icons();
 		this.page.clear_menu();
-
-		if (frappe.boot.desk_settings.form_sidebar) {
-			this.make_navigation();
-			this.make_menu_items();
-		}
+		this.make_navigation();
+		this.make_menu_items();
 	}
 
 	make_viewers() {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1552,13 +1552,15 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			});
 		}
 
-		items.push({
-			label: __("Toggle Sidebar", null, "Button in list view menu"),
-			action: () => this.toggle_side_bar(),
-			condition: () => !this.hide_sidebar,
-			standard: true,
-			shortcut: "Ctrl+K",
-		});
+		if (frappe.boot.desk_settings.form_sidebar) {
+			items.push({
+				label: __("Toggle Sidebar", null, "Button in list view menu"),
+				action: () => this.toggle_side_bar(),
+				condition: () => !this.hide_sidebar,
+				standard: true,
+				shortcut: "Ctrl+K",
+			});
+		}
 
 		items.push({
 			label: __("Share URL", null, "Button in list view menu"),


### PR DESCRIPTION
If the _form sidebar_ is deactivated for a _role_, the drop down menu in a DocType's _list view_ doesn't popup as the `make_menu_items()` function was not executed. The buttons to navigate to the previous and next documents are also hidden because `make_navigation()` never runs. It makes sense to only hide the _Toggle Sidebar_ entry from the drop-down instead of hiding the entire drop-down list when _form sidebar_ is deactivated for that role.