### PR TITLE
fix: hide slideshow if page builder is selected

### DIFF
--- a/frappe/website/doctype/web_page/web_page.json
+++ b/frappe/website/doctype/web_page/web_page.json
@@ -75,6 +75,7 @@
    "unique": 1
   },
   {
+   "depends_on": "eval: doc.content_type !== 'Page Builder'",
    "fieldname": "slideshow",
    "fieldtype": "Link",
    "label": "Slideshow",
@@ -313,7 +314,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2022-03-09 01:45:28.548671",
+ "modified": "2022-05-24 14:12:07.015819",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Page",


### PR DESCRIPTION
Since Slideshow is not used when Page Builder is selected (we can add Sideshow inside Page Builder) making it hidden.
![SlideShowFix](https://user-images.githubusercontent.com/30859809/170035122-8f020918-00ae-4985-aff1-c24c792c7cb6.gif)

