### PR TITLE
email_sync_option was set to UNSEEN when we choose ALL

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -237,7 +237,7 @@ frappe.ui.form.on("Email Account", {
 				"You are selecting Sync Option as ALL, It will resync all read as well as unread message from server. This may also cause the duplication of Communication (emails)."
 			);
 			frappe.confirm(msg, null, function () {
-				frm.set_value("email_sync_option", "UNSEEN");
+				frm.set_value("email_sync_option", "ALL");
 			});
 		}
 	},


### PR DESCRIPTION
In the last versions of frappe we have
```
frappe.confirm(msg, null, function () {
    frm.set_value("email_sync_option", "UNSEEN");
});
```

and in version 12 we have 
```
frappe.confirm(msg, null, function() {
    frm.set_value("email_sync_option", "ALL");
});
```

Confirm must be set to ALL and not to UNSEEN.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
