### PR TITLE
fix: Esbuild failing for non vue apps

### DIFF
--- a/esbuild/frappe-vue-style.js
+++ b/esbuild/frappe-vue-style.js
@@ -19,7 +19,7 @@ module.exports = {
 					out.contents = Buffer.from(modified);
 				}
 				if (!fs.existsSync(dir)) {
-					fs.mkdirSync(dir);
+					fs.mkdirSync(dir, { recursive: true });
 				}
 				fs.writeFile(out.path, out.contents, (err) => {
 					err && console.error(err);


### PR DESCRIPTION
Esbuild failing for non vue apps