### PR TITLE
fix: support symlinked /files directory

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -3,6 +3,8 @@
 import base64
 import json
 import os
+import shutil
+import tempfile
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
@@ -518,6 +520,34 @@ class TestFile(FrappeTestCase):
 			}
 		).insert()
 		assert test_file is not None
+
+	def test_symlinked_files_folder(self):
+		files_dir = os.path.abspath(get_files_path())
+		with convert_to_symlink(files_dir):
+			file = frappe.get_doc(
+				{
+					"doctype": "File",
+					"file_name": "symlinked_folder_test.txt",
+					"content": "42",
+				}
+			)
+			file.save()
+			file.content = ""
+			file._content = ""
+			file.save().reload()
+			self.assertIn("42", file.get_content())
+
+
+@contextmanager
+def convert_to_symlink(directory):
+	"""Moves a directory to temp directory and symlinks original path for testing"""
+	try:
+		new_directory = shutil.move(directory, tempfile.mkdtemp())
+		os.symlink(new_directory, directory)
+		yield
+	finally:
+		os.unlink(directory)
+		shutil.move(new_directory, directory)
 
 
 class TestAttachment(FrappeTestCase):

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -450,7 +450,7 @@ def is_safe_path(path: str) -> bool:
 
 	basedir = frappe.get_site_path()
 	# ref: https://docs.python.org/3/library/os.path.html#os.path.commonpath
-	matchpath = os.path.realpath(os.path.abspath(path))
-	basedir = os.path.realpath(os.path.abspath(basedir))
+	matchpath = os.path.abspath(path)
+	basedir = os.path.abspath(basedir)
 
 	return basedir == os.path.commonpath((basedir, matchpath))


### PR DESCRIPTION
Easiest way to move site/files or site/private directories is to symlink them, the validation for file path was failing because it resolves real path only until site path.

Resolving real path doesn't seem to be _REALLY_ required here.

alternate to https://github.com/frappe/frappe/pull/18316 https://github.com/frappe/frappe/pull/18313