### PR TITLE
perf: ~3x faster server side `_(translate)` calls

### DIFF
--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -132,6 +132,7 @@ class TestSearch(unittest.TestCase):
 	def test_link_search_in_foreign_language(self):
 		try:
 			frappe.local.lang = "fr"
+			frappe.local.lang_full_dict = None  # discard translation cache
 			search_widget(doctype="DocType", txt="pay", page_length=20)
 			output = frappe.response["values"]
 

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -29,11 +29,13 @@ class TestTranslate(unittest.TestCase):
 	def setUp(self):
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Guest")
+		frappe.local.lang_full_dict = None  # reset cached translations
 
 	def tearDown(self):
 		frappe.form_dict.pop("_lang", None)
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Administrator")
+		frappe.local.lang_full_dict = None  # reset cached translations
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -265,7 +265,7 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if getattr(frappe.local, "lang_full_dict", None) and frappe.local.lang_full_dict.get(lang, None):
+	if getattr(frappe.local, "lang_full_dict", None):
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)


### PR DESCRIPTION
Local caching of the merged translation dictionary was broken because it was attempting to find language code in the dictionary, which makes no sense because:
1. Language can't change during the same request. 
2. Dictionary is eng->translated string, why would it have language code in there?

before
```
In [1]: %timeit frappe._("Sales Invoice", lang="de")
7.54 µs ± 14.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

after
```
In [1]: %timeit frappe._("Sales Invoice", lang="de")
2.09 µs ± 7.11 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```