### PR TITLE
fix: cannot go back from recorder page

### DIFF
--- a/frappe/public/js/frappe/recorder/RecorderRoot.vue
+++ b/frappe/public/js/frappe/recorder/RecorderRoot.vue
@@ -12,8 +12,8 @@ import { useRoute } from "vue-router"
 
 let route = useRoute();
 
-watch(route, () => {
-	frappe.router.current_route = frappe.router.parse();
+watch(route, async () => {
+	frappe.router.current_route = await frappe.router.parse();
 	frappe.breadcrumbs.update();
 	frappe.recorder.route = route;
 });

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -27,6 +27,7 @@ window.addEventListener("popstate", (e) => {
 	// forward-back button, just re-render based on current route
 	frappe.router.route();
 	e.preventDefault();
+	e.stopImmediatePropagation();
 	return false;
 });
 


### PR DESCRIPTION
Happens because Vue router captures unnecessary `popstate` event:

![Screenshot-2022-10-18-205943](https://user-images.githubusercontent.com/16315650/196478177-4f9bba60-66ad-421d-89a7-970cbc254cd7.png)
