### PR TITLE
chore: remove middleware to clear `frappe.local`

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -5,7 +5,6 @@ import logging
 import os
 
 from werkzeug.exceptions import HTTPException, NotFound
-from werkzeug.local import LocalManager
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.shared_data import SharedDataMiddleware
 from werkzeug.wrappers import Request, Response
@@ -25,13 +24,10 @@ from frappe.utils import get_site_name, sanitize_html
 from frappe.utils.error import make_error_snapshot
 from frappe.website.serve import get_response
 
-local_manager = LocalManager(frappe.local)
-
 _site = None
 _sites_path = os.environ.get("SITES_PATH", ".")
 
 
-@local_manager.middleware
 @Request.application
 def application(request: Request):
 	response = None


### PR DESCRIPTION
From [`werkzeug` docs](https://werkzeug.palletsprojects.com/en/2.2.x/local/#releasing-data):

![image](https://user-images.githubusercontent.com/16315650/201824769-7f8cf2f0-fbc3-4cf0-86ab-abed35a8bb85.png)
