### PR TITLE
chore: re-generate yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,7 +1256,7 @@ fraction.js@^4.1.2:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.2.0.tgz#448e5109a313a3527f5a3ab2119ec4cf0e0e2950"
   integrity sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==
 
-frappe-charts@^2.0.0-rc22:
+frappe-charts@2.0.0-rc22:
   version "2.0.0-rc22"
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc22.tgz#9a5a747febdc381a1d4d7af96e89cf519dfba8c0"
   integrity sha512-N7f/8979wJCKjusOinaUYfMxB80YnfuVLrSkjpj4LtyqS0BGS6SuJxUnb7Jl4RWUFEIs7zEhideIKnyLeFZF4Q==


### PR DESCRIPTION
yarn lock wasn't updated correctly in last package.json update which
causes failure during update

closes https://github.com/frappe/frappe/issues/17744 