### PR TITLE
fix(Image View): make info field translatable

### DIFF
--- a/frappe/public/js/frappe/views/image/image_view.js
+++ b/frappe/public/js/frappe/views/image/image_view.js
@@ -75,8 +75,8 @@ frappe.views.ImageView = class ImageView extends frappe.views.ListView {
 		let set = false;
 		info_fields.forEach((field, index) => {
 			if (item[field] && !set) {
-				if (index == 0) info_html += `<li>${item[field]}</li>`;
-				else info_html += `<li class="text-muted">${item[field]}</li>`;
+				if (index == 0) info_html += `<li>${__(item[field])}</li>`;
+				else info_html += `<li class="text-muted">${__(item[field])}</li>`;
 				set = true;
 			}
 		});


### PR DESCRIPTION
Make the info field that is displayed under each image in the image view translatable.


![Bildschirmfoto 2022-06-24 um 11 37 16](https://user-images.githubusercontent.com/23150094/175509308-e3c15c1f-7c22-432a-8d9f-f64d11d022ba.png)

