### PR TITLE
feat(safe_exec): Allow more APIs

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1210,18 +1210,35 @@ def reload_doc(module, dt=None, dn=None, force=False, reset_permissions=False):
 
 
 @whitelist()
-def rename_doc(*args, **kwargs):
+def rename_doc(
+	doctype: str,
+	old: str,
+	new: str,
+	force: bool = False,
+	merge: bool = False,
+	*,
+	ignore_if_exists: bool = False,
+	show_alert: bool = True,
+	rebuild_search: bool = True,
+) -> str:
 	"""
 	Renames a doc(dt, old) to doc(dt, new) and updates all linked fields of type "Link"
 
 	Calls `frappe.model.rename_doc.rename_doc`
 	"""
-	kwargs.pop("ignore_permissions", None)
-	kwargs.pop("cmd", None)
 
 	from frappe.model.rename_doc import rename_doc
 
-	return rename_doc(*args, **kwargs)
+	return rename_doc(
+		doctype=doctype,
+		old=old,
+		new=new,
+		force=force,
+		merge=merge,
+		ignore_if_exists=ignore_if_exists,
+		show_alert=show_alert,
+		rebuild_search=rebuild_search,
+	)
 
 
 def get_module(modulename):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -15,6 +15,8 @@ import frappe.utils.data
 from frappe import _
 from frappe.frappeclient import FrappeClient
 from frappe.handler import execute_cmd
+from frappe.model.delete_doc import delete_doc
+from frappe.model.rename_doc import rename_doc
 from frappe.modules import scrub
 from frappe.utils.background_jobs import enqueue, get_jobs
 from frappe.website.utils import get_next_link, get_shade, get_toc
@@ -110,12 +112,15 @@ def get_safe_globals():
 			errprint=frappe.errprint,
 			qb=frappe.qb,
 			get_meta=frappe.get_meta,
+			new_doc=frappe.new_doc,
 			get_doc=frappe.get_doc,
+			get_last_doc=frappe.get_last_doc,
 			get_cached_doc=frappe.get_cached_doc,
 			get_list=frappe.get_list,
 			get_all=frappe.get_all,
 			get_system_settings=frappe.get_system_settings,
-			rename_doc=frappe.rename_doc,
+			rename_doc=rename_doc,
+			delete_doc=delete_doc,
 			utils=datautils,
 			get_url=frappe.utils.get_url,
 			render_template=frappe.render_template,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -16,6 +16,7 @@ from frappe import _
 from frappe.frappeclient import FrappeClient
 from frappe.handler import execute_cmd
 from frappe.model.delete_doc import delete_doc
+from frappe.model.mapper import get_mapped_doc
 from frappe.model.rename_doc import rename_doc
 from frappe.modules import scrub
 from frappe.utils.background_jobs import enqueue, get_jobs
@@ -114,6 +115,7 @@ def get_safe_globals():
 			get_meta=frappe.get_meta,
 			new_doc=frappe.new_doc,
 			get_doc=frappe.get_doc,
+			get_mapped_doc=get_mapped_doc,
 			get_last_doc=frappe.get_last_doc,
 			get_cached_doc=frappe.get_cached_doc,
 			get_list=frappe.get_list,


### PR DESCRIPTION
* rename_doc points to the un-whitelisted method which supports `ignore_permissions` check
* Allowed other safe utils for better DX
* Disallow loose args/kwargs in whitelisted `frappe.rename_doc` 

Methods added in safe_exec:
* frappe.new_doc
* frappe.delete_doc
* frappe.rename_doc [more powerful]
* frappe.get_last_doc
* frappe.get_mapped_doc

Closes https://github.com/frappe/frappe/issues/16545, https://github.com/frappe/frappe/issues/16481, https://github.com/frappe/frappe/issues/13957