### PR TITLE
chore: limit over-logging of handled exception

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -224,8 +224,9 @@ class Database:
 				raise
 
 			elif isinstance(e, self.ProgrammingError):
-				traceback.print_stack()
-				frappe.errprint(f"Error in query:\n{query, values}")
+				if frappe.conf.developer_mode:
+					traceback.print_stack()
+					frappe.errprint(f"Error in query:\n{query, values}")
 				raise
 
 			if not (


### PR DESCRIPTION
Most of the time these exceptions are handled and currently it's printing giant stack trace and query without exception message itself. 