### PR TITLE
fix: Show error page even when routing fails

### DIFF
--- a/frappe/website/page_renderers/base_template_page.py
+++ b/frappe/website/page_renderers/base_template_page.py
@@ -64,7 +64,9 @@ class BaseTemplatePage(BaseRenderer):
 			self.context.url_prefix += "/"
 
 		self.context.path = self.path
-		self.context.pathname = frappe.local.path if hasattr(frappe, "local") else self.path
+		self.context.pathname = (
+			getattr(frappe.local, "path", None) if hasattr(frappe, "local") else self.path
+		)
 
 	def update_website_context(self):
 		# apply context from hooks


### PR DESCRIPTION
since `frappe.local.path` is not set when routing itself failed for some reason we dont even get error page. 

This minor change lets us see the error at least. 

Before: internal server error (nginx shows its own error page)

After:

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/9079960/196201503-2525e10c-3da4-4f2c-8a56-3611d6c45179.png">



Works even if the resolver doesn't run at all:

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/9079960/196201968-71d8b2a0-dddb-487d-9b90-398fe0809a18.png">
