### PR TITLE
ci: Install wkhtmltopdf in fg sequentially

### DIFF
--- a/.github/helper/install_dependencies.sh
+++ b/.github/helper/install_dependencies.sh
@@ -3,11 +3,8 @@ set -e
 
 echo "Setting Up System Dependencies..."
 
-install_wkhtmltopdf() {
-  wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb
-  sudo apt install ./wkhtmltox_0.12.6-1.focal_amd64.deb
-}
-install_wkhtmltopdf &
+wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb
+sudo apt install ./wkhtmltox_0.12.6-1.focal_amd64.deb
 
 curl -LsS -O https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
 sudo bash mariadb_repo_setup --mariadb-server-version=10.6


### PR DESCRIPTION
bg execution causes `dpkg` locks and unnecessary complexity

