### PR TITLE
fix: use frappe.datetime.str_to_object instead of Date

### DIFF
--- a/frappe/public/js/frappe/form/footer/timeline.js
+++ b/frappe/public/js/frappe/form/footer/timeline.js
@@ -228,7 +228,7 @@ frappe.ui.form.Timeline = class Timeline {
 	compare_dates(b, c) {
 		let b_date = b.communication_date ? b.communication_date : b.creation;
 		let c_date = c.communication_date ? c.communication_date : c.creation;
-		let comparison = new Date(b_date) > new Date(c_date) ? -1 : 1;
+		let comparison = frappe.datetime.str_to_obj(b_date) > frappe.datetime.str_to_obj(c_date) ? -1 : 1;
 		return comparison;
 	}
 


### PR DESCRIPTION
Use frappe.datetime.str_to_object to convert string to object instead of new Date, because the pattern yyyy-MM-dd isn't an officially supported format for Date constructor (https://stackoverflow.com/questions/4310953/invalid-date-in-safari) and therefore timeline items are not in the correct order at all.

![image](https://user-images.githubusercontent.com/30859809/174069459-3ec5fee7-e3f8-4049-80bd-372ccdec05a5.png)
