### PR TITLE
fix: Datetime field not getting saved if use NOW button.

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -85,6 +85,6 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 		if (!value && !this.doc) {
 			value = this.last_value;
 		}
-		return frappe.datetime.get_datetime_as_string(value);
+		return !value ? "" : frappe.datetime.get_datetime_as_string(value);
 	}
 };


### PR DESCRIPTION
The DateTime field value is not saved when clicking on the NOW button.

<table>
<tr>
	<td> Before
	<td> After
<tr>
	<td> 

![DatetimeBug](https://user-images.githubusercontent.com/30859809/178021197-de09cf35-73b6-42cf-aac3-f4ddd95a8b05.gif)
	<td> 

![DatetimeFix](https://user-images.githubusercontent.com/30859809/178021214-01950e27-c0d2-4431-b51a-7c3fef225ec0.gif)

</td>
</table>

Fixes: https://github.com/frappe/frappe/issues/17382