### PR TITLE
fix(email): Maintain multi-tenancy translation sanity in error messages

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -298,8 +298,6 @@ def apply(doc=None, method=None, doctype=None, name=None):
 					if reopened:
 						break
 
-				# print(f"Rule:{assignment_rule}\nDoc: {doc}\nReOpened: {reopened}")
-
 			assignment_rule.close_assignments(doc)
 
 

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -22,14 +22,6 @@ if TYPE_CHECKING:
 	from frappe.core.doctype.communication.communication import Communication
 
 
-OUTGOING_EMAIL_ACCOUNT_MISSING = _(
-	"""
-	Unable to send mail because of a missing email account.
-	Please setup default Email Account from Setup > Email > Email Account
-"""
-)
-
-
 @frappe.whitelist()
 def make(
 	doctype=None,
@@ -170,7 +162,12 @@ def _make(
 
 	if cint(send_email):
 		if not comm.get_outgoing_email_account():
-			frappe.throw(msg=OUTGOING_EMAIL_ACCOUNT_MISSING, exc=frappe.OutgoingEmailError)
+			frappe.throw(
+				_(
+					"Unable to send mail because of a missing email account. Please setup default Email Account from Setup > Email > Email Account"
+				),
+				exc=frappe.OutgoingEmailError,
+			)
 
 		comm.send_email(
 			print_html=print_html,

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -23,10 +23,6 @@ from frappe.utils.error import raise_error_on_no_output
 from frappe.utils.jinja import render_template
 from frappe.utils.user import get_system_managers
 
-OUTGOING_EMAIL_ACCOUNT_MISSING = _(
-	"Please setup default Email Account from Setup > Email > Email Account"
-)
-
 
 class SentEmailInInbox(Exception):
 	pass
@@ -319,7 +315,7 @@ class EmailAccount(Document):
 	@classmethod
 	@raise_error_on_no_output(
 		keep_quiet=lambda: not cint(frappe.get_system_settings("setup_complete")),
-		error_message=OUTGOING_EMAIL_ACCOUNT_MISSING,
+		error_message=_("Please setup default Email Account from Setup > Email > Email Account"),
 		error_type=frappe.OutgoingEmailError,
 	)  # noqa
 	@cache_email_account("outgoing_email_account")


### PR DESCRIPTION
Defining translated strings as globals means the strings are evaluated at import time. So the value of these variables is set based on which site or user initializes the module. This makes it possible for  an english user to get Russian errors.

---

Other changes: Remove unreachable code, avoid importing _socket.error alias to `OSError`