### PR TITLE
fix: Dropdown selection list in Reports should be translatable

### DIFF
--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -235,7 +235,7 @@ frappe.views.ListViewSelect = class ListViewSelect {
 						// don't repeat
 						added.push(route);
 						reports_to_add.push({
-							name: r.title || r.name,
+							name: __(r.title || r.name),
 							route: route
 						});
 					}


### PR DESCRIPTION
For any Report View with Customized reports, there is a menu with a drop-down selection list on the left. The names of the reports in this list are not getting translated.

Before:
![image](https://user-images.githubusercontent.com/6947417/181729293-94092341-13a9-49cd-9b83-870c454f57f9.png)


after:
![image](https://user-images.githubusercontent.com/6947417/181729049-29367cfd-874f-4993-bff3-1b81adbf5f8e.png)
