### PR TITLE
fix: type-error in email signature code

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -175,7 +175,7 @@ class Communication(Document, CommunicationEmailMixin):
 		if html_signature:
 			_signature = html_signature.renderContents()
 
-		if (_signature or signature) not in self.content:
+		if (frappe.utils.cstr(_signature) or signature) not in self.content:
 			self.content = f'{self.content}</p><br><p class="signature">{signature}'
 
 	def before_save(self):

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -19,6 +19,7 @@ from frappe.core.doctype.communication.mixins import CommunicationEmailMixin
 from frappe.core.utils import get_parent_doc
 from frappe.model.document import Document
 from frappe.utils import (
+	cstr,
 	parse_addr,
 	split_emails,
 	strip_html,
@@ -175,7 +176,7 @@ class Communication(Document, CommunicationEmailMixin):
 		if html_signature:
 			_signature = html_signature.renderContents()
 
-		if (frappe.utils.cstr(_signature) or signature) not in self.content:
+		if (cstr(_signature) or signature) not in self.content:
 			self.content = f'{self.content}</p><br><p class="signature">{signature}'
 
 	def before_save(self):


### PR DESCRIPTION
This is a clean version from the previous messed up pull request:
https://github.com/frappe/frappe/pull/18350


When I try to send emails with a signature I get the following error:
```
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1585, in call
    return fn(*args, **newargs)
  File "apps/pcg_web/pcg_web/pcg_customer/doctype/pcg_customer_communication/pcg_customer_communication.py", line 116, in send_pcg_mail_to_customer
    set_timeline_links(message['name'], timeline_links)
  File "apps/pcg_web/pcg_web/overrides/communication.py", line 28, in set_timeline_links
    communication.save(ignore_permissions=True)
  File "apps/frappe/frappe/model/document.py", line 301, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 335, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1057, in run_before_save_methods
    self.run_method("before_save")
  File "apps/frappe/frappe/model/document.py", line 928, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1268, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1250, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 925, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/core/doctype/communication/communication.py", line 183, in before_save
    self.set_signature_in_email_content()
  File "apps/frappe/frappe/core/doctype/communication/communication.py", line 178, in set_signature_in_email_content
    if (_signature or signature) not in self.content:
TypeError: 'in <string>' requires string as left operand, not bytes
```

When looking at the code, it is obvious because `.renderContents` from BeautifulSoup returns bytes and not a string the the check below tries to search those bytes in a string.

This fixes this typeerror