### PR TITLE
fix: ensure directories with full stops aren't mistaken for extensions

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -574,7 +574,7 @@ class ImportFile:
 	######
 
 	def read_file(self, file_path):
-		extn = file_path.split(".")[1]
+		extn = os.path.splitext(file_path)[1][1:]
 
 		file_content = None
 		with io.open(file_path, mode="rb") as f:


### PR DESCRIPTION
### Problem

Data Import reads file paths containing full stops incorrectly, impeding functionality.

### Fix

Use `os.path.splitext` to return the correct extension every time. `os` module is already conveniently used elsewhere.


### Examples

Current functionality:

```
>>> file_path = '/sites/example.com/files/accounts.xlsx'
>>> extn = file_path.split(".")[1]
>>> print(extn)
com/files/accounts
```

Proposed fix:

```
>>> file_path = '/sites/example.com/files/accounts.xlsx'
>>> extn = os.path.splitext(file_path)[1][1:]
>>> print(extn)
xlsx
```