### PR TITLE
refactor: improved child table permission check

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -905,15 +905,25 @@ def only_has_select_perm(doctype, user=None, ignore_permissions=False):
 
 
 def has_permission(
-	doctype=None, ptype="read", doc=None, user=None, verbose=False, throw=False, parent_doctype=None
+	doctype=None,
+	ptype="read",
+	doc=None,
+	user=None,
+	verbose=False,
+	throw=False,
+	*,
+	parent_doctype=None,
 ):
-	"""Raises `frappe.PermissionError` if not permitted.
+	"""
+	Raises `frappe.PermissionError` if not permitted.
 
 	:param doctype: DocType for which permission is to be check.
 	:param ptype: Permission type (`read`, `write`, `create`, `submit`, `cancel`, `amend`). Default: `read`.
 	:param doc: [optional] Checks User permissions for given doc.
 	:param user: [optional] Check for given user. Default: current user.
-	:param parent_doctype: Required when checking permission for a child DocType (unless doc is specified)."""
+	:param verbose: DEPRECATED, will be removed in a future release.
+	:param parent_doctype: Required when checking permission for a child DocType (unless doc is specified).
+	"""
 	import frappe.permissions
 
 	if not doctype and doc:
@@ -923,7 +933,6 @@ def has_permission(
 		doctype,
 		ptype,
 		doc=doc,
-		verbose=verbose,
 		user=user,
 		raise_exception=throw,
 		parent_doctype=parent_doctype,

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -915,7 +915,8 @@ def has_permission(
 	parent_doctype=None,
 ):
 	"""
-	Raises `frappe.PermissionError` if not permitted.
+	Returns True if the user has permission `ptype` for given `doctype` or `doc`
+	Raises `frappe.PermissionError` if user isn't permitted and `throw` is truthy
 
 	:param doctype: DocType for which permission is to be check.
 	:param ptype: Permission type (`read`, `write`, `create`, `submit`, `cancel`, `amend`). Default: `read`.

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -97,6 +97,7 @@ class DatabaseQuery:
 		strict=True,
 		pluck=None,
 		ignore_ddl=False,
+		*,
 		parent_doctype=None,
 	) -> list:
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -195,15 +195,16 @@ class Document(BaseDocument):
 
 	def has_permission(self, permtype="read", verbose=False) -> bool:
 		"""
-		Call `frappe.has_permission` if `self.flags.ignore_permissions` is not set.
+		Call `frappe.permissions.has_permission` if `ignore_permissions` flag isn't truthy
 
-		:param permtype: one of `read`, `write`, `submit`, `cancel`, `delete`
+		:param permtype: `read`, `write`, `submit`, `cancel`, `delete`, etc.
 		:param verbose: DEPRECATED, will be removed in a future release.
 		"""
-		import frappe.permissions
 
 		if self.flags.ignore_permissions:
 			return True
+
+		import frappe.permissions
 
 		return frappe.permissions.has_permission(self.doctype, permtype, self)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -194,15 +194,18 @@ class Document(BaseDocument):
 			self.raise_no_permission_to(permlevel or permtype)
 
 	def has_permission(self, permtype="read", verbose=False) -> bool:
-		"""Call `frappe.has_permission` if `self.flags.ignore_permissions`
-		is not set.
+		"""
+		Call `frappe.has_permission` if `self.flags.ignore_permissions` is not set.
 
-		:param permtype: one of `read`, `write`, `submit`, `cancel`, `delete`"""
+		:param permtype: one of `read`, `write`, `submit`, `cancel`, `delete`
+		:param verbose: DEPRECATED, will be removed in a future release.
+		"""
 		import frappe.permissions
 
 		if self.flags.ignore_permissions:
 			return True
-		return frappe.permissions.has_permission(self.doctype, permtype, self, verbose=verbose)
+
+		return frappe.permissions.has_permission(self.doctype, permtype, self)
 
 	def raise_no_permission_to(self, perm_type):
 		"""Raise `frappe.PermissionError`."""

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -539,9 +539,9 @@ class Meta(Document):
 
 		return self.high_permlevel_fields
 
-	def get_permlevel_access(self, permission_type="read", parenttype=None):
+	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
 		has_access_to = []
-		roles = frappe.get_roles()
+		roles = frappe.get_roles(user)
 		for perm in self.get_permissions(parenttype):
 			if perm.role in roles and perm.get(permission_type):
 				if perm.permlevel not in has_access_to:

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -70,13 +70,13 @@ def has_permission(
 	if not user:
 		user = frappe.session.user
 
+	if user == "Administrator":
+		return True
+
 	if not doc and hasattr(doctype, "doctype"):
 		# first argument can be doc or doctype
 		doc = doctype
 		doctype = doc.doctype
-
-	if user == "Administrator":
-		return True
 
 	if frappe.is_table(doctype):
 		return has_child_table_permission(
@@ -667,32 +667,27 @@ def has_child_table_permission(
 	raise_exception=True,
 	parent_doctype=None,
 ):
-	parent_doc = None
-
 	if child_doc:
-		parent_doctype = child_doc.get("parenttype")
-		parent_doc = frappe.get_cached_doc(
-			{"doctype": parent_doctype, "docname": child_doc.get("parent")}
-		)
+		parent_doctype = child_doc.parenttype
 
-	if parent_doctype:
-		if not is_parent_valid(child_doctype, parent_doctype):
-			frappe.throw(
-				_("{0} is not a valid parent DocType for {1}").format(
-					frappe.bold(parent_doctype), frappe.bold(child_doctype)
-				),
-				title=_("Invalid Parent DocType"),
-			)
-	else:
+	if not parent_doctype:
 		frappe.throw(
 			_("Please specify a valid parent DocType for {0}").format(frappe.bold(child_doctype)),
 			title=_("Parent DocType Required"),
 		)
 
+	if not is_parent_valid(child_doctype, parent_doctype):
+		frappe.throw(
+			_("{0} is not a valid parent DocType for {1}").format(
+				frappe.bold(parent_doctype), frappe.bold(child_doctype)
+			),
+			title=_("Invalid Parent DocType"),
+		)
+
 	return has_permission(
 		parent_doctype,
 		ptype=ptype,
-		doc=parent_doc,
+		doc=getattr(child_doc, "parent_doc", child_doc.parent),
 		verbose=verbose,
 		user=user,
 		raise_exception=raise_exception,
@@ -700,10 +695,8 @@ def has_child_table_permission(
 
 
 def is_parent_valid(child_doctype, parent_doctype):
-	from frappe.core.utils import find
-
 	parent_meta = frappe.get_meta(parent_doctype)
-	child_table_field_exists = find(
-		parent_meta.get_table_fields(), lambda d: d.options == child_doctype
+
+	return not parent_meta.istable and any(
+		df.options == child_doctype for df in parent_meta.get_table_fields()
 	)
-	return not parent_meta.istable and child_table_field_exists

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -667,36 +667,55 @@ def has_child_table_permission(
 	raise_exception=True,
 	parent_doctype=None,
 ):
+	parent_doc = None
+
 	if child_doc:
+		if isinstance(child_doc, str):
+			child_doc = frappe.get_doc(child_doctype, child_doc)
+
 		parent_doctype = child_doc.parenttype
+		parent_doc = getattr(child_doc, "parent_doc", None)
+
+		if not parent_doc and child_doc.parent:
+			parent_doc = frappe.get_doc(parent_doctype, child_doc.parent)
+			child_doc.parent_doc = parent_doc
 
 	if not parent_doctype:
-		frappe.throw(
-			_("Please specify a valid parent DocType for {0}").format(frappe.bold(child_doctype)),
-			title=_("Parent DocType Required"),
+		push_perm_check_log(
+			_("Please specify a valid parent DocType for {0}").format(frappe.bold(child_doctype))
 		)
+		return False
 
-	if not is_parent_valid(child_doctype, parent_doctype):
-		frappe.throw(
+	parent_meta = parent_doc.meta if parent_doc else frappe.get_meta(parent_doctype)
+
+	if not parent_meta.istable and any(
+		df.options == child_doctype for df in parent_meta.get_table_fields()
+	):
+		push_perm_check_log(
 			_("{0} is not a valid parent DocType for {1}").format(
 				frappe.bold(parent_doctype), frappe.bold(child_doctype)
-			),
-			title=_("Invalid Parent DocType"),
+			)
 		)
+		return False
+
+	if (
+		child_doc
+		and child_doc.parentfield
+		and (
+			parent_meta.get_field(child_doc.parentfield).permlevel
+			not in parent_meta.get_permlevel_access(ptype)
+		)
+	):
+		push_perm_check_log(
+			_("Insufficient Permission Level for {0}").format(frappe.bold(parent_doctype))
+		)
+		return False
 
 	return has_permission(
 		parent_doctype,
 		ptype=ptype,
-		doc=getattr(child_doc, "parent_doc", child_doc.parent),
+		doc=parent_doc,
 		verbose=verbose,
 		user=user,
 		raise_exception=raise_exception,
-	)
-
-
-def is_parent_valid(child_doctype, parent_doctype):
-	parent_meta = frappe.get_meta(parent_doctype)
-
-	return not parent_meta.istable and any(
-		df.options == child_doctype for df in parent_meta.get_table_fields()
 	)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -695,8 +695,8 @@ def has_child_permission(
 
 	parent_meta = frappe.get_meta(parent_doctype)
 
-	if not parent_meta.istable and any(
-		df.options == child_doctype for df in parent_meta.get_table_fields()
+	if parent_meta.istable or all(
+		df.options != child_doctype for df in parent_meta.get_table_fields()
 	):
 		push_perm_check_log(
 			_("{0} is not a valid parent DocType for {1}").format(

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -60,6 +60,7 @@ def has_permission(
 	verbose=False,
 	user=None,
 	raise_exception=True,
+	*,
 	parent_doctype=None,
 ):
 	"""Returns True if user has permission `ptype` for given `doctype`.
@@ -68,7 +69,7 @@ def has_permission(
 	:param doctype: DocType to check permission for
 	:param ptype: Permission Type to check
 	:param doc: Check User Permissions for specified document.
-	:param verbose: DEPRECATED, will be removed in a future version.
+	:param verbose: DEPRECATED, will be removed in a future release.
 	:param user: User to check permission for. Defaults to session user.
 	:param raise_exception:
 	        DOES NOT raise an exception.

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -70,10 +70,11 @@ def has_permission(
 	:param ptype: Permission Type to check
 	:param doc: Check User Permissions for specified document.
 	:param verbose: DEPRECATED, will be removed in a future release.
-	:param user: User to check permission for. Defaults to session user.
+	:param user: User to check permission for. Defaults to current user.
 	:param raise_exception:
 	        DOES NOT raise an exception.
-	        If True, will print a message explaining why permission check failed.
+	        If not False, will display a message using frappe.msgprint
+	                which explains why the permission check failed.
 
 	:param parent_doctype:
 	        Required when checking permission for a child DocType (unless doc is specified)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -698,7 +698,6 @@ def has_child_table_permission(
 
 	if (
 		child_doc
-		and child_doc.parentfield
 		and (permlevel := parent_meta.get_field(child_doc.parentfield).permlevel) > 0
 		and permlevel not in parent_meta.get_permlevel_access(ptype)
 	):

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -79,9 +79,7 @@ def has_permission(
 		doctype = doc.doctype
 
 	if frappe.is_table(doctype):
-		return has_child_table_permission(
-			doctype, ptype, doc, verbose, user, raise_exception, parent_doctype
-		)
+		return has_child_permission(doctype, ptype, doc, verbose, user, raise_exception, parent_doctype)
 
 	meta = frappe.get_meta(doctype)
 
@@ -658,7 +656,7 @@ def push_perm_check_log(log):
 	frappe.flags.get("has_permission_check_logs").append(_(log))
 
 
-def has_child_table_permission(
+def has_child_permission(
 	child_doctype,
 	ptype="read",
 	child_doc=None,

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -667,18 +667,16 @@ def has_child_table_permission(
 	raise_exception=True,
 	parent_doctype=None,
 ):
-	parent_doc = None
-
 	if child_doc:
 		if isinstance(child_doc, str):
-			child_doc = frappe.get_doc(child_doctype, child_doc)
+			child_doc = frappe.db.get_value(
+				child_doctype,
+				child_doc,
+				("parent", "parenttype", "parentfield"),
+				as_dict=True,
+			)
 
 		parent_doctype = child_doc.parenttype
-		parent_doc = getattr(child_doc, "parent_doc", None)
-
-		if not parent_doc and child_doc.parent:
-			parent_doc = frappe.get_doc(parent_doctype, child_doc.parent)
-			child_doc.parent_doc = parent_doc
 
 	if not parent_doctype:
 		push_perm_check_log(
@@ -686,7 +684,7 @@ def has_child_table_permission(
 		)
 		return False
 
-	parent_meta = parent_doc.meta if parent_doc else frappe.get_meta(parent_doctype)
+	parent_meta = frappe.get_meta(parent_doctype)
 
 	if not parent_meta.istable and any(
 		df.options == child_doctype for df in parent_meta.get_table_fields()
@@ -714,7 +712,7 @@ def has_child_table_permission(
 	return has_permission(
 		parent_doctype,
 		ptype=ptype,
-		doc=parent_doc,
+		doc=child_doc and getattr(child_doc, "parent_doc", child_doc.parent),
 		verbose=verbose,
 		user=user,
 		raise_exception=raise_exception,

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -667,15 +667,15 @@ def has_child_table_permission(
 	raise_exception=True,
 	parent_doctype=None,
 ):
-	if child_doc:
-		if isinstance(child_doc, str):
-			child_doc = frappe.db.get_value(
-				child_doctype,
-				child_doc,
-				("parent", "parenttype", "parentfield"),
-				as_dict=True,
-			)
+	if isinstance(child_doc, str):
+		child_doc = frappe.db.get_value(
+			child_doctype,
+			child_doc,
+			("parent", "parenttype", "parentfield"),
+			as_dict=True,
+		)
 
+	if child_doc:
 		parent_doctype = child_doc.parenttype
 
 	if not parent_doctype:
@@ -699,10 +699,8 @@ def has_child_table_permission(
 	if (
 		child_doc
 		and child_doc.parentfield
-		and (
-			parent_meta.get_field(child_doc.parentfield).permlevel
-			not in parent_meta.get_permlevel_access(ptype)
-		)
+		and (permlevel := parent_meta.get_field(child_doc.parentfield).permlevel) > 0
+		and permlevel not in parent_meta.get_permlevel_access(ptype)
 	):
 		push_perm_check_log(
 			_("Insufficient Permission Level for {0}").format(frappe.bold(parent_doctype))

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -649,29 +649,13 @@ class TestPermissions(FrappeTestCase):
 		# reset the user
 		frappe.set_user(current_user)
 
-	def test_child_table_permissions(self):
+	def test_child_permissions(self):
 		frappe.set_user("test@example.com")
 		self.assertIsInstance(frappe.get_list("Has Role", parent_doctype="User", limit=1), list)
-		self.assertRaisesRegex(
-			frappe.exceptions.ValidationError,
-			".* is not a valid parent DocType for .*",
-			frappe.get_list,
-			doctype="Has Role",
-			parent_doctype="ToDo",
-		)
-		self.assertRaisesRegex(
-			frappe.exceptions.ValidationError,
-			"Please specify a valid parent DocType for .*",
-			frappe.get_list,
-			"Has Role",
-		)
-		self.assertRaisesRegex(
-			frappe.exceptions.ValidationError,
-			".* is not a valid parent DocType for .*",
-			frappe.get_list,
-			doctype="Has Role",
-			parent_doctype="Has Role",
-		)
+
+		self.assertRaises(frappe.PermissionError, frappe.get_list, "Has Role")
+		self.assertRaises(frappe.PermissionError, frappe.get_list, "Has Role", parent_doctype="ToDo")
+		self.assertRaises(frappe.PermissionError, frappe.get_list, "Has Role", parent_doctype="Has Role")
 
 	def test_select_user(self):
 		"""If test3@example.com is restricted by a User Permission to see only

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -650,7 +650,7 @@ class TestPermissions(FrappeTestCase):
 		frappe.set_user(current_user)
 
 	def test_child_permissions(self):
-		frappe.set_user("test@example.com")
+		frappe.set_user("test3@example.com")
 		self.assertIsInstance(frappe.get_list("DefaultValue", parent_doctype="User", limit=1), list)
 
 		# frappe.get_list

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -651,11 +651,28 @@ class TestPermissions(FrappeTestCase):
 
 	def test_child_permissions(self):
 		frappe.set_user("test@example.com")
-		self.assertIsInstance(frappe.get_list("Has Role", parent_doctype="User", limit=1), list)
+		self.assertIsInstance(frappe.get_list("DefaultValue", parent_doctype="User", limit=1), list)
 
-		self.assertRaises(frappe.PermissionError, frappe.get_list, "Has Role")
-		self.assertRaises(frappe.PermissionError, frappe.get_list, "Has Role", parent_doctype="ToDo")
-		self.assertRaises(frappe.PermissionError, frappe.get_list, "Has Role", parent_doctype="Has Role")
+		# frappe.get_list
+		self.assertRaises(frappe.PermissionError, frappe.get_list, "DefaultValue")
+		self.assertRaises(frappe.PermissionError, frappe.get_list, "DefaultValue", parent_doctype="ToDo")
+		self.assertRaises(
+			frappe.PermissionError, frappe.get_list, "DefaultValue", parent_doctype="DefaultValue"
+		)
+
+		# frappe.get_doc
+		user = frappe.get_doc("User", frappe.session.user)
+		doc = user.append("defaults")
+		doc.check_permission()
+
+		# false by permlevel
+		doc = user.append("roles")
+		self.assertRaises(frappe.PermissionError, doc.check_permission)
+
+		# false by user permission
+		user = frappe.get_doc("User", "Administrator")
+		doc = user.append("defaults")
+		self.assertRaises(frappe.PermissionError, doc.check_permission)
 
 	def test_select_user(self):
 		"""If test3@example.com is restricted by a User Permission to see only


### PR DESCRIPTION
## Changes Made
- Move `Administrator` check above `doctype` extraction.
- Handle case where `child_doc` may be a string - there is a perf optimisation here: since we don't really need the actual child doc, a `frappe._dict` with DB values has been set.
- Remove `is_parent_valid` helper, to be able to use `parent_meta` further.
- Check `permlevel` based on user's roles if `child_doc` is passed. Add `user` parameter in `Meta.get_permlevel_access` to do this right
- Don't use `get_cached_doc` to get parent doc:
  - Since only one arg was passed, it always initialized a new unsaved doc - not intended behavior.
  - Instead, use `child.parent_doc` if available, or fallback to `child.parent` - this gets loaded in `has_permission`
- In consistency with `has_permission`, don't throw errors -> use `push_perm_check_log` and return `False` instead.
- `has_child_table_permission` => `has_child_permission` (more accurate)
- Remove `verbose` parameter from `has_child_permission` -> it does nothing