### PR TITLE
fix: Show Report & Dashboard View for File Doctype

### DIFF
--- a/frappe/public/js/frappe/list/list_factory.js
+++ b/frappe/public/js/frappe/list/list_factory.js
@@ -5,13 +5,18 @@ frappe.provide('frappe.views.list_view');
 
 window.cur_list = null;
 frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
-	make (route) {
+	make(route) {
 		const me = this;
 		const doctype = route[1];
 
 		// List / Gantt / Kanban / etc
+		let view_name = frappe.utils.to_title_case(route[2] || 'List');
+
 		// File is a special view
-		const view_name = doctype !== 'File' ? frappe.utils.to_title_case(route[2] || 'List') : 'File';
+		if (doctype == "File" && !["Report", "Dashboard"].includes(view_name)) {
+			view_name = "File";
+		}
+
 		let view_class = frappe.views[view_name + 'View'];
 		if (!view_class) view_class = frappe.views.ListView;
 
@@ -48,7 +53,7 @@ frappe.views.ListFactory = class ListFactory extends frappe.views.Factory {
 		const last_route = frappe.route_history.slice(-2)[0];
 		if (
 			this.route[0] === 'List' &&
-			this.route.length === 2	&&
+			this.route.length === 2 &&
 			frappe.views.list_view[doctype] &&
 			last_route &&
 			last_route[0] === 'List' &&

--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -8,6 +8,9 @@ frappe.views.ListViewSelect = class ListViewSelect {
 	}
 
 	add_view_to_menu(view, action) {
+		if (this.doctype == "File" && view == "List") {
+			view = "File";
+		}
 		let $el = this.page.add_custom_menu_item(
 			this.parent,
 			__(view),
@@ -116,7 +119,7 @@ frappe.views.ListViewSelect = class ListViewSelect {
 				action: () => this.set_route("tree")
 			},
 			Kanban: {
-				condition: true,
+				condition: this.doctype != "File",
 				action: () => this.setup_kanban_boards(),
 				current_view_handler: () => {
 					frappe.views.KanbanView.get_kanbans(this.doctype).then(


### PR DESCRIPTION
**Issue:** File Doctype has Report View, Dashboard View & Kanban View in the View Dropdown, and none of them works.

Removed Kanban View from the list. Report & Dashboard View works now

**Before:**
<img width="1323" alt="image" src="https://user-images.githubusercontent.com/30859809/182109683-ba818471-e260-4bb7-ac94-79e1b30e6f1e.png">

**After:**
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/30859809/182109538-975c2eb2-9332-4835-8b27-cc54e617d3f0.png">
