### PR TITLE
fix(patch): Reload workspace child tables in pre_model_sync

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -190,6 +190,7 @@ frappe.patches.v14_0.transform_todo_schema
 frappe.patches.v14_0.remove_post_and_post_comment
 frappe.patches.v14_0.reset_creation_datetime
 frappe.patches.v14_0.remove_is_first_startup
+frappe.patches.v14_0.reload_workspace_child_tables
 
 [post_model_sync]
 frappe.patches.v14_0.drop_data_import_legacy

--- a/frappe/patches/v14_0/reload_workspace_child_tables.py
+++ b/frappe/patches/v14_0/reload_workspace_child_tables.py
@@ -1,5 +1,4 @@
 import frappe
-from frappe.modules import get_doctype_module
 
 
 def execute():

--- a/frappe/patches/v14_0/reload_workspace_child_tables.py
+++ b/frappe/patches/v14_0/reload_workspace_child_tables.py
@@ -10,5 +10,5 @@ def execute():
 	)
 
 	for child_table in child_tables:
-		module = get_doctype_module(child_table).lower()
-		frappe.reload_doc(module, "doctype", child_table, force=True)
+		if child_table != "Has Role":
+			frappe.reload_doc("desk", "doctype", child_table, force=True)

--- a/frappe/patches/v14_0/reload_workspace_child_tables.py
+++ b/frappe/patches/v14_0/reload_workspace_child_tables.py
@@ -4,10 +4,10 @@ from frappe.modules import get_doctype_module
 
 def execute():
 	child_tables = frappe.get_all(
-			"DocField",
-			pluck="options",
-			filters={"fieldtype": ["in", frappe.model.table_fields], "parent": "Workspace"},
-		)
+		"DocField",
+		pluck="options",
+		filters={"fieldtype": ["in", frappe.model.table_fields], "parent": "Workspace"},
+	)
 
 	for child_table in child_tables:
 		module = get_doctype_module(child_table).lower()

--- a/frappe/patches/v14_0/reload_workspace_child_tables.py
+++ b/frappe/patches/v14_0/reload_workspace_child_tables.py
@@ -1,0 +1,18 @@
+import frappe
+from frappe.modules import get_doctype_module
+
+
+def execute():
+	child_tables = [
+		r[0]
+		for r in frappe.get_all(
+			"DocField",
+			fields="options",
+			filters={"fieldtype": ["in", frappe.model.table_fields], "parent": "Workspace"},
+			as_list=1,
+		)
+	]
+
+	for child_table in child_tables:
+		module = get_doctype_module(child_table).lower()
+		frappe.reload_doc(module, "doctype", child_table, force=True)

--- a/frappe/patches/v14_0/reload_workspace_child_tables.py
+++ b/frappe/patches/v14_0/reload_workspace_child_tables.py
@@ -3,15 +3,11 @@ from frappe.modules import get_doctype_module
 
 
 def execute():
-	child_tables = [
-		r[0]
-		for r in frappe.get_all(
+	child_tables = frappe.get_all(
 			"DocField",
-			fields="options",
+			pluck="options",
 			filters={"fieldtype": ["in", frappe.model.table_fields], "parent": "Workspace"},
-			as_list=1,
 		)
-	]
 
 	for child_table in child_tables:
 		module = get_doctype_module(child_table).lower()


### PR DESCRIPTION
Patch test was failing in erpnext because the new child table "Workspace Quick List" was added in "Workspace" doctype and in [pre_model_sync] patch there is a patch which deletes healthcare workspace and their error occurs that Workspace Quick List does not exist in a database table.