### PR TITLE
fix: dont set standard fields in child doc using set_value

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1493,15 +1493,21 @@ frappe.ui.form.Form = class FrappeForm {
 			if(fieldobj) {
 				if(!if_missing || !frappe.model.has_value(me.doctype, me.doc.name, f)) {
 					if(frappe.model.table_fields.includes(fieldobj.df.fieldtype) && $.isArray(v)) {
-
+						// set entire child table from specified array as value
 						frappe.model.clear_table(me.doc, fieldobj.df.fieldname);
 
-						for (var i=0, j=v.length; i < j; i++) {
-							var d = v[i];
-							var child = frappe.model.add_child(me.doc, fieldobj.df.options,
-								fieldobj.df.fieldname, i+1);
-							$.extend(child, d);
-						}
+						const standard_fields = [...frappe.model.std_fields_list, ...frappe.model.child_table_field_list];
+						v.forEach((d, idx) => {
+							let child = frappe.model.add_child(me.doc, fieldobj.df.options,
+								fieldobj.df.fieldname, idx+1);
+
+							// Don't set standard field, avoid mutating input too.
+							let doc_copy = {...d};
+							standard_fields.forEach(field => {
+								delete doc_copy[field];
+							});
+							$.extend(child, doc_copy);
+						});
 
 						me.refresh_field(f);
 						return Promise.resolve();


### PR DESCRIPTION
`frm.set_value(table_field, array_of_rows, ...)` just adds all specified arrays to child table without any validation and leaves sanitization work to whoever passes array.

This causes catastrophic errors and breaks desk if std fields are incorrectly set, For example: https://github.com/frappe/erpnext/issues/31213


Solution: only update non-std fields. 

tested ERPNext sales cycle manually, where this is kinda used. 