### PR TITLE
fix: handle exceptions thrown in post_schema_updates

### DIFF
--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -174,6 +174,8 @@ class SiteMigration:
 			self.pre_schema_updates()
 			self.run_schema_updates()
 		finally:
-			self.post_schema_updates()
-			self.tearDown()
-			frappe.destroy()
+			try:
+				self.post_schema_updates()
+			finally:
+				self.tearDown()
+				frappe.destroy()

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -173,9 +173,7 @@ class SiteMigration:
 		try:
 			self.pre_schema_updates()
 			self.run_schema_updates()
+			self.post_schema_updates()
 		finally:
-			try:
-				self.post_schema_updates()
-			finally:
-				self.tearDown()
-				frappe.destroy()
+			self.tearDown()
+			frappe.destroy()


### PR DESCRIPTION
This change will handle the exceptions thrown during the post_schema_updates eventually running the tearDown.