### PR TITLE
fix(meta): ensure that `insert_after` is always considered when sorting fields

### DIFF
--- a/frappe/custom/doctype/custom_field/test_custom_field.py
+++ b/frappe/custom/doctype/custom_field/test_custom_field.py
@@ -79,4 +79,5 @@ class TestCustomField(FrappeTestCase):
 			)
 
 			# undo changes commited by DDL
+			# nosemgrep
 			frappe.db.commit()

--- a/frappe/custom/doctype/custom_field/test_custom_field.py
+++ b/frappe/custom/doctype/custom_field/test_custom_field.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.tests.utils import FrappeTestCase
 
 test_records = frappe.get_test_records("Custom Field")
@@ -9,8 +10,6 @@ test_records = frappe.get_test_records("Custom Field")
 
 class TestCustomField(FrappeTestCase):
 	def test_create_custom_fields(self):
-		from .custom_field import create_custom_fields
-
 		create_custom_fields(
 			{
 				"Address": [
@@ -37,3 +36,47 @@ class TestCustomField(FrappeTestCase):
 		self.assertTrue(frappe.db.exists("Custom Field", "Address-_test_custom_field_1"))
 		self.assertTrue(frappe.db.exists("Custom Field", "Address-_test_custom_field_2"))
 		self.assertTrue(frappe.db.exists("Custom Field", "Contact-_test_custom_field_2"))
+
+	def test_custom_field_sorting(self):
+		try:
+			custom_fields = {
+				"ToDo": [
+					{"fieldname": "a_test_field", "insert_after": "b_test_field"},
+					{"fieldname": "b_test_field", "insert_after": "status"},
+					{"fieldname": "c_test_field", "insert_after": "unknown_custom_field"},
+					{"fieldname": "d_test_field", "insert_after": "status"},
+				]
+			}
+
+			create_custom_fields(custom_fields, ignore_validate=True)
+
+			fields = frappe.get_meta("ToDo", cached=False).fields
+
+			for i, field in enumerate(fields):
+				if field.fieldname == "b_test_field":
+					self.assertEqual(fields[i - 1].fieldname, "status")
+
+				if field.fieldname == "d_test_field":
+					self.assertEqual(fields[i - 1].fieldname, "a_test_field")
+
+			self.assertEqual(fields[-1].fieldname, "c_test_field")
+
+		finally:
+			frappe.db.delete(
+				"Custom Field",
+				{
+					"dt": "ToDo",
+					"fieldname": (
+						"in",
+						(
+							"a_test_field",
+							"b_test_field",
+							"c_test_field",
+							"d_test_field",
+						),
+					),
+				},
+			)
+
+			# undo changes commited by DDL
+			frappe.db.commit()


### PR DESCRIPTION
In lieu of #18327 and #11486 😅 

Steps to replicate: https://github.com/frappe/frappe/pull/11486#issuecomment-727817751

Closes https://github.com/frappe/frappe/issues/17165