### PR TITLE
fix: patch to delete empty version logs

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -198,3 +198,4 @@ frappe.patches.v14_0.remove_db_aggregation
 frappe.patches.v14_0.update_color_names_in_kanban_board_column
 frappe.patches.v14_0.update_is_system_generated_flag
 frappe.patches.v14_0.update_auto_account_deletion_duration
+frappe.patches.v14_0.delete_unnecessary_versions

--- a/frappe/patches/v14_0/delete_unnecessary_versions.py
+++ b/frappe/patches/v14_0/delete_unnecessary_versions.py
@@ -1,0 +1,24 @@
+import frappe
+
+# ref: https://github.com/frappe/frappe/pull/14558
+VERSIONS_TO_DELETE = [
+	"Activity Log",
+	"Error Log",
+	"Error Snapshot",
+	"Energy Point Log",
+	"Notification Log",
+	"Route History",
+	"Scheduled Job Log",
+	"View Log",
+	"Web Page View",
+]
+
+
+def execute():
+	"""Some log-like doctypes had track changes enabled, these version logs
+	are empty but consume space. This patch removes such version logs.
+	"""
+	for doctype in VERSIONS_TO_DELETE:
+		if not frappe.get_meta(doctype).track_changes:
+			frappe.db.delete("Version", {"ref_doctype": doctype})
+			frappe.db.commit()


### PR DESCRIPTION
Just noticed that old logs are still consuming gigabytes of space on some very old sites. 


This patch removes the version log of all log doctypes which aren't modified after creation so version logs are empty _anyway_.

Should've been part of https://github.com/frappe/frappe/pull/14558 