### PR TITLE
fix: empty search shows `None`

### DIFF
--- a/frappe/templates/includes/navbar/navbar_search.html
+++ b/frappe/templates/includes/navbar/navbar_search.html
@@ -2,7 +2,7 @@
 	<li>
 		<form action='/search'>
 		<input name='q' class='form-control navbar-search' type='text'
-			value='{{ frappe.form_dict.q|e or ''}}'
+			value='{{ frappe.form_dict.q|e if frappe.form_dict.q else ''}}'
 			{% if not frappe.form_dict.q%}placeholder="{{ _("Search...") }}"{% endif %}>
 		</form>
 	</li>


### PR DESCRIPTION
fixes this

![image](https://user-images.githubusercontent.com/9079960/204731440-9f14daf7-3fe6-41d5-9dc6-e696563a5f71.png)
