### PR TITLE
fix: translations

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1383,7 +1383,7 @@ Object.assign(frappe.utils, {
 			: "";
 
 		return $(`<div class="summary-item">
-			<span class="summary-label">${summary.label}</span>
+			<span class="summary-label">${__(summary.label)}</span>
 			<div class="summary-value ${color}">${value}</div>
 		</div>`);
 	},

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1067,7 +1067,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				{
 					fieldname: "sb_1",
 					fieldtype: "Section Break",
-					label: "Y axis",
+					label: "Y Axis",
 				},
 				{
 					fieldname: "y_axis_fields",

--- a/frappe/translations/de.csv
+++ b/frappe/translations/de.csv
@@ -4080,7 +4080,7 @@ Scheduler Event,Scheduler-Ereignis,
 Select Event Type,Wählen Sie den Ereignistyp,
 Schedule Script,Zeitplan-Skript,
 Duration,Dauer,
-Donut,Krapfen,
+Donut,Donut,
 Custom Options,Benutzerdefinierte Optionen,
 "Ex: ""colors"": [""#d1d8dd"", ""#ff5858""]","Beispiel: &quot;Farben&quot;: [&quot;# d1d8dd&quot;, &quot;# ff5858&quot;]",
 Confirmation Email Template,Bestätigungs-E-Mail-Vorlage,
@@ -4818,3 +4818,8 @@ K,Tsd,Number system
 M,Mio,Number system
 B,Mrd,Number system
 T,Bio,Number system
+Type of Chart,Diagrammtyp,
+Preview Chart,Vorschau erzeugen,
+Please select X and Y fields,Bitte Felder für die X- und Y-Achse wählen,
+Notification sent to,Benachrichtigung gesendet an,
+Add to this activity by mailing to {0},"Senden Sie eine E-Mail an {0}, damit sie hier erscheint",


### PR DESCRIPTION
- Make labels on summary items translatable
- Capitalize label for one of the summary items (translations exist for the capitalized version)
- Add missing German translations