### PR TITLE
ci: misc ci things

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -9,7 +9,8 @@ bench -v init frappe-bench --skip-assets --python "$(which python)" --frappe-pat
 cd ./frappe-bench || exit
 
 bench -v setup requirements --dev
-if [ "$TYPE" == "ui" ]; then
+if [ "$TYPE" == "ui" ]
+then
   bench -v setup requirements --node;
 fi
 
@@ -18,58 +19,69 @@ echo "Setting Up Sites & Database..."
 mkdir ~/frappe-bench/sites/test_site
 cp "${GITHUB_WORKSPACE}/.github/helper/consumer_db/$DB.json" ~/frappe-bench/sites/test_site/site_config.json
 
-if [ "$TYPE" == "server" ]; then
-  mkdir ~/frappe-bench/sites/test_site_producer;
-  cp "${GITHUB_WORKSPACE}/.github/helper/producer_db/$DB.json" ~/frappe-bench/sites/test_site_producer/site_config.json;
+if [ "$TYPE" == "server" ]
+then
+  mkdir ~/frappe-bench/sites/test_site_producer
+  cp "${GITHUB_WORKSPACE}/.github/helper/producer_db/$DB.json" ~/frappe-bench/sites/test_site_producer/site_config.json
 fi
-if [ "$DB" == "mariadb" ];then
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "SET GLOBAL character_set_server = 'utf8mb4'";
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'";
 
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE DATABASE test_frappe_consumer";
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE USER 'test_frappe_consumer'@'localhost' IDENTIFIED BY 'test_frappe_consumer'";
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "GRANT ALL PRIVILEGES ON \`test_frappe_consumer\`.* TO 'test_frappe_consumer'@'localhost'";
+if [ "$DB" == "mariadb" ]
+then
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "SET GLOBAL character_set_server = 'utf8mb4'"
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE DATABASE test_frappe_producer";
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE USER 'test_frappe_producer'@'localhost' IDENTIFIED BY 'test_frappe_producer'";
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "GRANT ALL PRIVILEGES ON \`test_frappe_producer\`.* TO 'test_frappe_producer'@'localhost'";
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE DATABASE test_frappe_consumer"
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE USER 'test_frappe_consumer'@'localhost' IDENTIFIED BY 'test_frappe_consumer'"
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "GRANT ALL PRIVILEGES ON \`test_frappe_consumer\`.* TO 'test_frappe_consumer'@'localhost'"
 
-  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "FLUSH PRIVILEGES";
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE DATABASE test_frappe_producer"
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "CREATE USER 'test_frappe_producer'@'localhost' IDENTIFIED BY 'test_frappe_producer'"
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "GRANT ALL PRIVILEGES ON \`test_frappe_producer\`.* TO 'test_frappe_producer'@'localhost'"
+
+  mariadb --host 127.0.0.1 --port 3306 -u root -ptravis -e "FLUSH PRIVILEGES"
 fi
-if [ "$DB" == "postgres" ];then
-  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE DATABASE test_frappe_consumer" -U postgres;
-  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE USER test_frappe_consumer WITH PASSWORD 'test_frappe'" -U postgres;
 
-  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE DATABASE test_frappe_producer" -U postgres;
-  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE USER test_frappe_producer WITH PASSWORD 'test_frappe'" -U postgres;
+if [ "$DB" == "postgres" ]
+then
+  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE DATABASE test_frappe_consumer" -U postgres
+  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE USER test_frappe_consumer WITH PASSWORD 'test_frappe'" -U postgres
+
+  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE DATABASE test_frappe_producer" -U postgres
+  echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE USER test_frappe_producer WITH PASSWORD 'test_frappe'" -U postgres
 fi
 
 echo "Setting Up Procfile..."
 
 sed -i 's/^watch:/# watch:/g' Procfile
 sed -i 's/^schedule:/# schedule:/g' Procfile
-if [ "$TYPE" == "server" ]; then
-  sed -i 's/^socketio:/# socketio:/g' Procfile;
-  sed -i 's/^redis_socketio:/# redis_socketio:/g' Procfile;
+
+if [ "$TYPE" == "server" ]
+then
+  sed -i 's/^socketio:/# socketio:/g' Procfile
+  sed -i 's/^redis_socketio:/# redis_socketio:/g' Procfile
 fi
-if [ "$TYPE" == "ui" ]; then
-  sed -i 's/^web: bench serve/web: bench serve --with-coverage/g' Procfile;
+
+if [ "$TYPE" == "ui" ]
+then
+  sed -i 's/^web: bench serve/web: bench serve --with-coverage/g' Procfile
 fi
 
 echo "Starting Bench..."
 
 bench start &> bench_start.log &
 
