### PR TITLE
refactor!: Don't cast values of frappe.db.get_singles_dict by default

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2221,14 +2221,14 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 
 def get_website_settings(key):
 	if not hasattr(local, "website_settings"):
-		local.website_settings = db.get_singles_dict("Website Settings")
+		local.website_settings = db.get_singles_dict("Website Settings", cast=True)
 
 	return local.website_settings[key]
 
 
 def get_system_settings(key):
 	if not hasattr(local, "system_settings"):
-		local.system_settings = db.get_singles_dict("System Settings")
+		local.system_settings = db.get_singles_dict("System Settings", cast=True)
 
 	return local.system_settings[key]
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -22,7 +22,8 @@ from frappe.exceptions import DoesNotExistError
 from frappe.model.utils.link_count import flush_local_link_count
 from frappe.query_builder.functions import Count
 from frappe.query_builder.utils import DocType
-from frappe.utils import cast, get_datetime, get_table_name, getdate, now, sbool
+from frappe.utils import cast as cast_fieldtype
+from frappe.utils import get_datetime, get_table_name, getdate, now, sbool
 
 IFNULL_PATTERN = re.compile(r"ifnull\(", flags=re.IGNORECASE)
 INDEX_PATTERN = re.compile(r"\s*\([^)]+\)\s*")
@@ -651,7 +652,7 @@ class Database(object):
 
 		for fieldname, value in queried_result:
 			if df := meta.get_field(fieldname):
-				casted_value = cast(df.fieldtype, value)
+				casted_value = cast_fieldtype(df.fieldtype, value)
 			else:
 				casted_value = value
 			return_value[fieldname] = casted_value
@@ -719,7 +720,7 @@ class Database(object):
 				_("Invalid field name: {0}").format(frappe.bold(fieldname)), self.InvalidColumnName
 			)
 
-		val = cast(df.fieldtype, val)
+		val = cast_fieldtype(df.fieldtype, val)
 
 		self.value_cache[doctype][fieldname] = val
 

--- a/frappe/integrations/doctype/google_drive/google_drive.py
+++ b/frappe/integrations/doctype/google_drive/google_drive.py
@@ -259,13 +259,13 @@ def upload_system_backup_to_google_drive():
 
 
 def daily_backup():
-	drive_settings = frappe.db.get_singles_dict("Google Drive")
+	drive_settings = frappe.db.get_singles_dict("Google Drive", cast=True)
 	if drive_settings.enable and drive_settings.frequency == "Daily":
 		upload_system_backup_to_google_drive()
 
 
 def weekly_backup():
-	drive_settings = frappe.db.get_singles_dict("Google Drive")
+	drive_settings = frappe.db.get_singles_dict("Google Drive", cast=True)
 	if drive_settings.enable and drive_settings.frequency == "Weekly":
 		upload_system_backup_to_google_drive()
 


### PR DESCRIPTION
* Reverts `frappe.db.get_singles_dict` API's breaking nature via https://github.com/frappe/frappe/pull/17063 and maintains functionality
* Updates older code (wherever required) to adapt with old and new API changes 😄 

Alternate fix to https://github.com/frappe/frappe/pull/17184