### PR TITLE
fix(email): Link communications to "append_to" doctype

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -701,7 +701,7 @@ class EmailAccount(Document):
 					["reference_doctype", "reference_name"],
 					as_dict=1,
 				)
-				if comm:
+				if comm and comm.reference_doctype and comm.reference_name:
 					parent = frappe._dict(doctype=comm.reference_doctype, name=comm.reference_name)
 
 		return parent


### PR DESCRIPTION
If reference_doctype and reference_name is getting None then Communication will not link with append_to DocType.
