### PR TITLE
feat: custom info in frappe monitor

### DIFF
--- a/.github/helper/db/mariadb.json
+++ b/.github/helper/db/mariadb.json
@@ -13,5 +13,6 @@
     "root_login": "root",
     "root_password": "travis",
     "host_name": "http://test_site:8000",
+    "monitor": 1,
     "server_script_enabled": true
 }

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -37,7 +37,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: checkrun
-    if: ${{ needs.checkrun.outputs.build == 'strawberry' && env.GITHUB_REPOSITORY_OWNER == 'frappe' }}
+    if: ${{ needs.checkrun.outputs.build == 'strawberry' && github.repository_owner == 'frappe' }}
     timeout-minutes: 60
 
     strategy:

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -8,6 +8,7 @@ import frappe
 from frappe.desk.form.load import get_attachments
 from frappe.desk.query_report import generate_report_result
 from frappe.model.document import Document
+from frappe.monitor import add_data_to_monitor
 from frappe.utils import gzip_compress, gzip_decompress
 from frappe.utils.background_jobs import enqueue
 
@@ -24,6 +25,8 @@ class PreparedReport(Document):
 def run_background(prepared_report):
 	instance = frappe.get_doc("Prepared Report", prepared_report)
 	report = frappe.get_doc("Report", instance.ref_report_doctype)
+
+	add_data_to_monitor(report=instance.ref_report_doctype)
 
 	try:
 		report.custom_columns = []

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -5,6 +5,7 @@ import json
 
 import frappe
 from frappe.desk.form.load import run_onload
+from frappe.monitor import add_data_to_monitor
 
 
 @frappe.whitelist()
@@ -24,6 +25,8 @@ def savedocs(doc, action):
 	# update recent documents
 	run_onload(doc)
 	send_updated_docs(doc)
+
+	add_data_to_monitor(doctype=doc.doctype, action=action)
 
 	frappe.msgprint(frappe._("Saved"), indicator="green", alert=True)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -12,6 +12,7 @@ from frappe import _
 from frappe.core.utils import ljust_list
 from frappe.model.utils import render_include
 from frappe.modules import get_module_path, scrub
+from frappe.monitor import add_data_to_monitor
 from frappe.permissions import get_role_permissions
 from frappe.translate import send_translations
 from frappe.utils import (
@@ -253,6 +254,8 @@ def run(
 		result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
 
 	result["add_total_row"] = report.add_total_row and not result.get("skip_total_row", False)
+
+	add_data_to_monitor(report=report)
 
 	return result
 

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -105,7 +105,7 @@ class Monitor:
 	def store(self):
 		if frappe.cache().llen(MONITOR_REDIS_KEY) > MONITOR_MAX_ENTRIES:
 			frappe.cache().ltrim(MONITOR_REDIS_KEY, 1, -1)
-		serialized = json.dumps(self.data, sort_keys=True, default=str)
+		serialized = json.dumps(self.data, sort_keys=True, default=str, separators=(",", ":"))
 		frappe.cache().rpush(MONITOR_REDIS_KEY, serialized)
 
 

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -25,6 +25,13 @@ def stop(response=None):
 		frappe.local.monitor.dump(response)
 
 
+def add_data_to_monitor(**kwargs) -> None:
+	"""Add additional custom key-value pairs along with monitor log.
+	Note: Key-value pairs should be simple JSON exportable types."""
+	if hasattr(frappe.local, "monitor"):
+		frappe.local.monitor.add_custom_data(**kwargs)
+
+
 def log_file():
 	return os.path.join(frappe.utils.get_bench_path(), "logs", "monitor.json.log")
 
@@ -70,6 +77,10 @@ class Monitor:
 			self.data.uuid = job.id
 			waitdiff = self.data.timestamp - job.enqueued_at
 			self.data.job.wait = int(waitdiff.total_seconds() * 1000000)
+
+	def add_custom_data(self, **kwargs):
+		if self.data:
+			self.data.update(kwargs)
 
 	def dump(self, response=None):
 		try:


### PR DESCRIPTION
Adds some useful context to monitor data about duration a request/background job takes:
1. Doc save - doctype name and action
2. Reports - name of the report being generated

`no-docs`