### PR TITLE
fix: standard dashboards not loading

### DIFF
--- a/cypress/integration/dashboard.js
+++ b/cypress/integration/dashboard.js
@@ -1,0 +1,50 @@
+describe("Dashboard view", { scrollBehavior: false }, () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app");
+	});
+
+	it("should load", () => {
+		const chart = "TODO-YEARLY-TRENDS";
+		const dashboard = "TODO-TEST-DASHBOARD"; // check slash in name intentionally.
+
+		cy.insert_doc(
+			"Dashboard Chart",
+			{
+				is_standard: 0,
+				chart_name: chart,
+				chart_type: "Count",
+				document_type: "ToDo",
+				parent_document_type: "",
+				based_on: "creation",
+				group_by_type: "Count",
+				timespan: "Last Year",
+				time_interval: "Yearly",
+				timeseries: 1,
+				type: "Line",
+				filters_json: "[]",
+			},
+			true
+		);
+
+		cy.insert_doc(
+			"Dashboard",
+			{
+				name: dashboard,
+				dashboard_name: dashboard,
+				is_standard: 0,
+				charts: [
+					{
+						chart: chart,
+					},
+				],
+			},
+			true
+		);
+
+		cy.visit(`/app/dashboard-view/${dashboard}`);
+
+		// expect chart to be loaded
+		cy.findByText(chart).should("be.visible");
+	});
+});

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -137,13 +137,13 @@ frappe.breadcrumbs = {
 		const doctype_meta = frappe.get_doc("DocType", doctype);
 		if (
 			(doctype === "User" && !frappe.user.has_role("System Manager")) ||
-			(doctype_meta && doctype_meta.issingle)
+			doctype_meta?.issingle
 		) {
 			// no user listview for non-system managers and single doctypes
 		} else {
 			let route;
 			const doctype_route = frappe.router.slug(frappe.router.doctype_layout || doctype);
-			if (doctype_meta.is_tree) {
+			if (doctype_meta?.is_tree) {
 				let view = frappe.model.user_settings[doctype].last_view || "Tree";
 				route = `${doctype_route}/view/${view}`;
 			} else {


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/18662

adding list breadcrumbs fails because the dashboard isn't just used from lists, some standard dashboards are domain/module wise which are accessed from the workspace. 


