### PR TITLE
fix(bulk_insert): Cast values as list before subscripting

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1236,8 +1236,9 @@ class Database(object):
 		:param fields: list of fields
 		:params values: list of list of values
 		"""
-
+		values = list(values)
 		table = frappe.qb.DocType(doctype)
+
 		for start_index in range(0, len(values), chunk_size):
 			query = frappe.qb.into(table)
 			if ignore_duplicates:


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/16527 affected Cypress tests which caused all the red crosses in the PR & commit list.

![IMAGE 2022-04-20 16:44:21](https://user-images.githubusercontent.com/36654812/164218800-0c6a7271-3d0c-48b5-ab1d-f667876ffeb7.jpg)

Just casting values to `List` should handle set inputs too. Thanks to @rmehta for discovering this.