### PR TITLE
fix: update-password api call

### DIFF
--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -161,7 +161,7 @@ frappe.ready(function() {
 						.text("{{ _('Invalid Password') }}");
 				},
 				200: function(r) {
-					if (r.message && r.message.entropy) {
+					if (r.message && r.message.score) {
 						var score = r.message.score,
 							feedback = r.message.feedback;
 


### PR DESCRIPTION
The update-password dialog expects an `entropy` property from the zxcvbn library when evaluating password strength, but current versions of this library no longer return entropy as a measurement.

This PR changes the message update condition to depend on the zxcvbn `score` property instead.

See also: https://github.com/dwolfhub/zxcvbn-python/issues/19#issuecomment-351235001

closes #18888