-if [ "$TYPE" == "server" ]; then
-  CI=Yes bench build --app frappe &;
+if [ "$TYPE" == "server" ]
+then
+  CI=Yes bench build --app frappe &
   build_pid=$!
 fi
 
 bench --site test_site reinstall --yes
 
-if [ "$TYPE" == "server" ]; then
-  bench --site test_site_producer reinstall --yes;
+if [ "$TYPE" == "server" ]
+then
+  bench --site test_site_producer reinstall --yes
 fi
 
-# wait till all background jobs exit
+# wait till assets are built succesfully
 wait $build_pid

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -59,9 +59,17 @@ fi
 echo "Starting Bench..."
 
 bench start &> bench_start.log &
+
+if [ "$TYPE" == "server" ]; then
+  CI=Yes bench build --app frappe &;
+  build_pid=$!
+fi
+
 bench --site test_site reinstall --yes
 
 if [ "$TYPE" == "server" ]; then
   bench --site test_site_producer reinstall --yes;
-  CI=Yes bench build --app frappe;
 fi
+
+# wait till all background jobs exit
+wait $build_pid

--- a/.github/helper/install_dependencies.sh
+++ b/.github/helper/install_dependencies.sh
@@ -3,12 +3,11 @@ set -e
 
 echo "Setting Up System Dependencies..."
 
+sudo apt update
+sudo apt install libcups2-dev redis-server mariadb-client-10.3
+
 install_wkhtmltopdf() {
-  wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb
+  wget -q https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.focal_amd64.deb
   sudo apt install ./wkhtmltox_0.12.6-1.focal_amd64.deb
 }
 install_wkhtmltopdf &
-
-
-sudo apt update
-sudo apt install libcups2-dev redis-server mariadb-client-10.3

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -12,9 +12,31 @@ permissions:
   contents: read
 
 jobs:
+  checkrun:
+    name: Build Check
+    runs-on: ubuntu-latest
+
+    outputs:
+      build: ${{ steps.check-build.outputs.build }}
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Check if build should be run
+        id: check-build
+        run: |
+          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
+        env:
+          TYPE: "server"
+          PR_NUMBER: ${{ github.event.number }}
+          REPO_NAME: ${{ github.repository }}
+
   test:
     name: Patch
     runs-on: ubuntu-latest
+    needs: checkrun
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
     timeout-minutes: 60
 
     services:
@@ -37,34 +59,21 @@ jobs:
               exit 1
           fi
 
-      - name: Check if build should be run
-        id: check-build
-        run: |
-          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
-        env:
-          TYPE: "server"
-          PR_NUMBER: ${{ github.event.number }}
-          REPO_NAME: ${{ github.repository }}
-
       - name: Setup Python
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: "gabrielfalcao/pyenv-action@v10"
         with:
           versions: 3.10:latest, 3.7:latest
 
       - name: Setup Node
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/setup-node@v3
         with:
           node-version: 16
           check-latest: true
 
       - name: Add to Hosts
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
       - name: Cache pip
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -74,7 +83,6 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache node modules
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
@@ -87,12 +95,10 @@ jobs:
             ${{ runner.os }}-
 
       - name: Get yarn cache directory path
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v3
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -101,7 +107,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
           pip install frappe-bench
@@ -114,7 +119,6 @@ jobs:
           DB: mariadb
 
       - name: Run Patch Tests
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           cd ~/frappe-bench/
           wget https://frappeframework.com/files/v10-frappe.sql.gz

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -1,4 +1,4 @@
-name: Server (MariaDB)
+name: Patch (MariaDB)
 
 on:
   pull_request:

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -82,18 +82,6 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
 
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -93,18 +93,6 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
 
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -15,13 +15,32 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Unit Tests
+  checkrun:
+    name: Build Check
     runs-on: ubuntu-latest
-    timeout-minutes: 60
 
     outputs:
       build: ${{ steps.check-build.outputs.build }}
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Check if build should be run
+        id: check-build
+        run: |
+          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
+        env:
+          TYPE: "server"
+          PR_NUMBER: ${{ github.event.number }}
+          REPO_NAME: ${{ github.repository }}
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: checkrun
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -54,15 +73,6 @@ jobs:
               exit 1
           fi
 
