### PR TITLE
fix: ignore unpicklable hooks

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1432,6 +1432,8 @@ def get_doc_hooks():
 
 @request_cache
 def _load_app_hooks(app_name: str | None = None):
+	import types
+
 	hooks = {}
 	apps = [app_name] if app_name else get_installed_apps(sort=True)
 
@@ -1447,9 +1449,13 @@ def _load_app_hooks(app_name: str | None = None):
 			if not request:
 				raise SystemExit
 			raise
-		for key in dir(app_hooks):
+
+		def _is_valid_hook(obj):
+			return not isinstance(obj, (types.ModuleType, types.FunctionType, type))
+
+		for key, value in inspect.getmembers(app_hooks, predicate=_is_valid_hook):
 			if not key.startswith("_"):
-				append_hook(hooks, key, getattr(app_hooks, key))
+				append_hook(hooks, key, value)
 	return hooks
 
 


### PR DESCRIPTION
If any custom app use import statement in hooks.py everything breaks.
Hooks.py while being python file is still only supposed to be used for
configuring.

This PR ignores unpicklable members of hooks.py


```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 109, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 552, in migrate
    SiteMigration(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 172, in run
    self.setUp()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 74, in setUp
    clear_global_cache()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/cache_manager.py", line 102, in clear_global_cache
    clear_website_cache()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/utils.py", line 387, in clear_website_cache
    clear_cache(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/utils.py", line 370, in clear_cache
    frappe.clear_cache("Guest")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 872, in clear_cache
    frappe.cache_manager.clear_user_cache(user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/cache_manager.py", line 78, in clear_user_cache
    clear_notifications(user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/notifications.py", line 143, in clear_notifications
    config = get_notification_config()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/notifications.py", line 236, in get_notification_config
    return frappe.cache().hget("notification_config", user, _get)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/redis_wrapper.py", line 201, in hget
    value = generator()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/notifications.py", line 214, in _get
    subscribed_documents = get_subscribed_documents()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/doctype/notification_settings/notification_settings.py", line 68, in get_subscribed_documents
    if frappe.db.exists("Notification Settings", frappe.session.user):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 1091, in exists
    return self.get_value(dt, dn, ignore=True, cache=cache)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 495, in get_value
    result = self.get_values(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 592, in get_values
    out = self._get_values_from_table(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 809, in _get_values_from_table
    query = frappe.qb.engine.get_query(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/query.py", line 513, in get_query
    criterion = self.build_conditions(table, filters, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/query.py", line 369, in build_conditions
    criterion = self.dict_query(filters=filters, table=table, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/query.py", line 328, in dict_query
    _operator = self.OPERATOR_MAP["="]
  File "/usr/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/query.py", line 194, in OPERATOR_MAP
    if frappe.get_hooks("filters_config"):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1472, in get_hooks
    hooks = _dict(cache().get_value("app_hooks", _load_app_hooks))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/redis_wrapper.py", line 82, in get_value
    self.set_value(original_key, val, user=user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/redis_wrapper.py", line 50, in set_value
    self.set(key, pickle.dumps(val))
TypeError: cannot pickle 'module' object
```