### PR TITLE
fix: use the right filter value when flushing route history

### DIFF
--- a/frappe/desk/doctype/route_history/route_history.py
+++ b/frappe/desk/doctype/route_history/route_history.py
@@ -41,7 +41,7 @@ def flush_old_route_records():
 		frappe.db.sql('''
 			DELETE
 			FROM `tabRoute History`
-			WHERE `modified` <= %(modified)s and `user`=%(modified)s
+			WHERE `modified` <= %(modified)s and `user`=%(user)s
 		''', {
 			"modified": last_record_to_keep[0].modified,
 			"user": user


### PR DESCRIPTION
Reference: https://github.com/frappe/frappe/issues/16573

This is to fix the weekly job of flushing Route History documents.