### PR TITLE
ci: force modern python with pyupgrade

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -22,3 +22,6 @@ b2fc959307c7c79f5584625569d5aed04133ba13
 
 # Format codebase and sort imports
 c0c5b2ebdddbe8898ce2d5e5365f4931ff73b6bf
+
+# update python code to use 3.10 supported features
+81b37cb7d2160866afa2496873656afe53f0c145

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
         files: "frappe.*"
@@ -15,6 +15,16 @@ repos:
         args: ['--branch', 'develop']
       - id: check-merge-conflict
       - id: check-ast
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.34.0
+    hooks:
+      - id: pyupgrade
+        args: ['--py310-plus']
 
   - repo: https://github.com/adityahase/black
     rev: 9cb0a69f4d0030cdf687eddf314468b39ed54119
@@ -31,9 +41,7 @@ repos:
     rev: 3.9.2
     hooks:
       - id: flake8
-        additional_dependencies: [
-          'flake8-bugbear',
-        ]
+        additional_dependencies: ['flake8-bugbear',]
         args: ['--config', '.github/helper/flake8.conf']
 
 ci:


### PR DESCRIPTION
- also add previous bulk change to git-blame-ignore-revs
- also add more checks to prevent typical gotchas (JSON, toml, yaml syntax checker)