### PR TITLE
fix: JS error in page.js when the is a quote in button translation

### DIFF
--- a/cypress/integration/custom_buttons.js
+++ b/cypress/integration/custom_buttons.js
@@ -4,6 +4,7 @@ const test_button_names = [
 	"Porcupine Tree (the GOAT)",
 	"AC / DC",
 	`Electronic Dance "music"`,
+	"l'imperatrice",
 ];
 
 const add_button = (label, group = "TestGroup") => {

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -510,7 +510,7 @@ frappe.ui.Page = class Page {
 
 		if (!label || !parent) return false;
 
-		const item_selector = `${selector}[data-label='${encodeURIComponent(label)}']`;
+		const item_selector = `${selector}[data-label="${encodeURIComponent(label)}"]`;
 
 		const existing_items = $(parent).find(item_selector);
 		return existing_items?.length > 0 && existing_items;


### PR DESCRIPTION
When there is a simple quote in translation on button there is an JS error

https://user-images.githubusercontent.com/1050053/173228548-b37a4d54-e333-430a-a36a-2eb981a83a6f.mp4

I dig to this because in french translation file for ERPNext some simple quote are "HTML entitsed" with `&#39; `some not.

I wonder why and as @[marination](https://github.com/marination) on this ERPNext translation PR (https://github.com/frappe/erpnext/pull/31232) ask me why I change some simple quote to `&#39;`. The fact is if there is a bug with simple quote I first want to change all simple quote to `&#39;` to avoid all bugs, but this is a bad way to do it. 
I think it's better if we can avoid "HTML entitsed" into translation, write translation as we write in books is better.

So I found this in page.js and I propose the PR


