### PR TITLE
refactor!: misc changes and tests

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -30,9 +30,8 @@ jobs:
       - name: Clone
         uses: actions/checkout@v3
 
-      - name: Check for valid Python & Merge Conflicts
+      - name: Check for Merge Conflicts
         run: |
-          python -m compileall -f "${GITHUB_WORKSPACE}"
           if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
               then echo "Found merge conflicts"
               exit 1

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -3,9 +3,8 @@
 
 import frappe
 from frappe import _, msgprint
-from frappe.query_builder import DocType, Interval
-from frappe.query_builder.functions import Now
 from frappe.utils import cint, get_url, now_datetime
+from frappe.utils.data import getdate
 from frappe.utils.verified_command import get_signed_params, verify_request
 
 
@@ -16,26 +15,17 @@ def get_emails_sent_this_month(email_account=None):
 
 	if email_account=None, email account filter is not applied while counting
 	"""
-	q = """
-		SELECT
-			COUNT(*)
-		FROM
-			`tabEmail Queue`
-		WHERE
-			`status`='Sent'
-			AND
-			EXTRACT(YEAR_MONTH FROM `creation`) = EXTRACT(YEAR_MONTH FROM NOW())
-	"""
+	today = getdate()
+	month_start = today.replace(day=1)
 
-	q_args = {}
-	if email_account is not None:
-		if email_account:
-			q += " AND email_account = %(email_account)s"
-			q_args["email_account"] = email_account
-		else:
-			q += " AND (email_account is null OR email_account='')"
+	filters = {
+		"status": "Sent",
+		"creation": [">=", str(month_start)],
+	}
+	if email_account:
+		filters["email_account"] = email_account
 
-	return frappe.db.sql(q, q_args)[0][0]
+	return frappe.db.count("Email Queue", filters=filters)
 
 
 def get_emails_sent_today(email_account=None):

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -50,6 +50,7 @@ from frappe.utils.data import (
 	cast,
 	cstr,
 	duration_to_seconds,
+	get_datetime,
 	get_first_day_of_week,
 	get_time,
 	get_timedelta,
@@ -58,6 +59,7 @@ from frappe.utils.data import (
 	getdate,
 	now_datetime,
 	nowtime,
+	pretty_date,
 	to_timedelta,
 	validate_python_code,
 )
@@ -564,6 +566,31 @@ class TestDateUtils(unittest.TestCase):
 	def test_timesmap_utils(self):
 		self.assertEqual(get_year_ending(date(2021, 1, 1)), date(2021, 12, 31))
 		self.assertEqual(get_year_ending(date(2021, 1, 31)), date(2021, 12, 31))
+
+	def test_pretty_date(self):
+		from frappe import _
+
+		# differnt cases
+		now = get_datetime()
+
+		test_cases = {
+			now: _("just now"),
+			add_to_date(now, minutes=-1): _("1 minute ago"),
+			add_to_date(now, minutes=-3): _("3 minutes ago"),
+			add_to_date(now, hours=-1): _("1 hour ago"),
+			add_to_date(now, hours=-2): _("2 hours ago"),
+			add_to_date(now, days=-1): _("Yesterday"),
+			add_to_date(now, days=-5): _("5 days ago"),
+			add_to_date(now, days=-8): _("1 week ago"),
+			add_to_date(now, days=-14): _("2 weeks ago"),
+			add_to_date(now, days=-32): _("1 month ago"),
+			add_to_date(now, days=-32 * 2): _("2 months ago"),
+			add_to_date(now, years=-1, days=-5): _("1 year ago"),
+			add_to_date(now, years=-2, days=-10): _("2 years ago"),
+		}
+
+		for dt, exp_message in test_cases.items():
+			self.assertEqual(pretty_date(dt), exp_message)
 
 	def test_date_from_timegrain(self):
 		start_date = getdate("2021-01-01")

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -32,6 +32,7 @@ from frappe.utils import (
 	random_string,
 	scrub_urls,
 	validate_email_address,
+	validate_phone_number_with_country_code,
 	validate_url,
 )
 from frappe.utils.data import (
@@ -322,9 +323,23 @@ class TestValidationUtils(unittest.TestCase):
 		self.assertFalse(validate_email_address("someone"))
 		self.assertFalse(validate_email_address("someone@----.com"))
 
+		self.assertFalse(validate_email_address("test@example.com test2@example.com,undisclosed-recipient"))
+
 		# Invalid with throw
 		self.assertRaises(
 			frappe.InvalidEmailAddressError, validate_email_address, "someone.com", throw=True
+		)
+
+	def test_valid_phone(self):
+		valid_phones = ["+91 1234567890", ""]
+
+		for phone in valid_phones:
+			validate_phone_number_with_country_code(phone, "field")
+		self.assertRaises(
+			frappe.InvalidPhoneNumberError,
+			validate_phone_number_with_country_code,
+			"+420 1234567890",
+			"field",
 		)
 
 

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -19,6 +19,7 @@ from PIL import Image
 import frappe
 from frappe.installer import parse_app_name
 from frappe.model.document import Document
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import (
 	ceil,
 	evaluate_filters,
@@ -749,7 +750,7 @@ class TestLazyLoader(unittest.TestCase):
 		self.assertEqual(["Module `frappe.tests.data.load_sleep` loaded"], output)
 
 
-class TestIdenticon(unittest.TestCase):
+class TestIdenticon(FrappeTestCase):
 	def test_get_gravatar(self):
 		# developers@frappe.io has a gravatar linked so str URL will be returned
 		frappe.flags.in_test = False

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -32,6 +32,7 @@ from frappe.utils import (
 	random_string,
 	scrub_urls,
 	validate_email_address,
+	validate_name,
 	validate_phone_number_with_country_code,
 	validate_url,
 )
@@ -341,6 +342,15 @@ class TestValidationUtils(unittest.TestCase):
 			"+420 1234567890",
 			"field",
 		)
+
+	def test_validate_name(self):
+		valid_names = ["", "abc", "asd a13", "asd-asd"]
+		for name in valid_names:
+			validate_name(name, True)
+
+		invalid_names = ["asd$wat", "asasd/ads"]
+		for name in invalid_names:
+			self.assertRaises(frappe.InvalidNameError, validate_name, name, True)
 
 
 class TestImage(unittest.TestCase):

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -54,6 +54,7 @@ from frappe.utils.data import (
 	get_time,
 	get_timedelta,
 	get_timespan_date_range,
+	get_year_ending,
 	getdate,
 	now_datetime,
 	nowtime,
@@ -530,9 +531,39 @@ class TestDateUtils(unittest.TestCase):
 		self.assertEqual(duration_to_seconds("110m"), 110 * 60)
 		self.assertEqual(duration_to_seconds("110m"), 110 * 60)
 
-
 	def test_get_timespan_date_range(self):
-		get_timespan_date_range()
+
+		supported_timespans = [
+			"last week",
+			"last month",
+			"last quarter",
+			"last 6 months",
+			"last year",
+			"yesterday",
+			"today",
+			"tomorrow",
+			"this week",
+			"this month",
+			"this quarter",
+			"this year",
+			"next week",
+			"next month",
+			"next quarter",
+			"next 6 months",
+			"next year",
+		]
+
+		for ts in supported_timespans:
+			res = get_timespan_date_range(ts)
+			self.assertEqual(len(res), 2)
+
+			# Manual type checking eh?
+			self.assertIsInstance(res[0], date)
+			self.assertIsInstance(res[1], date)
+
+	def test_timesmap_utils(self):
+		self.assertEqual(get_year_ending(date(2021, 1, 1)), date(2021, 12, 31))
+		self.assertEqual(get_year_ending(date(2021, 1, 31)), date(2021, 12, 31))
 
 	def test_date_from_timegrain(self):
 		start_date = getdate("2021-01-01")

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -85,10 +85,7 @@ def get_formatted_email(user, mail=None):
 
 def extract_email_id(email):
 	"""fetch only the email part of the Email Address"""
-	email_id = parse_addr(email)[1]
-	if email_id and isinstance(email_id, str) and not isinstance(email_id, str):
-		email_id = email_id.decode("utf-8", "ignore")
-	return email_id
+	return cstr(parse_addr(email)[1])
 
 
 def validate_phone_number_with_country_code(phone_number: str, fieldname: str) -> None:

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -91,7 +91,7 @@ def extract_email_id(email):
 	return email_id
 
 
-def validate_phone_number_with_country_code(phone_number, fieldname):
+def validate_phone_number_with_country_code(phone_number: str, fieldname: str) -> None:
 	from phonenumbers import NumberParseException, is_valid_number, parse
 
 	from frappe import _

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -138,6 +138,8 @@ def validate_name(name, throw=False):
 	"""Returns True if the name is valid
 	valid names may have unicode and ascii characters, dash, quotes, numbers
 	anything else is considered invalid
