### PR TITLE
proposal: Use JSON datatype for tags and user assignments

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -51,6 +51,20 @@ class Database:
 	CHILD_TABLE_COLUMNS = ("parent", "parenttype", "parentfield")
 	MAX_WRITES_PER_TRANSACTION = 200_000
 
+	STANDARD_FIELD_CONVERSION_MAP = {
+		"name": "Link",
+		"owner": "Data",
+		"idx": "Int",
+		"creation": "Data",
+		"modified": "Data",
+		"modified_by": "Data",
+		"_user_tags": "JSON",
+		"_liked_by": "Data",
+		"_comments": "Text",
+		"_assign": "JSON",
+		"docstatus": "Int",
+	}
+
 	class InvalidColumnName(frappe.ValidationError):
 		pass
 

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -78,7 +78,7 @@ class DBTable:
 		# optional fields like _comments
 		if not self.meta.get("istable"):
 			for fieldname in frappe.db.OPTIONAL_COLUMNS:
-				fields.append({"fieldname": fieldname, "fieldtype": "Text"})
+				fields.append({"fieldname": fieldname, "fieldtype": frappe.db.STANDARD_FIELD_CONVERSION_MAP.get(fieldname, "Text")})
 
 			# add _seen column if track_seen
 			if self.meta.get("track_seen"):

--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -97,7 +97,7 @@ class ToDo(Document):
 			elif frappe.db.is_column_missing(e):
 				from frappe.database.schema import add_column
 
-				add_column(self.reference_type, "_assign", "Text")
+				add_column(self.reference_type, "_assign", frappe.db.STANDARD_FIELD_CONVERSION_MAP["_assign"])
 				self.update_in_reference()
 
 			else:

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -562,7 +562,7 @@ def get_stats(stats, doctype, filters=None):
 			tag_count = frappe.get_list(
 				doctype,
 				fields=[tag, "count(*)"],
-				filters=filters + [[tag, "!=", ""]],
+				filters=filters + [[tag, "is", "set"]],
 				group_by=tag,
 				as_list=True,
 				distinct=1,
@@ -573,7 +573,7 @@ def get_stats(stats, doctype, filters=None):
 				no_tag_count = frappe.get_list(
 					doctype,
 					fields=[tag, "count(*)"],
-					filters=filters + [[tag, "in", ("", ",")]],
+					filters=filters + [[tag, "is", "set"]],
 					as_list=True,
 					group_by=tag,
 					order_by=tag,
@@ -597,7 +597,6 @@ def get_stats(stats, doctype, filters=None):
 @frappe.whitelist()
 def get_filter_dashboard_data(stats, doctype, filters=None):
 	"""get tags info"""
-	import json
 
 	tags = json.loads(stats)
 	filters = json.loads(filters or [])
@@ -652,10 +651,7 @@ def scrub_user_tags(tagcount):
 	rdict = {}
 	tagdict = dict(tagcount)
 	for t in tagdict:
-		if not t:
-			continue
-		alltags = t.split(",")
-		for tag in alltags:
+		for tag in json.loads(t):
 			if tag:
 				if tag not in rdict:
 					rdict[tag] = 0

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -324,7 +324,7 @@ class BaseDocument:
 							eval_locals={"doc": self},
 						)
 
-				if isinstance(d[fieldname], list) and df.fieldtype not in table_fields:
+				if isinstance(d[fieldname], list) and df.fieldtype != "JSON" and df.fieldtype not in table_fields:
 					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label)))
 
 				if df.fieldtype == "Check":
@@ -333,7 +333,7 @@ class BaseDocument:
 				elif df.fieldtype == "Int" and not isinstance(d[fieldname], int):
 					d[fieldname] = cint(d[fieldname])
 
-				elif df.fieldtype == "JSON" and isinstance(d[fieldname], dict):
+				elif df.fieldtype == "JSON" and not isinstance(d[fieldname], str):
 					d[fieldname] = json.dumps(d[fieldname], sort_keys=True, indent=4, separators=(",", ": "))
 
 				elif df.fieldtype in float_like_fields and not isinstance(d[fieldname], float):

--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -8,19 +8,7 @@ from frappe import _
 from frappe.build import html_to_js_template
 from frappe.utils import cstr
 
-STANDARD_FIELD_CONVERSION_MAP = {
-	"name": "Link",
-	"owner": "Data",
-	"idx": "Int",
-	"creation": "Data",
-	"modified": "Data",
-	"modified_by": "Data",
-	"_user_tags": "Data",
-	"_liked_by": "Data",
-	"_comments": "Text",
-	"_assign": "Text",
-	"docstatus": "Int",
-}
+
 INCLUDE_DIRECTIVE_PATTERN = re.compile(r"""{% include\s['"](.*)['"]\s%}""")
 
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -192,6 +192,7 @@ frappe.patches.v14_0.reset_creation_datetime
 frappe.patches.v14_0.remove_is_first_startup
 frappe.patches.v14_0.clear_long_pending_stale_logs
 frappe.patches.v14_0.log_settings_migration
