### PR TITLE
fix: socketio spawn error

### DIFF
--- a/socketio.js
+++ b/socketio.js
@@ -303,7 +303,7 @@ function can_subscribe_list(args) {
 				}
 				return false;
 			} else if (res.status == 200) {
-				args.callback(err, res);
+				args.callback && args.callback(err, res);
 				return true;
 			}
 			log("ERROR (can_subscribe_list): ", err, res);

--- a/socketio.js
+++ b/socketio.js
@@ -303,7 +303,7 @@ function can_subscribe_list(args) {
 				}
 				return false;
 			} else if (res.status == 200) {
-				args?.callback(err, res);
+				args.callback(err, res);
 				return true;
 			}
 			log("ERROR (can_subscribe_list): ", err, res);


### PR DESCRIPTION
Restarting supervisorctl fails when attempting to spawn the instance due to syntax.

closes #19062