### PR TITLE
fix: progress bar not disappearing

### DIFF
--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -47,9 +47,8 @@ frappe.socketio = {
 					data.percent,
 					100,
 					data.description,
-					true,
+					true
 				);
-
 			}
 		});
 

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -42,16 +42,14 @@ frappe.socketio = {
 				data.percent = (flt(data.progress[0]) / data.progress[1]) * 100;
 			}
 			if (data.percent) {
-				if (data.percent == 100) {
-					frappe.hide_progress();
-				} else {
-					frappe.show_progress(
-						data.title || __("Progress"),
-						data.percent,
-						100,
-						data.description
-					);
-				}
+				frappe.show_progress(
+					data.title || __("Progress"),
+					data.percent,
+					100,
+					data.description,
+					true,
+				);
+
 			}
 		});
 


### PR DESCRIPTION
`hide_progress` was called from two different places and somehow it caused my progress bar to not disappear. 

My `progress` WS-Events came very fast 1/2 then 2/2 and the progress got stuck at 50%.

This fix just calls `show_progress` with the `hide_on_completion` argument to true and therefore reduces codeduplication and puts the responsibility of hiding the progress to the `show_progress` code, where it should belong.

If you really need me to give you reproduction instructions, let me know. I hope this goes in without any ;)