### PR TITLE
fix: load `doc_before_save` in `check_if_latest`

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -245,7 +245,6 @@ class Document(BaseDocument):
 		self._set_defaults()
 		self.set_user_and_timestamp()
 		self.set_docstatus()
-		self.load_doc_before_save()
 		self.check_if_latest()
 		self._validate_links()
 		self.check_permission("create")
@@ -326,7 +325,6 @@ class Document(BaseDocument):
 
 		self.set_user_and_timestamp()
 		self.set_docstatus()
-		self.load_doc_before_save()
 		self.check_if_latest()
 		self.set_parent_in_children()
 		self.set_name_in_children()
@@ -745,6 +743,8 @@ class Document(BaseDocument):
 
 		Will also validate document transitions (Save > Submit > Cancel) calling
 		`self.check_docstatus_transition`."""
+
+		self.load_doc_before_save()
 
 		self._action = "save"
 		previous = self.get_doc_before_save()


### PR DESCRIPTION
This is needed to ensure that `check_if_latest` does what it's supposed to. Apparently, it's called in `run_doc_method`:
https://sourcegraph.com/search?q=context:global+.check_if_latest%28%29&patternType=standard

Original PR: https://github.com/frappe/frappe/pull/18666