### PR TITLE
fix: set link fields from non_standard_fieldnames when creating new doc from dashboard connections

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1730,8 +1730,15 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.get_meta(doctype).fields.forEach(function(df) {
 			if (df.fieldtype === 'Link' && df.options === me.doctype) {
 				new_doc[df.fieldname] = me.doc.name;
-			} else if (['Link', 'Dynamic Link'].includes(df.fieldtype) && me.doc[df.fieldname]) {
-				new_doc[df.fieldname] = me.doc[df.fieldname];
+			} else if (['Link', 'Dynamic Link'].includes(df.fieldtype)) {
+				if (me.doc[df.fieldname]) {
+					new_doc[df.fieldname] = me.doc[df.fieldname];
+				} else if (me.dashboard.data.non_standard_fieldnames[doctype] && df.fieldname === me.dashboard.data.non_standard_fieldnames[doctype]) {
+					if (df.fieldtype == 'Dynamic Link') {
+						new_doc[df.options] = me.doctype;
+					}
+					new_doc[df.fieldname] = me.doc.name;
+				}
 			} else if (df.fieldtype === 'Table' && df.options && df.reqd) {
 				let row = new_doc[df.fieldname][0];
 				me.set_link_field(df.options, row);


### PR DESCRIPTION
fixes: ISS-22-23-00972