### PR TITLE
chore!: remove unused APIs from `frappe.client`

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -282,17 +282,6 @@ def set_default(key, value, parent=None):
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
-def make_width_property_setter(doc):
-	"""Set width Property Setter
-
-	:param doc: Property Setter document with `width` property"""
-	if isinstance(doc, str):
-		doc = json.loads(doc)
-	if doc["doctype"] == "Property Setter" and doc["property"] == "width":
-		frappe.get_doc(doc).insert(ignore_permissions=True)
-
-
-@frappe.whitelist(methods=["POST", "PUT"])
 def bulk_update(docs):
 	"""Bulk update documents
 
@@ -412,11 +401,6 @@ def attach_file(
 		doc.save()
 
 	return file
-
-
-@frappe.whitelist()
-def get_hooks(hook, app_name=None):
-	return frappe.get_hooks(hook, app_name)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Seems like they're not used by devs anyway:
https://sourcegraph.com/search?q=context:global+frappe.client.make_width_property_setter&patternType=literal
https://sourcegraph.com/search?q=context:global+frappe.client.get_hooks&patternType=literal