### PR TITLE
fix(Event Streaming): Set remote docname and site name before mapped doc insertion + fix mapping setup

### DIFF
--- a/frappe/event_streaming/doctype/document_type_mapping/document_type_mapping.js
+++ b/frappe/event_streaming/doctype/document_type_mapping/document_type_mapping.js
@@ -7,7 +7,7 @@ frappe.ui.form.on('Document Type Mapping', {
 			frappe.model.clear_table(frm.doc, 'field_mapping');
 			let fields = frm.events.get_fields(frm);
 			$.each(fields, function(i, data) {
-				let row = frappe.model.add_child(frm.doc, 'Document Type Mapping', 'field_mapping');
+				let row = frappe.model.add_child(frm.doc, 'Document Type Field Mapping', 'field_mapping');
 				row.local_fieldname = data;
 			});
 			refresh_field('field_mapping');

--- a/frappe/event_streaming/doctype/event_producer/event_producer.py
+++ b/frappe/event_streaming/doctype/event_producer/event_producer.py
@@ -315,8 +315,9 @@ def set_insert(update, producer_site, event_producer):
 	else:
 		# if event consumer is not saving documents with the same name as the producer
 		# store the remote docname in a custom field for future updates
-		local_doc = doc.insert(set_child_names=False)
-		set_custom_fields(local_doc, update.docname, event_producer)
+		doc.remote_docname = update.docname
+		doc.remote_site_name = event_producer
+		doc.insert(set_child_names=False)
 
 
 def set_update(update, producer_site):
@@ -567,9 +568,3 @@ def resync(update):
 		update = get_mapped_update(update, producer_site)
 		update.data = json.loads(update.data)
 	return sync(update, producer_site, event_producer, in_retry=True)
-
-
-def set_custom_fields(local_doc, remote_docname, remote_site_name):
-	"""sets custom field in doc for storing remote docname"""
-	frappe.db.set_value(local_doc.doctype, local_doc.name, "remote_docname", remote_docname)
-	frappe.db.set_value(local_doc.doctype, local_doc.name, "remote_site_name", remote_site_name)


### PR DESCRIPTION
## Problems

- When syncing is set up with mapping (docs having different names/doctype schema on the producer and consumer sites), the custom fields for remote doc name and site name are set in synced docs for future updates. They are set after insertion using `set_value`. Set them before doc insertion for easy differentiation between a synced doc and a local doc.

  <img width="1329" alt="image" src="https://user-images.githubusercontent.com/24353136/173534900-308f6891-aed6-4375-8202-57f730c21c30.png">

-  While creating a Document Type Mapping, on selecting the local doctype, the fields for that doctype are populated in the mapping child table but the wrong doctype name is passed to `add_child` causing errors. Pass the correct child table name.

    ![Kapture 2022-06-14 at 14 19 28](https://user-images.githubusercontent.com/24353136/173536030-5d7cce73-5558-445a-9ea8-44c99a2da4cb.gif)