### PR TITLE
fix: handle "No Letterhead" in new print format builder

### DIFF
--- a/frappe/utils/weasyprint.py
+++ b/frappe/utils/weasyprint.py
@@ -4,6 +4,7 @@
 import click
 
 import frappe
+from frappe import _
 
 
 @frappe.whitelist()
@@ -49,7 +50,11 @@ class PrintFormatGenerator:
 		self.base_url = frappe.utils.get_url()
 		self.print_format = frappe.get_doc("Print Format", print_format)
 		self.doc = doc
+
+		if letterhead == _("No Letterhead"):
+			letterhead = None
 		self.letterhead = frappe.get_doc("Letter Head", letterhead) if letterhead else None
+
 		self.build_context()
 		self.layout = self.get_layout(self.print_format)
 		self.context.layout = self.layout


### PR DESCRIPTION
Preview failed for new print format builder, when "No Letterhead" was selected.