### PR TITLE
fix: use proper validations for number card validation method

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -27,8 +27,11 @@ frappe.ui.form.on('Number Card', {
 			frm.trigger('set_method_description');
 			frm.trigger('render_filters_table');
 		}
-		frm.trigger('create_add_to_dashboard_button');
 		frm.trigger('set_parent_document_type');
+
+		if (!frm.is_new()) {
+			frm.trigger('create_add_to_dashboard_button');
+		}
 	},
 
 	create_add_to_dashboard_button: function(frm) {

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -20,15 +20,24 @@ class NumberCard(Document):
 			self.name = append_number_if_name_exists("Number Card", self.name)
 
 	def validate(self):
-		if not self.document_type:
-			frappe.throw(_("Document type is required to create a number card"))
+		if self.type == "Document Type":
+			if not (self.document_type and self.function):
+				frappe.throw(_("Document Type and Function are required to create a number card"))
 
-		if (
-			self.document_type
-			and frappe.get_meta(self.document_type).istable
-			and not self.parent_document_type
-		):
-			frappe.throw(_("Parent document type is required to create a number card"))
+			if (
+				self.document_type
+				and frappe.get_meta(self.document_type).istable
+				and not self.parent_document_type
+			):
+				frappe.throw(_("Parent Document Type is required to create a number card"))
+
+		elif self.type == "Report":
+			if not (self.report_name and self.report_field and self.function):
+				frappe.throw(_("Report Name, Report Field and Fucntion are required to create a number card"))
+
+		elif self.type == "Custom":
+			if not self.method:
+				frappe.throw(_("Method is required to create a number card"))
 
 	def on_update(self):
 		if frappe.conf.developer_mode and self.is_standard:

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -58,6 +58,8 @@ def get_report_doc(report_name):
 
 
 def get_report_result(report, filters):
+	res = None
+
 	if report.report_type == "Query Report":
 		res = report.execute_query_report(filters)
 
@@ -84,7 +86,7 @@ def generate_report_result(
 	res = get_report_result(report, filters) or []
 
 	columns, result, message, chart, report_summary, skip_total_row = ljust_list(res, 6)
-	columns = [get_column_as_dict(col) for col in columns]
+	columns = [get_column_as_dict(col) for col in (columns or [])]
 	report_column_names = [col["fieldname"] for col in columns]
 
 	# convert to list of dicts

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -249,7 +249,7 @@ frappe.dashboard_utils = {
 					{args: values}
 				).then(()=> {
 					let dashboard_route_html =
-						`<a href = "#dashboard/${values.dashboard}">${values.dashboard}</a>`;
+						`<a href = "/app/dashboard/${values.dashboard}">${values.dashboard}</a>`;
 					let message =
 						__("{0} {1} added to Dashboard {2}", [doctype, values.name, dashboard_route_html]);
 


### PR DESCRIPTION
ref: https://frappe.io/app/issue/ISS-21-22-14095

This pr aims to make the number card doctype controller's validation method more explicit as it currently doesn't make sense.

the previous validation had a bare conditional check (without any type check)

```python
if not self.document_type:
    frappe.throw(_("Document type is required to create a number card"))
```
but we have different types of types in Number Card Doctype

![Screenshot 2022-04-29 at 1 49 16 PM](https://user-images.githubusercontent.com/32034600/165908871-5389ab6f-43a8-4192-9867-eb352d500abb.png)

So, if a user chose say `Report` Type, they would still get that error `Document type is required to create a number card`

#

Other Changes:
- fixed broken dashboard link
- show `Add To Dashboard` button if the doc is not new