### PR TITLE
feat: Add URL Title while uploading links

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -390,7 +390,7 @@ export default {
 		},
 		upload_via_web_link() {
 			let file_url = this.$refs.web_link.url;
-			let file_name = this.$refs.web_link.url_title;
+			let file_name = this.$refs.web_link.file_name;
 			if (!file_url) {
 				frappe.msgprint(__('Invalid URL'));
 				this.close_dialog = true;

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -390,6 +390,7 @@ export default {
 		},
 		upload_via_web_link() {
 			let file_url = this.$refs.web_link.url;
+			let file_name = this.$refs.web_link.url_title;
 			if (!file_url) {
 				frappe.msgprint(__('Invalid URL'));
 				this.close_dialog = true;
@@ -398,7 +399,8 @@ export default {
 			file_url = decodeURI(file_url)
 			this.close_dialog = true;
 			return this.upload_file({
-				file_url
+				file_url,
+				file_name
 			});
 		},
 		return_as_dataurl() {

--- a/frappe/public/js/frappe/file_uploader/WebLink.vue
+++ b/frappe/public/js/frappe/file_uploader/WebLink.vue
@@ -13,6 +13,14 @@
 				v-model="url"
 			>
 		</div>
+		<div class="input-group">
+			<input
+				type="text"
+				class="form-control"
+				:placeholder="__('URL Title')"
+				v-model="url_title"
+			>
+		</div>
 	</div>
 </template>
 <script>
@@ -21,6 +29,7 @@ export default {
 	data() {
 		return {
 			url: '',
+			url_title: ''
 		}
 	}
 }

--- a/frappe/public/js/frappe/file_uploader/WebLink.vue
+++ b/frappe/public/js/frappe/file_uploader/WebLink.vue
@@ -17,7 +17,7 @@
 			<input
 				type="text"
 				class="form-control"
-				:placeholder="__('URL Title')"
+				:placeholder="__('File Name')"
 				v-model="url_title"
 			>
 		</div>

--- a/frappe/public/js/frappe/file_uploader/WebLink.vue
+++ b/frappe/public/js/frappe/file_uploader/WebLink.vue
@@ -18,7 +18,7 @@
 				type="text"
 				class="form-control"
 				:placeholder="__('File Name')"
-				v-model="url_title"
+				v-model="file_name"
 			>
 		</div>
 	</div>
@@ -29,7 +29,7 @@ export default {
 	data() {
 		return {
 			url: '',
-			url_title: ''
+			file_name: ''
 		}
 	}
 }


### PR DESCRIPTION
By default when you attach a link it set the name of the file as the long URL, which is not very useful 

<img width="633" alt="image" src="https://user-images.githubusercontent.com/7881486/168614007-bd660567-eb45-4927-bd33-258537877f26.png">

<img width="463" alt="image" src="https://user-images.githubusercontent.com/7881486/168613918-51e6e751-85c2-4ecf-b9a6-1381fc837f40.png">

It would be very helpful if we are able to set a human readable title

<img width="617" alt="image" src="https://user-images.githubusercontent.com/7881486/168614249-d9c7dec4-34ac-4801-8c56-eb7f60f65cc4.png">
<img width="259" alt="image" src="https://user-images.githubusercontent.com/7881486/168614781-7b24867e-c400-4ab3-aae0-c6254ff8b403.png">

If we choose not to set any title. It will fallback to the default behaviour

docs: `no-docs`