### PR TITLE
fix: stabilize shared with dialog

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/share.js
+++ b/frappe/public/js/frappe/form/sidebar/share.js
@@ -17,9 +17,12 @@ frappe.ui.form.Share = class Share {
 			this.parent.find(".share-doc-btn").hide();
 		}
 
-		this.parent.find(".share-doc-btn").on("click", () => {
-			this.frm.share_doc();
-		});
+		this.parent
+			.find(".share-doc-btn")
+			.off("click")
+			.on("click", () => {
+				this.frm.share_doc();
+			});
 
 		this.shares.empty();
 
@@ -41,6 +44,8 @@ frappe.ui.form.Share = class Share {
 		this.dialog = d;
 		this.dirty = false;
 
+		$(d.body).html('<p class="text-muted">' + __("Loading...") + "</p>");
+
 		frappe.call({
 			method: "frappe.share.get_users",
 			args: {
@@ -51,8 +56,6 @@ frappe.ui.form.Share = class Share {
 				me.render_shared(r.message || []);
 			},
 		});
-
-		$(d.body).html('<p class="text-muted">' + __("Loading...") + "</p>");
 
 		d.onhide = function () {
 			// reload comments
@@ -188,7 +191,6 @@ frappe.ui.form.Share = class Share {
 						}
 
 						me.dirty = true;
-						me.render_shared();
 						me.frm.shared.refresh();
 					},
 				});

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -82,7 +82,7 @@ def remove(doctype, name, user, flags=None):
 @frappe.whitelist()
 def set_permission(doctype, name, user, permission_to, value=1, everyone=0):
 	"""Expose function without flags to the client-side"""
-	set_docshare_permission(doctype, name, user, permission_to, value=value, everyone=everyone)
+	return set_docshare_permission(doctype, name, user, permission_to, value=value, everyone=everyone)
 
 
 def set_docshare_permission(doctype, name, user, permission_to, value=1, everyone=0, flags=None):


### PR DESCRIPTION
This pr fixes the weird behavior of shared with dialog.

the main causes are:
1. setting of multiple click events for opening shared with dialog
2. no return value when setting share permissions (via `frappe.share.set_permission`) even though they're being used on the client side - this is used in updating the avatar on the form sidebar

#

Before:


https://user-images.githubusercontent.com/32034600/206275380-76be9779-e3a7-4312-bd58-7306660062a4.mp4



After:

https://user-images.githubusercontent.com/32034600/206274826-590483b4-ebde-4670-94a1-5a44556dcb39.mp4


