### PR TITLE
build(deps): allow later stripe versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ semantic-version~=2.8.5
 simple-chalk~=0.1.0
 six~=1.15.0
 sqlparse~=0.4.1
-stripe~=2.56.0
+stripe>=2.56.0,<=5.0.0
 terminaltables~=3.1.0
 unittest-xml-reporting~=3.0.4
 urllib3~=1.26.4


### PR DESCRIPTION
Upgrade stripe library requirement.
Required for a new upgraded stripe integration to go live on frappe cloud

Tested and working
frappe >=v14 stripe integration has been moved to the new payments app
I will also patch that