### PR TITLE
fix: make --record optional for cypress tests

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -841,9 +841,10 @@ def run_parallel_tests(
 @click.option("--parallel", is_flag=True, help="Run UI Test in parallel mode")
 @click.option("--with-coverage", is_flag=True, help="Generate coverage report")
 @click.option("--ci-build-id")
+@click.option("--record", is_flag=True, help="Record using Cypress Dashboard")
 @pass_context
 def run_ui_tests(
-	context, app, headless=False, parallel=True, with_coverage=False, ci_build_id=None
+	context, app, headless=False, parallel=True, with_coverage=False, ci_build_id=None, record=False
 ):
 	"Run UI tests"
 	site = get_site(context)
@@ -888,8 +889,11 @@ def run_ui_tests(
 		frappe.commands.popen(f"yarn add {packages} --no-lockfile")
 
 	# run for headless mode
-	run_or_open = "run --browser chrome --record" if headless else "open"
+	run_or_open = "run --browser chrome" if headless else "open"
 	formatted_command = f"{site_env} {password_env} {coverage_env} {cypress_path} {run_or_open}"
+
+	if record:
+		run_or_open += " --record"
 
 	if parallel:
 		formatted_command += " --parallel"


### PR DESCRIPTION
Using the Guide in headless mode causes problem

https://frappeframework.com/docs/v14/user/en/ui-testing

results in error: `You passed the --record flag but did not provide us your Record Key.`

full trace:

```
You passed the --record flag but did not provide us your Record Key.
You can pass us your Record Key like this:
  $ cypress run --record --key <record_key>
You can also set the key as an environment variable with the name: CYPRESS_RECORD_KEY
https://on.cypress.io/how-do-i-record-runs
Traceback (most recent call last):
  File "/home/frappe/.pyenv/versions/3.10.5/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/frappe/.pyenv/versions/3.10.5/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 109, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/utils.py", line 901, in run_ui_tests
    frappe.commands.popen(formatted_command, cwd=app_base_path, raise_err=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 98, in popen
    raise subprocess.CalledProcessError(return_, command)
subprocess.CalledProcessError: Command 'CYPRESS_baseUrl=http://app.localhost:8000/  CYPRESS_coverage=false /home/frappe/frappe-bench/apps/cypress_tests/node_modules/.bin/cypress run --browser chrome --record' returned non-zero exit status 1.
```