### PR TITLE
fix: read only datetime field parsing

### DIFF
--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -180,9 +180,10 @@ $.extend(frappe.datetime, {
 		}
 
 		// user_fmt.replace("YYYY", "YY")? user might only input 2 digits of the year, which should also be parsed
-		return moment(val, [user_fmt.replace("YYYY", "YY"),
-			user_fmt]).locale("en").format(system_fmt);
-	},
+		// 2nd argument is array of formats to "parse", they are attempted in sequential order.
+		// ref: https://momentjs.com/docs/#/parsing/string-formats/
+		const user_formats = [user_fmt.replace("YYYY", "YY"), user_fmt, system_fmt];
+		return moment(val, user_formats).locale("en").format(system_fmt); },
 
 	user_to_obj: function(d) {
 		return frappe.datetime.str_to_obj(frappe.datetime.user_to_str(d));


### PR DESCRIPTION
when reading data from DB and showing to user it's getting parsed in
user format and hence it fails to parse.

Add system format as fallback format.

Steps to reproduce:

- set mm-dd-yyyy as date format
- create any read only datetime field
- even if the field has value it won't show up

reason: the field's value which is actually in system format is attempted and parsed as user format which becomes invalid date in most cases. 


closes https://github.com/frappe/frappe/issues/17332 