### PR TITLE
fix: only make fetch_from field read only if no input

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -53,6 +53,14 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		}
 	}
 
+	read_only_because_of_fetch_from() {
+		return (
+			this.df.fetch_from &&
+			!this.df.fetch_if_empty &&
+			this.frm?.doc?.[this.df.fetch_from.split(".")[0]]
+		);
+	}
+
 	// update input value, label, description
 	// display (show/hide/read-only),
 	// mandatory style on refresh
@@ -83,7 +91,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 				me.value = me.doc[me.df.fieldname] || "";
 			}
 
-			let is_fetch_from_read_only = me.df.fetch_from && !me.df.fetch_if_empty;
+			let is_fetch_from_read_only = me.read_only_because_of_fetch_from();
 
 			if (me.can_write() && !is_fetch_from_read_only) {
 				me.disp_area && $(me.disp_area).toggle(false);


### PR DESCRIPTION
Edge case on https://github.com/frappe/frappe/pull/19025

Example:

- A field is a link field. 
- B is a field that uses A to fetch some data. 

Currently `B` is always made read-only. The read-only behavior only makes sense when `B` will get overridden by fetched value based on A, which won't happen if `A` is unset. 