### PR TITLE
revert: "fix: color hex code not work as class name"

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -79,6 +79,6 @@ export default class ShortcutWidget extends Widget {
 		this.action_area.empty();
 		const label = get_label();
 		let color = this.color && count ? this.color.toLowerCase() : 'gray';
-		$(`<div class="indicator-pill ellipsis" style="color:${color}">${label}</div>`).appendTo(this.action_area);
+		$(`<div class="indicator-pill ellipsis ${color}">${label}</div>`).appendTo(this.action_area);
 	}
 }


### PR DESCRIPTION
As stated in issue, commit 4ff474d0883b356bc498cb62e7e4ff591e387429 changed the way indicator-pills are colored, and it looks broken.