### PR TITLE
fix: dont `db_set` on unsaved document

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1174,6 +1174,9 @@ class Document(BaseDocument):
 		# to trigger notification on value change
 		self.run_method("before_change")
 
+		if self.name is None:
+			return
+
 		frappe.db.set_value(
 			self.doctype,
 			self.name,


### PR DESCRIPTION
This causes unnecessary inserts and deletions from tab singles 🥴 


`doc.db_set` on new doc is effectively same as `doc.set` so this change just avoids the unnecessary query. 

This kind of usage is potentially a bug so you shouldn't be doing it TBH. 

<img width="1412" alt="Screenshot 2022-10-18 at 5 43 22 PM" src="https://user-images.githubusercontent.com/9079960/196426225-d6ec0937-1b9c-48d9-b6ed-ac729f5eafd5.png">
