### PR TITLE
fix: Read Only field UI broken in desk form and Web form

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -72,9 +72,12 @@ frappe.ui.form.Control = class BaseControl {
 				status = "Read";
 			}
 
+			let value = this.value || this.get_model_value();
+			value = this.get_parsed_value(value);
+
 			if (
 				status === "Read" &&
-				is_null(this.value) &&
+				is_null(value) &&
 				!in_list(["HTML", "Image", "Button"], this.df.fieldtype)
 			) status = "None";
 
@@ -93,9 +96,12 @@ frappe.ui.form.Control = class BaseControl {
 			}
 		}
 
+		let value = frappe.model.get_value(this.doctype, this.docname, this.df.fieldname);
+		value = this.get_parsed_value(value);
+
 		// hide if no value
 		if (this.doctype && status==="Read" && !this.only_input
-			&& is_null(frappe.model.get_value(this.doctype, this.docname, this.df.fieldname))
+			&& is_null(value)
 			&& !in_list(["HTML", "Image", "Button"], this.df.fieldtype)) {
 
 			// eslint-disable-next-line
@@ -159,14 +165,18 @@ frappe.ui.form.Control = class BaseControl {
 			return this.doc[this.df.fieldname];
 		}
 	}
+	get_parsed_value(value) {
+		if (this.parse) {
+			value = this.parse(value);
+		}
+		return value;
+	}
 
 	set_value(value, force_set_value=false) {
 		return this.validate_and_set_in_model(value, null, force_set_value);
 	}
 	parse_validate_and_set_in_model(value, e) {
-		if(this.parse) {
-			value = this.parse(value);
-		}
+		value = this.get_parsed_value(value);
 		return this.validate_and_set_in_model(value, e);
 	}
 	validate_and_set_in_model(value, e, force_set_value=false) {

--- a/frappe/public/js/frappe/form/controls/date.js
+++ b/frappe/public/js/frappe/form/controls/date.js
@@ -140,6 +140,9 @@ frappe.ui.form.ControlDate = class ControlDate extends frappe.ui.form.ControlDat
 	}
 	parse(value) {
 		if (value) {
+			if (value == "Invalid date") {
+				return "";
+			}
 			return frappe.datetime.user_to_str(value, false, true);
 		}
 	}

--- a/frappe/public/js/frappe/form/controls/date_range.js
+++ b/frappe/public/js/frappe/form/controls/date_range.js
@@ -41,9 +41,10 @@ frappe.ui.form.ControlDateRange = class ControlDateRange extends frappe.ui.form.
 		this.set_mandatory && this.set_mandatory(value);
 	}
 	parse(value) {
+		if (!value || (value && !value.includes('to'))) return value;
 		// replace the separator (which can be in user language) with comma
 		const to = __('{0} to {1}').replace('{0}', '').replace('{1}', '');
-		value = value.replace(to, ',');
+		value = value && value.replace(to, ',');
 
 		if(value && value.includes(',')) {
 			var vals = value.split(',');

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -43,8 +43,8 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 			if (value == "Invalid date") {
 				value = "";
 			}
-			return value;
 		}
+		return value;
 	}
 	format_for_input(value) {
 		if (!value) return "";

--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -40,6 +40,9 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 				value = frappe.datetime.convert_to_system_tz(value, true);
 			}
 
+			if (value == "Invalid date") {
+				value = "";
+			}
 			return value;
 		}
 	}

--- a/frappe/public/js/frappe/form/controls/duration.js
+++ b/frappe/public/js/frappe/form/controls/duration.js
@@ -109,6 +109,12 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 		return cint(this.value);
 	}
 
+	parse(value) {
+		if (!value) {
+			return "";
+		}
+	}
+
 	refresh_input() {
 		super.refresh_input();
 		this.set_duration_options();

--- a/frappe/public/js/frappe/form/controls/duration.js
+++ b/frappe/public/js/frappe/form/controls/duration.js
@@ -110,9 +110,7 @@ frappe.ui.form.ControlDuration = class ControlDuration extends frappe.ui.form.Co
 	}
 
 	parse(value) {
-		if (!value) {
-			return "";
-		}
+		return !value ? "" : value;
 	}
 
 	refresh_input() {

--- a/frappe/public/js/frappe/form/controls/multiselect_pills.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_pills.js
@@ -38,6 +38,10 @@ frappe.ui.form.ControlMultiSelectPills = class ControlMultiSelectPills extends f
 	}
 
 	parse(value) {
+		if (typeof value == "object" || !this.rows) {
+			return value;
+		}
+
 		if (value) {
 			this.rows.push(value);
 		}

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -50,6 +50,10 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends f
 		this.$input_area.find('.link-btn').remove();
 	}
 	parse(value, label) {
+		if (typeof value == "object" || !this.rows) {
+			return value;
+		}
+
 		const link_field = this.get_link_field();
 
 		if (value) {

--- a/frappe/public/js/frappe/form/controls/time.js
+++ b/frappe/public/js/frappe/form/controls/time.js
@@ -82,6 +82,9 @@ frappe.ui.form.ControlTime = class ControlTime extends frappe.ui.form.ControlDat
 	}
 	parse(value) {
 		if (value) {
+			if (value == "Invalid date") {
+				value = "";
+			}
 			return frappe.datetime.user_to_str(value, true);
 		}
 	}

--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -1,3 +1,5 @@
+$input-height: 28px !default;
+
 :root,
 [data-theme="light"] {
 	--brand-color: #0089FF;
@@ -249,6 +251,10 @@
 
 	--primary-color: #2490EF;
 	--btn-height: 30px;
+
+	// input
+	--input-height: #{$input-height};
+	--input-disabled-bg: var(--gray-200);
 
 	// Checkbox
 	--checkbox-right-margin: var(--margin-xs);

--- a/frappe/public/scss/common/form.scss
+++ b/frappe/public/scss/common/form.scss
@@ -13,6 +13,7 @@
 		font-weight: normal;
 		font-size: var(--text-sm);
 	}
+	min-height: var(--input-height);
 	border-radius: $border-radius;
 	font-weight: 400;
 	padding: 6px 12px;

--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -1,7 +1,5 @@
 @import '../common/css_variables.scss';
 
-$input-height: 28px !default;
-
 :root,
 [data-theme="light"] {
 	// breakpoints
@@ -30,10 +28,6 @@ $input-height: 28px !default;
 	// page
 	--page-head-height: 75px;
 	--page-bottom-margin: 60px;
-
-	// input
-	--input-height: #{$input-height};
-	--input-disabled-bg: var(--gray-200);
 
 	// checkbox
 	--checkbox-right-margin: var(--margin-xs);


### PR DESCRIPTION
**Desk Form:**

**Before:**
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/30859809/173554296-4e745738-69f2-4ca6-afe7-03ef8174745b.png">
**After:**
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/30859809/173554433-125c1ad2-f3a0-45c1-af10-7b840ba47e10.png">


**Web Form:**

|  Before  |  After  |
| --------- | ------- |
|  <img width="808" alt="image" src="https://user-images.githubusercontent.com/30859809/173553696-55b86a73-b565-41c7-8b6b-f71ebf5e3a40.png">  |  <img width="818" alt="image" src="https://user-images.githubusercontent.com/30859809/173553322-f74fddc4-ce14-4ce8-b862-903a3e7b1a12.png">  |



