### PR TITLE
chore: remove broken naming case feature

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -152,7 +152,6 @@
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",
- "name_case": "Title Case",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/contacts/doctype/contact/contact.json
+++ b/frappe/contacts/doctype/contact/contact.json
@@ -254,7 +254,6 @@
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Contact",
- "name_case": "Title Case",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -29,7 +29,6 @@
   "sb1",
   "naming_rule",
   "autoname",
-  "name_case",
   "allow_rename",
   "column_break_15",
   "description",
@@ -219,15 +218,6 @@
    "label": "Auto Name",
    "oldfieldname": "autoname",
    "oldfieldtype": "Data"
-  },
-  {
-   "depends_on": "eval:doc.naming_rule !== \"Autoincrement\"",
-   "fieldname": "name_case",
-   "fieldtype": "Select",
-   "label": "Name Case",
-   "oldfieldname": "name_case",
-   "oldfieldtype": "Select",
-   "options": "\nTitle Case\nUPPER CASE"
   },
   {
    "fieldname": "column_break_15",

--- a/frappe/custom/fixtures/temp_doctype.json
+++ b/frappe/custom/fixtures/temp_doctype.json
@@ -18,7 +18,6 @@
   "beta": 0,
   "is_virtual": 0,
   "naming_rule": "",
-  "name_case": "",
   "allow_rename": 1,
   "hide_toolbar": 0,
   "allow_copy": 0,

--- a/frappe/custom/fixtures/temp_singles.json
+++ b/frappe/custom/fixtures/temp_singles.json
@@ -18,7 +18,6 @@
   "beta": 0,
   "is_virtual": 0,
   "naming_rule": "",
-  "name_case": "",
   "allow_rename": 1,
   "hide_toolbar": 0,
   "allow_copy": 0,

--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -183,7 +183,6 @@ CREATE TABLE `tabDocType` (
   `app` varchar(255) DEFAULT NULL,
   `autoname` varchar(255) DEFAULT NULL,
   `naming_rule` varchar(40) DEFAULT NULL,
-  `name_case` varchar(255) DEFAULT NULL,
   `title_field` varchar(255) DEFAULT NULL,
   `image_field` varchar(255) DEFAULT NULL,
   `timeline_field` varchar(255) DEFAULT NULL,

--- a/frappe/database/postgres/framework_postgres.sql
+++ b/frappe/database/postgres/framework_postgres.sql
@@ -188,7 +188,6 @@ CREATE TABLE "tabDocType" (
   "app" varchar(255) DEFAULT NULL,
   "autoname" varchar(255) DEFAULT NULL,
   "naming_rule" varchar(40) DEFAULT NULL,
-  "name_case" varchar(255) DEFAULT NULL,
   "title_field" varchar(255) DEFAULT NULL,
   "image_field" varchar(255) DEFAULT NULL,
   "timeline_field" varchar(255) DEFAULT NULL,

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -169,7 +169,7 @@ def set_new_name(doc):
 	if not doc.name:
 		doc.name = make_autoname("hash", doc.doctype)
 
-	doc.name = validate_name(doc.doctype, doc.name, meta.get_field("name_case"))
+	doc.name = validate_name(doc.doctype, doc.name)
 
 
 def is_autoincremented(doctype: str, meta: Optional["Meta"] = None) -> bool:
@@ -439,7 +439,7 @@ def get_default_naming_series(doctype: str) -> str | None:
 			return option
 
 
-def validate_name(doctype: str, name: int | str, case: str | None = None):
+def validate_name(doctype: str, name: int | str):
 
 	if not name:
 		frappe.throw(_("No Name Specified for {0}").format(doctype))
@@ -457,10 +457,6 @@ def validate_name(doctype: str, name: int | str, case: str | None = None):
 		frappe.throw(
 			_("There were some errors setting the name, please contact the administrator"), frappe.NameError
 		)
-	if case == "Title Case":
-		name = name.title()
-	if case == "UPPER CASE":
-		name = name.upper()
 	name = name.strip()
 
 	if not frappe.get_meta(doctype).get("issingle") and (doctype == name) and (name != "DocType"):

--- a/frappe/website/doctype/help_category/help_category.json
+++ b/frappe/website/doctype/help_category/help_category.json
@@ -50,7 +50,6 @@
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Help Category",
- "name_case": "Title Case",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
This has never worked since 2016 https://github.com/frappe/frappe/pull/2029 ... which can mean two things:
- No one really uses this.
- If I fix this now suddenly people will find different behaviour in naming because `name_case` is selected in some doctypes (but never tested)

