### PR TITLE
fix: disable autocommit before each patch

### DIFF
--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -175,6 +175,7 @@ def execute_patch(patchmodule, method=None, methodargs=None):
 
 	start_time = time.time()
 	frappe.db.begin()
+	frappe.db.auto_commit_on_many_writes = 0
 	try:
 		if patchmodule:
 			if patchmodule.startswith("finally:"):


### PR DESCRIPTION
Patch authors frequently enable autocommit to patch large data, lets not rely on people to toggle it back and disable it before next patch ourselves 😄 