### PR TITLE
feat: allow multiple client scripts

### DIFF
--- a/frappe/custom/doctype/client_script/client_script.json
+++ b/frappe/custom/doctype/client_script/client_script.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_import": 1,
+ "autoname": "Prompt",
  "creation": "2013-01-10 16:34:01",
  "description": "Adds a custom client script to a DocType",
  "doctype": "DocType",
@@ -52,6 +53,7 @@
    "default": "Form",
    "fieldname": "view",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Apply To",
    "options": "List\nForm",
    "set_only_once": 1
@@ -75,10 +77,11 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-02-18 00:43:33.941466",
+ "modified": "2022-04-12 12:48:15.717985",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Client Script",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/custom/doctype/client_script/client_script.py
+++ b/frappe/custom/doctype/client_script/client_script.py
@@ -6,20 +6,6 @@ from frappe.model.document import Document
 
 
 class ClientScript(Document):
-	def autoname(self):
-		self.name = f"{self.dt}-{self.view}"
-
-	def validate(self):
-		if not self.is_new():
-			return
-
-		exists = frappe.db.exists("Client Script", {"dt": self.dt, "view": self.view})
-		if exists:
-			frappe.throw(
-				_("Client Script for {0} {1} already exists").format(frappe.bold(self.dt), self.view),
-				frappe.DuplicateEntryError,
-			)
-
 	def on_update(self):
 		frappe.clear_cache(doctype=self.dt)
 

--- a/frappe/custom/doctype/client_script/ui_test_client_script.js
+++ b/frappe/custom/doctype/client_script/ui_test_client_script.js
@@ -1,0 +1,101 @@
+context("Client Script", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app");
+	});
+
+	it("should run form script in doctype form", () => {
+		cy.insert_doc(
+			"Client Script",
+			{
+				name: "Todo form script",
+				dt: "ToDo",
+				view: "Form",
+				enabled: 1,
+				script: `console.log('todo form script')`
+			},
+			true
+		);
+		cy.visit("/app/todo/new", {
+			onBeforeLoad(win) {
+				cy.spy(win.console, "log").as("consoleLog");
+			}
+		});
+		cy.get("@consoleLog").should("be.calledWith", "todo form script");
+	});
+
+	it("should run list script in doctype list view", () => {
+		cy.insert_doc(
+			"Client Script",
+			{
+				name: "Todo list script",
+				dt: "ToDo",
+				view: "List",
+				enabled: 1,
+				script: `console.log('todo list script')`
+			},
+			true
+		);
+		cy.visit("/app/todo", {
+			onBeforeLoad(win) {
+				cy.spy(win.console, "log").as("consoleLog");
+			}
+		});
+		cy.get("@consoleLog").should("be.calledWith", "todo list script");
+	});
+
+	it("should not run disabled scripts", () => {
+		cy.insert_doc(
+			"Client Script",
+			{
+				name: "Todo disabled list",
+				dt: "ToDo",
+				view: "List",
+				enabled: 0,
+				script: `console.log('todo disabled script')`
+			},
+			true
+		);
+		cy.visit("/app/todo", {
+			onBeforeLoad(win) {
+				cy.spy(win.console, "log").as("consoleLog");
+			}
+		});
+		cy.get("@consoleLog").should(
+			"not.be.calledWith",
+			"todo disabled script"
+		);
+	});
+
+	it("should run multiple scripts", () => {
+		cy.insert_doc(
+			"Client Script",
+			{
+				name: "Todo form script 1",
+				dt: "ToDo",
+				view: "Form",
+				enabled: 1,
+				script: `console.log('todo form script 1')`
+			},
+			true
+		);
+		cy.insert_doc(
+			"Client Script",
+			{
+				name: "Todo form script 2",
+				dt: "ToDo",
+				view: "Form",
+				enabled: 1,
+				script: `console.log('todo form script 2')`
+			},
+			true
+		);
+		cy.visit("/app/todo/new", {
+			onBeforeLoad(win) {
+				cy.spy(win.console, "log").as("consoleLog");
+			}
+		});
+		cy.get("@consoleLog").should("be.calledWith", "todo form script 1");
+		cy.get("@consoleLog").should("be.calledWith", "todo form script 2");
+	});
+});

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -155,7 +155,7 @@ class FormMeta(Meta):
 			frappe.db.get_all(
 				"Client Script",
 				filters={"dt": self.name, "enabled": 1},
-				fields=["script", "view"],
+				fields=["name", "script", "view"],
 				order_by="creation asc",
 			)
 			or ""
@@ -165,10 +165,18 @@ class FormMeta(Meta):
 		form_script = ""
 		for script in client_scripts:
 			if script.view == "List":
-				list_script += script.script
+				list_script += f"""
+// {script.name}
+{script.script}
+
+"""
 
 			if script.view == "Form":
-				form_script += script.script
+				form_script += f"""
+// {script.name}
+{script.script}
+
+"""
 
 		file = scrub(self.name)
 		form_script += f"\n\n//# sourceURL={file}__custom_js"

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -354,8 +354,8 @@ class TestPythonExpressions(unittest.TestCase):
 class TestDiffUtils(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
-		cls.doc = frappe.get_doc(doctype="Client Script", dt="Client Script")
-		cls.doc.save(ignore_version=False)
+		cls.doc = frappe.get_doc(doctype="Client Script", dt="Client Script", name="test_client_script")
+		cls.doc.insert()
 		cls.doc.script = "2;"
 		cls.doc.save(ignore_version=False)
 		cls.doc.script = "42;"


### PR DESCRIPTION
Currently, only one Client Script can be written for one DocType view. This is an unnecessary validation.

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/9355208/162903142-b9a94ab8-8086-4fd8-b0fc-de31caab6896.png">

- [x] UI Test

<!-- no-docs -->