### PR TITLE
fix: grid search breaks if filter from other grid pages

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -298,15 +298,14 @@ export default class Grid {
 			show_search: true
 		});
 
-		Object.keys(this.filter).length !== 0 &&
-			this.update_search_columns();
+		this.filter_applied && this.update_search_columns();
 	}
 
 	update_search_columns() {
 		for (const field in this.filter) {
 			if (this.filter[field] && !this.header_search.search_columns[field]) {
 				delete this.filter[field];
-				this.data = this.get_data(Object.keys(this.filter).length !== 0);
+				this.data = this.get_data(this.filter_applied);
 				break;
 			}
 
@@ -323,7 +322,8 @@ export default class Grid {
 	refresh() {
 		if (this.frm && this.frm.setting_dependency) return;
 
-		this.data = this.get_data(Object.keys(this.filter).length !== 0);
+		this.filter_applied = Object.keys(this.filter).length !== 0;
+		this.data = this.get_data(this.filter_applied);
 
 		!this.wrapper && this.make();
 		let $rows = $(this.parent).find('.rows');

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -14,7 +14,7 @@ export default class GridRow {
 	make() {
 		var me = this;
 
-		this.wrapper = $('<div class="grid-row"></div>').appendTo(this.parent).data("grid_row", this);
+		this.wrapper = $('<div class="grid-row"></div>');
 		this.row = $('<div class="data-row row"></div>').appendTo(this.wrapper)
 			.on("click", function(e) {
 				if($(e.target).hasClass('grid-row-check') || $(e.target).hasClass('row-index') || $(e.target).parent().hasClass('row-index')) {
@@ -33,9 +33,9 @@ export default class GridRow {
 		} else {
 			this.render_row();
 		}
-		if(this.doc) {
-			this.set_data();
-		}
+
+		this.set_data();
+		this.wrapper.appendTo(this.parent);
 	}
 
 	set_docfields(update=false) {
@@ -55,8 +55,9 @@ export default class GridRow {
 
 	set_data() {
 		this.wrapper.data({
-			"doc": this.doc
-		})
+			"grid_row": this,
+			"doc": this.doc || "",
+		});
 	}
 	set_row_index() {
 		if(this.doc) {
@@ -750,6 +751,7 @@ export default class GridRow {
 				.option('disabled', Object.keys(this.grid.filter).length !== 0);
 
 			this.grid.prevent_build = true;
+			this.grid.grid_pagination.go_to_page(1);
 			this.grid.refresh();
 			this.grid.prevent_build = false;
 		}, 500));


### PR DESCRIPTION
**Issue:** If you switch the grid page and apply a filter Grid Search will not work as expected.

**Before:**
![GridSearchBug](https://user-images.githubusercontent.com/30859809/181052319-c5d2a2d6-9bbf-422a-a7d4-8ae1585df0e4.gif)

**After:**
![GridSearchFix](https://user-images.githubusercontent.com/30859809/181052365-27d6df15-19f2-4426-b99b-7ff90122c652.gif)