### PR TITLE
refactor: Email Domain

### DIFF
--- a/frappe/email/doctype/email_domain/email_domain.js
+++ b/frappe/email/doctype/email_domain/email_domain.js
@@ -1,5 +1,3 @@
 frappe.ui.form.on("Email Domain", {
-	email_id: function (frm){
-		frm.set_value("domain_name",frm.doc.email_id.split("@")[1])
-	},
+
 })

--- a/frappe/email/doctype/email_domain/email_domain.js
+++ b/frappe/email/doctype/email_domain/email_domain.js
@@ -4,6 +4,17 @@ frappe.ui.form.on("Email Domain", {
 			frm.dashboard.clear_headline();
 			let msg = __("Changing any setting will reflect on all the email accounts associated with this domain.");
 			frm.dashboard.set_headline_alert(msg);
+		} else {
+			if (!frm.doc.attachment_limit) {
+				frappe.call({
+					method: "frappe.core.api.file.get_max_file_size",
+					callback: function(r) {
+						if (!r.exc) {
+							frm.set_value("attachment_limit", Number(r.message)/(1024*1024));
+						}
+					},
+				});
+			}
 		}
 	}
 })

--- a/frappe/email/doctype/email_domain/email_domain.js
+++ b/frappe/email/doctype/email_domain/email_domain.js
@@ -1,28 +1,5 @@
 frappe.ui.form.on("Email Domain", {
-	email_id: function (frm) {
-		frm.set_value("domain_name", frm.doc.email_id.split("@")[1]);
+	email_id: function (frm){
+		frm.set_value("domain_name",frm.doc.email_id.split("@")[1])
 	},
-
-	refresh: function (frm) {
-		if (frm.doc.email_id) {
-			frm.set_value("domain_name", frm.doc.email_id.split("@")[1]);
-		}
-
-		if (frm.doc.__islocal != 1 && frappe.route_flags.return_to_email_account) {
-			var route = frappe.get_prev_route();
-			delete frappe.route_flags.return_to_email_account;
-			frappe.route_flags.set_domain_values = true;
-
-			(frappe.route_options = {
-				domain: frm.doc.name,
-				use_imap: frm.doc.use_imap,
-				email_server: frm.doc.email_server,
-				use_ssl: frm.doc.use_ssl,
-				smtp_server: frm.doc.smtp_server,
-				use_tls: frm.doc.use_tls,
-				smtp_port: frm.doc.smtp_port,
-			}),
-				frappe.set_route(route);
-		}
-	},
-});
+})

--- a/frappe/email/doctype/email_domain/email_domain.js
+++ b/frappe/email/doctype/email_domain/email_domain.js
@@ -1,20 +1,22 @@
 frappe.ui.form.on("Email Domain", {
-	onload: function(frm) {
+	onload: function (frm) {
 		if (!frm.doc.__islocal) {
 			frm.dashboard.clear_headline();
-			let msg = __("Changing any setting will reflect on all the email accounts associated with this domain.");
+			let msg = __(
+				"Changing any setting will reflect on all the email accounts associated with this domain."
+			);
 			frm.dashboard.set_headline_alert(msg);
 		} else {
 			if (!frm.doc.attachment_limit) {
 				frappe.call({
 					method: "frappe.core.api.file.get_max_file_size",
-					callback: function(r) {
+					callback: function (r) {
 						if (!r.exc) {
-							frm.set_value("attachment_limit", Number(r.message)/(1024*1024));
+							frm.set_value("attachment_limit", Number(r.message) / (1024 * 1024));
 						}
 					},
 				});
 			}
 		}
-	}
-})
+	},
+});

