### PR TITLE
fix: show 0 for empty currency, float, & duration fields in list view

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -66,10 +66,9 @@ frappe.form.formatters = {
 				}
 			}
 
-			return frappe.form.formatters._right(
-				value == null || value === "" ? "" : format_number(value, null, precision),
-				options
-			);
+			value = value == null || value === "" ? "" : value;
+
+			return frappe.form.formatters._right(format_number(value, null, precision), options);
 		}
 	},
 	Int: function (value, docfield, options) {
@@ -121,7 +120,8 @@ frappe.form.formatters = {
 			}
 		}
 
-		value = value == null || value === "" ? "" : format_currency(value, currency, precision);
+		value = value == null || value === "" ? "" : value;
+		value = format_currency(value, currency, precision);
 
 		if (options && options.only_value) {
 			return value;
@@ -248,7 +248,7 @@ frappe.form.formatters = {
 			value = frappe.utils.get_formatted_duration(value, duration_options);
 		}
 
-		return value || "";
+		return value || "0s";
 	},
 	LikedBy: function (value) {
 		var html = "";


### PR DESCRIPTION
Fix: https://github.com/frappe/frappe/issues/16124

Before:
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/30859809/199234713-ddda553e-ce8b-429f-818c-64de5bbcae30.png">

After:
<img width="1074" alt="image" src="https://user-images.githubusercontent.com/30859809/199234652-9cb72711-2fe6-43d7-83aa-d264493bf087.png">
