### PR TITLE
fix: Fixed spelling of "Submitting" in Bulk Submit modal

### DIFF
--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -48,7 +48,7 @@ def submit_cancel_or_update_docs(doctype, docnames, action="submit", data=None):
 			message = ""
 			if action == "submit" and doc.docstatus == 0:
 				doc.submit()
-				message = _("Submiting {0}").format(doctype)
+				message = _("Submitting {0}").format(doctype)
 			elif action == "cancel" and doc.docstatus == 1:
 				doc.cancel()
 				message = _("Cancelling {0}").format(doctype)


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

Just fixes the spelling of "Submitting" in the bulk submit modal.

Closes #16636 