-      - name: Check if build should be run
-        id: check-build
-        run: |
-          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
-        env:
-          TYPE: "server"
-          PR_NUMBER: ${{ github.event.number }}
-          REPO_NAME: ${{ github.repository }}
-
       - uses: actions/setup-node@v3
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         with:
@@ -70,13 +80,11 @@ jobs:
           check-latest: true
 
       - name: Add to Hosts
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
           echo "127.0.0.1 test_site_producer" | sudo tee -a /etc/hosts
 
       - name: Cache pip
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -86,7 +94,6 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache node modules
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
@@ -99,12 +106,10 @@ jobs:
             ${{ runner.os }}-
 
       - name: Get yarn cache directory path
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v3
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -113,7 +118,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
@@ -124,7 +128,6 @@ jobs:
           DB: mariadb
 
       - name: Run Tests
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: cd ~/frappe-bench/sites && ../env/bin/python3 ../apps/frappe/.github/helper/ci.py
         env:
           SITE: test_site
@@ -132,7 +135,6 @@ jobs:
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
 
       - name: Upload coverage data
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage-${{ matrix.container }}
@@ -140,18 +142,17 @@ jobs:
 
   coverage:
     name: Coverage Wrap Up
-    needs: test
+    needs: [test, checkrun]
     runs-on: ubuntu-latest
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
     steps:
       - name: Clone
         uses: actions/checkout@v3
 
       - name: Download artifacts
-        if: ${{ needs.test.outputs.build == 'strawberry' }}
         uses: actions/download-artifact@v3
 
       - name: Upload coverage data
-        if: ${{ needs.test.outputs.build == 'strawberry' }}
         uses: codecov/codecov-action@v3
         with:
           name: MariaDB

--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Check for valid Python & Merge Conflicts
         run: |
-          python -m compileall -f "${GITHUB_WORKSPACE}"
+          python -m compileall -q -f "${GITHUB_WORKSPACE}"
           if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
               then echo "Found merge conflicts"
               exit 1

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -14,13 +14,32 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Unit Tests
+  checkrun:
+    name: Build Check
     runs-on: ubuntu-latest
-    timeout-minutes: 60
 
     outputs:
       build: ${{ steps.check-build.outputs.build }}
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Check if build should be run
+        id: check-build
+        run: |
+          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
+        env:
+          TYPE: "server"
+          PR_NUMBER: ${{ github.event.number }}
+          REPO_NAME: ${{ github.repository }}
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: checkrun
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -57,29 +76,17 @@ jobs:
               exit 1
           fi
 
-      - name: Check if build should be run
-        id: check-build
-        run: |
-          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
-        env:
-          TYPE: "server"
-          PR_NUMBER: ${{ github.event.number }}
-          REPO_NAME: ${{ github.repository }}
-
       - uses: actions/setup-node@v3
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         with:
           node-version: '16'
           check-latest: true
 
       - name: Add to Hosts
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
           echo "127.0.0.1 test_site_producer" | sudo tee -a /etc/hosts
 
       - name: Cache pip
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -89,7 +96,6 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache node modules
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
@@ -102,12 +108,10 @@ jobs:
             ${{ runner.os }}-
 
       - name: Get yarn cache directory path
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v3
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -116,7 +120,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Dependencies
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
@@ -127,7 +130,6 @@ jobs:
           DB: postgres
 
       - name: Run Tests
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: cd ~/frappe-bench/sites && ../env/bin/python3 ../apps/frappe/.github/helper/ci.py
         env:
           SITE: test_site
@@ -135,7 +137,6 @@ jobs:
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
 
       - name: Upload coverage data
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage-${{ matrix.container }}
@@ -143,18 +144,17 @@ jobs:
 
   coverage:
     name: Coverage Wrap Up
-    needs: test
+    needs: [test, checkrun]
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
     runs-on: ubuntu-latest
     steps:
       - name: Clone
         uses: actions/checkout@v3
 
       - name: Download artifacts
-        if: ${{ needs.test.outputs.build == 'strawberry' }}
         uses: actions/download-artifact@v3
 
       - name: Upload coverage data
-        if: ${{ needs.test.outputs.build == 'strawberry' }}
         uses: codecov/codecov-action@v3
         with:
           name: Postgres

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -95,18 +95,6 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
 
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check for valid Python & Merge Conflicts
         run: |
