### PR TITLE
fix: only execute generator if value is not found in redis cache

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -950,14 +950,16 @@ class Document(BaseDocument):
 		from frappe.email.doctype.notification.notification import evaluate_alert
 
 		if self.flags.notifications is None:
-			alerts = frappe.cache().hget("notifications", self.doctype)
-			if alerts is None:
-				alerts = frappe.get_all(
+
+			def _get_notifications():
+				"""get notifications for this doctype to use as generator in `hget()`"""
+				return frappe.get_all(
 					"Notification",
 					fields=["name", "event", "method"],
 					filters={"enabled": 1, "document_type": self.doctype},
 				)
-				frappe.cache().hset("notifications", self.doctype, alerts)
+
+			alerts = frappe.cache().hget("notifications", self.doctype, _get_notifications)
 			self.flags.notifications = alerts
 
 		if not self.flags.notifications:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -952,7 +952,7 @@ class Document(BaseDocument):
 		if self.flags.notifications is None:
 
 			def _get_notifications():
-				"""returns all notifications for the doctype"""
+				"""returns enabled notifications for the current doctype"""
 
 				return frappe.get_all(
 					"Notification",

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -960,8 +960,9 @@ class Document(BaseDocument):
 					filters={"enabled": 1, "document_type": self.doctype},
 				)
 
-			alerts = frappe.cache().hget("notifications", self.doctype, _get_notifications)
-			self.flags.notifications = alerts
+			self.flags.notifications = frappe.cache().hget(
+				"notifications", self.doctype, _get_notifications
+			)
 
 		if not self.flags.notifications:
 			return

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -952,7 +952,8 @@ class Document(BaseDocument):
 		if self.flags.notifications is None:
 
 			def _get_notifications():
-				"""get notifications for this doctype to use as generator in `hget()`"""
+				"""returns all notifications for the doctype"""
+
 				return frappe.get_all(
 					"Notification",
 					fields=["name", "event", "method"],

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -218,7 +218,7 @@ class RedisWrapper(redis.Redis):
 		except redis.exceptions.ConnectionError:
 			pass
 
-		if value:
+		if value is not None:
 			value = pickle.loads(value)
 			frappe.local.cache[_name][key] = value
 		elif generator:


### PR DESCRIPTION
**Fix:**

1. The fix will handle those cases which return a falsy value but not None from the Redis cache. In such cases, the generator must not be called.
2. Use of generator to get and set values for doctype **Notifications**