### PR TITLE
build: Bump minimum required MariaDB version

### DIFF
--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -135,9 +135,9 @@ def check_compatible_versions():
 		version = get_mariadb_version()
 		version_tuple = tuple(int(v) for v in version[0].split("."))
 
-		if version_tuple < (10, 3):
+		if version_tuple < (10, 6):
 			click.secho(
-				f"Warning: MariaDB version {version} is less than 10.3 which is not supported by Frappe",
+				f"Warning: MariaDB version {version} is less than 10.6 which is not supported by Frappe",
 				fg="yellow",
 			)
 		elif version_tuple >= (10, 9):


### PR DESCRIPTION
10.3 is 5 months away from EOL, 10.6 is current LTS and it's already tested with FF and works fine.

Develop branch/v15 will require 10.6 minimum. You will not notice any immediate breakages apart from a warning on install. Most of our code is still compatible, but after this developers are free to use new features.

NOTE: We might still update it to 10.11 if that makes sense before `version-15` release.

ref: https://endoflife.date/mariadb
