### PR TITLE
fix: dont mutate `df` when creating custom fields

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -186,10 +186,13 @@ def create_custom_fields(custom_fields, ignore_validate=False, update=True):
 				field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": df["fieldname"]})
 				if not field:
 					try:
+						df = df.copy()
 						df["owner"] = "Administrator"
 						create_custom_field(doctype, df, ignore_validate=ignore_validate)
+
 					except frappe.exceptions.DuplicateEntryError:
 						pass
+
 				elif update:
 					custom_field = frappe.get_doc("Custom Field", field)
 					custom_field.flags.ignore_validate = ignore_validate


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/17815
Closes https://github.com/resilient-tech/india-compliance/issues/217

---

Since https://github.com/frappe/frappe/pull/14419, the same `df` can be used across multiple DocTypes. The field may exist for one of these DocTypes - but not another. So `owner` should not get set for all DocTypes.