### PR TITLE
fix: Check for file url before validating remote file

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -262,7 +262,7 @@ class File(Document):
 	def validate_remote_file(self):
 		"""Validates if file uploaded using URL already exist"""
 		site_url = get_url()
-		if "/files/" in self.file_url and self.file_url.startswith(site_url):
+		if self.file_url and "/files/" in self.file_url and self.file_url.startswith(site_url):
 			self.file_url = self.file_url.split(site_url, 1)[1]
 
 	def set_folder_name(self):

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -510,6 +510,16 @@ class TestFile(FrappeTestCase):
 		).insert(ignore_permissions=True)
 		self.assertRaisesRegex(ValidationError, "not a zip file", test_file.unzip)
 
+	def test_create_file_without_file_url(self):
+		test_file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "logo",
+				"content": "frappe",
+			}
+		).insert()
+		assert test_file is not None
+
 
 class TestAttachment(unittest.TestCase):
 	test_doctype = "Test For Attachment"


### PR DESCRIPTION
When uploading a zip file, if any of the zipped file is empty, it is being treated as a remote file and remote file validation is being triggered. Remote file validation should check for file url.

<img width="1047" alt="Screenshot 2022-07-14 at 18 13 47" src="https://user-images.githubusercontent.com/4463796/178992038-53a25d28-8241-406f-91b7-49a97e9436a3.png">
