### PR TITLE
fix(control): Properly set `this.value` & `this.last_value`

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -89,6 +89,7 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	}
 
 	set_input(value, dataurl) {
+		this.last_value = this.value;
 		this.value = value;
 		if (this.value) {
 			this.$input.toggle(false);

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -270,9 +270,6 @@ frappe.ui.form.Control = class BaseControl {
 		} else {
 			if (this.doc) {
 				this.doc[this.df.fieldname] = value;
-			} else {
-				// case where input is rendered on dialog where doc is not maintained
-				this.value = value;
 			}
 			this.set_input(value);
 			return Promise.resolve();

--- a/frappe/public/js/frappe/form/controls/check.js
+++ b/frappe/public/js/frappe/form/controls/check.js
@@ -31,11 +31,12 @@ frappe.ui.form.ControlCheck = class ControlCheck extends frappe.ui.form.ControlD
 		return cint(value);
 	}
 	set_input(value) {
+		this.last_value = this.value;
 		value = cint(value);
+		this.value = value;
 		if (this.input) {
 			this.input.checked = value ? 1 : 0;
 		}
-		this.last_value = value;
 		this.set_mandatory(value);
 		this.set_disp_area(value);
 	}


### PR DESCRIPTION
- Revert https://github.com/frappe/frappe/pull/17390 since it used to set `this.value` before triggering change events... due to this `this.last_value` & `this.value` was having same value in change events of some control (eg. link field)
- `set_input` has the responsibility to set `this.value` and `this.last_value` properly.

fixes: https://github.com/frappe/frappe/issues/17858

https://user-images.githubusercontent.com/13928957/186396329-7b620809-7a60-4151-8053-a232ddb6727a.mov


fixes: https://github.com/frappe/frappe/issues/17309