### PR TITLE
fix: remove default null definition for name column in tabSeries for postgres

### DIFF
--- a/frappe/database/postgres/framework_postgres.sql
+++ b/frappe/database/postgres/framework_postgres.sql
@@ -240,7 +240,7 @@ CREATE TABLE "tabDocType" (
 
 DROP TABLE IF EXISTS "tabSeries";
 CREATE TABLE "tabSeries" (
-  "name" varchar(100) DEFAULT NULL,
+  "name" varchar(100),
   "current" bigint NOT NULL DEFAULT 0,
   PRIMARY KEY ("name")
 ) ;


### PR DESCRIPTION
This pr removes the `default null` definition from name column in `tabSeries` table for postgres. (basically what the pr title says :P)