### PR TITLE
refactor: change Admin based OTP reset to role based reset (System Manager)

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -173,14 +173,16 @@ frappe.ui.form.on('User', {
 				});
 			}
 
-			frm.add_custom_button(__("Reset OTP Secret"), function() {
-				frappe.call({
-					method: "frappe.twofactor.reset_otp_secret",
-					args: {
-						"user": frm.doc.name
-					}
-				});
-			}, __("Password"));
+			if (frappe.session.user == doc.name || frappe.user.has_role("System Manager")) {
+				frm.add_custom_button(__("Reset OTP Secret"), function() {
+					frappe.call({
+						method: "frappe.twofactor.reset_otp_secret",
+						args: {
+							"user": frm.doc.name
+						}
+					});
+				}, __("Password"));
+			}
 
 			frm.trigger('enabled');
 

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -463,7 +463,7 @@ def disable():
 def reset_otp_secret(user):
 	otp_issuer = frappe.db.get_value("System Settings", "System Settings", "otp_issuer_name")
 	user_email = frappe.db.get_value("User", user, "email")
-	if frappe.session.user in ["Administrator", user]:
+	if frappe.session.user == user or "System Manager" in frappe.get_roles():
 		frappe.defaults.clear_default(user + "_otplogin")
 		frappe.defaults.clear_default(user + "_otpsecret")
 		email_args = {
@@ -490,4 +490,4 @@ def reset_otp_secret(user):
 			_("OTP Secret has been reset. Re-registration will be required on next login.")
 		)
 	else:
-		return frappe.throw(_("OTP secret can only be reset by the Administrator."))
+		return frappe.throw(_("OTP secret can only be reset by System Managers."))

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -461,33 +461,35 @@ def disable():
 
 @frappe.whitelist()
 def reset_otp_secret(user):
+	if frappe.session.user != user:
+		frappe.only_for("System Manager", message=True)
+
 	otp_issuer = frappe.db.get_value("System Settings", "System Settings", "otp_issuer_name")
 	user_email = frappe.db.get_value("User", user, "email")
-	if frappe.session.user == user or "System Manager" in frappe.get_roles():
-		frappe.defaults.clear_default(user + "_otplogin")
-		frappe.defaults.clear_default(user + "_otpsecret")
-		email_args = {
-			"recipients": user_email,
-			"sender": None,
-			"subject": _("OTP Secret Reset - {0}").format(otp_issuer or "Frappe Framework"),
-			"message": _(
-				"<p>Your OTP secret on {0} has been reset. If you did not perform this reset and did not request it, please contact your System Administrator immediately.</p>"
-			).format(otp_issuer or "Frappe Framework"),
-			"delayed": False,
-			"retry": 3,
-		}
-		enqueue(
-			method=frappe.sendmail,
-			queue="short",
-			timeout=300,
-			event=None,
-			is_async=True,
-			job_name=None,
-			now=False,
-			**email_args,
-		)
-		return frappe.msgprint(
-			_("OTP Secret has been reset. Re-registration will be required on next login.")
-		)
-	else:
-		return frappe.throw(_("OTP secret can only be reset by System Managers."))
+
+	frappe.defaults.clear_default(user + "_otplogin")
+	frappe.defaults.clear_default(user + "_otpsecret")
+
+	email_args = {
+		"recipients": user_email,
+		"sender": None,
+		"subject": _("OTP Secret Reset - {0}").format(otp_issuer or "Frappe Framework"),
+		"message": _(
+			"<p>Your OTP secret on {0} has been reset. If you did not perform this reset and did not request it, please contact your System Administrator immediately.</p>"
+		).format(otp_issuer or "Frappe Framework"),
+		"delayed": False,
+		"retry": 3,
+	}
+
+	enqueue(
+		method=frappe.sendmail,
+		queue="short",
+		timeout=300,
+		event=None,
+		is_async=True,
+		job_name=None,
+		now=False,
+		**email_args,
+	)
+
+	frappe.msgprint(_("OTP Secret has been reset. Re-registration will be required on next login."))


### PR DESCRIPTION
Currently only the Administrator user can reset OTP secrets. In a production environment this is quite inconvenient since the Administrator user should not be shared among different support users. Instead, it would be more feasible to enable the reset for System Managers. Thereby, following not a user but role based permission concept.