### PR TITLE
fix: translatable short number symbol

### DIFF
--- a/frappe/public/js/frappe/utils/number_systems.js
+++ b/frappe/public/js/frappe/utils/number_systems.js
@@ -2,19 +2,19 @@ export default {
 	default: [
 		{
 			divisor: 1.0e12,
-			symbol: "T"
+			symbol: __("T", null, "Number system")
 		},
 		{
 			divisor: 1.0e9,
-			symbol: "B"
+			symbol: __("B", null, "Number system")
 		},
 		{
 			divisor: 1.0e6,
-			symbol: "M"
+			symbol: __("M", null, "Number system")
 		},
 		{
 			divisor: 1.0e3,
-			symbol: "K"
+			symbol: __("K", null, "Number system")
 		}
 	],
 	indian: [

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1311,7 +1311,7 @@ Object.assign(frappe.utils, {
 				result = no_of_decimals > max_no_of_decimals
 					? result.toFixed(max_no_of_decimals)
 					: result;
-				return result + ' ' + __(map.symbol, null, "Number system");
+				return result + ' ' + symbol;
 			}
 		}
 


### PR DESCRIPTION
Because client-side translations parse all files they need source text to exist to translate values. 

after: 
<img width="104" alt="Screenshot 2022-08-01 at 2 17 29 PM" src="https://user-images.githubusercontent.com/9079960/182110774-cc8b5fce-b25f-4e9d-a760-03bf9312e6ed.png">




refer: https://github.com/frappe/frappe/pull/17662 & https://github.com/frappe/frappe/issues/17684 