### PR TITLE
feat: add exists function to query builder

### DIFF
--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -33,6 +33,11 @@ class Ifnull(IfNull):
 		super().__init__(condition, term, **kwargs)
 
 
+class Exists(Function):
+	def __init__(self, subquery, alias=None):
+		super().__init__("EXISTS", subquery, alias=alias)
+
+
 class Timestamp(Function):
 	def __init__(self, term: str, time=None, alias=None):
 		if time:


### PR DESCRIPTION
This function seems to be supported both by
MariaDB: https://mariadb.com/kb/en/subqueries-and-exists/
Postgresql: https://www.postgresql.org/docs/current/functions-subquery.html

I've seen some raw query in ERPNext using this function. Example: 

https://github.com/frappe/erpnext/blob/96b4211ea1cfc9a10ba79b54b5645105f0925943/erpnext/stock/stock_balance.py#L98-L138
