### PR TITLE
fix: print & breadcrumbs for forward slash

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -8,7 +8,7 @@ frappe.pages['print'].on_page_load = function(wrapper) {
 	$(wrapper).bind('show', () => {
 		const route = frappe.get_route();
 		const doctype = route[1];
-		const docname = route[2];
+		const docname = route.slice(2).join("/");
 		if (!frappe.route_options || !frappe.route_options.frm) {
 			frappe.model.with_doc(doctype, docname, () => {
 				let frm = { doctype: doctype, docname: docname };

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -150,7 +150,7 @@ frappe.breadcrumbs = {
 
 	set_form_breadcrumb(breadcrumbs, view) {
 		const doctype = breadcrumbs.doctype;
-		const docname = frappe.get_route()[2];
+		const docname = frappe.get_route().slice(2).join("/");
 		let form_route = `/app/${frappe.router.slug(doctype)}/${docname}`;
 		$(`<li><a href="${form_route}">${__(docname)}</a></li>`)
 			.appendTo(this.$breadcrumbs);


### PR DESCRIPTION
**problem:** route is split by [ "/" ] so when docname contains "/" it will split docname like this
```
['print', 'Sales Invoice', 'TEST', '0001']
```
**solution**: joined list by "/" from index 2 to length_of_list.

![breadcrumbs-fix](https://user-images.githubusercontent.com/39730881/172378769-6cbd0385-b3d6-4d61-8e8f-d7d00e086420.png)

### Before
https://user-images.githubusercontent.com/39730881/172373475-1746f6be-e991-47e6-b519-916c7382b60d.mp4

### After
https://user-images.githubusercontent.com/39730881/172379065-4ab2678e-42bc-4aea-8f90-c9de0e0ea6a4.mp4


This closes #17094 