### PR TITLE
fix: set system time on doc for `Now`

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -190,7 +190,12 @@ $.extend(frappe.model, {
 			} else if (default_val == "Today") {
 				value = frappe.datetime.get_today();
 			} else if ((default_val || "").toLowerCase() === "now") {
-				value = frappe.datetime.now_datetime();
+				if (df.fieldtype == "Time") {
+					value = frappe.datetime.now_time();
+				} else {
+					// datetime fields are stored in system tz
+					value = frappe.datetime.system_datetime();
+				}
 			} else if (default_val[0] === ":") {
 				var boot_doc = frappe.model.get_default_from_boot_docs(df, doc, parent_doc);
 				var is_allowed_boot_doc =

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -211,17 +211,21 @@ $.extend(frappe.datetime, {
 		return frappe.datetime._date(frappe.defaultDatetimeFormat, as_obj);
 	},
 
-	_date: function (format, as_obj = false) {
-		/**
-		 * Whenever we are getting now_date/datetime, always make sure dates are fetched using user time zone.
-		 * This is to make sure that time is as per user time zone set in User doctype, If a user had to change the timezone,
-		 * we will end up having multiple timezone by not honouring timezone in User doctype.
-		 * This will make sure that at any point we know which timezone the user if following and not have random timezone
-		 * when the timezone of the local machine changes.
-		 */
-		let time_zone = frappe.boot.time_zone
-			? frappe.boot.time_zone.user || frappe.boot.time_zone.system
-			: frappe.sys_defaults.time_zone;
+	system_datetime: function (as_obj = false) {
+		return frappe.datetime._date(frappe.defaultDatetimeFormat, as_obj, true);
+	},
+
+	_date: function (format, as_obj = false, system_time = false) {
+		let time_zone = frappe.boot.time_zone?.system || frappe.sys_defaults.time_zone;
+
+		// Whenever we are getting now_date/datetime, always make sure dates are fetched using user time zone.
+		// This is to make sure that time is as per user time zone set in User doctype, If a user had to change the timezone,
+		// we will end up having multiple timezone by not honouring timezone in User doctype.
+		// This will make sure that at any point we know which timezone the user if following and not have random timezone
+		// when the timezone of the local machine changes.
+		if (!system_time) {
+			time_zone = frappe.boot.time_zone?.user || time_zone;
+		}
 		let date = moment.tz(time_zone);
 
 		return as_obj ? frappe.datetime.moment_to_date_obj(date) : date.format(format);


### PR DESCRIPTION
setting the current time based on timezones is quite broken. 

While setting default:
- Time - is in user fmt
- Datetime - needs to be in system format after https://github.com/frappe/frappe/pull/13504


![telegram-cloud-photo-size-5-6190496682425299933-x](https://user-images.githubusercontent.com/9079960/193835138-7191ea98-38ab-421d-94e2-dcfb5f2050e3.jpg)
