### PR TITLE
refactor: Multi Step Web Form

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -8,6 +8,7 @@ frappe.ui.form.Layout = class Layout {
 		this.pages = [];
 		this.tabs = [];
 		this.sections = [];
+		this.page_breaks = [];
 		this.fields_list = [];
 		this.fields_dict = {};
 
@@ -150,6 +151,10 @@ frappe.ui.form.Layout = class Layout {
 				case "Fold":
 					this.make_page(df);
 					break;
+				case "Page Break":
+					this.make_page_break();
+					this.make_section(df);
+					break;
 				case "Section Break":
 					this.make_section(df);
 					break;
@@ -230,6 +235,10 @@ frappe.ui.form.Layout = class Layout {
 
 		fieldobj.layout = this;
 		return fieldobj;
+	}
+
+	make_page_break() {
+		this.page = $('<div class="form-page page-break"></div>').appendTo(this.wrapper);
 	}
 
 	make_page(df) {

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -221,10 +221,43 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	toggle_section() {
 		if (!this.is_multi_step_form) return;
 
+		this.render_progress_dots();
 		this.toggle_previous_button();
 		this.hide_form_pages();
 		this.show_form_page();
 		this.toggle_buttons();
+	}
+
+	render_progress_dots() {
+		$(".center-area.paging").empty();
+
+		this.$slide_progress = $(`<div class="slides-progress"></div>`).appendTo(
+			$(".center-area.paging")
+		);
+		this.$slide_progress.empty();
+
+		if (this.page_breaks.length < 1) return;
+
+		for (let i = 0; i <= this.page_breaks.length; i++) {
+			let $dot = $(`<div class="slide-step">
+				<div class="slide-step-indicator"></div>
+				<div class="slide-step-complete">${frappe.utils.icon("tick", "xs")}</div>
+			</div>`).attr({ "data-step-id": i });
+
+			if (i < this.current_section) {
+				$dot.addClass("step-success");
+			}
+			if (i === this.current_section) {
+				$dot.addClass("active");
+			}
+			this.$slide_progress.append($dot);
+		}
+
+		let paging_text = __("Page {0} of {1}", [
+			this.current_section + 1,
+			this.page_breaks.length + 1,
+		]);
+		$(".center-area.paging").append(`<div>${paging_text}</div>`);
 	}
 
 	toggle_buttons() {

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -10,6 +10,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		frappe.web_form.events = {};
 		Object.assign(frappe.web_form.events, EventEmitterMixin);
 		this.current_section = 0;
+		this.is_multi_step_form = false;
 	}
 
 	prepare(web_form_doc, doc) {
@@ -69,6 +70,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		if (this.page_breaks.length) return;
 
 		this.page_breaks = $(`.page-break`);
+		this.is_multi_step_form = true;
 	}
 
 	setup_footer_actions() {

--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -20,7 +20,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 	make() {
 		super.make();
-		this.set_sections();
+		this.set_page_breaks();
 		this.set_field_values();
 		this.setup_listeners();
 
@@ -65,10 +65,10 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		}
 	}
 
-	set_sections() {
-		if (this.sections.length) return;
+	set_page_breaks() {
+		if (this.page_breaks.length) return;
 
-		this.sections = $(`.form-section`);
+		this.page_breaks = $(`.page-break`);
 	}
 
 	setup_footer_actions() {
@@ -86,11 +86,12 @@ export default class WebForm extends frappe.ui.FieldGroup {
 			return;
 		}
 
-		$(".web-form-footer").after(`
-			<div id="form-step-footer" class="text-right">
-				<button class="btn btn-default btn-previous btn-sm ml-2">${__("Previous")}</button>
-				<button class="btn btn-default btn-next btn-sm ml-2">${__("Next")}</button>
-			</div>
+		$(".web-form-footer .web-form-actions .left-area").prepend(`
+			<button class="btn btn-default btn-previous btn-md mr-2">${__("Previous")}</button>
+		`);
+
+		$(".web-form-footer .web-form-actions .right-area").prepend(`
+			<button class="btn btn-default btn-next btn-md">${__("Next")}</button>
 		`);
 
 		$(".btn-previous").on("click", function () {
@@ -166,7 +167,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	validate_section() {
 		if (this.allow_incomplete) return true;
 
-		let fields = $(`.form-section:eq(${this.current_section}) .form-control`);
+		let fields = $(`.form-page:eq(${this.current_section}) .form-control`);
 		let errors = [];
 		let invalid_values = [];
 
@@ -221,13 +222,13 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		if (!this.is_multi_step_form) return;
 
 		this.toggle_previous_button();
-		this.hide_sections();
-		this.show_section();
+		this.hide_form_pages();
+		this.show_form_page();
 		this.toggle_buttons();
 	}
 
 	toggle_buttons() {
-		for (let idx = this.current_section; idx < this.sections.length; idx++) {
+		for (let idx = this.current_section; idx <= this.page_breaks.length; idx++) {
 			if (this.is_next_section_empty(idx)) {
 				this.show_save_and_hide_next_button();
 			} else {
@@ -238,18 +239,18 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	}
 
 	is_next_section_empty(section) {
-		if (section + 1 > this.sections.length) return true;
+		if (section + 1 > this.page_breaks.length + 1) return true;
 
-		let _section = $(`.form-section:eq(${section + 1})`);
+		let _section = $(`.form-page:eq(${section + 1})`);
 		let visible_controls = _section.find(".frappe-control:not(.hide-control)");
 
 		return !visible_controls.length ? true : false;
 	}
 
 	is_previous_section_empty(section) {
-		if (section - 1 > this.sections.length) return true;
+		if (section - 1 > this.page_breaks.length + 1) return true;
 
-		let _section = $(`.form-section:eq(${section - 1})`);
+		let _section = $(`.form-page:eq(${section - 1})`);
 		let visible_controls = _section.find(".frappe-control:not(.hide-control)");
 
 		return !visible_controls.length ? true : false;
@@ -257,26 +258,26 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 	show_save_and_hide_next_button() {
 		$(".btn-next").hide();
-		$(".web-form-footer").show();
+		$(".submit-btn").show();
 	}
 
 	show_next_and_hide_save_button() {
 		$(".btn-next").show();
-		$(".web-form-footer").hide();
+		$(".submit-btn").hide();
 	}
 
 	toggle_previous_button() {
 		this.current_section == 0 ? $(".btn-previous").hide() : $(".btn-previous").show();
 	}
 
-	show_section() {
-		$(`.form-section:eq(${this.current_section})`).show();
+	show_form_page() {
+		$(`.form-page:eq(${this.current_section})`).show();
 	}
 
-	hide_sections() {
-		for (let idx = 0; idx < this.sections.length; idx++) {
+	hide_form_pages() {
+		for (let idx = 0; idx <= this.page_breaks.length; idx++) {
 			if (idx !== this.current_section) {
-				$(`.form-section:eq(${idx})`).hide();
+				$(`.form-page:eq(${idx})`).hide();
 			}
 		}
 	}

--- a/frappe/public/scss/website/web_form.scss
+++ b/frappe/public/scss/website/web_form.scss
@@ -69,7 +69,22 @@
 			}
 
 			.web-form-footer {
-				text-align: right;
+				margin-top: 1rem;
+
+				.web-form-actions {
+					display: flex;
+					justify-content: space-between;
+
+					.btn {
+						font-size: var(--font-size-base);
+					}
+
+					.center-area {
+						padding: 0.5rem;
+						display: flex;
+						align-items: center;
+					}
+				}
 			}
 
 			.attachments {

--- a/frappe/public/scss/website/web_form.scss
+++ b/frappe/public/scss/website/web_form.scss
@@ -234,4 +234,63 @@
 			}
 		}
 	}
+
+	.slides-progress {
+		display: flex;
+		margin-right: .5rem;
+
+		.slide-step {
+			@include flex(flex, center, center, null);
+
+			height: 18px;
+			width: 18px;
+			border-radius: var(--border-radius-full);
+			border: 1px solid var(--gray-300);
+			margin: 0 var(--margin-xs);
+			background-color: var(--card-bg);
+
+			.slide-step-indicator {
+				height: 6px;
+				width: 6px;
+				background-color: var(--gray-300);
+				border-radius: var(--border-radius-full);
+			}
+
+			.slide-step-complete {
+				display: none;
+
+				.icon-xs {
+					height: 10px;
+					width: 10px;
+				}
+			}
+
+			&.active {
+				border: 1px solid var(--primary);
+
+				.slide-step-indicator {
+					display: block;
+					background-color: var(--primary);
+				}
+			}
+
+			&.step-success:not(.active) {
+				background-color: var(--primary);
+				border: 1px solid var(--primary);
+
+				.slide-step-indicator {
+					display: none;
+				}
+
+				.slide-step-complete {
+					display: flex;
+
+					.icon use {
+						stroke-width: 2;
+						stroke: var(--white);
+					}
+				}
+			}
+		}
+	}
 }

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -264,9 +264,9 @@ def update_webform_to_multistep():
 	if not frappe.db.exists("Web Form", "update-profile-duplicate"):
 		doc = frappe.get_doc("Web Form", "edit-profile")
 		_doc = frappe.copy_doc(doc)
-		_doc.is_multi_step_form = 1
 		_doc.title = "update-profile-duplicate"
 		_doc.route = "update-profile-duplicate"
+		_doc.web_form_fields[5].fieldtype = "Page Break"
 		_doc.is_standard = False
 		_doc.save()
 

--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -2,25 +2,38 @@
 
 {% block breadcrumbs %}{% endblock %}
 
-{% macro action_buttons() %}
+{% macro header_buttons() %}
 	{% if allow_print and not is_new %}
 		{% set print_format_url = "/printview?doctype=" + doc_type + "&name=" + doc_name + "&format=" + print_format %}
 		<!-- print button -->
-		<a href="{{ print_format_url }}" target="_blank" class="btn btn-light btn-sm ml-2">
+		<a href="{{ print_format_url }}" target="_blank" class="print-btn btn btn-light btn-sm ml-2">
 			<svg class="icon icon-sm"><use href="#icon-printer"></use></svg>
 		</a>
 	{% endif %}
 
 	{% if allow_edit and doc_name and not is_form_editable %}
 		<!-- edit button -->
-		<a href="/{{ route }}/{{ doc_name }}/edit" class="btn btn-primary btn-sm ml-2">{{ _("Edit", null, "Button in web form") }}</a>
+		<a href="/{{ route }}/{{ doc_name }}/edit" class="edit-button btn btn-primary btn-sm ml-2">{{ _("Edit", null, "Button in web form") }}</a>
 	{% endif %}
+{% endmacro %}
 
+{% macro action_buttons() %}
 	{% if is_new or is_form_editable %}
-		<!-- cancel button -->
-		<a href="/{{ route }}/{% if doc_name %}{{ doc_name }}{% endif %}" class="btn btn-light btn-sm ml-2">{{ _("Cancel", null, "Button in web form") }}</a>
-		<!-- submit button -->
-		<button type="submit" class="btn btn-primary btn-sm ml-2">{{ button_label or _("Save", null, "Button in web form") }}</button>
+		<div class="left-area">
+			<!-- cancel button -->
+			<a href="/{{ path }}" class="clear-btn btn btn-light btn-md">
+				{% if is_form_editable %}
+					{{ _("Reset Form", null, "Button in web form") }}
+				{% else %}
+					{{ _("Clear Form", null, "Button in web form") }}
+				{% endif %}
+			</a>
+		</div>
+		<div class="center-area paging"></div>
+		<div class="right-area">
+			<!-- submit button -->
+			<button type="submit" class="submit-btn btn btn-primary btn-md ml-2">{{ button_label or _("Submit", null, "Button in web form") }}</button>
+		</div>
 	{% endif %}
 {% endmacro %}
 
@@ -38,7 +51,7 @@
 		<div class="web-form-header">
 			<h1>{{ _(title) }}</h1>
 			<div class="web-form-actions">
-				{{ action_buttons() }}
+				{{ header_buttons() }}
 			</div>
 		</div>
 		<div class="web-form-body">
@@ -46,8 +59,10 @@
 				<div class="web-form-introduction">{{ introduction_text }}</div>
 			{% endif %}
 			<div class="web-form-wrapper"></div>
-			<div class="web-form-footer hide">
-				{{ action_buttons() }}
+			<div class="web-form-footer">
+				<div class="web-form-actions">
+					{{ action_buttons() }}
+				</div>
 			</div>
 		</div>
 

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -17,7 +17,6 @@
   "introduction_text",
   "form_settings_tab",
   "login_required",
-  "is_multi_step_form",
   "allow_multiple",
   "allow_edit",
   "allow_delete",
@@ -234,12 +233,6 @@
   },
   {
    "default": "0",
-   "fieldname": "is_multi_step_form",
-   "fieldtype": "Check",
-   "label": "Is Multi Step Form"
-  },
-  {
-   "default": "0",
    "depends_on": "login_required",
    "fieldname": "show_list",
    "fieldtype": "Check",
@@ -316,7 +309,7 @@
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2022-07-27 18:19:10.748079",
+ "modified": "2022-08-10 15:38:28.611328",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form_field/web_form_field.json
+++ b/frappe/website/doctype/web_form_field/web_form_field.json
@@ -39,7 +39,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Fieldtype",
-   "options": "Attach\nAttach Image\nCheck\nCurrency\nData\nDate\nDatetime\nDuration\nFloat\nHTML\nInt\nLink\nPassword\nRating\nSelect\nSignature\nSmall Text\nText\nText Editor\nTable\nTime\nSection Break\nColumn Break"
+   "options": "Attach\nAttach Image\nCheck\nCurrency\nData\nDate\nDatetime\nDuration\nFloat\nHTML\nInt\nLink\nPassword\nRating\nSelect\nSignature\nSmall Text\nText\nText Editor\nTable\nTime\nSection Break\nColumn Break\nPage Break"
   },
   {
    "fieldname": "label",
@@ -146,7 +146,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-06-06 16:00:55.627950",
+ "modified": "2022-08-10 12:59:51.170546",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form Field",


### PR DESCRIPTION
To make any Webform a multistep webform we used to use **Section Break** which kind of does not make sense.

Now you can implement it by using the **Page Break** field.
Also moved the Action buttons (Submit & Clear Form) in the footer. Edit & Print button will be on header.

<img width="1026" alt="Screenshot 2022-08-10 at 1 07 55 PM" src="https://user-images.githubusercontent.com/30859809/183843101-17b14245-32df-41cf-af9d-2c0aae4a3ed5.png">

![MultiStepWebform](https://user-images.githubusercontent.com/30859809/183875114-0d76a78f-f11a-4f51-a4c2-685e4ae4469a.gif)


