### PR TITLE
fix: incorrect attachment limit message

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -160,6 +160,12 @@ frappe.ui.form.Attachments = class Attachments {
 			this.dialog.$wrapper.remove();
 		}
 
+		const restrictions = {};
+		if (this.frm.meta.max_attachments) {
+			restrictions.max_number_of_files =
+				this.frm.meta.max_attachments - this.frm.attachments.get_attachments().length;
+		}
+
 		new frappe.ui.FileUploader({
 			doctype: this.frm.doctype,
 			docname: this.frm.docname,
@@ -168,10 +174,7 @@ frappe.ui.form.Attachments = class Attachments {
 			on_success: (file_doc) => {
 				this.attachment_uploaded(file_doc);
 			},
-			restrictions: {
-				max_number_of_files:
-					this.frm.meta.max_attachments - this.frm.attachments.get_attachments().length,
-			},
+			restrictions,
 		});
 	}
 	get_args() {


### PR DESCRIPTION

Right now if you try to attach images on doctypes having existing images, it shows a weird error like "max allowed files is -2".



<img width="401" alt="Screenshot 2022-08-16 at 8 20 30 PM" src="https://user-images.githubusercontent.com/9079960/184910059-58226b8e-800d-4919-9235-7a3be0e37d01.png">
