### PR TITLE
fix: set `doctype` and `name` in docinfo

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -110,6 +110,8 @@ def get_docinfo(doc=None, doctype=None, name=None):
 
 	docinfo.update(
 		{
+			"doctype": doc.doctype,
+			"name": doc.name,
 			"attachments": get_attachments(doc.doctype, doc.name),
 			"communications": communications_except_auto_messages,
 			"automated_messages": automated_messages,

--- a/frappe/public/js/frappe/model/sync.js
+++ b/frappe/public/js/frappe/model/sync.js
@@ -56,16 +56,11 @@ Object.assign(frappe.model, {
 	sync_docinfo: (r) => {
 		// set docinfo (comments, assign, attachments)
 		if (r.docinfo) {
-			var doc;
-			if (r.docs) {
-				doc = r.docs[0];
-			} else {
-				if (cur_frm) doc = cur_frm.doc;
+			const { doctype, name } = r.docinfo;
+			if (!frappe.model.docinfo[doctype]) {
+				frappe.model.docinfo[doctype] = {};
 			}
-			if (doc) {
-				if (!frappe.model.docinfo[doc.doctype]) frappe.model.docinfo[doc.doctype] = {};
-				frappe.model.docinfo[doc.doctype][doc.name] = r.docinfo;
-			}
+			frappe.model.docinfo[doctype][name] = r.docinfo;
 
 			// copy values to frappe.boot.user_info
 			Object.assign(frappe.boot.user_info, r.docinfo.user_info);


### PR DESCRIPTION
This is better than trusting `cur_frm` to be the same as the one `docinfo` is being set for.