### PR TITLE
fix: don't translate default argument

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2022,10 +2022,8 @@ def logger(
 	)
 
 
-def log_error(message=None, title=None):
+def log_error(message=None, title="Error"):
 	"""Log error to Error Log"""
-	if title is None:
-		title = _("Error")
 
 	# AI ALERT:
 	# the title and message may be swapped

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2022,8 +2022,10 @@ def logger(
 	)
 
 
-def log_error(message=None, title=_("Error")):
+def log_error(message=None, title=None):
 	"""Log error to Error Log"""
+	if title is None:
+		title = _("Error")
 
 	# AI ALERT:
 	# the title and message may be swapped


### PR DESCRIPTION
This was bad because the translate function was called when the function was defined, not when it was used.

`log_error`'s signature changed with v14, hence this fix is for v13 only.