### PR TITLE
fix: bad query if user has ' in the email address

### DIFF
--- a/frappe/core/doctype/user/test_records.json
+++ b/frappe/core/doctype/user/test_records.json
@@ -47,6 +47,13 @@
  },
  {
   "doctype": "User",
+  "email": "test'5@example.com",
+  "first_name": "_Test'5",
+  "new_password": "Eastern_43A1W",
+  "enabled": 1
+ },
+ {
+  "doctype": "User",
   "email": "testperm@example.com",
   "first_name": "_Test Perm",
   "new_password": "Eastern_43A1W",

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
@@ -28,7 +28,7 @@ def get_permission_query_conditions(user):
 	if not user:
 		user = frappe.session.user
 
-	return """(`tabDashboard Settings`.name = "{user}")""".format(user=user)
+	return """(`tabDashboard Settings`.name = {user})""".format(user=frappe.db.escape(user))
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.py
@@ -28,7 +28,7 @@ def get_permission_query_conditions(user):
 	if not user:
 		user = frappe.session.user
 
-	return """(`tabDashboard Settings`.name = '{user}')""".format(user=user)
+	return """(`tabDashboard Settings`.name = "{user}")""".format(user=user)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -34,7 +34,7 @@ def get_permission_query_conditions(user):
 	if user == "Administrator":
 		return ""
 
-	return """(`tabKanban Board`.private=0 or `tabKanban Board`.owner="{user}")""".format(user=user)
+	return """(`tabKanban Board`.private=0 or `tabKanban Board`.owner={user})""".format(user=frappe.db.escape(user))
 
 
 def has_permission(doc, ptype, user):

--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -34,7 +34,7 @@ def get_permission_query_conditions(user):
 	if user == "Administrator":
 		return ""
 
-	return """(`tabKanban Board`.private=0 or `tabKanban Board`.owner='{user}')""".format(user=user)
+	return """(`tabKanban Board`.private=0 or `tabKanban Board`.owner="{user}")""".format(user=user)
 
 
 def has_permission(doc, ptype, user):

--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -34,7 +34,9 @@ def get_permission_query_conditions(user):
 	if user == "Administrator":
 		return ""
 
-	return """(`tabKanban Board`.private=0 or `tabKanban Board`.owner={user})""".format(user=frappe.db.escape(user))
+	return """(`tabKanban Board`.private=0 or `tabKanban Board`.owner={user})""".format(
+		user=frappe.db.escape(user)
+	)
 
 
 def has_permission(doc, ptype, user):

--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -38,7 +38,7 @@ def get_permission_query_conditions(user):
 	if user == "Administrator":
 		return ""
 
-	return """(`tabNote`.public=1 or `tabNote`.owner="{user}")""".format(user=user)
+	return """(`tabNote`.public=1 or `tabNote`.owner={user})""".format(user=frappe.db.escape(user))
 
 
 def has_permission(doc, ptype, user):

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -30,7 +30,7 @@ def get_permission_query_conditions(for_user):
 	if for_user == "Administrator":
 		return
 
-	return """(`tabNotification Log`.for_user = '{user}')""".format(user=for_user)
+	return """(`tabNotification Log`.for_user = "{user}")""".format(user=for_user)
 
 
 def get_title(doctype, docname, title_field=None):

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -30,7 +30,7 @@ def get_permission_query_conditions(for_user):
 	if for_user == "Administrator":
 		return
 
-	return """(`tabNotification Log`.for_user = "{user}")""".format(user=for_user)
+	return """(`tabNotification Log`.for_user = {user})""".format(user=frappe.db.escape(for_user))
 
 
 def get_title(doctype, docname, title_field=None):

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -81,7 +81,7 @@ def get_permission_query_conditions(user):
 	if "System Manager" in roles:
 		return """(`tabNotification Settings`.name != 'Administrator')"""
 
-	return """(`tabNotification Settings`.name = "{user}")""".format(user=user)
+	return """(`tabNotification Settings`.name = {user})""".format(user=frappe.db.escape(user))
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -81,7 +81,7 @@ def get_permission_query_conditions(user):
 	if "System Manager" in roles:
 		return """(`tabNotification Settings`.name != 'Administrator')"""
 
-	return """(`tabNotification Settings`.name = '{user}')""".format(user=user)
+	return """(`tabNotification Settings`.name = "{user}")""".format(user=user)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -195,7 +195,7 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 	numberCard = DocType("Number Card")
 
 	if txt:
-		search_conditions = [numberCard[field].like('%{txt}%'.format(txt=txt)) for field in searchfields]
+		search_conditions = [numberCard[field].like("%{txt}%".format(txt=txt)) for field in searchfields]
 
 	condition_query = frappe.db.query.build_conditions(doctype, filters)
 

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -200,7 +200,7 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 			`tabNumber Card`
 		where
 			{conditions} and
-			(`tabNumber Card`.owner = '{user}' or
+			(`tabNumber Card`.owner = "{user}" or
 			`tabNumber Card`.is_public = 1)
 			{search_conditions}
 	""".format(

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -193,6 +193,8 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 	conditions, values = frappe.db.build_conditions(filters)
 	values["txt"] = "%" + txt + "%"
 
+	user = frappe.session.user
+
 	return frappe.db.sql(
 		"""select
 			`tabNumber Card`.name, `tabNumber Card`.label, `tabNumber Card`.document_type
@@ -200,12 +202,12 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 			`tabNumber Card`
 		where
 			{conditions} and
-			(`tabNumber Card`.owner = "{user}" or
+			(`tabNumber Card`.owner = {user} or
 			`tabNumber Card`.is_public = 1)
 			{search_conditions}
 	""".format(
 			filters=filters,
-			user=frappe.session.user,
+			user=frappe.db.escape(user),
 			search_conditions=search_conditions,
 			conditions=conditions,
 		),

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -8,9 +8,9 @@ from frappe.config import get_modules_from_all_apps_for_user
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
 from frappe.modules.export_file import export_to_files
-from frappe.utils import cint
 from frappe.query_builder import Criterion
 from frappe.query_builder.utils import DocType
+from frappe.utils import cint
 
 
 class NumberCard(Document):
@@ -192,18 +192,16 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 	if not frappe.db.exists("DocType", doctype):
 		return
 
+	numberCard = DocType("Number Card")
+
 	if txt:
-		search_conditions = [
-			numberCard[field].like('%{txt}%'.format(txt=txt)) 
-			for field in searchfields
-		]
+		search_conditions = [numberCard[field].like('%{txt}%'.format(txt=txt)) for field in searchfields]
 
 	condition_query = frappe.db.query.build_conditions(doctype, filters)
-	numberCard = DocType('Number Card')
-	user = frappe.session.user
 
-	return (condition_query.select(numberCard.name, numberCard.label, numberCard.document_type)
-		.where((numberCard.owner == frappe.db.escape(user)) | (numberCard.is_public == 1))
+	return (
+		condition_query.select(numberCard.name, numberCard.label, numberCard.document_type)
+		.where((numberCard.owner == frappe.session.user) | (numberCard.is_public == 1))
 		.where(Criterion.any(search_conditions))
 	).run()
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -693,16 +693,27 @@ class TestReportview(unittest.TestCase):
 		table_dt.delete()
 
 	def test_permission_query_condition(self):
-		from frappe.model.db_query import DatabaseQuery
+		from frappe.desk.doctype.dashboard_settings.dashboard_settings import create_dashboard_settings
 
 		self.doctype = "Dashboard Settings"
-		self.user = "user'a@frappe.io"
+		self.user = "test'5@example.com"
 
 		permission_query_conditions = DatabaseQuery.get_permission_query_conditions(self)
 
-		self.assertEqual(
-			permission_query_conditions, "(`tabDashboard Settings`.name = 'user\\'a@frappe.io')"
-		)
+		create_dashboard_settings(self.user)
+
+		dashboard_settings = frappe.db.sql(
+			"""
+				SELECT name
+				FROM `tabDashboard Settings`
+				WHERE {condition}
+			""".format(
+				condition=permission_query_conditions
+			),
+			as_dict=1,
+		)[0]
+
+		self.assertTrue(dashboard_settings)
 
 
 def add_child_table_to_blog_post():

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -704,6 +704,7 @@ class TestReportview(unittest.TestCase):
 			permission_query_conditions, "(`tabDashboard Settings`.name = 'user\\'a@frappe.io')"
 		)
 
+
 def add_child_table_to_blog_post():
 	child_table = frappe.get_doc(
 		{

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -692,6 +692,15 @@ class TestReportview(unittest.TestCase):
 		dt.delete()
 		table_dt.delete()
 
+	def test_permission_query_condition(self):
+		from frappe.model.db_query import DatabaseQuery
+
+		self.doctype = 'Dashboard Settings'
+		self.user = "user'a@frappe.io"
+
+		permission_query_conditions = DatabaseQuery.get_permission_query_conditions(self)
+
+		self.assertEqual(permission_query_conditions, "(`tabDashboard Settings`.name = 'user\\'a@frappe.io')")
 
 def add_child_table_to_blog_post():
 	child_table = frappe.get_doc(

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -695,12 +695,14 @@ class TestReportview(unittest.TestCase):
 	def test_permission_query_condition(self):
 		from frappe.model.db_query import DatabaseQuery
 
-		self.doctype = 'Dashboard Settings'
+		self.doctype = "Dashboard Settings"
 		self.user = "user'a@frappe.io"
 
 		permission_query_conditions = DatabaseQuery.get_permission_query_conditions(self)
 
-		self.assertEqual(permission_query_conditions, "(`tabDashboard Settings`.name = 'user\\'a@frappe.io')")
+		self.assertEqual(
+			permission_query_conditions, "(`tabDashboard Settings`.name = 'user\\'a@frappe.io')"
+		)
 
 def add_child_table_to_blog_post():
 	child_table = frappe.get_doc(

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -56,7 +56,9 @@ def get_permission_query_conditions(user):
 	return """(`tabWorkflow Action`.`name` in ({permitted_workflow_actions})
 		or `tabWorkflow Action`.`user`={user})
 		and `tabWorkflow Action`.`status`='Open'
-	""".format(permitted_workflow_actions=permitted_workflow_actions, user=frappe.db.escape(user))
+	""".format(
+		permitted_workflow_actions=permitted_workflow_actions, user=frappe.db.escape(user)
+	)
 
 
 def has_permission(doc, user):

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -54,7 +54,7 @@ def get_permission_query_conditions(user):
 	).get_sql()
 
 	return f"""(`tabWorkflow Action`.`name` in ({permitted_workflow_actions})
-		or `tabWorkflow Action`.`user`='{user}')
+		or `tabWorkflow Action`.`user`="{user}")
 		and `tabWorkflow Action`.`status`='Open'"""
 
 

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -53,9 +53,10 @@ def get_permission_query_conditions(user):
 		.where(WorkflowActionPermittedRole.role.isin(roles))
 	).get_sql()
 
-	return f"""(`tabWorkflow Action`.`name` in ({permitted_workflow_actions})
-		or `tabWorkflow Action`.`user`="{user}")
-		and `tabWorkflow Action`.`status`='Open'"""
+	return """(`tabWorkflow Action`.`name` in ({permitted_workflow_actions})
+		or `tabWorkflow Action`.`user`={user})
+		and `tabWorkflow Action`.`status`='Open'
+	""".format(permitted_workflow_actions=permitted_workflow_actions, user=frappe.db.escape(user))
 
 
 def has_permission(doc, user):


### PR DESCRIPTION
**Issue:**
If a user email contains ' in it, an error occurs if `get_permission_query_conditions()` method is called.

E.g if the user's email is `duncan.atang'a@frappe.io`
When `frappe.desk.reportview.get_list` is called for Dashboard Settings doctype. `get_permission_query_conditions()` method in dashboard_settings.py is called and the condition is returned in wrong format.

**Error:**
<img width="587" alt="image" src="https://user-images.githubusercontent.com/30859809/165740797-b6a8ba86-0943-41dd-8e38-c65dd6ad1542.png">


**Solution:**
<img width="704" alt="image" src="https://user-images.githubusercontent.com/30859809/165944425-0a07a35b-c618-4c13-a163-ab9732e80765.png">


**Query before the change:** 
<img width="795" alt="image" src="https://user-images.githubusercontent.com/30859809/165740037-cf2d8f17-b776-4ea2-a595-112c06104cc5.png">

**Query after the change:**
<img width="821" alt="image" src="https://user-images.githubusercontent.com/30859809/165740513-c89e3053-b9e3-4e69-986b-530d9e9015e4.png">


