### PR TITLE
build(deps): drop pyOpenSSL dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "premailer~=3.8.0",
     "psutil~=5.9.1",
     "psycopg2-binary~=2.9.1",
-    "pyOpenSSL~=20.0.1",
     "pycryptodome~=3.10.1",
     "pyotp~=2.6.0",
     "python-dateutil~=2.8.1",


### PR DESCRIPTION
- Not used anymore
- Official documentation suggests stopping use of
pyopenssl: https://github.com/pyca/pyopenssl

Use https://github.com/pyca/cryptography instead