### PR TITLE
fix: show user/pass fields when LDAP is active

### DIFF
--- a/frappe/www/login.html
+++ b/frappe/www/login.html
@@ -1,7 +1,7 @@
 {% extends "templates/web.html" %}
 
 {% macro email_login_body() -%}
-{% if not disable_user_pass_login %}
+{% if not disable_user_pass_login or (ldap_settings and ldap_settings.enabled) %}
 <div class="page-card-body">
 	<div class="form-group">
 		<label class="form-label sr-only" for="login_email">{{ login_label or _("Email")}}</label>


### PR DESCRIPTION
missed out in https://github.com/frappe/frappe/pull/18000

LDAP login uses same fields, so they should be shown even if username/pass based login is disabled. 

before
<img width="462" alt="Screenshot 2022-09-06 at 2 00 15 PM" src="https://user-images.githubusercontent.com/9079960/188587094-a28d3a41-088f-4c80-9e2a-99673f9dff79.png">


after

<img width="463" alt="Screenshot 2022-09-06 at 2 00 00 PM" src="https://user-images.githubusercontent.com/9079960/188587017-d67d085a-4a2d-44e2-902c-dca211b6f2cb.png">
