### PR TITLE
feat: add export option without template and headers

### DIFF
--- a/frappe/core/doctype/data_export/data_export.js
+++ b/frappe/core/doctype/data_export/data_export.js
@@ -27,6 +27,9 @@ frappe.ui.form.on("Data Export", {
 			reset_filter_and_field(frm);
 		}
 	},
+	export_without_main_header: (frm) => {
+		frm.refresh();
+	}
 });
 
 const can_export = (frm) => {
@@ -58,8 +61,9 @@ const export_data = (frm) => {
 			select_columns: JSON.stringify(columns),
 			filters: frm.filter_list.get_filters().map((filter) => filter.slice(1, 4)),
 			file_type: frm.doc.file_type,
-			template: true,
+			template: !frm.doc.export_without_main_header,
 			with_data: 1,
+			export_without_column_meta: frm.doc.export_without_main_header ? true : false,
 		};
 	};
 

--- a/frappe/core/doctype/data_export/data_export.json
+++ b/frappe/core/doctype/data_export/data_export.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "reference_doctype",
+  "export_without_main_header",
   "column_break_2",
   "file_type",
   "section_break",
@@ -47,12 +48,19 @@
    "fieldname": "fields_multicheck",
    "fieldtype": "HTML",
    "label": "Fields Multicheck"
+  },
+  {
+   "default": "0",
+   "description": "Checking this will export the data without any header notes and variable descriptions",
+   "fieldname": "export_without_main_header",
+   "fieldtype": "Check",
+   "label": "Export without main header"
   }
  ],
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-08-03 12:20:53.658574",
+ "modified": "2022-09-28 03:51:02.404681",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data Export",

--- a/frappe/core/doctype/data_export/data_export.json
+++ b/frappe/core/doctype/data_export/data_export.json
@@ -51,7 +51,7 @@
   },
   {
    "default": "0",
-   "description": "Checking this will export the data without any header notes and variable descriptions",
+   "description": "Export the data without any header notes and column descriptions",
    "fieldname": "export_without_main_header",
    "fieldtype": "Check",
    "label": "Export without main header"

--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -37,6 +37,7 @@ def export_data(
 	file_type="CSV",
 	template=False,
 	filters=None,
+	export_without_column_meta=False,
 ):
 	_doctype = doctype
 	if isinstance(_doctype, list):
@@ -48,6 +49,15 @@ def export_data(
 		filters=filters,
 		method=parent_doctype,
 	)
+
+	template_bool = template
+	if isinstance(template, str):
+		template_bool = template.lower() == "true"
+	
+	export_without_column_meta_bool = export_without_column_meta
+	if isinstance(export_without_column_meta, str):
+		export_without_column_meta_bool = export_without_column_meta.lower() == "true"
+
 	exporter = DataExporter(
 		doctype=doctype,
 		parent_doctype=parent_doctype,
@@ -55,8 +65,9 @@ def export_data(
 		with_data=with_data,
 		select_columns=select_columns,
 		file_type=file_type,
-		template=template,
+		template=template_bool,
 		filters=filters,
+		export_without_column_meta=export_without_column_meta_bool,
 	)
 	exporter.build_response()
 
@@ -72,6 +83,7 @@ class DataExporter:
 		file_type="CSV",
 		template=False,
 		filters=None,
+		export_without_column_meta=False,
 	):
 		self.doctype = doctype
 		self.parent_doctype = parent_doctype
@@ -81,6 +93,7 @@ class DataExporter:
 		self.file_type = file_type
 		self.template = template
 		self.filters = filters
+		self.export_without_column_meta = export_without_column_meta
 		self.data_keys = get_data_keys()
 
 		self.prepare_args()
@@ -117,7 +130,10 @@ class DataExporter:
 		if self.template:
 			self.add_main_header()
 
-		self.writer.writerow([""])
+		# No need of empty row at the start
+		if not self.export_without_column_meta:
+			self.writer.writerow([""])
+
 		self.tablerow = [self.data_keys.doctype]
 		self.labelrow = [_("Column Labels:")]
 		self.fieldrow = [self.data_keys.columns]
@@ -310,12 +326,18 @@ class DataExporter:
 			return ""
 
 	def add_field_headings(self):
-		self.writer.writerow(self.tablerow)
+		if not self.export_without_column_meta:
+			self.writer.writerow(self.tablerow)
+
+		# Just include Labels in the first row
 		self.writer.writerow(self.labelrow)
-		self.writer.writerow(self.fieldrow)
-		self.writer.writerow(self.mandatoryrow)
-		self.writer.writerow(self.typerow)
-		self.writer.writerow(self.inforow)
+
+		if not self.export_without_column_meta:
+			self.writer.writerow(self.fieldrow)
+			self.writer.writerow(self.mandatoryrow)
+			self.writer.writerow(self.typerow)
+			self.writer.writerow(self.inforow)
+
 		if self.template:
 			self.writer.writerow([self.data_keys.data_separator])
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

While exporting data using the Data Exporter, the export format does not match the import format at all. Hence while migrating a few master data from one site to another, a user has to export data from Site 1, then remove the headers, and then import it in Site 2.

This PR adds a Checkbox in the Data Export form that would allow a user to exclude the main header as well as other Metadata rows in the export template.

<img width="1412" alt="image" src="https://user-images.githubusercontent.com/19825455/192653769-2de07c81-461b-4955-b6fb-a850c09ee11e.png">

> Explain the **details** for making this change. What existing problem does the pull request solve?

Users can now export CSV from one site and import it in another without having to refactor the file.

> Screenshots/GIFs

If the checkbox is unchecked (default), the exported file is exactly like before.

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/19825455/192653973-be092b14-82ff-4486-aaf2-bdcff8aed34d.png">

However, if the checkbox is checked, the exported file does not include the header or the metadata rows above the columns

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/19825455/192654049-21014d20-2deb-4744-b262-e01306854cb2.png">


<!-- Add images/recordings to better visualize the change: expected/current behviour -->

While working on this I also saw that the Boolean variables from the frontend (true, false) were actually being treated like strings ("true", "false") in the Python function. I have now added an extra check and parsing on the Python function. This is so that the code doesn't include multiple string checks (e.g. `if is_template == "true"`), and the function works fine if no variables are passed to it and it defaults to the Boolean values.

### Further steps:

1. The export format without the metadata is still not 100% compatible if the data includes child tables (column naming conflicts). So a user would have to manually map the child table columns
2. The export format wraps the ID (name) of the document (or child row) in quotes (`"Administrator"`). This is again problematic because during import, the system does not remove these quotes. Is there a specific reason why we have quotes in the ID columns?

PS: By the looks of it, the default export format is supposed to be used as an import template (with multiple instructions) - but the import format does not use the said template 😅 Is there something that I am perhaps missing?
