### PR TITLE
fix: translate doctype in link error

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -364,7 +364,7 @@ def raise_link_exists_exception(doc, reference_doctype, reference_docname, row="
 
 	frappe.throw(
 		_("Cannot delete or cancel because {0} {1} is linked with {2} {3} {4}").format(
-			doc.doctype, doc_link, reference_doctype, reference_link, row
+			_(doc.doctype), doc_link, _(reference_doctype), reference_link, row
 		),
 		frappe.LinkExistsError,
 	)


### PR DESCRIPTION
Problem: english doctype names in an otherwise translated error message.
Fix: translate doctype names.