### PR TITLE
fix: absolute option for terminal progress bar

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -559,7 +559,7 @@ def is_cli() -> bool:
 	return invoked_from_terminal
 
 
-def update_progress_bar(txt, i, l):
+def update_progress_bar(txt, i, l, absolute=False):
 	if os.environ.get("CI"):
 		if i == 0:
 			sys.stdout.write(txt)
@@ -581,8 +581,9 @@ def update_progress_bar(txt, i, l):
 
 		complete = int(float(i + 1) / l * col)
 		completion_bar = ("=" * complete).ljust(col, " ")
-		percent_complete = str(int(float(i + 1) / l * 100))
-		sys.stdout.write(f"\r{txt}: [{completion_bar}] {percent_complete}%")
+		percent_complete = f"{str(int(float(i + 1) / l * 100))}%"
+		status = f"{i} of {l}" if absolute else percent_complete
+		sys.stdout.write(f"\r{txt}: [{completion_bar}] {status}")
 		sys.stdout.flush()
 
 


### PR DESCRIPTION
Show progress in absolute numbers in `update_progress_bar`

<img width="719" alt="image" src="https://user-images.githubusercontent.com/9355208/180975596-1e4cf85e-3776-4995-a0d2-fde972858912.png">
