### PR TITLE
fix: Append to - misleading message

### DIFF
--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -214,7 +214,7 @@
   },
   {
    "depends_on": "eval: doc.enable_incoming && !doc.use_imap",
-   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings).",
+   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings)",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hide_days": 1,

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -214,7 +214,7 @@
   },
   {
    "depends_on": "eval: doc.enable_incoming && !doc.use_imap",
-   "description": "Append as communication against this DocType (must have fields (\"Status\", \"Subject\") and \"Sender\" defined in the related doctype Email Settings).",
+   "description": "Append as communication against this DocType must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings.",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hide_days": 1,

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -214,7 +214,7 @@
   },
   {
    "depends_on": "eval: doc.enable_incoming && !doc.use_imap",
-   "description": "Append as communication against this DocType must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings.",
+   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings.)",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hide_days": 1,

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -214,7 +214,7 @@
   },
   {
    "depends_on": "eval: doc.enable_incoming && !doc.use_imap",
-   "description": "Append as communication against this DocType (must have fields, \"Status\", \"Subject\")",
+   "description": "Append as communication against this DocType (must have fields (\"Status\", \"Subject\") and \"Sender\" defined in the related doctype Email Settings).",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hide_days": 1,

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -214,7 +214,7 @@
   },
   {
    "depends_on": "eval: doc.enable_incoming && !doc.use_imap",
-   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings.)",
+   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings).",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hide_days": 1,

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -73,7 +73,7 @@
    "label": "Attachment Limit (MB)"
   },
   {
-   "description": "Append as communication against this DocType must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings.",
+   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings).",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hidden": 1,

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -73,7 +73,7 @@
    "label": "Attachment Limit (MB)"
   },
   {
-   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings).",
+   "description": "Append as communication against this DocType (must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings)",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hidden": 1,

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -73,7 +73,7 @@
    "label": "Attachment Limit (MB)"
   },
   {
-   "description": "Append as communication against this DocType (must have fields, \"Status\", \"Subject\")",
+   "description": "Append as communication against this DocType (must have fields (\"Status\", \"Subject\") and \"Sender\" defined in the related doctype Email Settings).",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hidden": 1,

--- a/frappe/email/doctype/email_domain/email_domain.json
+++ b/frappe/email/doctype/email_domain/email_domain.json
@@ -73,7 +73,7 @@
    "label": "Attachment Limit (MB)"
   },
   {
-   "description": "Append as communication against this DocType (must have fields (\"Status\", \"Subject\") and \"Sender\" defined in the related doctype Email Settings).",
+   "description": "Append as communication against this DocType must have field \"Status\" and both \"Sender\" and \"Subject\" defined in the related doctype Email Settings.",
    "fieldname": "append_to",
    "fieldtype": "Link",
    "hidden": 1,


### PR DESCRIPTION
Hello,

To append email to a doctype to enable automatic creation, there are two required fields listed
![image](https://user-images.githubusercontent.com/109596710/182173486-d7141ec9-451d-4de9-8303-a8e8dbd289bf.png)

However, there is a third one required which is lacking in the above description (as seen below), because the email settings of the document must be enabled.
![image_2022-08-01_163225456](https://user-images.githubusercontent.com/109596710/182173390-7285e92f-6f04-4e42-a215-ad45e50e0fd3.png)

I propose to simply modify the sentence to the following :

Append as communication against this DocType must have field "Status" and  both "Sender" and "Subject" defined in the related doctype Email Settings).

The same must be applied in lots of csv in translations of course.
Unfortunately, I don't have the right tool right now to change all csv of translations in one go so would it be possible for someone else to do this part ?

By the way, the status field is not mandatory ...

Pierre