### PR TITLE
test: use data fieldtype instead of int in `test_fieldname_starting_with_int`

### DIFF
--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -639,17 +639,18 @@ class TestReportview(unittest.TestCase):
 	def test_fieldname_starting_with_int(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
+		frappe.delete_doc_if_exists("DocType", "dt_with_int_named_fieldname")
 		dt = new_doctype(
 			"dt_with_int_named_fieldname",
-			fields=[{"label": "1field", "fieldname": "1field", "fieldtype": "Int"}],
+			fields=[{"label": "1field", "fieldname": "1field", "fieldtype": "Data"}],
 		).insert(ignore_permissions=True)
 
-		frappe.get_doc({"doctype": "dt_with_int_named_fieldname", "1field": 10}).insert(
+		frappe.get_doc({"doctype": "dt_with_int_named_fieldname", "1field": "10"}).insert(
 			ignore_permissions=True
 		)
 
 		query = DatabaseQuery("dt_with_int_named_fieldname")
-		self.assertTrue(query.execute(filters={"1field": 10}))
+		self.assertTrue(query.execute(filters={"1field": "10"}))
 		self.assertTrue(query.execute(filters={"1field": ["like", "1%"]}))
 		self.assertTrue(query.execute(filters={"1field": ["in", "1,2,10"]}))
 		self.assertTrue(query.execute(filters={"1field": ["is", "set"]}))

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -640,12 +640,26 @@ class TestReportview(unittest.TestCase):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
 		frappe.delete_doc_if_exists("DocType", "dt_with_int_named_fieldname")
+		frappe.delete_doc_if_exists("DocType", "table_dt")
+
+		table_dt = new_doctype(
+			"table_dt", istable=1, fields=[{"label": "1field", "fieldname": "2field", "fieldtype": "Data"}]
+		).insert()
+
 		dt = new_doctype(
 			"dt_with_int_named_fieldname",
-			fields=[{"label": "1field", "fieldname": "1field", "fieldtype": "Data"}],
+			fields=[
+				{"label": "1field", "fieldname": "1field", "fieldtype": "Data"},
+				{
+					"label": "2table_field",
+					"fieldname": "2table_field",
+					"fieldtype": "Table",
+					"options": table_dt.name,
+				},
+			],
 		).insert(ignore_permissions=True)
 
-		frappe.get_doc({"doctype": "dt_with_int_named_fieldname", "1field": "10"}).insert(
+		dt_data = frappe.get_doc({"doctype": "dt_with_int_named_fieldname", "1field": "10"}).insert(
 			ignore_permissions=True
 		)
 
@@ -655,8 +669,23 @@ class TestReportview(unittest.TestCase):
 		self.assertTrue(query.execute(filters={"1field": ["in", "1,2,10"]}))
 		self.assertTrue(query.execute(filters={"1field": ["is", "set"]}))
 		self.assertFalse(query.execute(filters={"1field": ["not like", "1%"]}))
+		self.assertTrue(query.execute(filters=[["table_dt", "2field", "is", "not set"]]))
 
+		frappe.get_doc(
+			{
+				"doctype": table_dt.name,
+				"2field": "10",
+				"parent": dt_data.name,
+				"parenttype": dt_data.doctype,
+				"parentfield": "2table_field",
+			}
+		).insert(ignore_permissions=True)
+
+		self.assertTrue(query.execute(filters=[["table_dt", "2field", "is", "set"]]))
+
+		# cleanup
 		dt.delete()
+		table_dt.delete()
 
 
 def add_child_table_to_blog_post():


### PR DESCRIPTION
postgres doesn't allow using like operator on int/any non-text/varchar column
ref: https://github.com/frappe/frappe/issues/16722

This is a remedy, we'll have to fix this separately.

Giving issues in CI - https://github.com/frappe/frappe/runs/6123599525?check_suite_focus=true#step:14:972, https://github.com/frappe/frappe/runs/6181701540?check_suite_focus=true#step:14:330 

other changes:
- updated the test with child table filters