### PR TITLE
perf: cache `FormMeta` directly

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -64,11 +64,9 @@ def getdoctype(doctype, with_parent=False, cached_timestamp=None):
 	parent_dt = None
 
 	# with parent (called from report builder)
-	if with_parent:
-		parent_dt = frappe.model.meta.get_parent_dt(doctype)
-		if parent_dt:
-			docs = get_meta_bundle(parent_dt)
-			frappe.response["parent_dt"] = parent_dt
+	if with_parent and (parent_dt := frappe.model.meta.get_parent_dt(doctype)):
+		docs = get_meta_bundle(parent_dt)
+		frappe.response["parent_dt"] = parent_dt
 
 	if not docs:
 		docs = get_meta_bundle(doctype)

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -36,11 +36,9 @@ def get_meta(doctype, cached=True):
 	# don't cache for developer mode as js files, templates may be edited
 	if cached and not frappe.conf.developer_mode:
 		meta = frappe.cache().hget("form_meta", doctype)
-		if meta:
-			meta = FormMeta(meta)
-		else:
+		if not meta:
 			meta = FormMeta(doctype)
-			frappe.cache().hset("form_meta", doctype, meta.as_dict())
+			frappe.cache().hset("form_meta", doctype, meta)
 	else:
 		meta = FormMeta(doctype)
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -666,10 +666,17 @@ def is_single(doctype):
 
 
 def get_parent_dt(dt):
-	parent_dt = frappe.get_all(
-		"DocField", "parent", dict(fieldtype=["in", frappe.model.table_fields], options=dt), limit=1
+	if not frappe.is_table(dt):
+		return ""
+
+	return (
+		frappe.db.get_value(
+			"DocField",
+			{"fieldtype": ("in", frappe.model.table_fields), "options": dt},
+			"parent",
+		)
+		or ""
 	)
-	return parent_dt and parent_dt[0].parent or ""
 
 
 def set_fieldname(field_id, fieldname):


### PR DESCRIPTION
Similar to https://github.com/frappe/frappe/pull/18164, but for `FormMeta`.

## 67% faster for Sales Invoice (Redis-only testing)

### Before

```python
In [4]: %timeit get_meta("Sales Invoice")
5.67 ms ± 139 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

### After

```python
In [4]: %timeit get_meta("Sales Invoice")
1.84 ms ± 33 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```