### PR TITLE
perf!: Only add modified index on parent doctypes

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -212,3 +212,4 @@ frappe.patches.v14_0.different_encryption_key
 frappe.patches.v14_0.update_multistep_webforms
 execute:frappe.delete_doc('Page', 'background_jobs', ignore_missing=True, force=True)
 frappe.patches.v14_0.drop_unused_indexes
+frappe.patches.v15_0.drop_modified_index

--- a/frappe/patches/v14_0/drop_unused_indexes.py
+++ b/frappe/patches/v14_0/drop_unused_indexes.py
@@ -30,7 +30,7 @@ def execute():
 		table = f"tab{doctype}"
 		if table not in db_tables:
 			continue
-		_drop_index_if_exists(table, "parent")
+		drop_index_if_exists(table, "parent")
 
 	# Unused composite indexes
 	for doctype, index_fields in UNUSED_INDEXES:
@@ -38,10 +38,10 @@ def execute():
 		index_name = frappe.db.get_index_name(index_fields)
 		if table not in db_tables:
 			continue
-		_drop_index_if_exists(table, index_name)
+		drop_index_if_exists(table, index_name)
 
 
-def _drop_index_if_exists(table: str, index: str):
+def drop_index_if_exists(table: str, index: str):
 	if not frappe.db.has_index(table, index):
 		click.echo(f"- Skipped {index} index for {table} because it doesn't exist")
 		return

--- a/frappe/patches/v15_0/drop_modified_index.py
+++ b/frappe/patches/v15_0/drop_modified_index.py
@@ -1,0 +1,21 @@
+import frappe
+from frappe.patches.v14_0.drop_unused_indexes import drop_index_if_exists
+
+
+def execute():
+	if frappe.db.db_type == "postgres":
+		return
+
+	db_tables = frappe.db.get_tables(cached=False)
+
+	child_tables = frappe.get_all(
+		"DocType",
+		{"istable": 1, "is_virtual": 0},
+		pluck="name",
+	)
+
+	for doctype in child_tables:
+		table = f"tab{doctype}"
+		if table not in db_tables:
+			continue
+		drop_index_if_exists(table, "modified")


### PR DESCRIPTION
summary: Don't add `modified` index on child tables by default. 

Child tables are frequently ONLY sorted by `idx` (when they are loaded in desk) and filtered mostly by `parent` index. I can't see any valid reason to have a modified index by **default**.

https://github.com/frappe/frappe/blob/f4a332b0098042241d1e553be2c97fd03aad0d9b/frappe/model/document.py#L162-L171


TODO:
- [x] patch
- [ ] default sort ordering - not changing. Refer comment below https://github.com/frappe/frappe/pull/18119#issuecomment-1248028363

migration guide: https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-%28future-v15%29