### PR TITLE
fix: make module def custom checkbox readonly in prod mode

### DIFF
--- a/frappe/core/doctype/module_def/module_def.js
+++ b/frappe/core/doctype/module_def/module_def.js
@@ -9,5 +9,12 @@ frappe.ui.form.on("Module Def", {
 				frm.set_value("app_name", "frappe");
 			}
 		});
+
+		if (!frappe.boot.developer_mode) {
+			frm.set_df_property("custom", "read_only", 1);
+			if (frm.is_new()) {
+				frm.set_value("custom", 1);
+			}
+		}
 	},
 });


### PR DESCRIPTION
This pr fixes the behaviour of custom checkbox in module def doctype.
we allowed users to check that even in prod mode which led to confusions like: https://github.com/frappe/frappe/issues/18691 


![Screenshot from 2022-11-01 12-48-49](https://user-images.githubusercontent.com/32034600/199179890-8f3f8f14-aa8e-4b3c-8fde-b6471dab15d9.png)

closes: #18691