### PR TITLE
fix: Grid layout broken for some grids

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -289,19 +289,23 @@ export default class GridRow {
 		var me = this;
 		if(this.doc && !this.grid.df.in_place_edit) {
 			// remove row
-			if(!this.open_form_button) {
-				this.open_form_button = $(`
-					<div class="btn-open-row">
-						<a>${frappe.utils.icon('edit', 'xs')}</a>
-						<div class="hidden-xs edit-grid-row">${ __("Edit") }</div>
-					</div>
-				`)
-					.appendTo($('<div class="col col-xs-1"></div>').appendTo(this.row))
-					.on('click', function() {
-						me.toggle_view(); return false;
-					});
+			if (!this.open_form_button) {
+				this.open_form_button = $('<div class="col col-xs-1"></div>').appendTo(this.row);
 
-				if(this.is_too_small()) {
+				if (!this.configure_columns) {
+					this.open_form_button = $(`
+						<div class="btn-open-row">
+							<a>${frappe.utils.icon('edit', 'xs')}</a>
+							<div class="hidden-xs edit-grid-row">${ __("Edit") }</div>
+						</div>
+					`)
+						.appendTo(this.open_form_button)
+						.on('click', function() {
+							me.toggle_view(); return false;
+						});
+				}
+
+				if (this.is_too_small()) {
 					// narrow
 					this.open_form_button.css({'margin-right': '-2px'});
 				}
@@ -310,7 +314,9 @@ export default class GridRow {
 	}
 
 	add_column_configure_button() {
-		if (this.configure_columns) {
+		if (this.grid.df.in_place_edit && !this.frm) return;
+
+		if (this.configure_columns && this.frm) {
 			this.configure_columns_button = $(`
 				<div class="col grid-static-col col-xs-1 d-flex justify-content-center" style="cursor: pointer;">
 					<a>${frappe.utils.icon('setting-gear', 'sm', '', 'filter: opacity(0.5)')}</a>
@@ -320,6 +326,10 @@ export default class GridRow {
 				.on('click', () => {
 					this.configure_dialog_for_columns_selector();
 				});
+		} else if (this.configure_columns && !this.frm) {
+			this.configure_columns_button = $(`
+				<div class="col grid-static-col col-xs-1"></div>
+			`).appendTo(this.row);
 		}
 	}
 


### PR DESCRIPTION
Closes: https://github.com/frappe/frappe/issues/15673
Closes: https://github.com/frappe/frappe/issues/16717

**Issue:**
Some grids which are added in dialog which has `in_place_edit` set as `true` are broken.

**Before:**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30859809/164431431-8907d51c-69fc-49ec-93ce-7481136eefd6.png">

**After:**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/30859809/164431113-343b21f3-c718-4e80-9012-090c83346bfc.png">

Some changes:
- Every grid has a configure column button but for some grids, that button is not working (grid created from code with limited fields), so removed the icon if we cannot configure columns.
	<img width="500" alt="image" src="https://user-images.githubusercontent.com/30859809/164434334-fb92208e-6136-4a0f-a61b-cc0f438c83ca.png">

- Removed both configure column and edit row column(remove if `in_place_edit` is set) if both are not enabled.
	<img width="500" alt="image" src="https://user-images.githubusercontent.com/30859809/164434720-0059a295-a5e8-402f-8e91-61c0a2a075cd.png">
- Show both buttons if both are enabled.
	<img width="500" alt="image" src="https://user-images.githubusercontent.com/30859809/164434951-ff2b87dc-4377-4734-8f74-15487d0bb21b.png">
- Remove the edit row button and show configure column if enabled. (This scenario I have not yet encountered and not even possible to achieve).
