### PR TITLE
Typo fix from PR #16805

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -922,12 +922,12 @@ def validate_autoincrement_autoname(dt: DocType) -> bool:
 	def get_autoname_before_save(dt: DocType) -> str:
 		if dt.name == "Customize Form":
 			property_value = frappe.db.get_value(
-				"Property Setter", {"doc_type": dt.doc_type, "property": "autoname"}, "value"
+				"Property Setter", {"doc_type": dt.doctype, "property": "autoname"}, "value"
 			)
 			# initially no property setter is set,
 			# hence getting autoname value from the doctype itself
 			if not property_value:
-				return frappe.db.get_value("DocType", dt.doc_type, "autoname") or ""
+				return frappe.db.get_value("DocType", dt.doctype, "autoname") or ""
 
 			return property_value
 


### PR DESCRIPTION
@phot0n There was a typo in https://github.com/frappe/frappe/pull/16805 ( dt: DocType) parameter doesn't have doc_type it has doctype.

