### PR TITLE
fix: Add missing doc event type `After Insert` option

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -49,7 +49,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nOn Payment Authorization"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nOn Payment Authorization"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -109,7 +109,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2022-04-22 11:24:01.151662",
+ "modified": "2022-04-27 11:42:52.032963",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",


### PR DESCRIPTION
In PR https://github.com/frappe/frappe/pull/16712 mistakenly removed `After Insert` doc event. 