### PR TITLE
fix!: Dont update modified by default in db.set_value

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -841,7 +841,7 @@ class Database:
 		val=None,
 		modified=None,
 		modified_by=None,
-		update_modified=True,
+		update_modified=False,
 		debug=False,
 		for_update=True,
 	):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1144,7 +1144,7 @@ class Document(BaseDocument):
 			data = {"doctype": self.doctype, "name": self.name, "user": frappe.session.user}
 			frappe.publish_realtime("list_update", data, after_commit=True)
 
-	def db_set(self, fieldname, value=None, update_modified=True, notify=False, commit=False):
+	def db_set(self, fieldname, value=None, update_modified=False, notify=False, commit=False):
 		"""Set a value in the document object, update the timestamp and update the database.
 
 		WARNING: This method does not trigger controller validations and should

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -728,6 +728,7 @@ class TestDBSetValue(FrappeTestCase):
 			"test_set_value change 1",
 			modified=custom_modified,
 			modified_by=custom_modified_by,
+			update_modified=True,
 		)
 		self.assertTupleEqual(
 			(custom_modified, custom_modified_by),


### PR DESCRIPTION
This default behavior is very confusing as it doesn't create a change log and the user can't know what changed. 


The point of this method is just to provide an abstraction over `UPDATE` SQL query, it shouldn't be doing this extra smartness by default. 


BREAKING CHANGE. Don't backport. 

TODO:
- [x] migration guide https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)#update_modified-behaviour-in-docdb_set-and-frappedbset_value
- [x] Rough audit of current usage