### PR TITLE
fix!: dynamic homepage for all users on login

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -194,7 +194,7 @@ class LoginManager:
 			frappe.local.cookie_manager.set_cookie("system_user", "yes")
 			if not resume:
 				frappe.local.response["message"] = "Logged In"
-				frappe.local.response["home_page"] = "/app"
+				frappe.local.response["home_page"] = "/" + get_home_page()
 
 		if not resume:
 			frappe.response["full_name"] = self.full_name

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -117,7 +117,12 @@ def get_home_page():
 			home_page = frappe.db.get_single_value("Website Settings", "home_page")
 
 		if not home_page:
-			home_page = "login" if frappe.session.user == "Guest" else "me"
+			if frappe.session.user == "Guest":
+				home_page = "login"
+			elif frappe.session.data.user_type == "System User":
+				home_page = "app"
+			else:
+				home_page = "me"
 
 		home_page = home_page.strip("/")
 

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -27,10 +27,7 @@ def get_context(context):
 
 	if frappe.session.user != "Guest":
 		if not redirect_to:
-			if frappe.session.data.user_type == "Website User":
-				redirect_to = get_home_page()
-			else:
-				redirect_to = "/app"
+			redirect_to = get_home_page()
 
 		if redirect_to != "login":
 			frappe.local.flags.redirect_location = redirect_to


### PR DESCRIPTION
There are a couple of ways to customize the default homepage when a user logs in, but it only works for "Website User". If you are a "System User" you will always be redirected to "/app". I think the homepage customization should be for all types of users. This PR makes that change.

Although this is technically a breaking change, it will only change the behavior of which page is shown when a user logs in. If you are already logged in, the `get_home_page` function is run for all user types. So it is inconsistent behavior.

