### PR TITLE
fix(quill): don't go beyond container for bubble

### DIFF
--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -71,6 +71,7 @@ frappe.ui.form.ControlComment = class ControlComment extends frappe.ui.form.Cont
 		const options = super.get_quill_options();
 		return Object.assign(options, {
 			theme: 'bubble',
+			bounds: this.quill_container[0],
 			modules: Object.assign(options.modules, {
 				mention: this.get_mention_options()
 			})


### PR DESCRIPTION
Comment box uses bubble type quill editor, options for which seem to spill
out and hide behind the comment container. This fixes the UI glitch.

ref: https://quilljs.com/docs/configuration/#bounds


before:
<img width="1087" alt="Screenshot 2022-07-12 at 5 50 21 PM" src="https://user-images.githubusercontent.com/9079960/178488209-736272f8-2efc-4982-a1ca-05604e403683.png">


after:
<img width="1087" alt="Screenshot 2022-07-12 at 5 48 16 PM" src="https://user-images.githubusercontent.com/9079960/178488242-eba18bd0-4496-4c83-a18f-e10c93d379f7.png">


