### PR TITLE
fix: kanban board without title field

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -124,7 +124,7 @@ frappe.views.BaseList = class BaseList {
 			// df is passed
 			const df = fieldname;
 			fieldname = df.fieldname;
-			doctype = df.parent;
+			doctype = df.parent || doctype;
 		}
 
 		if (!this.fields) this.fields = [];


### PR DESCRIPTION
If a doctype doesn't have a title field, `name` field is last fallback for kanban board. However since `name` isn't a "real" docfield it doesn't have `parent` attribute, which results in querying `undefined` doctype. 

ref:  https://github.com/frappe/frappe/blob/d4c4cdce62919d04438f68cb88132bb7f12e7941/frappe/public/js/frappe/views/kanban/kanban_view.js#L183-L185 

<img width="1044" alt="Screenshot 2022-04-18 at 6 32 59 PM" src="https://user-images.githubusercontent.com/9079960/163812226-d4bb9cc7-ac6d-457f-a52e-e71d8ba61804.png">



closes https://github.com/frappe/erpnext/issues/20130 
