### PR TITLE
feat: use babel to extract translation sources

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -19,7 +19,7 @@ from frappe.social.doctype.energy_point_log.energy_point_log import get_energy_p
 from frappe.social.doctype.energy_point_settings.energy_point_settings import (
 	is_energy_point_enabled,
 )
-from frappe.translate import get_lang_dict
+from frappe.translate import get_lang_dict, get_messages_for_boot
 from frappe.utils import add_user_info, cstr, get_time_zone
 from frappe.utils.change_log import get_versions
 from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
@@ -248,18 +248,8 @@ def get_user_pages_or_reports(parent, cache=False):
 
 
 def load_translations(bootinfo):
-	messages = frappe.get_lang_dict("boot")
-
 	bootinfo["lang"] = frappe.lang
-
-	# load translated report names
-	for name in bootinfo.user.all_reports:
-		messages[name] = frappe._(name)
-
-	# only untranslated
-	messages = {k: v for k, v in messages.items() if k != v}
-
-	bootinfo["__messages"] = messages
+	bootinfo["__messages"] = get_messages_for_boot()
 
 
 def get_user_info():

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -281,7 +281,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 
 	render_edit_in_full_page_link() {
 		var me = this;
-		this.dialog.add_custom_action(`${__("Edit Full Form")}`, () => me.open_doc(true));
+		this.dialog.add_custom_action(__("Edit Full Form"), () => me.open_doc(true));
 	}
 
 	set_defaults() {

--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -142,10 +142,10 @@ frappe.views.ListViewSelect = class ListViewSelect {
 	setup_dropdown_in_sidebar(view, items, default_action) {
 		if (!this.sidebar) return;
 		const views_wrapper = this.sidebar.sidebar.find(".views-section");
-		views_wrapper.find(".sidebar-label").html(`${__(view)}`);
+		views_wrapper.find(".sidebar-label").html(__(view));
 		const $dropdown = views_wrapper.find(".views-dropdown");
 
-		let placeholder = `${__("Select {0}", [__(view)])}`;
+		let placeholder = __("Select {0}", [__(view)]);
 		let html = ``;
 
 		if (!items || !items.length) {

--- a/frappe/public/js/frappe/views/workspace/blocks/header.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/header.js
@@ -43,7 +43,7 @@ export default class Header extends Block {
 				frappe.utils.icon("drag", "xs"),
 				null,
 				"drag-handle",
-				`${__("Drag")}`,
+				__("Drag"),
 				null,
 				$widget_control
 			);

--- a/frappe/public/js/frappe/views/workspace/blocks/paragraph.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/paragraph.js
@@ -133,7 +133,7 @@ export default class Paragraph extends Block {
 				frappe.utils.icon("drag", "xs"),
 				null,
 				"drag-handle",
-				`${__("Drag")}`,
+				__("Drag"),
 				null,
 				$para_control
 			);

--- a/frappe/public/js/frappe/views/workspace/blocks/spacer.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/spacer.js
@@ -41,7 +41,7 @@ export default class Spacer extends Block {
 				frappe.utils.icon("drag", "xs"),
 				null,
 				"drag-handle",
-				`${__("Drag")}`,
+				__("Drag"),
 				null,
 				$widget_control
 			);

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -222,7 +222,7 @@ frappe.views.Workspace = class Workspace {
 		}
 
 		let page = this.get_page_to_show();
-		this.page.set_title(`${__(page.name)}`);
+		this.page.set_title(__(page.name));
 
 		this.update_selected_sidebar(this.current_page, false); //remove selected from old page
 		this.update_selected_sidebar(page, true); //add selected on new page
@@ -476,7 +476,7 @@ frappe.views.Workspace = class Workspace {
 				frappe.utils.icon("duplicate", "sm"),
 				() => this.duplicate_page(item),
 				"duplicate-page",
-				`${__("Duplicate Workspace")}`,
+				__("Duplicate Workspace"),
 				null,
 				sidebar_control
 			);
@@ -485,7 +485,7 @@ frappe.views.Workspace = class Workspace {
 				frappe.utils.icon("drag", "xs"),
 				null,
 				"drag-handle",
-				`${__("Drag")}`,
+				__("Drag"),
 				null,
 				sidebar_control
 			);

--- a/frappe/public/js/frappe/widgets/base_widget.js
+++ b/frappe/public/js/frappe/widgets/base_widget.js
@@ -30,7 +30,7 @@ export default class Widget {
 				frappe.utils.icon("drag", "xs"),
 				null,
 				"drag-handle",
-				`${__("Drag")}`,
+				__("Drag"),
 				null,
 				this.action_area
 			);
@@ -43,7 +43,7 @@ export default class Widget {
 				this.footer.css("opacity", 0.5);
 			}
 			const classname = this.hidden ? "fa fa-eye" : "fa fa-eye-slash";
-			const title = this.hidden ? `${__("Show")}` : `${__("Hide")}`;
+			const title = this.hidden ? __("Show") : __("Hide");
 			frappe.utils.add_custom_button(
 				`<i class="${classname}" aria-hidden="true"></i>`,
 				() => this.hide_or_show(),
@@ -61,7 +61,7 @@ export default class Widget {
 				frappe.utils.icon("edit", "xs"),
 				() => this.edit(),
 				"edit-button",
-				`${__("Edit")}`,
+				__("Edit"),
 				null,
 				this.action_area
 			);
@@ -158,7 +158,7 @@ export default class Widget {
 			this.refresh();
 		}
 
-		const title = this.width == "Full" ? `${__("Collapse")}` : `${__("Expand")}`;
+		const title = this.width == "Full" ? __("Collapse") : __("Expand");
 		this.resize_button.attr("title", title);
 	}
 
@@ -177,7 +177,7 @@ export default class Widget {
 		this.show_or_hide_button.empty();
 
 		const classname = this.hidden ? "fa fa-eye" : "fa fa-eye-slash";
-		const title = this.hidden ? `${__("Show")}` : `${__("Hide")}`;
+		const title = this.hidden ? __("Show") : __("Hide");
 
 		$(`<i class="${classname}" aria-hidden="true" title="${title}"></i>`).appendTo(
 			this.show_or_hide_button

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -143,6 +143,11 @@ class TestTranslate(unittest.TestCase):
 				context="new line")
 			__("This wont be captured")
 			__init__("This shouldn't too")
+			_(
+				"broken on separate line",
+				)
+			_(not_a_string)
+			_(not_a_string, context="wat")
 		"""
 		)
 		expected_output = [
@@ -151,10 +156,11 @@ class TestTranslate(unittest.TestCase):
 			(4, "attr with", "attr context"),
 			(5, "name with", "name context"),
 			(6, "broken on", "new line"),
+			(10, "broken on separate line", None),
 		]
 
 		output = extract_messages_from_python_code(code)
-		self.assertEqual(output, expected_output)
+		self.assertEqual(output, expected_output, msg=output)
 
 
 def verify_translation_files(app):

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -216,7 +216,7 @@ class TestTranslate(unittest.TestCase):
 		self.assertEqual(args, ("attr with", None, "context"))
 
 		args = get_args("""__("attr with", ["format", "replacements"])""")
-		self.assertEqual(args, ("attr with", None))
+		self.assertEqual(args, "attr with")
 
 
 def verify_translation_files(app):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -213,6 +213,14 @@ def get_dict(fortype: str, name: str | None = None) -> dict[str, str]:
 	return translation_map
 
 
+def get_messages_for_boot():
+	"""Return all message translations that are required on boot."""
+	messages = get_full_dict(frappe.local.lang)
+	messages.update(get_dict_from_hooks("boot", None))
+
+	return messages
+
+
 def get_dict_from_hooks(fortype, name):
 	translated_dict = {}
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -637,6 +637,9 @@ def get_server_messages(app):
 	for basepath, folders, files in app_walk:
 		folders[:] = [folder for folder in folders if folder not in {".git", "__pycache__"}]
 
+		if "public/dist" in basepath:
+			continue
+
 		for f in files:
 			f = frappe.as_unicode(f)
 			if f.endswith(file_extensions):

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -7,8 +7,8 @@
 	Translation tools for frappe
 """
 
+import ast
 import functools
-import io
 import itertools
 import json
 import operator
@@ -682,7 +682,7 @@ def get_all_messages_from_js_files(app_name=None):
 	return messages
 
 
-def get_messages_from_file(path: str) -> list[tuple[str, str, str, str]]:
+def get_messages_from_file(path: str) -> list[tuple[str, str, str | None, int]]:
 	"""Returns a list of transatable strings from a code file
 
 	:param path: path of the code file
@@ -704,19 +704,71 @@ def get_messages_from_file(path: str) -> list[tuple[str, str, str, str]]:
 				print(f"Could not scan file for translation: {path}")
 				return []
 
+			if path.lower().endswith(".py"):
+				messages = extract_messages_from_python_code(file_contents)
+			else:
+				messages = extract_messages_from_code(file_contents)
 			return [
 				(os.path.relpath(path, bench_path), message, context, line)
-				for (line, message, context) in extract_messages_from_code(file_contents)
+				for (line, message, context) in messages
 			]
 	else:
 		return []
+
+
+def extract_messages_from_python_code(code: str) -> list[tuple[int, str, str | None]]:
+	"""Extracts translatable strings from python code using AST"""
+
+	tree = ast.parse(code)
+
+	TRANSLATE_FUNCTION = "_"
+	messages = []
+
+	for node in ast.walk(tree):
+		if not isinstance(node, ast.Call):
+			continue
+
+		# frappe._(...)
+		direct_call = isinstance(node.func, ast.Attribute) and node.func.attr == TRANSLATE_FUNCTION
+		# from frappe import _
+		# _(...)
+		imported_call = isinstance(node.func, ast.Name) and node.func.id == TRANSLATE_FUNCTION
+
+		if not (direct_call or imported_call):
+			continue
+
+		message = _extract_message_from_translation_node(node)
+		if message:
+			messages.append(message)
+
+	return messages
+
+
+def _extract_message_from_translation_node(node: ast.Call) -> tuple[int, str, str | None]:
+
+	# extract source text
+	source_text = None
+	if node.args and isinstance(node.args[0], ast.Constant):
+		source_text = node.args[0].value
+	if not isinstance(source_text, str):
+		# you can have non-str default args which don't make sense for translations
+		return
+
+	# Extract context, a kwarg called "context" should exist.
+	context = None
+	for kw in node.keywords:
+		if kw.arg != "context":
+			continue
+		if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+			context = kw.value.value
+
+	return (node.lineno, source_text, context)
 
 
 def extract_messages_from_code(code):
 	"""
 	Extracts translatable strings from a code file
 	:param code: code from which translatable files are to be extracted
-	:param is_py: include messages in triple quotes e.g. `_('''message''')`
 	"""
 	from jinja2 import TemplateError
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -784,7 +784,7 @@ def extract_messages_from_javascript_code(code: str) -> list[tuple[int, str, str
 	return messages
 
 
-def extract_javascript(code, keywords=("__"), options=None):
+def extract_javascript(code, keywords=("__",), options=None):
 	"""Extract messages from JavaScript source code.
 
 	This is a modified version of babel's JS parser. Reused under BSD license.


### PR DESCRIPTION
This piece of beauty has outlived its maintainability, I spent **hours** to extend it to accommodate new lines. Time to use something from a civilized age. 
![image](https://user-images.githubusercontent.com/9079960/182211655-3c3298cc-40a6-43c5-a282-b234fde3b1fa.png)



- [x] Use babel's parser for python
- [x] Use babel's lexer + modified parser for JS code
- [x] JS calls inside of template strings (HTML)
- [X] keep using regex for all other sources 


Why do this? 

- Babel operates on tokens instead of lines so it can handle newlines very well which regex can't. 
- Babel is already a dependency
- Babel is extensible if we end up adding a new translation function (e.g. lazy translations) then we need to change few lines to make it work with current extractors)


Pros:
- Far far more accurate parsing, using the same parser as the language itself.


Cons:
- Significantly slower than regex, but this doesn't happen that often so eh. 



`no-docs`


Concludes / continues: https://github.com/frappe/frappe/pull/16409 

---

This PR also changes how client-side translations work and makes them similar to how server-side translations work. This increases boot size for non-English users but makes translation more accurate and reliable. We will figure out a better way to cache boot messages on the client side in some future improvement. 

closes https://github.com/frappe/frappe/issues/17684 