### PR TITLE
chore: remove unused function `qrcode_as_png`

### DIFF
--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -399,30 +399,6 @@ def get_qr_svg_code(totp_uri):
 	return svg
 
 
-def qrcode_as_png(user, totp_uri):
-	"""Save temporary Qrcode to server."""
-	folder = create_barcode_folder()
-	png_file_name = f"{frappe.generate_hash(length=20)}.png"
-	_file = frappe.get_doc(
-		{
-			"doctype": "File",
-			"file_name": png_file_name,
-			"attached_to_doctype": "User",
-			"attached_to_name": user,
-			"folder": folder,
-			"content": png_file_name,
-		}
-	)
-	_file.save()
-	frappe.db.commit()
-	file_url = get_url(_file.file_url)
-	file_path = os.path.join(frappe.get_site_path("public", "files"), _file.file_name)
-	url = qrcreate(totp_uri)
-	with open(file_path, "w") as png_file:
-		url.png(png_file, scale=8, module_color=[0, 0, 0, 180], background=[0xFF, 0xFF, 0xCC])
-	return file_url
-
-
 def create_barcode_folder():
 	"""Get Barcodes folder."""
 	folder_name = "Barcodes"


### PR DESCRIPTION
not used anywhere:
https://sourcegraph.com/search?q=context:global+qrcode_as_png&patternType=standard

won't work after removal of `pypng` anyway 🤷🏼 