### PR TITLE
perf: add `__slots__` to most used classes

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -109,6 +109,9 @@ class HTTPRequest:
 
 
 class LoginManager:
+
+	__slots__ = ("user", "info", "full_name", "user_type", "resume")
+
 	def __init__(self):
 		self.user = None
 		self.info = None

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -30,6 +30,8 @@ def log_file():
 
 
 class Monitor:
+	__slots__ = ("data",)
+
 	def __init__(self, transaction_type, method, kwargs):
 		try:
 			self.data = frappe._dict(

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -213,6 +213,8 @@ def generate_csrf_token():
 
 
 class Session:
+	__slots__ = ("user", "device", "user_type", "full_name", "data", "time_diff", "sid")
+
 	def __init__(self, user, resume=False, full_name=None, user_type=None):
 		self.sid = cstr(
 			frappe.form_dict.get("sid") or unquote(frappe.request.cookies.get("sid", "Guest"))


### PR DESCRIPTION
Added slots for these classes:

- Session - Created on EACH request
- LoginManager - Created on each request
- Monitor - Created on each request if monitor is enabled (usually in prod setup)

ref: https://docs.python.org/3/reference/datamodel.html#slots