### PR TITLE
fix: App logo not set in website settings

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2238,7 +2238,7 @@ def get_system_settings(key):
 	if not hasattr(local, "system_settings"):
 		local.system_settings = db.get_singles_dict("System Settings", cast=True)
 
-	return local.system_settings[key]
+	return local.system_settings.get(key)
 
 
 def get_active_domains():

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2231,7 +2231,7 @@ def get_website_settings(key):
 	if not hasattr(local, "website_settings"):
 		local.website_settings = db.get_singles_dict("Website Settings", cast=True)
 
-	return local.website_settings[key]
+	return local.website_settings.get(key)
 
 
 def get_system_settings(key):


### PR DESCRIPTION
```bash
Traceback (most recent call last):
  File "apps/frappe/frappe/website/serve.py", line 17, in get_response
    response = renderer_instance.render()
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 78, in render
    html = self.get_html()
  File "apps/frappe/frappe/website/utils.py", line 497, in cache_html_decorator
    html = func(*args, **kwargs)
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 89, in get_html
    self.update_context()
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 157, in update_context
    data = self.run_pymodule_method("get_context")
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 219, in run_pymodule_method
    return method(self.context)
  File "apps/frappe/frappe/www/login.py", line 44, in get_context
    context["logo"] = frappe.get_website_settings("app_logo") or frappe.get_hooks("app_logo_url")[-1]
  File "apps/frappe/frappe/__init__.py", line 2234, in get_website_settings
    return local.website_settings[key]
KeyError: 'app_logo'
```

Login page shows an error if app logo is not set in website settings