### PR TITLE
refactor: Allow make_request() to return with response object

### DIFF
--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -10,7 +10,7 @@ from frappe import _
 from frappe.utils import get_request_session
 
 
-def make_request(method, url, auth=None, headers=None, data=None):
+def make_request(method, url, auth=None, headers=None, data=None, return_response_obj=None):
 	auth = auth or ""
 	data = data or {}
 	headers = headers or {}
@@ -19,7 +19,10 @@ def make_request(method, url, auth=None, headers=None, data=None):
 		s = get_request_session()
 		frappe.flags.integration_request = s.request(method, url, data=data, auth=auth, headers=headers)
 		frappe.flags.integration_request.raise_for_status()
-
+		
+		if return_response_obj :
+			return frappe.flags.integration_request
+		
 		if frappe.flags.integration_request.headers.get("content-type") == "text/plain; charset=utf-8":
 			return parse_qs(frappe.flags.integration_request.text)
 


### PR DESCRIPTION
To allow more flexibility in server script a new keyword argument `return_response_obj` added which will return the entire response object.

![image](https://user-images.githubusercontent.com/30042185/190986488-9004ca8b-35bb-4b23-8264-b34bb1c26805.png)
