### PR TITLE
build: reliable asset building in production

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -103,7 +103,7 @@ async function execute() {
 		log_error("There were some problems during build");
 		log();
 		log(chalk.dim(e.stack));
-		if (process.env.CI) {
+		if (process.env.CI || PRODUCTION) {
 			process.kill(process.pid);
 		}
 		return;

--- a/package.json
+++ b/package.json
@@ -61,9 +61,7 @@
     "vue": "2.6.14",
     "vue-router": "^2.0.0",
     "vuedraggable": "^2.24.3",
-    "vuex": "3"
-  },
-  "devDependencies": {
+    "vuex": "3",
     "@frappe/esbuild-plugin-postcss2": "^0.1.3",
     "@vue/component-compiler": "^4.2.4",
     "autoprefixer": "10",


### PR DESCRIPTION
- Move all build dependencies from dev dependency to real dependencies. Without ESBuild and other dependencies it's not possible to use any non-frappe app, it's quite a real dependency in that sense.
- IF esbuild fails to bundle from bundling errors like syntax, missing files then exit with non-zero exit code in production. This is done to avoid silently pushing bad assets in automated build pipelines. 



