### PR TITLE
fix(router-js): handle case when link is not of same host

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -38,16 +38,17 @@ $("body").on("click", "a", function (e) {
 		return false;
 	};
 
-	const href = e.currentTarget.getAttribute("href");
+	const targetElement = e.currentTarget;
+	const href = targetElement.getAttribute("href");
+	const isOfSameHost = targetElement.hostname === window.location.hostname;
 
 	// click handled, but not by href
 	if (
-		e.currentTarget.getAttribute("onclick") || // has a handler
+		targetElement.getAttribute("onclick") || // has a handler
 		e.ctrlKey ||
 		e.metaKey || // open in a new tab
-		href === "#"
+		href === "#" // hash is home
 	) {
-		// hash is home
 		return;
 	}
 
@@ -57,20 +58,20 @@ $("body").on("click", "a", function (e) {
 
 	if (href && href.startsWith("#")) {
 		// target startswith "#", this is a v1 style route, so remake it.
-		return override(e.currentTarget.hash);
+		return override(targetElement.hash);
 	}
 
-	if (frappe.router.is_app_route(e.currentTarget.pathname)) {
+	if (isOfSameHost && frappe.router.is_app_route(targetElement.pathname)) {
 		// target has "/app, this is a v2 style route.
 
-		if (e.currentTarget.search) {
+		if (targetElement.search) {
 			frappe.route_options = {};
-			let params = new URLSearchParams(e.currentTarget.search);
+			let params = new URLSearchParams(targetElement.search);
 			for (const [key, value] of params) {
 				frappe.route_options[key] = value;
 			}
 		}
-		return override(e.currentTarget.pathname + e.currentTarget.hash);
+		return override(targetElement.pathname + targetElement.hash);
 	}
 });
 

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -38,13 +38,13 @@ $("body").on("click", "a", function (e) {
 		return false;
 	};
 
-	const targetElement = e.currentTarget;
-	const href = targetElement.getAttribute("href");
-	const isOfSameHost = targetElement.hostname === window.location.hostname;
+	const target_element = e.currentTarget;
+	const href = target_element.getAttribute("href");
+	const is_on_same_host = target_element.hostname === window.location.hostname;
 
 	// click handled, but not by href
 	if (
-		targetElement.getAttribute("onclick") || // has a handler
+		target_element.getAttribute("onclick") || // has a handler
 		e.ctrlKey ||
 		e.metaKey || // open in a new tab
 		href === "#" // hash is home
@@ -58,20 +58,20 @@ $("body").on("click", "a", function (e) {
 
 	if (href && href.startsWith("#")) {
 		// target startswith "#", this is a v1 style route, so remake it.
-		return override(targetElement.hash);
+		return override(target_element.hash);
 	}
 
-	if (isOfSameHost && frappe.router.is_app_route(targetElement.pathname)) {
+	if (is_on_same_host && frappe.router.is_app_route(target_element.pathname)) {
 		// target has "/app, this is a v2 style route.
 
-		if (targetElement.search) {
+		if (target_element.search) {
 			frappe.route_options = {};
-			let params = new URLSearchParams(targetElement.search);
+			let params = new URLSearchParams(target_element.search);
 			for (const [key, value] of params) {
 				frappe.route_options[key] = value;
 			}
 		}
-		return override(targetElement.pathname + targetElement.hash);
+		return override(target_element.pathname + target_element.hash);
 	}
 });
 


### PR DESCRIPTION
**Problem:**

Even though the web link's route is on different host, it tries to route to `/app` on the same site. This happens because the host name is not considered before checking the `path`.

https://user-images.githubusercontent.com/34810212/198222886-013dda31-8325-48ef-b950-beed121bd237.mp4



**Solution:**

Handle the case when the `hostname`s (of window and anchor element) do not match.

