### PR TITLE
perf(doc): skip order_by when name is set in load_from_db

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -142,9 +142,14 @@ class Document(BaseDocument):
 			self._fix_numeric_types()
 
 		else:
+			get_value_kwargs = {"for_update": self.flags.for_update, "as_dict": True}
+			if not isinstance(self.name, (dict, list)):
+				get_value_kwargs["order_by"] = None
+
 			d = frappe.db.get_value(
-				self.doctype, self.name, "*", as_dict=1, for_update=self.flags.for_update
+				doctype=self.doctype, filters=self.name, fieldname="*", **get_value_kwargs
 			)
+
 			if not d:
 				frappe.throw(
 					_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError


### PR DESCRIPTION
Setting ORDER BY clause in the SQL nudges MariaDB to not use index (even) for primary keys.

![Screenshot from 2022-11-10 11-33-21](https://user-images.githubusercontent.com/36654812/201060094-92dd3c4d-c527-4a55-8e4b-99a4a82aeb4d.png)
