### PR TITLE
perf: ~90% faster `frappe.get_cached_doc`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1031,15 +1031,21 @@ def get_cached_doc(*args, **kwargs):
 		if doc := cache().hget("document_cache", key):
 			return _respond(doc, True)
 
-	# Not found in local/redis, fetch from DB and store in cache
+	# Not found in local/redis, fetch from DB
 	doc = get_doc(*args, **kwargs)
 
-	# Store in redis cache
-	key = get_document_cache_key(doc.doctype, doc.name)
+	# Store in cache
+	if not key:
+		key = get_document_cache_key(doc.doctype, doc.name)
 
 	local.document_cache[key] = doc
-	# Avoid setting in local.cache since there's separate cache
-	cache().hset("document_cache", key, doc.as_dict(), cache_locally=False)
+
+	# Avoid setting in local.cache since we're already using local.document_cache above
+	# Try pickling the doc object as-is first, else fallback to doc.as_dict()
+	try:
+		cache().hset("document_cache", key, doc, cache_locally=False)
+	except Exception:
+		cache().hset("document_cache", key, doc.as_dict(), cache_locally=False)
 
 	return doc
 
@@ -1115,6 +1121,7 @@ def get_doc(*args, **kwargs):
 	if key := can_cache_doc(args):
 		if key in local.document_cache:
 			local.document_cache[key] = doc
+
 		if cache().hexists("document_cache", key):
 			cache().hset("document_cache", key, doc.as_dict())
 

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -159,9 +159,7 @@ class RedisWrapper(redis.Redis):
 
 		# set in local
 		if cache_locally:
-			if _name not in frappe.local.cache:
-				frappe.local.cache[_name] = {}
-			frappe.local.cache[_name][key] = value
+			frappe.local.cache.setdefault(_name, {})[key] = value
 
 		# set in redis
 		try:


### PR DESCRIPTION
## Redis-only cache testing

### Before
```py
In [6]: %timeit frappe.get_cached_doc("Sales Invoice", "SINV-22-00016")
215 µs ± 988 ns per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [7]: %timeit frappe.get_cached_doc("System Settings")
34.9 µs ± 83.9 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

### After

```py


In [3]: %timeit frappe.get_cached_doc("Sales Invoice", "SINV-22-00016")
4.15 µs ± 6.44 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each) # 98% improvement

In [4]: %timeit frappe.get_cached_doc("System Settings")
4.14 µs ± 33.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each) # 88% improvement


```

Note that `frappe.get_cached_value` is slightly (4%) slower due to unpickling `Document` instead of `_dict`

[ERPNext Run](https://github.com/frappe/erpnext/actions/runs/2460739957)