### PR TITLE
fix: Add data titles to sidebar workspace fields for easier selection through CSS.

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -118,7 +118,7 @@ frappe.views.Workspace = class Workspace {
 	}
 
 	build_sidebar_section(title, root_pages) {
-		let sidebar_section = $(`<div class="standard-sidebar-section nested-container"></div>`);
+		let sidebar_section = $(`<div class="standard-sidebar-section nested-container" data-title="${title}"></div>`);
 
 		let $title = $(`<div class="standard-sidebar-label">
 			<span>${frappe.utils.icon("small-down", "xs")}</span>


### PR DESCRIPTION
Adding a data-title attribute to Workspace sidebar items