### PR TITLE
translataions for particular app

### DIFF
--- a/frappe/commands/translate.py
+++ b/frappe/commands/translate.py
@@ -48,11 +48,12 @@ def new_language(context, lang_code, app):
 
 
 @click.command("get-untranslated")
+@click.option('--app', default='all')
 @click.argument("lang")
 @click.argument("untranslated_file")
 @click.option("--all", default=False, is_flag=True, help="Get all message strings")
 @pass_context
-def get_untranslated(context, lang, untranslated_file, all=None):
+def get_untranslated(context, lang, untranslated_file, app='all', all=None):
 	"Get untranslated strings for language"
 	import frappe.translate
 
@@ -60,17 +61,18 @@ def get_untranslated(context, lang, untranslated_file, all=None):
 	try:
 		frappe.init(site=site)
 		frappe.connect()
-		frappe.translate.get_untranslated(lang, untranslated_file, get_all=all)
+		frappe.translate.get_untranslated(lang, untranslated_file, get_all=all, app=app)
 	finally:
 		frappe.destroy()
 
 
 @click.command("update-translations")
+@click.option('--app', default='all')
 @click.argument("lang")
 @click.argument("untranslated_file")
 @click.argument("translated-file")
 @pass_context
-def update_translations(context, lang, untranslated_file, translated_file):
+def update_translations(context, lang, untranslated_file, translated_file, app='all'):
 	"Update translated strings"
 	import frappe.translate
 
@@ -78,7 +80,7 @@ def update_translations(context, lang, untranslated_file, translated_file):
 	try:
 		frappe.init(site=site)
 		frappe.connect()
-		frappe.translate.update_translations(lang, untranslated_file, translated_file)
+		frappe.translate.update_translations(lang, untranslated_file, translated_file, app=app)
 	finally:
 		frappe.destroy()
 


### PR DESCRIPTION
get-untranslated/update-translations string for particular app frappe#17268 (feature request)
Alternative
For some APP:
bench get-untranslated --app myappname [lang] [/some/path]
bench update-translations --app myappname [lang] [/some/path]
For complete System:
bench get-untranslated [lang] [/some/path]
bench update-translations [lang] [/some/path]
If the --app myappname not passed, then the command get all translations for complete system. If option is passed then get translations only for this app
