### PR TITLE
fix: handle filters passed as dict to client.get

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -75,7 +75,7 @@ def get(doctype, name=None, filters=None, parent=None):
 		check_parent_permission(parent, doctype)
 
 	if filters and not name:
-		name = frappe.db.get_value(doctype, json.loads(filters))
+		name = frappe.db.get_value(doctype, frappe.parse_json(filters))
 		if not name:
 			frappe.throw(_("No document found for given filters"))
 

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -129,3 +129,15 @@ class TestClient(unittest.TestCase):
 		self.assertTrue("name" in first_item)
 		self.assertTrue("modified" in first_item)
 		frappe.local.login_manager.logout()
+
+	def test_client_get(self):
+		from frappe.client import get
+
+		todo = frappe.get_doc(doctype="ToDo", description="test").insert()
+		filters = {"name": todo.name}
+		filters_json = frappe.as_json(filters)
+
+		self.assertEqual(get("ToDo", filters=filters).description, "test")
+		self.assertEqual(get("ToDo", filters=filters_json).description, "test")
+
+		todo.delete()


### PR DESCRIPTION
Currently, you need to pass `filters` as stringified `JSON` via REST clients. IMO it should handle `dict` as well as `JSON`.

Before:
```js
fetch('/api/method/frappe.client.get', {
  ...
  body: JSON.stringify({
    doctype: 'ToDo',
    filters: JSON.stringify({ owner: 'user@example.com' }) // this shouldn't be needed
  })
})
```

After:
```js
fetch('/api/method/frappe.client.get', {
  ...
  body: JSON.stringify({
    doctype: 'ToDo',
    filters: { owner: 'user@example.com' } // this is parsed as dict by frappe request handler
  })
})
```
