### PR TITLE
fix: incorrect default fraction for USD

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -842,7 +842,7 @@
  "El Salvador": {
   "code": "sv",
   "currency": "USD",
-  "currency_fraction": "Centavo",
+  "currency_fraction": "Cent",
   "currency_fraction_units": 100,
   "smallest_currency_fraction_value": 0.01,
   "currency_name": "Dolar estadounidense",

--- a/frappe/geo/doctype/currency/test_currency.py
+++ b/frappe/geo/doctype/currency/test_currency.py
@@ -4,5 +4,10 @@
 # pre loaded
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 
-test_records = frappe.get_test_records("Currency")
+
+class TestUser(FrappeTestCase):
+	def test_default_currency_on_setup(self):
+		usd = frappe.get_doc("Currency", "USD")
+		self.assertDocumentEqual({"enabled": 1, "fraction": "Cent"}, usd)


### PR DESCRIPTION
El Salvador's currency fraction is set to "Centavo" (which is spanish for "Cent") this is anyways translated, so there's no need to hardcode translation. 

closes https://github.com/frappe/frappe/issues/13445 