### PR TITLE
fix: db.get_value -> db.get_single_value

### DIFF
--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -63,7 +63,7 @@ def send_sms(receiver_list, msg, sender_name="", success_msg=True):
 		"success_msg": success_msg,
 	}
 
-	if frappe.db.get_value("SMS Settings", None, "sms_gateway_url"):
+	if frappe.db.get_single_value("SMS Settings", "sms_gateway_url"):
 		send_via_gateway(arg)
 	else:
 		msgprint(_("Please Update SMS Settings"))

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -28,7 +28,7 @@ class SystemSettings(Document):
 
 		if self.enable_two_factor_auth:
 			if self.two_factor_method == "SMS":
-				if not frappe.db.get_value("SMS Settings", None, "sms_gateway_url"):
+				if not frappe.db.get_single_value("SMS Settings", "sms_gateway_url"):
 					frappe.throw(
 						_("Please setup SMS before setting it as an authentication method, via SMS Settings")
 					)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -611,10 +611,10 @@ class User(Document):
 		"""
 
 		login_with_mobile = cint(
-			frappe.db.get_value("System Settings", "System Settings", "allow_login_using_mobile_number")
+			frappe.db.get_single_value("System Settings", "allow_login_using_mobile_number")
 		)
 		login_with_username = cint(
-			frappe.db.get_value("System Settings", "System Settings", "allow_login_using_user_name")
+			frappe.db.get_single_value("System Settings", "allow_login_using_user_name")
 		)
 
 		or_filters = [{"name": user_name}]
@@ -861,7 +861,7 @@ def sign_up(email, full_name, redirect_to):
 		user.insert()
 
 		# set default signup role as per Portal Settings
-		default_role = frappe.db.get_value("Portal Settings", None, "default_role")
+		default_role = frappe.db.get_single_value("Portal Settings", "default_role")
 		if default_role:
 			user.add_roles(default_role)
 

--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -62,21 +62,21 @@ def take_backups_weekly():
 
 
 def take_backups_if(freq):
-	if frappe.db.get_value("Dropbox Settings", None, "backup_frequency") == freq:
+	if frappe.db.get_single_value("Dropbox Settings", "backup_frequency") == freq:
 		take_backup_to_dropbox()
 
 
 def take_backup_to_dropbox(retry_count=0, upload_db_backup=True):
 	did_not_upload, error_log = [], []
 	try:
-		if cint(frappe.db.get_value("Dropbox Settings", None, "enabled")):
+		if cint(frappe.db.get_single_value("Dropbox Settings", "enabled")):
 			validate_file_size()
 
 			did_not_upload, error_log = backup_to_dropbox(upload_db_backup)
 			if did_not_upload:
 				raise Exception
 
-			if cint(frappe.db.get_value("Dropbox Settings", None, "send_email_for_successful_backup")):
+			if cint(frappe.db.get_single_value("Dropbox Settings", "send_email_for_successful_backup")):
 				send_email(True, "Dropbox", "Dropbox Settings", "send_notifications_to")
 	except JobTimeoutException:
 		if retry_count < 2:

--- a/frappe/integrations/doctype/google_drive/google_drive.py
+++ b/frappe/integrations/doctype/google_drive/google_drive.py
@@ -48,7 +48,7 @@ def authorize_access(reauthorize=False, code=None):
 	"""
 
 	oauth_code = (
-		frappe.db.get_value("Google Drive", "Google Drive", "authorization_code") if not code else code
+		frappe.db.get_single_value("Google Drive", "authorization_code") if not code else code
 	)
 	oauth_obj = GoogleOAuth("drive")
 

--- a/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
+++ b/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
@@ -14,7 +14,9 @@ def get_oauth_settings():
 	"""Returns oauth settings"""
 	out = frappe._dict(
 		{
-			"skip_authorization": frappe.db.get_value("OAuth Provider Settings", None, "skip_authorization")
+			"skip_authorization": frappe.db.get_single_value(
+				"OAuth Provider Settings", "skip_authorization"
+			)
 		}
 	)
 

--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.py
@@ -76,8 +76,8 @@ def take_backups_monthly():
 
 
 def take_backups_if(freq):
