### PR TITLE
fix: email queue cleanup in pure SQL

### DIFF
--- a/frappe/email/doctype/email_queue/test_email_queue.py
+++ b/frappe/email/doctype/email_queue/test_email_queue.py
@@ -1,10 +1,41 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
 
-# test_records = frappe.get_test_records('Email Queue')
+import frappe
+from frappe.email.queue import clear_outbox
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEmailQueue(unittest.TestCase):
-	pass
+class TestEmailQueue(FrappeTestCase):
+	def test_email_queue_deletion_based_on_modified_date(self):
+		old_record = frappe.get_doc(
+			{
+				"doctype": "Email Queue",
+				"sender": "Test <test@example.com>",
+				"show_as_cc": "",
+				"message": "Test message",
+				"status": "Sent",
+				"priority": 1,
+				"recipients": [
+					{
+						"recipient": "test_auth@test.com",
+					}
+				],
+			}
+		).insert()
+
+		old_record.modified = "2010-01-01 00:00:01"
+		old_record.recipients[0].modified = old_record.modified
+		old_record.db_update_all()
+
+		new_record = frappe.copy_doc(old_record)
+		new_record.insert()
+
+		clear_outbox()
+
+		self.assertFalse(frappe.db.exists("Email Queue", old_record.name))
+		self.assertFalse(frappe.db.exists("Email Queue Recipient", {"parent": old_record.name}))
+
+		self.assertTrue(frappe.db.exists("Email Queue", new_record.name))
+		self.assertTrue(frappe.db.exists("Email Queue Recipient", {"parent": new_record.name}))


### PR DESCRIPTION
Currently, this background job constantly fails because of the way query
is written:

1. It tries to find all docs to delete using select query
2. Deletes them by using `in query` with a HUGE amount of docs
3. Deletes child table with parent, again using `IN` query with huge
   amount of docs.

This times out and never finishes on old sites.

Solution:

1. Modified deletion to straightaway delete all main table rows that are
   older
2. Apply same deletion logic to child table rows.


Tested on very old site, both queries finished in <30 seconds for ALL old rows. Newer ones will be significantly faster since it runs every day, only the first failure due to large old data was important to cleanup. 

PS: This has the potential to leave some orphan child table rows behind for a few more days iff the modified time was later than the parent doc (this is quite rare). But it's safe since the child table doesn't contain "links" anyway.


ref #16971 (don't close the issue yet, v13 has different problems with activity log cleanup)