### PR TITLE
refactor!: remove old weekly cleanup for route history

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -5,7 +5,6 @@ from typing import Any, Callable
 
 import frappe
 from frappe import _
-from frappe.boot import get_additional_filters_from_hooks
 from frappe.model.db_query import get_timespan_date_range
 from frappe.query_builder import Criterion, Field, Order, Table
 
@@ -173,6 +172,8 @@ class Query:
 
 	@cached_property
 	def OPERATOR_MAP(self):
+		from frappe.boot import get_additional_filters_from_hooks
+
 		# default operators
 		all_operators = OPERATOR_MAP.copy()
 

--- a/frappe/desk/doctype/route_history/route_history.py
+++ b/frappe/desk/doctype/route_history/route_history.py
@@ -4,43 +4,16 @@
 import frappe
 from frappe.deferred_insert import deferred_insert as _deferred_insert
 from frappe.model.document import Document
-from frappe.query_builder import DocType, Interval
-from frappe.query_builder.functions import Count, Now
 
 
 class RouteHistory(Document):
 	@staticmethod
 	def clear_old_logs(days=30):
+		from frappe.query_builder import Interval
+		from frappe.query_builder.functions import Now
+
 		table = frappe.qb.DocType("Route History")
 		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))
-
-
-def flush_old_route_records():
-	"""Deletes all route records except last 500 records per user"""
-	records_to_keep_limit = 500
-	RouteHistory = DocType("Route History")
-
-	users = (
-		frappe.qb.from_(RouteHistory)
-		.select(RouteHistory.user)
-		.groupby(RouteHistory.user)
-		.having(Count(RouteHistory.name) > records_to_keep_limit)
-	).run(pluck=True)
-
-	for user in users:
-		last_record_to_keep = frappe.get_all(
-			"Route History",
-			filters={"user": user},
-			limit_start=500,
-			fields=["modified"],
-			order_by="modified desc",
-			limit=1,
-		)
-
-		frappe.db.delete(
-			"Route History",
-			{"modified": ("<=", last_record_to_keep[0].modified), "user": user},
-		)
 
 
 @frappe.whitelist()

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -242,7 +242,6 @@ scheduler_events = {
 	"weekly_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_weekly",
 		"frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backups_weekly",
-		"frappe.desk.doctype.route_history.route_history.flush_old_route_records",
 		"frappe.desk.form.document_follow.send_weekly_updates",
 		"frappe.social.doctype.energy_point_log.energy_point_log.send_weekly_summary",
 		"frappe.integrations.doctype.google_drive.google_drive.weekly_backup",


### PR DESCRIPTION
This is now configurable with log settings.

This also fixes circular import issue that occurs when restoring backup. 

boot -> route_history -> query -> boot again

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 71, in get_app_commands
    app_command_module = importlib.import_module(app + ".commands")
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/user.py", line 10, in <module>
    from frappe.boot import get_allowed_reports
  File "/home/frappe/frappe-bench/apps/frappe/frappe/boot.py", line 11, in <module>
    from frappe.desk.doctype.route_history.route_history import frequently_visited_links
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/doctype/route_history/route_history.py", line 8, in <module>
    from frappe.query_builder.functions import Count, Now
  File "/home/frappe/frappe-bench/apps/frappe/frappe/query_builder/functions.py", line 5, in <module>
    from frappe.database.query import Query
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/query.py", line 8, in <module>
    from frappe.boot import get_additional_filters_from_hooks
ImportError: cannot import name 'get_additional_filters_from_hooks' from partially initialized module 'frappe.boot' (most likely due to a circular import) (/home/frappe/frappe-bench/apps/frappe/frappe/boot.py)
```