### PR TITLE
fix: get_title must return string

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1750,7 +1750,7 @@ frappe.ui.form.Form = class FrappeForm {
 		if (this.meta.title_field) {
 			return this.doc[this.meta.title_field];
 		} else {
-			return this.doc.name;
+			return String(this.doc.name);
 		}
 	}
 


### PR DESCRIPTION
**Problem**: `form.get_title()` returns an integer for doctypes having `Autoincrement` naming series. Replicate-able when you set the "Image Field" in DocType form settings. Breaks the render of the whole form.


**Solution**: Convert document name to String before returning

