### PR TITLE
test(cypress): show full response on insert_doc failure

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -313,7 +313,12 @@ Cypress.Commands.add('insert_doc', (doctype, args, ignore_duplicate) => {
 					if (ignore_duplicate) {
 						status_codes.push(409);
 					}
-					expect(res.status).to.be.oneOf(status_codes);
+
+					let message = null;
+					if (ignore_duplicate && !status_codes.includes(res.status)) {
+						message = `Document insert failed, response: ${JSON.stringify(res, null, '\t')}`;
+					}
+					expect(res.status).to.be.oneOf(status_codes, message);
 					return res.body.data;
 				});
 		});


### PR DESCRIPTION
When `ignore_if_duplicate` is passed no error log is shown on failure. This makes debugging tests difficult as status code alone is of little use. 