### PR TITLE
fix: handle `None` as amount in fmt_money

### DIFF
--- a/frappe/tests/test_fmt_money.py
+++ b/frappe/tests/test_fmt_money.py
@@ -95,6 +95,7 @@ class TestFmtMoney(unittest.TestCase):
 
 	def test_custom_fmt_money_format(self):
 		self.assertEqual(fmt_money(100000, format="#,###.##"), "100,000.00")
+		self.assertEqual(fmt_money(None, format="#,###.##"), "0.00")
 
 
 if __name__ == "__main__":

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1111,7 +1111,7 @@ def parse_val(v):
 
 
 def fmt_money(
-	amount: str | float | int,
+	amount: str | float | int | None,
 	precision: int | None = None,
 	currency: str | None = None,
 	format: str | None = None,
@@ -1134,6 +1134,9 @@ def fmt_money(
 
 	if isinstance(amount, str):
 		amount = flt(amount, precision)
+
+	if amount is None:
+		amount = 0
 
 	if decimal_str:
 		decimals_after = str(round(amount % 1, precision))


### PR DESCRIPTION
In most utils we handle currency/float fallback as 0, this function just throws error, which... isn't helpful. 0.0 is sane default value when no input is provided. 

closes https://github.com/frappe/frappe/issues/17392 