### PR TITLE
fix: return promise

### DIFF
--- a/frappe/public/js/frappe/ui/tree.js
+++ b/frappe/public/js/frappe/ui/tree.js
@@ -134,7 +134,7 @@ frappe.ui.Tree = class {
 	}
 
 	reload_node(node) {
-		this.load_children(node);
+		return this.load_children(node);
 	}
 
 	toggle() {
@@ -150,21 +150,20 @@ frappe.ui.Tree = class {
 	}
 
 	load_children(node, deep=false) {
-		let lab = node.label, value = node.data.value, is_root = node.is_root;
+		const value = node.data.value,
+			is_root = node.is_root;
 
-		if(!deep) {
-			frappe.run_serially([
+		return deep
+			? frappe.run_serially([
+				() => this.get_all_nodes(value, is_root, node.label),
+				data_list => this.render_children_of_all_nodes(data_list),
+				() => this.set_selected_node(node),
+			])
+			: frappe.run_serially([
 				() => this.get_nodes(value, is_root),
-				(data_set) => this.render_node_children(node, data_set),
-				() => this.set_selected_node(node)
+				data_set => this.render_node_children(node, data_set),
+				() => this.set_selected_node(node),
 			]);
-		} else {
-			frappe.run_serially([
-				() => this.get_all_nodes(value, is_root, lab),
-				(data_list) => this.render_children_of_all_nodes(data_list),
-				() => this.set_selected_node(node)
-			]);
-		}
 	}
 
 	render_children_of_all_nodes(data_list) {


### PR DESCRIPTION
`load_children`, and thus `reload_node`, executes a promise but doesn't return it. So it is useless for calling methods.

This PR makes them return the promise. Also refactored `load_children` a bit.