### PR TITLE
fix: dont override local proxies

### DIFF
--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -13,7 +13,7 @@ class SystemConsole(Document):
 	def run(self):
 		frappe.only_for("System Manager")
 		try:
-			frappe.debug_log = []
+			frappe.local.debug_log = []
 			if self.type == "Python":
 				safe_exec(self.console)
 				self.output = "\n".join(frappe.debug_log)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -57,7 +57,7 @@ def getdoc(doctype, name, user=None):
 	doc.add_seen()
 	set_link_titles(doc)
 	if frappe.response.docs is None:
-		frappe.response = _dict({"docs": []})
+		frappe.local.response = _dict({"docs": []})
 	frappe.response.docs.append(doc)
 
 


### PR DESCRIPTION
`frappe.form_dict` is proxy to `frappe.local.form_dict`. But it only allows reading/mutating the object. Proxies can't replace the object. 

Semgrep rule: https://github.com/frappe/semgrep-rules/pull/13 