### PR TITLE
fix: translatable web templates

### DIFF
--- a/frappe/website/web_template/hero/hero.html
+++ b/frappe/website/web_template/hero/hero.html
@@ -1,21 +1,21 @@
 <div class="hero {{ 'align-center' if align == 'Center' else '' }}">
 	<div class="hero-content">
-		<h1 class="hero-title">{{ title }}</h1>
+		<h1 class="hero-title">{{ _(title) }}</h1>
 		{%- if subtitle -%}
 		<p class="hero-subtitle">
-			{{ subtitle }}
+			{{ _(subtitle) }}
 		</p>
 		{%- endif -%}
 		{%- if primary_action or secondary_action -%}
 		<div class="hero-buttons">
 			{%- if primary_action -%}
 			<a class="btn btn-lg btn-dark" href="{{ primary_action }}">
-				{{ primary_action_label }}
+				{{ _(primary_action_label) }}
 			</a>
 			{%- endif -%}
 			{%- if secondary_action -%}
 			<a class="btn btn-lg btn-light ml-3" href="{{ secondary_action }}">
-				{{ secondary_action_label }}
+				{{ _(secondary_action_label) }}
 			</a>
 			{%- endif -%}
 		</div>

--- a/frappe/website/web_template/hero_with_right_image/hero_with_right_image.html
+++ b/frappe/website/web_template/hero_with_right_image/hero_with_right_image.html
@@ -2,22 +2,22 @@
 	<div class="hero-content">
 		<div>
 			<h1 class="hero-title">
-				{{ title }}
+				{{ _(title) }}
 			</h1>
 			{%- if subtitle -%}
 			<p class="hero-subtitle">
-				{{ subtitle }}
+				{{ _(subtitle) }}
 			</p>
 			{%- endif -%}
 			<div>
 				{%- if primary_action -%}
 				<a class="btn btn-lg btn-primary" href="{{ primary_action }}">
-					{{ primary_action_label }}
+					{{ _(primary_action_label) }}
 				</a>
 				{%- endif -%}
 				{%- if secondary_action -%}
 				<a class="btn btn-lg btn-primary-light" href="{{ secondary_action }}">
-					{{ secondary_action_label }}
+					{{ _(secondary_action_label) }}
 				</a>
 				{%- endif -%}
 			</div>

--- a/frappe/website/web_template/markdown/markdown.html
+++ b/frappe/website/web_template/markdown/markdown.html
@@ -1,5 +1,5 @@
 <div class="section-markdown">
 	<div class="from-markdown {{ 'mx-auto' if align == 'Center' else '' }}">
-		{{ frappe.utils.md_to_html(content) }}
+		{{ frappe.utils.md_to_html(_(content)) }}
 	</div>
 </div>

--- a/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
+++ b/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
@@ -1,7 +1,7 @@
 <div class="section-with-collapsible-content {{ 'align-center' if align == 'Center' else '' }}">
-	<h2 class="section-title">{{ title }}</h2>
+	<h2 class="section-title">{{ _(title) }}</h2>
 	{%- if subtitle -%}
-	<p class="section-description">{{ subtitle }}</p>
+	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}
 
 	<div class="collapsible-items">
@@ -10,7 +10,7 @@
 			{%- set collapse_id = 'id-' + frappe.utils.generate_hash('Collapse', 12) -%}
 			<a class="collapsible-title" data-toggle="collapse" href="#{{ collapse_id }}" role="button"
 				aria-expanded="false" aria-controls="{{ collapse_id }}">
-				<div class="collapsible-item-title">{{ item.title }}</div>
+				<div class="collapsible-item-title">{{ _(item.title) }}</div>
 				<svg class="collapsible-icon" width="24" height="24" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 					<path class="vertical" d="M8 4V12" stroke="currentColor" stroke-width="1.5" stroke-miterlimit="10"
 						stroke-linecap="round"
@@ -22,7 +22,7 @@
 			</a>
 			<div class="collapse collapsible-content from-markdown" id="{{ collapse_id }}">
 				<div>
-					{{ frappe.utils.md_to_html(item.content) }}
+					{{ frappe.utils.md_to_html(_(item.content)) }}
 				</div>
 			</div>
 		</div>

