### PR TITLE
perf: drop country_info from boot 

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -11,7 +11,6 @@ from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo, ge
 from frappe.desk.doctype.route_history.route_history import frequently_visited_links
 from frappe.desk.form.load import get_meta_bundle
 from frappe.email.inbox import get_email_accounts
-from frappe.geo.country_info import get_all
 from frappe.model.base_document import get_controller
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
@@ -68,7 +67,6 @@ def get_bootinfo():
 	bootinfo.home_folder = frappe.db.get_value("File", {"is_home_folder": 1})
 	bootinfo.navbar_settings = get_navbar_settings()
 	bootinfo.notification_settings = get_notification_settings()
-	get_country_codes(bootinfo)
 	set_time_zone(bootinfo)
 
 	# ipinfo
@@ -387,11 +385,6 @@ def get_desk_settings():
 
 def get_notification_settings():
 	return frappe.get_cached_doc("Notification Settings", frappe.session.user)
-
-
-def get_country_codes(bootinfo):
-	country_codes = get_all()
-	bootinfo.country_codes = frappe._dict(country_codes)
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/form/controls/phone.js
+++ b/frappe/public/js/frappe/form/controls/phone.js
@@ -22,7 +22,7 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 		// Replaces code when selected and removes previously selected.
 		this.country_code_picker.on_change = (country) => {
 			if (!country) {
-				return this.reset_inputx();
+				return this.reset_input();
 			}
 			const country_code = frappe.boot.country_codes[country].code;
 			const country_isd = frappe.boot.country_codes[country].isd;

--- a/frappe/public/js/frappe/form/controls/phone.js
+++ b/frappe/public/js/frappe/form/controls/phone.js
@@ -1,12 +1,25 @@
-
+import localforage from "localforage";
 import PhonePicker from '../../phone_picker/phone_picker';
 
 frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlData {
 
-	make_input() {
+	async make_input() {
+		await this.setup_country_codes();
 		super.make_input();
 		this.setup_country_code_picker();
 		this.input_events();
+	}
+
+	async setup_country_codes() {
+		const key = "country_code_info"
+		let data = await localforage.getItem(key);
+		if (data) {
+			this.country_codes = data;
+		} else {
+			const data = await frappe.xcall("frappe.geo.country_info.get_country_timezone_info");
+			this.country_codes = data?.country_info;
+			localforage.setItem(key, this.country_codes);
+		}
 	}
 
 	input_events() {
@@ -24,8 +37,8 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 			if (!country) {
 				return this.reset_input();
 			}
-			const country_code = frappe.boot.country_codes[country].code;
-			const country_isd = frappe.boot.country_codes[country].isd;
+			const country_code = this.country_codes[country].code;
+			const country_isd = this.country_codes[country].isd;
 			this.set_flag(country_code);
 			this.$icon = this.selected_icon.find('svg');
 			this.$flag = this.selected_icon.find('img');
@@ -69,7 +82,7 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 		let picker_wrapper = $('<div>');
 		this.country_code_picker = new PhonePicker({
 			parent: picker_wrapper,
-			countries: frappe.boot.country_codes
+			countries: this.country_codes
 		});
 
 		this.$wrapper.popover({
@@ -128,7 +141,10 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 		this.$input.css("padding-left", 30);
 	}
 
-	set_formatted_input(value) {
+	async set_formatted_input(value) {
+		if (!this.country_codes) {
+			await this.setup_country_codes();
+		}
 		if (value && value.includes('-') && value.split('-').length == 2)  {
 			let isd = this.value.split("-")[0];
 			this.get_country_code_and_change_flag(isd);
@@ -158,7 +174,7 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 
 	// country_code for India is 'in'
 	get_country_code_and_change_flag(isd) {
-		let country_data = frappe.boot.country_codes;
+		let country_data = this.country_codes;
 		let flag = this.selected_icon.find('img');
 		for (const country in country_data) {
 			if (Object.values(country_data[country]).includes(isd)) {
@@ -175,12 +191,12 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 	}
 
 	get_country(country) {
-		const country_codes = frappe.boot.country_codes;
+		const country_codes = this.country_codes;
 		return country_codes[country].isd;
 	}
 
 	get_country_flag(country) {
-		const country_codes = frappe.boot.country_codes;
+		const country_codes = this.country_codes;
 		let code = country_codes[country].code;
 		return frappe.utils.flag(code);
 	}


### PR DESCRIPTION
This is ~60kb of data that is sent with every boot but only used by Phone control. 

Fix: Asynchronously load this when phone control is encountered. Cache in local storage for subsequent visits.


Not a breaking change, introduced in v14 and no one uses it yet: https://sourcegraph.com/search?q=context:global+frappe.boot.country_codes&patternType=literal 


**before**
<img width="724" alt="Screenshot 2022-07-07 at 12 55 27 PM" src="https://user-images.githubusercontent.com/9079960/177716298-d2653f7a-b4b2-4b7a-8ab1-c976e0d41002.png">

**after**
<img width="724" alt="Screenshot 2022-07-07 at 12 55 44 PM" src="https://user-images.githubusercontent.com/9079960/177716282-8d775117-67bd-4bba-a5c4-634521b3fc60.png">


PS: this number reduces quite a bit when text compression is enabled in production servers.