### PR TITLE
fix(UX): warn about Etc/* timezones behaviour

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -17,6 +17,16 @@ frappe.ui.form.on("User", {
 		}
 	},
 
+	time_zone: function (frm) {
+		if (frm.doc.time_zone && frm.doc.time_zone.startsWith("Etc")) {
+			frm.set_df_property(
+				"time_zone",
+				"description",
+				__("Note: Etc timezones have their signs reversed.")
+			);
+		}
+	},
+
 	role_profile_name: function (frm) {
 		if (frm.doc.role_profile_name) {
 			frappe.call({
@@ -259,6 +269,7 @@ frappe.ui.form.on("User", {
 			}
 			frm.dirty();
 		}
+		frm.trigger("time_zone");
 	},
 	validate: function (frm) {
 		if (frm.roles_editor) {


### PR DESCRIPTION
> The special area of "Etc" is used for some administrative zones, particularly for "Etc/UTC" which represents Coordinated Universal Time. **In order to conform with the POSIX style, those zone names beginning with "Etc/GMT" have their sign reversed from the standard ISO 8601 convention.** In the "Etc" area, zones west of GMT have a positive sign and those east have a negative sign in their name (e.g "Etc/GMT-14" is 14 hours ahead of GMT).

https://en.wikipedia.org/wiki/Tz_database#Area
