### PR TITLE
Revert "chore: remove middleware to clear `frappe.local`"

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -5,6 +5,7 @@ import logging
 import os
 
 from werkzeug.exceptions import HTTPException, NotFound
+from werkzeug.local import LocalManager
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.shared_data import SharedDataMiddleware
 from werkzeug.wrappers import Request, Response
@@ -24,10 +25,13 @@ from frappe.utils import get_site_name, sanitize_html
 from frappe.utils.error import make_error_snapshot
 from frappe.website.serve import get_response
 
+local_manager = LocalManager(frappe.local)
+
 _site = None
 _sites_path = os.environ.get("SITES_PATH", ".")
 
 
+@local_manager.middleware
 @Request.application
 def application(request: Request):
 	response = None


### PR DESCRIPTION
Reverts frappe/frappe#18874

This breaks all UI tests and is not as "backward compatible" as we first thought. 


To reproduce run with gunicorn and remove web process. Wont reproduce if you're using dev server.

```
unicorn: gunicorn -b 127.0.0.1:8000 -w 1 --chdir /your/site/directory frappe.app:application --preload
```



```
  File "apps/frappe/frappe/app.py", line 52, in application
    response = frappe.api.handle()
               ^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1580, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/load.py", line 79, in getdoctype
    frappe.response.docs.extend(docs)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'extend'
```