### PR TITLE
fix: max_positive_value for Integer types

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -20,7 +20,7 @@ from frappe.modules import load_doctype_module
 from frappe.utils import cast_fieldtype, cint, cstr, flt, now, sanitize_html, strip_html
 from frappe.utils.html_utils import unescape_html
 
-max_positive_value = {"smallint": 2**15, "int": 2**31, "bigint": 2**63}
+max_positive_value = {"smallint": 2**15-1, "int": 2**31-1, "bigint": 2**63-1}
 
 DOCTYPE_TABLE_FIELDS = [
 	_dict(fieldname="fields", options="DocField"),

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -20,7 +20,7 @@ from frappe.modules import load_doctype_module
 from frappe.utils import cast_fieldtype, cint, cstr, flt, now, sanitize_html, strip_html
 from frappe.utils.html_utils import unescape_html
 
-max_positive_value = {"smallint": 2**15-1, "int": 2**31-1, "bigint": 2**63-1}
+max_positive_value = {"smallint": 2**15 - 1, "int": 2**31 - 1, "bigint": 2**63 - 1}
 
 DOCTYPE_TABLE_FIELDS = [
 	_dict(fieldname="fields", options="DocField"),


### PR DESCRIPTION
Source / Reference: ISS-22-23-01561

The max values for **Integer** types are:

- **SMALLINT**: (2**15 -1) = 32767
- **INT**: (2**31 -1) = 2147483647
- **BIGINT**: (2**63 -1) = 9223372036854775807

**Before:**

- An error will be thrown if we try to set **2147483648** for **INT**. Ideally, it should be truncated.

https://user-images.githubusercontent.com/63660334/182349542-2d8b3e9f-2137-4390-88b9-5d1b22d9bc1b.mov

**After:** 

https://user-images.githubusercontent.com/63660334/182349848-cdaa228f-51df-49db-9f24-b7c23047c365.mov


