### PR TITLE
perf: cache document naming rule to avoid recurring db calls

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -15,7 +15,12 @@ doctypes_for_mapping = {
 	"Document Naming Rule",
 }
 
-doctype_map_keys = tuple(f"{frappe.scrub(doctype)}_map" for doctype in doctypes_for_mapping)
+
+def get_doctype_map_key(doctype):
+	return frappe.scrub(doctype) + "_map"
+
+
+doctype_map_keys = tuple(map(get_doctype_map_key, doctypes_for_mapping))
 
 bench_cache_keys = ("assets_json",)
 
@@ -40,7 +45,7 @@ global_cache_keys = (
 	"sitemap_routes",
 	"db_tables",
 	"server_script_autocompletion_items",
-) + doctype_map_keys
+)
 
 user_cache_keys = (
 	"bootinfo",
@@ -164,13 +169,11 @@ def clear_controller_cache(doctype=None):
 
 
 def get_doctype_map(doctype, name, filters=None, order_by=None):
-	cache = frappe.cache()
-	cache_key = frappe.scrub(doctype) + "_map"
-
-	def _get_items():
-		return frappe.get_all(doctype, filters=filters, order_by=order_by, ignore_ddl=True)
-
-	return cache.hget(cache_key, name, _get_items)
+	return frappe.cache().hget(
+		get_doctype_map_key(doctype),
+		name,
+		lambda: frappe.get_all(doctype, filters=filters, order_by=order_by, ignore_ddl=True),
+	)
 
 
 def clear_doctype_map(doctype, name):

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -45,7 +45,7 @@ global_cache_keys = (
 	"sitemap_routes",
 	"db_tables",
 	"server_script_autocompletion_items",
-)
+) + doctype_map_keys
 
 user_cache_keys = (
 	"bootinfo",
@@ -74,7 +74,7 @@ doctype_cache_keys = (
 	"notifications",
 	"workflow",
 	"data_import_column_header_map",
-) + doctype_map_keys
+)
 
 
 def clear_user_cache(user=None):

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -12,11 +12,14 @@ class DocumentNamingRule(Document):
 	def validate(self):
 		self.validate_fields_in_conditions()
 
-	def on_update(self):
+	def clear_doctype_map(self):
 		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
 
+	def on_update(self):
+		self.clear_doctype_map()
+
 	def on_trash(self):
-		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+		self.clear_doctype_map()
 
 	def validate_fields_in_conditions(self):
 		if self.has_value_changed("document_type"):

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -12,6 +12,12 @@ class DocumentNamingRule(Document):
 	def validate(self):
 		self.validate_fields_in_conditions()
 
+	def on_update(self):
+		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+
+	def on_trash(self):
+		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+
 	def validate_fields_in_conditions(self):
 		if self.has_value_changed("document_type"):
 			docfields = [x.fieldname for x in frappe.get_meta(self.document_type).fields]

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -13,7 +13,7 @@ class DocumentNamingRule(Document):
 		self.validate_fields_in_conditions()
 
 	def clear_doctype_map(self):
-		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+		frappe.cache_manager.clear_doctype_map(self.doctype, self.document_type)
 
 	def on_update(self):
 		self.clear_doctype_map()

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -235,18 +235,11 @@ def set_naming_from_document_naming_rule(doc):
 	if doc.doctype in log_types:
 		return
 
-	def _get_document_naming_rule():
-		# ignore_ddl if naming is not yet bootstrapped
-
-		return frappe.get_all(
-			"Document Naming Rule",
-			{"document_type": doc.doctype, "disabled": 0},
-			order_by="priority desc",
-			ignore_ddl=True,
-		)
-
-	document_naming_rules = frappe.cache().hget(
-		"document_naming_rule", doc.doctype, _get_document_naming_rule
+	document_naming_rules = frappe.cache_manager.get_doctype_map(
+		"Document Naming Rule",
+		doc.doctype,
+		filters={"document_type": doc.doctype, "disabled": 0},
+		order_by="priority desc",
 	)
 
 	for d in document_naming_rules:


### PR DESCRIPTION
## Changes Made

- Simplify `get_doctype_map()`
- Use `get_doctype_map()` to avoid recurring DB calls for **Document Naming Rule** every time a document is named (generally during insert).
- Remove `doctype_map_keys` from `doctype_cache_keys`. This is not required because `clear_doctype_cache` is run when the "Reference Doctype" is changed. Change in the reference doctype does not invalidate caching of the doctypes for mapping.