### PR TITLE
feat: Undo/Redo changes on FormView

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -6,6 +6,7 @@ context('Form', () => {
 			return frappe.call("frappe.tests.ui_test_helpers.create_contact_records");
 		});
 	});
+
 	it('create a new form', () => {
 		cy.visit('/app/todo/new');
 		cy.get_field('description', 'Text Editor').type('this is a test todo', {force: true}).wait(200);
@@ -94,5 +95,64 @@ context('Form', () => {
 				cy.get_field("status", "Select").should("have.value", "Closed");
 			})
 		})
+	});
+
+	it('let user undo/redo field value changes', { scrollBehavior: false }, () => {
+		const jump_to_field = (field_label) => {
+			cy.get("body")
+				.type("{esc}")  // lose focus if any
+				.type("{ctrl+j}")  // jump to field
+				.type(field_label)
+				.wait(500)
+				.type("{enter}")
+				.wait(200)
+				.type("{enter}")
+				.wait(500);
+		};
+
+		const type_value = (value) => {
+			cy.focused()
+				.clear()
+				.type(value)
+				.type("{esc}");
+		};
+
+		const undo = () => cy.get("body").type("{esc}").type("{ctrl+z}").wait(500);
+		const redo = () => cy.get("body").type("{esc}").type("{ctrl+y}").wait(500);
+
+		cy.new_form('User');
+
+		jump_to_field("Email");
+		type_value("admin@example.com");
+
+		jump_to_field("Username");
+		type_value("admin42");
+
+		jump_to_field("Birth Date");
+		type_value("12-31-01");
+
+		jump_to_field("Send Welcome Email");
+		cy.focused().uncheck()
+
+		// make a mistake
+		jump_to_field("Username");
+		type_value("admin24");
+
+		// undo behaviour
+		undo();
+		cy.get_field("username").should('have.value', 'admin42');
+
+		// redo behaviour
+		redo();
+		cy.get_field("username").should('have.value', 'admin24');
+
+		// undo everything & redo everything, ensure same values at the end
+		undo(); undo(); undo(); undo(); undo();
+		redo(); redo(); redo(); redo(); redo();
+
+		cy.get_field("username").should('have.value', 'admin24');
+		cy.get_field("email").should('have.value', 'admin@example.com');
+		cy.get_field("birth_date").should('have.value', '12-31-2001'); // parsed  value
+		cy.get_field("send_welcome_email").should('not.be.checked');
 	});
 });

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -188,7 +188,14 @@ frappe.ui.form.Control = class BaseControl {
 		}
 
 		const old_value = this.get_model_value();
