### PR TITLE
fix(patch): only run patch if webform has is_multi_step_form field

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -209,4 +209,4 @@ frappe.patches.v14_0.set_document_expiry_default
 frappe.patches.v14_0.delete_data_migration_tool
 frappe.patches.v14_0.set_suspend_email_queue_default
 frappe.patches.v14_0.different_encryption_key
-frappe.patches.v14_0.update_multistep_webforms
+frappe.patches.v14_0.update_multistep_webforms #30-08-2022

--- a/frappe/patches/v14_0/update_multistep_webforms.py
+++ b/frappe/patches/v14_0/update_multistep_webforms.py
@@ -4,6 +4,9 @@ import frappe
 def execute():
 	frappe.reload_doctype("Web Form")
 
+	if not frappe.db.has_column("Web Form", "is_multi_step_form"):
+		return
+
 	for web_form in frappe.get_all("Web Form", filters={"is_multi_step_form": 1}):
 		web_form_fields = frappe.get_doc("Web Form", web_form.name).web_form_fields
 		for web_form_field in web_form_fields:


### PR DESCRIPTION
**Issue:**
Patch failing if migrating from version when the multistep feature was not introduced (is_multi_step_form field doesn't exist).