### PR TITLE
Fix: Delete Share in Frontend when read is de-selected

### DIFF
--- a/frappe/share.py
+++ b/frappe/share.py
@@ -93,7 +93,7 @@ def set_permission(doctype, name, user, permission_to, value=1, everyone=0):
 
 		if not (share.read or share.write or share.submit or share.share):
 			share.delete()
-			share = {}
+			share = None
 
 	return share
 


### PR DESCRIPTION
closes #17019

The problem is, that set_permission should return a value that is equal to false when a share is deleted, but it returns an empty dict/object, which in  is JS:
`boolean({}) == true `
Therefore, set_permission must return a value that equals to false in JS, I think None is the right choice here.
