### PR TITLE
feat: add video conferencing option (Google Meet) to Google Calendar integration

### DIFF
--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -54,7 +54,7 @@ class TestCustomizeForm(FrappeTestCase):
 
 		d = self.get_customize_form("Event")
 		self.assertEqual(d.doc_type, "Event")
-		self.assertEqual(len(d.get("fields")), 36)
+		self.assertEqual(len(d.get("fields")), 38)
 
 		d = self.get_customize_form("Event")
 		self.assertEqual(d.doc_type, "Event")

--- a/frappe/desk/doctype/event/event.js
+++ b/frappe/desk/doctype/event/event.js
@@ -41,6 +41,15 @@ frappe.ui.form.on("Event", {
 			},
 			__("Add Participants")
 		);
+
+		const [ends_on_date] = frm.doc.ends_on.split(" ");
+		if (frm.doc.google_meet_link && frappe.datetime.now_date() <= ends_on_date) {
+			frm.dashboard.set_headline(
+				__("Join video conference with {0}", [
+					`<a target='_blank' href='${frm.doc.google_meet_link}'>Google Meet</a>`
+				])
+			);
+		}
 	},
 	repeat_on: function (frm) {
 		if (frm.doc.repeat_on === "Every Day") {

--- a/frappe/desk/doctype/event/event.js
+++ b/frappe/desk/doctype/event/event.js
@@ -46,7 +46,7 @@ frappe.ui.form.on("Event", {
 		if (frm.doc.google_meet_link && frappe.datetime.now_date() <= ends_on_date) {
 			frm.dashboard.set_headline(
 				__("Join video conference with {0}", [
-					`<a target='_blank' href='${frm.doc.google_meet_link}'>Google Meet</a>`
+					`<a target='_blank' href='${frm.doc.google_meet_link}'>Google Meet</a>`,
 				])
 			);
 		}

--- a/frappe/desk/doctype/event/event.js
+++ b/frappe/desk/doctype/event/event.js
@@ -42,7 +42,9 @@ frappe.ui.form.on("Event", {
 			__("Add Participants")
 		);
 
-		const [ends_on_date] = frm.doc.ends_on.split(" ");
+		const [ends_on_date] = frm.doc.ends_on ?
+			frm.doc.ends_on.split(" ") : frm.doc.starts_on.split(" ");
+
 		if (frm.doc.google_meet_link && frappe.datetime.now_date() <= ends_on_date) {
 			frm.dashboard.set_headline(
 				__("Join video conference with {0}", [

--- a/frappe/desk/doctype/event/event.js
+++ b/frappe/desk/doctype/event/event.js
@@ -42,8 +42,9 @@ frappe.ui.form.on("Event", {
 			__("Add Participants")
 		);
 
-		const [ends_on_date] = frm.doc.ends_on ?
-			frm.doc.ends_on.split(" ") : frm.doc.starts_on.split(" ");
+		const [ends_on_date] = frm.doc.ends_on
+			? frm.doc.ends_on.split(" ")
+			: frm.doc.starts_on.split(" ");
 
 		if (frm.doc.google_meet_link && frappe.datetime.now_date() <= ends_on_date) {
 			frm.dashboard.set_headline(

--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -278,7 +278,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:(doc.sync_with_google_calendar && in_list([\"Event\", \"Meeting\", \"Other\"], doc.event_category))",
+   "depends_on": "eval:doc.sync_with_google_calendar",
    "description": "via Google Meet",
    "fieldname": "add_video_conferencing",
    "fieldtype": "Check",

--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -278,7 +278,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.sync_with_google_calendar",
+   "depends_on": "eval:(doc.sync_with_google_calendar && in_list([\"Event\", \"Meeting\", \"Other\"], doc.event_category))",
    "description": "via Google Meet",
    "fieldname": "add_video_conferencing",
    "fieldtype": "Check",
@@ -295,7 +295,7 @@
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2022-06-15 07:18:26.861999",
+ "modified": "2022-08-12 15:23:03.195044",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",

--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -227,7 +227,7 @@
   },
   {
    "collapsible": 1,
-   "depends_on": "eval:doc.sync_with_google_calendar",
+   "depends_on": "eval:doc.sync_with_google_calendar || doc.pulled_from_google_calendar",
    "fieldname": "sb_00",
    "fieldtype": "Section Break",
    "label": "Google Calendar"
@@ -295,7 +295,7 @@
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2022-08-12 15:23:03.195044",
+ "modified": "2022-08-12 19:24:34.794098",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",

--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -22,12 +22,14 @@
   "sender",
   "all_day",
   "sync_with_google_calendar",
+  "add_video_conferencing",
   "sb_00",
   "google_calendar",
-  "pulled_from_google_calendar",
-  "cb_00",
   "google_calendar_id",
+  "cb_00",
   "google_calendar_event_id",
+  "google_meet_link",
+  "pulled_from_google_calendar",
   "section_break_13",
   "repeat_on",
   "repeat_till",
@@ -245,6 +247,7 @@
    "fieldname": "google_calendar_event_id",
    "fieldtype": "Data",
    "label": "Google Calendar Event ID",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -272,12 +275,27 @@
    "label": "Sender",
    "options": "Email",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.sync_with_google_calendar",
+   "description": "via Google Meet",
+   "fieldname": "add_video_conferencing",
+   "fieldtype": "Check",
+   "label": "Add Video Conferencing"
+  },
+  {
+   "fieldname": "google_meet_link",
+   "fieldtype": "Data",
+   "label": "Google Meet Link",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "icon": "fa fa-calendar",
  "idx": 1,
  "links": [],
- "modified": "2022-05-12 05:43:27.935510",
+ "modified": "2022-06-15 07:18:26.861999",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event",

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -55,7 +55,11 @@ class Event(Document):
 		if self.sync_with_google_calendar and not self.google_calendar:
 			frappe.throw(_("Select Google Calendar to which event should be synced."))
 
-		if not self.sync_with_google_calendar or self.event_category not in ["Event", "Meeting", "Other"]:
+		if not self.sync_with_google_calendar or self.event_category not in [
+			"Event",
+			"Meeting",
+			"Other",
+		]:
 			self.add_video_conferencing = False
 
 	def on_update(self):

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -6,6 +6,7 @@ import json
 
 import frappe
 from frappe import _
+from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.desk.doctype.notification_settings.notification_settings import (
 	is_email_notifications_enabled_for_type,
 )
@@ -57,6 +58,8 @@ class Event(Document):
 
 		if not self.sync_with_google_calendar:
 			self.add_video_conferencing = 0
+
+		self.set_participants_email()
 
 	def on_update(self):
 		self.sync_communication()
@@ -133,6 +136,13 @@ class Event(Document):
 		"""
 		for participant in participants:
 			self.add_participant(participant["doctype"], participant["docname"])
+
+	def set_participants_email(self):
+		for participant in self.event_participants:
+			if participant.email:
+				continue
+			participant_contact = get_default_contact(participant.reference_doctype, participant.reference_docname)
+			participant.email = frappe.get_value("Contact", participant_contact, "email_id") if participant_contact else ""
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -55,12 +55,8 @@ class Event(Document):
 		if self.sync_with_google_calendar and not self.google_calendar:
 			frappe.throw(_("Select Google Calendar to which event should be synced."))
 
-		if not self.sync_with_google_calendar or self.event_category not in [
-			"Event",
-			"Meeting",
-			"Other",
-		]:
-			self.add_video_conferencing = False
+		if not self.sync_with_google_calendar:
+			self.add_video_conferencing = 0
 
 	def on_update(self):
 		self.sync_communication()

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -55,6 +55,9 @@ class Event(Document):
 		if self.sync_with_google_calendar and not self.google_calendar:
 			frappe.throw(_("Select Google Calendar to which event should be synced."))
 
+		if not self.sync_with_google_calendar:
+			self.add_video_conferencing = False
+
 	def on_update(self):
 		self.sync_communication()
 

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -141,8 +141,12 @@ class Event(Document):
 		for participant in self.event_participants:
 			if participant.email:
 				continue
-			participant_contact = get_default_contact(participant.reference_doctype, participant.reference_docname)
-			participant.email = frappe.get_value("Contact", participant_contact, "email_id") if participant_contact else ""
+			participant_contact = get_default_contact(
+				participant.reference_doctype, participant.reference_docname
+			)
+			participant.email = (
+				frappe.get_value("Contact", participant_contact, "email_id") if participant_contact else ""
+			)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -59,6 +59,7 @@ class Event(Document):
 		if not self.sync_with_google_calendar:
 			self.add_video_conferencing = 0
 
+	def before_save(self):
 		self.set_participants_email()
 
 	def on_update(self):
@@ -141,11 +142,12 @@ class Event(Document):
 		for participant in self.event_participants:
 			if participant.email:
 				continue
+
 			participant_contact = get_default_contact(
 				participant.reference_doctype, participant.reference_docname
 			)
 			participant.email = (
-				frappe.get_value("Contact", participant_contact, "email_id") if participant_contact else ""
+				frappe.get_value("Contact", participant_contact, "email_id") if participant_contact else None
 			)
 
 

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -55,7 +55,7 @@ class Event(Document):
 		if self.sync_with_google_calendar and not self.google_calendar:
 			frappe.throw(_("Select Google Calendar to which event should be synced."))
 
-		if not self.sync_with_google_calendar:
+		if not self.sync_with_google_calendar or self.event_category not in ["Event", "Meeting", "Other"]:
 			self.add_video_conferencing = False
 
 	def on_update(self):

--- a/frappe/desk/doctype/event_participants/event_participants.json
+++ b/frappe/desk/doctype/event_participants/event_participants.json
@@ -30,13 +30,12 @@
    "fieldname": "email",
    "fieldtype": "Data",
    "label": "Email",
-   "options": "Email",
-   "read_only": 1
+   "options": "Email"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-09-27 20:16:20.513286",
+ "modified": "2022-10-18 17:49:33.549459",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event Participants",

--- a/frappe/desk/doctype/event_participants/event_participants.json
+++ b/frappe/desk/doctype/event_participants/event_participants.json
@@ -6,7 +6,8 @@
  "engine": "InnoDB",
  "field_order": [
   "reference_doctype",
-  "reference_docname"
+  "reference_docname",
+  "email"
  ],
  "fields": [
   {
@@ -24,11 +25,18 @@
    "label": "Reference Name",
    "options": "reference_doctype",
    "reqd": 1
+  },
+  {
+   "fieldname": "email",
+   "fieldtype": "Data",
+   "label": "Email",
+   "options": "Email",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-08-03 12:20:50.466370",
+ "modified": "2022-09-27 20:16:20.513286",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Event Participants",

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -750,7 +750,9 @@ def get_attendees(doc):
 		if participant.get("email"):
 			attendees.append({"email": participant.email})
 		else:
-			email_not_found.append({"dt": participant.reference_doctype, "dn": participant.reference_docname})
+			email_not_found.append(
+				{"dt": participant.reference_doctype, "dn": participant.reference_docname}
+			)
 
 	if len(email_not_found):
 		frappe.msgprint(

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -510,7 +510,12 @@ def update_event_in_google_calendar(doc, method=None):
 		)
 
 		# if add_video_conferencing enabled or disabled during update, overwrite
-		frappe.db.set_value("Event", doc.name, {"google_meet_link": event.get("hangoutLink")})
+		frappe.db.set_value(
+			"Event",
+			doc.name,
+			{"google_meet_link": event.get("hangoutLink")},
+			update_modified=False,
+		)
 		doc.notify_update()
 
 		frappe.msgprint(_("Event Synced with Google Calendar."))

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -738,12 +738,12 @@ def get_attendees(doc):
 
 		participant_doc = frappe.get_doc(participant.reference_doctype, participant.reference_docname)
 
-		if participant_doc.meta.has_field('user') and participant_doc.user:
-			attendees.append({'email': participant_doc.user})
-		elif participant_doc.meta.has_field('user_id') and participant_doc.user_id:
-			attendees.append({'email': participant_doc.user_id})
-		elif participant_doc.meta.has_field('email') and participant_doc.email:
-			attendees.append({'email': participant_doc.email})
+		if participant_doc.meta.has_field("user") and participant_doc.user:
+			attendees.append({"email": participant_doc.user})
+		elif participant_doc.meta.has_field("user_id") and participant_doc.user_id:
+			attendees.append({"email": participant_doc.user_id})
+		elif participant_doc.meta.has_field("email") and participant_doc.email:
+			attendees.append({"email": participant_doc.email})
 		else:
 			frappe.msgprint(
 				_("Google Calendar - User / Email field not found, did not add attendee for {0} {1}").format(

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -409,8 +409,7 @@ def insert_event_in_google_calendar(doc, method=None):
 	if doc.repeat_on:
 		event.update({"recurrence": repeat_on_to_google_calendar_recurrence_rule(doc)})
 
-	if len(doc.event_participants):
-		event.update({"attendees": get_attendees(doc)})
+	event.update({"attendees": get_attendees(doc)})
 
 	conference_data_version = 0
 
@@ -495,8 +494,7 @@ def update_event_in_google_calendar(doc, method=None):
 			event.update({"conferenceData": None})
 			conference_data_version = 1
 
-		if len(doc.event_participants):
-			event.update({"attendees": get_attendees(doc)})
+		event.update({"attendees": get_attendees(doc)})
 
 		event = (
 			google_calendar.events()

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -478,6 +478,8 @@ def update_event_in_google_calendar(doc, method=None):
 
 		if doc.add_video_conferencing:
 			event.update({"conferenceData": get_conference_data(doc)})
+		else:
+			event.update({"conferenceData": None})
 
 		if len(doc.event_participants):
 			event.update({"attendees": get_attendees(doc)})
@@ -489,13 +491,13 @@ def update_event_in_google_calendar(doc, method=None):
 			conferenceDataVersion=1
 		).execute()
 
-		if doc.add_video_conferencing and event.get("hangoutLink"):
-			frappe.db.set_value("Event", doc.name, {
-					"google_meet_link": event.get("hangoutLink")
-				},
-				update_modified=False
-			)
-			doc.notify_update()
+		# if add_video_conferencing enabled or disabled during update, overwrite
+		frappe.db.set_value("Event", doc.name, {
+				"google_meet_link": event.get("hangoutLink")
+			},
+			update_modified=False
+		)
+		doc.notify_update()
 
 		frappe.msgprint(_("Event Synced with Google Calendar."))
 	except HttpError as err:

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -416,17 +416,17 @@ def insert_event_in_google_calendar(doc, method=None):
 		event.update({"attendees": get_attendees(doc)})
 
 	try:
-		event = google_calendar.events().insert(
-			calendarId=doc.google_calendar_id,
-			body=event,
-			conferenceDataVersion=1
-		).execute()
+		event = (
+			google_calendar.events()
+			.insert(calendarId=doc.google_calendar_id, body=event, conferenceDataVersion=1)
+			.execute()
+		)
 
-		frappe.db.set_value("Event", doc.name, {
-				"google_calendar_event_id": event.get("id"),
-				"google_meet_link": event.get("hangoutLink")
-			},
-			update_modified=False
+		frappe.db.set_value(
+			"Event",
+			doc.name,
+			{"google_calendar_event_id": event.get("id"), "google_meet_link": event.get("hangoutLink")},
+			update_modified=False,
 		)
 
 		frappe.msgprint(_("Event Synced with Google Calendar."))
@@ -486,18 +486,19 @@ def update_event_in_google_calendar(doc, method=None):
 		if len(doc.event_participants):
 			event.update({"attendees": get_attendees(doc)})
 
-		event = google_calendar.events().update(
-			calendarId=doc.google_calendar_id,
-			eventId=doc.google_calendar_event_id,
-			body=event,
-			conferenceDataVersion=1
-		).execute()
+		event = (
+			google_calendar.events()
+			.update(
+				calendarId=doc.google_calendar_id,
+				eventId=doc.google_calendar_event_id,
+				body=event,
+				conferenceDataVersion=1
+			)
+			.execute()
+		)
 
 		# if add_video_conferencing enabled or disabled during update, overwrite
-		frappe.db.set_value("Event", doc.name, {
-				"google_meet_link": event.get("hangoutLink")
-			}
-		)
+		frappe.db.set_value("Event", doc.name, {"google_meet_link": event.get("hangoutLink")})
 		doc.notify_update()
 
 		frappe.msgprint(_("Event Synced with Google Calendar."))
@@ -719,15 +720,9 @@ def get_recurrence_parameters(recurrence):
 
 def get_conference_data(doc):
 	return {
-			"createRequest": {
-				"requestId": doc.name,
-				"conferenceSolutionKey": {
-					"type": "hangoutsMeet"
-				}
-			},
-
-			"notes": doc.description
-		}
+		"createRequest": {"requestId": doc.name, "conferenceSolutionKey": {"type": "hangoutsMeet"}},
+		"notes": doc.description,
+	}
 
 
 def get_attendees(doc):
@@ -741,27 +736,22 @@ def get_attendees(doc):
 
 	for participant in doc.event_participants:
 
-			participant_doc = frappe.get_doc(participant.reference_doctype, participant.reference_docname)
+		participant_doc = frappe.get_doc(participant.reference_doctype, participant.reference_docname)
 
-			if participant_doc.meta.has_field('user') and participant_doc.user:
-				attendees.append({
-						'email': participant_doc.user
-				})
-			elif participant_doc.meta.has_field('user_id') and participant_doc.user_id:
-				attendees.append({
-						'email': participant_doc.user_id
-				})
-			elif participant_doc.meta.has_field('email') and participant_doc.email:
-				attendees.append({
-						'email': participant_doc.email
-				})
-			else:
-				frappe.msgprint(
-					_("Google Calendar - User / Email field not found, did not add attendee for {0} {1}").format(
-						participant.reference_doctype, participant.reference_docname
-					),
-					alert=True, indicator="red"
-				)
+		if participant_doc.meta.has_field('user') and participant_doc.user:
+			attendees.append({'email': participant_doc.user})
+		elif participant_doc.meta.has_field('user_id') and participant_doc.user_id:
+			attendees.append({'email': participant_doc.user_id})
+		elif participant_doc.meta.has_field('email') and participant_doc.email:
+			attendees.append({'email': participant_doc.email})
+		else:
+			frappe.msgprint(
+				_("Google Calendar - User / Email field not found, did not add attendee for {0} {1}").format(
+					participant.reference_doctype, participant.reference_docname
+				),
+				alert=True,
+				indicator="red",
+			)
 
 	return attendees
 

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -754,13 +754,13 @@ def get_attendees(doc):
 				{"dt": participant.reference_doctype, "dn": participant.reference_docname}
 			)
 
-	if len(email_not_found):
+	if email_not_found:
 		frappe.msgprint(
-			_("Google Calendar - Contact / email not found, did not add attendee for -<br>{0}").format(
+			_("Google Calendar - Contact / email not found. Did not add attendee for -<br>{0}").format(
 				"<br>".join(f"{d.get('dt')} {d.get('dn')}" for d in email_not_found)
 			),
 			alert=True,
-			indicator="red",
+			indicator="yellow",
 		)
 
 	return attendees


### PR DESCRIPTION
- Option to "Add Video Conferencing" in Event doctype
- Extend Google Calendar integration to add Google Meet link to calendar events 
    - insert and update APIs of Google Calendar now invoked with `conferenceDataVersion=1` [API Reference](https://developers.google.com/calendar/api/guides/create-events?hl=en#conferencing)
    - Add `conferenceData` as part of Google Calendar API
    - Add `attendees` based on Participants added to Event (adding attendees even if conferencing is not enabled, unlike the current implementation)
    - Event update (Add / Remove conferencing after syncing the event)
    - Show link to join video conference in Event document

Creating an Event with Video Conferencing enabled -
![Screen Shot 2022-08-11 at 2 03 34 PM](https://user-images.githubusercontent.com/3326959/185031032-d66f3fad-f0c9-4588-a071-9b6270acd873.png)

Google Meet link saved after inserting Event 
![Screen Shot 2022-08-11 at 5 32 59 PM](https://user-images.githubusercontent.com/3326959/185031223-24733f0a-7245-4a43-b414-cb0aa4285d72.png)

Show join link on dashboard
![2022-08-17 09 25 18](https://user-images.githubusercontent.com/3326959/185031797-f881f82b-2c42-434f-afa1-8d2eb8980769.jpg)

Docs, Google Calendar Integration [Draft]( https://frappeframework.com/docs/v14/user/en/guides/integration/google_calendar/edit-wiki?wiki_page_patch=7fa416deca )