### PR TITLE
ci: include v14 in patch test

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -125,23 +125,28 @@ jobs:
           cd apps/frappe/
           git remote set-url upstream https://github.com/frappe/frappe.git
 
-          pyenv global $(pyenv versions | grep '3.7')
-          for version in $(seq 12 13)
-          do
-              echo "Updating to v$version"
-              branch_name="version-$version-hotfix"
-              git fetch --depth 1 upstream $branch_name:$branch_name
-              git checkout -q -f $branch_name
-              pip install -U frappe-bench
+          function update_to_version() {
+            version=$1
+            branch_name="version-$version-hotfix"
+            echo "Updating to v$version"
+            git fetch --depth 1 upstream $branch_name:$branch_name
+            git checkout -q -f $branch_name
+            pip install -U frappe-bench
 
-              rm -rf ~/frappe-bench/env
-              bench -v setup env
-              bench --site test_site migrate
-          done
+            rm -rf ~/frappe-bench/env
+            bench -v setup env
+            bench --site test_site migrate
+          }
+
+          pyenv global $(pyenv versions | grep '3.7')
+          update_to_version 12
+          update_to_version 13
+
+          pyenv global $(pyenv versions | grep '3.10')
+          update_to_version 14
 
           echo "Updating to last commit"
           git checkout -q -f "$GITHUB_SHA"
-          pyenv global $(pyenv versions | grep '3.10')
           rm -rf ~/frappe-bench/env
           bench -v setup env
           bench --site test_site migrate


### PR DESCRIPTION
New patch order: V10 backup > v12 > v13 > v14 > PR


Might drop v12 after a while and create a new better database for v13 inline with https://github.com/frappe/frappe/issues/15089 