-		this.frm?.undo_manager.record_change({fieldname: me.df.fieldname, old_value, new_value: value});
+		this.frm?.undo_manager.record_change({
+			fieldname: me.df.fieldname,
+			old_value,
+			new_value: value,
+			doctype: this.doctype,
+			docname: this.docname,
+			is_child: Boolean(this.doc?.parenttype)
+		});
 		this.inside_change_event = true;
 		function set(value) {
 			me.inside_change_event = false;

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -188,7 +188,7 @@ frappe.ui.form.Control = class BaseControl {
 		}
 
 		const old_value = this.get_model_value();
-		this.frm?.undo_manager.record_change({
+		this.frm?.undo_manager?.record_change({
 			fieldname: me.df.fieldname,
 			old_value,
 			new_value: value,

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -187,6 +187,8 @@ frappe.ui.form.Control = class BaseControl {
 			return Promise.resolve();
 		}
 
+		const old_value = this.get_model_value();
+		this.frm?.undo_manager.record_change({fieldname: me.df.fieldname, old_value, new_value: value});
 		this.inside_change_event = true;
 		function set(value) {
 			me.inside_change_event = false;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -13,6 +13,7 @@ import './script_helpers';
 import './sidebar/form_sidebar';
 import './footer/footer';
 import './form_tour';
+import {UndoManager } from './undo_manager';
 
 frappe.ui.form.Controller = class FormController {
 	constructor(opts) {
@@ -38,6 +39,7 @@ frappe.ui.form.Form = class FrappeForm {
 		this.fetch_dict = {};
 		this.parent = parent;
 		this.doctype_layout = frappe.get_doc('DocType Layout', doctype_layout_name);
+		this.undo_manager = new UndoManager({frm: this});
 		this.setup_meta(doctype);
 
 		this.beforeUnloadListener = (event) => {
@@ -141,6 +143,26 @@ frappe.ui.form.Form = class FrappeForm {
 			description: __('Go to previous record'),
 			ignore_inputs: true,
 			condition: () => !this.is_new()
+		});
+
+		// Undo and redo
+		frappe.ui.keys.add_shortcut({
+			shortcut: 'ctrl+z',
+			action: () => this.undo_manager.undo(),
+			page: this.page,
+			description: __('Undo last action'),
+		});
+		frappe.ui.keys.add_shortcut({
+			shortcut: 'shift+ctrl+z',
+			action: () => this.undo_manager.redo(),
+			page: this.page,
+			description: __('Redo last action'),
+		});
+		frappe.ui.keys.add_shortcut({
+			shortcut: 'ctrl+y',
+			action: () => this.undo_manager.redo(),
+			page: this.page,
+			description: __('Redo last action'),
 		});
 
 		let grid_shortcut_keys = [

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -379,6 +379,8 @@ frappe.ui.form.Form = class FrappeForm {
 
 		cur_frm = this;
 
+		this.undo_manager.erase_history();
+
 		if(this.docname) { // document to show
 			this.save_disabled = false;
 			// set the doc

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -13,7 +13,7 @@ import './script_helpers';
 import './sidebar/form_sidebar';
 import './footer/footer';
 import './form_tour';
-import {UndoManager } from './undo_manager';
+import { UndoManager } from './undo_manager';
 
 frappe.ui.form.Controller = class FormController {
 	constructor(opts) {
@@ -1785,7 +1785,7 @@ frappe.ui.form.Form = class FrappeForm {
 		return sum;
 	}
 
-	scroll_to_field(fieldname) {
+	scroll_to_field(fieldname, focus=true) {
 		let field = this.get_field(fieldname);
 		if (!field) return;
 
@@ -1805,7 +1805,9 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.utils.scroll_to($el, true, 15);
 
 		// focus if text field
-		$el.find('input, select, textarea').focus();
+		if (focus) {
+			$el.find('input, select, textarea').focus();
+		}
 
 		// highlight control inside field
 		let control_element = $el.find('.form-control')

--- a/frappe/public/js/frappe/form/undo_manager.js
+++ b/frappe/public/js/frappe/form/undo_manager.js
@@ -1,0 +1,36 @@
+export class UndoManager {
+	constructor({ frm }) {
+		this.frm = frm;
+		this.undo_stack = [];
+		this.redo_stack = [];
+	}
+	record_change({ fieldname, old_value, new_value }) {
+		this.undo_stack.push({ fieldname, old_value, new_value });
+	}
+
+	undo() {
+		const change = this.undo_stack.pop();
+		if (change) {
+			this.frm.set_value(change.fieldname, change.old_value);
+			this.redo_stack.push(change);
+		} else {
+			this.show_alert(__("Nothing left to undo"));
+		}
+	}
+
+	redo() {
+		const change = this.redo_stack.pop();
+		if (change) {
+			this.frm.set_value(change.fieldname, change.new_value);
+			this.undo_stack.push(change);
+		} else {
+			this.show_alert(__("Nothing left to redo"));
+		}
+	}
+
+	show_alert(msg) {
+		// reduce duration
+		// keyboard interactions shouldn't have long running
+		frappe.show_alert(msg, 3);
+	}
+}

--- a/frappe/public/js/frappe/form/undo_manager.js
+++ b/frappe/public/js/frappe/form/undo_manager.js
@@ -33,4 +33,9 @@ export class UndoManager {
 		// keyboard interactions shouldn't have long running
 		frappe.show_alert(msg, 3);
 	}
+
+	erase_history() {
+		this.undo_stack = [];
+		this.redo_stack = [];
+	}
 }

--- a/frappe/public/js/frappe/form/undo_manager.js
+++ b/frappe/public/js/frappe/form/undo_manager.js
@@ -12,6 +12,10 @@ export class UndoManager {
 		docname,
 		is_child,
 	}) {
+		if (old_value == new_value) {
+			return;
+		}
+
 		this.undo_stack.push({
 			fieldname,
 			old_value,
@@ -30,24 +34,24 @@ export class UndoManager {
 	undo() {
 		const change = this.undo_stack.pop();
 		if (change) {
-			this.#apply_change(change);
-			this.#push_reverse_entry(change, this.redo_stack);
+			this._apply_change(change);
+			this._push_reverse_entry(change, this.redo_stack);
 		} else {
-			this.#show_alert(__("Nothing left to undo"));
+			this._show_alert(__("Nothing left to undo"));
 		}
 	}
 
 	redo() {
 		const change = this.redo_stack.pop();
 		if (change) {
-			this.#apply_change(change);
-			this.#push_reverse_entry(change, this.undo_stack);
+			this._apply_change(change);
+			this._push_reverse_entry(change, this.undo_stack);
 		} else {
-			this.#show_alert(__("Nothing left to redo"));
+			this._show_alert(__("Nothing left to redo"));
 		}
 	}
 
-	#push_reverse_entry(change, stack) {
+	_push_reverse_entry(change, stack) {
 		stack.push({
 			...change,
 			new_value: change.old_value,
@@ -55,7 +59,7 @@ export class UndoManager {
 		});
 	}
 
-	#apply_change(change) {
+	_apply_change(change) {
 		if (change.is_child) {
 			frappe.model.set_value(
 				change.doctype,
@@ -69,7 +73,7 @@ export class UndoManager {
 		}
 	}
 
-	#show_alert(msg) {
+	_show_alert(msg) {
 		// reduce duration
 		// keyboard interactions shouldn't have long running annoying toasts
 		frappe.show_alert(msg, 3);

--- a/frappe/public/js/frappe/form/undo_manager.js
+++ b/frappe/public/js/frappe/form/undo_manager.js
@@ -4,33 +4,69 @@ export class UndoManager {
 		this.undo_stack = [];
 		this.redo_stack = [];
 	}
-	record_change({ fieldname, old_value, new_value }) {
-		this.undo_stack.push({ fieldname, old_value, new_value });
+	record_change({
+		fieldname,
+		old_value,
+		new_value,
+		doctype,
+		docname,
+		is_child,
+	}) {
+		this.undo_stack.push({
+			fieldname,
+			old_value,
+			new_value,
+			doctype,
+			docname,
+			is_child,
+		});
+		console.log(this.undo_stack[this.undo_stack.length - 1]);
 	}
 
 	undo() {
 		const change = this.undo_stack.pop();
 		if (change) {
-			this.frm.set_value(change.fieldname, change.old_value);
-			this.redo_stack.push(change);
+			this.apply_change(change);
+			this.push_reverse_entry(change, this.redo_stack);
 		} else {
 			this.show_alert(__("Nothing left to undo"));
 		}
 	}
 
+	push_reverse_entry(change, stack) {
+		stack.push({
+			...change,
+			new_value: change.old_value,
+			old_value: change.new_value,
+		});
+	}
+
 	redo() {
 		const change = this.redo_stack.pop();
 		if (change) {
-			this.frm.set_value(change.fieldname, change.new_value);
-			this.undo_stack.push(change);
+			this.apply_change(change);
+			this.push_reverse_entry(change, this.undo_stack);
 		} else {
 			this.show_alert(__("Nothing left to redo"));
 		}
 	}
 
+	apply_change(change) {
+		if (change.is_child) {
+			frappe.model.set_value(
+				change.doctype,
+				change.docname,
+				change.fieldname,
+				change.old_value
+			);
+		} else {
+			this.frm.set_value(change.fieldname, change.old_value);
+		}
+	}
+
 	show_alert(msg) {
 		// reduce duration
-		// keyboard interactions shouldn't have long running
+		// keyboard interactions shouldn't have long running annoying toasts
 		frappe.show_alert(msg, 3);
 	}
 


### PR DESCRIPTION
You can now undo and redo changes with "ctrl+z" and "ctrl+shift+z" respectively. 

The way this works is:
- Whenever user changes any control, the change is logged in undo manager. Only user-initiated actions are logged in UndoManager, changes done programmatically are NOT. 
- When you issue undo using "ctrl+z" the last change is popped and applied to the document. All depended triggers re-apply. The reverse of this change is pushed on the redo stack. 
- When you issue redo it does pretty much the same thing but in opposite manner. 


![undo](https://user-images.githubusercontent.com/9079960/180042511-2939c6e3-54f5-4434-a5ec-02835665f03d.gif)


---


TODO:
- [x] Implement on main form
- [x] clear when doc changes/refreshes
- [x] highlight changed field 
- [x] Implement on child table
- [x] Duplicate entries bug (This is visible in the recording, happens due to same field present in grid and expanded view.)
- [x] Verify against all fieldtypes
- [x] Windows/Linux extra keybind - ctrl+y
- [x] Verify that all triggers retrigger for parent dt fields
- [x] Verify that all triggers retrigger for child doctype fields
- [x] UI tests


PS: this is an internal API of forms, can be changed without any notice and not termed "breaking" ;) 


`no-docs`


closes #17351 