### PR TITLE
refactor: which > find_executable

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -4,7 +4,6 @@ import os
 import re
 import shutil
 import subprocess
-from distutils.spawn import find_executable
 from subprocess import getoutput
 from tempfile import mkdtemp, mktemp
 from urllib.parse import urlparse
@@ -280,7 +279,7 @@ def check_node_executable():
 	warn = "⚠️ "
 	if node_version.major < 14:
 		click.echo(f"{warn} Please update your node version to 14")
-	if not find_executable("yarn"):
+	if not shutil.which("yarn"):
 		click.echo(f"{warn} Please install yarn using below command and try again.\nnpm install -g yarn")
 	click.echo()
 

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -2,7 +2,7 @@ import json
 import os
 import subprocess
 import sys
-from distutils.spawn import find_executable
+from shutil import which
 
 import click
 
@@ -12,6 +12,7 @@ from frappe.coverage import CodeCoverage
 from frappe.exceptions import SiteNotSpecifiedError
 from frappe.utils import cint, update_progress_bar
 
+find_executable = which  # backwards compatibility
 DATA_IMPORT_DEPRECATION = (
 	"[DEPRECATED] The `import-csv` command used 'Data Import Legacy' which has been deprecated.\n"
 	"Use `data-import` command instead to import data via 'Data Import'."
@@ -525,7 +526,7 @@ def postgres(context):
 def _mariadb():
 	from frappe.database.mariadb.database import MariaDBDatabase
 
-	mysql = find_executable("mysql")
+	mysql = which("mysql")
 	command = [
 		mysql,
 		"--port",
@@ -544,7 +545,7 @@ def _mariadb():
 
 
 def _psql():
-	psql = find_executable("psql")
+	psql = which("psql")
 	subprocess.run([psql, "-d", frappe.conf.db_name])
 
 

--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -51,12 +51,12 @@ class DbManager:
 	@staticmethod
 	def restore_database(target, source, user, password):
 		import os
-		from distutils.spawn import find_executable
+		from shutil import which
 
 		from frappe.utils import make_esc
 
 		esc = make_esc("$ ")
-		pv = find_executable("pv")
+		pv = which("pv")
 
 		if pv:
 			pipe = f"{pv} {source} |"


### PR DESCRIPTION
```python
17:15:28 web.1            | /home/gavin/Desktop/projects-bench/apps/frappe/frappe/build.py:7: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
17:15:28 web.1            |   from distutils.spawn import find_executable
```

Use shutil from the standard library instead of distutils to find executables in PATH