### PR TITLE
fix: Allow more columns on bigger screens

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -385,7 +385,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (window.innerWidth <= 1366) {
 			total_fields = 4;
 		} else if (window.innerWidth >= 1920) {
-			total_fields = 8;
+			total_fields = 10;
 		}
 
 		this.columns = this.columns.slice(0, this.list_view_settings.total_fields || total_fields);


### PR DESCRIPTION
Be consistent with other list view settings (after https://github.com/frappe/frappe/pull/16842), max fields allowed is 10.