### PR TITLE
fix: log unknown usernames too for failed attempts

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -230,10 +230,11 @@ class LoginManager:
 		if not (user and pwd):
 			self.fail(_("Incomplete login details"), user=user)
 
+		_raw_user_name = user
 		user = User.find_by_credentials(user, pwd)
 
 		if not user:
-			self.fail("Invalid login credentials")
+			self.fail("Invalid login credentials", user=_raw_user_name)
 
 		# Current login flow uses cached credentials for authentication while checking OTP.
 		# Incase of OTP check, tracker for auth needs to be disabled(If not, it can remove tracker history as it is going to succeed anyway)


### PR DESCRIPTION
Previously username wasn't logged if user didn't exist. For logging purposes we should log all usernames too. 

![image](https://user-images.githubusercontent.com/9079960/206443516-248f256a-36bc-4145-9726-22802b277732.png)
