### PR TITLE
fix: ignore if df doesn't exist

### DIFF
--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -169,6 +169,9 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 	}
 
 	set_df_property(fieldname, prop, value) {
+		if (!fieldname) {
+			return;
+		}
 		const field = this.get_field(fieldname);
 		field.df[prop] = value;
 		field.refresh();


### PR DESCRIPTION
1. Open lead
2. Activities tab
3. "New Event"

```
TypeError: Cannot read properties of undefined (reading 'df')
  at frappe.ui.Dialog.set_df_property(../../../../../apps/frappe/frappe/public/js/frappe/ui/field_group.js:173:9)
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/views/interaction.js:63:18)
  at Array.forEach(<anonymous>)
  at hn.onchange(../../../../../apps/frappe/frappe/public/js/frappe/views/interaction.js:61:22)
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/form/controls/base_control.js:240:50)
```


This happens because dialogs might not have set fieldname (specified in code directly)