### PR TITLE
fix: let charts handle remaining aggregation

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -293,13 +293,6 @@ def get_group_by_chart_config(chart, filters):
 	)
 
 	if data:
-		if chart.number_of_groups and chart.number_of_groups < len(data):
-			other_count = 0
-			for i in range(chart.number_of_groups - 1, len(data)):
-				other_count += data[i]["count"]
-			data = data[0 : chart.number_of_groups - 1]
-			data.append({"name": "Other", "count": other_count})
-
 		chart_config = {
 			"labels": [item["name"] if item["name"] else "Not Specified" for item in data],
 			"datasets": [{"name": chart.name, "values": [item["count"] for item in data]}],

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -571,12 +571,13 @@ export default class ChartWidget extends Widget {
 			Heatmap: "heatmap",
 		};
 
+		let max_slices = ["Pie", "Donut"].includes(this.chart_doc.type) ? 6 : 9;
 		let chart_args = {
 			data: this.data,
 			type: chart_type_map[this.chart_doc.type],
 			colors: colors,
 			height: this.height,
-			maxSlices: ["Pie", "Donut"].includes(this.chart_doc.type) ? 6 : 9,
+			maxSlices: this.chart_doc.number_of_groups || max_slices,
 			axisOptions: {
 				xIsSeries: this.chart_doc.timeseries,
 				shortenYAxisNumbers: 1,


### PR DESCRIPTION
Currently, we are doing aggregation of remaining slices manually BUT this breaks the basic principle of DRY:

- dashboard chart decides how many groups to consider
- frappe charts has different maxSlices config

This results in mess like frappe computing "Other" and Frappe charts computing "rest" separately.

Fix: Just pass all data to charts and let it figure out the "Rest".


<img width="991" alt="image" src="https://user-images.githubusercontent.com/9079960/193998099-466d92a9-33b5-43fd-96d5-b424da071241.png">
