### PR TITLE
fix: correctly fetch list of users with role

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -67,7 +67,10 @@ class Role(Document):
 def get_info_based_on_role(role, field="email"):
 	"""Get information of all users that have been assigned this role"""
 	users = frappe.get_list(
-		"Has Role", filters={"role": role}, parent_doctype="User", fields=["parent as user_name"]
+		"Has Role",
+		filters={"role": role, "parenttype": "User"},
+		parent_doctype="User",
+		fields=["parent as user_name"],
 	)
 
 	return get_user_info(users, field)

--- a/frappe/core/doctype/role/test_role.py
+++ b/frappe/core/doctype/role/test_role.py
@@ -3,6 +3,7 @@
 import unittest
 
 import frappe
+from frappe.core.doctype.role.role import get_info_based_on_role
 
 test_records = frappe.get_test_records("Role")
 
@@ -43,3 +44,11 @@ class TestUser(unittest.TestCase):
 		role.save()
 		user.reload()
 		self.assertTrue(user.user_type == "Website User")
+
+	def test_get_users_by_role(self):
+
+		role = "System Manager"
+		sys_managers = get_info_based_on_role(role, field="name")
+
+		for user in sys_managers:
+			self.assertIn(role, frappe.get_roles(user))


### PR DESCRIPTION
`HasRole` table is attached to many doctypes, only User should be filtered out.

caused by https://github.com/frappe/frappe/pull/16211

```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/email/doctype/notification/notification.py", line 140, in send
    self.create_system_notification(doc, context)
      self = <Notification: test quote>
      doc = <Quotation: SAL-QTN-2022-00034 docstatus=1>
      context = {'doc': <Quotation: SAL-QTN-2022-00034 docstatus=1>, 'alert': <Notification: test quote>, 'comments': None}
  File "apps/frappe/frappe/email/doctype/notification/notification.py", line 179, in create_system_notification
    recipients, cc, bcc = self.get_list_of_recipients(doc, context)
      self = <Notification: test quote>
      doc = <Quotation: SAL-QTN-2022-00034 docstatus=1>
      context = {'doc': <Quotation: SAL-QTN-2022-00034 docstatus=1>, 'alert': <Notification: test quote>, 'comments': None}
      subject = 'Customer Quotation PPID notification: SAL-QTN-2022-00034'
      attachments = None
  File "apps/frappe/frappe/email/doctype/notification/notification.py", line 300, in get_list_of_recipients
    emails = get_info_based_on_role(recipient.receiver_by_role, "email")
      self = <Notification: test quote>
      doc = <Quotation: SAL-QTN-2022-00034 docstatus=1>
      context = {'doc': <Quotation: SAL-QTN-2022-00034 docstatus=1>, 'alert': <Notification: test quote>, 'comments': None}
      recipients = []
      cc = []
      bcc = []
      recipient = <NotificationRecipient: ae75135b21 parent=test quote>
  File "apps/frappe/frappe/core/doctype/role/role.py", line 73, in get_info_based_on_role
    return get_user_info(users, field)
      role = 'System Manager'
      field = 'email'
      users = [{'user_name': 'Administrator'}, {'user_name': 'frappe@example.com'}, {'user_name': 'test_employee_exotel@company.com'}, {'user_name': 'shopify-import-products'}, {'user_name': 'test_link_validation@example.com'}, {'user_name': 'test@example.com'}, {'user_name': 'test1@example.com'}, {'user_name': 'Test report'}, {'user_name': 'test@admin.com'}, {'user_name': 'Loan Interest Report'}, {'user_name': 'Applicant-Wise Loan Security Exposure'}, {'user_name': 'Loan Security Status'}, {'user_name': 'Loan Security Exposure'}, {'user_name': 'Loan Repayment and Closure'}, {'user_name': 'Review'}, {'user_name': 'IRS 1099'}, {'user_name': 'KSA VAT'}, {'user_name': 'Asset Maintenance'}, {'user_name': 'YouTube Interactions'}, {'user_name': 'Support Hour Distribution'}, {'user_name': 'Stock Ledger Invariant Check'}, {'user_name': 'Cost of Poor Quality Report'}, {'user_name': 'Downtime Analysis'}, {'user_name': 'bom-comparison-tool'}, {'user_name': 'Monthly Attendance Sheet'}, {'user_name': 'Employee E...
  File "apps/frappe/frappe/core/doctype/role/role.py", line 80, in get_user_info
    user_info, enabled = frappe.db.get_value("User", user.get("user_name"), [field, "enabled"])
      users = [{'user_name': 'Administrator'}, {'user_name': 'frappe@example.com'}, {'user_name': 'test_employee_exotel@company.com'}, {'user_name': 'shopify-import-products'}, {'user_name': 'test_link_validation@example.com'}, {'user_name': 'test@example.com'}, {'user_name': 'test1@example.com'}, {'user_name': 'Test report'}, {'user_name': 'test@admin.com'}, {'user_name': 'Loan Interest Report'}, {'user_name': 'Applicant-Wise Loan Security Exposure'}, {'user_name': 'Loan Security Status'}, {'user_name': 'Loan Security Exposure'}, {'user_name': 'Loan Repayment and Closure'}, {'user_name': 'Review'}, {'user_name': 'IRS 1099'}, {'user_name': 'KSA VAT'}, {'user_name': 'Asset Maintenance'}, {'user_name': 'YouTube Interactions'}, {'user_name': 'Support Hour Distribution'}, {'user_name': 'Stock Ledger Invariant Check'}, {'user_name': 'Cost of Poor Quality Report'}, {'user_name': 'Downtime Analysis'}, {'user_name': 'bom-comparison-tool'}, {'user_name': 'Monthly Attendance Sheet'}, {'user_name': 'Employee E...
      field = 'email'
      info_list = ['frappe@example.com', 'test_employee_exotel@company.com']
      user = {'user_name': 'shopify-import-products'}
      user_info = 'test_employee_exotel@company.com'
      enabled = 1
builtins.TypeError: cannot unpack non-iterable NoneType object
```


