### PR TITLE
fix: has_content check for fieldtype TextEditor

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -671,10 +671,19 @@ class BaseDocument:
 
 			return _("Error: Value missing for {0}: {1}").format(_(df.parent), _(df.label))
 
+		def has_content(df):
+			value = cstr(self.get(df.fieldname))
+			has_text_content = strip_html(value).strip()
+			has_img_tag = "<img" in value
+			if df.fieldtype == "Text Editor" and (has_text_content or has_img_tag):
+				return True
+			else:
+				return has_text_content
+
 		missing = []
 
 		for df in self.meta.get("fields", {"reqd": ("=", 1)}):
-			if self.get(df.fieldname) in (None, []) or not strip_html(cstr(self.get(df.fieldname))).strip():
+			if self.get(df.fieldname) in (None, []) or not has_content(df):
 				missing.append((df.fieldname, get_msg(df)))
 
 		# check for missing parent and parenttype

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -101,6 +101,14 @@ class TestDocument(unittest.TestCase):
 		d.insert()
 		self.assertEqual(frappe.db.get_value("User", d.name), d.name)
 
+	def test_text_editor_field(self):
+		try:
+			frappe.get_doc(
+				doctype="Activity Log", subject="test", message='<img src="test.png" />'
+			).insert()
+		except frappe.MandatoryError:
+			self.fail("Text Editor false positive mandatory error")
+
 	def test_conflict_validation(self):
 		d1 = self.test_insert()
 		d2 = frappe.get_doc(d1.doctype, d1.name)


### PR DESCRIPTION
When a TextEditor field contains only an image, while checking for content, HTML tags are stripped off including the only image. 

This change adds a loose but explicit check for img tag.

- [x] Test