### PR TITLE
fix: remove old test runner doc

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -111,7 +111,7 @@ frappe.patches.v11_0.make_all_prepared_report_attachments_private #2019-11-26
 frappe.patches.v12_0.setup_email_linking
 frappe.patches.v12_0.change_existing_dashboard_chart_filters
 frappe.patches.v12_0.set_correct_assign_value_in_docs #2020-07-13
-execute:frappe.delete_doc("Test Runner")
+execute:frappe.delete_doc('DocType', 'Test Runner') # 2022-05-19
 execute:frappe.delete_doc_if_exists('DocType', 'Google Maps Settings')
 execute:frappe.db.set_default('desktop:home_page', 'workspace')
 execute:frappe.delete_doc_if_exists('DocType', 'GSuite Settings')


### PR DESCRIPTION
```
Installing education...
Updating DocTypes for education     : [========================================] 100%
An error occurred while installing education: Module import failed for Test Runner (frappe.core.doctype.test_runner.test_runner Error: No module named 'frappe.core.doctype.test_runner')
Traceback (most recent call last):
  File "apps/frappe/frappe/modules/utils.py", line 235, in load_doctype_module
    doctype_python_modules[key] = frappe.get_module(module_name)
  File "apps/frappe/frappe/__init__.py", line 1246, in get_module
    return importlib.import_module(modulename)
  File "/home/frappe/.pyenv/versions/3.9.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'frappe.core.doctype.test_runner'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "apps/frappe/frappe/commands/site.py", line 417, in install_app
    _install_app(app, verbose=context.verbose, force=force)
  File "apps/frappe/frappe/installer.py", line 281, in install_app
    add_to_installed_apps(name)
  File "apps/frappe/frappe/installer.py", line 308, in add_to_installed_apps
    post_install(rebuild_website)
  File "apps/frappe/frappe/installer.py", line 461, in post_install
    init_singles()
  File "apps/frappe/frappe/installer.py", line 479, in init_singles
    doc = frappe.new_doc(single)
  File "apps/frappe/frappe/__init__.py", line 1006, in new_doc
    return get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
  File "apps/frappe/frappe/model/create_new.py", line 22, in get_new_doc
    frappe.local.new_doc_templates[doctype] = make_new_doc(doctype)
  File "apps/frappe/frappe/model/create_new.py", line 37, in make_new_doc
    doc = frappe.get_doc(
  File "apps/frappe/frappe/__init__.py", line 1108, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 72, in get_doc
    controller = get_controller(doctype)
  File "apps/frappe/frappe/model/base_document.py", line 84, in get_controller
    site_controllers[doctype] = _get_controller()
  File "apps/frappe/frappe/model/base_document.py", line 66, in _get_controller
    module = load_doctype_module(doctype, module_name)
  File "apps/frappe/frappe/modules/utils.py", line 237, in load_doctype_module
    raise ImportError(
ImportError: Module import failed for Test Runner (frappe.core.doctype.test_runner.test_runner Error: No module named 'frappe.core.doctype.test_runner')```
```
This doctype used to exist a long time ago, so this error only occurs on old sites. ref: https://github.com/frappe/frappe/blob/25ad8ef16ce7f95ae80f49961bd1cac8be092916/frappe/core/doctype/test_runner/test_runner.js 



closes https://github.com/frappe/frappe/issues/16917
