### PR TITLE
chore: bump `pypng` to prevent conflict with India Compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "pyasn1~=0.4.8",
     "pycryptodome~=3.10.1",
     "pyotp~=2.6.0",
-    "pypng~=0.0.20",
+    "pypng~=0.20220715.0",
     "python-dateutil~=2.8.1",
     "pytz==2022.1",
     "rauth~=0.7.3",


### PR DESCRIPTION
This happens because India Compliance currently has the same branch for `v14` and `develop`.

Closes https://github.com/resilient-tech/india-compliance/issues/249