### PR TITLE
fix: show fields without labels in print format builder

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -281,7 +281,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 			} else if (f.fieldtype === "Column Break") {
 				set_column();
 			} else if (
-				!in_list(["Section Break", "Column Break", "Tab Break", "Fold"], f.fieldtype)
+				!in_list(frappe.model.layout_fields, f.fieldtype)
 			) {
 				if (!column) set_column();
 

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -281,8 +281,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 			} else if (f.fieldtype === "Column Break") {
 				set_column();
 			} else if (
-				!in_list(["Section Break", "Column Break", "Tab Break", "Fold"], f.fieldtype) &&
-				f.label
+				!in_list(["Section Break", "Column Break", "Tab Break", "Fold"], f.fieldtype)
 			) {
 				if (!column) set_column();
 

--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -34,7 +34,7 @@
 			<span class="drag-handle">
 				<svg class="icon icon-xs"><use href="#icon-drag"></use></svg>
 			</span>
-			<span class="field-label">{{ __(field.label) }}
+			<span class="field-label">{{ __(field.label) || __(field.fieldname) }}
 				<span> ({%= __("Table") %})</span>
 			</span>
 			<a class="pull-right select-columns btn btn-default btn-xs">


### PR DESCRIPTION
To reproduce:
- Add any table which doesn't have label on it to print format, e.g. "Items" table in sales invoice
- Save and reload, the field is there but not shown on the PFB.

Note: ERPNext started removing labels of tables to improve UX and reduce clutter. (e.g. if there's section called "items", it makes little sense to add another label for table too) 


After fix:

![image](https://user-images.githubusercontent.com/9079960/202697966-3550ea8e-31c4-4a7d-a1ff-8a609f0a611c.png)
