### PR TITLE
fix(dark theme): background color on version page

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,6 @@ trim_trailing_whitespace = true
 charset = utf-8
 
 # python, js indentation settings
-[{*.py,*.js,*.vue}]
+[{*.py,*.js,*.vue,*.css,*.scss,*.html}]
 indent_style = tab
 indent_size = 4

--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -46,7 +46,7 @@ def is_ci(file):
 	return ".github" in file
 
 def is_frontend_code(file):
-	return file.lower().endswith((".css", ".scss", ".less", ".sass", ".styl", ".js", ".ts", ".vue"))
+	return file.lower().endswith((".css", ".scss", ".less", ".sass", ".styl", ".js", ".ts", ".vue", ".html"))
 
 def is_docs(file):
 	regex = re.compile(r'\.(md|png|jpg|jpeg|csv|svg)$|^.github|LICENSE')

--- a/frappe/core/doctype/version/version_view.html
+++ b/frappe/core/doctype/version/version_view.html
@@ -18,8 +18,8 @@
 		{% for item in data.changed %}
 		<tr>
 			<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
-			<td class="danger">{{ item[1] }}</td>
-			<td class="success">{{ item[2] }}</td>
+			<td class="diff-remove">{{ item[1] }}</td>
+			<td class="diff-add">{{ item[2] }}</td>
 		</tr>
 		{% endfor %}
 	</tbody>
@@ -43,8 +43,7 @@
 			{% for item in values %}
 			<tr>
 				<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
-				<td class="{{
-					key==="added" ? __("success") : __("danger") }}">
+				<td class="{{ key==="added" ? "diff-add" : "diff-remove" }}">
 					{% var item_keys = Object.keys(item[1]).sort(); %}
 					<table class="table table-bordered">
 						<tbody>
@@ -86,8 +85,8 @@
 				<td>{{ frappe.meta.get_label(doc.ref_doctype, table_info[0]) }}</td>
 				<td>{{ table_info[1] }}</td>
 				<td>{{ item[0] }}</td>
-				<td class="danger">{{ item[1] }}</td>
-				<td class="success">{{ item[2] }}</td>
+				<td class="diff-remove">{{ item[1] }}</td>
+				<td class="diff-add">{{ item[2] }}</td>
 			</tr>
 			{% endfor %}
 		{% endfor %}

--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -134,7 +134,7 @@ $input-height: 28px !default;
 
 	--shadow-xs:  rgba(0, 0, 0, 0.05) 0px 0.5px 0px 0px, rgba(0, 0, 0, 0.08) 0px 0px 0px 1px, rgba(0, 0, 0, 0.05) 0px 2px 4px 0px;
 	--shadow-sm: 0px 1px 2px rgba(25, 39, 52, 0.05), 0px 0px 4px rgba(25, 39, 52, 0.1);
-	--shadow-base:  0px 4px 8px rgba(25, 39, 52, 0.06), 0px 0px 4px rgba(25, 39, 52, 0.12);
+	--shadow-base: 0px 4px 8px rgba(25, 39, 52, 0.06), 0px 0px 4px rgba(25, 39, 52, 0.12);
 	--shadow-md:  0px 8px 14px rgba(25, 39, 52, 0.08), 0px 2px 6px rgba(25, 39, 52, 0.04);
 	--shadow-lg: 0px 18px 22px rgba(25, 39, 52, 0.1), 0px 1px 10px rgba(0, 0, 0, 0.06), 0px 0.5px 5px rgba(25, 39, 52, 0.04);
 
@@ -262,9 +262,9 @@ $input-height: 28px !default;
 	--checkbox-focus-shadow: 0 0 0 2px var(--gray-300);
 	--checkbox-gradient: linear-gradient(180deg, #4AC3F8 -124.51%, var(--primary) 100%);
 
-    // "diff" colors
-    --diff-added: var(--green-100);
-    --diff-removed: var(--red-100);
+	// "diff" colors
+	--diff-added: var(--green-100);
+	--diff-removed: var(--red-100);
 
 	--right-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1.25 7.5L4.75 4L1.25 0.5' stroke='%231F272E' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 	--left-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M7.5 9.5L4 6l3.5-3.5' stroke='%231F272E' stroke-linecap='round' stroke-linejoin='round'></path></svg>");

--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -262,6 +262,10 @@ $input-height: 28px !default;
 	--checkbox-focus-shadow: 0 0 0 2px var(--gray-300);
 	--checkbox-gradient: linear-gradient(180deg, #4AC3F8 -124.51%, var(--primary) 100%);
 
+    // "diff" colors
+    --diff-added: var(--green-100);
+    --diff-removed: var(--red-100);
+
 	--right-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M1.25 7.5L4.75 4L1.25 0.5' stroke='%231F272E' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 	--left-arrow-svg: url("data: image/svg+xml;utf8, <svg width='6' height='8' viewBox='0 0 6 8' fill='none' xmlns='http://www.w3.org/2000/svg'><path d='M7.5 9.5L4 6l3.5-3.5' stroke='%231F272E' stroke-linecap='round' stroke-linejoin='round'></path></svg>");
 }

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -91,11 +91,11 @@
 
 	--highlight-shadow: 1px 1px 10px var(--blue-900), 0px 0px 4px var(--blue-500);
 
-	--shadow-base:  0px 4px 8px rgba(114, 176, 233, 0.06), 0px 0px 4px rgba(112, 172, 228, 0.12);
+	--shadow-base: 0px 4px 8px rgba(114, 176, 233, 0.06), 0px 0px 4px rgba(112, 172, 228, 0.12);
 
-    // "diff" colors
-    --diff-added: var(--green-800);
-    --diff-removed: var(--red-800);
+	// "diff" colors
+	--diff-added: var(--green-800);
+	--diff-removed: var(--red-800);
 
 	// input
 	--input-disabled-bg: none;

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -93,6 +93,10 @@
 
 	--shadow-base:  0px 4px 8px rgba(114, 176, 233, 0.06), 0px 0px 4px rgba(112, 172, 228, 0.12);
 
+    // "diff" colors
+    --diff-added: var(--green-800);
+    --diff-removed: var(--red-800);
+
 	// input
 	--input-disabled-bg: none;
 

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -579,22 +579,14 @@ details > summary:focus {
 	color: var(--text-color);
 }
 
-
-.diffview .insert {
-	background-color: var(--green-100);
+.diffview .insert,
+.diff-add {
+	background-color: var(--diff-added);
 }
 
-.diffview .delete {
-	background-color: var(--red-100);
-}
-
-[data-theme="dark"] {
-	.diffview .insert {
-		background-color: var(--green-800);
-	}
-	.diffview .delete {
-		background-color: var(--red-800);
-	}
+.diffview .delete,
+.diff-remove {
+	background-color: var(--diff-removed);
 }
 
 // REDESIGN TODO: Handling of broken images?


### PR DESCRIPTION
Version diff page had hardcoded styles. This PR fixes that and also moves dark versions to dark.scss.

<img width="1056" alt="Screenshot 2022-07-12 at 8 19 09 PM" src="https://user-images.githubusercontent.com/9079960/178518877-aef14312-bc81-4c25-ad00-fac7a0dc7083.png">


After:
<img width="1056" alt="Screenshot 2022-07-12 at 8 11 43 PM" src="https://user-images.githubusercontent.com/9079960/178518688-d861ec00-6020-4656-b769-3e450f167ae0.png">
