### PR TITLE
fix: comma looks like a decimal in report summary widget

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -196,8 +196,8 @@
 		&.blue { color: var(--blue-500); }
 
 		// SIZE & SPACING
-		margin-top: 12px;
-		margin-bottom: 5px;
+		padding-top: 12px;
+		padding-bottom: 5px;
 
 		// LAYOUT
 		text-align: center;


### PR DESCRIPTION
Before:
<img width="1303" alt="Screenshot 2022-09-02 at 10 56 20 AM" src="https://user-images.githubusercontent.com/30859809/188065261-48ba5920-40a6-4f4e-b4d9-f09cf580af14.png">

After:
<img width="1303" alt="Screenshot 2022-09-02 at 10 55 19 AM" src="https://user-images.githubusercontent.com/30859809/188065245-64749c8b-51a7-41f1-972b-58076d9e34e3.png">