--- a/frappe/email/doctype/email_domain/email_domain.js
+++ b/frappe/email/doctype/email_domain/email_domain.js
@@ -1,3 +1,9 @@
 frappe.ui.form.on("Email Domain", {
-
+	onload: function(frm) {
+		if (!frm.doc.__islocal) {
+			frm.dashboard.clear_headline();
+			let msg = __("Changing any setting will reflect on all the email accounts associated with this domain.");
+			frm.dashboard.set_headline_alert(msg);
+		}
+	}
 })

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -7,8 +7,6 @@
  "engine": "InnoDB",
  "field_order": [
   "email_settings",
-  "email_id",
-  "column_break_3",
   "domain_name",
   "mailbox_settings",
   "email_server",
@@ -32,18 +30,12 @@
    "fieldtype": "Section Break"
   },
   {
+   "description": "For example: for the email address <b>abcd@gmail.com</b>, the domain is <b>gmail.com</b>",
    "fieldname": "domain_name",
    "fieldtype": "Data",
    "label": "Domain Name",
    "reqd": 1,
    "unique": 1
-  },
-  {
-   "fieldname": "email_id",
-   "fieldtype": "Data",
-   "label": "Example Email Address",
-   "options": "Email",
-   "reqd": 1
   },
   {
    "fieldname": "mailbox_settings",
@@ -128,10 +120,6 @@
    "label": "Use SSL for Outgoing"
   },
   {
-   "fieldname": "column_break_3",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "column_break_9",
    "fieldtype": "Column Break"
   },
@@ -142,7 +130,7 @@
  ],
  "icon": "icon-inbox",
  "links": [],
- "modified": "2022-07-02 20:13:33.516564",
+ "modified": "2022-07-02 20:35:36.199633",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Domain",

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -61,7 +61,6 @@
    "label": "Use SSL"
   },
   {
-   "default": "1",
    "description": "Ignore attachments over this size",
    "fieldname": "attachment_limit",
    "fieldtype": "Int",

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -128,8 +128,13 @@
   }
  ],
  "icon": "icon-inbox",
- "links": [],
- "modified": "2022-07-14 11:37:55.873948",
+ "links": [
+  {
+   "link_doctype": "Email Account",
+   "link_fieldname": "domain"
+  }
+ ],
+ "modified": "2022-07-14 13:01:48.719727",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Domain",

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -7,12 +7,14 @@
  "engine": "InnoDB",
  "field_order": [
   "email_settings",
-  "domain_name",
   "email_id",
+  "column_break_3",
+  "domain_name",
   "mailbox_settings",
   "email_server",
   "use_imap",
   "use_ssl",
+  "column_break_9",
   "incoming_port",
   "attachment_limit",
   "append_to",
@@ -20,6 +22,7 @@
   "smtp_server",
   "use_tls",
   "use_ssl_for_outgoing",
+  "column_break_18",
   "append_emails_to_sent_folder",
   "smtp_port"
  ],
@@ -31,8 +34,8 @@
   {
    "fieldname": "domain_name",
    "fieldtype": "Data",
-   "label": "domain name",
-   "read_only": 1,
+   "label": "Domain Name",
+   "reqd": 1,
    "unique": 1
   },
   {
@@ -44,7 +47,8 @@
   },
   {
    "fieldname": "mailbox_settings",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Incoming Settings"
   },
   {
    "description": "e.g. pop.gmail.com / imap.gmail.com",
@@ -83,7 +87,8 @@
   },
   {
    "fieldname": "outgoing_mail_settings",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Outgoing Settings"
   },
   {
    "description": "e.g. smtp.gmail.com",
@@ -121,14 +126,27 @@
    "fieldname": "use_ssl_for_outgoing",
    "fieldtype": "Check",
    "label": "Use SSL for Outgoing"
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_18",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "icon-inbox",
  "links": [],
- "modified": "2019-12-18 15:57:34.445308",
+ "modified": "2022-07-02 20:13:33.516564",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Domain",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -142,5 +160,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
 }

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -21,8 +21,8 @@
   "use_tls",
   "use_ssl_for_outgoing",
   "column_break_18",
