### PR TITLE
fix: Improve Translation on To Do list view

### DIFF
--- a/frappe/desk/doctype/todo/todo_list.js
+++ b/frappe/desk/doctype/todo/todo_list.js
@@ -17,10 +17,10 @@ frappe.listview_settings["ToDo"] = {
 			return doc.reference_name;
 		},
 		get_label: function () {
-			return __("Open");
+			return __("Open", null, "Access");
 		},
 		get_description: function (doc) {
-			return __("Open {0}", [`${doc.reference_type} ${doc.reference_name}`]);
+			return __("Open {0}", [`${__(doc.reference_type)}: ${doc.reference_name}`]);
 		},
 		action: function (doc) {
 			frappe.set_route("Form", doc.reference_type, doc.reference_name);


### PR DESCRIPTION
- Add context to translation "Open" as "Access" becouse in spanish Open is when the document is in open state and Open means when you want to access to that document too.

- Improve tooltip translation

**Before:**
![before](https://user-images.githubusercontent.com/1592496/197075412-fa8aa770-3d74-4d13-839f-c64d870c0f2e.PNG)


**After:**
![After](https://user-images.githubusercontent.com/1592496/197075439-7991f10a-49b3-43f3-9c25-b4e2188ed08c.PNG)


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
