### PR TITLE
refactor: request DB transaction

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -320,12 +320,13 @@ def handle_exception(e):
 
 def after_request(rollback):
 	# if HTTP method would change server state, commit if necessary
-	if frappe.db and (
-		frappe.local.flags.commit or frappe.local.request.method in UNSAFE_HTTP_METHODS
+	if (
+		frappe.db
+		and (frappe.local.flags.commit or frappe.local.request.method in UNSAFE_HTTP_METHODS)
+		and frappe.db.transaction_writes
 	):
-		if frappe.db.transaction_writes:
-			frappe.db.commit()
-			rollback = False
+		frappe.db.commit()
+		rollback = False
 
 	# update session
 	if getattr(frappe.local, "session_obj", None):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -327,6 +327,9 @@ def after_request(rollback):
 	):
 		frappe.db.commit()
 		rollback = False
+	elif frappe.db:
+		frappe.db.rollback()
+		rollback = False
 
 	# update session
 	if getattr(frappe.local, "session_obj", None):

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -77,7 +77,7 @@ def application(request: Request):
 		rollback = after_request(rollback)
 
 	finally:
-		if request.method in ("POST", "PUT") and frappe.db and rollback:
+		if request.method in UNSAFE_HTTP_METHODS and frappe.db and rollback:
 			frappe.db.rollback()
 
 		frappe.rate_limiter.update()


### PR DESCRIPTION
- Simplify after_request a bit by flattening conditions
- Apply rollback on all methods that can write
- Apply rollback early to avoid committing things by mistake when updating session
