### PR TITLE
fix: correct stacklevel for warnings

### DIFF
--- a/frappe/utils/commands.py
+++ b/frappe/utils/commands.py
@@ -59,7 +59,7 @@ def log(message, colour=""):
 	print(colour + message + end_line)
 
 
-def warn(message, category=None, stacklevel=2):
+def warn(message, category=None, stacklevel=3):
 	from warnings import warn
 
 	warn(message=message, category=category, stacklevel=stacklevel)


### PR DESCRIPTION
Stacklevel=2 just points to frame that called warning and not frame
where it originated. This frame is useless in most cases as you can just
`grep` for it instead of looking at log.

stacklevel=3 gives frame which is calling the code with warnings.

Before:

![image](https://user-images.githubusercontent.com/9079960/198522272-f09ea2e5-a7d5-4422-9e55-6a2671b3439a.png)




After
![image](https://user-images.githubusercontent.com/9079960/198521973-ed6a6307-62af-432b-83be-b13550b87662.png)

