### PR TITLE
fix: consistent translation in meta.get_label

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -259,14 +259,13 @@ class Meta(Document):
 
 	def get_label(self, fieldname):
 		"""Get label of the given fieldname"""
-
 		if df := self.get_field(fieldname):
 			return df.label
 
 		if fieldname in DEFAULT_FIELD_LABELS:
 			return DEFAULT_FIELD_LABELS[fieldname]()
 
-		return _("No Label")
+		return "No Label"
 
 	def get_options(self, fieldname):
 		return self.get_field(fieldname).options


### PR DESCRIPTION
For "normal" cases, `meta.get_label` returns the untranslated label. Therefore, we should keep the "No label" string untranslated as well.