### PR TITLE
fix: parent selection on dashboard chart

### DIFF
--- a/cypress/integration/control_markdown_editor.js
+++ b/cypress/integration/control_markdown_editor.js
@@ -7,9 +7,12 @@ context("Control Markdown Editor", () => {
 	it("should allow inserting images by drag and drop", () => {
 		cy.visit("/app/web-page/new");
 		cy.fill_field("content_type", "Markdown", "Select");
-		cy.get_field("main_section_md", "Markdown Editor").attachFile("sample_image.jpg", {
-			subjectType: "drag-n-drop",
-		});
+		cy.get_field("main_section_md", "Markdown Editor").selectFile(
+			"cypress/fixtures/sample_image.jpg",
+			{
+				action: "drag-drop",
+			}
+		);
 		cy.click_modal_primary_button("Upload");
 		cy.get_field("main_section_md", "Markdown Editor").should(
 			"contain",

--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -21,9 +21,11 @@ context("FileUploader", () => {
 	it("should accept dropped files", () => {
 		open_upload_dialog();
 
-		cy.get_open_dialog().find(".file-upload-area").attachFile("example.json", {
-			subjectType: "drag-n-drop",
-		});
+		cy.get_open_dialog()
+			.find(".file-upload-area")
+			.selectFile("cypress/fixtures/example.json", {
+				action: "drag-drop",
+			});
 
 		cy.get_open_dialog().find(".file-name").should("contain", "example.json");
 		cy.intercept("POST", "/api/method/upload_file").as("upload_file");
@@ -64,9 +66,11 @@ context("FileUploader", () => {
 	it("should allow cropping and optimization for valid images", () => {
 		open_upload_dialog();
 
-		cy.get_open_dialog().find(".file-upload-area").attachFile("sample_image.jpg", {
-			subjectType: "drag-n-drop",
-		});
+		cy.get_open_dialog()
+			.find(".file-upload-area")
+			.selectFile("cypress/fixtures/sample_image.jpg", {
+				action: "drag-drop",
+			});
 
 		cy.get_open_dialog().findAllByText("sample_image.jpg").should("exist");
 		cy.get_open_dialog().find(".btn-crop").first().click();

--- a/cypress/integration/sidebar.js
+++ b/cypress/integration/sidebar.js
@@ -4,9 +4,11 @@ const verify_attachment_visibility = (document, is_private) => {
 	const assertion = is_private ? "be.checked" : "not.be.checked";
 	cy.findByRole("button", { name: "Attach File" }).click();
 
-	cy.get_open_dialog().find(".file-upload-area").attachFile("sample_image.jpg", {
-		subjectType: "drag-n-drop",
-	});
+	cy.get_open_dialog()
+		.find(".file-upload-area")
+		.selectFile("cypress/fixtures/sample_image.jpg", {
+			action: "drag-drop",
+		});
 
 	cy.get_open_dialog().findByRole("checkbox", { name: "Private" }).should(assertion);
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,4 +1,3 @@
-import "cypress-file-upload";
 import "@testing-library/cypress/add-commands";
 import "@4tw/cypress-drag-drop";
 import "cypress-real-events/support";

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -874,7 +874,6 @@ def run_ui_tests(
 
 	node_bin = subprocess.getoutput("npm bin")
 	cypress_path = f"{node_bin}/cypress"
-	plugin_path = f"{node_bin}/../cypress-file-upload"
 	drag_drop_plugin_path = f"{node_bin}/../@4tw/cypress-drag-drop"
 	real_events_plugin_path = f"{node_bin}/../cypress-real-events"
 	testing_library_path = f"{node_bin}/../@testing-library"
@@ -883,7 +882,6 @@ def run_ui_tests(
 	# check if cypress in path...if not, install it.
 	if not (
 		os.path.exists(cypress_path)
-		and os.path.exists(plugin_path)
 		and os.path.exists(drag_drop_plugin_path)
 		and os.path.exists(real_events_plugin_path)
 		and os.path.exists(testing_library_path)
@@ -894,7 +892,6 @@ def run_ui_tests(
 		packages = " ".join(
 			[
 				"cypress@^10",
-				"cypress-file-upload@^5",
 				"@4tw/cypress-drag-drop@^2",
 				"cypress-real-events",
 				"@testing-library/cypress@^8",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -532,25 +532,21 @@ frappe.ui.form.on("Dashboard Chart", {
 		frm.set_df_property("parent_document_type", "hidden", !doc_is_table);
 
 		if (document_type && doc_is_table) {
-			let parent = await frappe.db.get_list("DocField", {
-				filters: {
-					fieldtype: "Table",
-					options: document_type,
-				},
-				fields: ["parent"],
+			let parents = await frappe.xcall(
+				"frappe.desk.doctype.dashboard_chart.dashboard_chart.get_parent_doctypes",
+				{ child_type: document_type }
+			);
+
+			frm.set_query("parent_document_type", function () {
+				return {
+					filters: {
+						name: ["in", parents],
+					},
+				};
 			});
 
-			parent &&
-				frm.set_query("parent_document_type", function () {
-					return {
-						filters: {
-							name: ["in", parent.map(({ parent }) => parent)],
-						},
-					};
-				});
-
-			if (parent.length === 1) {
-				frm.set_value("parent_document_type", parent[0].parent);
+			if (parents.length === 1) {
+				frm.set_value("parent_document_type", parents[0]);
 			}
 		}
 	},

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -392,3 +392,25 @@ class DashboardChart(Document):
 				json.loads(self.custom_options)
 			except ValueError as error:
 				frappe.throw(_("Invalid json added in the custom options: {0}").format(error))
+
+
+@frappe.whitelist()
+def get_parent_doctypes(child_type: str) -> list[str]:
+	"""Get all parent doctypes that have the child doctype."""
+	assert isinstance(child_type, str)
+
+	standard = frappe.get_all(
+		"DocField",
+		fields="parent",
+		filters={"fieldtype": "Table", "options": child_type},
+		pluck="parent",
+	)
+
+	custom = frappe.get_all(
+		"Custom Field",
+		fields="dt",
+		filters={"fieldtype": "Table", "options": child_type},
+		pluck="dt",
+	)
+
+	return standard + custom

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -472,25 +472,21 @@ frappe.ui.form.on("Number Card", {
 		frm.set_df_property("parent_document_type", "hidden", !doc_is_table);
 
 		if (document_type && doc_is_table) {
-			let parent = await frappe.db.get_list("DocField", {
-				filters: {
-					fieldtype: "Table",
-					options: document_type,
-				},
-				fields: ["parent"],
+			let parents = await frappe.xcall(
+				"frappe.desk.doctype.dashboard_chart.dashboard_chart.get_parent_doctypes",
+				{ child_type: document_type }
+			);
+
+			frm.set_query("parent_document_type", function () {
+				return {
+					filters: {
+						name: ["in", parents],
+					},
+				};
 			});
 
-			parent &&
-				frm.set_query("parent_document_type", function () {
-					return {
-						filters: {
-							name: ["in", parent.map(({ parent }) => parent)],
-						},
-					};
-				});
-
-			if (parent.length === 1) {
-				frm.set_value("parent_document_type", parent[0].parent);
+			if (parents.length === 1) {
+				frm.set_value("parent_document_type", parents[0]);
 			}
 		}
 	},


### PR DESCRIPTION
Problem: Dashboard chart and number card queries `docfields` directly to find parent doctypes, which no one other than `Administrator` can do. 


<img width="1437" alt="Screenshot 2022-09-08 at 4 26 59 PM" src="https://user-images.githubusercontent.com/9079960/189105300-9fa83e93-5dfd-4cea-8cb4-4985ad74a406.png">


Fix: use a separate method for fetching docfield parents.


Unrelated change: Dropped file upload plugin for cypress, it can now do it natively. 