### PR TITLE
refactor: safer binding of outer scope in closures

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -652,14 +652,14 @@ class DocType(Document):
 					remaining_field_names = [f.fieldname for f in self.fields]
 
 					for fieldname in old_field_names:
-						field_dict = list(filter(lambda d: d["fieldname"] == fieldname, docdict["fields"]))
+						field_dict = [f for f in docdict["fields"] if f["fieldname"] == fieldname]
 						if field_dict:
 							new_field_dicts.append(field_dict[0])
 							if fieldname in remaining_field_names:
 								remaining_field_names.remove(fieldname)
 
 					for fieldname in remaining_field_names:
-						field_dict = list(filter(lambda d: d["fieldname"] == fieldname, docdict["fields"]))
+						field_dict = [f for f in docdict["fields"] if f["fieldname"] == fieldname]
 						new_field_dicts.append(field_dict[0])
 
 					docdict["fields"] = new_field_dicts
@@ -674,14 +674,14 @@ class DocType(Document):
 			remaining_field_names = [f["fieldname"] for f in docdict.get("fields", [])]
 
 			for fieldname in docdict.get("field_order"):
-				field_dict = list(filter(lambda d: d["fieldname"] == fieldname, docdict.get("fields", [])))
+				field_dict = [f for f in docdict.get("fields", []) if f["fieldname"] == fieldname]
 				if field_dict:
 					new_field_dicts.append(field_dict[0])
 					if fieldname in remaining_field_names:
 						remaining_field_names.remove(fieldname)
 
 			for fieldname in remaining_field_names:
-				field_dict = list(filter(lambda d: d["fieldname"] == fieldname, docdict.get("fields", [])))
+				field_dict = [f for f in docdict.get("fields", []) if f["fieldname"] == fieldname]
 				new_field_dicts.append(field_dict[0])
 
 			docdict["fields"] = new_field_dicts

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -87,7 +87,10 @@ class NamingSeries:
 		for count in range(1, 4):
 
 			def fake_counter(_prefix, digits):
-				return str(count).zfill(digits)
+				# ignore B023: binding `count` is not necessary because
+				# function is evaluated immediately and it can not be done
+				# because of function signature requirement
+				return str(count).zfill(digits)  # noqa: B023
 
 			generated_names.append(parse_naming_series(self.series, doc=doc, number_generator=fake_counter))
 		return generated_names

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -85,7 +85,8 @@ def get_snapshot(exception, context=10):
 
 		def reader(lnum=[lnum]):  # noqa
 			try:
-				return linecache.getline(file, lnum[0])
+				# B023: function is evaluated immediately, binding not necessary
+				return linecache.getline(file, lnum[0])  # noqa: B023
 			finally:
 				lnum[0] += 1
 


### PR DESCRIPTION
This addresses issues identified by a new check-in flake8-bugbear that flags incorrectly bound outer scope variables in closures. 

This is only an issue if the closure is executed AFTER the loop is finished, none of our current identified problems are actually bugs. 
