### PR TITLE
fix: added mailto to email displayed on contact us page

### DIFF
--- a/frappe/www/contact.html
+++ b/frappe/www/contact.html
@@ -67,7 +67,11 @@
 				<i class='fa fa-phone'></i> <span itemprop="telephone">{{ phone }}</span><br>
 			{% endif %}
 			{% if email_id %}
-				<i class='fa fa-envelope'></i> <span itemprop="email">{{ email_id }}</span><br>
+				<i class='fa fa-envelope'></i>
+				<span itemprop="email">
+					<a href="mailto:{{ email_id }}">{{ email_id }}</a>
+				</span>
+				<br>
 			{% endif %}
 			{% if skype %}
 				<i class='fa fa-skype'></i> <span itemprop="email">{{ skype }}</span><br>


### PR DESCRIPTION
**Issue:**

The email address displayed on the contact us page was not a mailto link

**Fix:**

<img width="1440" alt="Screenshot 2022-06-22 at 12 02 30 PM" src="https://user-images.githubusercontent.com/31363128/174959454-adfa3be1-9933-4ceb-a5fa-b26b88e3fd6d.png">

