### PR TITLE
fix(insert_many): list instead of set to maintain order

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -206,9 +206,9 @@ def insert_many(docs=None):
 	if len(docs) > 200:
 		frappe.throw(_("Only 200 inserts allowed in one request"))
 
-	out = set()
+	out = []
 	for doc in docs:
-		out.add(insert_doc(doc).name)
+		out.append(insert_doc(doc).name)
 
 	return out
 

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -227,14 +227,18 @@ class TestClient(FrappeTestCase):
 				"parent": note1.name,
 				"parentfield": "seen_by",
 			},
+			{"doctype": "Note", "title": "not-a-random-title", "content": "test"},
 			{"doctype": "Note", "title": get_random_title(), "content": "test"},
 			{"doctype": "Note", "title": get_random_title(), "content": "test"},
+			{"doctype": "Note", "title": "another-note-title", "content": "test"},
 		]
 
 		# insert all docs
 		docs = insert_many(doc_list)
 
-		self.assertEqual(len(docs), 5)
+		self.assertEqual(len(docs), 7)
+		self.assertEqual(docs[3], "not-a-random-title")
+		self.assertEqual(docs[6], "another-note-title")
 		self.assertIn(note1.name, docs)
 
 		# cleanup

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -234,8 +234,7 @@ class TestClient(FrappeTestCase):
 		# insert all docs
 		docs = insert_many(doc_list)
 
-		# make sure only 1 name is returned for the parent upon insertion of child docs
-		self.assertEqual(len(docs), 3)
+		self.assertEqual(len(docs), 5)
 		self.assertIn(note1.name, docs)
 
 		# cleanup


### PR DESCRIPTION
`insert_many` takes a list of docs and it used to return the names of these docs in order. While [this PR](https://github.com/frappe/frappe/pull/16840) improved child doc handling, it broke the order in which doc names were returned because it uses `set()` and it doesn't guarantee order.

This PR fixes the order of doc names.

Before:
![image](https://user-images.githubusercontent.com/9355208/198540242-507073f2-e70f-46cc-a21c-5257c0c81b46.png)


After:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/9355208/198540928-01fcece0-e257-411b-aaaa-e28f75c2437b.png">
