### PR TITLE
fix: Page builder fixes

### DIFF
--- a/frappe/templates/includes/navbar/navbar_items.html
+++ b/frappe/templates/includes/navbar/navbar_items.html
@@ -33,14 +33,16 @@
 {% else %}
 
 {% if parent %}
+{% set url = item.url or '' %}
+{% set url = url if url.startswith('#') else url | abs_url %}
 <li class="nav-item">
-	<a class="nav-link" href="{{ (item.url or '')|abs_url }}"
+	<a class="nav-link" href="{{ url }}"
 		{% if item.open_in_new_tab %} target="_blank" {% endif %}>
 		{{ _(item.label) }}
 	</a>
 </li>
 {% else %}
-<a class="dropdown-item" href="{{ (item.url or '') | abs_url }}"
+<a class="dropdown-item" href="{{ url }}"
 	{% if item.open_in_new_tab %} target="_blank" {% endif %}>
 	{{ _(item.label) }}
 </a>

--- a/frappe/templates/includes/web_block.html
+++ b/frappe/templates/includes/web_block.html
@@ -11,7 +11,9 @@
 
 {%- if web_template_type == 'Section' -%}
 {%- if not web_block.hide_block -%}
-<section class="section {{ classes }}" data-section-idx="{{ web_block.idx | e }}"
+<section class="section {{ classes }}"
+	{% if web_block.section_id %} id="{{ web_block.section_id }}" {% endif %}
+	data-section-idx="{{ web_block.idx | e }}"
 	data-section-template="{{ web_block.web_template | e }}"
 	{% if web_block.add_background_image -%}
 		style="background: url({{ web_block.background_image}}) no-repeat center center; background-size: cover;"

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -63,6 +63,11 @@ def web_blocks(blocks):
 	out = get_web_blocks_html(web_blocks)
 
 	html = out.html
+
+	if not frappe.flags.web_block_scripts:
+		frappe.flags.web_block_scripts = {}
+		frappe.flags.web_block_styles = {}
+
 	for template, scripts in out.scripts.items():
 		# deduplication of scripts when web_blocks methods are used in web pages
 		# see render_dynamic method web_page.py

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -36,6 +36,7 @@ def web_block(template, values=None, **kwargs):
 
 
 def web_blocks(blocks):
+	import frappe
 	from frappe import _, _dict, throw
 	from frappe.website.doctype.web_page.web_page import get_web_blocks_html
 
@@ -62,8 +63,21 @@ def web_blocks(blocks):
 	out = get_web_blocks_html(web_blocks)
 
 	html = out.html
-	for script in out.scripts:
-		html += "<script>{}</script>".format(script)
+	for template, scripts in out.scripts.items():
+		# deduplication of scripts when web_blocks methods are used in web pages
+		# see render_dynamic method web_page.py
+		if template not in frappe.flags.web_block_scripts:
+			for script in scripts:
+				html += f"<script data-web-template='{template}'>{script}</script>"
+			frappe.flags.web_block_scripts[template] = True
+
+	for template, styles in out.styles.items():
+		# deduplication of styles when web_blocks methods are used in web pages
+		# see render_dynamic method web_page.py
+		if template not in frappe.flags.web_block_styles:
+			for style in styles:
+				html += f"<style data-web-template='{template}'>{style}</style>"
+			frappe.flags.web_block_styles[template] = True
 
 	return html
 

--- a/frappe/website/doctype/web_page/templates/web_page.html
+++ b/frappe/website/doctype/web_page/templates/web_page.html
@@ -33,13 +33,18 @@
 {% endblock %}
 
 {% block style %}
-<style>
-{{ style or "" }}
-</style>
-
-{%- for style in page_builder_styles -%}
+{%- if style -%}
 <style>{{ style }}</style>
+{%- endif -%}
+
+{%- for web_template, styles in (page_builder_styles or {}).items() -%}
+{%- if styles -%}
+{%- for style in styles -%}
+<style data-web-template="{{ web_template }}">{{ style }}</style>
 {%- endfor -%}
+{%- endif -%}
+{%- endfor -%}
+
 {% endblock %}
 
 {% block script %}
