### PR TITLE
refactor: Prevent auto generate init file

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -528,6 +528,9 @@ def create_folder(path, with_init=False):
 	if not os.path.exists(path):
 		os.makedirs(path)
 
+		if sys.version_info[0] >= 3:
+			with_init = False
+
 		if with_init:
 			touch_file(os.path.join(path, "__init__.py"))
 

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import sys
 
 import frappe
 from frappe.model.document import Document
@@ -14,16 +15,21 @@ class ModuleDef(Document):
 		add in `modules.txt` of app if missing."""
 		frappe.clear_cache()
 		if not self.custom and frappe.conf.get("developer_mode"):
-			self.create_modules_folder()
+			self.create_modules_folder(create_init=True)
 			self.add_to_modules_txt()
 
-	def create_modules_folder(self):
+	def create_modules_folder(self, create_init=False):
 		"""Creates a folder `[app]/[module]` and adds `__init__.py`"""
 		module_path = frappe.get_app_path(self.app_name, self.name)
 		if not os.path.exists(module_path):
 			os.mkdir(module_path)
-			with open(os.path.join(module_path, "__init__.py"), "w") as f:
-				f.write("")
+
+			if sys.version_info[0] >= 3:
+				create_init = False
+
+			if create_init:
+				with open(os.path.join(module_path, "__init__.py"), "w") as f:
+					f.write("")
 
 	def add_to_modules_txt(self):
 		"""Adds to `[app]/modules.txt`"""

--- a/frappe/modules/export_file.py
+++ b/frappe/modules/export_file.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import os
+import sys
 
 import frappe
 import frappe.model
@@ -104,6 +105,9 @@ def create_folder(module, dt, dn, create_init):
 	frappe.create_folder(folder)
 
 	# create init_py_files
+	if sys.version_info[0] >= 3:
+		create_init = False
+
 	if create_init:
 		create_init_py(module_path, dt, dn)
 

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -4,6 +4,7 @@
 import io
 import os
 import re
+import sys
 
 from werkzeug.routing import Map, NotFound, Rule
 
@@ -69,20 +70,23 @@ def get_pages(app=None):
 			app_path = frappe.get_app_path(app)
 
 			for start in get_start_folders():
-				pages.update(get_pages_from_path(start, app, app_path))
+				pages.update(get_pages_from_path(start, app, app_path, create_init=True))
 
 		return pages
 
 	return frappe.cache().get_value("website_pages", lambda: _build(app))
 
 
-def get_pages_from_path(start, app, app_path):
+def get_pages_from_path(start, app, app_path, create_init=False):
 	pages = {}
 	start_path = os.path.join(app_path, start)
 	if os.path.exists(start_path):
 		for basepath, folders, files in os.walk(start_path):
 			# add missing __init__.py
-			if not "__init__.py" in files:
+			if sys.version_info[0] >= 3:
+				create_init = False
+
+			if not "__init__.py" in files and create_init:
 				open(os.path.join(basepath, "__init__.py"), "a").close()
 
 			for fname in files:


### PR DESCRIPTION
Basically, In higher python versions (>=3), we don't require `__init__.py` anymore.

So, this PR is to prevent the auto-generation of `__init__.py` files in Doctypes, modules, reports, etc.

>**Note:** Initial frappe version file and `__init__.py` file will stay the same in structure.