### PR TITLE
perf!: simpler `frappe.get_system_setting`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -217,7 +217,6 @@ def init(site, sites_path=None, new_site=False):
 
 	local.module_app = None
 	local.app_modules = None
-	local.system_settings = _dict()
 
 	local.user = None
 	local.user_perms = None
@@ -2139,9 +2138,7 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 
 
 def get_system_settings(key):
-	if key not in local.system_settings:
-		local.system_settings.update({key: db.get_single_value("System Settings", key)})
-	return local.system_settings.get(key)
+	return db.get_single_value("System Settings", key, cache=True)
 
 
 def get_active_domains():

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -53,7 +53,6 @@ class SystemSettings(Document):
 
 		frappe.cache().delete_value("system_settings")
 		frappe.cache().delete_value("time_zone")
-		frappe.local.system_settings = {}
 
 		if frappe.flags.update_last_reset_password_date:
 			update_last_reset_password_date()


### PR DESCRIPTION
Not sure why this needs to be "cached" in locals again when db object already caches it in value_cache.

Breaking Change: Got rid of local `frappe.local.system_settings`, which doesn't seem to be used by anywhere. Accessing this directly is dangerous anyway since it depends on whether `get_system_settings` was called with required key or not. 
