### PR TITLE
fix: Do not use `set_value` for default to avoid change event

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -22,15 +22,17 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			super.make();
 			this.refresh();
 			// set default
-			$.each(this.fields_list, (_, field) => {
-				if (!is_null(field.df.default)) {
-					let def_value = field.df.default;
+			$.each(this.fields_list, function(i, field) {
+				if (field.df["default"]) {
+					let def_value = field.df["default"];
 
-					if (def_value === "Today" && field.df.fieldtype === "Date") {
+					if (def_value == 'Today' && field.df["fieldtype"] == 'Date') {
 						def_value = frappe.datetime.get_today();
 					}
 
-					this.set_value(field.df.fieldname, def_value);
+					field.set_input(def_value);
+					// if default and has depends_on, render its fields.
+					me.refresh_dependency();
 				}
 			})
 
@@ -127,7 +129,6 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			if (f) {
 				f.set_value(val).then(() => {
 					f.set_input(val);
-					f.refresh();
 					this.refresh_dependency();
 					resolve();
 				});


### PR DESCRIPTION
- Directly reverting changes made in https://github.com/frappe/frappe/pull/16538/files#diff-d4552245eabd7394d58ce72832e28bba83bc9613b528763e3150ab22115c46b6 till we have a better fix.

fixes: https://github.com/frappe/frappe/issues/16643


Also, fixes bulk editing in list view (for doctypes with a status field)
```
bulk_operations.js:268 Uncaught TypeError: Cannot read properties of undefined (reading 'match')
    at set_value_field (bulk_operations.js:268:21)
    at BulkOperations.edit (bulk_operations.js:260:22)
    at HTMLAnchorElement.action (list_view.js:1839:22)
    at HTMLAnchorElement.dispatch (jquery.js:5430:27)
    at HTMLAnchorElement.elemData.handle (jquery.js:5234:28)
```