### PR TITLE
perf: store compact JSON in version diffs

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1818,18 +1818,21 @@ def get_value(*args, **kwargs):
 	return db.get_value(*args, **kwargs)
 
 
-def as_json(obj: Union[Dict, List], indent=1) -> str:
+def as_json(obj: Union[Dict, List], indent=1, separators=None) -> str:
 	from frappe.utils.response import json_handler
+
+	if separators is None:
+		separators = (",", ": ")
 
 	try:
 		return json.dumps(
-			obj, indent=indent, sort_keys=True, default=json_handler, separators=(",", ": ")
+			obj, indent=indent, sort_keys=True, default=json_handler, separators=separators
 		)
 	except TypeError:
 		# this would break in case the keys are not all os "str" type - as defined in the JSON
 		# adding this to ensure keys are sorted (expected behaviour)
 		sorted_obj = dict(sorted(obj.items(), key=lambda kv: str(kv[0])))
-		return json.dumps(sorted_obj, indent=indent, default=json_handler, separators=(",", ": "))
+		return json.dumps(sorted_obj, indent=indent, default=json_handler, separators=separators)
 
 
 def are_emails_muted():

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -15,7 +15,7 @@ class Version(Document):
 		if diff:
 			self.ref_doctype = new.doctype
 			self.docname = new.name
-			self.data = frappe.as_json(diff)
+			self.data = frappe.as_json(diff, indent=None, separators=(",", ":"))
 			return True
 		else:
 			return False


### PR DESCRIPTION
There's no need to prettify this data. 


Table size comparison:
- Before: 13.3MB
- After: 10.5 MB (compacted manually and partial backup-restored for accurate numbers)

So ~22% space savings (Which means a lot since this is one of the largest tables usually) 