### PR TITLE
fix: simplify `defaults._clear_cache`

### DIFF
--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -241,8 +241,4 @@ def get_defaults_for(parent="__default"):
 
 
 def _clear_cache(parent):
-	if parent in common_default_keys:
-		frappe.clear_cache()
-	else:
-		clear_notifications(user=parent)
-		frappe.clear_cache(user=parent)
+	frappe.clear_cache(user=parent if parent not in common_default_keys else None)


### PR DESCRIPTION
- `clear_notifications` already happens inside `frappe.clear_cache  --> clear_user_cache`