### PR TITLE
feat: redis_memoize

### DIFF
--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -128,3 +128,21 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 		return time_cache_wrapper(ttl)
 
 	return time_cache_wrapper
+
+
+def redis_memoize(fn):
+	"""Decorator to memoize function calls in Redis.
+
+	Note: Make sure memoized function has a return value and no side effects.
+	"""
+
+	@wraps(fn)
+	def wrapper(*args, **kwargs):
+		key = f"memoize:{fn.__module__}:{fn.__name__}:{args}:{kwargs}"
+		value = frappe.cache().get_value(key)
+		if value is None:
+			value = fn(*args, **kwargs)
+			frappe.cache().set_value(key, value)
+		return value
+
+	return wrapper


### PR DESCRIPTION
- Memoize your function calls under your site's Redis cache
- Uses Frappe Redis' get_value/set_value APIs
- This API utilizes the Redis cache as opposed to maintaining Py process caches that the other caching utils do
- Note: Make sure memoized function has a return value and no side effects.

Example


```python
In [1]: from frappe.utils.caching import redis_memoize

In [2]: @redis_memoize
   ...: def sleep_long(kwargs, string, boolean):
   ...:     import time
   ...:     time.sleep(5)
   ...:     return "LOL"
   ...: 

In [3]: sleep_long({"abc": 120, 1.3: 450}, "item_code", True)
[LOG]>>> LOL from memoize:frappe.commands.utils:sleep_long:({'abc': 120, 1.3: 450}, 'item_code', True):{}
Out[3]: 'LOL'

In [4]: sleep_long({"abc": 120, 1.3: 450}, "item_code", True)
[LOG]>>> LOL from memoize:frappe.commands.utils:sleep_long:({'abc': 120, 1.3: 450}, 'item_code', True):{}
Out[4]: 'LOL'
```