### PR TITLE
fix: remove duplicate tracebacks

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -222,10 +222,6 @@ def handle_exception(e):
 		or (frappe.local.request.path.startswith("/api/") and not accept_header.startswith("text"))
 	)
 
-	if frappe.conf.get("developer_mode"):
-		# don't fail silently
-		print(frappe.get_traceback())
-
 	if respond_as_json:
 		# handle ajax responses first
 		# if the request is ajax, send back the trace or error message
@@ -288,6 +284,10 @@ def handle_exception(e):
 
 	if return_as_message:
 		response = get_response("message", http_status_code=http_status_code)
+
+	if frappe.conf.get("developer_mode") and not respond_as_json:
+		# don't fail silently for non-json response errors
+		print(frappe.get_traceback())
 
 	return response
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1157,10 +1157,7 @@ class Database:
 		return INDEX_PATTERN.sub(r"", index_name)
 
 	def get_system_setting(self, key):
-		def _load_system_settings():
-			return self.get_singles_dict("System Settings")
-
-		return frappe.cache().get_value("system_settings", _load_system_settings).get(key)
+		return frappe.get_system_settings(key)
 
 	def close(self):
 		"""Close database connection."""

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -50,7 +50,6 @@ def getdoc(doctype, name, user=None):
 		get_docinfo(doc)
 
 	except Exception:
-		frappe.errprint(frappe.utils.get_traceback())
 		raise
 
 	doc.add_seen()

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -10,42 +10,33 @@ from frappe.desk.form.load import run_onload
 @frappe.whitelist()
 def savedocs(doc, action):
 	"""save / submit / update doclist"""
-	try:
-		doc = frappe.get_doc(json.loads(doc))
-		set_local_name(doc)
+	doc = frappe.get_doc(json.loads(doc))
+	set_local_name(doc)
 
-		# action
-		doc.docstatus = {"Save": 0, "Submit": 1, "Update": 1, "Cancel": 2}[action]
+	# action
+	doc.docstatus = {"Save": 0, "Submit": 1, "Update": 1, "Cancel": 2}[action]
 
-		if doc.docstatus == 1:
-			doc.submit()
-		else:
-			doc.save()
+	if doc.docstatus == 1:
+		doc.submit()
+	else:
+		doc.save()
 
-		# update recent documents
-		run_onload(doc)
-		send_updated_docs(doc)
+	# update recent documents
+	run_onload(doc)
+	send_updated_docs(doc)
 
-		frappe.msgprint(frappe._("Saved"), indicator="green", alert=True)
-	except Exception:
-		frappe.errprint(frappe.utils.get_traceback())
-		raise
+	frappe.msgprint(frappe._("Saved"), indicator="green", alert=True)
 
 
 @frappe.whitelist()
 def cancel(doctype=None, name=None, workflow_state_fieldname=None, workflow_state=None):
 	"""cancel a doclist"""
-	try:
-		doc = frappe.get_doc(doctype, name)
-		if workflow_state_fieldname and workflow_state:
-			doc.set(workflow_state_fieldname, workflow_state)
-		doc.cancel()
-		send_updated_docs(doc)
-		frappe.msgprint(frappe._("Cancelled"), indicator="red", alert=True)
-
-	except Exception:
-		frappe.errprint(frappe.utils.get_traceback())
-		raise
+	doc = frappe.get_doc(doctype, name)
+	if workflow_state_fieldname and workflow_state:
+		doc.set(workflow_state_fieldname, workflow_state)
+	doc.cancel()
+	send_updated_docs(doc)
+	frappe.msgprint(frappe._("Cancelled"), indicator="red", alert=True)
 
 
 def send_updated_docs(doc):


### PR DESCRIPTION
Currently traceback is printed when exception occurs while serving request. 

However, there are 2 more places where this is implicitly triggered:
1. Request handling code reprints traceback if in developer mode
2. Desk's save/cancel handler implement separate exception printing (for no apparent reason)


Removed both and sticking to the original exception handler for requests. This also respects the system setting related to tracebacks. 

<img width="598" alt="Screenshot 2022-07-04 at 11 28 12 AM" src="https://user-images.githubusercontent.com/9079960/177090527-0b5629cd-c9c4-456b-aa06-501e8da4a44a.png">





Example of duplicate tracebacks:

