### PR TITLE
fix: dashboard view from workspace

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -132,8 +132,11 @@ frappe.breadcrumbs = {
 		}
 	},
 
-	set_list_breadcrumb(breadcrumbs) {
+	async set_list_breadcrumb(breadcrumbs) {
 		const doctype = breadcrumbs.doctype;
+		if (!locals.DocType[doctype]) {
+			await frappe.model.with_doctype(doctype)
+		}
 		const doctype_meta = frappe.get_doc("DocType", doctype);
 		if (
 			(doctype === "User" && !frappe.user.has_role("System Manager")) ||


### PR DESCRIPTION
### While navigating to dashboard from workspace, an error will occur because of a document is missing in locals.

**BEFORE**
![before](https://user-images.githubusercontent.com/95607086/199963105-dc6b4b7b-5c18-4b1e-bd5a-6448601bc386.gif)

**AFTER**
![after](https://user-images.githubusercontent.com/95607086/199963147-b3c1380b-199b-4cdc-ba62-021b6cfb0903.gif)
