### PR TITLE
refactor!: dashboard links

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -980,35 +980,8 @@ def validate_links_table_fieldnames(meta):
 	if not meta.links or frappe.flags.in_patch or frappe.flags.in_fixtures:
 		return
 
-	fieldnames = tuple(field.fieldname for field in meta.fields)
 	for index, link in enumerate(meta.links, 1):
 		_test_connection_query(doctype=link.link_doctype, field=link.link_fieldname, idx=index)
-
-		if not link.is_child_table:
-			continue
-
-		if not link.parent_doctype:
-			message = _("Document Links Row #{0}: Parent DocType is mandatory for internal links").format(
-				index
-			)
-			frappe.throw(message, frappe.ValidationError, _("Parent Missing"))
-
-		if not link.table_fieldname:
-			message = _("Document Links Row #{0}: Table Fieldname is mandatory for internal links").format(
-				index
-			)
-			frappe.throw(message, frappe.ValidationError, _("Table Fieldname Missing"))
-
-		if meta.name == link.parent_doctype:
-			field_exists = link.table_fieldname in fieldnames
-		else:
-			field_exists = frappe.get_meta(link.parent_doctype).has_field(link.table_fieldname)
-
-		if not field_exists:
-			message = _("Document Links Row #{0}: Could not find field {1} in {2} DocType").format(
-				index, frappe.bold(link.table_fieldname), frappe.bold(meta.name)
-			)
-			frappe.throw(message, frappe.ValidationError, _("Invalid Table Fieldname"))
 
 
 def _test_connection_query(doctype, field, idx):

