### PR TITLE
fix: erase default before adding new series-es

### DIFF
--- a/.github/workflows/server-mariadb-tests.yml
+++ b/.github/workflows/server-mariadb-tests.yml
@@ -74,7 +74,6 @@ jobs:
           fi
 
       - uses: actions/setup-node@v3
-        if: ${{ steps.check-build.outputs.build == 'strawberry' }}
         with:
           node-version: 16
           check-latest: true

--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -113,6 +113,8 @@ class DocumentNamingSettings(Document):
 
 		option_string = "\n".join(options)
 
+		# Erase default first, it might not be in new options.
+		self.update_naming_series_property_setter(doctype, "default", "")
 		self.update_naming_series_property_setter(doctype, "options", option_string)
 		self.update_naming_series_property_setter(doctype, "default", default)
 


### PR DESCRIPTION
fixes https://github.com/frappe/frappe/issues/18078 

There's no other way, it's a two-step process, if you swap the steps it will require default to already exist. One way or another either you need to ignore validation or clear existing values first. 