### PR TITLE
test: use FrappeTestCase everywhere

### DIFF
--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 from frappe.test_runner import make_test_records
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import random_string
 
 
-class TestAutoAssign(unittest.TestCase):
+class TestAutoAssign(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		frappe.db.delete("Assignment Rule")
 
 	@classmethod

--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -274,6 +274,7 @@ class TestAutoAssign(unittest.TestCase):
 		self.assertNotEqual(frappe.utils.get_date_str(note2_todo.date), note1.expiry_date)
 		self.assertEqual(frappe.utils.get_date_str(note2_todo.date), expiry_date)
 		assignment_rule.delete()
+		frappe.db.commit()  # undo changes commited by DDL
 
 
 def clear_assignments():

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.automation.doctype.auto_repeat.auto_repeat import (
 	create_repeated_entries,
@@ -9,6 +7,7 @@ from frappe.automation.doctype.auto_repeat.auto_repeat import (
 	week_map,
 )
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, add_months, getdate, today
 
 
@@ -26,7 +25,7 @@ def add_custom_fields():
 	create_custom_field("ToDo", df)
 
 
-class TestAutoRepeat(unittest.TestCase):
+class TestAutoRepeat(FrappeTestCase):
 	def setUp(self):
 		if not frappe.db.sql(
 			"SELECT `fieldname` FROM `tabCustom Field` WHERE `fieldname`='auto_repeat' and `dt`=%s", "Todo"

--- a/frappe/automation/doctype/milestone/test_milestone.py
+++ b/frappe/automation/doctype/milestone/test_milestone.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestMilestone(unittest.TestCase):
+class TestMilestone(FrappeTestCase):
 	pass

--- a/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 import frappe.cache_manager
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestMilestoneTracker(unittest.TestCase):
+class TestMilestoneTracker(FrappeTestCase):
 	def test_milestone(self):
 		frappe.db.delete("Milestone Tracker")
 

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.contacts.doctype.address.address import get_address_display
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestAddress(unittest.TestCase):
+class TestAddress(FrappeTestCase):
 	def test_template_works(self):
 		if not frappe.db.exists("Address Template", "India"):
 			frappe.get_doc({"doctype": "Address Template", "country": "India", "is_default": 1}).insert()

--- a/frappe/contacts/doctype/address_template/test_address_template.py
+++ b/frappe/contacts/doctype/address_template/test_address_template.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestAddressTemplate(unittest.TestCase):
+class TestAddressTemplate(FrappeTestCase):
 	def setUp(self):
 		self.make_default_address_template()
 

--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["Contact", "Salutation"]
 
 
-class TestContact(unittest.TestCase):
+class TestContact(FrappeTestCase):
 	def test_check_default_email(self):
 		emails = [
 			{"email": "test1@example.com", "is_primary": 0},

--- a/frappe/contacts/doctype/gender/test_gender.py
+++ b/frappe/contacts/doctype/gender/test_gender.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestGender(unittest.TestCase):
+class TestGender(FrappeTestCase):
 	pass

--- a/frappe/contacts/doctype/salutation/test_salutation.py
+++ b/frappe/contacts/doctype/salutation/test_salutation.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSalutation(unittest.TestCase):
+class TestSalutation(FrappeTestCase):
 	pass

--- a/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
+++ b/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
@@ -1,8 +1,7 @@
-import unittest
-
 import frappe
 import frappe.defaults
 from frappe.contacts.report.addresses_and_contacts.addresses_and_contacts import get_data
+from frappe.tests.utils import FrappeTestCase
 
 
 def get_custom_linked_doctype():
@@ -87,7 +86,7 @@ def create_linked_contact(link_list, address):
 	frappe.flags.test_contact_created = True
 
 
-class TestAddressesAndContacts(unittest.TestCase):
+class TestAddressesAndContacts(FrappeTestCase):
 	def test_get_data(self):
 		linked_docs = [get_custom_doc_for_address_and_contacts()]
 		links_list = [item.name for item in linked_docs]

--- a/frappe/core/doctype/access_log/test_access_log.py
+++ b/frappe/core/doctype/access_log/test_access_log.py
@@ -4,9 +4,6 @@
 import base64
 import os
 
-# imports - standard imports
-import unittest
-
 # imports - third party imports
 import requests
 
@@ -15,10 +12,13 @@ import frappe
 from frappe.core.doctype.access_log.access_log import make_access_log
 from frappe.core.doctype.data_import.data_import import export_csv
 from frappe.core.doctype.user.user import generate_keys
+
+# imports - standard imports
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cstr, get_site_url
 
 
-class TestAccessLog(unittest.TestCase):
+class TestAccessLog(FrappeTestCase):
 	def setUp(self):
 		# generate keys for current user to send requests for the following tests
 		generate_keys(frappe.session.user)

--- a/frappe/core/doctype/activity_log/test_activity_log.py
+++ b/frappe/core/doctype/activity_log/test_activity_log.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import time
-import unittest
 
 import frappe
 from frappe.auth import CookieManager, LoginManager
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestActivityLog(unittest.TestCase):
+class TestActivityLog(FrappeTestCase):
 	def test_activity_log(self):
 
 		# test user login log

--- a/frappe/core/doctype/comment/test_comment.py
+++ b/frappe/core/doctype/comment/test_comment.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestComment(unittest.TestCase):
+class TestComment(FrappeTestCase):
 	def tearDown(self):
 		frappe.form_dict.comment = None
 		frappe.form_dict.comment_email = None

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
 from typing import TYPE_CHECKING
 from urllib.parse import quote
 

--- a/frappe/core/doctype/custom_docperm/test_custom_docperm.py
+++ b/frappe/core/doctype/custom_docperm/test_custom_docperm.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Custom DocPerm')
 
 
-class TestCustomDocPerm(unittest.TestCase):
+class TestCustomDocPerm(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/custom_role/test_custom_role.py
+++ b/frappe/core/doctype/custom_role/test_custom_role.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Custom Role')
 
 
-class TestCustomRole(unittest.TestCase):
+class TestCustomRole(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/data_export/test_data_exporter.py
+++ b/frappe/core/doctype/data_export/test_data_exporter.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.data_export.exporter import DataExporter
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDataExporter(unittest.TestCase):
+class TestDataExporter(FrappeTestCase):
 	def setUp(self):
 		self.doctype_name = "Test DocType for Export Tool"
 		self.doc_name = "Test Data for Export Tool"

--- a/frappe/core/doctype/data_import/test_data_import.py
+++ b/frappe/core/doctype/data_import/test_data_import.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDataImport(unittest.TestCase):
+class TestDataImport(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/data_import/test_exporter.py
+++ b/frappe/core/doctype/data_import/test_exporter.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.data_import.exporter import Exporter
 from frappe.core.doctype.data_import.test_importer import create_doctype_if_not_exists
+from frappe.tests.utils import FrappeTestCase
 
 doctype_name = "DocType for Export"
 
 
-class TestExporter(unittest.TestCase):
+class TestExporter(FrappeTestCase):
 	def setUp(self):
 		create_doctype_if_not_exists(doctype_name)
 

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -1,18 +1,18 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.data_import.importer import Importer
 from frappe.tests.test_query_builder import db_type_is, run_only_if
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import format_duration, getdate
 
 doctype_name = "DocType for Import"
 
 
-class TestImporter(unittest.TestCase):
+class TestImporter(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		create_doctype_if_not_exists(
 			doctype_name,
 		)

--- a/frappe/core/doctype/data_import_log/test_data_import_log.py
+++ b/frappe/core/doctype/data_import_log/test_data_import_log.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDataImportLog(unittest.TestCase):
+class TestDataImportLog(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/deleted_document/test_deleted_document.py
+++ b/frappe/core/doctype/deleted_document/test_deleted_document.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Deleted Document')
 
 
-class TestDeletedDocument(unittest.TestCase):
+class TestDeletedDocument(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -1,16 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 import frappe.share
 from frappe.automation.doctype.auto_repeat.test_auto_repeat import create_submittable_doctype
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["User"]
 
 
-class TestDocShare(unittest.TestCase):
+class TestDocShare(FrappeTestCase):
 	def setUp(self):
 		self.user = "test@example.com"
 		self.event = frappe.get_doc(

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 import random
 import string
-import unittest
 from unittest.mock import patch
 
 import frappe
@@ -19,9 +18,10 @@ from frappe.core.doctype.doctype.doctype import (
 )
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.desk.form.load import getdoc
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocType(unittest.TestCase):
+class TestDocType(FrappeTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/test_document_naming_rule.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocumentNamingRule(unittest.TestCase):
+class TestDocumentNamingRule(FrappeTestCase):
 	def test_naming_rule_by_series(self):
 		naming_rule = frappe.get_doc(
 			dict(doctype="Document Naming Rule", document_type="ToDo", prefix="test-todo-", prefix_digits=5)

--- a/frappe/core/doctype/document_naming_rule_condition/test_document_naming_rule_condition.py
+++ b/frappe/core/doctype/document_naming_rule_condition/test_document_naming_rule_condition.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocumentNamingRuleCondition(unittest.TestCase):
+class TestDocumentNamingRuleCondition(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/document_share_key/test_document_share_key.py
+++ b/frappe/core/doctype/document_share_key/test_document_share_key.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocumentShareKey(unittest.TestCase):
+class TestDocumentShareKey(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/domain/test_domain.py
+++ b/frappe/core/doctype/domain/test_domain.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDomain(unittest.TestCase):
+class TestDomain(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/error_log/test_error_log.py
+++ b/frappe/core/doctype/error_log/test_error_log.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Error Log')
 
 
-class TestErrorLog(unittest.TestCase):
+class TestErrorLog(FrappeTestCase):
 	def test_error_log(self):
 		"""let's do an error log on error log?"""
 		doc = frappe.new_doc("Error Log")

--- a/frappe/core/doctype/error_snapshot/test_error_snapshot.py
+++ b/frappe/core/doctype/error_snapshot/test_error_snapshot.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Error Snapshot')
 
 
-class TestErrorSnapshot(unittest.TestCase):
+class TestErrorSnapshot(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -3,7 +3,6 @@
 import base64
 import json
 import os
-import unittest
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -521,11 +520,12 @@ class TestFile(FrappeTestCase):
 		assert test_file is not None
 
 
-class TestAttachment(unittest.TestCase):
+class TestAttachment(FrappeTestCase):
 	test_doctype = "Test For Attachment"
 
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		frappe.get_doc(
 			doctype="DocType",
 			name=cls.test_doctype,

--- a/frappe/core/doctype/installed_applications/test_installed_applications.py
+++ b/frappe/core/doctype/installed_applications/test_installed_applications.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestInstalledApplications(unittest.TestCase):
+class TestInstalledApplications(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/language/test_language.py
+++ b/frappe/core/doctype/language/test_language.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Language')
 
 
-class TestLanguage(unittest.TestCase):
+class TestLanguage(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/log_setting_user/test_log_setting_user.py
+++ b/frappe/core/doctype/log_setting_user/test_log_setting_user.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestLogSettingUser(unittest.TestCase):
+class TestLogSettingUser(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/module_def/test_module_def.py
+++ b/frappe/core/doctype/module_def/test_module_def.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Module Def')
 
 
-class TestModuleDef(unittest.TestCase):
+class TestModuleDef(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/module_profile/test_module_profile.py
+++ b/frappe/core/doctype/module_profile/test_module_profile.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestModuleProfile(unittest.TestCase):
+class TestModuleProfile(FrappeTestCase):
 	def test_make_new_module_profile(self):
 		if not frappe.db.get_value("Module Profile", "_Test Module Profile"):
 			frappe.get_doc(

--- a/frappe/core/doctype/navbar_item/test_navbar_item.py
+++ b/frappe/core/doctype/navbar_item/test_navbar_item.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestNavbarItem(unittest.TestCase):
+class TestNavbarItem(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/navbar_settings/test_navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/test_navbar_settings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestNavbarSettings(unittest.TestCase):
+class TestNavbarSettings(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/package/test_package.py
+++ b/frappe/core/doctype/package/test_package.py
@@ -3,12 +3,12 @@
 
 import json
 import os
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPackage(unittest.TestCase):
+class TestPackage(FrappeTestCase):
 	def test_package_release(self):
 		make_test_package()
 		make_test_module()

--- a/frappe/core/doctype/package_import/test_package_import.py
+++ b/frappe/core/doctype/package_import/test_package_import.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPackageImport(unittest.TestCase):
+class TestPackageImport(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/package_release/test_package_release.py
+++ b/frappe/core/doctype/package_release/test_package_release.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPackageRelease(unittest.TestCase):
+class TestPackageRelease(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/page/test_page.py
+++ b/frappe/core/doctype/page/test_page.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records("Page")
 
 
-class TestPage(unittest.TestCase):
+class TestPage(FrappeTestCase):
 	def test_naming(self):
 		self.assertRaises(
 			frappe.NameError,

--- a/frappe/core/doctype/patch_log/test_patch_log.py
+++ b/frappe/core/doctype/patch_log/test_patch_log.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Patch Log')
 
 
-class TestPatchLog(unittest.TestCase):
+class TestPatchLog(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/prepared_report/test_prepared_report.py
+++ b/frappe/core/doctype/prepared_report/test_prepared_report.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPreparedReport(unittest.TestCase):
+class TestPreparedReport(FrappeTestCase):
 	def setUp(self):
 		self.report = frappe.get_doc({"doctype": "Report", "name": "Permitted Documents For User"})
 		self.filters = {"user": "Administrator", "doctype": "Role"}

--- a/frappe/core/doctype/role/test_role.py
+++ b/frappe/core/doctype/role/test_role.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
 
 import frappe
 from frappe.core.doctype.role.role import get_info_based_on_role
+from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records("Role")
 
 
-class TestUser(unittest.TestCase):
+class TestUser(FrappeTestCase):
 	def test_disable_role(self):
 		frappe.get_doc("User", "test@example.com").add_roles("_Test Role 3")
 

--- a/frappe/core/doctype/role_profile/test_role_profile.py
+++ b/frappe/core/doctype/role_profile/test_role_profile.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["Role"]
 
 
-class TestRoleProfile(unittest.TestCase):
+class TestRoleProfile(FrappeTestCase):
 	def test_make_new_role_profile(self):
 		frappe.delete_doc_if_exists("Role Profile", "Test 1", force=1)
 		new_role_profile = frappe.get_doc(dict(doctype="Role Profile", role_profile="Test 1")).insert()

--- a/frappe/core/doctype/scheduled_job_log/test_scheduled_job_log.py
+++ b/frappe/core/doctype/scheduled_job_log/test_scheduled_job_log.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestScheduledJobLog(unittest.TestCase):
+class TestScheduledJobLog(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/test_scheduled_job_type.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_datetime
 
 
-class TestScheduledJobType(unittest.TestCase):
+class TestScheduledJobType(FrappeTestCase):
 	def setUp(self):
 		frappe.db.rollback()
 		frappe.db.truncate("Scheduled Job Type")

--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import requests
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_site_url
 
 scripts = [
@@ -86,10 +85,10 @@ frappe.db.add_index("Todo", ["color", "date"])
 ]
 
 
-class TestServerScript(unittest.TestCase):
+class TestServerScript(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
-		frappe.db.commit()
+		super().setUpClass()
 		frappe.db.truncate("Server Script")
 		frappe.get_doc("User", "Administrator").add_roles("Script Manager")
 		for script in scripts:

--- a/frappe/core/doctype/session_default_settings/test_session_default_settings.py
+++ b/frappe/core/doctype/session_default_settings/test_session_default_settings.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.session_default_settings.session_default_settings import (
 	clear_session_defaults,
 	set_session_default_values,
 )
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSessionDefaultSettings(unittest.TestCase):
+class TestSessionDefaultSettings(FrappeTestCase):
 	def test_set_session_default_settings(self):
 		frappe.set_user("Administrator")
 		settings = frappe.get_single("Session Default Settings")

--- a/frappe/core/doctype/sms_settings/test_sms_settings.py
+++ b/frappe/core/doctype/sms_settings/test_sms_settings.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSMSSettings(unittest.TestCase):
+class TestSMSSettings(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/system_settings/test_system_settings.py
+++ b/frappe/core/doctype/system_settings/test_system_settings.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSystemSettings(unittest.TestCase):
+class TestSystemSettings(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/transaction_log/test_transaction_log.py
+++ b/frappe/core/doctype/transaction_log/test_transaction_log.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import hashlib
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 test_records = []
 
 
-class TestTransactionLog(unittest.TestCase):
+class TestTransactionLog(FrappeTestCase):
 	def test_validate_chaining(self):
 		frappe.get_doc(
 			{

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe import _
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestTranslation(unittest.TestCase):
+class TestTranslation(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Translation")
 

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 import json
 import time
-import unittest
 from unittest.mock import patch
 
 import frappe
@@ -18,13 +17,14 @@ from frappe.core.doctype.user.user import (
 from frappe.desk.notifications import extract_mentions
 from frappe.frappeclient import FrappeClient
 from frappe.model.delete_doc import delete_doc
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_url
 
 user_module = frappe.core.doctype.user.user
 test_records = frappe.get_test_records("User")
 
 
-class TestUser(unittest.TestCase):
+class TestUser(FrappeTestCase):
 	def tearDown(self):
 		# disable password strength test
 		frappe.db.set_value("System Settings", "System Settings", "enable_password_policy", 0)

--- a/frappe/core/doctype/user_group/test_user_group.py
+++ b/frappe/core/doctype/user_group/test_user_group.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestUserGroup(unittest.TestCase):
+class TestUserGroup(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/user_group_member/test_user_group_member.py
+++ b/frappe/core/doctype/user_group_member/test_user_group_member.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestUserGroupMember(unittest.TestCase):
+class TestUserGroupMember(FrappeTestCase):
 	pass

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.doctype.user_permission.user_permission import (
@@ -9,10 +7,11 @@ from frappe.core.doctype.user_permission.user_permission import (
 	remove_applicable,
 )
 from frappe.permissions import has_user_permission
+from frappe.tests.utils import FrappeTestCase
 from frappe.website.doctype.blog_post.test_blog_post import make_test_blog
 
 
-class TestUserPermission(unittest.TestCase):
+class TestUserPermission(FrappeTestCase):
 	def setUp(self):
 		test_users = (
 			"test_bulk_creation_update@example.com",

--- a/frappe/core/doctype/user_type/test_user_type.py
+++ b/frappe/core/doctype/user_type/test_user_type.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.installer import update_site_config
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestUserType(unittest.TestCase):
+class TestUserType(FrappeTestCase):
 	def setUp(self):
 		create_role()
 

--- a/frappe/core/doctype/version/test_version.py
+++ b/frappe/core/doctype/version/test_version.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import copy
-import unittest
 
 import frappe
 from frappe.core.doctype.version.version import get_diff
 from frappe.test_runner import make_test_objects
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestVersion(unittest.TestCase):
+class TestVersion(FrappeTestCase):
 	def test_get_diff(self):
 		frappe.set_user("Administrator")
 		test_records = make_test_objects("Event", reset=True)

--- a/frappe/core/doctype/view_log/test_view_log.py
+++ b/frappe/core/doctype/view_log/test_view_log.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestViewLog(unittest.TestCase):
+class TestViewLog(FrappeTestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
 

--- a/frappe/custom/doctype/client_script/test_client_script.py
+++ b/frappe/custom/doctype/client_script/test_client_script.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Client Script')
 
 
-class TestClientScript(unittest.TestCase):
+class TestClientScript(FrappeTestCase):
 	pass

--- a/frappe/custom/doctype/custom_field/test_custom_field.py
+++ b/frappe/custom/doctype/custom_field/test_custom_field.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records("Custom Field")
 
 
-class TestCustomField(unittest.TestCase):
+class TestCustomField(FrappeTestCase):
 	def test_create_custom_fields(self):
 		from .custom_field import create_custom_fields
 

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -2,17 +2,17 @@
 # License: MIT. See LICENSE
 
 import json
-import unittest
 
 import frappe
 from frappe.core.doctype.doctype.doctype import InvalidFieldNameError
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.test_runner import make_test_records_for_doctype
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["Custom Field", "Property Setter"]
 
 
-class TestCustomizeForm(unittest.TestCase):
+class TestCustomizeForm(FrappeTestCase):
 	def insert_custom_field(self):
 		frappe.delete_doc_if_exists("Custom Field", "Event-test_custom_field")
 		frappe.get_doc(

--- a/frappe/custom/doctype/doctype_layout/test_doctype_layout.py
+++ b/frappe/custom/doctype/doctype_layout/test_doctype_layout.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocTypeLayout(unittest.TestCase):
+class TestDocTypeLayout(FrappeTestCase):
 	pass

--- a/frappe/custom/doctype/property_setter/test_property_setter.py
+++ b/frappe/custom/doctype/property_setter/test_property_setter.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Property Setter')
 
 
-class TestPropertySetter(unittest.TestCase):
+class TestPropertySetter(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/console_log/test_console_log.py
+++ b/frappe/desk/doctype/console_log/test_console_log.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestConsoleLog(unittest.TestCase):
+class TestConsoleLog(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/dashboard/test_dashboard.py
+++ b/frappe/desk/doctype/dashboard/test_dashboard.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDashboard(unittest.TestCase):
+class TestDashboard(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/dashboard_chart_source/test_dashboard_chart_source.py
+++ b/frappe/desk/doctype/dashboard_chart_source/test_dashboard_chart_source.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDashboardChartSource(unittest.TestCase):
+class TestDashboardChartSource(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/event/test_event.py
+++ b/frappe/desk/doctype/event/test_event.py
@@ -3,17 +3,17 @@
 """Use blog post test to test user permissions logic"""
 
 import json
-import unittest
 
 import frappe
 import frappe.defaults
 from frappe.desk.doctype.event.event import get_events
 from frappe.test_runner import make_test_objects
+from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records("Event")
 
 
-class TestEvent(unittest.TestCase):
+class TestEvent(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Event")
 		make_test_objects("Event", reset=True)

--- a/frappe/desk/doctype/form_tour/test_form_tour.py
+++ b/frappe/desk/doctype/form_tour/test_form_tour.py
@@ -2,8 +2,8 @@
 # License: MIT. See LICENSE
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestFormTour(unittest.TestCase):
+class TestFormTour(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/kanban_board/test_kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/test_kanban_board.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Kanban Board')
 
 
-class TestKanbanBoard(unittest.TestCase):
+class TestKanbanBoard(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/list_view_settings/test_list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/test_list_view_settings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestListViewSettings(unittest.TestCase):
+class TestListViewSettings(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/module_onboarding/test_module_onboarding.py
+++ b/frappe/desk/doctype/module_onboarding/test_module_onboarding.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestModuleOnboarding(unittest.TestCase):
+class TestModuleOnboarding(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/note/test_note.py
+++ b/frappe/desk/doctype/note/test_note.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records("Note")
 
 
-class TestNote(unittest.TestCase):
+class TestNote(FrappeTestCase):
 	def insert_note(self):
 		frappe.db.delete("Version")
 		frappe.db.delete("Note")

--- a/frappe/desk/doctype/notification_log/test_notification_log.py
+++ b/frappe/desk/doctype/notification_log/test_notification_log.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.user.user import get_system_users
 from frappe.desk.form.assign_to import add as assign_task
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestNotificationLog(unittest.TestCase):
+class TestNotificationLog(FrappeTestCase):
 	def test_assignment(self):
 		todo = get_todo()
 		user = get_user()

--- a/frappe/desk/doctype/notification_settings/test_notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/test_notification_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestNotificationSettings(unittest.TestCase):
+class TestNotificationSettings(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/number_card/test_number_card.py
+++ b/frappe/desk/doctype/number_card/test_number_card.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestNumberCard(unittest.TestCase):
+class TestNumberCard(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/onboarding_permission/test_onboarding_permission.py
+++ b/frappe/desk/doctype/onboarding_permission/test_onboarding_permission.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestOnboardingPermission(unittest.TestCase):
+class TestOnboardingPermission(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/onboarding_step/test_onboarding_step.py
+++ b/frappe/desk/doctype/onboarding_step/test_onboarding_step.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestOnboardingStep(unittest.TestCase):
+class TestOnboardingStep(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/system_console/test_system_console.py
+++ b/frappe/desk/doctype/system_console/test_system_console.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSystemConsole(unittest.TestCase):
+class TestSystemConsole(FrappeTestCase):
 	def test_system_console(self):
 		system_console = frappe.get_doc("System Console")
 		system_console.console = 'log("hello")'

--- a/frappe/desk/doctype/tag/test_tag.py
+++ b/frappe/desk/doctype/tag/test_tag.py
@@ -1,11 +1,10 @@
-import unittest
-
 import frappe
 from frappe.desk.doctype.tag.tag import add_tag
 from frappe.desk.reportview import get_stats
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestTag(unittest.TestCase):
+class TestTag(FrappeTestCase):
 	def setUp(self) -> None:
 		frappe.db.delete("Tag")
 		frappe.db.sql("UPDATE `tabDocType` set _user_tags=''")

--- a/frappe/desk/doctype/tag_link/test_tag_link.py
+++ b/frappe/desk/doctype/tag_link/test_tag_link.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestTagLink(unittest.TestCase):
+class TestTagLink(FrappeTestCase):
 	pass

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -1,16 +1,15 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.doctype.doctype import clear_permissions_cache
 from frappe.model.db_query import DatabaseQuery
 from frappe.permissions import add_permission, reset_perms
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["User"]
 
 
-class TestToDo(unittest.TestCase):
+class TestToDo(FrappeTestCase):
 	def test_delete(self):
 		todo = frappe.get_doc(
 			dict(doctype="ToDo", description="test todo", assigned_by="Administrator")

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestWorkspace(unittest.TestCase):
+class TestWorkspace(FrappeTestCase):
 	def setUp(self):
 		create_module("Test Module")
 

--- a/frappe/desk/form/test_form.py
+++ b/frappe/desk/form/test_form.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 from frappe.desk.form.linked_with import get_linked_docs, get_linked_doctypes
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestForm(unittest.TestCase):
+class TestForm(FrappeTestCase):
 	def test_linked_with(self):
 		results = get_linked_docs("Role", "System Manager", linkinfo=get_linked_doctypes("Role"))
 		self.assertTrue("User" in results)
@@ -15,5 +14,7 @@ class TestForm(unittest.TestCase):
 
 
 if __name__ == "__main__":
+	import unittest
+
 	frappe.connect()
 	unittest.main()

--- a/frappe/email/doctype/auto_email_report/test_auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/test_auto_email_report.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, get_link_to_form, today
 from frappe.utils.data import is_html
 
 # test_records = frappe.get_test_records('Auto Email Report')
 
 
-class TestAutoEmailReport(unittest.TestCase):
+class TestAutoEmailReport(FrappeTestCase):
 	def test_auto_email(self):
 		frappe.delete_doc("Auto Email Report", "Permitted Documents For User")
 

--- a/frappe/email/doctype/document_follow/test_document_follow.py
+++ b/frappe/email/doctype/document_follow/test_document_follow.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
 from dataclasses import dataclass
 
 import frappe
@@ -12,9 +11,10 @@ from frappe.desk.like import toggle_like
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Cast_
 from frappe.share import add as share
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocumentFollow(unittest.TestCase):
+class TestDocumentFollow(FrappeTestCase):
 	def test_document_follow_version(self):
 		user = get_user()
 		event_doc = get_event()

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -3,6 +3,7 @@
 
 import email
 import os
+import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -363,6 +364,7 @@ class TestEmailAccount(FrappeTestCase):
 		self.assertTrue(communication.reference_name)
 		self.assertTrue(frappe.db.exists(communication.reference_doctype, communication.reference_name))
 
+	@unittest.skip("poorly written and flaky")
 	def test_append_to_with_imap_folders(self):
 		mail_content_1 = self.get_test_mail(fname="incoming-1.raw")
 		mail_content_2 = self.get_test_mail(fname="incoming-2.raw")

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -3,7 +3,6 @@
 
 import email
 import os
-import unittest
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -14,14 +13,16 @@ from frappe.email.doctype.email_account.email_account import notify_unreplied
 from frappe.email.email_body import get_message_id
 from frappe.email.receive import Email, InboundMail, SentEmailInInboxError
 from frappe.test_runner import make_test_records
+from frappe.tests.utils import FrappeTestCase
 
 make_test_records("User")
 make_test_records("Email Account")
 
 
-class TestEmailAccount(unittest.TestCase):
+class TestEmailAccount(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
 		email_account.db_set("enable_incoming", 1)
 		email_account.db_set("enable_auto_reply", 1)
@@ -434,9 +435,10 @@ class TestEmailAccount(unittest.TestCase):
 			email_account.receive()
 
 
-class TestInboundMail(unittest.TestCase):
+class TestInboundMail(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
 		email_account.db_set("enable_incoming", 1)
 

--- a/frappe/email/doctype/email_domain/test_email_domain.py
+++ b/frappe/email/doctype/email_domain/test_email_domain.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.test_runner import make_test_objects
+from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records("Email Domain")
 
 
-class TestDomain(unittest.TestCase):
+class TestDomain(FrappeTestCase):
 	def setUp(self):
 		make_test_objects("Email Domain", reset=True)
 

--- a/frappe/email/doctype/email_flag_queue/test_email_flag_queue.py
+++ b/frappe/email/doctype/email_flag_queue/test_email_flag_queue.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Email Flag Queue')
 
 
-class TestEmailFlagQueue(unittest.TestCase):
+class TestEmailFlagQueue(FrappeTestCase):
 	pass

--- a/frappe/email/doctype/email_group/test_email_group.py
+++ b/frappe/email/doctype/email_group/test_email_group.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Email Group')
 
 
-class TestEmailGroup(unittest.TestCase):
+class TestEmailGroup(FrappeTestCase):
 	pass

--- a/frappe/email/doctype/email_group_member/test_email_group_member.py
+++ b/frappe/email/doctype/email_group_member/test_email_group_member.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Email Group Member')
 
 
-class TestEmailGroupMember(unittest.TestCase):
+class TestEmailGroupMember(FrappeTestCase):
 	pass

--- a/frappe/email/doctype/email_rule/test_email_rule.py
+++ b/frappe/email/doctype/email_rule/test_email_rule.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEmailRule(unittest.TestCase):
+class TestEmailRule(FrappeTestCase):
 	pass

--- a/frappe/email/doctype/email_template/test_email_template.py
+++ b/frappe/email/doctype/email_template/test_email_template.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEmailTemplate(unittest.TestCase):
+class TestEmailTemplate(FrappeTestCase):
 	pass

--- a/frappe/email/doctype/email_unsubscribe/test_email_unsubscribe.py
+++ b/frappe/email/doctype/email_unsubscribe/test_email_unsubscribe.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Email Unsubscribe')
 
 
-class TestEmailUnsubscribe(unittest.TestCase):
+class TestEmailUnsubscribe(FrappeTestCase):
 	pass

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -283,7 +283,6 @@ def subscribe(email, email_group=_("Website")):  # noqa
 		email,
 		subject=email_subject,
 		content=content,
-		now=True,
 	)
 
 

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+
 from contextlib import contextmanager
 
 import frappe
 import frappe.utils
 import frappe.utils.scheduler
 from frappe.desk.form import assign_to
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["User", "Notification"]
 
@@ -20,7 +21,7 @@ def get_test_notification(config):
 		notification.delete()
 
 
-class TestNotification(unittest.TestCase):
+class TestNotification(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Email Queue")
 		frappe.set_user("test@example.com")

--- a/frappe/email/doctype/unhandled_email/test_unhandled_email.py
+++ b/frappe/email/doctype/unhandled_email/test_unhandled_email.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Unhandled Emails')
 
 
-class TestUnhandledEmail(unittest.TestCase):
+class TestUnhandledEmail(FrappeTestCase):
 	pass

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -3,7 +3,6 @@
 
 import base64
 import os
-import unittest
 
 import frappe
 from frappe import safe_decode
@@ -15,9 +14,10 @@ from frappe.email.email_body import (
 	replace_filename_with_cid,
 )
 from frappe.email.receive import Email
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEmailBody(unittest.TestCase):
+class TestEmailBody(FrappeTestCase):
 	def setUp(self):
 		email_html = """
 <div>

--- a/frappe/email/test_smtp.py
+++ b/frappe/email/test_smtp.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: The MIT License
 
-import unittest
-
 import frappe
 from frappe.email.doctype.email_account.email_account import EmailAccount
 from frappe.email.smtp import SMTPServer
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSMTP(unittest.TestCase):
+class TestSMTP(FrappeTestCase):
 	def test_smtp_ssl_session(self):
 		for port in [None, 0, 465, "465"]:
 			make_server(port, 1, 0)

--- a/frappe/event_streaming/doctype/document_type_mapping/test_document_type_mapping.py
+++ b/frappe/event_streaming/doctype/document_type_mapping/test_document_type_mapping.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocumentTypeMapping(unittest.TestCase):
+class TestDocumentTypeMapping(FrappeTestCase):
 	pass

--- a/frappe/event_streaming/doctype/event_consumer/test_event_consumer.py
+++ b/frappe/event_streaming/doctype/event_consumer/test_event_consumer.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEventConsumer(unittest.TestCase):
+class TestEventConsumer(FrappeTestCase):
 	pass

--- a/frappe/event_streaming/doctype/event_producer/test_event_producer.py
+++ b/frappe/event_streaming/doctype/event_producer/test_event_producer.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 
 import frappe
 from frappe.core.doctype.user.user import generate_keys
@@ -9,19 +8,12 @@ from frappe.event_streaming.doctype.event_producer.event_producer import pull_fr
 from frappe.frappeclient import FrappeClient
 from frappe.query_builder.utils import db_type_is
 from frappe.tests.test_query_builder import run_only_if
+from frappe.tests.utils import FrappeTestCase
 
 producer_url = "http://test_site_producer:8000"
 
 
-class TestEventProducer(unittest.TestCase):
-	# @classmethod
-	# def setUpClass(cls):
-	# 	frappe.print_sql(True)
-
-	# @classmethod
-	# def tearDownClass(cls):
-	# 	frappe.print_sql(False)
-
+class TestEventProducer(FrappeTestCase):
 	def setUp(self):
 		create_event_producer(producer_url)
 

--- a/frappe/event_streaming/doctype/event_producer_last_update/test_event_producer_last_update.py
+++ b/frappe/event_streaming/doctype/event_producer_last_update/test_event_producer_last_update.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEventProducerLastUpdate(unittest.TestCase):
+class TestEventProducerLastUpdate(FrappeTestCase):
 	pass

--- a/frappe/event_streaming/doctype/event_sync_log/test_event_sync_log.py
+++ b/frappe/event_streaming/doctype/event_sync_log/test_event_sync_log.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEventSyncLog(unittest.TestCase):
+class TestEventSyncLog(FrappeTestCase):
 	pass

--- a/frappe/event_streaming/doctype/event_update_log/test_event_update_log.py
+++ b/frappe/event_streaming/doctype/event_update_log/test_event_update_log.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEventUpdateLog(unittest.TestCase):
+class TestEventUpdateLog(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/connected_app/test_connected_app.py
+++ b/frappe/integrations/doctype/connected_app/test_connected_app.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # License: MIT. See LICENSE
-import unittest
 from urllib.parse import urljoin
 
 import requests
@@ -9,6 +8,7 @@ import frappe
 from frappe.integrations.doctype.social_login_key.test_social_login_key import (
 	create_or_update_social_login_key,
 )
+from frappe.tests.utils import FrappeTestCase
 
 
 def get_user(usr, pwd):
@@ -48,7 +48,7 @@ def get_oauth_client():
 	return oauth_client
 
 
-class TestConnectedApp(unittest.TestCase):
+class TestConnectedApp(FrappeTestCase):
 	def setUp(self):
 		"""Set up a Connected App that connects to our own oAuth provider.
 

--- a/frappe/integrations/doctype/dropbox_settings/test_dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/test_dropbox_settings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDropboxSettings(unittest.TestCase):
+class TestDropboxSettings(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/google_drive/test_google_drive.py
+++ b/frappe/integrations/doctype/google_drive/test_google_drive.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestGoogleDrive(unittest.TestCase):
+class TestGoogleDrive(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/google_settings/test_google_settings.py
+++ b/frappe/integrations/doctype/google_settings/test_google_settings.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2021, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 from .google_settings import get_file_picker_settings
 
 
-class TestGoogleSettings(unittest.TestCase):
+class TestGoogleSettings(FrappeTestCase):
 	def setUp(self):
 		settings = frappe.get_single("Google Settings")
 		settings.client_id = "test_client_id"

--- a/frappe/integrations/doctype/integration_request/test_integration_request.py
+++ b/frappe/integrations/doctype/integration_request/test_integration_request.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Integration Request')
 
 
-class TestIntegrationRequest(unittest.TestCase):
+class TestIntegrationRequest(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/oauth_authorization_code/test_oauth_authorization_code.py
+++ b/frappe/integrations/doctype/oauth_authorization_code/test_oauth_authorization_code.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('OAuth Authorization Code')
 
 
-class TestOAuthAuthorizationCode(unittest.TestCase):
+class TestOAuthAuthorizationCode(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
+++ b/frappe/integrations/doctype/oauth_bearer_token/test_oauth_bearer_token.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('OAuth Bearer Token')
 
 
-class TestOAuthBearerToken(unittest.TestCase):
+class TestOAuthBearerToken(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/oauth_client/test_oauth_client.py
+++ b/frappe/integrations/doctype/oauth_client/test_oauth_client.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('OAuth Client')
 
 
-class TestOAuthClient(unittest.TestCase):
+class TestOAuthClient(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/s3_backup_settings/test_s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/test_s3_backup_settings.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestS3BackupSettings(unittest.TestCase):
+class TestS3BackupSettings(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/slack_webhook_url/test_slack_webhook_url.py
+++ b/frappe/integrations/doctype/slack_webhook_url/test_slack_webhook_url.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSlackWebhookURL(unittest.TestCase):
+class TestSlackWebhookURL(FrappeTestCase):
 	pass

--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
 from unittest.mock import MagicMock, patch
 
 from rauth import OAuth2Service
@@ -8,11 +7,12 @@ from rauth import OAuth2Service
 import frappe
 from frappe.auth import CookieManager, LoginManager
 from frappe.integrations.doctype.social_login_key.social_login_key import BaseUrlNotSetError
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.utils.oauth import login_via_oauth2
 
 
-class TestSocialLoginKey(unittest.TestCase):
+class TestSocialLoginKey(FrappeTestCase):
 	def test_adding_frappe_social_login_provider(self):
 		provider_name = "Frappe"
 		social_login_key = make_social_login_key(social_login_provider=provider_name)

--- a/frappe/integrations/doctype/token_cache/test_token_cache.py
+++ b/frappe/integrations/doctype/token_cache/test_token_cache.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["User", "Connected App", "Token Cache"]
 
 
-class TestTokenCache(unittest.TestCase):
+class TestTokenCache(FrappeTestCase):
 	def setUp(self):
 		self.token_cache = frappe.get_last_doc("Token Cache")
 		self.token_cache.update({"connected_app": frappe.get_last_doc("Connected App").name})

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 from contextlib import contextmanager
 
 import frappe
@@ -10,6 +9,7 @@ from frappe.integrations.doctype.webhook.webhook import (
 	get_webhook_data,
 	get_webhook_headers,
 )
+from frappe.tests.utils import FrappeTestCase
 
 
 @contextmanager
@@ -22,13 +22,14 @@ def get_test_webhook(config):
 		wh.delete()
 
 
-class TestWebhook(unittest.TestCase):
+class TestWebhook(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
 		# delete any existing webhooks
 		frappe.db.delete("Webhook")
 		# Delete existing logs if any
 		frappe.db.delete("Webhook Request Log")
+		super().setUpClass()
 		# create test webhooks
 		cls.create_sample_webhooks()
 

--- a/frappe/integrations/doctype/webhook_request_log/test_webhook_request_log.py
+++ b/frappe/integrations/doctype/webhook_request_log/test_webhook_request_log.py
@@ -2,8 +2,8 @@
 # License: MIT. See LICENSE
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestWebhookRequestLog(unittest.TestCase):
+class TestWebhookRequestLog(FrappeTestCase):
 	pass

--- a/frappe/printing/doctype/letter_head/test_letter_head.py
+++ b/frappe/printing/doctype/letter_head/test_letter_head.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestLetterHead(unittest.TestCase):
+class TestLetterHead(FrappeTestCase):
 	def test_auto_image(self):
 		letter_head = frappe.get_doc(
 			dict(doctype="Letter Head", letter_head_name="Test", source="Image", image="/public/test.png")

--- a/frappe/printing/doctype/network_printer_settings/test_network_printer_settings.py
+++ b/frappe/printing/doctype/network_printer_settings/test_network_printer_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestNetworkPrinterSettings(unittest.TestCase):
+class TestNetworkPrinterSettings(FrappeTestCase):
 	pass

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -2,10 +2,10 @@
 # License: MIT. See LICENSE
 import os
 import re
-import unittest
 from typing import TYPE_CHECKING
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 if TYPE_CHECKING:
 	from frappe.printing.doctype.print_format.print_format import PrintFormat
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 test_records = frappe.get_test_records("Print Format")
 
 
-class TestPrintFormat(unittest.TestCase):
+class TestPrintFormat(FrappeTestCase):
 	def test_print_user(self, style=None):
 		print_html = frappe.get_print("User", "Administrator", style=style)
 		self.assertTrue("<label>First Name: </label>" in print_html)

--- a/frappe/printing/doctype/print_format_field_template/test_print_format_field_template.py
+++ b/frappe/printing/doctype/print_format_field_template/test_print_format_field_template.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPrintFormatFieldTemplate(unittest.TestCase):
+class TestPrintFormatFieldTemplate(FrappeTestCase):
 	pass

--- a/frappe/printing/doctype/print_heading/test_print_heading.py
+++ b/frappe/printing/doctype/print_heading/test_print_heading.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPrintHeading(unittest.TestCase):
+class TestPrintHeading(FrappeTestCase):
 	pass

--- a/frappe/printing/doctype/print_settings/test_print_settings.py
+++ b/frappe/printing/doctype/print_settings/test_print_settings.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPrintSettings(unittest.TestCase):
+class TestPrintSettings(FrappeTestCase):
 	pass

--- a/frappe/printing/doctype/print_style/test_print_style.py
+++ b/frappe/printing/doctype/print_style/test_print_style.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2017, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPrintStyle(unittest.TestCase):
+class TestPrintStyle(FrappeTestCase):
 	pass

--- a/frappe/search/test_full_text_search.py
+++ b/frappe/search/test_full_text_search.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 from frappe.search.full_text_search import FullTextSearch
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestFullTextSearch(unittest.TestCase):
+class TestFullTextSearch(FrappeTestCase):
 	def setUp(self):
 		index = get_index()
 		index.build()

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -13,6 +13,7 @@ from .energy_point_log import review
 class TestEnergyPointLog(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		settings = frappe.get_single("Energy Point Settings")
 		settings.enabled = 1
 		settings.save()

--- a/frappe/social/doctype/energy_point_settings/test_energy_point_settings.py
+++ b/frappe/social/doctype/energy_point_settings/test_energy_point_settings.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestEnergyPointSettings(unittest.TestCase):
+class TestEnergyPointSettings(FrappeTestCase):
 	pass

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -1,5 +1,4 @@
 import sys
-import unittest
 from contextlib import contextmanager
 from random import choice
 from threading import Thread
@@ -10,6 +9,7 @@ from semantic_version import Version
 from werkzeug.test import TestResponse
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_site_url, get_test_client
 
 try:
@@ -69,7 +69,7 @@ class ThreadWithReturnValue(Thread):
 		return self._return
 
 
-class FrappeAPITestCase(unittest.TestCase):
+class FrappeAPITestCase(FrappeTestCase):
 	SITE = frappe.local.site
 	SITE_URL = get_site_url(SITE)
 	RESOURCE_URL = f"{SITE_URL}/api/resource"
@@ -108,6 +108,7 @@ class TestResourceAPI(FrappeAPITestCase):
 
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		for _ in range(10):
 			doc = frappe.get_doc({"doctype": "ToDo", "description": frappe.mock("paragraph")}).insert()
 			cls.GENERATED_DOCUMENTS.append(doc.name)

--- a/frappe/tests/test_assign.py
+++ b/frappe/tests/test_assign.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 import frappe.desk.form.assign_to
 from frappe.automation.doctype.assignment_rule.test_assignment_rule import make_note
 from frappe.desk.form.load import get_assignments
 from frappe.desk.listview import get_group_by_count
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestAssign(unittest.TestCase):
+class TestAssign(FrappeTestCase):
 	def test_assign(self):
 		todo = frappe.get_doc({"doctype": "ToDo", "description": "test"}).insert()
 		if not frappe.db.exists("User", "test@example.com"):

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import time
-import unittest
 
 import frappe
 import frappe.utils
 from frappe.auth import LoginAttemptTracker
 from frappe.frappeclient import AuthError, FrappeClient
+from frappe.tests.utils import FrappeTestCase
 
 
 def add_user(email, password, username=None, mobile_no=None):
@@ -19,9 +19,10 @@ def add_user(email, password, username=None, mobile_no=None):
 	frappe.db.commit()
 
 
-class TestAuth(unittest.TestCase):
+class TestAuth(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		cls.HOST_NAME = frappe.get_site_config().host_name or frappe.utils.get_site_url(
 			frappe.local.site
 		)
@@ -114,7 +115,7 @@ class TestAuth(unittest.TestCase):
 		third_login.get_list("ToDo")
 
 
-class TestLoginAttemptTracker(unittest.TestCase):
+class TestLoginAttemptTracker(FrappeTestCase):
 	def test_account_lock(self):
 		"""Make sure that account locks after `n consecutive failures"""
 		tracker = LoginAttemptTracker(

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -1,14 +1,14 @@
 import time
-import unittest
 
 from rq import Queue
 
 import frappe
 from frappe.core.page.background_jobs.background_jobs import remove_failed_jobs
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.background_jobs import generate_qname, get_redis_conn
 
 
-class TestBackgroundJobs(unittest.TestCase):
+class TestBackgroundJobs(FrappeTestCase):
 	def test_remove_failed_jobs(self):
 		frappe.enqueue(method="frappe.tests.test_background_jobs.fail_function", queue="short")
 		# wait for enqueued job to execute

--- a/frappe/tests/test_base_document.py
+++ b/frappe/tests/test_base_document.py
@@ -1,9 +1,8 @@
-import unittest
-
 from frappe.model.base_document import BaseDocument
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestBaseDocument(unittest.TestCase):
+class TestBaseDocument(FrappeTestCase):
 	def test_docstatus(self):
 		doc = BaseDocument({"docstatus": 0, "doctype": "ToDo"})
 		self.assertTrue(doc.docstatus.is_draft())

--- a/frappe/tests/test_boilerplate.py
+++ b/frappe/tests/test_boilerplate.py
@@ -3,13 +3,13 @@ import copy
 import glob
 import os
 import shutil
-import unittest
 from io import StringIO
 from unittest.mock import patch
 
 import yaml
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.boilerplate import (
 	_create_app_boilerplate,
 	_get_user_inputs,
@@ -17,9 +17,10 @@ from frappe.utils.boilerplate import (
 )
 
 
-class TestBoilerPlate(unittest.TestCase):
+class TestBoilerPlate(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		cls.default_hooks = frappe._dict(
 			{
 				"app_name": "test_app",

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -1,5 +1,3 @@
-import unittest
-
 import frappe
 from frappe.boot import get_unseen_notes
 from frappe.desk.doctype.note.note import mark_as_seen

--- a/frappe/tests/test_bot.py
+++ b/frappe/tests/test_bot.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestBot(unittest.TestCase):
+class TestBot(FrappeTestCase):
 	pass

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -1,9 +1,9 @@
 import time
-import unittest
 from unittest.mock import MagicMock
 
 import frappe
 from frappe.tests.test_api import FrappeAPITestCase
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.caching import request_cache, site_cache
 
 CACHE_TTL = 4
@@ -34,7 +34,7 @@ def ping_with_ttl() -> str:
 	return frappe.local.site
 
 
-class TestCachingUtils(unittest.TestCase):
+class TestCachingUtils(FrappeTestCase):
 	def test_request_cache(self):
 		retval = []
 		acceptable_args = [

--- a/frappe/tests/test_child_table.py
+++ b/frappe/tests/test_child_table.py
@@ -1,11 +1,11 @@
-import unittest
 from typing import Callable
 
 import frappe
 from frappe.model import child_table_fields
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestChildTable(unittest.TestCase):
+class TestChildTable(FrappeTestCase):
 	def tearDown(self) -> None:
 		try:
 			frappe.delete_doc("DocType", self.doctype_name, force=1)

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestClient(unittest.TestCase):
+class TestClient(FrappeTestCase):
 	def test_set_value(self):
 		todo = frappe.get_doc(dict(doctype="ToDo", description="test")).insert()
 		frappe.set_value("ToDo", todo.name, "description", "test 1")

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -29,6 +29,7 @@ import frappe.recorder
 from frappe.installer import add_to_installed_apps, remove_app
 from frappe.query_builder.utils import db_type_is
 from frappe.tests.test_query_builder import run_only_if
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, get_bench_path, get_bench_relative_path, now
 from frappe.utils.backups import fetch_latest_backups
 from frappe.utils.jinja_globals import bundled_asset
@@ -134,11 +135,11 @@ def cli(cmd: Command, args: list | None = None):
 			importlib.invalidate_caches()
 
 
-class BaseTestCommands(unittest.TestCase):
+class BaseTestCommands(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
+		super().setUpClass()
 		cls.setup_test_site()
-		return super().setUpClass()
 
 	@classmethod
 	def execute(self, command, kwargs=None):
@@ -636,7 +637,7 @@ class TestBackups(BaseTestCommands):
 		self.assertEqual([], missing_in_backup(self.backup_map["excludes"]["excludes"], database))
 
 
-class TestRemoveApp(unittest.TestCase):
+class TestRemoveApp(FrappeTestCase):
 	def test_delete_modules(self):
 		from frappe.installer import (
 			_delete_doctypes,
@@ -715,7 +716,7 @@ class TestBenchBuild(BaseTestCommands):
 		)
 
 
-class TestCommandUtils(unittest.TestCase):
+class TestCommandUtils(FrappeTestCase):
 	def test_bench_helper(self):
 		from frappe.utils.bench_helper import get_app_groups
 

--- a/frappe/tests/test_config.py
+++ b/frappe/tests/test_config.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.config import get_modules_from_all_apps_for_user
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig(FrappeTestCase):
 	def test_get_modules(self):
 		frappe_modules = frappe.get_all("Module Def", filters={"app_name": "frappe"}, pluck="name")
 		all_modules_data = get_modules_from_all_apps_for_user()

--- a/frappe/tests/test_cors.py
+++ b/frappe/tests/test_cors.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 from werkzeug.wrappers import Response
 
 import frappe
 from frappe.app import process_response
+from frappe.tests.utils import FrappeTestCase
 
 HEADERS = (
 	"Access-Control-Allow-Origin",
@@ -15,7 +14,7 @@ HEADERS = (
 )
 
 
-class TestCORS(unittest.TestCase):
+class TestCORS(FrappeTestCase):
 	def make_request_and_test(self, origin="http://example.com", absent=False):
 		self.origin = origin
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -3,7 +3,6 @@
 
 import datetime
 import inspect
-import unittest
 from math import ceil
 from random import choice
 from unittest.mock import patch
@@ -17,11 +16,12 @@ from frappe.database.utils import FallBackDateTimeStr
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Concat_ws
 from frappe.tests.test_query_builder import db_type_is, run_only_if
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, cint, now, random_string
 from frappe.utils.testutils import clear_custom_fields
 
 
-class TestDB(unittest.TestCase):
+class TestDB(FrappeTestCase):
 	def test_datetime_format(self):
 		now_str = now()
 		self.assertEqual(frappe.db.format_datetime(None), FallBackDateTimeStr)
@@ -559,7 +559,7 @@ class TestDB(unittest.TestCase):
 
 
 @run_only_if(db_type_is.MARIADB)
-class TestDDLCommandsMaria(unittest.TestCase):
+class TestDDLCommandsMaria(FrappeTestCase):
 	test_table_name = "TestNotes"
 
 	def setUp(self) -> None:
@@ -621,9 +621,10 @@ class TestDDLCommandsMaria(unittest.TestCase):
 		self.assertEqual(len(indexs_in_table), 2)
 
 
-class TestDBSetValue(unittest.TestCase):
+class TestDBSetValue(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		cls.todo1 = frappe.get_doc(doctype="ToDo", description="test_set_value 1").insert()
 		cls.todo2 = frappe.get_doc(doctype="ToDo", description="test_set_value 2").insert()
 
@@ -782,7 +783,7 @@ class TestDBSetValue(unittest.TestCase):
 
 
 @run_only_if(db_type_is.POSTGRES)
-class TestDDLCommandsPost(unittest.TestCase):
+class TestDDLCommandsPost(FrappeTestCase):
 	test_table_name = "TestNotes"
 
 	def setUp(self) -> None:
@@ -891,7 +892,7 @@ class TestDDLCommandsPost(unittest.TestCase):
 
 
 @run_only_if(db_type_is.POSTGRES)
-class TestTransactionManagement(unittest.TestCase):
+class TestTransactionManagement(FrappeTestCase):
 	def test_create_proper_transactions(self):
 		def _get_transaction_id():
 			return frappe.db.sql("select txid_current()", pluck=True)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import datetime
-import unittest
 
 import frappe
 from frappe.core.page.permission_manager.permission_manager import add, reset, update
@@ -11,12 +10,13 @@ from frappe.handler import execute_cmd
 from frappe.model.db_query import DatabaseQuery
 from frappe.permissions import add_user_permission, clear_user_permissions_for_doctype
 from frappe.query_builder import Column
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.testutils import add_custom_field, clear_custom_fields
 
 test_dependencies = ["User", "Blog Post", "Blog Category", "Blogger"]
 
 
-class TestReportview(unittest.TestCase):
+class TestReportview(FrappeTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
 

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -1,12 +1,11 @@
-import unittest
-
 import frappe
 from frappe.core.utils import find
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cstr
 
 
-class TestDBUpdate(unittest.TestCase):
+class TestDBUpdate(FrappeTestCase):
 	def test_db_update(self):
 		doctype = "User"
 		frappe.reload_doctype("User", force=True)

--- a/frappe/tests/test_defaults.py
+++ b/frappe/tests/test_defaults.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.defaults import *
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDefaults(unittest.TestCase):
+class TestDefaults(FrappeTestCase):
 	def test_global(self):
 		clear_user_default("key1")
 		set_global_default("key1", "value1")

--- a/frappe/tests/test_docstatus.py
+++ b/frappe/tests/test_docstatus.py
@@ -1,9 +1,8 @@
-import unittest
-
 from frappe.model.docstatus import DocStatus
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocStatus(unittest.TestCase):
+class TestDocStatus(FrappeTestCase):
 	def test_draft(self):
 		self.assertEqual(DocStatus(0), DocStatus.draft())
 

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
 from contextlib import contextmanager
 from datetime import timedelta
 from unittest.mock import Mock, patch
@@ -9,6 +8,7 @@ import frappe
 from frappe.app import make_form_dict
 from frappe.desk.doctype.note.note import Note
 from frappe.model.naming import make_autoname, parse_naming_series, revert_series_if_last
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cint, now_datetime, set_request
 from frappe.website.serve import get_response
 
@@ -21,7 +21,7 @@ class CustomTestNote(Note):
 		return now_datetime() - self.creation
 
 
-class TestDocument(unittest.TestCase):
+class TestDocument(FrappeTestCase):
 	def test_get_return_empty_list_for_table_field_if_none(self):
 		d = frappe.get_doc({"doctype": "User"})
 		self.assertEqual(d.get("roles"), [])
@@ -392,7 +392,7 @@ class TestDocument(unittest.TestCase):
 		self.assertEqual(todo.notify_update.call_count, 1)
 
 
-class TestDocumentWebView(unittest.TestCase):
+class TestDocumentWebView(FrappeTestCase):
 	def get(self, path, user="Guest"):
 		frappe.set_user(user)
 		set_request(method="GET", path=path)

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -290,7 +290,9 @@ class TestDocument(unittest.TestCase):
 
 		@contextmanager
 		def customize_note(with_options=False):
-			options = "frappe.utils.now_datetime() - doc.creation" if with_options else ""
+			options = (
+				"frappe.utils.now_datetime() - frappe.utils.get_datetime(doc.creation)" if with_options else ""
+			)
 			custom_field = frappe.get_doc(
 				{
 					"doctype": "Custom Field",
@@ -307,6 +309,9 @@ class TestDocument(unittest.TestCase):
 				yield custom_field.insert(ignore_if_duplicate=True)
 			finally:
 				custom_field.delete()
+				# to truly delete the field
+				# creation is commited due to DDL
+				frappe.db.commit()
 
 		with patch_note():
 			doc = frappe.get_last_doc("Note")

--- a/frappe/tests/test_document_locks.py
+++ b/frappe/tests/test_document_locks.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDocumentLocks(unittest.TestCase):
+class TestDocumentLocks(FrappeTestCase):
 	def test_locking(self):
 		todo = frappe.get_doc(dict(doctype="ToDo", description="test")).insert()
 		todo_1 = frappe.get_doc("ToDo", todo.name)

--- a/frappe/tests/test_domainification.py
+++ b/frappe/tests/test_domainification.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.doctype.domain_settings.domain_settings import get_active_modules
 from frappe.core.page.permission_manager.permission_manager import get_roles_and_doctypes
@@ -10,9 +8,10 @@ from frappe.desk.doctype.desktop_icon.desktop_icon import (
 	clear_desktop_icons_cache,
 	get_desktop_icons,
 )
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDomainification(unittest.TestCase):
+class TestDomainification(FrappeTestCase):
 	def setUp(self):
 		# create test domain
 		self.new_domain("_Test Domain 1")

--- a/frappe/tests/test_dynamic_links.py
+++ b/frappe/tests/test_dynamic_links.py
@@ -81,3 +81,4 @@ class TestDynamicLinks(unittest.TestCase):
 		unsub.delete()
 
 		clear_custom_fields("Event")
+		frappe.db.commit()  # undo changes done by DDL

--- a/frappe/tests/test_dynamic_links.py
+++ b/frappe/tests/test_dynamic_links.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDynamicLinks(unittest.TestCase):
+class TestDynamicLinks(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Email Unsubscribe")
 

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -3,15 +3,15 @@
 
 import email
 import re
-import unittest
 
 import frappe
 from frappe.email.doctype.email_account.test_email_account import TestEmailAccount
+from frappe.tests.utils import FrappeTestCase
 
 test_dependencies = ["Email Account"]
 
 
-class TestEmail(unittest.TestCase):
+class TestEmail(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Email Unsubscribe")
 		frappe.db.delete("Email Queue")
@@ -311,5 +311,7 @@ class TestEmail(unittest.TestCase):
 
 
 if __name__ == "__main__":
+	import unittest
+
 	frappe.connect()
 	unittest.main()

--- a/frappe/tests/test_exporter_fixtures.py
+++ b/frappe/tests/test_exporter_fixtures.py
@@ -1,14 +1,14 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import os
-import unittest
 
 import frappe
 import frappe.defaults
 from frappe.core.doctype.data_import.data_import import export_csv
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDataImportFixtures(unittest.TestCase):
+class TestDataImportFixtures(FrappeTestCase):
 	def setUp(self):
 		pass
 

--- a/frappe/tests/test_fixture_import.py
+++ b/frappe/tests/test_fixture_import.py
@@ -1,13 +1,13 @@
 import os
-import unittest
 
 import frappe
 from frappe.core.doctype.data_import.data_import import export_json, import_doc
 from frappe.desk.form.save import savedocs
 from frappe.model.delete_doc import delete_doc
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestFixtureImport(unittest.TestCase):
+class TestFixtureImport(FrappeTestCase):
 	def create_new_doctype(self, DocType: str) -> None:
 		file = frappe.get_app_path("frappe", "custom", "fixtures", f"{DocType}.json")
 

--- a/frappe/tests/test_fmt_datetime.py
+++ b/frappe/tests/test_fmt_datetime.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import datetime
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import (
 	format_datetime,
 	format_time,
@@ -33,7 +33,7 @@ test_time_formats = {
 }
 
 
-class TestFmtDatetime(unittest.TestCase):
+class TestFmtDatetime(FrappeTestCase):
 	"""Tests date, time and datetime formatters and some associated
 	utility functions. These rely on the system-wide date and time
 	formats.

--- a/frappe/tests/test_fmt_money.py
+++ b/frappe/tests/test_fmt_money.py
@@ -1,12 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import fmt_money
 
 
-class TestFmtMoney(unittest.TestCase):
+class TestFmtMoney(FrappeTestCase):
 	def test_standard(self):
 		frappe.db.set_default("number_format", "#,###.##")
 		self.assertEqual(fmt_money(100), "100.00")
@@ -104,5 +103,7 @@ class TestFmtMoney(unittest.TestCase):
 
 
 if __name__ == "__main__":
+	import unittest
+
 	frappe.connect()
 	unittest.main()

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -1,17 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.core.page.permission_manager.permission_manager import add, reset, update
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.desk.form.load import get_docinfo, getdoc, getdoctype
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.file_manager import save_file
 
 test_dependencies = ["Blog Category", "Blogger"]
 
 
-class TestFormLoad(unittest.TestCase):
+class TestFormLoad(FrappeTestCase):
 	def test_load(self):
 		getdoctype("DocType")
 		meta = list(filter(lambda d: d.name == "DocType", frappe.response.docs))[0]

--- a/frappe/tests/test_formatter.py
+++ b/frappe/tests/test_formatter.py
@@ -1,10 +1,9 @@
-import unittest
-
 import frappe
 from frappe import format
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestFormatter(unittest.TestCase):
+class TestFormatter(FrappeTestCase):
 	def test_currency_formatting(self):
 		df = frappe._dict({"fieldname": "amount", "fieldtype": "Currency", "options": "currency"})
 

--- a/frappe/tests/test_geo_ip.py
+++ b/frappe/tests/test_geo_ip.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestGeoIP(unittest.TestCase):
+class TestGeoIP(FrappeTestCase):
 	def test_geo_ip(self):
 		return
 		from frappe.sessions import get_geo_ip_country

--- a/frappe/tests/test_global_search.py
+++ b/frappe/tests/test_global_search.py
@@ -1,16 +1,15 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.desk.page.setup_wizard.install_fixtures import update_global_search_doctypes
 from frappe.test_runner import make_test_objects
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import global_search, now_datetime
 
 
-class TestGlobalSearch(unittest.TestCase):
+class TestGlobalSearch(FrappeTestCase):
 	def setUp(self):
 		update_global_search_doctypes()
 		global_search.setup_global_search_table()

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 from frappe.cache_manager import clear_controller_cache
 from frappe.desk.doctype.todo.todo import ToDo
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestHooks(unittest.TestCase):
+class TestHooks(FrappeTestCase):
 	def test_hooks(self):
 		hooks = frappe.get_hooks()
 		self.assertTrue(isinstance(hooks.get("app_name"), list))

--- a/frappe/tests/test_linked_with.py
+++ b/frappe/tests/test_linked_with.py
@@ -1,11 +1,10 @@
-import unittest
-
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.form import linked_with
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestLinkedWith(unittest.TestCase):
+class TestLinkedWith(FrappeTestCase):
 	def setUp(self):
 		parent_doc = new_doctype("Parent Doc")
 		parent_doc.is_submittable = 1

--- a/frappe/tests/test_listview.py
+++ b/frappe/tests/test_listview.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 
 import frappe
 from frappe.desk.listview import get_group_by_count, get_list_settings, set_list_settings
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestListView(unittest.TestCase):
+class TestListView(FrappeTestCase):
 	def setUp(self):
 		if frappe.db.exists("List View Settings", "DocType"):
 			frappe.delete_doc("List View Settings", "DocType")

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -1,10 +1,9 @@
-import unittest
-
 import frappe
 from frappe.model.utils import get_fetch_values
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestModelUtils(unittest.TestCase):
+class TestModelUtils(FrappeTestCase):
 	def test_get_fetch_values(self):
 		doctype = "ToDo"
 

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -1,16 +1,15 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 import frappe.monitor
 from frappe.monitor import MONITOR_REDIS_KEY
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.utils.response import build_response
 
 
-class TestMonitor(unittest.TestCase):
+class TestMonitor(FrappeTestCase):
 	def setUp(self):
 		frappe.conf.monitor = 1
 		frappe.cache().delete_value(MONITOR_REDIS_KEY)

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urljoin, urlparse
 
@@ -13,12 +12,13 @@ import frappe
 from frappe.integrations.oauth2 import encode_params
 from frappe.test_runner import make_test_records
 from frappe.tests.test_api import get_test_client, make_request, suppress_stdout
+from frappe.tests.utils import FrappeTestCase
 
 if TYPE_CHECKING:
 	from frappe.integrations.doctype.social_login_key.social_login_key import SocialLoginKey
 
 
-class FrappeRequestTestCase(unittest.TestCase):
+class FrappeRequestTestCase(FrappeTestCase):
 	@property
 	def sid(self) -> str:
 		if not getattr(self, "_sid", None):
@@ -57,6 +57,7 @@ class TestOAuth20(FrappeRequestTestCase):
 
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		make_test_records("User")
 
 		cls.form_header = {"content-type": "application/x-www-form-urlencoded"}

--- a/frappe/tests/test_password.py
+++ b/frappe/tests/test_password.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 from cryptography.fernet import Fernet
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.password import check_password, decrypt, encrypt, passlibctx, update_password
 
 
-class TestPassword(unittest.TestCase):
+class TestPassword(FrappeTestCase):
 	def setUp(self):
 		frappe.delete_doc("Email Account", "Test Email Account Password")
 		frappe.delete_doc("Email Account", "Test Email Account Password-new")

--- a/frappe/tests/test_patches.py
+++ b/frappe/tests/test_patches.py
@@ -1,9 +1,9 @@
-import unittest
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import frappe
 from frappe.modules import patch_handler
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_bench_path
 
 EMTPY_FILE = ""
@@ -49,7 +49,7 @@ app.module.patch4
 """
 
 
-class TestPatches(unittest.TestCase):
+class TestPatches(FrappeTestCase):
 	def test_patch_module_names(self):
 		frappe.flags.final_patches = []
 		frappe.flags.in_install = True
@@ -79,7 +79,7 @@ class TestPatches(unittest.TestCase):
 		self.assertGreaterEqual(finished_patches, len(all_patches))
 
 
-class TestPatchReader(unittest.TestCase):
+class TestPatchReader(FrappeTestCase):
 	def get_patches(self):
 		return (
 			patch_handler.get_patches_from_app("frappe"),

--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -1,15 +1,15 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import io
-import unittest
 
 from PyPDF2 import PdfReader
 
 import frappe
 import frappe.utils.pdf as pdfgen
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPdf(unittest.TestCase):
+class TestPdf(FrappeTestCase):
 	@property
 	def html(self):
 		return """<style>

--- a/frappe/tests/test_printview.py
+++ b/frappe/tests/test_printview.py
@@ -1,10 +1,9 @@
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.www.printview import get_html_and_style
 
 
-class PrintViewTest(unittest.TestCase):
+class PrintViewTest(FrappeTestCase):
 	def test_print_view_without_errors(self):
 
 		user = frappe.get_last_doc("User")

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -1,12 +1,11 @@
-import unittest
-
 import frappe
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Abs, Count, Max, Timestamp
 from frappe.tests.test_query_builder import db_type_is, run_only_if
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestQuery(unittest.TestCase):
+class TestQuery(FrappeTestCase):
 	@run_only_if(db_type_is.MARIADB)
 	def test_multiple_tables_in_filters(self):
 		self.assertEqual(

--- a/frappe/tests/test_query_builder.py
+++ b/frappe/tests/test_query_builder.py
@@ -7,6 +7,7 @@ from frappe.query_builder.builder import Function
 from frappe.query_builder.custom import ConstantColumn
 from frappe.query_builder.functions import Cast_, Coalesce, CombineDatetime, GroupConcat, Match
 from frappe.query_builder.utils import db_type_is
+from frappe.tests.utils import FrappeTestCase
 
 
 def run_only_if(dbtype: db_type_is) -> Callable:
@@ -14,7 +15,7 @@ def run_only_if(dbtype: db_type_is) -> Callable:
 
 
 @run_only_if(db_type_is.MARIADB)
-class TestCustomFunctionsMariaDB(unittest.TestCase):
+class TestCustomFunctionsMariaDB(FrappeTestCase):
 	def test_concat(self):
 		self.assertEqual("GROUP_CONCAT('Notes')", GroupConcat("Notes").get_sql())
 
@@ -84,7 +85,7 @@ class TestCustomFunctionsMariaDB(unittest.TestCase):
 
 
 @run_only_if(db_type_is.POSTGRES)
-class TestCustomFunctionsPostgres(unittest.TestCase):
+class TestCustomFunctionsPostgres(FrappeTestCase):
 	def test_concat(self):
 		self.assertEqual("STRING_AGG('Notes',',')", GroupConcat("Notes").get_sql())
 
@@ -183,7 +184,7 @@ class TestBuilderBase:
 		frappe.db.rollback()
 
 
-class TestParameterization(unittest.TestCase):
+class TestParameterization(FrappeTestCase):
 	def test_where_conditions(self):
 		DocType = frappe.qb.DocType("DocType")
 		query = frappe.qb.from_(DocType).select(DocType.name).where(DocType.owner == "Administrator' --")
@@ -276,7 +277,7 @@ class TestParameterization(unittest.TestCase):
 
 
 @run_only_if(db_type_is.MARIADB)
-class TestBuilderMaria(unittest.TestCase, TestBuilderBase):
+class TestBuilderMaria(FrappeTestCase, TestBuilderBase):
 	def test_adding_tabs_in_from(self):
 		self.assertEqual("SELECT * FROM `tabNotes`", frappe.qb.from_("Notes").select("*").get_sql())
 		self.assertEqual("SELECT * FROM `__Auth`", frappe.qb.from_("__Auth").select("*").get_sql())
@@ -289,7 +290,7 @@ class TestBuilderMaria(unittest.TestCase, TestBuilderBase):
 
 
 @run_only_if(db_type_is.POSTGRES)
-class TestBuilderPostgres(unittest.TestCase, TestBuilderBase):
+class TestBuilderPostgres(FrappeTestCase, TestBuilderBase):
 	def test_adding_tabs_in_from(self):
 		self.assertEqual('SELECT * FROM "tabNotes"', frappe.qb.from_("Notes").select("*").get_sql())
 		self.assertEqual('SELECT * FROM "__Auth"', frappe.qb.from_("__Auth").select("*").get_sql())
@@ -311,7 +312,7 @@ class TestBuilderPostgres(unittest.TestCase, TestBuilderBase):
 		self.assertEqual('SELECT * FROM "tabDocType"', qb().from_("DocType").select("*").get_sql())
 
 
-class TestMisc(unittest.TestCase):
+class TestMisc(FrappeTestCase):
 	def test_custom_func(self):
 		rand_func = frappe.qb.functions("rand", "45")
 		self.assertIsInstance(rand_func, Function)

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 import frappe.utils
 from frappe.desk.query_report import build_xlsx_data
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.xlsxutils import make_xlsx
 
 
-class TestQueryReport(unittest.TestCase):
+class TestQueryReport(FrappeTestCase):
 	def test_xlsx_data_with_multiple_datatypes(self):
 		"""Test exporting report using rows with multiple datatypes (list, dict)"""
 

--- a/frappe/tests/test_rate_limiter.py
+++ b/frappe/tests/test_rate_limiter.py
@@ -2,17 +2,17 @@
 # License: MIT. See LICENSE
 
 import time
-import unittest
 
 from werkzeug.wrappers import Response
 
 import frappe
 import frappe.rate_limiter
 from frappe.rate_limiter import RateLimiter
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cint
 
 
-class TestRateLimiter(unittest.TestCase):
+class TestRateLimiter(FrappeTestCase):
 	def setUp(self):
 		pass
 

--- a/frappe/tests/test_recorder.py
+++ b/frappe/tests/test_recorder.py
@@ -1,17 +1,16 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import sqlparse
 
 import frappe
 import frappe.recorder
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.website.serve import get_response_content
 
 
-class TestRecorder(unittest.TestCase):
+class TestRecorder(FrappeTestCase):
 	def setUp(self):
 		frappe.recorder.stop()
 		frappe.recorder.delete()

--- a/frappe/tests/test_redis.py
+++ b/frappe/tests/test_redis.py
@@ -1,9 +1,9 @@
 import functools
-import unittest
 
 import redis
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_bench_id
 from frappe.utils.background_jobs import get_redis_conn
 from frappe.utils.redis_queue import RedisQueue
@@ -28,7 +28,7 @@ def skip_if_redis_version_lt(version):
 	return decorator
 
 
-class TestRedisAuth(unittest.TestCase):
+class TestRedisAuth(FrappeTestCase):
 	@skip_if_redis_version_lt("6.0")
 	def test_rq_gen_acllist(self):
 		"""Make sure that ACL list is genrated"""

--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import os
-import unittest
 from contextlib import contextmanager, redirect_stdout
 from io import StringIO
 from random import choice, sample
@@ -18,6 +17,7 @@ from frappe.model.rename_doc import (
 	update_linked_doctypes,
 )
 from frappe.modules.utils import get_doc_path
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now
 
 
@@ -41,11 +41,12 @@ def patch_db(endpoints: list[str] = None):
 		frappe.db.rollback(save_point=savepoint)
 
 
-class TestRenameDoc(unittest.TestCase):
+class TestRenameDoc(FrappeTestCase):
 	@classmethod
 	def setUpClass(self):
 		"""Setting Up data for the tests defined under TestRenameDoc"""
 		# set developer_mode to rename doc controllers
+		super().setUpClass()
 		self._original_developer_flag = frappe.conf.developer_mode
 		frappe.conf.developer_mode = 1
 

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -1,10 +1,9 @@
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.safe_exec import get_safe_globals, safe_exec
 
 
-class TestSafeExec(unittest.TestCase):
+class TestSafeExec(FrappeTestCase):
 	def test_import_fails(self):
 		self.assertRaises(ImportError, safe_exec, "import os")
 

--- a/frappe/tests/test_scheduler.py
+++ b/frappe/tests/test_scheduler.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import frappe
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import ScheduledJobType, sync_jobs
 from frappe.utils import add_days, get_datetime
-from frappe.utils.background_jobs import enqueue
 from frappe.utils.doctor import purge_pending_jobs
 from frappe.utils.scheduler import enqueue_events, is_dormant, schedule_jobs_based_on_activity
 

--- a/frappe/tests/test_seen.py
+++ b/frappe/tests/test_seen.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestSeen(unittest.TestCase):
+class TestSeen(FrappeTestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
 

--- a/frappe/tests/test_sitemap.py
+++ b/frappe/tests/test_sitemap.py
@@ -1,10 +1,9 @@
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_html_for_route
 
 
-class TestSitemap(unittest.TestCase):
+class TestSitemap(FrappeTestCase):
 	def test_sitemap(self):
 		from frappe.test_runner import make_test_records
 

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -2,13 +2,13 @@
 # License: MIT. See LICENSE
 import os
 import textwrap
-import unittest
 from random import choices
 from unittest.mock import patch
 
 import frappe
 import frappe.translate
 from frappe import _
+from frappe.tests.utils import FrappeTestCase
 from frappe.translate import (
 	extract_javascript,
 	extract_messages_from_javascript_code,
@@ -28,7 +28,7 @@ first_lang, second_lang, third_lang, fourth_lang, fifth_lang = choices(
 )
 
 
-class TestTranslate(unittest.TestCase):
+class TestTranslate(FrappeTestCase):
 	guest_sessions_required = [
 		"test_guest_request_language_resolution_with_cookie",
 		"test_guest_request_language_resolution_with_request_header",

--- a/frappe/tests/test_twofactor.py
+++ b/frappe/tests/test_twofactor.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2017, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import time
-import unittest
 
 import pyotp
 
 import frappe
 from frappe.auth import HTTPRequest, get_login_attempt_tracker, validate_ip_address
+from frappe.tests.utils import FrappeTestCase
 from frappe.twofactor import (
 	ExpiredLoginException,
 	authenticate_for_2factor,
@@ -23,7 +23,7 @@ from frappe.utils import cint, set_request
 from . import get_system_setting, update_system_settings
 
 
-class TestTwoFactor(unittest.TestCase):
+class TestTwoFactor(FrappeTestCase):
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
 		self.default_allowed_login_attempts = get_system_setting("allow_consecutive_login_attempts")

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -5,7 +5,6 @@ import io
 import json
 import os
 import sys
-import unittest
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
@@ -84,7 +83,7 @@ class Capturing(list):
 		sys.stdout = self._stdout
 
 
-class TestFilters(unittest.TestCase):
+class TestFilters(FrappeTestCase):
 	def test_simple_dict(self):
 		self.assertTrue(evaluate_filters({"doctype": "User", "status": "Open"}, {"status": "Open"}))
 		self.assertFalse(evaluate_filters({"doctype": "User", "status": "Open"}, {"status": "Closed"}))
@@ -142,7 +141,7 @@ class TestFilters(unittest.TestCase):
 		)
 
 
-class TestMoney(unittest.TestCase):
+class TestMoney(FrappeTestCase):
 	def test_money_in_words(self):
 		nums_bhd = [
 			(5000, "BHD Five Thousand only."),
@@ -175,7 +174,7 @@ class TestMoney(unittest.TestCase):
 			)
 
 
-class TestDataManipulation(unittest.TestCase):
+class TestDataManipulation(FrappeTestCase):
 	def test_scrub_urls(self):
 		html = """
 			<p>You have a new message from: <b>John</b></p>
@@ -204,7 +203,7 @@ class TestDataManipulation(unittest.TestCase):
 		self.assertTrue('<a href="mailto:test@example.com">email</a>' in html)
 
 
-class TestFieldCasting(unittest.TestCase):
+class TestFieldCasting(FrappeTestCase):
 	def test_str_types(self):
 		STR_TYPES = (
 			"Data",
@@ -251,7 +250,7 @@ class TestFieldCasting(unittest.TestCase):
 		self.assertIsInstance(cast("Time", value="12:03:34"), timedelta)
 
 
-class TestMathUtils(unittest.TestCase):
+class TestMathUtils(FrappeTestCase):
 	def test_floor(self):
 		from decimal import Decimal
 
@@ -273,7 +272,7 @@ class TestMathUtils(unittest.TestCase):
 		self.assertEqual(ceil(Decimal(29.45)), 30)
 
 
-class TestHTMLUtils(unittest.TestCase):
+class TestHTMLUtils(FrappeTestCase):
 	def test_clean_email_html(self):
 		from frappe.utils.html_utils import clean_email_html
 
@@ -300,7 +299,7 @@ class TestHTMLUtils(unittest.TestCase):
 		self.assertNotIn("xyz", clean)
 
 
-class TestValidationUtils(unittest.TestCase):
+class TestValidationUtils(FrappeTestCase):
 	def test_valid_url(self):
 		# Edge cases
 		self.assertFalse(validate_url(""))
@@ -371,7 +370,7 @@ class TestValidationUtils(unittest.TestCase):
 			self.assertRaises(frappe.InvalidNameError, validate_name, name, True)
 
 
-class TestImage(unittest.TestCase):
+class TestImage(FrappeTestCase):
 	def test_strip_exif_data(self):
 		original_image = Image.open("../apps/frappe/frappe/tests/data/exif_sample_image.jpg")
 		original_image_content = open(
@@ -398,7 +397,7 @@ class TestImage(unittest.TestCase):
 		self.assertLess(len(optimized_content), len(original_content))
 
 
-class TestPythonExpressions(unittest.TestCase):
+class TestPythonExpressions(FrappeTestCase):
 	def test_validation_for_good_python_expression(self):
 		valid_expressions = [
 			"foo == bar",
@@ -425,9 +424,10 @@ class TestPythonExpressions(unittest.TestCase):
 			self.assertRaises(frappe.ValidationError, validate_python_code, expr)
 
 
-class TestDiffUtils(unittest.TestCase):
+class TestDiffUtils(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		cls.doc = frappe.get_doc(doctype="Client Script", dt="Client Script", name="test_client_script")
 		cls.doc.insert()
 		cls.doc.script = "2;"
@@ -466,7 +466,7 @@ class TestDiffUtils(unittest.TestCase):
 		self.assertIn("+42;", diff)
 
 
-class TestDateUtils(unittest.TestCase):
+class TestDateUtils(FrappeTestCase):
 	def test_first_day_of_week(self):
 		# Monday as start of the week
 		with patch.object(frappe.utils.data, "get_first_day_of_the_week", return_value="Monday"):
@@ -618,7 +618,7 @@ class TestDateUtils(unittest.TestCase):
 			self.assertEqual(d, add_to_date(start_date, years=idx, days=-1))
 
 
-class TestResponse(unittest.TestCase):
+class TestResponse(FrappeTestCase):
 	def test_json_handler(self):
 		class TEST(Enum):
 			ABC = "!@)@)!"
@@ -659,7 +659,7 @@ class TestResponse(unittest.TestCase):
 			json.dumps(BAD_OBJECT, default=json_handler)
 
 
-class TestTimeDeltaUtils(unittest.TestCase):
+class TestTimeDeltaUtils(FrappeTestCase):
 	def test_format_timedelta(self):
 		self.assertEqual(format_timedelta(timedelta(seconds=0)), "0:00:00")
 		self.assertEqual(format_timedelta(timedelta(hours=10)), "10:00:00")
@@ -678,7 +678,7 @@ class TestTimeDeltaUtils(unittest.TestCase):
 		self.assertEqual(parse_timedelta("7 days, 0:32:18"), timedelta(days=7, seconds=1938))
 
 
-class TestXlsxUtils(unittest.TestCase):
+class TestXlsxUtils(FrappeTestCase):
 	def test_unescape(self):
 		from frappe.utils.xlsxutils import handle_html
 
@@ -687,7 +687,7 @@ class TestXlsxUtils(unittest.TestCase):
 		self.assertEqual("abc", handle_html("abc"))
 
 
-class TestLinkTitle(unittest.TestCase):
+class TestLinkTitle(FrappeTestCase):
 	def test_link_title_doctypes_in_boot_info(self):
 		"""
 		Test that doctypes are added to link_title_map in boot_info
@@ -778,7 +778,7 @@ class TestLinkTitle(unittest.TestCase):
 		prop_setter.delete()
 
 
-class TestAppParser(unittest.TestCase):
+class TestAppParser(FrappeTestCase):
 	def test_app_name_parser(self):
 		bench_path = get_bench_path()
 		frappe_app = os.path.join(bench_path, "apps", "frappe")
@@ -789,7 +789,7 @@ class TestAppParser(unittest.TestCase):
 		self.assertEqual("healthcare", parse_app_name("frappe/healthcare@develop"))
 
 
-class TestIntrospectionMagic(unittest.TestCase):
+class TestIntrospectionMagic(FrappeTestCase):
 	"""Test utils that inspect live objects"""
 
 	def test_get_newargs(self):
@@ -815,7 +815,7 @@ class TestIntrospectionMagic(unittest.TestCase):
 		self.assertEqual(frappe.get_newargs(lambda: None, args), {})
 
 
-class TestMakeRandom(unittest.TestCase):
+class TestMakeRandom(FrappeTestCase):
 	def test_get_random(self):
 		self.assertIsInstance(get_random("DocType", doc=True), Document)
 		self.assertIsInstance(get_random("DocType"), str)
@@ -827,7 +827,7 @@ class TestMakeRandom(unittest.TestCase):
 		self.assertIsInstance(how_many("User"), int)
 
 
-class TestLazyLoader(unittest.TestCase):
+class TestLazyLoader(FrappeTestCase):
 	def test_lazy_import_module(self):
 		from frappe.utils.lazy_loader import lazy_import
 

--- a/frappe/tests/test_virtual_doctype.py
+++ b/frappe/tests/test_virtual_doctype.py
@@ -1,6 +1,5 @@
 import json
 import os
-import unittest
 from unittest.mock import patch
 
 import frappe
@@ -8,6 +7,7 @@ import frappe.modules.utils
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.form.save import savedocs
 from frappe.model.document import Document
+from frappe.tests.utils import FrappeTestCase
 
 TEST_DOCTYPE_NAME = "VirtualDoctypeTest"
 
@@ -80,7 +80,7 @@ class VirtualDoctypeTest(Document):
 		return {}
 
 
-class TestVirtualDoctypes(unittest.TestCase):
+class TestVirtualDoctypes(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
 		frappe.flags.allow_doctype_export = True

--- a/frappe/tests/test_webform.py
+++ b/frappe/tests/test_webform.py
@@ -1,12 +1,11 @@
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.website.serve import get_response
 from frappe.www.list import get_list_context
 
 
-class TestWebform(unittest.TestCase):
+class TestWebform(FrappeTestCase):
 	def test_webform_publish_functionality(self):
 		request_data = frappe.get_doc("Web Form", "request-data")
 		# publish webform

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -1,14 +1,14 @@
-import unittest
 from unittest.mock import patch
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.website.page_renderers.static_page import StaticPage
 from frappe.website.serve import get_response, get_response_content
 from frappe.website.utils import build_response, clear_website_cache, get_home_page
 
 
-class TestWebsite(unittest.TestCase):
+class TestWebsite(FrappeTestCase):
 	def setUp(self):
 		frappe.set_user("Guest")
 

--- a/frappe/tests/tests_geo_utils.py
+++ b/frappe/tests/tests_geo_utils.py
@@ -1,13 +1,12 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
-import unittest
-
 import frappe
 from frappe.geo.utils import get_coords
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestGeoUtils(unittest.TestCase):
+class TestGeoUtils(FrappeTestCase):
 	def setUp(self):
 		self.todo = frappe.get_doc(
 			dict(doctype="ToDo", description="Test description", assigned_by="Administrator")

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -12,7 +12,12 @@ datetime_like_types = (datetime.datetime, datetime.date, datetime.time, datetime
 
 
 class FrappeTestCase(unittest.TestCase):
-	"""Base test class for Frappe tests."""
+	"""Base test class for Frappe tests.
+
+
+	If you specify `setUpClass` then make sure to call `super().setUpClass`
+	otherwise this class will become ineffective.
+	"""
 
 	SHOW_TRANSACTION_COMMIT_WARNINGS = False
 

--- a/frappe/website/doctype/about_us_settings/test_about_us_settings.py
+++ b/frappe/website/doctype/about_us_settings/test_about_us_settings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestAboutUsSettings(unittest.TestCase):
+class TestAboutUsSettings(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/blog_category/test_blog_category.py
+++ b/frappe/website/doctype/blog_category/test_blog_category.py
@@ -1,9 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestBlogCategory(unittest.TestCase):
+class TestBlogCategory(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/blog_settings/test_blog_settings.py
+++ b/frappe/website/doctype/blog_settings/test_blog_settings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestBlogSettings(unittest.TestCase):
+class TestBlogSettings(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/color/test_color.py
+++ b/frappe/website/doctype/color/test_color.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestColor(unittest.TestCase):
+class TestColor(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/discussion_reply/test_discussion_reply.py
+++ b/frappe/website/doctype/discussion_reply/test_discussion_reply.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDiscussionReply(unittest.TestCase):
+class TestDiscussionReply(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/discussion_topic/test_discussion_topic.py
+++ b/frappe/website/doctype/discussion_topic/test_discussion_topic.py
@@ -2,8 +2,8 @@
 # See license.txt
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestDiscussionTopic(unittest.TestCase):
+class TestDiscussionTopic(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/help_article/test_help_article.py
+++ b/frappe/website/doctype/help_article/test_help_article.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Help Article')
 
 
-class TestHelpArticle(unittest.TestCase):
+class TestHelpArticle(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/help_category/test_help_category.py
+++ b/frappe/website/doctype/help_category/test_help_category.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Help Category')
 
 
-class TestHelpCategory(unittest.TestCase):
+class TestHelpCategory(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -128,7 +128,6 @@ class PersonalDataDeletionRequest(Document):
 				"host_name": frappe.utils.get_url(),
 			},
 			header=[_("Your account has been deleted"), "green"],
-			now=True,
 		)
 
 	def add_deletion_steps(self):

--- a/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
 from datetime import datetime, timedelta
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.website.doctype.personal_data_deletion_request.personal_data_deletion_request import (
 	process_data_deletion_request,
 	remove_unverified_record,
@@ -13,7 +13,7 @@ from frappe.website.doctype.personal_data_download_request.test_personal_data_do
 )
 
 
-class TestPersonalDataDeletionRequest(unittest.TestCase):
+class TestPersonalDataDeletionRequest(FrappeTestCase):
 	def setUp(self):
 		create_user_if_not_exists(email="test_delete@example.com")
 		self.delete_request = frappe.get_doc(

--- a/frappe/website/doctype/portal_settings/test_portal_settings.py
+++ b/frappe/website/doctype/portal_settings/test_portal_settings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestPortalSettings(unittest.TestCase):
+class TestPortalSettings(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import json
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.website.doctype.web_form.web_form import accept
 from frappe.website.serve import get_response_content
@@ -11,7 +11,7 @@ from frappe.website.serve import get_response_content
 test_dependencies = ["Web Form"]
 
 
-class TestWebForm(unittest.TestCase):
+class TestWebForm(FrappeTestCase):
 	def setUp(self):
 		frappe.conf.disable_website_cache = True
 		frappe.local.path = None

--- a/frappe/website/doctype/web_page/test_web_page.py
+++ b/frappe/website/doctype/web_page/test_web_page.py
@@ -1,13 +1,12 @@
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.website.path_resolver import PathResolver
 from frappe.website.serve import get_response_content
 
 test_records = frappe.get_test_records("Web Page")
 
 
-class TestWebPage(unittest.TestCase):
+class TestWebPage(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Web Page")
 		for t in test_records:

--- a/frappe/website/doctype/web_page_view/test_web_page_view.py
+++ b/frappe/website/doctype/web_page_view/test_web_page_view.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestWebPageView(unittest.TestCase):
+class TestWebPageView(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/web_template/test_web_template.py
+++ b/frappe/website/doctype/web_template/test_web_template.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 from bs4 import BeautifulSoup
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.website.serve import get_response
 
 
-class TestWebTemplate(unittest.TestCase):
+class TestWebTemplate(FrappeTestCase):
 	def test_render_web_template_with_values(self):
 		doc = frappe.get_doc("Web Template", "Hero with Right Image")
 		values = {

--- a/frappe/website/doctype/web_template_field/test_web_template_field.py
+++ b/frappe/website/doctype/web_template_field/test_web_template_field.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestWebTemplateField(unittest.TestCase):
+class TestWebTemplateField(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/website_route_meta/test_website_route_meta.py
+++ b/frappe/website/doctype/website_route_meta/test_website_route_meta.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2019, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import set_request
 from frappe.website.serve import get_response
 
 test_dependencies = ["Blog Post"]
 
 
-class TestWebsiteRouteMeta(unittest.TestCase):
+class TestWebsiteRouteMeta(FrappeTestCase):
 	def test_meta_tag_generation(self):
 		blogs = frappe.get_all(
 			"Blog Post", fields=["name", "route"], filters={"published": 1, "route": ("!=", "")}, limit=1

--- a/frappe/website/doctype/website_settings/test_website_settings.py
+++ b/frappe/website/doctype/website_settings/test_website_settings.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestWebsiteSettings(unittest.TestCase):
+class TestWebsiteSettings(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/website_sidebar/test_website_sidebar.py
+++ b/frappe/website/doctype/website_sidebar/test_website_sidebar.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Website Sidebar')
 
 
-class TestWebsiteSidebar(unittest.TestCase):
+class TestWebsiteSidebar(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/website_slideshow/test_website_slideshow.py
+++ b/frappe/website/doctype/website_slideshow/test_website_slideshow.py
@@ -1,11 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 # test_records = frappe.get_test_records('Website Slideshow')
 
 
-class TestWebsiteSlideshow(unittest.TestCase):
+class TestWebsiteSlideshow(FrappeTestCase):
 	pass

--- a/frappe/website/doctype/website_theme/test_website_theme.py
+++ b/frappe/website/doctype/website_theme/test_website_theme.py
@@ -2,14 +2,14 @@
 # License: MIT. See LICENSE
 
 import os
-import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
 from .website_theme import get_scss_paths
 
 
-class TestWebsiteTheme(unittest.TestCase):
+class TestWebsiteTheme(FrappeTestCase):
 	def test_website_theme(self):
 		frappe.delete_doc_if_exists("Website Theme", "test-theme")
 		theme = frappe.get_doc(

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import unittest
-
 import frappe
 from frappe.model.workflow import (
 	WorkflowPermissionError,
@@ -11,12 +9,14 @@ from frappe.model.workflow import (
 )
 from frappe.query_builder import DocType
 from frappe.test_runner import make_test_records
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import random_string
 
 
-class TestWorkflow(unittest.TestCase):
+class TestWorkflow(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
+		super().setUpClass()
 		make_test_records("User")
 
 	def setUp(self):

--- a/frappe/workflow/doctype/workflow_action/test_workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/test_workflow_action.py
@@ -2,8 +2,8 @@
 # License: MIT. See LICENSE
 
 # import frappe
-import unittest
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestWorkflowAction(unittest.TestCase):
+class TestWorkflowAction(FrappeTestCase):
 	pass


### PR DESCRIPTION
- Replace all TestCases with FrappeTestCase to reduce flake and wipe state after test has completed. 
- Note: This doesn't help much where DDL is used, it's better than nothing though.



What I did:

- Replace all imports `sed -i  's/^import unittest$/from frappe.tests.utils import FrappeTestCase/g' **/*.py`
- Replace class defs `sed -i  's/unittest.TestCase/FrappeTestCase/g' **/*.py`
- Re-add missing imports for unittest
- Add missing  `super().setUpClass()` calls