### PR TITLE
feat: Zero* downtime migrations

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2225,13 +2225,18 @@ def log_error(title=None, message=None, reference_doctype=None, reference_name=N
 	title = title or "Error"
 	traceback = as_unicode(traceback or get_traceback(with_context=True))
 
-	return get_doc(
+	error_log = get_doc(
 		doctype="Error Log",
 		error=traceback,
 		method=title,
 		reference_doctype=reference_doctype,
 		reference_name=reference_name,
-	).insert(ignore_permissions=True)
+	)
+
+	if flags.read_only:
+		error_log.deferred_insert()
+	else:
+		return error_log.insert(ignore_permissions=True)
 
 
 def get_desk_link(doctype, name):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -203,6 +203,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False) -> None:
 			"mute_emails": False,
 			"has_dataurl": False,
 			"new_site": new_site,
+			"read_only": False,
 		}
 	)
 	local.rollback_observers = []

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -285,9 +285,7 @@ def connect_replica():
 		user = local.conf.replica_db_name
 		password = local.conf.replica_db_password
 
-	local.replica_db = get_db(
-		host=local.conf.replica_host, user=user, password=password, port=port, read_only=True
-	)
+	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)
 
 	# swap db connections
 	local.primary_db = local.db

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -117,7 +117,10 @@ def init_request(request):
 
 	if frappe.local.conf.get("maintenance_mode"):
 		frappe.connect()
-		raise frappe.SessionStopped("Session Stopped")
+		if frappe.local.conf.get("allow_reads_during_maintenance"):
+			setup_read_only_mode()
+		else:
+			raise frappe.SessionStopped("Session Stopped")
 	else:
 		frappe.connect(set_admin_as_user=False)
 
@@ -127,6 +130,24 @@ def init_request(request):
 
 	if request.method != "OPTIONS":
 		frappe.local.http_request = frappe.auth.HTTPRequest()
+
+
+def setup_read_only_mode():
+	"""During maintenance_mode reads to DB can still be performed to reduce downtime. This
+	function sets up read only mode
+
+	- Setting global flag so other pages, desk and database can know that we are in read only mode.
+	- Setup read only database access either by:
+	    - Connecting to read replica if one exists
+	    - Or setting up read only SQL transactions.
+	"""
+	frappe.flags.read_only = True
+
+	# If replica is available then just connect replica, else setup read only transaction.
+	if frappe.conf.read_from_replica:
+		frappe.connect_replica()
+	else:
+		frappe.db.begin(read_only=True)
 
 
 def log_request(request, response):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -115,9 +115,9 @@ def init_request(request):
 		# site does not exist
 		raise NotFound
 
-	if frappe.local.conf.get("maintenance_mode"):
+	if frappe.local.conf.maintenance_mode:
 		frappe.connect()
-		if frappe.local.conf.get("allow_reads_during_maintenance"):
+		if frappe.local.conf.allow_reads_during_maintenance:
 			setup_read_only_mode()
 		else:
 			raise frappe.SessionStopped("Session Stopped")

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -8,7 +8,6 @@ import frappe.utils
 import frappe.utils.user
 from frappe import _
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
-from frappe.modules.patch_handler import check_session_stopped
 from frappe.sessions import Session, clear_sessions, delete_session
 from frappe.translate import get_language
 from frappe.twofactor import (
@@ -41,9 +40,6 @@ class HTTPRequest:
 
 		# write out latest cookies
 		frappe.local.cookie_manager.init_cookies()
-
-		# check session status
-		check_session_stopped()
 
 	@property
 	def domain(self):

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -9,7 +9,7 @@ from frappe.query_builder.functions import Now
 
 class ErrorLog(Document):
 	def onload(self):
-		if not self.seen:
+		if not self.seen and not frappe.flags.read_only:
 			self.db_set("seen", 1, update_modified=0)
 			frappe.db.commit()
 

--- a/frappe/core/doctype/view_log/view_log.json
+++ b/frappe/core/doctype/view_log/view_log.json
@@ -14,7 +14,6 @@
    "fieldname": "viewed_by",
    "fieldtype": "Data",
    "label": "Viewed By",
-   "search_index": 1,
    "set_only_once": 1
   },
   {
@@ -22,7 +21,6 @@
    "fieldtype": "Link",
    "label": "Reference Document Type",
    "options": "DocType",
-   "search_index": 1,
    "set_only_once": 1
   },
   {
@@ -35,7 +33,7 @@
   }
  ],
  "links": [],
