### PR TITLE
fix: Update modified timestamp on Notification Settings (only when needed)

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -148,6 +148,6 @@ def trigger_indicator_hide():
 
 def set_notifications_as_unseen(user):
 	try:
-		frappe.db.set_value("Notification Settings", user, "seen", 0)
+		frappe.db.set_value("Notification Settings", user, "seen", 0, update_modified=False)
 	except frappe.DoesNotExistError:
 		return

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -48,9 +48,15 @@ def create_notification_settings(user):
 		_doc.insert(ignore_permissions=True)
 
 
-def toggle_notifications(user, enable=False):
-	if frappe.db.exists("Notification Settings", user):
-		frappe.db.set_value("Notification Settings", user, "enabled", enable)
+def toggle_notifications(user: str, enable: bool = False):
+	try:
+		settings = frappe.get_doc("Notification Settings", user)
+	except frappe.DoesNotExistError:
+		return
+
+	if settings.enabled != enable:
+		settings.enabled = enable
+		settings.save()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Get rid of partially silent updates to Notification Settings - Right now, only the modified timestamp is updated...randomly leaving us to wonder what in the world is going on 😿 
