### PR TITLE
fix: translation context for print format align values

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -441,7 +441,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 			const field = $(e.currentTarget).parent();
 			// new dialog
 			var d = new frappe.ui.Dialog({
-				title: "Set Properties",
+				title: __("Set Properties"),
 				fields: [
 					{
 						label: __("Label"),

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -452,7 +452,8 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 						label: __("Align Value"),
 						fieldname: "align",
 						fieldtype: "Select",
-						options: [{'label': __('Left'), 'value': 'left'}, {'label': __('Right'), 'value': 'right'}]
+						options: [{'label': __('Left', null, 'direction'), 'value': 'left'},
+							{'label': __('Right', null, 'direction'), 'value': 'right'}]
 					},
 					{
 						label: __("Remove Field"),

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -452,8 +452,8 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 						label: __("Align Value"),
 						fieldname: "align",
 						fieldtype: "Select",
-						options: [{'label': __('Left', null, 'direction'), 'value': 'left'},
-							{'label': __('Right', null, 'direction'), 'value': 'right'}]
+						options: [{'label': __('Left', null, 'align'), 'value': 'left'},
+							{'label': __('Right', null, 'align'), 'value': 'right'}]
 					},
 					{
 						label: __("Remove Field"),

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -452,8 +452,8 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 						label: __("Align Value"),
 						fieldname: "align",
 						fieldtype: "Select",
-						options: [{'label': __('Left', null, 'align'), 'value': 'left'},
-							{'label': __('Right', null, 'align'), 'value': 'right'}]
+						options: [{'label': __('Left', null, 'alignment'), 'value': 'left'},
+							{'label': __('Right', null, 'alignment'), 'value': 'right'}]
 					},
 					{
 						label: __("Remove Field"),

--- a/frappe/public/js/print_format_builder/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatControls.vue
@@ -181,8 +181,8 @@ export default {
 			return [
 				{ label: __("Top"), fieldname: "margin_top" },
 				{ label: __("Bottom"), fieldname: "margin_bottom" },
-				{ label: __("Left", null, 'direction'), fieldname: "margin_left" },
-				{ label: __("Right", null, 'direction'), fieldname: "margin_right" }
+				{ label: __("Left", null, 'align'), fieldname: "margin_left" },
+				{ label: __("Right", null, 'align'), fieldname: "margin_right" }
 			];
 		},
 		fields() {

--- a/frappe/public/js/print_format_builder/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatControls.vue
@@ -181,8 +181,8 @@ export default {
 			return [
 				{ label: __("Top"), fieldname: "margin_top" },
 				{ label: __("Bottom"), fieldname: "margin_bottom" },
-				{ label: __("Left"), fieldname: "margin_left" },
-				{ label: __("Right"), fieldname: "margin_right" }
+				{ label: __("Left", null, 'direction'), fieldname: "margin_left" },
+				{ label: __("Right", null, 'direction'), fieldname: "margin_right" }
 			];
 		},
 		fields() {

--- a/frappe/public/js/print_format_builder/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatControls.vue
@@ -181,8 +181,8 @@ export default {
 			return [
 				{ label: __("Top"), fieldname: "margin_top" },
 				{ label: __("Bottom"), fieldname: "margin_bottom" },
-				{ label: __("Left", null, 'align'), fieldname: "margin_left" },
-				{ label: __("Right", null, 'align'), fieldname: "margin_right" }
+				{ label: __("Left", null, 'alignment'), fieldname: "margin_left" },
+				{ label: __("Right", null, 'alignment'), fieldname: "margin_right" }
 			];
 		},
 		fields() {

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -4717,3 +4717,5 @@ Document has been cancelled,Document annulé
 Document is in draft state,Document au statut brouillon
 Copy to Clipboard,Copier vers le presse-papiers
 Don't have an account?,Vous n&#39;avez pas de compte?
+Left:direction,Gauche
+Right:direction,Droite

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -4719,3 +4719,4 @@ Copy to Clipboard,Copier vers le presse-papiers
 Don't have an account?,Vous n&#39;avez pas de compte?
 Left:direction,Gauche
 Right:direction,Droite
+Set Properties,Gérer les proriétés

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -4717,6 +4717,6 @@ Document has been cancelled,Document annulé
 Document is in draft state,Document au statut brouillon
 Copy to Clipboard,Copier vers le presse-papiers
 Don't have an account?,Vous n&#39;avez pas de compte?
-Left:direction,Gauche
-Right:direction,Droite
+Left:align,Gauche
+Right:align,Droite
 Set Properties,Gérer les proriétés

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -4717,6 +4717,6 @@ Document has been cancelled,Document annulé
 Document is in draft state,Document au statut brouillon
 Copy to Clipboard,Copier vers le presse-papiers
 Don't have an account?,Vous n&#39;avez pas de compte?
-Left:align,Gauche
-Right:align,Droite
+Left:alignment,Gauche
+Right:alignment,Droite
 Set Properties,Gérer les proriétés


### PR DESCRIPTION
closes: #17025 

In french "Left" in the direction/align context have to be translated => "Gauche"
In french "Right" in the direction/align context have to be translated => "Droite"

The word Left as a verb in english can be "to left" (like in "to leave a place") can be translated as french verb "Partir"
The world Right as a noun in english can be "_the right_ given by the law" can be translated in french by "_Le droit_"

So the initial translation for Left => "Parti", and Right => "Droit" are not false but heavily depends on context

In the print format editor the align value select input display is wrong (align the value on your "leave" ? Align the value on the "law" ?)

Before

![image](https://user-images.githubusercontent.com/1050053/171004462-1f3336a0-3719-4e35-9fdc-3eaa864465a6.png)


After

![image](https://user-images.githubusercontent.com/1050053/171004490-ce647432-e9cd-45dc-8867-b6ad189f647f.png)
