### PR TITLE
fix(UI): child table custom horizontal scroll

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -835,6 +835,18 @@ export default class GridRow {
 				: "";
 		add_class += ["Check"].indexOf(df.fieldtype) !== -1 ? " text-center" : "";
 
+		let grid;
+		let gridContainer;
+
+		let initalPositionX = 0;
+		let startX = 0;
+		let startY = 0;
+
+		let inputInFocus = false;
+
+		let vertical = false;
+		let horizontal = false;
+
 		var $col = $(
 			'<div class="col grid-static-col col-xs-' + colsize + " " + add_class + '"></div>'
 		)
@@ -842,15 +854,107 @@ export default class GridRow {
 			.attr("data-fieldtype", df.fieldtype)
 			.data("df", df)
 			.appendTo(this.row)
-			.on("click", function () {
-				if (frappe.ui.form.editable_row === me) {
-					return;
+			// initialize grid for horizontal scroll on mobile devices.
+			.on("touchstart", function (event) {
+				gridContainer = $(event.currentTarget).closest(".form-grid-container")[0];
+				grid = $(event.currentTarget).closest(".form-grid")[0];
+
+				grid.style.position != "relative" && $(grid).css("position", "relative");
+				!grid.style.left && $(grid).css("left", 0);
+
+				startX = event.touches[0].clientX;
+				startY = event.touches[0].clientY;
+
+				initalPositionX = -parseFloat(grid.style.left || 0) + startX;
+			})
+			// calculate X and Y movement based on touch events.
+			.on("touchmove", function (event) {
+				if (inputInFocus) return;
+
+				let movedX;
+				let movedY;
+
+				if (!horizontal && !vertical) {
+					movedX = Math.abs(startX - event.touches[0].clientX);
+					movedY = Math.abs(startY - event.touches[0].clientY);
 				}
-				var out = me.toggle_editable_row();
+
+				if (!vertical && movedX > 16) {
+					horizontal = true;
+				} else if (!horizontal && movedY > 16) {
+					vertical = true;
+				}
+				if (horizontal) {
+					event.preventDefault();
+
+					let gridStart = initalPositionX - event.touches[0].clientX;
+					let gridEnd = grid.clientWidth - gridContainer.clientWidth;
+
+					if (gridStart < 0) {
+						gridStart = 0;
+					} else if (gridStart > gridEnd) {
+						gridStart = gridEnd;
+					}
+					grid.style.left = `-${gridStart}px`;
+				}
+			})
+			.on("touchend", function () {
+				vertical = false;
+				horizontal = false;
+			})
+			.on("click", function () {
+				if (frappe.ui.form.editable_row !== me) {
+					var out = me.toggle_editable_row();
+				}
 				var col = this;
-				setTimeout(function () {
-					$(col).find('input[type="Text"]:first').focus();
-				}, 500);
+				let firstInputField = $(col).find('input[type="Text"]:first');
+				// prevent random layout shifts caused by widgets and on click position elements inside view (UX).
+				function onInputFocus(el) {
+					inputInFocus = true;
+
+					let containerWidth = gridContainer.getBoundingClientRect().width;
+					let containerLeft = gridContainer.getBoundingClientRect().left;
+					let gridLeft = parseFloat(grid.style.left);
+					let elementLeft = el.offset().left;
+					let fieldType = el.data("fieldtype");
+
+					let offsetRight = containerWidth - (elementLeft + el.width());
+					let offsetLeft = 0;
+					let elementScreenX = elementLeft - containerLeft;
+					let elementPositionX = containerWidth - (elementLeft - containerLeft);
+
+					if (["Date", "Time", "Datetime"].includes(fieldType)) {
+						offsetLeft = elementPositionX - 220;
+					}
+					if (["Link", "Dynamic Link"].includes(fieldType)) {
+						offsetLeft = elementPositionX - 250;
+					}
+					if (elementScreenX < 0) {
+						grid.style.left = `${gridLeft - elementScreenX}px`;
+					} else if (offsetLeft < 0) {
+						grid.style.left = `${gridLeft + offsetLeft}px`;
+					} else if (offsetRight < 0) {
+						grid.style.left = `${gridLeft + offsetRight}px`;
+					}
+				}
+
+				firstInputField.length && onInputFocus(firstInputField);
+
+				firstInputField.focus();
+				firstInputField.one("blur", () => (inputInFocus = false));
+
+				// Delay datePicker widget to prevent temparary layout shift (UX).
+				if (firstInputField.data("fieldtype") == "Date") {
+					let dateTimePicker = document.querySelectorAll(".datepicker.active")[0];
+
+					dateTimePicker.classList.remove("active");
+
+					dateTimePicker.style.width = "220px";
+
+					setTimeout(() => {
+						dateTimePicker.classList.add("active");
+					}, 600);
+				}
 				return out;
 			});
 
@@ -1151,6 +1255,7 @@ export default class GridRow {
 	show_form() {
 		if (frappe.utils.is_xs()) {
 			$(this.grid.form_grid).css("min-width", "0");
+			$(this.grid.form_grid).css("position", "unset");
 		}
 		if (!this.grid_form) {
 			this.grid_form = new GridRowForm({
@@ -1191,7 +1296,8 @@ export default class GridRow {
 	}
 	hide_form() {
 		if (frappe.utils.is_xs()) {
-			$(this.grid.form_grid).css("min-width", "1000px");
+			$(this.grid.form_grid).css("min-width", "738px");
+			$(this.grid.form_grid).css("position", "relative");
 		}
 		frappe.dom.unfreeze();
 		this.row.toggle(true);

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -930,7 +930,7 @@ export default class GridRow {
 					event.preventDefault();
 
 					let grid_start = inital_position_x - event.touches[0].clientX;
-					let grid_end = grid.clientWidth - grid_container.clientWidth;
+					let grid_end = grid.clientWidth - grid_container.clientWidth + 2;
 
 					if (grid_start < 0) {
 						grid_start = 0;

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -508,12 +508,6 @@
 			position: unset!important;
 		}
 	}
-
-	.form-column.col-sm-6 .form-grid {
-		.row-index {
-			display: block;
-		}
-	}
 }
 
 @media (max-width: map-get($grid-breakpoints, "sm")) {

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -486,10 +486,26 @@
 
 @media (max-width: map-get($grid-breakpoints, "md")) {
 	.form-grid-container {
-		overflow-x: scroll;
+		overflow-x: clip;
 
 		.form-grid {
-			min-width: 1000px;
+			min-width: 738px;
+		}
+	}
+
+	.form-column.col-sm-6 .form-grid {
+		.row-index {
+			display: block;
+		}
+	}
+}
+
+@media (min-width: map-get($grid-breakpoints, "md")) {
+	.form-grid-container {
+		overflow-x: unset!important;
+
+		.form-grid {
+			position: unset!important;
 		}
 	}
 

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -268,8 +268,8 @@
 	.editable-row .frappe-control {
 		padding-top: 0px !important;
 		padding-bottom: 0px !important;
-		margin-left: -5px !important;
-		margin-right: -5px !important;
+		margin-left: -1px !important;
+		margin-right: -1px !important;
 	}
 }
 


### PR DESCRIPTION
This PR extends concept of horizontal scroll on small screen size ( mobile view ) that was introduced in #18400 .

> Note: This doesn't uses mouse events instead it uses touch events so it is only applicable on mobile devices.

- Default horizontal scroll creates container so when we only have few items in child table container's height is less than some widgets (Autocomplete). As a result, those will be hidden and horizontal scroll is added by the browser that creates some problems as shown below. I have also shown after fix result as well.

https://user-images.githubusercontent.com/39730881/196052511-5fbf0994-a049-4cfa-9bf8-e42cacf87a81.mov

- If User selects the text in the input field and by mistake touch goes out of input field it creates this infinite kind of scroll.
  ( edge case )

https://user-images.githubusercontent.com/39730881/196053273-2f9463c3-ae3f-4dfd-80a5-1d84ca79dab2.mov

- As we have introduced horizontal scroll, few cases needed to be handled like input field that user clicked on is only half in view and other half is hidden on left/right side of the container.

- Also widgets such as Autocomplete & DatePicker made layout shift if they were not in the middle of the screen .

    - Currently, only Autocomplete & DatePicker related fields are handled as some widgets don't use standard input field need to be handled in separate PR.

https://user-images.githubusercontent.com/39730881/196054146-78da2473-8952-49fd-a121-d82f6a15f7ac.mov


