### PR TITLE
fix: hardcode doctype in google oauth callback

### DIFF
--- a/frappe/email/oauth.py
+++ b/frappe/email/oauth.py
@@ -132,19 +132,18 @@ def oauth_access(email_account: str, service: str):
 	if not service:
 		frappe.throw(frappe._("No Service is selected. Please select one and try again!"))
 
-	doctype = "Email Account"
-
 	if service == "GMail":
-		return authorize_google_access(email_account, doctype)
+		return authorize_google_access(email_account)
 
 	raise NotImplementedError(f"Service {service} currently doesn't have oauth implementation.")
 
 
-def authorize_google_access(email_account, doctype: str = "Email Account", code: str = None):
+def authorize_google_access(email_account: str, code: str = None):
 	"""Facilitates google oauth for email.
-	This is invoked 2 times - first time when user clicks `Authorze API Access` for getting the authorization url
+	This is invoked 2 times - first time when user clicks `Authorize API Access` for getting the authorization url
 	and second time for setting the refresh and access token in db when google redirects back with oauth code."""
 
+	doctype = "Email Account"
 	oauth_obj = GoogleOAuth("mail")
 
 	if not code:


### PR DESCRIPTION
- Function signature changed to remove DocType parameter
- Call to function fixed
- Calls from `google_oauth.callback` didn't specify `doctype` anyway

Tested Locally:
```py
In [4]: authorize_google_access("ok")
Out[4]: {'url': 'https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&response_type=code&prompt=consent&include_granted_scopes=true&client_id=test_client_id&scope=https://mail.google.com/&redirect_uri=http://localhost:8000/api/method/frappe.integrations.google_oauth.callback&state={"redirect": "/app/Form/Email%20Account/ok", "success_query_param": "successful_authorization=1", "email_account": "ok", "domain": "mail"}'}
```