### PR TITLE
fix: hide value only if it's equal to the label

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -284,8 +284,9 @@ def build_for_autosuggest(res: list[tuple], doctype: str) -> list[dict]:
 			item = list(item)
 			label = item[1]  # use title as label
 			item[1] = item[0]  # show name in description instead of title
-			if len(item) >= 3:
-				del item[2]  # remove redundant title ("label") value
+			if len(item) >= 3 and item[2] == label:
+				# remove redundant title ("label") value
+				del item[2]
 			results.append({"value": item[0], "label": label, "description": to_string(item[1:])})
 	else:
 		results.extend({"value": item[0], "description": to_string(item[1:])} for item in res)


### PR DESCRIPTION
As an improvement on #18719, hide value only if it's equal to the label