### PR TITLE
fix: allow All to select a User

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -722,7 +722,7 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2022-03-09 01:47:56.745069",
+ "modified": "2022-05-25 01:00:51.345319",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",
@@ -747,6 +747,10 @@
    "read": 1,
    "role": "System Manager",
    "write": 1
+  },
+  {
+   "role": "All",
+   "select": 1
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
A link field is used to select a **User** on

- the profile page "switch user" dialog, and
- on the sidebar "assign to" and "share with" dialogs

Not sure why, but **User Permissions** restricting to a subset of users didn't take effect. By adding the "Select" Role Permission, **User Permissions** on **User** will take effect.

Edit: I suspect that the cause of the problem may be along these lines. The first `if`-condition was true, so the `else`-block was not executed and user perms were not getting added to the query. By adding the "Select" role permission, the `else`-block now gets executed. 🤔 
 https://github.com/frappe/frappe/blob/576af52ec6039beb344388030112ad3de6f6d2d9/frappe/model/db_query.py#L686-L709