### PR TITLE
fix: disallow serving uploaded public xml-like files

### DIFF
--- a/frappe/middlewares.py
+++ b/frappe/middlewares.py
@@ -8,6 +8,7 @@ from werkzeug.middleware.shared_data import SharedDataMiddleware
 
 import frappe
 from frappe.utils import cstr, get_site_name
+from frappe.utils.response import is_xml_like_file
 
 
 class StaticDataMiddleware(SharedDataMiddleware):
@@ -26,3 +27,6 @@ class StaticDataMiddleware(SharedDataMiddleware):
 				# return None, None
 
 		return loader
+
+	def is_allowed(self, filename):
+		return not is_xml_like_file(filename)

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -250,11 +250,7 @@ def send_private_file(path):
 
 	# no need for content disposition and force download. let browser handle its opening.
 	# Except for those that can be injected with scripts.
-
-	extension = os.path.splitext(path)[1]
-	blacklist = [".svg", ".html", ".htm", ".xml"]
-
-	if extension.lower() in blacklist:
+	if is_xml_like_file(path):
 		response.headers.add("Content-Disposition", "attachment", filename=filename.encode("utf-8"))
 
 	response.mimetype = mimetypes.guess_type(filename)[0] or "application/octet-stream"
@@ -274,3 +270,10 @@ def handle_session_stopped():
 		primary_action=None,
 	)
 	return get_response("message", http_status_code=503)
+
+
+def is_xml_like_file(path):
+	extension = os.path.splitext(path)[1]
+	xml_extns = [".svg", ".html", ".htm", ".xml"]
+
+	return extension.lower() in xml_extns


### PR DESCRIPTION
If you upload an `.html` file as a public file and visit it's URL, it won't be downloaded, but it will be served as a web page rendered by the browser. This means any scripts written in that file will execute. This is undesirable for obvious reasons.

This does not happen with private files because `/private/files` routes go through application logic
https://github.com/frappe/frappe/blob/develop/frappe/utils/response.py#L233-L262

whereas `/public` routes are handled by SharedDataMiddleware
https://github.com/frappe/frappe/blob/c0c5b2ebdddbe8898ce2d5e5365f4931ff73b6bf/frappe/app.py#L332-L334

This PR disallows the serving of public files that have `.html`, `.xml`, `.svg` and `.htm` extension, the response will be 404.
Not sure if this is the best solution.