### PR TITLE
ci: bump node version to node16

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -56,11 +56,6 @@ bench -v setup requirements --dev
 
 if [ "$TYPE" == "ui" ]; then sed -i 's/^web: bench serve/web: bench serve --with-coverage/g' Procfile; fi
 
-# install node-sass which is required for website theme test
-cd ./apps/frappe || exit
-yarn add node-sass@4.13.1
-cd ../..
-
 bench start &
 bench --site test_site reinstall --yes
 if [ "$TYPE" == "server" ]; then bench --site test_site_producer reinstall --yes; fi

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           check-latest: true
 
       - name: Add to Hosts

--- a/.github/workflows/publish-assets-develop.yml
+++ b/.github/workflows/publish-assets-develop.yml
@@ -15,7 +15,7 @@ jobs:
           path: 'frappe'
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/publish-assets-releases.yml
+++ b/.github/workflows/publish-assets-releases.yml
@@ -16,9 +16,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: 'frappe'
+
       - uses: actions/setup-node@v3
         with:
-          python-version: '12.x'
+          node-version: 16
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Node.js v14
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Setup dependencies
         run: |
           npm install @semantic-release/git @semantic-release/exec --no-save
@@ -31,4 +31,4 @@ jobs:
           GIT_AUTHOR_EMAIL: "developers@frappe.io"
           GIT_COMMITTER_NAME: "Frappe PR Bot"
           GIT_COMMITTER_EMAIL: "developers@frappe.io"
-        run: npx semantic-release 
+        run: npx semantic-release

--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           check-latest: true
 
       - name: Check commit titles

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         with:
-          node-version: 14
+          node-version: 16
           check-latest: true
 
       - name: Add to Hosts

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         with:
-          node-version: '14'
+          node-version: '16'
           check-latest: true
 
       - name: Add to Hosts

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         with:
-          node-version: 14
+          node-version: 16
           check-latest: true
 
       - name: Add to Hosts


### PR DESCRIPTION
Node14 will reach EOL within 1 year of v14 release. Hence bumping node requirements to be on safe side. 

![telegram-cloud-photo-size-5-6253413623984665160-y](https://user-images.githubusercontent.com/9079960/180178182-0137b25c-06c1-4ee3-bd1d-3c409cc8bfed.jpg)


Installation guide updated to recommend node16: https://frappeframework.com/docs/v14/user/en/installation 