### PR TITLE
perf: option to skip realtime notify update after insert

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1092,7 +1092,9 @@ class Document(BaseDocument):
 			self.run_method("on_update_after_submit")
 
 		self.clear_cache()
-		self.notify_update()
+
+		if not hasattr(self.flags, "notify_update") or self.flags.notify_update == True:
+			self.notify_update()
 
 		update_global_search(self)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1093,7 +1093,7 @@ class Document(BaseDocument):
 
 		self.clear_cache()
 
-		if not hasattr(self.flags, "notify_update") or self.flags.notify_update == True:
+		if not hasattr(self.flags, "notify_update") or self.flags.notify_update:
 			self.notify_update()
 
 		update_global_search(self)


### PR DESCRIPTION
While doing optimization for the period closing voucher, found that `notify_update` takes a significant amount of time to execute (200 seconds in this case), even though it was not required at all in this specific case (insert of GL Entry). That's why made the function optional by using a flag.

Related PR: https://github.com/frappe/erpnext/pull/31626
