### PR TITLE
feat: provision to handle payment authorization event in server script for custom documents

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -49,7 +49,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nOn Payment Authorization"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -109,7 +109,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2022-04-07 19:41:23.178772",
+ "modified": "2022-04-22 11:24:01.151662",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -4,19 +4,20 @@ import frappe
 # to avoid circular imports
 
 EVENT_MAP = {
-	"before_insert": "Before Insert",
-	"after_insert": "After Insert",
-	"before_validate": "Before Validate",
-	"validate": "Before Save",
-	"on_update": "After Save",
-	"before_submit": "Before Submit",
-	"on_submit": "After Submit",
-	"before_cancel": "Before Cancel",
-	"on_cancel": "After Cancel",
-	"on_trash": "Before Delete",
-	"after_delete": "After Delete",
-	"before_update_after_submit": "Before Save (Submitted Document)",
-	"on_update_after_submit": "After Save (Submitted Document)",
+	'before_insert': 'Before Insert',
+	'after_insert': 'After Insert',
+	'before_validate': 'Before Validate',
+	'validate': 'Before Save',
+	'on_update': 'After Save',
+	'before_submit': 'Before Submit',
+	'on_submit': 'After Submit',
+	'before_cancel': 'Before Cancel',
+	'on_cancel': 'After Cancel',
+	'on_trash': 'Before Delete',
+	'after_delete': 'After Delete',
+	'before_update_after_submit': 'Before Save (Submitted Document)',
+	'on_update_after_submit': 'After Save (Submitted Document)',
+	'on_payment_authorized': 'On Payment Authorization'
 }
 
 

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -4,20 +4,20 @@ import frappe
 # to avoid circular imports
 
 EVENT_MAP = {
-	'before_insert': 'Before Insert',
-	'after_insert': 'After Insert',
-	'before_validate': 'Before Validate',
-	'validate': 'Before Save',
-	'on_update': 'After Save',
-	'before_submit': 'Before Submit',
-	'on_submit': 'After Submit',
-	'before_cancel': 'Before Cancel',
-	'on_cancel': 'After Cancel',
-	'on_trash': 'Before Delete',
-	'after_delete': 'After Delete',
-	'before_update_after_submit': 'Before Save (Submitted Document)',
-	'on_update_after_submit': 'After Save (Submitted Document)',
-	'on_payment_authorized': 'On Payment Authorization'
+	"before_insert": "Before Insert",
+	"after_insert": "After Insert",
+	"before_validate": "Before Validate",
+	"validate": "Before Save",
+	"on_update": "After Save",
+	"before_submit": "Before Submit",
+	"on_submit": "After Submit",
+	"before_cancel": "Before Cancel",
+	"on_cancel": "After Cancel",
+	"on_trash": "Before Delete",
+	"after_delete": "After Delete",
+	"before_update_after_submit": "Before Save (Submitted Document)",
+	"on_update_after_submit": "After Save (Submitted Document)",
+	"on_payment_authorized": "On Payment Authorization",
 }
 
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -146,6 +146,7 @@ def get_safe_globals():
 			),
 			make_get_request=frappe.integrations.utils.make_get_request,
 			make_post_request=frappe.integrations.utils.make_post_request,
+			get_payment_gateway_controller = frappe.integrations.utils.get_payment_gateway_controller,
 			socketio_port=frappe.conf.socketio_port,
 			get_hooks=get_hooks,
 			enqueue=safe_enqueue,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -146,7 +146,7 @@ def get_safe_globals():
 			),
 			make_get_request=frappe.integrations.utils.make_get_request,
 			make_post_request=frappe.integrations.utils.make_post_request,
-			get_payment_gateway_controller = frappe.integrations.utils.get_payment_gateway_controller,
+			get_payment_gateway_controller=frappe.integrations.utils.get_payment_gateway_controller,
 			socketio_port=frappe.conf.socketio_port,
 			get_hooks=get_hooks,
 			enqueue=safe_enqueue,


### PR DESCRIPTION
Currently, there is no provision to handle payment authorization events via server script. So it's not possible if a user wants to link payments against custom documents. 

Thus adding a provision in server script 
- Setup checkout for custom doc 
<img width="1299" alt="Screenshot 2022-03-11 at 2 44 19 PM" src="https://user-images.githubusercontent.com/3784093/157838010-989f6009-83d6-4329-92a6-bb2b6b38438b.png">

- Handle payment callback
<img width="1051" alt="Screenshot 2022-04-22 at 11 28 19 AM" src="https://user-images.githubusercontent.com/3784093/164612613-d321edb3-c7f8-4063-b809-8ae5fe46ee66.png">

## Documentation
https://frappeframework.com/docs/v13/user/en/desk/scripting/server-script/edit?wiki_page_patch=bbed0fcd9a