### PR TITLE
fix: Pass *args and **kwargs in `db_insert` boilerplate for Virtual DocType

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -296,7 +296,7 @@ def make_boilerplate(
 		controller_body = indent(
 			dedent(
 				"""
-			def db_insert(self):
+			def db_insert(self, *args, **kwargs):
 				pass
 
 			def load_from_db(self):


### PR DESCRIPTION
**Problem**: If `*args` and `**kwargs` are missing, we get the following error:

![image](https://user-images.githubusercontent.com/34810212/204126593-18d0e38f-bab1-4699-a390-e05209630dfd.png)
