### PR TITLE
feat: configurable auto email reports limit

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -68,6 +68,8 @@
   "prepared_report_section",
   "enable_prepared_report_auto_deletion",
   "prepared_report_expiry_period",
+  "column_break_64",
+  "max_auto_email_report_per_user",
   "system_updates_section",
   "disable_system_update_notification"
  ],
@@ -445,7 +447,7 @@
    "collapsible": 1,
    "fieldname": "prepared_report_section",
    "fieldtype": "Section Break",
-   "label": "Prepared Report"
+   "label": "Reports"
   },
   {
    "default": "Frappe",
@@ -485,12 +487,22 @@
    "fieldtype": "Select",
    "label": "First Day of the Week",
    "options": "Sunday\nMonday\nTuesday\nWednesday\nThursday\nFriday\nSaturday"
+  },
+  {
+   "fieldname": "column_break_64",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "20",
+   "fieldname": "max_auto_email_report_per_user",
+   "fieldtype": "Int",
+   "label": "Max auto email report per user"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2022-01-04 11:28:34.881192",
+ "modified": "2022-04-21 09:11:35.218721",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -12,6 +12,7 @@ from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import (
 	add_to_date,
+	cint,
 	format_time,
 	get_link_to_form,
 	get_url_to_report,
@@ -51,14 +52,18 @@ class AutoEmailReport(Document):
 		self.email_to = "\n".join(valid)
 
 	def validate_report_count(self):
-		"""check that there are only 3 enabled reports per user"""
-		count = frappe.db.sql(
-			"select count(*) from `tabAuto Email Report` where user=%s and enabled=1", self.user
-		)[0][0]
-		max_reports_per_user = frappe.local.conf.max_reports_per_user or 3
+		count = frappe.db.count("Auto Email Report", {"user": self.user, "enabled": 1})
+
+		max_reports_per_user = (
+			cint(frappe.local.conf.max_reports_per_user)  # kept for backward compatibilty
+			or cint(frappe.db.get_single_value("System Settings", "max_auto_email_report_per_user"))
+			or 20
+		)
 
 		if count > max_reports_per_user + (-1 if self.flags.in_insert else 0):
-			frappe.throw(_("Only {0} emailed reports are allowed per user").format(max_reports_per_user))
+			msg = _("Only {0} emailed reports are allowed per user.").format(max_reports_per_user)
+			msg += " " + _("To allow more reports update limit in System Settings.")
+			frappe.throw(msg, title=_("Report limit reached"))
 
 	def validate_report_format(self):
 		"""check if user has select correct report format"""

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -226,7 +226,6 @@ scheduler_events = {
 		"frappe.sessions.clear_expired_sessions",
 		"frappe.email.doctype.notification.notification.trigger_daily_alerts",
 		"frappe.utils.scheduler.restrict_scheduler_events_if_dormant",
-		"frappe.email.doctype.auto_email_report.auto_email_report.send_daily",
 		"frappe.website.doctype.personal_data_deletion_request.personal_data_deletion_request.remove_unverified_record",
 		"frappe.desk.form.document_follow.send_daily_updates",
 		"frappe.social.doctype.energy_point_settings.energy_point_settings.allocate_review_points",
@@ -241,6 +240,7 @@ scheduler_events = {
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily",
 		"frappe.utils.change_log.check_for_update",
 		"frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backups_daily",
+		"frappe.email.doctype.auto_email_report.auto_email_report.send_daily",
 		"frappe.integrations.doctype.google_drive.google_drive.daily_backup",
 	],
 	"weekly_long": [


### PR DESCRIPTION
- The previous limit was 3 per user which is way too less, no known reason to
restrict this other than hogging of system with too many reports. Bumped
default limit to 20.
- site config is not easily discoverable or editable, added config in
  system settings.
- Moved auto email report background job form daily queue to `daily_long` queue. 

closes https://github.com/frappe/frappe/issues/16681 


<img width="1049" alt="Screenshot 2022-04-20 at 12 33 06 PM" src="https://user-images.githubusercontent.com/9079960/164170117-5612d9df-da91-441b-a4f6-acd89d30336e.png">


`no-docs` (error message is sufficient to explain to user what to do without referring docs)


ref: 

ISS-21-22-10245
ISS-21-22-07742
ISS-20-21-10850
ISS-20-21-10112

and many more times. This is such a stupid validation 🤦 