### PR TITLE
fix: frappe.throw in case of list of errors

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -390,7 +390,7 @@ def msgprint(msg, title=None, raise_exception=0, as_table=False, as_list=False, 
 	if as_table and type(msg) in (list, tuple):
 		out.as_table = 1
 
-	if as_list and type(msg) in (list, tuple) and len(msg) > 1:
+	if as_list and type(msg) in (list, tuple):
 		out.as_list = 1
 
 	if flags.print_messages and out.message:


### PR DESCRIPTION
```frappe.throw(["Error 1"], as_list=1)``` raises an unhandled exception

<img width="1440" alt="CleanShot 2022-05-09 at 18 03 47@2x" src="https://user-images.githubusercontent.com/25369014/167411058-9883f5b3-8c8e-4e0c-baad-ce8c9d560a62.png">
