### PR TITLE
Fix: Change currency fraction for Singapore from Sen to Cent

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2412,7 +2412,7 @@
  "Singapore": {
   "code": "sg",
   "currency": "SGD",
-  "currency_fraction": "Sen",
+  "currency_fraction": "Cent",
   "currency_fraction_units": 100,
   "currency_name": "Singapore Dollar",
   "currency_symbol": "$",


### PR DESCRIPTION
The currency_fraction value for Singapore Dollars is set to Sen, which is incorrect. According to [Wikipedia](https://en.wikipedia.org/wiki/Singapore_dollar), it should be Cent.

This PR fixes this in the develop branch but should be applied in other branches as well.