### PR TITLE
perf: faster generate_hash

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1018,10 +1018,13 @@ def get_precision(
 	return get_field_precision(get_meta(doctype).get_field(fieldname), doc, currency)
 
 
-def generate_hash(txt: str | None = None, length: int | None = 56) -> str:
+def generate_hash(txt: str | None = None, length: int = 56) -> str:
 	"""Generate random hash using best available randomness source."""
 	import math
 	import secrets
+
+	if not length:
+		length = 56
 
 	return secrets.token_hex(math.ceil(length / 2))[:length]
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1018,19 +1018,12 @@ def get_precision(
 	return get_field_precision(get_meta(doctype).get_field(fieldname), doc, currency)
 
 
-def generate_hash(txt: str | None = None, length: int | None = None) -> str:
-	"""Generates random hash for given text + current timestamp + random string."""
-	import hashlib
-	import time
+def generate_hash(txt: str | None = None, length: int | None = 56) -> str:
+	"""Generate random hash using best available randomness source."""
+	import math
+	import secrets
 
-	from .utils import random_string
-
-	digest = hashlib.sha224(
-		((txt or "") + repr(time.time()) + repr(random_string(8))).encode()
-	).hexdigest()
-	if length:
-		digest = digest[:length]
-	return digest
+	return secrets.token_hex(math.ceil(length / 2))[:length]
 
 
 def reset_metadata_version():

--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -432,7 +432,7 @@ class DataExporter:
 				row[_column_start_end.start + i + 1] = value
 
 	def build_response_as_excel(self):
-		filename = frappe.generate_hash("", 10)
+		filename = frappe.generate_hash(length=10)
 		with open(filename, "wb") as f:
 			f.write(cstr(self.writer.getvalue()).encode("utf-8"))
 		f = open(filename)

--- a/frappe/core/doctype/data_import/test_importer.py
+++ b/frappe/core/doctype/data_import/test_importer.py
@@ -97,7 +97,7 @@ class TestImporter(FrappeTestCase):
 	def test_data_import_update(self):
 		existing_doc = frappe.get_doc(
 			doctype=doctype_name,
-			title=frappe.generate_hash(doctype_name, 8),
+			title=frappe.generate_hash(length=8),
 			table_field_1=[{"child_title": "child title to update"}],
 		)
 		existing_doc.save()

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -278,7 +278,7 @@ def make_autoname(key="", doctype="", doc=""):
 	                DE/09/01/00001 where 09 is the year, 01 is the month and 00001 is the series
 	"""
 	if key == "hash":
-		return frappe.generate_hash(doctype, 10)
+		return frappe.generate_hash(length=10)
 
 	series = NamingSeries(key)
 	return series.generate_next_name(doc)

--- a/frappe/patches/v11_0/remove_skip_for_doctype.py
+++ b/frappe/patches/v11_0/remove_skip_for_doctype.py
@@ -60,7 +60,7 @@ def execute():
 					# Maintain sequence (name, user, allow, for_value, applicable_for, apply_to_all_doctypes, creation, modified)
 					new_user_permissions_list.append(
 						(
-							frappe.generate_hash("", 10),
+							frappe.generate_hash(length=10),
 							user_permission.user,
 							user_permission.allow,
 							user_permission.for_value,

--- a/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
+++ b/frappe/patches/v12_0/move_email_and_phone_to_child_table.py
@@ -27,7 +27,7 @@ def execute():
 			email_values.append(
 				(
 					1,
-					frappe.generate_hash(contact_detail.email_id, 10),
+					frappe.generate_hash(length=10),
 					contact_detail.email_id,
 					"email_ids",
 					"Contact",
@@ -44,7 +44,7 @@ def execute():
 			phone_values.append(
 				(
 					phone_counter,
-					frappe.generate_hash(contact_detail.email_id, 10),
+					frappe.generate_hash(length=10),
 					contact_detail.phone,
 					"phone_nos",
 					"Contact",
@@ -63,7 +63,7 @@ def execute():
 			phone_values.append(
 				(
 					phone_counter,
-					frappe.generate_hash(contact_detail.email_id, 10),
+					frappe.generate_hash(length=10),
 					contact_detail.mobile_no,
 					"phone_nos",
 					"Contact",

--- a/frappe/patches/v12_0/setup_tags.py
+++ b/frappe/patches/v12_0/setup_tags.py
@@ -28,7 +28,7 @@ def execute():
 
 				tag_list.append((tag.strip(), time, time, "Administrator"))
 
-				tag_link_name = frappe.generate_hash(_user_tags.name + tag.strip() + doctype.name, 10)
+				tag_link_name = frappe.generate_hash(length=10)
 				tag_links.append(
 					(tag_link_name, doctype.name, _user_tags.name, tag.strip(), time, time, "Administrator")
 				)

--- a/frappe/templates/includes/navbar/navbar_items.html
+++ b/frappe/templates/includes/navbar/navbar_items.html
@@ -3,7 +3,7 @@
 
 {% if parent %}
 
-{%- set dropdown_id = 'id-' + frappe.utils.generate_hash('Dropdown', 12) -%}
+{%- set dropdown_id = 'id-' + frappe.utils.generate_hash(length=12) -%}
 <li class="nav-item dropdown {% if submenu %} dropdown-submenu {% endif %}">
 	<a class="nav-link dropdown-toggle" href="#" id="{{ dropdown_id }}" role="button"
 		data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -16,7 +16,7 @@
 	</ul>
 </li>
 {% else %}
-{%- set dropdown_id = 'id-' + frappe.utils.generate_hash('Dropdown', 12) -%}
+{%- set dropdown_id = 'id-' + frappe.utils.generate_hash(length=12) -%}
 <li class="dropdown {% if submenu %} dropdown-submenu {% endif %}">
 	<a class="dropdown-item dropdown-toggle" href="#" id="{{ dropdown_id }}" role="button"
 		data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/frappe/tests/test_modules.py
+++ b/frappe/tests/test_modules.py
@@ -47,7 +47,7 @@ class TestUtils(FrappeTestCase):
 
 		if self._testMethodName == "test_export_doc":
 			self.note = frappe.new_doc("Note")
-			self.note.title = frappe.generate_hash("Note", length=10)
+			self.note.title = frappe.generate_hash(length=10)
 			self.note.save()
 
 		if self._testMethodName == "test_make_boilerplate":

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -92,9 +92,7 @@ def web_blocks(blocks):
 def get_dom_id(seed=None):
 	from frappe import generate_hash
 
-	if not seed:
-		seed = "DOM"
-	return "id-" + generate_hash(seed, 12)
+	return "id-" + generate_hash(12)
 
 
 def include_script(path, preload=True):

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -266,7 +266,7 @@ def update_oauth_user(user, data, provider):
 				"email": get_email(data),
 				"gender": gender,
 				"enabled": 1,
-				"new_password": frappe.generate_hash(get_email(data)),
+				"new_password": frappe.generate_hash(),
 				"location": data.get("location"),
 				"user_type": "Website User",
 				"user_image": data.get("picture") or data.get("avatar_url"),

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -75,7 +75,7 @@ class WebsiteTheme(Document):
 			self.delete_old_theme_files(folder_path)
 
 		# add a random suffix
-		suffix = frappe.generate_hash("Website Theme", 8) if self.custom else "style"
+		suffix = frappe.generate_hash(length=8) if self.custom else "style"
 		file_name = frappe.scrub(self.name) + "_" + suffix + ".css"
 		output_path = join_path(folder_path, file_name)
 

--- a/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
+++ b/frappe/website/web_template/section_with_collapsible_content/section_with_collapsible_content.html
@@ -7,7 +7,7 @@
 	<div class="collapsible-items">
 		{%- for item in items -%}
 		<div class="collapsible-item">
-			{%- set collapse_id = 'id-' + frappe.utils.generate_hash('Collapse', 12) -%}
+			{%- set collapse_id = 'id-' + frappe.utils.generate_hash(length=12) -%}
 			<a class="collapsible-title" data-toggle="collapse" href="#{{ collapse_id }}" role="button"
 				aria-expanded="false" aria-controls="{{ collapse_id }}">
 				<div class="collapsible-item-title">{{ _(item.title) }}</div>

--- a/frappe/website/web_template/section_with_tabs/section_with_tabs.html
+++ b/frappe/website/web_template/section_with_tabs/section_with_tabs.html
@@ -11,8 +11,8 @@
 
 	{%- for index in ['1', '2', '3', '4', '5', '6'] -%}
 
-	{%- set buttonid = 'id-' + frappe.utils.generate_hash('TabButton', 12) -%}
-	{%- set panelid = 'id-' + frappe.utils.generate_hash('TabPanel', 12) -%}
+	{%- set buttonid = 'id-' + frappe.utils.generate_hash(length=12) -%}
+	{%- set panelid = 'id-' + frappe.utils.generate_hash(length=12) -%}
 
 	{%- set tab = {
 		'title': values['tab_' + index + '_title'],

--- a/frappe/website/web_template/slideshow/slideshow.html
+++ b/frappe/website/web_template/slideshow/slideshow.html
@@ -1,6 +1,6 @@
 {%- set slideshow = frappe.get_doc('Website Slideshow', website_slideshow) -%}
 {%- set slides = slideshow.slideshow_items -%}
-{%- set slideshow_id = 'id-' + frappe.utils.generate_hash('Slideshow', 12) -%}
+{%- set slideshow_id = 'id-' + frappe.utils.generate_hash(length=12) -%}
 
 {{ slideshow.header or '' }}
 


### PR DESCRIPTION
- Use system randomness
- Ignores `txt` parameter, kept for backward compat. 

~8x faster. 


Before:
```
In [1]: %timeit frappe.generate_hash()
7.57 µs ± 43.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

```

After:
```
In [1]: %timeit frappe.generate_hash()
974 ns ± 3.61 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```