### PR TITLE
fix: cast list to tuple when using parameterized query for postgres

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -403,13 +403,12 @@ def modify_query(query):
 
 
 def modify_values(values):
-	def stringify_value(value):
-		if isinstance(value, int):
+	def modify_value(value):
+		if isinstance(value, (list, tuple)):
+			value = tuple(modify_values(value))
+
+		elif isinstance(value, int):
 			value = str(value)
-		elif isinstance(value, float):
-			truncated_float = int(value)
-			if value == truncated_float:
-				value = str(truncated_float)
 
 		return value
 
@@ -418,20 +417,15 @@ def modify_values(values):
 
 	if isinstance(values, dict):
 		for k, v in values.items():
-			if isinstance(v, list):
-				v = tuple(v)
-
-			values[k] = stringify_value(v)
+			values[k] = modify_value(v)
 	elif isinstance(values, (tuple, list)):
 		new_values = []
 		for val in values:
-			if isinstance(val, list):
-				val = tuple(val)
+			new_values.append(modify_value(val))
 
-			new_values.append(stringify_value(val))
 		values = new_values
 	else:
-		values = stringify_value(values)
+		values = modify_value(values)
 
 	return values
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -418,10 +418,16 @@ def modify_values(values):
 
 	if isinstance(values, dict):
 		for k, v in values.items():
+			if isinstance(v, list):
+				v = tuple(v)
+
 			values[k] = stringify_value(v)
 	elif isinstance(values, (tuple, list)):
 		new_values = []
 		for val in values:
+			if isinstance(val, list):
+				val = tuple(val)
+
 			new_values.append(stringify_value(val))
 		values = new_values
 	else:

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -511,6 +511,37 @@ class TestDB(unittest.TestCase):
 
 		frappe.db.rollback()
 
+	@run_only_if(db_type_is.POSTGRES)
+	def test_modify_query(self):
+		from frappe.database.postgres.database import modify_query
+
+		query = "select * from `tabtree b` where lft > 13 and rgt <= 16 and name =1.0 and parent = 4134qrsdc and isgroup = 1.00045"
+		self.assertEqual(
+			"select * from \"tabtree b\" where lft > '13' and rgt <= '16' and name = '1' and parent = 4134qrsdc and isgroup = 1.00045",
+			modify_query(query),
+		)
+
+		query = (
+			'select locate(".io", "frappe.io"), locate("3", cast(3 as varchar)), locate("3", 3::varchar)'
+		)
+		self.assertEqual(
+			'select strpos( "frappe.io", ".io"), strpos( cast(3 as varchar), "3"), strpos( 3::varchar, "3")',
+			modify_query(query),
+		)
+
+	@run_only_if(db_type_is.POSTGRES)
+	def test_modify_values(self):
+		from frappe.database.postgres.database import modify_values
+
+		self.assertEqual(
+			{"a": "23", "b": 23.0, "c": 23.0345, "d": "wow", "e": ("1", "2", "3", "abc")},
+			modify_values({"a": 23, "b": 23.0, "c": 23.0345, "d": "wow", "e": [1, 2, 3, "abc"]}),
+		)
+		self.assertEqual(
+			["23", 23.0, 23.00004345, "wow", ("1", "2", "3", "abc")],
+			modify_values((23, 23.0, 23.00004345, "wow", [1, 2, 3, "abc"])),
+		)
+
 
 @run_only_if(db_type_is.MARIADB)
 class TestDDLCommandsMaria(unittest.TestCase):
@@ -812,35 +843,6 @@ class TestDDLCommandsPost(unittest.TestCase):
 			""",
 		)
 		self.assertEqual(len(indexs_in_table), 1)
-
-	def test_modify_query(self):
-		from frappe.database.postgres.database import modify_query
-
-		query = "select * from `tabtree b` where lft > 13 and rgt <= 16 and name =1.0 and parent = 4134qrsdc and isgroup = 1.00045"
-		self.assertEqual(
-			"select * from \"tabtree b\" where lft > '13' and rgt <= '16' and name = '1' and parent = 4134qrsdc and isgroup = 1.00045",
-			modify_query(query),
-		)
-
-		query = (
-			'select locate(".io", "frappe.io"), locate("3", cast(3 as varchar)), locate("3", 3::varchar)'
-		)
-		self.assertEqual(
-			'select strpos( "frappe.io", ".io"), strpos( cast(3 as varchar), "3"), strpos( 3::varchar, "3")',
-			modify_query(query),
-		)
-
-	def test_modify_values(self):
-		from frappe.database.postgres.database import modify_values
-
-		self.assertEqual(
-			{"a": "23", "b": 23.0, "c": 23.0345, "d": "wow", "e": ("1", "2", "3", "abc")},
-			modify_values({"a": 23, "b": 23.0, "c": 23.0345, "d": "wow", "e": [1, 2, 3, "abc"]}),
-		)
-		self.assertEqual(
-			["23", 23.0, 23.00004345, "wow", ("1", "2", "3", "abc")],
-			modify_values((23, 23.0, 23.00004345, "wow", [1, 2, 3, "abc"])),
-		)
 
 	def test_sequence_table_creation(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -834,10 +834,13 @@ class TestDDLCommandsPost(unittest.TestCase):
 		from frappe.database.postgres.database import modify_values
 
 		self.assertEqual(
-			{"abcd": "23", "efgh": "23", "ijkl": 23.0345, "mnop": "wow"},
-			modify_values({"abcd": 23, "efgh": 23.0, "ijkl": 23.0345, "mnop": "wow"}),
+			{"a": "23", "b": 23.0, "c": 23.0345, "d": "wow", "e": ("1", "2", "3", "abc")},
+			modify_values({"a": 23, "b": 23.0, "c": 23.0345, "d": "wow", "e": [1, 2, 3, "abc"]}),
 		)
-		self.assertEqual(["23", "23", 23.00004345, "wow"], modify_values((23, 23.0, 23.00004345, "wow")))
+		self.assertEqual(
+			["23", 23.0, 23.00004345, "wow", ("1", "2", "3", "abc")],
+			modify_values((23, 23.0, 23.00004345, "wow", [1, 2, 3, "abc"])),
+		)
 
 	def test_sequence_table_creation(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype


### PR DESCRIPTION
psycopg automatically converts python list(s) to postgres array(s). Hence casting them to tuple as we use them interchangeably.

refs:
- https://www.psycopg.org/docs/usage.html#lists-adaptation
- https://www.psycopg.org/docs/usage.html#tuples-adaptation 

#

<img width="938" alt="Screenshot 2022-06-17 at 6 48 08 PM" src="https://user-images.githubusercontent.com/32034600/174306007-4544c993-656f-4530-8f71-723e688cc08f.png">

closes: https://github.com/frappe/frappe/issues/17231

#

Other Change(s):
- moved out `test_modify_values` and `test_modify_query` from `TestDDLCommandsPost` to `TestDB` class
- don't stringify (truncatable) floats in `modify_values`