### PR TITLE
refactor!: improve/extend log settings

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -17,7 +17,7 @@ import json
 import os
 import re
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import click
 from werkzeug.local import Local, release_local
@@ -1551,7 +1551,15 @@ def call(fn, *args, **kwargs):
 	return fn(*args, **newargs)
 
 
-def get_newargs(fn, kwargs):
+def get_newargs(fn: Callable, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+	"""Remove any kwargs that are not supported by the function.
+
+	Example:
+	        >>> def fn(a=1, b=2): pass
+
+	        >>> get_newargs(fn, {"a": 2, "c": 1})
+	                {"a": 2}
+	"""
 
 	# if function has any **kwargs parameter that capture arbitrary keyword arguments
 	# Ref: https://docs.python.org/3/library/inspect.html#inspect.Parameter.kind

--- a/frappe/core/doctype/activity_log/activity_log.py
+++ b/frappe/core/doctype/activity_log/activity_log.py
@@ -25,6 +25,13 @@ class ActivityLog(Document):
 		if self.reference_doctype and self.reference_name:
 			self.status = "Linked"
 
+	@staticmethod
+	def clear_old_logs(days=None):
+		if not days:
+			days = 90
+		doctype = DocType("Activity Log")
+		frappe.db.delete(doctype, filters=(doctype.modified < (Now() - Interval(days=days))))
+
 
 def on_doctype_update():
 	"""Add indexes in `tabActivity Log`"""
@@ -43,12 +50,3 @@ def add_authentication_log(subject, user, operation="Login", status="Success"):
 			"operation": operation,
 		}
 	).insert(ignore_permissions=True, ignore_links=True)
-
-
-def clear_activity_logs(days=None):
-	"""clear 90 day old authentication logs or configured in log settings"""
-
-	if not days:
-		days = 90
-	doctype = DocType("Activity Log")
-	frappe.db.delete(doctype, filters=(doctype.creation < (Now() - Interval(days=days))))

--- a/frappe/core/doctype/activity_log/activity_log_list.js
+++ b/frappe/core/doctype/activity_log/activity_log_list.js
@@ -4,5 +4,10 @@ frappe.listview_settings['Activity Log'] = {
 			return [__(doc.status), "green"];
 		else if(doc.operation == "Login" && doc.status == "Failed")
 			return [__(doc.status), "red"];
-	}
+	},
+	onload: function(listview) {
+		frappe.require("logtypes.bundle.js", () => {
+			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+		})
+	},
 };

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -13,14 +13,6 @@ class ErrorLog(Document):
 			frappe.db.commit()
 
 
-def set_old_logs_as_seen():
-	# set logs as seen
-	frappe.db.sql(
-		"""UPDATE `tabError Log` SET `seen`=1
-		WHERE `seen`=0 AND `creation` < (NOW() - INTERVAL '7' DAY)"""
-	)
-
-
 @frappe.whitelist()
 def clear_error_logs():
 	"""Flush all Error Logs"""

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -4,6 +4,8 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 
 
 class ErrorLog(Document):
@@ -11,6 +13,11 @@ class ErrorLog(Document):
 		if not self.seen:
 			self.db_set("seen", 1, update_modified=0)
 			frappe.db.commit()
+
+	@staticmethod
+	def clear_old_logs(days=30):
+		table = frappe.qb.DocType("Error Log")
+		frappe.db.delete(table, filters=(table.creation < (Now() - Interval(days=days))))
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -17,7 +17,7 @@ class ErrorLog(Document):
 	@staticmethod
 	def clear_old_logs(days=30):
 		table = frappe.qb.DocType("Error Log")
