### PR TITLE
fix(minor): Use colors passed to `render_graph` on form dashboards

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -568,7 +568,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		this.chart_area.body.empty();
 		$.extend(args, {
 			type: "line",
-			colors: ["green"],
+			colors: args.colors || ["green"],
 			truncateLegends: 1,
 			axisOptions: {
 				shortenYAxisNumbers: 1,


### PR DESCRIPTION
**Before**:

`render_graph` does not consider the colors argument passed for the chart

```javascript
frm.dashboard.render_graph({
	data: {
		labels: labels,
		datasets: [
			{
				name: "Maximum Score",
				chartType: "bar",
				values: maximum_scores,
			},
			{
				name: "Score Obtained",
				chartType: "bar",
				values: scores,
			}
		]
	},
	title: __("Scores"),
	height: 300,
	type: "bar",
	colors: ["blue", "green"]
});
```

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/24353136/190137424-167c3692-d7d7-49d0-8a9d-b6f354b347a4.png">

**After**:

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/24353136/190137251-ffce50a8-1f38-4543-a7d8-7cc23d9f1e90.png">
