### PR TITLE
fix: username for Notification Log was wrong for Administrator

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -71,14 +71,15 @@ def make_notification_logs(doc, users):
 	)
 
 	for user in users:
-		if frappe.db.exists("User", {"email": user, "enabled": 1}):
+		username = frappe.db.exists("User", {"email": user, "enabled": 1})
+		if username:
 			if is_notifications_enabled(user):
 				if doc.type == "Energy Point" and not is_energy_point_enabled():
 					return
 
 				_doc = frappe.new_doc("Notification Log")
 				_doc.update(doc)
-				_doc.for_user = user
+				_doc.for_user = username
 				if _doc.for_user != _doc.from_user or doc.type == "Energy Point" or doc.type == "Alert":
 					_doc.insert(ignore_permissions=True)
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -96,12 +96,16 @@ def send_notification_email(doc):
 
 	from frappe.utils import get_url_to_form, strip_html
 
+	email = frappe.db.get_value("User", doc.for_user, "email")
+	if not email:
+		return
+
 	doc_link = get_url_to_form(doc.document_type, doc.document_name)
 	header = get_email_header(doc)
 	email_subject = strip_html(doc.subject)
 
 	frappe.sendmail(
-		recipients=doc.for_user,
+		recipients=email,
 		subject=email_subject,
 		template="new_notification",
 		args={

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -42,12 +42,16 @@ def get_title_html(title):
 	return f'<b class="subject-title">{title}</b>'
 
 
-def enqueue_create_notification(users, doc):
+def enqueue_create_notification(users: list[str] | str, doc: dict):
+	"""Send notification to users.
+
+	users: list of user emails or string of users with comma separated emails
+	doc: contents of `Notification` doc
 	"""
-	During installation of new site, enqueue_create_notification tries to connect to Redis.
-	This breaks new site creation if Redis server is not running.
-	We do not need any notifications in fresh installation
-	"""
+
+	# During installation of new site, enqueue_create_notification tries to connect to Redis.
+	# This breaks new site creation if Redis server is not running.
+	# We do not need any notifications in fresh installation
 	if frappe.flags.in_install:
 		return
 
@@ -66,22 +70,23 @@ def enqueue_create_notification(users, doc):
 
 
 def make_notification_logs(doc, users):
-	from frappe.social.doctype.energy_point_settings.energy_point_settings import (
-		is_energy_point_enabled,
+	for user in _get_user_ids(users):
+		notification = frappe.new_doc("Notification Log")
+		notification.update(doc)
+		notification.for_user = user
+		if (
+			notification.for_user != notification.from_user
+			or doc.type == "Energy Point"
+			or doc.type == "Alert"
+		):
+			notification.insert(ignore_permissions=True)
+
+
+def _get_user_ids(user_emails):
+	user_names = frappe.db.get_values(
+		"User", {"enabled": 1, "email": ("in", user_emails)}, "name", pluck=True
 	)
-
-	for user in users:
-		username = frappe.db.exists("User", {"email": user, "enabled": 1})
-		if username:
-			if is_notifications_enabled(user):
-				if doc.type == "Energy Point" and not is_energy_point_enabled():
-					return
-
-				_doc = frappe.new_doc("Notification Log")
-				_doc.update(doc)
-				_doc.for_user = username
-				if _doc.for_user != _doc.from_user or doc.type == "Energy Point" or doc.type == "Alert":
-					_doc.insert(ignore_permissions=True)
+	return [user for user in user_names if is_notifications_enabled(user)]
 
 
 def send_notification_email(doc):


### PR DESCRIPTION
There is a problem for the user 'Administrator' which has the property, that the document name for that User-document is NOT the email. For all other users, the email is also the docname for the User-document.

The problem is, that notification log tries to create a notification for the "User" with the administrator email, but then frappe complains that this user can not be found.

This is of course the case because that Users name is not his/her email, but 'Administrator'.

This fixes that