### PR TITLE
feat(ui): add option to define min and max date for date field

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -23,6 +23,23 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			this.refresh();
 			// set default
 			$.each(this.fields_list, function(i, field) {
+				if (field.df["fieldtype"] == 'Date') {
+					// set min date
+					if (field.df["minDate"]) {
+						console.log('minDate');
+						field.datepicker.update({
+							minDate: new Date(field.df["minDate"])
+						});
+					}
+					// set max date
+					if (field.df["maxDate"]) {
+						console.log('maxDate');
+						field.datepicker.update({
+							maxDate: new Date(field.df["maxDate"])
+						});
+					}
+				}
+
 				if (field.df["default"]) {
 					let def_value = field.df["default"];
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Specify min date and/or max date in Date fieldtype.

```
...
new frappe.ui.Dialog({
  ...
    { fieldtype: 'Date', label: 'Date', minDate: frappe.datetime.get_today(), reqd: 1, fieldname: 'date' },
  ...
});
```

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Prevent user to chose a date from not permitted range (enhance user experience)

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
![minDate](https://user-images.githubusercontent.com/963110/170776463-8a4b6afd-159e-4a32-a9ea-dbdc36dac175.png)

