### PR TITLE
fix: Set email account in Communication only if exists

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -165,7 +165,8 @@ class CommunicationEmailMixin:
 				)
 
 				if self.sent_or_received == "Sent" and self._outgoing_email_account:
-					self.db_set("email_account", self._outgoing_email_account.name)
+					if frappe.db.exists("Email Account", self._outgoing_email_account.name):
+						self.db_set("email_account", self._outgoing_email_account.name)
 
 		return self._outgoing_email_account
 


### PR DESCRIPTION
**Issue:**
When the outgoing email server/account is defined in `site_config.json`, the system creates a fake Email Account based on keys defined in site_config. But as the Email Account actually does not exist, there is no point in setting the field in Communication.

In frappe.io, all the outgoing communication records have an invalid email account, which creates a problem while creating duplicate communication records while creating an Opportunity from a Lead.

