### PR TITLE
feat: support strikethrough in text-editor/comments

### DIFF
--- a/frappe/public/js/frappe/form/controls/comment.js
+++ b/frappe/public/js/frappe/form/controls/comment.js
@@ -103,7 +103,7 @@ frappe.ui.form.ControlComment = class ControlComment extends frappe.ui.form.Cont
 
 	get_toolbar_options() {
 		return [
-			['bold', 'italic', 'underline'],
+			['bold', 'italic', 'underline', 'strike'],
 			['blockquote', 'code-block'],
 			[{ 'direction': "rtl" }],
 			['link', 'image'],

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -184,7 +184,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 		return [
 			[{ header: [1, 2, 3, false] }],
 			[{ size: font_sizes }],
-			['bold', 'italic', 'underline', 'clean'],
+			['bold', 'italic', 'underline', 'strike', 'clean'],
 			[{ 'color': [] }, { 'background': [] }],
 			['blockquote', 'code-block'],
 			// Adding Direction tool to give the user the ability to change text direction.


### PR DESCRIPTION
IMO strikethrough is useful way more often (than many other options that we
already support in the editor) so adding it in the default config.

closes #17470



<img width="741" alt="Screenshot 2022-07-12 at 6 37 42 PM" src="https://user-images.githubusercontent.com/9079960/178497155-28385503-9ba4-47b5-a53e-5e63055e3e28.png">
