### PR TITLE
fix: Preserve data type in excel export except for composite

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import datetime
 import json
 import os
 from datetime import timedelta
@@ -384,6 +385,18 @@ def format_duration_fields(data: frappe._dict) -> None:
 
 
 def build_xlsx_data(data, visible_idx, include_indentation, ignore_visible_idx=False):
+	EXCEL_TYPES = (
+		str,
+		bool,
+		type(None),
+		int,
+		float,
+		datetime.datetime,
+		datetime.date,
+		datetime.time,
+		datetime.timedelta,
+	)
+
 	result = [[]]
 	column_widths = []
 
@@ -408,7 +421,9 @@ def build_xlsx_data(data, visible_idx, include_indentation, ignore_visible_idx=F
 					label = column.get("label")
 					fieldname = column.get("fieldname")
 					cell_value = row.get(fieldname, row.get(label, ""))
-					cell_value = cstr(cell_value) if isinstance(cell_value, list) else cell_value
+					if not isinstance(cell_value, EXCEL_TYPES):
+						cell_value = cstr(cell_value)
+
 					if cint(include_indentation) and "indent" in row and col_idx == 0:
 						cell_value = ("    " * cint(row["indent"])) + cstr(cell_value)
 					row_data.append(cell_value)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -407,7 +407,8 @@ def build_xlsx_data(data, visible_idx, include_indentation, ignore_visible_idx=F
 						continue
 					label = column.get("label")
 					fieldname = column.get("fieldname")
-					cell_value = cstr(row.get(fieldname, row.get(label, "")))
+					cell_value = row.get(fieldname, row.get(label, ""))
+					cell_value = cstr(cell_value) if isinstance(cell_value, list) else cell_value
 					if cint(include_indentation) and "indent" in row and col_idx == 0:
 						cell_value = ("    " * cint(row["indent"])) + cstr(cell_value)
 					row_data.append(cell_value)

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -39,7 +39,12 @@ class TestQueryReport(unittest.TestCase):
 		self.assertListEqual(column_widths, [0, 10, 15])
 
 		for row in xlsx_data:
-			self.assertEqual(type(row), list)
+			self.assertIsInstance(row, list)
+
+		# ensure all types are preserved
+		for row in xlsx_data[1:]:
+			for cell in row:
+				self.assertIsInstance(cell, (int, float))
 
 	def test_xlsx_export_with_composite_cell_value(self):
 		"""Test excel export using rows with composite cell value"""


### PR DESCRIPTION
### Preserve data type in Export
Unless the cell value is of List, preserve data type of cell value while exporting to Excel.  Custom Cash flow report is the only report that have a list in cell value. I don't see where cell's can have dict or object as cell values. So, ignoring them.

|With casting | without casting |
|-|-|
|<img width="365" alt="str" src="https://user-images.githubusercontent.com/3272205/178453333-ac1b7fd3-83f1-43b6-b994-c573d2010e5d.png"> | <img width="236" alt="preserved" src="https://user-images.githubusercontent.com/3272205/178453528-73fcd138-a2c2-4525-b39e-cf57ce25288c.png"> |



