### PR TITLE
fix: raise exception if doc before save is not found

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -749,6 +749,7 @@ class Document(BaseDocument):
 		self._action = "save"
 		previous = self._doc_before_save
 
+		# previous is None for new document insert
 		if not previous:
 			self.check_docstatus_transition(0)
 			return

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -744,12 +744,12 @@ class Document(BaseDocument):
 		Will also validate document transitions (Save > Submit > Cancel) calling
 		`self.check_docstatus_transition`."""
 
-		self.load_doc_before_save()
+		self.load_doc_before_save(raise_exception=True)
 
 		self._action = "save"
-		previous = self.get_doc_before_save()
+		previous = self._doc_before_save
 
-		if not previous or self.meta.get("is_virtual"):
+		if not previous:
 			self.check_docstatus_transition(0)
 			return
 
@@ -1048,7 +1048,7 @@ class Document(BaseDocument):
 
 		self.set_title_field()
 
-	def load_doc_before_save(self):
+	def load_doc_before_save(self, *, raise_exception: bool = False):
 		"""load existing document from db before saving"""
 
 		self._doc_before_save = None
@@ -1059,6 +1059,9 @@ class Document(BaseDocument):
 		try:
 			self._doc_before_save = frappe.get_doc(self.doctype, self.name, for_update=True)
 		except frappe.DoesNotExistError:
+			if raise_exception:
+				raise
+
 			frappe.clear_last_message()
 
 	def run_post_save_methods(self):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -411,8 +411,8 @@ class TestDocument(FrappeTestCase):
 		todo.save()
 		self.assertEqual(todo.notify_update.call_count, 1)
 
-	def test_error_on_saving_new_doc(self):
-		"""Trying to insert a new doc with `doc.save()` should raise error"""
+	def test_error_on_saving_new_doc_with_name(self):
+		"""Trying to save a new doc with name should raise DoesNotExistError"""
 
 		doc = frappe.get_doc(
 			{

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -411,6 +411,19 @@ class TestDocument(FrappeTestCase):
 		todo.save()
 		self.assertEqual(todo.notify_update.call_count, 1)
 
+	def test_error_on_saving_new_doc(self):
+		"""Trying to insert a new doc with `doc.save()` should raise error"""
+
+		doc = frappe.get_doc(
+			{
+				"doctype": "ToDo",
+				"description": "this should raise frappe.DoesNotExistError",
+				"name": "lets-trick-doc-save",
+			}
+		)
+
+		self.assertRaises(frappe.DoesNotExistError, doc.save)
+
 
 class TestDocumentWebView(FrappeTestCase):
 	def get(self, path, user="Guest"):


### PR DESCRIPTION
Required due to code removed by yours truly in https://github.com/frappe/frappe/pull/18666

**Added Validation for Virtual DocTypes:**
Previously `check_if_latest` didn't do much for virtual doctypes. This was because it depended on SQL queries. Now that we're getting the existing values using `get_doc`, we can run the validation for virtual doctypes as well.


## Changes Made
- Added `raise_exception` param to `load_doc_before_save`. Used the same in `check_if_latest`.
- Remove special treatment for virtual doctypes. 