### PR TITLE
build(deps): bump restricted python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "PyPika~=0.48.9",
     "PyQRCode~=1.2.1",
     "PyYAML~=5.4.1",
-    "RestrictedPython~=5.1",
+    "RestrictedPython~=5.2",
     "WeasyPrint==52.5",
     "Werkzeug~=2.2.2",
     "Whoosh~=2.7.4",


### PR DESCRIPTION
has better support for 3.10, will have to bump to 6.0 for 3.11 support. 

https://github.com/zopefoundation/RestrictedPython/pull/215/files
