### PR TITLE
fix: duplicate list_update realtime events

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1973,22 +1973,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		return filters;
 	}
-
-	static trigger_list_update(data) {
-		const doctype = data.doctype;
-		if (!doctype) return;
-		frappe.provide("frappe.views.trees");
-
-		// refresh list view
-		const page_name = frappe.get_route_str();
-		const list_view = frappe.views.list_view[page_name];
-		list_view && list_view.on_update(data);
-	}
 };
 
-$(document).on("save", (event, doc) => {
-	frappe.views.ListView.trigger_list_update(doc);
-});
 
 frappe.get_list_view = (doctype) => {
 	let route = `List/${doctype}/List`;

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -47,8 +47,6 @@ $.extend(frappe.model, {
 	init: function() {
 		// setup refresh if the document is updated somewhere else
 		frappe.realtime.on("doc_update", function(data) {
-			// set list dirty
-			frappe.views.ListView.trigger_list_update(data);
 			var doc = locals[data.doctype] && locals[data.doctype][data.name];
 
 			if(doc) {
@@ -69,11 +67,6 @@ $.extend(frappe.model, {
 				}
 			}
 		});
-
-		frappe.realtime.on("list_update", function(data) {
-			frappe.views.ListView.trigger_list_update(data);
-		});
-
 	},
 
 	is_value_type: function(fieldtype) {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -48,7 +48,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	setup_view() {
 		this.setup_columns();
 		super.setup_new_doc_event();
+		this.setup_events()
 		this.page.main.addClass('report-view');
+	}
+
+	setup_events() {
+		frappe.realtime.on("list_update", (data) => this.on_update(data));
 	}
 
 	setup_page() {


### PR DESCRIPTION

`doc_update` event was triggering list update, which doesn't make sense because doc_update event anyway proceeds with `list_update` event in document.py 

---

ListView refresh is a weird OO inheritance mess. 

1. ListView has it's on realtime listener that's only applicable to main list view (not inherited classes, cause they override the functions)
2. TreeView has a separate function that was called from listview real-time update. This was removed recently. 
3. ListView also has static function `trigger_list_update` which triggers `on_update` but doesn't actually trigger listview realtime update cause that function is empty. 
4. ReportView has `on_update` which from OO hierarchy gets called. 

Removed all this mess and just added separate listener on report view.
