### PR TITLE
fix(file): attached_to_name can be an integer

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -101,8 +101,8 @@ class File(Document):
 		if not self.attached_to_doctype:
 			return
 
-		if not self.attached_to_name:
-			frappe.throw(_("Attached To Name is not set"), frappe.ValidationError)
+		if not self.attached_to_name or not isinstance(self.attached_to_name, (str, int)):
+			frappe.throw(_("Attached To Name must be a string or an integer"), frappe.ValidationError)
 
 		if not self.attached_to_field:
 			return

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -101,8 +101,8 @@ class File(Document):
 		if not self.attached_to_doctype:
 			return
 
-		if self.attached_to_name and not isinstance(self.attached_to_name, str):
-			frappe.throw(_("Attached To Name must be a string"), TypeError)
+		if not self.attached_to_name:
+			frappe.throw(_("Attached To Name is not set"), frappe.ValidationError)
 
 		if not self.attached_to_field:
 			return

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -85,7 +85,7 @@ class TestBase64File(FrappeTestCase):
 				"doctype": "File",
 				"file_name": "test_base64.txt",
 				"attached_to_doctype": self.attached_to_doctype,
-				"attached_to_docname": self.attached_to_docname,
+				"attached_to_name": self.attached_to_docname,
 				"content": self.test_content,
 				"decode": True,
 			}


### PR DESCRIPTION
incorrect validation introduced via https://github.com/frappe/frappe/pull/18880

