### PR TITLE
test: clear filters on ToDo before running test

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -17,7 +17,8 @@ context('Form', () => {
 		cy.get('.primary-action').click();
 		cy.wait('@form_save').its('response.statusCode').should('eq', 200);
 
-		cy.visit('/app/todo');
+		cy.go_to_list('ToDo');
+		cy.clear_filters()
 		cy.get('.page-head').findByTitle('To Do').should('exist');
 		cy.get('.list-row').should('contain', 'this is a test todo');
 	});

--- a/cypress/integration/list_paging.js
+++ b/cypress/integration/list_paging.js
@@ -9,6 +9,7 @@ context('List Paging', () => {
 
 	it('test load more with count selection buttons', () => {
 		cy.visit('/app/todo/view/report');
+		cy.clear_filters()
 
 		cy.get('.list-paging-area .list-count').should('contain.text', '20 of');
 		cy.get('.list-paging-area .btn-more').click();

--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -9,6 +9,7 @@ context('List View', () => {
 
 	it('Keep checkbox checked after Refresh', () => {
 		cy.go_to_list('ToDo');
+		cy.clear_filters()
 		cy.get('.list-row-container .list-row-checkbox').click({ multiple: true, force: true });
 		cy.get('.actions-btn-group button').contains('Actions').should('be.visible');
 		cy.intercept('/api/method/frappe.desk.reportview.get').as('list-refresh');
@@ -21,6 +22,7 @@ context('List View', () => {
 	it('enables "Actions" button', () => {
 		const actions = ['Approve', 'Reject', 'Edit', 'Export', 'Assign To', 'Apply Assignment Rule', 'Add Tags', 'Print', 'Delete'];
 		cy.go_to_list('ToDo');
+		cy.clear_filters()
 		cy.get('.list-row-container:contains("Pending") .list-row-checkbox').click({ multiple: true, force: true });
 		cy.get('.actions-btn-group button').contains('Actions').should('be.visible').click();
 		cy.get('.dropdown-menu li:visible .dropdown-item').should('have.length', 9).each((el, index) => {

--- a/cypress/integration/timeline.js
+++ b/cypress/integration/timeline.js
@@ -12,7 +12,8 @@ context('Timeline', () => {
 		cy.get('[data-fieldname="description"] .ql-editor.ql-blank').type('Test ToDo', {force: true}).wait(200);
 		cy.get('.page-head .page-actions').findByRole('button', {name: 'Save'}).click();
 
-		cy.visit('/app/todo');
+		cy.go_to_list('ToDo');
+		cy.clear_filters()
 		cy.click_listview_row_item(0);
 
 		//To check if the comment box is initially empty and tying some text into it


### PR DESCRIPTION
fixes currently broken UI tests. 

After https://github.com/frappe/frappe/pull/17296 ToDo list view gets default filter for logged in user which causes some tests to fail. 

This filter makes sense in practice but not so much in tests.  (you'd wanna see todo assigned to you by default)