### PR TITLE
feat: table_field.fieldname field syntax for db_query

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -171,7 +171,7 @@ def raise_invalid_field(fieldname):
 
 def is_standard(fieldname):
 	if "." in fieldname:
-		parenttype, fieldname = get_parenttype_and_fieldname(fieldname, None)
+		fieldname = fieldname.split(".")[1].strip("`")
 	return (
 		fieldname in default_fields or fieldname in optional_fields or fieldname in child_table_fields
 	)
@@ -235,7 +235,16 @@ def parse_json(data):
 
 def get_parenttype_and_fieldname(field, data):
 	if "." in field:
-		parenttype, fieldname = field.split(".")[0][4:-1], field.split(".")[1].strip("`")
+		parts = field.split(".")
+		parenttype = parts[0]
+		fieldname = parts[1]
+		if parenttype.startswith("`tab"):
+			# `tabChild DocType`.`fieldname`
+			parenttype = parenttype[4:-1]
+			fieldname = fieldname.strip("`")
+		else:
+			# tablefield.fieldname
+			parenttype = frappe.get_meta(data.doctype).get_field(parenttype).options
 	else:
 		parenttype = data.doctype
 		fieldname = field.strip("`")

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -34,6 +34,7 @@ class DatabaseQuery(object):
 	def __init__(self, doctype, user=None):
 		self.doctype = doctype
 		self.tables = []
+		self.link_tables = []
 		self.conditions = []
 		self.or_conditions = []
 		self.fields = None
@@ -131,7 +132,6 @@ class DatabaseQuery(object):
 		self.run = run
 		self.strict = strict
 		self.ignore_ddl = ignore_ddl
-		self.link_tables = []
 
 		# for contextual user permission check
 		# to determine which user permission is applicable on link field of specific doctype

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -51,6 +51,19 @@ class TestReportview(unittest.TestCase):
 		self.assertEqual(result[0].seen_by, "Administrator")
 		note.delete()
 
+	def test_link_field_syntax(self):
+		todo = frappe.get_doc(
+			doctype="ToDo", description=f"Test ToDo", allocated_to="Administrator"
+		).insert()
+		result = frappe.db.get_all(
+			"ToDo",
+			filters={"name": todo.name},
+			fields=["name", "allocated_to.email as allocated_user_email"],
+			limit=1,
+		)
+		self.assertEqual(result[0].allocated_user_email, "admin@example.com")
+		todo.delete()
+
 	def test_build_match_conditions(self):
 		clear_user_permissions_for_doctype("Blog Post", "test2@example.com")
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -53,7 +53,7 @@ class TestReportview(unittest.TestCase):
 
 	def test_link_field_syntax(self):
 		todo = frappe.get_doc(
-			doctype="ToDo", description=f"Test ToDo", allocated_to="Administrator"
+			doctype="ToDo", description="Test ToDo", allocated_to="Administrator"
 		).insert()
 		result = frappe.db.get_all(
 			"ToDo",

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -35,6 +35,22 @@ class TestReportview(unittest.TestCase):
 
 		clear_custom_fields("DocType")
 
+	def test_child_table_field_syntax(self):
+		note = frappe.get_doc(
+			doctype="Note",
+			title=f"Test {frappe.utils.random_string(8)}",
+			content="test",
+			seen_by=[{"user": "Administrator"}],
+		).insert()
+		result = frappe.db.get_all(
+			"Note",
+			filters={"name": note.name},
+			fields=["name", "seen_by.user as seen_by"],
+			limit=1,
+		)
+		self.assertEqual(result[0].seen_by, "Administrator")
+		note.delete()
+
 	def test_build_match_conditions(self):
 		clear_user_permissions_for_doctype("Blog Post", "test2@example.com")
 


### PR DESCRIPTION
```py
# Before
result = frappe.db.get_all('Note', fields=['name', '`tabNote Seen By`.`user` as seen_by'])

# After
result = frappe.db.get_all('Note', fields=['name', 'seen_by.user as seen_by'])

# result
[
  {'name': 'Test', 'seen_by': 'Administrator'},
  {'name': 'Test r2jkXux4', 'seen_by': 'Administrator'}
]
```

Edit: This now works for link fields as well.

```py
# Before
get_all doesn't support joining link tables

# After
result = frappe.db.get_all('ToDo', fields=['name', 'allocated_to.email as allocated_email'])

# result
[
  {'name': 'Test', 'allocated_email': 'admin@example.com'}
]
```


- [x] Test
- [x] Docs: https://frappeframework.com/compare?wiki_page=docs/v13/user/en/api/database&&compare=1ab07ce6d6