### PR TITLE
fix: refresh tree when the treeview is  loaded

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -21,6 +21,19 @@ frappe.views.TreeFactory = class TreeFactory extends frappe.views.Factory {
 			frappe.views.trees[options.doctype] = new frappe.views.TreeView(options);
 		});
 	}
+
+	on_show() {
+		/**
+		 * When the the treeview is visited using the previous button,
+		 * the framework just show the treeview element that is hidden.
+		 * Due to this, the data of the tree can be old.
+		 * To deal with this, the tree will be refreshed whenever the
+		 * treeview is visible.
+		 */
+		let route = frappe.get_route();
+		let treeview = frappe.views.trees[route[1]];
+		treeview && treeview.make_tree();
+	}
 }
 
 frappe.views.TreeView = class TreeView {


### PR DESCRIPTION
- When the treeview is visited using the previous button, the framework just show the treeview element that is hidden. 
- Due to this, the data of the tree can be old. To deal with this, the tree will be refreshed whenever the treeview is visible.
- Before
![before](https://user-images.githubusercontent.com/7310479/177161693-e04fd6c8-4667-4fc1-b3fd-93fa43cf2f06.gif)

- After
![after](https://user-images.githubusercontent.com/7310479/177161728-a8626fe3-95a0-4f5b-b5f9-127dd7dca4cf.gif)
