### PR TITLE
refactor: standardise document map caches

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -5,21 +5,20 @@ from collections.abc import Iterable
 
 import frappe
 from frappe import _
-from frappe.cache_manager import clear_doctype_map, get_doctype_map
+from frappe.cache_manager import get_doctype_map
 from frappe.desk.form import assign_to
 from frappe.model import log_types
 from frappe.model.document import Document
 
 
 class AssignmentRule(Document):
+	@property
+	def doctype_map_names(self):
+		return (self.document_type, f"due_date_rules_for_{self.document_type}")
+
 	def validate(self):
 		self.validate_document_types()
 		self.validate_assignment_days()
-
-	def clear_cache(self):
-		super().clear_cache()
-		clear_doctype_map(self.doctype, self.document_type)
-		clear_doctype_map(self.doctype, f"due_date_rules_for_{self.document_type}")
 
 	def validate_document_types(self):
 		if self.document_type == "ToDo":

--- a/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
@@ -2,17 +2,14 @@
 # License: MIT. See LICENSE
 
 import frappe
-import frappe.cache_manager
 from frappe.model import log_types
 from frappe.model.document import Document
 
 
 class MilestoneTracker(Document):
-	def on_update(self):
-		frappe.cache_manager.clear_doctype_map("Milestone Tracker", self.document_type)
-
-	def on_trash(self):
-		frappe.cache_manager.clear_doctype_map("Milestone Tracker", self.document_type)
+	@property
+	def doctype_map_names(self):
+		return self.document_type
 
 	def apply(self, doc):
 		before_save = doc.get_doc_before_save()

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -15,7 +15,12 @@ doctypes_for_mapping = {
 	"Document Naming Rule",
 }
 
-doctype_map_keys = tuple(f"{frappe.scrub(doctype)}_map" for doctype in doctypes_for_mapping)
+
+def get_doctype_map_key(doctype):
+	return frappe.scrub(doctype) + "_map"
+
+
+doctype_map_keys = tuple(map(get_doctype_map_key, doctypes_for_mapping))
 
 bench_cache_keys = ("assets_json",)
 
@@ -40,7 +45,7 @@ global_cache_keys = (
 	"sitemap_routes",
 	"db_tables",
 	"server_script_autocompletion_items",
-) + doctype_map_keys
+)
 
 user_cache_keys = (
 	"bootinfo",
@@ -164,13 +169,11 @@ def clear_controller_cache(doctype=None):
 
 
 def get_doctype_map(doctype, name, filters=None, order_by=None):
-	cache = frappe.cache()
-	cache_key = frappe.scrub(doctype) + "_map"
-
-	def _get_items():
-		return frappe.get_all(doctype, filters=filters, order_by=order_by, ignore_ddl=True)
-
-	return cache.hget(cache_key, name, _get_items)
+	return frappe.cache().hget(
+		get_doctype_map_key(doctype),
+		name,
+		lambda: frappe.get_all(doctype, filters=filters, order_by=order_by, ignore_ddl=True),
+	)
 
 
 def clear_doctype_map(doctype, name):

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -45,7 +45,7 @@ global_cache_keys = (
 	"sitemap_routes",
 	"db_tables",
 	"server_script_autocompletion_items",
-)
+) + doctype_map_keys
 
 user_cache_keys = (
 	"bootinfo",
@@ -74,7 +74,7 @@ doctype_cache_keys = (
 	"notifications",
 	"workflow",
 	"data_import_column_header_map",
-) + doctype_map_keys
+)
 
 
 def clear_user_cache(user=None):

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -12,11 +12,14 @@ class DocumentNamingRule(Document):
 	def validate(self):
 		self.validate_fields_in_conditions()
 
-	def on_update(self):
+	def clear_doctype_map(self):
 		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
 
+	def on_update(self):
+		self.clear_doctype_map()
+
 	def on_trash(self):
-		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+		self.clear_doctype_map()
 
 	def validate_fields_in_conditions(self):
 		if self.has_value_changed("document_type"):

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -12,6 +12,12 @@ class DocumentNamingRule(Document):
 	def validate(self):
 		self.validate_fields_in_conditions()
 
+	def on_update(self):
+		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+
+	def on_trash(self):
+		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+
 	def validate_fields_in_conditions(self):
 		if self.has_value_changed("document_type"):
 			docfields = [x.fieldname for x in frappe.get_meta(self.document_type).fields]

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -13,7 +13,7 @@ class DocumentNamingRule(Document):
 		self.validate_fields_in_conditions()
 
 	def clear_doctype_map(self):
