### PR TITLE
perf: Perform `db.set_value` with single query only

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -28,7 +28,6 @@ from frappe.database.utils import (
 from frappe.exceptions import DoesNotExistError, ImplicitCommitError
 from frappe.model.utils.link_count import flush_local_link_count
 from frappe.query_builder.functions import Count
-from frappe.query_builder.utils import DocType
 from frappe.utils import cast as cast_fieldtype
 from frappe.utils import get_datetime, get_table_name, getdate, now, sbool
 
@@ -880,23 +879,11 @@ class Database:
 			frappe.clear_document_cache(dt, dt)
 
 		else:
-			table = DocType(dt)
-
-			if for_update:
-				docnames = tuple(
-					self.get_values(dt, dn, "name", debug=debug, for_update=for_update, pluck=True)
-				) or (NullValue(),)
-				query = frappe.qb.update(table).where(table.name.isin(docnames))
-
-				for docname in docnames:
-					frappe.clear_document_cache(dt, docname)
-
-			else:
-				query = frappe.qb.engine.build_conditions(table=dt, filters=dn, update=True)
-				# TODO: Fix this; doesn't work rn - gavin@frappe.io
-				# frappe.cache().hdel_keys(dt, "document_cache")
-				# Workaround: clear all document caches
-				frappe.cache().delete_value("document_cache")
+			query = frappe.qb.engine.build_conditions(table=dt, filters=dn, update=True)
+			# TODO: Fix this; doesn't work rn - gavin@frappe.io
+			# frappe.cache().hdel_keys(dt, "document_cache")
+			# Workaround: clear all document caches
+			frappe.cache().delete_value("document_cache")
 
 			for column, value in to_update.items():
 				query = query.set(column, value)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -735,7 +735,7 @@ class TestDBSetValue(FrappeTestCase):
 			frappe.db.get_value("ToDo", todo.name, ["modified", "modified_by"]),
 		)
 
-	def test_for_update(self):
+	def test_set_value(self):
 		self.todo1.reload()
 
 		with patch.object(Database, "sql") as sql_called:
@@ -746,28 +746,23 @@ class TestDBSetValue(FrappeTestCase):
 				f"{self.todo1.description}-edit by `test_for_update`",
 			)
 			first_query = sql_called.call_args_list[0].args[0]
-			second_query = sql_called.call_args_list[1].args[0]
 
-			self.assertTrue(sql_called.call_count == 2)
-			self.assertTrue("FOR UPDATE" in first_query)
 			if frappe.conf.db_type == "postgres":
 				from frappe.database.postgres.database import modify_query
 
-				self.assertTrue(modify_query("UPDATE `tabToDo` SET") in second_query)
+				self.assertTrue(modify_query("UPDATE `tabToDo` SET") in first_query)
 			if frappe.conf.db_type == "mariadb":
-				self.assertTrue("UPDATE `tabToDo` SET" in second_query)
+				self.assertTrue("UPDATE `tabToDo` SET" in first_query)
 
 	def test_cleared_cache(self):
 		self.todo2.reload()
+		frappe.get_cached_doc(self.todo2.doctype, self.todo2.name)  # init cache
 
-		with patch.object(frappe, "clear_document_cache") as clear_cache:
-			frappe.db.set_value(
-				self.todo2.doctype,
-				self.todo2.name,
-				"description",
-				f"{self.todo2.description}-edit by `test_cleared_cache`",
-			)
-			clear_cache.assert_called()
+		description = f"{self.todo2.description}-edit by `test_cleared_cache`"
+
+		frappe.db.set_value(self.todo2.doctype, self.todo2.name, "description", description)
+		cached_doc = frappe.get_cached_doc(self.todo2.doctype, self.todo2.name)
+		self.assertEqual(cached_doc.description, description)
 
 	def test_update_alias(self):
 		args = (self.todo1.doctype, self.todo1.name, "description", "Updated by `test_update_alias`")

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -50,6 +50,20 @@ class TestPerformance(FrappeTestCase):
 		with self.assertQueryCount(0):
 			frappe.get_meta("User")
 
+	def test_set_value_query_count(self):
+		frappe.db.set_value("User", "Administrator", "interest", "Nothing")
+
+		with self.assertQueryCount(1):
+			frappe.db.set_value("User", "Administrator", "interest", "Nothing")
+
+		with self.assertQueryCount(1):
+			frappe.db.set_value("User", {"user_type": "System User"}, "interest", "Nothing")
+
+		with self.assertQueryCount(1):
+			frappe.db.set_value(
+				"User", {"user_type": "System User"}, {"interest": "Nothing", "bio": "boring person"}
+			)
+
 	def test_controller_caching(self):
 
 		get_controller("User")


### PR DESCRIPTION
Concludes https://github.com/frappe/frappe/pull/15560  by making all set_value calls to non-single doctypes run with 1 query only. 


#### Explanation:

Previously we were fetching all the primary keys which need to be updated and then updating separately. 

Before:
```
names = frappe.db.get_values(... filters)
frappe.qb.update(fields).where(table.name.isin(names))
```

After:
```
frappe.qb.update(fields).where(filters)
```


QB can already do single update query without much fuss. The last reason for keeping this appears to be `for update` which locks the rows before updating them. 

#### Why remove `for_update` completely?

This was added to make sure that N+1 queries that happen don't cause inconsistencies during the time queries are ran. Now that set_value is 1-1 translated to single `UPDATE` query there's no point in locking rows before updating them. `UPDATE` locks rows automatically. 


Before:
`1.02 ms ± 166 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)`

After:
`530 µs ± 144 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)`


Roughly 2x faster. This will be much better on queries that end up affecting more than 1 row. 

TODO:

- [x] better cache eviction when dn is not a filter
- [ ] ~~evict only doctype~~ (deferred, needs design change in cache keys)

ERPNext CI: https://github.com/frappe/erpnext/actions/runs/3197465411 ✅