### PR TITLE
fix: replace incorrect validation on doctype connections

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -17,7 +17,7 @@ from frappe.cache_manager import clear_controller_cache, clear_user_cache
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.database.schema import validate_column_length, validate_column_name
-from frappe.desk.notifications import delete_notification_count_for
+from frappe.desk.notifications import delete_notification_count_for, get_filters_for
 from frappe.desk.utils import validate_route_conflict
 from frappe.model import (
 	child_table_fields,
@@ -982,11 +982,7 @@ def validate_links_table_fieldnames(meta):
 
 	fieldnames = tuple(field.fieldname for field in meta.fields)
 	for index, link in enumerate(meta.links, 1):
-		if not frappe.get_meta(link.link_doctype).has_field(link.link_fieldname):
-			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(
-				index, frappe.bold(link.link_fieldname), frappe.bold(link.link_doctype)
-			)
-			frappe.throw(message, InvalidFieldNameError, _("Invalid Fieldname"))
+		_test_connection_query(doctype=link.link_doctype, field=link.link_fieldname, idx=index)
 
 		if not link.is_child_table:
 			continue
@@ -1013,6 +1009,25 @@ def validate_links_table_fieldnames(meta):
 				index, frappe.bold(link.table_fieldname), frappe.bold(meta.name)
 			)
 			frappe.throw(message, frappe.ValidationError, _("Invalid Table Fieldname"))
+
+
+def _test_connection_query(doctype, field, idx):
+	"""Make sure that connection can be queried.
+
+	This function executes query similar to one that would be executed for
+	finding count on dashboard and hence validates if fieldname/doctype are
+	correct.
+	"""
+	filters = get_filters_for(doctype) or {}
+	filters[field] = ""
+
+	try:
+		frappe.get_all(doctype, filters=filters, limit=1, distinct=True, ignore_ifnull=True)
+	except Exception as e:
+		frappe.clear_last_message()
+		msg = _("Document Links Row #{0}: Invalid doctype or fieldname.").format(idx)
+		msg += "<br>" + str(e)
+		frappe.throw(msg, InvalidFieldNameError)
 
 
 def validate_fields_for_doctype(doctype):

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -543,7 +543,7 @@ class TestDocType(unittest.TestCase):
 
 		# check invalid doctype
 		doc.append("links", {"link_doctype": "User2", "link_fieldname": "first_name"})
-		self.assertRaises(frappe.DoesNotExistError, validate_links_table_fieldnames, doc)
+		self.assertRaises(InvalidFieldNameError, validate_links_table_fieldnames, doc)
 		doc.links = []  # reset links table
 
 		# check invalid fieldname


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/16083 


Currently, this validation doesn't allow adding any field that's not part of linked doctype's top-level fields, however doing exactly that in doctype_dashboard.py is allowed. 

Fix: replace this validation with an exact query that runs on the dashboard. This gives a somewhat worse error message but it's _correct_ validation.


E.g. 

```python
frappe.get_list("Website Item", {"item_code": docname})

frappe.get_list("Sales Order", {"item_code": docname})
```


Both these are technically valid even though SO doesn't have item code field, this is because ORM implicitly joins the SO table with SO item table which does have item_code... that's how all the dashboards are working right now. 


---

TODO:
- [x] test on all existing links
- [x] Add an example of how to use this in docs. - https://frappeframework.com/docs/v13/user/en/basics/doctypes/actions-and-links  






**Example:** Link blanket orders to items (this is currently impossible without editing code)

![telegram-cloud-photo-size-5-6251261325678326477-y](https://user-images.githubusercontent.com/9079960/179952892-3e2e4808-d6ac-4cdc-b8cd-f32b05882cb7.jpg)


<img width="1314" alt="Screenshot 2022-07-20 at 3 20 30 PM" src="https://user-images.githubusercontent.com/9079960/179953308-7aef0787-e50b-4ae0-9f03-55beb67ff268.png">