-	if cint(frappe.db.get_value("S3 Backup Settings", None, "enabled")):
-		if frappe.db.get_value("S3 Backup Settings", None, "frequency") == freq:
+	if cint(frappe.db.get_single_value("S3 Backup Settings", "enabled")):
+		if frappe.db.get_single_value("S3 Backup Settings", "frequency") == freq:
 			take_backups_s3()
 
 

--- a/frappe/patches/v11_0/set_dropbox_file_backup.py
+++ b/frappe/patches/v11_0/set_dropbox_file_backup.py
@@ -4,6 +4,6 @@ from frappe.utils import cint
 
 def execute():
 	frappe.reload_doctype("Dropbox Settings")
-	check_dropbox_enabled = cint(frappe.db.get_value("Dropbox Settings", None, "enabled"))
+	check_dropbox_enabled = cint(frappe.db.get_single_value("Dropbox Settings", "enabled"))
 	if check_dropbox_enabled == 1:
 		frappe.db.set_value("Dropbox Settings", None, "file_backup", 1)

--- a/frappe/templates/pages/integrations/razorpay_checkout.py
+++ b/frappe/templates/pages/integrations/razorpay_checkout.py
@@ -51,7 +51,7 @@ def get_context(context):
 
 
 def get_api_key():
-	api_key = frappe.db.get_value("Razorpay Settings", None, "api_key")
+	api_key = frappe.db.get_single_value("Razorpay Settings", "api_key")
 	if cint(frappe.form_dict.get("use_sandbox")):
 		api_key = frappe.conf.sandbox_api_key
 

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -27,10 +27,10 @@ def toggle_two_factor_auth(state, roles=None):
 
 def two_factor_is_enabled(user=None):
 	"""Returns True if 2FA is enabled."""
-	enabled = int(frappe.db.get_value("System Settings", None, "enable_two_factor_auth") or 0)
+	enabled = int(frappe.db.get_single_value("System Settings", "enable_two_factor_auth") or 0)
 	if enabled:
 		bypass_two_factor_auth = int(
-			frappe.db.get_value("System Settings", None, "bypass_2fa_for_retricted_ip_users") or 0
+			frappe.db.get_single_value("System Settings", "bypass_2fa_for_retricted_ip_users") or 0
 		)
 		if bypass_two_factor_auth and user:
 			user_doc = frappe.get_doc("User", user)
@@ -127,7 +127,7 @@ def get_otpsecret_for_(user):
 
 
 def get_verification_method():
-	return frappe.db.get_value("System Settings", None, "two_factor_method")
+	return frappe.db.get_single_value("System Settings", "two_factor_method")
 
 
 def confirm_otp_token(login_manager, otp=None, tmp_id=None):
@@ -173,7 +173,7 @@ def confirm_otp_token(login_manager, otp=None, tmp_id=None):
 
 
 def get_verification_obj(user, token, otp_secret):
-	otp_issuer = frappe.db.get_value("System Settings", "System Settings", "otp_issuer_name")
+	otp_issuer = frappe.db.get_single_value("System Settings", "otp_issuer_name")
 	verification_method = get_verification_method()
 	verification_obj = None
 	if verification_method == "SMS":
@@ -249,7 +249,7 @@ def process_2fa_for_email(user, token, otp_secret, otp_issuer, method="Email"):
 def get_email_subject_for_2fa(kwargs_dict):
 	"""Get email subject for 2fa."""
 	subject_template = _("Login Verification Code from {}").format(
-		frappe.db.get_value("System Settings", "System Settings", "otp_issuer_name")
+		frappe.db.get_single_value("System Settings", "otp_issuer_name")
 	)
 	subject = frappe.render_template(subject_template, kwargs_dict)
 	return subject
@@ -269,7 +269,7 @@ def get_email_body_for_2fa(kwargs_dict):
 def get_email_subject_for_qr_code(kwargs_dict):
 	"""Get QRCode email subject."""
 	subject_template = _("One Time Password (OTP) Registration Code from {}").format(
-		frappe.db.get_value("System Settings", "System Settings", "otp_issuer_name")
+		frappe.db.get_single_value("System Settings", "otp_issuer_name")
 	)
 	subject = frappe.render_template(subject_template, kwargs_dict)
 	return subject
