### PR TITLE
fix: hide border for a section break

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -62,6 +62,10 @@
 	border-bottom: none;
 }
 
+.form-section.card-section.hide-border {
+	border-bottom: none;
+}
+
 .form-dashboard-section {
 	.section-body:first-child {
 		margin-top: 0;


### PR DESCRIPTION
The feature was introduced via #10116 but was broken for some time.