### PR TITLE
feat: add param letterhead to frappe.get_print

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1985,6 +1985,7 @@ def get_print(
 	doc=None,
 	output=None,
 	no_letterhead=0,
+	letterhead=None,
 	password=None,
 	pdf_options=None,
 ):
@@ -2005,6 +2006,7 @@ def get_print(
 	local.form_dict.style = style
 	local.form_dict.doc = doc
 	local.form_dict.no_letterhead = no_letterhead
+	local.form_dict.letterhead = letterhead
 
 	pdf_options = pdf_options or {}
 	if password:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1985,9 +1985,9 @@ def get_print(
 	doc=None,
 	output=None,
 	no_letterhead=0,
-	letterhead=None,
 	password=None,
 	pdf_options=None,
+	letterhead=None,
 ):
 	"""Get Print Format for given document.
 


### PR DESCRIPTION
Until now, there was no way to specify the letterhead to be used by `frappe.get_print`.

> no-docs