### PR TITLE
fix: correct import for markupsafe.escape

### DIFF
--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -3,8 +3,11 @@
 
 
 import frappe
+from frappe.app import make_form_dict
 from frappe.desk.search import get_names_for_mentions, search_link, search_widget
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import set_request
+from frappe.website.serve import get_response
 
 
 class TestSearch(FrappeTestCase):
@@ -235,3 +238,22 @@ def teardown_test_link_field_order(TestCase):
 	)
 
 	TestCase.tree_doc.delete()
+
+
+class TestWebsiteSearch(FrappeTestCase):
+	def get(self, path, user="Guest"):
+		frappe.set_user(user)
+		set_request(method="GET", path=path)
+		make_form_dict(frappe.local.request)
+		response = get_response()
+		frappe.set_user("Administrator")
+		return response
+
+	def test_basic_search(self):
+
+		no_search = self.get("/search")
+		self.assertEqual(no_search.status_code, 200)
+
+		response = self.get("/search?q=b")
+		self.assertEqual(response.status_code, 200)
+		self.assertIn("Search Results", response.get_data(as_text=True))

--- a/frappe/www/search.py
+++ b/frappe/www/search.py
@@ -1,4 +1,4 @@
-from jinja2 import utils
+import markupsafe
 
 import frappe
 from frappe import _
@@ -10,7 +10,7 @@ from frappe.utils.global_search import web_search
 def get_context(context):
 	context.no_cache = 1
 	if frappe.form_dict.q:
-		query = str(utils.escape(sanitize_html(frappe.form_dict.q)))
+		query = str(markupsafe.escape(sanitize_html(frappe.form_dict.q)))
 		context.title = _("Search Results for")
 		context.query = query
 		context.route = "/search"


### PR DESCRIPTION
ref: https://github.com/pallets/jinja/issues/1626

https://discuss.erpnext.com/t/website-search-is-not-working-erpnext-v14-2-2-version-14/95589 