### PR TITLE
fix: multiple issues with values in controls

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -155,8 +155,10 @@ frappe.ui.form.Control = class BaseControl {
 			&& locals[this.doctype] && locals[this.doctype][this.docname] || {};
 	}
 	get_model_value() {
-		if(this.doc) {
+		if (this.doc) {
 			return this.doc[this.df.fieldname];
+		} else {
+			return this.value;
 		}
 	}
 
@@ -207,12 +209,20 @@ frappe.ui.form.Control = class BaseControl {
 		}
 	}
 	get_value() {
-		if(this.get_status()==='Write') {
-			return this.get_input_value ?
-				(this.parse ? this.parse(this.get_input_value()) : this.get_input_value()) :
-				undefined;
+		if (this.get_status() === 'Write') {
+			let value;
+
+			if (this.get_input_value) {
+				value = this.get_input_value();
+			}
+
+			if (this.parse) {
+				value = this.parse(value);
+			}
+
+			return value;
 		} else {
-			return this.value || undefined;
+			return this.value;
 		}
 	}
 	set_model_value(value) {

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -81,9 +81,6 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 
 	get_model_value() {
 		let value = super.get_model_value();
-		if (!value && !this.doc) {
-			value = this.last_value;
-		}
 		return frappe.datetime.get_datetime_as_string(value);
 	}
 };


### PR DESCRIPTION
Solves https://github.com/frappe/frappe/issues/16541 and not being able to unset a **Date** field in `Dialog`

---

Because the new value and result of `get_model_value()` were `undefined` for **Date** fields in a Dialog box, it wasn't getting unset.

---

### Before

![before_date](https://user-images.githubusercontent.com/16315650/162965247-5fc63ad5-41fb-441b-b7dd-7e628d98761b.gif)


### After

![after_date](https://user-images.githubusercontent.com/16315650/162965225-5c52199a-6cbb-4860-be77-b8211ccd9837.gif)
