### PR TITLE
perf(BaseDocument): remove duplicate code

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -241,7 +241,6 @@ class BaseDocument(object):
 				raise AttributeError(key)
 
 			value = get_controller(value["doctype"])(value)
-			value.init_valid_columns()
 
 		value.parent = self.name
 		value.parenttype = self.doctype


### PR DESCRIPTION
The removed line isn't needed because:
- `value` is a dict. This gets interpreted as `kwargs` by `Document.__init__` inside `get_controller`.
- Inside `Document.__init__`, since `kwargs` are found, `init_valid_columns` gets executed [here](https://github.com/frappe/frappe/blob/6e6fe9521e403aadb73df5e0b20eb683b3f30617/frappe/model/document.py#L116).