### PR TITLE
fix: add dependent status field in reportview

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -809,7 +809,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 	add_status_dependency_column(col, doctype) {
 		// Adds dependent column from which status is derived if required
-		if (!this.fields.find(f => f[0] === col)) {
+		if (col && !this.fields.find(f => f[0] === col)) {
 			const field = [col, doctype];
 			this.fields.push(field);
 			this.refresh();
@@ -1157,12 +1157,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				// get status from docstatus
 				let status = frappe.get_indicator(d, this.doctype);
 				if (status) {
-					if (!status[0]) {
-						// get_indicator returns the dependent field's condition as the 3rd parameter
-						let dependent_col = status[2].split(',')[0];
-						// add status dependency column
-						this.add_status_dependency_column(dependent_col, this.doctype);
-					}
+					// get_indicator returns the dependent field's condition as the 3rd parameter
+					let dependent_col = status[2]?.split(',')[0];
+					// add status dependency column
+					this.add_status_dependency_column(dependent_col, this.doctype);
 					return {
 						name: d.name,
 						doctype: col.docfield.parent,


### PR DESCRIPTION
This PR fixes report view for status fields which are dynamically computed from indicator. 

This was handled already before: https://github.com/frappe/frappe/pull/9278 

The problem is the previous PR required status to be empty, while some indicators will just fall back to the default value when it's not found OR just not return any indicator. So `enabled` field reportview column just shows "disabled" for every row if `enabled` column isn't selected. 

Solution: Always check status indicator's last field regardless of returned value. If it's already found in field list then nothing is done anyway. 


Before:

<img width="1224" alt="Screenshot 2022-05-16 at 11 57 52 AM" src="https://user-images.githubusercontent.com/9079960/168532711-e67b9546-5c0f-4266-938f-55ad893806a0.png">

<img width="1224" alt="Screenshot 2022-05-16 at 11 58 11 AM" src="https://user-images.githubusercontent.com/9079960/168532729-c9c9d53d-06dd-4fda-80ca-c08f93ce545c.png">



After:

<img width="1286" alt="Screenshot 2022-05-16 at 11 58 22 AM" src="https://user-images.githubusercontent.com/9079960/168532745-74eb2dce-950f-419f-bd66-18fe51b6015d.png">
