### PR TITLE
fix(web form): Directly pass `link_title_doctypes` instead of calling for it

### DIFF
--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -85,7 +85,7 @@ frappe.boot = {
 		system: "{{ frappe.utils.get_time_zone() }}",
 		user: "{{ frappe.db.get_value('User', frappe.session.user, 'time_zone') or frappe.utils.get_time_zone() }}"
 	},
-	link_title_doctypes: `{{ frappe.call('frappe.boot.get_link_title_doctypes') }}`
+	link_title_doctypes: {{ link_title_doctypes }}
 };
 // for backward compatibility of some libs
 frappe.sys_defaults = frappe.boot.sysdefaults;

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -198,6 +198,7 @@ def get_context(context):
 
 		context.show_in_grid = self.show_in_grid
 		self.load_translations(context)
+		context.link_title_doctypes = frappe.boot.get_link_title_doctypes()
 
 	def load_translations(self, context):
 		translated_messages = frappe.translate.get_dict("doctype", self.doc_type)


### PR DESCRIPTION
Directly pass `link_title_doctypes` instead of calling it to avoid permission error. Due to this, Webforms even with "Login Required" disabled was throwing permission error for Guest users.

The issue was introduced with https://github.com/frappe/frappe/pull/16271

cc @pateljannat, @nextchamp-saqib 