### PR TITLE
fix: Filters Won't Work While Routing in Report

### DIFF
--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -340,7 +340,8 @@ export default class ChartWidget extends Widget {
 				handler: () => {
 					frappe.set_route(
 						"query-report",
-						this.chart_doc.report_name
+						this.chart_doc.report_name,
+						this.filters
 					);
 				}
 			});


### PR DESCRIPTION
If Chart type is Report and we Redirect to the report from the Dashboard it will not apply filters that we have applied in dashboard.

1] Setting Filters in(Group by - Customer) (Refer- First Image)
![image](https://user-images.githubusercontent.com/18363620/168267212-1217ed4a-3ccb-4430-bc3c-5832c79ccd4c.png)


2] After Redirect From Dashboard, Filter Group by - Customer Not Applied (Refer - Second Image)
![image](https://user-images.githubusercontent.com/18363620/168267521-0018c779-4ee4-4292-b62e-0be9a65f0223.png)

