### PR TITLE
fix: prevent deleting standard doctypes in prod

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -670,6 +670,9 @@ class TestDocType(FrappeTestCase):
 
 		self.assertEqual(test_json.test_json_field["hello"], "world")
 
+	def test_no_delete_doc(self):
+		self.assertRaises(frappe.ValidationError, frappe.delete_doc, "DocType", "Address")
+
 	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_custom_field_deletion(self):
 		"""Custom child tables whose doctype doesn't exist should be auto deleted."""

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -402,7 +402,7 @@ def _delete_modules(modules: list[str], dry_run: bool) -> list[str]:
 
 			if not dry_run:
 				if doctype.issingle:
-					frappe.delete_doc("DocType", doctype.name, ignore_on_trash=True)
+					frappe.delete_doc("DocType", doctype.name, ignore_on_trash=True, force=True)
 				else:
 					drop_doctypes.append(doctype.name)
 
@@ -460,7 +460,7 @@ def _delete_doctypes(doctypes: list[str], dry_run: bool) -> None:
 	for doctype in set(doctypes):
 		print(f"* dropping Table for '{doctype}'...")
 		if not dry_run:
-			frappe.delete_doc("DocType", doctype, ignore_on_trash=True)
+			frappe.delete_doc("DocType", doctype, ignore_on_trash=True, force=True)
 			frappe.db.sql_ddl(f"DROP TABLE IF EXISTS `tab{doctype}`")
 
 

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -92,6 +92,8 @@ def delete_doc(
 
 			else:
 				doc = frappe.get_doc(doctype, name)
+				if not (doc.custom or frappe.conf.developer_mode or frappe.flags.in_patch or force):
+					frappe.throw(_("Standard DocType can not be deleted."))
 
 				update_flags(doc, flags, ignore_permissions)
 				check_permission_and_not_submitted(doc)

--- a/frappe/tests/test_modules.py
+++ b/frappe/tests/test_modules.py
@@ -69,7 +69,7 @@ class TestUtils(FrappeTestCase):
 			delattr(self, "note")
 
 		if self._testMethodName == "test_make_boilerplate":
-			self.doctype.delete()
+			self.doctype.delete(force=True)
 			scrubbed = frappe.scrub(self.doctype.name)
 			self.addCleanup(
 				delete_path,

--- a/frappe/tests/test_virtual_doctype.py
+++ b/frappe/tests/test_virtual_doctype.py
@@ -87,7 +87,7 @@ class TestVirtualDoctypes(FrappeTestCase):
 		cls.addClassCleanup(frappe.flags.pop, "allow_doctype_export", None)
 
 		vdt = new_doctype(name=TEST_DOCTYPE_NAME, is_virtual=1, custom=0).insert()
-		cls.addClassCleanup(vdt.delete)
+		cls.addClassCleanup(vdt.delete, force=True)
 
 		patch_virtual_doc = patch(
 			"frappe.controllers", new={frappe.local.site: {TEST_DOCTYPE_NAME: VirtualDoctypeTest}}

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -451,7 +451,7 @@ def create_test_user():
 
 @frappe.whitelist()
 def setup_tree_doctype():
-	frappe.delete_doc_if_exists("DocType", "Custom Tree")
+	frappe.delete_doc_if_exists("DocType", "Custom Tree", force=True)
 
 	frappe.get_doc(
 		{
@@ -475,7 +475,7 @@ def setup_tree_doctype():
 
 @frappe.whitelist()
 def setup_image_doctype():
-	frappe.delete_doc_if_exists("DocType", "Custom Image")
+	frappe.delete_doc_if_exists("DocType", "Custom Image", force=True)
 
 	frappe.get_doc(
 		{


### PR DESCRIPTION
- Deleting doctypes in production isn't required (they come back on next migrate anyway)
- Prevents unintentional deletes.


closes https://github.com/frappe/frappe/issues/18802



handle

- [x] patches
- [x] uninstall app
- [x] dt tests
- [x] UI tests