### PR TITLE
fix(Link): dont validate DocType twice when setting value

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -89,23 +89,19 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 	is_translatable() {
 		return in_list(frappe.boot?.translated_doctypes || [], this.get_options());
 	}
-	set_link_title(value) {
-		let doctype = this.get_options();
+	async set_link_title(value) {
+		const doctype = this.get_options();
 
-		if (!doctype) return;
-
-		if (in_list(frappe.boot.link_title_doctypes, doctype)) {
-			let link_title = frappe.utils.get_link_title(doctype, value);
-			if (!link_title) {
-				link_title = frappe.utils.fetch_link_title(doctype, value).then((link_title) => {
-					this.translate_and_set_input_value(link_title, value);
-				});
-			} else {
-				this.translate_and_set_input_value(link_title, value);
-			}
-		} else {
+		if (!doctype || !in_list(frappe.boot.link_title_doctypes, doctype)) {
 			this.translate_and_set_input_value(value, value);
+			return;
 		}
+
+		const link_title =
+			frappe.utils.get_link_title(doctype, value) ||
+			(await frappe.utils.fetch_link_title(doctype, value));
+
+		this.translate_and_set_input_value(link_title, value);
 	}
 	translate_and_set_input_value(link_title, value) {
 		let translated_link_text = this.get_translated(link_title);


### PR DESCRIPTION
In List View, we allow setting values for Dynamic Links without validation:
https://github.com/frappe/frappe/blob/40f27f908a3890c9a90d2d96794fc31fcea63c59/frappe/public/js/frappe/list/base_list.js#L797

However, this never worked because `options` was getting validated in `set_link_title` before setting the value. This is also the reason why Dynamic Link filters set using `frappe.route_options` didn't work earlier.

`options` is already being validated here, but only if `ignore_link_validation` isn't set:
https://github.com/frappe/frappe/blob/40f27f908a3890c9a90d2d96794fc31fcea63c59/frappe/public/js/frappe/form/controls/link.js#L581

## Screenshots

### Before

![filter_before](https://user-images.githubusercontent.com/16315650/189096133-7cc03241-e29a-49d8-9fa2-26b6d3a514ad.gif)


### After

![filter_after](https://user-images.githubusercontent.com/16315650/189096159-581e49ab-4d80-44b4-8a85-0510ff904804.gif)

## Changes Made

- Set value without title if `options` is empty.
- Refactor code to make it flatter.