### PR TITLE
fix(Data Import): make warnings translatable

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -990,10 +990,11 @@ class Column:
 			not_exists = list(set(values) - set(exists))
 			if not_exists:
 				missing_values = ", ".join(not_exists)
+				message = _("The following values do not exist for {0}: {1}")
 				self.warnings.append(
 					{
 						"col": self.column_number,
-						"message": (f"The following values do not exist for {self.df.options}: {missing_values}"),
+						"message": message.format(self.df.options, missing_values),
 						"type": "warning",
 					}
 				)
@@ -1003,17 +1004,18 @@ class Column:
 			if not self.date_format:
 				if self.df.fieldtype == "Time":
 					self.date_format = "%H:%M:%S"
-					format = "HH:mm:ss"
+					date_format = "HH:mm:ss"
 				else:
 					self.date_format = "%Y-%m-%d"
-					format = "yyyy-mm-dd"
+					date_format = "yyyy-mm-dd"
 
+				message = _(
+					"{0} format could not be determined from the values in this column. Defaulting to {1}."
+				)
 				self.warnings.append(
 					{
 						"col": self.column_number,
-						"message": _(
-							"{0} format could not be determined from the values in this column. Defaulting to {1}."
-						).format(self.df.fieldtype, format),
+						"message": message.format(self.df.fieldtype, date_format),
 						"type": "info",
 					}
 				)
@@ -1025,13 +1027,11 @@ class Column:
 				if invalid:
 					valid_values = ", ".join(frappe.bold(o) for o in options)
 					invalid_values = ", ".join(frappe.bold(i) for i in invalid)
+					message = _("The following values are invalid: {0}. Values must be one of {1}")
 					self.warnings.append(
 						{
 							"col": self.column_number,
-							"message": (
-								"The following values are invalid: {}. Values must be"
-								" one of {}".format(invalid_values, valid_values)
-							),
+							"message": message.format(invalid_values, valid_values),
 						}
 					)
 


### PR DESCRIPTION
Also, rename variable from `format` to `date_format`, to avoid [shadowing the builtin](https://docs.sourcery.ai/comments/avoid-builtin-shadow/).
