### PR TITLE
perf: remove naming series from log-like doctypes

### DIFF
--- a/frappe/core/doctype/access_log/access_log.json
+++ b/frappe/core/doctype/access_log/access_log.json
@@ -1,5 +1,6 @@
 {
- "autoname": "format:AL-{#####}",
+ "actions": [],
+ "autoname": "hash",
  "creation": "2019-07-25 15:44:44.955496",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -127,10 +128,12 @@
    "read_only": 1
   }
  ],
- "modified": "2019-08-05 19:00:13.839471",
+ "links": [],
+ "modified": "2022-05-03 09:34:19.337551",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Access Log",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -146,5 +149,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_seen": 1
 }

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "WEBHOOK-REQ-.#####",
+ "autoname": "hash",
  "creation": "2021-05-24 21:35:59.104776",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -56,10 +56,11 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-05-26 23:57:58.495261",
+ "modified": "2022-05-03 09:33:49.240777",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook Request Log",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -77,5 +78,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
Removed naming series from:
- webhook request log
- access log

These are unnecessary and make operations sequential because of the naming series lock. 

Example: 20+ parallel workers effectively operating sequentially because they are all waiting for lock for incrementing series counter on a log table 💸 

![2022-05-03 19 14 05](https://user-images.githubusercontent.com/9079960/166464674-6d9b3f0b-750c-4a12-b80d-769ad0fec227.jpg)





PS: If you want it on your site, it's easy to add it back from "Customize form" having this by default isn't required. 