### PR TITLE
perf: dont fetch meta unless required

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -206,11 +206,16 @@ def search_widget(
 				)
 				order_by = f"_relevance, {order_by}"
 
-			ptype = "select" if frappe.only_has_select_perm(doctype) else "read"
 			ignore_permissions = (
 				True
 				if doctype == "DocType"
-				else (cint(ignore_user_permissions) and has_permission(doctype, ptype=ptype))
+				else (
+					cint(ignore_user_permissions)
+					and has_permission(
+						doctype,
+						ptype="select" if frappe.only_has_select_perm(doctype) else "read",
+					)
+				)
 			)
 
 			values = frappe.get_list(

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -455,10 +455,10 @@ class DatabaseQuery:
 		)
 
 	def check_read_permission(self, doctype):
-		ptype = "select" if frappe.only_has_select_perm(doctype) else "read"
-
 		if not self.flags.ignore_permissions and not frappe.has_permission(
-			doctype, ptype=ptype, parent_doctype=self.doctype
+			doctype,
+			ptype="select" if frappe.only_has_select_perm(doctype) else "read",
+			parent_doctype=self.doctype,
 		):
 			frappe.flags.error_message = _("Insufficient Permission for {0}").format(frappe.bold(doctype))
 			raise frappe.PermissionError(doctype)


### PR DESCRIPTION
`frappe.only_has_select_perm` fetches meta. This PR avoids calling that in cases where permissions are ignored anyway.