+
+	Note: "Name" here is name of a person, not the primary key in Frappe doctypes.
 	"""
 	if not name:
 		return False

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -748,7 +748,7 @@ def get_site_info():
 
 	kwargs = {
 		"fields": ["user", "creation", "full_name"],
-		"filters": {"Operation": "Login", "Status": "Success"},
+		"filters": {"operation": "Login", "status": "Success"},
 		"limit": "10",
 	}
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -14,6 +14,7 @@ from email.header import decode_header, make_header
 from email.utils import formataddr, parseaddr
 from gzip import GzipFile
 from urllib.parse import quote, urlparse
+from typing import Literal
 
 from redis.exceptions import ConnectionError
 from traceback_with_variables import iter_exc_lines
@@ -260,9 +261,7 @@ def has_gravatar(email):
 		# since querying gravatar for every item will be slow
 		return ""
 
-	hexdigest = hashlib.md5(frappe.as_unicode(email).encode("utf-8")).hexdigest()
-
-	gravatar_url = f"https://secure.gravatar.com/avatar/{hexdigest}?d=404&s=200"
+	gravatar_url = get_gravatar_url(email, "404")
 	try:
 		res = requests.get(gravatar_url)
 		if res.status_code == 200:
@@ -273,10 +272,9 @@ def has_gravatar(email):
 		return ""
 
 
-def get_gravatar_url(email):
-	return "https://secure.gravatar.com/avatar/{hash}?d=mm&s=200".format(
-		hash=hashlib.md5(email.encode("utf-8")).hexdigest()
-	)
+def get_gravatar_url(email, default: Literal["mm", "404"]="mm"):
+	hexdigest = hashlib.md5(frappe.as_unicode(email).encode("utf-8")).hexdigest()
+	return f"https://secure.gravatar.com/avatar/{hexdigest}?d={default}&s=200"
 
 
 def get_gravatar(email):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -724,60 +724,77 @@ def get_weekday(datetime: datetime.datetime | None = None) -> str:
 	return weekdays[datetime.weekday()]
 
 
-def get_timespan_date_range(timespan: str) -> tuple[datetime.datetime, datetime.datetime]:
+def get_timespan_date_range(timespan: str) -> tuple[datetime.datetime, datetime.datetime] | None:
 	today = nowdate()
-	date_range_map = {
-		"last week": lambda: (
-			get_first_day_of_week(add_to_date(today, days=-7)),
-			get_last_day_of_week(add_to_date(today, days=-7)),
-		),
-		"last month": lambda: (
-			get_first_day(add_to_date(today, months=-1)),
-			get_last_day(add_to_date(today, months=-1)),
-		),
-		"last quarter": lambda: (
-			get_quarter_start(add_to_date(today, months=-3)),
-			get_quarter_ending(add_to_date(today, months=-3)),
-		),
-		"last 6 months": lambda: (
-			get_quarter_start(add_to_date(today, months=-6)),
-			get_quarter_ending(add_to_date(today, months=-3)),
-		),
-		"last year": lambda: (
-			get_year_start(add_to_date(today, years=-1)),
-			get_year_ending(add_to_date(today, years=-1)),
-		),
-		"yesterday": lambda: (add_to_date(today, days=-1),) * 2,
-		"today": lambda: (today, today),
-		"tomorrow": lambda: (add_to_date(today, days=1),) * 2,
-		"this week": lambda: (get_first_day_of_week(today), get_last_day_of_week(today)),
-		"this month": lambda: (get_first_day(today), get_last_day(today)),
-		"this quarter": lambda: (get_quarter_start(today), get_quarter_ending(today)),
-		"this year": lambda: (get_year_start(today), get_year_ending(today)),
-		"next week": lambda: (
-			get_first_day_of_week(add_to_date(today, days=7)),
-			get_last_day_of_week(add_to_date(today, days=7)),
-		),
-		"next month": lambda: (
-			get_first_day(add_to_date(today, months=1)),
-			get_last_day(add_to_date(today, months=1)),
-		),
-		"next quarter": lambda: (
-			get_quarter_start(add_to_date(today, months=3)),
-			get_quarter_ending(add_to_date(today, months=3)),
-		),
-		"next 6 months": lambda: (
-			get_quarter_start(add_to_date(today, months=3)),
-			get_quarter_ending(add_to_date(today, months=6)),
-		),
-		"next year": lambda: (
-			get_year_start(add_to_date(today, years=1)),
-			get_year_ending(add_to_date(today, years=1)),
-		),
-	}
 
-	if timespan in date_range_map:
-		return date_range_map[timespan]()
+	match timespan:
+		case "last week":
+			return (
+				get_first_day_of_week(add_to_date(today, days=-7)),
+				get_last_day_of_week(add_to_date(today, days=-7)),
+			)
+		case "last month":
+			return (
+				get_first_day(add_to_date(today, months=-1)),
+				get_last_day(add_to_date(today, months=-1)),
+			)
+		case "last quarter":
+			return (
+				get_quarter_start(add_to_date(today, months=-3)),
+				get_quarter_ending(add_to_date(today, months=-3)),
+			)
+		case "last 6 months":
+			return (
+				get_quarter_start(add_to_date(today, months=-6)),
+				get_quarter_ending(add_to_date(today, months=-3)),
+			)
+		case "last year":
+			return (
+				get_year_start(add_to_date(today, years=-1)),
+				get_year_ending(add_to_date(today, years=-1)),
+			)
+
+		case "yesterday":
+			return (add_to_date(today, days=-1),) * 2
+		case "today":
+			return (today, today)
+		case "tomorrow":
+			return (add_to_date(today, days=1),) * 2
+		case "this week":
+			return (get_first_day_of_week(today), get_last_day_of_week(today))
+		case "this month":
+			return (get_first_day(today), get_last_day(today))
+		case "this quarter":
+			return (get_quarter_start(today), get_quarter_ending(today))
+		case "this year":
+			return (get_year_start(today), get_year_ending(today))
+		case "next week":
+			return (
+				get_first_day_of_week(add_to_date(today, days=7)),
+				get_last_day_of_week(add_to_date(today, days=7)),
+			)
+		case "next month":
+			return (
+				get_first_day(add_to_date(today, months=1)),
+				get_last_day(add_to_date(today, months=1)),
+			)
+		case "next quarter":
+			return (
+				get_quarter_start(add_to_date(today, months=3)),
+				get_quarter_ending(add_to_date(today, months=3)),
+			)
+		case "next 6 months":
+			return (
+				get_quarter_start(add_to_date(today, months=3)),
+				get_quarter_ending(add_to_date(today, months=6)),
+			)
+		case "next year":
+			return (
+				get_year_start(add_to_date(today, years=1)),
+				get_year_ending(add_to_date(today, years=1)),
+			)
+		case _:
+			return
 
 
 def global_date_format(date, format="long"):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1475,15 +1475,15 @@ def pretty_date(iso_datetime: datetime.datetime | str) -> str:
 	elif dt_diff_days < 12:
 		return _("1 week ago")
 	elif dt_diff_days < 31.0:
-		return _("{0} weeks ago").format(cint(math.ceil(dt_diff_days / 7.0)))
+		return _("{0} weeks ago").format(dt_diff_days // 7)
 	elif dt_diff_days < 46:
 		return _("1 month ago")
 	elif dt_diff_days < 365.0:
-		return _("{0} months ago").format(cint(math.ceil(dt_diff_days / 30.0)))
+		return _("{0} months ago").format(dt_diff_days // 30)
 	elif dt_diff_days < 550.0:
 		return _("1 year ago")
 	else:
-		return f"{cint(math.floor(dt_diff_days / 365.0))} years ago"
+		return _("{0} years ago").format(dt_diff_days // 365)
 
 
 def comma_or(some_list, add_quotes=True):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1673,14 +1673,14 @@ operator_map = {
 	"in": lambda a, b: operator.contains(b, a),
 	"not in": lambda a, b: not operator.contains(b, a),
 	# comparison operators
-	"=": lambda a, b: operator.eq(a, b),
-	"!=": lambda a, b: operator.ne(a, b),
-	">": lambda a, b: operator.gt(a, b),
-	"<": lambda a, b: operator.lt(a, b),
-	">=": lambda a, b: operator.ge(a, b),
-	"<=": lambda a, b: operator.le(a, b),
-	"not None": lambda a, b: a and True or False,
-	"None": lambda a, b: (not a) and True or False,
+	"=": operator.eq,
+	"!=": operator.ne,
+	">": operator.gt,
+	"<": operator.lt,
+	">=": operator.ge,
+	"<=": operator.le,
+	"not None": lambda a, b: a is not None,
+	"None": lambda a, b: a is None,
 }
 
 
@@ -1702,13 +1702,12 @@ def evaluate_filters(doc, filters: dict | list | tuple):
 
 
 def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
-	ret = False
 	if fieldtype:
 		val2 = cast(fieldtype, val2)
 	if condition in operator_map:
-		ret = operator_map[condition](val1, val2)
+		return operator_map[condition](val1, val2)
 
-	return ret
+	return False
 
 
 def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "frappe._dict":

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -483,13 +483,11 @@ def get_quarter_ending(date):
 	return date
 
 
-def get_year_ending(date):
+def get_year_ending(date) -> datetime.date:
 	"""returns year ending of the given date"""
 	date = getdate(date)
-	# first day of next year (note year starts from 1)
-	date = add_to_date(f"{date.year}-01-01", months=12)
-	# last day of this month
-	return add_to_date(date, days=-1)
+	next_year_start = datetime.date(date.year + 1, 1, 1)
+	return add_to_date(next_year_start, days=-1)
 
 
 def get_time(time_str: str) -> datetime.time:
@@ -725,7 +723,7 @@ def get_weekday(datetime: datetime.datetime | None = None) -> str:
 
 
 def get_timespan_date_range(timespan: str) -> tuple[datetime.datetime, datetime.datetime] | None:
-	today = nowdate()
+	today = getdate()
 
 	match timespan:
 		case "last week":


### PR DESCRIPTION
Breaking changes:
- `get_year_ending` now returns date object, consistent with other functions
- `get_timespan_date_range` always returns date object now, previously for some timespan it returned string dates 🙄 
- pretty_date always `floors` to find next interval, for some reason in 2 cases it was `ceil`ed. This is consistent with popular pretty date library in JS. 


Refactors:
- better type annotations in utils/__init__.py
- gravatar code duplication
- simpler pretty date using `//` operator instead of weird usage of ceil/cint.
- Make `X years ago` translatable
- Use operator functions directly instead of lambdas (few nanoseconds faster 🤌)

New tests:
- pretty date
- name validation
- misc date utils
- container utils (dict to string, squashify)
- safe_json_loads
- get_site, get_site_info




TODO:
- [x] fix Postgres CI broken from new test
- [x] update migration guide -  https://github.com/frappe/frappe/wiki/Migrating-to-Version-15