### PR TITLE
Revert "fix: drop Meta cache during update"

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -58,8 +58,8 @@ user_cache_keys = (
 )
 
 doctype_cache_keys = (
-	"meta",
-	"form_meta",
+	"doctype_meta",
+	"doctype_form_meta",
 	"table_columns",
 	"last_modified",
 	"linked_doctypes",

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -35,10 +35,10 @@ ASSET_KEYS = (
 def get_meta(doctype, cached=True):
 	# don't cache for developer mode as js files, templates may be edited
 	if cached and not frappe.conf.developer_mode:
-		meta = frappe.cache().hget("form_meta", doctype)
+		meta = frappe.cache().hget("doctype_form_meta", doctype)
 		if not meta:
 			meta = FormMeta(doctype)
-			frappe.cache().hset("form_meta", doctype, meta)
+			frappe.cache().hset("doctype_form_meta", doctype, meta)
 	else:
 		meta = FormMeta(doctype)
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -56,7 +56,7 @@ DEFAULT_FIELD_LABELS = {
 
 
 def get_meta(doctype, cached=True) -> "Meta":
-	if not cached or frappe.flags.in_patch:
+	if not cached:
 		return Meta(doctype)
 
 	if meta := frappe.cache().hget("meta", doctype):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -59,11 +59,11 @@ def get_meta(doctype, cached=True) -> "Meta":
 	if not cached:
 		return Meta(doctype)
 
-	if meta := frappe.cache().hget("meta", doctype):
+	if meta := frappe.cache().hget("doctype_meta", doctype):
 		return meta
 
 	meta = Meta(doctype)
-	frappe.cache().hset("meta", doctype, meta)
+	frappe.cache().hset("doctype_meta", doctype, meta)
 	return meta
 
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -211,6 +211,5 @@ frappe.patches.v14_0.set_suspend_email_queue_default
 frappe.patches.v14_0.different_encryption_key
 frappe.patches.v14_0.update_multistep_webforms
 execute:frappe.delete_doc('Page', 'background_jobs', ignore_missing=True, force=True)
-frappe.patches.v14_0.drop_meta_cache
 frappe.patches.v14_0.drop_unused_indexes
 frappe.patches.v15_0.drop_modified_index

--- a/frappe/patches/v14_0/drop_meta_cache.py
+++ b/frappe/patches/v14_0/drop_meta_cache.py
@@ -1,7 +1,0 @@
-import frappe
-
-
-def execute():
-	cache = frappe.cache()
-	for key in cache.hkeys("meta"):
-		cache.hdel("meta", key)

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -74,7 +74,7 @@ class TestPerformance(FrappeTestCase):
 		"""Ideally should be ran against gunicorn worker, though I have not seen any difference
 		when using werkzeug's run_simple for synchronous requests."""
 
-		EXPECTED_RPS = 55  # measured on GHA
+		EXPECTED_RPS = 50  # measured on GHA
 		FAILURE_THREASHOLD = 0.1
 
 		req_count = 1000

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -74,7 +74,7 @@ class TestPerformance(FrappeTestCase):
 		"""Ideally should be ran against gunicorn worker, though I have not seen any difference
 		when using werkzeug's run_simple for synchronous requests."""
 
-		EXPECTED_RPS = 50  # measured on GHA
+		EXPECTED_RPS = 55  # measured on GHA
 		FAILURE_THREASHOLD = 0.1
 
 		req_count = 1000


### PR DESCRIPTION
Reverts frappe/frappe#18182 and adds alternate fix


why? `cache=False` is ridiculously slow. 

Renaming keys instead of deleting them to avoid confusion with types. 