### PR TITLE
fix: Chart filter not working if not operator is used

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -215,7 +215,6 @@ def get_chart_config(chart, filters, timespan, timegrain, from_date, to_date):
 		group_by="_unit",
 		order_by="_unit asc",
 		as_list=True,
-		ignore_ifnull=True,
 	)
 
 	result = get_result(data, timegrain, from_date, to_date, chart.chart_type)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -642,7 +642,7 @@ class DatabaseQuery:
 				f.value = date_range
 				fallback = f"'{FallBackDateTimeStr}'"
 
-			if f.operator in (">", "<") and (f.fieldname in ("creation", "modified")):
+			if f.operator in (">", "<", ">=", "<=") and (f.fieldname in ("creation", "modified")):
 				value = cstr(f.value)
 				fallback = f"'{FallBackDateTimeStr}'"
 


### PR DESCRIPTION
**Issue:**
In the Chart filter if we use the "Not" operator. 
E.g `Organization != "Frappe"` then it will only get records whose Organization value is not equal to Frappe and it will not consider records with empty Organization.

E.g. 
In the below screenshot, we can see 2 Lead records in the report view with the filters
`Organization Name != "Frappe"`, `Status = "Lead"`, `Series = "WEB-"` for month `Sept 2022`
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/30859809/191274677-83922dba-8ab2-4843-8124-9c384f17d3a6.png">

If we apply the same filters in the Website Leads Chart we get 0 records because it is not considering the leads with empty Organization Name
Before:
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/30859809/191275247-a430a566-090a-4971-aa32-2b4d9f126e96.png">

After:
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/30859809/191274958-98b22df3-50f0-4261-8c2c-27fcf990e7d1.png">