-		frappe.cache_manager.clear_doctype_map("Document Naming Rule", self.document_type)
+		frappe.cache_manager.clear_doctype_map(self.doctype, self.document_type)
 
 	def on_update(self):
 		self.clear_doctype_map()

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -9,11 +9,12 @@ from frappe.utils.data import evaluate_filters
 
 
 class DocumentNamingRule(Document):
+	@property
+	def doctype_map_names(self):
+		return self.document_type
+
 	def validate(self):
 		self.validate_fields_in_conditions()
-
-	def clear_doctype_map(self):
-		frappe.cache_manager.clear_doctype_map(self.doctype, self.document_type)
 
 	def on_update(self):
 		self.clear_doctype_map()

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -16,12 +16,6 @@ class DocumentNamingRule(Document):
 	def validate(self):
 		self.validate_fields_in_conditions()
 
-	def on_update(self):
-		self.clear_doctype_map()
-
-	def on_trash(self):
-		self.clear_doctype_map()
-
 	def validate_fields_in_conditions(self):
 		if self.has_value_changed("document_type"):
 			docfields = [x.fieldname for x in frappe.get_meta(self.document_type).fields]

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -18,6 +18,10 @@ from frappe.utils.safe_exec import get_safe_globals
 
 
 class Notification(Document):
+	@property
+	def doctype_map_names(self):
+		return self.document_type
+
 	def onload(self):
 		"""load message"""
 		if self.is_standard:
@@ -42,7 +46,6 @@ class Notification(Document):
 		self.validate_forbidden_types()
 		self.validate_condition()
 		self.validate_standard()
-		frappe.cache().hdel("notifications", self.document_type)
 
 	def on_update(self):
 		path = export_module_json(self, self.is_standard, self.module)
@@ -386,9 +389,6 @@ def get_context(context):
 
 		if not is_html(self.message):
 			self.message = frappe.utils.md_to_html(self.message)
-
-	def on_trash(self):
-		frappe.cache().hdel("notifications", self.document_type)
 
 
 @frappe.whitelist()

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -17,28 +17,12 @@ def run_webhooks(doc, method):
 	if frappe.flags.webhooks_executed is None:
 		frappe.flags.webhooks_executed = {}
 
-	# TODO: remove this hazardous unnecessary cache in flags
-	if frappe.flags.webhooks is None:
-		# load webhooks from cache
-		webhooks = frappe.cache().get_value("webhooks")
-		if webhooks is None:
-			# query webhooks
-			webhooks_list = frappe.get_all(
-				"Webhook",
-				fields=["name", "condition", "webhook_docevent", "webhook_doctype"],
-				filters={"enabled": True},
-			)
-
-			# make webhooks map for cache
-			webhooks = {}
-			for w in webhooks_list:
-				webhooks.setdefault(w.webhook_doctype, []).append(w)
-			frappe.cache().set_value("webhooks", webhooks)
-
-		frappe.flags.webhooks = webhooks
-
-	# get webhooks for this doctype
-	webhooks_for_doc = frappe.flags.webhooks.get(doc.doctype, None)
+	webhooks_for_doc = frappe.cache_manager.get_doctype_map(
+		"Webhook",
+		doc.doctype,
+		fields=["name", "condition", "webhook_docevent"],
+		filters={"enabled": True},
+	)
 
 	if not webhooks_for_doc:
 		# no webhooks, quit

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -21,7 +21,7 @@ def run_webhooks(doc, method):
 		"Webhook",
 		doc.doctype,
 		fields=["name", "condition", "webhook_docevent"],
-		filters={"enabled": True},
+		filters={"webhook_doctype": doc.doctype, "enabled": True},
 	)
 
 	if not webhooks_for_doc:

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -97,7 +97,7 @@ class TestWebhook(FrappeTestCase):
 	def test_webhook_trigger_with_enabled_webhooks(self):
 		"""Test webhook trigger for enabled webhooks"""
 
-		frappe.cache().delete_value("webhooks")
+		frappe.cache_manager.clear_doctype_map("Webhook")
 		frappe.flags.webhooks = None
 
 		# Insert the user to db

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -97,15 +97,13 @@ class TestWebhook(FrappeTestCase):
 	def test_webhook_trigger_with_enabled_webhooks(self):
 		"""Test webhook trigger for enabled webhooks"""
 
