### PR TITLE
fix: Chart date format on x-axis is inaccurate

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -222,7 +222,7 @@ def get_chart_config(chart, filters, timespan, timegrain, from_date, to_date):
 
 	return {
 		"labels": [
-			format_date(get_period(r[0], timegrain), day_first=True)
+			format_date(get_period(r[0], timegrain), parse_day_first=True)
 			if timegrain in ("Daily", "Weekly")
 			else get_period(r[0], timegrain)
 			for r in result

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -222,7 +222,7 @@ def get_chart_config(chart, filters, timespan, timegrain, from_date, to_date):
 
 	return {
 		"labels": [
-			format_date(get_period(r[0], timegrain))
+			format_date(get_period(r[0], timegrain), day_first=True)
 			if timegrain in ("Daily", "Weekly")
 			else get_period(r[0], timegrain)
 			for r in result

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -173,7 +173,7 @@ class TestDashboardChart(FrappeTestCase):
 		self.assertEqual(result.get("datasets")[0].get("values"), [200.0, 400.0, 300.0, 0.0, 100.0, 0.0])
 		self.assertEqual(
 			result.get("labels"),
-			["06-01-2019", "07-01-2019", "08-01-2019", "09-01-2019", "10-01-2019", "11-01-2019"],
+			["01-06-2019", "01-07-2019", "01-08-2019", "01-09-2019", "01-10-2019", "01-11-2019"],
 		)
 
 	def test_weekly_dashboard_chart(self):
@@ -203,7 +203,7 @@ class TestDashboardChart(FrappeTestCase):
 			result = get(chart_name="Test Weekly Dashboard Chart", refresh=1)
 
 			self.assertEqual(result.get("datasets")[0].get("values"), [50.0, 300.0, 800.0, 0.0])
-			self.assertEqual(result.get("labels"), ["30-12-2018", "06-01-2019", "13-01-2019", "20-01-2019"])
+			self.assertEqual(result.get("labels"), ["12-30-2018", "01-06-2019", "01-13-2019", "01-20-2019"])
 
 	def test_avg_dashboard_chart(self):
 		insert_test_records()
@@ -230,7 +230,7 @@ class TestDashboardChart(FrappeTestCase):
 
 		with patch.object(frappe.utils.data, "get_first_day_of_the_week", return_value="Monday"):
 			result = get(chart_name="Test Average Dashboard Chart", refresh=1)
-			self.assertEqual(result.get("labels"), ["30-12-2018", "06-01-2019", "13-01-2019", "20-01-2019"])
+			self.assertEqual(result.get("labels"), ["12-30-2018", "01-06-2019", "01-13-2019", "01-20-2019"])
 			self.assertEqual(result.get("datasets")[0].get("values"), [50.0, 150.0, 266.6666666666667, 0.0])
 
 	def test_user_date_label_dashboard_chart(self):

--- a/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/test_dashboard_chart.py
@@ -203,7 +203,7 @@ class TestDashboardChart(FrappeTestCase):
 			result = get(chart_name="Test Weekly Dashboard Chart", refresh=1)
 
 			self.assertEqual(result.get("datasets")[0].get("values"), [50.0, 300.0, 800.0, 0.0])
-			self.assertEqual(result.get("labels"), ["12-30-2018", "06-01-2019", "01-13-2019", "01-20-2019"])
+			self.assertEqual(result.get("labels"), ["30-12-2018", "06-01-2019", "13-01-2019", "20-01-2019"])
 
 	def test_avg_dashboard_chart(self):
 		insert_test_records()
@@ -230,7 +230,7 @@ class TestDashboardChart(FrappeTestCase):
 
 		with patch.object(frappe.utils.data, "get_first_day_of_the_week", return_value="Monday"):
 			result = get(chart_name="Test Average Dashboard Chart", refresh=1)
-			self.assertEqual(result.get("labels"), ["12-30-2018", "06-01-2019", "01-13-2019", "01-20-2019"])
+			self.assertEqual(result.get("labels"), ["30-12-2018", "06-01-2019", "13-01-2019", "20-01-2019"])
 			self.assertEqual(result.get("datasets")[0].get("values"), [50.0, 150.0, 266.6666666666667, 0.0])
 
 	def test_user_date_label_dashboard_chart(self):
@@ -255,13 +255,13 @@ class TestDashboardChart(FrappeTestCase):
 		with patch.object(frappe.utils.data, "get_user_date_format", return_value="dd.mm.yyyy"):
 			result = get(chart_name="Test Dashboard Chart Date Label")
 			self.assertEqual(
-				sorted(result.get("labels")), sorted(["01.05.2019", "01.12.2019", "19.01.2019"])
+				sorted(result.get("labels")), sorted(["05.01.2019", "12.01.2019", "19.01.2019"])
 			)
 
 		with patch.object(frappe.utils.data, "get_user_date_format", return_value="mm-dd-yyyy"):
 			result = get(chart_name="Test Dashboard Chart Date Label")
 			self.assertEqual(
-				sorted(result.get("labels")), sorted(["01-19-2019", "05-01-2019", "12-01-2019"])
+				sorted(result.get("labels")), sorted(["01-19-2019", "01-05-2019", "01-12-2019"])
 			)
 
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -73,7 +73,7 @@ def is_invalid_date_string(date_string: str) -> bool:
 
 
 def getdate(
-	string_date: Optional["DateTimeLikeObject"] = None, day_first: bool = False
+	string_date: Optional["DateTimeLikeObject"] = None, parse_day_first: bool = False
 ) -> datetime.date | None:
 	"""
 	Converts string date (yyyy-mm-dd) to datetime.date object.
@@ -93,7 +93,7 @@ def getdate(
 	if is_invalid_date_string(string_date):
 		return None
 	try:
-		return parser.parse(string_date, dayfirst=day_first).date()
+		return parser.parse(string_date, dayfirst=parse_day_first).date()
 	except ParserError:
 		frappe.throw(
 			frappe._("{} is not a valid date string.").format(frappe.bold(string_date)),
@@ -551,7 +551,7 @@ def get_user_time_format() -> str:
 
 
 def format_date(
-	string_date=None, format_string: str | None = None, day_first: bool = False
+	string_date=None, format_string: str | None = None, parse_day_first: bool = False
 ) -> str:
 	"""Converts the given string date to :data:`user_date_format`
 	User format specified in defaults
@@ -568,7 +568,7 @@ def format_date(
 	if not string_date:
 		return ""
 
-	date = getdate(string_date, day_first)
+	date = getdate(string_date, parse_day_first)
 	if not format_string:
 		format_string = get_user_date_format()
 	format_string = format_string.replace("mm", "MM").replace("Y", "y")

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -72,7 +72,7 @@ def is_invalid_date_string(date_string: str) -> bool:
 	)
 
 
-def getdate(string_date: Optional["DateTimeLikeObject"] = None) -> datetime.date | None:
+def getdate(string_date: Optional["DateTimeLikeObject"] = None, day_first: bool = False) -> datetime.date | None:
 	"""
 	Converts string date (yyyy-mm-dd) to datetime.date object.
 	If no input is provided, current date is returned.
@@ -91,7 +91,7 @@ def getdate(string_date: Optional["DateTimeLikeObject"] = None) -> datetime.date
 	if is_invalid_date_string(string_date):
 		return None
 	try:
-		return parser.parse(string_date).date()
+		return parser.parse(string_date, dayfirst=day_first).date()
 	except ParserError:
 		frappe.throw(
 			frappe._("{} is not a valid date string.").format(frappe.bold(string_date)),
@@ -548,7 +548,7 @@ def get_user_time_format() -> str:
 	return frappe.local.user_time_format or "HH:mm:ss"
 
 
-def format_date(string_date=None, format_string: str | None = None) -> str:
+def format_date(string_date=None, format_string: str | None = None, day_first: bool = False) -> str:
 	"""Converts the given string date to :data:`user_date_format`
 	User format specified in defaults
 
@@ -564,7 +564,7 @@ def format_date(string_date=None, format_string: str | None = None) -> str:
 	if not string_date:
 		return ""
 
-	date = getdate(string_date)
+	date = getdate(string_date, day_first)
 	if not format_string:
 		format_string = get_user_date_format()
 	format_string = format_string.replace("mm", "MM").replace("Y", "y")

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -72,7 +72,9 @@ def is_invalid_date_string(date_string: str) -> bool:
 	)
 
 
-def getdate(string_date: Optional["DateTimeLikeObject"] = None, day_first: bool = False) -> datetime.date | None:
+def getdate(
+	string_date: Optional["DateTimeLikeObject"] = None, day_first: bool = False
+) -> datetime.date | None:
 	"""
 	Converts string date (yyyy-mm-dd) to datetime.date object.
 	If no input is provided, current date is returned.
@@ -548,7 +550,9 @@ def get_user_time_format() -> str:
 	return frappe.local.user_time_format or "HH:mm:ss"
 
 
-def format_date(string_date=None, format_string: str | None = None, day_first: bool = False) -> str:
+def format_date(
+	string_date=None, format_string: str | None = None, day_first: bool = False
+) -> str:
 	"""Converts the given string date to :data:`user_date_format`
 	User format specified in defaults
 


### PR DESCRIPTION
**Issue:**
The date format of some dates on the x-axis of the chart is inaccurate as you can see in the below screenshots.

**Before:**
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/30859809/191204476-9dbd939d-2778-4861-8267-ca42d82704af.png">

**After:**
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/30859809/191204037-4807ebdb-34a1-4237-aabd-48658e7e0d18.png">
