### PR TITLE
fix: Handle case where document title can be NONE

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -472,7 +472,7 @@ class Document(BaseDocument):
 
 	def get_title(self):
 		"""Get the document title based on title_field or `title` or `name`"""
-		return self.get(self.meta.get_title_field())
+		return self.get(self.meta.get_title_field()) or ""
 
 	def set_title_field(self):
 		"""Set title field based on template"""

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -79,7 +79,7 @@ def get_context(context):
 		"body": body,
 		"print_style": print_style,
 		"comment": frappe.session.user,
-		"title": frappe.utils.strip_html(doc.get_title()),
+		"title": frappe.utils.strip_html(doc.get_title() or doc.name),
 		"lang": frappe.local.lang,
 		"layout_direction": "rtl" if is_rtl() else "ltr",
 		"is_invalid_print": is_invalid_print,


### PR DESCRIPTION
Fixes following error while loading document printview where document does not have the title set.
<img width="870" alt="Screenshot 2022-06-13 at 11 14 32 AM" src="https://user-images.githubusercontent.com/13928957/173287638-5e66128c-bf61-4977-9374-991da74670d3.png">

```
Traceback (most recent call last):
  File "apps/frappe/frappe/website/context.py", line 61, in update_controller_context
    ret = module.get_context(context)
  File "apps/frappe/frappe/www/printview.py", line 82, in get_context
    "title": frappe.utils.strip_html(doc.get_title()),
  File "apps/frappe/frappe/utils/data.py", line 1281, in strip_html
    return _striptags_re.sub("", text)
TypeError: expected string or bytes-like object
```