### PR TITLE
fix: site creation using non-root users

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -119,7 +119,7 @@ class MariaDBConnectionUtil:
 			"use_unicode": True,
 		}
 
-		if self.user != "root":
+		if self.user not in (frappe.flags.root_login, "root"):
 			conn_settings["database"] = self.user
 
 		if self.port:


### PR DESCRIPTION
make sure non-root user you do end up using has all privileges + `with grant option`. 

closes https://github.com/frappe/frappe/issues/3354
