### PR TITLE
fix: explicitly start a new transaction

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -185,9 +185,12 @@ def insert_single_event(frequency: str, event: str, cron_format: str = None):
 	if not frappe.db.exists(
 		"Scheduled Job Type", {"method": event, "frequency": frequency, **cron_expr}
 	):
+		savepoint = "scheduled_job_type_creation"
 		try:
+			frappe.db.savepoint(savepoint)
 			doc.insert()
 		except frappe.DuplicateEntryError:
+			frappe.db.rollback(save_point=savepoint)
 			doc.delete()
 			doc.insert()
 

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -161,6 +161,7 @@ def create_custom_field(doctype, df, ignore_validate=False, is_system_generated=
 		custom_field.update(df)
 		custom_field.flags.ignore_validate = ignore_validate
 		custom_field.insert()
+		return custom_field
 
 
 def create_custom_fields(custom_fields, ignore_validate=False, update=True):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -917,6 +917,9 @@ class Database(object):
 			frappe.call(method[0], *(method[1] or []), **(method[2] or {}))
 
 		self.sql("commit")
+		if frappe.conf.db_type == "postgres":
+			# Postgres requires explicitly starting new transaction
+			self.begin()
 
 		frappe.local.rollback_observers = []
 		self.flush_realtime_log()

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -195,6 +195,9 @@ class Database(object):
 
 			elif frappe.conf.db_type == "postgres":
 				# TODO: added temporarily
+				import traceback
+
+				traceback.print_stack()
 				print(e)
 				raise
 

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -6,6 +6,7 @@ import frappe
 def setup_database(force, source_sql=None, verbose=False):
 	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
 	root_conn.commit()
+	root_conn.sql("end")
 	root_conn.sql("DROP DATABASE IF EXISTS `{0}`".format(frappe.conf.db_name))
 	root_conn.sql("DROP USER IF EXISTS {0}".format(frappe.conf.db_name))
 	root_conn.sql("CREATE DATABASE `{0}`".format(frappe.conf.db_name))

--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -72,7 +72,7 @@ class TestNewsletterMixin:
 						"doctype": doctype,
 						**email_filters,
 					}
-				).insert()
+				).insert(ignore_if_duplicate=True)
 			except Exception:
 				frappe.db.rollback(save_point=savepoint)
 				frappe.db.update(doctype, email_filters, "unsubscribed", 0)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -182,10 +182,12 @@ class TestDB(unittest.TestCase):
 		self.assertIn("tabToDo", frappe.flags.touched_tables)
 
 		frappe.flags.touched_tables = set()
-		create_custom_field("ToDo", {"label": "ToDo Custom Field"})
-
+		cf = create_custom_field("ToDo", {"label": "ToDo Custom Field"})
 		self.assertIn("tabToDo", frappe.flags.touched_tables)
 		self.assertIn("tabCustom Field", frappe.flags.touched_tables)
+		if cf:
+			cf.delete()
+		frappe.db.commit()
 		frappe.flags.in_migrate = False
 		frappe.flags.touched_tables.clear()
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -867,3 +867,18 @@ class TestDDLCommandsPost(unittest.TestCase):
 		self.assertIn(
 			"is null", frappe.db.get_values(user, filters={user.name: ("is", "not set")}, run=False).lower()
 		)
+
+
+@run_only_if(db_type_is.POSTGRES)
+class TestTransactionManagement(unittest.TestCase):
+	def test_create_proper_transactions(self):
+		def _get_transaction_id():
+			return frappe.db.sql("select txid_current()", pluck=True)
+
+		self.assertEqual(_get_transaction_id(), _get_transaction_id())
+
+		frappe.db.rollback()
+		self.assertEqual(_get_transaction_id(), _get_transaction_id())
+
+		frappe.db.commit()
+		self.assertEqual(_get_transaction_id(), _get_transaction_id())

--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -100,8 +100,6 @@ class TestRenameDoc(unittest.TestCase):
 				frappe.delete_doc("DocType", dt)
 				frappe.db.sql_ddl(f"DROP TABLE IF EXISTS `tab{dt}`")
 
-		frappe.delete_doc_if_exists("Renamed Doc", "ToDo")
-
 		# reset original value of developer_mode conf
 		frappe.conf.developer_mode = self._original_developer_flag
 


### PR DESCRIPTION
Postgres connection goes in autocommit mode if transaction isn't explicitly started by using `frappe.db.begin`. This is because we use cursor to issue transaction commands instead of `connection.commit/rollback`


Related/required changes:
1. Wrap setup fixture creation process in savepoint and ignore duplicates explicitly. 
2. Print the entire stack on PG DB exceptions to aid debugging. 


Example:


![telegram-cloud-photo-size-5-6283049375068434577-y](https://user-images.githubusercontent.com/9079960/165029794-14816439-434f-46d2-8a63-ede7c0e46ff6.jpg)


ERPNext CI: https://github.com/frappe/erpnext/actions/runs/2440634744