### PR TITLE
fix!: remove relaxations for Cordova

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -12,13 +12,13 @@ from werkzeug.wrappers import Request, Response
 
 import frappe
 import frappe.api
-import frappe.auth
 import frappe.handler
 import frappe.monitor
 import frappe.rate_limiter
 import frappe.recorder
 import frappe.utils.response
 from frappe import _
+from frappe.auth import SAFE_HTTP_METHODS, UNSAFE_HTTP_METHODS, HTTPRequest
 from frappe.core.doctype.comment.comment import update_comments_in_parent_after_request
 from frappe.middlewares import StaticDataMiddleware
 from frappe.utils import get_site_name, sanitize_html
@@ -29,8 +29,6 @@ local_manager = LocalManager(frappe.local)
 
 _site = None
 _sites_path = os.environ.get("SITES_PATH", ".")
-SAFE_HTTP_METHODS = ("GET", "HEAD", "OPTIONS")
-UNSAFE_HTTP_METHODS = ("POST", "PUT", "DELETE", "PATCH")
 
 
 @local_manager.middleware
@@ -118,7 +116,7 @@ def init_request(request):
 	make_form_dict(request)
 
 	if request.method != "OPTIONS":
-		frappe.local.http_request = frappe.auth.HTTPRequest()
+		frappe.local.http_request = HTTPRequest()
 
 
 def setup_read_only_mode():


### PR DESCRIPTION
Removes the following relaxations for Cordova (unsupported since a long time anyway):
- `SameSite` is set to `None` instead of the default `"Lax"`
- CSRF token verification is skipped

Other changes:
- Simplified `validate_csrf_token`
- Support CSRF verification for **PATCH** requests
- Convert internal constants `SAFE_HTTP_METHODS` and `UNSAFE_HTTP_METHODS` to `frozenset` type for quicker lookup