### PR TITLE
perf(Document Follow): specify reference doctype in filters

### DIFF
--- a/frappe/desk/form/document_follow.py
+++ b/frappe/desk/form/document_follow.py
@@ -161,9 +161,14 @@ def get_document_followed_by_user(user):
 
 def get_version(doctype, doc_name, frequency, user):
 	timeline = []
-	filters = get_filters("docname", doc_name, frequency, user)
 	version = frappe.get_all(
-		"Version", filters=filters, fields=["ref_doctype", "data", "modified", "modified_by"]
+		"Version",
+		filters=[
+			["ref_doctype", "=", doctype],
+			["docname", "=", doc_name],
+			*_get_filters(frequency, user),
+		],
+		fields=["data", "modified", "modified_by"],
 	)
 	if version:
 		for v in version:
@@ -186,9 +191,14 @@ def get_comments(doctype, doc_name, frequency, user):
 	from frappe.core.utils import html2text
 
 	timeline = []
-	filters = get_filters("reference_name", doc_name, frequency, user)
 	comments = frappe.get_all(
-		"Comment", filters=filters, fields=["content", "modified", "modified_by", "comment_type"]
+		"Comment",
+		filters=[
+			["reference_doctype", "=", doctype],
+			["reference_name", "=", doc_name],
+			*_get_filters(frequency, user),
+		],
+		fields=["content", "modified", "modified_by", "comment_type"],
 	)
 	for comment in comments:
 		if comment.comment_type == "Like":
@@ -306,29 +316,27 @@ def send_weekly_updates():
 	send_document_follow_mails("Weekly")
 
 
-def get_filters(search_by, name, frequency, user):
-	filters = []
+def _get_filters(frequency, user):
+	filters = [
+		["modified_by", "!=", user],
+	]
 
 	if frequency == "Weekly":
-		filters = [
-			[search_by, "=", name],
+		filters += [
 			["modified", ">", frappe.utils.add_days(frappe.utils.nowdate(), -7)],
 			["modified", "<", frappe.utils.nowdate()],
-			["modified_by", "!=", user],
 		]
+
 	elif frequency == "Daily":
-		filters = [
-			[search_by, "=", name],
+		filters += [
 			["modified", ">", frappe.utils.add_days(frappe.utils.nowdate(), -1)],
 			["modified", "<", frappe.utils.nowdate()],
-			["modified_by", "!=", user],
 		]
+
 	elif frequency == "Hourly":
-		filters = [
-			[search_by, "=", name],
+		filters += [
 			["modified", ">", frappe.utils.add_to_date(frappe.utils.now_datetime(), hours=-1)],
 			["modified", "<", frappe.utils.now_datetime()],
-			["modified_by", "!=", user],
 		]
 
 	return filters


### PR DESCRIPTION
`tabVersion` can be HUGE, and not specifying proper filters can render the whole site unusable.

## Screenshots

#### MariaDB Processlist (before)

![image](https://user-images.githubusercontent.com/16315650/182267854-f6ef4cf4-074a-4602-8118-8d8cbda0587a.png)

#### Query Test

![photo_2022-08-02_06-32-27](https://user-images.githubusercontent.com/16315650/182270147-ab7a78b6-c3e8-4465-b0e5-c2ce3cfeebd5.jpg)


## Other changes
- Don't get `ref_doctype` in version query - it isn't used.
- The function `get_filters` has been changed:
  - This is an internal function and isn't used anywhere else. Renamed to `_get_filters` to mark it as internal.
  - Removed `search_by` and `name` params - handled separately.

## Tests Passing

![image](https://user-images.githubusercontent.com/16315650/182269187-37ad9557-9a7f-454c-ae44-011b2853f922.png)


Sponsored by @aakvatech