### PR TITLE
feat: specify sender for auto email report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -39,7 +39,8 @@ frappe.ui.form.on("Auto Email Report", {
 		frm.set_query("sender", function () {
 			return {
 				filters: {
-					enable_outgoing: true,
+					enable_outgoing: 1,
+					awaiting_password: 0,
 				},
 			};
 		});

--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -35,6 +35,14 @@ frappe.ui.form.on("Auto Email Report", {
 				frm.set_value("email_to", frappe.session.user);
 			}
 		}
+
+		frm.set_query("sender", function () {
+			return {
+				filters: {
+					enable_outgoing: true,
+				},
+			};
+		});
 	},
 	report: function (frm) {
 		frm.set_value("filters", "");

--- a/frappe/email/doctype/auto_email_report/auto_email_report.json
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -30,7 +30,6 @@
   "day_of_week",
   "column_break_13",
   "sender",
-  "sender_email",
   "frequency",
   "format",
   "section_break_15",
@@ -208,14 +207,6 @@
    "fieldtype": "Link",
    "label": "Sender",
    "options": "Email Account"
-  },
-  {
-   "fetch_from": "sender.email_id",
-   "fieldname": "sender_email",
-   "fieldtype": "Data",
-   "label": "Sender Email",
-   "options": "Email",
-   "read_only": 1
   }
  ],
  "links": [],

