### PR TITLE
fix: set proper cache key for singles when name is passed as `None`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1115,7 +1115,7 @@ def can_cache_doc(args) -> str | None:
 		return
 
 	doctype = args[0]
-	name = doctype if len(args) == 1 else args[1]
+	name = doctype if len(args) == 1 or args[1] is None else args[1]
 
 	# Only cache if both doctype and name are strings
 	if isinstance(doctype, str) and isinstance(name, str):


### PR DESCRIPTION
The following code never worked as expected:

```python
frappe.get_cached_value("System Settings", None, "language")
```

It's counterpart is quite common:

```python
frappe.db.get_value("System Settings", None, "language")
```