### PR TITLE
fix: allow guests/users without desk access to upload text files

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -25,6 +25,7 @@ ALLOWED_MIMETYPES = (
 	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 	"application/vnd.oasis.opendocument.text",
 	"application/vnd.oasis.opendocument.spreadsheet",
+	"text/plain",
 )
 
 
@@ -202,7 +203,7 @@ def upload_file():
 	if not file_url and (frappe.session.user == "Guest" or (user and not user.has_desk_access())):
 		filetype = guess_type(filename)[0]
 		if filetype not in ALLOWED_MIMETYPES:
-			frappe.throw(_("You can only upload JPG, PNG, PDF, or Microsoft documents."))
+			frappe.throw(_("You can only upload JPG, PNG, PDF, Text or Microsoft documents."))
 
 	if method:
 		method = frappe.get_attr(method)

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -203,7 +203,7 @@ def upload_file():
 	if not file_url and (frappe.session.user == "Guest" or (user and not user.has_desk_access())):
 		filetype = guess_type(filename)[0]
 		if filetype not in ALLOWED_MIMETYPES:
-			frappe.throw(_("You can only upload JPG, PNG, PDF, Text or Microsoft documents."))
+			frappe.throw(_("You can only upload JPG, PNG, PDF, TXT or Microsoft documents."))
 
 	if method:
 		method = frappe.get_attr(method)


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/16882

This pr allows users who don't have desk access or are Guests to upload text/log files (if they've been allowed to do so)

mimetypes of text and log files:
![Screenshot 2022-05-18 at 10 45 14 AM](https://user-images.githubusercontent.com/32034600/168962377-9b9ceab4-608a-43d1-9ea1-10b57c1cddc5.png)