### PR TITLE
feat: Show link titles in list view

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -69,12 +69,12 @@ frappe.views.BaseList = class BaseList {
 		];
 	}
 
-	setup_fields() {
-		this.set_fields();
+	async setup_fields() {
+		await this.set_fields();
 		this.build_fields();
 	}
 
-	set_fields() {
+	async set_fields() {
 		let fields = [].concat(
 			frappe.model.std_fields_list,
 			this.meta.title_field

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -187,7 +187,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		);
 	}
 
-	set_fields() {
+	get_fields() {
+		return super.get_fields().concat(Object.entries(this.link_field_title_fields).map((entry) => entry.join(".")))
+	}
+
+	async set_fields() {
+		this.link_field_title_fields = {}
 		let fields = [].concat(
 			frappe.model.std_fields_list,
 			this.get_fields_in_list_view(),
@@ -200,7 +205,25 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			"color"
 		);
 
-		fields.forEach((f) => this._add_field(f));
+		await Promise.all(fields.map((f) => {
+			return new Promise((resolve) => {
+				const df = typeof f === "string" ? frappe.meta.get_docfield(this.doctype, f) : f;
+				if (df && df.fieldtype == "Link") {
+					frappe.model.with_doctype(df.options, () => {
+						const meta = frappe.get_meta(df.options)
+						if (meta.show_title_field_in_link) {
+							this.link_field_title_fields[typeof f === "string"  ? f : f.fieldname] = meta.title_field
+						}
+
+						this._add_field(f)
+						resolve()
+					})
+				} else {
+					this._add_field(f)
+					resolve()
+				}
+			})
+		}))
 
 		this.fields.forEach((f) => {
 			const df = frappe.meta.get_docfield(f[1], f[0]);
@@ -716,7 +739,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		const df = col.df || {};
 		const label = df.label;
 		const fieldname = df.fieldname;
+		const link_title_fieldname = this.link_field_title_fields[fieldname]
 		const value = doc[fieldname] || "";
+		const value_display = link_title_fieldname ? doc[link_title_fieldname] || value : value
 
 		const format = () => {
 			if (df.fieldtype === "Code") {
@@ -742,12 +767,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					["Text", "Small Text"].includes(df.fieldtype));
 
 			if (strip_html_required) {
-				_value = strip_html(value);
+				_value = strip_html(value_display);
 			} else {
 				_value =
-					typeof value === "string"
-						? frappe.utils.escape_html(value)
-						: value;
+					typeof value_display === "string"
+						? frappe.utils.escape_html(value_display)
+						: value_display;
 			}
 
 			if (df.fieldtype === "Rating") {


### PR DESCRIPTION
Addresses  #16022 and continues upon #15321. These changes will ensure that once "Show Title in Link Fields" is set in a doctype, that the title field will be queried in a related list view. So for example:

1. Assuming that in DocType "Project" the flag "Show Title in Link Fields" is set.
2. The "Task" list view will show under the column field "Project" the value of "project.project_name" instead of "project"

Hope this is useful.
