### PR TITLE
feat: show utilization percent on RQ Worker

### DIFF
--- a/frappe/core/doctype/rq_worker/rq_worker.json
+++ b/frappe/core/doctype/rq_worker/rq_worker.json
@@ -20,7 +20,8 @@
   "column_break_12",
   "birth_date",
   "last_heartbeat",
-  "total_working_time"
+  "total_working_time",
+  "utilization_percent"
  ],
  "fields": [
   {
@@ -59,7 +60,6 @@
   {
    "fieldname": "successful_job_count",
    "fieldtype": "Int",
-   "in_list_view": 1,
    "label": "Successful Job Count"
   },
   {
@@ -102,12 +102,18 @@
   {
    "fieldname": "column_break_12",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "utilization_percent",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "Utilization %"
   }
  ],
  "in_create": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2022-09-11 05:02:53.981705",
+ "modified": "2022-11-14 15:35:32.786012",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "RQ Worker",

--- a/frappe/core/doctype/rq_worker/rq_worker.py
+++ b/frappe/core/doctype/rq_worker/rq_worker.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2022, Frappe Technologies and contributors
 # For license information, please see license.txt
 
+import datetime
+from contextlib import suppress
+
 from rq import Worker
 
 import frappe
@@ -66,4 +69,11 @@ def serialize_worker(worker: Worker) -> frappe._dict:
 		_comment_count=0,
 		modified=convert_utc_to_user_timezone(worker.last_heartbeat),
 		creation=convert_utc_to_user_timezone(worker.birth_date),
+		utilization_percent=compute_utilization(worker),
 	)
+
+
+def compute_utilization(worker: Worker) -> float:
+	with suppress(Exception):
+		total_time = (datetime.datetime.utcnow() - worker.birth_date).total_seconds()
+		return worker.total_working_time / total_time * 100


### PR DESCRIPTION
Makes it easy to visualize how well background workers are being utilized. 

Utilization % = working time / total time. 

![image](https://user-images.githubusercontent.com/9079960/201633473-17da242a-a100-4e79-a8d7-16539c29ca5d.png)


