### PR TITLE
fix: disable signups by default

### DIFF
--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -169,6 +169,7 @@ def before_tests():
 	if not int(frappe.db.get_single_value("System Settings", "setup_complete") or 0):
 		complete_setup_wizard()
 
+	frappe.db.set_value("Website Settings", "Website Settings", "disable_signup", 0)
 	frappe.db.commit()
 	frappe.clear_cache()
 

--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -247,7 +247,7 @@
    "read_only": 1
   },
   {
-   "default": "0",
+   "default": "1",
    "description": "Disable Customer Signup link in Login page",
    "fieldname": "disable_signup",
    "fieldtype": "Check",
@@ -476,7 +476,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-10-18 09:50:24.621839",
+ "modified": "2022-12-05 04:17:56.478757",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",


### PR DESCRIPTION
tested locally by creating a new site. this will only apply to new sites.