### PR TITLE
fix: Simplify setup wizard

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -49,7 +49,6 @@ frappe.pages['setup-wizard'].on_page_load = function (wrapper) {
 				}
 				frappe.wizard = new frappe.setup.SetupWizard(wizard_settings);
 				frappe.setup.run_event("after_load");
-				// frappe.wizard.values = test_values_edu;
 				let route = frappe.get_route();
 				if (route) {
 					frappe.wizard.show_slide(route[1]);
@@ -145,7 +144,7 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 
 	refresh_slides() {
 		// For Translations, etc.
-		if (this.in_refresh_slides || !this.current_slide.set_values()) {
+		if (this.in_refresh_slides || !this.current_slide.set_values(true)) {
 			return;
 		}
 		this.in_refresh_slides = true;
@@ -344,63 +343,39 @@ frappe.setup.slides_settings = [
 		// Welcome (language) slide
 		name: "welcome",
 		title: __("Hello!"),
-		icon: "fa fa-world",
-		// help: __("Let's prepare the system for first use."),
 
 		fields: [
 			{
-				fieldname: "language", label: __("Your Language"),
-				fieldtype: "Select", reqd: 1
-			}
-		],
-
-		onload: function (slide) {
-			this.setup_fields(slide);
-			let browser_language = frappe.setup.utils.get_language_name_from_code(navigator.language);
-			let language_field = slide.get_field("language");
-
-			language_field.set_input(browser_language || "English");
-
-			if (!frappe.setup._from_load_messages) {
-				language_field.$input.trigger("change");
-			}
-			delete frappe.setup._from_load_messages;
-			moment.locale("en");
-		},
-
-		setup_fields: function (slide) {
-			frappe.setup.utils.setup_language_field(slide);
-			frappe.setup.utils.bind_language_events(slide);
-		},
-	},
-
-	{
-		// Region slide
-		name: 'region',
-		title: __("Select Your Region"),
-		icon: "fa fa-flag",
-		// help: __("Select your Country, Time Zone and Currency"),
-		fields: [
-			{
-				fieldname: "country", label: __("Your Country"), reqd: 1,
-				fieldtype: "Autocomplete",
-				placeholder: __('Select Country')
+				fieldname: "language",
+				label: __("Your Language"),
+				fieldtype: "Select",
+				placeholder: __('Select Language'),
+				reqd: 1,
 			},
-			{ fieldtype: "Section Break" },
+			{
+				fieldname: "country",
+				label: __("Your Country"),
+				fieldtype: "Autocomplete",
+				placeholder: __('Select Country'),
+				reqd: 1,
+			},
+			{
+				fieldtype: "Section Break"
+			},
 			{
 				fieldname: "timezone",
 				label: __("Time Zone"),
 				placeholder: __('Select Time Zone'),
-				reqd: 1,
 				fieldtype: "Select",
+				reqd: 1,
 			},
 			{ fieldtype: "Column Break" },
 			{
 				fieldname: "currency",
 				label: __("Currency"),
 				placeholder: __('Select Currency'),
-				reqd: 1,
 				fieldtype: "Select",
+				reqd: 1,
 			}
 		],
 
@@ -410,14 +385,25 @@ frappe.setup.slides_settings = [
 			} else {
 				frappe.setup.utils.load_regional_data(slide, this.setup_fields);
 			}
+			if (!slide.get_value("language")) {
+				let session_language = frappe.setup.utils.get_language_name_from_code(frappe.boot.lang || navigator.language);
+				let language_field = slide.get_field("language");
+				language_field.set_input(session_language || "English");
+				if (!frappe.setup._from_load_messages) {
+					language_field.$input.trigger("change");
+				}
+				delete frappe.setup._from_load_messages;
+				moment.locale("en");
+			}
+			frappe.setup.utils.bind_region_events(slide);
+			frappe.setup.utils.bind_language_events(slide);
 		},
 
 		setup_fields: function (slide) {
 			frappe.setup.utils.setup_region_fields(slide);
-			frappe.setup.utils.bind_region_events(slide);
-		}
+			frappe.setup.utils.setup_language_field(slide);
+		},
 	},
-
 	{
 		// Profile slide
 		name: 'user',
@@ -438,7 +424,7 @@ frappe.setup.slides_settings = [
 			},
 			{ "fieldname": "password", "label": __("Password"), "fieldtype": "Password" }
 		],
-		// help: __('The first user will become the System Manager (you can change this later).'),
+
 		onload: function (slide) {
 			if (frappe.session.user !== "Administrator") {
 				slide.form.fields_dict.email.$wrapper.toggle(false);
@@ -555,9 +541,7 @@ frappe.setup.utils = {
 		}
 
 		slide.get_field("currency").set_input(frappe.wizard.values.currency);
-
 		slide.get_field("timezone").set_input(frappe.wizard.values.timezone);
-
 	},
 
 	bind_language_events: function (slide) {

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -348,8 +348,9 @@ frappe.setup.slides_settings = [
 			{
 				fieldname: "language",
 				label: __("Your Language"),
-				fieldtype: "Select",
+				fieldtype: "Autocomplete",
 				placeholder: __('Select Language'),
+				default: "English",
 				reqd: 1,
 			},
 			{
@@ -386,9 +387,10 @@ frappe.setup.slides_settings = [
 				frappe.setup.utils.load_regional_data(slide, this.setup_fields);
 			}
 			if (!slide.get_value("language")) {
-				let session_language = frappe.setup.utils.get_language_name_from_code(frappe.boot.lang || navigator.language);
+				let session_language = frappe.setup.utils.get_language_name_from_code(frappe.boot.lang || navigator.language) || "English";
 				let language_field = slide.get_field("language");
-				language_field.set_input(session_language || "English");
+
+				language_field.set_input(session_language);
 				if (!frappe.setup._from_load_messages) {
 					language_field.$input.trigger("change");
 				}
@@ -502,7 +504,7 @@ frappe.setup.utils = {
 	setup_language_field: function (slide) {
 		var language_field = slide.get_field("language");
 		language_field.df.options = frappe.setup.data.lang.languages;
-		language_field.refresh();
+		language_field.set_options();
 	},
 
 	setup_region_fields: function (slide) {

--- a/frappe/public/js/frappe/ui/slides.js
+++ b/frappe/public/js/frappe/ui/slides.js
@@ -309,6 +309,8 @@ frappe.ui.Slides = class Slides {
 		// Can be called by a slide to update states
 		this.$slide_progress.empty();
 
+		if (this.slides.length <= 1) return
+
 		this.slides.map((slide, id) => {
 			let $dot = $(`<div class="slide-step">
 				<div class="slide-step-indicator"></div>

--- a/frappe/public/js/frappe/ui/slides.js
+++ b/frappe/public/js/frappe/ui/slides.js
@@ -105,8 +105,8 @@ frappe.ui.Slide = class Slide {
 		});
 	}
 
-	set_values() {
-		this.values = this.form.get_values();
+	set_values(ignore_errors) {
+		this.values = this.form.get_values(ignore_errors);
 		if (this.values === null) {
 			return false;
 		}


### PR DESCRIPTION
### Changes

* Merge Language & Country slides
* Make language field Autocomplete instead of Select
* This translates to a single setup slide when developer_mode is set and two otherwise (one for first user setup)

<img width="1552" alt="Screenshot 2022-05-04 at 11 27 15 AM" src="https://user-images.githubusercontent.com/36654812/166629428-13dd2328-dfd3-448f-9853-e2cead7d6312.png">

<img width="1552" alt="Screenshot 2022-05-04 at 11 27 30 AM" src="https://user-images.githubusercontent.com/36654812/166629421-1286aa2f-aad5-407a-8f8e-d499620f5b3e.png">
