### PR TITLE
fix(UX): misc login page issues

### DIFF
--- a/frappe/public/scss/website/base.scss
+++ b/frappe/public/scss/website/base.scss
@@ -7,6 +7,8 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 	font-size: 16px;
 	color: $body-color;
+	display: flex;
+	flex-direction: column;
 }
 
 img {

--- a/frappe/public/scss/website/footer.scss
+++ b/frappe/public/scss/website/footer.scss
@@ -3,6 +3,7 @@
 	min-height: 140px;
 	background-color: var(--fg-color);
 	border-top: 1px solid $border-color;
+	margin-top: auto;
 }
 
 .footer-logo {

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -40,6 +40,7 @@ def get_context(context):
 	context.no_header = True
 	context.for_test = "login.html"
 	context["title"] = "Login"
+	context["hide_login"] = True  # dont show login link on login page again.
 	context["provider_logins"] = []
 	context["disable_signup"] = cint(frappe.get_website_settings("disable_signup"))
 	context["disable_user_pass_login"] = cint(frappe.get_system_settings("disable_user_pass_login"))


### PR DESCRIPTION
1. "Login" link still shows up on login page.
<img width="1329" alt="Screenshot 2022-09-08 at 12 33 07 PM" src="https://user-images.githubusercontent.com/9079960/189057238-aaaab26e-b7bd-4f82-bfed-808c265f2d81.png">



2. Footer doesn't stick to bottom. 

Before:
<img width="1329" alt="Screenshot 2022-09-08 at 12 34 28 PM" src="https://user-images.githubusercontent.com/9079960/189057222-e7a9cb64-88d7-461b-b7b9-74563ef436d7.png">


After:

NOTE: regenerate website theme for this to take effect.

<img width="1329" alt="Screenshot 2022-09-08 at 12 35 14 PM" src="https://user-images.githubusercontent.com/9079960/189057206-3568cca7-acd4-465f-9089-21e4af2b12a0.png">


Mobile:

<img width="547" alt="Screenshot 2022-09-08 at 12 35 29 PM" src="https://user-images.githubusercontent.com/9079960/189057183-01b9bd64-6d6c-46e0-8036-948f807b6a8d.png">
