### PR TITLE
incomplete translations for customs APPS, when language parent is en

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -44,8 +44,7 @@ def get_meta(doctype, cached=True):
 	else:
 		meta = FormMeta(doctype)
 
-	if frappe.local.lang != "en":
-		meta.set_translations(frappe.local.lang)
+	meta.set_translations(frappe.local.lang)
 
 	return meta
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -284,7 +284,7 @@ def get_full_dict(lang):
 
 def get_lang_data(lang, apps):
 	out = {}
-	for app in (apps or frappe.get_all_apps(True)):
+	for app in apps or frappe.get_all_apps(True):
 		path = os.path.join(frappe.get_pymodule_path(app), "translations", lang + ".csv")
 		out.update(get_translation_dict_from_file(path, lang, app) or {})
 	return out

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -300,8 +300,8 @@ def load_lang(lang, apps=None):
 		return {}
 	if not out:
 		out = get_lang_data(lang=lang, apps=apps)
-	if '-' in lang:
-		parent = lang.split('-')[0]
+	if "-" in lang:
+		parent = lang.split("-")[0]
 		parent_out = get_lang_data(lang=parent, apps=apps)
 		parent_out.update(out)
 		out = parent_out


### PR DESCRIPTION
We have recently added a new option for Commands: get-untranslated /update-translations for customs APPS. For example:
For particular an APP:
bench get-untranslated --app my_custom_app lang /path/
bench update-translations --app my_custom_app lang /path/ /other/path
For all system:
bench get-untranslated lang /path/
bench update-translations lang /path/ /other/path

The reason for this issue is the following:
If a custom app is developed with a native language other than English, for example Spanish. When we apply the translations for the parent language en [bench get-untranslated --app my_custom_app en /path/] and bench update-translations --app my_custom_app en /path /other/path], some words are not translated. But for other languages ​​like en-US, or en-GB which are not parent, it works perfectly. This case is only for parent laguage en.
