### PR TITLE
fix: Email Dialog 'To' field is not full width

### DIFF
--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -211,21 +211,18 @@ body.modal-open[style^="padding-right"] {
 		display: flex;
 		align-items: center;
 
-		.frappe-control {
+		.frappe-control:first-child {
 			&[data-fieldname="sender"] {
-				flex: 1;
-				margin-bottom: 0px;
+				margin-right: 10px;
 			}
-			&[data-fieldname="recipients"] {
-				margin-left: 10px;
-			}
-			&[data-fieldname="option_toggle_button"] {
-				margin-left: 10px;
-				margin-bottom: -24px;
-				button {
-					// same as form-control input
-					height: calc(1.5em + .75rem + 2px);
-				}
+			flex: 1;
+		}
+		.frappe-control:last-child {
+			margin-left: 10px;
+			margin-bottom: -24px;
+			button {
+				// same as form-control input
+				height: calc(1.5em + .75rem + 2px);
 			}
 		}
 	}


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/16507
Before:

<img width="784" alt="image" src="https://user-images.githubusercontent.com/30859809/163132479-978e28da-180a-4cd6-a32b-f2a2ce49938d.png">


**After:**
No from field
<img width="788" alt="image" src="https://user-images.githubusercontent.com/30859809/163131972-b930a6e5-7f63-41d0-a6b0-9ca7aa0c3922.png">

With from field
<img width="790" alt="image" src="https://user-images.githubusercontent.com/30859809/163132157-f500cabf-19e8-4f41-b7f8-f7e1da7360f2.png">

