### PR TITLE
refactor: html2text and fix diff render

### DIFF
--- a/frappe/core/doctype/version/version_view.html
+++ b/frappe/core/doctype/version/version_view.html
@@ -18,8 +18,8 @@
 		{% for item in data.changed %}
 		<tr>
 			<td>{{ frappe.meta.get_label(doc.ref_doctype, item[0]) }}</td>
-			<td class="diff-remove">{{ item[1] }}</td>
-			<td class="diff-add">{{ item[2] }}</td>
+			<td class="diff-remove">{{ frappe.utils.escape_html(item[1]) }}</td>
+			<td class="diff-add">{{ frappe.utils.escape_html(item[2]) }}</td>
 		</tr>
 		{% endfor %}
 	</tbody>
@@ -50,7 +50,7 @@
 							{% for row_key in item_keys %}
 							<tr>
 								<td class="small">{{ row_key }}</td>
-								<td class="small">{{ item[1][row_key] }}</td>
+								<td class="small">{{ frappe.utils.escape_html(item[1][row_key]) }}</td>
 							</tr>
 							{% endfor %}
 						</tbody>
@@ -85,8 +85,8 @@
 				<td>{{ frappe.meta.get_label(doc.ref_doctype, table_info[0]) }}</td>
 				<td>{{ table_info[1] }}</td>
 				<td>{{ item[0] }}</td>
-				<td class="diff-remove">{{ item[1] }}</td>
-				<td class="diff-add">{{ item[2] }}</td>
+				<td class="diff-remove">{{ frappe.utils.escape_html(item[1]) }}</td>
+				<td class="diff-add">{{ frappe.utils.escape_html(item[2]) }}</td>
 			</tr>
 			{% endfor %}
 		{% endfor %}

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -278,7 +278,6 @@ function format_content_for_timeline(content) {
 	// limits content to 40 characters
 	// escapes HTML
 	// and makes it bold
-	content = frappe.utils.html2text(content);
 	content = frappe.ellipsis(content, 40) || '""';
 	content = frappe.utils.escape_html(content);
 	return content.bold();

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -280,9 +280,9 @@ Object.assign(frappe.utils, {
 	},
 
 	html2text: function (html) {
-		let d = document.createElement("div");
-		d.innerHTML = html;
-		return d.textContent;
+		const parser = new DOMParser();
+		const dom = parser.parseFromString(html);
+		return dom.textContent;
 	},
 
 	is_url: function (txt) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -281,8 +281,8 @@ Object.assign(frappe.utils, {
 
 	html2text: function (html) {
 		const parser = new DOMParser();
-		const dom = parser.parseFromString(html);
-		return dom.textContent;
+		const dom = parser.parseFromString(html, "text/html");
+		return dom.body.textContent;
 	},
 
 	is_url: function (txt) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -843,13 +843,13 @@ frappe.views.CommunicationComposer = class {
 
 	html2text(html) {
 		// convert HTML to text and try and preserve whitespace
-		const d = document.createElement("div");
-		d.innerHTML = html
+
+		html = html
 			.replace(/<\/div>/g, "<br></div>") // replace end of blocks
 			.replace(/<\/p>/g, "<br></p>") // replace end of paragraphs
 			.replace(/<br>/g, "\n");
 
-		// replace multiple empty lines with just one
-		return d.textContent.replace(/\n{3,}/g, "\n\n");
+		const text = frappe.utils.html2text(html);
+		return text.replace(/\n{3,}/g, "\n\n");
 	}
 };


### PR DESCRIPTION
- Version diff behaves erratically when diffing code/html fields.
- html2text now uses new `DOMParser` API - https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
