### PR TITLE
feat: allow auto clearing notification log

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -20,6 +20,14 @@ class NotificationLog(Document):
 			except frappe.OutgoingEmailError:
 				self.log_error(_("Failed to send notification email"))
 
+	@staticmethod
+	def clear_old_logs(days=180):
+		from frappe.query_builder import Interval
+		from frappe.query_builder.functions import Now
+
+		table = frappe.qb.DocType("Notification Log")
+		frappe.db.delete(table, filters=(table.modified < (Now() - Interval(days=days))))
+
 
 def get_permission_query_conditions(for_user):
 	if not for_user:

--- a/frappe/desk/doctype/notification_log/notification_log_list.js
+++ b/frappe/desk/doctype/notification_log/notification_log_list.js
@@ -1,0 +1,7 @@
+frappe.listview_settings["Notification Log"] = {
+	onload: function (listview) {
+		frappe.require("logtypes.bundle.js", () => {
+			frappe.utils.logtypes.show_log_retention_message(cur_list.doctype);
+		});
+	},
+};


### PR DESCRIPTION
Nothing special, you can now auto delete old notifications by setting it up from "log settings"
<img width="296" alt="Screenshot 2022-10-10 at 3 57 23 PM" src="https://user-images.githubusercontent.com/9079960/194846173-11e2c9bf-5f9a-4d64-a3be-ea75802dd1b6.png">

<img width="1337" alt="image" src="https://user-images.githubusercontent.com/9079960/194846191-fab815fc-b38a-4342-b196-45b56c69a804.png">



NOTE: This is not enabled by default. 
NOTE: This does not check if the notification is read or not. So set the retention policy sensibly. 🤷 


`no-docs`