### PR TITLE
build!: dependency cleanup (round 2)

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -72,7 +72,6 @@ frappe.patches.v11_0.rename_email_alert_to_notification #13-06-2018
 frappe.patches.v11_0.delete_duplicate_user_permissions
 frappe.patches.v11_0.set_dropbox_file_backup
 frappe.patches.v10_0.set_default_locking_time
-frappe.patches.v11_0.rename_google_maps_doctype
 frappe.patches.v10_0.modify_smallest_currency_fraction
 frappe.patches.v10_0.modify_naming_series_table
 frappe.patches.v10_0.enhance_security

--- a/frappe/patches/v11_0/rename_google_maps_doctype.py
+++ b/frappe/patches/v11_0/rename_google_maps_doctype.py
@@ -1,9 +1,0 @@
-import frappe
-from frappe.model.rename_doc import rename_doc
-
-
-def execute():
-	if frappe.db.exists("DocType", "Google Maps") and not frappe.db.exists(
-		"DocType", "Google Maps Settings"
-	):
-		rename_doc("DocType", "Google Maps", "Google Maps Settings")

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -631,12 +631,10 @@ def get_sites(sites_path=None):
 
 def get_request_session(max_retries=5):
 	import requests
-	from urllib3.util import Retry
+	from requests.adapters import HTTPAdapter, Retry
 
 	session = requests.Session()
-	http_adapter = requests.adapters.HTTPAdapter(
-		max_retries=Retry(total=max_retries, status_forcelist=[500])
-	)
+	http_adapter = HTTPAdapter(max_retries=Retry(total=max_retries, status_forcelist=[500]))
 
 	session.mount("http://", http_adapter)
 	session.mount("https://", http_adapter)

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -5,7 +5,8 @@ import io
 import os
 import re
 
-from werkzeug.routing import Map, NotFound, Rule
+from werkzeug.exceptions import NotFound
+from werkzeug.routing import Map, Rule
 
 import frappe
 from frappe.website.utils import extract_title, get_frontmatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "PyYAML~=5.4.1",
     "RestrictedPython~=5.1",
     "WeasyPrint==52.5",
-    "Werkzeug~=2.1.2",
+    "Werkzeug~=2.2.2",
     "Whoosh~=2.7.4",
     "beautifulsoup4~=4.9.3",
     "bleach-allowlist~=1.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
     "cryptography~=37.0.2",
     "email-reply-parser~=0.5.12",
     "git-url-parse~=1.2.2",
-    "gitdb~=4.0.7",
     "gunicorn~=20.1.0",
     "html5lib~=1.1",
     "ipython~=8.4.0",
@@ -50,10 +49,8 @@ dependencies = [
     "psutil~=5.9.1",
     "psycopg2-binary~=2.9.1",
     "pyOpenSSL~=20.0.1",
-    "pyasn1~=0.4.8",
     "pycryptodome~=3.10.1",
     "pyotp~=2.6.0",
-    "pypng~=0.0.20",
     "python-dateutil~=2.8.1",
     "pytz==2022.1",
     "rauth~=0.7.3",
@@ -69,7 +66,6 @@ dependencies = [
     "tenacity~=8.0.1",
     "terminaltables~=3.1.0",
     "traceback-with-variables~=2.0.4",
-    "urllib3~=1.26.4",
     "xlrd~=2.0.1",
     "zxcvbn-python~=4.4.24",
     "markdownify~=0.11.2",
@@ -78,10 +74,8 @@ dependencies = [
     "boto3~=1.18.49",
     "dropbox~=11.7.0",
     "google-api-python-client~=2.2.0",
-    "google-auth-httplib2~=0.1.0",
     "google-auth-oauthlib~=0.4.4",
     "google-auth~=1.29.0",
-    "googlemaps~=4.4.5",
 ]
 
 [build-system]


### PR DESCRIPTION
Continuation of https://github.com/frappe/frappe/pull/17127 

Updated depdendency:
- `werkzeug` - has a faster router now! (which is one of the overheads for us) - https://github.com/pallets/werkzeug/pull/2433

Dropped dependencies:
- `googlemaps` - unused
- `urllib3` - replaceable with `requests` easily
- `gitdb` - unused, pinned during py2 era
- `pyasn1` - unused, pinned during py2 era
- `pypng` - unused
- `google-auth-httplib2` - unused, deprecated

ERPNext CI run: https://github.com/frappe/erpnext/actions/runs/2927302931 ✅ 