### PR TITLE
fix: show Roles child table for custom reports

### DIFF
--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -128,7 +128,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "depends_on": "eval:doc.is_standard == 'Yes'",
    "fieldname": "roles",
    "fieldtype": "Table",
    "label": "Roles",
@@ -192,10 +191,11 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-08-17 16:49:28.474274",
+ "modified": "2022-09-15 13:37:24.531848",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -242,5 +242,6 @@
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
The **Roles** child table is hidden when non-standard reports are created. Users have to go all the way to **Role Permission Manager for Page and Report** to configure permissions for custom reports. RPM for Reports picks up roles from the Report document and creates a new record in the "Custom Role" doctype (unnecessary overhead?)

Don't hide the table in the report. Did not find any side-effects to this
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/24353136/190356039-e1888db8-b733-4e75-a722-43597ae36833.png">