--- a/frappe/website/web_template/section_with_cta/section_with_cta.html
+++ b/frappe/website/web_template/section_with_cta/section_with_cta.html
@@ -1,19 +1,19 @@
 <div class="section-cta-container">
 	<div class="section-cta">
-		<h2 class="title mt-0">{{ title }}</h2>
+		<h2 class="title mt-0">{{ _(title) }}</h2>
 		{%- if subtitle -%}
-		<p class="subtitle">{{ subtitle }}</p>
+		<p class="subtitle">{{ _(subtitle) }}</p>
 		{%- endif -%}
 		<div class="mt-3">
 			<h4 class="action">
-				<a href="{{ cta_url }}" class="no-decoration">{{ cta_label }}
+				<a href="{{ cta_url }}" class="no-decoration">{{ _(cta_label) }}
 					<svg class="icon icon-md"><use xlink:href="#icon-right"></use></svg>
 				</a>
 			</h4>
 		</div>
 		{%- if cta_description -%}
 		<div class="description">
-			{{ cta_description }}
+			{{ _(cta_description) }}
 		</div>
 		{%- endif -%}
 	</div>

--- a/frappe/website/web_template/section_with_embed/section_with_embed.html
+++ b/frappe/website/web_template/section_with_embed/section_with_embed.html
@@ -1,10 +1,10 @@
 <div class="section-with-embed">
-	<h2 class="section-title">{{ title }}</h2>
+	<h2 class="section-title">{{ _(title) }}</h2>
 	{%- if subtitle -%}
-	<p class="section-description">{{ subtitle }}</p>
+	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}
 
 	<div class="embed-container from-markdown">
-		{{ frappe.utils.md_to_html(embed_html) }}
+		{{ frappe.utils.md_to_html(_(embed_html)) }}
 	</div>
 </div>

--- a/frappe/website/web_template/section_with_features/section_with_features.html
+++ b/frappe/website/web_template/section_with_features/section_with_features.html
@@ -1,9 +1,9 @@
 <div class="section-with-features">
 	{%- if title -%}
-	<h2 class="section-title">{{ title }}</h2>
+	<h2 class="section-title">{{ _(title) }}</h2>
 	{%- endif -%}
 	{%- if subtitle -%}
-	<p class="section-description">{{ subtitle }}</p>
+	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}
 
 	<div class="section-features" data-columns="{{ columns or 3 }}"
@@ -15,10 +15,10 @@
 				<img class="feature-icon" src="{{ feature.icon }}" alt="Icon for {{ feature.title }}">
 				{%- endif -%}
 				{%- if feature.title -%}
-				<h3 class="feature-title mt-0">{{ feature.title }}</h3>
+				<h3 class="feature-title mt-0">{{ _(feature.title) }}</h3>
 				{%- endif -%}
 				{%- if feature.content -%}
-				<p class="feature-content">{{ frappe.utils.md_to_html(feature.content) }}</p>
+				<p class="feature-content">{{ frappe.utils.md_to_html(_(feature.content)) }}</p>
 				{%- endif -%}
 			</div>
 			<div>

--- a/frappe/website/web_template/section_with_image/section_with_image.html
+++ b/frappe/website/web_template/section_with_image/section_with_image.html
@@ -1,7 +1,7 @@
 <div class="section-with-image {{ 'align-center' if align == 'Center' else '' }}">
-	<h2 class="section-title">{{ title }}</h2>
+	<h2 class="section-title">{{ _(title) }}</h2>
 	{%- if subtitle -%}
-	<p class="section-description">{{ subtitle }}</p>
+	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}
 
 	{%- if image -%}


### PR DESCRIPTION
## Made the following web templates translatable:

 - Hero with Right Image
 - Hero
 - Section with Collapsible content
 - Section with Embed
 - Markdown
 - Section with Image
 - Section with CTA
 - Section with Features

<img width="1157" alt="Screenshot 2022-06-07 at 9 40 36 AM" src="https://user-images.githubusercontent.com/31363128/172295347-16a9f5f7-1e66-474b-b322-061e6cf20da1.png">

