### PR TITLE
feat(minor): delete kanban board from kanban view

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -35,12 +35,28 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 			this.card_meta = this.get_card_meta();
 			this.page_length = 0;
 
-			this.menu_items.push({
-				label: __("Save filters"),
-				action: () => {
-					this.save_kanban_board_filters();
-				},
-			});
+			this.menu_items.push(
+				...[
+					{
+						label: __("Save filters"),
+						action: () => {
+							this.save_kanban_board_filters();
+						},
+					},
+					{
+						label: __("Delete Kanban Board"),
+						action: () => {
+							frappe.confirm("Are you sure you want to proceed?", () => {
+								frappe.db.delete_doc("Kanban Board", this.board_name).then(() => {
+									frappe.show_alert(`Kanban Board ${this.board_name} deleted.`);
+									frappe.set_route("List", this.doctype, "List");
+								});
+							});
+						},
+					},
+				]
+			);
+
 			return this.get_board();
 		});
 	}


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/17628


Added a menu option to delete kanban board from kanban view.

https://user-images.githubusercontent.com/32034600/190788223-964108dd-a89d-4b34-aaaf-109393141bea.mov


> no-docs