### PR TITLE
feat(workspace): start searching on alphabetic keypress

### DIFF
--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -81,6 +81,7 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 		}
 		let html = shortcuts
 			.filter(s => s.condition ? s.condition() : true)
+			.filter(s => !!s.description)
 			.map(shortcut => {
 				let shortcut_label = shortcut.shortcut
 					.split('+')
@@ -94,6 +95,8 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 					<td width="60%">${shortcut.description || ''}</td>
 				</tr>`;
 			}).join('');
+		if (!html) return '';
+
 		html = `<h5 style="margin: 0;">${heading}</h5>
 			<table style="margin-top: 10px;" class="table table-bordered">
 				${html}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -106,6 +106,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				frappe.set_route(item.route);
 			}
 			$input.val("");
+			$input.trigger('blur');
 		});
 
 		$input.on("awesomplete-selectcomplete", function(e) {

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -37,6 +37,7 @@ frappe.views.Workspace = class Workspace {
 
 		this.prepare_container();
 		this.setup_pages();
+		this.register_awesomebar_shortcut();
 	}
 
 	prepare_container() {
@@ -1227,5 +1228,19 @@ frappe.views.Workspace = class Workspace {
 	remove_sidebar_skeleton() {
 		$('.desk-sidebar').removeClass('hidden');
 		$('.list-sidebar').find('.workspace-sidebar-skeleton').remove();
+	}
+
+	register_awesomebar_shortcut() {
+		'abcdefghijklmnopqrstuvwxyz'.split('').forEach(letter => {
+			const default_shortcut = {
+				action: (e) => {
+					$("#navbar-search").focus();
+					return false; // don't prevent default = type the letter in awesomebar
+				},
+				page: this.page,
+			};
+			frappe.ui.keys.add_shortcut({shortcut: letter, ...default_shortcut});
+			frappe.ui.keys.add_shortcut({shortcut: `shift+${letter}`, ...default_shortcut});
+		});
 	}
 };


### PR DESCRIPTION
This PR reduces one click / keybind. 

When you're on the homepage / any workspace you can now start typing and go straight to where you want to. 


https://user-images.githubusercontent.com/9079960/172055715-099baa71-4eea-4b1e-b9b2-658b0af7e8af.mov



Other changes:
- Don't show registered KB shortcuts if they don't have description. 
- Blur awesome bar once any result is selected


`no-docs`