### PR TITLE
feat: Document Naming Settings

### DIFF
--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.js
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.js
@@ -34,7 +34,6 @@ frappe.ui.form.on("Document Naming Settings", {
 				frm.set_value("naming_series_options", r.message);
 				if (r.message && r.message.split("\n")[0] == "")
 					frm.set_value("user_must_always_select", 1);
-				frm.refresh();
 			},
 		});
 	},
@@ -74,21 +73,5 @@ frappe.ui.form.on("Document Naming Settings", {
 				}
 			},
 		});
-	},
-
-	add_series(frm) {
-		const series = frm.doc.try_naming_series;
-
-		if (!series) {
-			frappe.show_alert(__("Please type a valid series."));
-			return;
-		}
-
-		if (!frm.doc.naming_series_options.includes(series)) {
-			const current_series = frm.doc.naming_series_options;
-			frm.set_value("naming_series_options", `${current_series}\n${series}`);
-		} else {
-			frappe.show_alert(__("Series already added to transaction."));
-		}
 	},
 });

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.js
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.js
@@ -16,7 +16,7 @@ frappe.ui.form.on("Document Naming Settings", {
 			doc: frm.doc,
 			callback: function(r) {
 				frm.set_df_property(
-					"select_doc_for_series",
+					"transaction_type",
 					"options",
 					r.message.transactions
 				);
@@ -25,13 +25,13 @@ frappe.ui.form.on("Document Naming Settings", {
 		});
 	},
 
-	select_doc_for_series: function(frm) {
+	transaction_type: function(frm) {
 		frm.set_value("user_must_always_select", 0);
 		frappe.call({
 			method: "get_options",
 			doc: frm.doc,
 			callback: function(r) {
-				frm.set_value("set_options", r.message);
+				frm.set_value("naming_series_options", r.message);
 				if (r.message && r.message.split("\n")[0] == "")
 					frm.set_value("user_must_always_select", 1);
 				frm.refresh();
@@ -59,7 +59,7 @@ frappe.ui.form.on("Document Naming Settings", {
 		});
 	},
 
-	naming_series_to_check(frm) {
+	try_naming_series(frm) {
 		frappe.call({
 			method: "preview_series",
 			doc: frm.doc,
@@ -77,16 +77,16 @@ frappe.ui.form.on("Document Naming Settings", {
 	},
 
 	add_series(frm) {
-		const series = frm.doc.naming_series_to_check;
+		const series = frm.doc.try_naming_series;
 
 		if (!series) {
 			frappe.show_alert(__("Please type a valid series."));
 			return;
 		}
 
-		if (!frm.doc.set_options.includes(series)) {
-			const current_series = frm.doc.set_options;
-			frm.set_value("set_options", `${current_series}\n${series}`);
+		if (!frm.doc.naming_series_options.includes(series)) {
+			const current_series = frm.doc.naming_series_options;
+			frm.set_value("naming_series_options", `${current_series}\n${series}`);
 		} else {
 			frappe.show_alert(__("Series already added to transaction."));
 		}

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.js
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.js
@@ -45,8 +45,11 @@ frappe.ui.form.on("Document Naming Settings", {
 		frappe.call({
 			method: "update_series",
 			doc: frm.doc,
+			freeze: true,
+			freeze_msg: __("Updating naming series options"),
 			callback: function(r) {
 				frm.trigger("setup_transaction_autocomplete");
+				frm.trigger("transaction_type");
 			},
 		});
 	},

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.js
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.js
@@ -2,25 +2,18 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Document Naming Settings", {
-	onload: function(frm) {
-		frm.events.get_doc_and_prefix(frm);
-	},
-
 	refresh: function(frm) {
+		frm.trigger("setup_transaction_autocomplete");
 		frm.disable_save();
 	},
 
-	get_doc_and_prefix: function(frm) {
+	setup_transaction_autocomplete: function(frm) {
 		frappe.call({
 			method: "get_transactions",
 			doc: frm.doc,
 			callback: function(r) {
-				frm.set_df_property(
-					"transaction_type",
-					"options",
-					r.message.transactions
-				);
-				frm.set_df_property("prefix", "options", r.message.prefixes);
+				frm.fields_dict.transaction_type.set_data(r.message.transactions);
+				frm.fields_dict.prefix.set_data(r.message.prefixes);
 			},
 		});
 	},
@@ -53,7 +46,7 @@ frappe.ui.form.on("Document Naming Settings", {
 			method: "update_series",
 			doc: frm.doc,
 			callback: function(r) {
-				frm.events.get_doc_and_prefix(frm);
+				frm.trigger("setup_transaction_autocomplete");
 			},
 		});
 	},

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.js
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.js
@@ -57,10 +57,10 @@ frappe.ui.form.on("Document Naming Settings", {
 			doc: frm.doc,
 			callback: function(r) {
 				if (!r.exc) {
-					frm.set_value("preview", r.message);
+					frm.set_value("series_preview", r.message);
 				} else {
 					frm.set_value(
-						"preview",
+						"series_preview",
 						__("Failed to generate preview of series")
 					);
 				}

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.js
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.js
@@ -9,7 +9,7 @@ frappe.ui.form.on("Document Naming Settings", {
 
 	setup_transaction_autocomplete: function(frm) {
 		frappe.call({
-			method: "get_transactions",
+			method: "get_transactions_and_prefixes",
 			doc: frm.doc,
 			callback: function(r) {
 				frm.fields_dict.transaction_type.set_data(r.message.transactions);

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.js
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.js
@@ -1,0 +1,94 @@
+// Copyright (c) 2022, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Document Naming Settings", {
+	onload: function(frm) {
+		frm.events.get_doc_and_prefix(frm);
+	},
+
+	refresh: function(frm) {
+		frm.disable_save();
+	},
+
+	get_doc_and_prefix: function(frm) {
+		frappe.call({
+			method: "get_transactions",
+			doc: frm.doc,
+			callback: function(r) {
+				frm.set_df_property(
+					"select_doc_for_series",
+					"options",
+					r.message.transactions
+				);
+				frm.set_df_property("prefix", "options", r.message.prefixes);
+			},
+		});
+	},
+
+	select_doc_for_series: function(frm) {
+		frm.set_value("user_must_always_select", 0);
+		frappe.call({
+			method: "get_options",
+			doc: frm.doc,
+			callback: function(r) {
+				frm.set_value("set_options", r.message);
+				if (r.message && r.message.split("\n")[0] == "")
+					frm.set_value("user_must_always_select", 1);
+				frm.refresh();
+			},
+		});
+	},
+
+	prefix: function(frm) {
+		frappe.call({
+			method: "get_current",
+			doc: frm.doc,
+			callback: function(r) {
+				frm.refresh_field("current_value");
+			},
+		});
+	},
+
+	update: function(frm) {
+		frappe.call({
+			method: "update_series",
+			doc: frm.doc,
+			callback: function(r) {
+				frm.events.get_doc_and_prefix(frm);
+			},
+		});
+	},
+
+	naming_series_to_check(frm) {
+		frappe.call({
+			method: "preview_series",
+			doc: frm.doc,
+			callback: function(r) {
+				if (!r.exc) {
+					frm.set_value("preview", r.message);
+				} else {
+					frm.set_value(
+						"preview",
+						__("Failed to generate preview of series")
+					);
+				}
+			},
+		});
+	},
+
+	add_series(frm) {
+		const series = frm.doc.naming_series_to_check;
+
+		if (!series) {
+			frappe.show_alert(__("Please type a valid series."));
+			return;
+		}
+
+		if (!frm.doc.set_options.includes(series)) {
+			const current_series = frm.doc.set_options;
+			frm.set_value("set_options", `${current_series}\n${series}`);
+		} else {
+			frappe.show_alert(__("Series already added to transaction."));
+		}
+	},
+});

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.json
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -6,12 +6,12 @@
  "engine": "InnoDB",
  "field_order": [
   "setup_series",
-  "select_doc_for_series",
+  "transaction_type",
   "help_html",
-  "naming_series_to_check",
+  "try_naming_series",
   "preview",
   "add_series",
-  "set_options",
+  "naming_series_options",
   "user_must_always_select",
   "update",
   "column_break_13",
@@ -28,21 +28,11 @@
    "label": "Setup Series"
   },
   {
-   "fieldname": "select_doc_for_series",
-   "fieldtype": "Select",
-   "label": "Select Transaction"
-  },
-  {
-   "depends_on": "select_doc_for_series",
+   "depends_on": "transaction_type",
    "fieldname": "help_html",
    "fieldtype": "HTML",
    "label": "Help HTML",
    "options": "<div class=\"well\">\n    Edit list of Series in the box below. Rules:\n    <ul>\n        <li>Each Series Prefix on a new line.</li>\n        <li>Allowed special characters are \"/\" and \"-\"</li>\n        <li>\n            Optionally, set the number of digits in the series using dot (.)\n            followed by hashes (#). For example, \".####\" means that the series\n            will have four digits. Default is five digits.\n        </li>\n        <li>\n            You can also use variables in the series name by putting them\n            between (.) dots\n            <br>\n            Support Variables:\n            <ul>\n                <li><code>.YYYY.</code> - Year in 4 digits</li>\n                <li><code>.YY.</code> - Year in 2 digits</li>\n                <li><code>.MM.</code> - Month</li>\n                <li><code>.DD.</code> - Day of month</li>\n                <li><code>.WW.</code> - Week of the year</li>\n                <li><code>.FY.</code> - Fiscal Year</li>\n                <li>\n                    <code>.{fieldname}.</code> - fieldname on the document e.g.\n                    <code>branch</code>\n                </li>\n            </ul>\n        </li>\n    </ul>\n    Examples:\n    <ul>\n        <li>INV-</li>\n        <li>INV-10-</li>\n        <li>INVK-</li>\n        <li>INV-.YYYY.-.{branch}.-.MM.-.####</li>\n    </ul>\n</div>\n<br>\n"
-  },
-  {
-   "fieldname": "naming_series_to_check",
-   "fieldtype": "Data",
-   "label": "Try a naming Series"
   },
   {
    "default": " ",
@@ -57,21 +47,15 @@
    "label": "Add this Series"
   },
   {
-   "depends_on": "select_doc_for_series",
-   "fieldname": "set_options",
-   "fieldtype": "Text",
-   "label": "Series List for this Transaction"
-  },
-  {
    "default": "0",
-   "depends_on": "select_doc_for_series",
+   "depends_on": "transaction_type",
    "description": "Check this if you want to force the user to select a series before saving. There will be no default if you check this.",
    "fieldname": "user_must_always_select",
    "fieldtype": "Check",
    "label": "User must always select"
   },
   {
-   "depends_on": "select_doc_for_series",
+   "depends_on": "transaction_type",
    "fieldname": "update",
    "fieldtype": "Button",
    "label": "Update"
@@ -101,13 +85,29 @@
    "fieldname": "update_series_start",
    "fieldtype": "Button",
    "label": "Update Series Number"
+  },
+  {
+   "depends_on": "transaction_type",
+   "fieldname": "naming_series_options",
+   "fieldtype": "Text",
+   "label": "Series List for this Transaction"
+  },
+  {
+   "fieldname": "try_naming_series",
+   "fieldtype": "Data",
+   "label": "Try a naming Series"
+  },
+  {
+   "fieldname": "transaction_type",
+   "fieldtype": "Select",
+   "label": "Select Transaction"
   }
  ],
  "hide_toolbar": 1,
  "icon": "fa fa-sort-by-order",
  "issingle": 1,
  "links": [],
- "modified": "2022-05-30 08:00:20.236345",
+ "modified": "2022-05-30 08:07:28.047633",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Document Naming Settings",

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.json
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -1,0 +1,129 @@
+{
+ "actions": [],
+ "creation": "2022-05-30 07:24:07.736646",
+ "description": "Set prefix for numbering series on your transactions",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "setup_series",
+  "select_doc_for_series",
+  "help_html",
+  "naming_series_to_check",
+  "preview",
+  "add_series",
+  "set_options",
+  "user_must_always_select",
+  "update",
+  "column_break_13",
+  "update_series",
+  "prefix",
+  "current_value",
+  "update_series_start"
+ ],
+ "fields": [
+  {
+   "description": "Set prefix for numbering series on your transactions",
+   "fieldname": "setup_series",
+   "fieldtype": "Section Break",
+   "label": "Setup Series"
+  },
+  {
+   "fieldname": "select_doc_for_series",
+   "fieldtype": "Select",
+   "label": "Select Transaction"
+  },
+  {
+   "depends_on": "select_doc_for_series",
+   "fieldname": "help_html",
+   "fieldtype": "HTML",
+   "label": "Help HTML",
+   "options": "<div class=\"well\">\n    Edit list of Series in the box below. Rules:\n    <ul>\n        <li>Each Series Prefix on a new line.</li>\n        <li>Allowed special characters are \"/\" and \"-\"</li>\n        <li>\n            Optionally, set the number of digits in the series using dot (.)\n            followed by hashes (#). For example, \".####\" means that the series\n            will have four digits. Default is five digits.\n        </li>\n        <li>\n            You can also use variables in the series name by putting them\n            between (.) dots\n            <br>\n            Support Variables:\n            <ul>\n                <li><code>.YYYY.</code> - Year in 4 digits</li>\n                <li><code>.YY.</code> - Year in 2 digits</li>\n                <li><code>.MM.</code> - Month</li>\n                <li><code>.DD.</code> - Day of month</li>\n                <li><code>.WW.</code> - Week of the year</li>\n                <li><code>.FY.</code> - Fiscal Year</li>\n                <li>\n                    <code>.{fieldname}.</code> - fieldname on the document e.g.\n                    <code>branch</code>\n                </li>\n            </ul>\n        </li>\n    </ul>\n    Examples:\n    <ul>\n        <li>INV-</li>\n        <li>INV-10-</li>\n        <li>INVK-</li>\n        <li>INV-.YYYY.-.{branch}.-.MM.-.####</li>\n    </ul>\n</div>\n<br>\n"
+  },
+  {
+   "fieldname": "naming_series_to_check",
+   "fieldtype": "Data",
+   "label": "Try a naming Series"
+  },
+  {
+   "default": " ",
+   "fieldname": "preview",
+   "fieldtype": "Text",
+   "label": "Preview of generated names",
+   "read_only": 1
+  },
+  {
+   "fieldname": "add_series",
+   "fieldtype": "Button",
+   "label": "Add this Series"
+  },
+  {
+   "depends_on": "select_doc_for_series",
+   "fieldname": "set_options",
+   "fieldtype": "Text",
+   "label": "Series List for this Transaction"
+  },
+  {
+   "default": "0",
+   "depends_on": "select_doc_for_series",
+   "description": "Check this if you want to force the user to select a series before saving. There will be no default if you check this.",
+   "fieldname": "user_must_always_select",
+   "fieldtype": "Check",
+   "label": "User must always select"
+  },
+  {
+   "depends_on": "select_doc_for_series",
+   "fieldname": "update",
+   "fieldtype": "Button",
+   "label": "Update"
+  },
+  {
+   "fieldname": "column_break_13",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Change the starting / current sequence number of an existing series.",
+   "fieldname": "update_series",
+   "fieldtype": "Section Break",
+   "label": "Update Series"
+  },
+  {
+   "fieldname": "prefix",
+   "fieldtype": "Select",
+   "label": "Prefix"
+  },
+  {
+   "description": "This is the number of the last created transaction with this prefix",
+   "fieldname": "current_value",
+   "fieldtype": "Int",
+   "label": "Current Value"
+  },
+  {
+   "fieldname": "update_series_start",
+   "fieldtype": "Button",
+   "label": "Update Series Number"
+  }
+ ],
+ "hide_toolbar": 1,
+ "icon": "fa fa-sort-by-order",
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-05-30 08:00:20.236345",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Document Naming Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.json
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -8,13 +8,12 @@
   "naming_series_tab",
   "setup_series",
   "transaction_type",
-  "try_naming_series",
-  "preview",
-  "add_series",
   "naming_series_options",
   "user_must_always_select",
   "update",
   "column_break_9",
+  "try_naming_series",
+  "preview",
   "help_html",
   "update_series",
   "prefix",
@@ -34,7 +33,7 @@
    "fieldname": "help_html",
    "fieldtype": "HTML",
    "label": "Help HTML",
-   "options": "<div class=\"well\">\n    Edit list of Series in the box below. Rules:\n    <ul>\n        <li>Each Series Prefix on a new line.</li>\n        <li>Allowed special characters are \"/\" and \"-\"</li>\n        <li>\n            Optionally, set the number of digits in the series using dot (.)\n            followed by hashes (#). For example, \".####\" means that the series\n            will have four digits. Default is five digits.\n        </li>\n        <li>\n            You can also use variables in the series name by putting them\n            between (.) dots\n            <br>\n            Support Variables:\n            <ul>\n                <li><code>.YYYY.</code> - Year in 4 digits</li>\n                <li><code>.YY.</code> - Year in 2 digits</li>\n                <li><code>.MM.</code> - Month</li>\n                <li><code>.DD.</code> - Day of month</li>\n                <li><code>.WW.</code> - Week of the year</li>\n                <li><code>.FY.</code> - Fiscal Year</li>\n                <li>\n                    <code>.{fieldname}.</code> - fieldname on the document e.g.\n                    <code>branch</code>\n                </li>\n            </ul>\n        </li>\n    </ul>\n    Examples:\n    <ul>\n        <li>INV-</li>\n        <li>INV-10-</li>\n        <li>INVK-</li>\n        <li>INV-.YYYY.-.{branch}.-.MM.-.####</li>\n    </ul>\n</div>\n<br>\n"
+   "options": "<div class=\"well\">\n    Edit list of Series in the box. Rules:\n    <ul>\n        <li>Each Series Prefix on a new line.</li>\n        <li>Allowed special characters are \"/\" and \"-\"</li>\n        <li>\n            Optionally, set the number of digits in the series using dot (.)\n            followed by hashes (#). For example, \".####\" means that the series\n            will have four digits. Default is five digits.\n        </li>\n        <li>\n            You can also use variables in the series name by putting them\n            between (.) dots\n            <br>\n            Supported Variables:\n            <ul>\n                <li><code>.YYYY.</code> - Year in 4 digits</li>\n                <li><code>.YY.</code> - Year in 2 digits</li>\n                <li><code>.MM.</code> - Month</li>\n                <li><code>.DD.</code> - Day of month</li>\n                <li><code>.WW.</code> - Week of the year</li>\n                <li><code>.FY.</code> - Fiscal Year</li>\n                <li>\n                    <code>.{fieldname}.</code> - fieldname on the document e.g.\n                    <code>branch</code>\n                </li>\n            </ul>\n        </li>\n    </ul>\n    Examples:\n    <ul>\n        <li>INV-</li>\n        <li>INV-10-</li>\n        <li>INVK-</li>\n        <li>INV-.YYYY.-.{branch}.-.MM.-.####</li>\n    </ul>\n</div>\n<br>\n"
   },
   {
    "default": " ",
@@ -42,11 +41,6 @@
    "fieldtype": "Text",
    "label": "Preview of generated names",
    "read_only": 1
-  },
-  {
-   "fieldname": "add_series",
-   "fieldtype": "Button",
-   "label": "Add this Series"
   },
   {
    "default": "0",
@@ -71,7 +65,7 @@
   },
   {
    "fieldname": "prefix",
-   "fieldtype": "Select",
+   "fieldtype": "Autocomplete",
    "label": "Prefix"
   },
   {
@@ -93,13 +87,14 @@
    "label": "Series List for this Transaction"
   },
   {
+   "depends_on": "transaction_type",
    "fieldname": "try_naming_series",
    "fieldtype": "Data",
    "label": "Try a naming Series"
   },
   {
    "fieldname": "transaction_type",
-   "fieldtype": "Select",
+   "fieldtype": "Autocomplete",
    "label": "Select Transaction"
   },
   {

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.json
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -13,7 +13,7 @@
   "update",
   "column_break_9",
   "try_naming_series",
-  "preview",
+  "series_preview",
   "help_html",
   "update_series",
   "prefix",
@@ -34,13 +34,6 @@
    "fieldtype": "HTML",
    "label": "Help HTML",
    "options": "<div class=\"well\">\n    Edit list of Series in the box. Rules:\n    <ul>\n        <li>Each Series Prefix on a new line.</li>\n        <li>Allowed special characters are \"/\" and \"-\"</li>\n        <li>\n            Optionally, set the number of digits in the series using dot (.)\n            followed by hashes (#). For example, \".####\" means that the series\n            will have four digits. Default is five digits.\n        </li>\n        <li>\n            You can also use variables in the series name by putting them\n            between (.) dots\n            <br>\n            Supported Variables:\n            <ul>\n                <li><code>.YYYY.</code> - Year in 4 digits</li>\n                <li><code>.YY.</code> - Year in 2 digits</li>\n                <li><code>.MM.</code> - Month</li>\n                <li><code>.DD.</code> - Day of month</li>\n                <li><code>.WW.</code> - Week of the year</li>\n                <li><code>.FY.</code> - Fiscal Year</li>\n                <li>\n                    <code>.{fieldname}.</code> - fieldname on the document e.g.\n                    <code>branch</code>\n                </li>\n            </ul>\n        </li>\n    </ul>\n    Examples:\n    <ul>\n        <li>INV-</li>\n        <li>INV-10-</li>\n        <li>INVK-</li>\n        <li>INV-.YYYY.-.{branch}.-.MM.-.####</li>\n    </ul>\n</div>\n<br>\n"
-  },
-  {
-   "default": " ",
-   "fieldname": "preview",
-   "fieldtype": "Text",
-   "label": "Preview of generated names",
-   "read_only": 1
   },
   {
    "default": "0",
@@ -88,6 +81,7 @@
   },
   {
    "depends_on": "transaction_type",
+   "description": "Generate 3 preview of names generate by any valid series.",
    "fieldname": "try_naming_series",
    "fieldtype": "Data",
    "label": "Try a naming Series"
@@ -105,6 +99,12 @@
    "fieldname": "naming_series_tab",
    "fieldtype": "Tab Break",
    "label": "Naming Series"
+  },
+  {
+   "fieldname": "series_preview",
+   "fieldtype": "Text",
+   "label": "Preview of generated names",
+   "read_only": 1
   }
  ],
  "hide_toolbar": 1,

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.json
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.json
@@ -1,20 +1,21 @@
 {
  "actions": [],
  "creation": "2022-05-30 07:24:07.736646",
- "description": "Set prefix for numbering series on your transactions",
+ "description": "Configure various aspects of how document naming works like naming series, current counter.",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "naming_series_tab",
   "setup_series",
   "transaction_type",
-  "help_html",
   "try_naming_series",
   "preview",
   "add_series",
   "naming_series_options",
   "user_must_always_select",
   "update",
-  "column_break_13",
+  "column_break_9",
+  "help_html",
   "update_series",
   "prefix",
   "current_value",
@@ -22,10 +23,11 @@
  ],
  "fields": [
   {
-   "description": "Set prefix for numbering series on your transactions",
+   "collapsible": 1,
+   "description": "Set Naming Series options on your transactions.",
    "fieldname": "setup_series",
    "fieldtype": "Section Break",
-   "label": "Setup Series"
+   "label": "Setup Series for transactions"
   },
   {
    "depends_on": "transaction_type",
@@ -61,14 +63,11 @@
    "label": "Update"
   },
   {
-   "fieldname": "column_break_13",
-   "fieldtype": "Column Break"
-  },
-  {
-   "description": "Change the starting / current sequence number of an existing series.",
+   "collapsible": 1,
+   "description": "Change the starting / current sequence number of an existing series. <br>\n\nWarning: Incorrectly updating counters can prevent documents from getting created. ",
    "fieldname": "update_series",
    "fieldtype": "Section Break",
-   "label": "Update Series"
+   "label": "Update Series Counter"
   },
   {
    "fieldname": "prefix",
@@ -84,7 +83,8 @@
   {
    "fieldname": "update_series_start",
    "fieldtype": "Button",
-   "label": "Update Series Number"
+   "label": "Update Series Number",
+   "options": "update_series_start"
   },
   {
    "depends_on": "transaction_type",
@@ -101,13 +101,22 @@
    "fieldname": "transaction_type",
    "fieldtype": "Select",
    "label": "Select Transaction"
+  },
+  {
+   "fieldname": "column_break_9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "naming_series_tab",
+   "fieldtype": "Tab Break",
+   "label": "Naming Series"
   }
  ],
  "hide_toolbar": 1,
  "icon": "fa fa-sort-by-order",
  "issingle": 1,
  "links": [],
- "modified": "2022-05-30 08:07:28.047633",
+ "modified": "2022-05-30 23:51:36.136535",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Document Naming Settings",

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -38,7 +38,6 @@ class DocumentNamingSettings(Document):
 				options = self.get_options(d)
 			except frappe.DoesNotExistError:
 				frappe.msgprint(_("Unable to find DocType {0}").format(d))
-				# frappe.pass_does_not_exist_error()
 				continue
 
 			if options:

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -167,9 +167,13 @@ class DocumentNamingSettings(Document):
 			)
 
 	@frappe.whitelist()
-	def get_options(self, arg=None):
-		if frappe.get_meta(arg or self.transaction_type).get_field("naming_series"):
-			return frappe.get_meta(arg or self.transaction_type).get_field("naming_series").options
+	def get_options(self, doctype=None):
+		doctype = doctype or self.transaction_type
+		if not doctype:
+			return
+
+		if frappe.get_meta(doctype or self.transaction_type).get_field("naming_series"):
+			return frappe.get_meta(doctype or self.transaction_type).get_field("naming_series").options
 
 	@frappe.whitelist()
 	def get_current(self, arg=None):

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -144,6 +144,7 @@ class DocumentNamingSettings(Document):
 		if self.prefix:
 			prefix = NamingSeries(self.prefix).get_prefix()
 			self.current_value = frappe.db.get_value("Series", prefix, "current", order_by="name")
+		return self.current_value
 
 	@frappe.whitelist()
 	def update_series_start(self):
@@ -155,7 +156,7 @@ class DocumentNamingSettings(Document):
 		db_prefix = NamingSeries(self.prefix).get_prefix()
 
 		if frappe.db.get_value("Series", db_prefix, "name", order_by="name") is None:
-			series.insert(db_prefix, 0).columns(series.name, series.current).run()
+			frappe.db.sql("insert into `tabSeries` (`name`, `current`) values (%s, 0)", (db_prefix))
 
 		(
 			frappe.qb.update(series)

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.core.doctype.doctype.doctype import validate_series
 from frappe.model.document import Document
-from frappe.model.naming import NamingSeries, make_autoname
+from frappe.model.naming import NamingSeries, parse_naming_series
 from frappe.permissions import get_doctypes_with_read
 from frappe.utils import cint
 
@@ -173,23 +173,16 @@ class DocumentNamingSettings(Document):
 	def preview_series(self) -> str:
 		"""Preview what the naming series will generate."""
 
-		generated_names = []
 		series = self.try_naming_series
 		if not series:
 			return ""
-
 		try:
 			doc = self._fetch_last_doc_if_available()
-			for _count in range(3):
-				generated_names.append(make_autoname(series, doc=doc))
+			return "\n".join(NamingSeries(series).get_preview(doc=doc))
 		except Exception as e:
 			if frappe.message_log:
 				frappe.message_log.pop()
 			return _("Failed to generate names from the series") + f"\n{str(e)}"
-
-		# Explcitly rollback in case any changes were made to series table.
-		frappe.db.rollback()  # nosemgrep
-		return "\n".join(generated_names)
 
 	def _fetch_last_doc_if_available(self):
 		"""Fetch last doc for evaluating naming series with fields."""

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2022, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _, msgprint, throw
+from frappe.core.doctype.doctype.doctype import validate_series
+from frappe.model.document import Document
+from frappe.model.naming import make_autoname, parse_naming_series
+from frappe.permissions import get_doctypes_with_read
+from frappe.utils import cint, cstr
+
+
+class NamingSeriesNotSetError(frappe.ValidationError):
+	pass
+
+
+class DocumentNamingSettings(Document):
+	@frappe.whitelist()
+	def get_transactions(self, arg=None):
+		doctypes = list(
+			set(
+				frappe.db.sql_list(
+					"""select parent
+				from `tabDocField` df where fieldname='naming_series'"""
+				)
+				+ frappe.db.sql_list(
+					"""select dt from `tabCustom Field`
+				where fieldname='naming_series'"""
+				)
+			)
+		)
+
+		doctypes = list(set(get_doctypes_with_read()).intersection(set(doctypes)))
+		prefixes = ""
+		for d in doctypes:
+			options = ""
+			try:
+				options = self.get_options(d)
+			except frappe.DoesNotExistError:
+				frappe.msgprint(_("Unable to find DocType {0}").format(d))
+				# frappe.pass_does_not_exist_error()
+				continue
+
+			if options:
+				prefixes = prefixes + "\n" + options
+		prefixes.replace("\n\n", "\n")
+		prefixes = prefixes.split("\n")
+
+		custom_prefixes = frappe.get_all(
+			"DocType",
+			fields=["autoname"],
+			filters={
+				"name": ("not in", doctypes),
+				"autoname": ("like", "%.#%"),
+				"module": ("not in", ["Core"]),
+			},
+		)
+		if custom_prefixes:
+			prefixes = prefixes + [d.autoname.rsplit(".", 1)[0] for d in custom_prefixes]
+
+		prefixes = "\n".join(sorted(prefixes))
+
+		return {"transactions": "\n".join([""] + sorted(doctypes)), "prefixes": prefixes}
+
+	def scrub_options_list(self, ol):
+		options = list(filter(lambda x: x, [cstr(n).strip() for n in ol]))
+		return options
+
+	@frappe.whitelist()
+	def update_series(self, arg=None):
+		"""update series list"""
+		self.validate_series_set()
+		self.check_duplicate()
+		series_list = self.set_options.split("\n")
+
+		# set in doctype
+		self.set_series_for(self.select_doc_for_series, series_list)
+
+		# create series
+		map(self.insert_series, [d.split(".")[0] for d in series_list if d.strip()])
+
+		msgprint(_("Series Updated"))
+
+		return self.get_transactions()
+
+	def validate_series_set(self):
+		if self.select_doc_for_series and not self.set_options:
+			frappe.throw(_("Please set the series to be used."))
+
+	def set_series_for(self, doctype, ol):
+		options = self.scrub_options_list(ol)
+
+		# validate names
+		for i in options:
+			self.validate_series_name(i)
+
+		if options and self.user_must_always_select:
+			options = [""] + options
+
+		default = options[0] if options else ""
+
+		# update in property setter
+		prop_dict = {"options": "\n".join(options), "default": default}
+
+		for prop in prop_dict:
+			ps_exists = frappe.db.get_value(
+				"Property Setter", {"field_name": "naming_series", "doc_type": doctype, "property": prop}
+			)
+
+			if ps_exists:
+				ps = frappe.get_doc("Property Setter", ps_exists)
+				ps.value = prop_dict[prop]
+				ps.save()
+			else:
+				ps = frappe.get_doc(
+					{
+						"doctype": "Property Setter",
+						"doctype_or_field": "DocField",
+						"doc_type": doctype,
+						"field_name": "naming_series",
+						"property": prop,
+						"value": prop_dict[prop],
+						"property_type": "Text",
+						"__islocal": 1,
+					}
+				)
+				ps.save()
+
+		self.set_options = "\n".join(options)
+
+		frappe.clear_cache(doctype=doctype)
+
+	def check_duplicate(self):
+		parent = list(
+			set(
+				frappe.db.sql_list(
+					"""select dt.name
+				from `tabDocField` df, `tabDocType` dt
+				where dt.name = df.parent and df.fieldname='naming_series' and dt.name != %s""",
+					self.select_doc_for_series,
+				)
+				+ frappe.db.sql_list(
+					"""select dt.name
+				from `tabCustom Field` df, `tabDocType` dt
+				where dt.name = df.dt and df.fieldname='naming_series' and dt.name != %s""",
+					self.select_doc_for_series,
+				)
+			)
+		)
+		sr = [[frappe.get_meta(p).get_field("naming_series").options, p] for p in parent]
+		dt = frappe.get_doc("DocType", self.select_doc_for_series)
+		options = self.scrub_options_list(self.set_options.split("\n"))
+		for series in options:
+			validate_series(dt, series)
+			for i in sr:
+				if i[0]:
+					existing_series = [d.split(".")[0] for d in i[0].split("\n")]
+					if series.split(".")[0] in existing_series:
+						frappe.throw(_("Series {0} already used in {1}").format(series, i[1]))
+
+	def validate_series_name(self, n):
+		import re
+
+		if not re.match(r"^[\w\- \/.#{}]+$", n, re.UNICODE):
+			throw(
+				_('Special Characters except "-", "#", ".", "/", "{" and "}" not allowed in naming series')
+			)
+
+	@frappe.whitelist()
+	def get_options(self, arg=None):
+		if frappe.get_meta(arg or self.select_doc_for_series).get_field("naming_series"):
+			return frappe.get_meta(arg or self.select_doc_for_series).get_field("naming_series").options
+
+	@frappe.whitelist()
+	def get_current(self, arg=None):
+		"""get series current"""
+		if self.prefix:
+			prefix = self.parse_naming_series()
+			self.current_value = frappe.db.get_value("Series", prefix, "current", order_by="name")
+
+	def insert_series(self, series):
+		"""insert series if missing"""
+		if frappe.db.get_value("Series", series, "name", order_by="name") == None:
+			frappe.db.sql("insert into tabSeries (name, current) values (%s, 0)", (series))
+
+	@frappe.whitelist()
+	def update_series_start(self):
+		if self.prefix:
+			prefix = self.parse_naming_series()
+			self.insert_series(prefix)
+			frappe.db.sql(
+				"update `tabSeries` set current = %s where name = %s", (cint(self.current_value), prefix)
+			)
+			msgprint(_("Series Updated Successfully"))
+		else:
+			msgprint(_("Please select prefix first"))
+
+	def parse_naming_series(self):
+		parts = self.prefix.split(".")
+
+		# Remove ### from the end of series
+		if parts[-1] == "#" * len(parts[-1]):
+			del parts[-1]
+
+		prefix = parse_naming_series(parts)
+		return prefix
+
+	@frappe.whitelist()
+	def preview_series(self) -> str:
+		"""Preview what the naming series will generate."""
+
+		generated_names = []
+		series = self.naming_series_to_check
+		if not series:
+			return ""
+
+		try:
+			doc = self._fetch_last_doc_if_available()
+			for _count in range(3):
+				generated_names.append(make_autoname(series, doc=doc))
+		except Exception as e:
+			if frappe.message_log:
+				frappe.message_log.pop()
+			return _("Failed to generate names from the series") + f"\n{str(e)}"
+
+		# Explcitly rollback in case any changes were made to series table.
+		frappe.db.rollback()  # nosemgrep
+		return "\n".join(generated_names)
+
+	def _fetch_last_doc_if_available(self):
+		"""Fetch last doc for evaluating naming series with fields."""
+		try:
+			return frappe.get_last_doc(self.select_doc_for_series)
+		except Exception:
+			return None
+
+
+def set_by_naming_series(
+	doctype, fieldname, naming_series, hide_name_field=True, make_mandatory=1
+):
+	from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+	if naming_series:
+		make_property_setter(
+			doctype, "naming_series", "hidden", 0, "Check", validate_fields_for_doctype=False
+		)
+		make_property_setter(
+			doctype, "naming_series", "reqd", make_mandatory, "Check", validate_fields_for_doctype=False
+		)
+
+		# set values for mandatory
+		try:
+			frappe.db.sql(
+				"""update `tab{doctype}` set naming_series={s} where
+				ifnull(naming_series, '')=''""".format(
+					doctype=doctype, s="%s"
+				),
+				get_default_naming_series(doctype),
+			)
+		except NamingSeriesNotSetError:
+			pass
+
+		if hide_name_field:
+			make_property_setter(doctype, fieldname, "reqd", 0, "Check", validate_fields_for_doctype=False)
+			make_property_setter(
+				doctype, fieldname, "hidden", 1, "Check", validate_fields_for_doctype=False
+			)
+	else:
+		make_property_setter(
+			doctype, "naming_series", "reqd", 0, "Check", validate_fields_for_doctype=False
+		)
+		make_property_setter(
+			doctype, "naming_series", "hidden", 1, "Check", validate_fields_for_doctype=False
+		)
+
+		if hide_name_field:
+			make_property_setter(
+				doctype, fieldname, "hidden", 0, "Check", validate_fields_for_doctype=False
+			)
+			make_property_setter(doctype, fieldname, "reqd", 1, "Check", validate_fields_for_doctype=False)
+
+			# set values for mandatory
+			frappe.db.sql(
+				"""update `tab{doctype}` set `{fieldname}`=`name` where
+				ifnull({fieldname}, '')=''""".format(
+					doctype=doctype, fieldname=fieldname
+				)
+			)
+
+
+def get_default_naming_series(doctype):
+	naming_series = frappe.get_meta(doctype).get_field("naming_series").options or ""
+	naming_series = naming_series.split("\n")
+	out = naming_series[0] or (naming_series[1] if len(naming_series) > 1 else None)
+
+	if not out:
+		frappe.throw(
+			_("Please set Naming Series for {0} via Setup > Settings > Naming Series").format(doctype),
+			NamingSeriesNotSetError,
+		)
+	else:
+		return out

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -58,9 +58,7 @@ class DocumentNamingSettings(Document):
 		if custom_prefixes:
 			prefixes = prefixes + [d.autoname.rsplit(".", 1)[0] for d in custom_prefixes]
 
-		prefixes = "\n".join(sorted(prefixes))
-
-		return {"transactions": "\n".join([""] + sorted(doctypes)), "prefixes": prefixes}
+		return {"transactions": sorted(doctypes), "prefixes": sorted(prefixes)}
 
 	def scrub_options_list(self, ol):
 		options = list(filter(lambda x: x, [cstr(n).strip() for n in ol]))

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.core.doctype.document_naming_settings.document_naming_settings import (
+	NAMING_SERIES_PATTERN,
 	DocumentNamingSettings,
 )
 from frappe.model.naming import get_default_naming_series
@@ -11,24 +12,24 @@ from frappe.tests.utils import FrappeTestCase
 
 class TestNamingSeries(FrappeTestCase):
 	def setUp(self):
-		self.ns: DocumentNamingSettings = frappe.get_doc("Document Naming Settings")
+		self.dns: DocumentNamingSettings = frappe.get_doc("Document Naming Settings")
 
 	def tearDown(self):
 		frappe.db.rollback()
 
 	def test_naming_preview(self):
-		self.ns.transaction_type = "Webhook"
+		self.dns.transaction_type = "Webhook"
 
-		self.ns.try_naming_series = "AXBZ.####"
-		serieses = self.ns.preview_series().split("\n")
+		self.dns.try_naming_series = "AXBZ.####"
+		serieses = self.dns.preview_series().split("\n")
 		self.assertEqual(["AXBZ0001", "AXBZ0002", "AXBZ0003"], serieses)
 
-		self.ns.try_naming_series = "AXBZ-.{currency}.-"
-		serieses = self.ns.preview_series().split("\n")
+		self.dns.try_naming_series = "AXBZ-.{currency}.-"
+		serieses = self.dns.preview_series().split("\n")
 
 	def test_get_transactions(self):
 
-		naming_info = self.ns.get_transactions_and_prefixes()
+		naming_info = self.dns.get_transactions_and_prefixes()
 		self.assertIn("Webhook", naming_info["transactions"])
 
 		existing_naming_series = frappe.get_meta("Webhook").get_field("naming_series").options

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.core.doctype.document_naming_settings.document_naming_settings import (
 	DocumentNamingSettings,
 )
+from frappe.model.naming import get_default_naming_series
 from frappe.tests.utils import FrappeTestCase
 
 
@@ -16,7 +17,7 @@ class TestNamingSeries(FrappeTestCase):
 		frappe.db.rollback()
 
 	def test_naming_preview(self):
-		self.ns.transaction_type = "Sales Invoice"
+		self.ns.transaction_type = "Webhook"
 
 		self.ns.try_naming_series = "AXBZ.####"
 		serieses = self.ns.preview_series().split("\n")
@@ -27,10 +28,14 @@ class TestNamingSeries(FrappeTestCase):
 
 	def test_get_transactions(self):
 
-		naming_info = self.ns.get_transactions()
-		self.assertIn("Sales Invoice", naming_info["transactions"])
+		naming_info = self.ns.get_transactions_and_prefixes()
+		self.assertIn("Webhook", naming_info["transactions"])
 
-		existing_naming_series = frappe.get_meta("Sales Invoice").get_field("naming_series").options
+		existing_naming_series = frappe.get_meta("Webhook").get_field("naming_series").options
 
 		for series in existing_naming_series.split("\n"):
 			self.assertIn(series, naming_info["prefixes"])
+
+	def test_default_naming_series(self):
+		self.assertIn("HOOK", get_default_naming_series("Webhook"))
+		self.assertIsNone(get_default_naming_series("DocType"))

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -62,4 +62,4 @@ class TestNamingSeries(FrappeTestCase):
 			new_count = self.dns.current_value = current_count + 1
 			self.dns.update_series_start()
 
-			self.assertEqual(self.dns.get_current(), new_count)
+			self.assertEqual(self.dns.get_current(), new_count, f"Incorrect update for {series}")

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -5,7 +5,7 @@ import frappe
 from frappe.core.doctype.document_naming_settings.document_naming_settings import (
 	DocumentNamingSettings,
 )
-from frappe.model.naming import get_default_naming_series
+from frappe.model.naming import NamingSeries, get_default_naming_series
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cint
 
@@ -40,7 +40,7 @@ class TestNamingSeries(FrappeTestCase):
 		existing_naming_series = frappe.get_meta("Webhook").get_field("naming_series").options
 
 		for series in existing_naming_series.split("\n"):
-			self.assertIn(series, naming_info["prefixes"])
+			self.assertIn(NamingSeries(series).get_prefix(), naming_info["prefixes"])
 
 	def test_default_naming_series(self):
 		self.assertIn("HOOK", get_default_naming_series("Webhook"))

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -10,7 +10,7 @@ from frappe.tests.utils import FrappeTestCase
 
 class TestNamingSeries(FrappeTestCase):
 	def setUp(self):
-		self.ns: DocumentNamingSettings = frappe.get_doc("Naming Series Settings")
+		self.ns: DocumentNamingSettings = frappe.get_doc("Document Naming Settings")
 
 	def tearDown(self):
 		frappe.db.rollback()

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2022, Frappe Technologies and Contributors
+# See license.txt
+
+import frappe
+from frappe.core.doctype.document_naming_settings.document_naming_settings import (
+	DocumentNamingSettings,
+)
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestNamingSeries(FrappeTestCase):
+	def setUp(self):
+		self.ns: DocumentNamingSettings = frappe.get_doc("Naming Series Settings")
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_naming_preview(self):
+		self.ns.select_doc_for_series = "Sales Invoice"
+
+		self.ns.naming_series_to_check = "AXBZ.####"
+		serieses = self.ns.preview_series().split("\n")
+		self.assertEqual(["AXBZ0001", "AXBZ0002", "AXBZ0003"], serieses)
+
+		self.ns.naming_series_to_check = "AXBZ-.{currency}.-"
+		serieses = self.ns.preview_series().split("\n")
+
+	def test_get_transactions(self):
+
+		naming_info = self.ns.get_transactions()
+		self.assertIn("Sales Invoice", naming_info["transactions"])
+
+		existing_naming_series = frappe.get_meta("Sales Invoice").get_field("naming_series").options
+
+		for series in existing_naming_series.split("\n"):
+			self.assertIn(series, naming_info["prefixes"])

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -16,13 +16,13 @@ class TestNamingSeries(FrappeTestCase):
 		frappe.db.rollback()
 
 	def test_naming_preview(self):
-		self.ns.select_doc_for_series = "Sales Invoice"
+		self.ns.transaction_type = "Sales Invoice"
 
-		self.ns.naming_series_to_check = "AXBZ.####"
+		self.ns.try_naming_series = "AXBZ.####"
 		serieses = self.ns.preview_series().split("\n")
 		self.assertEqual(["AXBZ0001", "AXBZ0002", "AXBZ0003"], serieses)
 
-		self.ns.naming_series_to_check = "AXBZ-.{currency}.-"
+		self.ns.try_naming_series = "AXBZ-.{currency}.-"
 		serieses = self.ns.preview_series().split("\n")
 
 	def test_get_transactions(self):

--- a/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/test_document_naming_settings.py
@@ -3,7 +3,6 @@
 
 import frappe
 from frappe.core.doctype.document_naming_settings.document_naming_settings import (
-	NAMING_SERIES_PATTERN,
 	DocumentNamingSettings,
 )
 from frappe.model.naming import get_default_naming_series

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -17,6 +17,7 @@ Example:
 import json
 import os
 from datetime import datetime
+from typing import List
 
 import click
 
@@ -340,6 +341,16 @@ class Meta(Document):
 
 	def get_workflow(self):
 		return get_workflow_name(self.name)
+
+	def get_naming_series_options(self) -> List[str]:
+		"""Get list naming series options."""
+
+		field = self.get_field("naming_series")
+		if field:
+			options = field.options or ""
+
+			return options.split("\n")
+		return []
 
 	def add_custom_fields(self):
 		if not frappe.db.table_exists("Custom Field"):

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -311,14 +311,15 @@ def revert_series_if_last(key, name, doc=None):
 		frappe.db.sql("UPDATE `tabSeries` SET `current` = `current` - 1 WHERE `name`=%s", prefix)
 
 
-def get_default_naming_series(doctype):
+def get_default_naming_series(doctype: str) -> Optional[str]:
 	"""get default value for `naming_series` property"""
-	naming_series = frappe.get_meta(doctype).get_field("naming_series").options or ""
-	if naming_series:
-		naming_series = naming_series.split("\n")
-		return naming_series[0] or naming_series[1]
-	else:
-		return None
+	naming_series_options = frappe.get_meta(doctype).get_naming_series_options()
+
+	# Return first truthy options
+	# Empty strings are used to avoid populating forms by default
+	for option in naming_series_options:
+		if option:
+			return option
 
 
 def validate_name(doctype: str, name: Union[int, str], case: Optional[str] = None):

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -80,6 +80,17 @@ class NamingSeries:
 
 		return prefix
 
+	def get_preview(self, doc=None) -> List[str]:
+		"""Generate preview of naming series without using DB counters"""
+		generated_names = []
+		for count in range(1, 4):
+
+			def fake_counter(_prefix, digits):
+				return str(count).zfill(digits)
+
+			generated_names.append(parse_naming_series(self.series, doc=doc, number_generator=fake_counter))
+		return generated_names
+
 
 def set_new_name(doc):
 	"""

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.model.naming import (
 	append_number_if_name_exists,
 	determine_consecutive_week_number,
+	get_naming_series_prefix,
 	getseries,
 	revert_series_if_last,
 )
@@ -287,6 +286,21 @@ class TestNaming(FrappeTestCase):
 			self.assertEqual(frappe.new_doc(doctype).save(ignore_permissions=True).name, i)
 
 		dt.delete(ignore_permissions=True)
+
+	def test_naming_series_prefix(self):
+		today = now_datetime()
+		year = today.strftime("%y")
+		month = today.strftime("%m")
+
+		prefix_test_cases = {
+			"SINV-.YY.-.####": f"SINV-{year}-",
+			"SINV-.YY.-.MM.-.####": f"SINV-{year}-{month}-",
+			"SINV": "SINV",
+			"SINV-.": "SINV-",
+		}
+
+		for series, prefix in prefix_test_cases.items():
+			self.assertEqual(prefix, get_naming_series_prefix(series))
 
 
 def make_invalid_todo():


### PR DESCRIPTION
Collection of tools related to document naming will now be part of "Document Naming Settings"

These include:
- Updating naming series for any doctype
- Previewing naming series values
- Changing counter of naming series values
- Moar in future. 

screens:

Collapsed sections / tabs

<img width="591" alt="Screenshot 2022-05-30 at 8 17 05 PM" src="https://user-images.githubusercontent.com/9079960/171016755-084f5e6f-e04a-4dd7-9274-19842b827275.png">


Expanded sections

<img width="659" alt="Screenshot 2022-05-30 at 8 17 24 PM" src="https://user-images.githubusercontent.com/9079960/171016734-30cba498-27f3-4c0b-951b-432deedf9dca.png">


Autocomplete to pick transaction / prefix:

<img width="659" alt="Screenshot 2022-05-30 at 8 17 29 PM" src="https://user-images.githubusercontent.com/9079960/171016658-8d3b7f7c-d4f8-4fe5-be5f-678ef79b4764.png">



Live preview, help in 2nd column

<img width="1262" alt="Screenshot 2022-05-30 at 8 17 50 PM" src="https://user-images.githubusercontent.com/9079960/171016611-b209da10-1c28-4112-a1a1-b5932ed95322.png">

Support updating arbitrary naming series like batch/serial nos too. 

<img width="660" alt="Screenshot 2022-05-31 at 12 34 54 PM" src="https://user-images.githubusercontent.com/9079960/171112742-9d104337-5ac2-4777-9b50-9423382de2f8.png">

Create a version log when values are changed

<img width="1334" alt="Screenshot 2022-05-31 at 12 47 43 PM" src="https://user-images.githubusercontent.com/9079960/171114981-f6d44abc-6887-436e-9347-254d63784fdb.png">




TODO:
- [x] Code cleanup 💩 
- [x] Docs: https://docs.erpnext.com/docs/v14/user/manual/en/setting-up/settings/document-naming-settings 
- [x] tests for previously untested bits. 
- [x] Basic validation for selected naming series like it should actually be a series
- [x] Better solution for prefix counter hacks
- [x] Generate naming series preview without any DB calls
- [x] Refactor a whole bunch of naming series operations into a new `naming.NamingSeries` class



closes https://github.com/frappe/frappe/issues/4848 (replaced giant select field with autocomplete)
closes https://github.com/frappe/frappe/issues/5937 
closes https://github.com/frappe/frappe/issues/16998 


ERPNext CI: https://github.com/frappe/erpnext/actions/runs/2413337908 