### PR TITLE
fix: Prioritize report custom roles

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -89,7 +89,9 @@ class Report(Document):
 		]
 
 		custom_roles = get_custom_allowed_roles("report", self.name)
-		allowed.extend(custom_roles)
+
+		if custom_roles:
+			allowed = custom_roles
 
 		if not allowed:
 			return True

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -189,7 +189,7 @@ class TestReport(FrappeTestCase):
 	def test_report_custom_permissions(self):
 		frappe.set_user("test@example.com")
 		frappe.db.delete("Custom Role", {"report": "Test Custom Role Report"})
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep
 		if not frappe.db.exists("Report", "Test Custom Role Report"):
 			report = frappe.get_doc(
 				{
@@ -206,7 +206,7 @@ class TestReport(FrappeTestCase):
 
 		self.assertEqual(report.is_permitted(), True)
 
-		custom_role = frappe.get_doc(
+		frappe.get_doc(
 			{
 				"doctype": "Custom Role",
 				"report": "Test Custom Role Report",

--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -186,6 +186,38 @@ class TestReport(FrappeTestCase):
 		self.assertNotEqual(report.is_permitted(), True)
 		frappe.set_user("Administrator")
 
+	def test_report_custom_permissions(self):
+		frappe.set_user("test@example.com")
+		frappe.db.delete("Custom Role", {"report": "Test Custom Role Report"})
+		frappe.db.commit()
+		if not frappe.db.exists("Report", "Test Custom Role Report"):
+			report = frappe.get_doc(
+				{
+					"doctype": "Report",
+					"ref_doctype": "User",
+					"report_name": "Test Custom Role Report",
+					"report_type": "Query Report",
+					"is_standard": "No",
+					"roles": [{"role": "_Test Role"}, {"role": "System Manager"}],
+				}
+			).insert(ignore_permissions=True)
+		else:
+			report = frappe.get_doc("Report", "Test Custom Role Report")
+
+		self.assertEqual(report.is_permitted(), True)
+
+		custom_role = frappe.get_doc(
+			{
+				"doctype": "Custom Role",
+				"report": "Test Custom Role Report",
+				"roles": [{"role": "_Test Role 2"}],
+				"ref_doctype": "User",
+			}
+		).insert(ignore_permissions=True)
+
+		self.assertNotEqual(report.is_permitted(), True)
+		frappe.set_user("Administrator")
+
 	# test for the `_format` method if report data doesn't have sort_by parameter
 	def test_format_method(self):
 		if frappe.db.exists("Report", "User Activity Report Without Sort"):


### PR DESCRIPTION
**Issue:** 
If any report (Gross Profit) has supposed **Accounts Manager** & **Accounts User** roles.
<img width="800" alt="image" src="https://user-images.githubusercontent.com/30859809/170039584-43839c14-89b3-4bb6-a0d5-f9e4dd026bb3.png">

Now if any User doesn't have **Accounts Manager** Role but has **Accounts User** Role. User will still have access to see the **Gross Profit** Report
<img width="839" alt="image" src="https://user-images.githubusercontent.com/30859809/170040199-80014ef3-42bc-47e9-b1dd-15f810ad5a8c.png">

Now go to **Role Permission for Page and Report** and remove **Accounts User** permission for **Gross Profit** Report. So that users with only **Accounts Manager** can access the report.
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/30859809/170040822-0f8664fb-8293-4ef8-86de-668d8e53bb0d.png">

Now since the user doesn't have an **Accounts Manager** role he/she should not be able to access the report but still, he/she is able to access the report.

**Before:**
<img width="1324" alt="image" src="https://user-images.githubusercontent.com/30859809/170042327-234cd546-7f1e-4eed-83c3-15a68788238f.png">


**After:**
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/30859809/170042558-32831cd5-0d4a-4d99-83d4-84099ed3ee72.png">

