### PR TITLE
ci: enable codecov annotations

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,17 +2,16 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
+  range: 60..90
   status:
     project:
-      default: false
-      server-mariadb:
+      default:
         target: auto
         threshold: 0.5%
         flags:
           - server-mariadb
     patch:
-      default: false
-      server-mariadb:
+      default:
         target: 85%
         threshold: 0%
         only_pulls: true


### PR DESCRIPTION
These comments are disabled most likely because of `default: false`

![telegram-cloud-photo-size-5-6066760323894981493-y](https://user-images.githubusercontent.com/9079960/186342644-cd3756bb-7916-49ba-8a4d-0849fd2c8ccb.jpg)
