### PR TITLE
refactor: scheduler without external libraries

### DIFF
--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -12,13 +12,10 @@ Events:
 import os
 import time
 
-# imports - third party imports
-import schedule
-
 # imports - module imports
 import frappe
 from frappe.installer import update_site_config
-from frappe.utils import get_datetime, get_sites, now_datetime
+from frappe.utils import cint, get_datetime, get_sites, now_datetime
 from frappe.utils.background_jobs import get_jobs
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -34,16 +31,14 @@ def cprint(*args, **kwargs):
 
 
 def start_scheduler():
-	"""Run enqueue_events_for_all_sites every 2 minutes (default).
+	"""Run enqueue_events_for_all_sites based on scheduler tick.
 	Specify scheduler_interval in seconds in common_site_config.json"""
 
-	schedule.every(frappe.get_conf().scheduler_tick_interval or 60).seconds.do(
-		enqueue_events_for_all_sites
-	)
+	tick = cint(frappe.get_conf().scheduler_tick_interval) or 60
 
 	while True:
-		schedule.run_pending()
-		time.sleep(1)
+		time.sleep(tick)
+		enqueue_events_for_all_sites()
 
 
 def enqueue_events_for_all_sites():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ dependencies = [
     "requests~=2.27.1",
     "rq~=1.10.1",
     "rsa>=4.1",
-    "schedule~=1.1.0",
     "semantic-version~=2.10.0",
     "sqlparse~=0.4.1",
     "tenacity~=8.0.1",


### PR DESCRIPTION
idk why we need a scheduling library when all we do with it is run 1 infinite loop. 

`time.sleep(tick)` effectively puts the thread and process to sleep so the scheduler process pretty much doesn't do anything until it's resumed again. This is *slightly* 🤏 better cause we don't wake the thread every second for no reason. 


<img width="830" alt="Screenshot 2022-10-09 at 2 51 55 PM" src="https://user-images.githubusercontent.com/9079960/194748925-f3bb50f5-dcd9-488f-9db4-4ebc5664a5db.png">


Updated migration guide: https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)
No one uses this: https://sourcegraph.com/search?q=context:global+/import%5Cs*schedule%5Cb/+repo:.*frappe.*&patternType=standard 