### PR TITLE
fix: query params for list filters

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -121,7 +121,7 @@ frappe.router = {
 		route = this.get_sub_path_string(route).split('/');
 		if (!route) return [];
 		route = $.map(route, this.decode_component);
-		this.set_route_options_from_url();
+		this.set_route_options_from_url([route, window.location.serach]);
 		return this.convert_to_standard_route(route);
 	},
 


### PR DESCRIPTION
I could no longer call a List-view and set filter params via the query parameters.

This fixes it.