### PR TITLE
feat: run tests on Module Def

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -730,6 +730,7 @@ def transform_database(context, table, engine, row_format, failfast):
 @click.command("run-tests")
 @click.option("--app", help="For App")
 @click.option("--doctype", help="For DocType")
+@click.option("--module-def", help="For all Doctypes in Module Def")
 @click.option("--case", help="Select particular TestCase")
 @click.option(
 	"--doctype-list-path",
@@ -754,6 +755,7 @@ def run_tests(
 	app=None,
 	module=None,
 	doctype=None,
+	module_def=None,
 	test=(),
 	profile=False,
 	coverage=False,
@@ -790,6 +792,7 @@ def run_tests(
 			app,
 			module,
 			doctype,
+			module_def,
 			context.verbose,
 			tests=tests,
 			force=context.force,

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -41,6 +41,7 @@ def main(
 	app=None,
 	module=None,
 	doctype=None,
+	module_def=None,
 	verbose=False,
 	tests=(),
 	force=False,
@@ -96,6 +97,13 @@ def main(
 		if doctype:
 			ret = run_tests_for_doctype(
 				doctype, verbose, tests, force, profile, failfast=failfast, junit_xml_output=junit_xml_output
+			)
+		elif module_def:
+			doctypes = frappe.db.get_list(
+				"DocType", filters={"module": module_def, "istable": 0}, pluck="name"
+			)
+			ret = run_tests_for_doctype(
+				doctypes, verbose, tests, force, profile, failfast=failfast, junit_xml_output=junit_xml_output
 			)
 		elif module:
 			ret = run_tests_for_module(


### PR DESCRIPTION
## new option '--module-def' for run-tests

Runs test for all DocTypes in specified Module Def. 

<img width="992" alt="Screenshot 2022-06-08 at 11 58 04 AM" src="https://user-images.githubusercontent.com/3272205/172547376-ef6a73b9-33cf-4729-bb74-59ba92d94cf3.png">


docs: https://frappeframework.com/docs/v14/user/en/testing#running-tests
