### PR TITLE
fix: dont scrub key if found in defaults, but falsy

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -937,7 +937,10 @@ class Database:
 		if not key:
 			return defaults
 
-		return defaults.get(key) or defaults.get(frappe.scrub(key))
+		if key in defaults:
+			return defaults.get(key)
+
+		return defaults.get(frappe.scrub(key))
 
 	def begin(self):
 		self.sql("START TRANSACTION")

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -938,7 +938,7 @@ class Database:
 			return defaults
 
 		if key in defaults:
-			return defaults.get(key)
+			return defaults[key]
 
 		return defaults.get(frappe.scrub(key))
 


### PR DESCRIPTION
`defaults.get(key)` could return an empty string, shouldn't fallback to `defaults.get(frappe.scrub(key))` in that case.