### PR TITLE
fix: show portal sidebar on login

### DIFF
--- a/frappe/www/me.py
+++ b/frappe/www/me.py
@@ -13,3 +13,4 @@ def get_context(context):
 		frappe.throw(_("You need to be logged in to access this page"), frappe.PermissionError)
 
 	context.current_user = frappe.get_doc("User", frappe.session.user)
+	context.show_sidebar = True


### PR DESCRIPTION
If a supplier logs in to the supplier portal they see nothing on the sidebar to navigate to "supplier portal". 

<img width="1422" alt="Screenshot 2022-09-14 at 3 32 00 PM" src="https://user-images.githubusercontent.com/9079960/190124820-85732d0e-d046-4536-b1fc-8d788189739c.png">


caused by https://github.com/frappe/frappe/pull/16356 