### PR TITLE
fix: google calendar sync times (system tz)

### DIFF
--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -567,12 +567,20 @@ def google_calendar_to_repeat_on(start, end, recurrence=None):
 	Both have been mapped in a dict for easier mapping.
 	"""
 	repeat_on = {
-		"starts_on": get_datetime(start.get("date"))
-		if start.get("date")
-		else parser.parse(start.get("dateTime")).astimezone(ZoneInfo(get_time_zone())).replace(tzinfo=None),
-		"ends_on": get_datetime(end.get("date"))
-		if end.get("date")
-		else parser.parse(end.get("dateTime")).astimezone(ZoneInfo(get_time_zone())).replace(tzinfo=None),
+		"starts_on": (
+			get_datetime(start.get("date")) 
+			if start.get("date")
+			else parser.parse(start.get("dateTime"))
+				.astimezone(ZoneInfo(get_time_zone()))
+				.replace(tzinfo=None)
+		),
+		"ends_on": (
+			get_datetime(end.get("date"))
+			if end.get("date")
+			else parser.parse(end.get("dateTime"))
+				.astimezone(ZoneInfo(get_time_zone()))
+				.replace(tzinfo=None)
+		),
 		"all_day": 1 if start.get("date") else 0,
 		"repeat_this_event": 1 if recurrence else 0,
 		"repeat_on": None,

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 import google.oauth2.credentials
 import requests
 from dateutil import parser
+from zoneinfo import ZoneInfo
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -568,10 +569,10 @@ def google_calendar_to_repeat_on(start, end, recurrence=None):
 	repeat_on = {
 		"starts_on": get_datetime(start.get("date"))
 		if start.get("date")
-		else parser.parse(start.get("dateTime")).astimezone().replace(tzinfo=None),
+		else parser.parse(start.get("dateTime")).astimezone(ZoneInfo(get_time_zone())).replace(tzinfo=None),
 		"ends_on": get_datetime(end.get("date"))
 		if end.get("date")
-		else parser.parse(end.get("dateTime")).astimezone().replace(tzinfo=None),
+		else parser.parse(end.get("dateTime")).astimezone(ZoneInfo(get_time_zone())).replace(tzinfo=None),
 		"all_day": 1 if start.get("date") else 0,
 		"repeat_this_event": 1 if recurrence else 0,
 		"repeat_on": None,

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -4,11 +4,11 @@
 
 from datetime import datetime, timedelta
 from urllib.parse import quote
+from zoneinfo import ZoneInfo
 
 import google.oauth2.credentials
 import requests
 from dateutil import parser
-from zoneinfo import ZoneInfo
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -568,7 +568,7 @@ def google_calendar_to_repeat_on(start, end, recurrence=None):
 	"""
 	repeat_on = {
 		"starts_on": (
-			get_datetime(start.get("date")) 
+			get_datetime(start.get("date"))
 			if start.get("date")
 			else parser.parse(start.get("dateTime"))
 			.astimezone(ZoneInfo(get_time_zone()))

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -571,15 +571,15 @@ def google_calendar_to_repeat_on(start, end, recurrence=None):
 			get_datetime(start.get("date")) 
 			if start.get("date")
 			else parser.parse(start.get("dateTime"))
-				.astimezone(ZoneInfo(get_time_zone()))
-				.replace(tzinfo=None)
+			.astimezone(ZoneInfo(get_time_zone()))
+			.replace(tzinfo=None)
 		),
 		"ends_on": (
 			get_datetime(end.get("date"))
 			if end.get("date")
 			else parser.parse(end.get("dateTime"))
-				.astimezone(ZoneInfo(get_time_zone()))
-				.replace(tzinfo=None)
+			.astimezone(ZoneInfo(get_time_zone()))
+			.replace(tzinfo=None)
 		),
 		"all_day": 1 if start.get("date") else 0,
 		"repeat_this_event": 1 if recurrence else 0,


### PR DESCRIPTION
This PR is a follow-up on #18384

Additional logic has been added to ensure that the timezone used matches the one set in System Settings (rather than the one determined by the server).

I am still a bit unclear about the interactions between System Settings, User Settings, and server configuration when it comes to timezone. Nevertheless, the updated code seems to work empirically.