### PR TITLE
ci: stablilize coverage tracking

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -62,7 +62,6 @@ if __name__ == "__main__":
 	# this is a push build, run all builds
 	if not pr_number:
 		os.system('echo "::set-output name=build::strawberry"')
-		os.system('echo "::set-output name=build-server::strawberry"')
 		sys.exit(0)
 
 	files_list = files_list or get_files_list(pr_number=pr_number, repo=repo)

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -129,10 +129,26 @@ jobs:
 
       - name: Upload coverage data
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{ matrix.container }}
+          path: /home/runner/frappe-bench/sites/coverage.xml
+
+  coverage:
+    name: Coverage Wrap Up
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Upload coverage data
         uses: codecov/codecov-action@v3
         with:
           name: MariaDB
           fail_ci_if_error: true
-          files: /home/runner/frappe-bench/sites/coverage.xml
           verbose: true
-          flags: server
+          flags: server-mariadb

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -132,10 +132,26 @@ jobs:
 
       - name: Upload coverage data
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{ matrix.container }}
+          path: /home/runner/frappe-bench/sites/coverage.xml
+
+  coverage:
+    name: Coverage Wrap Up
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Upload coverage data
         uses: codecov/codecov-action@v3
         with:
           name: Postgres
           fail_ci_if_error: true
-          files: /home/runner/frappe-bench/sites/coverage.xml
           verbose: true
-          flags: server
+          flags: server-postgres

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -149,20 +149,15 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
 
+      # Required to flush python coverage files
       - name: Stop server
-        if: ${{ steps.check-build.outputs.build-server == 'strawberry' }}
+        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           ps -ef | grep "frappe serve" | awk '{print $2}' | xargs kill -s SIGINT 2> /dev/null || true
           sleep 5
 
-      - name: Check If Coverage Report Exists
-        id: check_coverage
-        uses: andstor/file-existence-action@v1
-        with:
-          files: "/home/runner/frappe-bench/apps/frappe/.cypress-coverage/clover.xml"
-
       - name: Upload JS coverage data
