### PR TITLE
fix: geolocation

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -38,6 +38,7 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 		this.bind_leaflet_draw_control();
 		this.bind_leaflet_locate_control();
 		this.bind_leaflet_refresh_button();
+		this.map.setView(frappe.utils.map_defaults.center, frappe.utils.map_defaults.zoom);
 	}
 
 	format_for_input(value) {


### PR DESCRIPTION
- set center and zoom for leaflet.
- geolocation map would not load and throws this error.
![image](https://user-images.githubusercontent.com/48166553/192776948-79c73d8f-89a9-4c64-ab88-5f21df1cd98d.png)
