### PR TITLE
feat(UX)!: always sharable URLs on List/Report/Kanbanview

### DIFF
--- a/cypress/integration/routing.js
+++ b/cypress/integration/routing.js
@@ -1,0 +1,36 @@
+const list_view = "/app/todo";
+
+// test round trip with filter types
+
+const test_queries = [
+	"?status=Open",
+	`?date=%5B"Between"%2C%5B"2022-06-01"%2C"2022-06-30"%5D%5D`,
+	`?date=%5B">"%2C"2022-06-01"%5D`,
+	`?name=%5B"like"%2C"%2542%25"%5D`,
+	`?status=%5B"not%20in"%2C%5B"Open"%2C"Closed"%5D%5D`,
+];
+
+describe("SPA Routing", { scrollBehavior: false }, () => {
+	before(() => {
+		cy.login();
+		cy.go_to_list("ToDo");
+	});
+
+	it("should apply filter on list view from route", () => {
+		test_queries.forEach((query) => {
+			const full_url = `${list_view}${query}`;
+			cy.visit(full_url);
+			cy.findByTitle("To Do").should("exist");
+
+			const expected = new URLSearchParams(query);
+			cy.location().then((loc) => {
+				const actual = new URLSearchParams(loc.search);
+				// This might appear like a dumb test checking visited URL to itself
+				// but it's actually doing a round trip
+				// URL with params -> parsed filters -> new URL
+				// if it's same that means everything worked in between.
+				expect(actual.toString()).to.eq(expected.toString());
+			});
+		});
+	});
+});

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -621,6 +621,8 @@ class FilterArea {
 
 		filters = filters.filter(f => !this.exists(f));
 
+		// standard filters = filters visible on list view
+		// non-standard filters = filters set by filter button
 		const { non_standard_filters, promise } = this.set_standard_filter(
 			filters
 		);
@@ -680,9 +682,14 @@ class FilterArea {
 			out.promise = out.promise || Promise.resolve();
 			out.non_standard_filters = out.non_standard_filters || [];
 
+			// set in list view area if filters are present
+			// don't set like filter on link fields (gets reset)
 			if (
 				fields_dict[fieldname] &&
-				(condition === "=" || condition === "like")
+				(
+					condition === "=" ||
+					(condition === "like" && fields_dict[fieldname]?.df?.fieldtype != "Link")
+				)
 			) {
 				// standard filter
 				out.promise = out.promise.then(() =>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1461,9 +1461,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	get_url_with_filters() {
 		const query_params = this.get_filters_for_args()
 			.map((filter) => {
-				filter[3] = encodeURIComponent(filter[3]);
 				if (filter[2] === "=") {
-					return `${filter[1]}=${filter[3]}`;
+					return `${filter[1]}=${encodeURIComponent(filter[3])}`;
 				}
 				return [
 					filter[1],

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1473,7 +1473,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			})
 			.join("&");
 
-		let full_url = window.location.href;
+		let full_url = window.location.href.replace(window.location.search, "");
 		if (query_params) {
 			full_url += "?" + query_params;
 		}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1454,7 +1454,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	on_update() {}
 
-	get_share_url() {
+	on_filter_change() {
+		window.history.replaceState(null, null, this.get_url_with_filters());
+	}
+
+	get_url_with_filters() {
 		const query_params = this.get_filters_for_args()
 			.map((filter) => {
 				filter[3] = encodeURIComponent(filter[3]);
@@ -1474,27 +1478,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			full_url += "?" + query_params;
 		}
 		return full_url;
-	}
-
-	share_url() {
-		const d = new frappe.ui.Dialog({
-			title: __("Share URL"),
-			fields: [
-				{
-					fieldtype: "Code",
-					fieldname: "url",
-					label: "URL",
-					default: this.get_share_url(),
-					read_only: 1,
-				},
-			],
-			primary_action_label: __("Copy to clipboard"),
-			primary_action: () => {
-				frappe.utils.copy_to_clipboard(this.get_share_url());
-				d.hide();
-			},
-		});
-		d.show();
 	}
 
 	get_menu_items() {
@@ -1559,13 +1542,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			condition: () => !this.hide_sidebar,
 			standard: true,
 			shortcut: "Ctrl+K",
-		});
-
-		items.push({
-			label: __("Share URL", null, "Button in list view menu"),
-			action: () => this.share_url(),
-			standard: true,
-			shortcut: "Ctrl+L",
 		});
 
 		if (

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -291,6 +291,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		super.refresh().then(() => {
 			this.render_header(refresh_header);
 			this.update_checkbox();
+			this.update_url_with_filters();
 		});
 	}
 
@@ -1454,7 +1455,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	on_update() {}
 
-	on_filter_change() {
+	update_url_with_filters() {
 		window.history.replaceState(null, null, this.get_url_with_filters());
 	}
 

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -121,7 +121,7 @@ frappe.router = {
 		route = this.get_sub_path_string(route).split('/');
 		if (!route) return [];
 		route = $.map(route, this.decode_component);
-		this.set_route_options_from_url(route);
+		this.set_route_options_from_url();
 		return this.convert_to_standard_route(route);
 	},
 
@@ -410,18 +410,17 @@ frappe.router = {
 		return route;
 	},
 
-	set_route_options_from_url(route) {
+	set_route_options_from_url() {
 		// set query parameters as frappe.route_options
-		var last_part = route[route.length - 1];
-		if (last_part.indexOf("?") < last_part.indexOf("=")) {
-			// has ? followed by =
-			let parts = last_part.split("?");
+		let query_string = window.location.search;
 
-			// route should not contain string after ?
-			route[route.length - 1] = parts[0];
+		if (!frappe.route_options) {
+			frappe.route_options = {};
+		}
 
-			let query_params = frappe.utils.get_query_params(parts[1]);
-			frappe.route_options = $.extend(frappe.route_options || {}, query_params);
+		let params = new URLSearchParams(query_string);
+		for (const [key, value] of params) {
+			frappe.route_options[key] = value;
 		}
 	},
 

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -64,10 +64,6 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 			});
 	}
 
-	before_refresh() {
-
-	}
-
 	setup_page() {
 		this.hide_sidebar = true;
 		this.hide_page_form = true;
@@ -105,6 +101,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		} else {
 			this.page.clear_indicator();
 		}
+		super.on_filter_change();
 	}
 
 	save_kanban_board_filters() {
@@ -154,7 +151,10 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 
 	get_card_meta() {
 		var meta = frappe.get_meta(this.doctype);
+		// preserve route options erased by new doc
+		let route_options = {...frappe.route_options};
 		var doc = frappe.model.get_new_doc(this.doctype);
+		frappe.route_options = route_options;
 		var title_field = null;
 		var quick_entry = false;
 

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -101,7 +101,6 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		} else {
 			this.page.clear_indicator();
 		}
-		super.on_filter_change();
 	}
 
 	save_kanban_board_filters() {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -57,6 +57,30 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.menu_items = [];
 	}
 
+	on_filter_change() {
+		window.history.replaceState(null, null, this.get_url_with_filters());
+	}
+
+	get_url_with_filters() {
+		const query_params = Object.entries(this.get_filter_values())
+			.map(([field, value], _idx) => {
+				// multiselects
+				if (Array.isArray(value)) {
+					if (!value.length) return '';
+					value = JSON.stringify(value);
+				}
+				return `${field}=${encodeURIComponent(value)}`;
+			})
+			.filter(Boolean)
+			.join("&");
+
+		let full_url = window.location.href.replace(window.location.search, "");
+		if (query_params) {
+			full_url += "?" + query_params;
+		}
+		return full_url;
+	}
+
 	set_default_secondary_action() {
 		this.refresh_button && this.refresh_button.remove();
 		this.refresh_button = this.page.add_action_icon("refresh", () => {
@@ -482,6 +506,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			if (df.on_change) f.on_change = df.on_change;
 
 			df.onchange = () => {
+				this.on_filter_change();
 				this.refresh_filters_dependency();
 
 				let current_filters = this.get_filter_values();

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -538,7 +538,11 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 			const promises = filters_to_set.map(f => {
 				return () => {
-					const value = route_options[f.df.fieldname];
+					let value = route_options[f.df.fieldname];
+					if (typeof value === 'string' && value[0] === '[') {
+						// multiselect array
+						value = JSON.parse(value);
+					}
 					f.set_value(value);
 				};
 			});

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -57,7 +57,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.menu_items = [];
 	}
 
-	on_filter_change() {
+	update_url_with_filters() {
 		window.history.replaceState(null, null, this.get_url_with_filters());
 	}
 
@@ -506,7 +506,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			if (df.on_change) f.on_change = df.on_change;
 
 			df.onchange = () => {
-				this.on_filter_change();
 				this.refresh_filters_dependency();
 
 				let current_filters = this.get_filter_values();
@@ -681,6 +680,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			frappe.hide_progress();
 		}).finally(() => {
 			this.hide_loading_screen();
+			this.update_url_with_filters();
 		});
 	}
 


### PR DESCRIPTION
"Share URL" feature is completely broken:

1. Doesn't show any link right now (copy to clipboard works)
2. If you reshare URL same params are added to URL again. (simple concatenation)
3. Shared URLs aren't working at all, router strips out the search string as first step in routing, so you end up on basic unfiltered list view. 🤡 

https://github.com/frappe/frappe/blob/d666769360ec80b0942dd50a090f5215d37a01e8/frappe/public/js/frappe/router.js#L385-L386



After:

Any change in filters are immediately reflected in URL.

Why? Simple rationale, you can share exactly what you're seeing with someone else without having to know about (_broken_) share URL feature. 

<img width="1286" alt="Screenshot 2022-06-07 at 2 23 26 PM" src="https://user-images.githubusercontent.com/9079960/172339362-6282f845-5213-4eba-b144-c40e6cc2d9e0.png">




- [x] list view refresh URL
- [x] kanban board refresh URL
- [x] Report view 
- [x] refactor - use https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams ?
- [x] UI tests
- [x] saved filters with LIKE filtering



closes https://github.com/frappe/frappe/issues/16040
closes https://github.com/frappe/frappe/issues/16492
closes https://github.com/frappe/frappe/issues/16850 
closes https://github.com/frappe/frappe/issues/16371





`no-docs`