### PR TITLE
test: Disable flaky test

### DIFF
--- a/cypress/integration/form_tour.js
+++ b/cypress/integration/form_tour.js
@@ -1,4 +1,4 @@
-context('Form Tour', () => {
+context.skip('Form Tour', () => {
 	before(() => {
 		cy.login();
 		cy.visit('/app/form-tour');


### PR DESCRIPTION
Unable to find the cause of the flakiness of the test. Disabling it for now.

Also, the form_tour test is full of `wait` which is bad anyway.
