### PR TITLE
fix: translate doctype in error messages

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -926,7 +926,7 @@ def has_permission(
 
 	if throw and not out:
 		# mimics frappe.throw
-		document_label = f"{doc.doctype} {doc.name}" if doc else doctype
+		document_label = f"{_(doc.doctype)} {doc.name}" if doc else _(doctype)
 		msgprint(
 			_("No permission for {0}").format(document_label),
 			raise_exception=ValidationError,

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -101,7 +101,7 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 		check_parent_permission(parent, doctype)
 
 	if not frappe.has_permission(doctype, parent_doctype=parent):
-		frappe.throw(_("No permission for {0}").format(doctype), frappe.PermissionError)
+		frappe.throw(_("No permission for {0}").format(_(doctype)), frappe.PermissionError)
 
 	filters = get_safe_filters(filters)
 	if isinstance(filters, str):
@@ -143,7 +143,7 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 @frappe.whitelist()
 def get_single_value(doctype, field):
 	if not frappe.has_permission(doctype):
-		frappe.throw(_("No permission for {0}").format(doctype), frappe.PermissionError)
+		frappe.throw(_("No permission for {0}").format(_(doctype)), frappe.PermissionError)
 	value = frappe.db.get_single_value(doctype, field)
 	return value
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -743,7 +743,7 @@ class DatabaseQuery(object):
 		):
 			only_if_shared = True
 			if not self.shared:
-				frappe.throw(_("No permission to read {0}").format(self.doctype), frappe.PermissionError)
+				frappe.throw(_("No permission to read {0}").format(_(self.doctype)), frappe.PermissionError)
 			else:
 				self.conditions.append(self.get_share_condition())
 

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -175,7 +175,7 @@ def check_share_permission(doctype, name):
 	"""Check if the user can share with other users"""
 	if not frappe.has_permission(doctype, ptype="share", doc=name):
 		frappe.throw(
-			_("No permission to {0} {1} {2}").format("share", doctype, name), frappe.PermissionError
+			_("No permission to {0} {1} {2}").format("share", _(doctype), name), frappe.PermissionError
 		)
 
 
@@ -190,7 +190,7 @@ def notify_assignment(shared_by, doctype, doc_name, everyone, notify=0):
 
 	reference_user = get_fullname(frappe.session.user)
 	notification_message = _("{0} shared a document {1} {2} with you").format(
-		frappe.bold(reference_user), frappe.bold(doctype), get_title_html(title)
+		frappe.bold(reference_user), frappe.bold(_(doctype)), get_title_html(title)
 	)
 
 	notification_doc = {


### PR DESCRIPTION
The DocType gets translated everywhere else, except in these error messages. This is confusing to users, so let's translate them here as well.