### PR TITLE
fix: send all messages on boot instead of scanning

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -21,7 +21,7 @@ from frappe.social.doctype.energy_point_settings.energy_point_settings import (
 	is_energy_point_enabled,
 )
 from frappe.social.doctype.post.post import frequently_visited_links
-from frappe.translate import get_lang_dict, get_translated_doctypes
+from frappe.translate import get_lang_dict, get_messages_for_boot, get_translated_doctypes
 from frappe.utils import cstr
 from frappe.utils.change_log import get_versions
 from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
@@ -253,18 +253,8 @@ def get_column(doctype):
 
 
 def load_translations(bootinfo):
-	messages = frappe.get_lang_dict("boot")
-
 	bootinfo["lang"] = frappe.lang
-
-	# load translated report names
-	for name in bootinfo.user.all_reports:
-		messages[name] = frappe._(name)
-
-	# only untranslated
-	messages = {k: v for k, v in iteritems(messages) if k != v}
-
-	bootinfo["__messages"] = messages
+	bootinfo["__messages"] = get_messages_for_boot()
 
 
 def get_user_info():

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import json
 import os
 
-from six import integer_types, iteritems, string_types
+from six import string_types
 
 import frappe
 import frappe.model
@@ -348,11 +348,6 @@ def get_js(items):
 		contentpath = os.path.join(frappe.local.sites_path, *src)
 		with open(contentpath, "r") as srcfile:
 			code = frappe.utils.cstr(srcfile.read())
-
-		if frappe.local.lang != "en":
-			messages = frappe.get_lang_dict("jsfile", contentpath)
-			messages = json.dumps(messages)
-			code += "\n\n$.extend(frappe._messages, {})".format(messages)
 
 		out.append(code)
 

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -19,7 +19,6 @@ from frappe.permissions import (
 	setup_custom_perms,
 	update_permission_property,
 )
-from frappe.translate import send_translations
 from frappe.utils.user import get_users_with_role as _get_user_with_role
 
 not_allowed_in_permission_manager = ["DocType", "Patch Log", "Module Def", "Transaction Log"]
@@ -28,7 +27,6 @@ not_allowed_in_permission_manager = ["DocType", "Patch Log", "Module Def", "Tran
 @frappe.whitelist()
 def get_roles_and_doctypes():
 	frappe.only_for("System Manager")
-	send_translations(frappe.get_lang_dict("doctype", "DocPerm"))
 
 	active_domains = frappe.get_active_domains()
 

--- a/frappe/desk/desk_page.py
+++ b/frappe/desk/desk_page.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 import frappe
-from frappe.translate import send_translations
 
 
 @frappe.whitelist()
@@ -32,10 +31,6 @@ def getpage():
 	"""
 	page = frappe.form_dict.get("name")
 	doc = get(page)
-
-	# load translations
-	if frappe.lang != "en":
-		send_translations(frappe.get_lang_dict("page", page))
 
 	frappe.response.docs.append(doc)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -16,7 +16,6 @@ from frappe.core.utils import ljust_list
 from frappe.model.utils import render_include
 from frappe.modules import get_module_path, scrub
 from frappe.permissions import get_role_permissions
-from frappe.translate import send_translations
 from frappe.utils import (
 	cint,
 	cstr,
@@ -203,10 +202,6 @@ def get_script(report_name):
 
 	if not script:
 		script = "frappe.query_reports['%s']={}" % report_name
-
-	# load translations
-	if frappe.lang != "en":
-		send_translations(frappe.get_lang_dict("report", report_name))
 
 	return {
 		"script": render_include(script),

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -219,6 +219,14 @@ def get_dict(fortype: str, name: Optional[str] = None) -> Dict:
 	return translation_map
 
 
+def get_messages_for_boot():
+	"""Return all message translations that are required on boot."""
+	messages = get_full_dict(frappe.local.lang)
+	messages.update(get_dict_from_hooks("boot", None))
+
+	return messages
+
+
 def get_dict_from_hooks(fortype, name):
 	translated_dict = {}
 


### PR DESCRIPTION
- Backport ec8f20c0972d264b1c60452cb1ed8f84ea73722d from #17697
- Remove redundant translation

    As _all_ translations are now loaded on boot, additionally loading specific translations does not make sense any more.

Todo:

- [x] Frontport [2bc8c26](https://github.com/frappe/frappe/pull/18764/commits/2bc8c2630e633c253c3b3d78f79b0aa6e64a1b6d) (#18775)