### PR TITLE
feat: bulk insert simple Docs and iterator support for db.bulk_insert

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -3,12 +3,14 @@
 
 import datetime
 import json
+import itertools
 import random
 import re
 import string
 import traceback
 from contextlib import contextmanager, suppress
 from time import time
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 from pypika.dialects import MySQLQueryBuilder, PostgreSQLQueryBuilder
 from pypika.terms import Criterion, NullValue
@@ -1204,28 +1206,36 @@ class Database:
 				frappe.flags.touched_tables = set()
 			frappe.flags.touched_tables.update(tables)
 
-	def bulk_insert(self, doctype, fields, values, ignore_duplicates=False, *, chunk_size=10_000):
+	def bulk_insert(
+		self,
+		doctype: str,
+		fields: List[str],
+		values: Iterable[Sequence[Any]],
+		ignore_duplicates=False,
+		*,
+		chunk_size=10_000,
+	):
 		"""
 		Insert multiple records at a time
 
 		:param doctype: Doctype name
 		:param fields: list of fields
-		:params values: list of list of values
+		:params values: iterable of values
 		"""
-		values = list(values)
 		table = frappe.qb.DocType(doctype)
 
-		for start_index in range(0, len(values), chunk_size):
-			query = frappe.qb.into(table)
-			if ignore_duplicates:
-				# Pypika does not have same api for ignoring duplicates
-				if self.db_type == "mariadb":
-					query = query.ignore()
-				elif self.db_type == "postgres":
-					query = query.on_conflict().do_nothing()
+		query = frappe.qb.into(table).columns(fields)
 
-			values_to_insert = values[start_index : start_index + chunk_size]
-			query.columns(fields).insert(*values_to_insert).run()
+		if ignore_duplicates:
+			# Pypika does not have same api for ignoring duplicates
+			if frappe.conf.db_type == "mariadb":
+				query = query.ignore()
+			elif frappe.conf.db_type == "postgres":
+				query = query.on_conflict().do_nothing()
+
+		value_iterator = iter(values)
+		while value_chunk := tuple(itertools.islice(value_iterator, chunk_size)):
+			query.insert(*value_chunk).run()
 
 	def create_sequence(self, *args, **kwargs):
 		from frappe.database.sequence import create_sequence

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -2,15 +2,15 @@
 # License: MIT. See LICENSE
 
 import datetime
-import json
 import itertools
+import json
 import random
 import re
 import string
 import traceback
 from contextlib import contextmanager, suppress
 from time import time
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Iterable, Sequence
 
 from pypika.dialects import MySQLQueryBuilder, PostgreSQLQueryBuilder
 from pypika.terms import Criterion, NullValue
@@ -1209,7 +1209,7 @@ class Database:
 	def bulk_insert(
 		self,
 		doctype: str,
-		fields: List[str],
+		fields: list[str],
 		values: Iterable[Sequence[Any]],
 		ignore_duplicates=False,
 		*,

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -230,7 +230,7 @@ class Meta(Document):
 
 		return fields
 
-	def get_valid_columns(self):
+	def get_valid_columns(self) -> list[str]:
 		if not hasattr(self, "_valid_columns"):
 			table_exists = frappe.db.table_exists(self.name)
 			if self.name in self.special_doctypes and table_exists:

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -469,3 +469,21 @@ class TestDocumentWebView(FrappeTestCase):
 
 		# Logged-in user can access the page without key
 		self.assertEqual(self.get(url_without_key, "Administrator").status, "200 OK")
+
+	def test_bulk_inserts(self):
+		from frappe.model.document import bulk_insert
+
+		doctype = "ToDo"
+		sent_todo = set()
+
+		def doc_generator():
+			for i in range(690):
+				doc = frappe.new_doc(doctype)
+				doc.name = doc.description = frappe.generate_hash()
+				sent_todo.add(doc.name)
+				yield doc
+
+		bulk_insert(doctype, doc_generator(), chunk_size=100)
+
+		all_todos = set(frappe.get_all("ToDo", pluck="name"))
+		self.assertEqual(sent_todo - all_todos, set(), "All docs should be inserted")


### PR DESCRIPTION
```python
from frappe.model.document import bulk_insert

def doc_generator(file):
    for data in file:
        doc = frappe.new_doc(doctype)
        doc.data = data
        yield doc

bulk_insert(doctype, doc_generator(file), chunk_size=10_000)
```

#### Why? / Pros
1. Simpler interface to `frappe.db.bulk_insert` which requires you to generate column and values all by yourself, this is too much CRUD-type work. No tx. 
2. Bulk insert required generating all values upfront, this change now allows it to accept iterator of unknown size so you can pass a generator, this way memory usage is nearly constant and things can be made to execute in coroutine fashion. 🚀 



#### Cons:
- Hooks etc are not triggered (DUH!) but you can still use doc methods to process whatever you need by yourself. 
- This is an alternative to `doc.db_insert` NOT `doc.insert`


#### very dumb benchmark - insert 1 million records.

| method | time (seconds) | speedup |
| --- | --- | --- |
| Sequential `db_insert` in loop | 429 | baseline |
| bulk_insert docs | 214 | 50% |
| hand-crafted `frappe.db.bulk_insert` | 136 | 68% |


TODO: 
- [x] naming is not handled. Naming can become a serious bottleneck for such a feature, hence as of now users of this API need to handle it themselves. We can build `get_n_names` API for bulk naming using tabSeries if required. Out of scope of this PR.


Inspired by Django's bulk_create: https://docs.djangoproject.com/en/4.0/ref/models/querysets/#bulk-create 

Possible use cases:
- Inserting data during setup - like country info, UOM, GST codes
- Serial No like docs
- Deferred inserts (logs)


Closes https://github.com/frappe/frappe/issues/15705



`no-docs`