### PR TITLE
fix: format currency value as float while grid upload

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1011,6 +1011,7 @@ export default class Grid {
 				Int: (val) => cint(val),
 				Check: (val) => cint(val),
 				Float: (val) => flt(val),
+				Currency: (val) => flt(val),
 			};
 
 			// upload


### PR DESCRIPTION
**Issue:** 
While uploading a CSV file in the grid with currency fields in the table its value is formatted as a string which is causing an error.
<img width="590" alt="image" src="https://user-images.githubusercontent.com/30859809/195106553-b56dff88-2121-4baa-b667-18d9770205c5.png">
