### PR TITLE
perf: dont clear all cache during default install

### DIFF
--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -241,4 +241,6 @@ def get_defaults_for(parent="__default"):
 
 
 def _clear_cache(parent):
+	if frappe.flags.in_install:
+		return
 	frappe.clear_cache(user=parent if parent not in common_default_keys else None)


### PR DESCRIPTION
When installing frappe all system settings are for some reason moved to tabDefaultValue, each default insert clears cache so meta is fetched again on each insert.

Overall this results in ~12% of install time. This is almost entirely removed from install step so installs are 12% faster now :rocket: 

![image](https://user-images.githubusercontent.com/9079960/205018996-eb98e621-6284-4138-be26-7e6ed6d746c0.png)
