### PR TITLE
fix(minor): consider only email id as sender email for auto email report

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -40,8 +40,7 @@ class AutoEmailReport(Document):
 
 	@property
 	def sender_email(self):
-		email_id, login_id = frappe.db.get_value("Email Account", self.sender, ["email_id", "login_id"])
-		return login_id if login_id else email_id
+		return frappe.db.get_value("Email Account", self.sender, "email_id")
 
 	def validate_emails(self):
 		"""Cleanup list of emails"""


### PR DESCRIPTION
Consider only email id as `sender_email` in auto email report.