### PR TITLE
fix: ignore integration request when deleting doc

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -31,6 +31,7 @@ doctypes_to_skip = (
 	"Notification Log",
 	"Email Queue",
 	"Document Share Key",
+	"Integration Request",
 )
 
 


### PR DESCRIPTION
Integration Request accepts a reference document. However, it's a logging DocType and shouldn't prevent deletion of said document.
