### PR TITLE
fix: do not escape undefined txt

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -246,6 +246,7 @@ Object.assign(frappe.utils, {
 	},
 
 	escape_html: function (txt) {
+		if (!txt) return "";
 		let escape_html_mapping = {
 			"&": "&amp;",
 			"<": "&lt;",


### PR DESCRIPTION
Before:
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/30859809/204770488-dd95f696-748f-45f7-90b8-a7b9c4158ae0.png">

After:
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/30859809/204770395-94080486-f211-41f9-8e79-0d985c71c9bb.png">
