### PR TITLE
fix: Validate "autoname" for Customize Form

### DIFF
--- a/cypress/integration/customize_form.js
+++ b/cypress/integration/customize_form.js
@@ -1,0 +1,23 @@
+context('Customize Form', () => {
+	before(() => {
+		cy.visit('/app/customize-form');
+	});
+	it('Changing to naming rule should update autoname', () => {
+		cy.fill_field("doc_type", "ToDo", "Link").blur();
+		cy.click_form_section("Naming");
+		const naming_rule_default_autoname_map = {
+			"Autoincrement": "autoincrement",
+			"Set by user": "prompt",
+			"By fieldname": "field:",
+			'By "Naming Series" field': "naming_series:",
+			"Expression": "format:",
+			"Expression (old style)": "",
+			"Random": "hash",
+			"By script": ""
+		};
+		Cypress._.forOwn(naming_rule_default_autoname_map, (value, naming_rule) => {
+			cy.fill_field("naming_rule", naming_rule, "Select");
+			cy.get_field("autoname", "Data").should("have.value", value);
+		});
+	});
+});

--- a/cypress/integration/customize_form.js
+++ b/cypress/integration/customize_form.js
@@ -6,7 +6,6 @@ context('Customize Form', () => {
 		cy.fill_field("doc_type", "ToDo", "Link").blur();
 		cy.click_form_section("Naming");
 		const naming_rule_default_autoname_map = {
-			"Autoincrement": "autoincrement",
 			"Set by user": "prompt",
 			"By fieldname": "field:",
 			'By "Naming Series" field': "naming_series:",

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -340,3 +340,7 @@ Cypress.Commands.add('click_timeline_action_btn', (btn_name) => {
 Cypress.Commands.add('select_listview_row_checkbox', (row_no) => {
 	cy.get('.frappe-list .select-like > .list-row-checkbox').eq(row_no).click();
 });
+
+Cypress.Commands.add('click_form_section', (section_name) => {
+	cy.get('.section-head').contains(section_name).click();
+});

--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -57,8 +57,8 @@ frappe.ui.form.on('DocType', {
 		frm.get_docfield('fields', 'in_list_view').label = frm.doc.istable ?
 			__('In Grid View') : __('In List View');
 
-		frm.events.autoname(frm);
-		frm.events.set_naming_rule_description(frm);
+		frm.cscript.autoname(frm);
+		frm.cscript.set_naming_rule_description(frm);
 	},
 
 	istable: (frm) => {
@@ -66,80 +66,6 @@ frappe.ui.form.on('DocType', {
 			frm.set_value('autoname', 'autoincrement');
 			frm.set_value('allow_rename', 0);
 		}
-	},
-
-	naming_rule: function(frm) {
-		// set the "autoname" property based on naming_rule
-		if (frm.doc.naming_rule && !frm.__from_autoname) {
-
-			// flag to avoid recursion
-			frm.__from_naming_rule = true;
-
-			if (frm.doc.naming_rule=='Set by user') {
-				frm.set_value('autoname', 'Prompt');
-			} else if (frm.doc.naming_rule === 'Autoincrement') {
-				frm.set_value('autoname', 'autoincrement');
-				// set allow rename to be false when using autoincrement
-				frm.set_value('allow_rename', 0);
-			} else if (frm.doc.naming_rule=='By fieldname') {
-				frm.set_value('autoname', 'field:');
-			} else if (frm.doc.naming_rule=='By "Naming Series" field') {
-				frm.set_value('autoname', 'naming_series:');
-			} else if (frm.doc.naming_rule=='Expression') {
-				frm.set_value('autoname', 'format:');
-			} else if (frm.doc.naming_rule=='Expression (old style)') {
-				// pass
-			} else if (frm.doc.naming_rule=='Random') {
-				frm.set_value('autoname', 'hash');
-			}
-			setTimeout(() =>frm.__from_naming_rule = false, 500);
-
-			frm.events.set_naming_rule_description(frm);
-		}
-
-	},
-
-	set_naming_rule_description(frm) {
-		let naming_rule_description = {
-			'Set by user': '',
-			'Autoincrement': 'Uses Auto Increment feature of database.<br><b>WARNING: After using this option, any other naming option will not be accessible.</b>',
-			'By fieldname': 'Format: <code>field:[fieldname]</code>. Valid fieldname must exist',
-			'By "Naming Series" field': 'Format: <code>naming_series:[fieldname]</code>. Fieldname called <code>naming_series</code> must exist',
-			'Expression': 'Format: <code>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</code> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.',
-			'Expression (old style)': 'Format: <code>EXAMPLE-.#####</code> Series by prefix (separated by a dot)',
-			'Random': '',
-			'By script': ''
-		};
-
-		if (frm.doc.naming_rule) {
-			frm.get_field('autoname').set_description(naming_rule_description[frm.doc.naming_rule]);
-		}
-	},
-
-	autoname: function(frm) {
-		// set naming_rule based on autoname (for old doctypes where its not been set)
-		if (frm.doc.autoname && !frm.doc.naming_rule && !frm.__from_naming_rule) {
-			// flag to avoid recursion
-			frm.__from_autoname = true;
-			if (frm.doc.autoname.toLowerCase() === 'prompt') {
-				frm.set_value('naming_rule', 'Set by user');
-			} else if (frm.doc.autoname.toLowerCase() === 'autoincrement') {
-				frm.set_value('naming_rule', 'Autoincrement');
-			} else if (frm.doc.autoname.startsWith('field:')) {
-				frm.set_value('naming_rule', 'By fieldname');
-			} else if (frm.doc.autoname.startsWith('naming_series:')) {
-				frm.set_value('naming_rule', 'By "Naming Series" field');
-			} else if (frm.doc.autoname.startsWith('format:')) {
-				frm.set_value('naming_rule', 'Expression');
-			} else if (frm.doc.autoname.toLowerCase() === 'hash') {
-				frm.set_value('naming_rule', 'Random');
-			} else {
-				frm.set_value('naming_rule', 'Expression (old style)');
-			}
-			setTimeout(() => frm.__from_autoname = false, 500);
-		}
-
-		frm.set_df_property('fields', 'reqd', frm.doc.autoname !== 'Prompt');
 	},
 });
 

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -208,7 +208,7 @@
    "label": "Naming"
   },
   {
-   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>autoincrement</b> - Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
+   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>autoincrement</b> - Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -817,10 +817,8 @@ class DocType(Document):
 					self.autoname != "autoincrement" and doc_before_save.autoname == "autoincrement"
 				):
 					frappe.throw(_("Cannot change to/from Autoincrement naming rule"))
-
-		else:
-			if self.autoname == "autoincrement":
-				self.allow_rename = 0
+		if self.autoname == "autoincrement":
+			self.allow_rename = 0
 
 	def validate_name(self, name=None):
 		if not name:
@@ -865,8 +863,13 @@ def validate_series(dt, autoname=None, name=None):
 
 	if not autoname and dt.get("fields", {"fieldname": "naming_series"}):
 		dt.autoname = "naming_series:"
-	elif dt.autoname == "naming_series:" and not dt.get("fields", {"fieldname": "naming_series"}):
-		frappe.throw(_("Invalid fieldname '{0}' in autoname").format(dt.autoname))
+	elif dt.autoname.startswith("naming_series:"):
+		fieldname = dt.autoname.split("naming_series:")[0] or "naming_series"
+		if not dt.get("fields", {"fieldname": fieldname}):
+			frappe.throw(
+				_("Fieldname called {0} must exist to enable autonaming").format(frappe.bold(fieldname)),
+				title=_("Field Missing"),
+			)
 
 	# validate field name if autoname field:fieldname is used
 	# Create unique index on autoname field automatically.

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -863,7 +863,7 @@ def validate_series(dt, autoname=None, name=None):
 
 	if not autoname and dt.get("fields", {"fieldname": "naming_series"}):
 		dt.autoname = "naming_series:"
-	elif dt.autoname.startswith("naming_series:"):
+	elif dt.autoname and dt.autoname.startswith("naming_series:"):
 		fieldname = dt.autoname.split("naming_series:")[0] or "naming_series"
 		if not dt.get("fields", {"fieldname": fieldname}):
 			frappe.throw(

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -152,6 +152,10 @@ frappe.ui.form.on("Customize Form", {
 				},
 				__("Actions")
 			);
+
+			const is_autoname_autoincrement = frm.doc.autoname === 'autoincrement';
+			frm.set_df_property("naming_rule", "hidden", is_autoname_autoincrement);
+			frm.set_df_property("autoname", "read_only", is_autoname_autoincrement);
 		}
 
 		frm.events.setup_export(frm);

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -56,7 +56,7 @@
    "fieldtype": "Select",
    "label": "Naming Rule",
    "length": 40,
-   "options": "\nSet by user\nAutoincrement\nBy fieldname\nBy \"Naming Series\" field\nExpression\nExpression (old style)\nRandom\nBy script"
+   "options": "\nSet by user\nBy fieldname\nBy \"Naming Series\" field\nExpression\nExpression (old style)\nRandom\nBy script"
   },
   {
    "fieldname": "doc_type",
@@ -287,7 +287,7 @@
    "label": "Naming"
   },
   {
-   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>autoincrement</b> - Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
+   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name"

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -24,6 +24,7 @@
   "fields_section_break",
   "fields",
   "naming_section",
+  "naming_rule",
   "autoname",
   "view_settings_section",
   "title_field",
@@ -50,6 +51,13 @@
   "sort_order"
  ],
  "fields": [
+  {
+   "fieldname": "naming_rule",
+   "fieldtype": "Select",
+   "label": "Naming Rule",
+   "length": 40,
+   "options": "\nSet by user\nAutoincrement\nBy fieldname\nBy \"Naming Series\" field\nExpression\nExpression (old style)\nRandom\nBy script"
+  },
   {
    "fieldname": "doc_type",
    "fieldtype": "Link",
@@ -279,7 +287,7 @@
    "label": "Naming"
   },
   {
-   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
+   "description": "Naming Options:\n<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>autoincrement</b> - Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>",
    "fieldname": "autoname",
    "fieldtype": "Data",
    "label": "Auto Name"

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -571,6 +571,7 @@ doctype_properties = {
 	"email_append_to": "Check",
 	"subject_field": "Data",
 	"sender_field": "Data",
+	"naming_rule": "Data",
 	"autoname": "Data",
 	"show_title_field_in_link": "Check",
 }

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -5,7 +5,6 @@ frappe.provide("frappe.model");
 	apply to both DocType form and customize form.
 */
 frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.Controller {
-
 	max_attachments() {
 		if (!this.frm.doc.max_attachments) {
 			return;
@@ -50,7 +49,7 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 					this.frm.set_value("autoname", "hash");
 					break;
 			}
-			setTimeout(() =>this.frm.__from_naming_rule = false, 500);
+			setTimeout(() => (this.frm.__from_naming_rule = false), 500);
 
 			this.set_naming_rule_description();
 		}
@@ -103,7 +102,7 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 				default:
 					this.frm.set_value('naming_rule', 'Expression (old style)');
 			}
-			setTimeout(() => this.frm.__from_autoname = false, 500);
+			setTimeout(() => (this.frm.__from_autoname = false), 500);
 		}
 
 		this.frm.set_df_property('fields', 'reqd', this.frm.doc.autoname !== 'Prompt');

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -20,4 +20,92 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 				__("Number of attachment fields are more than {}, limit updated to {}.", [label, no_of_attach_fields]));
 		}
 	}
-}
+
+	naming_rule() {
+		// set the "autoname" property based on naming_rule
+		if (this.frm.doc.naming_rule && !this.frm.__from_autoname) {
+
+			// flag to avoid recursion
+			this.frm.__from_naming_rule = true;
+
+			switch (this.frm.doc.naming_rule) {
+				case "Set by user":
+					this.frm.set_value("autoname", "Prompt");
+					break;
+				case "Autoincrement":
+					this.frm.set_value("autoname", "autoincrement");
+					break;
+				case "By fieldname":
+					this.frm.set_value("autoname", "field:");
+					break;
+				case 'By "Naming Series" field':
+					this.frm.set_value("autoname", "naming_series:");
+					break;
+				case "Expression":
+					this.frm.set_value("autoname", "format:");
+					break;
+				case "Expression (old style)":
+					break;
+				case "Random":
+					this.frm.set_value("autoname", "hash");
+					break;
+			}
+			setTimeout(() =>this.frm.__from_naming_rule = false, 500);
+
+			this.set_naming_rule_description();
+		}
+
+	}
+
+	set_naming_rule_description() {
+		let naming_rule_description = {
+			'Set by user': '',
+			'Autoincrement': 'Uses Auto Increment feature of database.<br><b>WARNING: After using this option, any other naming option will not be accessible.</b>',
+			'By fieldname': 'Format: <code>field:[fieldname]</code>. Valid fieldname must exist',
+			'By "Naming Series" field': 'Format: <code>naming_series:[fieldname]</code>. Default fieldname is <code>naming_series</code>',
+			'Expression': 'Format: <code>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</code> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.',
+			'Expression (old style)': 'Format: <code>EXAMPLE-.#####</code> Series by prefix (separated by a dot)',
+			'Random': '',
+			'By script': ''
+		};
+
+		if (this.frm.doc.naming_rule) {
+			this.frm.get_field('autoname').set_description(naming_rule_description[this.frm.doc.naming_rule]);
+		}
+	}
+
+	autoname() {
+		// set naming_rule based on autoname (for old doctypes where its not been set)
+		if (this.frm.doc.autoname && !this.frm.doc.naming_rule && !this.frm.__from_naming_rule) {
+			// flag to avoid recursion
+			this.frm.__from_autoname = true;
+			const autoname = this.frm.doc.autoname.toLowerCase();
+
+			switch (autoname) {
+				case 'prompt':
+					this.frm.set_value('naming_rule', 'Set by user');
+					break;
+				case 'autoincrement':
+					this.frm.set_value('naming_rule', 'Autoincrement');
+					break;
+				case (autoname.startsWith('field:')):
+					this.frm.set_value('naming_rule', 'By fieldname');
+					break;
+				case (autoname.startsWith('naming_series:')):
+					this.frm.set_value('naming_rule', 'By "Naming Series" field');
+					break;
+				case (autoname.startsWith('format:')):
+					this.frm.set_value('naming_rule', 'Expression');
+					break;
+				case 'hash':
+					this.frm.set_value('naming_rule', 'Random');
+					break;
+				default:
+					this.frm.set_value('naming_rule', 'Expression (old style)');
+			}
+			setTimeout(() => this.frm.__from_autoname = false, 500);
+		}
+
+		this.frm.set_df_property('fields', 'reqd', this.frm.doc.autoname !== 'Prompt');
+	}
+};

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -27,28 +27,17 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 			// flag to avoid recursion
 			this.frm.__from_naming_rule = true;
 
