### PR TITLE
build!: Bump minimum Python version to 3.10

### DIFF
--- a/.github/workflows/deps-checker.yml
+++ b/.github/workflows/deps-checker.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - uses: actions/checkout@v3
       - run: pip install pip-audit
       - run: pip-audit ${GITHUB_WORKSPACE}

--- a/.github/workflows/docs-checker.yml
+++ b/.github/workflows/docs-checker.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 'Setup Environment'
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: 'Clone repo'
         uses: actions/checkout@v3

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -31,9 +31,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: "gabrielfalcao/pyenv-action@v9"
         with:
-          python-version: '3.10'
+          versions: 3.10:latest, 3.7:latest, 2.7:latest
+          command: pyenv local 3.10
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -120,15 +121,23 @@ jobs:
           for version in $(seq 12 13)
           do
               echo "Updating to v$version"
+              if [ $version == 12 ]; then
+                pyenv local 2.7
+              elif [ $version == 13 ]; then
+                pyenv local 3.7
+              fi
               branch_name="version-$version-hotfix"
               git fetch --depth 1 upstream $branch_name:$branch_name
-
               git checkout -q -f $branch_name
-              bench setup requirements --python
+
+              rm -rf ~/frappe-bench/env
+              bench setup env
               bench --site test_site migrate
           done
 
           echo "Updating to last commit"
           git checkout -q -f "$GITHUB_SHA"
-          bench setup requirements --python
+          pyenv local 3.10
+          rm -rf ~/frappe-bench/env
+          bench setup env
           bench --site test_site migrate

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/publish-assets-develop.yml
+++ b/.github/workflows/publish-assets-develop.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: 14
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Set up bench and build assets
         run: |
           npm install -g yarn

--- a/.github/workflows/publish-assets-releases.yml
+++ b/.github/workflows/publish-assets-releases.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: '12.x'
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Set up bench and build assets
         run: |
           npm install -g yarn

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Check if build should be run
         id: check-build

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Check if build should be run
         id: check-build

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
 
       - name: Check if build should be run
         id: check-build

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -478,7 +478,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: '3.10'
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "developers@frappe.io"}
 ]
 description = "Metadata driven, full-stack low code web framework"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
| Frappe/ERPNext Contributors | @frappetech Engineering Team |
|-|-|
| ![image](https://user-images.githubusercontent.com/36654812/176449198-a2773e0e-120f-4b6c-a762-2ffaf4d943e5.png) | ![Screenshot from 2022-06-29 19-02-45](https://user-images.githubusercontent.com/36654812/176449231-e339bcab-e94e-4d28-86d4-d538319a5fb8.png) |

Given how widespread PY310's usage has become, and how we're just a
few months away from the PY311 major release. This is a slightly late
bumping but **necessary to ensure smoother updates & maintenance for**
Frappe v14, ERPNext & other apps in the coming years. Almost all people
who participated in the pool from the community, as well as the Frappe team,
voted (via active telegram groups) PY310 as their preferred minimum
requirement for v14.