- "modified": "2022-08-03 12:20:52.857103",
+ "modified": "2022-09-07 05:16:14.587628",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "View Log",

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -39,18 +39,14 @@ def drop_user_and_database(db_name, root_login=None, root_password=None):
 		)
 
 
-def get_db(host=None, user=None, password=None, port=None, read_only=False):
+def get_db(host=None, user=None, password=None, port=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.database
 
-		return frappe.database.postgres.database.PostgresDatabase(
-			host, user, password, port=port, read_only=read_only
-		)
+		return frappe.database.postgres.database.PostgresDatabase(host, user, password, port=port)
 	else:
 		import frappe.database.mariadb.database
 
-		return frappe.database.mariadb.database.MariaDBDatabase(
-			host, user, password, port=port, read_only=read_only
-		)
+		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port=port)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -969,9 +969,7 @@ class Database:
 			frappe.call(method[0], *(method[1] or []), **(method[2] or {}))
 
 		self.sql("commit")
-		if self.db_type == "postgres":
-			# Postgres requires explicitly starting new transaction
-			self.begin()
+		self.begin()  # explicitly start a new transaction
 
 		frappe.local.rollback_observers = []
 		self.flush_realtime_log()

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -221,6 +221,15 @@ class Database:
 			elif self.is_timedout(e):
 				raise frappe.QueryTimeoutError(e) from e
 
+			elif self.is_read_only_mode_error(e):
+				frappe.throw(
+					_(
+						"Site is running in read only mode, this action can not be performed right now. Please try again later."
+					),
+					title=_("In Read Only Mode"),
+					exc=frappe.InReadOnlyMode,
+				)
+
 			# TODO: added temporarily
 			elif self.db_type == "postgres":
 				traceback.print_stack()

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -83,14 +83,12 @@ class Database:
 		ac_name=None,
 		use_default=0,
 		port=None,
-		read_only=False,
 	):
 		self.setup_type_map()
 		self.host = host or frappe.conf.db_host or "127.0.0.1"
 		self.port = port or frappe.conf.db_port or ""
 		self.user = user or frappe.conf.db_name
 		self.db_name = frappe.conf.db_name
-		self.read_only = read_only  # Uses READ ONLY connection if set
 		self._conn = None
 
 		if ac_name:

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -958,8 +958,10 @@ class Database:
 
 		return defaults.get(frappe.scrub(key))
 
-	def begin(self):
-		self.sql("START TRANSACTION")
+	def begin(self, *, read_only=False):
+		read_only = read_only or frappe.flags.read_only
+		mode = "READ ONLY" if read_only else ""
+		self.sql(f"START TRANSACTION {mode}")
 
 	def commit(self):
 		"""Commit current transaction. Calls SQL `COMMIT`."""

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -33,6 +33,10 @@ class MariaDBExceptionUtil:
 		return e.args[0] == ER.LOCK_WAIT_TIMEOUT
 
 	@staticmethod
+	def is_read_only_mode_error(e: pymysql.Error) -> bool:
+		return e.args[0] == 1792
+
+	@staticmethod
 	def is_table_missing(e: pymysql.Error) -> bool:
 		return e.args[0] == ER.NO_SUCH_TABLE
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -12,7 +12,7 @@ from psycopg2.errorcodes import (
 	UNDEFINED_TABLE,
 	UNIQUE_VIOLATION,
 )
-from psycopg2.errors import SequenceGeneratorLimitExceeded, SyntaxError
+from psycopg2.errors import ReadOnlySqlTransaction, SequenceGeneratorLimitExceeded, SyntaxError
 from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
 
 import frappe
@@ -54,6 +54,10 @@ class PostgresExceptionUtil:
 	def is_timedout(e):
 		# http://initd.org/psycopg/docs/extensions.html?highlight=datatype#psycopg2.extensions.QueryCanceledError
 		return isinstance(e, psycopg2.extensions.QueryCanceledError)
