### PR TITLE
fix!: allow system managers to toggle email queue

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -275,13 +275,6 @@ def delete(doctype, name):
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
-def set_default(key, value, parent=None):
-	"""set a user default value"""
-	frappe.db.set_default(key, value, parent or frappe.session.user)
-	frappe.clear_cache(user=frappe.session.user)
-
-
-@frappe.whitelist(methods=["POST", "PUT"])
 def bulk_update(docs):
 	"""Bulk update documents
 

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -114,7 +114,7 @@ class EmailQueue(Document):
 		if (
 			frappe.are_emails_muted()
 			or not self.is_to_be_sent()
-			or cint(frappe.db.get_default("hold_queue")) == 1
+			or cint(frappe.db.get_default("suspend_email_queue")) == 1
 		):
 			return False
 
@@ -384,7 +384,7 @@ def send_now(name):
 @frappe.whitelist()
 def toggle_sending(enable):
 	frappe.only_for("System Manager")
-	frappe.db.set_default("hold_queue", 0 if sbool(enable) else 1)
+	frappe.db.set_default("suspend_email_queue", 0 if sbool(enable) else 1)
 
 
 def on_doctype_update():

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -27,6 +27,7 @@ from frappe.utils import (
 	get_hook_method,
 	get_string_between,
 	nowdate,
+	sbool,
 	split_emails,
 )
 
@@ -110,8 +111,11 @@ class EmailQueue(Document):
 		return self.status in ["Not Sent", "Partially Sent"]
 
 	def can_send_now(self):
-		hold_queue = cint(frappe.defaults.get_defaults().get("hold_queue")) == 1
-		if frappe.are_emails_muted() or not self.is_to_be_sent() or hold_queue:
+		if (
+			frappe.are_emails_muted()
+			or not self.is_to_be_sent()
+			or cint(frappe.db.get_default("hold_queue")) == 1
+		):
 			return False
 
 		return True
@@ -359,6 +363,8 @@ class SendMailContext:
 @frappe.whitelist()
 def retry_sending(name):
 	doc = frappe.get_doc("Email Queue", name)
+	doc.check_permission()
+
 	if doc and (doc.status == "Error" or doc.status == "Partially Errored"):
 		doc.status = "Not Sent"
 		for d in doc.recipients:
@@ -371,7 +377,14 @@ def retry_sending(name):
 def send_now(name):
 	record = EmailQueue.find(name)
 	if record:
+		record.check_permission()
 		record.send()
+
+
+@frappe.whitelist()
+def toggle_sending(enable):
+	frappe.only_for("System Manager")
+	frappe.db.set_default("hold_queue", 0 if sbool(enable) else 1)
 
 
 def on_doctype_update():

--- a/frappe/email/doctype/email_queue/email_queue_list.js
+++ b/frappe/email/doctype/email_queue/email_queue_list.js
@@ -15,7 +15,7 @@ function show_toggle_sending_button(list_view) {
 	if (!has_common(frappe.user_roles, ["Administrator", "System Manager"]))
 		return;
 
-	const sending_disabled = cint(frappe.sys_defaults.hold_queue);
+	const sending_disabled = cint(frappe.sys_defaults.suspend_email_queue);
 	const label = sending_disabled ? __("Resume Sending") : __("Suspend Sending");
 
 	list_view.page.add_inner_button(
@@ -28,8 +28,8 @@ function show_toggle_sending_button(list_view) {
 				{enable: sending_disabled}
 			);
 
-			// set new value for hold_queue in sys_defaults
-			frappe.sys_defaults.hold_queue = sending_disabled ? 0 : 1;
+			// set new value for suspend_email_queue in sys_defaults
+			frappe.sys_defaults.suspend_email_queue = sending_disabled ? 0 : 1;
 
 			// clear the button and show one with the opposite label
 			list_view.page.remove_inner_button(label);

--- a/frappe/email/doctype/email_queue/email_queue_list.js
+++ b/frappe/email/doctype/email_queue/email_queue_list.js
@@ -3,27 +3,37 @@ frappe.listview_settings['Email Queue'] = {
 		var colour = {'Sent': 'green', 'Sending': 'blue', 'Not Sent': 'grey', 'Error': 'red', 'Expired': 'orange'};
 		return [__(doc.status), colour[doc.status], "status,=," + doc.status];
 	},
-	refresh: function(doclist){
-		if (has_common(frappe.user_roles, ["Administrator", "System Manager"])){
-			if (cint(frappe.defaults.get_default("hold_queue"))){
-				doclist.page.clear_inner_toolbar()
-				doclist.page.add_inner_button(__("Resume Sending"), function() {
-					frappe.defaults.set_default("hold_queue", 0);
-					cur_list.refresh();
-				})
-			} else {
-				doclist.page.clear_inner_toolbar()
-				doclist.page.add_inner_button(__("Suspend Sending"), function() {
-					frappe.defaults.set_default("hold_queue", 1)
-					cur_list.refresh();
-				})
-			}
-		}
-	},
-
-	onload: function(listview) {
+	refresh: show_toggle_sending_button,
+	onload: function(list_view) {
 		frappe.require("logtypes.bundle.js", () => {
-			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+			frappe.utils.logtypes.show_log_retention_message(list_view.doctype);
 		})
 	}
+};
+
+function show_toggle_sending_button(list_view) {
+	if (!has_common(frappe.user_roles, ["Administrator", "System Manager"]))
+		return;
+
+	const sending_disabled = cint(frappe.sys_defaults.hold_queue);
+	const label = sending_disabled ? __("Resume Sending") : __("Suspend Sending");
+
+	list_view.page.add_inner_button(
+		label,
+		async () => {
+			await frappe.xcall(
+				"frappe.email.doctype.email_queue.email_queue.toggle_sending",
+
+				// enable if disabled
+				{enable: sending_disabled}
+			);
+
+			// set new value for hold_queue in sys_defaults
+			frappe.sys_defaults.hold_queue = sending_disabled ? 0 : 1;
+
+			// clear the button and show one with the opposite label
+			list_view.page.remove_inner_button(label);
+			show_toggle_sending_button(list_view);
+		}
+	);
 }

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -148,7 +148,7 @@ def flush(from_test=False):
 		msgprint(_("Emails are muted"))
 		from_test = True
 
-	if cint(frappe.db.get_default("hold_queue")) == 1:
+	if cint(frappe.db.get_default("suspend_email_queue")) == 1:
 		return
 
 	for row in get_queue():

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -148,7 +148,7 @@ def flush(from_test=False):
 		msgprint(_("Emails are muted"))
 		from_test = True
 
-	if cint(frappe.defaults.get_defaults().get("hold_queue")) == 1:
+	if cint(frappe.db.get_default("hold_queue")) == 1:
 		return
 
 	for row in get_queue():

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -205,3 +205,4 @@ frappe.patches.v14_0.update_auto_account_deletion_duration
 frappe.patches.v14_0.update_integration_request
 frappe.patches.v14_0.set_document_expiry_default
 frappe.patches.v14_0.delete_data_migration_tool
+frappe.patches.v14_0.set_hold_queue_default

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -205,4 +205,4 @@ frappe.patches.v14_0.update_auto_account_deletion_duration
 frappe.patches.v14_0.update_integration_request
 frappe.patches.v14_0.set_document_expiry_default
 frappe.patches.v14_0.delete_data_migration_tool
-frappe.patches.v14_0.set_hold_queue_default
+frappe.patches.v14_0.set_suspend_email_queue_default

--- a/frappe/patches/v14_0/set_hold_queue_default.py
+++ b/frappe/patches/v14_0/set_hold_queue_default.py
@@ -1,0 +1,20 @@
+import frappe
+from frappe.cache_manager import clear_defaults_cache
+
+
+def execute():
+	frappe.db.set_default(
+		"hold_queue",
+		frappe.db.get_default("hold_queue", "Administrator") or 0,
+		parent="__default",
+	)
+
+	frappe.db.delete(
+		"DefaultValue",
+		{
+			"defkey": "hold_queue",
+			"parent": ("!=", "__default"),
+		},
+	)
+
+	clear_defaults_cache()

--- a/frappe/patches/v14_0/set_suspend_email_queue_default.py
+++ b/frappe/patches/v14_0/set_suspend_email_queue_default.py
@@ -4,17 +4,10 @@ from frappe.cache_manager import clear_defaults_cache
 
 def execute():
 	frappe.db.set_default(
-		"hold_queue",
+		"suspend_email_queue",
 		frappe.db.get_default("hold_queue", "Administrator") or 0,
 		parent="__default",
 	)
 
-	frappe.db.delete(
-		"DefaultValue",
-		{
-			"defkey": "hold_queue",
-			"parent": ("!=", "__default"),
-		},
-	)
-
+	frappe.db.delete("DefaultValue", {"defkey": "hold_queue"})
 	clear_defaults_cache()

--- a/frappe/public/js/frappe/defaults.js
+++ b/frappe/public/js/frappe/defaults.js
@@ -47,20 +47,6 @@ frappe.defaults = {
 		if(!$.isArray(d)) d = [d];
 		return d;
 	},
-	set_default: function(key, value, callback) {
-		if(typeof value!=="string")
-			value = JSON.stringify(value);
-
-		frappe.boot.user.defaults[key] = value;
-		return frappe.call({
-			method: "frappe.client.set_default",
-			args: {
-				key: key,
-				value: value
-			},
-			callback: callback || function(r) {}
-		});
-	},
 	set_user_default_local: function(key, value) {
 		frappe.boot.user.defaults[key] = value;
 	},


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/14218

## Why did the **Resume / Suspend Sending** button only work for Administrator?

The button set the default `hold_queue` using the `frappe.defaults.set_default` JS API which called the `frappe.client.set_default` API without explicitly passing a `parent`. In absence of a parent, the `set_default` API chose `frappe.session.user` as one (why?). When processing the queue in `EmailQueue.process`, we're using `frappe.defaults.get_defaults` which gets defaults from the `__default` + `frappe.session.user` parents. When called from redis queue, the `frappe.session.user` is Administrator. Hence, `get_defaults` gives the correct value of `hold_queue` only if set by Administrator, but not other users.

## Changes Made

- **BREAKING:** remove `frappe.client.set_default` and the corresponding `frappe.default.set_default` API. Shouldn't affect a lot of users:
  https://sourcegraph.com/search?q=context:global+frappe.client.set_default&patternType=literal
  https://sourcegraph.com/search?q=context:global+frappe.defaults.set_default+lang:javascript+&patternType=literal

- New whitelisted method for System Managers to toggle sending - corresponding implementation in `email_queue_list.js`
- The toggle between List View and other views wasn't showing before due to call of `clear_inner_toolbar` - fixed.
- Use `frappe.db.get_default` instead of `frappe.defaults.get_defaults` when checking `hold_queue`.
- Patch to set `hold_queue` in the `__default` parent instead of `Administrator`, and to remove the default from all other user parents.
- Update existing whitelisted methods to check permission.

## Screenshots

### Patch Test

![image](https://user-images.githubusercontent.com/16315650/178320751-d9f9b6b3-d9b6-478f-880f-bdb34e466d55.png)

### UI

![email queue after](https://user-images.githubusercontent.com/16315650/178321194-976639f7-137c-4a01-9544-d188b886d292.gif)
