### PR TITLE
fix: always show list filters and add confirmation when deleting filters

### DIFF
--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -9,6 +9,7 @@
   "disable_count",
   "disable_sidebar_stats",
   "disable_auto_refresh",
+  "show_saved_filters",
   "total_fields",
   "fields_html",
   "fields"
@@ -49,10 +50,16 @@
    "hidden": 1,
    "label": "Fields",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "show_saved_filters",
+   "fieldtype": "Check",
+   "label": "Auto-Show Saved Filters"
   }
  ],
  "links": [],
- "modified": "2020-05-12 18:27:15.568199",
+ "modified": "2022-10-10 04:45:04.081715",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List View Settings",

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -9,7 +9,6 @@
   "disable_count",
   "disable_sidebar_stats",
   "disable_auto_refresh",
-  "show_saved_filters",
   "total_fields",
   "fields_html",
   "fields"
@@ -50,16 +49,10 @@
    "hidden": 1,
    "label": "Fields",
    "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "show_saved_filters",
-   "fieldtype": "Check",
-   "label": "Auto-Show Saved Filters"
   }
  ],
  "links": [],
- "modified": "2022-10-10 04:45:04.081715",
+ "modified": "2020-05-12 18:27:15.568199",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List View Settings",

--- a/frappe/public/js/frappe/list/list_filter.js
+++ b/frappe/public/js/frappe/list/list_filter.js
@@ -26,6 +26,12 @@ export default class ListFilter {
 		this.$saved_filters_preview = this.wrapper.find(".saved-filters-preview");
 		this.saved_filters_hidden = true;
 
+		// show saved filters by default based on list setting; since a local
+		// state (saved_filters_hidden) is also maintained, add a conditional check
+		if (this.list_view.list_view_settings.show_saved_filters) {
+			this.toggle_saved_filters(true);
+		}
+
 		this.filter_input = frappe.ui.form.make_control({
 			df: {
 				fieldtype: "Data",
@@ -102,11 +108,18 @@ export default class ListFilter {
 	bind_remove_filter() {
 		this.wrapper.on("click", ".filter-pill .remove", (e) => {
 			const $li = $(e.currentTarget).closest(".filter-pill");
-			const name = $li.attr("data-name");
-			const applied_filters = this.get_filters_values(name);
-			$li.remove();
-			this.remove_filter(name).then(() => this.refresh());
-			this.list_view.filter_area.remove_filters(applied_filters);
+			const filter_label = $li.text().trim();
+
+			frappe.confirm(
+				__("Are you sure you want to remove the {0} filter?", [filter_label.bold()]),
+				() => {
+					const name = $li.attr("data-name");
+					const applied_filters = this.get_filters_values(name);
+					$li.remove();
+					this.remove_filter(name).then(() => this.refresh());
+					this.list_view.filter_area.remove_filters(applied_filters);
+				}
+			);
 		});
 	}
 

--- a/frappe/public/js/frappe/list/list_filter.js
+++ b/frappe/public/js/frappe/list/list_filter.js
@@ -25,12 +25,7 @@ export default class ListFilter {
 		this.$saved_filters = this.wrapper.find(".saved-filters").hide();
 		this.$saved_filters_preview = this.wrapper.find(".saved-filters-preview");
 		this.saved_filters_hidden = true;
-
-		// show saved filters by default based on list setting; since a local
-		// state (saved_filters_hidden) is also maintained, add a conditional check
-		if (this.list_view.list_view_settings.show_saved_filters) {
-			this.toggle_saved_filters(true);
-		}
+		this.toggle_saved_filters(true);
 
 		this.filter_input = frappe.ui.form.make_control({
 			df: {


### PR DESCRIPTION
**Problem:** Once a saved filter is setup, it's very easy to misclick and accidentally delete the saved filter, which leads to bad UX.
 
**Change:** Added a confirmation dialog when trying to remove a saved filter.

[confirm-delete-list-filter.webm](https://user-images.githubusercontent.com/13396535/194845660-a651ecb2-87a8-4ab6-ac72-fdf9cf8382cc.webm)