### PR TITLE
fix: only get fields which is not already in webform fields table

### DIFF
--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -79,7 +79,7 @@ frappe.ui.form.on("Web Form", {
 				.get_field("Web Form Field", "fieldtype")
 				.options.split("\n");
 
-			let added_fields = (frm.doc.fields || []).map((d) => d.fieldname);
+			let added_fields = (frm.doc.web_form_fields || []).map((d) => d.fieldname);
 
 			get_fields_for_doctype(frm.doc.doc_type).then((fields) => {
 				for (let df of fields) {


### PR DESCRIPTION
**Issue:** When we click on get fields button all the fields are added to the web form fields table
**Fix:** Now fields which are not present in the webform fields table will be added.