### PR TITLE
fix: Show Report button should appear only if the doc is saved

### DIFF
--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -8,26 +8,29 @@ frappe.ui.form.on("Report", {
 		}
 
 		let doc = frm.doc;
-		frm.add_custom_button(
-			__("Show Report"),
-			function () {
-				switch (doc.report_type) {
-					case "Report Builder":
-						frappe.set_route("List", doc.ref_doctype, "Report", doc.name);
-						break;
-					case "Query Report":
-						frappe.set_route("query-report", doc.name);
-						break;
-					case "Script Report":
-						frappe.set_route("query-report", doc.name);
-						break;
-					case "Custom Report":
-						frappe.set_route("query-report", doc.name);
-						break;
-				}
-			},
-			"fa fa-table"
-		);
+		if (!doc.__islocal) {
+			frm.add_custom_button(
+				__("Show Report"),
+				function () {
+					switch (doc.report_type) {
+						case "Report Builder":
+							frappe.set_route("List", doc.ref_doctype, "Report", doc.name);
+							break;
+						case "Query Report":
+							frappe.set_route("query-report", doc.name);
+							break;
+						case "Script Report":
+							frappe.set_route("query-report", doc.name);
+							break;
+						case "Custom Report":
+							frappe.set_route("query-report", doc.name);
+							break;
+					}
+				},
+				"fa fa-table"
+			);
+		}
+
 
 		if (doc.is_standard === "Yes" && frm.perm[0].write) {
 			frm.add_custom_button(


### PR DESCRIPTION
Currently, the "Show Report" button appears even before saving Doctype. In addition to not making sense within the form, it is a dead button as it does not match with any case of the switch.

![image](https://user-images.githubusercontent.com/54215258/193319773-b3799b49-4d9b-49fe-ba46-0bb62ec53c14.png)

With this small change it is possible to solve the problem as shown below:
![image](https://user-images.githubusercontent.com/54215258/193320233-9262978c-2c72-4b7a-86a4-e481c2358584.png)


But something that doesn't make much sense to me and I couldn't find it in the code, why is the Menu button disappears if explicitly is the Show Report button that is being hidden?
