### PR TITLE
fix: check if the doctype exists before adding default logtypes in log settings

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -69,6 +69,9 @@ class LogSettings(Document):
 		added_logtypes = set()
 		for logtype, retention in DEFAULT_LOGTYPES_RETENTION.items():
 			if logtype not in existing_logtypes and _supports_log_clearing(logtype):
+				if not frappe.db.exists("DocType", logtype):
+					continue
+
 				self.append("logs_to_clear", {"ref_doctype": logtype, "days": cint(retention)})
 				added_logtypes.add(logtype)
 


### PR DESCRIPTION
fixes the patch faliure: https://github.com/frappe/erpnext/actions/runs/3458604831/jobs/5773193630#step:13:3382