@@ -289,9 +289,7 @@ def get_link_for_qrcode(user, totp_uri):
 	key = frappe.generate_hash(length=20)
 	key_user = f"{key}_user"
 	key_uri = f"{key}_uri"
-	lifespan = (
-		int(frappe.db.get_value("System Settings", "System Settings", "lifespan_qrcode_image")) or 240
-	)
+	lifespan = int(frappe.db.get_single_value("System Settings", "lifespan_qrcode_image")) or 240
 	frappe.cache().set_value(key_uri, totp_uri, expires_in_sec=lifespan)
 	frappe.cache().set_value(key_user, user, expires_in_sec=lifespan)
 	return get_url(f"/qrcode?k={key}")
@@ -447,9 +445,7 @@ def should_remove_barcode_image(barcode):
 	"""Check if it's time to delete barcode image from server."""
 	if isinstance(barcode, str):
 		barcode = frappe.get_doc("File", barcode)
-	lifespan = (
-		frappe.db.get_value("System Settings", "System Settings", "lifespan_qrcode_image") or 240
-	)
+	lifespan = frappe.db.get_single_value("System Settings", "lifespan_qrcode_image") or 240
 	if time_diff_in_seconds(get_datetime(), barcode.creation) > int(lifespan):
 		return True
 	return False
@@ -464,7 +460,7 @@ def reset_otp_secret(user):
 	if frappe.session.user != user:
 		frappe.only_for("System Manager", message=True)
 
-	otp_issuer = frappe.db.get_value("System Settings", "System Settings", "otp_issuer_name")
+	otp_issuer = frappe.db.get_single_value("System Settings", "otp_issuer_name")
 	user_email = frappe.db.get_value("User", user, "email")
 
 	frappe.defaults.clear_default(user + "_otplogin")

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1545,7 +1545,7 @@ def get_url(uri: str | None = None, full_address: bool = False) -> str:
 			host_name = protocol + frappe.local.site
 
 		else:
-			host_name = frappe.db.get_value("Website Settings", "Website Settings", "subdomain")
+			host_name = frappe.db.get_single_value("Website Settings", "subdomain")
 
 			if not host_name:
 				host_name = "http://localhost"

--- a/frappe/website/doctype/web_page_view/web_page_view.py
+++ b/frappe/website/doctype/web_page_view/web_page_view.py
@@ -49,4 +49,4 @@ def get_page_view_count(path):
 
 
 def is_tracking_enabled():
-	return frappe.db.get_value("Website Settings", "Website Settings", "enable_view_tracking")
+	return frappe.db.get_single_value("Website Settings", "enable_view_tracking")

--- a/frappe/website/doctype/website_settings/google_indexing.py
+++ b/frappe/website/doctype/website_settings/google_indexing.py
@@ -16,7 +16,7 @@ def authorize_access(reauthorize=False, code=None):
 	"""If no Authorization code get it from Google and then request for Refresh Token."""
 
 	oauth_code = (
-		frappe.db.get_value("Website Settings", "Website Settings", "indexing_authorization_code")
+		frappe.db.get_single_value("Website Settings", "indexing_authorization_code")
 		if not code
 		else code
 	)

--- a/frappe/www/contact.py
+++ b/frappe/www/contact.py
@@ -51,7 +51,7 @@ def send_message(subject="Website Query", message="", sender=""):
 		return
 
 	# send email
-	forward_to_email = frappe.db.get_value("Contact Us Settings", None, "forward_to_email")
+	forward_to_email = frappe.db.get_single_value("Contact Us Settings", "forward_to_email")
 	if forward_to_email:
 		frappe.sendmail(recipients=forward_to_email, sender=sender, content=message, subject=subject)
 


### PR DESCRIPTION
db.get_value for singles returns string type always, this is confusing
behavior, db.get_single_value should be used instead.

semgrep rule: https://github.com/frappe/semgrep-rules/pull/16

