### PR TITLE
feat(UI): Add beforeunload Listener for 'Leave Site' Dialog to dirty forms

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -44,7 +44,7 @@ frappe.ui.form.Form = class FrappeForm {
 			event.preventDefault();
 			// A String is returned for compatability with older Browsers. Return Value has to be truthy to trigger "Leave Site" Dialog
 			return event.returnValue = 'There are unsaved changes, are you sure you want to exit?';
-	 	};
+		};
 	}
 
 	setup_meta() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1244,7 +1244,7 @@ frappe.ui.form.Form = class FrappeForm {
 	dirty() {
 		this.doc.__unsaved = 1;
 		this.$wrapper.trigger('dirty');
-		if(!frappe.boot.developer_mode){
+		if (!frappe.boot.developer_mode) {
 			addEventListener("beforeunload", this.beforeUnloadListener, {capture: true});
 		}
 	}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -112,6 +112,7 @@ frappe.ui.form.Form = class FrappeForm {
 		this.setup_file_drop();
 		this.setup_doctype_actions();
 		this.setup_notify_on_rename();
+		this.set_dirty_listener()
 
 		this.setup_done = true;
 	}
@@ -419,6 +420,17 @@ frappe.ui.form.Form = class FrappeForm {
 				});
 			}
 		}
+	}
+
+
+	// Adds un beforeunload Listener to trigger a "Leave Site" Dialog, when a dirty (unsaved) form is closed
+	set_dirty_listener() {
+		addEventListener('beforeunload', (event) => {
+			if (cur_frm.is_dirty()) {
+			event.preventDefault();
+			return event.returnValue = 'There are unsaved changes, are you sure you want to exit?';
+			}
+			}, {capture: true});
 	}
 
 	execute_action(action) {


### PR DESCRIPTION
This closes #17058
When the tab of an unsaved document form is closed, a "Leave Site" Dialog is triggered.

The Dialog will not be triggered when the Bench is in developer mode

For performance reasons, the Listener for the Dialog is only added when dirty() is called on the frame and removed when the frame is refreshed

Link to Documentation: https://frappeframework.com/docs/v14/user/en/desk/edit?wiki_page_patch=f4109a89cc