### PR TITLE
fix: misc fixes

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -59,7 +59,7 @@ frappe.socketio = {
 		frappe.socketio.setup_reconnect();
 
 		$(document).on("form-load form-rename", function (e, frm) {
-			if (frm.is_new()) {
+			if (!frm.doc || frm.is_new()) {
 				return;
 			}
 
@@ -75,7 +75,7 @@ frappe.socketio = {
 		});
 
 		$(document).on("form-refresh", function (e, frm) {
-			if (frm.is_new()) {
+			if (!frm.doc || frm.is_new()) {
 				return;
 			}
 
@@ -83,7 +83,7 @@ frappe.socketio = {
 		});
 
 		$(document).on("form-unload", function (e, frm) {
-			if (frm.is_new()) {
+			if (!frm.doc || frm.is_new()) {
 				return;
 			}
 
@@ -100,14 +100,11 @@ frappe.socketio = {
 		});
 
 		window.addEventListener("beforeunload", () => {
-			if (!cur_frm || cur_frm.is_new()) {
+			if (!cur_frm || !cur_frm.doc || cur_frm.is_new()) {
 				return;
 			}
 
-			// if tab/window is closed, notify other users
-			if (cur_frm.doc) {
-				frappe.socketio.doc_close(cur_frm.doctype, cur_frm.docname);
-			}
+			frappe.socketio.doc_close(cur_frm.doctype, cur_frm.docname);
 		});
 	},
 	get_host: function (port = 3000) {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -536,7 +536,6 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		this.last_chart_type = args.chart_type;
 
 		const get_df = (field) => this.columns_map[field].docfield;
-		const get_doc = (value, field) => this.data.find((d) => d[field] === value);
 
 		this.$charts_wrapper.removeClass("hidden");
 
@@ -551,13 +550,12 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 				numberFormatter: frappe.utils.format_chart_axis_number,
 			},
 			tooltipOptions: {
-				formatTooltipY: (value) =>
-					frappe.format(
-						value,
-						get_df(this.chart_args.y_axes[0]),
-						{ always_show_decimals: true, inline: true },
-						get_doc(value.doc)
-					),
+				formatTooltipY: (value) => {
+					return frappe.format(value, get_df(this.chart_args.y_axes[0]), {
+						always_show_decimals: true,
+						inline: true,
+					});
+				},
 			},
 		});
 	}


### PR DESCRIPTION
1. realtime events check if active form is new or not, the form might not have a doc in which case `is_new` fails. Ignore form object without docs. 
```
TypeError: Cannot read properties of undefined (reading '__islocal')
  at frappe.ui.form.Form.is_new(../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:1276:19)
  at HTMLDocument.<anonymous>(../../../../../apps/frappe/frappe/public/js/frappe/socketio_client.js:90:12)
  at HTMLDocument.dispatch(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:5430:27)
  at c1.handle(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:5234:28)
  at Object.trigger(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:8719:12)
  at HTMLDocument.<anonymous>(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:8797:17)
  at Function.each(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:385:19)
  at l.fn.init.each(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:207:17)
  at l.fn.init.trigger(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:8796:15)
  at HTMLDivElement.<anonymous>(../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:520:17)
  at HTMLDivElement.dispatch(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:5430:27)
  at c1.handle(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:5234:28)
  at Object.trigger(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:8719:12)
  at HTMLDivElement.<anonymous>(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:8797:17)
  at Function.each(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:385:19)
  at l.fn.init.each(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:207:17)
  at l.fn.init.trigger(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:8796:15)
  at frappe.views.Container.change_to(../../../../../apps/frappe/frappe/public/js/frappe/views/container.js:66:17)
  at frappe.views.ListFactory.show(../../../../../apps/frappe/frappe/public/js/frappe/views/factory.js:19:21)
  at Object.render_page(../../../../../apps/frappe/frappe/public/js/frappe/router.js:226:33)
  at Object.render(../../../../../apps/frappe/frappe/public/js/frappe/router.js:205:9)
  at Object.route(../../../../../apps/frappe/frappe/public/js/frappe/router.js:115:8)
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/router.js:28:16)
```


2. Report view chart formatter doesn't work because `value.doc` is passed as a document to `frappe.formatter`. Value is a numeric value as per frappe charts API, no idea why it as written like this is 🤷 Remove the code. 

```
TypeError: Cannot read properties of undefined (reading 'doc')
  at formatTooltipY(../../../../../apps/frappe/frappe/public/js/frappe/views/reports/report_view.js:536:146)
  at ? (../../../../../apps/frappe/node_modules/frappe-charts/src/js/charts/AxisChart.js:379:27)
  at Array.map(<anonymous>)
  at ? (../../../../../apps/frappe/node_modules/frappe-charts/src/js/charts/AxisChart.js:372:37)
  at Array.map(<anonymous>)
  at e.value(../../../../../apps/frappe/node_modules/frappe-charts/src/js/charts/AxisChart.js:371:10)
  at e.value(../../../../../apps/frappe/node_modules/frappe-charts/src/js/charts/AxisChart.js:67:8)
  at e.value(../../../../../apps/frappe/node_modules/frappe-charts/src/js/charts/BaseChart.js:154:8)
  at ResizeObserver.boundDrawFn(../../../../../apps/frappe/node_modules/frappe-charts/src/js/charts/BaseChart.js:97:33)

```