### PR TITLE
fix(sanitize-html): allow all data-* attrs

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -254,6 +254,13 @@ class TestHTMLUtils(unittest.TestCase):
 		self.assertTrue("<h1>Hello</h1>" in clean)
 		self.assertTrue('<a href="http://test.com">text</a>' in clean)
 
+	def test_sanitize_html(self):
+		from frappe.utils.html_utils import sanitize_html
+
+		clean = sanitize_html("<ol data-list='ordered' unknown_attr='xyz'></ol>")
+		self.assertIn("ordered", clean)
+		self.assertNotIn("xyz", clean)
+
 
 class TestValidationUtils(unittest.TestCase):
 	def test_valid_url(self):

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -162,7 +162,13 @@ def sanitize_html(html, linkify=False):
 		+ mathml_elements
 		+ ["html", "head", "meta", "link", "body", "style", "o:p"]
 	)
-	attributes = {"*": acceptable_attributes, "svg": svg_attributes}
+
+	def attributes_filter(tag, name, value):
+		if name.startswith("data-"):
+			return True
+		return name in acceptable_attributes
+
+	attributes = {"*": attributes_filter, "svg": svg_attributes}
 	styles = bleach_allowlist.all_styles
 	strip_comments = False
 


### PR DESCRIPTION
Frappe sanitizes most field values using `sanitize_html` method. Sanitization is done using a whitelist of acceptable tags and attributes. However, attributes that start with `data-` can be introduced by any rich text editor and they are mostly harmless. And It'll take forever to whitelist every `data-` attribute. With this change, all `data-` attributes in HTML tags are whitelisted.

I am using [TipTap editor](https://tiptap.dev/) which uses these attributes for some cool functionality.