### PR TITLE
perf!: improve document caching

### DIFF
--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -30,7 +30,7 @@ class RedisWrapper(redis.Redis):
 
 		return "{0}|{1}".format(frappe.conf.db_name, key).encode("utf-8")
 
-	def set_value(self, key, val, user=None, expires_in_sec=None, shared=False):
+	def set_value(self, key, val, user=None, expires_in_sec=None, shared=False, cache_locally=True):
 		"""Sets cache value.
 
 		:param key: Cache key
@@ -40,7 +40,7 @@ class RedisWrapper(redis.Redis):
 		"""
 		key = self.make_key(key, user, shared)
 
-		if not expires_in_sec:
+		if not expires_in_sec and cache_locally:
 			frappe.local.cache[key] = val
 
 		try:
@@ -151,16 +151,17 @@ class RedisWrapper(redis.Redis):
 	def ltrim(self, key, start, stop):
 		return super(RedisWrapper, self).ltrim(self.make_key(key), start, stop)
 
-	def hset(self, name, key, value, shared=False):
+	def hset(self, name: str, key: str, value, shared: bool = False, cache_locally: bool = True):
 		if key is None:
 			return
 
 		_name = self.make_key(name, shared=shared)
 
 		# set in local
-		if _name not in frappe.local.cache:
-			frappe.local.cache[_name] = {}
-		frappe.local.cache[_name][key] = value
+		if cache_locally:
+			if _name not in frappe.local.cache:
+				frappe.local.cache[_name] = {}
+			frappe.local.cache[_name][key] = value
 
 		# set in redis
 		try:

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -169,6 +169,15 @@ class RedisWrapper(redis.Redis):
 		except redis.exceptions.ConnectionError:
 			pass
 
+	def hexists(self, name: str, key: str, shared: bool = False) -> bool:
+		if key is None:
+			return False
+		_name = self.make_key(name, shared=shared)
+		try:
+			return super(RedisWrapper, self).hexists(_name, key)
+		except redis.exceptions.ConnectionError:
+			return False
+
 	def hgetall(self, name):
 		value = super(RedisWrapper, self).hgetall(self.make_key(name))
 		return {key: pickle.loads(value) for key, value in value.items()}


### PR DESCRIPTION
Re of https://github.com/frappe/frappe/pull/13580 with concerns addressed (only took me 1 year 🤓)


Problem:
- Every call to `get_doc` stores the document in cache. If you scan through codebase, they are hardly, if ever read from cache. This is sort of a waste of memory and compute. 
- When long running processing of multiple docs is performed the docs are not cleared from memory. Take this very silly example (a lot of similar real world usage exists, one of which triggered this PR)

```python
processed_names = []
for name in frappe.get_all("Item", pluck="name"):
    doc = frappe.get_doc("Item", name)
    doc.process()
    processed_names.append(doc.name)
```

Here from basic logic of garbage collection, the underlying `doc` object is discarded after every loop iteration and it's reference count should go to 0, so Python's GC can reclaim this memory. However, because we cache the same document object internally in `local.document_cache` and dictionary version in `local.cache["document_cache"]` this doc's reference count never goes to 0 and memory usage just keeps growing.



**Solution:**
- Do not cache from `get_doc`
- Cache to redis/local when `get_cached_doc` is called first time, subsequent calls are same as before. 
- When `get_doc` is done, replace the existing cached document iff cached document exist. i.e. don't bother creating new cache from `get_doc`


**Pros:**
- Lower redis memory usage. 
- Faster `get_doc` - avoids one `HSET` and `.to_dict()` call for every call
- Reduces chances of memory blowing up on web/background worker due to unnecessary caching in worker's local. 

**Cons:**
This type of code will hit DB twice since the first call to get_cached_doc will always be cache-miss IF the document wasn't already in the cache. Not that common, but possible, a small cost to pay IMO :p 
```python
frappe.get_doc(...)
...
frappe.get_cached_doc(...)
...
frappe.get_cached_doc(...)
```



**Memory usage (in MiB)**

~98-99% reduction in memory usage from `get_doc`. It's nearly constant now!

```python
@profile
def process_all_stock_entries(limit=None):
	processed = []

	frappe.get_last_doc("Stock Entry") # trigger all one time memory cost to be paid related to get_doc
	for se_name in frappe.get_all("Stock Entry", pluck="name", limit=limit):
		se = frappe.get_doc("Stock Entry", se_name)
		processed.append(se.name)

	return len(processed)
```

Docs processed | Current | Disable cache 
-- | -- | -- 
100 | 2.4 | 0.8 
250 | 5.7 | 1 
500 | 11.7 | 1.1 
750 | 17.2 | 1.1 


<img width="595" alt="Screenshot 2022-06-03 at 10 14 40 PM" src="https://user-images.githubusercontent.com/9079960/171909150-01ff0640-1ed2-4b75-824a-4bc2c930b053.png">



---

`get_doc` performance ~ 8% faster

```
Before
2.89 s ± 35.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


After
2.64 s ± 139 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
