### PR TITLE
test: FrappeClient tests not running

### DIFF
--- a/.github/helper/ci.py
+++ b/.github/helper/ci.py
@@ -18,6 +18,7 @@ STANDARD_EXCLUSIONS = [
 	"*/node_modules/*",
 	"*/doctype/*/*_dashboard.py",
 	"*/patches/*",
+	".github/*",
 ]
 
 # tested via commands' test suite

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -143,7 +143,6 @@ def set_test_email_config():
 			"mail_server": "smtp.example.com",
 			"mail_login": "test@example.com",
 			"mail_password": "test",
-			"admin_password": "admin",
 		}
 	)
 

--- a/frappe/tests/test_frappe_client.py
+++ b/frappe/tests/test_frappe_client.py
@@ -2,30 +2,18 @@
 # License: MIT. See LICENSE
 
 import base64
-import unittest
 
 import requests
 
 import frappe
 from frappe.core.doctype.user.user import generate_keys
-from frappe.frappeclient import AuthError, FrappeClient, FrappeException
+from frappe.frappeclient import FrappeClient, FrappeException
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils.data import get_url
 
 
-class TestFrappeClient(unittest.TestCase):
+class TestFrappeClient(FrappeTestCase):
 	PASSWORD = frappe.conf.admin_password or "admin"
-
-	@classmethod
-	def setUpClass(cls) -> None:
-		site_url = get_url()
-		try:
-			FrappeClient(site_url, "Administrator", cls.PASSWORD, verify=False)
-		except AuthError:
-			raise unittest.SkipTest(
-				f"AuthError raised for {site_url} [usr=Administrator, pwd={cls.PASSWORD}]"
-			)
-
-		return super().setUpClass()
 
 	def test_insert_many(self):
 		server = FrappeClient(get_url(), "Administrator", self.PASSWORD, verify=False)


### PR DESCRIPTION
- frappe client tests weren't running because of auth error
- AUth error was happening because previous tests modified something without committing / rolling back, so while logging in you can't add actvitity log 💩 


![telegram-cloud-photo-size-5-6330064294703640922-y](https://user-images.githubusercontent.com/9079960/184832132-469c031a-c078-40f7-9791-4b97312f2103.jpg)


![telegram-cloud-photo-size-5-6330064294703640942-y](https://user-images.githubusercontent.com/9079960/184832089-2e7dfa36-dbca-4cae-8ef6-5f0eb4e7c9a7.jpg)
