### PR TITLE
fix: calendar view set in assign time

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/assign_to.js
+++ b/frappe/public/js/frappe/form/sidebar/assign_to.js
@@ -165,15 +165,7 @@ frappe.ui.form.AssignToDialog = class AssignToDialog {
 				}
 			},
 			{
-				label: __("Comment"),
-				fieldtype: 'Small Text',
-				fieldname: 'description'
-			},
-			{
 				fieldtype: 'Section Break'
-			},
-			{
-				fieldtype: 'Column Break'
 			},
 			{
 				label: __("Complete By"),
@@ -203,6 +195,14 @@ frappe.ui.form.AssignToDialog = class AssignToDialog {
 				],
 				// Pick up priority from the source document, if it exists and is available in ToDo
 				default: ["Low", "Medium", "High"].includes(me.frm && me.frm.doc.priority ? me.frm.doc.priority : 'Medium')
+			},
+			{
+				fieldtype: 'Section Break'
+			},
+			{
+				label: __("Comment"),
+				fieldtype: 'Small Text',
+				fieldname: 'description'
 			}
 		];
 	}


### PR DESCRIPTION
**`Version`**
ERPNext: v14.0.0-develop
Frappe Framework: v14.x.x-develop

- Please also update version 13

**Before:**

- When assign click from any doctype then calendar view does not show proper.

https://user-images.githubusercontent.com/99652762/176854933-82003525-693f-4d74-9d15-6dcd184f9cea.mp4

**After:**

- After developing the file like assign_to.js, the calendar view does show properly.
- Changes like Complete By (date) and Priority (priority) section set above in the comment section.


https://user-images.githubusercontent.com/99652762/176855945-f851216f-f50f-49e1-ab2e-10a1685aecba.mp4


If convenient for the changes then go ahead with the process.


Thank You!