### PR TITLE
fix: Set files private by default

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -320,7 +320,7 @@ export default {
 						request_succeeded: false,
 						error_message: null,
 						uploading: false,
-						private: !is_image
+						private: true
 					};
 				});
 


### PR DESCRIPTION
Make all file uploads private by default

Resolves [this](https://github.com/frappe/frappe/issues/17154) on client-side.