### PR TITLE
perf: ~65% faster `create_custom_fields`

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -80,17 +80,15 @@ class CustomField(Document):
 		check_fieldname_conflicts(self)
 
 	def on_update(self):
-		if not frappe.flags.in_setup_wizard:
-			frappe.clear_cache(doctype=self.dt)
-
+		# validate field
 		if not self.flags.ignore_validate:
-			# validate field
 			from frappe.core.doctype.doctype.doctype import validate_fields_for_doctype
 
 			validate_fields_for_doctype(self.dt)
 
-		# update the schema
-		if not frappe.db.get_value("DocType", self.dt, "issingle") and not frappe.flags.in_setup_wizard:
+		# clear cache and update the schema
+		if not frappe.flags.in_create_custom_fields:
+			frappe.clear_cache(doctype=self.dt)
 			frappe.db.updatedb(self.dt)
 
 	def on_trash(self):
@@ -169,35 +167,45 @@ def create_custom_fields(custom_fields, ignore_validate=False, update=True):
 
 	:param custom_fields: example `{'Sales Invoice': [dict(fieldname='test')]}`"""
 
-	if not ignore_validate and frappe.flags.in_setup_wizard:
-		ignore_validate = True
+	try:
+		frappe.flags.in_create_custom_fields = True
+		doctypes_to_update = set()
 
-	for doctypes, fields in custom_fields.items():
-		if isinstance(fields, dict):
-			# only one field
-			fields = [fields]
+		if frappe.flags.in_setup_wizard:
+			ignore_validate = True
 
-		if isinstance(doctypes, str):
-			# only one doctype
-			doctypes = (doctypes,)
+		for doctypes, fields in custom_fields.items():
+			if isinstance(fields, dict):
+				# only one field
+				fields = [fields]
 
-		for doctype in doctypes:
-			for df in fields:
-				field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": df["fieldname"]})
-				if not field:
-					try:
-						df = df.copy()
-						df["owner"] = "Administrator"
-						create_custom_field(doctype, df, ignore_validate=ignore_validate)
+			if isinstance(doctypes, str):
+				# only one doctype
+				doctypes = (doctypes,)
 
-					except frappe.exceptions.DuplicateEntryError:
-						pass
+			for doctype in doctypes:
+				doctypes_to_update.add(doctype)
 
-				elif update:
-					custom_field = frappe.get_doc("Custom Field", field)
-					custom_field.flags.ignore_validate = ignore_validate
-					custom_field.update(df)
-					custom_field.save()
+				for df in fields:
+					field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": df["fieldname"]})
+					if not field:
+						try:
+							df = df.copy()
+							df["owner"] = "Administrator"
+							create_custom_field(doctype, df, ignore_validate=ignore_validate)
 
-		frappe.clear_cache(doctype=doctype)
-		frappe.db.updatedb(doctype)
+						except frappe.exceptions.DuplicateEntryError:
+							pass
+
+					elif update:
+						custom_field = frappe.get_doc("Custom Field", field)
+						custom_field.flags.ignore_validate = ignore_validate
+						custom_field.update(df)
+						custom_field.save()
+
+		for doctype in doctypes_to_update:
+			frappe.clear_cache(doctype=doctype)
+			frappe.db.updatedb(doctype)
+
+	finally:
+		frappe.flags.in_create_custom_fields = False


### PR DESCRIPTION
This PR basically extends the benefits of https://github.com/frappe/frappe/pull/13139/ for all execution of `create_custom_fields`

## Performance Improvement

Time spent for creating India Compliance fields

### Before

```python
In [2]: %time create_custom_fields(CUSTOM_FIELDS)
CPU times: user 15.8 s, sys: 458 ms, total: 16.2 s
Wall time: 26.3 s
```


### After

```python
In [2]: %time create_custom_fields(CUSTOM_FIELDS)
CPU times: user 7.04 s, sys: 218 ms, total: 7.26 s
Wall time: 9.11 s
```

## Changes Made

### `create_custom_fields`
- Introduce new flag called `in_create_custom_fields`. Use this flag to disable certain code in `CustomField.on_update`
- Create new Set called `doctypes_to_update`. This is looped over after creating custom fields to execute the disabled code of `CustomField.on_update` only once for each DocType - this was being executed anyway earlier 😄
- Remove redundant condition when setting `ignore_validate` for Setup Wizard.

### `CustomField.on_update`
- Move `clear_cache` to below where validation is being done.
- Check for `frappe.flags.in_create_custom_fields` instead of `frappe.flags.in_setup_wizard`. Should still meet original design requirements of https://github.com/frappe/frappe/pull/13139/

  (I don't mind keeping `frappe.flags.in_setup_wizard` anyway - if needed)

- Remove check for single doctypes - this already happens in `db.updatedb`
