### PR TITLE
refactor: translation caching

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -109,7 +109,6 @@ def _(msg, lang=None, context=None):
 	if not translated_string:
 		translated_string = get_full_dict(lang).get(msg)
 
-	# return lang_full_dict according to lang passed parameter
 	return translated_string or non_translated_string
 
 
@@ -218,7 +217,6 @@ def init(site, sites_path=None, new_site=False):
 
 	local.conf = _dict(get_site_config())
 	local.lang = local.conf.lang or "en"
-	local.lang_full_dict = None
 
 	local.module_app = None
 	local.app_modules = None

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -114,4 +114,4 @@ def create_translation(key, val):
 
 
 def clear_translation_cache():
-	frappe.cache.delete_key("lang_full_dict", shared=True)
+	frappe.cache().delete_key("lang_full_dict")

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -13,18 +13,18 @@ class TestTranslation(unittest.TestCase):
 
 	def tearDown(self):
 		frappe.local.lang = "en"
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 
 	def test_doctype(self):
 		translation_data = get_translation_data()
 		for key, val in translation_data.items():
 			frappe.local.lang = key
-			frappe.local.lang_full_dict = None
+			clear_translation_cache()
 			translation = create_translation(key, val)
 			self.assertEqual(_(val[0]), val[1])
 
 			frappe.delete_doc("Translation", translation.name)
-			frappe.local.lang_full_dict = None
+			clear_translation_cache()
 
 			self.assertEqual(_(val[0]), val[0])
 
@@ -40,20 +40,20 @@ class TestTranslation(unittest.TestCase):
 
 		frappe.local.lang = "es"
 
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[0][0]), data[0][1])
 
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[1][0]), data[1][1])
 
 		frappe.local.lang = "es-MX"
 
 		# different translation for es-MX
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[2][0]), data[2][1])
 
 		# from spanish (general)
-		frappe.local.lang_full_dict = None
+		clear_translation_cache()
 		self.assertTrue(_(data[1][0]), data[1][1])
 
 	def test_html_content_data_translation(self):
@@ -111,3 +111,7 @@ def create_translation(key, val):
 	translation.translated_text = val[1]
 	translation.save()
 	return translation
+
+
+def clear_translation_cache():
+	frappe.cache.delete_key("lang_full_dict", shared=True)

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -90,4 +90,4 @@ def create_translations(translation_map, language):
 
 
 def clear_user_translation_cache(lang):
-	frappe.cache().hdel("lang_user_translations", lang)
+	frappe.cache().hdel("lang_full_dict", lang)

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -90,4 +90,5 @@ def create_translations(translation_map, language):
 
 
 def clear_user_translation_cache(lang):
-	frappe.cache().hdel("lang_full_dict", lang)
+	for cache_key in ("lang_full_dict", "lang_user_translations"):
+		frappe.cache().hdel(cache_key, lang)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -4,6 +4,7 @@
 import unittest
 
 import frappe
+from frappe.core.doctype.translation.test_translation import clear_translation_cache
 from frappe.desk.search import get_names_for_mentions, search_link, search_widget
 
 
@@ -132,7 +133,7 @@ class TestSearch(unittest.TestCase):
 	def test_link_search_in_foreign_language(self):
 		try:
 			frappe.local.lang = "fr"
-			frappe.local.lang_full_dict = None  # discard translation cache
+			clear_translation_cache()
 			search_widget(doctype="DocType", txt="pay", page_length=20)
 			output = frappe.response["values"]
 

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import frappe
 import frappe.translate
 from frappe import _
+from frappe.core.doctype.translation.test_translation import clear_translation_cache
 from frappe.translate import get_language, get_parent_language, get_translation_dict_from_file
 from frappe.utils import set_request
 
