### PR TITLE
perf: rebuild website search index in background

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python "${GITHUB_WORKSPACE}/.github/helper/roulette.py"
         env:
-          TYPE: "server"
+          TYPE: "ui"
           PR_NUMBER: ${{ github.event.number }}
           REPO_NAME: ${{ github.repository }}
 

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -89,8 +89,8 @@ class SiteMigration:
 			json.dump(list(frappe.flags.touched_tables), f, sort_keys=True, indent=4)
 
 		if not self.skip_search_index:
-			print(f"Building search index for {frappe.local.site}")
-			build_index_for_all_routes()
+			print(f"Queued rebuilding of search index for {frappe.local.site}")
+			frappe.enqueue(build_index_for_all_routes, queue="long")
 
 		frappe.publish_realtime("version-update")
 		frappe.flags.touched_tables.clear()

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -86,6 +86,7 @@ def enqueue(
 		q = get_queue(queue, is_async=is_async)
 	except ConnectionError:
 		# If redis is not available for queueing execute the job directly
+		print(f"Redis queue is unreachable: Executing {method} synchronously")
 		return frappe.call(method, **kwargs)
 
 	if not timeout:

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -3,7 +3,7 @@ import socket
 import time
 from collections import defaultdict
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 import redis
@@ -55,7 +55,7 @@ def enqueue(
 	*,
 	at_front=False,
 	**kwargs,
-) -> "Job":
+) -> "Job" | Any:
 	"""
 	Enqueue method to be executed using a background worker
 
@@ -78,11 +78,16 @@ def enqueue(
 			)
 		)
 
-	call_directly = now or frappe.flags.in_migrate or (not is_async and not frappe.flags.in_test)
+	call_directly = now or (not is_async and not frappe.flags.in_test)
 	if call_directly:
 		return frappe.call(method, **kwargs)
 
-	q = get_queue(queue, is_async=is_async)
+	try:
+		q = get_queue(queue, is_async=is_async)
+	except ConnectionError:
+		# If redis is not available for queueing execute the job directly
+		return frappe.call(method, **kwargs)
+
 	if not timeout:
 		timeout = get_queues_timeout().get(queue) or 300
 	queue_args = {


### PR DESCRIPTION
Changes:

1. Move website search index rebuilding to background
2. Don't execute all enqueued jobs synchronously during migration. This was added to accommodate the lack of Redis queue availability during the update... but that's not the case now. https://github.com/frappe/frappe/pull/2988

refer https://github.com/frappe/frappe/issues/17949