### PR TITLE
fix: do not rename fieldtype options

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -527,7 +527,12 @@ def get_select_fields(old: str, new: str) -> list[dict]:
 	standard_fields = (
 		frappe.qb.from_(df)
 		.select(df.parent, df.fieldname, st_issingle)
-		.where((df.parent != new) & (df.fieldtype == "Select") & (df.options.like(f"%{old}%")))
+		.where(
+			(df.parent != new)
+			& (df.fieldname != "fieldtype")
+			& (df.fieldtype == "Select")
+			& (df.options.like(f"%{old}%"))
+		)
 		.run(as_dict=True)
 	)
 


### PR DESCRIPTION
### Problem:
If you create a doctype named "Table" and then rename it to "Table 2" then this happens

![CleanShot 2022-09-15 at 17 10 02@2x](https://user-images.githubusercontent.com/25369014/190394580-6530f220-5e73-4f3a-9bb2-7fff9e67a587.png)

It seems, while renaming a doctype, all the options of the select fields are modified

### Temporary Fix:
Do not rename options of any `DocField` that has fieldname `fieldtype`

### Permanent Fix: (needs discussion)
Do not rename select field options at all. Hardly there will be a case where select options are a list of `DocType` 

