### PR TITLE
fix: pop pwd from form dict, disable auth logging

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -156,6 +156,7 @@ class LoginManager:
 			authenticate_for_2factor(self.user)
 			if not confirm_otp_token(self):
 				return False
+		frappe.form_dict.pop("pwd", None)
 		self.post_login()
 
 	def post_login(self):

--- a/frappe/core/doctype/activity_log/test_activity_log.py
+++ b/frappe/core/doctype/activity_log/test_activity_log.py
@@ -12,13 +12,19 @@ class TestActivityLog(FrappeTestCase):
 
 		# test user login log
 		frappe.local.form_dict = frappe._dict(
-			{"cmd": "login", "sid": "Guest", "pwd": "admin", "usr": "Administrator"}
+			{
+				"cmd": "login",
+				"sid": "Guest",
+				"pwd": frappe.conf.admin_password or "admin",
+				"usr": "Administrator",
+			}
 		)
 
 		frappe.local.cookie_manager = CookieManager()
 		frappe.local.login_manager = LoginManager()
 
 		auth_log = self.get_auth_log()
+		self.assertFalse(frappe.form_dict.pwd)
 		self.assertEqual(auth_log.status, "Success")
 
 		# test user logout log

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -354,7 +354,7 @@ def login():
 	args = frappe.form_dict
 	ldap: LDAPSettings = frappe.get_doc("LDAP Settings")
 
-	user = ldap.authenticate(frappe.as_unicode(args.usr), frappe.as_unicode(args.pop("pwd")))
+	user = ldap.authenticate(frappe.as_unicode(args.usr), frappe.as_unicode(args.pop("pwd", None)))
 
 	frappe.local.login_manager.user = user.name
 	if should_run_2fa(user.name):

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -354,7 +354,7 @@ def login():
 	args = frappe.form_dict
 	ldap: LDAPSettings = frappe.get_doc("LDAP Settings")
 
-	user = ldap.authenticate(frappe.as_unicode(args.usr), frappe.as_unicode(args.pwd))
+	user = ldap.authenticate(frappe.as_unicode(args.usr), frappe.as_unicode(args.pop("pwd")))
 
 	frappe.local.login_manager.user = user.name
 	if should_run_2fa(user.name):

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -12,12 +12,24 @@ import pydoc
 import sys
 import traceback
 
+from ldap3.core.exceptions import LDAPInvalidCredentialsResult
+
 import frappe
 from frappe.utils import cstr, encode
+
+EXCLUDE_EXCEPTIONS = (
+	frappe.AuthenticationError,
+	frappe.CSRFTokenError,  # CSRF covers OAuth too
+	frappe.SecurityException,
+	LDAPInvalidCredentialsResult,
+)
 
 
 def make_error_snapshot(exception):
 	if frappe.conf.disable_error_snapshot:
+		return
+
+	if isinstance(exception, EXCLUDE_EXCEPTIONS):
 		return
 
 	logger = frappe.logger(with_more_info=True)


### PR DESCRIPTION
- This prevents accidental logging of this info somewhere down the line.
- Disable exception logging for auth failures