### PR TITLE
fix: 'EmailServer' object has no attribute 'imap'

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -734,6 +734,12 @@ class EmailAccount(Document):
 
 
 	def append_email_to_sent_folder(self, message):
+		if not (self.enable_incoming and self.use_imap):
+			# don't try appending if enable incoming and imap is not set
+			# as email domain's updation can cause email account(s) to forcibly
+			# update their settings.
+			return
+
 		email_server = None
 		try:
 			email_server = self.get_incoming_server(in_receive=True)


### PR DESCRIPTION
This PR is intended to fix the following traceback:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/email/queue.py", line 581, in send_one                        
    smtpserver.email_account.append_email_to_sent_folder(message)
  File "apps/frappe/frappe/email/doctype/email_account/email_account.py", line 834, in append_email_to_sent_folder
    if email_server.imap:                         
AttributeError: 'EmailServer' object has no attribute 'imap'
```

I have email partially set up on my server (which is experiencing the above traceback): I use a notifications email address for outgoing emails, but I don't have any incoming email address configured, and I don't use imap for anything.