### PR TITLE
fix(dx): resolve_class

### DIFF
--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -317,6 +317,22 @@ class TestWebsite(FrappeTestCase):
 		self.assertIn('<meta name="title" content="Test Title Metatag">', content)
 		self.assertIn('<meta name="description" content="Test Description for Metatag">', content)
 
+	def test_resolve_class(self):
+		from frappe.utils.jinja_globals import resolve_class
+
+		context = frappe._dict(primary=True)
+		self.assertEqual(resolve_class("test"), "test")
+		self.assertEqual(resolve_class("test", "test-2"), "test test-2")
+		self.assertEqual(resolve_class("test", {"test-2": False, "test-3": True}), "test test-3")
+		self.assertEqual(
+			resolve_class(["test1", "test2", context.primary and "primary"]), "test1 test2 primary"
+		)
+
+		content = '<a class="{{ resolve_class("btn btn-default", primary and "btn-primary") }}">Test</a>'
+		self.assertEqual(
+			frappe.render_template(content, context), '<a class="btn btn-default btn-primary">Test</a>'
+		)
+
 
 def set_home_page_hook(key, value):
 	from frappe import hooks

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -5,6 +5,8 @@
 def resolve_class(classes):
 	if classes is None:
 		return ""
+	if classes is False:
+		return ""
 
 	if isinstance(classes, str):
 		return classes

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -11,9 +11,6 @@ def resolve_class(*classes):
 	if classes is False:
 		return ""
 
-	if isinstance(classes, str):
-		return classes
-
 	if isinstance(classes, (list, tuple)):
 		return " ".join(resolve_class(c) for c in classes).strip()
 

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -2,7 +2,10 @@
 # License: MIT. See LICENSE
 
 
-def resolve_class(classes):
+def resolve_class(*classes):
+	if classes and len(classes) == 1:
+		classes = classes[0]
+
 	if classes is None:
 		return ""
 	if classes is False:


### PR DESCRIPTION
This PR adds a small improvement in resolve_class API

**Before:**
```
<div
    class="{{ resolve_class([
        'bg-gray-900 font-bold text-white inline-block',
        {'py-2 px-5 text-xl rounded-[10px]': size == 'small'},
        {'py-6 px-14 text-3xl rounded-[14px]': size == 'large'},
    ]) }}"
>
```

**After:**
```
<div
    class="{{ resolve_class(
        'bg-gray-900 font-bold text-white inline-block',
        size == 'small' and 'py-2 px-5 text-xl rounded-[10px]',
        size == 'large' and 'py-6 px-14 text-3xl rounded-[14px]',
    ) }}">
```

- [x] Python Test

