### PR TITLE
fix: `frappe.db.get_defaults` needn't always give defaults from `__default`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -934,14 +934,11 @@ class Database(object):
 	@staticmethod
 	def get_defaults(key=None, parent="__default"):
 		"""Get all defaults"""
-		if key:
-			defaults = frappe.defaults.get_defaults(parent)
-			d = defaults.get(key, None)
-			if not d and key != frappe.scrub(key):
-				d = defaults.get(frappe.scrub(key), None)
-			return d
-		else:
-			return frappe.defaults.get_defaults(parent)
+		defaults = frappe.defaults.get_defaults_for(parent)
+		if not key:
+			return defaults
+
+		return defaults.get(key) or defaults.get(frappe.scrub(key))
 
 	def begin(self):
 		self.sql("START TRANSACTION")

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -222,7 +222,7 @@ def get_defaults_for(parent="__default"):
 			.run(as_dict=True)
 		)
 
-		defaults = frappe._dict({})
+		defaults = frappe._dict()
 		for d in res:
 			if d.defkey in defaults:
 				# listify


### PR DESCRIPTION
It previously used to get data from `frappe.defaults.get_defaults`, which always gave defaults for the `__default` parent in addition to the specified parent.