### PR TITLE
fix: handle isatty correctly

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -452,7 +452,7 @@ def msgprint(
 	if as_list and type(msg) in (list, tuple):
 		out.as_list = 1
 
-	if sys.stdin.isatty():
+	if sys.stdin and sys.stdin.isatty():
 		msg = _strip_html_tags(out.message)
 
 	if flags.print_messages and out.message:

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -557,7 +557,7 @@ def is_cli() -> bool:
 	try:
 		invoked_from_terminal = bool(os.get_terminal_size())
 	except Exception:
-		invoked_from_terminal = sys.stdin.isatty()
+		invoked_from_terminal = sys.stdin and sys.stdin.isatty()
 	return invoked_from_terminal
 
 


### PR DESCRIPTION
sys.stdin can be `None` when underlying fd is not valid. 

ref: https://github.com/jupyter/notebook/pull/2454 
