### PR TITLE
fix: LDAP - check each email in list before creating user

### DIFF
--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.json
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.json
@@ -24,6 +24,7 @@
   "ldap_email_field",
   "ldap_username_field",
   "ldap_first_name_field",
+  "do_not_create_new_user",
   "column_break_19",
   "ldap_middle_name_field",
   "ldap_last_name_field",
@@ -289,12 +290,19 @@
    "fieldname": "section_break_40",
    "fieldtype": "Section Break",
    "hide_border": 1
+  },
+  {
+   "default": "0",
+   "description": "Do not create new user if user with email does not exist in the system",
+   "fieldname": "do_not_create_new_user",
+   "fieldtype": "Check",
+   "label": "Do Not Create New User "
   }
  ],
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-07-07 16:51:46.230793",
+ "modified": "2022-12-05 21:52:31.146035",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "LDAP Settings",

--- a/frappe/integrations/doctype/ldap_settings/ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/ldap_settings.py
@@ -172,7 +172,7 @@ class LDAPSettings(Document):
 		if frappe.db.exists("User", user_data["email"]):
 			user = frappe.get_doc("User", user_data["email"])
 			LDAPSettings.update_user_fields(user=user, user_data=user_data)
-		else:
+		elif not self.do_not_create_new_user:
 			doc = user_data | {
 				"doctype": "User",
 				"send_welcome_email": 0,
@@ -181,6 +181,12 @@ class LDAPSettings(Document):
 			}
 			user = frappe.get_doc(doc)
 			user.insert(ignore_permissions=True)
+		else:
+			frappe.throw(
+				_(
+					"User with email: {0} does not exist in the system. Please ask 'System Administrator' to create the user for you."
+				).format(user_data["email"])
+			)
 
 		if self.default_user_type == "System User":
 			role = self.default_role
@@ -324,11 +330,21 @@ class LDAPSettings(Document):
 
 	def convert_ldap_entry_to_dict(self, user_entry: Entry):
 		# support multiple email values
-		email = user_entry[self.ldap_email_field]
+		email = user_entry[self.ldap_email_field].value
+
+		if isinstance(email, list):
+			# check if any of the email in the list already exist
+			for e in email:
+				if frappe.db.exists("User", e):
+					email = e
+					break
+			else:
+				# if none of the email exist, use the first email
+				email = email[0]
 
 		data = {
 			"username": user_entry[self.ldap_username_field].value,
-			"email": str(email.value[0] if isinstance(email.value, list) else email.value),
+			"email": email,
 			"first_name": user_entry[self.ldap_first_name_field].value,
 		}
 


### PR DESCRIPTION
**Issue:** If the LDAP server has users with multiple emails, we only check if the first user exists in the system, if not we create a new user

**Fix:** If any of the emails in the list exists in the system log in with that user. If non exist create a new user with the first email in the list. 

Also, added a check `do_not_create_new_user`. If it is set the new user will not be created an error will come. By default it is not set
<img width="511" alt="image" src="https://user-images.githubusercontent.com/30859809/205695572-a0966763-6ee4-4b8a-be49-7c984e358034.png">
