### PR TITLE
fix: pass docfield for custom indicator formatter

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -26,7 +26,7 @@ frappe.form.formatters = {
 		if (df) {
 			const std_df = frappe.meta.docfield_map[df.parent] && frappe.meta.docfield_map[df.parent][df.fieldname];
 			if (std_df && std_df.formatter && typeof std_df.formatter==='function') {
-				value = std_df.formatter(value);
+				value = std_df.formatter(value, df);
 			}
 		}
 		return value;


### PR DESCRIPTION
- [x] Select fields with custom formatters break the whole form (check Event producer or asset maintenance)


```
form.js:1658 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'options')
    at frappe.meta.docfield_map.<computed>.<computed>.formatter (form.js:1658:48)
    at Object._apply_custom_formatter (formatters.js:29:20)
    at Object.Data (formatters.js:40:33)
    at Select (formatters.js:46:36)
    at frappe.format (formatters.js:358:18)
    at grid_row.js:612:12
    at Array.forEach (<anonymous>)
    at GridRow.setup_columns (grid_row.js:604:29)
    at GridRow.render_row (grid_row.js:270:8)
    at GridRow.make (grid_row.js:34:9)
```



most likely caused by https://github.com/frappe/frappe/pull/17108 