### PR TITLE
fix: correct owner for new child on existing doc

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -510,7 +510,7 @@ class Document(BaseDocument):
 			d.modified = self.modified
 			d.modified_by = self.modified_by
 			if not d.owner:
-				d.owner = self.owner
+				d.owner = frappe.session.user
 			if not d.creation:
 				d.creation = self.creation
 


### PR DESCRIPTION
Steps to reproduce:

1. User A creates a document
2. User B modifies adds a child item to the document.
3. "Owner" of added child item is still A. 

Potentially breaking change (?)


TODO:
- modified_by behaviour on child table is similar issue