### PR TITLE
perf: install hiredis for faster response parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "pytz==2022.1",
     "rauth~=0.7.3",
     "redis~=3.5.3",
+    "hiredis~=2.0.0",
     "requests-oauthlib~=1.3.0",
     "requests~=2.27.1",
     "rq~=1.10.1",


### PR DESCRIPTION
`hiredis` is compiled response parser for Redis. 

https://github.com/redis/hiredis-py 

It's 10% faster for basic things like GET/SET and much much faster for other ops: https://github.com/redis/hiredis-py#benchmarks 

This has no visible change to the end user. Parsing just moves from python to C 🚀 



Note: ERPNext users have this installed indirectly from `redisearch` dependency. So in a way this is in use in production for many many users already 😄 

```
λ pipdeptree --reverse --package hiredis

hiredis==2.0.0
  - redisearch==2.1.1 [requires: hiredis>=2.0.0,<3.0.0]
    - erpnext==14.0.0.dev0 [requires: redisearch~=2.1.0]
```