### PR TITLE
fix: ignore empty/`None` scripts

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -156,6 +156,9 @@ class FormMeta(Meta):
 		list_script = ""
 		form_script = ""
 		for script in client_scripts:
+			if not script.script:
+				continue
+
 			if script.view == "List":
 				list_script += f"""
 // {script.name}
@@ -163,7 +166,7 @@ class FormMeta(Meta):
 
 """
 
-			if script.view == "Form":
+			elif script.view == "Form":
 				form_script += f"""
 // {script.name}
 {script.script}


### PR DESCRIPTION
Ignore empty custom scripts. 


```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 38, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 76, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1457, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/load.py", line 78, in getdoctype
    docs = get_meta_bundle(doctype)
  File "apps/frappe/frappe/desk/form/load.py", line 89, in get_meta_bundle
    bundle = [frappe.desk.form.meta.get_meta(doctype)]
  File "apps/frappe/frappe/desk/form/meta.py", line 49, in get_meta
    meta = FormMeta(doctype)
  File "apps/frappe/frappe/desk/form/meta.py", line 63, in __init__
    self.load_assets()
  File "apps/frappe/frappe/desk/form/meta.py", line 80, in load_assets
    self.add_custom_script()
  File "apps/frappe/frappe/desk/form/meta.py", line 178, in add_custom_script
    form_script += script.script
TypeError: can only concatenate str (not "NoneType") to str
```