### PR TITLE
fix: prettyDate safari issue due to Invalid date.

### DIFF
--- a/frappe/public/js/frappe/utils/pretty_date.js
+++ b/frappe/public/js/frappe/utils/pretty_date.js
@@ -6,7 +6,7 @@ function prettyDate(date, mini) {
 		date = new Date((date || "").replace(/-/g, "/").replace(/[TZ]/g, " ").replace(/\.[0-9]*/, ""));
 	}
 
-	let diff = (((new Date(frappe.datetime.now_datetime())).getTime() - date.getTime()) / 1000);
+	let diff = (((new Date(frappe.datetime.now_datetime().replace(/-/g, "/"))).getTime() - date.getTime()) / 1000);
 	let day_diff = Math.floor(diff / 86400);
 
 	if (isNaN(day_diff) || day_diff < 0) return '';


### PR DESCRIPTION
Safari throws invalid date error with 2022-07-09 (-) format. so added replace for (-) with (/) 2022/07/09.

<img width="803" alt="safari prettyDate fix" src="https://user-images.githubusercontent.com/39730881/178116839-9189f5ba-7100-4152-851b-e61f45068a26.png">

