### PR TITLE
fix(UX): show next execution time on scheduled job

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -171,7 +171,7 @@ class DocType(Document):
 
 			if docfield.fieldname in method_set:
 				conflict_type = "controller method"
-			if docfield.fieldname in property_set:
+			if docfield.fieldname in property_set and not docfield.is_virtual:
 				conflict_type = "class property"
 
 			if conflict_type:

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -16,8 +16,11 @@
   "server_script",
   "frequency",
   "cron_format",
+  "create_log",
+  "status_section",
   "last_execution",
-  "create_log"
+  "column_break_9",
+  "next_execution"
  ],
  "fields": [
   {
@@ -72,6 +75,22 @@
    "options": "Server Script",
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "next_execution",
+   "fieldtype": "Datetime",
+   "is_virtual": 1,
+   "label": "Next Execution",
+   "read_only": 1
+  },
+  {
+   "fieldname": "status_section",
+   "fieldtype": "Section Break",
+   "label": "Status"
+  },
+  {
+   "fieldname": "column_break_9",
+   "fieldtype": "Column Break"
   }
  ],
  "in_create": 1,
@@ -81,7 +100,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2020-10-07 10:39:24.519460",
+ "modified": "2022-06-28 02:55:12.470915",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",
@@ -103,5 +122,7 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
+ "title_field": "method",
  "track_changes": 1
 }

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -50,6 +50,10 @@ class ScheduledJobType(Document):
 		queued_jobs = get_jobs(site=frappe.local.site, key="job_type")[frappe.local.site]
 		return self.method in queued_jobs
 
+	@property
+	def next_execution(self):
+		return self.get_next_execution()
+
 	def get_next_execution(self):
 		CRON_MAP = {
 			"Yearly": "0 0 1 1 *",


### PR DESCRIPTION
Added virtual field to show next execution time. 

<img width="1392" alt="Screenshot 2022-06-28 at 1 55 00 PM" src="https://user-images.githubusercontent.com/9079960/176131584-dddadbbc-e962-4ffd-a4f1-108cc662f564.png">
