### PR TITLE
fix: Allow to set empty values in Bulk Edit

### DIFF
--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -208,7 +208,7 @@ export default class BulkOperations {
 		const default_field = field_options.find(value => status_regex.test(value));
 
 		const dialog = new frappe.ui.Dialog({
-			title: __('Edit'),
+			title: __('Bulk Edit'),
 			fields: [
 				{
 					'fieldtype': 'Select',
@@ -225,7 +225,9 @@ export default class BulkOperations {
 					'fieldtype': 'Data',
 					'label': __('Value'),
 					'fieldname': 'value',
-					'reqd': 1
+					onchange() {
+						show_help_text();
+					}
 				}
 			],
 			primary_action: ({ value }) => {
@@ -239,7 +241,7 @@ export default class BulkOperations {
 						docnames: docnames,
 						action: 'update',
 						data: {
-							[fieldname]: value
+							[fieldname]: value || null
 						}
 					}
 				}).then(r => {
@@ -254,10 +256,11 @@ export default class BulkOperations {
 					frappe.show_alert(__('Updated successfully'));
 				});
 			},
-			primary_action_label: __('Update')
+			primary_action_label: __('Update {0} records', [docnames.length]),
 		});
 
 		if (default_field) set_value_field(dialog); // to set `Value` df based on default `Field`
+		show_help_text();
 
 		function set_value_field (dialogObj) {
 			const new_df = Object.assign({},
@@ -275,9 +278,20 @@ export default class BulkOperations {
 				new_df.default = options[0] || options[1];
 			}
 			new_df.label = __('Value');
-			new_df.reqd = 1;
+			new_df.onchange = show_help_text;
+
 			delete new_df.depends_on;
 			dialogObj.replace_field('value', new_df);
+			show_help_text();
+		}
+
+		function show_help_text() {
+			let value = dialog.get_value('value');
+			if (value == null || value === '') {
+				dialog.set_df_property('value', 'description', __('You have not entered a value. The field will be set to empty.'));
+			} else {
+				dialog.set_df_property('value', 'description', '');
+			}
 		}
 
 		dialog.refresh();


### PR DESCRIPTION
## The Fix

The Value field was set as required which did not allow empty values to be set.

<img width="684" alt="image" src="https://user-images.githubusercontent.com/9355208/173046515-067ccdce-b109-4d0a-9ebb-18441873ffaa.png">


## UX improvements

- Show how many records are going to be updated
- Show help text stating explicitly that the field will be set to empty if no value is entered.