### PR TITLE
fix: remove redundant translation

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -333,11 +333,6 @@ def get_js(items):
 		with open(contentpath) as srcfile:
 			code = frappe.utils.cstr(srcfile.read())
 
-		if frappe.local.lang != "en":
-			messages = frappe.get_lang_dict("jsfile", contentpath)
-			messages = json.dumps(messages)
-			code += f"\n\n$.extend(frappe._messages, {messages})"
-
 		out.append(code)
 
 	return out

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -19,7 +19,6 @@ from frappe.permissions import (
 	setup_custom_perms,
 	update_permission_property,
 )
-from frappe.translate import send_translations
 from frappe.utils.user import get_users_with_role as _get_user_with_role
 
 not_allowed_in_permission_manager = ["DocType", "Patch Log", "Module Def", "Transaction Log"]
@@ -28,7 +27,6 @@ not_allowed_in_permission_manager = ["DocType", "Patch Log", "Module Def", "Tran
 @frappe.whitelist()
 def get_roles_and_doctypes():
 	frappe.only_for("System Manager")
-	send_translations(frappe.get_lang_dict("doctype", "DocPerm"))
 
 	active_domains = frappe.get_active_domains()
 

--- a/frappe/desk/desk_page.py
+++ b/frappe/desk/desk_page.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import frappe
-from frappe.translate import send_translations
 
 
 @frappe.whitelist()
@@ -30,10 +29,6 @@ def getpage():
 	"""
 	page = frappe.form_dict.get("name")
 	doc = get(page)
-
-	# load translations
-	if frappe.lang != "en":
-		send_translations(frappe.get_lang_dict("page", page))
 
 	frappe.response.docs.append(doc)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -14,7 +14,6 @@ from frappe.model.utils import render_include
 from frappe.modules import get_module_path, scrub
 from frappe.monitor import add_data_to_monitor
 from frappe.permissions import get_role_permissions
-from frappe.translate import send_translations
 from frappe.utils import (
 	cint,
 	cstr,
@@ -201,10 +200,6 @@ def get_script(report_name):
 
 	if not script:
 		script = "frappe.query_reports['%s']={}" % report_name
-
-	# load translations
-	if frappe.lang != "en":
-		send_translations(frappe.get_lang_dict("report", report_name))
 
 	return {
 		"script": render_include(script),


### PR DESCRIPTION
Frontport https://github.com/frappe/frappe/pull/18764/commits/2bc8c2630e633c253c3b3d78f79b0aa6e64a1b6d of #18764

Since _all_ translations are loaded on boot, additionally loading specific translations does not make sense.