### PR TITLE
docs(README): Add PWD button for Frappe

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,16 @@
 
 Full-stack web application framework that uses Python and MariaDB on the server side and a tightly integrated client side library. Built for [ERPNext](https://erpnext.com)
 
-<div align="center">
+<div align="center" style="max-height: 40px;">
 	<a href="https://frappecloud.com/frappe/signup">
 		<img src=".github/try-on-f-cloud-button.svg" height="40">
 	</a>
+	<a href="https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/gavindsouza/install-scripts/main/frappe/pwd.yml">
+		<img src="https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png" alt="Try in PWD" height="37"/>
+	</a>
 </div>
+
+> Login for the PWD site: (username: Administrator, password: admin)
 
 ## Table of Contents
 * [Installation](#installation)


### PR DESCRIPTION
Clicking on the button will take you to Play with Docker site which will give you a new vanilla Frappe site to test and play around with for 3 hours

---

PWD File from https://github.com/gavindsouza/install-scripts/blob/main/frappe/pwd.yml
Related ERPNext PR: https://github.com/frappe/erpnext/pull/30817
How does this look on the README? https://github.com/gavindsouza/frappe/tree/readme-pwd

<img width="895" alt="Screenshot 2022-04-28 at 1 55 40 PM" src="https://user-images.githubusercontent.com/36654812/165710532-1a2ba11e-298c-485e-9a56-a1645c313d0e.png">
 
PS: There's extra padding on the FC button which makes the alignment look off