### PR TITLE
fix: (ctrl/cmd)+click for clickable divs

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -12,6 +12,7 @@ frappe.route_history = [];
 frappe.view_factory = {};
 frappe.view_factories = [];
 frappe.route_options = null;
+frappe.open_in_new_tab = false;
 frappe.route_hooks = {};
 
 $(window).on("hashchange", function (e) {
@@ -347,8 +348,12 @@ frappe.router = {
 			let sub_path = this.make_url(route);
 			// replace each # occurrences in the URL with encoded character except for last
 			// sub_path = sub_path.replace(/[#](?=.*[#])/g, "%23");
-			this.push_state(sub_path);
-
+			if (frappe.open_in_new_tab) {
+				window.open(sub_path, "_blank");
+				frappe.open_in_new_tab = false;
+			} else {
+				this.push_state(sub_path);
+			}
 			setTimeout(() => {
 				frappe.after_ajax &&
 					frappe.after_ajax(() => {

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -463,7 +463,12 @@ frappe.ui.Page = class Page {
 			`);
 		}
 
-		$link = $li.find("a").on("click", click);
+		$link = $li.find("a").on("click", (e) => {
+			if (e.ctrlKey || e.metaKey) {
+				frappe.open_in_new_tab = true;
+			}
+			return click();
+		});
 
 		if (standard) {
 			$li.appendTo(parent);

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -107,6 +107,10 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			if (item.onclick) {
 				item.onclick(item.match);
 			} else {
+				let event = o.originalEvent;
+				if (event.ctrlKey || event.metaKey) {
+					frappe.open_in_new_tab = true;
+				}
 				frappe.set_route(item.route);
 			}
 			$input.val("");

--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -161,7 +161,10 @@ export default class QuickListWidget extends Widget {
 			$quick_list_item
 		);
 
-		$quick_list_item.click(() => {
+		$quick_list_item.click((e) => {
+			if (e.ctrlKey || e.metaKey) {
+				frappe.open_in_new_tab = true;
+			}
 			frappe.set_route(`${frappe.utils.get_form_link(this.document_type, doc.name)}`);
 		});
 
@@ -243,7 +246,14 @@ export default class QuickListWidget extends Widget {
 		}
 		let route = frappe.utils.generate_route({ type: "doctype", name: this.document_type });
 		this.see_all_button = $(`
-			<a href="${route}"class="see-all btn btn-xs">${__("View List")}</a>
+			<div class="see-all btn btn-xs">${__("View List")}</div>
 		`).appendTo(this.footer);
+
+		this.see_all_button.click((e) => {
+			if (e.ctrlKey || e.metaKey) {
+				frappe.open_in_new_tab = true;
+			}
+			frappe.set_route(route);
+		});
 	}
 }

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -24,7 +24,7 @@ export default class ShortcutWidget extends Widget {
 	}
 
 	setup_events() {
-		this.widget.click(() => {
+		this.widget.click((e) => {
 			if (this.in_customize_mode) return;
 
 			let route = frappe.utils.generate_route({
@@ -40,6 +40,11 @@ export default class ShortcutWidget extends Widget {
 			if (this.type == "DocType" && filters) {
 				frappe.route_options = filters;
 			}
+
+			if (e.ctrlKey || e.metaKey) {
+				frappe.open_in_new_tab = true;
+			}
+
 			frappe.set_route(route);
 		});
 	}


### PR DESCRIPTION
Fixes: https://github.com/frappe/frappe/issues/18788

This PR makes following elements support cmd+click

- [x] Workspace Shortcut
- [x] Workspace Quick List
- [x] Awesomebar results
- [x] Menu items on any page