### PR TITLE
fix(UX): mentions - prioritize involved users

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -195,13 +195,25 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 				let values = await frappe.xcall(method, {
 					search_term
 				});
-				renderList(values, search_term);
+
+				let sorted_values = me.prioritize_involved_users_in_mention(values);
+				renderList(sorted_values, search_term);
 			}, 300),
 			renderItem(item) {
 				let value = item.value;
 				return `${value} ${item.is_group ? frappe.utils.icon('users') : ''}`;
 			}
 		};
+	}
+
+	prioritize_involved_users_in_mention(values) {
+		const involved_users = this.frm?.get_involved_users()   // input on form
+			|| cur_frm?.get_involved_users()   // comment box / dialog on active form
+			|| [];
+
+		return values
+			.filter(val => involved_users.includes(val.id))
+			.concat(values.filter(val => !involved_users.includes(val.id)));
 	}
 
 	get_toolbar_options() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1873,6 +1873,29 @@ frappe.ui.form.Form = class FrappeForm {
 	get_active_tab() {
 		return this.active_tab_map && this.active_tab_map[this.docname];
 	}
+
+	get_involved_users() {
+		const user_fields = this.meta.fields
+			.filter(d => d.fieldtype === 'Link' && d.options === 'User')
+			.map(d => d.fieldname);
+
+		user_fields.push('owner');
+		let involved_users = user_fields.map(field => this.doc[field]);
+
+		const docinfo = this.get_docinfo();
+
+		involved_users = involved_users.concat(
+			docinfo.communications.map(d => d.sender && d.delivery_status === 'sent'),
+			docinfo.comments.map(d => d.owner),
+			docinfo.versions.map(d => d.owner),
+			docinfo.assignments.map(d => d.owner)
+		);
+
+		return involved_users
+			.uniqBy(u => u)
+			.filter(user => !['Administrator', frappe.session.user].includes(user))
+			.filter(Boolean);
+	}
 };
 
 frappe.validated = 0;

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1875,11 +1875,11 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	get_involved_users() {
-		const user_fields = this.meta.fields
+		let user_fields = this.meta.fields
 			.filter(d => d.fieldtype === 'Link' && d.options === 'User')
 			.map(d => d.fieldname);
 
-		user_fields.push('owner');
+		user_fields = [...user_fields, "owner", "modified_by"];
 		let involved_users = user_fields.map(field => this.doc[field]);
 
 		const docinfo = this.get_docinfo();

--- a/frappe/public/js/frappe/form/sidebar/review.js
+++ b/frappe/public/js/frappe/form/sidebar/review.js
@@ -38,30 +38,9 @@ frappe.ui.form.Review = class Review {
 			review_button.click(() => this.show_review_dialog());
 		}
 	}
-	get_involved_users() {
-		const user_fields = this.frm.meta.fields
-			.filter(d => d.fieldtype === 'Link' && d.options === 'User')
-			.map(d => d.fieldname);
 
-		user_fields.push('owner');
-		let involved_users = user_fields.map(field => this.frm.doc[field]);
-
-		const docinfo = this.frm.get_docinfo();
-
-		involved_users = involved_users.concat(
-			docinfo.communications.map(d => d.sender && d.delivery_status === 'sent'),
-			docinfo.comments.map(d => d.owner),
-			docinfo.versions.map(d => d.owner),
-			docinfo.assignments.map(d => d.owner)
-		);
-
-		return involved_users
-			.uniqBy(u => u)
-			.filter(user => !['Administrator', frappe.session.user].includes(user))
-			.filter(Boolean);
-	}
 	show_review_dialog() {
-		const user_options = this.get_involved_users();
+		const user_options = this.frm.get_involved_users();
 		const review_dialog = new frappe.ui.Dialog({
 			'title': __('Add Review'),
 			'fields': [{


### PR DESCRIPTION
If you have lots of users on the system and their names have some overlap; the mention list is very annoying to sift through. 

Fix: by default prioritize all "involved users" on the form. 

Involved user:
- User who have commented / emailed on that doc
- Assigned
- Creator or Modifier

Before:
<img width="906" alt="Screenshot 2022-07-25 at 6 43 13 PM" src="https://user-images.githubusercontent.com/9079960/180786067-72ca782d-333c-4bfc-a514-218236935748.png">


After:

<img width="906" alt="Screenshot 2022-07-25 at 6 42 26 PM" src="https://user-images.githubusercontent.com/9079960/180786028-17191f18-ebf4-4819-acc5-202220ce619f.png">


This feature is similar to how large platforms filter out or sort @mention suggestions based on context (in this case the active form/document)