### PR TITLE
fix: allow changing counter for prefix-less series

### DIFF
--- a/frappe/core/doctype/document_naming_settings/document_naming_settings.py
+++ b/frappe/core/doctype/document_naming_settings/document_naming_settings.py
@@ -165,7 +165,7 @@ class DocumentNamingSettings(Document):
 	@frappe.whitelist()
 	def get_current(self):
 		"""get series current"""
-		if self.prefix:
+		if self.prefix is not None:
 			self.current_value = NamingSeries(self.prefix).get_current_value()
 		return self.current_value
 
@@ -173,7 +173,7 @@ class DocumentNamingSettings(Document):
 	def update_series_start(self):
 		frappe.only_for("System Manager")
 
-		if not self.prefix:
+		if self.prefix is None:
 			frappe.throw(_("Please select prefix first"))
 
 		naming_series = NamingSeries(self.prefix)
@@ -193,7 +193,7 @@ class DocumentNamingSettings(Document):
 	def create_version_log_for_change(self, series, old, new):
 		version = frappe.new_doc("Version")
 		version.ref_doctype = "Series"
-		version.docname = series
+		version.docname = series or ".#"
 		version.data = frappe.as_json({"changed": [["current", old, new]]})
 		version.flags.ignore_links = True  # series is not a "real" doctype
 		version.flags.ignore_permissions = True


### PR DESCRIPTION
Allow setting counter value of series having no prefix.
Eg: `.##.-.YY.-INV` or just `.#`

https://user-images.githubusercontent.com/52111700/206209954-23412403-c809-40e1-9265-399276ca900b.mp4