-		frappe.cache_manager.clear_doctype_map("Webhook")
-		frappe.flags.webhooks = None
+		frappe.cache_manager.clear_doctype_map("Webhook", "User")
 
 		# Insert the user to db
 		self.test_user.insert()
 
-		self.assertTrue("User" in frappe.flags.webhooks)
 		# only 1 hook (enabled) must be queued
-		self.assertEqual(len(frappe.flags.webhooks.get("User")), 1)
+		self.assertEqual(len(frappe.cache().hget("webhook_map", "User")), 1)
 		self.assertTrue(self.test_user.email in frappe.flags.webhooks_executed)
 		self.assertEqual(
 			frappe.flags.webhooks_executed.get(self.test_user.email)[0], self.sample_webhooks[0].name

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -20,6 +20,10 @@ WEBHOOK_SECRET_HEADER = "X-Frappe-Webhook-Signature"
 
 
 class Webhook(Document):
+	@property
+	def doctype_map_names(self):
+		return self.webhook_doctype
+
 	def validate(self):
 		self.validate_docevent()
 		self.validate_condition()
@@ -27,9 +31,6 @@ class Webhook(Document):
 		self.validate_request_body()
 		self.validate_repeating_fields()
 		self.preview_document = None
-
-	def on_update(self):
-		frappe.cache().delete_value("webhooks")
 
 	def validate_docevent(self):
 		if self.webhook_doctype:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -950,18 +950,11 @@ class Document(BaseDocument):
 		from frappe.email.doctype.notification.notification import evaluate_alert
 
 		if self.flags.notifications is None:
-
-			def _get_notifications():
-				"""returns enabled notifications for the current doctype"""
-
-				return frappe.get_all(
-					"Notification",
-					fields=["name", "event", "method"],
-					filters={"enabled": 1, "document_type": self.doctype},
-				)
-
-			self.flags.notifications = frappe.cache().hget(
-				"notifications", self.doctype, _get_notifications
+			self.flags.notifications = frappe.cache_manager.get_doctype_map(
+				"Notification",
+				self.doctype,
+				fields=["name", "event", "method"],
+				filters={"enabled": 1, "document_type": self.doctype},
 			)
 
 		if not self.flags.notifications:
@@ -1119,6 +1112,7 @@ class Document(BaseDocument):
 
 	def clear_cache(self):
 		frappe.clear_document_cache(self.doctype, self.name)
+		frappe.cache_manager.clear_doctype_maps(self)
 
 	def reset_seen(self):
 		"""Clear _seen property and set current user as seen"""

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -235,18 +235,11 @@ def set_naming_from_document_naming_rule(doc):
 	if doc.doctype in log_types:
 		return
 
-	def _get_document_naming_rule():
-		# ignore_ddl if naming is not yet bootstrapped
-
-		return frappe.get_all(
-			"Document Naming Rule",
-			{"document_type": doc.doctype, "disabled": 0},
-			order_by="priority desc",
-			ignore_ddl=True,
-		)
-
-	document_naming_rules = frappe.cache().hget(
-		"document_naming_rule", doc.doctype, _get_document_naming_rule
+	document_naming_rules = frappe.cache_manager.get_doctype_map(
+		"Document Naming Rule",
+		doc.doctype,
+		filters={"document_type": doc.doctype, "disabled": 0},
+		order_by="priority desc",
 	)
 
 	for d in document_naming_rules:

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import frappe
-import frappe.cache_manager
 from frappe import _
 from frappe.core.doctype.user.user import get_enabled_users
 from frappe.model import log_types
@@ -14,11 +13,9 @@ from frappe.social.doctype.energy_point_settings.energy_point_settings import (
 
 
 class EnergyPointRule(Document):
-	def on_update(self):
-		frappe.cache_manager.clear_doctype_map("Energy Point Rule", self.reference_doctype)
-
-	def on_trash(self):
-		frappe.cache_manager.clear_doctype_map("Energy Point Rule", self.reference_doctype)
+	@property
+	def doctype_map_names(self):
+		return self.reference_doctype
 
 	def apply(self, doc):
 		if self.rule_condition_satisfied(doc):


### PR DESCRIPTION
**⚠️ Extends #18491**

**TODO**
- [ ] Rebuild doctype maps after migrate?
- [ ] Add support for Server Script
- [ ] Add support for Workflow?