### PR TITLE
refactor!: drop lazy loading utility

### DIFF
--- a/frappe/public/scss/website/website_image.scss
+++ b/frappe/public/scss/website/website_image.scss
@@ -18,12 +18,6 @@ img {
 	background: $light;
 }
 
-.website-image-lazy {
-	min-height: 200px;
-	height: 100%;
-	background-color: $light;
-}
-
 @mixin website-image {
 	display: inline-block;
 	object-fit: contain;

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -371,50 +371,6 @@ $.extend(frappe, {
 				$($heading).append($a);
 			});
 	},
-	setup_lazy_images: function () {
-		// Use IntersectionObserver to only load images that are visible in the viewport
-		// Fallback for browsers that don't support it
-		// To use this feature, instead of adding an img tag, add
-		// <div class="website-image-lazy" data-class="img-class" data-src="image.jpg" data-alt="image"></div>
-
-		const allowed_attributes = ["src", "srcset", "alt", "title", "width", "height"];
-
-		function replace_with_image(target) {
-			const $target = $(target);
-			const attrs = $target.data();
-			const data_string = Object.keys(attrs)
-				.filter((key) => allowed_attributes.includes(key))
-				.map((key) => `${key}="${attrs[key]}"`)
-				.join(" ");
-			$target.replaceWith(`<img ${data_string}>`);
-		}
-
-		if (!window.IntersectionObserver) {
-			$(".website-image-lazy").each((_, el) => {
-				replace_with_image(el);
-			});
-			return;
-		}
-
-		const io = new IntersectionObserver(
-			(entries) => {
-				entries.forEach((e) => {
-					if (e.intersectionRatio > 0) {
-						io.unobserve(e.target);
-						replace_with_image(e.target);
-					}
-				});
-			},
-			{
-				threshold: [0, 0.2, 0.4, 0.6],
-			}
-		);
-
-		$(".website-image-lazy").each((_, el) => {
-			// Start observing an element
-			io.observe(el);
-		});
-	},
 	show_language_picker() {
 		if (frappe.session.user === "Guest" && window.show_language_picker) {
 			frappe
@@ -665,7 +621,6 @@ $(document).ready(function () {
 	}
 
 	frappe.render_user();
-	frappe.setup_lazy_images();
 
 	$(document).trigger("page-change");
 });

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -377,10 +377,13 @@ $.extend(frappe, {
 		// To use this feature, instead of adding an img tag, add
 		// <div class="website-image-lazy" data-class="img-class" data-src="image.jpg" data-alt="image"></div>
 
+		const allowed_attributes = ["src", "srcset", "alt", "title", "width", "height"];
+
 		function replace_with_image(target) {
 			const $target = $(target);
 			const attrs = $target.data();
 			const data_string = Object.keys(attrs)
+				.filter((key) => allowed_attributes.includes(key))
 				.map((key) => `${key}="${attrs[key]}"`)
 				.join(" ");
 			$target.replaceWith(`<img ${data_string}>`);


### PR DESCRIPTION
BREAKING CHANGE.


Deprecating this since `img` tag natively supports this with `loading="lazy"` https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading 

TODO:

- [x] fix frappe usage - none
- [x] fix erpnext usage -  https://github.com/frappe/erpnext/pull/31814
- [x] other usage - none: https://sourcegraph.com/search?q=context:global+website-image-lazy&patternType=standard
