### PR TITLE
fix: description metatag

### DIFF
--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -312,6 +312,11 @@ class TestWebsite(unittest.TestCase):
 		self.assertIn("test.__test", content)
 		self.assertNotIn("frappe.exceptions.ValidationError: Illegal template", content)
 
+	def test_metatags(self):
+		content = get_response_content("/_test/_test_metatags")
+		self.assertIn('<meta name="title" content="Test Title Metatag">', content)
+		self.assertIn('<meta name="description" content="Test Description for Metatag">', content)
+
 
 def set_home_page_hook(key, value):
 	from frappe import hooks

--- a/frappe/website/website_components/metatags.py
+++ b/frappe/website/website_components/metatags.py
@@ -16,7 +16,7 @@ class MetaTags:
 
 	def init_metatags_from_context(self):
 		for key in METATAGS:
-			if key not in self.tags and self.context.get(key):
+			if not self.tags.get(key) and self.context.get(key):
 				self.tags[key] = self.context[key]
 
 		if not self.tags.get("title"):

--- a/frappe/www/_test/_test_metatags.html
+++ b/frappe/www/_test/_test_metatags.html
@@ -1,0 +1,5 @@
+---
+base_template: frappe/templates/web.html
+---
+
+<h1>Test Metatags</h1>

--- a/frappe/www/_test/_test_metatags.py
+++ b/frappe/www/_test/_test_metatags.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+from __future__ import unicode_literals
+
+
+def get_context():
+	return {"title": "Test Title Metatag", "description": "Test Description for Metatag"}


### PR DESCRIPTION
If you set the following keys in context of a web page:
```
context.title = 'Title'
context.description = 'Description'
```
The web page should render metatags for them. Currently, it doesn't render `description` meta tags because of a minor bug.

Fixed it and added a basic test.