### PR TITLE
Revert "fix!: Dont update modified by default in db.set_value"

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -840,7 +840,7 @@ class Database:
 		val=None,
 		modified=None,
 		modified_by=None,
-		update_modified=False,
+		update_modified=True,
 		debug=False,
 		for_update=True,
 	):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1144,7 +1144,7 @@ class Document(BaseDocument):
 			data = {"doctype": self.doctype, "name": self.name, "user": frappe.session.user}
 			frappe.publish_realtime("list_update", data, after_commit=True)
 
-	def db_set(self, fieldname, value=None, update_modified=False, notify=False, commit=False):
+	def db_set(self, fieldname, value=None, update_modified=True, notify=False, commit=False):
 		"""Set a value in the document object, update the timestamp and update the database.
 
 		WARNING: This method does not trigger controller validations and should

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -728,7 +728,6 @@ class TestDBSetValue(FrappeTestCase):
 			"test_set_value change 1",
 			modified=custom_modified,
 			modified_by=custom_modified_by,
-			update_modified=True,
 		)
 		self.assertTupleEqual(
 			(custom_modified, custom_modified_by),


### PR DESCRIPTION
Reverts frappe/frappe#18301


This has potential to break conflict checking code: 


Not sure if worth it, will revert if I can't find any alternatives.

Ref: https://github.com/frappe/frappe/blob/bfa6a5fbdff932c8c3033d70682cd6a751095989/frappe/model/document.py#L738