### PR TITLE
test(meta): control JS bundle sizes

### DIFF
--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -12,6 +12,7 @@ import unittest
 from contextlib import contextmanager
 from functools import wraps
 from glob import glob
+from pathlib import Path
 from typing import List, Optional
 from unittest.case import skipIf
 from unittest.mock import patch
@@ -31,6 +32,7 @@ from frappe.query_builder.utils import db_type_is
 from frappe.tests.test_query_builder import run_only_if
 from frappe.utils import add_to_date, get_bench_path, get_bench_relative_path, now
 from frappe.utils.backups import fetch_latest_backups
+from frappe.utils.jinja_globals import bundled_asset
 
 _result: Optional[Result] = None
 TEST_SITE = "commands-site-O4PN2QKA.test"  # added random string tag to avoid collisions
@@ -692,7 +694,25 @@ class TestSiteMigration(BaseTestCommands):
 
 
 class TestBenchBuild(BaseTestCommands):
-	def test_build_assets(self):
-		with cli(frappe.commands.utils.build) as result:
+	def test_build_assets_size_check(self):
+		with cli(frappe.commands.utils.build, "--force --production") as result:
 			self.assertEqual(result.exit_code, 0)
 			self.assertEqual(result.exception, None)
+
+		CURRENT_SIZE = 3.7  # MB
+		JS_ASSET_THRESHOLD = 0.1
+
+		hooks = frappe.get_hooks()
+		default_bundle = hooks["app_include_js"]
+
+		default_bundle_size = 0.0
+
+		for chunk in default_bundle:
+			abs_path = Path.cwd() / frappe.local.sites_path / bundled_asset(chunk)[1:]
+			default_bundle_size += abs_path.stat().st_size
+
+		self.assertLessEqual(
+			default_bundle_size / (1024 * 1024),
+			CURRENT_SIZE * (1 + JS_ASSET_THRESHOLD),
+			f"Default JS bundle size increased by {JS_ASSET_THRESHOLD:.2%} or more",
+		)


### PR DESCRIPTION
Any drastic increase in production bundle sizes should fail in CI.

Added a test that fails if size goes >10% of current sizes. 


A tiny mistake like https://github.com/frappe/frappe/pull/17237 can result in unnecessary increase in bundle size. This test prevents such mistakes AND initiates the conversation about bundle sizes again if any large code is to be added in the default bundles in future. 