### PR TITLE
fix: discovery and styling issues in grid buttons

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -61,57 +61,56 @@ export default class Grid {
 
 	make() {
 		let template = `
-			<label class="control-label">${__(this.df.label || "")}</label>
-			<span class="ml-1 help"></span>
-			<p class="text-muted small grid-description"></p>
-			<div class="grid-custom-buttons grid-field"></div>
-			<div class="form-grid-container">
-				<div class="form-grid">
-					<div class="grid-heading-row"></div>
-					<div class="grid-body">
-						<div class="rows"></div>
-						<div class="grid-empty text-center">
-							<img
-								src="/assets/frappe/images/ui-states/grid-empty-state.svg"
-								alt="Grid Empty State"
-								class="grid-empty-illustration"
-							>
-							${__("No Data")}
+			<div class="grid-field">
+				<label class="control-label">${__(this.df.label || "")}</label>
+				<span class="ml-1 help"></span>
+				<p class="text-muted small grid-description"></p>
+				<div class="grid-custom-buttons"></div>
+				<div class="form-grid-container">
+					<div class="form-grid">
+						<div class="grid-heading-row"></div>
+						<div class="grid-body">
+							<div class="rows"></div>
+							<div class="grid-empty text-center">
+								<img
+									src="/assets/frappe/images/ui-states/grid-empty-state.svg"
+									alt="Grid Empty State"
+									class="grid-empty-illustration"
+								>
+								${__("No Data")}
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
-			<div class="small form-clickable-section grid-footer">
-				<div class="flex justify-between">
-					<div class="grid-buttons">
-						<button class="btn btn-xs btn-danger grid-remove-rows hidden"
-							style="margin-right: 4px;"
-							data-action="delete_rows">
-							${__("Delete")}
-						</button>
-						<button class="btn btn-xs btn-danger grid-remove-all-rows hidden"
-							style="margin-right: 4px;"
-							data-action="delete_all_rows">
-							${__("Delete All")}
-						</button>
-						<button class="grid-add-multiple-rows btn btn-xs btn-secondary hidden"
-							style="margin-right: 4px;">
-							${__("Add Multiple")}</a>
-						</button>
-						<!-- hack to allow firefox include this in tabs -->
-						<button class="btn btn-xs btn-secondary grid-add-row">
-							${__("Add Row")}
-						</button>
-					</div>
-					<div class="grid-pagination">
-					</div>
-					<div class="text-right">
-						<a href="#" class="grid-download btn btn-xs btn-secondary hidden">
-							${__("Download")}
-						</a>
-						<a href="#" class="grid-upload btn btn-xs btn-secondary hidden">
-							${__("Upload")}
-						</a>
+				<div class="small form-clickable-section grid-footer">
+					<div class="flex justify-between">
+						<div class="grid-buttons">
+							<button class="btn btn-xs btn-danger grid-remove-rows hidden"
+								data-action="delete_rows">
+								${__("Delete")}
+							</button>
+							<button class="btn btn-xs btn-danger grid-remove-all-rows hidden"
+								data-action="delete_all_rows">
+								${__("Delete All")}
+							</button>
+							<button class="grid-add-multiple-rows btn btn-xs btn-secondary hidden">
+								${__("Add Multiple")}</a>
+							</button>
+							<!-- hack to allow firefox include this in tabs -->
+							<button class="btn btn-xs btn-secondary grid-add-row">
+								${__("Add Row")}
+							</button>
+						</div>
+						<div class="grid-pagination">
+						</div>
+						<div class="grid-bulk-actions text-right">
+							<button class="grid-download btn btn-xs btn-secondary hidden">
+								${__("Download")}
+							</button>
+							<button class="grid-upload btn btn-xs btn-secondary hidden">
+								${__("Upload")}
+							</button>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -1150,7 +1149,7 @@ export default class Grid {
 		const $wrapper = position === "top" ? this.grid_custom_buttons : this.grid_buttons;
 		let $btn = this.custom_buttons[label];
 		if (!$btn) {
-			$btn = $(`<button class="btn btn-default btn-xs btn-custom">${__(label)}</button>`)
+			$btn = $(`<button class="btn btn-secondary btn-xs btn-custom">${__(label)}</button>`)
 				.prependTo($wrapper)
 				.on("click", click);
 			this.custom_buttons[label] = $btn;

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -398,16 +398,21 @@
 	}
 }
 
-.grid-buttons {
+.grid-buttons, .grid-bulk-actions {
 	display: inline-flex;
 }
 
-.grid-footer {
+.grid-footer, .grid-custom-buttons {
 	padding: var(--padding-sm) 0px;
 	background-color: var(--fg-color);
 	.btn {
 		box-shadow: none;
 		margin-top: -3px;
+		margin-bottom: -3px;
+	}
+
+	.btn:not(:last-child) {
+		margin-right: 4px;
 	}
 }
 


### PR DESCRIPTION
Custom buttons did not work earlier (on top of the child table). 

## Before

### Wrapper 

![Screenshot 2022-11-25 203314](https://user-images.githubusercontent.com/10496564/204012309-28c47aad-98f8-4dee-988f-7e1f4413a63c.png)

hence `wrapper.find(".grid-custom-buttons")` did not work

### Buttons 
No button was added to the top

![image](https://user-images.githubusercontent.com/10496564/204012139-e2f0e2d7-a345-4c8d-86d5-1f29b9b136b0.png)

## After

### Buttons

![image](https://user-images.githubusercontent.com/10496564/204013548-36088343-ad0d-41d7-9654-4afd66f664dc.png)

### Wrapper

![image](https://user-images.githubusercontent.com/10496564/204013662-107a2d4d-7f2d-4367-a2ad-ed51ecbca999.png)


---
[Hide whitespace](https://github.com/frappe/frappe/pull/19012/files?diff=split&w=1) for a quick overview of changes.