### PR TITLE
fix: link field self linking

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -166,7 +166,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		frappe.route_options.name_field = this.get_label_value();
 
 		// reference to calling link
-		frappe._from_link = this;
+		frappe._from_link = frappe.utils.deep_clone(this);
 		frappe._from_link_scrollY = $(document).scrollTop();
 
 		frappe.ui.form.make_quick_entry(doctype, (doc) => {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -3,6 +3,7 @@
 
 import deep_equal from "fast-deep-equal";
 import number_systems from "./number_systems";
+import cloneDeepWith from "lodash/cloneDeepWith";
 
 frappe.provide("frappe.utils");
 
@@ -998,6 +999,10 @@ Object.assign(frappe.utils, {
 
 	deep_equal(a, b) {
 		return deep_equal(a, b);
+	},
+
+	deep_clone(obj, customizer) {
+		return cloneDeepWith(obj, customizer);
 	},
 
 	file_name_ellipsis(filename, length) {


### PR DESCRIPTION
This pr fixes the issue of self linking when we create a new document from link field which shows and is present in the same doctype.


Before:

https://user-images.githubusercontent.com/32034600/194831681-158f1c1d-cd51-4946-ba45-805b44fbb973.mov

After:


https://user-images.githubusercontent.com/32034600/194831717-44df417f-2734-47fd-86ac-3c390db9b94f.mov


#


- [x] test show_title_field_in_link
- [x] test quick entry