### PR TITLE
feat: Expose add index in exec_globals

### DIFF
--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -74,6 +74,16 @@ frappe.method_that_doesnt_exist("do some magic")
 frappe.db.commit()
 """,
 	),
+	dict(
+		name="test_add_index",
+		script_type="DocType Event",
+		doctype_event="Before Save",
+		reference_doctype="ToDo",
+		disabled=1,
+		script="""
+frappe.db.add_index("Todo", ["color", "date"])
+""",
+	),
 ]
 
 
@@ -143,6 +153,18 @@ class TestServerScript(unittest.TestCase):
 
 	def test_commit_in_doctype_event(self):
 		server_script = frappe.get_doc("Server Script", "test_todo_commit")
+		server_script.disabled = 0
+		server_script.save()
+
+		self.assertRaises(
+			AttributeError, frappe.get_doc(dict(doctype="ToDo", description="test me")).insert
+		)
+
+		server_script.disabled = 1
+		server_script.save()
+
+	def test_add_index_in_doctype_event(self):
+		server_script = frappe.get_doc("Server Script", "test_add_index")
 		server_script.disabled = 0
 		server_script.save()
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -56,8 +56,10 @@ def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=Fals
 		exec_globals.update(_globals)
 
 	if restrict_commit_rollback:
+		# prevent user from using these in docevents
 		exec_globals.frappe.db.pop("commit", None)
 		exec_globals.frappe.db.pop("rollback", None)
+		exec_globals.frappe.db.pop("add_index", None)
 
 	# execute script compiled by RestrictedPython
 	frappe.flags.in_safe_exec = True
@@ -155,6 +157,7 @@ def get_safe_globals():
 				sql=read_sql,
 				commit=frappe.db.commit,
 				rollback=frappe.db.rollback,
+				add_index=frappe.db.add_index
 			),
 		),
 		FrappeClient=FrappeClient,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -157,7 +157,7 @@ def get_safe_globals():
 				sql=read_sql,
 				commit=frappe.db.commit,
 				rollback=frappe.db.rollback,
-				add_index=frappe.db.add_index
+				add_index=frappe.db.add_index,
 			),
 		),
 		FrappeClient=FrappeClient,


### PR DESCRIPTION
There may be certain cases where the user may require to add database indexes to some tables. For eg there is a complex query (this query can be in custom script reports, server scripts. etc) that maybe taking a lot of time to retrieve data and can be speeded up by adding indexes on some columns.

The only way to do this earlier was to ssh into the server and then add the indexes. There are situations where the user doesn't have the access to the server so this PR will allow users to add indexes via System Console

`no-docs`