### PR TITLE
perf: use cached docs for website and system settings

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2283,14 +2283,22 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 
 def get_website_settings(key):
 	if not hasattr(local, "website_settings"):
-		local.website_settings = db.get_singles_dict("Website Settings", cast=True)
+		try:
+			local.website_settings = get_cached_doc("Website Settings")
+		except DoesNotExistError:
+			clear_last_message()
+			return
 
 	return local.website_settings.get(key)
 
 
 def get_system_settings(key):
 	if not hasattr(local, "system_settings"):
-		local.system_settings = db.get_singles_dict("System Settings", cast=True)
+		try:
+			local.system_settings = get_cached_doc("System Settings")
+		except DoesNotExistError:  # possible during new install
+			clear_last_message()
+			return
 
 	return local.system_settings.get(key)
 


### PR DESCRIPTION

![telegram-cloud-photo-size-5-6321180494154280914-y](https://user-images.githubusercontent.com/9079960/184532324-ce0d9b39-f72f-4c67-bd27-ea2470552e74.jpg)


This appears to be a performance regression from some bug fixes.

 `get_system_settings` went through multiple iterations:
1. query key and store in locals
2. dont store in local since key already is present in db.value_cache
3. Use single_dict for single query for entire sys setting
4. Cast it to avoid type issues. <--- This is where regression occurs, casting requires meta and that's yuge. 

Fix:
- Use cached system setting dict as is. 



| | Req per second | % increase | 
| --- | --- | --- |
| Current |  ~49 | baseline | 
| After this fix | ~63 |  ~29% increase |


This is similar to RPS after https://github.com/frappe/frappe/pull/16950 