### PR TITLE
refactor(minor): get_success_recipients -> get_queued_recipients 

### DIFF
--- a/frappe/email/doctype/email_queue_recipient/email_queue_recipient.json
+++ b/frappe/email/doctype/email_queue_recipient/email_queue_recipient.json
@@ -22,7 +22,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "\nNot Sent\nSending\nSent\nError\nExpired",
+   "options": "\nNot Sent\nSent",
    "search_index": 1
   },
   {
@@ -33,7 +33,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-07-11 16:38:10.644417",
+ "modified": "2022-09-06 13:38:10.644417",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue Recipient",

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -128,15 +128,11 @@ class Newsletter(WebsiteGenerator):
 			pluck="name",
 		)
 
-	def get_success_recipients(self) -> list[str]:
-		"""Recipients who have already received the newsletter.
-
-		Couldn't think of a better name ;)
-		"""
+	def get_queued_recipients(self) -> list[str]:
+		"""Recipients who have already been queued for receiving the newsletter."""
 		return frappe.get_all(
 			"Email Queue Recipient",
 			filters={
-				"status": ("in", ["Not Sent", "Sending", "Sent"]),
 				"parent": ("in", self.get_linked_email_queue()),
 			},
 			pluck="recipient",
@@ -146,8 +142,7 @@ class Newsletter(WebsiteGenerator):
 		"""Get list of pending recipients of the newsletter. These
 		recipients may not have receive the newsletter in the previous iteration.
 		"""
-		success_recipients = set(self.get_success_recipients())
-		return [x for x in self.newsletter_recipients if x not in success_recipients]
+		return [x for x in self.newsletter_recipients if x not in self.get_queued_recipients()]
 
 	def queue_all(self):
 		"""Queue Newsletter to all the recipients generated from the `Email Group` table"""


### PR DESCRIPTION
Changes:
1. removed not used statuses from Email Queue Recipient
2. remove status filter from `get_queued_recipients` (previously `get_success_recipients`)

#

<details>
<summary>Rationale for Change 1</summary>

Except for `Not Sent` and `Sent`, other statuses for Email Queue Recipient were not being used.

https://github.com/frappe/frappe/blob/b47205ff01d3276d87c590c9ad0d9595e6c5eb45/frappe/email/doctype/email_queue/email_queue.py#L209-L243

All the `update_status` methods are for updating the status of the Email Queue document (not Email Queue Recipient docs).
Also, they (Email Queue Recipient docs) don't really need those statuses, it will always be a binary thing, either the mail was sent to the recipient or it was not.

After an email has been successfully sent, we then change the recipient status to `Sent` (it's `Not Sent` by default)

https://github.com/frappe/frappe/blob/b47205ff01d3276d87c590c9ad0d9595e6c5eb45/frappe/email/doctype/email_queue/email_queue.py#L258-L261

</details>

<details>
<summary>Rationale for Change 2</summary>

So previously the method `get_success_recipients` (now `get_queued_recipients`) used to consider only 3 statuses (while there were 5 - which were not used :P) and the method name `get_success_recipients` (as well as it's docstring) made it extremely confusing to understand the method's intention.

It's basically to get all the already "queued" recipients so that when when the newsletter is retried (in case of any faliure), we don't start queuing duplicate queue documents ..only the ones who haven't been queued.

Hence, fetching all the recipients which have been queued irrespective of their status made much more sense to me.

</details>