### PR TITLE
chore: remove tag link patch

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -106,7 +106,6 @@ frappe.patches.v12_0.set_default_incoming_email_port
 frappe.patches.v12_0.update_global_search
 frappe.patches.v12_0.setup_tags
 frappe.patches.v12_0.update_auto_repeat_status_and_not_submittable
-frappe.patches.v12_0.copy_to_parent_for_tags
 frappe.patches.v12_0.create_notification_settings_for_user
 frappe.patches.v11_0.make_all_prepared_report_attachments_private #2019-11-26
 frappe.patches.v12_0.setup_email_linking

--- a/frappe/patches/v12_0/copy_to_parent_for_tags.py
+++ b/frappe/patches/v12_0/copy_to_parent_for_tags.py
@@ -1,7 +1,0 @@
-import frappe
-
-
-def execute():
-
-	frappe.db.sql("UPDATE `tabTag Link` SET parenttype=document_type")
-	frappe.db.sql("UPDATE `tabTag Link` SET parent=document_name")


### PR DESCRIPTION
Missed in #15411 

This pr removes an unnecessary tag link patch (for v14) - as it's a non-child table doctype