### PR TITLE
fix: naming using doc fields

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -54,7 +54,7 @@ class NamingSeries:
 	def generate_next_name(self, doc: "Document") -> str:
 		self.validate()
 		parts = self.series.split(".")
-		return parse_naming_series(parts, doc)
+		return parse_naming_series(parts, doc=doc)
 
 	def get_prefix(self) -> str:
 		"""Naming series stores prefix to maintain a counter in DB. This prefix can be used to update counter or validations.

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -319,6 +319,15 @@ class TestNaming(FrappeTestCase):
 		for series in invalid:
 			self.assertRaises(InvalidNamingSeriesError, NamingSeries(series).validate)
 
+	def test_naming_using_fields(self):
+
+		webhook = frappe.new_doc("Webhook")
+		webhook.webhook_docevent = "on_update"
+		name = NamingSeries("KOOH-.{webhook_docevent}.").generate_next_name(webhook)
+		self.assertTrue(
+			name.startswith("KOOH-on_update"), f"incorrect name generated {name}, missing field value"
+		)
+
 
 def make_invalid_todo():
 	frappe.get_doc({"doctype": "ToDo", "description": "Test"}).insert(set_name="ToDo")


### PR DESCRIPTION
doc was passed incorrectly to the function that generates the next name. The 2nd parameter is actually unused 🤷 

Caused by https://github.com/frappe/frappe/pull/17027