### PR TITLE
fix: allow standard webforms to be unpublished

### DIFF
--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -72,6 +72,14 @@ frappe.ui.form.on("Web Form", {
 				frm.refresh();
 			});
 		});
+		frm.trigger('add_publish_button');
+	},
+
+	add_publish_button(frm) {
+		frm.add_custom_button(frm.doc.published ? __("Unpublish") : __("Publish"), () => {
+			frm.set_value("published", !frm.doc.published);
+			frm.save();
+		});
 	},
 
 	title: function(frm) {

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -36,17 +36,20 @@ class WebForm(WebsiteGenerator):
 		if not self.module:
 			self.module = frappe.db.get_value("DocType", self.doc_type, "module")
 
-		if (
-			not (
-				frappe.flags.in_install
-				or frappe.flags.in_patch
-				or frappe.flags.in_test
-				or frappe.flags.in_fixtures
-			)
-			and self.is_standard
-			and not frappe.conf.developer_mode
-		):
-			frappe.throw(_("You need to be in developer mode to edit a Standard Web Form"))
+		in_user_env = not (
+			frappe.flags.in_install
+			or frappe.flags.in_patch
+			or frappe.flags.in_test
+			or frappe.flags.in_fixtures
+		)
+		if in_user_env and self.is_standard and not frappe.conf.developer_mode:
+			# only published can be changed for standard web forms
+			if self.has_value_changed('published'):
+				published_value = self.published
+				self.reload()
+				self.published = published_value
+			else:
+				frappe.throw(_("You need to be in developer mode to edit a Standard Web Form"))
 
 		if not frappe.flags.in_import:
 			self.validate_fields()

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -44,7 +44,7 @@ class WebForm(WebsiteGenerator):
 		)
 		if in_user_env and self.is_standard and not frappe.conf.developer_mode:
 			# only published can be changed for standard web forms
-			if self.has_value_changed('published'):
+			if self.has_value_changed("published"):
 				published_value = self.published
 				self.reload()
 				self.published = published_value


### PR DESCRIPTION
Backport commit https://github.com/frappe/frappe/pull/17232/commits/b3e425d44d36e041e6dc384f548133a745257e50 to version-13-hotfix