--- a/frappe/email/doctype/auto_email_report/auto_email_report.json
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -1,238 +1,257 @@
 {
-   "allow_rename": 1,
-   "creation": "2016-09-01 01:34:34.985457",
-   "doctype": "DocType",
-   "editable_grid": 1,
-   "engine": "InnoDB",
-   "field_order": [
-    "report",
-    "user",
-    "enabled",
-    "column_break_4",
-    "report_type",
-    "reference_report",
-    "filter_data",
-    "send_if_data",
-    "data_modified_till",
-    "no_of_rows",
-    "report_filters",
-    "filters_display",
-    "filters",
-    "filter_meta",
-    "dynamic_report_filters_section",
-    "from_date_field",
-    "to_date_field",
-    "column_break_17",
-    "dynamic_date_period",
-    "email_settings",
-    "email_to",
-    "day_of_week",
-    "column_break_13",
-    "frequency",
-    "format",
-    "section_break_15",
-    "description"
-   ],
-   "fields": [
-    {
-     "fieldname": "report",
-     "fieldtype": "Link",
-     "label": "Report",
-     "options": "Report",
-     "reqd": 1
-    },
-    {
-     "default": "User",
-     "fieldname": "user",
-     "fieldtype": "Link",
-     "label": "Based on Permissions For User",
-     "options": "User",
-     "reqd": 1
-    },
-    {
-     "default": "1",
-     "fieldname": "enabled",
-     "fieldtype": "Check",
-     "label": "Enabled"
-    },
-    {
-     "fieldname": "column_break_4",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fetch_from": "report.report_type",
-     "fieldname": "report_type",
-     "fieldtype": "Read Only",
-     "label": "Report Type"
-    },
-    {
-     "fieldname": "filter_data",
-     "fieldtype": "Section Break",
-     "label": "Filter Data"
-    },
-    {
-     "default": "1",
-     "fieldname": "send_if_data",
-     "fieldtype": "Check",
-     "label": "Send only if there is any data"
-    },
-    {
-     "depends_on": "eval:doc.report_type=='Report Builder'",
-     "description": "Zero means send records updated at anytime",
-     "fieldname": "data_modified_till",
-     "fieldtype": "Int",
-     "label": "Only Send Records Updated in Last X Hours"
-    },
-    {
-     "default": "100",
-     "fieldname": "no_of_rows",
-     "fieldtype": "Int",
-     "label": "No of Rows (Max 500)"
-    },
-    {
-     "collapsible": 1,
-     "depends_on": "eval:doc.report_type !== 'Report Builder'",
-     "fieldname": "report_filters",
-     "fieldtype": "Section Break",
-     "label": "Report Filters"
-    },
-    {
-     "fieldname": "filters_display",
-     "fieldtype": "HTML",
-     "label": "Filters Display"
-    },
-    {
-     "fieldname": "filters",
-     "fieldtype": "Text",
-     "hidden": 1,
-     "label": "Filters"
-    },
-    {
-     "fieldname": "filter_meta",
-     "fieldtype": "Text",
-     "hidden": 1,
-     "label": "Filter Meta",
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "depends_on": "eval:doc.report_type !== 'Report Builder'",
-     "fieldname": "dynamic_report_filters_section",
-     "fieldtype": "Section Break",
-     "label": "Dynamic Report Filters"
-    },
-    {
-     "fieldname": "from_date_field",
-     "fieldtype": "Select",
-     "label": "From Date Field"
-    },
-    {
-     "fieldname": "to_date_field",
-     "fieldtype": "Select",
-     "label": "To Date Field"
-    },
-    {
-     "fieldname": "column_break_17",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "dynamic_date_period",
-     "fieldtype": "Select",
-     "label": "Period",
-     "options": "\nDaily\nWeekly\nMonthly\nQuarterly\nHalf Yearly\nYearly"
-    },
-    {
-     "fieldname": "email_settings",
-     "fieldtype": "Section Break",
-     "label": "Email Settings"
-    },
-    {
-     "description": "For multiple addresses, enter the address on different line. e.g. test@test.com \u23ce test1@test.com",
-     "fieldname": "email_to",
-     "fieldtype": "Small Text",
-     "label": "Email To",
-     "reqd": 1
-    },
-    {
-     "default": "Monday",
-     "depends_on": "eval:doc.frequency=='Weekly'",
-     "fieldname": "day_of_week",
-     "fieldtype": "Select",
-     "label": "Day of Week",
-     "options": "Monday\nTuesday\nWednesday\nThursday\nFriday\nSaturday\nSunday"
-    },
-    {
-     "fieldname": "column_break_13",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "frequency",
-     "fieldtype": "Select",
-     "in_list_view": 1,
-     "in_standard_filter": 1,
-     "label": "Frequency",
-     "options": "Daily\nWeekdays\nWeekly\nMonthly",
-     "reqd": 1
-    },
-    {
-     "fieldname": "format",
-     "fieldtype": "Select",
-     "label": "Format",
-     "options": "HTML\nXLSX\nCSV",
-     "reqd": 1
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "section_break_15",
-     "fieldtype": "Section Break",
-     "label": "Message"
-    },
-    {
-     "fieldname": "description",
-     "fieldtype": "Text Editor",
-     "label": "Message"
-    },
-    {
-     "fetch_from": "report.reference_report",
-     "fieldname": "reference_report",
-     "fieldtype": "Data",
-     "hidden": 1,
-     "label": "Reference Report",
-     "read_only": 1
-    }
-   ],
-   "modified": "2021-01-28 15:59:43.151995",
-   "modified_by": "Administrator",
-   "module": "Email",
-   "name": "Auto Email Report",
-   "owner": "Administrator",
-   "permissions": [
-    {
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "export": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "System Manager",
-     "share": 1,
-     "write": 1
-    },
-    {
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "export": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Report Manager",
-     "share": 1,
-     "write": 1
-    }
-   ],
-   "sort_field": "modified",
-   "sort_order": "DESC",
-   "track_changes": 1
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2016-09-01 01:34:34.985457",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "report",
+  "user",
+  "enabled",
+  "column_break_4",
+  "report_type",
+  "reference_report",
+  "filter_data",
+  "send_if_data",
+  "data_modified_till",
+  "no_of_rows",
+  "report_filters",
+  "filters_display",
+  "filters",
+  "filter_meta",
+  "dynamic_report_filters_section",
+  "from_date_field",
+  "to_date_field",
+  "column_break_17",
+  "dynamic_date_period",
+  "email_settings",
+  "email_to",
+  "day_of_week",
+  "column_break_13",
+  "sender",
+  "sender_email",
+  "frequency",
+  "format",
+  "section_break_15",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "report",
+   "fieldtype": "Link",
+   "label": "Report",
+   "options": "Report",
+   "reqd": 1
+  },
+  {
+   "default": "User",
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "label": "Based on Permissions For User",
+   "options": "User",
+   "reqd": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "label": "Enabled"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "report.report_type",
+   "fieldname": "report_type",
+   "fieldtype": "Read Only",
+   "label": "Report Type"
+  },
+  {
+   "fieldname": "filter_data",
+   "fieldtype": "Section Break",
+   "label": "Filter Data"
+  },
+  {
+   "default": "1",
+   "fieldname": "send_if_data",
+   "fieldtype": "Check",
+   "label": "Send only if there is any data"
+  },
+  {
+   "depends_on": "eval:doc.report_type=='Report Builder'",
+   "description": "Zero means send records updated at anytime",
+   "fieldname": "data_modified_till",
+   "fieldtype": "Int",
+   "label": "Only Send Records Updated in Last X Hours"
+  },
+  {
+   "default": "100",
+   "fieldname": "no_of_rows",
+   "fieldtype": "Int",
+   "label": "No of Rows (Max 500)"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:doc.report_type !== 'Report Builder'",
+   "fieldname": "report_filters",
+   "fieldtype": "Section Break",
+   "label": "Report Filters"
+  },
+  {
+   "fieldname": "filters_display",
+   "fieldtype": "HTML",
+   "label": "Filters Display"
+  },
+  {
+   "fieldname": "filters",
+   "fieldtype": "Text",
+   "hidden": 1,
+   "label": "Filters"
+  },
+  {
+   "fieldname": "filter_meta",
+   "fieldtype": "Text",
+   "hidden": 1,
+   "label": "Filter Meta",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:doc.report_type !== 'Report Builder'",
+   "fieldname": "dynamic_report_filters_section",
+   "fieldtype": "Section Break",
+   "label": "Dynamic Report Filters"
+  },
+  {
+   "fieldname": "from_date_field",
+   "fieldtype": "Select",
+   "label": "From Date Field"
+  },
+  {
+   "fieldname": "to_date_field",
+   "fieldtype": "Select",
+   "label": "To Date Field"
+  },
+  {
+   "fieldname": "column_break_17",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "dynamic_date_period",
+   "fieldtype": "Select",
+   "label": "Period",
+   "options": "\nDaily\nWeekly\nMonthly\nQuarterly\nHalf Yearly\nYearly"
+  },
+  {
+   "fieldname": "email_settings",
+   "fieldtype": "Section Break",
+   "label": "Email Settings"
+  },
+  {
+   "description": "For multiple addresses, enter the address on different line. e.g. test@test.com \u23ce test1@test.com",
+   "fieldname": "email_to",
+   "fieldtype": "Small Text",
+   "label": "Email To",
+   "reqd": 1
+  },
+  {
+   "default": "Monday",
+   "depends_on": "eval:doc.frequency=='Weekly'",
+   "fieldname": "day_of_week",
+   "fieldtype": "Select",
+   "label": "Day of Week",
+   "options": "Monday\nTuesday\nWednesday\nThursday\nFriday\nSaturday\nSunday"
+  },
+  {
+   "fieldname": "column_break_13",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "frequency",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Frequency",
+   "options": "Daily\nWeekdays\nWeekly\nMonthly",
+   "reqd": 1
+  },
+  {
+   "fieldname": "format",
+   "fieldtype": "Select",
+   "label": "Format",
+   "options": "HTML\nXLSX\nCSV",
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_15",
+   "fieldtype": "Section Break",
+   "label": "Message"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Message"
+  },
+  {
+   "fetch_from": "report.reference_report",
+   "fieldname": "reference_report",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Reference Report",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sender",
+   "fieldtype": "Link",
+   "label": "Sender",
+   "options": "Email Account"
+  },
+  {
+   "fetch_from": "sender.email_id",
+   "fieldname": "sender_email",
+   "fieldtype": "Data",
+   "label": "Sender Email",
+   "options": "Email",
+   "read_only": 1
   }
