### PR TITLE
test: less flaky date control test

### DIFF
--- a/cypress/integration/control_date.js
+++ b/cypress/integration/control_date.js
@@ -68,16 +68,15 @@ context('Date Control', () => {
 		cy.clear_dialogs();
 		cy.clear_datepickers();
 
-		get_dialog({ default: '2020-01-15' }).as('dialog');
+		get_dialog().as('dialog');
 		cy.get_field('date', 'Date').click();
 
 		//Clicking on "Today" button
 		cy.get('.datepicker--button').click();
 
-		//Picking up the todays date
-		const todays_date = new Date().toJSON().split('T')[0];
-
 		//Verifying if clicking on "Today" button matches today's date
-		cy.window().its('cur_dialog.fields_dict.date.value').should('be.equal', todays_date);
+		cy.window().then(win => {
+			expect(win.cur_dialog.fields_dict.date.value).to.be.equal(win.frappe.datetime.get_today());
+		});
 	});
 });

--- a/cypress/integration/control_date.js
+++ b/cypress/integration/control_date.js
@@ -1,23 +1,27 @@
 context('Date Control', () => {
 	before(() => {
 		cy.login();
-		cy.visit('/app/doctype');
-		return cy.window().its('frappe').then(frappe => {
-			return frappe.xcall('frappe.tests.ui_test_helpers.create_doctype', {
-				name: 'Test Date Control',
-				fields: [
-					{
-						"label": "Date",
-						"fieldname": "date",
-						"fieldtype": "Date",
-						"in_list_view": 1
-					},
-				]
-			});
-		});
+		cy.visit('/app');
 	});
+
+	function get_dialog(date_field_options) {
+		return cy.dialog({
+			title: 'Date',
+			fields: [{
+				"label": "Date",
+				"fieldname": "date",
+				"fieldtype": "Date",
+				"in_list_view": 1,
+				...date_field_options
+			}]
+		});
+	}
+
 	it('Selecting a date from the datepicker', () => {
-		cy.new_form('Test Date Control');
+		cy.clear_dialogs();
+		cy.clear_datepickers();
+
+		get_dialog().as('dialog');
 		cy.get_field('date', 'Date').click();
 		cy.get('.datepicker--nav-title').click();
 		cy.get('.datepicker--nav-title').click({force: true});
@@ -28,12 +32,16 @@ context('Date Control', () => {
 		cy.get('.datepicker--months > .datepicker--cells > .datepicker--cell[data-month=0]').click();
 		cy.get('.datepicker--days > .datepicker--cells > .datepicker--cell[data-date=15]').click();
 
-		//Verifying if the selected date is displayed in the date field
-		cy.get_field('date', 'Date').should('have.value', '01-15-2020');		
+		// Verify if the selected date is set the date field
+		cy.window().its('cur_dialog.fields_dict.date.value').should('be.equal', '2020-01-15');
 	});
 
 	it('Checking next and previous button', () => {
-		cy.get_field('date', 'Date').click();	
+		cy.clear_dialogs();
+		cy.clear_datepickers();
+
+		get_dialog({ default: '2020-01-15' }).as('dialog');
+		cy.get_field('date', 'Date').click();
 
 		//Clicking on the next button in the datepicker
 		cy.get('.datepicker--nav-action[data-action=next]').click();
@@ -42,7 +50,7 @@ context('Date Control', () => {
 		cy.get('.datepicker--cell[data-date=15]').click({force: true});
 
 		//Verifying if the selected date has been displayed in the date field
-		cy.get_field('date', 'Date').should('have.value', '02-15-2020');	
+		cy.window().its('cur_dialog.fields_dict.date.value').should('be.equal', '2020-02-15');
 		cy.wait(500);
 		cy.get_field('date', 'Date').click();
 
@@ -53,19 +61,23 @@ context('Date Control', () => {
 		cy.get('.datepicker--cell[data-date=15]').click({force: true});
 
 		//Verifying if the selected date has been displayed in the date field
-		cy.get_field('date', 'Date').should('have.value', '01-15-2020');
+		cy.window().its('cur_dialog.fields_dict.date.value').should('be.equal', '2020-01-15');
 	});
 
 	it('Clicking on "Today" button gives todays date', () => {
-		cy.get_field('date', 'Date').click();	
+		cy.clear_dialogs();
+		cy.clear_datepickers();
+
+		get_dialog({ default: '2020-01-15' }).as('dialog');
+		cy.get_field('date', 'Date').click();
 
 		//Clicking on "Today" button
 		cy.get('.datepicker--button').click();
 
 		//Picking up the todays date
-		const todays_date = Cypress.moment().format('MM-DD-YYYY');
+		const todays_date = new Date().toJSON().split('T')[0];
 
 		//Verifying if clicking on "Today" button matches today's date
-		cy.get_field('date', 'Date').should('have.value', todays_date);
+		cy.window().its('cur_dialog.fields_dict.date.value').should('be.equal', todays_date);
 	});
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -258,6 +258,20 @@ Cypress.Commands.add('hide_dialog', () => {
 	cy.get('.modal:visible').should('not.exist');
 });
 
+Cypress.Commands.add('clear_dialogs', () => {
+	cy.window().then((win) => {
+		win.$('.modal, .modal-backdrop').remove();
+	});
+	cy.get('.modal').should('not.exist');
+})
+
+Cypress.Commands.add('clear_datepickers', () => {
+	cy.window().then((win) => {
+		win.$('.datepicker').remove();
+	});
+	cy.get('.datepicker').should('not.exist');
+})
+
 Cypress.Commands.add('insert_doc', (doctype, args, ignore_duplicate) => {
 	return cy
 		.window()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -241,8 +241,20 @@ Cypress.Commands.add('clear_cache', () => {
 });
 
 Cypress.Commands.add('dialog', opts => {
-	return cy.window().then(win => {
-		var d = new win.frappe.ui.Dialog(opts);
+	return cy.window({ log: false }).its('frappe', { log: false }).then(frappe => {
+		Cypress.log({
+			name: "dialog",
+			displayName: "dialog",
+			message: 'frappe.ui.Dialog',
+			consoleProps: () => {
+				return {
+					options: opts,
+					dialog: d
+				}
+			}
+		});
+
+		var d = new frappe.ui.Dialog(opts);
 		d.show();
 		return d;
 	});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -263,14 +263,14 @@ Cypress.Commands.add('clear_dialogs', () => {
 		win.$('.modal, .modal-backdrop').remove();
 	});
 	cy.get('.modal').should('not.exist');
-})
+});
 
 Cypress.Commands.add('clear_datepickers', () => {
 	cy.window().then((win) => {
 		win.$('.datepicker').remove();
 	});
 	cy.get('.datepicker').should('not.exist');
-})
+});
 
 Cypress.Commands.add('insert_doc', (doctype, args, ignore_duplicate) => {
 	return cy


### PR DESCRIPTION
- Assert the actual value of the field rather than the formatted value
- Always start a new test from a clean state, currently the date test assumes the state created by the previous test
- No need to create an entire doctype just to test a single field, can be done in a dialog