### PR TITLE
fix: dashboard view from workspace

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -29,7 +29,7 @@ frappe.breadcrumbs = {
 		return localStorage["preferred_breadcrumbs:" + doctype];
 	},
 
-	add(module, doctype, type) {
+	async add(module, doctype, type) {
 		let obj;
 		if (typeof module === "object") {
 			obj = module;
@@ -40,7 +40,7 @@ frappe.breadcrumbs = {
 				type: type,
 			};
 		}
-
+		await frappe.model.with_doctype(doctype);
 		this.all[frappe.breadcrumbs.current_page()] = obj;
 		this.update();
 	},

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -29,7 +29,7 @@ frappe.breadcrumbs = {
 		return localStorage["preferred_breadcrumbs:" + doctype];
 	},
 
-	async add(module, doctype, type) {
+	add(module, doctype, type) {
 		let obj;
 		if (typeof module === "object") {
 			obj = module;
@@ -40,7 +40,6 @@ frappe.breadcrumbs = {
 				type: type,
 			};
 		}
-		await frappe.model.with_doctype(doctype);
 		this.all[frappe.breadcrumbs.current_page()] = obj;
 		this.update();
 	},
@@ -132,8 +131,9 @@ frappe.breadcrumbs = {
 		}
 	},
 
-	set_list_breadcrumb(breadcrumbs) {
+	async set_list_breadcrumb(breadcrumbs) {
 		const doctype = breadcrumbs.doctype;
+		await frappe.model.with_doctype(doctype);
 		const doctype_meta = frappe.get_doc("DocType", doctype);
 		if (
 			(doctype === "User" && !frappe.user.has_role("System Manager")) ||


### PR DESCRIPTION
**changes requested in [#18763](https://github.com/frappe/frappe/pull/18763)**

### While navigating to dashboard from workspace, an error will occur because of a document is missing in locals.

**BEFORE**
![199963105-dc6b4b7b-5c18-4b1e-bd5a-6448601bc386](https://user-images.githubusercontent.com/95607086/200163812-72cea7c0-0b68-43b3-9095-9617eddd49bc.gif)

**AFTER**
![after](https://user-images.githubusercontent.com/95607086/199963147-b3c1380b-199b-4cdc-ba62-021b6cfb0903.gif)