### PR TITLE
fix(UX)!: respect "no filters" set by user

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -764,10 +764,6 @@ class FilterArea {
 
 		const doctype_fields = this.list_view.meta.fields;
 		const title_field = this.list_view.meta.title_field;
-		const has_existing_filters = (
-			this.list_view.filters
-			&& this.list_view.filters.length > 0
-		);
 
 		fields = fields.concat(
 			doctype_fields
@@ -803,23 +799,12 @@ class FilterArea {
 						}
 					}
 
-					let default_value;
-
-					if (fieldtype === "Link" && !has_existing_filters) {
-						default_value = frappe.defaults.get_user_default(options);
-					}
-
-					if (["__default", "__global"].includes(default_value)) {
-						default_value = null;
-					}
-
 					return {
 						fieldtype: fieldtype,
 						label: __(df.label),
 						options: options,
 						fieldname: df.fieldname,
 						condition: condition,
-						default: default_value,
 						onchange: () => this.refresh_list_view(),
 						ignore_link_validation: fieldtype === "Dynamic Link",
 						is_filter: 1,

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -87,10 +87,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		this.menu_items = this.menu_items.concat(this.get_menu_items());
 
 		// set filters from view_user_settings or list_settings
-		if (
-			this.view_user_settings.filters &&
-			this.view_user_settings.filters.length
-		) {
+		if (Array.isArray(this.view_user_settings.filters)) {
 			// Priority 1: view_user_settings
 			const saved_filters = this.view_user_settings.filters;
 			this.filters = this.validate_filters(saved_filters);

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1537,4 +1537,29 @@ Object.assign(frappe.utils, {
 	is_current_user(user) {
 		return user === frappe.session.user;
 	},
+
+	debug: {
+		watch_property(obj, prop, callback=console.trace) {
+			if (!frappe.boot.developer_mode) {
+				return;
+			}
+			console.warn("Adding property watcher, make sure to remove it after debugging.");
+
+			// Adapted from https://stackoverflow.com/a/11658693
+			// Reused under CC-BY-SA 4.0
+			// changes: variable names are changed for consistency with our codebase
+			const private_prop = "$_" + prop + "_$";
+			obj[private_prop] = obj[prop];
+
+			Object.defineProperty(obj, prop, {
+				get: function() {
+					return obj[private_prop];
+				},
+				set: function(value) {
+					callback();
+					obj[private_prop] = value;
+				},
+			});
+		},
+	}
 });


### PR DESCRIPTION
Currently, if the user clears all filters and comes back to the same view default filters get populated. This is annoying behavior especially since this is already saved in the user setting, so from where default filters are coming back?

Fix: Always respect the user's preference, if their last choice was no filters then load view without filters.

Before:

https://user-images.githubusercontent.com/9079960/179247530-de837fa3-d1bb-4817-b8d3-de6d16040944.mov


After:


https://user-images.githubusercontent.com/9079960/179247575-56abe247-5645-4c7d-8e76-5392368e7c53.mov





---

Order of preference now:

- URL parameters
- user's last preference
- list view settings
- user defaults (These have always been annoying IMO xD)

This PR in the current state essentially removes the behavior where user defaults are auto-populated to link field filters. 

TBH I think it's the right thing to do, these user defaults in filters have caused a lot of annoyance which the user is not even able to control properly. 


discuss thread: https://discuss.erpnext.com/t/removing-user-defaults-from-getting-set-as-default-filters-on-list-view/92101/2 

---


This PR also adds unrelated but useful debugging utility `frappe.utils.debug.watch_property` : 

This util adds a watcher on any JS object for purpose of debugging,
whenever the property changes a console trace is generated. A custom
callback function can also be passed if required.

Usage:

```javascript
filters = {}

frappe.utils.debug.watch_property(filters, "company");

// any changes to company key on filters object from now on will print a console trace
```

only for debugging, make sure to not commit it in codebase! :)