+
+	@staticmethod
+	def is_read_only_mode_error(e) -> bool:
+		return isinstance(e, ReadOnlySqlTransaction)
 
 	@staticmethod
 	def is_syntax_error(e):

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -373,7 +373,7 @@ def run_onload(doc):
 def get_view_logs(doctype, docname):
 	"""get and return the latest view logs if available"""
 	logs = []
-	if hasattr(frappe.get_meta(doctype), "track_views") and frappe.get_meta(doctype).track_views:
+	if getattr(frappe.get_meta(doctype), "track_views", None):
 		view_logs = frappe.get_all(
 			"View Log",
 			filters={

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -236,6 +236,10 @@ class QueryDeadlockError(Exception):
 	pass
 
 
+class InReadOnlyMode(ValidationError):
+	http_status_code = 503  # temporarily not available
+
+
 class TooManyWritesError(Exception):
 	pass
 

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -13,6 +13,7 @@ from frappe.cache_manager import clear_global_cache
 from frappe.core.doctype.language.language import sync_languages
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
 from frappe.database.schema import add_column
+from frappe.deferred_insert import save_to_db as flush_deferred_inserts
 from frappe.desk.notifications import clear_notifications
 from frappe.modules.patch_handler import PatchType
 from frappe.modules.utils import sync_customizations
@@ -123,6 +124,7 @@ class SiteMigration:
 		* Sync in-Desk Module Dashboards
 		* Sync customizations: Custom Fields, Property Setters, Custom Permissions
 		* Sync Frappe's internal language master
+		* Flush deferred inserts made during maintenance mode.
 		* Sync Portal Menu Items
 		* Sync Installed Applications Version History
 		* Execute `after_migrate` hooks
@@ -132,6 +134,7 @@ class SiteMigration:
 		sync_dashboards()
 		sync_customizations()
 		sync_languages()
+		flush_deferred_inserts()
 
 		frappe.get_single("Portal Settings").sync_menu()
 		frappe.get_single("Installed Applications").update_versions()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1369,7 +1369,7 @@ class Document(BaseDocument):
 		if not user:
 			user = frappe.session.user
 
-		if self.meta.track_seen:
+		if self.meta.track_seen and not frappe.flags.read_only:
 			_seen = self.get("_seen") or []
 			_seen = frappe.parse_json(_seen)
 
@@ -1384,15 +1384,19 @@ class Document(BaseDocument):
 			user = frappe.session.user
 
 		if hasattr(self.meta, "track_views") and self.meta.track_views:
-			frappe.get_doc(
+			view_log = frappe.get_doc(
 				{
 					"doctype": "View Log",
 					"viewed_by": frappe.session.user,
 					"reference_doctype": self.doctype,
 					"reference_name": self.name,
 				}
-			).insert(ignore_permissions=True)
-			frappe.local.flags.commit = True
+			)
+			if frappe.flags.read_only:
+				view_log.deferred_insert()
+			else:
+				view_log.insert(ignore_permissions=True)
+				frappe.local.flags.commit = True
 
 	def log_error(self, title=None, message=None):
 		"""Helper function to create an Error Log"""
@@ -1538,6 +1542,20 @@ class Document(BaseDocument):
 		from frappe.desk.doctype.tag.tag import DocTags
 
 		return DocTags(self.doctype).get_tags(self.name).split(",")[1:]
+
+	def deferred_insert(self) -> None:
+		"""Push the document to redis temporarily and insert later.
+
+		WARN: This doesn't guarantee insertion as redis can be restarted
+		before data is flushed to database.
+		"""
+
+		from frappe.deferred_insert import deferred_insert
+
+		self.set_user_and_timestamp()
+
+		doc = self.get_valid_dict(convert_dates_to_str=True, ignore_virtual=True)
+		deferred_insert(doctype=self.doctype, records=doc)
 
 	def __repr__(self):
 		name = self.name or "unsaved"

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -8,17 +8,17 @@ import os
 
 import frappe
 from frappe.modules.import_file import import_file_by_path
-from frappe.modules.patch_handler import block_user
+from frappe.modules.patch_handler import _patch_mode
 from frappe.utils import update_progress_bar
 
 
 def sync_all(force=0, reset_permissions=False):
-	block_user(True)
+	_patch_mode(True)
 
 	for app in frappe.get_installed_apps():
 		sync_for(app, force, reset_permissions=reset_permissions)
 
-	block_user(False)
+	_patch_mode(False)
 
 	frappe.clear_cache()
 

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -154,7 +154,7 @@ def run_single(patchmodule=None, method=None, methodargs=None, force=False):
 
 def execute_patch(patchmodule, method=None, methodargs=None):
 	"""execute the patch"""
-	block_user(True)
+	_patch_mode(True)
 
 	if patchmodule.startswith("execute:"):
 		has_patch_file = False
@@ -197,7 +197,7 @@ def execute_patch(patchmodule, method=None, methodargs=None):
 	else:
 		frappe.db.commit()
 		end_time = time.time()
-		block_user(False)
+		_patch_mode(False)
 		print(f"Success: Done in {round(end_time - start_time, 3)}s")
 
 	return True
@@ -216,18 +216,7 @@ def executed(patchmodule):
 	return frappe.db.get_value("Patch Log", {"patch": patchmodule})
 
 
-def block_user(block, msg=None):
+def _patch_mode(enable):
 	"""stop/start execution till patch is run"""
-	frappe.local.flags.in_patch = block
-	frappe.db.begin()
-	if not msg:
-		msg = "Patches are being executed in the system. Please try again in a few moments."
-	frappe.db.set_global("__session_status", block and "stop" or None)
-	frappe.db.set_global("__session_status_message", block and msg or None)
+	frappe.local.flags.in_patch = enable
 	frappe.db.commit()
-
-
-def check_session_stopped():
-	if frappe.db.get_global("__session_status") == "stop":
-		frappe.msgprint(frappe.db.get_global("__session_status_message"))
-		raise frappe.SessionStopped("Session Stopped")

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -450,6 +450,10 @@ frappe.ui.form.Form = class FrappeForm {
 				.toggleClass("cancelled-form", this.doc.docstatus === 2);
 
 			this.show_conflict_message();
+
+			if (frappe.boot.read_only) {
+				this.disable_form();
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -215,7 +215,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	set_primary_action() {
-		if (this.can_create) {
+		if (this.can_create && !frappe.boot.read_only) {
 			const doctype_name = __(frappe.router.doctype_layout) || __(this.doctype);
 
 			// Better style would be __("Add {0}", [doctype_name], "Primary action in list view")

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -7,7 +7,7 @@
 		<div class="collapse navbar-collapse justify-content-end">
 			<form class="form-inline fill-width justify-content-end" role="search" onsubmit="return false;">
 				{% if (frappe.boot.read_only) { %}
-					<span class="indicator-pill yellow" title="{%= __("Your site is getting upgraded.") %}">
+					<span class="indicator-pill yellow no-indicator-dot" title="{%= __("Your site is getting upgraded.") %}">
 						{%= __("Read Only Mode") %}
 					</span>
 				{% } %}

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -6,6 +6,11 @@
 		<ul class="nav navbar-nav d-none d-sm-flex" id="navbar-breadcrumbs"></ul>
 		<div class="collapse navbar-collapse justify-content-end">
 			<form class="form-inline fill-width justify-content-end" role="search" onsubmit="return false;">
+				{% if (frappe.boot.read_only) { %}
+					<span class="indicator-pill yellow" title="{%= __("Your site is getting upgraded.") %}">
+						{%= __("Read Only Mode") %}
+					</span>
+				{% } %}
 				<div class="input-group search-bar text-muted hidden">
 					<input
 						id="navbar-search"

--- a/frappe/public/scss/common/indicator.scss
+++ b/frappe/public/scss/common/indicator.scss
@@ -48,7 +48,7 @@
 	height: 24px;
 }
 
-.indicator-pill::before,
+.indicator-pill:not(.no-indicator-dot)::before,
 .indicator-pill-right::after {
 	content:'';
 	display: inline-table;

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -407,7 +407,7 @@ class Session:
 
 		# database persistence is secondary, don't update it too often
 		updated_in_db = False
-		if force or (time_diff is None) or (time_diff > 600):
+		if (force or (time_diff is None) or (time_diff > 600)) and not frappe.flags.read_only:
 			# update sessions table
 			frappe.db.sql(
 				"""update `tabSessions` set sessiondata=%s,
@@ -426,7 +426,6 @@ class Session:
 
 			updated_in_db = True
 
-		# set in memcache
 		frappe.cache().hset("session", self.sid, self.data)
 
 		return updated_in_db

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -179,6 +179,7 @@ def get():
 
 	bootinfo.notes = get_unseen_notes()
 	bootinfo.assets_json = get_assets_json()
+	bootinfo.read_only = bool(frappe.flags.read_only)
 
 	for hook in frappe.get_hooks("extend_bootinfo"):
 		frappe.get_attr(hook)(bootinfo=bootinfo)

--- a/frappe/templates/includes/navbar/navbar_items.html
+++ b/frappe/templates/includes/navbar/navbar_items.html
@@ -89,6 +89,15 @@
 	</div>
 	{% endif %}
 
+	{% if read_only_mode %}
+		<div
+			class="indicator-pill yellow no-indicator-dot align-self-center"
+			title="{{ _("This site is in read only mode, full functionality will be restored soon.") }}"
+		>
+			{{ _("Read Only Mode") }}
+		</div>
+	{% endif %}
+
 	{% include "templates/includes/navbar/navbar_login.html" %}
 
 </ul>

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -9,6 +9,7 @@ from semantic_version import Version
 from werkzeug.test import TestResponse
 
 import frappe
+from frappe.installer import update_site_config
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_site_url, get_test_client
 
@@ -273,3 +274,29 @@ class TestMethodAPI(FrappeAPITestCase):
 		self.assertEqual(response.json["message"], "Administrator")
 
 		authorization_token = None
+
+
+class TestReadOnlyMode(FrappeAPITestCase):
+	"""During migration if read only mode can be enabled.
+	Test if reads work well and writes are blocked"""
+
+	REQ_PATH = "/api/resource/ToDo"
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		update_site_config("allow_reads_during_maintenance", 1)
+		cls.addClassCleanup(update_site_config, "maintenance_mode", 0)
+		# XXX: this has potential to crumble rest of the test suite.
+		update_site_config("maintenance_mode", 1)
+
+	def test_reads(self):
+		response = self.get(self.REQ_PATH, {"sid": self.sid})
+		self.assertEqual(response.status_code, 200)
+		self.assertIsInstance(response.json, dict)
+		self.assertIsInstance(response.json["data"], list)
+
+	def test_blocked_writes(self):
+		response = self.post(self.REQ_PATH, {"description": frappe.mock("paragraph"), "sid": self.sid})
+		self.assertEqual(response.status_code, 503)
+		self.assertEqual(response.json["exc_type"], "InReadOnlyMode")

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -460,6 +460,14 @@ class TestDB(FrappeTestCase):
 			# recover transaction to continue other tests
 			raise Exception
 
+	def test_read_only_errors(self):
+		frappe.db.rollback()
+		frappe.db.begin(read_only=True)
+		self.addCleanup(frappe.db.rollback)
+
+		with self.assertRaises(frappe.InReadOnlyMode):
+			frappe.db.set_value("User", "Administrator", "full_name", "Haxor")
+
 	def test_exists(self):
 		dt, dn = "User", "Administrator"
 		self.assertEqual(frappe.db.exists(dt, dn, cache=True), dn)

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -64,9 +64,10 @@ def generate_and_cache_results(args, function, cache_key, chart):
 		else:
 			raise
 
-	frappe.db.set_value(
-		"Dashboard Chart", args.chart_name, "last_synced_on", frappe.utils.now(), update_modified=False
-	)
+	if not frappe.flags.read_only:
+		frappe.db.set_value(
+			"Dashboard Chart", args.chart_name, "last_synced_on", frappe.utils.now(), update_modified=False
+		)
 	return results
 
 

--- a/frappe/website/doctype/web_page_view/web_page_view.py
+++ b/frappe/website/doctype/web_page_view/web_page_view.py
@@ -37,7 +37,10 @@ def make_view_log(path, referrer=None, browser=None, version=None, url=None, use
 	view.is_unique = is_unique
 
 	try:
-		view.insert(ignore_permissions=True)
+		if frappe.flags.read_only:
+			view.deferred_insert()
+		else:
+			view.insert(ignore_permissions=True)
 	except Exception:
 		if frappe.message_log:
 			frappe.message_log.pop()

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -191,6 +191,7 @@ def get_website_settings(context=None):
 	if settings.splash_image:
 		context["splash_image"] = settings.splash_image
 
+	context.read_only_mode = frappe.flags.read_only
 	context.boot = get_boot_data()
 
 	return context


### PR DESCRIPTION
\* = if read-only mode is not considered "downtime" for you ;) 

You can now keep a read-only version of your site running during upgrades too. This means your website/desk will still be accessible and you can browse around but can't perform any write actions. 


**How?** 
- You need to add a config key for this - `allow_reads_during_maintenance`
- This will automatically switch reads to replica db if available OR create and force read-only transactions until maintenance mode is lifted. 
- If you have an app or page that needs to modify behavior during read-only mode then use `frappe.flags.read_only` to check if the site is running in read-only mode. 


**Should I?**
- Depends on your site and apps. Not all apps will automatically support this. They need to handle read-only mode so the user doesn't see unexpected errors. The best way to find out is to just try it out. 


**Intent**

This is only meant for minor version upgrades that happen weekly/monthly on many sites. Major versions change code so much that it probably would be unusable anyway during upgrades. But those are once-a-year events.

Similarly, not everything "read only" will keep working as you'd expect. The intent is just to lessen the impact of downtimes, nothing else. 

**Screens**

Desk forms are disabled and a persistent indicator for read-only mode added. List views won't show "add doctype" button too.

<img width="1329" alt="Screenshot 2022-09-08 at 1 23 48 AM" src="https://user-images.githubusercontent.com/9079960/188965078-b7ae0ec0-8ebd-4a87-bb34-9ed13d8e55a1.png">

Similar warning on "website pages".

<img width="1404" alt="Screenshot 2022-09-08 at 6 26 19 PM" src="https://user-images.githubusercontent.com/9079960/189127461-70d92ab3-9dfe-4f79-8715-09c5e0e32777.png">



Not all actions are explicitly handled (cause it's damn near impossible and not worth it).  They'll just fail with this message when attempting to write to db. 


<img width="1309" alt="Screenshot 2022-09-07 at 11 40 09 PM" src="https://user-images.githubusercontent.com/9079960/188948776-a7a9ed33-3d27-4b41-a0e2-8cd00740e882.png">

API requests that attempt to write will fail and receive 503 (previously this was an HTML response 💩 fixed separately: https://github.com/frappe/frappe/pull/18057 )

<img width="1041" alt="Screenshot 2022-09-07 at 11 51 13 PM" src="https://user-images.githubusercontent.com/9079960/188950704-c6a3bdc0-bbcf-447b-84d5-df689db3677c.png">


Docs for setup and devs: https://frappeframework.com/docs/v14/user/en/zero*_downtime_migrations 


TODO: 
- [x] enable read-only mode, either from read replica or read-only transactions.
- [x] Handle scheduler - should be ignored, "READ" type scheduled jobs are close to 0.
- [x] handle WSGI app
- [x] Database are initiated twice hence losing transaction if created at start of request. https://github.com/frappe/frappe/pull/18049 
- [x] handle patch handler's separate "maintenance mode" implementation - removed this. Not sure why we need to have 2 different "maintenance mode" implementations.
- [x] automated tests and manual testing



UX/DX parts:
- [x] handle session related logging
- [x] Raise `frappe.InReadOnlyMode` and respond with `503` when writes are attempted. 
- [x] Handle updation of last active TS
- [x] Show read-only mode warning on desk and web pages
- [x] Make forms and other known inputs read-only.
- [x] Defer logging - errors, web view, desk view, seen, etc
- [x] Flush deferred inserts during migrate
- [x] `db.read_only` - removed till mariadb client switch happens.


Unrelated changes:
- Drop useless indexes from "View Log" doctype. ref docname has the highest cardinality, the rest aren't used at all. 
- Added `doc.deferred_insert()` to use deferred insert on any random document. This is flushed after the upgrade to avoid losing data during redis restarts. 

Closes https://github.com/frappe/frappe/issues/17812