### PR TITLE
fix: only commit in email queue if is_background_task

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -276,7 +276,6 @@ def subscribe(email, email_group=_("Website")):  # noqa
 		email,
 		subject=email_subject,
 		content=content,
-		now=True,
 	)
 
 

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -128,7 +128,6 @@ class PersonalDataDeletionRequest(Document):
 				"host_name": frappe.utils.get_url(),
 			},
 			header=[_("Your account has been deleted"), "green"],
-			now=True,
 		)
 
 	def add_deletion_steps(self):


### PR DESCRIPTION
If `sendmail(now=True)` is performed from outside of scheduler then commiting will commit partial state.




Only found two instances of `sendmail(now=True)` both don't seem valid 👀 


`semgrep  -lpython -e 'frappe.sendmail(..., now=True, ...)'`