### PR TITLE
fix: Strip all spacing characters from Message-ID & In-Reply-To

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -12,9 +12,9 @@ from frappe.utils import (
 	cint,
 	get_datetime,
 	get_formatted_email,
+	get_string_between,
 	list_to_str,
 	split_emails,
-	strip_whitespace,
 	validate_email_address,
 )
 
@@ -153,7 +153,7 @@ def _make(
 			"reference_doctype": doctype,
 			"reference_name": name,
 			"email_template": email_template,
-			"message_id": strip_whitespace(get_message_id()).strip("<>"),
+			"message_id": get_string_between("<", get_message_id(), ">"),
 			"read_receipt": read_receipt,
 			"has_attachment": 1 if attachments else 0,
 			"communication_type": communication_type,

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -14,6 +14,7 @@ from frappe.utils import (
 	get_formatted_email,
 	list_to_str,
 	split_emails,
+	strip_whitespace,
 	validate_email_address,
 )
 
@@ -152,7 +153,7 @@ def _make(
 			"reference_doctype": doctype,
 			"reference_name": name,
 			"email_template": email_template,
-			"message_id": get_message_id().strip(" <>"),
+			"message_id": strip_whitespace(get_message_id()).strip("<>"),
 			"read_receipt": read_receipt,
 			"has_attachment": 1 if attachments else 0,
 			"communication_type": communication_type,

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -284,7 +284,7 @@ class TestEmailAccount(unittest.TestCase):
 			messages = {
 				# append_to = ToDo
 				'"INBOX"': {
-					"latest_messages": [f.read().replace("{{ message_id }}", last_mail.message_id)],
+					"latest_messages": [f.read().replace("{{ message_id }}", "<" + last_mail.message_id + ">")],
 					"seen_status": {2: "UNSEEN"},
 					"uid_list": [2],
 				}

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -19,7 +19,15 @@ from frappe.email.email_body import add_attachment, get_email, get_formatted_htm
 from frappe.email.queue import get_unsubcribed_url, get_unsubscribe_message
 from frappe.model.document import Document
 from frappe.query_builder.utils import DocType
-from frappe.utils import add_days, cint, cstr, get_hook_method, nowdate, split_emails
+from frappe.utils import (
+	add_days,
+	cint,
+	cstr,
+	get_hook_method,
+	nowdate,
+	split_emails,
+	strip_whitespace,
+)
 
 MAX_RETRY_COUNT = 3
 
@@ -635,7 +643,7 @@ class QueueBuilder:
 		d = {
 			"priority": self.send_priority,
 			"attachments": json.dumps(self.get_attachments()),
-			"message_id": mail.msg_root["Message-Id"].strip(" <>"),
+			"message_id": strip_whitespace(mail.msg_root["Message-Id"]).strip("<>"),
 			"message": mail_to_string,
 			"sender": self.sender,
 			"reference_doctype": self.reference_doctype,

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -24,9 +24,9 @@ from frappe.utils import (
 	cint,
 	cstr,
 	get_hook_method,
+	get_string_between,
 	nowdate,
 	split_emails,
-	strip_whitespace,
 )
 
 MAX_RETRY_COUNT = 3
@@ -643,7 +643,7 @@ class QueueBuilder:
 		d = {
 			"priority": self.send_priority,
 			"attachments": json.dumps(self.get_attachments()),
-			"message_id": strip_whitespace(mail.msg_root["Message-Id"]).strip("<>"),
+			"message_id": get_string_between("<", mail.msg_root["Message-Id"], ">"),
 			"message": mail_to_string,
 			"sender": self.sender,
 			"reference_doctype": self.reference_doctype,

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -425,7 +425,7 @@ class Email:
 		self.set_content_and_type()
 		self.set_subject()
 		self.set_from()
-		self.message_id = (self.mail.get("Message-ID") or "").strip(" <>")
+		self.message_id = (self.mail.get("Message-ID") or "").strip("\n\r\t <>")
 
 		if self.mail["Date"]:
 			try:
@@ -441,7 +441,7 @@ class Email:
 
 	@property
 	def in_reply_to(self):
-		return (self.mail.get("In-Reply-To") or "").strip(" <>")
+		return (self.mail.get("In-Reply-To") or "").strip("\n\r\t <>")
 
 	def parse(self):
 		"""Walk and process multi-part email."""

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -25,12 +25,12 @@ from frappe.utils import (
 	cstr,
 	extract_email_id,
 	get_datetime,
+	get_string_between,
 	markdown,
 	now,
 	parse_addr,
 	sanitize_html,
 	strip,
-	strip_whitespace,
 )
 from frappe.utils.html_utils import clean_email_html
 from frappe.utils.user import is_system_user
@@ -428,7 +428,7 @@ class Email:
 		self.set_from()
 
 		message_id = self.mail.get("Message-ID") or ""
-		self.message_id = strip_whitespace(message_id).strip("<>")
+		self.message_id = get_string_between("<", message_id, ">")
 
 		if self.mail["Date"]:
 			try:
@@ -445,7 +445,7 @@ class Email:
 	@property
 	def in_reply_to(self):
 		in_reply_to = self.mail.get("In-Reply-To") or ""
-		return strip_whitespace(in_reply_to).strip("<>")
+		return get_string_between("<", in_reply_to, ">")
 
 	def parse(self):
 		"""Walk and process multi-part email."""

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -30,6 +30,7 @@ from frappe.utils import (
 	parse_addr,
 	sanitize_html,
 	strip,
+	strip_whitespace,
 )
 from frappe.utils.html_utils import clean_email_html
 from frappe.utils.user import is_system_user
@@ -425,7 +426,9 @@ class Email:
 		self.set_content_and_type()
 		self.set_subject()
 		self.set_from()
-		self.message_id = (self.mail.get("Message-ID") or "").strip("\n\r\t <>")
+
+		message_id = self.mail.get("Message-ID") or ""
+		self.message_id = strip_whitespace(message_id).strip("<>")
 
 		if self.mail["Date"]:
 			try:
@@ -441,7 +444,8 @@ class Email:
 
 	@property
 	def in_reply_to(self):
-		return (self.mail.get("In-Reply-To") or "").strip("\n\r\t <>")
+		in_reply_to = self.mail.get("In-Reply-To") or ""
+		return strip_whitespace(in_reply_to).strip("<>")
 
 	def parse(self):
 		"""Walk and process multi-part email."""

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1887,15 +1887,14 @@ def strip(val: str, chars: Optional[str] = None) -> str:
 	return (val or "").replace("\ufeff", "").replace("\u200b", "").strip(chars)
 
 
-def strip_whitespace(input_string: str) -> str:
-	import string
+def get_string_between(start: str, string: str, end: str) -> str:
+	if not string:
+		return ""
 
-	new_string = ""
-	for character in input_string:
-		if character not in string.whitespace:
-			new_string = new_string + character
+	regex = "{0}(.*){1}".format(start, end)
+	out = re.search(regex, string)
 
-	return new_string
+	return out.group(1) if out else ""
 
 
 def to_markdown(html: str) -> str:

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1894,7 +1894,7 @@ def get_string_between(start: str, string: str, end: str) -> str:
 	regex = "{0}(.*){1}".format(start, end)
 	out = re.search(regex, string)
 
-	return out.group(1) if out else ""
+	return out.group(1) if out else string
 
 
 def to_markdown(html: str) -> str:

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1887,6 +1887,17 @@ def strip(val: str, chars: Optional[str] = None) -> str:
 	return (val or "").replace("\ufeff", "").replace("\u200b", "").strip(chars)
 
 
+def strip_whitespace(input_string: str) -> str:
+	import string
+
+	new_string = ""
+	for character in input_string:
+		if character not in string.whitespace:
+			new_string = new_string + character
+
+	return new_string
+
+
 def to_markdown(html: str) -> str:
 	from html.parser import HTMLParser
 


### PR DESCRIPTION
Instead of removing characters (including <>) before **'<'** and after **'>'**  get string between **< & >** for **Message-ID** & **In-Reply-To** coming from email headers

Emails coming from any outlook emails has Message-ID in this format
<img width="812" alt="image" src="https://user-images.githubusercontent.com/30859809/170487806-d60fff1f-6756-4b2d-bf28-d7104ed8604d.png">

It is getting saved as
Before:
<img width="521" alt="image" src="https://user-images.githubusercontent.com/30859809/170487952-2e7f6942-e7ec-491c-9580-26dfbd70dce5.png">

After:
<img width="516" alt="image" src="https://user-images.githubusercontent.com/30859809/170488191-187ee2ef-52fc-44cd-9fc9-ffe1720ac391.png">
