### PR TITLE
fix: 'TopBarItem' object does not support item assignment

### DIFF
--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -218,7 +218,7 @@ def modify_header_footer_items(items: list):
 				continue
 
 			if not top_bar_item.get("child_items"):
-				top_bar_item["child_items"] = []
+				top_bar_item.child_items = []
 
 			top_bar_item.child_items.append(item)
 			break


### PR DESCRIPTION
TypeError: 'TopBarItem' object does not support item assignment

<img width="1317" alt="image" src="https://user-images.githubusercontent.com/9355208/186333242-1780768f-f630-4440-afbc-4b007de75e6d.png">

Introduced via #17891