### PR TITLE
fix: extend autoname validation to child items

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -869,7 +869,7 @@ class BaseDocument(object):
 		autoname = self.meta.autoname or ""
 		_empty, _field_specifier, fieldname = autoname.partition("field:")
 
-		if fieldname and self.name and self.name != self.get("fieldname"):
+		if fieldname and self.name and self.name != self.get(fieldname):
 			self.set(fieldname, self.name)
 
 	def throw_length_exceeded_error(self, df, max_length, value):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -528,6 +528,7 @@ class Document(BaseDocument):
 			d._validate_non_negative()
 			d._validate_length()
 			d._validate_code_fields()
+			d._sync_autoname_field()
 			d._extract_images_from_text_editor()
 			d._sanitize_content()
 			d._save_passwords()

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -4,11 +4,11 @@
 import unittest
 
 import frappe
+from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.model.naming import (
 	append_number_if_name_exists,
 	determine_consecutive_week_number,
 	getseries,
-	parse_naming_series,
 	revert_series_if_last,
 )
 from frappe.utils import now_datetime
@@ -50,6 +50,40 @@ class TestNaming(unittest.TestCase):
 
 		self.assertEqual(country.name, original_name)
 		self.assertEqual(country.name, country.country_name)
+
+	def test_child_table_naming(self):
+		child_dt_with_naming = new_doctype(
+			"childtable_with_autonaming", istable=1, autoname="field:some_fieldname"
+		).insert()
+		dt_with_child_autoname = new_doctype(
+			"dt_with_childtable_naming",
+			fields=[
+				{
+					"label": "table with naming",
+					"fieldname": "table_with_naming",
+					"options": "childtable_with_autonaming",
+					"fieldtype": "Table",
+				}
+			],
+		).insert()
+
+		name = frappe.generate_hash(length=10)
+
+		doc = frappe.new_doc("dt_with_childtable_naming")
+		doc.append("table_with_naming", {"some_fieldname": name})
+		doc.save()
+		self.assertEqual(doc.table_with_naming[0].name, name)
+
+		# change autoname field
+		doc.table_with_naming[0].some_fieldname = "Something else"
+		doc.save()
+
+		self.assertEqual(doc.table_with_naming[0].name, name)
+		self.assertEqual(doc.table_with_naming[0].some_fieldname, name)
+
+		doc.delete()
+		dt_with_child_autoname.delete()
+		child_dt_with_naming.delete()
 
 	def test_format_autoname(self):
 		"""


### PR DESCRIPTION
extends https://github.com/frappe/frappe/pull/16436 for https://github.com/frappe/frappe/pull/16608