### PR TITLE
fix(frappe.client): delete child doc via parent

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -270,7 +270,7 @@ def delete(doctype, name):
 
 	:param doctype: DocType of the document to be deleted
 	:param name: name of the document to be deleted"""
-	frappe.delete_doc(doctype, name, ignore_missing=False)
+	delete_doc(doctype, name)
 
 
 @frappe.whitelist(methods=["POST", "PUT"])
@@ -462,3 +462,23 @@ def insert_doc(doc) -> "Document":
 		return parent
 
 	return frappe.get_doc(doc).insert()
+
+
+def delete_doc(doctype, name):
+	"""Deletes document
+	if doctype is a child table, then deletes the child record using the parent doc
+	so that the parent doc's `on_update` is called
+	"""
+
+	if frappe.is_table(doctype):
+		parenttype, parent, parentfield = frappe.db.get_value(
+			doctype, name, ["parenttype", "parent", "parentfield"]
+		)
+		parent = frappe.get_doc(parenttype, parent)
+		for row in parent.get(parentfield):
+			if row.name == name:
+				parent.remove(row)
+				parent.save()
+				break
+	else:
+		frappe.delete_doc(doctype, name, ignore_missing=False)

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -471,9 +471,10 @@ def delete_doc(doctype, name):
 	"""
 
 	if frappe.is_table(doctype):
-		parenttype, parent, parentfield = frappe.db.get_value(
-			doctype, name, ["parenttype", "parent", "parentfield"]
-		)
+		values = frappe.db.get_value(doctype, name, ["parenttype", "parent", "parentfield"])
+		if not values:
+			raise frappe.DoesNotExistError
+		parenttype, parent, parentfield = values
 		parent = frappe.get_doc(parenttype, parent)
 		for row in parent.get(parentfield):
 			if row.name == name:

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
@@ -15,12 +17,26 @@ class TestClient(FrappeTestCase):
 
 	def test_delete(self):
 		from frappe.client import delete
+		from frappe.desk.doctype.note.note import Note
 
-		todo = frappe.get_doc(dict(doctype="ToDo", description="description")).insert()
-		delete("ToDo", todo.name)
+		note = frappe.get_doc(
+			doctype="Note",
+			title=frappe.generate_hash(length=8),
+			content="test",
+			seen_by=[{"user": "Administrator"}],
+		).insert()
 
-		self.assertFalse(frappe.db.exists("ToDo", todo.name))
-		self.assertRaises(frappe.DoesNotExistError, delete, "ToDo", todo.name)
+		child_row_name = note.seen_by[0].name
+
+		with patch.object(Note, "save") as save:
+			delete("Note Seen By", child_row_name)
+			save.assert_called()
+
+		delete("Note", note.name)
+
+		self.assertFalse(frappe.db.exists("Note", note.name))
+		self.assertRaises(frappe.DoesNotExistError, delete, "Note", note.name)
+		self.assertRaises(frappe.DoesNotExistError, delete, "Note Seen By", child_row_name)
 
 	def test_http_valid_method_access(self):
 		from frappe.client import delete


### PR DESCRIPTION
So that parent's on_update is called. No change for deletion of normal doctype. This is similar to the functionality of insert function.

