### PR TITLE
fix: support for multiple order by in add_conditions

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -108,11 +108,14 @@ def change_orderby(order: str):
 	        tuple: field, order
 	"""
 	order = order.split()
-	if order[1].lower() == "asc":
-		orderby, order = order[0], Order.asc
-		return orderby, order
-	orderby, order = order[0], Order.desc
-	return orderby, order
+
+	try:
+		if order[1].lower() == "asc":
+			return order[0], Order.asc
+	except IndexError:
+		pass
+
+	return order[0], Order.desc
 
 
 OPERATOR_MAP = {
@@ -175,10 +178,13 @@ class Query:
 		"""
 		if kwargs.get("orderby"):
 			orderby = kwargs.get("orderby")
-			order = kwargs.get("order") if kwargs.get("order") else Order.desc
 			if isinstance(orderby, str) and len(orderby.split()) > 1:
-				orderby, order = change_orderby(orderby)
-			conditions = conditions.orderby(orderby, order=order)
+				for ordby in orderby.split(","):
+					if ordby := ordby.strip():
+						orderby, order = change_orderby(ordby)
+						conditions = conditions.orderby(orderby, order=order)
+			else:
+				conditions = conditions.orderby(orderby, order=kwargs.get("order") or Order.desc)
 
 		if kwargs.get("limit"):
 			conditions = conditions.limit(kwargs.get("limit"))

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -294,7 +294,7 @@ class Query:
 		table: str,
 		fields: Union[List, Tuple],
 		filters: Union[Dict[str, Union[str, int]], str, int] = None,
-		**kwargs
+		**kwargs,
 	):
 		criterion = self.build_conditions(table, filters, **kwargs)
 		if isinstance(fields, (list, tuple)):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -90,8 +90,10 @@ class TestDB(unittest.TestCase):
 		# test multiple orderby's
 		delimiter = '"' if frappe.db.db_type == "postgres" else "`"
 		self.assertIn(
-			"ORDER BY {deli}creation{deli} DESC,{deli}modified{deli} ASC,{deli}name{deli} DESC".format(deli=delimiter),
-			frappe.db.get_value("DocType", "DocField", order_by="creation desc, modified asc, name", run=0)
+			"ORDER BY {deli}creation{deli} DESC,{deli}modified{deli} ASC,{deli}name{deli} DESC".format(
+				deli=delimiter
+			),
+			frappe.db.get_value("DocType", "DocField", order_by="creation desc, modified asc, name", run=0),
 		)
 
 	def test_get_value_limits(self):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -87,6 +87,13 @@ class TestDB(unittest.TestCase):
 			frappe.db.get_values("User", filters=[["name", "=", "Administrator"]], fieldname="email"),
 		)
 
+		# test multiple orderby's
+		delimiter = '"' if frappe.db.db_type == "postgres" else "`"
+		self.assertIn(
+			"ORDER BY {deli}creation{deli} DESC,{deli}modified{deli} ASC,{deli}name{deli} DESC".format(deli=delimiter),
+			frappe.db.get_value("DocType", "DocField", order_by="creation desc, modified asc, name", run=0)
+		)
+
 	def test_get_value_limits(self):
 
 		# check both dict and list style filters


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/16663

This pr adds support for multiple orderby conditions when building query using `add_conditions`.

![Screenshot 2022-04-20 at 2 43 22 PM](https://user-images.githubusercontent.com/32034600/164194405-f6462d3b-00d8-4f13-acda-6561fcaf457b.png)
![Screenshot 2022-04-20 at 6 05 38 PM](https://user-images.githubusercontent.com/32034600/164231602-de35acda-846d-4ff1-901f-04f3e7cdb666.png)

