### PR TITLE
revert: remove global click event from workspace

### DIFF
--- a/frappe/public/js/frappe/views/workspace/blocks/block.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/block.js
@@ -214,10 +214,6 @@ export default class Block {
 			$button.find('.dropdown-list').toggleClass('hidden');
 		});
 
-		$(document).click(() => {
-			$button.find('.dropdown-list').addClass('hidden');
-		});
-
 		$widget_control.prepend($button);
 
 		this.dropdown_list.forEach((item) => {

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -693,11 +693,6 @@ frappe.views.Workspace = class Workspace {
 			$button.filter('.dropdown-list').toggleClass('hidden');
 		});
 
-		$(document).click(event => {
-			event.stopPropagation();
-			$('.dropdown-list:not(.hidden)').addClass('hidden');
-		});
-
 		sidebar_control.append($button);
 
 		this.dropdown_list.forEach((i) => {


### PR DESCRIPTION
Removed global click events interfering with other functionalities (Form Tour etc.)