-  "append_emails_to_sent_folder",
-  "smtp_port"
+  "smtp_port",
+  "append_emails_to_sent_folder"
  ],
  "fields": [
   {
@@ -30,7 +30,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "description": "For example: for the email address <b>abcd@gmail.com</b>, the domain is <b>gmail.com</b>",
    "fieldname": "domain_name",
    "fieldtype": "Data",
    "label": "Domain Name",
@@ -46,7 +45,7 @@
    "description": "e.g. pop.gmail.com / imap.gmail.com",
    "fieldname": "email_server",
    "fieldtype": "Data",
-   "label": "Email Server",
+   "label": "Incoming Server",
    "reqd": 1
   },
   {
@@ -86,7 +85,7 @@
    "description": "e.g. smtp.gmail.com",
    "fieldname": "smtp_server",
    "fieldtype": "Data",
-   "label": "SMTP Server",
+   "label": "Outgoing Server",
    "reqd": 1
   },
   {
@@ -117,7 +116,7 @@
    "default": "0",
    "fieldname": "use_ssl_for_outgoing",
    "fieldtype": "Check",
-   "label": "Use SSL for Outgoing"
+   "label": "Use SSL"
   },
   {
    "fieldname": "column_break_9",
@@ -130,7 +129,7 @@
  ],
  "icon": "icon-inbox",
  "links": [],
- "modified": "2022-07-02 20:35:36.199633",
+ "modified": "2022-07-14 11:37:55.873948",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Domain",

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -1,94 +1,27 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and contributors
 # License: MIT. See LICENSE
 
-import imaplib
-import poplib
 import smtplib
 
 import frappe
 from frappe import _
+from frappe.email.receive import Timed_IMAP4, Timed_IMAP4_SSL, Timed_POP3, Timed_POP3_SSL
 from frappe.email.utils import get_port
 from frappe.model.document import Document
-from frappe.utils import cint, cstr
+from frappe.utils import cint
 
 
 class EmailDomain(Document):
 	def validate(self):
 		"""Validate email id and check POP3/IMAP and SMTP connections is enabled."""
-		logger = frappe.logger()
 
 		if frappe.local.flags.in_patch or frappe.local.flags.in_test:
 			return
 
 		if not frappe.local.flags.in_install and not frappe.local.flags.in_patch:
-			try:
-				if self.use_imap:
-					logger.info(
-						"Checking incoming IMAP email server {host}:{port} ssl={ssl}...".format(
-							host=self.email_server, port=get_port(self), ssl=self.use_ssl
-						)
-					)
-					if self.use_ssl:
-						test = imaplib.IMAP4_SSL(self.email_server, port=get_port(self))
-					else:
-						test = imaplib.IMAP4(self.email_server, port=get_port(self))
-
-				else:
-					logger.info(
-						"Checking incoming POP3 email server {host}:{port} ssl={ssl}...".format(
-							host=self.email_server, port=get_port(self), ssl=self.use_ssl
-						)
-					)
-					if self.use_ssl:
-						test = poplib.POP3_SSL(self.email_server, port=get_port(self))
-					else:
-						test = poplib.POP3(self.email_server, port=get_port(self))
-
-			except Exception as e:
-				logger.warn(f'Incoming email account "{self.email_server}" not correct', exc_info=e)
-				frappe.throw(
-					title=_("Incoming email account not correct"),
-					msg=f'Error connecting IMAP/POP3 "{self.email_server}": {e}',
-				)
-
-			finally:
-				try:
-					if self.use_imap:
-						test.logout()
-					else:
-						test.quit()
-				except Exception:
-					pass
-
-			try:
-				if self.get("use_ssl_for_outgoing"):
-					if not self.get("smtp_port"):
-						self.smtp_port = 465
-
-					logger.info(
-						"Checking outgoing SMTPS email server {host}:{port}...".format(
-							host=self.smtp_server, port=self.smtp_port
-						)
-					)
-					sess = smtplib.SMTP_SSL(
-						(self.smtp_server or "").encode("utf-8"), cint(self.smtp_port) or None
-					)
-				else:
-					if self.use_tls and not self.smtp_port:
-						self.smtp_port = 587
-					logger.info(
-						"Checking outgoing SMTP email server {host}:{port} STARTTLS={tls}...".format(
-							host=self.smtp_server, port=self.get("smtp_port"), tls=self.use_tls
-						)
-					)
-					sess = smtplib.SMTP(cstr(self.smtp_server or ""), cint(self.smtp_port) or None)
-				sess.quit()
-			except Exception as e:
-				logger.warn(f'Outgoing email account "{self.smtp_server}" not correct', exc_info=e)
-				frappe.throw(
-					title=_("Outgoing email account not correct"),
-					msg=f'Error connecting SMTP "{self.smtp_server}": {e}',
-				)
+			self.logger = frappe.logger()
+			self.validate_incoming_server_conn()
+			self.validate_outgoing_server_conn()
 
 	def on_update(self):
 		"""update all email accounts using this domain"""
@@ -114,3 +47,66 @@ class EmailDomain(Document):
 				frappe.msgprint(
 					_("Error has occurred in {0}").format(email_account.name), raise_exception=e.__class__
 				)
+
+	def validate_incoming_server_conn(self):
+		self.incoming_port = get_port(self)
+
+		try:
+			if self.use_imap:
+				self.logger.info(
+					"Checking incoming IMAP email server {host}:{port} ssl={ssl}...".format(
+						host=self.email_server, port=self.incoming_port, ssl=self.use_ssl
+					)
+				)
+
+				smtp_method = Timed_IMAP4_SSL if self.use_ssl else Timed_IMAP4
+				incoming_server = smtp_method(self.email_server, port=self.incoming_port)
+				incoming_server.logout()
+			else:
+				self.logger.info(
+					"Checking incoming POP3 email server {host}:{port} ssl={ssl}...".format(
+						host=self.email_server, port=self.incoming_port, ssl=self.use_ssl
+					)
+				)
+
+				pop_method = Timed_POP3_SSL if self.use_ssl else Timed_POP3
+				incoming_server = pop_method(self.email_server, port=self.incoming_port)
+				incoming_server.quit()
+		except Exception as e:
+			self.logger.warn(f'Incoming email server "{self.email_server}" not correct', exc_info=e)
+			frappe.throw(
+				title=_("Incoming email server not correct"),
+				msg=f'Error connecting IMAP/POP3 "{self.email_server}": {e}',
+			)
+
+	def validate_outgoing_server_conn(self):
+		try:
+			if self.use_ssl_for_outgoing:
+				if not self.smtp_port:
+					self.smtp_port = 465
+
+				self.logger.info(
+					"Checking outgoing SMTPS email server {host}:{port}...".format(
+						host=self.smtp_server, port=self.smtp_port
+					)
+				)
+				outgoing_server = smtplib.SMTP_SSL((self.smtp_server or ""), cint(self.smtp_port) or 0)
+			else:
+				if self.use_tls and not self.smtp_port:
+					self.smtp_port = 587
+
+				self.logger.info(
+					"Checking outgoing SMTP email server {host}:{port} STARTTLS={tls}...".format(
+						host=self.smtp_server, port=self.get("smtp_port"), tls=self.use_tls
+					)
+				)
+
+				outgoing_server = smtplib.SMTP((self.smtp_server or ""), cint(self.smtp_port) or 0)
+
+			outgoing_server.quit()
+		except Exception as e:
+			self.logger.warn(f'Outgoing email server "{self.smtp_server}" not correct', exc_info=e)
+			frappe.throw(
+				title=_("Outgoing email server not correct"),
+				msg=f'Error connecting SMTP "{self.smtp_server}": {e}',
+			)

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -13,10 +13,6 @@ from frappe.utils import cint, cstr, validate_email_address
 
 
 class EmailDomain(Document):
-	def autoname(self):
-		if self.domain_name:
-			self.name = self.domain_name
-
 	def validate(self):
 		"""Validate email id and check POP3/IMAP and SMTP connections is enabled."""
 		logger = frappe.logger()

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -17,9 +17,6 @@ class EmailDomain(Document):
 		"""Validate email id and check POP3/IMAP and SMTP connections is enabled."""
 		logger = frappe.logger()
 
-		if self.email_id:
-			validate_email_address(self.email_id, True)
-
 		if frappe.local.flags.in_patch or frappe.local.flags.in_test:
 			return
 

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -9,7 +9,7 @@ import frappe
 from frappe import _
 from frappe.email.utils import get_port
 from frappe.model.document import Document
-from frappe.utils import cint, cstr, validate_email_address
+from frappe.utils import cint, cstr
 
 
 class EmailDomain(Document):


### PR DESCRIPTION
This pr tries to fix the ux (as well as do a bit of controller cleanup) of email domain doctype.

before:
<img width="1323" alt="Screenshot 2022-07-14 at 1 08 52 PM" src="https://user-images.githubusercontent.com/32034600/178928457-4bc2dd0f-0644-4c9b-a066-9344a73e2f8d.png">


after:
<img width="1345" alt="Screenshot 2022-07-14 at 1 04 34 PM" src="https://user-images.githubusercontent.com/32034600/178927648-c2a9e907-e0eb-4fb5-ac93-ee5a1fa7a9a9.png">

#

Other Changes:
- cleaned/separated validation logic in email domain controller for incoming and outgoing settings
- used timed mixins for incoming server connection validation (same as email account)
- removed `email_id` field - was only used to getting the domain name (which is only used for naming)
- removed `autoname` hook from email domain controller
- enabled tracking changes for email domain doctype
- fetched default `attachment_limit` using file api


closes: https://github.com/frappe/frappe/issues/15501