### PR TITLE
fix(UX): freeze on delete

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -644,6 +644,8 @@ $.extend(frappe.model, {
 					doctype: doctype,
 					name: docname,
 				},
+				freeze: true,
+				freeze_message: __("Deleting {0}...", [title]),
 				callback: function (r, rt) {
 					if (!r.exc) {
 						frappe.utils.play_sound("delete");


### PR DESCRIPTION
### Before

https://user-images.githubusercontent.com/14891507/205492933-716d3d51-44e6-40a9-8264-4d856e6f7637.mov

Imagine, some `on_trash` hooks taking a couple of seconds... Users click on "Delete" and nothing happens. They just see the normal view, maybe click on delete again, or navigate to a different page. This may lead to unnecessary error messages and a buggy UX.

### After

https://user-images.githubusercontent.com/14891507/205492940-cf152102-7f5b-450a-b483-6588dd6f417e.mov

Screen gets frozen during deletion, with a message showing clearly what is happening.