### PR TITLE
fix: better error logging for setup exceptions

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -436,6 +436,7 @@ def make_records(records, debug=False):
 			frappe.db.savepoint(savepoint)
 			doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
 		except Exception as e:
+			frappe.clear_last_message()
 			frappe.db.rollback(save_point=savepoint)
 			exception = record.get("__exception")
 			if exception:
@@ -451,3 +452,4 @@ def make_records(records, debug=False):
 def show_document_insert_error():
 	print("Document Insert Error")
 	print(frappe.get_traceback())
+	frappe.log_error("Exception during Setup")


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/16727 this PR caused exceptions during setup to be shown as msgprints instead of getting silenced like before with `frappe.clear_messages()`


Fix: added `frappe.clear_last_message()` to only discard last error message caused by the exception being handled. Root cause is old code related to `Department` doctype creation which is suppressing NSM updates and hence throwing this error, will fix it in ERPNext. 

```
Document Insert Error
Traceback (most recent call last):
  File "apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 437, in make_records
    doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
  File "apps/frappe/frappe/model/document.py", line 268, in insert
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1071, in run_post_save_methods
    self.run_method("on_update")
  File "apps/frappe/frappe/model/document.py", line 912, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1251, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1233, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 909, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/hr/doctype/department/department.py", line 36, in on_update
    super(Department, self).on_update()
  File "apps/frappe/frappe/utils/nestedset.py", line 246, in on_update
    update_nsm(self)
  File "apps/frappe/frappe/utils/nestedset.py", line 55, in update_nsm
    update_add_node(doc, parent or "", parent_field)
  File "apps/frappe/frappe/utils/nestedset.py", line 77, in update_add_node
    validate_loop(doc.doctype, doc.name, left, right)
  File "apps/frappe/frappe/utils/nestedset.py", line 237, in validate_loop
    frappe.throw(_("Item cannot be added to its own descendents"), NestedSetRecursionError)
  File "apps/frappe/frappe/__init__.py", line 494, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 469, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 424, in _raise_exception
    raise raise_exception(msg)
frappe.utils.nestedset.NestedSetRecursionError: Item cannot be added to its own descendents
```