-		frappe.db.delete(table, filters=(table.creation < (Now() - Interval(days=days))))
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/error_log/error_log_list.js
+++ b/frappe/core/doctype/error_log/error_log_list.js
@@ -1,7 +1,7 @@
-frappe.listview_settings['Error Log'] = {
+frappe.listview_settings["Error Log"] = {
 	add_fields: ["seen"],
 	get_indicator: function(doc) {
-		if(cint(doc.seen)) {
+		if (cint(doc.seen)) {
 			return [__("Seen"), "green", "seen,=,1"];
 		} else {
 			return [__("Not Seen"), "red", "seen,=,0"];
@@ -11,11 +11,15 @@ frappe.listview_settings['Error Log'] = {
 	onload: function(listview) {
 		listview.page.add_menu_item(__("Clear Error Logs"), function() {
 			frappe.call({
-				method:'frappe.core.doctype.error_log.error_log.clear_error_logs',
+				method: "frappe.core.doctype.error_log.error_log.clear_error_logs",
 				callback: function() {
 					listview.refresh();
-				}
+				},
 			});
 		});
-	}
+
+		frappe.require("logtypes.bundle.js", () => {
+			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+		})
+	},
 };

--- a/frappe/core/doctype/error_snapshot/error_snapshot.py
+++ b/frappe/core/doctype/error_snapshot/error_snapshot.py
@@ -4,6 +4,8 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 
 
 class ErrorSnapshot(Document):
@@ -32,3 +34,8 @@ class ErrorSnapshot(Document):
 			frappe.db.set_value("Error Snapshot", parent["name"], "relapses", parent["relapses"] + 1)
 			if parent["seen"]:
 				frappe.db.set_value("Error Snapshot", parent["name"], "seen", False)
+
+	@staticmethod
+	def clear_old_logs(days=30):
+		table = frappe.qb.DocType("Error Snapshot")
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))

--- a/frappe/core/doctype/error_snapshot/error_snapshot_list.js
+++ b/frappe/core/doctype/error_snapshot/error_snapshot_list.js
@@ -10,5 +10,10 @@ frappe.listview_settings["Error Snapshot"] = {
 		} else {
 			return [__("First Level"), !doc.seen ? "red" : "green", "parent_error_snapshot,=,"];
 		}
-	}
+	},
+	onload: function(listview) {
+		frappe.require("logtypes.bundle.js", () => {
+			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+		})
+	},
 }

--- a/frappe/core/doctype/log_settings/log_settings.js
+++ b/frappe/core/doctype/log_settings/log_settings.js
@@ -1,8 +1,16 @@
 // Copyright (c) 2020, Frappe Technologies and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('Log Settings', {
-	// refresh: function(frm) {
-
-	// }
+frappe.ui.form.on("Log Settings", {
+	refresh: (frm) => {
+		frm.set_query("ref_doctype", "logs_to_clear", () => {
+			const added_doctypes = frm.doc.logs_to_clear.map((r) => r.ref_doctype);
+			return {
+				query: "frappe.core.doctype.log_settings.log_settings.get_log_doctypes",
+				filters: [
+					["name", "not in", added_doctypes],
+				],
+			};
+		});
+	},
 });

