### PR TITLE
fix: check for bad zip files during unzipping in file doctype

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -423,7 +423,10 @@ class File(Document):
 					continue
 
 				file_doc = frappe.new_doc("File")
-				file_doc.content = z.read(file.filename)
+				try:
+					file_doc.content = z.read(file.filename)
+				except zipfile.BadZipFile:
+					frappe.throw(_("{0} is a bad zip file").format(self.file_name))
 				file_doc.file_name = filename
 				file_doc.folder = self.folder
 				file_doc.is_private = self.is_private

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -426,7 +426,7 @@ class File(Document):
 				try:
 					file_doc.content = z.read(file.filename)
 				except zipfile.BadZipFile:
-					frappe.throw(_("{0} is a bad zip file").format(self.file_name))
+					frappe.throw(_("{0} is a not a valid zip file").format(self.file_name))
 				file_doc.file_name = filename
 				file_doc.folder = self.folder
 				file_doc.is_private = self.is_private


### PR DESCRIPTION
Before the error message was a exception message of `zipfile`

After:
<img width="973" alt="image" src="https://user-images.githubusercontent.com/30789322/204743986-6187b4b2-b4ed-49d7-8357-7ebc10d31d60.png">
