### PR TITLE
revert: Remove emoji from doctype

### DIFF
--- a/cypress/integration/control_data.js
+++ b/cypress/integration/control_data.js
@@ -42,7 +42,7 @@ context("Data Control", () => {
 		cy.visit(`/app/doctype/User`);
 		cy.get(
 			'[data-fieldname="fields"] .grid-row[data-idx="2"] [data-fieldname="fieldtype"] .static-area'
-		).should("have.text", "🔵 Section Break");
+		).should("have.text", "Section Break");
 	});
 
 	it('Verifying data control by inputting different patterns for "Name" field', () => {

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -11,12 +11,12 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 			this.frm.doctype === "DocType" ? "DocField" : "Customize Form Field"
 		].fieldtype.formatter = (value) => {
 			const prefix = {
-				"Tab Break": "🔴",
-				"Section Break": "🔵",
-				"Column Break": "🟡",
+				"Tab Break": "--red-600",
+				"Section Break": "--blue-600",
+				"Column Break": "--yellow-600",
 			};
 			if (prefix[value]) {
-				value = prefix[value] + " " + value;
+				value = `<span class="bold" style="color: var(${prefix[value]})">${value}</span>`;
 			}
 			return value;
 		};


### PR DESCRIPTION
This looks so out-of-place. IMO this should not be the part of FF
<img width="1026" alt="Screenshot 2022-08-08 at 3 44 19 PM" src="https://user-images.githubusercontent.com/13928957/183398851-51e6e9d6-6548-4d83-b9cf-216c6e79fb0b.png">

Going ahead with following implementation
![image](https://user-images.githubusercontent.com/13928957/183410272-4193b46c-f784-4df4-94cf-553b78e6e96d.png)

Feel free to implement better solution.