--- a/frappe/core/doctype/log_settings/log_settings.json
+++ b/frappe/core/doctype/log_settings/log_settings.json
@@ -5,61 +5,20 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "error_log_notification_section",
-  "users_to_notify",
-  "log_cleanup_section",
-  "clear_error_log_after",
-  "clear_activity_log_after",
-  "column_break_4",
-  "clear_email_queue_after"
+  "logs_to_clear"
  ],
  "fields": [
   {
-   "fieldname": "log_cleanup_section",
-   "fieldtype": "Section Break",
-   "label": "Log Cleanup"
-  },
-  {
-   "fieldname": "column_break_4",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "error_log_notification_section",
-   "fieldtype": "Section Break",
-   "label": "Error Log Notification"
-  },
-  {
-   "fieldname": "users_to_notify",
-   "fieldtype": "Table MultiSelect",
-   "label": "Users To Notify",
-   "options": "Log Setting User"
-  },
-  {
-   "default": "90",
-   "description": "In Days",
-   "fieldname": "clear_error_log_after",
-   "fieldtype": "Int",
-   "label": "Clear Error log After"
-  },
-  {
-   "default": "90",
-   "description": "In Days",
-   "fieldname": "clear_activity_log_after",
-   "fieldtype": "Int",
-   "label": "Clear Activity Log After"
-  },
-  {
-   "default": "30",
-   "description": "In Days",
-   "fieldname": "clear_email_queue_after",
-   "fieldtype": "Int",
-   "label": "Clear Email Queue After"
+   "fieldname": "logs_to_clear",
+   "fieldtype": "Table",
+   "label": "Logs to Clear",
+   "options": "Logs To Clear"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-10-13 12:18:48.649038",
+ "modified": "2022-06-11 02:17:30.803721",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Log Settings",
@@ -79,5 +38,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -72,7 +72,8 @@ class LogSettings(Document):
 			frappe.db.commit()
 
 	def register_doctype(self, doctype: str, days=30):
-		if doctype not in {d.ref_doctype for d in self.logs_to_clear}:
+		existing_logtypes = {d.ref_doctype for d in self.logs_to_clear}
+		if doctype not in existing_logtypes and _supports_log_clearing(doctype):
 			self.append("logs_to_clear", {"ref_doctype": doctype, "days": cint(days)})
 
 

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -15,7 +15,6 @@ DEFAULT_LOGTYPES_RETENTION = {
 	"Error Log": 30,
 	"Activity Log": 90,
 	"Email Queue": 30,
-	"Route History": 90,
 	"Error Snapshot": 30,
 	"Scheduled Job Log": 90,
 }

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -11,7 +11,7 @@ from frappe.model.document import Document
 from frappe.utils import cint
 from frappe.utils.caching import site_cache
 
-DEFAULT_LOGTYPES = {
+DEFAULT_LOGTYPES_RETENTION = {
 	"Error Log": 30,
 	"Activity Log": 90,
 	"Email Queue": 30,
@@ -67,7 +67,7 @@ class LogSettings(Document):
 	def add_default_logtypes(self):
 		existing_logtypes = {d.ref_doctype for d in self.logs_to_clear}
 		added_logtypes = set()
-		for logtype, frequency in DEFAULT_LOGTYPES.items():
+		for logtype, frequency in DEFAULT_LOGTYPES_RETENTION.items():
 			if logtype not in existing_logtypes and _supports_log_clearing(logtype):
 				self.append("logs_to_clear", {"ref_doctype": logtype, "days": cint(frequency)})
 				added_logtypes.add(logtype)

--- a/frappe/core/doctype/log_settings/test_log_settings.py
+++ b/frappe/core/doctype/log_settings/test_log_settings.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 
 import frappe
-from frappe.core.doctype.log_settings.log_settings import run_log_clean_up
+from frappe.core.doctype.log_settings.log_settings import _supports_log_clearing, run_log_clean_up
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now_datetime
 
@@ -55,6 +55,23 @@ class TestLogSettings(FrappeTestCase):
 		self.assertEqual(activity_log_count, 0)
 		self.assertEqual(error_log_count, 0)
 		self.assertEqual(email_queue_count, 0)
+
+	def test_logtype_identification(self):
+		supported_types = [
+			"Error Log",
+			"Activity Log",
+			"Email Queue",
+			"Route History",
+			"Error Snapshot",
+			"Scheduled Job Log",
+		]
+
+		for lt in supported_types:
+			self.assertTrue(_supports_log_clearing(lt), f"{lt} should be recognized as log type")
+
+		unsupported_types = ["DocType", "User", "Non Existing dt"]
+		for dt in unsupported_types:
+			self.assertFalse(_supports_log_clearing(dt), f"{dt} shouldn't be recognized as log type")
 
 
 def setup_test_logs(past: datetime) -> None:

--- a/frappe/core/doctype/logs_to_clear/logs_to_clear.json
+++ b/frappe/core/doctype/logs_to_clear/logs_to_clear.json
@@ -18,6 +18,7 @@
    "reqd": 1
   },
   {
+   "default": "30",
    "fieldname": "days",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -29,7 +30,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-06-11 03:20:47.721188",
+ "modified": "2022-06-11 04:35:54.706775",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Logs To Clear",

--- a/frappe/core/doctype/logs_to_clear/logs_to_clear.json
+++ b/frappe/core/doctype/logs_to_clear/logs_to_clear.json
@@ -3,6 +3,7 @@
  "autoname": "autoincrement",
  "creation": "2022-06-11 02:02:39.472511",
  "doctype": "DocType",
+ "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "ref_doctype",
@@ -30,7 +31,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-06-11 04:35:54.706775",
+ "modified": "2022-06-13 02:51:36.857786",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Logs To Clear",

--- a/frappe/core/doctype/logs_to_clear/logs_to_clear.json
+++ b/frappe/core/doctype/logs_to_clear/logs_to_clear.json
@@ -1,0 +1,42 @@
+{
+ "actions": [],
+ "autoname": "autoincrement",
+ "creation": "2022-06-11 02:02:39.472511",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "ref_doctype",
+  "days"
+ ],
+ "fields": [
+  {
+   "fieldname": "ref_doctype",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Log DocType",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "days",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Clear Logs After (days)",
+   "non_negative": 1,
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2022-06-11 03:20:47.721188",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Logs To Clear",
+ "naming_rule": "Autoincrement",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/logs_to_clear/logs_to_clear.py
+++ b/frappe/core/doctype/logs_to_clear/logs_to_clear.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class LogsToClear(Document):
+	pass

--- a/frappe/core/doctype/scheduled_job_log/scheduled_job_log.py
+++ b/frappe/core/doctype/scheduled_job_log/scheduled_job_log.py
@@ -2,9 +2,14 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 
 
 class ScheduledJobLog(Document):
-	pass
+	@staticmethod
+	def clear_old_logs(days=90):
+		table = frappe.qb.DocType("Scheduled Job Log")
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))

--- a/frappe/core/doctype/scheduled_job_log/scheduled_job_log_list.js
+++ b/frappe/core/doctype/scheduled_job_log/scheduled_job_log_list.js
@@ -1,0 +1,7 @@
+frappe.listview_settings["Scheduled Job Log"] = {
+	onload: function(listview) {
+		frappe.require("logtypes.bundle.js", () => {
+			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+		})
+	},
+};

--- a/frappe/desk/doctype/route_history/route_history.py
+++ b/frappe/desk/doctype/route_history/route_history.py
@@ -4,12 +4,15 @@
 import frappe
 from frappe.deferred_insert import deferred_insert as _deferred_insert
 from frappe.model.document import Document
-from frappe.query_builder import DocType
-from frappe.query_builder.functions import Count
+from frappe.query_builder import DocType, Interval
+from frappe.query_builder.functions import Count, Now
 
 
 class RouteHistory(Document):
-	pass
+	@staticmethod
+	def clear_old_logs(days=30):
+		table = frappe.qb.DocType("Route History")
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))
 
 
 def flush_old_route_records():

--- a/frappe/desk/doctype/route_history/route_history_list.js
+++ b/frappe/desk/doctype/route_history/route_history_list.js
@@ -1,0 +1,7 @@
+frappe.listview_settings["Route History"] = {
+	onload: function(listview) {
+		frappe.require("logtypes.bundle.js", () => {
+			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+		})
+	},
+};

--- a/frappe/email/doctype/email_queue/email_queue_list.js
+++ b/frappe/email/doctype/email_queue/email_queue_list.js
@@ -19,5 +19,11 @@ frappe.listview_settings['Email Queue'] = {
 				})
 			}
 		}
