### PR TITLE
perf: remove duplicate database initialisation

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -6,7 +6,7 @@ import frappe
 import frappe.database
 import frappe.utils
 import frappe.utils.user
-from frappe import _, conf
+from frappe import _
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
 from frappe.modules.patch_handler import check_session_stopped
 from frappe.sessions import Session, clear_sessions, delete_session
@@ -29,9 +29,6 @@ class HTTPRequest:
 
 		# load cookies
 		self.set_cookies()
-
-		# set frappe.local.db
-		self.connect()
 
 		# login and start/resume user session
 		self.set_session()
@@ -96,16 +93,6 @@ class HTTPRequest:
 
 	def set_lang(self):
 		frappe.local.lang = get_language()
-
-	def get_db_name(self):
-		"""get database name from conf"""
-		return conf.db_name
-
-	def connect(self):
-		"""connect to db, from ac_name or db_name"""
-		frappe.local.db = frappe.database.get_db(
-			user=self.get_db_name(), password=getattr(conf, "db_password", "")
-		)
 
 
 class LoginManager:


### PR DESCRIPTION
Not sure why the database is initialized twice on every request. Not sure why auth.py even has anything to do with databases. 

```python
def init_request(request):
	...
	if frappe.local.conf.get("maintenance_mode"):
		frappe.connect()
		raise frappe.SessionStopped("Session Stopped")
	else:
		frappe.connect(set_admin_as_user=False)  # Both branches here initialize the database

	request.max_content_length = frappe.local.conf.get("max_file_size") or 10 * 1024 * 1024

	make_form_dict(request)

	if request.method != "OPTIONS":
		frappe.local.http_request = frappe.auth.HTTPRequest()  # This again inits db
```