### PR TITLE
fix: add flags to set_permission for docshares

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -237,7 +237,7 @@ class User(Document):
 		)
 
 	def share_with_self(self):
-		frappe.share.add(
+		frappe.share.add_docshare(
 			self.doctype, self.name, self.name, write=1, share=1, flags={"ignore_share_permission": True}
 		)
 

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -13,31 +13,24 @@ from frappe.utils import cint
 
 
 @frappe.whitelist()
-def add(
-	doctype, 
-	name, 
-	user=None, 
-	read=1, 
-	write=0, 
-	submit=0, 
-	share=0, 
-	everyone=0, 
-	notify=0
-):
+def add(doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, notify=0):
 	"""Expose function without flags to the client-side"""
 	return add_docshare(
 		doctype,
-		name, 
-		user=user, 
-		read=read, 
-		write=write, 
-		submit=submit, 
-		share=share, 
-		everyone=everyone, 
-		notify=notify
+		name,
+		user=user,
+		read=read,
+		write=write,
+		submit=submit,
+		share=share,
+		everyone=everyone,
+		notify=notify,
 	)
-	
-def add_docshare(doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, flags=None, notify=0):
+
+
+def add_docshare(
+	doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, flags=None, notify=0
+):
 	"""Share the given document with a user."""
 	if not user:
 		user = frappe.session.user
@@ -90,6 +83,7 @@ def remove(doctype, name, user, flags=None):
 def set_permission(doctype, name, user, permission_to, value=1, everyone=0):
 	"""Expose function without flags to the client-side"""
 	set_docshare_permission(doctype, name, user, permission_to, value=value, everyone=everyone)
+
 
 def set_docshare_permission(doctype, name, user, permission_to, value=1, everyone=0, flags=None):
 	"""Set share permission."""

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -65,22 +65,25 @@ def remove(doctype, name, user, flags=None):
 
 
 @frappe.whitelist()
-def set_permission(doctype, name, user, permission_to, value=1, everyone=0):
+def set_permission(doctype, name, user, permission_to, value=1, everyone=0, flags=None):
 	"""Set share permission."""
-	check_share_permission(doctype, name)
+	if not (flags or {}).get("ignore_share_permission"):
+		check_share_permission(doctype, name)
 
 	share_name = get_share_name(doctype, name, user, everyone)
 	value = int(value)
 
 	if not share_name:
 		if value:
-			share = add(doctype, name, user, everyone=everyone, **{permission_to: 1})
+			share = add(doctype, name, user, everyone=everyone, **{permission_to: 1}, flags=flags)
 		else:
 			# no share found, nothing to remove
 			share = {}
 			pass
 	else:
 		share = frappe.get_doc("DocShare", share_name)
+		if flags:
+			share.flags.update(flags)
 		share.flags.ignore_permissions = True
 		share.set(permission_to, value)
 

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -101,7 +101,7 @@ def set_docshare_permission(doctype, name, user, permission_to, value=1, everyon
 
 	if not share_name:
 		if value:
-			share = add(doctype, name, user, everyone=everyone, **{permission_to: 1}, flags=flags)
+			share = add_docshare(doctype, name, user, everyone=everyone, **{permission_to: 1}, flags=flags)
 		else:
 			# no share found, nothing to remove
 			share = {}

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -14,8 +14,30 @@ from frappe.utils import cint
 
 @frappe.whitelist()
 def add(
-	doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, flags=None, notify=0
+	doctype, 
+	name, 
+	user=None, 
+	read=1, 
+	write=0, 
+	submit=0, 
+	share=0, 
+	everyone=0, 
+	notify=0
 ):
+	"""Expose function without flags to the client-side"""
+	return add_docshare(
+		doctype,
+		name, 
+		user=user, 
+		read=read, 
+		write=write, 
+		submit=submit, 
+		share=share, 
+		everyone=everyone, 
+		notify=notify
+	)
+	
+def add_docshare(doctype, name, user=None, read=1, write=0, submit=0, share=0, everyone=0, flags=None, notify=0):
 	"""Share the given document with a user."""
 	if not user:
 		user = frappe.session.user
@@ -65,7 +87,11 @@ def remove(doctype, name, user, flags=None):
 
 
 @frappe.whitelist()
-def set_permission(doctype, name, user, permission_to, value=1, everyone=0, flags=None):
+def set_permission(doctype, name, user, permission_to, value=1, everyone=0):
+	"""Expose function without flags to the client-side"""
+	set_docshare_permission(doctype, name, user, permission_to, value=value, everyone=everyone)
+
+def set_docshare_permission(doctype, name, user, permission_to, value=1, everyone=0, flags=None):
 	"""Set share permission."""
 	if not (flags or {}).get("ignore_share_permission"):
 		check_share_permission(doctype, name)


### PR DESCRIPTION
At the moment, when the `add` function is called in `share.py` the `ignore_share_permission` flag is evaluated. (Which means adding any new docshare can be done with this flag). However, when changing an existing docshare via `set_permission` function in `share.py` the flags are not evaluated, even though in `docshare.py` (which is used in `set_permission`) itself, the flags would be evaluated again, if they would be passed.
In my opinion there is only this missing part here in `set_permission` to transport the flags all the way through to the docshare creation.

More detailed explanation of the use case:
I am giving permissions based on docshares for the doctype Event. The `check_share_permission` function in `share.py` further down the line calls the `has_permission` function in `event.py` which evaluates to false if the event is not public and the current user is not the owner of the document.
In combination with the above, I can add new docshares with whatever permissions I want and I can remove them again, but I cannot edit them, because the flags are not evaluated and passed by the `set_permission` function.