```
11:33:44 web.1            |   warn("'filters_config' hook is not completely implemented yet in frappe.db.query engine")
11:33:44 web.1            | Traceback (most recent call last):
11:33:44 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 38, in getdoc
11:33:44 web.1            |     run_onload(doc)
11:33:44 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 374, in run_onload
11:33:44 web.1            |     doc.run_method("onload")
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 925, in run_method
11:33:44 web.1            |     out = Document.hook(fn)(self, *args, **kwargs)
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 1263, in composer
11:33:44 web.1            |     return composed(self, method, *args, **kwargs)
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 1245, in runner
11:33:44 web.1            |     add_to_return_value(self, fn(self, *args, **kwargs))
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 922, in fn
11:33:44 web.1            |     return method_object(*args, **kwargs)
11:33:44 web.1            |   File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 236, in onload
11:33:44 web.1            |     1/0
11:33:44 web.1            | ZeroDivisionError: division by zero
11:33:44 web.1            |
11:33:44 web.1            | Traceback (most recent call last):
11:33:44 web.1            |   File "apps/frappe/frappe/app.py", line 68, in application
11:33:44 web.1            |     response = frappe.api.handle()
11:33:44 web.1            |   File "apps/frappe/frappe/api.py", line 54, in handle
11:33:44 web.1            |     return frappe.handler.handle()
11:33:44 web.1            |   File "apps/frappe/frappe/handler.py", line 45, in handle
11:33:44 web.1            |     data = execute_cmd(cmd)
11:33:44 web.1            |   File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
11:33:44 web.1            |     return frappe.call(method, **frappe.form_dict)
11:33:44 web.1            |   File "apps/frappe/frappe/__init__.py", line 1548, in call
11:33:44 web.1            |     return fn(*args, **newargs)
11:33:44 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 38, in getdoc
11:33:44 web.1            |     run_onload(doc)
11:33:44 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 374, in run_onload
11:33:44 web.1            |     doc.run_method("onload")
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 925, in run_method
11:33:44 web.1            |     out = Document.hook(fn)(self, *args, **kwargs)
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 1263, in composer
11:33:44 web.1            |     return composed(self, method, *args, **kwargs)
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 1245, in runner
11:33:44 web.1            |     add_to_return_value(self, fn(self, *args, **kwargs))
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 922, in fn
11:33:44 web.1            |     return method_object(*args, **kwargs)
11:33:44 web.1            |   File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 236, in onload
11:33:44 web.1            |     1/0
11:33:44 web.1            | ZeroDivisionError: division by zero
11:33:44 web.1            |
11:33:44 web.1            | Traceback (most recent call last):
11:33:44 web.1            |   File "apps/frappe/frappe/app.py", line 68, in application
11:33:44 web.1            |     response = frappe.api.handle()
11:33:44 web.1            |   File "apps/frappe/frappe/api.py", line 54, in handle
11:33:44 web.1            |     return frappe.handler.handle()
11:33:44 web.1            |   File "apps/frappe/frappe/handler.py", line 45, in handle
11:33:44 web.1            |     data = execute_cmd(cmd)
11:33:44 web.1            |   File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
11:33:44 web.1            |     return frappe.call(method, **frappe.form_dict)
11:33:44 web.1            |   File "apps/frappe/frappe/__init__.py", line 1548, in call
11:33:44 web.1            |     return fn(*args, **newargs)
11:33:44 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 38, in getdoc
11:33:44 web.1            |     run_onload(doc)
11:33:44 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 374, in run_onload
11:33:44 web.1            |     doc.run_method("onload")
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 925, in run_method
11:33:44 web.1            |     out = Document.hook(fn)(self, *args, **kwargs)
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 1263, in composer
11:33:44 web.1            |     return composed(self, method, *args, **kwargs)
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 1245, in runner
11:33:44 web.1            |     add_to_return_value(self, fn(self, *args, **kwargs))
11:33:44 web.1            |   File "apps/frappe/frappe/model/document.py", line 922, in fn
11:33:44 web.1            |     return method_object(*args, **kwargs)
11:33:44 web.1            |   File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 236, in onload
11:33:44 web.1            |     1/0
11:33:44 web.1            | ZeroDivisionError: division by zero
```



After, just 1 traceback

```
11:33:27 web.1            | Traceback (most recent call last):
11:33:27 web.1            |   File "apps/frappe/frappe/app.py", line 68, in application
11:33:27 web.1            |     response = frappe.api.handle()
11:33:27 web.1            |   File "apps/frappe/frappe/api.py", line 54, in handle
11:33:27 web.1            |     return frappe.handler.handle()
11:33:27 web.1            |   File "apps/frappe/frappe/handler.py", line 45, in handle
11:33:27 web.1            |     data = execute_cmd(cmd)
11:33:27 web.1            |   File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
11:33:27 web.1            |     return frappe.call(method, **frappe.form_dict)
11:33:27 web.1            |   File "apps/frappe/frappe/__init__.py", line 1548, in call
11:33:27 web.1            |     return fn(*args, **newargs)
11:33:27 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 38, in getdoc
11:33:27 web.1            |     run_onload(doc)
11:33:27 web.1            |   File "apps/frappe/frappe/desk/form/load.py", line 373, in run_onload
11:33:27 web.1            |     doc.run_method("onload")
11:33:27 web.1            |   File "apps/frappe/frappe/model/document.py", line 925, in run_method
11:33:27 web.1            |     out = Document.hook(fn)(self, *args, **kwargs)
11:33:27 web.1            |   File "apps/frappe/frappe/model/document.py", line 1263, in composer
11:33:27 web.1            |     return composed(self, method, *args, **kwargs)
11:33:27 web.1            |   File "apps/frappe/frappe/model/document.py", line 1245, in runner
11:33:27 web.1            |     add_to_return_value(self, fn(self, *args, **kwargs))
11:33:27 web.1            |   File "apps/frappe/frappe/model/document.py", line 922, in fn
11:33:27 web.1            |     return method_object(*args, **kwargs)
11:33:27 web.1            |   File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 236, in onload
11:33:27 web.1            |     1/0
11:33:27 web.1            | ZeroDivisionError: division by zero

```