### PR TITLE
fix: Unexpected triggers in forms on shifting focus

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -315,7 +315,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			let last_value = me.last_value || "";
 			let last_label = me.label || "";
 
-			if (value !== last_value || label !== last_label) {
+			if (value !== last_value) {
 				me.parse_validate_and_set_in_model(value, null, label);
 			}
 		});


### PR DESCRIPTION
Introduced in https://github.com/frappe/frappe/pull/15321

Label fields should not be used for triggering form events, that should only be dependent on value, checking labels leads to unexpected triggers