### PR TITLE
test: show locals on test failure

### DIFF
--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -117,6 +117,7 @@ class ParallelTestRunner:
 
 class ParallelTestResult(unittest.TextTestResult):
 	def startTest(self, test):
+		self.tb_locals = True
 		self._started_at = time.time()
 		super(unittest.TextTestResult, self).startTest(test)
 		test_class = unittest.util.strclass(test.__class__)

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -15,6 +15,7 @@ import frappe
 import frappe.utils.scheduler
 from frappe.model.naming import revert_series_if_last
 from frappe.modules import get_module_name, load_doctype_module
+from frappe.utils import cint
 
 unittest_runner = unittest.TextTestRunner
 SLOW_TEST_THRESHOLD = 2
@@ -177,10 +178,13 @@ def run_all_tests(
 					_add_test(app, path, filename, verbose, test_suite, ui_tests)
 
 	if junit_xml_output:
-		runner = unittest_runner(verbosity=1 + (verbose and 1 or 0), failfast=failfast)
+		runner = unittest_runner(verbosity=1 + cint(verbose), failfast=failfast)
 	else:
 		runner = unittest_runner(
-			resultclass=TimeLoggingTestResult, verbosity=1 + (verbose and 1 or 0), failfast=failfast
+			resultclass=TimeLoggingTestResult,
+			verbosity=1 + cint(verbose),
+			failfast=failfast,
+			tb_locals=verbose,
 		)
 
 	if profile:
@@ -279,10 +283,13 @@ def _run_unittest(
 			test_suite.addTest(module_test_cases)
 
 	if junit_xml_output:
-		runner = unittest_runner(verbosity=1 + (verbose and 1 or 0), failfast=failfast)
+		runner = unittest_runner(verbosity=1 + cint(verbose), failfast=failfast)
 	else:
 		runner = unittest_runner(
-			resultclass=TimeLoggingTestResult, verbosity=1 + (verbose and 1 or 0), failfast=failfast
+			resultclass=TimeLoggingTestResult,
+			verbosity=1 + cint(verbose),
+			failfast=failfast,
+			tb_locals=verbose,
 		)
 
 	if profile:


### PR DESCRIPTION
- Show locals always in CI
- Show locals locally when running in verbose mode

ref: https://docs.python.org/3/library/unittest.html#unittest.TestResult.tb_locals 