### PR TITLE
fix: horizontal scroll in rtl language

### DIFF
--- a/frappe/public/scss/common/datepicker.scss
+++ b/frappe/public/scss/common/datepicker.scss
@@ -1,6 +1,4 @@
-/*rtl:begin:ignore*/
 @import "~air-datepicker/dist/css/datepicker.min";
-/*rtl:end:ignore*/
 
 .datepicker {
 	direction: ltr;
@@ -10,6 +8,11 @@
 	color: var(--text-color);
 	border-radius: var(--border-radius);
 	border: 1px solid var(--border-color);
+	position: fixed;
+
+	&.active {
+		position: absolute;
+	}
 
 	&--nav {
 		border-bottom: 1px solid var(--border-color);


### PR DESCRIPTION
In RTL Language there is a horizontal scroll because of datepicker CSS

Before:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/30859809/203333620-ae341d33-af79-42bf-b3cc-52a952ffb88a.png">


After:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/30859809/203333343-23a82480-f001-43bd-b2b9-36fcda83e209.png">


>NOTE: ignore comment for rtlcss is not working
