### PR TITLE
test: fix newsletter tests setup due to duplicate entry of email group member for postgres

### DIFF
--- a/frappe/email/doctype/newsletter/test_newsletter.py
+++ b/frappe/email/doctype/newsletter/test_newsletter.py
@@ -1,13 +1,11 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See LICENSE
 
-import unittest
 from random import choice
 from typing import Union
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import frappe
-from frappe.desk.form.load import run_onload
 from frappe.email.doctype.newsletter.exceptions import (
 	NewsletterAlreadySentError,
 	NoRecipientFoundError,
@@ -18,9 +16,9 @@ from frappe.email.doctype.newsletter.newsletter import (
 	send_scheduled_email,
 )
 from frappe.email.queue import flush
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, getdate
 
-test_dependencies = ["Email Group"]
 emails = [
 	"test_subscriber1@example.com",
 	"test_subscriber2@example.com",
@@ -64,6 +62,10 @@ class TestNewsletterMixin:
 		for email in emails:
 			doctype = "Email Group Member"
 			email_filters = {"email": email, "email_group": "_Test Email Group"}
+
+			savepoint = "setup_email_group"
+			frappe.db.savepoint(savepoint)
+
 			try:
 				frappe.get_doc(
 					{
@@ -72,7 +74,10 @@ class TestNewsletterMixin:
 					}
 				).insert()
 			except Exception:
+				frappe.db.rollback(save_point=savepoint)
 				frappe.db.update(doctype, email_filters, "unsubscribed", 0)
+
+			frappe.db.release_savepoint(savepoint)
 
 	def send_newsletter(self, published=0, schedule_send=None) -> Union[str, None]:
 		frappe.db.delete("Email Queue")
@@ -128,7 +133,7 @@ class TestNewsletterMixin:
 		return newsletter
 
 
-class TestNewsletter(TestNewsletterMixin, unittest.TestCase):
+class TestNewsletter(TestNewsletterMixin, FrappeTestCase):
 	def test_send(self):
 		self.send_newsletter()
 


### PR DESCRIPTION
This pr fixes the ci failures in newsletter tests due to duplicate emails in email group member.
ref: https://github.com/frappe/frappe/runs/6585728531?check_suite_focus=true#step:14:281

This was happening as postgres doesn't allow us to move forward in a transaction if any error occurs.