### PR TITLE
fix: can't select dynamic link on address doctype

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -170,7 +170,9 @@ def delete_contact_and_address(doctype, docname):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def filter_dynamic_link_doctypes(txt: str, filters: Dict) -> List[List[str]]:
+def filter_dynamic_link_doctypes(
+	doctype, txt: str, searchfield, start, page_len, filters: Dict
+) -> List[List[str]]:
 	from frappe.permissions import get_doctypes_with_read
 
 	txt = txt or ""


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/17225 
caused by https://github.com/frappe/frappe/pull/17063


Root cause: the function signature was changed, all search widgets need to follow the default signature 👀 

test: UI test will be added for this on ERPNext repo, so avoiding here, also this isn't "unit testable" without hardcoding how UI sends requests :P 