### PR TITLE
fix(UX): suggest app-specific password for gmail logins

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -134,10 +134,11 @@ frappe.ui.form.on("Email Account", {
 
 	show_gmail_message_for_less_secure_apps: function(frm) {
 		frm.dashboard.clear_headline();
+		let msg = __("GMail will only work if you enable 2-step authentication and use app-specific password.");
+		let cta = __("Read the step by step guide here.");
+		msg += ` <a target="_blank" href="https://docs.erpnext.com/docs/v13/user/manual/en/setting-up/email/email_account_setup_with_gmail">${cta}</a>`;
 		if (frm.doc.service==="GMail") {
-			frm.dashboard.set_headline_alert('Gmail will only work if you allow access for less secure \
-				apps in Gmail settings. <a target="_blank" \
-				href="https://support.google.com/accounts/answer/6010255?hl=en">Read this for details</a>');
+			frm.dashboard.set_headline_alert(msg);
 		}
 	},
 


### PR DESCRIPTION
GMail is deprecating insecure logins

> To help keep your account secure, starting May 30, 2022, Google will no longer support the use of third-party apps or devices which ask you to sign in to your Google Account using only your username and password.

 

To continue using GMail in ERPNext you need to follow steps described in docs here:

https://docs.erpnext.com/docs/v13/user/manual/en/setting-up/email/email_account_setup_with_gmail 