@@ -47,7 +52,11 @@
 	<script>{{ script }}</script>
 	{%- endif -%}
 
-	{%- for script in page_builder_scripts -%}
-	<script>{{ script }}</script>
+	{%- for web_template, scripts in (page_builder_scripts or {}).items() -%}
+	{%- if scripts -%}
+	{%- for script in scripts -%}
+	<script data-web-template="{{ web_template }}">{{ script }}</script>
+	{%- endfor -%}
+	{%- endif -%}
 	{%- endfor -%}
 {% endblock %}

--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -77,15 +77,23 @@ class WebPage(WebsiteGenerator):
 
 	def render_dynamic(self, context):
 		# dynamic
-		is_jinja = context.dynamic_template or "<!-- jinja -->" in context.main_section
-		if is_jinja or ("{{" in context.main_section):
+		is_jinja = (
+			context.dynamic_template
+			or "<!-- jinja -->" in context.main_section
+			or ("{{" in context.main_section)
+		)
+		if is_jinja:
+			frappe.flags.web_block_scripts = {}
+			frappe.flags.web_block_styles = {}
 			try:
 				context["main_section"] = render_template(context.main_section, context)
 				if not "<!-- static -->" in context.main_section:
 					context["no_cache"] = 1
 			except TemplateSyntaxError:
-				if is_jinja:
-					raise
+				raise
+			finally:
+				frappe.flags.web_block_scripts = {}
+				frappe.flags.web_block_styles = {}
 
 	def set_breadcrumbs(self, context):
 		"""Build breadcrumbs template"""
@@ -191,9 +199,9 @@ def check_publish_status():
 def get_web_blocks_html(blocks):
 	"""Converts a list of blocks into Raw HTML and extracts out their scripts for deduplication"""
 
-	out = frappe._dict(html="", scripts=[], styles=[])
-	extracted_scripts = []
-	extracted_styles = []
+	out = frappe._dict(html="", scripts={}, styles={})
+	extracted_scripts = {}
+	extracted_styles = {}
 	for block in blocks:
 		web_template = frappe.get_cached_doc("Web Template", block.web_template)
 		rendered_html = frappe.render_template(
@@ -207,11 +215,15 @@ def get_web_blocks_html(blocks):
 		html, scripts, styles = extract_script_and_style_tags(rendered_html)
 		out.html += html
 		if block.web_template not in extracted_scripts:
-			out.scripts += scripts
-			extracted_scripts.append(block.web_template)
+			extracted_scripts.setdefault(block.web_template, [])
+			extracted_scripts[block.web_template] += scripts
+
 		if block.web_template not in extracted_styles:
-			out.styles += styles
-			extracted_styles.append(block.web_template)
+			extracted_styles.setdefault(block.web_template, [])
+			extracted_styles[block.web_template] += styles
+
+	out.scripts = extracted_scripts
+	out.styles = extracted_styles
 
 	return out
 

--- a/frappe/website/doctype/web_page_block/web_page_block.json
+++ b/frappe/website/doctype/web_page_block/web_page_block.json
@@ -9,6 +9,7 @@
   "edit_values",
   "web_template_values",
   "css_class",
+  "section_id",
   "column_break_5",
   "add_container",
   "add_top_padding",
@@ -103,11 +104,17 @@
    "fieldname": "background_image",
    "fieldtype": "Attach Image",
    "label": "Background Image"
+  },
+  {
+   "description": "IDs must contain only alphanumeric characters, not contain spaces, and should be unique.",
+   "fieldname": "section_id",
+   "fieldtype": "Data",
+   "label": "Section ID"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-03-21 14:23:32.665108",
+ "modified": "2022-06-21 20:00:17.025272",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Page Block",


### PR DESCRIPTION
## Section IDs
IDs can be set for sections so that they are linkable using anchor tags

```
<section id="section-id">
...
```

## Set data-web-template in script and style
This is mostly for debugging

```
<style data-web-template="Section Name">...</style>

<script data-web-template="Section Name">...</script>
```

## Deduplication of scripts and styles when web_blocks is used
When you use `web_blocks` Jinja helper to render sections, script and style tags were duplicated. Fixed this, not entirely happy with the solution, but it works.