### PR TITLE
fix: data import preview link warning

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -984,7 +984,9 @@ class Column:
 		if self.df.fieldtype == "Link":
 			# find all values that dont exist
 			values = list({cstr(v) for v in self.column_values[1:] if v})
-			exists = [d.name for d in frappe.db.get_all(self.df.options, filters={"name": ("in", values)})]
+			exists = [
+				cstr(d.name) for d in frappe.db.get_all(self.df.options, filters={"name": ("in", values)})
+			]
 			not_exists = list(set(values) - set(exists))
 			if not_exists:
 				missing_values = ", ".join(not_exists)


### PR DESCRIPTION
## Overview
When preforming data import on a column of type Link, if the field type of the document to be linked is not a string, warnings the document doesn't exist will be produced.

## Fix
Because all values imported from the file are converted to string. The values fetched from the DB must also be converted to string.