### PR TITLE
feat: Display button "Create User Email" only if current user can create an Email Account

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -194,14 +194,14 @@ frappe.ui.form.on('User', {
 				}
 			}
 		}
-		if (frm.doc.user_emails){
-			var found =0;
-			for (var i = 0;i<frm.doc.user_emails.length;i++){
-				if (frm.doc.email==frm.doc.user_emails[i].email_id){
+		if (frm.doc.user_emails && frappe.model.can_create("Email Account")) {
+			var found = 0;
+			for (var i = 0; i < frm.doc.user_emails.length; i++) {
+				if (frm.doc.email == frm.doc.user_emails[i].email_id) {
 					found = 1;
 				}
 			}
-			if (!found){
+			if (!found) {
 				frm.add_custom_button(__("Create User Email"), function() {
 					frm.events.create_user_email(frm);
 				});


### PR DESCRIPTION
Display button "Create User Email" only if current user has permissions to create an Email Account. If not, the button would fail, so no there's no use in showing it.

> no-docs