+frappe.patches.v14_0.convert_to_json_fields
 
 [post_model_sync]
 frappe.patches.v14_0.drop_data_import_legacy

--- a/frappe/patches/v14_0/convert_to_json_fields.py
+++ b/frappe/patches/v14_0/convert_to_json_fields.py
@@ -1,0 +1,26 @@
+from multiprocessing.sharedctypes import Value
+import frappe
+import json
+
+
+def execute():
+	for doctype in frappe.get_list("DocType", filters={"istable": 0, "issingle": 0}):
+		if not frappe.db.has_table(doctype.name):
+			continue
+
+		if frappe.db.has_column(doctype.name, "_user_tags"):
+			# Ensure _user_tags is a valid json string
+			for record in frappe.db.get_all(doctype.name, filters=[("_user_tags", "is", "set")], fields=["name", "_user_tags"]):
+				try:
+					tags = json.loads(record["_user_tags"])
+				except ValueError:
+					tags = [tag for tag in record["_user_tags"].split(",") if tag]
+					frappe.db.set_value(doctype.name, record["name"], "_user_tags", json.dumps(tags))
+
+
+		if frappe.db.has_column(doctype.name, "_user_tags") or frappe.db.has_column(doctype.name, "_assign"):
+			# Migrate to JSON fields
+			frappe.db.updatedb(doctype.name)
+
+
+

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -244,7 +244,11 @@ frappe.form.formatters = {
 	},
 	Tag: function(value) {
 		var html = "";
-		$.each((value || "").split(","), function(i, v) {
+		let tags = typeof value == "string" && value && value.startsWith('[') ? JSON.parse(value) : []
+		if (typeof tags == "string") {
+			tags = [tags]
+		}
+		$.each(tags, function(i, v) {
 			if (v) html += `
 				<span
 					class="data-pill btn-xs align-center ellipsis"

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -198,21 +198,22 @@ frappe.views.ListSidebar = class ListSidebar {
 
 		let tag_list = $(frappe.render_template("list_sidebar_stat", args)).on("click", ".stat-link", (e) => {
 			let fieldname = $(e.currentTarget).attr('data-field');
-			let label = $(e.currentTarget).attr('data-label');
-			let condition = "like";
+			let value = $(e.currentTarget).attr('data-label');
+			let condition = "in";
 			let existing = this.list_view.filter_area.filter_list.get_filter(fieldname);
 			if (existing) {
 				existing.remove();
 			}
-			if (label == "No Tags") {
-				label = "%,%";
-				condition = "not like";
+			if (value == "No Tags") {
+				value = "not set";
+				condition = "is";
 			}
+
 			this.list_view.filter_area.add(
 				this.doctype,
 				fieldname,
 				condition,
-				label
+				value
 			);
 		});
 

--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -276,8 +276,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 			value = 'not set';
 		}
 		if (fieldname === '_assign') {
-			operator = 'like';
-			value = `%${value}%`;
+			operator = 'in';
 		}
 		return this.list_view.filter_area.add(
 			this.doctype,

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -706,7 +706,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		if (col.type === "Tag") {
 			const tags_display_class = !this.tags_shown ? 'hide' : '';
-			let tags_html = doc._user_tags ? this.get_tags_html(doc._user_tags, 2) : '<div class="tags-empty">-</div>';
+			let tags_html = doc._user_tags ? this.get_tags_html(JSON.parse(doc._user_tags), 2) : '<div class="tags-empty">-</div>';
 			return `
 				<div class="list-row-col tag-col ${tags_display_class} hidden-xs ellipsis">
 					${tags_html}
@@ -838,7 +838,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				return `<div class="tag-pill ellipsis" title="${tag}" style="${style}">${tag}</div>`;
 			}
 		};
-		return user_tags.split(',').slice(1, limit + 1).map(get_tag_html).join('');
+		return user_tags.slice(0, limit).map(get_tag_html).join('');
 	}
 
 	get_meta_html(doc) {


### PR DESCRIPTION
Upon trying to filter `Assigned To` field against multiple users, i found out that this will never work.

This is due the fact that these fields do not utilise the JSON datatype. Further more there was no query logic to support this.

I want to propose the usage of https://mariadb.com/kb/en/json_value/

What I have done is the following:

- Provide `STANDARD_FIELD_CONVERSION_MAP` as a single source of truth for standard fields.
- Change `_user_tags` and `_assigned` to "JSON"
- Allow "JSON" fields to contain array's instead of only objects.
- Provide filter logic using JSON_VALUE()
- Fix the frontend to work with json values and no longer rely on "%wildcard%" filters for users and tags.
- Provide a patch to rewrite all records and force update the schema.

With these changes the following is now possible:

<img width="500" alt="Screenshot 2022-07-12 at 16 17 14" src="https://user-images.githubusercontent.com/1424733/178512673-6e952a47-515e-44a2-866a-25791ec95ac6.png">

<img width="505" alt="Screenshot 2022-07-12 at 16 16 59" src="https://user-images.githubusercontent.com/1424733/178512807-1cae7dcc-b222-4202-bbb3-c219562abc2d.png">

Regards

