### PR TITLE
fix: ignore perm level validation if row deleted

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1175,7 +1175,10 @@ class BaseDocument:
 				# get values from old doc
 				if self.get("parent_doc"):
 					parent_doc = self.parent_doc.get_latest()
-					ref_doc = [d for d in parent_doc.get(self.parentfield) if d.name == self.name][0]
+					child_docs = [d for d in parent_doc.get(self.parentfield) if d.name == self.name]
+					if not child_docs:
+						return
+					ref_doc = child_docs[0]
 				else:
 					ref_doc = self.get_latest()
 


### PR DESCRIPTION
Steps to reproduce:

Note: this is only reproducible when rows are deleted using code manually without using supported methods. Ideally, this fix shouldn't be required.

- Setup perm level on any child table field of SO
- Create and submit SO with 1 item
- "Update items" -> delete the row and add new one
- You'll get IndexError

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 38, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 76, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1457, in call
    return fn(*args, **newargs)
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 2708, in update_child_qty_rate
    parent.save()
  File "apps/frappe/frappe/model/document.py", line 310, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 345, in _save
    self.validate_higher_perm_levels()
  File "apps/frappe/frappe/model/document.py", line 707, in validate_higher_perm_levels
    d.reset_values_if_no_permlevel_access(has_access_to, high_permlevel_fields)
  File "apps/frappe/frappe/model/base_document.py", line 1054, in reset_values_if_no_permlevel_access
    ref_doc = [d for d in parent_doc.get(self.parentfield) if d.name == self.name][0]
IndexError: list index out of range
```