### PR TITLE
perf: cache `Meta` directly and other improvements

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -239,7 +239,6 @@ def init(site: str, sites_path: str = ".", new_site: bool = False) -> None:
 	local.jloader = None
 	local.cache = {}
 	local.document_cache = {}
-	local.meta_cache = {}
 	local.form_dict = _dict()
 	local.preload_assets = {"style": [], "script": []}
 	local.session = _dict()

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1063,21 +1063,9 @@ def set_value(doctype, docname, fieldname, value=None):
 	return frappe.client.set_value(doctype, docname, fieldname, value)
 
 
-@overload
-def get_cached_doc(doctype, docname, _allow_dict=True) -> dict:
-	...
-
-
-@overload
 def get_cached_doc(*args, **kwargs) -> "Document":
-	...
-
-
-def get_cached_doc(*args, **kwargs):
-	allow_dict = kwargs.pop("_allow_dict", False)
-
 	def _respond(doc, from_redis=False):
-		if not allow_dict and isinstance(doc, dict):
+		if isinstance(doc, dict):
 			local.document_cache[key] = doc = get_doc(doc)
 
 		elif from_redis:
@@ -1150,7 +1138,7 @@ def get_cached_value(
 	doctype: str, name: str, fieldname: str = "name", as_dict: bool = False
 ) -> Any:
 	try:
-		doc = get_cached_doc(doctype, name, _allow_dict=True)
+		doc = get_cached_doc(doctype, name)
 	except DoesNotExistError:
 		clear_last_message()
 		return

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1089,16 +1089,19 @@ def get_cached_doc(*args, **kwargs) -> "Document":
 	if not key:
 		key = get_document_cache_key(doc.doctype, doc.name)
 
-	local.document_cache[key] = doc
+	_set_document_in_cache(key, doc)
 
+	return doc
+
+
+def _set_document_in_cache(key: str, doc: "Document") -> None:
 	# Avoid setting in local.cache since we're already using local.document_cache above
 	# Try pickling the doc object as-is first, else fallback to doc.as_dict()
+	local.document_cache[key] = doc
 	try:
 		cache().hset("document_cache", key, doc, cache_locally=False)
 	except Exception:
 		cache().hset("document_cache", key, doc.as_dict(), cache_locally=False)
-
-	return doc
 
 
 def can_cache_doc(args) -> str | None:
@@ -1174,13 +1177,10 @@ def get_doc(*args, **kwargs) -> "Document":
 
 	doc = frappe.model.document.get_doc(*args, **kwargs)
 
-	# Replace cache
+	# Replace cache if stale one exists
 	if key := can_cache_doc(args):
-		if key in local.document_cache:
-			local.document_cache[key] = doc
-
 		if cache().hexists("document_cache", key):
-			cache().hset("document_cache", key, doc.as_dict())
+			_set_document_in_cache(key, doc)
 
 	return doc
 

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -116,9 +116,6 @@ def clear_doctype_cache(doctype=None):
 	clear_controller_cache(doctype)
 	cache = frappe.cache()
 
-	if getattr(frappe.local, "meta_cache") and (doctype in frappe.local.meta_cache):
-		del frappe.local.meta_cache[doctype]
-
 	for key in ("is_table", "doctype_modules", "document_cache"):
 		cache.delete_value(key)
 

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -895,6 +895,7 @@ def run_ui_tests(
 				"@4tw/cypress-drag-drop@^2",
 				"cypress-real-events",
 				"@testing-library/cypress@^8",
+				"@testing-library/dom@8.17.1",
 				"@cypress/code-coverage@^3",
 			]
 		)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -414,10 +414,6 @@ class DocType(Document):
 		if not frappe.flags.in_install and hasattr(self, "before_update"):
 			self.sync_global_search()
 
-		# clear from local cache
-		if self.name in frappe.local.meta_cache:
-			del frappe.local.meta_cache[self.name]
-
 		clear_linked_doctype_cache()
 
 	def setup_autoincrement_and_sequence(self):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -59,7 +59,12 @@ def get_meta(doctype, cached=True) -> "Meta":
 	if not cached:
 		return Meta(doctype)
 
