### PR TITLE
fix!: dont delete customizations when doctypes are deleted 

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1258,8 +1258,10 @@ def get_module_path(module, *joins):
 
 	:param module: Module name.
 	:param *joins: Join additional path elements using `os.path.join`."""
-	module = scrub(module)
-	return get_pymodule_path(local.module_app[module] + "." + module, *joins)
+	from frappe.modules.utils import get_module_app
+
+	app = get_module_app(module)
+	return get_pymodule_path(app + "." + scrub(module), *joins)
 
 
 def get_app_path(app_name, *joins):

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -88,10 +88,6 @@ def delete_doc(
 				update_flags(doc, flags, ignore_permissions)
 				check_permission_and_not_submitted(doc)
 
-				frappe.db.delete("Custom Field", {"dt": name})
-				frappe.db.delete("Client Script", {"dt": name})
-				frappe.db.delete("Property Setter", {"doc_type": name})
-				frappe.db.delete("Report", {"ref_doctype": name})
 				frappe.db.delete("Custom DocPerm", {"parent": name})
 				frappe.db.delete("__global_search", {"doctype": name})
 


### PR DESCRIPTION
If someone deletes doctype and restores it back all customization are
lost, there's no "real" reason to delete all these customization. They
are only ever active if the doctype is being used.

Explanations:

- Custom field: is used by meta when doctype meta is requested, if meta
  isn't requested then the custom field is effectively inactive.
- Client script: loaded by meta when doctype is requested by the desk. So
  inactive in a deleted state.
- Property setter: loaded by meta, so inactive when doctype isn't
  present.
- Report: will break doctype isn't present, but the user should delete them
  manually to avoid loss of "scripts" or anything special they might
  have done. Also, report's doctype don't 100% indicate that it's based
  solely on that doctype.


More unrelated fixes:
- Don't init non-existing single doctypes during app install - permanent fix for https://github.com/frappe/frappe/issues/16917
- Throw better error when doctype or module isn't found instead of `keyerror`
- Simplify `delete_from_table` 


IDK any other error that occurs during routine usage with stale doctype/modules. If you find any point it out and we will handle it better 😅 basically:
- Opening the stale doctype page should throw error
- anything else should not be affected by non-exisitng doctypes.