### PR TITLE
fix: escape comma from brazilian portuguese translation

### DIFF
--- a/frappe/translations/pt-BR.csv
+++ b/frappe/translations/pt-BR.csv
@@ -2473,7 +2473,7 @@ There should remain at least one System Manager,Não deve permanecer pelo menos 
 There was an error saving filters,Houve um erro ao salvar os filtros,
 There were errors,Ocorreram erros,
 There were errors while creating the document. Please try again.,"Houve erros ao criar o documento. Por favor, tente novamente.",
-There were errors while sending email. Please try again.,Ocorreram erros durante o envio de email. Por favor, tente novamente.,
+There were errors while sending email. Please try again.,"Ocorreram erros durante o envio de email. Por favor, tente novamente.",
 "There were some errors setting the name, please contact the administrator","Houve alguns erros de definir o nome, por favor, entre em contato com o administrador",
 These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Esses valores serão atualizados automaticamente em transações e também serão úteis para restringir as permissões para este usuário em operações que contenham esses valores.,
 Third Party Apps,Aplicativos de terceiros,

--- a/frappe/translations/pt_br.csv
+++ b/frappe/translations/pt_br.csv
@@ -2473,7 +2473,7 @@ There should remain at least one System Manager,Não deve permanecer pelo menos 
 There was an error saving filters,Houve um erro ao salvar os filtros,
 There were errors,Ocorreram erros,
 There were errors while creating the document. Please try again.,"Houve erros ao criar o documento. Por favor, tente novamente.",
-There were errors while sending email. Please try again.,Ocorreram erros durante o envio de email. Por favor, tente novamente.,
+There were errors while sending email. Please try again.,"Ocorreram erros durante o envio de email. Por favor, tente novamente.",
 "There were some errors setting the name, please contact the administrator","Houve alguns erros de definir o nome, por favor, entre em contato com o administrador",
 These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values.,Esses valores serão atualizados automaticamente em transações e também serão úteis para restringir as permissões para este usuário em operações que contenham esses valores.,
 Third Party Apps,Aplicativos de terceiros,


### PR DESCRIPTION
CI failure(s): https://github.com/frappe/frappe/runs/7106871443?check_suite_focus=true

Caused by: #17305 