### PR TITLE
fix: color hex code not work as class name

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -79,6 +79,6 @@ export default class ShortcutWidget extends Widget {
 		this.action_area.empty();
 		const label = get_label();
 		let color = this.color && count ? this.color.toLowerCase() : 'gray';
-		$(`<div class="indicator-pill ellipsis ${color}">${label}</div>`).appendTo(this.action_area);
+		$(`<div class="indicator-pill ellipsis" style="color:${color}">${label}</div>`).appendTo(this.action_area);
 	}
 }


### PR DESCRIPTION
We have a color picker inside the child table for color selection of shortcuts but in customization, we have a dropdown for color selection. When we customize any workspace that time color is applied because it saves the color name but when we set it from workspace it saves the hex code of the color.
Both will work if we add color to the style attribute.


