### PR TITLE
fix: make module to export required.

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -178,6 +178,7 @@ frappe.ui.form.on("Customize Form", {
 								fieldname: "module",
 								options: "Module Def",
 								label: __("Module to Export"),
+								reqd: 1,
 							},
 							{
 								fieldtype: "Check",


### PR DESCRIPTION
The `module` is a required parameter on the API side.

https://github.com/frappe/frappe/blob/4263aace2750e903039a3122df2fea6083e190d0/frappe/modules/utils.py#L57-L59