### PR TITLE
fix: delete email queue first

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -11,9 +11,9 @@ from frappe.query_builder.functions import Now
 
 class LogSettings(Document):
 	def clear_logs(self):
+		self.clear_email_queue()
 		self.clear_error_logs()
 		self.clear_activity_logs()
-		self.clear_email_queue()
 
 	def clear_error_logs(self):
 		table = DocType("Error Log")


### PR DESCRIPTION
Steps to reproduce:
1. Open two console (each has it's own transaction, imagine these are two bg workers)
2. clear activity log from one console and try to insert new one from another one. 
3. Lock timeout occurs. 


During background job that removes old logs, email queue is deleted last and usually slowest to process, moving it to top resolves the issue of extended locks on log tables. 

Long term solution is planned: https://github.com/frappe/frappe/issues/16969 


```
------------
TRANSACTIONS
------------
Trx id counter 1636353
Purge done for trx's n:o < 1636352 undo n:o < 0 state: running
History list length 1
LIST OF TRANSACTIONS FOR EACH SESSION:
---TRANSACTION 1636352, ACTIVE 19 sec inserting
mysql tables in use 1, locked 1
LOCK WAIT 3 lock struct(s), heap size 1128, 2 row lock(s)
MariaDB thread id 471, OS thread handle 6139981824, query id 8910 localhost 127.0.0.1 _541daae9e38f203a Update
INSERT INTO `tabActivity Log` (`name`, `owner`, `creation`, `modified`, `modified_by`, `docstatus`, `idx`, `subject`, `content`, `communication_date`, `operation`, `status`, `reference_doctype`, `reference_name`, `reference_owner`, `timeline_doctype`, `timeline_name`, `link_doctype`, `link_name`, `user`, `full_name`)
                                        VALUES ('0e23c84461', 'Administrator', '2022-05-24 02:08:06.543682', '2022-05-24 02:08:06.543682', 'Administrator', '0', 0, 'shit', NULL, '2022-05-24 02:08:06.521051', '', 'Linked', 'Sales Invoice', 'SINV-22-00135', 'Administrator', 'Customer', '_Test Customer', NULL, NULL, '
Trx read view will not see trx with id >= 1636352, sees < 1636349
------- TRX HAS BEEN WAITING 7218341 ns FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 13293 page no 71 n bits 72 index PRIMARY of table `_541daae9e38f203a`.`tabactivity log` trx id 1636352 lock_mode X locks gap before rec insert intention waiting
Record lock, heap no 34 PHYSICAL RECORD: n_fields 28; compact format; info bits 32
 0: len 10; hex 30653237383166383736; asc 0e2781f876;;
 1: len 6; hex 00000018f7fd; asc       ;;
 2: len 7; hex 78000001810244; asc x     D;;
 3: len 8; hex 99ac9e38a809e056; asc    8   V;;
 4: len 8; hex 99ac9e38a809e056; asc    8   V;;
 5: len 13; hex 41646d696e6973747261746f72; asc Administrator;;
 6: len 13; hex 41646d696e6973747261746f72; asc Administrator;;
 7: len 4; hex 80000000; asc     ;;
 8: len 4; hex 80000000; asc     ;;
 9: len 14; hex 5465737420466f726d6174746564; asc Test Formatted;;
 10: SQL NULL;
 11: len 8; hex 99ac9e38a809e021; asc    8   !;;
 12: len 0; hex ; asc ;;
 13: len 6; hex 4c696e6b6564; asc Linked;;
 14: len 7; hex 446f6354797065; asc DocType;;
 15: len 14; hex 5465737420466f726d6174746564; asc Test Formatted;;
 16: len 13; hex 41646d696e6973747261746f72; asc Administrator;;
 17: SQL NULL;
 18: SQL NULL;
 19: SQL NULL;
 20: SQL NULL;
 21: len 13; hex 41646d696e6973747261746f72; asc Administrator;;
 22: len 13; hex 41646d696e6973747261746f72; asc Administrator;;
 23: SQL NULL;
 24: SQL NULL;
 25: SQL NULL;
 26: SQL NULL;
 27: SQL NULL;
```

