### PR TITLE
fix(bug): required meta field is used inplace of mandatory

### DIFF
--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -132,7 +132,7 @@ frappe.ui.SortSelector = class SortSelector {
 			// bold, mandatory and fields that are available in list view
 			meta.fields.forEach(function(df) {
 				if (
-					(df.mandatory || df.bold || df.in_list_view)
+					(df.mandatory || df.bold || df.in_list_view || df.reqd)
 					&& frappe.model.is_value_type(df.fieldtype)
 					&& frappe.perm.has_perm(me.doctype, df.permlevel, "read")
 				) {


### PR DESCRIPTION
## Description of the Issue
The sort_by filter in the work order list initially shows the "Planned Start Date" field and then it is not visible on the filter list. The issue is well explained in #16461 

## The stated solution
The concerning file is [sort_selector.js ](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/ui/sort_selector.js). The arguments passed on this class are:- 
```
 args:
	options: {fieldname:, label:}
	sort_by:
	sort_by_label:
	sort_order:
	doctype: (optional)
```
For Gantt, Report and List view, the argument `options` (which are preset array values of sort_by) field are not passed. Thus, meta fields are derived for the Doctype; in our case - 'Work Order' doctype. The field types which are mandatory, bold, or in_list_view are added to the filter list which is shown to the user.

There are two possible solutions to this issue :
A. Mandatory field for a particular fieldtype is renamed to `reqd`. Thus a possible solution is to change the condition here - 
`df.mandatory || df.bold || df.in_list_view`
to 
`df.reqd || df.bold || df.in_list_view`
<br>
The filter list now seen to user is - 
<img width="215" alt="Capture1" src="https://user-images.githubusercontent.com/65107474/166111290-a8f4d9f2-f529-48b8-9fe0-45852f53a342.PNG" >

Note: This change affects all the list and pages that use Sort Selector
B. Simply enable the 'in_list_view' for the field type - 'Planned Start Date'
