### PR TITLE
perf: reduce DB calls in `frappe.client.get` (and other changes)

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -78,16 +78,9 @@ def get(doctype, name=None, filters=None, parent=None):
 	if frappe.is_table(doctype):
 		check_parent_permission(parent, doctype)
 
-	if filters and not name:
-		name = frappe.db.get_value(doctype, frappe.parse_json(filters))
-		if not name:
-			frappe.throw(_("No document found for given filters"))
-
-	doc = frappe.get_doc(doctype, name)
-	if not doc.has_permission("read"):
-		raise frappe.PermissionError
-
-	return frappe.get_doc(doctype, name).as_dict()
+	doc = frappe.get_doc(doctype, name or frappe.parse_json(filters))
+	doc.check_permission()
+	return doc.as_dict()
 
 
 @frappe.whitelist()
@@ -144,8 +137,8 @@ def get_value(doctype, fieldname, filters=None, as_dict=True, debug=False, paren
 def get_single_value(doctype, field):
 	if not frappe.has_permission(doctype):
 		frappe.throw(_("No permission for {0}").format(_(doctype)), frappe.PermissionError)
-	value = frappe.db.get_single_value(doctype, field)
-	return value
+
+	return frappe.db.get_single_value(doctype, field)
 
 
 @frappe.whitelist(methods=["POST", "PUT"])


### PR DESCRIPTION
DB calls reduced:
- `frappe.db.get_value` to get `name` from `filters`
- `frappe.get_doc` repeated when returning 🤦🏼 

We lose the ability to have a special error message in case of filters, but I don't think that's a big deal.

---

There is one small change in `client.get_single_value` as well, we're no longer creating a variable just to return it.