### PR TITLE
fix(UI): Horizontal shift issue while opening and closing the modal

### DIFF
--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -1,6 +1,12 @@
 h5.modal-title {
 	margin: 0px !important;
 }
+// Keeping the scroll bar division but unable to scroll behaviour
+body.modal-open {
+	overflow: scroll !important;
+	position:fixed;
+	width: 100%;
+}
 
 // Hack to fix incorrect padding applied by Bootstrap
 body.modal-open[style^="padding-right"] {

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -4,7 +4,7 @@ h5.modal-title {
 
 // Hack to fix incorrect padding applied by Bootstrap
 body.modal-open[style^="padding-right"] {
-	padding-right: 12px !important;
+	// padding-right: 12px !important;
 
 	header.navbar {
 		padding-right: 12px !important;


### PR DESCRIPTION
### The issue:
While opening and closing modals, you can observe a slight horizontal shift. The issue is well described here - #16451. While 

### The stated solution:
1. When the modal is opened, the scroll bar hides out making the UI expand; thus causing a horizontal shift to the left side. A simple solution to this is to keep the scroll bar intact along with disabling the scroll behavior. Thus all the attention of the user is on the modal window only. <br>
`.modal-open` was the responsible class in our case. You can find the styling modifications in the modal.scss file

2. Still there was a slight shift behavior while opening the modal. This was most probably caused by the extra padding added to the web page. This additional padding was given to fix the bootstrap default padding. I don't think we need this. If there is any requirement of such modifications, we can keep this part of the styling.
<br>
<img src="https://i.postimg.cc/bY0j93QD/672b4996-0882-4824-8b9c-71c4209f.gif"/>
