### PR TITLE
build(deps): bump redis-py to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "python-dateutil~=2.8.1",
     "pytz==2022.1",
     "rauth~=0.7.3",
-    "redis~=3.5.3",
+    "redis~=4.3.4",
     "hiredis~=2.0.0",
     "requests-oauthlib~=1.3.0",
     "requests~=2.27.1",


### PR DESCRIPTION
- Bump redis to latest version of redis-py
- Also added a basic wrapper around redisearch.

depends on https://github.com/frappe/erpnext/pull/31980


changelog: https://github.com/redis/redis-py/releases  