### PR TITLE
feat(utils): Caching Utils

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -834,6 +834,7 @@ def clear_cache(user=None, doctype=None):
 	:param user: If user is given, only user cache is cleared.
 	:param doctype: If doctype is given, only DocType cache is cleared."""
 	import frappe.cache_manager
+	import frappe.utils.caching
 
 	if doctype:
 		frappe.cache_manager.clear_doctype_cache(doctype)
@@ -853,7 +854,10 @@ def clear_cache(user=None, doctype=None):
 		for fn in get_hooks("clear_cache"):
 			get_attr(fn)()
 
+	frappe.utils.caching._SITE_CACHE.clear()
 	local.role_permissions = {}
+	if hasattr(local, "request_cache"):
+		local.request_cache.clear()
 
 
 def only_has_select_perm(doctype, user=None, ignore_permissions=False):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -411,6 +411,7 @@ def msgprint(
 	:param wide: [optional] Show wide modal
 	"""
 	import inspect
+	import sys
 
 	from frappe.utils import strip_html_tags
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -14,6 +14,7 @@ from frappe.model import child_table_fields, default_fields, optional_fields
 from frappe.model.base_document import get_controller
 from frappe.model.db_query import DatabaseQuery
 from frappe.utils import add_user_info, cstr, format_duration
+from frappe.utils.caching import site_cache
 
 
 @frappe.whitelist()
