### PR TITLE
fix!: dont delete custom permissions when doctype is deleted

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -89,8 +89,6 @@ def delete_doc(
 
 				update_flags(doc, flags, ignore_permissions)
 				check_permission_and_not_submitted(doc)
-
-				frappe.db.delete("Custom DocPerm", {"parent": name})
 				frappe.db.delete("__global_search", {"doctype": name})
 
 			delete_from_table(doctype, name, ignore_doctypes, None)


### PR DESCRIPTION
Continues efforts started in https://github.com/frappe/frappe/pull/17009
This is needed to allow user to continue using existing custom permissions after ERPNext split.