### PR TITLE
fix: clear password when saving email account with Oauth

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -90,6 +90,7 @@ class EmailAccount(Document):
 		if use_oauth:
 			# no need for awaiting password for oauth
 			self.awaiting_password = 0
+			self.password = None
 
 		elif self.refresh_token:
 			# clear access & refresh token


### PR DESCRIPTION
This pr clears the password when a user changes to Oauth authentication.