### PR TITLE
fix: Comment tag extractor code

### DIFF
--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -321,10 +321,8 @@ def extract_comment_tag(source: str, tag: str):
 	:param source: raw template source in HTML
 	:param title: tag to search, example "title"
 	"""
-
-	if f"<!-- {tag}:" in source:
-		return re.search(f"<!-- {tag}:([^>]*) -->", source).group().strip()
-	return None
+	matched_pattern = re.search(f"<!-- {tag}:([^>]*) -->", source)
+	return matched_pattern.groups()[0].strip() if matched_pattern else None
 
 
 def get_html_content_based_on_type(doc, fieldname, content_type):


### PR DESCRIPTION
`extract_comment_tag` is supposed to return the value of a tag and not a complete comment.

```py
source = """<!-- base_template: frappe/templates/test/_test_base.html -->
{% block content %}
<p>Test content</p>
{% endblock %}"""

tag = "base_template"
```

**Before:**
```py
In [1]: extract_comment_tag(source, tag) # re.search(f"<!-- {tag}:([^>]*) -->", source).group().strip()
Out[1]: '<!-- base_template: frappe/templates/test/_test_base.html -->'
```

**Now:**
```py
In [2]: extract_comment_tag(source, tag) # re.search(f"<!-- {tag}:([^>]*) -->", source).groups()[0].strip()
Out[2]: 'frappe/templates/test/_test_base.html'
```

fixes: https://github.com/frappe/frappe/runs/6804747759?check_suite_focus=true#step:14:1136

Issue introduced via https://github.com/frappe/frappe/pull/17111
