### PR TITLE
ci: disable parallel tests on v13

### DIFF
--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -10,8 +10,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-       container: [1, 2]
 
     name: Python Unit Tests (MariaDB)
 
@@ -108,7 +106,4 @@ jobs:
 
       - name: Run Tests
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --use-orchestrator
-        env:
-          CI_BUILD_ID: ${{ github.run_id }}
-          ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
+        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -10,8 +10,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-       container: [1, 2]
 
     name: Python Unit Tests (Postgres)
 
@@ -112,7 +110,4 @@ jobs:
 
       - name: Run Tests
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --use-orchestrator
-        env:
-          CI_BUILD_ID: ${{ github.run_id }}
-          ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
+        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests


### PR DESCRIPTION
- After removing coverage reporting, the tests run much faster
- 5-6 min for setup and 2-3 minutes for test on each container is just
  not optimum / waste of resources.

<img width="1045" alt="Screenshot 2022-06-06 at 3 13 12 PM" src="https://user-images.githubusercontent.com/9079960/172137953-dabe7a40-f804-4525-aedb-e499f9e88ba8.png">
