### PR TITLE
chore: Add semantic releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Entire Repository
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Generate Semantic Release
+on:
+  push:
+    branches:
+      - version-13
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout Entire Repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js v14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Setup dependencies
+        run: |
+          npm install @semantic-release/git @semantic-release/exec --no-save
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release 

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,12 @@
 {
 	"branches": ["version-13"],
 	"plugins": [
-		"@semantic-release/commit-analyzer",
+		"@semantic-release/commit-analyzer", {
+			"preset": "angular",
+			"releaseRules": [
+				{"breaking": true, "release": false}
+			]
+		},
 		"@semantic-release/release-notes-generator",
 		[
 			"@semantic-release/exec", {

--- a/.releaserc
+++ b/.releaserc
@@ -19,12 +19,6 @@
 				"message": "chore(release): Bumped to Version ${nextRelease.version}\n\n${nextRelease.notes}"
 			}
 		],
-		[
-			"@semantic-release/github", {
-				"assets": [
-					{"path": "dist/*"},
-				]
-			}
-		]
+		"@semantic-release/github"
 	]
 } 

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,25 @@
+{
+	"branches": ["version-13"],
+	"plugins": [
+		"@semantic-release/commit-analyzer",
+		"@semantic-release/release-notes-generator",
+		[
+			"@semantic-release/exec", {
+				"prepareCmd": 'sed -ir "s/[0-9]*\.[0-9]*\.[0-9]*/${nextRelease.version}/" frappe/__init__.py'
+			}
+		],
+		[
+			"@semantic-release/git", {
+				"assets": ["frappe/__init__.py"],
+				"message": "chore(release): Bumped to Version ${nextRelease.version}\n\n${nextRelease.notes}"
+			}
+		],
+		[
+			"@semantic-release/github", {
+				"assets": [
+					{"path": "dist/*"},
+				]
+			}
+		]
+	]
+} 


### PR DESCRIPTION
Automates:
1. Version bump
2. git tag
3. GitHub release (with changelog)

On pushing commits to version-13 branch. 

Largely similar to https://github.com/frappe/bench/pull/1110 (sans pypi / wheels)