### PR TITLE
feat(minor): add ignore_xss_filter to customize form field

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -347,7 +347,7 @@
   },
   {
    "default": "0",
-   "description": "Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
+   "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
    "fieldname": "ignore_xss_filter",
    "fieldtype": "Check",
    "label": "Ignore XSS Filter"
@@ -547,7 +547,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-03-02 17:07:32.117897",
+ "modified": "2022-04-19 12:27:28.641580",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -596,6 +596,7 @@ docfield_properties = {
 	"in_preview": "Check",
 	"bold": "Check",
 	"no_copy": "Check",
+	"ignore_xss_filter": "Check",
 	"hidden": "Check",
 	"collapsible": "Check",
 	"collapsible_depends_on": "Data",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -21,7 +21,6 @@
   "in_global_search",
   "in_preview",
   "bold",
-  "ignore_xss_filter",
   "no_copy",
   "allow_in_quick_entry",
   "translatable",
@@ -47,6 +46,7 @@
   "report_hide",
   "remember_last_selected_value",
   "hide_border",
+  "ignore_xss_filter",
   "property_depends_on_section",
   "mandatory_depends_on",
   "column_break_33",
@@ -457,6 +457,7 @@
   },
   {
    "default": "0",
+   "description": "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field",
    "fieldname": "ignore_xss_filter",
    "fieldtype": "Check",
    "label": "Ignore XSS Filter"

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -21,6 +21,7 @@
   "in_global_search",
   "in_preview",
   "bold",
+  "ignore_xss_filter",
   "no_copy",
   "allow_in_quick_entry",
   "translatable",
@@ -453,13 +454,19 @@
    "hidden": 1,
    "label": "Is System Generated",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_xss_filter",
+   "fieldtype": "Check",
+   "label": "Ignore XSS Filter"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-03-31 12:05:11.799654",
+ "modified": "2022-04-13 22:31:14.162661",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",


### PR DESCRIPTION
This pr adds Ignore XSS Filter check to Customise Form Field doctype.

Currently there is no way end users can apply this setting on any docfield of standard doctypes without setting up developer mode.

Working:

https://user-images.githubusercontent.com/32034600/163393220-63c4da9f-6f77-4f37-add5-9096a183c9ea.mov



> no-docs