### PR TITLE
fix: coalesce `not in` queries

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -370,7 +370,7 @@ def get_workspace_sidebar_items():
 
 	filters = {
 		"restrict_to_domain": ["in", frappe.get_active_domains()],
-		"module": ["not in", blocked_modules],
+		"ifnull(module, '')": ("not in", blocked_modules)
 	}
 
 	if has_access:

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -370,7 +370,7 @@ def get_workspace_sidebar_items():
 
 	filters = {
 		"restrict_to_domain": ["in", frappe.get_active_domains()],
-		"ifnull(module, '')": ("not in", blocked_modules)
+		"module": ["not in", blocked_modules],
 	}
 
 	if has_access:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -613,7 +613,10 @@ class DatabaseQuery:
 
 		elif f.operator.lower() in ("in", "not in"):
 			# if values contain '' or falsy values then only coalesce column
-			can_be_null = not f.value or any(v is None or v == "" for v in f.value)
+			# for `in` query this is only required if values contain '' or values are empty.
+			# for `not in` queries we can't be sure as column values might contain null.
+			if f.operator.lower() == "in":
+				can_be_null = not f.value or any(v is None or v == "" for v in f.value)
 
 			values = f.value or ""
 			if isinstance(values, str):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -835,6 +835,10 @@ class TestReportview(FrappeTestCase):
 		self.assertNotIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", "b"])}, run=0))
 		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", None])}, run=0))
 		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", ""])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", [])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", ["a"])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", [])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", [""])}, run=0))
 
 
 def add_child_table_to_blog_post():


### PR DESCRIPTION
It used to work before now it is breaking might be because of this PR https://github.com/frappe/frappe/pull/17537