### PR TITLE
fix: webform read only field not working

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -79,7 +79,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 			if (me.frm) {
 				me.value = frappe.model.get_value(me.doctype, me.docname, me.df.fieldname);
 			} else if (me.doc) {
-				me.value = me.doc[me.df.fieldname];
+				me.value = me.doc[me.df.fieldname] || "";
 			}
 
 			if (me.can_write()) {

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -55,7 +55,7 @@ frappe.ready(function () {
 	function setup_fields(web_form_doc, doc_data) {
 		web_form_doc.web_form_fields.forEach((df) => {
 			df.is_web_form = true;
-			df.read_only = !web_form_doc.is_new && !web_form_doc.in_edit_mode;
+			df.read_only = df.read_only || (!web_form_doc.is_new && !web_form_doc.in_edit_mode);
 			if (df.fieldtype === "Table") {
 				df.get_data = () => {
 					let data = [];


### PR DESCRIPTION
In Web Form, read-only fields are not working

**Before:**
<img width="819" alt="image" src="https://user-images.githubusercontent.com/30859809/202157252-fe4352d0-6f21-4796-a03a-bcec0f89757b.png">


**After:**
<img width="819" alt="image" src="https://user-images.githubusercontent.com/30859809/202157149-eeba140d-2cdd-490a-bbcd-5bc43fc30a47.png">
