### PR TITLE
fix: default tab fieldname conflict

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -122,7 +122,8 @@ frappe.ui.form.Layout = class Layout {
 		}
 
 		if (this.is_tabbed_layout()) {
-			let default_tab = {label: __('Details'), fieldname: 'details', fieldtype: "Tab Break"};
+			// add a tab without `fieldname` to avoid conflicts
+			let default_tab = {label: __('Details'), fieldtype: "Tab Break"};
 			let first_tab = this.fields[1].fieldtype === "Tab Break" ? this.fields[1] : null;
 			if (!first_tab) {
 				this.fields.splice(1, 0, default_tab);


### PR DESCRIPTION
If you have any field before first tab a new default tab with `details` as fieldname is created, this can conflict with any exisiting tab called `details` e.g. Item doctype. 


Fix: dont set `fieldname` for default tab. All standard + custom tab breaks must have unique id anyway so this `undefined` can't conflict with them. 

Before:

https://user-images.githubusercontent.com/9079960/173088544-ba2c2f7a-29d0-4a18-9ab2-b4f1771a46fe.mov


After:

https://user-images.githubusercontent.com/9079960/173088504-26daf1b2-275c-4db1-b71d-1b32b6151200.mov



