### PR TITLE
feat: delete User Permission when User is deleted

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -424,6 +424,9 @@ class User(Document):
 
 		frappe.cache().delete_key("enabled_users")
 
+		# delete user permissions
+		frappe.db.delete("User Permission", {"user": self.name})
+
 	def before_rename(self, old_name, new_name, merge=False):
 		frappe.clear_cache(user=old_name)
 		self.validate_rename(old_name, new_name)


### PR DESCRIPTION
Currently existing **User Permissions** prevents us from deleting a **User**.
-> If the **User** is gone, we no longer need the **User Permissions**. 

> no-docs