### PR TITLE
chore: change log and version bump

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -35,7 +35,7 @@ from frappe.query_builder import get_query_builder, patch_query_execute
 # Lazy imports
 faker = lazy_import('faker')
 
-__version__ = '13.25.0'
+__version__ = "13.26.0"
 
 __title__ = "Frappe Framework"
 

--- a/frappe/change_log/v13/v13_26_0.md
+++ b/frappe/change_log/v13/v13_26_0.md
@@ -1,0 +1,16 @@
+## Version 13.26.0 Release Notes
+
+### Features & Enhancements
+
+- feat(minor): use specific email signature via from field ([#16507](https://github.com/frappe/frappe/pull/16507))
+- feat: add "After Insert" doctype event to server script ([#16543](https://github.com/frappe/frappe/pull/16543))
+- feat: Ignore permlevel for specific fields ([#16590](https://github.com/frappe/frappe/pull/16590))
+
+### Fixes & Enhancements
+
+- fix: use the right filter value when flushing route history ([#16586](https://github.com/frappe/frappe/pull/16586))
+- fix(desk): Use Int control for Long Int ([#16572](https://github.com/frappe/frappe/pull/16572))
+- fix: stabilize leaflet map ([#16513](https://github.com/frappe/frappe/pull/16513))
+- fix: new route syntax for Logs in System Console ([#16554](https://github.com/frappe/frappe/pull/16554))
+- fix: update french translation ([#16550](https://github.com/frappe/frappe/pull/16550))
+- fix: Show assignments based on allocated todo only ([#16535](https://github.com/frappe/frappe/pull/16535))


### PR DESCRIPTION
## Version 13.26.0 Release Notes

### Features & Enhancements

- feat(minor): use specific email signature via from field ([#16507](https://github.com/frappe/frappe/pull/16507))
- feat: add "After Insert" doctype event to server script ([#16543](https://github.com/frappe/frappe/pull/16543))
- feat: Ignore permlevel for specific fields ([#16590](https://github.com/frappe/frappe/pull/16590))

### Fixes & Enhancements

- fix: use the right filter value when flushing route history ([#16586](https://github.com/frappe/frappe/pull/16586))
- fix(desk): Use Int control for Long Int ([#16572](https://github.com/frappe/frappe/pull/16572))
- fix: stabilize leaflet map ([#16513](https://github.com/frappe/frappe/pull/16513))
- fix: new route syntax for Logs in System Console ([#16554](https://github.com/frappe/frappe/pull/16554))
- fix: update french translation ([#16550](https://github.com/frappe/frappe/pull/16550))
- fix: Show assignments based on allocated todo only ([#16535](https://github.com/frappe/frappe/pull/16535))