### PR TITLE
fix: incorrect type in make_property_setter query

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1536,7 +1536,7 @@ def make_property_setter(
 			.select(DocField_doctype.parent)
 			.where(DocField_doctype.fieldname == args.fieldname)
 			.distinct()
-		).run(as_list=True)
+		).run(as_list=True, pluck=True)
 
 	else:
 		doctype_list = [args.doctype]

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1536,7 +1536,7 @@ def make_property_setter(
 			.select(DocField_doctype.parent)
 			.where(DocField_doctype.fieldname == args.fieldname)
 			.distinct()
-		).run(as_list=True, pluck=True)
+		).run(pluck=True)
 
 	else:
 		doctype_list = [args.doctype]


### PR DESCRIPTION
The query is returning nested lists

![telegram-cloud-photo-size-5-6244637103128425257-y](https://user-images.githubusercontent.com/9079960/162893831-d6390e1f-403a-4ff0-88ae-82ea6aed46ec.jpg)


```
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/install.py", line 23, in after_install
    set_single_defaults()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/setup/install.py", line 63, in set_single_defaults
    doc.save()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 295, in save
    return self._save(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 329, in _save
    self.run_before_save_methods()
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in run_before_save_methods
    self.run_method("validate")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 920, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1242, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1224, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 917, in fn
    return method_object(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_settings/stock_settings.py", line 49, in validate
    frappe.make_property_setter(
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 1551, in make_property_setter
    ps = get_doc(
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 1115, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 76, in get_doc
    return controller(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 117, in __init__
    super(Document, self).__init__(kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/base_document.py", line 78, in __init__
    self.update(d)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/base_document.py", line 110, in update
    self.set(key, value)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/base_document.py", line 164, in set
    self.extend(key, value)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/base_document.py", line 215, in extend
    self.append(key, v)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/base_document.py", line 206, in append
    raise ValueError(
ValueError: Document for field "doc_type" attached to child table of "None" must be a dict or BaseDocument, not class 'str' (Item Barcode)
```
 

erpnext CI: https://github.com/frappe/erpnext/actions/runs/2153096976
caused by https://github.com/frappe/frappe/pull/16107