### PR TITLE
fix: No need to check for permission again while attaching a file

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -1024,6 +1024,6 @@ def attach_files_to_document(doc, event):
 				attached_to_doctype=doc.doctype,
 				attached_to_field=df.fieldname,
 				folder="Home/Attachments",
-			).insert()
+			).insert(ignore_permissions=True)
 		except Exception:
 			frappe.log_error(title=_("Error Attaching File"))


### PR DESCRIPTION
backport of https://github.com/frappe/frappe/pull/17550