-	return frappe.cache().hget("meta", doctype, lambda: Meta(doctype))
+	if meta := frappe.cache().hget("meta", doctype):
+		return meta
+
+	meta = Meta(doctype)
+	frappe.cache().hset("meta", doctype, meta)
+	return meta
 
 
 def load_meta(doctype):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -56,19 +56,10 @@ DEFAULT_FIELD_LABELS = {
 
 
 def get_meta(doctype, cached=True) -> "Meta":
-	if cached:
-		if not frappe.local.meta_cache.get(doctype):
-			meta = frappe.cache().hget("meta", doctype)
-			if meta:
-				meta = Meta(meta)
-			else:
-				meta = Meta(doctype)
-				frappe.cache().hset("meta", doctype, meta.as_dict())
-			frappe.local.meta_cache[doctype] = meta
+	if not cached:
+		return Meta(doctype)
 
-		return frappe.local.meta_cache[doctype]
-	else:
-		return load_meta(doctype)
+	return frappe.cache().hget("meta", doctype, lambda: Meta(doctype))
 
 
 def load_meta(doctype):

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -16,14 +16,21 @@ query. This test can be written like this.
 >>> 		get_controller("User")
 
 """
+import time
 import unittest
 
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
+
 import frappe
+from frappe.frappeclient import FrappeClient
 from frappe.model.base_document import get_controller
+from frappe.query_builder.utils import db_type_is
+from frappe.tests.test_query_builder import run_only_if
 from frappe.tests.utils import FrappeTestCase
 from frappe.website.path_resolver import PathResolver
 
 
+@run_only_if(db_type_is.MARIADB)
 class TestPerformance(FrappeTestCase):
 	def reset_request_specific_caches(self):
 		# To simulate close to request level of handling
@@ -33,6 +40,8 @@ class TestPerformance(FrappeTestCase):
 		frappe.clear_cache()
 
 	def setUp(self) -> None:
+		self.HOST = frappe.utils.get_site_url(frappe.local.site)
+
 		self.reset_request_specific_caches()
 
 	def test_meta_caching(self):
@@ -54,6 +63,36 @@ class TestPerformance(FrappeTestCase):
 
 		with self.assertQueryCount(0):
 			doc.get_invalid_links()
+
+	@retry(
+		retry=retry_if_exception_type(AssertionError),
+		stop=stop_after_attempt(3),
+		wait=wait_fixed(0.5),
+		reraise=True,
+	)
+	def test_req_per_seconds_basic(self):
+		"""Ideally should be ran against gunicorn worker, though I have not seen any difference
+		when using werkzeug's run_simple for synchronous requests."""
+
+		EXPECTED_RPS = 55  # measured on GHA
+		FAILURE_THREASHOLD = 0.1
+
+		req_count = 1000
+		client = FrappeClient(self.HOST, "Administrator", self.ADMIN_PASSWORD)
+
+		start = time.perf_counter()
+		for _ in range(req_count):
+			client.get_list("ToDo", limit_page_length=1)
+		end = time.perf_counter()
+
+		rps = req_count / (end - start)
+
+		print(f"Completed {req_count} in {end - start} @ {rps} requests per seconds")
+		self.assertGreaterEqual(
+			rps,
+			EXPECTED_RPS * (1 - FAILURE_THREASHOLD),
+			f"Possible performance regression in basic /api/Resource list  requests",
+		)
 
 	@unittest.skip("Not implemented")
 	def test_homepage_resolver(self):

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -26,9 +26,9 @@ class FrappeTestCase(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
 		cls.TEST_SITE = getattr(frappe.local, "site", None) or cls.TEST_SITE
+		cls.ADMIN_PASSWORD = frappe.get_conf(cls.TEST_SITE).admin_password
 		# flush changes done so far to avoid flake
 		frappe.db.commit()
-		frappe.db.begin()
 		if cls.SHOW_TRANSACTION_COMMIT_WARNINGS:
 			frappe.db.add_before_commit(_commit_watcher)
 


### PR DESCRIPTION
## Main Improvement

`local.meta_cache` only lasted for the specific request, so it wasn't really useful. This has been removed completely, and replaced by `local.cache` (still per request). Instead of caching _serialized_ meta in Redis, the actual objects are now being cached.

### Before (Redis-only cache testing)
```python
In [10]: %timeit frappe.get_meta("Sales Invoice")
5.42 ms ± 58.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

### After (71% better in production!)
```python
In [4]: %timeit frappe.get_meta("Sales Invoice")
1.57 ms ± 43.4 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
 ```

## Other Improvements
   
- Initialize field map when creating meta, instead of inside `get_field`.
- Only translate required labels from default labels.
- `special_doctypes` is a set for faster lookup.

### Before

```python
In [9]: %timeit meta.get_field("localization")
104 ns ± 1.32 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [10]: %timeit meta.has_field("localization")
156 ns ± 2.12 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

In [11]: %timeit meta.get_label("name")
24.9 µs ± 156 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

### After

```python
# 15% better
In [5]: %timeit meta.get_field("localization") 
88.9 ns ± 1.43 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

# 50% better
In [6]: %timeit meta.has_field("localization")
78.9 ns ± 0.515 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)

# 90% better
In [8]: %timeit meta.get_label("name")
2.45 µs ± 20.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

```

