### PR TITLE
fix: incorrect filtering on address doctype

### DIFF
--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -177,7 +177,6 @@ def filter_dynamic_link_doctypes(
 
 	txt = txt or ""
 	filters = filters or {}
-	TXT_PATTERN = re.compile(f"{txt}.*")
 
 	_doctypes_from_df = frappe.get_all(
 		"DocField",
@@ -186,13 +185,13 @@ def filter_dynamic_link_doctypes(
 		distinct=True,
 		order_by=None,
 	)
-	doctypes_from_df = {d for d in _doctypes_from_df if TXT_PATTERN.search(_(d), re.IGNORECASE)}
+	doctypes_from_df = {d for d in _doctypes_from_df if txt.lower() in d.lower()}
 
 	filters.update({"dt": ("not in", doctypes_from_df)})
 	_doctypes_from_cdf = frappe.get_all(
 		"Custom Field", filters=filters, pluck="dt", distinct=True, order_by=None
 	)
-	doctypes_from_cdf = {d for d in _doctypes_from_cdf if TXT_PATTERN.search(_(d), re.IGNORECASE)}
+	doctypes_from_cdf = {d for d in _doctypes_from_cdf if txt.lower() in d.lower()}
 
 	all_doctypes = doctypes_from_df.union(doctypes_from_cdf)
 	allowed_doctypes = set(get_doctypes_with_read())


### PR DESCRIPTION
Address doctype link filter is not showing supported doctypes.

Root cause: Incorrect regex flag on compiled object. 

Fix: Replaced regex with simple text substring search instead.


Caused by https://github.com/frappe/frappe/pull/17063