### PR TITLE
feat: Multilanguage sites: language selector only will show "enabled" languages and language default always will be System default

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -99,8 +99,8 @@ def get_language(lang_list: list = None) -> str:
 		if parent_language in lang_set:
 			return parent_language
 
-	# fallback to language set in User or System Settings
-	return frappe.local.lang
+	# fallback to language set in System Settings or "en"
+	return frappe.db.get_default("lang") or "en"
 
 
 @functools.lru_cache
@@ -1270,13 +1270,13 @@ def get_translator_url():
 
 @frappe.whitelist(allow_guest=True)
 def get_all_languages(with_language_name=False):
-	"""Returns all language codes ar, ch etc"""
+	"""Returns all enabled language codes ar, ch etc"""
 
 	def get_language_codes():
-		return frappe.get_all("Language", pluck="name")
+		return frappe.get_all("Language", filters={"enabled": 1}, pluck="name")
 
 	def get_all_language_with_name():
-		return frappe.db.get_all("Language", ["language_code", "language_name"])
+		return frappe.get_all("Language", fields=["language_code", "language_name"], filters={"enabled": 1})
 
 	if not frappe.db:
 		frappe.connect()

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -1276,7 +1276,7 @@ def get_all_languages(with_language_name=False):
 		return frappe.get_all("Language", filters={"enabled": 1}, pluck="name")
 
 	def get_all_language_with_name():
-		return frappe.get_all("Language", fields=["language_code", "language_name"], filters={"enabled": 1})
+		return frappe.get_all("Language", ["language_code", "language_name"], {"enabled": 1})
 
 	if not frappe.db:
 		frappe.connect()


### PR DESCRIPTION
If you need a multilangual site, but only some languages being available and you need to define one language as default.

Solves:

- Only some languages can be selected as "available" for websites ("Language" > Disable the ones you want to hide). It affects: frontend language selector, and all methods using "frappe.translate.get_all_languages"
- Default language will be the one defined into "Website Settings". It affects everything using "frappe.translate.get_language"

How:

- Doctype "Language" field "enabled" is used as filter for frontend language selector. So only "enabled" languages will be used for the whole website (get_all_languages get only enabled ones).
- frappe.translate.get_language will use the same logic as now, but as last option, it will use the System default language or "en".


`no-docs`