### PR TITLE
ci: check commit messages with commitlint

### DIFF
--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -1,0 +1,30 @@
+name: Semantic Commits
+
+on:
+  pull_request: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: commitcheck-frappe-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    name: Check Commit Titles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          check-latest: true
+
+      - name: Check commit titles
+        run: |
+          npm install
+          npx commitlint --verbose --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -26,5 +26,5 @@ jobs:
 
       - name: Check commit titles
         run: |
-          npm install
+          npm install @commitlint/cli @commitlint/config-conventional
           npx commitlint --verbose --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}

--- a/package.json
+++ b/package.json
@@ -82,5 +82,10 @@
   "snyk": true,
   "nyc": {
     "report-dir": ".cypress-coverage"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }


### PR DESCRIPTION
After the [semantic check service died](https://github.com/zeke/semantic-pull-requests) we have seen few PRs getting merged with incorrect titles. This is mostly okay but becomes a problem during automated releases/change log generation. 


This PR adds commitlint in CI: it's feature-packed tool that does many things, we just need to validate commit messages 😄 

closes https://github.com/frappe/frappe/issues/16700 