### PR TITLE
refactor: Sync fixtures

### DIFF
--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -17,11 +17,9 @@ def sync_fixtures(app=None):
 	frappe.flags.in_fixtures = True
 
 	for app in apps:
-		if os.path.exists(frappe.get_app_path(app, "fixtures")):
-			fixture_files = sorted(os.listdir(frappe.get_app_path(app, "fixtures")))
-			for fname in fixture_files:
-				if fname.endswith(".json"):
-					import_doc(frappe.get_app_path(app, "fixtures", fname))
+		fixtures_path = frappe.get_app_path(app, "fixtures")
+		if os.path.exists(fixtures_path):
+			import_doc(fixtures_path)
 
 		import_custom_scripts(app)
 


### PR DESCRIPTION
`import_doc` already does everything that's needed:

https://github.com/frappe/frappe/blob/0334936449e5e2fdb80782316c0e543ca666542f/frappe/core/doctype/data_import/data_import.py#L208-L223

I guess the sorting is not needed as the doctype name says nothing about the order it should be imported.