### PR TITLE
chore: include charts in website

### DIFF
--- a/frappe/public/js/frappe-web.bundle.js
+++ b/frappe/public/js/frappe-web.bundle.js
@@ -24,3 +24,4 @@ import "./bootstrap-4-web.bundle";
 
 import "../../website/js/website.js";
 import "./frappe/socketio_client.js";
+import "./frappe/ui/chart.js";


### PR DESCRIPTION
Previously chart.js was only included in desk.bundle.js. So it was only available through the desk.

This change will include chart.js in frappe-web.bundle.js so make it available from the website.