### PR TITLE
fix: ERPNext migration to version-14 Healcare Module Not Found

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -42,7 +42,7 @@ class Workspace(Document):
 			self.name = doc.name = doc.label = doc.title
 
 	def after_delete(self):
-		if self.module:
+		if self.module and frappe.local.module_app.get(frappe.scrub(self.module)):
 			delete_folder(self.module, "Workspace", self.title)
 
 	@staticmethod


### PR DESCRIPTION
On ERPNext Migration there is a problem with Healthcare module

`  File "/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/site.py", line 549, in migrate
    SiteMigration(
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 172, in run
    self.run_schema_updates()
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 40, in wrapper
    ret = method(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 113, in run_schema_updates
    frappe.modules.patch_handler.run_all(
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 75, in run_all
    run_patch(patch)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 150, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 185, in execute_patch
    _patch()
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/patches/v14_0/delete_healthcare_doctypes.py", line 8, in execute
    frappe.delete_doc("Workspace", "Healthcare", ignore_missing=True, force=True)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 1252, in delete_doc
    return frappe.model.delete_doc.delete_doc(
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/delete_doc.py", line 134, in delete_doc
    doc.run_method("after_delete")
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 928, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1272, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1254, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 925, in fn
    return method_object(*args, **kwargs)
  File "/home/runner/frappe-bench/apps/frappe/frappe/desk/doctype/workspace/workspace.py", line 46, in after_delete
    delete_folder(self.module, "Workspace", self.title)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/export_file.py", line 100, in delete_folder
    module_path = get_module_path(module)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 1356, in get_module_path
    app = get_module_app(module)
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/utils.py", line 257, in get_module_app
    frappe.throw(_("Module {} not found").format(module), exc=frappe.DoesNotExistError)
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 523, in throw
    msgprint(
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 491, in msgprint
    _raise_exception()
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 443, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: Module Healthcare not found`

https://github.com/frappe/erpnext/runs/8023126660?check_suite_focus=true

This is a way to fix it, but it's in frappe, I would prefer a fix in erpnext/patches/v14_0/delete_healthcare_doctypes.py but create a  module as we want to delete it seems counter intuitive.

This fix seems hurt less as we should not be in this case. 

I'm open to any better suggestion