### PR TITLE
fix(webform): Only show published web forms

### DIFF
--- a/frappe/tests/test_webform.py
+++ b/frappe/tests/test_webform.py
@@ -1,10 +1,27 @@
 import unittest
 
 import frappe
+from frappe.utils import set_request
+from frappe.website.serve import get_response
 from frappe.www.list import get_list_context
 
 
-class TestWebsite(unittest.TestCase):
+class TestWebform(unittest.TestCase):
+	def test_webform_publish_functionality(self):
+		edit_profile = frappe.get_doc("Web Form", "edit-profile")
+		# publish webform
+		edit_profile.published = True
+		edit_profile.save()
+		set_request(method="GET", path="update-profile")
+		response = get_response()
+		self.assertEqual(response.status_code, 200)
+
+		# un-publish webform
+		edit_profile.published = False
+		edit_profile.save()
+		response = get_response()
+		self.assertEqual(response.status_code, 404)
+
 	def test_get_context_hook_of_webform(self):
 		create_custom_doctype()
 		create_webform()

--- a/frappe/website/page_renderers/web_form.py
+++ b/frappe/website/page_renderers/web_form.py
@@ -4,7 +4,7 @@ from frappe.website.page_renderers.document_page import DocumentPage
 
 class WebFormPage(DocumentPage):
 	def can_render(self):
-		webform_name = frappe.db.exists("Web Form", {"route": self.path}, cache=True)
+		webform_name = frappe.db.exists("Web Form", {"route": self.path, "published": 1}, cache=True)
 		if webform_name:
 			self.doctype = "Web Form"
 			self.docname = webform_name


### PR DESCRIPTION
Web Form was accessible through URL even after it was unpublished.

fixes: https://github.com/frappe/frappe/issues/16853

The issue was introduced via https://github.com/frappe/frappe/pull/12334