### PR TITLE
fix: missing six import

### DIFF
--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -11,10 +11,10 @@ import json
 import linecache
 import os
 import pydoc
-import six
 import sys
 import traceback
 
+import six
 from ldap3.core.exceptions import LDAPInvalidCredentialsResult
 
 import frappe

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -11,6 +11,7 @@ import json
 import linecache
 import os
 import pydoc
+import six
 import sys
 import traceback
 


### PR DESCRIPTION
`six` is referenced in `get_snapshot` function but never imported.