### PR TITLE
fix: handle no data in set_open_count

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -375,7 +375,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	}
 
 	set_open_count() {
-		if (!this.data.transactions || !this.data.fieldname) {
+		if (!this.data || (!this.data.transactions || !this.data.fieldname)) {
 			return;
 		}
 


### PR DESCRIPTION
Depending on the user's permissions, `this.data` might be undefined when `set_open_count` is called. This PR prevents the error "undefined does not have property transactions".