### PR TITLE
fix(UX): correct message for empty prepared report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -623,6 +623,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 			if (data.prepared_report) {
 				this.prepared_report = true;
+				this.prepared_report_document = data.doc
 				// If query_string contains prepared_report_name then set filters
 				// to match the mentioned prepared report doc and disable editing
 				if (query_params.prepared_report_name) {
@@ -1800,7 +1801,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	toggle_nothing_to_show(flag) {
-		let message = this.prepared_report
+		let message = (this.prepared_report && !this.prepared_report_document)
 			? __('This is a background report. Please set the appropriate filters and then generate a new one.')
 			: this.get_no_result_message();
 


### PR DESCRIPTION
The message shown when rendering empty prepared reports is misleading and suggests regenerating report.


Steps to reproduce:
- ANy report that returns 0 rows for set filters. (To simplify just edit code and return empty list to reproduce)

before

https://user-images.githubusercontent.com/9079960/178991419-df8fec8a-8148-4899-85c7-a59a1a4c2c05.mov




after



https://user-images.githubusercontent.com/9079960/178991559-9c2bb14b-7d6e-404c-9f32-9bcc47a9ffa1.mov



