### PR TITLE
fix(newsletter): Pass `parent` instead of `parentfield`

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -124,7 +124,7 @@ class Newsletter(WebsiteGenerator):
 		)
 
 	def get_success_recipients(self) -> List[str]:
-		"""Recipients who have already recieved the newsletter.
+		"""Recipients who have already received the newsletter.
 
 		Couldn't think of a better name ;)
 		"""
@@ -132,7 +132,7 @@ class Newsletter(WebsiteGenerator):
 			"Email Queue Recipient",
 			filters={
 				"status": ("in", ["Not Sent", "Sending", "Sent"]),
-				"parentfield": ("in", self.get_linked_email_queue()),
+				"parent": ("in", self.get_linked_email_queue()),
 			},
 			pluck="recipient",
 		)

--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -221,3 +221,24 @@ class TestNewsletter(TestNewsletterMixin, unittest.TestCase):
 
 		newsletter.reload()
 		self.assertEqual(newsletter.email_sent, 0)
+
+	def test_retry_partially_sent_newsletter(self):
+		frappe.db.delete("Email Queue")
+		frappe.db.delete("Email Queue Recipient")
+		frappe.db.delete("Newsletter")
+
+		newsletter = self.get_newsletter()
+		newsletter.send_emails()
+		email_queue_list = [frappe.get_doc("Email Queue", e.name) for e in frappe.get_all("Email Queue")]
+		self.assertEqual(len(email_queue_list), 4)
+
+		# emulate partial send
+		email_queue_list[0].status = "Error"
+		email_queue_list[0].recipients[0].status = "Error"
+		email_queue_list[0].save()
+		newsletter.email_sent = False
+
+		# retry
+		newsletter.send_emails()
+		email_queue_list = [frappe.get_doc("Email Queue", e.name) for e in frappe.get_all("Email Queue")]
+		self.assertEqual(len(email_queue_list), 5)


### PR DESCRIPTION
Pass `parent` instead of `parentfield` while getting successful recipients of a newsletter
