### PR TITLE
fix: valueerror on export with composite cell valu

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -407,7 +407,7 @@ def build_xlsx_data(data, visible_idx, include_indentation, ignore_visible_idx=F
 						continue
 					label = column.get("label")
 					fieldname = column.get("fieldname")
-					cell_value = row.get(fieldname, row.get(label, ""))
+					cell_value = cstr(row.get(fieldname, row.get(label, "")))
 					if cint(include_indentation) and "indent" in row and col_idx == 0:
 						cell_value = ("    " * cint(row["indent"])) + cstr(cell_value)
 					row_data.append(cell_value)


### PR DESCRIPTION
'Value Error' thrown when table with composite cell value is exported in Excel Format.

<img width="945" alt="Screenshot 2022-07-05 at 8 57 00 AM" src="https://user-images.githubusercontent.com/3272205/177244877-08f1bba7-d8d9-437f-a4b8-11ee8b9463aa.png">

