### PR TITLE
chore(DX): RQ job name when func object is passed

### DIFF
--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -30,11 +30,9 @@ class TestRQJob(FrappeTestCase):
 	def test_serialization(self):
 
 		job = frappe.enqueue(method=self.BG_JOB, queue="short")
-
 		rq_job = frappe.get_doc("RQ Job", job.id)
 
 		self.assertEqual(job, rq_job.job)
-
 		self.assertDocumentEqual(
 			{
 				"name": job.id,
@@ -46,6 +44,11 @@ class TestRQJob(FrappeTestCase):
 			rq_job,
 		)
 		self.check_status(job, "finished")
+
+	def test_func_obj_serialization(self):
+		job = frappe.enqueue(method=test_func, queue="short")
+		rq_job = frappe.get_doc("RQ Job", job.id)
+		self.assertEqual(rq_job.job_name, "test_func")
 
 	def test_get_list_filtering(self):
 


### PR DESCRIPTION
function objects aren't properly shown in title field cause they are interpreted as HTML tag :lol: 

<img width="829" alt="Screenshot 2022-09-13 at 6 49 43 PM" src="https://user-images.githubusercontent.com/9079960/189912826-cf6d45c7-1799-408f-ae9a-3d18fe973f79.png">


This doesn't apply to other doctypes, hence local fix. 