### PR TITLE
fix: Switch to form view from print preview page

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -85,6 +85,11 @@ frappe.ui.form.PrintView = class {
 			() => this.refresh_print_format(),
 			{ icon: 'refresh' }
 		);
+		this.page.add_button(
+			__(''),
+			() => this.hide_print_doc(),
+			{ icon: 'printer' }
+		);
 	}
 
 	setup_sidebar() {
@@ -496,6 +501,13 @@ frappe.ui.form.PrintView = class {
 					: this.frm.page.previous_view_name || 'main'
 			);
 		}
+	}
+
+	hide_print_doc() {
+		frappe.route_options = {
+			frm: this,
+		};
+		frappe.set_route('Form', this.frm.doctype, this.frm.doc.name);
 	}
 
 	show_footer() {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -86,9 +86,9 @@ frappe.ui.form.PrintView = class {
 			{ icon: 'refresh' }
 		);
 
-		this.page.add_action_icon("printer", () => {
+		this.page.add_action_icon("file", () => {
 			this.hide_print_doc();
-		}, '', __("Print"));
+		}, '', __("Form"));
 	}
 
 	setup_sidebar() {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -19,7 +19,8 @@ frappe.pages['print'].on_page_load = function(wrapper) {
 				});
 			});
 		} else {
-			print_view.frm = frappe.route_options.frm;
+			print_view.frm = frappe.route_options.frm.doctype ?
+				frappe.route_options.frm : frappe.route_options.frm.frm;
 			frappe.route_options.frm = null;
 			print_view.show(print_view.frm);
 		}

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -86,7 +86,7 @@ frappe.ui.form.PrintView = class {
 			{ icon: 'refresh' }
 		);
 
-		this.page.add_action_icon("printer", ()=> {
+		this.page.add_action_icon("printer", () => {
 			this.hide_print_doc();
 		}, '', __("Print"));
 	}

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -506,7 +506,7 @@ frappe.ui.form.PrintView = class {
 		frappe.route_options = {
 			frm: this,
 		};
-		frappe.set_route('Form', this.frm.doctype, this.frm.doc.name);
+		frappe.set_route('Form', this.frm.doctype, this.frm.docname);
 	}
 
 	show_footer() {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -85,11 +85,10 @@ frappe.ui.form.PrintView = class {
 			() => this.refresh_print_format(),
 			{ icon: 'refresh' }
 		);
-		this.page.add_button(
-			__(''),
-			() => this.hide_print_doc(),
-			{ icon: 'printer' }
-		);
+
+		this.page.add_action_icon("printer", ()=> {
+			this.hide_print_doc();
+		}, '', __("Print"));
 	}
 
 	setup_sidebar() {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -87,7 +87,7 @@ frappe.ui.form.PrintView = class {
 		);
 
 		this.page.add_action_icon("file", () => {
-			this.hide_print_doc();
+			this.go_to_form_view();
 		}, '', __("Form"));
 	}
 
@@ -502,7 +502,7 @@ frappe.ui.form.PrintView = class {
 		}
 	}
 
-	hide_print_doc() {
+	go_to_form_view() {
 		frappe.route_options = {
 			frm: this,
 		};


### PR DESCRIPTION
Problem: As a user, I found it difficult to go back to the form view, when I was in print preview mode. There is no print icon button just like in version 12. so, Pressing the back button on the browser, to go back to the form view, is kind of difficult as the user experience

before:
![Peek 2022-06-07 10-46](https://user-images.githubusercontent.com/6947417/172301290-4da3ecc6-11d3-4de3-aebe-b08e663486cc.gif)


after:
![Peek 2022-06-07 10-44](https://user-images.githubusercontent.com/6947417/172301154-588ee820-e057-4bfc-b15c-745d081077e0.gif)
 
After Removing Print Icon
![Peek 2022-06-07 12-01](https://user-images.githubusercontent.com/6947417/172311482-f6351232-27d5-438f-a402-358507833966.gif)