@@ -29,13 +30,15 @@ class TestTranslate(unittest.TestCase):
 	def setUp(self):
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Guest")
-		frappe.local.lang_full_dict = None  # reset cached translations
+
+		clear_translation_cache()
 
 	def tearDown(self):
 		frappe.form_dict.pop("_lang", None)
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Administrator")
-		frappe.local.lang_full_dict = None  # reset cached translations
+
+		clear_translation_cache()
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -83,7 +83,6 @@ def _restore_thread_locals(flags):
 	frappe.local.conf = frappe._dict(frappe.get_site_config())
 	frappe.local.cache = {}
 	frappe.local.lang = "en"
-	frappe.local.lang_full_dict = None
 
 
 @contextmanager

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -353,6 +353,10 @@ def get_translation_dict_from_file(path, lang, app, throw=False):
 
 
 def get_user_translations(lang):
+	return frappe.cache().hget("lang_user_translations", lang, lambda: _get_user_translations(lang))
+
+
+def _get_user_translations(lang):
 	if not frappe.db:
 		frappe.connect()
 
@@ -383,6 +387,7 @@ def clear_cache():
 	cache.delete_key("bootinfo")
 	cache.delete_key("lang_full_dict", shared=True)
 	cache.delete_key("translation_assets", shared=True)
+	cache.delete_key("lang_user_translations")
 
 
 def get_messages_for_app(app, deduplicate=True):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -385,9 +385,12 @@ def clear_cache():
 
 	# clear translations saved in boot cache
 	cache.delete_key("bootinfo")
-	cache.delete_key("lang_full_dict", shared=True)
-	cache.delete_key("translation_assets", shared=True)
+
+	cache.delete_key("lang_full_dict")
 	cache.delete_key("lang_user_translations")
+
+	cache.delete_key("lang_csv_dict", shared=True)
+	cache.delete_key("translation_assets", shared=True)
 
 
 def get_messages_for_app(app, deduplicate=True):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -274,15 +274,15 @@ def _get_full_dict(lang):
 
 	try:
 		# get user specific translation data
-		user_translations = get_user_translations(lang)
+		if user_translations := get_user_translations(lang):
+			if frappe.flags.in_test:
+				# copy to avoid mutation of frappe.local.cache["lang_csv_dict"]
+				# this is not being done outside tests,
+				# since frappe.local.cache is re-initialised in every request
+				lang_full_dict = lang_full_dict.copy()
 
-		if frappe.flags.in_test:
-			# copy to avoid mutation of frappe.local.cache["lang_csv_dict"]
-			# this is not being done outside tests,
-			# since frappe.local.cache is re-initialised in every request
-			lang_full_dict = lang_full_dict.copy()
+			lang_full_dict.update(user_translations)
 
-		lang_full_dict.update(user_translations)
 	except Exception:
 		pass
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -324,7 +324,7 @@ def _load_lang(lang, apps=None):
 		return out
 
 	parent = lang.split("-")[0]
-	parent_out = load_lang(parent, apps)
+	parent_out = _load_lang(parent, apps)
 	parent_out.update(out)
 	return parent_out
 

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -199,7 +199,7 @@ class RedisWrapper(redis.Redis):
 			frappe.local.cache[_name][key] = value
 		elif generator:
 			value = generator()
-			self.hset(name, key, value)
+			self.hset(name, key, value, shared=shared)
 		return value
 
 	def hdel(self, name, key, shared=False):


### PR DESCRIPTION
## Features

- Introduce `lang_csv_dict` cache for CSV translation data. This is more correct than the earlier `lang_full_dict` key.

## Performance fix

- Deprecate `frappe.local.lang_full_dict` in favour of `frappe.local.cache.lang_full_dict`. Since we are caching CSV + user translations in one key, we can avoid compiling both caches into one in every request.

## Bug fixes

- Don't cache the output of `load_lang` if `apps` are specified.
- Copy `lang_csv_dict` to avoid mutation (only in tests).
- Redis: Pass `shared` param into `hset` when using `generator`.