### PR TITLE
fix: misc fixes (google oauth)

### DIFF
--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -358,7 +358,6 @@ def create_email_account():
 			"send_notification_to": "test_comm@example.com",
 			"pop3_server": "pop.test.example.com",
 			"imap_folder": [{"folder_name": "INBOX", "append_to": "ToDo"}],
-			"no_remaining": "0",
 			"enable_automatic_linking": 1,
 		}
 	).insert(ignore_permissions=True)

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -287,6 +287,18 @@ frappe.ui.form.on('User', {
 	}
 });
 
+
+frappe.ui.form.on('User Email', {
+	email_account(frm, cdt, cdn) {
+		let child_row = locals[cdt][cdn];
+		frappe.model.get_value("Email Account", child_row.email_account, "auth_method", (value) => {
+			child_row.used_oauth = value.auth_method === "OAuth";
+			frm.refresh_field("user_emails", cdn, "used_oauth");
+		});
+	}
+});
+
+
 function has_access_to_edit_user() {
 	return has_common(frappe.user_roles, get_roles_for_editing_user());
 }

--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -123,8 +123,6 @@ frappe.ui.form.on("Email Account", {
 	},
 
 	enable_incoming: function(frm) {
-		frm.doc.no_remaining = null; //perform full sync
-		//frm.set_df_property("append_to", "reqd", frm.doc.enable_incoming);
 		frm.trigger("warn_autoreply_on_incoming");
 	},
 

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -70,7 +70,6 @@
   "brand_logo",
   "uidvalidity",
   "uidnext",
-  "no_remaining",
   "no_failed"
  ],
  "fields": [
@@ -473,15 +472,6 @@
    "no_copy": 1
   },
   {
-   "fieldname": "no_remaining",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "No of emails remaining to be synced",
-   "no_copy": 1
-  },
-  {
    "fieldname": "no_failed",
    "fieldtype": "Int",
    "hidden": 1,
@@ -616,7 +606,7 @@
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-11 18:34:06.945668",
+ "modified": "2022-07-13 13:05:45.445572",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/test_records.json
+++ b/frappe/email/doctype/email_account/test_records.json
@@ -18,7 +18,6 @@
 		"unreplied_for_mins": 20,
 		"send_notification_to": "test_unreplied@example.com",
 		"pop3_server": "pop.test.example.com",
-		"no_remaining":"0",
 		"append_to": "ToDo",
 		"imap_folder": [{"folder_name": "INBOX", "append_to": "ToDo"}, {"folder_name": "Test Folder", "append_to": "Communication"}],
 		"track_email_status": 1

--- a/frappe/email/oauth.py
+++ b/frappe/email/oauth.py
@@ -150,7 +150,6 @@ def authorize_google_access(email_account, doctype: str = "Email Account", code:
 	if not code:
 		return oauth_obj.get_authentication_url(
 			{
-				"method": "frappe.email.oauth.authorize_google_access",
 				"redirect": f"/app/Form/{quote(doctype)}/{quote(email_account)}",
 				"success_query_param": "successful_authorization=1",
 				"email_account": email_account,

--- a/frappe/email/oauth.py
+++ b/frappe/email/oauth.py
@@ -102,12 +102,18 @@ class Oauth:
 	def _refresh_access_token(self) -> str:
 		"""Refreshes access token via calling `refresh_access_token` method of oauth service object"""
 		service_obj = self._get_service_object()
-		access_token = service_obj.refresh_access_token(self._refresh_token).get("access_token", None)
+		access_token = service_obj.refresh_access_token(self._refresh_token).get("access_token")
 
-		# set the new access token in db
-		frappe.db.set_value(
-			"Email Account", self.email_account, "access_token", access_token, update_modified=False
-		)
+		if access_token:
+			# set the new access token in db
+			frappe.db.set_value(
+				"Email Account",
+				self.email_account,
+				"access_token",
+				encrypt(access_token),
+				update_modified=False,
+			)
+
 		return access_token
 
 	def _get_service_object(self):

--- a/frappe/integrations/doctype/google_contacts/google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.py
@@ -45,7 +45,6 @@ def authorize_access(g_contact, reauthorize=False, code=None):
 	if not oauth_code or reauthorize:
 		return oauth_obj.get_authentication_url(
 			{
-				"method": "frappe.integrations.doctype.google_contacts.google_contacts.authorize_access",
 				"g_contact": g_contact,
 				"redirect": f"/app/Form/{quote('Google Contacts')}/{quote(g_contact)}",
 			},

--- a/frappe/integrations/doctype/google_drive/google_drive.py
+++ b/frappe/integrations/doctype/google_drive/google_drive.py
@@ -57,7 +57,6 @@ def authorize_access(reauthorize=False, code=None):
 			frappe.db.set_value("Google Drive", None, "backup_folder_id", "")
 		return oauth_obj.get_authentication_url(
 			{
-				"method": "frappe.integrations.doctype.google_drive.google_drive.authorize_access",
 				"redirect": f"/app/Form/{quote('Google Drive')}",
 			},
 		)

--- a/frappe/integrations/google_oauth.py
+++ b/frappe/integrations/google_oauth.py
@@ -59,7 +59,6 @@ class GoogleOAuth:
 		"""Returns a dict with access and refresh token.
 
 		:param oauth_code: code got back from google upon successful auhtorization
-		:param site_address: side address from which the request is being made
 		"""
 
 		data = {
@@ -102,8 +101,7 @@ class GoogleOAuth:
 	def get_authentication_url(self, state: dict[str, str]) -> dict[str, str]:
 		"""Returns google authentication url.
 
-		:param site_address: side address from which the request is being made (for redirect back to site)
-		:param state: [optional] dict of values which you need on callback (for calling methods, redirection back to the form, doc name, etc)
+		:param state: dict of values which you need on callback (for calling methods, redirection back to the form, doc name, etc)
 		"""
 
 		state.update({"domain": self.domain})

--- a/frappe/website/doctype/website_settings/google_indexing.py
+++ b/frappe/website/doctype/website_settings/google_indexing.py
@@ -26,7 +26,6 @@ def authorize_access(reauthorize=False, code=None):
 	if not oauth_code or reauthorize:
 		return oauth_obj.get_authentication_url(
 			{
-				"method": "frappe.website.doctype.website_settings.google_indexing.authorize_access",
 				"redirect": f"/app/Form/{quote('Website Settings')}",
 			},
 		)


### PR DESCRIPTION
Changes:
- encrypt `access_token` when pushing it to db while refreshing it 
- only allow "whitelisted" domain callback methods for google callback (it's a god callback method which let's users execute any method on the backend) - Thanks @sagarvora
- auto fetch `used_oauth` field when user adds a new email account in User Email table
- removed unused `no_remaining` field from Email Account doctype