-			switch (this.frm.doc.naming_rule) {
-				case "Set by user":
-					this.frm.set_value("autoname", "Prompt");
-					break;
-				case "Autoincrement":
-					this.frm.set_value("autoname", "autoincrement");
-					break;
-				case "By fieldname":
-					this.frm.set_value("autoname", "field:");
-					break;
-				case 'By "Naming Series" field':
-					this.frm.set_value("autoname", "naming_series:");
-					break;
-				case "Expression":
-					this.frm.set_value("autoname", "format:");
-					break;
-				case "Expression (old style)":
-					break;
-				case "Random":
-					this.frm.set_value("autoname", "hash");
-					break;
-			}
+			const naming_rule_default_autoname_map = {
+				"Autoincrement": "autoincrement",
+				"Set by user": "prompt",
+				"By fieldname": "field:",
+				'By "Naming Series" field': "naming_series:",
+				"Expression": "format:",
+				"Expression (sld style)": "",
+				"Random": "hash",
+				"By script": ""
+			};
+			this.frm.set_value("autoname", naming_rule_default_autoname_map[this.frm.doc.naming_rule] || "");
 			setTimeout(() => (this.frm.__from_naming_rule = false), 500);
 
 			this.set_naming_rule_description();
@@ -80,28 +69,21 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 			this.frm.__from_autoname = true;
 			const autoname = this.frm.doc.autoname.toLowerCase();
 
