### PR TITLE
ENH: kanban view can be disabled by custom flag named skip_kanban

### DIFF
--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -108,7 +108,9 @@ frappe.views.ListViewSelect = class ListViewSelect {
 				action: () => this.set_route("tree"),
 			},
 			Kanban: {
-				condition: this.doctype != "File",
+				condition:
+					this.doctype != "File" &&
+					!(frappe.listview_settings[this.doctype] != null && frappe.listview_settings[this.doctype].skip_kanban),
 				action: () => this.setup_kanban_boards(),
 				current_view_handler: () => {
 					frappe.views.KanbanView.get_kanbans(this.doctype).then((kanbans) =>


### PR DESCRIPTION
### Hide Kanban view for custom doctypes
I’m working on my first custom frappe app and I need to hide kanban menu item from view selection dropdown.

At the moment the only way I found is customizing the Kanban view configuration in the setup_views function at the following path: sites/assets/frappe/js/frappe/list/list_view_select.js.

Please refer to my forum post form more details.

[Hide Kanban view for custom doctypes](https://discuss.erpnext.com/t/hide-kanban-view-for-custom-doctypes/97959)