### PR TITLE
fix: reload shared dialog upon checking any perm

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/share.js
+++ b/frappe/public/js/frappe/form/sidebar/share.js
@@ -191,6 +191,7 @@ frappe.ui.form.Share = class Share {
 						}
 
 						me.dirty = true;
+						me.render_shared();
 						me.frm.shared.refresh();
 					},
 				});


### PR DESCRIPTION
accidentally removed in #19170 