### PR TITLE
feat: configurable location of currency symbol

### DIFF
--- a/frappe/geo/doctype/currency/currency.json
+++ b/frappe/geo/doctype/currency/currency.json
@@ -15,6 +15,7 @@
   "fraction_units",
   "smallest_currency_fraction_value",
   "symbol",
+  "symbol_on_right",
   "number_format"
  ],
  "fields": [
@@ -69,16 +70,23 @@
    "in_list_view": 1,
    "label": "Number Format",
    "options": "\n#,###.##\n#.###,##\n# ###.##\n# ###,##\n#'###.##\n#, ###.##\n#,##,###.##\n#,###.###\n#.###\n#,###"
+  },
+  {
+   "default": "0",
+   "fieldname": "symbol_on_right",
+   "fieldtype": "Check",
+   "label": "Show Currency Symbol on Right Side"
   }
  ],
  "icon": "fa fa-bitcoin",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-29 06:33:12.879978",
+ "modified": "2022-07-04 09:42:52.425440",
  "modified_by": "Administrator",
  "module": "Geo",
  "name": "Currency",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -109,5 +117,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -122,16 +122,22 @@ window.format_number = function (v, format, decimals) {
 };
 
 function format_currency(v, currency, decimals) {
-	var format = get_number_format(currency);
-	var symbol = get_currency_symbol(currency);
-	if(decimals === undefined) {
+	const format = get_number_format(currency);
+	const symbol = get_currency_symbol(currency);
+	const show_symbol_on_right = frappe.model.get_value(":Currency", currency, "symbol_on_right") ?? false;
+
+	if (decimals === undefined) {
 		decimals = frappe.boot.sysdefaults.currency_precision || null;
 	}
 
-	if (symbol)
+	if (symbol) {
+		if (show_symbol_on_right) {
+			return format_number(v, format, decimals) + " " + __(symbol);
+		}
 		return __(symbol) + " " + format_number(v, format, decimals);
-	else
-		return format_number(v, format, decimals);
+	}
+
+	return format_number(v, format, decimals);
 }
 
 function get_currency_symbol(currency) {

--- a/frappe/tests/test_fmt_money.py
+++ b/frappe/tests/test_fmt_money.py
@@ -97,6 +97,11 @@ class TestFmtMoney(unittest.TestCase):
 		self.assertEqual(fmt_money(100000, format="#,###.##"), "100,000.00")
 		self.assertEqual(fmt_money(None, format="#,###.##"), "0.00")
 
+	def test_fmt_with_symbol_pos(self):
+		frappe.db.set_value("Currency", "JPY", "symbol_on_right", 1)
+		self.assertEqual(fmt_money(100.0, format="#,###.##", currency="JPY"), "100.00 ¥")
+		self.assertEqual(fmt_money(100.0, format="#,###.##", currency="USD"), "$ 100.00")
+
 
 if __name__ == "__main__":
 	frappe.connect()

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1187,7 +1187,12 @@ def fmt_money(
 
 	if currency and frappe.defaults.get_global_default("hide_currency_symbol") != "Yes":
 		symbol = frappe.db.get_value("Currency", currency, "symbol", cache=True) or currency
-		amount = frappe._(symbol) + " " + amount
+		symbol_on_right = frappe.db.get_value("Currency", currency, "symbol_on_right", cache=True)
+
+		if symbol_on_right:
+			amount = f"{amount} {frappe._(symbol)}"
+		else:
+			amount = f"{frappe._(symbol)} {amount}"
 
 	return amount
 


### PR DESCRIPTION
We stick all currency symbols to the left of currency value.

1. This is not expected behavior in some countries where the symbol is suffixed.
2. This is almost always not expected behaviour when currency code is used instead of the currency symbol. Code is almost always suffixed. e.g. "200 INR" not "INR 200"


<img width="454" alt="Screenshot 2022-07-04 at 8 36 00 PM" src="https://user-images.githubusercontent.com/9079960/177181183-c7929ec4-b9b2-4de6-80e1-dc77789b07ea.png">

<img width="788" alt="Screenshot 2022-07-05 at 11 24 26 AM" src="https://user-images.githubusercontent.com/9079960/177258988-5b09a475-9dfe-4ae5-aca0-86a8c6f4f0b7.png">



This PR adds a way to configure this behavior on Currency doctype. 


- [x] form view / client side
- [x] server side
- [x] print views



closes https://github.com/frappe/frappe/issues/16956 

docs: https://docs.erpnext.com/docs/v14/user/manual/en/accounts/currency