### PR TITLE
fix: Patch qb for different schemas in same process

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -45,7 +45,7 @@ local = Local()
 STANDARD_USERS = ("Guest", "Administrator")
 
 _dev_server = int(sbool(os.environ.get("DEV_SERVER", False)))
-_qb_patched = False
+_qb_patched = {}
 re._MAXCACHE = (
 	50  # reduced from default 512 given we are already maintaining this on parent worker
 )
@@ -243,7 +243,7 @@ def init(site, sites_path=None, new_site=False):
 
 	setup_module_map()
 
-	if not _qb_patched:
+	if not _qb_patched.get(local.conf.db_type):
 		patch_query_execute()
 		patch_query_aggregation()
 

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -104,7 +104,7 @@ def patch_query_execute():
 
 	builder_class.run = execute_query
 	builder_class.walk = prepare_query
-	frappe._qb_patched = True
+	frappe._qb_patched[frappe.conf.db_type] = True
 
 
 def patch_query_aggregation():
@@ -115,4 +115,4 @@ def patch_query_aggregation():
 	frappe.qb.min = _min
 	frappe.qb.avg = _avg
 	frappe.qb.sum = _sum
-	frappe._qb_patched = True
+	frappe._qb_patched[frappe.conf.db_type] = True


### PR DESCRIPTION
You would want to switch schemas in the same process. Eversince the change https://github.com/frappe/frappe/commit/64e52737646d1661e0d295868fc85aa0da47b1f2 we stopped patching on every frappe.init call which meant, if a MariaDB site was initialized first, `frappe._qb_patched` would be set to `True` and
if a Postgres site was initialized after, _qb_patched would be lying as the Postgres engine isn't patched yet. Sooooo we need a Dict instead to maintain this record of patching. This issue caused weird errors lol

### Sample Use case

Run `bench --site all migrate` on a bench that has postgres & mariadb sites

### Traceback

```python
  File "/home/frappe/Desktop/frappe-bench-dev/env/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/commands/site.py", line 524, in migrate
    SiteMigration(
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/migrate.py", line 169, in run
    self.setUp()
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/migrate.py", line 73, in setUp
    clear_global_cache()
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/cache_manager.py", line 102, in clear_global_cache
    clear_website_cache()
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/website/utils.py", line 374, in clear_website_cache
    clear_cache(path)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/website/utils.py", line 369, in clear_cache
    for method in frappe.get_hooks("website_clear_cache"):
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/__init__.py", line 1440, in get_hooks
    hooks = _dict(_load_app_hooks())
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/utils/caching.py", line 57, in wrapper
    return_val = func(*args, **kwargs)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/__init__.py", line 1407, in _load_app_hooks
    apps = [app_name] if app_name else get_installed_apps(sort=True)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/utils/caching.py", line 57, in wrapper
    return_val = func(*args, **kwargs)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/__init__.py", line 1374, in get_installed_apps
    installed = json.loads(db.get_global("installed_apps") or "[]")
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/database/database.py", line 917, in get_global
    return self.get_default(key, user)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/database/database.py", line 921, in get_default
    d = self.get_defaults(key, parent)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/database/database.py", line 938, in get_defaults
    defaults = frappe.defaults.get_defaults(parent)
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/defaults.py", line 88, in get_defaults
    globald = get_defaults_for()
  File "/home/frappe/Desktop/frappe-bench-dev/apps/frappe/frappe/defaults.py", line 218, in get_defaults_for
    frappe.qb.from_(table)
TypeError: 'Field' object is not callable
```