### PR TITLE
feat: UI for document queued action

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -130,6 +130,7 @@ def get_docinfo(doc=None, doctype=None, name=None):
 			"is_document_followed": is_document_followed(doc.doctype, doc.name, frappe.session.user),
 			"tags": get_tags(doc.doctype, doc.name),
 			"document_email": get_document_email(doc.doctype, doc.name),
+			"queued_action": get_queued_action(doc),
 		}
 	)
 
@@ -486,6 +487,10 @@ def send_link_titles(link_titles):
 		frappe.local.response["_link_titles"] = {}
 
 	frappe.local.response["_link_titles"].update(link_titles)
+
+
+def get_queued_action(doc):
+	return doc.get_queued_action()
 
 
 def update_user_info(docinfo):

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -130,7 +130,7 @@ def get_docinfo(doc=None, doctype=None, name=None):
 			"is_document_followed": is_document_followed(doc.doctype, doc.name, frappe.session.user),
 			"tags": get_tags(doc.doctype, doc.name),
 			"document_email": get_document_email(doc.doctype, doc.name),
-			"queued_action": get_queued_action(doc),
+			"queued_action": doc.get_queued_action(),
 		}
 	)
 
@@ -487,10 +487,6 @@ def send_link_titles(link_titles):
 		frappe.local.response["_link_titles"] = {}
 
 	frappe.local.response["_link_titles"].update(link_titles)
-
-
-def get_queued_action(doc):
-	return doc.get_queued_action()
 
 
 def update_user_info(docinfo):

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1847,16 +1847,13 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	cancel_queued_action_interval() {
-		console.log('asdf')
 		if (this.queued_action_interval) {
-			console.log('canceling queued action interval');
 			clearInterval(this.queued_action_interval);
 			this.queued_action_interval = null;
 		}
 	}
 
 	render_queued_action(queued_action) {
-		console.log('render queued action');
 		let $wrapper = this.layout.wrapper.find('.queued-action-message');
 		if (!$wrapper.length) {
 			$wrapper = $('<div class="queued-action-message form-message blue">');


### PR DESCRIPTION
There is a `Document.queue_action` method that enqueues document methods. There is no UI indication if a document method is running as a background job. This PR adds a UI for it.

<img width="1332" alt="image" src="https://user-images.githubusercontent.com/9355208/169525511-e99feac6-6918-43c3-b7ca-8e38c5e11151.png">

![document-queued-action](https://user-images.githubusercontent.com/9355208/169525829-57dca6e9-1476-4a7f-9394-cc7c4a89de4d.gif)

#### Also updated the message for TimestampMismatchError

**Before:**
Error: Document has been modified after you have opened it (2022-05-20 17:38:30.318657, 2022-05-20 17:35:42.384584). Please refresh to get the latest document

**After:**
Error: Document Team(frappe-cloud) has been modified after you have opened it (2022-05-20 17:38:30.318657, 2022-05-20 17:35:42.384584). Please refresh to get the latest document

<!-- no docs -->