### PR TITLE
perf: ~45% faster Desk first response

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -240,6 +240,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False) -> None:
 	local.document_cache = {}
 	local.meta_cache = {}
 	local.form_dict = _dict()
+	local.preload_assets = {"style": [], "script": []}
 	local.session = _dict()
 	local.dev_server = _dev_server
 	local.qb = get_query_builder(local.conf.db_type or "mariadb")

--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -192,4 +192,4 @@ def get_documents_for_tag(tag):
 
 @frappe.whitelist()
 def get_tags_list_for_awesomebar():
-	return [t.name for t in frappe.get_list("Tag")]
+	return frappe.get_list("Tag", pluck="name", order_by=None)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -452,7 +452,9 @@ def get_title_values_for_link_and_dynamic_link_fields(doc, link_fields=None):
 		if not meta or not (meta.title_field and meta.show_title_field_in_link):
 			continue
 
-		link_title = frappe.db.get_value(doctype, doc.get(field.fieldname), meta.title_field, cache=True)
+		link_title = frappe.db.get_value(
+			doctype, doc.get(field.fieldname), meta.title_field, cache=True, order_by=None
+		)
 		link_titles.update({doctype + "::" + doc.get(field.fieldname): link_title})
 
 	return link_titles

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -15,6 +15,7 @@ from frappe.model import optional_fields, table_fields
 from frappe.model.base_document import BaseDocument, get_controller
 from frappe.model.docstatus import DocStatus
 from frappe.model.naming import set_new_name, validate_name
+from frappe.model.utils import is_virtual_doctype
 from frappe.model.workflow import set_workflow_state_on_action, validate_workflow
 from frappe.utils import cstr, date_diff, file_lock, flt, get_datetime_str, now
 from frappe.utils.data import get_absolute_url
@@ -154,11 +155,7 @@ class Document(BaseDocument):
 			# Make sure not to query the DB for a child table, if it is a virtual one.
 			# During frappe is installed, the property "is_virtual" is not available in tabDocType, so
 			# we need to filter those cases for the access to frappe.db.get_value() as it would crash otherwise.
-			if (
-				hasattr(self, "doctype")
-				and not hasattr(self, "module")
-				and frappe.db.get_value("DocType", df.options, "is_virtual", cache=True)
-			):
+			if hasattr(self, "doctype") and not hasattr(self, "module") and is_virtual_doctype(df.options):
 				self.set(df.fieldname, [])
 				continue
 

--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -128,6 +128,6 @@ def get_fetch_values(doctype, fieldname, value):
 	return result
 
 