@@ -733,5 +734,6 @@ def get_filters_cond(
 	return cond
 
 
+@site_cache(maxsize=128)
 def is_virtual_doctype(doctype):
 	return frappe.db.get_value("DocType", doctype, "is_virtual")

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -1,0 +1,95 @@
+import time
+import unittest
+from typing import Dict, List, Tuple, Union
+from unittest.mock import MagicMock
+
+import frappe
+from frappe.tests.test_api import FrappeAPITestCase
+from frappe.utils.caching import request_cache, site_cache
+
+CACHE_TTL = 4
+external_service = MagicMock(return_value=30)
+register_with_external_service = MagicMock(return_value=True)
+
+
+@request_cache
+def request_specific_api(a: Union[List, Tuple, Dict, int], b: int) -> int:
+	# API that takes very long to return a result
+	todays_value = external_service()
+	if not isinstance(a, (int, float)):
+		a = 1
+	return a**b * todays_value
+
+
+@frappe.whitelist(allow_guest=True)
+@site_cache
+def ping() -> str:
+	register_with_external_service(frappe.local.site)
+	return frappe.local.site
+
+
+@frappe.whitelist(allow_guest=True)
+@site_cache(ttl=CACHE_TTL)
+def ping_with_ttl() -> str:
+	register_with_external_service(frappe.local.site)
+	return frappe.local.site
+
+
+class TestCachingUtils(unittest.TestCase):
+	def test_request_cache(self):
+		retval = []
+		acceptable_args = [
+			[1, 2, 3, 4],
+			range(10),
+			{"abc": "test-key"},
+			frappe.get_last_doc("DocType"),
+			frappe._dict(),
+		]
+		same_output_received = lambda: all([x for x in set(retval) if x == retval[0]])
+
+		# ensure that external service was called only once
+		# thereby return value of request_specific_api is cached
+		for _ in range(5):
+			retval.append(request_specific_api(120, 23))
+		external_service.assert_called_once()
+		self.assertTrue(same_output_received())
+
+		# ensure that cache differentiates between int & float
+		# types. Giving different return values for both
+		retval.append(request_specific_api(120.0, 23))
+		self.assertTrue(external_service.call_count, 2)
+
+		# ensure that function is executed when call isn't
+		# already cached
+		retval.clear()
+		for _ in range(10):
+			request_specific_api(120, 13)
+		self.assertTrue(external_service.call_count, 3)
+		self.assertTrue(same_output_received())
+
+		# ensure key generation capacity for different types
+		retval.clear()
+		for arg in acceptable_args:
+			external_service.call_count = 0
+			for _ in range(2):
+				request_specific_api(arg, 13)
+			self.assertTrue(external_service.call_count, 1)
+		self.assertTrue(same_output_received())
+
+
+class TestSiteCache(FrappeAPITestCase):
+	def test_site_cache(self):
+		module = __name__
+		api_with_ttl = f"{module}.ping_with_ttl"
+		api_without_ttl = f"{module}.ping"
+
+		start = time.monotonic()
+		for _ in range(5):
+			self.get(f"/api/method/{api_with_ttl}")
+			self.get(f"/api/method/{api_without_ttl}")
+		end = time.monotonic()
+
+		self.assertEqual(register_with_external_service.call_count, 2)
+		time.sleep(CACHE_TTL - (end - start))
+		self.get(f"/api/method/{api_with_ttl}")
+		self.assertEqual(register_with_external_service.call_count, 3)

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. Check LICENSE
+
+import json
+from functools import wraps
+
+import frappe
+
+
+def __generate_key(func, args, kwargs):
+	"""Generate a key for the cache."""
+	return f"{func.__module__}.{func.__name__}{json.dumps((args, kwargs))}"
+
+
+def request_cache(func):
+	"""Decorator to cache function calls mid-request. Cache is stored in
+	frappe.local.request_cache. The cache only persists for the current request
+	and is cleared when the request is over. The function is called just once
+	per request with the same set of (kw)arguments.
+
+	Usage:
+	        from frappe.utils.caching import request_cache
+
+	        @request_cache
+	        def calculate_pi(num_terms=0):
+	                import math, time
+	                print(f"{num_terms = }")
+	                time.sleep(10)
+	                return math.pi
+
+	        calculate_pi(10) # will calculate value
+	        calculate_pi(10) # will return value from cache
+	"""
+
+	@wraps(func)
+	def wrapper(*args, **kwargs):
+		if not getattr(frappe.local, "initialised", None):
+			return func(*args, **kwargs)
+		if not hasattr(frappe.local, "request_cache"):
+			frappe.local.request_cache = {}
+
+		logger = frappe.logger(module=__name__)
+
+		try:
+			key = __generate_key(func, args, kwargs)
+		except Exception:
+			logger.warning(f"request_cache: Couldn't generate key for args: {args}, kwargs: {kwargs}")
+			return func(*args, **kwargs)
+
+		if key not in frappe.local.request_cache:
+			frappe.local.request_cache[key] = func(*args, **kwargs)
+			logger.debug(f"request_cache: Cached key {key}")
+		logger.debug(f"request_cache: Hit cache with key {key}")
+		return frappe.local.request_cache[key]
+
+	return wrapper

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -86,8 +86,6 @@ def site_cache(ttl: Optional[int] = None, maxsize: Optional[int] = None) -> Call
 	"""
 
 	def time_cache_wrapper(func: Callable = None) -> Callable:
-		nonlocal ttl, maxsize
-
 		func_key = f"{func.__module__}.{func.__name__}"
 
 		def clear_cache():
@@ -114,7 +112,7 @@ def site_cache(ttl: Optional[int] = None, maxsize: Optional[int] = None) -> Call
 
 				if hasattr(func, "maxsize") and len(_SITE_CACHE[func_key][frappe.local.site]) >= func.maxsize:
 					_SITE_CACHE[func_key][frappe.local.site].pop(
-						next(iter(_SITE_CACHE[func_key][frappe.local.site]))
+						next(iter(_SITE_CACHE[func_key][frappe.local.site])), None
 					)
 
 				if func_call_key not in _SITE_CACHE[func_key][frappe.local.site]:

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -2,17 +2,21 @@
 # License: MIT. Check LICENSE
 
 import json
+from collections import defaultdict
 from functools import wraps
+from typing import Callable, Dict, Tuple
 
 import frappe
 
+_SITE_CACHE = defaultdict(lambda: defaultdict(dict))
 
-def __generate_key(func, args, kwargs):
+
+def __generate_request_cache_key(func: Callable, args: Tuple, kwargs: Dict):
 	"""Generate a key for the cache."""
 	return f"{func.__module__}.{func.__name__}{json.dumps((args, kwargs))}"
 
 
-def request_cache(func):
+def request_cache(func: Callable) -> Callable:
 	"""Decorator to cache function calls mid-request. Cache is stored in
 	frappe.local.request_cache. The cache only persists for the current request
 	and is cleared when the request is over. The function is called just once
@@ -42,7 +46,7 @@ def request_cache(func):
 		logger = frappe.logger(module=__name__)
 
 		try:
-			key = __generate_key(func, args, kwargs)
+			key = __generate_request_cache_key(func, args, kwargs)
 		except Exception:
 			logger.warning(f"request_cache: Couldn't generate key for args: {args}, kwargs: {kwargs}")
 			return func(*args, **kwargs)
@@ -52,5 +56,51 @@ def request_cache(func):
 			logger.debug(f"request_cache: Cached key {key}")
 		logger.debug(f"request_cache: Hit cache with key {key}")
 		return frappe.local.request_cache[key]
+
+	return wrapper
+
+
+def site_cache(func: Callable) -> Callable:
+	"""Decorator to cache method calls across requests. The cache is stored in
+	frappe.utils.caching._SITE_CACHE. The cache persists on the parent process.
+	It offers a light-weight cache for the current process without the additional
+	overhead of serializing / deserializing Python objects.
+
+	Note: This cache isn't shared among workers. If you need to share data across
+	workers, use redis (frappe.cache API) instead.
+
+	Usage:
+	        from frappe.utils.caching import site_cache
+
+	        @site_cache
+	        def calculate_pi():
+	                import math, time
+	                precision = get_precision("Math Constant", "Pi") # depends on site data
+	                return round(math.pi, precision)
+
+	        calculate_pi(10) # will calculate value
+	        calculate_pi(10) # will return value from cache
+	        calculate_pi.clear_cache() # clear this function's cache for all sites
+	        calculate_pi(10) # will calculate value
+	"""
+	func_key = f"{func.__module__}.{func.__name__}"
+
+	def clear_cache():
+		"""Clear cache for this function for all sites if not specified."""
+		_SITE_CACHE[func_key].clear()
+
+	func.clear_cache = clear_cache
+
+	@wraps(func)
+	def wrapper(*args, **kwargs):
+		if getattr(frappe.local, "initialised", None):
+			func_call_key = json.dumps((args, kwargs))
+
+			if func_call_key not in _SITE_CACHE[func_key][frappe.local.site]:
+				_SITE_CACHE[func_key][frappe.local.site][func_call_key] = func(*args, **kwargs)
+
+			return _SITE_CACHE[func_key][frappe.local.site][func_call_key]
+
+		return func(*args, **kwargs)
 
 	return wrapper

--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -7,10 +7,7 @@ from logging.handlers import RotatingFileHandler
 import frappe
 from frappe.utils import get_sites
 
-# imports - third party imports
-
-
-default_log_level = logging.DEBUG
+default_log_level = logging.WARNING if frappe._dev_server else logging.ERROR
 
 
 def get_logger(
@@ -21,7 +18,7 @@ def get_logger(
 	max_size=100_000,
 	file_count=20,
 	stream_only=False,
-):
+) -> "logging.Logger":
 	"""Application Logger for your given module
 
 	Args:
@@ -90,7 +87,7 @@ def get_logger(
 class SiteContextFilter(logging.Filter):
 	"""This is a filter which injects request information (if available) into the log."""
 
-	def filter(self, record):
+	def filter(self, record) -> bool:
 		if "Form Dict" not in str(record.msg):
 			site = getattr(frappe.local, "site", None)
 			form_dict = getattr(frappe.local, "form_dict", None)
@@ -98,7 +95,7 @@ class SiteContextFilter(logging.Filter):
 			return True
 
 
-def set_log_level(level):
+def set_log_level(level: int) -> None:
 	"""Use this method to set log level to something other than the default DEBUG"""
 	frappe.log_level = getattr(logging, (level or "").upper(), None) or default_log_level
 	frappe.loggers = {}

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from typing import Dict, List
 from urllib.parse import quote
 
 import frappe
@@ -7,7 +8,6 @@ from frappe import _
 from frappe.integrations.doctype.google_settings.google_settings import get_auth_url
 from frappe.model.document import Document
 from frappe.utils import encode, get_request_site_address
-from frappe.website.doctype.website_theme.website_theme import add_website_theme
 
 INDEXING_SCOPES = "https://www.googleapis.com/auth/indexing"
 
@@ -124,7 +124,9 @@ class WebsiteSettings(Document):
 
 def get_website_settings(context=None):
 	hooks = frappe.get_hooks()
-	context = context or frappe._dict()
+	context = frappe._dict(context or {})
+	settings: "WebsiteSettings" = frappe.get_single("Website Settings")
+
 	context = context.update(
 		{
 			"top_bar_items": get_items("top_bar_items"),
@@ -136,7 +138,6 @@ def get_website_settings(context=None):
 		}
 	)
 
-	settings: "WebsiteSettings" = frappe.get_single("Website Settings")
 	for k in [
 		"banner_html",
 		"banner_image",
@@ -161,11 +162,8 @@ def get_website_settings(context=None):
 		"show_language_picker",
 		"footer_powered",
 	]:
-		if hasattr(settings, k):
-			context[k] = settings.get(k)
-
-	if settings.address:
-		context["footer_address"] = settings.address
+		if setting_value := settings.get(k):
+			context[k] = setting_value
 
 	for k in [
 		"facebook_share",
@@ -176,6 +174,9 @@ def get_website_settings(context=None):
 	]:
 		context[k] = int(context.get(k) or 0)
 
+	if settings.address:
+		context["footer_address"] = settings.address
+
 	if frappe.request:
 		context.url = quote(str(get_request_site_address(full_address=True)), safe="/:")
 
@@ -185,7 +186,7 @@ def get_website_settings(context=None):
 
 	context.web_include_css = hooks.web_include_css or []
 
-	via_hooks = frappe.get_hooks("website_context")
+	via_hooks = hooks.website_context or []
 	for key in via_hooks:
 		context[key] = via_hooks[key]
 		if key not in ("top_bar_items", "footer_items", "post_login") and isinstance(
@@ -193,7 +194,13 @@ def get_website_settings(context=None):
 		):
 			context[key] = context[key][-1]
 
-	add_website_theme(context)
+	if context.disable_website_theme:
+		context.theme = frappe._dict()
+
+	else:
+		from frappe.website.doctype.website_theme.website_theme import get_active_theme
+
+		context.theme = get_active_theme() or frappe._dict()
 
 	if not context.get("favicon"):
 		context["favicon"] = "/assets/frappe/images/frappe-favicon.svg"
@@ -203,33 +210,37 @@ def get_website_settings(context=None):
 
 	context["hide_login"] = settings.hide_login
 
-	if splash_image := settings.splash_image or context.get("splash_image"):
-		context["splash_image"] = splash_image
+	if settings.splash_image:
+		context["splash_image"] = settings.splash_image
 
 	return context
 
 
-def get_items(parentfield):
-	all_top_items = frappe.db.sql(
-		"""\
-		select * from `tabTop Bar Item`
-		where parent='Website Settings' and parentfield= %s
-		order by idx asc""",
-		parentfield,
-		as_dict=1,
+def get_items(parentfield: str) -> List[Dict]:
+	_items = frappe.get_all(
+		"Top Bar Item",
+		filters={"parent": "Website Settings", "parentfield": parentfield},
+		order_by="idx asc",
+		fields="*",
 	)
-
-	top_items = all_top_items[:]
+	top_items = _items.copy()
 
 	# attach child items to top bar
-	for d in all_top_items:
-		if d["parent_label"]:
-			for t in top_items:
-				if t["label"] == d["parent_label"]:
-					if not "child_items" in t:
-						t["child_items"] = []
-					t["child_items"].append(d)
-					break
+	for item in _items:
+		if not item["parent_label"]:
+			continue
+
+		for top_bar_item in top_items:
+			if top_bar_item["label"] != item["parent_label"]:
+				continue
+
+			if "child_items" not in top_bar_item:
+				top_bar_item["child_items"] = []
+
+			top_bar_item["child_items"].append(item)
+
+			break
+
 	return top_items
 
 

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -5,6 +5,7 @@ from os.path import abspath
 from os.path import exists as path_exists
 from os.path import join as join_path
 from os.path import splitext
+from typing import Optional
 
 import frappe
 from frappe import _
@@ -131,17 +132,8 @@ class WebsiteTheme(Document):
 		return out
 
 
-def add_website_theme(context):
-	context.theme = frappe._dict()
-
-	if not context.disable_website_theme:
-		website_theme = get_active_theme()
-		context.theme = website_theme or frappe._dict()
-
-
-def get_active_theme():
-	website_theme = frappe.db.get_single_value("Website Settings", "website_theme")
-	if website_theme:
+def get_active_theme() -> Optional["WebsiteTheme"]:
+	if website_theme := frappe.db.get_single_value("Website Settings", "website_theme"):
 		try:
 			return frappe.get_doc("Website Theme", website_theme)
 		except frappe.DoesNotExistError:


### PR DESCRIPTION
`functools` not multi-tenant, so what? We have our own caching utils now ;) This PR introduces utils for caching that persist inter and intra request. Both cache utils are boundless by default, didn't make sense to add a bound to the short lived request_cache, for site_cache, maxsize can be set (see eg in `reportview`).

#### @request_cache

Memoization cache that persists for the duration of the request (depends on `frappe.local`). You may want to use this over a function that's called multiple times during a request but it may not need re-computation (and if the overhead of request_cache is acceptable/comparable).

Consider an example use case here: User hits the `get_portfolio_value` API (which is a highly simplified example). The API has to fetch live conversion rate for each currency / symbol.

```python
@request_cache
def get_live_conversion_rate(currency: Currency) -> Decimal:
    return CONVERSION_SERVICE.fetch({"currency": currency}).value

def get_holding_rate(symbol: Symbol) -> Decimal:
    return HOLDING_SERVICE.fetch({"symbol": symbol}).value

def get_holding_value(symbol: Symbol) -> Decimal:
    return get_live_conversion_rate(symbol.currency) * get_holding_rate(symbol)

@frappe.whitelist(methods=["GET"])
def get_portfolio_value():
    liquid_value = ... # cash der - debt 
    for symbol in ...:
        liquid_value += get_holding_value(symbol)
    return liquid_value
```
Because of `@request_cache`, you can be certain that `get_live_conversion_rate` will be **called just once** for a unique set of `*args, **kwargs` it's called with during a single request.

Alternate solutions may include maintaining a dict of already computed / fetched currencies or responses. Another common pattern I've noticed is adding a separate named dict to the `local` object - `document_cache`, `cache`, `db.value_cache` and many more 😉. 

> Note: During the time of writing this, the key acts as functools cache with typed=False option. This means that the cache can't differentiate between args `(1, 2.0, "abcd")` and `(1, 2, "abcd")`. Adding the provision for allowing typed=True may be relatively easy to do, but I don't plan on doing it right now. This has to do with how key is generated using builtins' `hash` function instead of my previous implementation which used `json.dumps` (which is a lot more expensive than hash). If there's a better way for key generation, I'm happy to discuss it. 

#### @site_cache

`functools.lru_cache` but with multi-tenant, `typed=True`, maxsize & TTL support. This cache persists through requests. 

Consider the previous example, but now that you have a rate-limit restriction from the `HOLDING_SERVICE` that you can make only one request every 5 seconds for a given Symbol. The easiest way to do this would be using site_cache with ttl.

```diff
+@site_cache(ttl=5)
def get_holding_rate(symbol: Symbol) -> Decimal:
    return HOLDING_SERVICE.fetch({"symbol": symbol}).value

get_holding_rate.clear_cache() # to manually clear cache (for all sites)
```

Both caches are cleared on `frappe.clear_cache` for given process.

Docs: https://frappeframework.com/docs/v14/user/en/api/utils [Should be there once Wiki allows me to write docs 😄]