### PR TITLE
fix: set first tab active after routing via mapper and update global time format

### DIFF
--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -78,7 +78,7 @@ export default class Tab {
 
 	set_active() {
 		this.parent.find('.nav-link').tab('show');
-		this.wrapper.addClass('show');
+		this.wrapper.addClass('active');
 		this.frm.active_tab = this;
 	}
 

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -191,7 +191,7 @@ $.extend(frappe.datetime, {
 	global_date_format: function(d) {
 		var m = moment(d);
 		if(m._f && m._f.indexOf("HH")!== -1) {
-			return m.format("Do MMMM YYYY, h:mma")
+			return m.format("Do MMMM YYYY, hh:mm A");
 		} else {
 			return m.format('Do MMMM YYYY');
 		}


### PR DESCRIPTION
- Set the first Tab active after routed through the mapper
- Global Date format should use "AM/PM" instead of "am/pm"