### PR TITLE
fix: ensure `after_install` hooks always run when installing app

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -277,8 +277,6 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 
 	sync_for(name, force=force, reset_permissions=True)
 
-	frappe.get_doc("Portal Settings", "Portal Settings").sync_menu()
-
 	if set_as_patched:
 		set_all_patches_as_completed(name)
 
@@ -286,9 +284,12 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 		frappe.get_attr(after_install)()
 
 	add_to_installed_apps(name)
+
 	sync_jobs()
 	sync_fixtures(name)
 	sync_customizations(name)
+
+	frappe.get_doc("Portal Settings", "Portal Settings").sync_menu()
 
 	for after_sync in app_hooks.after_sync or []:
 		frappe.get_attr(after_sync)()  #

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -277,8 +277,6 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 
 	sync_for(name, force=force, reset_permissions=True)
 
-	add_to_installed_apps(name)
-
 	frappe.get_doc("Portal Settings", "Portal Settings").sync_menu()
 
 	if set_as_patched:
@@ -287,6 +285,7 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 	for after_install in app_hooks.after_install or []:
 		frappe.get_attr(after_install)()
 
+	add_to_installed_apps(name)
 	sync_jobs()
 	sync_fixtures(name)
 	sync_customizations(name)


### PR DESCRIPTION
Before, if an after install hook failed, the app would still get marked as installed and there wouldn't be a way to trigger it again by running a command.

Now, the app won't get marked as install until after install script is successfully completed.