### PR TITLE
fix(client): better validation for child insert

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -189,7 +189,10 @@ def insert(doc=None):
 	if isinstance(doc, str):
 		doc = json.loads(doc)
 
-	if doc.get("parenttype"):
+	doc = frappe._dict(doc)
+	if frappe.is_table(doc.doctype):
+		if not (doc.parenttype and doc.parent and doc.parentfield):
+			frappe.throw(_("parenttype, parent and parentfield are required to insert a child record"))
 		# inserting a child record
 		parent = frappe.get_doc(doc.parenttype, doc.parent)
 		parent.append(doc.parentfield, doc)

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -141,3 +141,40 @@ class TestClient(unittest.TestCase):
 		self.assertEqual(get("ToDo", filters=filters_json).description, "test")
 
 		todo.delete()
+
+	def test_client_insert(self):
+		from frappe.client import insert
+
+		def get_random_title():
+			return "test-{0}".format(frappe.generate_hash())
+
+		# test insert dict
+		doc = {"doctype": "Note", "title": get_random_title(), "content": "test"}
+		note1 = insert(doc)
+		self.assertTrue(note1)
+
+		# test insert json
+		doc["title"] = get_random_title()
+		json_doc = frappe.as_json(doc)
+		note2 = insert(json_doc)
+		self.assertTrue(note2)
+
+		# test insert child doc without parent fields
+		child_doc = {"doctype": "Note Seen By", "user": "Administrator"}
+		with self.assertRaises(frappe.ValidationError):
+			insert(child_doc)
+
+		# test insert child doc with parent fields
+		child_doc = {
+			"doctype": "Note Seen By",
+			"user": "Administrator",
+			"parenttype": "Note",
+			"parent": note1.name,
+			"parentfield": "seen_by",
+		}
+		note3 = insert(child_doc)
+		self.assertTrue(note3)
+
+		# cleanup
+		frappe.delete_doc("Note", note1.name)
+		frappe.delete_doc("Note", note2.name)


### PR DESCRIPTION
Currently Child Table insert is detected by checking `doc.parenttype` ignoring other required fields `parent` and `parentfield`. Added better validation that will check for each required field and also throw a readable error message.

- [x] Tests