### PR TITLE
fix: return found items from duplicate btn check

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -513,7 +513,7 @@ frappe.ui.Page = class Page {
 		const item_selector = `${selector}[data-label='${encodeURIComponent(label)}']`;
 
 		const existing_items = $(parent).find(item_selector);
-		return existing_items?.length > 0;
+		return existing_items?.length > 0 && existing_items;
 	}
 
 	clear_btn_group(parent) {


### PR DESCRIPTION
Previous signature of this code used to return found items (despite what the innocent name suggests)

This breaks in some cases, identified by ERPNext's smoke tests: https://github.com/frappe/frappe/commit/fe8520a2bdd18dda3c1e23577a231124e8ac5a4d#r74289943 