### PR TITLE
ci: `Skip CI` label for not running build processes

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -7,16 +7,26 @@ import sys
 import urllib.request
 
 
-def get_files_list(pr_number, repo="frappe/frappe"):
-	req = urllib.request.Request(f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files")
+def fetch_pr_data(pr_number, repo, endpoint):
+	api_url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
+
+	if endpoint:
+		api_url += f"/{endpoint}"
+
+	req = urllib.request.Request(api_url)
 	res = urllib.request.urlopen(req)
-	dump = json.loads(res.read().decode('utf8'))
-	return [change["filename"] for change in dump]
+	return json.loads(res.read().decode('utf8'))
+
+def get_files_list(pr_number, repo="frappe/frappe"):
+	return [change["filename"] for change in fetch_pr_data(pr_number, repo, "files")]
 
 def get_output(command, shell=True):
 	print(command)
 	command = shlex.split(command)
 	return subprocess.check_output(command, shell=shell, encoding="utf8").strip()
+
+def has_skip_ci_label(pr_number, repo="frappe/frappe"):
+	return any([label["name"] for label in fetch_pr_data(pr_number, repo, "")["labels"] if label["name"] == "Skip CI"])
 
 def is_py(file):
 	return file.endswith("py")
@@ -59,6 +69,10 @@ if __name__ == "__main__":
 	if ci_files_changed:
 		print("CI related files were updated, running all build processes.")
 
+	elif has_skip_ci_label(pr_number, repo):
+		print("Found `Skip CI` label on pr, stopping build process.")
+		sys.exit(0)
+
 	elif only_docs_changed:
 		print("Only docs were updated, stopping build process.")
 		sys.exit(0)
@@ -67,12 +81,8 @@ if __name__ == "__main__":
 		print("Only Frontend code was updated; Stopping Python build process.")
 		sys.exit(0)
 
-	elif build_type == "ui":
-		if only_py_changed:
-			print("Only Python code was updated, stopping Cypress build process.")
-			sys.exit(0)
-		elif updated_py_file_count > 0:
-			# both frontend and backend code were updated
-			os.system('echo "::set-output name=build-server::strawberry"')
+	elif build_type == "ui" and only_py_changed:
+		print("Only Python code was updated, stopping Cypress build process.")
+		sys.exit(0)
 
 	os.system('echo "::set-output name=build::strawberry"')


### PR DESCRIPTION
This pr provides the option of not running ci by using `Skip CI` label (added the label as well :P).

This helps in cases like when we do some minor "commenting" or just remove unnecessary/non-used imports for which we don't want to run the ci - but still want others to have a look (without pushing directly to branches)