### PR TITLE
ci: disable parallel tests

### DIFF
--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -22,8 +22,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-       container: [1, 2]
 
     services:
       mariadb:
@@ -122,7 +120,4 @@ jobs:
 
       - name: Run Tests
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --use-orchestrator
-        env:
-          CI_BUILD_ID: ${{ github.run_id }}
-          ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
+        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests

--- a/.github/workflows/server-postgres-tests.yml
+++ b/.github/workflows/server-postgres-tests.yml
@@ -21,8 +21,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-       container: [1, 2]
 
     services:
       postgres:
@@ -125,7 +123,4 @@ jobs:
 
       - name: Run Tests
         if: ${{ steps.check-build.outputs.build == 'strawberry' }}
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --use-orchestrator
-        env:
-          CI_BUILD_ID: ${{ github.run_id }}
-          ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
+        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       containers: [1, 2, 3]
+       containers: [1, 2]
 
     name: UI Tests (Cypress)
 


### PR DESCRIPTION
Not required on stable branches.

Also setup time ~= test time, so it's waste of resources. 


https://en.wikipedia.org/wiki/Amdahl%27s_law 