### PR TITLE
fix: respect `Accept` headers during maintenance mode

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -83,9 +83,6 @@ def application(request: Request):
 	except HTTPException as e:
 		return e
 
-	except frappe.SessionStopped as e:
-		response = frappe.utils.response.handle_session_stopped()
-
 	except Exception as e:
 		response = handle_exception(e)
 
@@ -237,6 +234,9 @@ def handle_exception(e):
 		# handle ajax responses first
 		# if the request is ajax, send back the trace or error message
 		response = frappe.utils.response.report_error(http_status_code)
+
+	elif isinstance(e, frappe.SessionStopped):
+		response = frappe.utils.response.handle_session_stopped()
 
 	elif (
 		http_status_code == 500


### PR DESCRIPTION
Right now if site is in maintenance mode then all responses are HTML. If user specifies `Accept: application/json` then they should receive JSON response.
