### PR TITLE
ci: don't lock PRs after 14 days

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -18,4 +18,3 @@ jobs:
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: 14
-          pr-inactive-days: 14


### PR DESCRIPTION
Not able to reopen locked prs.

Consider the default value of `pr-inactive-days` i.e 365 days

#

Note: for unlocking your locked pr, use - https://docs.github.com/en/rest/issues/issues#unlock-an-issue