### PR TITLE
fix: dont release `frappe.local` twice

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -86,7 +86,7 @@ def application(request: Request):
 
 		log_request(request, response)
 		process_response(response)
-		frappe.destroy()
+		frappe.db.close()
 
 	return response
 


### PR DESCRIPTION
The `local_manager.middleware` decorator already does the job:
https://werkzeug.palletsprojects.com/en/2.2.x/local/#werkzeug.local.LocalManager.middleware