### PR TITLE
fix(file): set fieldname to table fieldname

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -79,7 +79,11 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 		if (this.frm) {
 			options.doctype = this.frm.doctype;
 			options.docname = this.frm.docname;
-			options.fieldname = this.df.fieldname;
+			if (this.grid) {
+				options.fieldname = this.grid.control.df.fieldname;
+			} else {
+				options.fieldname = this.df.fieldname;
+			}
 			options.make_attachments_public = this.frm.meta.make_attachments_public;
 		}
 

--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -79,11 +79,7 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 		if (this.frm) {
 			options.doctype = this.frm.doctype;
 			options.docname = this.frm.docname;
-			if (this.grid) {
-				options.fieldname = this.grid.control.df.fieldname;
-			} else {
-				options.fieldname = this.df.fieldname;
-			}
+			options.fieldname = this.grid ? this.grid.df.fieldname : this.df.fieldname;
 			options.make_attachments_public = this.frm.meta.make_attachments_public;
 		}
 


### PR DESCRIPTION
This PR https://github.com/frappe/frappe/pull/18880 introduced `attached_to_field` validation.
When you upload a file in a Attach field inside child table, it is linked to the parent doctype. In this case, the attached_to_field must be the table fieldname for the validation to work properly.
