### PR TITLE
fix: get single doc using client.get

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -78,7 +78,13 @@ def get(doctype, name=None, filters=None, parent=None):
 	if frappe.is_table(doctype):
 		check_parent_permission(parent, doctype)
 
-	doc = frappe.get_doc(doctype, name or frappe.parse_json(filters))
+	if name:
+		doc = frappe.get_doc(doctype, name)
+	elif filters or filters == {}:
+		doc = frappe.get_doc(doctype, frappe.parse_json(filters))
+	else:
+		doc = frappe.get_doc(doctype)  # single
+
 	doc.check_permission()
 	return doc.as_dict()
 

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -139,7 +139,8 @@ class TestClient(unittest.TestCase):
 
 		self.assertEqual(get("ToDo", filters=filters).description, "test")
 		self.assertEqual(get("ToDo", filters=filters_json).description, "test")
-
+		self.assertEqual(get("System Settings", "", "").doctype, "System Settings")
+		self.assertEqual(get("ToDo", filters={}), get("ToDo", filters="{}"))
 		todo.delete()
 
 	def test_client_insert(self):


### PR DESCRIPTION
### App Versions
```
{
	"ecommerce_integrations": "1.x.x-dev",
	"erpnext": "14.0.0-dev",
	"frappe": "14.0.0-dev",
	"hrms": "0.0.1",
	"payments": "0.0.1"
}
```
### Route
```

```
### Trackeback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1597, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/client.py", line 81, in get
    doc = frappe.get_doc(doctype, name or frappe.parse_json(filters))
  File "apps/frappe/frappe/__init__.py", line 2378, in parse_json
    return parse_json(val)
  File "apps/frappe/frappe/utils/__init__.py", line 783, in parse_json
    val = json.loads(val)
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/opt/homebrew/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"doctype": "POS Settings",
		"filters": null
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.client.get"
}
```
### Response Data
```
{
	"exception": "json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)"
}
```


caused by https://github.com/frappe/frappe/pull/17665 