### PR TITLE
fix: attachment visibility UX

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FilePreview.vue
+++ b/frappe/public/js/frappe/file_uploader/FilePreview.vue
@@ -13,14 +13,8 @@
 			<div>
 				<a class="flex" :href="file.doc.file_url" v-if="file.doc" target="_blank">
 					<span class="file-name">{{ file.name | file_name }}</span>
-					<div class="ml-2" v-html="private_icon"></div>
 				</a>
-				<span class="flex" v-else>
-					<span class="file-name">{{ file.name | file_name }}</span>
-					<button class="ml-2 btn-reset" @click="$emit('toggle_private')" :title="__('Toggle Public/Private')">
-						<div v-html="private_icon"></div>
-					</button>
-				</span>
+				<span class="file-name" v-else>{{ file.name | file_name }}</span>
 			</div>
 
 			<div>
@@ -28,7 +22,11 @@
 					{{ file.file_obj.size | file_size }}
 				</span>
 			</div>
-			<label v-if="is_optimizable" class="optimize-checkbox"><input type="checkbox" :checked="optimize" @change="$emit('toggle_optimize')">Optimize</label>
+
+			<div class="flex config-area">
+				<label v-if="is_optimizable" class="frappe-checkbox"><input type="checkbox" :checked="optimize" @change="$emit('toggle_optimize')">Optimize</label>
+				<label class="frappe-checkbox"><input type="checkbox" :checked="file.private" @change="$emit('toggle_private')">Private</label>
+			</div>
 			<div>
 				<span v-if="file.error_message" class="file-error text-danger">
 					{{ file.error_message }}
@@ -87,9 +85,6 @@ export default {
 		}
 	},
 	computed: {
-		private_icon() {
-			return frappe.utils.icon(this.is_private ? 'lock' : 'unlock');
-		},
 		is_private() {
 			return this.file.doc ? this.file.doc.is_private : this.file.private;
 		},
@@ -206,12 +201,16 @@ export default {
 	opacity: 1;
 }
 
-.optimize-checkbox {
+.frappe-checkbox {
 	font-size: var(--text-sm);
 	color: var(--text-light);
 	display: flex;
 	align-items: center;
 	padding-top: 0.25rem;
+}
+
+.config-area {
+	gap: 0.5rem;
 }
 
 .file-error {

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -228,7 +228,7 @@ export default {
 				});
 		}
 		if (this.restrictions.max_number_of_files == null && this.doctype) {
-			this.restrictions.max_number_of_files = frappe.get_meta(self.doctype).max_attachments;
+			this.restrictions.max_number_of_files = frappe.get_meta(this.doctype)?.max_attachments;
 		}
 	},
 	watch: {


### PR DESCRIPTION
Public-private toggle was kinda hard to find for most people and the difference is literally 3-5 pixel long curve that indicates open lock. 

Before:
<img width="618" alt="Screenshot 2022-08-17 at 2 25 22 PM" src="https://user-images.githubusercontent.com/9079960/185078118-45d12145-e564-49ac-bedd-1dcc4980ded0.png">


After:

<img width="618" alt="Screenshot 2022-08-17 at 2 25 13 PM" src="https://user-images.githubusercontent.com/9079960/185078085-8ef5c547-87cf-482c-aa9b-b45c63582f82.png">
