### PR TITLE
fix: don't attempt to delete session during read only session

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -251,6 +251,12 @@ def handle_exception(e):
 		or (frappe.local.request.path.startswith("/api/") and not accept_header.startswith("text"))
 	)
 
+	if not frappe.session.user:
+		# If session creation fails then user won't be unset. This causes a lot of code that
+		# assumes presence of this to fail. Session creation fails => guest or expired login
+		# usually.
+		frappe.session.user = "Guest"
+
 	if respond_as_json:
 		# handle ajax responses first
 		# if the request is ajax, send back the trace or error message

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -90,6 +90,11 @@ def get_sessions_to_clear(user=None, keep_current=False, device=None):
 def delete_session(sid=None, user=None, reason="Session Expired"):
 	from frappe.core.doctype.activity_log.feed import logout_feed
 
+	if frappe.flags.read_only:
+		# This isn't manually initated logout, most likely user's cookies were expired in such case
+		# we should just ignore it till database is back up again.
+		return
+
 	frappe.cache().hdel("session", sid)
 	frappe.cache().hdel("last_db_session_update", sid)
 	if sid and not user:


### PR DESCRIPTION
Extends https://github.com/frappe/frappe/pull/18050

- When someone with expired cookie visits the page and we aren't able to delete session it fails, usually this means SID is already deleted from database so we can just log user out and continue. 
- `handle_exception` now sets user to guest to avoid causing exceptions WHILE handling exception. 


```
Traceback (most recent call last):
  File "/Users/ankush/benches/develop/apps/frappe/frappe/app.py", line 55, in application
    init_request(request)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/app.py", line 132, in init_request
    frappe.local.http_request = frappe.auth.HTTPRequest()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/auth.py", line 33, in __init__
    self.set_session()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/auth.py", line 67, in set_session
    frappe.local.login_manager = LoginManager()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/auth.py", line 116, in __init__
    self.make_session(resume=True)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/auth.py", line 204, in make_session
    frappe.local.session_obj = Session(
  File "/Users/ankush/benches/develop/apps/frappe/frappe/sessions.py", line 233, in __init__
    self.resume()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/sessions.py", line 300, in resume
    data = self.get_session_record()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/sessions.py", line 318, in get_session_record
    r = self.get_session_data()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/sessions.py", line 334, in get_session_data
    data = self.get_session_data_from_db()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/sessions.py", line 382, in get_session_data_from_db
    self._delete_session()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/sessions.py", line 388, in _delete_session
    delete_session(self.sid, reason="Session Expired")
  File "/Users/ankush/benches/develop/apps/frappe/frappe/sessions.py", line 104, in delete_session
    frappe.db.delete("Sessions", {"sid": sid})
  File "/Users/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 1226, in delete
    return query.run(**kwargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/query_builder/utils.py", line 76, in execute_query
    return frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
  File "/Users/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 223, in sql
    frappe.throw(
  File "/Users/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 522, in throw
    msgprint(
  File "/Users/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 490, in msgprint
    _raise_exception()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 442, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.InReadOnlyMode: Site is running in read only mode, this action can not be performed right now. Please try again later.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/serve.py", line 18, in get_response
    response = renderer_instance.render()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 78, in render
    html = self.get_html()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/utils.py", line 510, in cache_html_decorator
    html = func(*args, **kwargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 93, in get_html
    self.post_process_context()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 101, in post_process_context
    self.set_user_info()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 302, in set_user_info
    info = get_fullname_and_avatar(frappe.session.user)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/utils/user.py", line 275, in get_fullname_and_avatar
    first_name, last_name, avatar, name = frappe.db.get_value(
TypeError: cannot unpack non-iterable NoneType object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/ankush/benches/develop/apps/frappe/frappe/middlewares.py", line 16, in __call__
    return super().__call__(environ, start_response)
  File "/Users/ankush/benches/develop/env/lib/python3.10/site-packages/werkzeug/middleware/shared_data.py", line 247, in __call__
    return self.app(environ, start_response)
  File "/Users/ankush/benches/develop/env/lib/python3.10/site-packages/werkzeug/middleware/shared_data.py", line 247, in __call__
    return self.app(environ, start_response)
  File "/Users/ankush/benches/develop/env/lib/python3.10/site-packages/werkzeug/local.py", line 237, in application
    return ClosingIterator(app(environ, start_response), self.cleanup)
  File "/Users/ankush/benches/develop/env/lib/python3.10/site-packages/werkzeug/wrappers/request.py", line 187, in application
    resp = f(*args[:-2] + (request,))
  File "/Users/ankush/benches/develop/apps/frappe/frappe/app.py", line 87, in application
    response = handle_exception(e)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/app.py", line 318, in handle_exception
    response = get_response("message", http_status_code=http_status_code)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/serve.py", line 27, in get_response
    response = ErrorPage(exception=e).render()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 78, in render
    html = self.get_html()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/utils.py", line 510, in cache_html_decorator
    html = func(*args, **kwargs)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 93, in get_html
    self.post_process_context()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 101, in post_process_context
    self.set_user_info()
  File "/Users/ankush/benches/develop/apps/frappe/frappe/website/page_renderers/template_page.py", line 302, in set_user_info
    info = get_fullname_and_avatar(frappe.session.user)
  File "/Users/ankush/benches/develop/apps/frappe/frappe/utils/user.py", line 275, in get_fullname_and_avatar
    first_name, last_name, avatar, name = frappe.db.get_value(
TypeError: cannot unpack non-iterable NoneType object
```