### PR TITLE
fix: notifications always showing up as "unread"

### DIFF
--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -322,7 +322,7 @@ class NotificationsView extends BaseNotificationsView {
 
 	get_notifications_list(limit) {
 		return frappe.db.get_list('Notification Log', {
-			fields: ['subject', "type", "document_type", "document_name", "creation", "from_user", "name"],
+			fields: ["*"],
 			limit: limit,
 			order_by: 'creation desc'
 		});


### PR DESCRIPTION
caused by https://github.com/frappe/frappe/pull/17649 

Because `read` isn't fetched all notifications are showing up as unread
