### PR TITLE
fix(validate_links): invalid links validation not working in a certain case

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -711,6 +711,8 @@ class BaseDocument(object):
 					):
 
 						cancelled_links.append((df.fieldname, docname, get_msg(df, docname)))
+				else:
+					invalid_links.append((df.fieldname, docname, get_msg(df, docname)))
 
 		return invalid_links, cancelled_links
 


### PR DESCRIPTION
**Issue:**

In a certain case invalid links are not being validated and document can be saved with links that do not exist

When a Link field which is referenced by fetch_from, the invalid link validation does not work properly. This is caused by the fact that frappe.db.get_value for fetch values will return None and the validation ignores if values is falsy

**Fix:**

Add to `invalid_links` list if `values` is None