### PR TITLE
fix: No copy not working on amend from UI

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -270,7 +270,7 @@ $.extend(frappe.model, {
 	},
 
 	copy_doc: function (doc, from_amend, parent_doc, parentfield) {
-		var no_copy_list = ["name", "amended_from", "amendment_date", "cancel_reason"];
+		var no_copy_list = frappe.model.get_no_copy_list(doc.doctype);
 		var newdoc = frappe.model.get_new_doc(doc.doctype, parent_doc, parentfield);
 
 		for (var key in doc) {


### PR DESCRIPTION
Amend function internally uses copy doc and even though some fields in a doctype had no copy updated as 1 they were getting copied on amending

On investigating found out that it was considering only a specific set of fields for no_copy and not all the values from meta.
This I found on my very initial investigation and this code hasn't been touched in a while so not sure when this was broken and if this is an appropriate fix or not  