### PR TITLE
fix: Check for required services running after frappe init

### DIFF
--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -159,12 +159,12 @@ class SiteMigration:
 		"""Run Migrate operation on site specified. This method initializes
 		and destroys connections to the site database.
 		"""
-		if not self.required_services_running():
-			raise SystemExit(1)
-
 		if site:
 			frappe.init(site=site)
 			frappe.connect()
+
+		if not self.required_services_running():
+			raise SystemExit(1)
 
 		self.setUp()
 		try:


### PR DESCRIPTION
Each site on a single app server can run on separate DBMS' on separate servers. This site-specific config resides in each site's `site_config.json` file. Thereby, we need to load the site's config before checking for service's availability.

Closes https://github.com/frappe/frappe/issues/16632