### PR TITLE
fix: handle dict data in deferred_insert

### DIFF
--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -42,8 +42,6 @@ def save_to_db():
 				record_count += 1
 				insert_record(record, doctype)
 
-	frappe.db.commit()
-
 
 def insert_record(record: Union[Dict, "Document"], doctype: str):
 	try:

--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -46,8 +46,8 @@ def save_to_db():
 
 
 def insert_record(record: Union[Dict, "Document"], doctype: str):
-	setattr(record, "doctype", doctype)
 	try:
+		record.update({"doctype": doctype})
 		frappe.get_doc(record).insert()
 	except Exception as e:
 		frappe.logger().error(f"Error while inserting deferred {doctype} record: {e}")

--- a/frappe/tests/test_deferred_insert.py
+++ b/frappe/tests/test_deferred_insert.py
@@ -1,0 +1,12 @@
+import frappe
+from frappe.deferred_insert import deferred_insert, save_to_db
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDeferredInsert(FrappeTestCase):
+	def test_deferred_insert(self):
+		route_history = {"route": frappe.generate_hash(), "user": "Administrator"}
+		deferred_insert("Route History", [route_history])
+
+		save_to_db()
+		self.assertTrue(frappe.db.exists("Route History", route_history))


### PR DESCRIPTION
vanilla dict doesn't have attrs, setattr fails

```
Traceback (most recent call last):
  File "apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 84, in execute
    frappe.get_attr(self.method)()
  File "apps/frappe/frappe/deferred_insert.py", line 43, in save_to_db
    insert_record(record, doctype)
  File "apps/frappe/frappe/deferred_insert.py", line 49, in insert_record
    setattr(record, "doctype", doctype)
AttributeError: 'dict' object has no attribute 'doctype'
```

closes https://github.com/frappe/frappe/issues/16828 

Unrelated: removed transaction commit since this function only runs from a scheduled job which commits after completion. 