### PR TITLE
fix: remove return statement from override_email_send hook logic

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -527,9 +527,8 @@ def send_one(email, smtpserver=None, auto_commit=True, now=False):
 			if not frappe.flags.in_test:
 				method = get_hook_method("override_email_send")
 				if method:
-					queue = frappe.get_doc("Email Queue", email.name)
+					queue = frappe.get_cached_doc("Email Queue", email.name)
 					method(queue, email.sender, recipient.recipient, message)
-					return
 				else:
 					smtpserver.sess.sendmail(email.sender, recipient.recipient, message)
 


### PR DESCRIPTION
* should've been like this from start, since email ctx is different for different recipients
* this was working before because Mailgun used to pick recipients from mime message header, which seems to be deprecated now 😕

> no-docs