### PR TITLE
chore: add depreciation warning for event streaming

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -196,6 +196,7 @@ frappe.patches.v14_0.log_settings_migration
 frappe.patches.v14_0.setup_likes_from_feedback
 frappe.patches.v14_0.update_webforms
 frappe.patches.v14_0.delete_payment_gateways
+frappe.patches.v14_0.event_streaming_deprecation_warning
 
 [post_model_sync]
 frappe.patches.v14_0.drop_data_import_legacy

--- a/frappe/patches/v14_0/event_streaming_deprecation_warning.py
+++ b/frappe/patches/v14_0/event_streaming_deprecation_warning.py
@@ -1,0 +1,9 @@
+import click
+
+
+def execute():
+	click.secho(
+		"Event Streaming is moved to a separate app in version 15.\n"
+		"When upgrading to Frappe version-15, Please install the 'Event Streaming' app to continue using them: https://github.com/frappe/event_streaming",
+		fg="yellow",
+	)


### PR DESCRIPTION
This pr adds deprecation warning for event_streaming.