### PR TITLE
feat: Added Subscription Banner for remotely logging into FrappeCloud dashboard from site

### DIFF
--- a/.github/helper/documentation.py
+++ b/.github/helper/documentation.py
@@ -1,7 +1,7 @@
 import sys
-import requests
 from urllib.parse import urlparse
 
+import requests
 
 docs_repos = [
 	"frappe_docs",

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -101,6 +101,7 @@ def get_bootinfo():
 	bootinfo.app_logo_url = get_app_logo()
 	bootinfo.link_title_doctypes = get_link_title_doctypes()
 	bootinfo.translated_doctypes = get_translated_doctypes()
+	bootinfo.subscription_expiry = add_subscription_expiry()
 
 	return bootinfo
 
@@ -428,3 +429,10 @@ def load_currency_docs(bootinfo):
 	)
 
 	bootinfo.docs += currency_docs
+
+
+def add_subscription_expiry():
+	try:
+		return frappe.conf.subscription["expiry"]
+	except Exception:
+		return ""

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -228,6 +228,7 @@ scheduler_events = {
 		"frappe.email.doctype.unhandled_email.unhandled_email.remove_old_unhandled_emails",
 		"frappe.core.doctype.prepared_report.prepared_report.delete_expired_prepared_reports",
 		"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",
+		"frappe.utils.subscription.enable_manage_subscription",
 	],
 	"daily_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily",

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -213,3 +213,4 @@ frappe.patches.v14_0.set_suspend_email_queue_default
 frappe.patches.v14_0.different_encryption_key
 frappe.patches.v14_0.update_multistep_webforms
 frappe.patches.v14_0.drop_unused_indexes
+frappe.patches.v14_0.add_manage_subscriptions_in_navbar_settings

--- a/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
+++ b/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
@@ -1,0 +1,24 @@
+import frappe
+
+
+def execute():
+	navbar_settings = frappe.get_single("Navbar Settings")
+
+	if frappe.db.exists("Navbar Item", {"item_label": "Manage Subscriptions"}):
+		return
+
+	for navbar_item in navbar_settings.settings_dropdown[5:]:
+		navbar_item.idx = navbar_item.idx + 1
+
+	navbar_settings.append(
+		"settings_dropdown",
+		{
+			"item_label": "Manage Subscriptions",
+			"item_type": "Action",
+			"action": "frappe.ui.toolbar.redirectToUrl()",
+			"is_standard": 1,
+			"idx": 3,
+		},
+	)
+
+	navbar_settings.save()

--- a/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
+++ b/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
@@ -17,6 +17,7 @@ def execute():
 			"item_type": "Action",
 			"action": "frappe.ui.toolbar.redirectToUrl()",
 			"is_standard": 1,
+			"hidden": 1,
 			"idx": 3,
 		},
 	)

--- a/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
+++ b/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
@@ -7,6 +7,9 @@ def execute():
 	if frappe.db.exists("Navbar Item", {"item_label": "Manage Subscriptions"}):
 		return
 
+	for idx, row in enumerate(navbar_settings.settings_dropdown[2:], start=4):
+		row.idx = idx
+
 	navbar_settings.append(
 		"settings_dropdown",
 		{
@@ -18,8 +21,5 @@ def execute():
 			"idx": 3,
 		},
 	)
-
-	for idx, row in enumerate(navbar_settings.settings_dropdown, start=1):
-		row.idx = idx
 
 	navbar_settings.save()

--- a/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
+++ b/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
@@ -7,9 +7,6 @@ def execute():
 	if frappe.db.exists("Navbar Item", {"item_label": "Manage Subscriptions"}):
 		return
 
-	for idx, row in enumerate(navbar_settings.settings_dropdown, 2):
-		row.idx = idx
-
 	navbar_settings.append(
 		"settings_dropdown",
 		{
@@ -21,5 +18,8 @@ def execute():
 			"idx": 3,
 		},
 	)
