### PR TITLE
fix: Allow `fields` to have "*" without array

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -225,7 +225,7 @@ def parse_json(data):
 	if isinstance(data.get("or_filters"), str):
 		data["or_filters"] = json.loads(data["or_filters"])
 	if isinstance(data.get("fields"), str):
-		data["fields"] = json.loads(data["fields"])
+		data["fields"] = ["*"] if data["fields"] == "*" else json.loads(data["fields"])
 	if isinstance(data.get("docstatus"), str):
 		data["docstatus"] = json.loads(data["docstatus"])
 	if isinstance(data.get("save_user_settings"), str):


### PR DESCRIPTION
To support `frappe.db.get_list("User", { fields: "*"})` from client-side.

**Before:**
<img width="1440" alt="Screenshot 2022-07-20 at 11 38 15 AM" src="https://user-images.githubusercontent.com/13928957/179909050-8f1aad04-f785-43e4-9ddd-dc4fc4eef952.png">

<details>
<summary> Traceback </summary>

```
request.js:438 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1579, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 780, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/reportview.py", line 36, in get_list
    args = get_form_params()
  File "apps/frappe/frappe/desk/reportview.py", line 72, in get_form_params
    validate_args(data)
  File "apps/frappe/frappe/desk/reportview.py", line 77, in validate_args
    parse_json(data)
  File "apps/frappe/frappe/desk/reportview.py", line 228, in parse_json
    data["fields"] = json.loads(data["fields"])
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

</details>

**After:**
<img width="1440" alt="Screenshot 2022-07-20 at 11 36 47 AM" src="https://user-images.githubusercontent.com/13928957/179909062-79f17f92-0a37-44d9-940b-a57b6a9b1df4.png">

**Note:** 
- We already support `fields: ["*"]` but `fields: "*"` seems more intuitive.
- I guess we already had support for it in past... we might have broke the compatibility in [this PR](https://github.com/frappe/frappe/pull/12713)