### PR TITLE
chore: fully commented, consistently formatted JS boilerplates

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/controller.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller.js
@@ -1,8 +1,8 @@
 // Copyright (c) {year}, {app_publisher} and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('{doctype}', {{
-	// refresh: function(frm) {{
+// frappe.ui.form.on("{doctype}", {{
+// 	refresh(frm) {{
 
-	// }}
-}});
+// 	}},
+// }});

--- a/frappe/core/doctype/doctype/boilerplate/controller_list.js
+++ b/frappe/core/doctype/doctype/boilerplate/controller_list.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-frappe.listview_settings['{doctype}'] = {{
-	// add_fields: ["status"],
-	// filters:[["status","=", "Open"]]
-}};
+// frappe.listview_settings["{doctype}"] = {{
+// 	add_fields: ["status"],
+// 	filters: [["status","=", "Open"]],
+// }};


### PR DESCRIPTION
- use of double quotes
- trailing commas
- comment same as code editor
- newer JS syntax
- comment fully to avoid unnecessary execution of `frappe.ui.form.on`