### PR TITLE
fix: type conversion for read receipt in communication email

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -92,7 +92,7 @@ def make(
 		send_me_a_copy=cint(send_me_a_copy),
 		cc=cc,
 		bcc=bcc,
-		read_receipt=read_receipt,
+		read_receipt=cint(read_receipt),
 		print_letterhead=print_letterhead,
 		email_template=email_template,
 		communication_type=communication_type,


### PR DESCRIPTION
Closes: #19103 

**Issue**
`Send Read Receipt` in the email Communication composer was not working as expected. Form values are passed as a string.
So, `mail.msg_root["Disposition-Notification-To"] = <sender-name>` is always being set.

![image](https://user-images.githubusercontent.com/54097382/205827175-5b58a536-7822-436a-9a60-7ee0a99e2d93.png)

