### PR TITLE
refactor: improve `frappe.only_for`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -836,7 +836,9 @@ def only_for(roles: list[str] | tuple[str] | str, message=False):
 			raise PermissionError
 
 		throw(
-			_("This action is only allowed for {}").format(bold(", ".join(roles))),
+			_("This action is only allowed for {}").format(
+				", ".join(bold(_(role)) for role in roles),
+			),
 			PermissionError,
 			_("Not Permitted"),
 		)

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -832,12 +832,14 @@ def only_for(roles: list[str] | tuple[str] | str, message=False):
 		roles = (roles,)
 
 	if not set(roles).intersection(get_roles()):
-		if message:
-			msgprint(
-				_("This action is only allowed for {}").format(bold(", ".join(roles))),
-				_("Not Permitted"),
-			)
-		raise PermissionError
+		if not message:
+			raise PermissionError
+
+		throw(
+			_("This action is only allowed for {}").format(bold(", ".join(roles))),
+			PermissionError,
+			_("Not Permitted"),
+		)
 
 
 def get_domain_data(module):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -818,21 +818,24 @@ def write_only():
 	return innfn
 
 
-def only_for(roles: list[str] | str, message=False):
-	"""Raise `frappe.PermissionError` if the user does not have any of the given **Roles**.
+def only_for(roles: list[str] | tuple[str] | str, message=False):
+	"""
+	Raises `frappe.PermissionError` if the user does not have any of the permitted roles.
 
-	:param roles: List of roles to check."""
-	if local.flags.in_test:
+	:param roles: Permitted role(s)
+	"""
+
+	if local.flags.in_test or local.session.user == "Administrator":
 		return
 
-	if not isinstance(roles, (tuple, list)):
+	if isinstance(roles, str):
 		roles = (roles,)
-	roles = set(roles)
-	myroles = set(get_roles())
-	if not roles.intersection(myroles):
+
+	if not set(roles).intersection(get_roles()):
 		if message:
 			msgprint(
-				_("This action is only allowed for {}").format(bold(", ".join(roles))), _("Not Permitted")
+				_("This action is only allowed for {}").format(bold(", ".join(roles))),
+				_("Not Permitted"),
 			)
 		raise PermissionError
 

--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -4,18 +4,17 @@
 import frappe
 import frappe.utils.user
 from frappe.model import data_fieldtypes
-from frappe.permissions import check_admin_or_system_manager, rights
+from frappe.permissions import rights
 
 
 def execute(filters=None):
+	frappe.only_for("System Manager")
+
 	user, doctype, show_permissions = (
 		filters.get("user"),
 		filters.get("doctype"),
 		filters.get("show_permissions"),
 	)
-
-	if not validate(user, doctype):
-		return [], []
 
 	columns, fields = get_columns_and_fields(doctype)
 	data = frappe.get_list(doctype, fields=fields, as_list=True, user=user)
@@ -28,12 +27,6 @@ def execute(filters=None):
 			data[i] = doc + tuple(permission.get(right) for right in rights)
 
 	return columns, data
-
-
-def validate(user, doctype):
-	# check if current user is System Manager
-	check_admin_or_system_manager()
-	return user and doctype
 
 
 def get_columns_and_fields(doctype):

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -28,10 +28,13 @@ rights = (
 
 
 def check_admin_or_system_manager(user=None):
-	"""
-	DEPRECATED: This function will be removed in version 15.
-	Use `frappe.only_for` instead.
-	"""
+	from frappe.utils.commands import warn
+
+	warn(
+		"The function check_admin_or_system_manager will be deprecated in version 15."
+		'Please use frappe.only_for("System Manager") instead.',
+		category=PendingDeprecationWarning,
+	)
 
 	if not user:
 		user = frappe.session.user

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -28,6 +28,11 @@ rights = (
 
 
 def check_admin_or_system_manager(user=None):
+	"""
+	DEPRECATED: This function will be removed in version 15.
+	Use `frappe.only_for` instead.
+	"""
+
 	if not user:
 		user = frappe.session.user
 


### PR DESCRIPTION
## frappe.only_for

- Always allow `Administrator`
- Check for `str` instead of `list` and `tuple`
- Don't coerce the output of `get_roles()` to a set, not required

## other changes

- Mark `frappe.permissions.check_admin_or_system_manager` as deprecated in favor of `frappe.only_for`
- Update usage of deprecated function