### PR TITLE
fix: dont assume issingle exists

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -744,7 +744,7 @@ class BaseDocument:
 						# don't cache if fetching other values too
 						values = frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True)
 
-				if frappe.get_meta(doctype).issingle:
+				if getattr(frappe.get_meta(doctype), "issingle", 0):
 					values.name = doctype
 
 				if frappe.get_meta(doctype).get("is_virtual"):
@@ -884,7 +884,7 @@ class BaseDocument:
 		if frappe.flags.in_install:
 			return
 
-		if self.meta.issingle:
+		if getattr(self.meta, "issingle", 0):
 			# single doctype value type is mediumtext
 			return
 


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/18071 


While migrating special doctypes like `DocType` or `DocField` these fields are missing in meta for some reason. 