### PR TITLE
ci: stale doctype check

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -141,3 +141,5 @@ jobs:
           rm -rf ~/frappe-bench/env
           bench -v setup env
           bench --site test_site migrate
+
+          bench --site test_site execute frappe.tests.utils.test_stale_doctypes

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -212,3 +212,4 @@ frappe.patches.v14_0.different_encryption_key
 frappe.patches.v14_0.update_multistep_webforms
 execute:frappe.delete_doc('Page', 'background_jobs', ignore_missing=True, force=True)
 frappe.patches.v14_0.drop_unused_indexes
+frappe.patches.v14_0.remove_stale_deleted_doctypes

--- a/frappe/patches/v14_0/remove_stale_deleted_doctypes.py
+++ b/frappe/patches/v14_0/remove_stale_deleted_doctypes.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe.model.base_document import get_controller
+
+DELETED_DOCTYPES = [
+	"Feedback",
+	"Test rename new",
+	"test",
+	"Scheduler Log",
+]
+
+
+def execute():
+	for doctype in DELETED_DOCTYPES:
+		if not controller_exists(doctype):
+			frappe.delete_doc("DocType", doctype, force=True, ignore_missing=True)
+
+
+def controller_exists(doctype: str) -> bool:
+	try:
+		get_controller(doctype)
+		return True  # Another controller exists for this doctype, perhaps a separate app?
+	except Exception:
+		return False


### PR DESCRIPTION
To avoid errors like: https://github.com/frappe/erpnext/pull/27313 https://github.com/frappe/erpnext/pull/27700 and many many more. 

Since we do release-wise migration test ideally any doctype added in v12+ and not present anymore in code should get caught by this test. 

- [x] doctypes
- [ ] reports
- [ ] page

re of https://github.com/frappe/erpnext/pull/27703 
workaround for https://github.com/frappe/frappe/issues/18114