### PR TITLE
fix: dont throw error for a bad translation

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -22,7 +22,7 @@ from pypika.terms import PseudoColumn
 import frappe
 from frappe.model.utils import InvalidIncludePath, render_include
 from frappe.query_builder import DocType, Field
-from frappe.utils import get_bench_path, is_html, strip, strip_html_tags
+from frappe.utils import cstr, get_bench_path, is_html, strip, strip_html_tags
 
 TRANSLATE_PATTERN = re.compile(
 	r"_\([\s\n]*"  # starts with literal `_(`, ignore following whitespace/newlines
@@ -319,11 +319,11 @@ def get_translation_dict_from_file(path, lang, app):
 			elif len(item) in [2, 3]:
 				translation_map[item[0]] = strip(item[1])
 			elif item:
-				raise Exception(
-					"Bad translation in '{app}' for language '{lang}': {values}".format(
-						app=app, lang=lang, values=repr(item).encode("utf-8")
-					)
+				msg = "Bad translation in '{app}' for language '{lang}': {values}".format(
+					app=app, lang=lang, values=cstr(item)
 				)
+				frappe.log_error(message=msg, title="Error in translation file")
+				frappe.msgprint(msg)
 
 	return translation_map
 


### PR DESCRIPTION
steps to reproduce:
1. mess up one line in translation.csv file
2. open the page, and fake your browser's language using some extension/headers. 

<img width="1420" alt="Screenshot 2022-04-26 at 7 36 16 PM" src="https://user-images.githubusercontent.com/9079960/165319269-7df6174a-3043-435a-adc0-548d63c888b8.png">



No need to bring everything crumbling down for 1 erroneous line in translations 🙃 