--- a/frappe/core/doctype/doctype_link/doctype_link.json
+++ b/frappe/core/doctype/doctype_link/doctype_link.json
@@ -7,11 +7,8 @@
  "field_order": [
   "link_doctype",
   "link_fieldname",
-  "parent_doctype",
-  "table_fieldname",
   "group",
   "hidden",
-  "is_child_table",
   "custom"
  ],
  "fields": [
@@ -48,40 +45,19 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Custom"
-  },
-  {
-   "depends_on": "is_child_table",
-   "fieldname": "parent_doctype",
-   "fieldtype": "Link",
-   "label": "Parent DocType",
-   "mandatory_depends_on": "is_child_table",
-   "options": "DocType"
-  },
-  {
-   "default": "0",
-   "fetch_from": "link_doctype.istable",
-   "fieldname": "is_child_table",
-   "fieldtype": "Check",
-   "label": "Is Child Table",
-   "read_only": 1
-  },
-  {
-   "fieldname": "table_fieldname",
-   "fieldtype": "Data",
-   "label": "Table Fieldname"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-07-31 15:23:12.237491",
+ "modified": "2022-09-08 13:34:00.094077",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType Link",
  "owner": "Administrator",
  "permissions": [],
- "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -274,9 +274,6 @@ def get_open_count(doctype, name, items=None):
 
 	out = []
 	for d in items:
-		if d in links.get("internal_links", {}):
-			continue
-
 		filters = get_filters_for(d)
 		fieldname = links.get("non_standard_fieldnames", {}).get(d, links.get("fieldname"))
 		data = {"name": d}

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -227,7 +227,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	init_data() {
 		this.data = this.frm.meta.__dashboard || {};
 		if (!this.data.transactions) this.data.transactions = [];
-		if (!this.data.internal_links) this.data.internal_links = {};
+		// if (!this.data.internal_links) this.data.internal_links = {};
 		this.filter_permissions();
 	}
 
@@ -344,16 +344,17 @@ frappe.ui.form.Dashboard = class FormDashboard {
 
 	open_document_list($link, show_open) {
 		// show document list with filters
-		let doctype = $link.attr("data-doctype"),
-			names = $link.attr("data-names") || [];
+		let doctype = $link.attr("data-doctype");
+		// let names = $link.attr("data-names") || [];
 
-		if (this.data.internal_links[doctype]) {
-			if (names.length) {
-				frappe.route_options = { name: ["in", names] };
-			} else {
-				return false;
-			}
-		} else if (this.data.fieldname) {
+		// if (this.data.internal_links[doctype]) {
+		// 	if (names.length) {
+		// 		frappe.route_options = { name: ["in", names] };
+		// 	} else {
+		// 		return false;
+		// 	}
+		// } else
+		if (this.data.fieldname) {
 			frappe.route_options = this.get_document_filter(doctype);
 			if (show_open && frappe.ui.notifications) {
 				frappe.ui.notifications.show_open_count_list(doctype);
@@ -415,26 +416,26 @@ frappe.ui.form.Dashboard = class FormDashboard {
 				});
 
 				// update from internal links
-				$.each(me.data.internal_links, (doctype, link) => {
-					let names = [];
-					if (typeof link === "string" || link instanceof String) {
-						// get internal links in parent document
-						let value = me.frm.doc[link];
-						if (value && !names.includes(value)) {
-							names.push(value);
-						}
-					} else if (Array.isArray(link)) {
-						// get internal links in child documents
-						let [table_fieldname, link_fieldname] = link;
-						(me.frm.doc[table_fieldname] || []).forEach((d) => {
-							let value = d[link_fieldname];
-							if (value && !names.includes(value)) {
-								names.push(value);
-							}
-						});
-					}
-					me.frm.dashboard.set_badge_count(doctype, 0, names.length, names);
-				});
+				// $.each(me.data.internal_links, (doctype, link) => {
+				// 	let names = [];
+				// 	if (typeof link === "string" || link instanceof String) {
+				// 		// get internal links in parent document
+				// 		let value = me.frm.doc[link];
+				// 		if (value && !names.includes(value)) {
+				// 			names.push(value);
+				// 		}
+				// 	} else if (Array.isArray(link)) {
+				// 		// get internal links in child documents
+				// 		let [table_fieldname, link_fieldname] = link;
+				// 		(me.frm.doc[table_fieldname] || []).forEach((d) => {
+				// 			let value = d[link_fieldname];
+				// 			if (value && !names.includes(value)) {
+				// 				names.push(value);
+				// 			}
+				// 		});
+				// 	}
+				// 	me.frm.dashboard.set_badge_count(doctype, 0, names.length, names);
+				// });
 
 				me.frm.dashboard_data = r.message;
 				me.frm.trigger("dashboard_update");
@@ -459,14 +460,6 @@ frappe.ui.form.Dashboard = class FormDashboard {
 				.find(".count")
 				.removeClass("hidden")
 				.text(count > 99 ? "99+" : count);
-		}
-
-		if (this.data.internal_links[doctype]) {
-			if (names && names.length) {
-				$link.attr("data-names", names ? names.join(",") : "");
-			} else {
-				$link.find("a").attr("disabled", true);
-			}
 		}
 	}
 

--- a/frappe/public/js/frappe/form/templates/form_links.html
+++ b/frappe/public/js/frappe/form/templates/form_links.html
@@ -17,12 +17,10 @@
 						<span class="open-notification hidden"
 							title="{{ __("Open {0}", [__(doctype)])}}">
 						</span>
-						{% if !internal_links[doctype] %}
-							<button class="btn btn-new btn-secondary btn-xs icon-btn hidden"
-								data-doctype="{{ doctype }}">
-								<svg class="icon icon-sm"><use href="#icon-add"></use></svg>
-							</button>
-						{% endif %}
+						<button class="btn btn-new btn-secondary btn-xs icon-btn hidden"
+							data-doctype="{{ doctype }}">
+							<svg class="icon icon-sm"><use href="#icon-add"></use></svg>
+						</button>
 					</div>
 				{% } %}
 			</div>


### PR DESCRIPTION
TODO:
- [ ] complete logic
- [ ] remove keys from dashboard.py files (+ patch for ingesting the format in doctype links table?)
- [ ] check with custom field(s) - same field present in parent and in child (can we make links to both?)
- [ ] erpnext cleanup
- [ ] see if migration doesnt overwrite this