### PR TITLE
fix: parse non-margin options in pdf templates, and allow non mm margin values

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -176,12 +176,12 @@ def read_options_from_html(html):
 		except:
 			pass
 
-	css_units = ['cm', 'mm', 'in', 'px', 'pt', 'pc']
-	margin_units = {k:v[-2:] if v[-2:] in css_units else ''
+	css_units = ["cm", "mm", "in", "px", "pt", "pc"]
+	margin_units = {k:v[-2:] if v[-2:] in css_units else ""
 				for k,v in options.items() if k.startswith("margin")}
 	if len(margin_units) > 0:
 		if not all(u == u[0] for u in margin_units.values()):
-			raise Exception(f'All units used for margins must be the same (got {margin_units})')
+			raise Exception(f"All units used for margins must be the same (got {margin_units})")
 
 	return str(soup), options
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -177,8 +177,9 @@ def read_options_from_html(html):
 			pass
 
 	css_units = ["cm", "mm", "in", "px", "pt", "pc"]
-	margin_units = {k:v[-2:] if v[-2:] in css_units else ""
-				for k,v in options.items() if k.startswith("margin")}
+	margin_units = {
+		k:v[-2:] if v[-2:] in css_units else "" for k,v in options.items() if k.startswith("margin")
+	}
 	if len(margin_units) > 0:
 		if not all(u == u[0] for u in margin_units.values()):
 			raise Exception(f"All units used for margins must be the same (got {margin_units})")

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -178,7 +178,7 @@ def read_options_from_html(html):
 
 	css_units = ["cm", "mm", "in", "px", "pt", "pc"]
 	margin_units = {
-		k:v[-2:] if v[-2:] in css_units else "" for k,v in options.items() if k.startswith("margin")
+		k: v[-2:] if v[-2:] in css_units else "" for k, v in options.items() if k.startswith("margin")
 	}
 	if len(margin_units) > 0:
 		if not all(u == u[0] for u in margin_units.values()):

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -181,7 +181,8 @@ def read_options_from_html(html):
 		k: v[-2:] if v[-2:] in css_units else "" for k, v in options.items() if k.startswith("margin")
 	}
 	if len(margin_units) > 0:
-		if not all(u == u[0] for u in margin_units.values()):
+		margin_unit = next(iter(margin_units.values()))
+		if not all(u == margin_unit for u in margin_units.values()):
 			raise Exception(f"All units used for margins must be the same (got {margin_units})")
 
 	return str(soup), options

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -169,12 +169,19 @@ def read_options_from_html(html):
 		"page-height",
 	):
 		try:
-			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
+			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+);")
 			match = pattern.findall(html)
 			if match:
 				options[attr] = str(match[-1][3]).strip()
 		except:
 			pass
+
+	css_units = ['cm', 'mm', 'in', 'px', 'pt', 'pc']
+	margin_units = {k:v[-2:] if v[-2:] in css_units else ''
+				for k,v in options.items() if k.startswith("margin")}
+	if len(margin_units) > 0:
+		if not all(u == u[0] for u in margin_units.values()):
+			raise Exception(f'All units used for margins must be the same (got {margin_units})')
 
 	return str(soup), options
 


### PR DESCRIPTION
closes #11706

Currently the only `attr` actually used during pdf creation is `margin-*`, because nothing else ends in `mm;`. This PR intends to fix that.

There is a problem though; if not all of the units used are the same, the code will crash with an obscure stack trace. The PR attempts to clarify the cause of the crash.

**Note: I am primarily creating this PR in the hopes that it will make it into a v13 release.**