-        if: ${{ steps.check-build.outputs.build == 'strawberry' && steps.check_coverage.outputs.files_exists == 'true' }}
+        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage-js-${{ matrix.container }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -149,12 +149,12 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
 
-      # Required to flush python coverage files
-      - name: Stop server
+      - name: Stop server and wait for coverage file
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
-          ps -ef | grep "frappe serve" | awk '{print $2}' | xargs kill -s SIGINT 2> /dev/null || true
+          ps -ef | grep "[f]rappe serve" | awk '{print $2}' | xargs kill -s SIGINT
           sleep 5
+          ( tail -f /home/runner/frappe-bench/sites/coverage.xml & ) | grep -q "\/coverage"
 
       - name: Upload JS coverage data
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
@@ -170,9 +170,9 @@ jobs:
           name: coverage-py-${{ matrix.container }}
           path: /home/runner/frappe-bench/sites/coverage.xml
 
-      - name: Show bench console if tests failed
-        if: ${{ failure() }}
-        run: cat ~/frappe-bench/bench_start.log
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat ~/frappe-bench/bench_start.log || true
 
 
   coverage:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -21,7 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       containers: [1, 2, 3]
+       # Make sure you modify coverage submission file list if changing this
+       container: [1, 2, 3]
 
     name: UI Tests (Cypress)
 
@@ -160,26 +161,50 @@ jobs:
         with:
           files: "/home/runner/frappe-bench/apps/frappe/.cypress-coverage/clover.xml"
 
-      - name: Upload Coverage Data
+      - name: Upload JS coverage data
         if: ${{ steps.check-build.outputs.build == 'strawberry' && steps.check_coverage.outputs.files_exists == 'true' }}
-        uses: codecov/codecov-action@v3
+        uses: actions/upload-artifact@v3
         with:
-          name: Cypress
-          fail_ci_if_error: true
-          directory: /home/runner/frappe-bench/apps/frappe/.cypress-coverage/
-          verbose: true
-          flags: ui-tests
+          name: coverage-js-${{ matrix.container }}
+          path: /home/runner/frappe-bench/apps/frappe/.cypress-coverage/clover.xml
 
-      - name: Upload Server Coverage Data
-        if: ${{ steps.check-build.outputs.build-server == 'strawberry' }}
-        uses: codecov/codecov-action@v3
+      - name: Upload python coverage data
+        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
+        uses: actions/upload-artifact@v3
         with:
-          name: MariaDB
-          fail_ci_if_error: true
-          files: /home/runner/frappe-bench/sites/coverage.xml
-          verbose: true
-          flags: server
+          name: coverage-py-${{ matrix.container }}
+          path: /home/runner/frappe-bench/sites/coverage.xml
 
       - name: Show bench console if tests failed
         if: ${{ failure() }}
         run: cat ~/frappe-bench/bench_start.log
+
+
+  coverage:
+    name: Coverage Wrap Up
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Upload python coverage data
+        uses: codecov/codecov-action@v3
+        with:
+          name: MariaDB
+          fail_ci_if_error: true
+          verbose: true
+          files: ./coverage-py-1/coverage.xml,./coverage-py-2/coverage.xml,./coverage-py-3/coverage.xml
+          flags: server-ui
+
+      - name: Upload JS coverage data
+        uses: codecov/codecov-action@v3
+        with:
+          name: Cypress
+          fail_ci_if_error: true
+          files: ./coverage-js-1/clover.xml,./coverage-js-2/clover.xml,./coverage-js-3/clover.xml
+          verbose: true
+          flags: ui-tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,20 +5,20 @@ coverage:
   status:
     project:
       default: false
-      server:
+      server-mariadb:
         target: auto
         threshold: 0.5%
         flags:
-          - server
+          - server-mariadb
     patch:
       default: false
-      server:
+      server-mariadb:
         target: 85%
         threshold: 0%
         only_pulls: true
         if_ci_failed: ignore
         flags:
-          - server
+          - server-mariadb
 
 comment:
   layout: "diff, flags"

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,11 +25,19 @@ comment:
   require_changes: true
 
 flags:
-  server:
+  server-mariadb:
     paths:
-      - ".*\\.py"
+      - "**/*.py"
+    carryforward: true
+  server-postgres:
+    paths:
+      - "**/*.py"
     carryforward: true
   ui-tests:
     paths:
-      - ".*\\.js"
+      - "**/*.js"
+    carryforward: true
+  server-ui:
+    paths:
+      - "**/*.py"
     carryforward: true

--- a/frappe/coverage.py
+++ b/frappe/coverage.py
@@ -73,3 +73,4 @@ class CodeCoverage:
 			self.coverage.stop()
 			self.coverage.save()
 			self.coverage.xml_report()
+			print("Saved Coverage")


### PR DESCRIPTION
An attempt to fix this 💩 
<img width="1112" alt="Screenshot 2022-08-13 at 7 07 37 PM" src="https://user-images.githubusercontent.com/9079960/184496613-6e582aa0-104c-49a2-b5e7-d5e0bd283437.png">




Problems:
1. Each job captures and submits coverage independently. So if any of the jobs fails that part is lost and you'll see fluctuation.
2. We capture backend coverage from UI tests, so if UI tests fail then it also fluctuates server-side coverage.


Fix:
1. Collect coverage from all jobs inside a workflow before uploading. 
2. **Each workflow is one flag only**, it's either submitted or not. There's no partial submission ever. 
3. When any workflow fails that flag is automatically carried forward from the previous build so coverage doesn't fluctuate wildly.
4. Revert https://github.com/frappe/frappe/pull/16048 this is causing the weird partial submission of server coverage. Since they are all separate flags this isn't required. 


One submission per workflow (2 separate ones from UI):
<img width="623" alt="Screenshot 2022-08-14 at 11 16 04 AM" src="https://user-images.githubusercontent.com/9079960/184524263-fdc37d2e-8c54-4826-9de4-71095bd76139.png">


This is so complex that I have zero confidence that it's even gonna work 🥴 


A possibly simpler alternative:
- Collect coverage from all workflows and if all are successful then only submit it.


Unrelated change:
- I've dropped log/artefact retention to 30 days from 90 days. We don't need any of these on github and codecov keeps them around forever IIRC. 



TODO:
- [x] Verify that flags can be reused for same set of files. 
- [x] remove old flags from checks 


Frappe repo is complex but this solution has worked fine for ERPNext

<img width="1115" alt="Screenshot 2022-08-13 at 8 10 01 PM" src="https://user-images.githubusercontent.com/9079960/184499020-8c6bcda5-4470-49cf-91b2-7c34512d4720.png">
