### PR TITLE
fix: mention only users that can be read

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -348,7 +348,7 @@ def get_names_for_mentions(search_term):
 
 
 def get_users_for_mentions():
-	return frappe.get_all(
+	return frappe.get_list(
 		"User",
 		fields=["name as id", "full_name as value"],
 		filters={
@@ -361,7 +361,7 @@ def get_users_for_mentions():
 
 
 def get_user_groups():
-	return frappe.get_all(
+	return frappe.get_list(
 		"User Group", fields=["name as id", "name as value"], update={"is_group": True}
 	)
 


### PR DESCRIPTION
Full Name and Email ID of a **User** are sensitive data.

With **Role and User Permissions** we can restrict which other users a user can see, thus maintaining data protection. This could be circumvented by using the `@mention` functionality in comments. It allows us to see all users and their names, regardless of our permissions.

This PR aims to fix this issue by using `get_list` instead of `get_all` while retrieving options for `@mention`.