### PR TITLE
fix: don't use cache for sequence in mariadb

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -61,7 +61,9 @@ class Database:
 	# from that value when inserting any new record in the doctype.
 	# By default the cache is 1000 which will mess up the sequence when
 	# using the system after a restore.
-	# issue link: https://jira.mariadb.org/browse/MDEV-20070
+	#
+	# Another case could be if the cached values expire then also there is a chance of
+	# the cache being skipped.
 	#
 	# FOR POSTGRES - The sequence cache for postgres is per connection.
 	# Since we're opening and closing connections for every request this results in skipping the cache

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -54,6 +54,21 @@ class Database:
 	CHILD_TABLE_COLUMNS = ("parent", "parenttype", "parentfield")
 	MAX_WRITES_PER_TRANSACTION = 200_000
 
+	# NOTE:
+	# FOR MARIADB - using no cache - as during backup, if the sequence was used in anyform,
+	# it drops the cache and uses the next non cached value in setval query and
+	# puts that in the backup file, which will start the counter
+	# from that value when inserting any new record in the doctype.
+	# By default the cache is 1000 which will mess up the sequence when
+	# using the system after a restore.
+	# issue link: https://jira.mariadb.org/browse/MDEV-20070
+	#
+	# FOR POSTGRES - The sequence cache for postgres is per connection.
+	# Since we're opening and closing connections for every request this results in skipping the cache
+	# to the next non-cached value hence not using cache in postgres.
+	# ref: https://stackoverflow.com/questions/21356375/postgres-9-0-4-sequence-skipping-numbers
+	SEQUENCE_CACHE = 0
+
 	class InvalidColumnName(frappe.ValidationError):
 		pass
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -129,15 +129,6 @@ class MariaDBConnectionUtil:
 
 class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 	REGEX_CHARACTER = "regexp"
-
-	# NOTE: using a very small cache - as during backup, if the sequence was used in anyform,
-	# it drops the cache and uses the next non cached value in setval query and
-	# puts that in the backup file, which will start the counter
-	# from that value when inserting any new record in the doctype.
-	# By default the cache is 1000 which will mess up the sequence when
-	# using the system after a restore.
-	# issue link: https://jira.mariadb.org/browse/MDEV-21786
-	SEQUENCE_CACHE = 50
 	CONVERSION_MAP = conversions | {
 		FIELD_TYPE.NEWDECIMAL: float,
 		FIELD_TYPE.DATETIME: get_datetime,

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -44,7 +44,7 @@ class MariaDBTable(DBTable):
 
 			# NOTE: not used nextval func as default as the ability to restore
 			# database with sequences has bugs in mariadb and gives a scary error.
-			# issue link: https://jira.mariadb.org/browse/MDEV-21786
+			# issue link: https://jira.mariadb.org/browse/MDEV-20070
 			name_column = "name bigint primary key"
 
 		# create table

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -102,12 +102,6 @@ class PostgresExceptionUtil:
 
 class PostgresDatabase(PostgresExceptionUtil, Database):
 	REGEX_CHARACTER = "~"
-
-	# NOTE; The sequence cache for postgres is per connection.
-	# Since we're opening and closing connections for every transaction this results in skipping the cache
-	# to the next non-cached value hence not using cache in postgres.
-	# ref: https://stackoverflow.com/questions/21356375/postgres-9-0-4-sequence-skipping-numbers
-	SEQUENCE_CACHE = 0
 	default_port = "5432"
 
 	def setup_type_map(self):


### PR DESCRIPTION
This pr removes sequence caching for mariadb - as it's being skipped without any definite behaviour (in production - locally seems to be working fine 🤔)

![telegram-cloud-photo-size-5-6271619393351954690-y](https://user-images.githubusercontent.com/32034600/181241503-cc9ed2e5-5a91-4793-9cb0-fd49451b7267.jpg)
