### PR TITLE
fix: don't validate to & from dates if any one is missing in validate_from_to_dates

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1507,15 +1507,21 @@ class Document(BaseDocument):
 			frappe.local.locked_documents.remove(self)
 
 	# validation helpers
-	def validate_from_to_dates(self, from_date_field, to_date_field):
+	def validate_from_to_dates(self, from_date_field: str, to_date_field: str) -> None:
 		"""
 		Generic validation to verify date sequence
 		"""
-		if date_diff(self.get(to_date_field), self.get(from_date_field)) < 0:
+		from_date = self.get(from_date_field)
+		to_date = self.get(to_date_field)
+		if not (from_date and to_date):
+			return
+
+		# an empty to_date is deemed to be later than every possible from_date
+		if date_diff(to_date, from_date) < 0:
 			frappe.throw(
 				_("{0} must be after {1}").format(
-					frappe.bold(self.meta.get_label(to_date_field)),
-					frappe.bold(self.meta.get_label(from_date_field)),
+					frappe.bold(_(self.meta.get_label(to_date_field))),
+					frappe.bold(_(self.meta.get_label(from_date_field))),
 				),
 				frappe.exceptions.InvalidDates,
 			)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1506,17 +1506,13 @@ class Document(BaseDocument):
 		if self in frappe.local.locked_documents:
 			frappe.local.locked_documents.remove(self)
 
-	# validation helpers
 	def validate_from_to_dates(self, from_date_field: str, to_date_field: str) -> None:
-		"""
-		Generic validation to verify date sequence
-		"""
+		"""Validate that the value of `from_date_field` is not later than the value of `to_date_field`."""
 		from_date = self.get(from_date_field)
 		to_date = self.get(to_date_field)
 		if not (from_date and to_date):
 			return
 
-		# an empty to_date is deemed to be later than every possible from_date
 		if date_diff(to_date, from_date) < 0:
 			frappe.throw(
 				_("{0} must be after {1}").format(

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -424,6 +424,30 @@ class TestDocument(FrappeTestCase):
 
 		self.assertRaises(frappe.DoesNotExistError, doc.save)
 
+	def test_validate_from_to_dates(self):
+		doc = frappe.new_doc("Web Page")
+		doc.start_date = None
+		doc.end_date = None
+		doc.validate_from_to_dates("start_date", "end_date")
+
+		doc.start_date = "2020-01-01"
+		doc.end_date = None
+		doc.validate_from_to_dates("start_date", "end_date")
+
+		doc.start_date = None
+		doc.end_date = "2020-12-31"
+		doc.validate_from_to_dates("start_date", "end_date")
+
+		doc.start_date = "2020-01-01"
+		doc.end_date = "2020-12-31"
+		doc.validate_from_to_dates("start_date", "end_date")
+
+		doc.end_date = "2020-01-01"
+		doc.start_date = "2020-12-31"
+		self.assertRaises(
+			frappe.exceptions.InvalidDates, doc.validate_from_to_dates, "start_date", "end_date"
+		)
+
 
 class TestDocumentWebView(FrappeTestCase):
 	def get(self, path, user="Guest"):


### PR DESCRIPTION
- Previously, if either date was missing, we implicitly compared it to the current date. Now we don't compare at all.
- Previously, the error message was translated but field labels were not. Now we translate the field labels as well.
- Added a test for this method

https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)#validate-from-and-to-dates