### PR TITLE
fix: Letter head image not working

### DIFF
--- a/frappe/printing/doctype/letter_head/letter_head.py
+++ b/frappe/printing/doctype/letter_head/letter_head.py
@@ -61,8 +61,11 @@ class LetterHead(Document):
 
 		# To preserve the aspect ratio of the image, apply constraints only on
 		# the greater dimension and allow the other to scale accordingly
-		dimension = "width" if width > height else "height"
+		dimension = "width" if self.get(width) > self.get(height) else "height"
 		dimension_value = self.get(f"{dimension_prefix}{dimension}")
+
+		if not dimension_value:
+			dimension_value = ""
 
 		self.set(
 			html_field,


### PR DESCRIPTION
**Issue:** Letter Head of type Image doesn't work if width or height is not set.
**Solution:** Let's not consider the height & width values as zero if not set.

Before:
<img width="1321" alt="Screenshot 2022-07-25 at 5 32 04 PM" src="https://user-images.githubusercontent.com/30859809/180773390-a69cc80a-dd48-4557-bb2c-bd46deb1c52a.png">


After:
<img width="1359" alt="image" src="https://user-images.githubusercontent.com/30859809/180773127-435760f3-50e9-4585-a480-b10f8630df88.png">
