### PR TITLE
fix: Widget control on dashboard chart breaks on smaller screens

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -237,12 +237,19 @@ body {
 		.widget-head {
 			padding: var(--padding-sm);
 			position: relative;
+			@media (max-width: 1300px) {
+				display: grid;
+			}
 		}
 
 		.widget-control {
-			position: absolute;
+			position: inherit;
 			right: var(--margin-sm);
 			top: var(--padding-sm);
+			@media (min-width: 1300px) {
+				top: auto;
+			}
+
 		}
 
 		.chart-loading-state {

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -94,7 +94,7 @@ body {
 		}
 
 		.grid-col-2 {
-			grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+			grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 			.full-width {
 				grid-column-start: 1;
 				grid-column-end: 2;
@@ -216,6 +216,9 @@ body {
 
 		.btn-xs {
 			box-shadow: none;
+			min-width: max-content;
+			font-size: 12px;
+			padding: 4px 6px;
 		}
 
 		.chart-actions {
@@ -236,20 +239,17 @@ body {
 
 		.widget-head {
 			padding: var(--padding-sm);
-			position: relative;
-			@media (max-width: 1300px) {
-				display: grid;
-			}
+			display: flex;
+			justify-content: space-between;
+			flex-wrap: wrap;
+			gap: 6px;
 		}
 
 		.widget-control {
-			position: inherit;
-			right: var(--margin-sm);
-			top: var(--padding-sm);
-			@media (min-width: 1300px) {
-				top: auto;
-			}
-
+			display: flex;
+			align-items: center;
+			flex: 1;
+			font-size: 10px;
 		}
 
 		.chart-loading-state {


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->
widget-control on dashboard chart breaks when resizing screen overlapping widget-label.

> Screenshots/GIFs

- Before

[Screencast from 2022-11-24 10-30-16.webm](https://user-images.githubusercontent.com/54215258/203803986-548fff72-716c-49b5-88ef-e5cf0f7333a7.webm)

- After

[Screencast from 2022-11-24 10-56-55.webm](https://user-images.githubusercontent.com/54215258/203804776-9d0b1bfe-b2aa-41f4-970e-e341f4dbc56e.webm)