-          python -m compileall -f "${GITHUB_WORKSPACE}"
+          python -m compileall -q -f "${GITHUB_WORKSPACE}"
           if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
               then echo "Found merge conflicts"
               exit 1

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -14,11 +14,31 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  checkrun:
+    name: Build Check
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+
     outputs:
       build: ${{ steps.check-build.outputs.build }}
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+
+      - name: Check if build should be run
+        id: check-build
+        run: |
+          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
+        env:
+          TYPE: "server"
+          PR_NUMBER: ${{ github.event.number }}
+          REPO_NAME: ${{ github.repository }}
+
+  test:
+    runs-on: ubuntu-latest
+    needs: checkrun
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -54,29 +74,17 @@ jobs:
               exit 1
           fi
 
-      - name: Check if build should be run
-        id: check-build
-        run: |
-          python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
-        env:
-          TYPE: "ui"
-          PR_NUMBER: ${{ github.event.number }}
-          REPO_NAME: ${{ github.repository }}
-
       - uses: actions/setup-node@v3
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         with:
           node-version: 16
           check-latest: true
 
       - name: Add to Hosts
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
           echo "127.0.0.1 test_site_producer" | sudo tee -a /etc/hosts
 
       - name: Cache pip
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
@@ -86,7 +94,6 @@ jobs:
             ${{ runner.os }}-
 
       - name: Cache node modules
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
@@ -99,12 +106,10 @@ jobs:
             ${{ runner.os }}-
 
       - name: Get yarn cache directory path
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v3
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -113,7 +118,6 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Cache cypress binary
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/cache@v3
         with:
           path: ~/.cache
@@ -123,7 +127,6 @@ jobs:
             ${{ runner.os }}-
 
       - name: Install Dependencies
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
@@ -134,39 +137,32 @@ jobs:
           DB: mariadb
 
       - name: Instrument Source Code
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: cd ~/frappe-bench/apps/frappe/ && npx nyc instrument -x 'frappe/public/dist/**' -x 'frappe/public/js/lib/**' -x '**/*.bundle.js' --compact=false --in-place frappe
 
       - name: Build
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: cd ~/frappe-bench/ && bench build --apps frappe
 
       - name: Site Setup
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: cd ~/frappe-bench/ && bench --site test_site execute frappe.utils.install.complete_setup_wizard
 
       - name: UI Tests
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: cd ~/frappe-bench/ && bench --site test_site run-ui-tests frappe --with-coverage --headless --parallel --ci-build-id $GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT
         env:
           CYPRESS_RECORD_KEY: 4a48f41c-11b3-425b-aa88-c58048fa69eb
 
       - name: Stop server and wait for coverage file
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         run: |
           ps -ef | grep "[f]rappe serve" | awk '{print $2}' | xargs kill -s SIGINT
           sleep 5
           ( tail -f /home/runner/frappe-bench/sites/coverage.xml & ) | grep -q "\/coverage"
 
       - name: Upload JS coverage data
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage-js-${{ matrix.container }}
           path: /home/runner/frappe-bench/apps/frappe/.cypress-coverage/clover.xml
 
       - name: Upload python coverage data
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         uses: actions/upload-artifact@v3
         with:
           name: coverage-py-${{ matrix.container }}
@@ -179,18 +175,17 @@ jobs:
 
   coverage:
     name: Coverage Wrap Up
-    needs: test
+    needs: [test, checkrun]
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
     runs-on: ubuntu-latest
     steps:
       - name: Clone
         uses: actions/checkout@v2
 
       - name: Download artifacts
-        if: ${{ needs.test.outputs.build == 'strawberry' }}
         uses: actions/download-artifact@v3
 
       - name: Upload python coverage data
-        if: ${{ needs.test.outputs.build == 'strawberry' }}
         uses: codecov/codecov-action@v3
         with:
           name: UIBackend
@@ -200,7 +195,6 @@ jobs:
           flags: server-ui
 
       - name: Upload JS coverage data
-        if: ${{ needs.test.outputs.build == 'strawberry' }}
         uses: codecov/codecov-action@v3
         with:
           name: Cypress

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Check for valid Python & Merge Conflicts
         run: |
-          python -m compileall -f "${GITHUB_WORKSPACE}"
+          python -m compileall -q -f "${GITHUB_WORKSPACE}"
           if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
               then echo "Found merge conflicts"
               exit 1

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -93,18 +93,6 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
 
-      - name: Cache node modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
Disable "passing" checks when they are skipped, Multiple reasons for doing this:
1. Green check is fake, tests don't actually run in all the cases. 
2. All the containers spin up and set things up - waste of resources. 

---

- don't cache npm, we don't use it, why is it cached 🥴 
- suppress success messages in compileall
- install wkhtml after other apt things finish... so apt processes don't wait for lock
- build js assets concurrntly. 