### PR TITLE
fix: upload dialog working without a wrapper

### DIFF
--- a/frappe/public/js/frappe/file_uploader/index.js
+++ b/frappe/public/js/frappe/file_uploader/index.js
@@ -55,6 +55,8 @@ export default class FileUploader {
 
 		if (!this.dialog) {
 			this.uploader.wrapper_ready = true;
+		} else {
+			this.dialog.show();
 		}
 
 		this.uploader.$watch(
@@ -118,7 +120,6 @@ export default class FileUploader {
 		});
 
 		this.wrapper = this.dialog.body;
-		this.dialog.show();
 		this.dialog.$wrapper.on("hidden.bs.modal", function () {
 			$(this).data("bs.modal", null);
 			$(this).remove();


### PR DESCRIPTION
I had the problem of calling the upload dialog like this:
```js
new frappe.ui.FileUploader({"allow_multiple":false,"restrictions":{}, "on_success": my_handler})
```

But got an error along the lines of:
```
desk.bundle.5CEEKGIL.js:2308 Uncaught (in promise) TypeError: Cannot set properties of undefined (setting 'wrapper_ready')
    at frappe.ui.Dialog.on_page_show (desk.bundle.5CEEKGIL.js:2308:2098)
    at frappe.ui.Dialog.show (desk.bundle.5CEEKGIL.js:421:16426)
    at Sr.make_dialog (desk.bundle.5CEEKGIL.js:2308:2147)
    at new Sr (desk.bundle.5CEEKGIL.js:2308:584)
    at myCode (my_code.js:17:24)
    at eval (my_code.js:8:7)
    at HTMLButtonElement.s (desk.bundle.5CEEKGIL.js:653:552)
    at HTMLButtonElement.dispatch (libs.bundle.YZMCKPNH.js:1:45084)
    at HTMLButtonElement.c1.handle (libs.bundle.YZMCKPNH.js:1:42972)
    ```
    
   This will fix this problem