-@site_cache(maxsize=128)
+@site_cache()
 def is_virtual_doctype(doctype):
 	return frappe.db.get_value("DocType", doctype, "is_virtual")

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -278,7 +278,10 @@ frappe.ui.form.Layout = class Layout {
 
 	make_section(df = {}) {
 		this.section_count++;
-		if (!df.fieldname) df.fieldname = `__section_${this.section_count}`;
+		if (!df.fieldname) {
+			df.fieldname = `__section_${this.section_count}`;
+			df.fieldtype = "Section Break";
+		}
 
 		this.section = new Section(
 			this.current_tab ? this.current_tab.wrapper : this.page,
@@ -300,7 +303,10 @@ frappe.ui.form.Layout = class Layout {
 
 	make_column(df = {}) {
 		this.column_count++;
-		if (!df.fieldname) df.fieldname = `__column_${this.section_count}`;
+		if (!df.fieldname) {
+			df.fieldname = `__column_${this.section_count}`;
+			df.fieldtype = "Column Break";
+		}
 
 		this.column = new Column(this.section, df);
 		if (df && df.fieldname) {

--- a/frappe/public/js/frappe/recorder/RequestDetail.vue
+++ b/frappe/public/js/frappe/recorder/RequestDetail.vue
@@ -25,8 +25,8 @@
 							<li v-for="(column, index) in table_columns.filter(c => c.sortable)" :key="index" @click="query.sort = column.slug"><a class="option">{{ column.label }}</a></li>
 						</ul>
 					</div>
-					<button class="btn btn-default btn-xs btn-order">
-						<span class="octicon text-muted" :class="query.order == 'asc' ? 'octicon-arrow-down' : 'octicon-arrow-up'"  @click="query.order = (query.order == 'asc') ? 'desc' : 'asc'"></span>
+					<button class="btn btn-default btn-xs btn-order" @click="query.order = (query.order == 'asc') ? 'desc' : 'asc'">
+						<span class="octicon text-muted" :class="query.order == 'asc' ? 'octicon-arrow-down' : 'octicon-arrow-up'"></span>
 					</button>
 				</div>
 			</div>

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -95,13 +95,33 @@ def get_dom_id(seed=None):
 	return "id-" + generate_hash(seed, 12)
 
 
-def include_script(path):
+def include_script(path, preload=True):
+	"""Get path of bundled script files.
+
+	If preload is specified the path will be added to preload headers so browsers can prefetch
+	assets."""
 	path = bundled_asset(path)
+
+	if preload:
+		import frappe
+
+		frappe.local.preload_assets["script"].append(path)
+
 	return f'<script type="text/javascript" src="{path}"></script>'
 
 
-def include_style(path, rtl=None):
+def include_style(path, rtl=None, preload=True):
+	"""Get path of bundled style files.
+
+	If preload is specified the path will be added to preload headers so browsers can prefetch
+	assets."""
 	path = bundled_asset(path)
+
+	if preload:
+		import frappe
+
+		frappe.local.preload_assets["style"].append(path)
+
 	return f'<link type="text/css" rel="stylesheet" href="{path}">'
 
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -273,7 +273,7 @@ def get_user_fullname(user: str) -> str:
 
 def get_fullname_and_avatar(user: str) -> _dict:
 	first_name, last_name, avatar, name = frappe.db.get_value(
-		"User", user, ["first_name", "last_name", "user_image", "name"]
+		"User", user, ["first_name", "last_name", "user_image", "name"], order_by=None
 	)
 	return _dict(
 		{

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -133,9 +133,9 @@ class WebsiteTheme(Document):
 
 
 def get_active_theme() -> Optional["WebsiteTheme"]:
-	if website_theme := frappe.db.get_single_value("Website Settings", "website_theme"):
+	if website_theme := frappe.get_website_settings("website_theme"):
 		try:
-			return frappe.get_doc("Website Theme", website_theme)
+			return frappe.get_cached_doc("Website Theme", website_theme)
 		except frappe.DoesNotExistError:
 			pass
 

--- a/frappe/website/page_renderers/static_page.py
+++ b/frappe/website/page_renderers/static_page.py
@@ -12,6 +12,8 @@ UNSUPPORTED_STATIC_PAGE_TYPES = ("html", "md", "js", "xml", "css", "txt", "py", 
 
 
 class StaticPage(BaseRenderer):
+	__slots__ = ("path", "file_path")
+
 	def __init__(self, path, http_status_code=None):
 		super().__init__(path=path, http_status_code=http_status_code)
 		self.set_file_path()

--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -105,7 +105,7 @@ def resolve_redirect(path, query_string=None):
 	        ]
 	"""
 	redirects = frappe.get_hooks("website_redirects")
-	redirects += frappe.db.get_all("Website Route Redirect", ["source", "target"])
+	redirects += frappe.get_all("Website Route Redirect", ["source", "target"], order_by=None)
 
 	if not redirects:
 		return

--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -17,6 +17,8 @@ from frappe.website.utils import can_cache, get_home_page
 
 
 class PathResolver:
+	__slots__ = ("path",)
+
 	def __init__(self, path):
 		self.path = path.strip("/ ")
 
@@ -36,6 +38,11 @@ class PathResolver:
 			return frappe.flags.redirect_location, RedirectPage(self.path)
 
 		endpoint = resolve_path(self.path)
+
+		# WARN: Hardcoded for better performance
+		if endpoint == "app":
+			return endpoint, TemplatePage(endpoint, 200)
+
 		custom_renderers = self.get_custom_page_renderers()
 		renderers = custom_renderers + [
 			StaticPage,

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -18,7 +18,9 @@ CLOSING_SCRIPT_TAG_PATTERN = re.compile(r"</script\>")
 def get_context(context):
 	if frappe.session.user == "Guest":
 		frappe.throw(_("Log in to access this page."), frappe.PermissionError)
-	elif frappe.db.get_value("User", frappe.session.user, "user_type") == "Website User":
+	elif (
+		frappe.db.get_value("User", frappe.session.user, "user_type", order_by=None) == "Website User"
+	):
 		frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
 
 	hooks = frappe.get_hooks()


### PR DESCRIPTION
Continuation of https://github.com/frappe/frappe/pull/16950

Major changes:

- Hardcode `/app/` for higher resolution priority. Currently everytime you open Desk whole lot of crap is checked before just rendering it as template. This includes web forms, static pages, web views etc etc. Just utter waste. 
- Consistently use Website settings from cache only. Half the time it's used from cache, other time it was from DB which meant it was worst of both worlds. Found all usage in critical path and converted all to cached version.
- Remove preload header computation and automatically add any included bundled assets to preload instead. Currently, we are parsing responses to find css/js files... which in itself was overhead and required hacks like straining HTML before parsing. 😄 
- Use cached `is_virtual_doctype` function
- Drop `order_by` from queries where it doesn't matter. 

TODO:
- [x] ~~remove preload hints completely?~~ This was added here https://github.com/frappe/frappe/pull/10229 but it's not in use on FC https://github.com/frappe/agent/commit/24d08328545d0249afd8aa6e196dbda3e480b635 Though not useful for server push much, preload hints still help. Current implementation has almost zero overhead so 🤷 



#### Numbers - TTFB measured using cURL (n = 100)

This drops `/app` query count from 33 to 8! (check using recorder)


  | Before | After | Improvement
-- | -- | -- | --
p50 (median) | 0.156 | 0.084 | 46.1%
p75 | 0.158 | 0.087 | 44.7%
p90 | 0.165 | 0.091 | 44.9%


In simple words, ~**70 milliseconds** fewer on each desk load. 🤌 

<details>
  <summary>Test setup and script</summary>

- Disable developer mode
- Set `frappe._dev_server = 0`
- Use gunicorn instead of werkzeug: `gunicorn -b 127.0.0.1:8000 -w 1 -t 120 --chdir /Users/ankush/benches/develop/sites frappe.app:application --preload`
- copy /app request from browser as cURL. Modify it a bit like this:

```bash
repeat 100 sleep 0.4 &&
curl -o /dev/null -s -w '%{time_starttransfer}\n' 'http://develop:8000/app' \
  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
  -H 'Cache-Control: max-age=0' \
  -H 'Connection: keep-alive' \
  -H 'Cookie: sid=0081c74af96540c1ef032a46cc296e053727a0ec28bd87d6131799d8; system_user=yes; full_name=User%20C; user_id=lowperm%40user.com; user_image=' \
  -H 'Referer: http://develop:8000/' \
  -H 'Upgrade-Insecure-Requests: 1' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36' \
  --compressed \
  --insecure >> new.txt

```
</details>

closes https://github.com/frappe/frappe/issues/17885 caused by https://github.com/frappe/frappe/pull/17785 
closes https://github.com/frappe/frappe/issues/17001 
closes https://github.com/frappe/frappe/issues/17423 