+	},
+
+	onload: function(listview) {
+		frappe.require("logtypes.bundle.js", () => {
+			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+		})
 	}
 }

--- a/frappe/email/doctype/email_queue/test_email_queue.py
+++ b/frappe/email/doctype/email_queue/test_email_queue.py
@@ -3,12 +3,13 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.email.queue import clear_outbox
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestEmailQueue(FrappeTestCase):
 	def test_email_queue_deletion_based_on_modified_date(self):
+		from frappe.email.doctype.email_queue.email_queue import EmailQueue
+
 		old_record = frappe.get_doc(
 			{
 				"doctype": "Email Queue",
@@ -32,7 +33,7 @@ class TestEmailQueue(FrappeTestCase):
 		new_record = frappe.copy_doc(old_record)
 		new_record.insert()
 
-		clear_outbox()
+		EmailQueue.clear_old_logs()
 
 		self.assertFalse(frappe.db.exists("Email Queue", old_record.name))
 		self.assertFalse(frappe.db.exists("Email Queue Recipient", {"parent": old_record.name}))

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -190,31 +190,6 @@ def get_queue():
 	)
 
 
-def clear_outbox(days: int = None) -> None:
-	"""Remove low priority older than 31 days in Outbox or configured in Log Settings.
-	Note: Used separate query to avoid deadlock
-	"""
-	days = days or 31
-	email_queue = frappe.qb.DocType("Email Queue")
-	email_recipient = frappe.qb.DocType("Email Queue Recipient")
-
-	# Delete queue table
-	(
-		frappe.qb.from_(email_queue)
-		.delete()
-		.where((email_queue.modified < (Now() - Interval(days=days))))
-	).run()
-
-	# delete child tables, note that this has potential to leave some orphan
-	# child table behind if modified time was later than parent doc (rare).
-	# But it's safe since child table doesn't contain links.
-	(
-		frappe.qb.from_(email_recipient)
-		.delete()
-		.where((email_recipient.modified < (Now() - Interval(days=days))))
-	).run()
-
-
 def set_expiry_for_email_queue():
 	"""Mark emails as expire that has not sent for 7 days.
 	Called daily via scheduler.

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -219,7 +219,6 @@ scheduler_events = {
 	"daily": [
 		"frappe.email.queue.set_expiry_for_email_queue",
 		"frappe.desk.notifications.clear_notifications",
-		"frappe.core.doctype.error_log.error_log.set_old_logs_as_seen",
 		"frappe.desk.doctype.event.event.send_event_digest",
 		"frappe.sessions.clear_expired_sessions",
 		"frappe.email.doctype.notification.notification.trigger_daily_alerts",

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -191,6 +191,7 @@ frappe.patches.v14_0.remove_post_and_post_comment
 frappe.patches.v14_0.reset_creation_datetime
 frappe.patches.v14_0.remove_is_first_startup
 frappe.patches.v14_0.reload_workspace_child_tables
+frappe.patches.v14_0.log_settings_migration
 
 [post_model_sync]
 frappe.patches.v14_0.drop_data_import_legacy

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -191,6 +191,7 @@ frappe.patches.v14_0.remove_post_and_post_comment
 frappe.patches.v14_0.reset_creation_datetime
 frappe.patches.v14_0.remove_is_first_startup
 frappe.patches.v14_0.reload_workspace_child_tables
+frappe.patches.v14_0.clear_long_pending_stale_logs
 frappe.patches.v14_0.log_settings_migration
 
 [post_model_sync]

--- a/frappe/patches/v14_0/clear_long_pending_stale_logs.py
+++ b/frappe/patches/v14_0/clear_long_pending_stale_logs.py
@@ -18,7 +18,6 @@ def execute():
 		"Error Snapshot": get_current_setting("clear_error_log_after") or 90,
 		# newly added
 		"Scheduled Job Log": 90,
-		"Route History": 90,
 	}
 
 	for doctype, retention in DOCTYPE_RETENTION_MAP.items():

--- a/frappe/patches/v14_0/clear_long_pending_stale_logs.py
+++ b/frappe/patches/v14_0/clear_long_pending_stale_logs.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe.core.doctype.log_settings.log_settings import clear_log_table
+from frappe.utils import add_to_date, today
+
+
+def execute():
+	"""Due to large size of log tables on old sites some table cleanups never finished during daily log clean up. This patch discards such data by using "big delete" code.
+
+	ref: https://github.com/frappe/frappe/issues/16971
+	"""
+
+	DOCTYPE_RETENTION_MAP = {
+		"Error Log": get_current_setting("clear_error_log_after") or 90,
+		"Activity Log": get_current_setting("clear_activity_log_after") or 90,
+		"Email Queue": get_current_setting("clear_email_queue_after") or 30,
+		# child table on email queue
+		"Email Queue Recipient": get_current_setting("clear_email_queue_after") or 30,
+		"Error Snapshot": get_current_setting("clear_error_log_after") or 90,
+		# newly added
+		"Scheduled Job Log": 90,
+		"Route History": 90,
+	}
+
+	for doctype, retention in DOCTYPE_RETENTION_MAP.items():
+		if is_log_cleanup_stuck(doctype, retention):
+			print(f"Clearing old {doctype} records")
+			clear_log_table(doctype, retention)
+
+
+def is_log_cleanup_stuck(doctype: str, retention: int) -> bool:
+	"""Check if doctype has data significantly older than configured cleanup period"""
+	threshold = add_to_date(today(), days=retention * -2)
+
+	return bool(frappe.db.exists(doctype, {"modified": ("<", threshold)}))
+
+
+def get_current_setting(fieldname):
+	try:
+		return frappe.db.get_single_value("Log Settings", fieldname)
+	except Exception:
+		# Field might be gone if patch is reattempted
+		pass

--- a/frappe/patches/v14_0/log_settings_migration.py
+++ b/frappe/patches/v14_0/log_settings_migration.py
@@ -14,9 +14,9 @@ def execute():
 	log_settings = frappe.get_doc("Log Settings")
 	log_settings.add_default_logtypes()
 
-	for doctype, days in old_settings.items():
-		if days:
-			log_settings.register_doctype(doctype, days)
+	for doctype, retention in old_settings.items():
+		if retention:
+			log_settings.register_doctype(doctype, retention)
 
 	log_settings.save()
 
@@ -25,4 +25,5 @@ def get_current_setting(fieldname):
 	try:
 		return frappe.db.get_single_value("Log Settings", fieldname)
 	except Exception:
+		# Field might be gone if patch is reattempted
 		pass

--- a/frappe/patches/v14_0/log_settings_migration.py
+++ b/frappe/patches/v14_0/log_settings_migration.py
@@ -6,6 +6,9 @@ def execute():
 		"Error Log": get_current_setting("clear_error_log_after") or 30,
 		"Activity Log": get_current_setting("clear_activity_log_after") or 90,
 		"Email Queue": get_current_setting("clear_email_queue_after") or 30,
+		"Route History": 90,
+		"Error Snapshot": 30,
+		"Scheduled Job Log": 90,
 	}
 
 	frappe.reload_doc("core", "doctype", "Logs To Clear")

--- a/frappe/patches/v14_0/log_settings_migration.py
+++ b/frappe/patches/v14_0/log_settings_migration.py
@@ -2,22 +2,21 @@ import frappe
 
 
 def execute():
-	logging_doctypes = {
-		"Error Log": get_current_setting("clear_error_log_after") or 30,
-		"Activity Log": get_current_setting("clear_activity_log_after") or 90,
-		"Email Queue": get_current_setting("clear_email_queue_after") or 30,
-		"Route History": 90,
-		"Error Snapshot": 30,
-		"Scheduled Job Log": 90,
+	old_settings = {
+		"Error Log": get_current_setting("clear_error_log_after"),
+		"Activity Log": get_current_setting("clear_activity_log_after"),
+		"Email Queue": get_current_setting("clear_email_queue_after"),
 	}
 
 	frappe.reload_doc("core", "doctype", "Logs To Clear")
 	frappe.reload_doc("core", "doctype", "Log Settings")
 
 	log_settings = frappe.get_doc("Log Settings")
+	log_settings.add_default_logtypes()
 
-	for doctype, days in logging_doctypes.items():
-		log_settings.register_doctype(doctype, days)
+	for doctype, days in old_settings.items():
+		if days:
+			log_settings.register_doctype(doctype, days)
 
 	log_settings.save()
 

--- a/frappe/patches/v14_0/log_settings_migration.py
+++ b/frappe/patches/v14_0/log_settings_migration.py
@@ -1,0 +1,26 @@
+import frappe
+
+
+def execute():
+	logging_doctypes = {
+		"Error Log": get_current_setting("clear_error_log_after") or 30,
+		"Activity Log": get_current_setting("clear_activity_log_after") or 90,
+		"Email Queue": get_current_setting("clear_email_queue_after") or 30,
+	}
+
+	frappe.reload_doc("core", "doctype", "Logs To Clear")
+	frappe.reload_doc("core", "doctype", "Log Settings")
+
+	log_settings = frappe.get_doc("Log Settings")
+
+	for doctype, days in logging_doctypes.items():
+		log_settings.register_doctype(doctype, days)
+
+	log_settings.save()
+
+
+def get_current_setting(fieldname):
+	try:
+		return frappe.db.get_single_value("Log Settings", fieldname)
+	except Exception:
+		pass

--- a/frappe/public/js/frappe/logtypes.js
+++ b/frappe/public/js/frappe/logtypes.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+// MIT License. See license.txt
+
+// Common utility functions for logging doctypes.
+
+frappe.provide("frappe.utils.logtypes");
+
+frappe.utils.logtypes.show_log_retention_message = (doctype) => {
+	if (!frappe.model.can_write("Log Settings")) {
+		return;
+	}
+
+	const add_sidebar_message = (message) => {
+		let sidebar_entry = $('<ul class="list-unstyled sidebar-menu"></ul>').appendTo(cur_list.page.sidebar);
+		$(`<div>${message}</div>`).appendTo(sidebar_entry);
+	};
+
+	const log_settings_link = `<a href='/app/log-settings'>${__('Log Settings')}</a>`;
+	const cta = __("You can change the retention policy from {0}.", [log_settings_link,]);
+	let message = __("{0} records are not automatically deleted.", [__(doctype),]);
+
+	frappe.db
+		.get_value("Logs To Clear", { ref_doctype: doctype }, "days", null, "Log Settings")
+		.then((r) => {
+			if (!r.exc && r.message && r.message.days) {
+				message = __("{0} records are retained for {1} days.", [__(doctype), r.message.days,]);
+			}
+			add_sidebar_message(`${message} ${cta}`);
+		});
+};

--- a/frappe/public/js/logtypes.bundle.js
+++ b/frappe/public/js/logtypes.bundle.js
@@ -1,0 +1,1 @@
+import "./frappe/logtypes"

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -526,11 +526,16 @@ class TestBackups(BaseTestCommands):
 		d.db_set("modified", "2010-01-01", update_modified=False)
 		frappe.db.commit()
 
+		tables_before = frappe.db.get_tables(cached=False)
+
 		self.execute("bench --site {site} clear-log-table --days=30 --doctype='Error Log'")
 		self.assertEqual(self.returncode, 0)
 		frappe.db.commit()
 
 		self.assertFalse(frappe.db.exists("Error Log", d.name))
+		tables_after = frappe.db.get_tables(cached=False)
+
+		self.assertEqual(set(tables_before), set(tables_after))
 
 	def test_backup_with_custom_path(self):
 		"""Backup to a custom path (--backup-path)"""


### PR DESCRIPTION
closes #17014 

#### Before:

3 hardcoded doctypes:
<img width="1358" alt="Screenshot 2022-06-13 at 10 09 59 AM" src="https://user-images.githubusercontent.com/9079960/173280887-3be8d54e-0bcf-448e-9fda-ceb4c6ee566f.png">


#### After:

Table that can let user configure any doctype that supports log clearing. 

<img width="1312" alt="Screenshot 2022-06-13 at 10 08 36 AM" src="https://user-images.githubusercontent.com/9079960/173280914-a8bb21fb-3f11-420e-9252-c6ee855dbffe.png">


Any doctype that implements the defined interface automatically shows up on the list:

```python
@runtime_checkable
class LogType(Protocol):
  """Interface requirement for doctypes that can be cleared using log settings."""
  
  @staticmethod
  def clear_old_logs(days: int) -> None:
    ...
````


<img width="785" alt="Screenshot 2022-06-13 at 10 09 01 AM" src="https://user-images.githubusercontent.com/9079960/173280898-d285c247-d32e-47f9-b283-c7b645c122eb.png">


---

Show instructions on listview, thanks for the tip @gavindsouza 

<img width="913" alt="Screenshot 2022-06-14 at 1 39 07 PM" src="https://user-images.githubusercontent.com/9079960/173527232-124d8313-bea5-48ba-ba9c-902e51db0dab.png">

---

In addition to this also added a command line util to empty very large table that can't be cleared using DELETE queries because of the size. 


```sh
λ bench --site sitename clear-log-table --doctype="Error Log" --days=30
Backed up Error Log
Copying Error Log records from last 30 days to temporary table.
Cleared Error Log records older than 30 days
```


TODO:
- [x] patch for big deletes for users migrating to v14 
- [x] Message about retention setting on list / formview. 