### PR TITLE
fix(date control): Do not try to convert timezone of date

### DIFF
--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -137,13 +137,13 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 		});
 	}
 	parse(value) {
-		if(value) {
-			return frappe.datetime.user_to_str(value);
+		if (value) {
+			return frappe.datetime.user_to_str(value, false, true);
 		}
 	}
 	format_for_input(value) {
-		if(value) {
-			return frappe.datetime.str_to_user(value);
+		if (value) {
+			return frappe.datetime.str_to_user(value, false, true);
 		}
 		return "";
 	}

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -45,8 +45,6 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 	}
 	format_for_input(value) {
 		if (!value) return "";
-
-
 		return frappe.datetime.str_to_user(value, false);
 	}
 	set_description() {

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -133,7 +133,7 @@ $.extend(frappe.datetime, {
 		return frappe.sys_defaults && frappe.sys_defaults.date_format || "yyyy-mm-dd";
 	},
 
-	str_to_user: function(val, only_time = false) {
+	str_to_user: function(val, only_time=false, only_date=false) {
 		if (!val) return "";
 		const user_date_fmt = frappe.datetime.get_user_date_fmt().toUpperCase();
 		const user_time_fmt = frappe.datetime.get_user_time_fmt();
@@ -142,6 +142,9 @@ $.extend(frappe.datetime, {
 		if (only_time) {
 			let date_obj = moment(val, frappe.defaultTimeFormat);
 			return date_obj.format(user_format);
+		} else if (only_date) {
+			let date_obj = moment(val, frappe.defaultDateFormat);
+			return date_obj.format(user_date_fmt);
 		} else {
 			let date_obj = moment.tz(val, frappe.boot.time_zone.system);
 			if (typeof val !== "string" || val.indexOf(" ") === -1) {


### PR DESCRIPTION
Do not convert the `timezone` of the date field value since the "only date" value will be the same across all timezones.

**Before:** 
We were converting timezone for the date field as well which is why date was inconsistent between timezones that are a day apart.

https://user-images.githubusercontent.com/13928957/167081074-2c7810f7-bd07-4a82-a3d3-b22b3a377a8a.mov

**After:** 

https://user-images.githubusercontent.com/13928957/167081278-7c87a69d-0b22-4433-af10-8c6a6f5f62da.mov

---

The issue was introduced via https://github.com/frappe/frappe/pull/13504

Fixes: https://github.com/frappe/frappe/issues/16732
