### PR TITLE
fix(tabs): Set first visible tab as active

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -575,8 +575,6 @@ frappe.ui.form.Form = class FrappeForm {
 
 		this.$wrapper.trigger('render_complete');
 
-		this.layout.set_first_tab_as_active(switched || this.cscript.is_onload);
-
 		if(!this.hidden) {
 			this.layout.show_empty_form_message();
 		}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1840,6 +1840,15 @@ frappe.ui.form.Form = class FrappeForm {
 			});
 		});
 	}
+	set_active_tab(tab) {
+		if (!this.active_tab_map) {
+			this.active_tab_map = {};
+		}
+		this.active_tab_map[this.docname] = tab;
+	}
+	get_active_tab() {
+		return this.active_tab_map && this.active_tab_map[this.docname];
+	}
 };
 
 frappe.validated = 0;

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -343,7 +343,7 @@ frappe.ui.form.Layout = class Layout {
 		if (this.tabs.length && !this.frm.active_tab) {
 			// set first tab as active when opening for first time, or new doc
 			let first_visible_tab = this.tabs.find(tab => !tab.is_hidden());
-			first_visible_tab.set_active();
+			first_visible_tab && first_visible_tab.set_active();
 		}
 	}
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -336,11 +336,14 @@ frappe.ui.form.Layout = class Layout {
 		if (visible_tabs && visible_tabs.length == 1) {
 			visible_tabs[0].parent.toggleClass('hide show');
 		}
-		this.set_first_tab_as_active();
+		this.set_tab_as_active();
 	}
 
-	set_first_tab_as_active() {
-		if (this.tabs.length && !this.frm.active_tab) {
+	set_tab_as_active() {
+		let frm_active_tab = this?.frm.get_active_tab?.();
+		if (frm_active_tab) {
+			frm_active_tab.set_active();
+		} else if (this.tabs.length) {
 			// set first tab as active when opening for first time, or new doc
 			let first_visible_tab = this.tabs.find(tab => !tab.is_hidden());
 			first_visible_tab && first_visible_tab.set_active();

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -123,7 +123,7 @@ frappe.ui.form.Layout = class Layout {
 
 		if (this.is_tabbed_layout()) {
 			// add a tab without `fieldname` to avoid conflicts
-			let default_tab = {label: __('Details'), fieldtype: "Tab Break"};
+			let default_tab = {label: __('Details'), fieldtype: "Tab Break", fieldname: "__details"};
 			let first_tab = this.fields[1].fieldtype === "Tab Break" ? this.fields[1] : null;
 			if (!first_tab) {
 				this.fields.splice(1, 0, default_tab);
@@ -336,12 +336,14 @@ frappe.ui.form.Layout = class Layout {
 		if (visible_tabs && visible_tabs.length == 1) {
 			visible_tabs[0].parent.toggleClass('hide show');
 		}
+		this.set_first_tab_as_active();
 	}
 
-	set_first_tab_as_active(switched) {
-		if (this.tabs.length && (switched || !this.frm.active_tab)) {
+	set_first_tab_as_active() {
+		if (this.tabs.length && !this.frm.active_tab) {
 			// set first tab as active when opening for first time, or new doc
-			this.tabs[0].set_active();
+			let first_visible_tab = this.tabs.find(tab => !tab.is_hidden());
+			first_visible_tab.set_active();
 		}
 	}
 

--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -10,6 +10,7 @@ export default class Tab {
 		this.fields_list = [];
 		this.fields_dict = {};
 		this.make();
+		this.setup_listeners();
 		this.refresh();
 	}
 
@@ -79,7 +80,6 @@ export default class Tab {
 	set_active() {
 		this.parent.find('.nav-link').tab('show');
 		this.wrapper.addClass('active');
-		this.frm.active_tab = this;
 	}
 
 	is_active() {
@@ -88,5 +88,11 @@ export default class Tab {
 
 	is_hidden() {
 		return this.wrapper.hasClass('hide');
+	}
+
+	setup_listeners() {
+		this.parent.find('.nav-link').on('shown.bs.tab', () => {
+			this?.frm.set_active_tab?.(this);
+		});
 	}
 }

--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -87,7 +87,6 @@ export default class Tab {
 	}
 
 	is_hidden() {
-		this.wrapper.hasClass('hide')
-			&& this.parent.hasClass('hide');
+		return this.wrapper.hasClass('hide');
 	}
 }


### PR DESCRIPTION
- No tab was set as active if all the elements of first tab was hidden.
	  <img width="1309" alt="Screenshot 2022-06-17 at 4 22 04 PM" src="https://user-images.githubusercontent.com/13928957/174284846-39a911b1-1ba5-4d00-8d91-66c2f2f67452.png">
	   
	**After fix:** 

	  Activate first tab that has visible elements.
	  
	<img width="1308" alt="Screenshot 2022-06-17 at 4 24 39 PM" src="https://user-images.githubusercontent.com/13928957/174285031-01ca7063-8d61-438e-a3c1-224fbd1b69f3.png">

- Remember last active tab while navigating through multiple documents
	**Before:** 
	(It used always show first tab as active even after activating different tab for a document)
	
	https://user-images.githubusercontent.com/13928957/174301521-9817460c-f0d5-4e66-98bb-2b1b61dc9e64.mov



	
	**After:**
	Remembers last active tab for a document.

	https://user-images.githubusercontent.com/13928957/174301567-2948384d-54b8-4a5f-81bc-1774b420002e.mov




