### PR TITLE
feat: add lang to safe globals

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -167,6 +167,7 @@ def get_safe_globals():
 				rollback=frappe.db.rollback,
 				add_index=frappe.db.add_index,
 			),
+			lang=getattr(frappe.local, "lang", "en"),
 		),
 		FrappeClient=FrappeClient,
 		style=frappe._dict(border_color="#d1d8dd"),
@@ -181,7 +182,6 @@ def get_safe_globals():
 		run_script=run_script,
 		is_job_queued=is_job_queued,
 		get_visible_columns=get_visible_columns,
-		lang=getattr(frappe.local, "lang", "en"),
 	)
 
 	add_module_properties(

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -181,6 +181,7 @@ def get_safe_globals():
 		run_script=run_script,
 		is_job_queued=is_job_queued,
 		get_visible_columns=get_visible_columns,
+		lang=getattr(frappe.local, "lang", "en"),
 	)
 
 	add_module_properties(


### PR DESCRIPTION
This way we can do more in print formats, like:

```
{% if frappe.lang == "de" %}
    <p>Hallo 🇩🇪</p>
    <p>langer text hier</p>
{% else %}
    <p>Hi 🇬🇧</p>
    <p>long text here</p>
{% endif %}
```

Docs: https://frappeframework.com/docs/v14/user/en/api/jinja/edit-wiki?wiki_page_patch=3e4e62eac9
https://frappeframework.com/docs/v13/user/en/api/jinja/edit-wiki?wiki_page_patch=25342c1b05