### PR TITLE
Revert "fix: allow All to select a User (backport #16983)"

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -668,7 +668,7 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2022-05-25 01:00:51.345319",
+ "modified": "2022-03-09 01:47:56.745069",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",
@@ -693,10 +693,6 @@
    "read": 1,
    "role": "System Manager",
    "write": 1
-  },
-  {
-   "role": "All",
-   "select": 1
   }
  ],
  "quick_entry": 1,

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -623,31 +623,3 @@ class TestPermissions(unittest.TestCase):
 
 		# reset the user
 		frappe.set_user(current_user)
-
-	def test_select_user(self):
-		"""If test3@example.com is restricted by a User Permission to see only
-		users linked to a certain doctype (in this case: Gender "Female"), he
-		should not be able to query other users (Gender "Male").
-		"""
-		# ensure required genders exist
-		for gender in ("Male", "Female"):
-			if frappe.db.exists("Gender", gender):
-				continue
-
-			frappe.get_doc({"doctype": "Gender", "gender": gender}).insert()
-
-		# asssign gender to test users
-		frappe.db.set_value("User", "test1@example.com", "gender", "Male")
-		frappe.db.set_value("User", "test2@example.com", "gender", "Female")
-		frappe.db.set_value("User", "test3@example.com", "gender", "Female")
-
-		# restrict test3@example.com to see only female users
-		add_user_permission("Gender", "Female", "test3@example.com")
-
-		# become user test3@example.com and see what users he can query
-		frappe.set_user("test3@example.com")
-		users = frappe.get_list("User", pluck="name")
-
-		self.assertNotIn("test1@example.com", users)
-		self.assertIn("test2@example.com", users)
-		self.assertIn("test3@example.com", users)


### PR DESCRIPTION
Reverts frappe/frappe#17178


Breaking ERPNext ci (and unknown side effects 👀 )