### PR TITLE
feat: operation level locking for CLI commands

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2214,6 +2214,10 @@ def log_error(title=None, message=None, reference_doctype=None, reference_name=N
 	title = title or "Error"
 	traceback = as_unicode(traceback or get_traceback(with_context=True))
 
+	if not db:
+		print(f"Failed to log error in db: {title}")
+		return
+
 	error_log = get_doc(
 		doctype="Error Log",
 		error=traceback,

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -76,40 +76,38 @@ def _new_site(
 
 	make_site_dirs()
 
-	installing = touch_file(get_site_path("locks", "installing.lock"))
+	with filelock("bench_new_site", timeout=1):
+		install_db(
+			root_login=db_root_username,
+			root_password=db_root_password,
+			db_name=db_name,
+			admin_password=admin_password,
+			verbose=verbose,
+			source_sql=source_sql,
+			force=force,
+			reinstall=reinstall,
+			db_password=db_password,
+			db_type=db_type,
+			db_host=db_host,
+			db_port=db_port,
+			no_mariadb_socket=no_mariadb_socket,
+		)
 
-	install_db(
-		root_login=db_root_username,
-		root_password=db_root_password,
-		db_name=db_name,
-		admin_password=admin_password,
-		verbose=verbose,
-		source_sql=source_sql,
-		force=force,
-		reinstall=reinstall,
-		db_password=db_password,
-		db_type=db_type,
-		db_host=db_host,
-		db_port=db_port,
-		no_mariadb_socket=no_mariadb_socket,
-	)
-	apps_to_install = (
-		["frappe"] + (frappe.conf.get("install_apps") or []) + (list(install_apps) or [])
-	)
+		apps_to_install = (
+			["frappe"] + (frappe.conf.get("install_apps") or []) + (list(install_apps) or [])
+		)
 
-	for app in apps_to_install:
-		# NOTE: not using force here for 2 reasons:
-		# 	1. It's not really needed here as we've freshly installed a new db
-		# 	2. If someone uses a sql file to do restore and that file already had
-		# 		installed_apps then it might cause problems as that sql file can be of any previous version(s)
-		# 		which might be incompatible with the current version and using force might cause problems.
-		# 		Example: the DocType DocType might not have `migration_hash` column which will cause failure in the restore.
-		install_app(app, verbose=verbose, set_as_patched=not source_sql, force=False)
+		for app in apps_to_install:
+			# NOTE: not using force here for 2 reasons:
+			# 	1. It's not really needed here as we've freshly installed a new db
+			# 	2. If someone uses a sql file to do restore and that file already had
+			# 		installed_apps then it might cause problems as that sql file can be of any previous version(s)
+			# 		which might be incompatible with the current version and using force might cause problems.
+			# 		Example: the DocType DocType might not have `migration_hash` column which will cause failure in the restore.
+			install_app(app, verbose=verbose, set_as_patched=not source_sql, force=False)
 
-	os.remove(installing)
-
-	scheduler.toggle_scheduler(enable_scheduler)
-	frappe.db.commit()
+		scheduler.toggle_scheduler(enable_scheduler)
+		frappe.db.commit()
 
 	scheduler_status = "disabled" if frappe.utils.scheduler.is_scheduler_disabled() else "enabled"
 	print("*** Scheduler is", scheduler_status, "***")

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -9,6 +9,7 @@ from whoosh.fields import ID, TEXT, Schema
 import frappe
 from frappe.search.full_text_search import FullTextSearch
 from frappe.utils import set_request, update_progress_bar
+from frappe.utils.synchronization import filelock
 from frappe.website.serve import get_response_content
 
 INDEX_NAME = "web_routes"
@@ -140,6 +141,7 @@ def remove_document_from_index(path):
 	return ws.remove_document_from_index(path)
 
 
+@filelock("building_website_search")
 def build_index_for_all_routes():
 	ws = WebsiteSearch(INDEX_NAME)
 	return ws.build()

--- a/frappe/utils/synchronization.py
+++ b/frappe/utils/synchronization.py
@@ -43,7 +43,7 @@ def filelock(lock_name: str, *, timeout=30, is_global=False):
 		frappe.log_error("Filelock: Failed to aquire {lock_path}")
 
 		raise LockTimeoutError(
-			_("Failed to aquire lock: {}").format(lock_name)
+			_("Failed to aquire lock: {}. Lock may be held by another process.").format(lock_name)
 			+ "<br>"
 			+ _("You can manually remove the lock if you think it's safe: {}").format(lock_path)
 		) from e


### PR DESCRIPTION
This prevents mistakenly issuing same commands twice which can be dangerous.

added global lock(s):
- [x] bench build

added site level lock(s):
- [x] new-site
- [x] migrate
- [x] install-app
- [x] restore
- [x] uninstall-app

closes https://github.com/frappe/frappe/issues/13215
extends https://github.com/frappe/frappe/pull/19133


`no-docs`