### PR TITLE
feat: country specific number shortening in charts

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -554,7 +554,8 @@ frappe.ui.form.Dashboard = class FormDashboard {
 			colors: ['green'],
 			truncateLegends: 1,
 			axisOptions: {
-				shortenYAxisNumbers: 1
+				shortenYAxisNumbers: 1,
+				numberFormatter: frappe.utils.format_chart_axis_number,
 			}
 		});
 		this.show();

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1145,7 +1145,12 @@ Object.assign(frappe.utils, {
 				{
 					divisor: 1.0e+5,
 					symbol: 'Lakh'
-				}],
+				},
+				{
+					divisor: 1.0e+3,
+					symbol: 'K',
+				}
+				],
 			'':
 				[{
 					divisor: 1.0e+12,
@@ -1205,7 +1210,8 @@ Object.assign(frappe.utils, {
 			axisOptions: {
 				xIsSeries: 1,
 				shortenYAxisNumbers: 1,
-				xAxisMode: 'tick'
+				xAxisMode: 'tick',
+				numberFormatter: frappe.utils.format_chart_axis_number,
 			}
 		};
 
@@ -1218,6 +1224,11 @@ Object.assign(frappe.utils, {
 		}
 
 		return new frappe.Chart(wrapper, chart_args);
+	},
+
+	format_chart_axis_number(label, country) {
+		const default_country = frappe.sys_defaults.country;
+		return frappe.utils.shorten_number(label, country || default_country, 3);
 	},
 
 	generate_route(item) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -944,10 +944,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			};
 		}
 		options.axisOptions = {
-			shortenYAxisNumbers: 1
+			shortenYAxisNumbers: 1,
+			numberFormatter: frappe.utils.format_chart_axis_number,
 		};
 		options.height = 280;
-
 		return options;
 	}
 

--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -30,7 +30,8 @@ frappe.report_utils = {
 			colors: colors,
 			axisOptions: {
 				shortenYAxisNumbers: 1,
-				xAxisMode: 'tick'
+				xAxisMode: 'tick',
+				numberFormatter: frappe.utils.format_chart_axis_number,
 			}
 		};
 

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -529,7 +529,8 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			truncateLegends: 1,
 			colors: ['#70E078', 'light-blue', 'orange', 'red'],
 			axisOptions: {
-				shortenYAxisNumbers: 1
+				shortenYAxisNumbers: 1,
+				numberFormatter: frappe.utils.format_chart_axis_number,
 			},
 			tooltipOptions: {
 				formatTooltipY: value => frappe.format(value, get_df(this.chart_args.y_axes[0]), { always_show_decimals: true, inline: true }, get_doc(value.doc))

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -589,6 +589,10 @@ details > summary:focus {
 	background-color: var(--diff-removed);
 }
 
+.chart-wrapper {
+	padding: 1em;
+}
+
 // REDESIGN TODO: Handling of broken images?
 // img.no-image:before {
 // 	.img-background();

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "driver.js": "^0.9.8",
     "editorjs-undo": "0.1.6",
     "fast-deep-equal": "^2.0.1",
-    "frappe-charts": "^2.0.0-rc13",
+    "frappe-charts": "2.0.0-rc22",
     "frappe-datatable": "^1.16.4",
     "frappe-gantt": "^0.6.0",
     "highlight.js": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,10 +1256,10 @@ fraction.js@^4.1.2:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
-frappe-charts@^2.0.0-rc13:
-  version "2.0.0-rc13"
-  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc13.tgz#fdb251d7ae311c41e38f90a3ae108070ec6b9072"
-  integrity sha512-Bv7IfllIrjRbKWHn5b769dOSenqdBixAr6m5kurf8ZUOJSLOgK4HOXItJ7BA8n9PvviH9/k5DaloisjLM2Bm1w==
+frappe-charts@^2.0.0-rc22:
+  version "2.0.0-rc22"
+  resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc22.tgz#9a5a747febdc381a1d4d7af96e89cf519dfba8c0"
+  integrity sha512-N7f/8979wJCKjusOinaUYfMxB80YnfuVLrSkjpj4LtyqS0BGS6SuJxUnb7Jl4RWUFEIs7zEhideIKnyLeFZF4Q==
 
 frappe-datatable@^1.16.4:
   version "1.16.4"


### PR DESCRIPTION
Charts will now be able to shorten y-axis numbers based on country/ any custom function. 

<img width="1315" alt="Screenshot 2022-07-18 at 4 35 50 PM" src="https://user-images.githubusercontent.com/9079960/179498663-9917cf15-8cf4-4c1f-8cf8-aee028574be0.png">


TODO:
- [x] charts PR https://github.com/frappe/charts/pull/388
- [x] charts release & bump  
- [x] fix query report charts
- [x] Fix report builder charts
- [x] Fix individual manually tinkered reports/charts - fixed most used report and utils after a shallow review, rest can be addressed on case to case basis ref:  https://github.com/frappe/erpnext/pull/31603
- [x] reduce code duplication


Other change:

Add padding to chart container; currently, large numbers hit the borders and look ugly

<img width="1315" alt="Screenshot 2022-07-18 at 4 33 28 PM" src="https://user-images.githubusercontent.com/9079960/179498347-93bb376c-6a16-4381-9c3b-e0362ed9a54e.png">


`no-docs`