### PR TITLE
perf(translation): improve if condition to return all values except `None`

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -265,7 +265,7 @@ def get_full_dict(lang):
 		return {}
 
 	# found in local, return!
-	if getattr(frappe.local, "lang_full_dict", None):
+	if getattr(frappe.local, "lang_full_dict", None) is not None:
 		return frappe.local.lang_full_dict
 
 	frappe.local.lang_full_dict = load_lang(lang)


### PR DESCRIPTION
Improves #16949 

### Before


```python

In [3]: %timeit frappe._("Sales Invoice", "en")
9.33 µs ± 556 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)


```

### After

```python

In [3]: %timeit frappe._("Sales Invoice", "en")
2.79 µs ± 7.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

```