### PR TITLE
refactor: accurate translation caching

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -107,14 +107,15 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	msg = as_unicode(msg).strip()
 
 	translated_string = ""
+
+	all_translations = get_all_translations(lang)
 	if context:
 		string_key = f"{msg}:{context}"
-		translated_string = get_all_translations(lang).get(string_key)
+		translated_string = all_translations.get(string_key)
 
 	if not translated_string:
-		translated_string = get_all_translations(lang).get(msg)
+		translated_string = all_translations.get(msg)
 
-	# return lang_full_dict according to lang passed parameter
 	return translated_string or non_translated_string
 
 
@@ -222,7 +223,6 @@ def init(site: str, sites_path: str = ".", new_site: bool = False) -> None:
 
 	local.conf = _dict(get_site_config())
 	local.lang = local.conf.lang or "en"
-	local.lang_full_dict = None
 
 	local.module_app = None
 	local.app_modules = None

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -89,7 +89,7 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	        _('Change')
 	        _('Change', context='Coins')
 	"""
-	from frappe.translate import get_full_dict
+	from frappe.translate import get_all_translations
 	from frappe.utils import is_html, strip_html_tags
 
 	if not hasattr(local, "lang"):
@@ -109,10 +109,10 @@ def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
 	translated_string = ""
 	if context:
 		string_key = f"{msg}:{context}"
-		translated_string = get_full_dict(lang).get(string_key)
+		translated_string = get_all_translations(lang).get(string_key)
 
 	if not translated_string:
-		translated_string = get_full_dict(lang).get(msg)
+		translated_string = get_all_translations(lang).get(msg)
 
 	# return lang_full_dict according to lang passed parameter
 	return translated_string or non_translated_string

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -3,6 +3,7 @@
 import frappe
 from frappe import _
 from frappe.tests.utils import FrappeTestCase
+from frappe.translate import clear_cache
 
 
 class TestTranslation(FrappeTestCase):
@@ -11,20 +12,17 @@ class TestTranslation(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.local.lang = "en"
-		clear_translation_cache()
+		clear_cache()
 
 	def test_doctype(self):
 		translation_data = get_translation_data()
 		for key, val in translation_data.items():
 			frappe.local.lang = key
 
-			clear_translation_cache()
 			translation = create_translation(key, val)
 			self.assertEqual(_(val[0]), val[1])
 
 			frappe.delete_doc("Translation", translation.name)
-			clear_translation_cache()
-
 			self.assertEqual(_(val[0]), val[0])
 
 	def test_parent_language(self):
@@ -54,6 +52,10 @@ class TestTranslation(FrappeTestCase):
 		# from spanish (general)
 		clear_translation_cache()
 		self.assertTrue(_(data[1][0]), data[1][1])
+
+	def test_multi_language_translations(self):
+		source = "User"
+		self.assertNotEqual(_(source, lang="de"), _(source, lang="es"))
 
 	def test_html_content_data_translation(self):
 		source = """
@@ -113,5 +115,4 @@ def create_translation(key, val):
 
 
 def clear_translation_cache():
-	frappe.local.lang_full_dict = None
-	frappe.cache().delete_key("lang_full_dict", shared=True)
+	frappe.cache().delete_key("translations_from_apps", shared=True)

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -5,7 +5,7 @@ import json
 
 import frappe
 from frappe.model.document import Document
-from frappe.translate import get_translator_url
+from frappe.translate import MERGED_TRANSLATION_KEY, USER_TRANSLATION_KEY, get_translator_url
 from frappe.utils import is_html, strip_html_tags
 
 
@@ -89,4 +89,5 @@ def create_translations(translation_map, language):
 
 
 def clear_user_translation_cache(lang):
-	frappe.cache().hdel("lang_user_translations", lang)
+	frappe.cache().hdel(USER_TRANSLATION_KEY, lang)
+	frappe.cache().hdel(MERGED_TRANSLATION_KEY, lang)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -135,7 +135,6 @@ class TestSearch(FrappeTestCase):
 	def test_link_search_in_foreign_language(self):
 		try:
 			frappe.local.lang = "fr"
-			frappe.local.lang_full_dict = None  # discard translation cache
 			search_widget(doctype="DocType", txt="pay", page_length=20)
 			output = frappe.response["values"]
 

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -108,7 +108,6 @@ def _restore_thread_locals(flags):
 	frappe.local.conf = frappe._dict(frappe.get_site_config())
 	frappe.local.cache = {}
 	frappe.local.lang = "en"
-	frappe.local.lang_full_dict = None
 	frappe.local.preload_assets = {"style": [], "script": []}
 
 


### PR DESCRIPTION
Translation asset caching in redis is kinda hacky with following bad patterns:
- get, set manually instead of using `generator`
- Manual re-caching of same thing in `frappe.local` even though frappe.cache() does it already
- This leads to bugs like https://github.com/frappe/frappe/pull/18499


Changes:
- use generators
- make all functions stateless, no more manual cache management. (except internal local.cache)
- Cache the entire merged dictionary. Computation saving > few megs of memory.
- Call get_all_translations only once in `_`