### PR TITLE
fix: misc url/routing fixes

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1456,8 +1456,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	on_update() {}
 
 	update_url_with_filters() {
-		if (frappe.get_route_str() == this.page_name) {
+		if (frappe.get_route_str() == this.page_name && !this.report_name) {
 			// only update URL if the route still matches current page.
+			// do not update if current list is a "saved report".
 			window.history.replaceState(null, null, this.get_url_with_filters());
 		}
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1456,7 +1456,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	on_update() {}
 
 	update_url_with_filters() {
-		window.history.replaceState(null, null, this.get_url_with_filters());
+		if (frappe.get_route_str() == this.page_name) {
+			// only update URL if the route still matches current page.
+			window.history.replaceState(null, null, this.get_url_with_filters());
+		}
 	}
 
 	get_url_with_filters() {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -58,7 +58,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	update_url_with_filters() {
-		window.history.replaceState(null, null, this.get_url_with_filters());
+		if (frappe.get_route_str() == this.page_name) {
+			window.history.replaceState(null, null, this.get_url_with_filters());
+		}
 	}
 
 	get_url_with_filters() {


### PR DESCRIPTION
If you rapidly move from a list view while it was being refreshed then
changed URL is applied on a page that MIGHT not be the list/report view. Throttle network to slow 3g to reproduce.

This check ensures that same page is present before updating URL.

---


- [x] don't apply filtering from URL on _saved_ reports. - saved reports contain their own filter and column config. URL shouldn't be updated for them. 
- [x] if report/list view is changed immediately to some other view then filters are still applied on that view... (async bug)

related https://github.com/frappe/frappe/issues/17376 