### PR TITLE
fix: remove mariadb specific comments from column

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -456,7 +456,7 @@ def get_site_base_path():
 
 
 def get_site_path(*path):
-	return get_path(base=get_site_base_path(), *path)
+	return get_path(*path, base=get_site_base_path())
 
 
 def get_files_path(*path, **kwargs):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -45,6 +45,7 @@ URL_NOTATION_PATTERN = re.compile(
 )  # background-image: url('/assets/...')
 DURATION_PATTERN = re.compile(r"^(?:(\d+d)?((^|\s)\d+h)?((^|\s)\d+m)?((^|\s)\d+s)?)$")
 HTML_TAG_PATTERN = re.compile("<[^>]+>")
+MARIADB_SPECIFIC_COMMENT = re.compile(r"#.*")
 
 
 class Weekday(Enum):
@@ -1827,8 +1828,11 @@ def sanitize_column(column_name: str) -> None:
 
 	from frappe import _
 
-	regex = re.compile("^.*[,'();].*")
 	column_name = sqlparse.format(column_name, strip_comments=True, keyword_case="lower")
+	if frappe.db and frappe.db.db_type == "mariadb":
+		# strip mariadb specific comments which are like python single line comments
+		column_name = MARIADB_SPECIFIC_COMMENT.sub("", column_name)
+
 	blacklisted_keywords = [
 		"select",
 		"create",
@@ -1844,6 +1848,7 @@ def sanitize_column(column_name: str) -> None:
 	def _raise_exception():
 		frappe.throw(_("Invalid field name {0}").format(column_name), frappe.DataError)
 
+	regex = re.compile("^.*[,'();].*")
 	if "ifnull" in column_name:
 		if regex.match(column_name):
 			# to avoid and, or


### PR DESCRIPTION
MariaDB has additional syntax for comments which are like python. ref: https://mariadb.com/kb/en/comment-syntax/


ERPNext CI: https://github.com/frappe/erpnext/actions/runs/3125386318
