### PR TITLE
chore: remove old code where User Permissions were set in `tabDefaultValue`

### DIFF
--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -11,18 +11,19 @@ class TestTranslation(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.local.lang = "en"
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 
 	def test_doctype(self):
 		translation_data = get_translation_data()
 		for key, val in translation_data.items():
 			frappe.local.lang = key
-			frappe.local.lang_full_dict = None
+
+			clear_translation_cache()
 			translation = create_translation(key, val)
 			self.assertEqual(_(val[0]), val[1])
 
 			frappe.delete_doc("Translation", translation.name)
-			frappe.local.lang_full_dict = None
+			clear_translation_cache()
 
 			self.assertEqual(_(val[0]), val[0])
 
@@ -38,20 +39,20 @@ class TestTranslation(FrappeTestCase):
 
 		frappe.local.lang = "es"
 
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[0][0]), data[0][1])
 
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[1][0]), data[1][1])
 
 		frappe.local.lang = "es-MX"
 
 		# different translation for es-MX
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[2][0]), data[2][1])
 
 		# from spanish (general)
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[1][0]), data[1][1])
 
 	def test_html_content_data_translation(self):
@@ -109,3 +110,8 @@ def create_translation(key, val):
 	translation.translated_text = val[1]
 	translation.save()
 	return translation
+
+
+def clear_translation_cache():
+	frappe.local.lang_full_dict = None
+	frappe.cache().delete_key("lang_full_dict", shared=True)

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -6,8 +6,7 @@ from frappe.cache_manager import clear_defaults_cache, common_default_keys
 from frappe.desk.notifications import clear_notifications
 from frappe.query_builder import DocType
 
-# Note: DefaultValue records are identified by parenttype
-# __default, __global or 'User Permission'
+# Note: DefaultValue records are identified by parent (e.g. __default, __global)
 
 
 def set_user_default(key, value, user=None, parenttype=None):

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -387,6 +387,9 @@ def get_context(context):
 		if not is_html(self.message):
 			self.message = frappe.utils.md_to_html(self.message)
 
+	def on_trash(self):
+		frappe.cache().hdel("notifications", self.document_type)
+
 
 @frappe.whitelist()
 def get_documents_for_today(notification):

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -167,9 +167,6 @@ def delete_doc(
 				except ImportError:
 					pass
 
-			# delete user_permissions
-			frappe.defaults.clear_default(parenttype="User Permission", key=doctype, value=name)
-
 
 def add_to_deleted_document(doc):
 	"""Add this document to Deleted Document table. Called after delete"""

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -197,14 +197,6 @@ def rename_doc(
 	if not merge:
 		rename_password(doctype, old, new)
 
-	# update user_permissions
-	DefaultValue = frappe.qb.DocType("DefaultValue")
-	frappe.qb.update(DefaultValue).set(DefaultValue.defvalue, new).where(
-		(DefaultValue.parenttype == "User Permission")
-		& (DefaultValue.defkey == doctype)
-		& (DefaultValue.defvalue == old)
-	).run()
-
 	if merge:
 		new_doc.add_comment("Edit", _("merged {0} into {1}").format(frappe.bold(old), frappe.bold(new)))
 	else:

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import frappe
 import frappe.translate
 from frappe import _
+from frappe.core.doctype.translation.test_translation import clear_translation_cache
 from frappe.tests.utils import FrappeTestCase
 from frappe.translate import (
 	extract_javascript,
@@ -37,13 +38,15 @@ class TestTranslate(FrappeTestCase):
 	def setUp(self):
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Guest")
-		frappe.local.lang_full_dict = None  # reset cached translations
+
+		clear_translation_cache()
 
 	def tearDown(self):
 		frappe.form_dict.pop("_lang", None)
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Administrator")
-		frappe.local.lang_full_dict = None  # reset cached translations
+
+		clear_translation_cache()
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)


### PR DESCRIPTION
This doesn't seem to be used:

![image](https://user-images.githubusercontent.com/16315650/175800091-5bd038a9-9b97-4ab3-9c1e-4a9618076acc.png)