### PR TITLE
fix: encode docname when routing

### DIFF
--- a/cypress/integration/table_multiselect.js
+++ b/cypress/integration/table_multiselect.js
@@ -46,6 +46,6 @@ context('Table MultiSelect', () => {
 		cy.get(`.list-subject:contains("table multiselect")`).last().find('a').click();
 		cy.get('.frappe-control[data-fieldname="users"] .form-control .tb-selected-value').as('existing_value');
 		cy.get('@existing_value').find('.btn-link-to-form').click();
-		cy.location('pathname').should('contain', '/user/test@erpnext.com');
+		cy.location('pathname').should('contain', '/user/test%40erpnext.com');
 	});
 });

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -903,11 +903,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return this.settings.get_form_link(doc);
 		}
 
-		const docname = doc.name.match(/[%'"#\s]/)
-			? encodeURIComponent(doc.name)
-			: doc.name;
-
-		return `/app/${frappe.router.slug(frappe.router.doctype_layout || this.doctype)}/${docname}`;
+		return `/app/${frappe.router.slug(frappe.router.doctype_layout || this.doctype)}/${encodeURIComponent(doc.name)}`;
 	}
 
 	get_seen_class(doc) {

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -334,11 +334,7 @@ frappe.router = {
 				frappe.route_options = a;
 				return null;
 			} else {
-				a = String(a);
-				if (a && a.match(/[%'"#\s\t]/)) {
-					// if special chars, then encode
-					a = encodeURIComponent(a);
-				}
+				a = encodeURIComponent(String(a));
 				return a;
 			}
 		}).join('/');


### PR DESCRIPTION
This pr aims to encode non-ascii characters (in docnames).

before:

https://user-images.githubusercontent.com/32034600/172355580-1971d9f9-69ab-40a0-b938-47406498e4fa.mov


after:

https://user-images.githubusercontent.com/32034600/172355612-7ffc098b-6aea-4c38-b858-cab393c05205.mov

#

Checked for link fields as well, seems we already encoded the docname there using `frappe.utils.get_form_link`

https://github.com/frappe/frappe/blob/3bf154c7ce473a6b1ad9e536242e3071fa4d9466/frappe/public/js/frappe/form/controls/link.js#L34

https://github.com/frappe/frappe/blob/3bf154c7ce473a6b1ad9e536242e3071fa4d9466/frappe/public/js/frappe/utils/utils.js#L843-L854

#

<details>
<summary>Also, tried making a simple report (using report builder) as well (just to check if datatable also has encoding - seems it does 🤓 )</summary>

please check the url at the bottom :)

![Screenshot 2022-06-07 at 4 32 09 PM](https://user-images.githubusercontent.com/32034600/172364398-0549ee65-5d0c-4e45-9b73-2ba67d15f4ac.png)

</details>