### PR TITLE
feat: translate links to Module Def, Role Profile, Module Profile, and User Type

### DIFF
--- a/frappe/core/doctype/module_def/module_def.json
+++ b/frappe/core/doctype/module_def/module_def.json
@@ -123,7 +123,7 @@
    "link_fieldname": "module"
   }
  ],
- "modified": "2022-01-03 13:56:52.817954",
+ "modified": "2022-05-16 15:59:22.030007",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Module Def",
@@ -162,5 +162,6 @@
  "sort_field": "modified",
  "sort_order": "ASC",
  "states": [],
- "track_changes": 1
+ "track_changes": 1,
+ "translate_link_fields": 1
 }

--- a/frappe/core/doctype/module_profile/module_profile.json
+++ b/frappe/core/doctype/module_profile/module_profile.json
@@ -40,7 +40,7 @@
    "link_fieldname": "module_profile"
   }
  ],
- "modified": "2021-12-03 15:47:21.296443",
+ "modified": "2022-05-16 16:03:55.036420",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Module Profile",
@@ -62,5 +62,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "track_changes": 1
+ "states": [],
+ "track_changes": 1,
+ "translate_link_fields": 1
 }

--- a/frappe/core/doctype/role_profile/role_profile.json
+++ b/frappe/core/doctype/role_profile/role_profile.json
@@ -42,7 +42,7 @@
    "link_fieldname": "role_profile_name"
   }
  ],
- "modified": "2021-12-03 15:45:45.270963",
+ "modified": "2022-05-16 16:04:14.555142",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Role Profile",
@@ -75,6 +75,8 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "role_profile",
- "track_changes": 1
+ "track_changes": 1,
+ "translate_link_fields": 1
 }

--- a/frappe/core/doctype/user_type/user_type.json
+++ b/frappe/core/doctype/user_type/user_type.json
@@ -107,10 +107,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-03-12 16:25:18.639050",
+ "modified": "2022-05-16 16:09:21.746568",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Type",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -137,5 +138,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "track_changes": 1
+ "states": [],
+ "track_changes": 1,
+ "translate_link_fields": 1
 }

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -368,4 +368,4 @@ global_search_doctypes = {
 	]
 }
 
-translated_search_doctypes = ["DocType", "Role", "Country", "Gender", "Salutation"]
+translated_search_doctypes = ["Module Def", "DocType", "Role", "Country", "Gender", "Salutation"]

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -368,4 +368,12 @@ global_search_doctypes = {
 	]
 }
 
-translated_search_doctypes = ["Module Def", "DocType", "Role", "Country", "Gender", "Salutation"]
+translated_search_doctypes = [
+	"Module Def",
+	"DocType",
+	"Role",
+	"Role Profile",
+	"Country",
+	"Gender",
+	"Salutation",
+]

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -373,6 +373,7 @@ translated_search_doctypes = [
 	"DocType",
 	"Role",
 	"Role Profile",
+	"Module Profile",
 	"Country",
 	"Gender",
 	"Salutation",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -371,6 +371,7 @@ global_search_doctypes = {
 translated_search_doctypes = [
 	"Module Def",
 	"DocType",
+	"User Type",
 	"Role",
 	"Role Profile",
 	"Module Profile",


### PR DESCRIPTION
Users will only see translated values in Link fields to these DocTypes.

Reason for selection: there is a low and limited number of records for these DocTypes, so live translation during search doesn't hurt the performance.

Based on #15451

> no-docs