### PR TITLE
patch: Reload Workspace Quick List

### DIFF
--- a/frappe/patches/v14_0/update_workspace2.py
+++ b/frappe/patches/v14_0/update_workspace2.py
@@ -5,6 +5,7 @@ from frappe import _
 
 
 def execute():
+	frappe.reload_doc("desk", "doctype", "workspace_quick_list", force=True)
 	frappe.reload_doc("desk", "doctype", "workspace", force=True)
 
 	for seq, workspace in enumerate(frappe.get_all("Workspace", order_by="name asc")):


### PR DESCRIPTION
Migrating from `version-13` to `develop` failed because **Workspace Quick List** was missing while running the workspace patch.
-> Reload doc in patch