### PR TITLE
feat: barcode settings

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -135,6 +135,7 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 
 		this.$scan_btn = this.$wrapper.find('.link-btn');
 		this.$scan_btn.toggle(true);
+		this.$scan_btn.css("right", "30px");
 
 		const me = this;
 		this.$scan_btn.on('click', 'a', () => {
@@ -147,6 +148,37 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 					}
 				}
 			});
+		});
+
+		this.$wrapper.find('.control-input').append(
+			`<span class="link-btn scan-settings" style="display: inline;">
+				<a class="btn-open no-decoration" title="${__("Settings")}">
+					${frappe.utils.icon('setting-gear', 'md')}
+				</a>
+			</span>`
+		);
+		this.$scan_settings_btn = this.$wrapper.find('.scan-settings');
+		this.$scan_settings_btn.on('click', 'a', () => {
+			const settings = frappe.get_user_settings(me.frm.doc.doctype, "BarcodeScan");
+
+			new frappe.ui.Dialog({
+				title: __("Update Barcode Scan Settings"),
+				fields: [
+					{
+						fieldtype: "Check",
+						fieldname: "prompt_qty",
+						label: __("Prompt Qty"),
+						default: settings["prompt_qty"]
+					}
+				],
+				primary_action_label: __("Save"),
+				primary_action(values) {
+					frappe.model.user_settings.save(me.frm.doc.doctype, "BarcodeScan", values).then(() => {
+						frappe.msgprint(__("Barcode Scan Settings Saved!"));
+						this.hide();
+					})
+				}
+			}).show();
 		});
 	}
 


### PR DESCRIPTION
As the ERPNext barcode scan API functionality is expanded, there will be some toggleable settings that may be applicable for certain doctypes and not others.

**Pros**
If a certain functionality such as the ability to "Prompt Qty" is applicable for multiple doctypes then this field needs to be added to every form wanting to utilize this functionality. This clutters the form and makes it look ugly, also It's a waste of time for developers to add such option to all usable doctypes when a new option is introduced.

**Cons**
It feels un-natural to add such functionality to frappe repo as most of the options that will be added are ERPNext specific.
When ERPNext needs a new option for barcode scan, it will have to simultaneously released with frappe. 

**Preview**

https://user-images.githubusercontent.com/29856401/174922469-797a5b71-7404-46d9-a2c1-739ff2ad420b.mp4
