### PR TITLE
fix: fetch email domain values for email account

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -210,10 +210,11 @@ frappe.ui.form.on("Email Account", {
 		oauth_access(frm);
 	},
 
-	domain: function (frm) {
+	domain: frappe.utils.debounce((frm) => {
 		if (frm.doc.domain) {
 			frappe.call({
 				method: "get_domain_values",
+				doc: frm.doc,
 				args: {
 					domain: frm.doc.domain,
 				},
@@ -226,7 +227,7 @@ frappe.ui.form.on("Email Account", {
 				},
 			});
 		}
-	},
+	}),
 
 	email_sync_option: function (frm) {
 		// confirm if the ALL sync option is selected

--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -158,7 +158,6 @@ frappe.ui.form.on("Email Account", {
 	},
 
 	refresh: function (frm) {
-		frm.events.set_domain_fields(frm);
 		frm.events.enable_incoming(frm);
 		frm.events.notify_if_unreplied(frm);
 		frm.events.show_gmail_message_for_less_secure_apps(frm);
@@ -211,41 +210,22 @@ frappe.ui.form.on("Email Account", {
 		oauth_access(frm);
 	},
 
-	email_id: function (frm) {
-		//pull domain and if no matching domain go create one
-		frm.events.update_domain(frm);
-	},
-
-	update_domain: function (frm) {
-		if (!frm.doc.email_id && !frm.doc.service) {
-			return;
+	domain: function (frm) {
+		if (frm.doc.domain) {
+			frappe.call({
+				method: "get_domain_values",
+				args: {
+					domain: frm.doc.domain,
+				},
+				callback: function (r) {
+					if (!r.exc) {
+						for (let field in r.message) {
+							frm.set_value(field, r.message[field]);
+						}
+					}
+				},
+			});
 		}
-
-		frappe.call({
-			method: "get_domain",
-			doc: frm.doc,
-			args: {
-				email_id: frm.doc.email_id,
-			},
-			callback: function (r) {
-				if (r.message) {
-					frm.events.set_domain_fields(frm, r.message);
-				}
-			},
-		});
-	},
-
-	set_domain_fields: function (frm, args) {
-		if (!args) {
-			args = frappe.route_flags.set_domain_values ? frappe.route_options : {};
-		}
-
-		for (var field in args) {
-			frm.set_value(field, args[field]);
-		}
-
-		delete frappe.route_flags.set_domain_values;
-		frappe.route_options = {};
 	},
 
 	email_sync_option: function (frm) {

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -145,7 +145,7 @@
    "hide_seconds": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Domain (optional)",
+   "label": "Domain",
    "options": "Email Domain"
   },
   {
@@ -154,7 +154,7 @@
    "fieldtype": "Select",
    "hide_days": 1,
    "hide_seconds": 1,
-   "label": "Service (optional)",
+   "label": "Service",
    "options": "\nGMail\nSendgrid\nSparkPost\nYahoo Mail\nOutlook.com\nYandex.Mail"
   },
   {
@@ -615,7 +615,7 @@
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-08-16 13:05:45.445572",
+ "modified": "2022-08-23 00:31:05.305462",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -12,6 +12,7 @@ from poplib import error_proto
 import frappe
 from frappe import _, are_emails_muted, safe_encode
 from frappe.desk.form import assign_to
+from frappe.email.doctype.email_domain.email_domain import EMAIL_DOMAIN_FIELDS
 from frappe.email.receive import EmailServer, InboundMail, SentEmailInInboxError
 from frappe.email.smtp import SMTPServer
 from frappe.email.utils import get_port
@@ -180,19 +181,7 @@ class EmailAccount(Document):
 
 	@frappe.whitelist()
 	def get_domain_values(self, domain: str):
-		fields = [
-			"use_imap",
-			"email_server",
-			"use_ssl",
-			"use_starttls",
-			"smtp_server",
-			"use_tls",
-			"smtp_port",
-			"incoming_port",
-			"append_emails_to_sent_folder",
-			"use_ssl_for_outgoing",
-		]
-		return frappe.db.get_value("Email Domain", domain, fields, as_dict=True)
+		return frappe.db.get_value("Email Domain", domain, EMAIL_DOMAIN_FIELDS, as_dict=True)
 
 	def get_incoming_server(self, in_receive=False, email_sync_rule="UNSEEN"):
 		"""Returns logged in POP3/IMAP connection object."""

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -179,26 +179,20 @@ class EmailAccount(Document):
 				email_account.save()
 
 	@frappe.whitelist()
-	def get_domain(self, email_id):
-		"""look-up the domain and then full"""
-		try:
-			domain = email_id.split("@")
-			fields = [
-				"name as domain",
-				"use_imap",
-				"email_server",
-				"use_ssl",
-				"use_starttls",
-				"smtp_server",
-				"use_tls",
-				"smtp_port",
-				"incoming_port",
-				"append_emails_to_sent_folder",
-				"use_ssl_for_outgoing",
-			]
-			return frappe.db.get_value("Email Domain", domain[1], fields, as_dict=True)
-		except Exception:
-			pass
+	def get_domain_values(self, domain: str):
+		fields = [
+			"use_imap",
+			"email_server",
+			"use_ssl",
+			"use_starttls",
+			"smtp_server",
+			"use_tls",
+			"smtp_port",
+			"incoming_port",
+			"append_emails_to_sent_folder",
+			"use_ssl_for_outgoing",
+		]
+		return frappe.db.get_value("Email Domain", domain, fields, as_dict=True)
 
 	def get_incoming_server(self, in_receive=False, email_sync_rule="UNSEEN"):
 		"""Returns logged in POP3/IMAP connection object."""

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -11,6 +11,20 @@ from frappe.email.utils import get_port
 from frappe.model.document import Document
 from frappe.utils import cint
 
+EMAIL_DOMAIN_FIELDS = [
+	"email_server",
+	"use_imap",
+	"use_ssl",
+	"use_starttls",
+	"use_tls",
+	"attachment_limit",
+	"smtp_server",
+	"smtp_port",
+	"use_ssl_for_outgoing",
+	"append_emails_to_sent_folder",
+	"incoming_port",
+]
+
 
 def get_error_message(event):
 	return {
@@ -52,19 +66,7 @@ class EmailDomain(Document):
 		for email_account in frappe.get_all("Email Account", filters={"domain": self.name}):
 			try:
 				email_account = frappe.get_doc("Email Account", email_account.name)
-				for attr in [
-					"email_server",
-					"use_imap",
-					"use_ssl",
-					"use_starttls",
-					"use_tls",
-					"attachment_limit",
-					"smtp_server",
-					"smtp_port",
-					"use_ssl_for_outgoing",
-					"append_emails_to_sent_folder",
-					"incoming_port",
-				]:
+				for attr in EMAIL_DOMAIN_FIELDS:
 					email_account.set(attr, self.get(attr, default=0))
 				email_account.save()
 


### PR DESCRIPTION
This pr adds support for fetching email domain values for email account upon domain's selection. This was broken due to #17377 - hence fixing the same.

Other Changes:
- moved all email domain fields to a global constant
- removed `optional` tag from `domain` and `service` field(s) in Email Account Doctype