### PR TITLE
fix: Reset role editor while loading a new user form

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -59,6 +59,10 @@ frappe.ui.form.on('User', {
 	onload: function(frm) {
 		frm.can_edit_roles = has_access_to_edit_user();
 
+		if (frm.is_new() && frm.roles_editor) {
+			frm.roles_editor.reset();
+		}
+
 		if (frm.can_edit_roles && !frm.is_new() && in_list(['System User', 'Website User'], frm.doc.user_type)) {
 			if (!frm.roles_editor) {
 				const role_area = $('<div class="role-editor">')

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -52,6 +52,7 @@ def toggle_notifications(user: str, enable: bool = False):
 	try:
 		settings = frappe.get_doc("Notification Settings", user)
 	except frappe.DoesNotExistError:
+		frappe.clear_last_message()
 		return
 
 	if settings.enabled != enable:

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -94,10 +94,14 @@ frappe.RoleEditor = class {
 			.css("max-width", "80vw");
 	}
 	show() {
-		let user_roles = this.frm.doc.roles.map(a => a.role);
+		this.reset();
+		this.set_enable_disable();
+	}
+
+	reset() {
+		let user_roles = (this.frm.doc.roles || []).map(a => a.role);
 		this.multicheck.selected_options = user_roles;
 		this.multicheck.refresh_input();
-		this.set_enable_disable();
 	}
 	set_roles_in_table() {
 		let roles = this.frm.doc.roles || [];


### PR DESCRIPTION
**Before:** When a new user is created after opening an existing user's form, "roles" used to get copied to the new user.

https://user-images.githubusercontent.com/13928957/172530574-40c6b7df-88d5-4759-91f8-dc6988f9f69e.mov

**After:**

https://user-images.githubusercontent.com/13928957/172530600-39e45e0d-5237-4a1e-837a-f740d918d491.mov



fixes: https://github.com/frappe/frappe/issues/17098