### PR TITLE
ci: Verify yarn lock file

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -120,6 +120,12 @@ jobs:
           TYPE: ui
           DB: mariadb
 
+      - name: Verify yarn.lock
+        run: |
+          cd ~/frappe-bench/apps/frappe
+          yarn install --immutable --immutable-cache --check-cache
+          git diff --exit-code yarn.lock
+
       - name: Instrument Source Code
         run: cd ~/frappe-bench/apps/frappe/ && npx nyc instrument -x 'frappe/public/dist/**' -x 'frappe/public/js/lib/**' -x '**/*.bundle.js' --compact=false --in-place frappe
 


### PR DESCRIPTION
to avoid https://github.com/frappe/frappe/pull/18326 


Yarn has no exact equivalent for `npm ci` to check lockfile status, so this is a work around to regen it and then see if there were any changes. 