### PR TITLE
fix: restore `_dict` in safe exec, override RestrictedPython transformer to add compatibility

### DIFF
--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -104,9 +104,8 @@ def patch_query_execute():
 				# frame1: execute_query()
 				# frame2: frame that called `query.run()`
 				#
-				# if frame2 is server script it wont have a filename and hence
+				# if frame2 is server script <serverscript> is set as the filename
 				# it shouldn't be allowed.
-				# p.s. stack() returns `"<unknown>"` as filename if not a file.
 				pass
 			else:
 				raise frappe.PermissionError("Only SELECT SQL allowed in scripting")

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -76,5 +76,9 @@ class TestSafeExec(FrappeTestCase):
 		unsafe_global = {"frappe": frappe}
 		self.assertRaises(SyntaxError, safe_exec, """frappe.msgprint("Hello")""", unsafe_global)
 
-	def test_frappe_dict_in_jinja(self):
+	def test_attrdict(self):
+		# jinja
 		frappe.render_template("{% set my_dict = _dict() %} {{- my_dict.works -}}")
+
+		# RestrictedPython
+		safe_exec("my_dict = _dict()")

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -75,3 +75,6 @@ class TestSafeExec(FrappeTestCase):
 	def test_unsafe_objects(self):
 		unsafe_global = {"frappe": frappe}
 		self.assertRaises(SyntaxError, safe_exec, """frappe.msgprint("Hello")""", unsafe_global)
+
+	def test_frappe_dict_in_jinja(self):
+		frappe.render_template("{% set my_dict = _dict() %} {{- my_dict.works -}}", {})

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -77,4 +77,4 @@ class TestSafeExec(FrappeTestCase):
 		self.assertRaises(SyntaxError, safe_exec, """frappe.msgprint("Hello")""", unsafe_global)
 
 	def test_frappe_dict_in_jinja(self):
-		frappe.render_template("{% set my_dict = _dict() %} {{- my_dict.works -}}", {})
+		frappe.render_template("{% set my_dict = _dict() %} {{- my_dict.works -}}")

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -76,7 +76,7 @@ def render_template(template, context=None, is_path=None, safe_render=True):
 	if not template:
 		return ""
 
-	if not context:
+	if context is None:
 		context = {}
 
 	if is_path or guess_is_path(template):

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -60,7 +60,7 @@ def validate_template(html):
 		frappe.throw(frappe._("Syntax error in template"))
 
 
-def render_template(template, context, is_path=None, safe_render=True):
+def render_template(template, context=None, is_path=None, safe_render=True):
 	"""Render a template using Jinja
 
 	:param template: path or HTML containing the jinja template
@@ -75,6 +75,9 @@ def render_template(template, context, is_path=None, safe_render=True):
 
 	if not template:
 		return ""
+
+	if not context:
+		context = {}
 
 	if is_path or guess_is_path(template):
 		return get_jenv().get_template(template).render(context)

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -78,8 +78,11 @@ def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=Fals
 
 	with safe_exec_flags(), patched_qb():
 		# execute script compiled by RestrictedPython
-		# pylint: disable-next=exec-used
-		exec(compile_restricted(script, policy=FrappeTransformer), exec_globals, _locals)
+		exec(
+			compile_restricted(script, filename="<serverscript>", policy=FrappeTransformer),
+			exec_globals,
+			_locals,
+		)
 
 	return exec_globals, _locals
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 import RestrictedPython.Guards
 from RestrictedPython import compile_restricted, safe_globals
+from RestrictedPython.transformer import RestrictingNodeTransformer
 
 import frappe
 import frappe.exceptions
@@ -45,6 +46,14 @@ class NamespaceDict(frappe._dict):
 		return ret
 
 
+class FrappeTransformer(RestrictingNodeTransformer):
+	def check_name(self, node, name, *args, **kwargs):
+		if name == "_dict":
+			return
+
+		return super().check_name(node, name, *args, **kwargs)
+
+
 def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=False):
 	# server scripts can be disabled via site_config.json
 	# they are enabled by default
@@ -69,7 +78,9 @@ def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=Fals
 
 	with safe_exec_flags(), patched_qb():
 		# execute script compiled by RestrictedPython
-		exec(compile_restricted(script), exec_globals, _locals)  # pylint: disable=exec-used
+		exec(
+			compile_restricted(script, policy=FrappeTransformer), exec_globals, _locals
+		)  # pylint: disable=exec-used
 
 	return exec_globals, _locals
 
@@ -105,7 +116,7 @@ def get_safe_globals():
 		json=NamespaceDict(loads=json.loads, dumps=json.dumps),
 		as_json=frappe.as_json,
 		dict=dict,
-		_dict=frappe._dict,  # this isn't usable with RestrictedPython, but kept for Jinja compatibility
+		_dict=frappe._dict,
 		log=frappe.log,
 		args=form_dict,
 		frappe=NamespaceDict(
@@ -117,7 +128,6 @@ def get_safe_globals():
 			time_format=time_format,
 			format_date=frappe.utils.data.global_date_format,
 			form_dict=form_dict,
-			as_dict=frappe._dict,
 			bold=frappe.bold,
 			copy_doc=frappe.copy_doc,
 			errprint=frappe.errprint,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -78,9 +78,8 @@ def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=Fals
 
 	with safe_exec_flags(), patched_qb():
 		# execute script compiled by RestrictedPython
-		exec(
-			compile_restricted(script, policy=FrappeTransformer), exec_globals, _locals
-		)  # pylint: disable=exec-used
+		# pylint: disable-next=exec-used
+		exec(compile_restricted(script, policy=FrappeTransformer), exec_globals, _locals)
 
 	return exec_globals, _locals
 

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -115,8 +115,8 @@ def get_safe_globals():
 		json=NamespaceDict(loads=json.loads, dumps=json.dumps),
 		as_json=frappe.as_json,
 		dict=dict,
-		_dict=frappe._dict,
 		log=frappe.log,
+		_dict=frappe._dict,
 		args=form_dict,
 		frappe=NamespaceDict(
 			call=call_whitelisted_function,

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -105,6 +105,7 @@ def get_safe_globals():
 		json=NamespaceDict(loads=json.loads, dumps=json.dumps),
 		as_json=frappe.as_json,
 		dict=dict,
+		_dict=frappe._dict,  # this isn't usable with RestrictedPython, but kept for Jinja compatibility
 		log=frappe.log,
 		args=form_dict,
 		frappe=NamespaceDict(


### PR DESCRIPTION
Also adds minor feature, ability to call `render_template` without specifying `context`