### PR TITLE
feat: Ignore permlevel for specific fields

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -130,6 +130,17 @@ class TestUser(unittest.TestCase):
 		# system manager is not added (it is reset)
 		self.assertFalse("System Manager" in [d.role for d in me.roles])
 
+		# ignore permlevel using flags
+		me.flags.ignore_permlevel_for_fields = ["roles"]
+		me.add_roles("System Manager")
+
+		# system manager now added due to flags
+		self.assertTrue("System Manager" in [d.role for d in me.get("roles")])
+
+		# reset flags
+		me.flags.ignore_permlevel_for_fields = None
+
+		# change user
 		frappe.set_user("Administrator")
 
 		me = frappe.get_doc("User", "testperm@example.com")

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1096,7 +1096,11 @@ class BaseDocument(object):
 		to_reset = []
 
 		for df in high_permlevel_fields:
-			if df.permlevel not in has_access_to and df.fieldtype not in display_fieldtypes:
+			if (
+				df.permlevel not in has_access_to
+				and df.fieldtype not in display_fieldtypes
+				and df.fieldname not in self.flags.get("ignore_permlevel_for_fields", [])
+			):
 				to_reset.append(df)
 
 		if to_reset:


### PR DESCRIPTION
**Current Behaviour:**
Currently, if a field has a higher permlevel and a user does not have permission to that permlevel, on saving the document system resets the value of the field if there are any changes.

**Solution:**
There are some use-cases where the value of the field is changed by the code, not by the user. To allow those changes, introduced a document level flag to mention those specific fields for which permlevel will be ignored.

**Actual Use Case:**
In the ERPNext sales cycle, users want to set a higher permlevel for the price_list field because they want to control and it is set based on configuration.
On loading a transaction, the default value for price_list is set based on default_price_list set on Selling Settings. Then on the selection of Customers, it gets overwritten by the customer's default price list. But on saving the transaction, the system resets the price_list field's value to the original (system settings). This change will fix it.

Associated PR on the ERPNext: https://github.com/frappe/erpnext/pull/30686

docs: no-docs