### PR TITLE
fix(oauth): Send id_token of the authorized user instead of Guest

### DIFF
--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -323,10 +323,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		# Check whether frappe server URL is set
 		id_token_header = {"typ": "jwt", "alg": "HS256"}
 
-		user = frappe.get_doc(
-			"User",
-			frappe.session.user,
-		)
+		user = frappe.get_doc("User", request.user)
 
 		if request.nonce:
 			id_token["nonce"] = request.nonce

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -16,7 +16,9 @@ class TestOAuth20(unittest.TestCase):
 	def setUp(self):
 		make_test_records("OAuth Client")
 		make_test_records("User")
-		self.client_id = frappe.get_all("OAuth Client", fields=["*"])[0].get("client_id")
+		client = frappe.get_all("OAuth Client", fields=["*"])[0]
+		self.client_id = client.get("client_id")
+		self.client_secret = client.get("client_secret")
 		self.form_header = {"content-type": "application/x-www-form-urlencoded"}
 		self.scope = "all openid"
 		self.redirect_uri = "http://localhost"
@@ -90,6 +92,9 @@ class TestOAuth20(unittest.TestCase):
 		self.assertTrue(bearer_token.get("token_type") == "Bearer")
 		self.assertTrue(check_valid_openid_response(bearer_token.get("access_token")))
 
+		decoded_token = self.decode_id_token(bearer_token.get("id_token"))
+		self.assertEqual(decoded_token["email"], "test@example.com")
+
 	def test_login_using_authorization_code_with_pkce(self):
 		update_client_for_auth_code_grant(self.client_id)
 
@@ -141,6 +146,9 @@ class TestOAuth20(unittest.TestCase):
 
 		self.assertTrue(bearer_token.get("access_token"))
 		self.assertTrue(bearer_token.get("id_token"))
+
+		decoded_token = self.decode_id_token(bearer_token.get("id_token"))
+		self.assertEqual(decoded_token["email"], "test@example.com")
 
 	def test_revoke_token(self):
 		client = frappe.get_doc("OAuth Client", self.client_id)
@@ -316,15 +324,18 @@ class TestOAuth20(unittest.TestCase):
 		# Parse bearer token json
 		bearer_token = token_response.json()
 
-		id_token = bearer_token.get("id_token")
-		payload = jwt.decode(
-			id_token,
-			audience=client.client_id,
-			key=client.client_secret,
-			algorithms=["HS256"],
-		)
+		payload = self.decode_id_token(bearer_token.get("id_token"))
+		self.assertEqual(payload["email"], "test@example.com")
 
 		self.assertTrue(payload.get("nonce") == nonce)
+
+	def decode_id_token(self, id_token):
+		return jwt.decode(
+			id_token,
+			audience=self.client_id,
+			key=self.client_secret,
+			algorithms=["HS256"],
+		)
 
 
 def check_valid_openid_response(access_token=None):


### PR DESCRIPTION
This only affects OAuth clients that use `id_token` obtained from `frappe.integrations.oauth2.get_token`.

Doesn't affect OAuth clients that ignore id_token and explicitly use `frappe.integrations.oauth2.openid_profile` endpoint for getting user details. e.g. Frappe OAuth client.

A simple way to replicate this is to setup Frappe-Frappe OAuth client-server pair and use `login_via_oauth2_id_token` instead of `login_via_oauth2` in `login_via_frappe`.

```python
FAIL  test_login_using_authorization_code (frappe.tests.test_oauth20.TestOAuth20)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/frappe/frappe/tests/test_oauth20.py", line 96, in test_login_using_authorization_code
    self.assertEqual(decoded_token["email"], "test@example.com")
    auth_code = '8xDxDU8wFZ6Yj8ZHApaiXzbJpvm8HF'
    bearer_token = {'access_token': 'BCkfz3SIxlxA1m17JwBYwzwBs1NUqT', 'expires_in': 3600, 'token_type': 'Bearer', 'scope': 'all openid', 'refresh_token': 'bzdPyQ1sCiitmOpOAfqPeuhCVoBlS3', 'id_token': '***'}
    decoded_token = {'aud': 'fc0171f657', 'iat': 1655827639, 'at_hash': 'rEU6GMvyNXUdRDahttMtDg', 'iss': 'http://test_site:8000', 'sub': None, 'name': 'Guest', 'given_name': 'Guest', 'family_name': None, 'email': 'guest@example.com', 'picture': None, 'roles': ['Guest']}
    query = {'code': ['8xDxDU8wFZ6Yj8ZHApaiXzbJpvm8HF']}
    redirect_destination = 'http://localhost?code=8xDxDU8wFZ6Yj8ZHApaiXzbJpvm8HF'
    self = <frappe.tests.test_oauth20.TestOAuth20 testMethod=test_login_using_authorization_code>
    session = <requests.sessions.Session object at 0x7fe7d90c6040>
    token_response = <Response [200]>
AssertionError: 'guest@example.com' != 'test@example.com'
- guest@example.com
? ^^       -
+ test@example.com
? ^
```
Reference: https://github.com/frappe/frappe/runs/6988384120?check_suite_focus=true#step:14:1019 In case the test results get lost.

<details>
<summary>This came up while setting up OAuth for Sentry. </summary>


https://user-images.githubusercontent.com/8528887/174851951-7cd29025-a44c-44d5-b196-1d3b6decf37a.mp4

https://user-images.githubusercontent.com/8528887/174851935-33d11314-e078-4b6e-89b8-346526893364.mp4


</details>

<details>
<summary>But mere mortals probably don't have Sentry instances lying around. Replicating with frappe works too. </summary>


https://user-images.githubusercontent.com/8528887/174856503-2f5ab9c7-45a0-45a0-9045-d365e9e56bc6.mp4


https://user-images.githubusercontent.com/8528887/174856518-0c23ca4c-4f9a-46fe-973d-1e9e4b998427.mp4



</details>