### PR TITLE
fix: delete custom tables when doctype is deleted

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -129,11 +129,17 @@ def clear_doctype_cache(doctype=None):
 		clear_single(doctype)
 
 		# clear all parent doctypes
-
 		for dt in frappe.get_all(
 			"DocField", "parent", dict(fieldtype=["in", frappe.model.table_fields], options=doctype)
 		):
 			clear_single(dt.parent)
+
+		# clear all parent doctypes
+		if not frappe.flags.in_install:
+			for dt in frappe.get_all(
+				"Custom Field", "dt", dict(fieldtype=["in", frappe.model.table_fields], options=doctype)
+			):
+				clear_single(dt.dt)
 
 		# clear all notifications
 		delete_notification_count_for(doctype)

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -670,6 +670,17 @@ class TestDocType(FrappeTestCase):
 
 		self.assertEqual(test_json.test_json_field["hello"], "world")
 
+	def test_custom_field_deletion(self):
+		"""Custom child tables whose doctype doesn't exist should be auto deleted."""
+		doctype = new_doctype(custom=0).insert().name
+		child = new_doctype(custom=0, istable=1).insert().name
+
+		field = "abc"
+		create_custom_fields({doctype: [{"fieldname": field, "fieldtype": "Table", "options": child}]})
+
+		frappe.delete_doc("DocType", child)
+		self.assertFalse(frappe.get_meta(doctype).get_field(field))
+
 	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_delete_doctype_with_customization(self):
 		from frappe.custom.doctype.property_setter.property_setter import make_property_setter

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -670,6 +670,7 @@ class TestDocType(FrappeTestCase):
 
 		self.assertEqual(test_json.test_json_field["hello"], "world")
 
+	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_custom_field_deletion(self):
 		"""Custom child tables whose doctype doesn't exist should be auto deleted."""
 		doctype = new_doctype(custom=0).insert().name

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -95,6 +95,10 @@ def delete_doc(
 
 				update_flags(doc, flags, ignore_permissions)
 				check_permission_and_not_submitted(doc)
+				# delete custom table fields using this doctype.
+				frappe.db.delete(
+					"Custom Field", {"options": name, "fieldtype": ("in", frappe.model.table_fields)}
+				)
 				frappe.db.delete("__global_search", {"doctype": name})
 
 			delete_from_table(doctype, name, ignore_doctypes, None)


### PR DESCRIPTION
Imagine this scenario:
- App creates a custom table on standard doctype
- App is uninstalled, custom table remains. This makes original doctype unusable because it doesn't load. 

Fix: Delete custom field when related child table is being deleted. 

Note that this doesn't delete any data whatsoever, it's just deleting a dead custom field. 


Example: https://github.com/frappe/lms/issues/369 

Extends https://github.com/frappe/frappe/pull/17009 