### PR TITLE
fix: Notifications. Get Alerts for Today button

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -176,7 +176,7 @@ frappe.ui.form.on("Notification", {
 					},
 					callback: function (r) {
 						if (r.message && r.message.length > 0) {
-							frappe.msgprint(r.message);
+							frappe.msgprint(r.message.toString());
 						} else {
 							frappe.msgprint(__("No alerts for today"));
 						}


### PR DESCRIPTION
Fixes button "Get Alerts for Today" funcionality in notifications, when you select "Days after" or "Days before" on "Set alerts on". This is not showing any data now.

Before
![before](https://user-images.githubusercontent.com/94137451/195996414-4d0b7d0f-b015-4cc8-83b6-05a903c73fe9.gif)

After
![after](https://user-images.githubusercontent.com/94137451/195996541-0068dd52-4b40-447a-8f1c-82d122b0ddd6.gif)

