### PR TITLE
feat(UX): generate preview of Webhook request data

### DIFF
--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -17,6 +17,7 @@ def run_webhooks(doc, method):
 	if frappe.flags.webhooks_executed is None:
 		frappe.flags.webhooks_executed = {}
 
+	# TODO: remove this hazardous unnecessary cache in flags
 	if frappe.flags.webhooks is None:
 		# load webhooks from cache
 		webhooks = frappe.cache().get_value("webhooks")

--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -72,6 +72,17 @@ frappe.ui.form.on('Webhook', {
 
 	enable_security: (frm) => {
 		frm.toggle_reqd('webhook_secret', frm.doc.enable_security);
+	},
+
+	preview_document: (frm) => {
+		frappe.call({
+			method: "generate_preview",
+			doc: frm.doc,
+			callback: (r) => {
+				frm.refresh_field("meets_condition");
+				frm.refresh_field("preview_request_body");
+			},
+		});
 	}
 });
 

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -28,7 +28,13 @@
   "webhook_headers",
   "sb_webhook_data",
   "webhook_data",
-  "webhook_json"
+  "webhook_json",
+  "preview_tab",
+  "preview_document",
+  "column_break_26",
+  "meets_condition",
+  "section_break_28",
+  "preview_request_body"
  ],
  "fields": [
   {
@@ -163,13 +169,45 @@
    "label": "Request Method",
    "options": "POST\nPUT\nDELETE",
    "reqd": 1
+  },
+  {
+   "fieldname": "preview_tab",
+   "fieldtype": "Tab Break",
+   "label": "Preview"
+  },
+  {
+   "fieldname": "preview_document",
+   "fieldtype": "Dynamic Link",
+   "label": "Select Document",
+   "options": "webhook_doctype"
+  },
+  {
+   "fieldname": "preview_request_body",
+   "fieldtype": "Code",
+   "is_virtual": 1,
+   "label": "Request Body"
+  },
+  {
+   "fieldname": "meets_condition",
+   "fieldtype": "Data",
+   "is_virtual": 1,
+   "label": "Meets Condition?"
+  },
+  {
+   "fieldname": "column_break_26",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_28",
+   "fieldtype": "Section Break"
   }
  ],
  "links": [],
- "modified": "2021-05-25 11:11:28.555291",
+ "modified": "2022-07-11 08:54:10.740512",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -187,6 +225,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "webhook_doctype",
  "track_changes": 1
 }

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -118,9 +118,9 @@ def log_request(url: str, headers: dict, data: dict, res: requests.Response | No
 			"doctype": "Webhook Request Log",
 			"user": frappe.session.user if frappe.session.user else None,
 			"url": url,
-			"headers": json.dumps(headers, indent=4) if headers else None,
-			"data": json.dumps(data, indent=4) if isinstance(data, dict) else data,
-			"response": json.dumps(res.json(), indent=4) if res else None,
+			"headers": frappe.as_json(headers) if headers else None,
+			"data": frappe.as_json(data) if data else None,
+			"response": frappe.as_json(res.json()) if res else None,
 		}
 	)
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -47,7 +47,7 @@ class Webhook(Document):
 			try:
 				frappe.safe_eval(self.condition, eval_locals=get_context(temp_doc))
 			except Exception as e:
-				frappe.throw(_(e))
+				frappe.throw(_("Invalid Condition: {}").format(e))
 
 	def validate_request_url(self):
 		try:

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import base64
-import datetime
 import hashlib
 import hmac
 import json
@@ -27,6 +26,7 @@ class Webhook(Document):
 		self.validate_request_url()
 		self.validate_request_body()
 		self.validate_repeating_fields()
+		self.preview_document = None
 
 	def on_update(self):
 		frappe.cache().delete_value("webhooks")
@@ -73,6 +73,38 @@ class Webhook(Document):
 
 		if len(webhook_data) != len(set(webhook_data)):
 			frappe.throw(_("Same Field is entered more than once"))
+
+	@frappe.whitelist()
+	def generate_preview(self):
+		# This function doesn't need to do anything specific as virtual fields
+		# get evaluated automatically.
+		pass
+
+	@property
+	def meets_condition(self):
+		if not self.condition:
+			return _("Yes")
+
+		if not (self.preview_document and self.webhook_doctype):
+			return _("Select a document to check if it meets conditions.")
+
+		try:
+			doc = frappe.get_cached_doc(self.webhook_doctype, self.preview_document)
+			met_condition = frappe.safe_eval(self.condition, eval_locals=get_context(doc))
+		except Exception as e:
+			return _("Failed to evaluate conditions: {}").format(e)
+		return _("Yes") if met_condition else _("No")
+
+	@property
+	def preview_request_body(self):
+		if not (self.preview_document and self.webhook_doctype):
+			return _("Select a document to preview request data")
+
+		try:
+			doc = frappe.get_cached_doc(self.webhook_doctype, self.preview_document)
+			return frappe.as_json(get_webhook_data(doc, self))
+		except Exception as e:
+			return _("Failed to compute request body: {}").format(e)
 
 
 def get_context(doc):

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -539,7 +539,9 @@ class BaseDocument:
 			return
 
 		d = self.get_valid_dict(
-			convert_dates_to_str=True, ignore_nulls=self.doctype in DOCTYPES_FOR_DOCTYPE
+			convert_dates_to_str=True,
+			ignore_nulls=self.doctype in DOCTYPES_FOR_DOCTYPE,
+			ignore_virtual=True,
 		)
 
 		# don't update name, as case might've been changed


### PR DESCRIPTION
Currently, to see generated response for any webhook you need to host a server and see what will be the generated response, this takes a lot of time for iterating and fixing minor errors (imagine a silly missed comma that causes JSON encoding failure)


After this change, you can select any existing document to evaluate if it meets the conditions and what will be the request data. 


<img width="1087" alt="Screenshot 2022-07-11 at 5 19 13 PM" src="https://user-images.githubusercontent.com/9079960/178257803-07c8d77f-2b8b-4f20-8dbb-556b3b280233.png">



https://user-images.githubusercontent.com/9079960/178257886-d305b1db-7c05-4e89-bde9-6c3e96a7a750.mov


---

Also includes 2 fixes
- Correct condition validation message, currently it's just throwing a useless exception.
- Allow `Array` type request bodies, this is allowed in webhook but fails when the request is logged since it is unable to convert Array to JSON string.


```
Traceback (most recent call last):
  File "apps/frappe/frappe/utils/background_jobs.py", line 134, in execute_job
    method(**kwargs)
  File "apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 105, in enqueue_webhook
    log_request(webhook.request_url, headers, data, r)
  File "apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 125, in log_request
    request_log.save(ignore_permissions=True)
  File "apps/frappe/frappe/model/document.py", line 310, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 332, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 262, in insert
    self._validate()
  File "apps/frappe/frappe/model/document.py", line 542, in _validate
    self._validate_length()
  File "apps/frappe/frappe/model/base_document.py", line 780, in _validate_length
    for fieldname, value in iteritems(self.get_valid_dict()):
  File "apps/frappe/frappe/model/base_document.py", line 291, in get_valid_dict
    frappe.throw(_("Value for {0} cannot be a list").format(_(df.label)))
  File "apps/frappe/frappe/__init__.py", line 511, in throw
    as_list=as_list,
  File "apps/frappe/frappe/__init__.py", line 479, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 434, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Value for Data cannot be a list
```

`no-docs` obvious af behaviour