### PR TITLE
fix(UI): Grid UI glitch when child table is used with column breaks 

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -45,7 +45,7 @@
 
 // hide row index in 6 column child tables
 .form-column.col-sm-6 .form-grid {
-	.row-index > span {
+	.row-index {
 		display: none;
 	}
 
@@ -56,7 +56,7 @@
 	}
 }
 
-.modal .form-grid .row-index > span {
+.modal .form-grid .row-index {
 	display: none;
 }
 


### PR DESCRIPTION
fixes: https://github.com/frappe/frappe/issues/17576

Before:
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/30859809/189060669-5200228c-bc97-4ff9-8d21-fb4b795a2a1f.png">


After:
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/30859809/189060503-5167cf22-3f6e-42ee-9878-5676accf203f.png">
