### PR TITLE
Revert "fix: use `is_file_path_valid` instead of `is_safe_path` (backport #18316)"

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -433,7 +433,6 @@ class TestFile(FrappeTestCase):
 		self.assertRaisesRegex(IOError, "does not exist", test_file.validate)
 
 		test_file.file_url = None
-		test_file.is_private = 1
 		test_file.file_name = "/private/files/_file"
 		self.assertRaisesRegex(ValidationError, "File name cannot have", test_file.validate)
 

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -449,3 +449,15 @@ def add_attachments(doctype, name, attachments):
 			files.append(f)
 
 	return files
+
+
+def is_safe_path(path: str) -> bool:
+	if path.startswith(("http://", "https://")):
+		return True
+
+	basedir = frappe.get_site_path()
+	# ref: https://docs.python.org/3/library/os.path.html#os.path.commonpath
+	matchpath = os.path.realpath(os.path.abspath(path))
+	basedir = os.path.realpath(os.path.abspath(basedir))
+
+	return basedir == os.path.commonpath((basedir, matchpath))


### PR DESCRIPTION
Reverts frappe/frappe#18642