### PR TITLE
refactor(qb): Term subqry renamed to SubQuery

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -15,7 +15,7 @@ from frappe.geo.country_info import get_all
 from frappe.model.base_document import get_controller
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
-from frappe.query_builder.terms import subqry
+from frappe.query_builder.terms import SubQuery
 from frappe.social.doctype.energy_point_log.energy_point_log import get_energy_points
 from frappe.social.doctype.energy_point_settings.energy_point_settings import (
 	is_energy_point_enabled,
@@ -211,7 +211,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			if parent == "Report":
 				has_role[p.name].update({"ref_doctype": p.ref_doctype})
 
-	no_of_roles = (
+	no_of_roles = SubQuery(
 		frappe.qb.from_(hasRole).select(Count("*")).where(hasRole.parent == parentTable.name)
 	)
 
@@ -221,7 +221,7 @@ def get_user_pages_or_reports(parent, cache=False):
 		pages_with_no_roles = (
 			frappe.qb.from_(parentTable)
 			.select(parentTable.name, parentTable.modified, *columns)
-			.where(subqry(no_of_roles) == 0)
+			.where(no_of_roles == 0)
 		).run(as_dict=True)
 
 		for p in pages_with_no_roles:
@@ -327,7 +327,7 @@ def get_unseen_notes():
 			(note.notify_on_every_login == 1)
 			& (note.expire_notification_on > frappe.utils.now())
 			& (
-				subqry(frappe.qb.from_(nsb).select(nsb.user).where(nsb.parent == note.name)).notin(
+				SubQuery(frappe.qb.from_(nsb).select(nsb.user).where(nsb.parent == note.name)).notin(
 					[frappe.session.user]
 				)
 			)

--- a/frappe/query_builder/terms.py
+++ b/frappe/query_builder/terms.py
@@ -100,7 +100,7 @@ class ParameterizedFunction(Function):
 		return function_sql
 
 
-class subqry(Criterion):
+class SubQuery(Criterion):
 	def __init__(
 		self,
 		subq: QueryBuilder,
@@ -112,3 +112,6 @@ class subqry(Criterion):
 	def get_sql(self, **kwg: Any) -> str:
 		kwg["subquery"] = True
 		return self.subq.get_sql(**kwg)
+
+
+subqry = SubQuery

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -17,6 +17,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.query_builder import Order
 from frappe.query_builder.functions import Coalesce, Max
+from frappe.query_builder.terms import SubQuery
 from frappe.query_builder.utils import DocType
 
 
@@ -336,14 +337,15 @@ class NestedSet(Document):
 def get_root_of(doctype):
 	"""Get root element of a DocType with a tree structure"""
 	from frappe.query_builder.functions import Count
-	from frappe.query_builder.terms import subqry
 
 	Table = DocType(doctype)
 	t1 = Table.as_("t1")
 	t2 = Table.as_("t2")
 
-	subq = frappe.qb.from_(t2).select(Count("*")).where((t2.lft < t1.lft) & (t2.rgt > t1.rgt))
-	result = frappe.qb.from_(t1).select(t1.name).where((subqry(subq) == 0) & (t1.rgt > t1.lft)).run()
+	node_query = SubQuery(
+		frappe.qb.from_(t2).select(Count("*")).where((t2.lft < t1.lft) & (t2.rgt > t1.rgt))
+	)
+	result = frappe.qb.from_(t1).select(t1.name).where((node_query == 0) & (t1.rgt > t1.lft)).run()
 
 	return result[0][0] if result else None
 


### PR DESCRIPTION
`"SubQuery"` conforms with terms named in PyPika. Kept `subqry` that points to the same def for maintaining APIs.