### PR TITLE
refactor: improved CORS support and caching

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -186,12 +186,12 @@ def set_cors_headers(response):
 
 	# only required for preflight requests
 	if request.method == "OPTIONS":
-		cors_headers.update(
-			{
-				"Access-Control-Allow-Methods": request.headers.get("Access-Control-Request-Method"),
-				"Access-Control-Allow-Headers": request.headers.get("Access-Control-Request-Headers"),
-			}
+		cors_headers["Access-Control-Allow-Methods"] = request.headers.get(
+			"Access-Control-Request-Method"
 		)
+
+		if allowed_headers := request.headers.get("Access-Control-Request-Headers"):
+			cors_headers["Access-Control-Allow-Headers"] = allowed_headers
 
 		# allow browsers to cache preflight requests for upto a day
 		if not frappe.conf.developer_mode:

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -180,8 +180,9 @@ def set_cors_headers(response):
 			return
 
 	cors_headers = {
-		"Access-Control-Allow-Origin": origin,
 		"Access-Control-Allow-Credentials": "true",
+		"Access-Control-Allow-Origin": origin,
+		"Vary": "Origin",
 	}
 
 	# only required for preflight requests

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -160,35 +160,44 @@ def process_response(response):
 		response.headers.extend(frappe.local.rate_limiter.headers())
 
 	# CORS headers
-	if hasattr(frappe.local, "conf") and frappe.conf.allow_cors:
+	if hasattr(frappe.local, "conf"):
 		set_cors_headers(response)
 
 
 def set_cors_headers(response):
-	origin = frappe.request.headers.get("Origin")
-	allow_cors = frappe.conf.allow_cors
-	if not (origin and allow_cors):
+	if not (
+		(allowed_origins := frappe.conf.allow_cors)
+		and (request := frappe.local.request)
+		and (origin := request.headers.get("Origin"))
+	):
 		return
 
-	if allow_cors != "*":
-		if not isinstance(allow_cors, list):
-			allow_cors = [allow_cors]
+	if allowed_origins != "*":
+		if not isinstance(allowed_origins, list):
+			allowed_origins = [allowed_origins]
 
-		if origin not in allow_cors:
+		if origin not in allowed_origins:
 			return
 
-	response.headers.extend(
-		{
-			"Access-Control-Allow-Origin": origin,
-			"Access-Control-Allow-Credentials": "true",
-			"Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-			"Access-Control-Allow-Headers": (
-				"Authorization,DNT,X-Mx-ReqToken,"
-				"Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,"
-				"Cache-Control,Content-Type"
-			),
-		}
-	)
+	cors_headers = {
+		"Access-Control-Allow-Origin": origin,
+		"Access-Control-Allow-Credentials": "true",
+	}
+
+	# only required for preflight requests
+	if request.method == "OPTIONS":
+		cors_headers.update(
+			{
+				"Access-Control-Allow-Methods": request.headers.get("Access-Control-Request-Method"),
+				"Access-Control-Allow-Headers": request.headers.get("Access-Control-Request-Headers"),
+			}
+		)
+
+		# allow browsers to cache preflight requests for upto a day
+		if not frappe.conf.developer_mode:
+			cors_headers["Access-Control-Max-Age"] = "86400"
+
+	response.headers.extend(cors_headers)
 
 
 def make_form_dict(request):

--- a/frappe/tests/test_cors.py
+++ b/frappe/tests/test_cors.py
@@ -20,9 +20,13 @@ class TestCORS(FrappeTestCase):
 
 		headers = {}
 		if origin:
-			headers = {"Origin": origin}
+			headers = {
+				"Origin": origin,
+				"Access-Control-Request-Method": "POST",
+				"Access-Control-Request-Headers": "X-Test-Header",
+			}
 
-		frappe.utils.set_request(headers=headers)
+		frappe.utils.set_request(method="OPTIONS", headers=headers)
 
 		self.response = Response()
 		process_response(self.response)

--- a/frappe/tests/test_cors.py
+++ b/frappe/tests/test_cors.py
@@ -11,6 +11,7 @@ HEADERS = (
 	"Access-Control-Allow-Credentials",
 	"Access-Control-Allow-Methods",
 	"Access-Control-Allow-Headers",
+	"Vary",
 )
 
 


### PR DESCRIPTION
## Changes made
- Dynamically set [`Access-Control-Allow-Methods`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods) and [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) to allow all values in request. This allows use of methods and headers not currently hardcoded.

  Also note that these headers are now only set for preflight requests - which is enough.
- **Perf:** Allow browsers to cache preflight responses from instances with Developer Mode disabled for upto one day ([this is the maximum value permitted by major browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age#directives)). This should be okay, since the `allow_cors` config is not changed very frequently.

  Other implementation options:
    - Always set this header unless a `disable_cors_cache` config is set.
    - Allow setting this using a `cors_max_age` site config.
    - Allow setting this and other custom headers using a new `custom_response_headers` site config.

- A new `Vary` header has been set to [indicate to browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#cors_and_caching) that the response differs based on the `Origin` header.
- Remove duplicate check for `allow_cors` conf.
- Improve variable naming: `allow_cors` => `allowed_origins` (config name unchanged)