### PR TITLE
fix: permissions dont refresh when switching doc

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -33,6 +33,14 @@ frappe.ui.form.Control = class BaseControl {
 		this.refresh();
 	}
 
+	get perm() {
+		return this.frm?.perm;
+	}
+
+	set perm(_perm) {
+		console.error("Setting perm on controls isn't supported, update form's perm instead");
+	}
+
 	// returns "Read", "Write" or "None"
 	// as strings based on permissions
 	get_status(explain) {

--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -8,7 +8,6 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 		this.grid = new Grid({
 			frm: this.frm,
 			df: this.df,
-			perm: this.perm || (this.frm && this.frm.perm) || this.df.perm,
 			parent: this.wrapper,
 			control: this,
 		});

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -403,10 +403,16 @@ frappe.ui.form.Form = class FrappeForm {
 			this.doc = frappe.get_doc(this.doctype, this.docname);
 
 			// check permissions
+			this.fetch_permissions();
 			if (!this.has_read_permission()) {
 				frappe.show_not_permitted(__(this.doctype) + " " + __(cstr(this.docname)));
 				return;
 			}
+
+			// update grids with new permissions
+			this.grids.forEach((table) => {
+				table.grid.refresh();
+			});
 
 			// read only (workflow)
 			this.read_only = frappe.workflow.is_read_only(this.doctype, this.docname);
@@ -1157,11 +1163,12 @@ frappe.ui.form.Form = class FrappeForm {
 			.attr("target", "_blank");
 	}
 
-	has_read_permission() {
-		// get perm
-		var dt = this.parent_doctype ? this.parent_doctype : this.doctype;
+	fetch_permissions() {
+		let dt = this.parent_doctype ? this.parent_doctype : this.doctype;
 		this.perm = frappe.perm.get_perm(dt, this.doc);
+	}
 
+	has_read_permission() {
 		if (!this.perm[0].read) {
 			return 0;
 		}

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -43,6 +43,14 @@ export default class Grid {
 		this.debounced_refresh = frappe.utils.debounce(this.debounced_refresh, 100);
 	}
 
+	get perm() {
+		return this.control?.perm || this.frm?.perm || this.df.perm;
+	}
+
+	set perm(_perm) {
+		console.error("Setting perm on grid isn't supported, update form's perm instead");
+	}
+
 	allow_on_grid_editing() {
 		if (frappe.utils.is_xs()) {
 			return false;

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -194,9 +194,6 @@ frappe.ui.form.Layout = class Layout {
 			this.fields_dict[fieldname].$wrapper.remove();
 			this.fields_list.splice(this.fields_dict[fieldname], 1, fieldobj);
 			this.fields_dict[fieldname] = fieldobj;
-			if (this.frm) {
-				fieldobj.perm = this.frm.perm;
-			}
 			this.section.fields_list.splice(this.section.fields_dict[fieldname], 1, fieldobj);
 			this.section.fields_dict[fieldname] = fieldobj;
 			this.refresh_fields([df]);
@@ -210,9 +207,6 @@ frappe.ui.form.Layout = class Layout {
 		const fieldobj = this.init_field(df, render);
 		this.fields_list.push(fieldobj);
 		this.fields_dict[df.fieldname] = fieldobj;
-		if (this.frm) {
-			fieldobj.perm = this.frm.perm;
-		}
 
 		this.section.add_field(fieldobj);
 		this.column.add_field(fieldobj);
@@ -465,11 +459,6 @@ frappe.ui.form.Layout = class Layout {
 				fieldobj.df =
 					frappe.meta.get_docfield(me.doc.doctype, fieldobj.df.fieldname, me.doc.name) ||
 					fieldobj.df;
-
-				// on form change, permissions can change
-				if (me.frm) {
-					fieldobj.perm = me.frm.perm;
-				}
 			}
 			refresh && fieldobj.df && fieldobj.refresh && fieldobj.refresh();
 		}


### PR DESCRIPTION
Grid permissions aren't refreshed when switching docs.

Setup permissions like this:

1. Normal perm - read
2. If owner - read + write + others
3. Open a normal doc -> is read only so grid is read only.
4. Now go back and open a created doc -> grid will be read only or empty
   (if no rows)

ref: ISS-22-23-01733


Fix: make `grid.perm` a computed property and not pass and sync objects like maniacs. 👁️ `frm.perm` is the single source of truth now for all other components attached on form. 
