### PR TITLE
fix: #17982 Duplicate Link Fields filled

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1854,7 +1854,6 @@ frappe.ui.form.Form = class FrappeForm {
 		} else {
 			frappe.model.with_doctype(doctype, function () {
 				let new_doc = frappe.model.get_new_doc(doctype, null, null, true);
-
 				// set link fields (if found)
 				me.set_link_field(doctype, new_doc);
 
@@ -1866,8 +1865,11 @@ frappe.ui.form.Form = class FrappeForm {
 
 	set_link_field(doctype, new_doc) {
 		let me = this;
+		let links = frappe.get_meta(me.doctype).links
+					.filter(link => link.link_doctype == new_doc.doctype)
+					.map(link => link.link_fieldname)
 		frappe.get_meta(doctype).fields.forEach(function (df) {
-			if (df.fieldtype === "Link" && df.options === me.doctype) {
+			if (links.includes(df.fieldname) && df.fieldtype === "Link" && df.options === me.doctype) {
 				new_doc[df.fieldname] = me.doc.name;
 			} else if (["Link", "Dynamic Link"].includes(df.fieldtype) && me.doc[df.fieldname]) {
 				new_doc[df.fieldname] = me.doc[df.fieldname];


### PR DESCRIPTION
Closes #17982

This is not perfect, because it does not use the information of which connection button was clicked to create the new doc. That means, if the origin DocType has multiple connections to the same Target DocType but from different fields, all those fields will be filled with the Origin DocType Name.

But as far as I can see, this information is already lost when rendering the page, since the buttons for creating a new doc for a connection only hold the info of what DocType the created Document should be, not for which link field the connection is actually there for. See https://github.com/frappe/frappe/blob/fbee80f7342ae6345010426be3ea1458dbfc900b/frappe/public/js/frappe/form/templates/form_links.html#L10-L27

The Template is rendered at https://github.com/frappe/frappe/blob/fbee80f7342ae6345010426be3ea1458dbfc900b/frappe/public/js/frappe/form/dashboard.js#L300
At this point, the this.data.transactions variable would already have to include the information for which link the connection is for.  


Also, I didn't touch the Dynamic Link and Table Logic.