### PR TITLE
fix: add string to translate function onboarding widget

### DIFF
--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -117,13 +117,13 @@ export default class OnboardingWidget extends Widget {
 		const set_description = () => {
 			let content = step.description
 				? frappe.markdown(step.description)
-				: `<h1>${step.title}</h1>`;
+				: `<h1>${__(step.title)}</h1>`;
 
 			if (step.action === "Create Entry") {
 				// add a secondary action to view list
 				content += `<p>
 					<a href='/app/${frappe.router.slug(step.reference_document)}'>
-						${__("Show {0} List", [step.reference_document])}</a>
+						${__("Show {0} List", [__(step.reference_document)])}</a>
 				</p>`;
 			}
 


### PR DESCRIPTION
Before: 

![OB Before](https://user-images.githubusercontent.com/1592496/191044671-d2490e70-193e-4509-908f-9987dc9b9839.PNG)


After:

![OB After](https://user-images.githubusercontent.com/1592496/191044694-df21fd5a-cd22-4631-91af-ff561552f4a1.PNG)
