### PR TITLE
fix: filters not working on "select items" dialog boxes

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -151,7 +151,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	}
 
 	is_child_selection_enabled() {
-		return this.dialog.fields_dict['allow_child_item_selection'].get_value();
+		return this.allow_child_item_selection;
 	}
 
 	toggle_child_selection() {

--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -151,7 +151,7 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	}
 
 	is_child_selection_enabled() {
-		return this.allow_child_item_selection;
+		return this.dialog.fields_dict['allow_child_item_selection']?.get_value();
 	}
 
 	toggle_child_selection() {


### PR DESCRIPTION
Fixes the filter for the multi select dialog. 
When selecting a Value for a filter nothing happens and the Console shows the error: "Uncaught TypeError: this.dialog.fields_dict.allow_child_item_selection is undefined"