### PR TITLE
fix: drop RQ failed jobs TTL from 1y to 7d

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -56,6 +56,12 @@ yarn add node-sass@4.13.1
 cd ../..
 
 bench start &
+
+CI=Yes bench build --app frappe &
+build_pid=$!
+
+
 bench --site test_site reinstall --yes
 if [ "$TYPE" == "server" ]; then bench --site test_site_producer reinstall --yes; fi
-CI=Yes bench build --app frappe
+
+wait $build_pid

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1255,10 +1255,21 @@ class Database(object):
 
 
 def enqueue_jobs_after_commit():
-	from frappe.utils.background_jobs import execute_job, get_queue
+	from frappe.utils.background_jobs import (
+		RQ_JOB_FAILURE_TTL,
+		RQ_RESULTS_TTL,
+		execute_job,
+		get_queue,
+	)
 
 	if frappe.flags.enqueue_after_commit and len(frappe.flags.enqueue_after_commit) > 0:
 		for job in frappe.flags.enqueue_after_commit:
 			q = get_queue(job.get("queue"), is_async=job.get("is_async"))
-			q.enqueue_call(execute_job, timeout=job.get("timeout"), kwargs=job.get("queue_args"))
+			q.enqueue_call(
+				execute_job,
+				timeout=job.get("timeout"),
+				kwargs=job.get("queue_args"),
+				failure_ttl=RQ_JOB_FAILURE_TTL,
+				result_ttl=RQ_RESULTS_TTL,
+			)
 		frappe.flags.enqueue_after_commit = []


### PR DESCRIPTION
port of fix 5152f13b109011e9a4fdde91dd12823c893fa5ae from https://github.com/frappe/frappe/pull/18086