### PR TITLE
feat: persistant database connections

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -344,10 +344,13 @@ class init_site:
 		destroy()
 
 
-def destroy():
+def destroy(keep_connection=False):
 	"""Closes connection and releases werkzeug local."""
 	if db:
-		db.close()
+		if keep_connection:
+			db.clear_cursor()
+		else:
+			db.close()
 
 	release_local(local)
 

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -87,7 +87,7 @@ def application(request: Request):
 		log_request(request, response)
 		process_response(response)
 		if frappe.db:
-			frappe.db.close()
+			frappe.db.clear_cursor()
 
 	return response
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1132,8 +1132,11 @@ class Database:
 		"""Close database connection."""
 		if self._conn:
 			self._conn.close()
-			self._cursor = None
-			self._conn = None
+			self.clear_cursor()
+
+	def clear_cursor(self):
+		self._cursor = None
+		self._conn = None
 
 	@staticmethod
 	def escape(s, percent=True):

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -74,16 +74,14 @@ def enqueue_events_for_site(site):
 		enqueue_events(site=site)
 
 		frappe.logger("scheduler").debug(f"Queued events for site {site}")
-	except frappe.db.OperationalError as e:
+	except Exception as e:
 		if frappe.db.is_access_denied(e):
 			frappe.logger("scheduler").debug(f"Access denied for site {site}")
 		else:
+			frappe.db.rollback()
 			log_and_raise()
-	except Exception:
-		log_and_raise()
-
 	finally:
-		frappe.destroy()
+		frappe.destroy(keep_connection=True)
 
 
 def enqueue_events(site):


### PR DESCRIPTION
Alternative to connection pooling attempted here: https://github.com/frappe/frappe/pull/16961 

NOTE: This PR in current state is just a _POC_.


**Why persistent connections?** 

- We open a new connection on **each** request, this is widely considered to be a bad practice for perf and scalability.
- Connections aren't cheap, they have ~200-300 microseconds of overhead + it can be quite high if your application and DB server are not on the same network. 
- Each connection is stored in the thread's locals so it's supposedly "thread-safe"

**How many persistent connections will be there?**

Assuming all sites are active on the bench...

- `sync` workers ~= # of workers * # of sites 
- `gthread` workers ~= workers * thread pool size * # of sites
- Other worker types like `gevent` - dont enable. 
- scheduler ~= # of sites

**Why NOT connection pooling?** 

- Most popular deployment of frappe apps is with gunicorn `sync` workers. Both FC and bench do this. This means each process is handling one request at most at any given time. There's no way for them to utilize a pool of connections with current architecture? 
- Another most used deployment is frappe docker which uses `gthread` with fixed worker + threads model. Here a worker can utilize a connection pool but it's limited by # of threads, so essentially connection pool size ~= # of threads unless you go crazy and spin up too many threads. 
- For pools to work they need to be shared by all processes and created outside of workers. I don't think this is simple or _feasible_. If you can figure it out feel free to create a proposal. You'll likely need some other tool sitting between frappe and database to control this. E.g. Pgbouncer 


TODO:

- [x] Web requests
- [x] Scheduler
- [ ] ~~Background jobs~~ - RQ architecture most likely won't allow this, read https://python-rq.org/docs/workers/#the-worker-lifecycle 
- [ ] Make this configurable. Disable when using werkzeug threaded mode (?)
- [ ] health checks on connection / make this more robust in general
- [ ] Review possible stale uncommitted writes.
- [ ] Timeout if not used for extended period.
- [ ] Docs

fixes https://github.com/frappe/frappe/issues/11378 
fixes https://github.com/frappe/frappe/issues/14959 