### PR TITLE
fix(security): prevent xss attack in the search field

### DIFF
--- a/frappe/templates/includes/navbar/navbar_search.html
+++ b/frappe/templates/includes/navbar/navbar_search.html
@@ -2,7 +2,7 @@
 	<li>
 		<form action='/search'>
 		<input name='q' class='form-control navbar-search' type='text'
-			value='{{ frappe.form_dict.q or ''}}'
+			value='{{ frappe.form_dict.q|e or ''}}'
 			{% if not frappe.form_dict.q%}placeholder="{{ _("Search...") }}"{% endif %}>
 		</form>
 	</li>


### PR DESCRIPTION
When the `navbar_search` checkbox of the Website Settings is checked an attack is possible where the attacker sends the victim a link. If the victim clicks on the link, some JavaScript code can be executed. 