### PR TITLE
fix: Check if email account exists before picking signature

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -764,17 +764,23 @@ frappe.views.CommunicationComposer = class {
 				filters['default_outgoing'] = 1;
 			}
 
-			const email = await frappe.db.get_list("Email Account", {
+			const email_accounts = await frappe.db.get_list("Email Account", {
 				filters: filters,
 				fields: ['signature', 'email_id'],
 				limit: 1
 			});
 
-			signature = email && email[0].signature;
+			let filtered_email = null;
+			if (email_accounts.length) {
+				signature = email_accounts[0].signature;
+				filtered_email = email_accounts[0].email_id;
+			}
 
-			if (this.user_email_accounts &&
-				this.user_email_accounts.includes(email[0].email_id)) {
-				this.dialog.set_value('sender', email[0].email_id);
+			if (!sender_email && filtered_email) {
+				if (this.user_email_accounts &&
+					this.user_email_accounts.includes(filtered_email)) {
+					this.dialog.set_value('sender', filtered_email);
+				}
 			}
 		}
 


### PR DESCRIPTION
Email Dialog used to fail with the following error if no "Default Outgoing Email" was set up.

```
communication.js:773 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'signature')
    at frappe.views.CommunicationComposer.get_signature (communication.js:773:34)
    at async frappe.views.CommunicationComposer.set_content (communication.js:744:14)
    at async frappe.views.CommunicationComposer.set_values (communication.js:355:3)
```
- Due to this failure other functionality like setting the default email template was also not working.

**Before:**
<img width="1425" alt="Screenshot 2022-05-18 at 2 15 20 PM" src="https://user-images.githubusercontent.com/13928957/168997517-4f936321-d97f-4cda-b21f-7a84724ece2c.png">

**After:** (Default email template got set as expected)
<img width="1440" alt="Screenshot 2022-05-18 at 2 19 50 PM" src="https://user-images.githubusercontent.com/13928957/168998480-49b2789a-8a20-46a4-832f-c747ed6f8466.png">


---
This issue was introduced via https://github.com/frappe/frappe/pull/16507