### PR TITLE
fix: recursion error in translations

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import frappe
 import frappe.translate
 from frappe import _
-from frappe.translate import get_language, get_parent_language
+from frappe.translate import get_language, get_parent_language, get_translation_dict_from_file
 from frappe.utils import set_request
 
 dirname = os.path.dirname(__file__)
@@ -118,6 +118,23 @@ class TestTranslate(unittest.TestCase):
 		set_request(method="POST", path="/", headers=[("Accept-Language", third_lang)])
 		return_val = get_language()
 		self.assertNotIn(return_val, [third_lang, get_parent_language(third_lang)])
+
+	def test_load_all_translate_files(self):
+		"""Load all CSV files to ensure they have correct format"""
+		verify_translation_files("frappe")
+
+
+def verify_translation_files(app):
+	"""Function to verify translation file syntax in app."""
+	# Do not remove/rename this, other apps depend on it to test their translations
+
+	from pathlib import Path
+
+	translations_dir = Path(frappe.get_app_path(app)) / "translations"
+
+	for file in translations_dir.glob("*.csv"):
+		lang = file.stem  # basename of file = lang
+		get_translation_dict_from_file(file, lang, app, throw=True)
 
 
 expected_output = [

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -323,7 +323,6 @@ def get_translation_dict_from_file(path, lang, app):
 					app=app, lang=lang, values=cstr(item)
 				)
 				frappe.log_error(message=msg, title="Error in translation file")
-				frappe.msgprint(msg)
 
 	return translation_map
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -306,7 +306,7 @@ def load_lang(lang, apps=None):
 	return out or {}
 
 
-def get_translation_dict_from_file(path, lang, app):
+def get_translation_dict_from_file(path, lang, app, throw=False):
 	"""load translation dict from given path"""
 	translation_map = {}
 	if os.path.exists(path):
@@ -323,6 +323,8 @@ def get_translation_dict_from_file(path, lang, app):
 					app=app, lang=lang, values=cstr(item)
 				)
 				frappe.log_error(message=msg, title="Error in translation file")
+				if throw:
+					frappe.throw(msg, title="Error in translation file")
 
 	return translation_map
 


### PR DESCRIPTION
- If bad translations is found then while `msgprint`ing it attempts to load
translation again because of its arg `title = _("Message")`


Fix:
- removed msgprint (not visible to web users anyway)
- add a test instead so erroneous files don't get added in the first place.
