### PR TITLE
refactor: simplify api.py

### DIFF
--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -275,6 +275,12 @@ class TestMethodAPI(FrappeAPITestCase):
 
 		authorization_token = None
 
+	def test_404s(self):
+		response = self.get("/api/rest", {"sid": self.sid})
+		self.assertEqual(response.status_code, 404)
+		response = self.get("/api/resource/User/NonExistent@s.com", {"sid": self.sid})
+		self.assertEqual(response.status_code, 404)
+
 
 class TestReadOnlyMode(FrappeAPITestCase):
 	"""During migration if read only mode can be enabled.


### PR DESCRIPTION
Break giant api.py into pieces for readability and extensibility. 

- `/api/{call}/` is handled by each handler - `resource` and `method`
- `/api/resource/doctype` is handled by separate handler for create/list
- `/api/resource/doctype/docname` is handled by separate handler for get/put/delete


Why do this? Look at the final version, now there's _VERY CLEAR_ location for where to extend next HTTP method or call if you want to (which I do 😄)

PS: View side by side diff instead of unified.
PPS: Doesn't need new tests but will see if I can plug something missing. 