### PR TITLE
feat(minor): redirect after login from NotPermittedPage

### DIFF
--- a/frappe/website/page_renderers/not_permitted_page.py
+++ b/frappe/website/page_renderers/not_permitted_page.py
@@ -14,9 +14,10 @@ class NotPermittedPage(TemplatePage):
 		return True
 
 	def render(self):
+		action = "/login?redirect-to={}".format(frappe.request.path)
 		frappe.local.message_title = _("Not Permitted")
 		frappe.local.response["context"] = dict(
-			indicator_color="red", primary_action="/login", primary_label=_("Login"), fullpage=True
+			indicator_color="red", primary_action=action, primary_label=_("Login"), fullpage=True
 		)
 		self.set_standard_path("message")
 		return super().render()

--- a/frappe/website/page_renderers/not_permitted_page.py
+++ b/frappe/website/page_renderers/not_permitted_page.py
@@ -14,7 +14,7 @@ class NotPermittedPage(TemplatePage):
 		return True
 
 	def render(self):
-		action = "/login?redirect-to={}".format(frappe.request.path)
+		action = f"/login?redirect-to={frappe.request.path}"
 		frappe.local.message_title = _("Not Permitted")
 		frappe.local.response["context"] = dict(
 			indicator_color="red", primary_action=action, primary_label=_("Login"), fullpage=True


### PR DESCRIPTION
At present, the NotPermittedPage contains an action button linking to the login page. Once login is complete, the user is redirected back to the default desk page.

With this PR, the user is returned to the page they had attempted to view instead.