### PR TITLE
ci: fix weird version check in cypress tests

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -872,7 +872,6 @@ def run_ui_tests(
 		and os.path.exists(real_events_plugin_path)
 		and os.path.exists(testing_library_path)
 		and os.path.exists(coverage_plugin_path)
-		and cint(subprocess.getoutput("npm view cypress version")[:1]) >= 6
 	):
 		# install cypress
 		click.secho("Installing Cypress...", fg="yellow")


### PR DESCRIPTION
This check is checking if new version exists on npm repository and the proceeds to reinstall same old version, waste of time and annoyance; will add better check when we update. 