### PR TITLE
ci: version bump regex in automated release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,7 +7,7 @@
 		"@semantic-release/release-notes-generator",
 		[
 			"@semantic-release/exec", {
-				"prepareCmd": 'sed -ir "s/[0-9]*\.[0-9]*\.[0-9]*/${nextRelease.version}/" frappe/__init__.py'
+				"prepareCmd": 'sed -ir -E "s/\"[0-9]+\.[0-9]+\.[0-9]+\"/\"${nextRelease.version}\"/" frappe/__init__.py'
 			}
 		],
 		[


### PR DESCRIPTION
The current regex is dumb and also matches `...`

Went wild in last release:

![telegram-cloud-photo-size-5-6293910393877279830-y](https://user-images.githubusercontent.com/9079960/182583007-a9764660-8c19-48eb-8137-30d3ac9fa11d.jpg)

- [x] port to bench, erpnext
