### PR TITLE
fix: "_dict" is an invalid attribute name because it starts with "_"

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -106,7 +106,6 @@ def get_safe_globals():
 		as_json=frappe.as_json,
 		dict=dict,
 		log=frappe.log,
-		as_dict=frappe._dict,
 		args=form_dict,
 		frappe=NamespaceDict(
 			call=call_whitelisted_function,
@@ -117,6 +116,7 @@ def get_safe_globals():
 			time_format=time_format,
 			format_date=frappe.utils.data.global_date_format,
 			form_dict=form_dict,
+			as_dict=frappe._dict,
 			bold=frappe.bold,
 			copy_doc=frappe.copy_doc,
 			errprint=frappe.errprint,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -106,7 +106,7 @@ def get_safe_globals():
 		as_json=frappe.as_json,
 		dict=dict,
 		log=frappe.log,
-		_dict=frappe._dict,
+		as_dict=frappe._dict,
 		args=form_dict,
 		frappe=NamespaceDict(
 			call=call_whitelisted_function,


### PR DESCRIPTION
When we try to use "_dict({"test": 123})" in the server script or a report script or any other resource that uses safe_exec.py, it returns the following error

"_dict" is an invalid attribute name because it starts with "_"

So for these resources "frappe._dict" will be "as_dict":
Example: 
mydict = as_dict({"test": 123})


