### PR TITLE
refactor(minor)!: remove is_first_startup from System Settings

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -11,7 +11,6 @@
   "language",
   "column_break_3",
   "time_zone",
-  "is_first_startup",
   "enable_onboarding",
   "setup_complete",
   "date_and_number_format",
@@ -102,14 +101,6 @@
    "label": "Time Zone",
    "read_only": 1,
    "reqd": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "is_first_startup",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Is First Startup",
-   "read_only": 1
   },
   {
    "default": "0",
@@ -502,7 +493,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2022-04-21 09:11:35.218721",
+ "modified": "2022-05-02 18:53:35.218721",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -269,7 +269,6 @@ def add_all_roles_to(name):
 def disable_future_access():
 	frappe.db.set_default("desktop:home_page", "workspace")
 	frappe.db.set_value("System Settings", "System Settings", "setup_complete", 1)
-	frappe.db.set_value("System Settings", "System Settings", "is_first_startup", 1)
 
 	# Enable onboarding after install
 	frappe.db.set_value("System Settings", "System Settings", "enable_onboarding", 1)
@@ -332,11 +331,6 @@ def load_user_details():
 		"full_name": frappe.cache().hget("full_name", "signup"),
 		"email": frappe.cache().hget("email", "signup"),
 	}
-
-
-@frappe.whitelist()
-def reset_is_first_startup():
-	frappe.db.set_value("System Settings", "System Settings", "is_first_startup", 0)
 
 
 def prettify_args(args):

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -189,6 +189,7 @@ frappe.patches.v14_0.save_ratings_in_fraction #23-12-2021
 frappe.patches.v14_0.transform_todo_schema
 frappe.patches.v14_0.remove_post_and_post_comment
 frappe.patches.v14_0.reset_creation_datetime
+frappe.patches.v14_0.remove_is_first_startup
 
 [post_model_sync]
 frappe.patches.v14_0.drop_data_import_legacy

--- a/frappe/patches/v14_0/remove_is_first_startup.py
+++ b/frappe/patches/v14_0/remove_is_first_startup.py
@@ -2,6 +2,7 @@ import frappe
 
 
 def execute():
-	frappe.db.sql(
-		"""DELETE FROM `tabSingles` where doctype = 'System Settings' and field = 'is_first_startup'"""
-	)
+	singles = frappe.qb.Table("tabSingles")
+	frappe.qb.from_(singles).delete().where(
+		(singles.doctype == "System Settings") & (singles.field == "is_first_startup")
+	).run()

--- a/frappe/patches/v14_0/remove_is_first_startup.py
+++ b/frappe/patches/v14_0/remove_is_first_startup.py
@@ -1,0 +1,7 @@
+import frappe
+
+
+def execute():
+	frappe.db.sql(
+		"""DELETE FROM `tabSingles` where doctype = 'System Settings' and field = 'is_first_startup'"""
+	)

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -187,9 +187,6 @@ def get():
 	bootinfo["disable_async"] = frappe.conf.disable_async
 
 	bootinfo["setup_complete"] = cint(frappe.db.get_single_value("System Settings", "setup_complete"))
-	bootinfo["is_first_startup"] = cint(
-		frappe.db.get_single_value("System Settings", "is_first_startup")
-	)
 
 	bootinfo["desk_theme"] = frappe.db.get_value("User", frappe.session.user, "desk_theme") or "Light"
 


### PR DESCRIPTION
This pr removes `is_first_startup` hidden field from System Settings - ~~as it's not being used anywhere~~ it's used in support app (but that can be taken out without any major change [hopefully]) 👇 

https://github.com/frappe/erpnext_support/blob/5903efb3713eb5dfd910b1ae6cab1132f4b830d4/erpnext_support/public/js/erpnext_support.js#L523

that condition will always be true as we never reset the is_first_startup flag and it's always set to 1 after the setup (along with the setup_complete flag), which kind of goes against it's name :P