### PR TITLE
fix: Do not relay email to standard users

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -73,7 +73,8 @@ class CommunicationEmailMixin:
 		if include_sender:
 			cc.append(self.sender_mailid)
 		if is_inbound_mail_communcation:
-			cc.append(self.get_owner())
+			if (doc_owner := self.get_owner()) not in frappe.STANDARD_USERS:
+				cc.append(doc_owner)
 			cc = set(cc) - {self.sender_mailid}
 			cc.update(self.get_assignees())
 


### PR DESCRIPTION
We relay all emails to the owner of the document but since "Guest" is not a valid email the system was failing to relay the email.

**Error Info**
![telegram-cloud-photo-size-4-5945080434360694723-y](https://user-images.githubusercontent.com/13928957/178984765-ad0cc769-8fb5-4ea5-9136-c8981296dce0.jpg)
