### PR TITLE
fix: ignore if integration_type column doesn't exist (for direct v14 installations) for integration request patch

### DIFF
--- a/frappe/patches/v14_0/update_integration_request.py
+++ b/frappe/patches/v14_0/update_integration_request.py
@@ -3,6 +3,10 @@ import frappe
 
 def execute():
 	doctype = "Integration Request"
+
+	if not frappe.db.has_column(doctype, "integration_type"):
+		return
+
 	frappe.db.set_value(
 		doctype,
 		{"integration_type": "Remote", "integration_request_service": ("!=", "PayPal")},


### PR DESCRIPTION
Failing on local (for direct v14/develop installation)

```py
Migrating ofrappe
Executing frappe.patches.v14_0.update_integration_request in ofrappe (_368f4919b2eeab35)
Updating Dashboard for frappe
Building search index for ofrappe
Retrieving Routes                   : [========================================] 100%
Building Index                      : [========================================] 100%
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/utils/bench_helper.py", line 109, in <module>
    main()
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/commands/site.py", line 524, in migrate
    SiteMigration(
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/migrate.py", line 172, in run
    self.run_schema_updates()
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/migrate.py", line 40, in wrapper
    ret = method(*args, **kwargs)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/migrate.py", line 109, in run_schema_updates
    frappe.modules.patch_handler.run_all(
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/modules/patch_handler.py", line 76, in run_all
    run_patch(patch)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_patch
    if not run_single(patchmodule=patch):
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/modules/patch_handler.py", line 151, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/modules/patch_handler.py", line 186, in execute_patch
    _patch()
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/patches/v14_0/update_integration_request.py", line 6, in execute
    frappe.db.set_value(
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/database/database.py", line 860, in set_value
    self.get_values(dt, dn, "name", debug=debug, for_update=for_update, pluck=True)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/database/database.py", line 529, in get_values
    out = self._get_values_from_table(
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/database/database.py", line 771, in _get_values_from_table
    r = self.sql(query, as_dict=as_dict, debug=debug, update=update, run=run, pluck=pluck)
  File "/Users/ritwik-frappe/Desktop/dev/newb/apps/frappe/frappe/database/database.py", line 191, in sql
    self._cursor.execute(query)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/Users/ritwik-frappe/Desktop/dev/newb/env/lib/python3.8/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'integration_type' in 'where clause'")
```