### PR TITLE
refactor: simplify fetching of readable records

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -21,7 +21,7 @@ from frappe.social.doctype.energy_point_settings.energy_point_settings import (
 	is_energy_point_enabled,
 )
 from frappe.translate import get_lang_dict
-from frappe.utils import add_user_info, get_time_zone
+from frappe.utils import add_user_info, cstr, get_time_zone
 from frappe.utils.change_log import get_versions
 from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
 
@@ -140,6 +140,10 @@ def get_allowed_pages(cache=False):
 
 def get_allowed_reports(cache=False):
 	return get_user_pages_or_reports("Report", cache=cache)
+
+
+def get_allowed_report_names(cache=False) -> set[str]:
+	return {cstr(report) for report in get_allowed_reports(cache).keys() if report}
 
 
 def get_user_pages_or_reports(parent, cache=False):

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -8,7 +8,6 @@ from frappe.core.doctype.doctype.doctype import validate_series
 from frappe.model.document import Document
 from frappe.model.naming import NamingSeries
 from frappe.permissions import get_doctypes_with_read
-from frappe.utils import cint
 
 
 class NamingSeriesNotSetError(frappe.ValidationError):

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -6,7 +6,7 @@ import json
 
 import frappe
 from frappe import _
-from frappe.boot import get_allowed_reports
+from frappe.boot import get_allowed_report_names
 from frappe.config import get_modules_from_all_apps_for_user
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
@@ -40,10 +40,7 @@ def get_permission_query_conditions(user):
 	allowed_doctypes = [
 		frappe.db.escape(doctype) for doctype in frappe.permissions.get_doctypes_with_read()
 	]
-	allowed_reports = [
-		frappe.db.escape(key) if type(key) == str else key.encode("UTF8")
-		for key in get_allowed_reports()
-	]
+	allowed_reports = [frappe.db.escape(report) for report in get_allowed_report_names()]
 	allowed_modules = [
 		frappe.db.escape(module.get("module_name")) for module in get_modules_from_all_apps_for_user()
 	]
@@ -83,10 +80,7 @@ def has_permission(doc, ptype, user):
 		return True
 
 	if doc.chart_type == "Report":
-		allowed_reports = [
-			key if type(key) == str else key.encode("UTF8") for key in get_allowed_reports()
-		]
-		if doc.report_name in allowed_reports:
+		if doc.report_name in get_allowed_report_names():
 			return True
 	else:
 		allowed_doctypes = frappe.permissions.get_doctypes_with_read()

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.boot import get_allowed_reports
+from frappe.boot import get_allowed_report_names
 from frappe.config import get_modules_from_all_apps_for_user
 from frappe.model.document import Document
 from frappe.model.naming import append_number_if_name_exists
@@ -91,10 +91,7 @@ def has_permission(doc, ptype, user):
 		return True
 
 	if doc.type == "Report":
-		allowed_reports = [
-			key if type(key) == str else key.encode("UTF8") for key in get_allowed_reports()
-		]
-		if doc.report_name in allowed_reports:
+		if doc.report_name in get_allowed_report_names():
 			return True
 	else:
 		allowed_doctypes = tuple(frappe.permissions.get_doctypes_with_read())

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -6,7 +6,7 @@ import frappe
 import frappe.share
 from frappe import _, msgprint
 from frappe.query_builder import DocType
-from frappe.utils import cint
+from frappe.utils import cint, cstr
 
 rights = (
 	"select",
@@ -360,9 +360,7 @@ def has_controller_permissions(doc, ptype, user=None):
 
 
 def get_doctypes_with_read():
-	return list(
-		{p.parent if type(p.parent) == str else p.parent.encode("UTF8") for p in get_valid_perms()}
-	)
+	return list({cstr(p.parent) for p in get_valid_perms() if p.parent})
 
 
 def get_valid_perms(doctype=None, user=None):


### PR DESCRIPTION
- remove encoding, use cstr directly
- remove falsy values by default like `None`, empty string.

closes https://github.com/frappe/frappe/issues/17311 


```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 37, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 75, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1447, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/email/__init__.py", line 23, in get_contact_list
    match_conditions = build_match_conditions("Contact")
  File "apps/frappe/frappe/desk/reportview.py", line 664, in build_match_conditions
    as_condition=as_condition
  File "apps/frappe/frappe/model/db_query.py", line 711, in build_match_conditions
    doctype_conditions = self.get_permission_query_conditions()
  File "apps/frappe/frappe/model/db_query.py", line 801, in get_permission_query_conditions
    c = frappe.call(frappe.get_attr(method), self.user)
  File "apps/frappe/frappe/__init__.py", line 1447, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/contacts/address_and_contact.py", line 100, in get_permission_query_conditions_for_contact
    return get_permission_query_conditions("Contact")
  File "apps/frappe/frappe/contacts/address_and_contact.py", line 108, in get_permission_query_conditions
    links = get_permitted_and_not_permitted_links(doctype)
  File "apps/frappe/frappe/contacts/address_and_contact.py", line 143, in get_permitted_and_not_permitted_links
    allowed_doctypes = frappe.permissions.get_doctypes_with_read()
  File "apps/frappe/frappe/permissions.py", line 366, in get_doctypes_with_read
    set([p.parent if type(p.parent) == str else p.parent.encode("UTF8") for p in get_valid_perms()])
  File "apps/frappe/frappe/permissions.py", line 366, in <listcomp>
    set([p.parent if type(p.parent) == str else p.parent.encode("UTF8") for p in get_valid_perms()])
AttributeError: 'NoneType' object has no attribute 'encode'
```