### PR TITLE
build(deps): bump werkzeug

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -5,7 +5,8 @@ import io
 import os
 import re
 
-from werkzeug.routing import Map, NotFound, Rule
+from werkzeug.exceptions import NotFound
+from werkzeug.routing import Map, Rule
 
 import frappe
 from frappe.website.utils import extract_title, get_frontmatter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "PyYAML~=5.4.1",
     "RestrictedPython~=5.1",
     "WeasyPrint==52.5",
-    "Werkzeug~=2.1.2",
+    "Werkzeug~=2.2.2",
     "Whoosh~=2.7.4",
     "beautifulsoup4~=4.9.3",
     "bleach-allowlist~=1.0.3",


### PR DESCRIPTION
Werkzeug has a faster router now! 

This has no breaking change. If you had incorrectly imported some exception class from routing file then your app might break.


Example:
```diff
- from werkzeug.routing import NotFound
+ from werkzeug.exceptions import NotFound
```

Partial backport of https://github.com/frappe/frappe/pull/17962 