### PR TITLE
fix: misc app installer fix

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -579,7 +579,7 @@ def add_module_defs(app):
 		d = frappe.new_doc("Module Def")
 		d.app_name = app
 		d.module_name = module
-		d.save(ignore_permissions=True)
+		d.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 
 def remove_missing_apps():

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -242,8 +242,8 @@ def install_app(name, verbose=False, set_as_patched=True):
 	# install pre-requisites
 	if app_hooks.required_apps:
 		for app in app_hooks.required_apps:
-			name = parse_app_name(app)
-			install_app(name, verbose=verbose)
+			required_app = parse_app_name(app)
+			install_app(required_app, verbose=verbose)
 
 	frappe.flags.in_install = name
 	frappe.clear_cache()


### PR DESCRIPTION
1. When app install fails but the module is already installed, reattempting install results in primary key violation for the module def. 
2. When `required_apps` contains an app that's already installed, it does nothing and just exits. The root cause of this is mutating variables storing the original app that was requested to be installed and replacing it with the dependent app name. 