### PR TITLE
refactor!: cleanup email (a bit)

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -249,7 +249,6 @@ frappe.ui.form.on('User', {
 				if (!Array.isArray(r.message)) {
 					frappe.route_options = {
 						"email_id": frm.doc.email,
-						"awaiting_password": 1,
 						"enable_incoming": 1
 					};
 					frappe.model.with_doctype("Email Account", function(doc) {
@@ -284,17 +283,6 @@ frappe.ui.form.on('User', {
 			// Clear cache after saving to refresh the values of boot.
 			frappe.ui.toolbar.clear_cache();
 		}
-	}
-});
-
-
-frappe.ui.form.on('User Email', {
-	email_account(frm, cdt, cdn) {
-		let child_row = locals[cdt][cdn];
-		frappe.model.get_value("Email Account", child_row.email_account, "auth_method", (value) => {
-			child_row.used_oauth = value.auth_method === "OAuth";
-			frm.refresh_field("user_emails", cdn, "used_oauth");
-		});
 	}
 });
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -84,7 +84,6 @@ class User(Document):
 		self.validate_username()
 		self.remove_disabled_roles()
 		self.validate_user_email_inbox()
-		ask_pass_update()
 		self.validate_roles()
 		self.validate_allowed_modules()
 		self.validate_user_image()
@@ -757,25 +756,6 @@ def test_password_strength(new_password, key=None, old_password=None, user_data=
 @frappe.whitelist()
 def has_email_account(email):
 	return frappe.get_list("Email Account", filters={"email_id": email})
-
-
-@frappe.whitelist(allow_guest=False)
-def get_email_awaiting(user):
-	return frappe.get_all(
-		"User Email",
-		fields=["email_account", "email_id"],
-		filters={"awaiting_password": 1, "parent": user, "used_oauth": 0},
-	)
-
-
-def ask_pass_update():
-	# update the sys defaults as to awaiting users
-	from frappe.utils import set_default
-
-	password_list = frappe.get_all(
-		"User Email", filters={"awaiting_password": 1, "used_oauth": 0}, pluck="parent", distinct=True
-	)
-	set_default("email_user_password", ",".join(password_list))
 
 
 def _get_user_for_update_password(key, old_password):

--- a/frappe/core/doctype/user_email/user_email.json
+++ b/frappe/core/doctype/user_email/user_email.json
@@ -8,8 +8,6 @@
   "email_account",
   "email_id",
   "column_break_3",
-  "awaiting_password",
-  "used_oauth",
   "enable_outgoing"
  ],
  "fields": [
@@ -35,33 +33,16 @@
   },
   {
    "default": "0",
-   "fetch_from": "email_account.awaiting_password",
-   "fieldname": "awaiting_password",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Awaiting Password",
-   "read_only": 1
-  },
-  {
-   "default": "0",
    "fetch_from": "email_account.enable_outgoing",
    "fieldname": "enable_outgoing",
    "fieldtype": "Check",
    "label": "Enable Outgoing",
    "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "used_oauth",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Used OAuth",
-   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-06-03 14:25:46.944733",
+ "modified": "2022-07-28 23:28:34.466034",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Email",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -17,7 +17,6 @@
   "auth_method",
   "authorize_api_access",
   "password",
-  "awaiting_password",
   "ascii_encode_password",
   "column_break_10",
   "refresh_token",
@@ -108,15 +107,6 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Password"
-  },
-  {
-   "default": "0",
-   "depends_on": "eval: doc.auth_method === \"Basic\"",
-   "fieldname": "awaiting_password",
-   "fieldtype": "Check",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Awaiting password"
   },
   {
    "default": "0",
@@ -606,7 +596,7 @@
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-13 13:05:45.445572",
+ "modified": "2022-07-28 23:22:10.183495",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -21,8 +21,6 @@
   "column_break_10",
   "refresh_token",
   "access_token",
-  "login_id_is_different",
-  "login_id",
   "mailbox_settings",
   "enable_incoming",
   "default_incoming",
@@ -83,22 +81,6 @@
    "options": "Email",
    "reqd": 1,
    "unique": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "login_id_is_different",
-   "fieldtype": "Check",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Use different Email ID"
-  },
-  {
-   "depends_on": "login_id_is_different",
-   "fieldname": "login_id",
-   "fieldtype": "Data",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Alternative Email ID"
   },
   {
    "depends_on": "eval: doc.auth_method === \"Basic\"",
@@ -596,7 +578,7 @@
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-28 23:22:10.183495",
+ "modified": "2022-07-29 00:11:13.252936",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -65,14 +65,7 @@ class EmailAccount(Document):
 	def validate(self):
 		"""Validate Email Address and check POP3/IMAP and SMTP connections is enabled."""
 
-		if self.email_id:
-			validate_email_address(self.email_id, True)
-
-		if self.login_id_is_different:
-			if not self.login_id:
-				frappe.throw(_("Login Id is required"))
-		else:
-			self.login_id = None
+		validate_email_address(self.email_id, True)
 
 		# validate the imap settings
 		if self.enable_incoming and self.use_imap and len(self.imap_folder) <= 0:
@@ -202,7 +195,7 @@ class EmailAccount(Document):
 				"email_account": self.name,
 				"host": self.email_server,
 				"use_ssl": self.use_ssl,
-				"username": getattr(self, "login_id", None) or self.email_id,
+				"username": self.email_id,
 				"service": getattr(self, "service", ""),
 				"use_imap": self.use_imap,
 				"email_sync_rule": email_sync_rule,
@@ -383,7 +376,6 @@ class EmailAccount(Document):
 			"smtp_server": {"conf_names": ("mail_server",)},
 			"smtp_port": {"conf_names": ("mail_port",)},
 			"use_tls": {"conf_names": ("use_tls", "mail_login")},
-			"login_id": {"conf_names": ("mail_login",)},
 			"email_id": {
 				"conf_names": ("auto_email_id", "mail_login"),
 				"default": "notifications@example.com",
@@ -421,7 +413,7 @@ class EmailAccount(Document):
 			"email_account": self.name,
 			"server": self.smtp_server,
 			"port": cint(self.smtp_port),
-			"login": getattr(self, "login_id", None) or self.email_id,
+			"login": self.email_id,
 			"password": self._password,
 			"use_ssl": cint(self.use_ssl_for_outgoing),
 			"use_tls": cint(self.use_tls),


### PR DESCRIPTION
- [ ] Check UID logic
- [ ] Check email_sync logic (UNSEEN, ALL)
- [ ] Check IMAP folder thing
- [ ] check expose_recipients thing
- [ ] Timed mixin class only seem to work in case of pop3 (?)
- [ ] isnotification header (seems sus)
- [ ] revert [refactor: remove login_id field from email account](https://github.com/frappe/frappe/pull/17678/commits/a629121ff14154e97632fdb08f015effa32bb529) (????)
- [ ] `email flag queue` seems unnecessary (?)
- [ ] don't mark emails as read in mailbox when fetching (?)
- [ ] disable the email account if it doesn't work for `X` no of times in a row - dead code
- [ ] https://github.com/frappe/frappe/pull/17776 (?) - email sending
- [ ] support for non-auth email accounts
- [ ] remove all test internet logic
- [ ] do we really need email unsubscribe doctype? - normal emails don't really need unsubscribe link (only use case valid is of newsletter which again has it's own separate unsubscribe thing) - encountered one use case where email is configured for a role then, someone in the role might want to unsubscribe from the email blast (?)