### PR TITLE
perf: remove redundant render template call

### DIFF
--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -62,10 +62,6 @@ class WebsiteTheme(Document):
 	def generate_bootstrap_theme(self):
 		from subprocess import PIPE, Popen
 
-		self.theme_scss = frappe.render_template(
-			"frappe/website/doctype/website_theme/website_theme_template.scss", self.as_dict()
-		)
-
 		# create theme file in site public files folder
 		folder_path = abspath(frappe.utils.get_files_path("website_theme", is_private=False))
 		# create folder if not exist


### PR DESCRIPTION
It is getting set again here: 

https://github.com/frappe/frappe/blob/1916a815caa71dd53812f47126f68844d082a7bf/frappe/website/doctype/website_theme/website_theme.py#L78

The [`get_scss`](https://github.com/frappe/frappe/blob/1916a815caa71dd53812f47126f68844d082a7bf/frappe/website/doctype/website_theme/website_theme.py#L139) function calls returns exact same render template (that is being removed) with some extra context.