### PR TITLE
removing realpath requirement for symbolically linked site directories

### DIFF
--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -457,7 +457,7 @@ def is_safe_path(path: str) -> bool:
 
 	basedir = frappe.get_site_path()
 	# ref: https://docs.python.org/3/library/os.path.html#os.path.commonpath
-	matchpath = os.path.realpath(os.path.abspath(path))
+	matchpath = os.path.abspath(path)
 	basedir = os.path.realpath(os.path.abspath(basedir))
 
 	return basedir == os.path.commonpath((basedir, matchpath))


### PR DESCRIPTION
Some of us have sites where the `private` and `public` folders are symbolically linked and shared across multiple machines (behind a load balancer). We mount a single datastore between machines which causes the directories or the `is_safe_path` method to fail even though its perfectly valid.

Removing the `os.path.realpath` requirement for the `matchpath` ensures it works as designed, and also works for symbolically linked directories.