### PR TITLE
fix: reshuffle __newname field to accommodate under 1st Tab Break

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -144,8 +144,16 @@ frappe.ui.form.Layout = class Layout {
 				fieldname: "__details",
 			};
 			let first_tab = this.fields[1].fieldtype === "Tab Break" ? this.fields[1] : null;
+
 			if (!first_tab) {
-				this.fields.splice(1, 0, default_tab);
+				this.fields.splice(0, 0, default_tab);
+			} else {
+				// reshuffle __newname field to accomodate under 1st Tab Break
+				let newname_field = this.fields.find((df) => df.fieldname === "__newname");
+				if (newname_field.get_status(this) === "Write") {
+					this.fields.splice(0, 1);
+					this.fields.splice(1, 0, newname_field);
+				}
 			}
 		}
 

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -150,7 +150,7 @@ frappe.ui.form.Layout = class Layout {
 			} else {
 				// reshuffle __newname field to accomodate under 1st Tab Break
 				let newname_field = this.fields.find((df) => df.fieldname === "__newname");
-				if (newname_field.get_status(this) === "Write") {
+				if (newname_field && newname_field.get_status(this) === "Write") {
 					this.fields.splice(0, 1);
 					this.fields.splice(1, 0, newname_field);
 				}


### PR DESCRIPTION
If doctype contains Tab Breaks and the auto naming field is set to Prompt, then the `__newname` field gets rendered in a different section outside the Tab Structure.

## Before Fix

<img width="885" alt="Screenshot 2022-10-13 at 11 42 30 AM" src="https://user-images.githubusercontent.com/3784093/195521948-548aab1a-d9fa-423a-96ca-1797b8b795d3.png">

`New section for __newname field`
<img width="1428" alt="Screenshot 2022-10-13 at 11 42 40 AM" src="https://user-images.githubusercontent.com/3784093/195523584-2711fc80-d5ec-427a-a710-3c7ea0c51b4c.png">


## After Fix
`__newfield get rendered under 1st Tab Break`

<img width="1039" alt="Screenshot 2022-10-13 at 11 39 26 AM" src="https://user-images.githubusercontent.com/3784093/195523690-becd5ee9-16b1-40f3-8433-a35c04deb623.png">



