### PR TITLE
fix: Avoid `update_order` twice on Kanban load

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -175,9 +175,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 				cur_list: this,
 				user_settings: this.view_user_settings,
 			});
-		}
-
-		if (this.kanban && board_name === this.kanban.board_name) {
+		} else if (this.kanban && board_name === this.kanban.board_name) {
 			this.kanban.update(this.data);
 		}
 	}

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -175,7 +175,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 				cur_list: this,
 				user_settings: this.view_user_settings,
 			});
-		} else if (this.kanban && board_name === this.kanban.board_name) {
+		} else if (board_name === this.kanban.board_name) {
 			this.kanban.update(this.data);
 		}
 	}


### PR DESCRIPTION
**Issue:**

<img width="1440" alt="Screenshot 2022-11-25 at 7 42 40 PM" src="https://user-images.githubusercontent.com/25857446/204006299-7515fe27-3017-44d6-85c7-c6eab2888293.png">

- The older logic called `kanban.update()` on a refresh (not on load) and built a new board on load
- Source: https://github.com/frappe/frappe/pull/18409/files#diff-ea11dc9b08e7598deacee82aaa1656000e287340160f1222f978b116acd75d58R180-R182
- After https://github.com/frappe/frappe/pull/18409, it calls `kanban.update()` AND builds a new board (both) on load, which invokes `update_order` twice consecutively and causes a timestamp error to be thrown
