### PR TITLE
fix: set primary action after clearing previous action

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -145,7 +145,8 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		return this.get_primary_btn()
 			.removeClass("hide")
 			.html(label)
-			.click(function() {
+			.off('click')
+			.on('click', function() {
 				me.primary_action_fulfilled = true;
 				// get values and send it
 				// as first parameter to click callback


### PR DESCRIPTION
Issue:
If `set_primary_action` is overridden, if will still perform all previous actions.

Fix:
removing previous actions before setting new action.

