### PR TITLE
fix: frappe.db.exists will always return error for virtual doctype

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -31,7 +31,7 @@ def getdoc(doctype, name, user=None):
 	if not name:
 		name = doctype
 
-	if not frappe.db.exists(doctype, name) and not is_virtual_doctype(doctype):
+	if not is_virtual_doctype(doctype) and not frappe.db.exists(doctype, name):
 		return []
 
 	doc = frappe.get_doc(doctype, name)


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/17548

![is_virtual](https://user-images.githubusercontent.com/11792643/180443612-49407e09-1d7b-464b-9b44-919f4347f693.gif)
8