### PR TITLE
perf(workflow): get_transitions

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -1,11 +1,16 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import json
+from typing import TYPE_CHECKING, Union
 
 import frappe
 from frappe import _
 from frappe.model.docstatus import DocStatus
 from frappe.utils import cint
+
+if TYPE_CHECKING:
+	from frappe.model.document import Document
+	from frappe.workflow.doctype.workflow.workflow import Workflow
 
 
 class WorkflowStateError(frappe.ValidationError):
@@ -32,20 +37,22 @@ def get_workflow_name(doctype):
 
 
 @frappe.whitelist()
-def get_transitions(doc, workflow=None, raise_exception=False):
+def get_transitions(
+	doc: Union["Document", str, dict], workflow: "Workflow" = None, raise_exception: bool = False
+) -> list[dict]:
 	"""Return list of possible transitions for the given doc"""
-	doc = frappe.get_doc(frappe.parse_json(doc))
+	from frappe.model.document import Document
+
+	if not isinstance(doc, Document):
+		doc = frappe.get_doc(frappe.parse_json(doc))
+		doc.load_from_db()
 
 	if doc.is_new():
 		return []
 
-	doc.load_from_db()
+	doc.check_permission("read")
 
-	frappe.has_permission(doc, "read", throw=True)
-	roles = frappe.get_roles()
-
-	if not workflow:
-		workflow = get_workflow(doc.doctype)
+	workflow = workflow or get_workflow(doc.doctype)
 	current_state = doc.get(workflow.workflow_state_field)
 
 	if not current_state:
@@ -55,11 +62,14 @@ def get_transitions(doc, workflow=None, raise_exception=False):
 			frappe.throw(_("Workflow State not set"), WorkflowStateError)
 
 	transitions = []
+	roles = frappe.get_roles()
+
 	for transition in workflow.transitions:
 		if transition.state == current_state and transition.allowed in roles:
 			if not is_transition_condition_satisfied(transition, doc):
 				continue
 			transitions.append(transition.as_dict())
+
 	return transitions
 
 
@@ -79,7 +89,7 @@ def get_workflow_safe_globals():
 	)
 
 
-def is_transition_condition_satisfied(transition, doc):
+def is_transition_condition_satisfied(transition, doc) -> bool:
 	if not transition.condition:
 		return True
 	else:
@@ -198,7 +208,7 @@ def validate_workflow(doc):
 			)
 
 
-def get_workflow(doctype):
+def get_workflow(doctype) -> "Workflow":
 	return frappe.get_doc("Workflow", get_workflow_name(doctype))
 
 


### PR DESCRIPTION
* [perf] Don't load from db again if Document is passed. This was added earlier to load in case of dicts. ref: https://github.com/frappe/frappe/pull/11883
* [fix] Check permissions for Document and not just doctype - frappe.has_permissions 
* Move blocks to evaluate only if required
* Add typing hints