### PR TITLE
fix: Avoid deadlock on documents with workflows

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -91,7 +91,11 @@ def is_transition_condition_satisfied(transition, doc):
 @frappe.whitelist()
 def apply_workflow(doc, action):
 	"""Allow workflow action on the current doc"""
-	doc = frappe.get_doc(frappe.parse_json(doc))
+	if isinstance(doc, str):
+		doc = frappe.get_doc(frappe.parse_json(doc), for_update=True)
+	elif isinstance(doc, dict):
+		doc = frappe.get_doc(doc, for_update=True)
+
 	workflow = get_workflow(doc.doctype)
 	transitions = get_transitions(doc, workflow)
 	user = frappe.session.user
@@ -241,7 +245,7 @@ def bulk_workflow_approval(docnames, doctype, action):
 		message_dict = {}
 		try:
 			show_progress(docnames, _("Applying: {0}").format(action), idx, docname)
-			apply_workflow(frappe.get_doc(doctype, docname), action)
+			apply_workflow(frappe.get_doc(doctype, docname, for_update=True), action)
 			frappe.db.commit()
 		except Exception as e:
 			if not frappe.message_log:


### PR DESCRIPTION
```bash
Traceback (most recent call last):
  File "apps/frappe/frappe/database/database.py", line 174, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.7/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "env/lib/python3.7/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.7/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.7/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1213, 'Deadlock found when trying to get lock; try restarting transaction')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "apps/frappe/frappe/model/workflow.py", line 248, in bulk_workflow_approval
    apply_workflow(frappe.get_doc(doctype, docname), action)
  File "apps/frappe/frappe/model/workflow.py", line 129, in apply_workflow
    doc.submit()
  File "apps/frappe/frappe/model/document.py", line 1018, in submit
    return self._submit()
  File "apps/frappe/frappe/model/document.py", line 1007, in _submit
    return self.save()
  File "apps/frappe/frappe/model/document.py", line 310, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 364, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1088, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 941, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1262, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1244, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 938, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 287, in on_submit
    self.update_against_document_in_jv()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 1021, in update_against_document_in_jv
    reconcile_against_document(lst)
  File "apps/erpnext/erpnext/accounts/utils.py", line 452, in reconcile_against_document
    update_reference_in_payment_entry(entry, doc, do_not_save=True)
  File "apps/erpnext/erpnext/accounts/utils.py", line 616, in update_reference_in_payment_entry
    payment_entry.set_missing_values()
  File "apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 224, in set_missing_values
    self.set_missing_ref_details()
  File "apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 242, in set_missing_ref_details
    d.db_set(field, value)
  File "apps/frappe/frappe/model/document.py", line 1180, in db_set
    update_modified=update_modified,
  File "apps/frappe/frappe/database/database.py", line 806, in set_value
    ).run(debug=debug)
  File "apps/frappe/frappe/query_builder/utils.py", line 66, in execute_query
    return frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
  File "apps/frappe/frappe/database/database.py", line 199, in sql
    raise frappe.QueryDeadlockError(e)
frappe.exceptions.QueryDeadlockError: (1213, 'Deadlock found when trying to get lock; try restarting transaction')
```

If you are trying to update something in a document via some server-side scripts on some event and there is also a workflow configured for that document, there are  chances that a deadlock might be faced because both the workflow and server-side script are trying to update the doc