### PR TITLE
feat(website-settings): Configurable Splash Image

### DIFF
--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -21,6 +21,7 @@
   "website_theme_image_link",
   "brand",
   "banner_image",
+  "splash_image",
   "brand_html",
   "set_banner_from_image",
   "favicon",
@@ -413,6 +414,11 @@
    "fieldname": "footer_powered",
    "fieldtype": "Small Text",
    "label": "Footer \"Powered By\""
+  },
+  {
+   "fieldname": "splash_image",
+   "fieldtype": "Attach Image",
+   "label": "Splash Image"
   }
  ],
  "icon": "fa fa-cog",
@@ -420,7 +426,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-03-09 01:47:31.094462",
+ "modified": "2022-05-27 12:33:29.019998",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -136,7 +136,7 @@ def get_website_settings(context=None):
 		}
 	)
 
-	settings = frappe.get_single("Website Settings")
+	settings: "WebsiteSettings" = frappe.get_single("Website Settings")
 	for k in [
 		"banner_html",
 		"banner_image",
@@ -202,6 +202,8 @@ def get_website_settings(context=None):
 		context["favicon"] = settings.favicon
 
 	context["hide_login"] = settings.hide_login
+
+	context["splash_image"] = settings.splash_image or context["splash_image"]
 
 	return context
 

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -203,7 +203,8 @@ def get_website_settings(context=None):
 
 	context["hide_login"] = settings.hide_login
 
-	context["splash_image"] = settings.splash_image or context["splash_image"]
+	if splash_image := settings.splash_image or context.get("splash_image"):
+		context["splash_image"] = splash_image
 
 	return context
 


### PR DESCRIPTION
Configurable Splash Image option which will override an(y) app's splash_image hook set

<img width="1552" alt="Screenshot 2022-05-27 at 4 43 45 PM" src="https://user-images.githubusercontent.com/36654812/170689999-2245fb4d-83c0-4482-b95b-217945d195cc.png">

<img width="1552" alt="Screenshot 2022-05-27 at 4 50 35 PM" src="https://user-images.githubusercontent.com/36654812/170689952-458e98ae-ce71-4fa5-95d6-8bad58b5d061.png">
.
<!-- no-docs -->