### PR TITLE
fix(Web Form): Translate success message

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -398,7 +398,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 		success_dialog.show();
 		const success_message =
-			this.success_message || __("Your information has been submitted");
+			__(this.success_message) || __("Your information has been submitted");
 		success_dialog.set_message(success_message);
 	}
 }


### PR DESCRIPTION
Version 14 handles this differently, therefore this PR is only for v13.