### PR TITLE
fix: another approach for updating navbar items

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -146,7 +146,7 @@ frappe.patches.v13_0.update_duration_options
 frappe.patches.v13_0.replace_old_data_import # 2020-06-24
 frappe.patches.v13_0.create_custom_dashboards_cards_and_charts
 frappe.patches.v13_0.rename_is_custom_field_in_dashboard_chart
-frappe.patches.v13_0.add_standard_navbar_items # 2020-12-15
+frappe.patches.v13_0.add_standard_navbar_items # 2022-04-18
 frappe.patches.v13_0.generate_theme_files_in_public_folder
 frappe.patches.v13_0.increase_password_length
 frappe.patches.v12_0.fix_email_id_formatting

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -323,9 +323,7 @@ def add_standard_navbar_items():
 	standard_navbar_items = get_custom_navbar_items(
 			navbar_settings.settings_dropdown, standard_navbar_items
 	)
-	standard_help_items = get_custom_navbar_items(
-			navbar_settings.help_dropdown, standard_help_items
-	)
+	standard_help_items = get_custom_navbar_items(navbar_settings.help_dropdown, standard_help_items)
 
 	navbar_settings.settings_dropdown = []
 	navbar_settings.help_dropdown = []

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -320,6 +320,9 @@ def add_standard_navbar_items():
 		},
 	]
 
+	standard_navbar_items = get_custom_navbar_items(navbar_settings.settings_dropdown, standard_navbar_items)
+	standard_help_items = get_custom_navbar_items(navbar_settings.help_dropdown, standard_help_items)
+
 	navbar_settings.settings_dropdown = []
 	navbar_settings.help_dropdown = []
 
@@ -330,3 +333,23 @@ def add_standard_navbar_items():
 		navbar_settings.append("help_dropdown", item)
 
 	navbar_settings.save()
+
+def get_custom_navbar_items(navbar_items, standard_items):
+	#hack to maintain the order of custom and standard items
+	counter = 0
+	for d in navbar_items:
+		if not d.is_standard:
+			row = {
+				"item_label": d.item_label,
+				"item_type": d.item_type,
+				"route": d.route,
+				"action": d.action,
+				"is_standard": 0,
+				"idx": d.idx
+			}
+			standard_items.insert(d.idx - 1, row)
+			counter += 1
+		else:
+			d.idx += counter
+
+	return standard_items

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -320,8 +320,12 @@ def add_standard_navbar_items():
 		},
 	]
 
-	standard_navbar_items = get_custom_navbar_items(navbar_settings.settings_dropdown, standard_navbar_items)
-	standard_help_items = get_custom_navbar_items(navbar_settings.help_dropdown, standard_help_items)
+	standard_navbar_items = get_custom_navbar_items(
+			navbar_settings.settings_dropdown, standard_navbar_items
+	)
+	standard_help_items = get_custom_navbar_items(
+			navbar_settings.help_dropdown, standard_help_items
+	)
 
 	navbar_settings.settings_dropdown = []
 	navbar_settings.help_dropdown = []
@@ -335,7 +339,7 @@ def add_standard_navbar_items():
 	navbar_settings.save()
 
 def get_custom_navbar_items(navbar_items, standard_items):
-	#hack to maintain the order of custom and standard items
+	# hack to maintain the order of custom and standard items
 	counter = 0
 	for d in navbar_items:
 		if not d.is_standard:
@@ -345,7 +349,7 @@ def get_custom_navbar_items(navbar_items, standard_items):
 				"route": d.route,
 				"action": d.action,
 				"is_standard": 0,
-				"idx": d.idx
+				"idx": d.idx,
 			}
 			standard_items.insert(d.idx - 1, row)
 			counter += 1


### PR DESCRIPTION
### Changes:
This PR is an attempt to follow a different approach than https://github.com/frappe/frappe/pull/16472 to update navbar items without disturbing the order of custom items (if added any).

### Before:
<img width="365" alt="Screenshot 2022-04-18 at 1 26 21 PM" src="https://user-images.githubusercontent.com/30501401/163777187-7b312e9f-0cc8-4b13-9354-e5c6568192c1.png">

### After:
<img width="414" alt="Screenshot 2022-04-18 at 1 31 39 PM" src="https://user-images.githubusercontent.com/30501401/163777275-2dd0cac3-e66c-4637-bd76-d83381618da2.png">


