### PR TITLE
fix: On updating standard workspace name update json file

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -16,6 +16,7 @@ import inspect
 import json
 import os
 import re
+import shutil
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, overload
 
@@ -528,6 +529,12 @@ def throw(
 		wide=wide,
 		as_list=as_list,
 	)
+
+
+def delete_folder(path: str) -> None:
+	"""Delete folder and all the content inside that folder."""
+	if os.path.exists(path):
+		shutil.rmtree(path)
 
 
 def create_folder(path, with_init=False):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -16,7 +16,6 @@ import inspect
 import json
 import os
 import re
-import shutil
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, overload
 
@@ -529,12 +528,6 @@ def throw(
 		wide=wide,
 		as_list=as_list,
 	)
-
-
-def delete_folder(path: str) -> None:
-	"""Delete folder and all the content inside that folder."""
-	if os.path.exists(path):
-		shutil.rmtree(path)
 
 
 def create_folder(path, with_init=False):

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -107,7 +107,8 @@
   {
    "fieldname": "icon",
    "fieldtype": "Icon",
-   "label": "Icon"
+   "label": "Icon",
+   "read_only": 1
   },
   {
    "fieldname": "links",
@@ -122,18 +123,21 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Public",
+   "read_only": 1,
    "search_index": 1
   },
   {
    "fieldname": "title",
    "fieldtype": "Data",
    "label": "Title",
+   "read_only": 1,
    "reqd": 1
   },
   {
    "fieldname": "parent_page",
    "fieldtype": "Data",
-   "label": "Parent Page"
+   "label": "Parent Page",
+   "read_only": 1
   },
   {
    "default": "[]",
@@ -145,7 +149,8 @@
   {
    "fieldname": "sequence_id",
    "fieldtype": "Float",
-   "label": "Sequence Id"
+   "label": "Sequence Id",
+   "read_only": 1
   },
   {
    "fieldname": "roles",
@@ -172,7 +177,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2022-05-12 13:00:03.925605",
+ "modified": "2022-08-16 18:01:42.632238",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -9,7 +9,7 @@ from frappe.desk.desktop import save_new_widget
 from frappe.desk.utils import validate_route_conflict
 from frappe.model.document import Document
 from frappe.model.rename_doc import rename_doc
-from frappe.modules.export_file import export_to_files
+from frappe.modules.export_file import delete_folder, export_to_files
 
 
 class Workspace(Document):
@@ -28,8 +28,22 @@ class Workspace(Document):
 		if disable_saving_as_public():
 			return
 
-		if frappe.conf.developer_mode and self.module and self.public:
-			export_to_files(record_list=[["Workspace", self.name]], record_module=self.module)
+		if frappe.conf.developer_mode and self.public:
+			if self.module:
+				export_to_files(record_list=[["Workspace", self.name]], record_module=self.module)
+
+			if self.has_value_changed("title") or self.has_value_changed("module"):
+				previous = self.get_doc_before_save()
+				if previous and previous.get("module") and previous.get("title"):
+					delete_folder(previous.get("module"), "Workspace", previous.get("title"))
+
+	def before_export(self, doc):
+		if doc.title != doc.label and doc.label == doc.name:
+			self.name = doc.name = doc.label = doc.title
+
+	def after_delete(self):
+		if self.module:
+			delete_folder(self.module, "Workspace", self.title)
 
 	@staticmethod
 	def get_module_page_map():

--- a/frappe/modules/export_file.py
+++ b/frappe/modules/export_file.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import os
+import shutil
 
 import frappe
 import frappe.model
@@ -103,7 +104,8 @@ def delete_folder(module, dt, dn):
 	# delete folder
 	folder = os.path.join(module_path, dt, dn)
 
-	frappe.delete_folder(folder)
+	if os.path.exists(folder):
+		shutil.rmtree(folder)
 
 
 def create_folder(module, dt, dn, create_init):

--- a/frappe/modules/export_file.py
+++ b/frappe/modules/export_file.py
@@ -92,6 +92,20 @@ def get_module_name(doc):
 	return module
 
 
+def delete_folder(module, dt, dn):
+	if frappe.db.get_value("Module Def", module, "custom"):
+		module_path = get_custom_module_path(module)
+	else:
+		module_path = get_module_path(module)
+
+	dt, dn = scrub_dt_dn(dt, dn)
+
+	# delete folder
+	folder = os.path.join(module_path, dt, dn)
+
+	frappe.delete_folder(folder)
+
+
 def create_folder(module, dt, dn, create_init):
 	if frappe.db.get_value("Module Def", module, "custom"):
 		module_path = get_custom_module_path(module)


### PR DESCRIPTION
**Issue:**
If you will edit the name of any public workspace (only standard workspace for which JSON files exist) multiple times multiple JSON files get created and when you migrate multiple workspaces are added.

**Fix:**
If the "Title" or "Module" field of the standard workspace is updated JSON file also gets created based on the module and title value and the old JSON is deleted.
Also added logic to delete JSON file if the workspace is deleted or module value is set to empty.

Also made Title, Parent Page, Icon, Sequence Id, and Public field read-only since we can update all these values from Workspace UI.