### PR TITLE
fix: Allow permitted number card of type report

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.boot import get_allowed_reports
 from frappe.config import get_modules_from_all_apps_for_user
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
@@ -90,9 +91,16 @@ def has_permission(doc, ptype, user):
 	if "System Manager" in roles:
 		return True
 
-	allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())
-	if doc.document_type in allowed_doctypes:
-		return True
+	if doc.type == "Report":
+		allowed_reports = [
+			key if type(key) == str else key.encode("UTF8") for key in get_allowed_reports()
+		]
+		if doc.report_name in allowed_reports:
+			return True
+	else:
+		allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())
+		if doc.document_type in allowed_doctypes:
+			return True
 
 	return False
 


### PR DESCRIPTION
fixes: https://github.com/frappe/frappe/issues/17315
Users are not able to access the public **Number Card** of type **Report** even though they have access to the report.

**Before:**

![NumberCardPermBug](https://user-images.githubusercontent.com/30859809/175892655-eecff4ea-76e6-4fa9-bb8d-96475718f478.gif)

**After:**

![NumberCardPermFix](https://user-images.githubusercontent.com/30859809/175892677-4658bf4e-aba0-4a7f-95f2-fe697ac46b3f.gif)
