### PR TITLE
fix: page has an empty menu button

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -327,13 +327,14 @@ frappe.ui.Page = class Page {
 
 	//--- Menu --//
 
-	add_menu_item(label, click, standard, shortcut) {
+	add_menu_item(label, click, standard, shortcut, show_parent) {
 		return this.add_dropdown_item({
 			label,
 			click,
 			standard,
 			parent: this.menu,
 			shortcut,
+			show_parent,
 		});
 	}
 
@@ -424,7 +425,7 @@ frappe.ui.Page = class Page {
 		icon = null,
 	}) {
 		if (show_parent) {
-			parent.parent().removeClass("hide");
+			parent.parent().removeClass("hide hidden-xl");
 		}
 
 		let $link = this.is_in_group_button_dropdown(parent, "li > a.grey-link > span", label);
@@ -602,8 +603,11 @@ frappe.ui.Page = class Page {
 		};
 		// Add actions as menu item in Mobile View
 		let menu_item_label = group ? `${group} > ${label}` : label;
-		let menu_item = this.add_menu_item(menu_item_label, _action, false);
+		let menu_item = this.add_menu_item(menu_item_label, _action, false, false, false);
 		menu_item.parent().addClass("hidden-xl");
+		if (this.menu_btn_group.hasClass("hide")) {
+			this.menu_btn_group.removeClass("hide").addClass("hidden-xl");
+		}
 
 		if (group) {
 			var $group = this.get_or_add_inner_group_button(group);


### PR DESCRIPTION
**Caused by:** https://github.com/frappe/frappe/pull/18720

**Issue:** If any page has action buttons which will go inside the menu button for smaller screen sizes then in the large screen an empty menu button still appears

**Before:**

<img width="1316" alt="image" src="https://user-images.githubusercontent.com/30859809/201040316-1277f77b-0740-4d8a-a519-aab5c1ecf4ce.png">


**After:**
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/30859809/201040184-1351c712-f507-4d61-be2b-2809e3b77043.png">