+ ],
+ "links": [],
+ "modified": "2022-09-08 15:31:55.031023",
+ "modified_by": "Administrator",
+ "module": "Email",
+ "name": "Auto Email Report",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Report Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -38,6 +38,11 @@ class AutoEmailReport(Document):
 		self.validate_report_format()
 		self.validate_mandatory_fields()
 
+	@property
+	def sender_email(self):
+		email_id, login_id = frappe.db.get_value("Email Account", self.sender, ["email_id", "login_id"])
+		return login_id if login_id else email_id
+
 	def validate_emails(self):
 		"""Cleanup list of emails"""
 		if "," in self.email_to:
@@ -202,13 +207,9 @@ class AutoEmailReport(Document):
 		if not self.format == "HTML":
 			attachments = [{"fname": self.get_file_name(), "fcontent": data}]
 
-		sender = None
-		if self.sender and self.sender_email:
-			sender = formataddr((self.sender, self.sender_email))
-
 		frappe.sendmail(
 			recipients=self.email_to.split(),
-			sender=sender,
+			sender=formataddr((self.sender, self.sender_email)) if self.sender else "",
 			subject=self.name,
 			message=message,
 			attachments=attachments,

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -3,6 +3,7 @@
 
 import calendar
 from datetime import timedelta
+from email.utils import formataddr
 
 import frappe
 from frappe import _
@@ -201,8 +202,13 @@ class AutoEmailReport(Document):
 		if not self.format == "HTML":
 			attachments = [{"fname": self.get_file_name(), "fcontent": data}]
 
+		sender = None
+		if self.sender and self.sender_email:
+			sender = formataddr((self.sender, self.sender_email))
+
 		frappe.sendmail(
 			recipients=self.email_to.split(),
+			sender=sender,
 			subject=self.name,
 			message=message,
 			attachments=attachments,


### PR DESCRIPTION
This PR will allow user to specify the sender for auto email report, exactly same way Notification does.

If left blank, the default email account will be used. (Current behavior)

docs: https://docs.erpnext.com/docs/v14/user/manual/en/setting-up/email/auto-email-reports/edit?wiki_page_patch=7c843e970a

![image](https://user-images.githubusercontent.com/29856401/189218537-56102fc3-8519-42db-817f-4351f29994bf.png)
