### PR TITLE
fix: map view doesnt open

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -88,6 +88,7 @@ frappe.router = {
 		"dashboard",
 		"image",
 		"inbox",
+		"map",
 	],
 	list_views_route: {
 		list: "List",
@@ -100,6 +101,7 @@ frappe.router = {
 		image: "Image",
 		inbox: "Inbox",
 		file: "Home",
+		map: "Map",
 	},
 	layout_mapped: {},
 


### PR DESCRIPTION
Changing the view to "Map" changes the URL but doesnt open the map view.

Refer below recording:

Before fix: 

https://user-images.githubusercontent.com/81952590/197131410-76926adf-1cc3-4edb-8ad8-fb6159a980a5.mov

After fix:

https://user-images.githubusercontent.com/81952590/197131572-e47d2fe3-23a4-44c2-a76a-0ae1067e255c.mov


