### PR TITLE
fix: dont init table if value is of type `str`

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -152,8 +152,9 @@ class BaseDocument:
 		if "name" in d:
 			self.name = d["name"]
 
+		ignore_children = hasattr(self, "flags") and self.flags.ignore_children
 		for key, value in d.items():
-			self.set(key, value)
+			self.set(key, value, as_value=ignore_children)
 
 		return self
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -129,6 +129,7 @@ class Document(BaseDocument):
 	def load_from_db(self):
 		"""Load document and children from database and create properties
 		from fields"""
+		self.flags.ignore_children = True
 		if not getattr(self, "_metaclass", False) and self.meta.issingle:
 			single_doc = frappe.db.get_singles_dict(self.doctype, for_update=self.flags.for_update)
 			if not single_doc:
@@ -150,6 +151,7 @@ class Document(BaseDocument):
 				)
 
 			super().__init__(d)
+		self.flags.pop("ignore_children", None)
 
 		for df in self._get_table_fields():
 			# Make sure not to query the DB for a child table, if it is a virtual one.

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -375,6 +375,12 @@ class TestDocument(FrappeTestCase):
 		doc.set("user_emails", None)
 		self.assertEqual(doc.user_emails, [])
 
+		# setting a string value should fail
+		self.assertRaises(TypeError, doc.set, "user_emails", "fail")
+		# but not when loading from db
+		doc.flags.ignore_children = True
+		doc.update({"user_emails": "ok"})
+
 	def test_doc_events(self):
 		"""validate that all present doc events are correct methods"""
 


### PR DESCRIPTION
Fixes one of the issues mentioned in https://github.com/frappe/frappe/issues/18022 OR https://github.com/frappe/erpnext/issues/31800