### PR TITLE
fix: load avatars of user in notification dropdown

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -134,6 +134,22 @@ def get_email_header(doc):
 
 
 @frappe.whitelist()
+def get_notification_logs(limit=20):
+	notification_logs = frappe.db.get_list(
+		"Notification Log", fields=["*"], limit=limit, order_by="creation desc"
+	)
+
+	users = [log.from_user for log in notification_logs]
+	users = [*set(users)]  # remove duplicates
+	user_info = frappe._dict()
+
+	for user in users:
+		frappe.utils.add_user_info(user, user_info)
+
+	return {"notification_logs": notification_logs, "user_info": user_info}
+
+
+@frappe.whitelist()
 def mark_all_as_read():
 	unread_docs_list = frappe.db.get_all(
 		"Notification Log", filters={"read": 0, "for_user": frappe.session.user}

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -189,19 +189,22 @@ class NotificationsView extends BaseNotificationsView {
 		);
 
 		this.setup_notification_listeners();
-		this.get_notifications_list(this.max_length).then(list => {
-			this.dropdown_items = list;
+		this.get_notifications_list(this.max_length).then(r => {
+			if (!r.message) return;
+			this.dropdown_items = r.message.notification_logs;
+			frappe.update_user_info(r.message.user_info);
 			this.render_notifications_dropdown();
 			if (this.settings.seen == 0) {
 				this.toggle_notification_icon(false);
 			}
 		});
-
 	}
 
 	update_dropdown() {
 		this.get_notifications_list(1).then(r => {
-			let new_item = r[0];
+			if (!r.message) return;
+			let new_item = r.message.notification_logs[0];
+			frappe.update_user_info(r.message.user_info);
 			this.dropdown_items.unshift(new_item);
 			if (this.dropdown_items.length > this.max_length) {
 				this.container
@@ -322,11 +325,10 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	get_notifications_list(limit) {
-		return frappe.db.get_list('Notification Log', {
-			fields: ['*'],
-			limit: limit,
-			order_by: 'creation desc'
-		});
+		return frappe.call(
+			'frappe.desk.doctype.notification_log.notification_log.get_notification_logs',
+			{ limit: limit }
+		);
 	}
 
 	get_item_link(notification_doc) {

--- a/frappe/public/js/frappe/utils/user.js
+++ b/frappe/public/js/frappe/utils/user.js
@@ -14,6 +14,16 @@ frappe.user_info = function(uid) {
 	return user_info;
 };
 
+frappe.update_user_info = function(user_info) {
+	for (let user in user_info) {
+		if (frappe.boot.user_info[user]) {
+			Object.assign(frappe.boot.user_info[user], user_info[user])
+		} else {
+			frappe.boot.user_info[user] = user_info[user]
+		}
+	}
+}
+
 frappe.provide('frappe.user');
 
 $.extend(frappe.user, {

--- a/frappe/public/js/frappe/utils/user.js
+++ b/frappe/public/js/frappe/utils/user.js
@@ -17,12 +17,12 @@ frappe.user_info = function(uid) {
 frappe.update_user_info = function(user_info) {
 	for (let user in user_info) {
 		if (frappe.boot.user_info[user]) {
-			Object.assign(frappe.boot.user_info[user], user_info[user])
+			Object.assign(frappe.boot.user_info[user], user_info[user]);
 		} else {
-			frappe.boot.user_info[user] = user_info[user]
+			frappe.boot.user_info[user] = user_info[user];
 		}
 	}
-}
+};
 
 frappe.provide('frappe.user');
 


### PR DESCRIPTION
**Issue:** Avatars of the users in Notification Dropdown items are missing even though users have uploaded an image.

|  Before  |  After  |
|  -------  |  -----  |
|  <img width="478" alt="image" src="https://user-images.githubusercontent.com/30859809/181005403-404a3071-3240-4384-8992-d7f21907e957.png">  |  <img width="477" alt="image" src="https://user-images.githubusercontent.com/30859809/181005085-50e0d25b-0beb-4e88-941c-6945b7648a25.png">  |

