### PR TITLE
fix: Show quick list only if user has access

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -291,12 +291,13 @@ class Workspace:
 		quick_lists = self.doc.quick_lists
 
 		for item in quick_lists:
-			new_item = item.as_dict().copy()
+			if self.is_item_allowed(item.document_type, "doctype"):
+				new_item = item.as_dict().copy()
 
-			# Translate label
-			new_item["label"] = _(item.label) if item.label else _(item.document_type)
+				# Translate label
+				new_item["label"] = _(item.label) if item.label else _(item.document_type)
 
-			items.append(new_item)
+				items.append(new_item)
 
 		return items
 


### PR DESCRIPTION
Quick lists are visible to everyone irrespective of whether they have access or not. Show quick lists only if the user has access to the doctype

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/189836511-92f252a0-8c4a-464a-b208-7488a27926c9.png">
