### PR TITLE
feat(Language): show title in link field

### DIFF
--- a/frappe/core/doctype/language/language.json
+++ b/frappe/core/doctype/language/language.json
@@ -51,7 +51,7 @@
  "icon": "fa fa-globe",
  "in_create": 1,
  "links": [],
- "modified": "2021-10-18 14:02:06.818219",
+ "modified": "2022-08-14 18:54:03.490836",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Language",
@@ -76,8 +76,10 @@
   }
  ],
  "search_fields": "language_name",
+ "show_title_field_in_link": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "language_name",
  "track_changes": 1
 }


### PR DESCRIPTION
The title is already stored in local language, therefore not enabling “Translated DocType”.

### Before

![Bildschirmfoto 2022-08-14 um 18 53 45](https://user-images.githubusercontent.com/14891507/184547143-034b2688-0940-41bb-a141-642f9cb6bd97.png)


### After

![Bildschirmfoto 2022-08-14 um 18 54 20](https://user-images.githubusercontent.com/14891507/184547147-7a4ac96b-557d-44cc-817b-af6d06d46f38.png)

> no-docs