+
+	for idx, row in enumerate(navbar_settings.settings_dropdown, start=1):
+		row.idx = idx
 
 	navbar_settings.save()

--- a/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
+++ b/frappe/patches/v14_0/add_manage_subscriptions_in_navbar_settings.py
@@ -7,8 +7,8 @@ def execute():
 	if frappe.db.exists("Navbar Item", {"item_label": "Manage Subscriptions"}):
 		return
 
-	for navbar_item in navbar_settings.settings_dropdown[5:]:
-		navbar_item.idx = navbar_item.idx + 1
+	for idx, row in enumerate(navbar_settings.settings_dropdown, 2):
+		row.idx = idx
 
 	navbar_settings.append(
 		"settings_dropdown",

--- a/frappe/patches/v14_0/update_github_endpoints.py
+++ b/frappe/patches/v14_0/update_github_endpoints.py
@@ -1,5 +1,6 @@
-import frappe
 import json
+
+import frappe
 
 
 def execute():

--- a/frappe/public/js/desk.bundle.js
+++ b/frappe/public/js/desk.bundle.js
@@ -83,6 +83,7 @@ import "./frappe/ui/toolbar/search_utils.js";
 import "./frappe/ui/toolbar/about.js";
 import "./frappe/ui/toolbar/navbar.html";
 import "./frappe/ui/toolbar/toolbar.js";
+import "./frappe/ui/toolbar/subscription.js";
 // import "./frappe/ui/toolbar/notifications.js";
 import "./frappe/views/communication.js";
 import "./frappe/views/translation_manager.js";

--- a/frappe/public/js/frappe/ui/toolbar/subscription.js
+++ b/frappe/public/js/frappe/ui/toolbar/subscription.js
@@ -1,16 +1,19 @@
 $(document).on("startup", async () => {
-	let response = await frappe.call({
-		method: "frappe.utils.subscription.show_banner",
-		callback: (response) => response,
-	});
+	let response = await frappe.xcall("frappe.utils.subscription.show_banner");
 
-	if (response.message !== false && frappe.boot.setup_complete) {
+	if (
+		response.length > 0 &&
+		frappe.boot.setup_complete &&
+		frappe.user.has_role("System Manager")
+	) {
 		let diff_days =
-			frappe.datetime.get_day_diff(cstr(response.message), frappe.datetime.get_today()) - 1;
+			frappe.datetime.get_day_diff(cstr(response), frappe.datetime.get_today()) - 1;
 
-		let subscription_string = `Your subscription will end in ${cstr(diff_days).bold()} ${
-			diff_days > 1 ? "days" : "day"
-		}. After that your site will be suspended.`;
+		let subscription_string = __(
+			`Your subscription will end in ${cstr(diff_days).bold()} ${
+				diff_days > 1 ? "days" : "day"
+			}. After that your site will be suspended.`
+		);
 
 		let $bar = $(`
 		<div

--- a/frappe/public/js/frappe/ui/toolbar/subscription.js
+++ b/frappe/public/js/frappe/ui/toolbar/subscription.js
@@ -5,7 +5,6 @@ $(document).on("startup", async () => {
 	});
 
 	if (response.message !== false && frappe.boot.setup_complete) {
-
 		let diff_days =
 			frappe.datetime.get_day_diff(cstr(response.message), frappe.datetime.get_today()) - 1;
 
@@ -14,12 +13,29 @@ $(document).on("startup", async () => {
 		}. After that your site will be suspended.`;
 
 		let $bar = $(`
-	<div class="position-absolute top-100 start-20 translate-middle shadow sm:rounded-lg py-2" style="left: 10%; bottom:20px; width:80%; margin: auto; text-align: center; border-radius: 10px; background-color: rgb(240 249 255); z-index: 1">
-				<div style="display: flex; align-items: center; justify-content: space-between; text-align: center;", class="text-muted">
+		<div
+			class="position-fixed top-100 start-20 translate-middle shadow sm:rounded-lg py-2"
+			style="left: 10%; bottom:20px; width:80%; margin: auto; text-align: center; border-radius: 10px; background-color: rgb(240 249 255); z-index: 1"
+		>
+			<div
+				style="display: flex; align-items: center; justify-content: space-between; text-align: center;"
+				class="text-muted"
+			>
 					<p style="float: left; margin: auto; font-size: 17px">${subscription_string}</p>
 					<div style="display: flex; align-items: center; justify-content: space-between">
-					<button type="button" class="button-renew px-4 py-2 border border-transparent text-white hover:bg-indigo-700 focus:outline-none focus:ring-offset-2 focus:ring-indigo-500" style="background-color: #0089FF; border-radius: 5px; margin-right: 10px; height: fit-content;">Subscribe</button>
-				<a type="button" class="dismiss-upgrade text-muted" data-dismiss="modal" aria-hidden="true" style="font-size:30px; margin-bottom: 5px; margin-right: 10px">\u00d7</a>
+					<button
+						type="button"
+						class="button-renew px-4 py-2 border border-transparent text-white hover:bg-indigo-700 focus:outline-none focus:ring-offset-2 focus:ring-indigo-500"
+						style="background-color: #0089FF; border-radius: 5px; margin-right: 10px; height: fit-content;"
+					>
+					Subscribe
+					</button>
+					<a
+						type="button"
+						class="dismiss-upgrade text-muted" data-dismiss="modal" aria-hidden="true" style="font-size:30px; margin-bottom: 5px; margin-right: 10px"
+					>
+					\u00d7
+					</a>
 				</div>
 			</div>
 		</div>
@@ -57,5 +73,5 @@ function redirectToUrl() {
 $.extend(frappe.ui.toolbar, {
 	redirectToUrl() {
 		redirectToUrl();
-	}
-})
+	},
+});

--- a/frappe/public/js/frappe/ui/toolbar/subscription.js
+++ b/frappe/public/js/frappe/ui/toolbar/subscription.js
@@ -38,7 +38,6 @@ $(document).on("startup", async () => {
 });
 
 function redirectToUrl() {
-	console.log('executing');
 	frappe.call({
 		method: "frappe.utils.subscription.remote_login",
 		callback: (url) => {

--- a/frappe/public/js/frappe/ui/toolbar/subscription.js
+++ b/frappe/public/js/frappe/ui/toolbar/subscription.js
@@ -1,11 +1,11 @@
 $(document).on("startup", async () => {
+	if (!frappe.boot.setup_complete || !frappe.user.has_role("System Manager")) {
+		return;
+	}
+
 	let response = await frappe.xcall("frappe.utils.subscription.show_banner");
 
-	if (
-		response.length > 0 &&
-		frappe.boot.setup_complete &&
-		frappe.user.has_role("System Manager")
-	) {
+	if (response.length > 0) {
 		let diff_days =
 			frappe.datetime.get_day_diff(cstr(response), frappe.datetime.get_today()) - 1;
 

--- a/frappe/public/js/frappe/ui/toolbar/subscription.js
+++ b/frappe/public/js/frappe/ui/toolbar/subscription.js
@@ -3,11 +3,11 @@ $(document).on("startup", async () => {
 		return;
 	}
 
-	let response = await frappe.xcall("frappe.utils.subscription.show_banner");
+	const expiry = frappe.boot.subscription_expiry;
 
-	if (response.length > 0) {
+	if (expiry) {
 		let diff_days =
-			frappe.datetime.get_day_diff(cstr(response), frappe.datetime.get_today()) - 1;
+			frappe.datetime.get_day_diff(cstr(expiry), frappe.datetime.get_today()) - 1;
 
 		let subscription_string = __(
 			`Your subscription will end in ${cstr(diff_days).bold()} ${

--- a/frappe/public/js/frappe/ui/toolbar/subscription.js
+++ b/frappe/public/js/frappe/ui/toolbar/subscription.js
@@ -1,0 +1,62 @@
+$(document).on("startup", async () => {
+	let response = await frappe.call({
+		method: "frappe.utils.subscription.show_banner",
+		callback: (response) => response,
+	});
+
+	if (response.message !== false && frappe.boot.setup_complete) {
+
+		let diff_days =
+			frappe.datetime.get_day_diff(cstr(response.message), frappe.datetime.get_today()) - 1;
+
+		let subscription_string = `Your subscription will end in ${cstr(diff_days).bold()} ${
+			diff_days > 1 ? "days" : "day"
+		}. After that your site will be suspended.`;
+
+		let $bar = $(`
+	<div class="position-absolute top-100 start-20 translate-middle shadow sm:rounded-lg py-2" style="left: 10%; bottom:20px; width:80%; margin: auto; text-align: center; border-radius: 10px; background-color: rgb(240 249 255); z-index: 1">
+				<div style="display: flex; align-items: center; justify-content: space-between; text-align: center;", class="text-muted">
+					<p style="float: left; margin: auto; font-size: 17px">${subscription_string}</p>
+					<div style="display: flex; align-items: center; justify-content: space-between">
+					<button type="button" class="button-renew px-4 py-2 border border-transparent text-white hover:bg-indigo-700 focus:outline-none focus:ring-offset-2 focus:ring-indigo-500" style="background-color: #0089FF; border-radius: 5px; margin-right: 10px; height: fit-content;">Subscribe</button>
+				<a type="button" class="dismiss-upgrade text-muted" data-dismiss="modal" aria-hidden="true" style="font-size:30px; margin-bottom: 5px; margin-right: 10px">\u00d7</a>
+				</div>
+			</div>
+		</div>
+		`);
+
+		$("footer").append($bar);
+
+		$bar.find(".dismiss-upgrade").on("click", () => {
+			$bar.remove();
+		});
+
+		$bar.find(".button-renew").on("click", () => {
+			redirectToUrl();
+		});
+	}
+});
+
+function redirectToUrl() {
+	console.log('executing');
+	frappe.call({
+		method: "frappe.utils.subscription.remote_login",
+		callback: (url) => {
+			if (url.message !== false) {
+				window.open(url.message, "_blank");
+			} else {
+				frappe.msgprint({
+					title: __("Message"),
+					indicator: "orange",
+					message: __("No active subscriptions found."),
+				});
+			}
+		},
+	});
+}
+
+$.extend(frappe.ui.toolbar, {
+	redirectToUrl() {
+		redirectToUrl();
+	}
+})

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -259,6 +259,13 @@ def add_standard_navbar_items():
 			"is_standard": 1,
 		},
 		{
+			"item_label": "Manage Subscriptions",
+			"item_type": "Action",
+			"action": "frappe.ui.toolbar.redirectToUrl()",
+			"hidden": 1,
+			"is_standard": 1,
+		},
+		{
 			"item_label": "Session Defaults",
 			"item_type": "Action",
 			"action": "frappe.ui.toolbar.setup_session_defaults()",

--- a/frappe/utils/subscription.py
+++ b/frappe/utils/subscription.py
@@ -1,0 +1,25 @@
+import json
+import requests
+import frappe
+
+
+@frappe.whitelist()
+def show_banner():
+	expiry = frappe.conf.expiry
+	if expiry and frappe.conf.login_url:
+		return expiry
+	return False
+
+
+@frappe.whitelist()
+def remote_login():
+	login_url = frappe.conf.login_url
+	if frappe.conf.expiry and login_url:
+		resp = requests.post(login_url)
+
+		if resp.status_code != 200:
+			return
+
+		return json.loads(resp.text)["message"]
+	else:
+		return False

--- a/frappe/utils/subscription.py
+++ b/frappe/utils/subscription.py
@@ -1,5 +1,7 @@
 import json
+
 import requests
+
 import frappe
 
 
@@ -7,6 +9,13 @@ import frappe
 def show_banner():
 	expiry = frappe.conf.expiry
 	if expiry and frappe.conf.login_url:
+		navbar_item, hidden = frappe.db.get_value(
+			"Navbar Item", {"item_label": "Manage Subscriptions"}, ["name", "hidden"]
+		)
+		if navbar_item and hidden:
+			doc = frappe.get_cached_doc("Navbar Item", navbar_item)
+			doc.hidden = False
+			doc.save()
 		return expiry
 	return False
 

--- a/frappe/utils/subscription.py
+++ b/frappe/utils/subscription.py
@@ -7,28 +7,34 @@ import frappe
 
 @frappe.whitelist()
 def show_banner():
-	expiry = frappe.conf.expiry
-	if expiry and frappe.conf.login_url:
-		navbar_item, hidden = frappe.db.get_value(
-			"Navbar Item", {"item_label": "Manage Subscriptions"}, ["name", "hidden"]
-		)
-		if navbar_item and hidden:
-			doc = frappe.get_cached_doc("Navbar Item", navbar_item)
-			doc.hidden = False
-			doc.save()
-		return expiry
+	if frappe.conf.subscription:
+		try:
+			navbar_item, hidden = frappe.db.get_value(
+				"Navbar Item", {"item_label": "Manage Subscriptions"}, ["name", "hidden"]
+			)
+			if navbar_item and hidden:
+				doc = frappe.get_cached_doc("Navbar Item", navbar_item)
+				doc.hidden = False
+				doc.save()
+			return frappe.conf.subscription["expiry"]
+		except Exception:
+			return False
+
 	return False
 
 
 @frappe.whitelist()
 def remote_login():
-	login_url = frappe.conf.login_url
-	if frappe.conf.expiry and login_url:
-		resp = requests.post(login_url)
+	try:
+		login_url = frappe.conf.subscription["login_url"]
+		if frappe.conf.subscription["expiry"] and login_url:
+			resp = requests.post(login_url)
 
-		if resp.status_code != 200:
-			return
+			if resp.status_code != 200:
+				return
 
-		return json.loads(resp.text)["message"]
-	else:
+			return json.loads(resp.text)["message"]
+	except Exception:
 		return False
+
+	return False

--- a/frappe/utils/subscription.py
+++ b/frappe/utils/subscription.py
@@ -6,24 +6,6 @@ import frappe
 
 
 @frappe.whitelist()
-def show_banner():
-	if frappe.conf.subscription:
-		try:
-			navbar_item, hidden = frappe.db.get_value(
-				"Navbar Item", {"item_label": "Manage Subscriptions"}, ["name", "hidden"]
-			)
-			if navbar_item and hidden:
-				doc = frappe.get_cached_doc("Navbar Item", navbar_item)
-				doc.hidden = False
-				doc.save()
-			return frappe.conf.subscription["expiry"]
-		except Exception:
-			return False
-
-	return False
-
-
-@frappe.whitelist()
 def remote_login():
 	try:
 		login_url = frappe.conf.subscription["login_url"]
@@ -38,3 +20,16 @@ def remote_login():
 		return False
 
 	return False
+
+
+def enable_manage_subscription():
+	if not frappe.db.exists("Navbar Item", {"item_label": "Manage Subscriptions"}):
+		return
+
+	navbar_item, hidden = frappe.db.get_value(
+		"Navbar Item", {"item_label": "Manage Subscriptions"}, ["name", "hidden"]
+	)
+	if navbar_item and hidden:
+		doc = frappe.get_cached_doc("Navbar Item", navbar_item)
+		doc.hidden = False
+		doc.save()


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
* Added a floating subscription banner and `Manage Subscriptions` button for managing subscriptions/redirecting to other urls.
* The banner is only shown if `expiry` and `login_url` field is setup in site config.
* In this case it's being used to remote login users from site to FrappeCloud dashboard.
<!-- You can skip this if you're fixing a typo or updating existing documentation -->


<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
![Screenshot from 2022-09-30 14-17-08](https://user-images.githubusercontent.com/50401596/193231281-0f9169be-bccd-4464-99da-a8f1026e7e14.png)

>no-docs
