### PR TITLE
fix: use reference to form instead of global var

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1370,7 +1370,7 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 		for (var i=0, l=fnames.length; i<l; i++) {
 			var fieldname = fnames[i];
-			var field = frappe.meta.get_docfield(cur_frm.doctype, fieldname, this.docname);
+			var field = frappe.meta.get_docfield(this.doctype, fieldname, this.docname);
 			if(field) {
 				fn(field);
 				this.refresh_field(fieldname);


### PR DESCRIPTION
If you navigate away while some computation was going on in async manner
this reference becomes null and fails.

Difficult to replicate reliably, but if you want to try.

1. Throttle CPU/Network to max
2. Go to sales invoice and add a item
3. Move away to page which doesn't have cur_frm reference, like print
   view.


`cur_frm` is assigned to the current form here:

https://github.com/frappe/frappe/blob/fcb9597f88acea0367f1c856747eb9ab679c1d0b/frappe/public/js/frappe/form/form.js#L350 

Traceback:

```
TypeError: Cannot read properties of null (reading 'doctype')
  at frappe.ui.form.Form.field_map(../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:1373:49)
  at frappe.ui.form.Form.toggle_display(../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:1431:8)
  at frappe.ui.form.Form.cleanup_refresh(../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:644:9)
  at frappe.ui.form.Form.refresh_fields(../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:613:8)
  at frappe.ui.form.Controller.calculate_taxes_and_totals(../../../../../apps/erpnext/erpnext/public/js/controllers/taxes_and_totals.js:70:12)
```