### PR TITLE
fix!: remove dangerous "rollback_on_exception" flag

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -432,9 +432,6 @@ def msgprint(
 
 	def _raise_exception():
 		if raise_exception:
-			if flags.rollback_on_exception:
-				db.rollback()
-
 			if inspect.isclass(raise_exception) and issubclass(raise_exception, Exception):
 				raise raise_exception(msg)
 			else:


### PR DESCRIPTION
Not used anywhere: https://sourcegraph.com/search?q=context:global+rollback_on_exception+repo:%5Egithub%5C.com/frappe/.*+&patternType=literal 


Tis crazy crazy flag. 