### PR TITLE
feat(bench): add new bench command for add user

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -505,13 +505,18 @@ def add_system_manager(context, email, first_name, last_name, send_welcome_email
 @click.option("--add-role", multiple=True)
 @click.option("--send-welcome-email", default=False, is_flag=True)
 @pass_context
-def add_user_for_sites(context, email, first_name, last_name, user_type, send_welcome_email, password, add_role):
+def add_user_for_sites(
+    context, email, first_name, last_name, user_type, send_welcome_email, password, add_role
+):
     "Add user to a site"
     import frappe.utils.user
+
     for site in context.sites:
         frappe.connect(site=site)
         try:
-            add_new_user(email, first_name, last_name, user_type, send_welcome_email, password, add_role)
+            add_new_user(
+                email, first_name, last_name, user_type, send_welcome_email, password, add_role
+            )
             frappe.db.commit()
         finally:
             frappe.destroy()
@@ -1298,7 +1303,15 @@ def handle_data(data: dict, format="json"):
 		render_table(data)
 
 
-def add_new_user(email, first_name=None, last_name=None, user_type="System User", send_welcome_email=False, password=None,role=None):
+def add_new_user(
+    email,
+    first_name=None,
+    last_name=None,
+    user_type="System User",
+    send_welcome_email=False,
+    password=None,
+    role=None,
+):
     # add user
     user = frappe.new_doc("User")
     user.update(
@@ -1316,8 +1329,8 @@ def add_new_user(email, first_name=None, last_name=None, user_type="System User"
     user.add_roles(*role)
     if password:
         from frappe.utils.password import update_password
-        update_password(user=user.name, pwd=password)
 
+        update_password(user=user.name, pwd=password)
 
 
 commands = [

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -496,21 +496,22 @@ def add_system_manager(context, email, first_name, last_name, send_welcome_email
 		raise SiteNotSpecifiedError
 
 
-@click.command("add-new-user")
+@click.command("add-user")
 @click.argument("email")
 @click.option("--first-name")
 @click.option("--last-name")
 @click.option("--password")
+@click.option("--user-type")
 @click.option("--add-role", multiple=True)
 @click.option("--send-welcome-email", default=False, is_flag=True)
 @pass_context
-def add_new_user_for_sites(context, email, first_name, last_name, send_welcome_email, password, add_role):
-    "Add a new user to a site"
+def add_user_for_sites(context, email, first_name, last_name, user_type, send_welcome_email, password, add_role):
+    "Add user to a site"
     import frappe.utils.user
     for site in context.sites:
         frappe.connect(site=site)
         try:
-            add_new_user(email, first_name, last_name, send_welcome_email, password, add_role)
+            add_new_user(email, first_name, last_name, user_type, send_welcome_email, password, add_role)
             frappe.db.commit()
         finally:
             frappe.destroy()
@@ -1297,52 +1298,31 @@ def handle_data(data: dict, format="json"):
 		render_table(data)
 
 
-def add_new_user(
-		email, first_name=None, last_name=None, send_welcome_email=False, password=None,role=None):
-	# add user
-	user = frappe.new_doc("User")
-	user.update(
-		{
-			"name": email,
-			"email": email,
-			"enabled": 1,
-			"first_name": first_name or email,
-			"last_name": last_name,
-			"user_type": "System User",
-			"send_welcome_email": 1 if send_welcome_email else 0,
-		}
-	)
-	user.insert()
-	user.add_roles(*role)
-	if password:
-		from frappe.utils.password import update_password
-		update_password(user=user.name, pwd=password)
+def add_new_user(email, first_name=None, last_name=None, user_type="System User", send_welcome_email=False, password=None,role=None):
+    # add user
+    user = frappe.new_doc("User")
+    user.update(
+        {
+            "name": email,
+            "email": email,
+            "enabled": 1,
+            "first_name": first_name or email,
+            "last_name": last_name,
+            "user_type": user_type,
+            "send_welcome_email": 1 if send_welcome_email else 0,
+        }
+    )
+    user.insert()
+    user.add_roles(*role)
+    if password:
+        from frappe.utils.password import update_password
+        update_password(user=user.name, pwd=password)
 
 
-@click.command("list-roles")
-@pass_context
-def get_roles(context):
-    "get site available roles for users"
-    import frappe.utils.user
-    for site in context.sites:
-        frappe.connect(site=site)
-        site_title = click.style(f"{site}", fg="green")
-        print(site_title)
-        try:
-            role = frappe.get_list("Role")
-            for i in role:
-                if i.name not in ['All','Guest','Administrator']:
-                    print(i.name)		  
-            print("\n")
-        finally:
-            frappe.destroy()
-    if not context.sites:
-        raise SiteNotSpecifiedError
 
 commands = [
 	add_system_manager,
-	add_new_user_for_sites,
-	get_roles,
+	add_user_for_sites,
 	backup,
 	drop_site,
 	install_app,

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -689,6 +689,19 @@ class TestSiteMigration(BaseTestCommands):
 			self.assertEqual(result.exit_code, 0)
 			self.assertEqual(result.exception, None)
 
+class TestAddNewUser(BaseTestCommands):
+	def test_create_user(self):
+		self.execute(f"bench --site {TEST_SITE} add-user  --first-name test --last-name test --password 123 --user-type 'System User' --send-welcome-email test@gmail.com --add-role 'Accounts User' --add-role 'Sales User'")
+		self.assertEqual(self.returncode, 0)
+		roles=[]
+		user=frappe.get_doc("User","test@gmail.com")
+		for i in user.roles:
+			role = frappe.get_doc("Has Role",i.name)
+			roles.append(role.role)
+		self.assertEqual(user.name,"test9@gmail.com")
+		self.assertIn("Accounts User",roles)
+		self.assertIn("Sales User",roles)
+		self.assertTrue(len(roles)==2)
 
 class TestBenchBuild(BaseTestCommands):
 	def test_build_assets_size_check(self):

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -692,19 +692,19 @@ class TestSiteMigration(BaseTestCommands):
 
 class TestAddNewUser(BaseTestCommands):
 	def test_create_user(self):
-        self.execute(
-            f"bench --site {TEST_SITE} add-user test@gmail.com --first-name test --last-name test --password 123 --user-type 'System User' --add-role 'Accounts User' --add-role 'Sales User'"
-        )
+		self.execute(
+			f"bench --site {TEST_SITE} add-user test@gmail.com --first-name test --last-name test --password 123 --user-type 'System User' --add-role 'Accounts User' --add-role 'Sales User'"
+		)
 		self.assertEqual(self.returncode, 0)
-        roles = []
-        user = frappe.get_doc("User", "test@gmail.com")
+		roles = []
+		user = frappe.get_doc("User", "test@gmail.com")
 		for i in user.roles:
-            role = frappe.get_doc("Has Role", i.name)
+			role = frappe.get_doc("Has Role", i.name)
 			roles.append(role.role)
-        self.assertEqual(user.name, "test@gmail.com")
-        self.assertIn("Accounts User", roles)
-        self.assertIn("Sales User", roles)
-        self.assertTrue(len(roles) == 2)
+		self.assertEqual(user.name, "test@gmail.com")
+		self.assertIn("Accounts User", roles)
+		self.assertIn("Sales User", roles)
+		self.assertTrue(len(roles) == 2)
 
 
 class TestBenchBuild(BaseTestCommands):

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -689,19 +689,23 @@ class TestSiteMigration(BaseTestCommands):
 			self.assertEqual(result.exit_code, 0)
 			self.assertEqual(result.exception, None)
 
+
 class TestAddNewUser(BaseTestCommands):
 	def test_create_user(self):
-		self.execute(f"bench --site {TEST_SITE} add-user  --first-name test --last-name test --password 123 --user-type 'System User' --send-welcome-email test@gmail.com --add-role 'Accounts User' --add-role 'Sales User'")
+        self.execute(
+            f"bench --site {TEST_SITE} add-user test@gmail.com --first-name test --last-name test --password 123 --user-type 'System User' --add-role 'Accounts User' --add-role 'Sales User'"
+        )
 		self.assertEqual(self.returncode, 0)
-		roles=[]
-		user=frappe.get_doc("User","test@gmail.com")
+        roles = []
+        user = frappe.get_doc("User", "test@gmail.com")
 		for i in user.roles:
-			role = frappe.get_doc("Has Role",i.name)
+            role = frappe.get_doc("Has Role", i.name)
 			roles.append(role.role)
-		self.assertEqual(user.name,"test@gmail.com")
-		self.assertIn("Accounts User",roles)
-		self.assertIn("Sales User",roles)
-		self.assertTrue(len(roles)==2)
+        self.assertEqual(user.name, "test@gmail.com")
+        self.assertIn("Accounts User", roles)
+        self.assertIn("Sales User", roles)
+        self.assertTrue(len(roles) == 2)
+
 
 class TestBenchBuild(BaseTestCommands):
 	def test_build_assets_size_check(self):

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -698,7 +698,7 @@ class TestAddNewUser(BaseTestCommands):
 		for i in user.roles:
 			role = frappe.get_doc("Has Role",i.name)
 			roles.append(role.role)
-		self.assertEqual(user.name,"test9@gmail.com")
+		self.assertEqual(user.name,"test@gmail.com")
 		self.assertIn("Accounts User",roles)
 		self.assertIn("Sales User",roles)
 		self.assertTrue(len(roles)==2)


### PR DESCRIPTION
Branch: Develop 
New Feature:
We are A SAAS company trying to manage all operations of our success team through [Bench Manager](https://github.com/frappe/bench_manager) we made a lot of effort to make this possible. We use the multisite concept to create sites for our clients.
User Story:
As a multisite Erpnext company, we want to allow our operation team to create a user with custom roles So to be able to do this we suggest adding new bench commands for adding new Users with specific roles
like=>
- bench --site test1.localhost  add-user test2@gmail.com --first-name test1 --last-name test1 --password 123 --add-role 'Accounts User' --add-role 'Sales User' --send-welcome-email

Document: [Frappe commands](https://frappeframework.com/docs/v14/user/en/bench/frappe-commands/edit-wiki?wiki_page_patch=9dc5093709)
We want to add this in version 13 also if that is possible