### PR TITLE
fix: pass parent doctype on client.get_value

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -100,7 +100,7 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 	if frappe.is_table(doctype):
 		check_parent_permission(parent, doctype)
 
-	if not frappe.has_permission(doctype):
+	if not frappe.has_permission(doctype, parent_doctype=parent):
 		frappe.throw(_("No permission for {0}").format(doctype), frappe.PermissionError)
 
 	filters = get_safe_filters(filters)


### PR DESCRIPTION
`frappe.db.get_value` on client side doesn't work as passed parent doctype isn't passed down to the `frappe.has_permisssion`