### PR TITLE
fix: delete user mention cache when a user is disabled or enabled

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -134,11 +134,11 @@ class User(Document):
 		if self.time_zone:
 			frappe.defaults.set_default("time_zone", self.time_zone, self.name)
 
-		if self.has_value_changed("allow_in_mentions") or self.has_value_changed("user_type"):
-			frappe.cache().delete_key("users_for_mentions")
-
 		if self.has_value_changed("enabled"):
+			frappe.cache().delete_key("users_for_mentions")
 			frappe.cache().delete_key("enabled_users")
+		elif self.has_value_changed("allow_in_mentions") or self.has_value_changed("user_type"):
+			frappe.cache().delete_key("users_for_mentions")
 
 	def has_website_permission(self, ptype, user, verbose=False):
 		"""Returns true if current user is the session user"""


### PR DESCRIPTION
User Mention cache is deleted on 3 occasions:
- when a new user is inserted
- when `allowed_in_mention` or `user_type` value has changed
- when a user is deleted

But we didn't delete it when a user was enabled or disabled as we maintain the mention cache for enabled users

https://github.com/frappe/frappe/blob/9fa69e26104c09aeb8a444ab22566559a562e8f9/frappe/desk/search.py#L350-L360