### PR TITLE
chore: reduce margin to occupy more items

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -162,7 +162,7 @@
 
 	.summary-item {
 		// SIZE & SPACING
-		margin: 0px 30px;
+		margin: 0px 25px;
 		min-width: 180px;
 		max-width: 300px;
 		height: 62px;

--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -159,11 +159,13 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
+	justify-content: space-evenly;
+	gap: 20px;
 
 	.summary-item {
 		// SIZE & SPACING
-		margin: 0px 25px;
-		min-width: 180px;
+		margin: 0px 20px;
+		min-width: 160px;
 		max-width: 300px;
 		height: 62px;
 


### PR DESCRIPTION
### Previously:
Due to the 30px margin, it only accommodates 4 items in a row and leaves too much white space.
<img width="1256" alt="Screenshot 2022-10-07 at 11 38 07 AM" src="https://user-images.githubusercontent.com/30501401/194479680-b5f4b4ef-1825-4eba-85f6-238c1cea819e.png">

### After reducing margin by 5px:
<img width="1261" alt="Screenshot 2022-10-07 at 11 36 51 AM" src="https://user-images.githubusercontent.com/30501401/194479663-57afd350-e66c-43c5-9b98-41159f8349f4.png">

### Responsive:

https://user-images.githubusercontent.com/30859809/195019895-9ca49c28-c349-43c7-b06f-6ab49aba2d2e.mov



