### PR TITLE
fix: ignore global translations

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -112,6 +112,14 @@ class TestTranslate(FrappeTestCase):
 
 		self.assertIn(return_val, [second_lang, get_parent_language(second_lang)])
 
+	def test_global_translations(self):
+		""" """
+		site = frappe.local.site
+		frappe.destroy()
+		_("this shouldn't break")
+		frappe.init(site=site)
+		frappe.connect()
+
 	def test_guest_request_language_resolution_with_request_header(self):
 		"""Test for frappe.translate.get_language
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -291,7 +291,12 @@ def get_all_translations(lang: str) -> dict[str, str]:
 
 		return all_translations
 
-	return frappe.cache().hget(MERGED_TRANSLATION_KEY, lang, generator=_merge_translations)
+	try:
+		return frappe.cache().hget(MERGED_TRANSLATION_KEY, lang, generator=_merge_translations)
+	except Exception:
+		# People mistakenly call translation function on global variables
+		# where locals are not initalized, translations dont make much sense there
+		return {}
 
 
 def get_translations_from_apps(lang, apps=None):


### PR DESCRIPTION
_("string") outside of function/methods don't make any sense cause they
are initialized the moment module is imported. This is already checked
in CI yet people make this mistake.

Ignore and refuse to translate in those cases.

closes https://github.com/frappe/frappe/issues/18724
closes https://github.com/frappe/frappe/issues/18725