### PR TITLE
fix: chart label not being translated

### DIFF
--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -26,16 +26,14 @@ frappe.dashboard_utils = {
 				options_html = filter.options
 					.map(
 						(option, i) =>
-							// TODO: Make option translatable - be careful, since the text of the a tag is later used to perform some action
 							`<li>
-						<a class="dropdown-item" data-fieldname="${filter.fieldnames[i]}">${option}</a>
+						<a class="dropdown-item" data-fieldname="${filter.fieldnames[i]}" option-name="${option}">${__(option)}</a>
 					</li>`
 					)
 					.join("");
 			} else {
-				// TODO: Make option translatable - be careful, since the text of the a tag is later used to perform some action
 				options_html = filter.options
-					.map((option) => `<li><a class="dropdown-item">${option}</a></li>`)
+					.map((option) => `<li><a class="dropdown-item" option-name="${option}">${__(option)}</a></li>`)
 					.join("");
 			}
 
@@ -54,8 +52,8 @@ frappe.dashboard_utils = {
 					fieldname = $el.attr("data-fieldname");
 				}
 
-				let selected_item = $el.text();
-				$el.parents(`.${button_class}`).find(".filter-label").text(selected_item);
+				let selected_item = $el.attr("option-name");
+				$el.parents(`.${button_class}`).find(".filter-label").html(__(selected_item));
 				filter.action(selected_item, fieldname);
 			});
 		});

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -15,7 +15,7 @@ frappe.dashboard_utils = {
 			let chart_filter_html = `<div class="${button_class} ${filter_class} btn-group dropdown pull-right">
 					<a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 						<button class="btn btn-secondary btn-xs">
-			 				${icon_html}
+							${icon_html}
 							<span class="filter-label">${__(filter.label)}</span>
 							${frappe.utils.icon("select", "xs")}
 						</button>
@@ -27,13 +27,20 @@ frappe.dashboard_utils = {
 					.map(
 						(option, i) =>
 							`<li>
-						<a class="dropdown-item" data-fieldname="${filter.fieldnames[i]}" option-name="${option}">${__(option)}</a>
+						<a class="dropdown-item" data-fieldname="${
+							filter.fieldnames[i]
+						}" data-option="${encodeURIComponent(option)}">${__(option)}</a>
 					</li>`
 					)
 					.join("");
 			} else {
 				options_html = filter.options
-					.map((option) => `<li><a class="dropdown-item" option-name="${option}">${__(option)}</a></li>`)
+					.map(
+						(option) =>
+							`<li><a class="dropdown-item" data-option="${encodeURIComponent(
+								option
+							)}">${__(option)}</a></li>`
+					)
 					.join("");
 			}
 
@@ -52,7 +59,7 @@ frappe.dashboard_utils = {
 					fieldname = $el.attr("data-fieldname");
 				}
 
-				let selected_item = $el.attr("option-name");
+				let selected_item = decodeURIComponent($el.data("option"));
 				$el.parents(`.${button_class}`).find(".filter-label").html(__(selected_item));
 				filter.action(selected_item, fieldname);
 			});


### PR DESCRIPTION
also used .html() instead of .text() in line 58, because otherwise it resulted in html escape errors. In french `` ' ``is used in many words and when using the text() method it results in this string being inserted ``&#39``;
Between this is my first ever contribution to Frappe so I am not sure if i should make an issue first then the pull request.
I also sadly didn't find the issue if (it exists)
I simply had problem with this and when I looked in the code I found a TODO comment


> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
![image](https://user-images.githubusercontent.com/55487948/192043925-e7ae6631-8649-4377-b379-16404510900e.png)


closes https://github.com/frappe/frappe/issues/17279 