### PR TITLE
fix: Query for unseen notification

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -14,7 +14,7 @@ from frappe.email.inbox import get_email_accounts
 from frappe.model.base_document import get_controller
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
-from frappe.query_builder.terms import SubQuery
+from frappe.query_builder.terms import ParameterizedValueWrapper, SubQuery
 from frappe.social.doctype.energy_point_log.energy_point_log import get_energy_points
 from frappe.social.doctype.energy_point_settings.energy_point_settings import (
 	is_energy_point_enabled,
@@ -331,8 +331,8 @@ def get_unseen_notes():
 			(note.notify_on_every_login == 1)
 			& (note.expire_notification_on > frappe.utils.now())
 			& (
-				SubQuery(frappe.qb.from_(nsb).select(nsb.user).where(nsb.parent == note.name)).notin(
-					[frappe.session.user]
+				ParameterizedValueWrapper(frappe.session.user).notin(
+					SubQuery(frappe.qb.from_(nsb).select(nsb.user).where(nsb.parent == note.name))
 				)
 			)
 		)

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -328,7 +328,7 @@ def get_unseen_notes():
 		frappe.qb.from_(note)
 		.select(note.name, note.title, note.content, note.notify_on_every_login)
 		.where(
-			(note.notify_on_every_login == 1)
+			(note.notify_on_login == 1)
 			& (note.expire_notification_on > frappe.utils.now())
 			& (
 				ParameterizedValueWrapper(frappe.session.user).notin(

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -1,0 +1,29 @@
+import unittest
+
+import frappe
+from frappe.boot import get_unseen_notes
+from frappe.desk.doctype.note.note import mark_as_seen
+
+
+class TestBootData(unittest.TestCase):
+	def test_get_unseen_notes(self):
+		frappe.db.delete("Note")
+		frappe.db.delete("Note Seen By")
+		note = frappe.get_doc(
+			{
+				"doctype": "Note",
+				"title": "Test Note",
+				"notify_on_login": 1,
+				"content": "Test Note 1",
+				"public": 1,
+			}
+		)
+		note.insert()
+
+		frappe.set_user("test@example.com")
+		unseen_notes = [d.title for d in get_unseen_notes()]
+		self.assertListEqual(unseen_notes, ["Test Note"])
+
+		mark_as_seen(note.name)
+		unseen_notes = [d.title for d in get_unseen_notes()]
+		self.assertListEqual(unseen_notes, [])


### PR DESCRIPTION
"Note" notification functionality was not working because of the incorrect subquery.
<img width="791" alt="Screenshot 2022-07-20 at 10 41 43 AM" src="https://user-images.githubusercontent.com/13928957/179901847-0f684634-c36b-4b1b-8f16-f2c67fc9283f.png">
(for context)


The issue was introduced via: https://github.com/frappe/frappe/pull/16107