### PR TITLE
feat: Set default SQL statement timeouts

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -115,7 +115,7 @@ class Database:
 		frappe.local.rollback_observers = []
 
 		try:
-			if execution_timeout := get_ideal_query_execution_timeout():
+			if execution_timeout := get_query_execution_timeout():
 				self.set_execution_timeout(execution_timeout)
 		except Exception as e:
 			frappe.logger("database").warning(f"Couldn't set execution timeout {e}")
@@ -1353,20 +1353,24 @@ def savepoint(catch: type | tuple[type, ...] = Exception):
 		frappe.db.release_savepoint(savepoint)
 
 
-def get_ideal_query_execution_timeout() -> int:
-	"""Get execution timeout based on current timeout in contexts.
+def get_query_execution_timeout() -> int:
+	"""Get execution timeout based on current timeout in different contexts.
 
-	HTTP requests: HTTP timeout or a default (300)
-	Background jobs: Job timeout
+	    HTTP requests: HTTP timeout or a default (300)
+	    Background jobs: Job timeout
+	Console/Commands: No timeout = 0.
 
-	Note: Timeout adds 1.5x as "safety factor"
+	    Note: Timeout adds 1.5x as "safety factor"
 	"""
 	from rq import get_current_job
+
+	if not frappe.conf.get("enable_db_statement_timeout"):
+		return 0
 
 	# Zero means no timeout, which is the default value in db.
 	timeout = 0
 	with suppress(Exception):
-		if hasattr(frappe.local, "request"):
+		if getattr(frappe.local, "request", None):
 			timeout = frappe.conf.http_timeout or 300
 		elif job := get_current_job():
 			timeout = job.timeout

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -7,7 +7,7 @@ import random
 import re
 import string
 import traceback
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from time import time
 
 from pypika.dialects import MySQLQueryBuilder, PostgreSQLQueryBuilder
@@ -29,7 +29,7 @@ from frappe.exceptions import DoesNotExistError, ImplicitCommitError
 from frappe.model.utils.link_count import flush_local_link_count
 from frappe.query_builder.functions import Count
 from frappe.utils import cast as cast_fieldtype
-from frappe.utils import get_datetime, get_table_name, getdate, now, sbool
+from frappe.utils import cint, get_datetime, get_table_name, getdate, now, sbool
 
 IFNULL_PATTERN = re.compile(r"ifnull\(", flags=re.IGNORECASE)
 INDEX_PATTERN = re.compile(r"\s*\([^)]+\)\s*")
@@ -113,6 +113,17 @@ class Database:
 		self._conn = self.get_connection()
 		self._cursor = self._conn.cursor()
 		frappe.local.rollback_observers = []
+
+		try:
+			if execution_timeout := get_ideal_query_execution_timeout():
+				self.set_execution_timeout(execution_timeout)
+		except Exception as e:
+			frappe.logger("database").warning(f"Couldn't set execution timeout {e}")
+
+	def set_execution_timeout(self, seconds: int):
+		"""Set session speicifc timeout on exeuction of statements.
+		If any statement takes more time it will be killed along with entire transaction."""
+		raise NotImplementedError
 
 	def use(self, db_name):
 		"""`USE` db_name."""
@@ -1340,3 +1351,24 @@ def savepoint(catch: type | tuple[type, ...] = Exception):
 		frappe.db.rollback(save_point=savepoint)
 	else:
 		frappe.db.release_savepoint(savepoint)
+
+
+def get_ideal_query_execution_timeout() -> int:
+	"""Get execution timeout based on current timeout in contexts.
+
+	HTTP requests: HTTP timeout or a default (300)
+	Background jobs: Job timeout
+
+	Note: Timeout adds 1.5x as "safety factor"
+	"""
+	from rq import get_current_job
+
+	# Zero means no timeout, which is the default value in db.
+	timeout = 0
+	with suppress(Exception):
+		if hasattr(frappe.local, "request"):
+			timeout = frappe.conf.http_timeout or 300
+		elif job := get_current_job():
+			timeout = job.timeout
+
+	return int(cint(timeout) * 1.5)

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -69,6 +69,10 @@ class MariaDBExceptionUtil:
 		return e.args[0] == ER.PARSE_ERROR
 
 	@staticmethod
+	def is_statement_timeout(e: pymysql.Error) -> bool:
+		return e.args[0] == 1969
+
+	@staticmethod
 	def is_data_too_long(e: pymysql.Error) -> bool:
 		return e.args[0] == ER.DATA_TOO_LONG
 
@@ -101,6 +105,9 @@ class MariaDBConnectionUtil:
 
 	def create_connection(self):
 		return pymysql.connect(**self.get_connection_settings())
+
+	def set_execution_timeout(self, seconds: int):
+		self.sql("set session max_statement_time = %s", int(seconds))
 
 	def get_connection_settings(self) -> dict:
 		conn_settings = {

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -100,6 +100,10 @@ class PostgresExceptionUtil:
 		return getattr(e, "pgcode", None) == DUPLICATE_COLUMN
 
 	@staticmethod
+	def is_statement_timeout(e):
+		return PostgresDatabase.is_timedout(e) or isinstance(e, frappe.QueryTimeoutError)
+
+	@staticmethod
 	def is_data_too_long(e):
 		return getattr(e, "pgcode", None) == STRING_DATA_RIGHT_TRUNCATION
 
@@ -160,6 +164,10 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
 
 		return conn
+
+	def set_execution_timeout(self, seconds: int):
+		# Postgres expects milliseconds as input
+		self.sql("set local statement_timeout = %s", int(seconds) * 1000)
 
 	def escape(self, s, percent=True):
 		"""Escape quotes and percent in given string."""

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 import redis
 from redis.exceptions import BusyLoadingError, ConnectionError
 from rq import Connection, Queue, Worker
-from rq.command import send_stop_job_command
 from rq.logutils import setup_loghandlers
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 


### PR DESCRIPTION
In *"SOME"* cases queries keep running even after client has disconnected or died.

If you have sent some crazy queries they can keep running for long time and wreak havoc.

This is a MySQL bug, which will likely never get fixed because as per mysql devs:

> In my understanding (I may be wrong):
> - such behaviour is by design;
> - such behaviour is common for most socket programs;
> - the easiest way to work around such problem is to use TCP keepalive feature.


Reference: https://bugs.mysql.com/bug.php?id=78809

WARNING: Experimental and internal to framework, might get removed! :shrug: 


To enable set `enable_db_statement_time` to 1 in site or common config.

TODO:
- [x] Manual testing a bit
- [x] Is this *REALLY* required in postgres (?) [yes](https://dba.stackexchange.com/questions/81408/is-a-postgres-long-running-query-aborted-if-the-connection-is-lost-broken)
- [x] Does this add any significant overhead? Doesn't seem to.
- [x] Fixing PG tests
- [x] Disable by default, enable with config for now

Alternative: Suggest setting these globally in config files (?)

closes https://github.com/frappe/frappe/issues/18768

`no-docs` - not user facing.

