### PR TITLE
fix: dashboard view from workspace

### DIFF
--- a/frappe/core/page/dashboard_view/dashboard_view.js
+++ b/frappe/core/page/dashboard_view/dashboard_view.js
@@ -27,8 +27,11 @@ class Dashboard {
 		this.page = wrapper.page;
 	}
 
-	show() {
+	async show() {
 		this.route = frappe.get_route();
+		if (!locals.DocType["Dashboard"]) {
+			await frappe.model.with_doctype("Dashboard")
+		}
 		this.set_breadcrumbs();
 		if (this.route.length > 1) {
 			// from route


### PR DESCRIPTION
### While navigating to dashboard from workspace, an error will occur because of a document is missing in locals.

**BEFORE**
![before](https://user-images.githubusercontent.com/95607086/199963105-dc6b4b7b-5c18-4b1e-bd5a-6448601bc386.gif)

**AFTER**
![after](https://user-images.githubusercontent.com/95607086/199963147-b3c1380b-199b-4cdc-ba62-021b6cfb0903.gif)
