### PR TITLE
fix: give more weight to sequential matches

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
+++ b/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
@@ -14,7 +14,7 @@
 //	 J�rgen Tjern� - async helper
 //	 Anurag Awasthi - updated to 0.2.0
 
-const SEQUENTIAL_BONUS = 15; // bonus for adjacent matches
+const SEQUENTIAL_BONUS = 25; // bonus for adjacent matches
 const SEPARATOR_BONUS = 30; // bonus if match occurs after a separator
 const CAMEL_BONUS = 30; // bonus if match is uppercase and prev is lower
 const FIRST_LETTER_BONUS = 15; // bonus if the first letter is matched


### PR DESCRIPTION
Tweak reward in fuzzy matcher to giver higher preferences to continuous sequential matches.


This improves searches for doctypes like `Item`, `Employee`.


TODO: Manual testing a bit (?)

Following things should continue to work:
- [x] decent typo tolerance for edit distance of ~2
- [x] Acronyms - `so` -> Sales Order
- [ ] Give extra preference to FULL matches somehow?


Item

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/9079960/205633371-650a4e65-7a08-4d8d-99e6-1a656f05849d.png) | ![image](https://user-images.githubusercontent.com/9079960/205633041-319ce51a-97ba-4be0-a098-71b3a320e42f.png) |
| ![image](https://user-images.githubusercontent.com/9079960/205633335-90c29f66-2b00-43a1-a0b1-7d8a40c78de3.png) | ![image](https://user-images.githubusercontent.com/9079960/205633262-b948831c-8f08-4ea5-807d-355a8affc777.png) |