-			switch (autoname) {
-				case 'prompt':
-					this.frm.set_value('naming_rule', 'Set by user');
-					break;
-				case 'autoincrement':
-					this.frm.set_value('naming_rule', 'Autoincrement');
-					break;
-				case (autoname.startsWith('field:')):
-					this.frm.set_value('naming_rule', 'By fieldname');
-					break;
-				case (autoname.startsWith('naming_series:')):
-					this.frm.set_value('naming_rule', 'By "Naming Series" field');
-					break;
-				case (autoname.startsWith('format:')):
-					this.frm.set_value('naming_rule', 'Expression');
-					break;
-				case 'hash':
-					this.frm.set_value('naming_rule', 'Random');
-					break;
-				default:
-					this.frm.set_value('naming_rule', 'Expression (old style)');
-			}
+			if (autoname === "prompt")
+				this.frm.set_value("naming_rule", "Set by user");
+			else if (autoname === "autoincrement")
+				this.frm.set_value("naming_rule", "Autoincrement");
+			else if (autoname.startsWith("field:"))
+				this.frm.set_value("naming_rule", "By fieldname");
+			else if (autoname.startsWith("naming_series:"))
+				this.frm.set_value("naming_rule", 'By "Naming Series" field');
+			else if (autoname.startsWith("format:"))
+				this.frm.set_value("naming_rule", "Expression");
+			else if (autoname === "hash")
+				this.frm.set_value("naming_rule", "Random");
+			else
+				this.frm.set_value("naming_rule", "Expression (old style)");
+
 			setTimeout(() => (this.frm.__from_autoname = false), 500);
 		}
 


### PR DESCRIPTION
Fixed validation for autoname based on naming_series.

**Before:**

https://user-images.githubusercontent.com/13928957/165678544-38f578b1-76a5-4b0d-b306-766a26d4f199.mov

Notice how autoname `naming_series:naming_series` was accepted even though there's no `naming_series` field in ToDo doctype 


**After:**


https://user-images.githubusercontent.com/13928957/165678556-b212be98-d7a9-4cd3-8fe2-bf3f32b07415.mov




