### PR TITLE
fix: Do not change direction of text if already in RTL mode

### DIFF
--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -7,6 +7,7 @@
 	font-family: inherit;
 }
 
+/*rtl:begin:ignore*/
 .ql-editor {
 	font-family: var(--font-stack);
 	color: var(--text-color);
@@ -22,7 +23,15 @@
 	a[href] {
 		text-decoration: underline;
 	}
+	.ql-direction-rtl {
+		direction: rtl;
+		+ .table {
+			direction: ltr;
+		}
+	}
 }
+/*rtl:end:ignore*/
+
 
 .ql-toolbar.ql-snow {
 	border-top-left-radius: var(--border-radius);
@@ -70,6 +79,7 @@
 		min-height: 0;
 		max-height: none;
 		overflow: hidden;
+		resize: none;
 	}
 }
 


### PR DESCRIPTION
Do not change the direction of the text and table while switching to RTL if it is already in RTL mode

**In LTR mode:**
![Screenshot 2022-04-21 at 8 48 04 AM](https://user-images.githubusercontent.com/13928957/164365561-cfa4a294-5dd1-4d95-8602-410c599a9be5.png)

**Before in RTL mode:** Notice that the direction of the 2nd table (which was already forced to be RTL) is switched as well.
![Screenshot 2022-04-21 at 8 55 39 AM](https://user-images.githubusercontent.com/13928957/164365883-c87f0c8a-3c31-4c03-9052-2728268d93da.png)

**After in RTL Mode**
![Screenshot 2022-04-21 at 8 47 54 AM](https://user-images.githubusercontent.com/13928957/164365565-0fccfefe-4ef7-4021-b859-e5e17819d2ad.png)

