### PR TITLE
fix: create a private workspace if user doesn't have access while duplicating

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -266,6 +266,7 @@ def duplicate_page(page_name, new_page):
 	doc.public = new_page.get("is_public")
 	doc.for_user = ""
 	doc.label = doc.title
+	doc.module = ""
 	if not doc.public:
 		doc.for_user = doc.for_user or frappe.session.user
 		doc.label = f"{doc.title}-{doc.for_user}"

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -794,7 +794,11 @@ frappe.views.Workspace = class Workspace {
 
 	duplicate_page(page) {
 		var me = this;
-		let parent_pages = this.get_parent_pages(page);
+		let new_page = { ...page };
+		if (!this.has_access && new_page.public) {
+			new_page.public = 0;
+		}
+		let parent_pages = this.get_parent_pages({ public: new_page.public });
 		const d = new frappe.ui.Dialog({
 			title: __("Create Duplicate"),
 			fields: [
@@ -809,14 +813,14 @@ frappe.views.Workspace = class Workspace {
 					fieldtype: "Select",
 					fieldname: "parent",
 					options: parent_pages,
-					default: page.parent_page,
+					default: new_page.parent_page,
 				},
 				{
 					label: __("Public"),
 					fieldtype: "Check",
 					fieldname: "is_public",
 					depends_on: `eval:${this.has_access}`,
-					default: page.public,
+					default: new_page.public,
 					onchange: function () {
 						d.set_df_property(
 							"parent",
@@ -832,7 +836,7 @@ frappe.views.Workspace = class Workspace {
 					label: __("Icon"),
 					fieldtype: "Icon",
 					fieldname: "icon",
-					default: page.icon,
+					default: new_page.icon,
 				},
 			],
 			primary_action_label: __("Duplicate"),
@@ -853,8 +857,6 @@ frappe.views.Workspace = class Workspace {
 						}
 					},
 				});
-
-				let new_page = { ...page };
 
 				new_page.title = values.title;
 				new_page.public = values.is_public || 0;

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -390,18 +390,17 @@ frappe.views.Workspace = class Workspace {
 
 		this.clear_page_actions();
 
-		current_page.is_editable &&
-			this.page.set_secondary_action(__("Edit"), async () => {
-				if (!this.editor || !this.editor.readOnly) return;
-				this.is_read_only = false;
-				await this.editor.readOnly.toggle();
-				this.editor.isReady.then(() => {
-					this.initialize_editorjs_undo();
-					this.setup_customization_buttons(current_page);
-					this.show_sidebar_actions();
-					this.make_blocks_sortable();
-				});
+		this.page.set_secondary_action(__("Edit"), async () => {
+			if (!this.editor || !this.editor.readOnly) return;
+			this.is_read_only = false;
+			await this.editor.readOnly.toggle();
+			this.editor.isReady.then(() => {
+				this.initialize_editorjs_undo();
+				this.setup_customization_buttons(current_page);
+				this.show_sidebar_actions();
+				this.make_blocks_sortable();
 			});
+		});
 
 		this.page.add_inner_button(__("Create Workspace"), () => {
 			this.initialize_new_page();


### PR DESCRIPTION
**Issue:**
If a user who doesn't have access to create a public workspace tries to create a duplicate of any existing public workspace a public workspace is created but after the refresh, it goes away. (I don't know how I missed this, I am very certain that I did test this scenario anyway fixing it now)

Also, if the user doesn't have access to create or edit a public workspace he/she cannot create a duplicate of a public page because the "Edit" button is not visible.  It becomes visible if he/she has at least one private workspace.

**Fix:** Show **Edit** button always, the user will still be able to edit the currently opened public workspace if he/she clicks on the Edit button he/she will not be able to save the changes as the Save button is not visible.

**Before:**
![DuplicateWorkspaceBug](https://user-images.githubusercontent.com/30859809/189890061-a9ca9124-d399-4502-a3c2-4d5c04113655.gif)

**After:**
![DuplicateWorkspaceFix](https://user-images.githubusercontent.com/30859809/189890119-6ad31172-39dc-4f71-bcfa-24b0190edf44.gif)