### PR TITLE
fix: dynamic label for document rename

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -197,10 +197,16 @@ frappe.ui.form.Toolbar = class Toolbar {
 
 			// check if docname is updatable
 			if (me.can_rename()) {
+				let label = __("New Name");
+				if (me.frm.meta.autoname && me.frm.meta.autoname.startsWith("field:")) {
+					let fieldname = me.frm.meta.autoname.split(":")[1];
+					label = __("New {0}", [me.frm.get_docfield(fieldname).label]);
+				}
+
 				fields.push(
 					...[
 						{
-							label: __("New Name"),
+							label: label,
 							fieldname: "name",
 							fieldtype: "Data",
 							reqd: 1,


### PR DESCRIPTION
**Issue**

While renaming "Item", system shows two value to rename

1. Item Code
2. Item Name

Item Name field has a label as New Item Name, where as Item Code has label as New Name which is confusing for the new user. This PR will get the label if the Auto-name is set based on fieldname

<img width="666" alt="Screenshot 2022-09-14 at 3 28 23 PM" src="https://user-images.githubusercontent.com/8780500/190124207-256fd507-c251-4ec0-9d3a-3d382463ad8a.png">


**After Fix**
<img width="795" alt="Screenshot 2022-09-14 at 3 21 51 PM" src="https://user-images.githubusercontent.com/8780500/190124242-466b3802-8b96-4106-a1af-caf644c48180.png">


Fix https://github.com/frappe/erpnext/issues/31987

