### PR TITLE
fix(style): Add box shadow for quick lists to bind the list and button

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -710,6 +710,8 @@ body {
 	}
 
 	&.quick-list-widget-box {
+		box-shadow: var(--card-shadow);
+
 		.list-loading-state, .list-no-data-state {
 			display: flex;
 			justify-content: center;


### PR DESCRIPTION
If there are lesser items in the quick list, the list and the button don't look like one unit. The button looks like an orphan.

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/189841901-462dbd28-c24d-47a8-9511-8c3e6a5d86e4.png">

Add box shadow for quick lists to bind the list and the button:

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/189841379-cfa6ab4b-87c8-4151-bb81-021724ce7e31.png">

P.S. Just close the PR if this is looking weird 🙃