### PR TITLE
refactor(minor): use naming series instead of autoname method for address doctype

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -2,12 +2,13 @@
  "actions": [],
  "allow_import": 1,
  "allow_rename": 1,
+ "autoname": "naming_series:",
  "creation": "2013-01-10 16:34:32",
  "doctype": "DocType",
  "document_type": "Setup",
  "engine": "InnoDB",
  "field_order": [
-  "address_details",
+  "naming_series",
   "address_title",
   "address_type",
   "address_line1",
@@ -28,11 +29,6 @@
   "links"
  ],
  "fields": [
-  {
-   "fieldname": "address_details",
-   "fieldtype": "Section Break",
-   "options": "fa fa-map-marker"
-  },
   {
    "fieldname": "address_title",
    "fieldtype": "Data",
@@ -143,16 +139,26 @@
    "fieldtype": "Table",
    "label": "Links",
    "options": "Dynamic Link"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Series",
+   "no_copy": 1,
+   "options": "{address_title}.-.{address_type}.-.#",
+   "set_only_once": 1
   }
  ],
  "icon": "fa fa-map-marker",
  "idx": 5,
  "links": [],
- "modified": "2020-10-21 16:14:37.284830",
+ "modified": "2022-10-11 14:49:25.729358",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",
  "name_case": "Title Case",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -212,5 +218,6 @@
  ],
  "search_fields": "country, state",
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -16,19 +16,12 @@ class Address(Document):
 	def __setup__(self):
 		self.flags.linked = False
 
-	def autoname(self):
+	def before_naming(self):
 		if not self.address_title:
-			if self.links:
-				self.address_title = self.links[0].link_name
+			if not self.links:
+				throw(_("Address Title is mandatory."))
 
-		if self.address_title:
-			self.name = cstr(self.address_title).strip() + "-" + cstr(_(self.address_type)).strip()
-			if frappe.db.exists("Address", self.name):
-				self.name = make_autoname(
-					cstr(self.address_title).strip() + "-" + cstr(self.address_type).strip() + "-.#"
-				)
-		else:
-			throw(_("Address Title is mandatory."))
+			self.address_title = self.links[0].link_name
 
 	def validate(self):
 		self.link_address()

--- a/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
+++ b/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
@@ -90,8 +90,8 @@ class TestAddressesAndContacts(FrappeTestCase):
 	def test_get_data(self):
 		linked_docs = [get_custom_doc_for_address_and_contacts()]
 		links_list = [item.name for item in linked_docs]
-		d = create_linked_address(links_list)
-		create_linked_contact(links_list, d)
+		address_name = create_linked_address(links_list)
+		create_linked_contact(links_list, address_name)
 		report_data = get_data({"reference_doctype": "Test Custom Doctype"})
 		for idx, link in enumerate(links_list):
 			test_item = [
@@ -105,7 +105,7 @@ class TestAddressesAndContacts(FrappeTestCase):
 				0,
 				"_Test First Name",
 				"_Test Last Name",
-				"_Test Address-Billing",
+				address_name,
 				"+91 0000000000",
 				"",
 				"test_contact@example.com",


### PR DESCRIPTION
This pr removes the `autoname` method of address doctype and uses naming series to do the same.

This consequently makes the address document's name configurable from customize form/document naming setting.