### PR TITLE
perf: `Document` objects without circular references

### DIFF
--- a/frappe/core/utils.py
+++ b/frappe/core/utils.py
@@ -8,7 +8,7 @@ import frappe
 
 def get_parent_doc(doc):
 	"""Return document of `reference_doctype`, `reference_doctype`."""
-	if not hasattr(doc, "parent_doc"):
+	if not getattr(doc, "parent_doc", None):
 		if doc.reference_doctype and doc.reference_name:
 			doc.parent_doc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
 		else:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -2,9 +2,9 @@
 # License: MIT. See LICENSE
 import datetime
 import json
+import weakref
 from functools import cached_property
 from typing import TYPE_CHECKING, TypeVar
-import weakref
 
 import frappe
 from frappe import _, _dict
@@ -263,8 +263,8 @@ class BaseDocument:
 		ret_value = self._init_child(value, key)
 		table.append(ret_value)
 
-		# reference parent document
-		ret_value.parent_doc = self
+		# reference parent document but with weak reference, parent_doc will be deleted if self is garbage collected.
+		ret_value.parent_doc = weakref.ref(self)
 
 		return ret_value
 
@@ -279,8 +279,7 @@ class BaseDocument:
 
 	@parent_doc.setter
 	def parent_doc(self, value):
-		if isinstance(value, BaseDocument):
-			self._parent_doc = weakref.ref(value)
+		self._parent_doc = value
 
 	@parent_doc.deleter
 	def parent_doc(self):

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -193,3 +193,8 @@ class TestPerformance(FrappeTestCase):
 			result = frappe.db.sql(query, **kwargs)
 			self.assertEqual(sys.getrefcount(result), 2)  # Note: This always returns +1
 			self.assertFalse(gc.get_referrers(result))
+
+	def test_no_cyclic_references(self):
+		doc = frappe.get_doc("User", "Administrator")
+		gc.collect()
+		self.assertEqual(sys.getrefcount(doc), 2)  # Note: This always returns +1

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -196,5 +196,4 @@ class TestPerformance(FrappeTestCase):
 
 	def test_no_cyclic_references(self):
 		doc = frappe.get_doc("User", "Administrator")
-		gc.collect()
 		self.assertEqual(sys.getrefcount(doc), 2)  # Note: This always returns +1


### PR DESCRIPTION
Split from https://github.com/frappe/frappe/pull/17061 (This change requires careful review / better checks, so might take more time.  😐 

## Eliminate cyclic references for better GC performance

When you do `get_doc` all child docs are also fetched, child docs have reference to parent doc using `self.parent_doc` this causes cyclic references which are usually considered bad. Don't think it's used extensively anyway, so tried replacing it with weakref. 



Before:

```ipython
In [1]: item = frappe.get_doc("Item", "_Test Item")

In [2]: sys.getrefcount(item)
Out[2]: 13
```


After:
```ipython
In [1]: item = frappe.get_doc("Item", "_Test Item")

In [2]: sys.getrefcount(item)
Out[2]: 2 # sys.getrefcount returns +1 extra
```

Ref:  https://devguide.python.org/garbage_collector/ 

---



**Memory usage (in MiB)**

Further reduces memory usage as `Document` objects can be garbage collected immediately when ref count drops to 0 without the overhead of generation-based GC. 

```python
@profile
def process_all_stock_entries(limit=None):
	processed = []

	frappe.get_last_doc("Stock Entry") # trigger all one time memory cost to be paid related to get_doc
	for se_name in frappe.get_all("Stock Entry", pluck="name", limit=limit):
		se = frappe.get_doc("Stock Entry", se_name)
		processed.append(se.name)

	return len(processed)
```

Docs processed | Old | After #17061 | remove cyclic references
-- | -- | -- | --
100 | 2.4 | 0.8 | 0.05
250 | 5.7 | 1 | 0.1
500 | 11.7 | 1.1 | 0.2
750 | 17.2 | 1.1 | 0.2

