### PR TITLE
perf: avoid coalescing wherever possible

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -612,6 +612,9 @@ class DatabaseQuery:
 			)
 
 		elif f.operator.lower() in ("in", "not in"):
+			# if values contain '' or falsy values then only coalesce column
+			can_be_null = not f.value or any(v is None or v == "" for v in f.value)
+
 			values = f.value or ""
 			if isinstance(values, str):
 				values = values.split(",")

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -831,6 +831,11 @@ class TestReportview(FrappeTestCase):
 
 		self.assertTrue(dashboard_settings)
 
+	def test_coalesce_with_in_ops(self):
+		self.assertNotIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", "b"])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", None])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", ""])}, run=0))
+
 
 def add_child_table_to_blog_post():
 	child_table = frappe.get_doc(


### PR DESCRIPTION

closes https://github.com/frappe/frappe/issues/17866 (well explained there, not repeating everything)

Basically, because we coalesce the column index becomes useless and queries become very slow. In `in` and `not in` operators there are two cases of encountering null:

1. Column itself contains null values
2. passed tuple contains null values. 



Both of these cases will require None/"" to be present in values, hence added condition for this. 


Use case: Imagine filtering on link fields empty link is also supposed to be filtered.