### PR TITLE
refactor: rename `_dict` to `attrdict`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -34,3 +34,6 @@ c0c5b2ebdddbe8898ce2d5e5365f4931ff73b6bf
 
 # db.get_all -> get_all
 2eec621e95564c359ad22da79501a855c1f32b03
+
+# _dict -> attrdict
+2b656aa5e95b13a4c7e9c8b497f145baedc5cbdf

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -61,7 +61,7 @@ if _dev_server:
 	warnings.simplefilter("always", PendingDeprecationWarning)
 
 
-class _dict(dict):
+class attrdict(dict):
 	"""dict like object that exposes keys as attributes"""
 
 	__slots__ = ()
@@ -80,7 +80,10 @@ class _dict(dict):
 		return self
 
 	def copy(self):
-		return _dict(self)
+		return attrdict(self)
+
+
+_dict = attrdict  # for backward compatibility
 
 
 def _(msg: str, lang: str | None = None, context: str | None = None) -> str:
@@ -191,7 +194,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False) -> None:
 	local.message_log = []
 	local.debug_log = []
 	local.realtime_log = []
-	local.flags = _dict(
+	local.flags = attrdict(
 		{
 			"currently_saving": [],
 			"redirect_location": "",
@@ -218,10 +221,10 @@ def init(site: str, sites_path: str = ".", new_site: bool = False) -> None:
 	local.all_apps = None
 
 	local.request_ip = None
-	local.response = _dict({"docs": []})
+	local.response = attrdict({"docs": []})
 	local.task_id = None
 
-	local.conf = _dict(get_site_config())
+	local.conf = attrdict(get_site_config())
 	local.lang = local.conf.lang or "en"
 
 	local.module_app = None
@@ -239,9 +242,9 @@ def init(site: str, sites_path: str = ".", new_site: bool = False) -> None:
 	local.jloader = None
 	local.cache = {}
 	local.document_cache = {}
-	local.form_dict = _dict()
+	local.form_dict = attrdict()
 	local.preload_assets = {"style": [], "script": []}
-	local.session = _dict()
+	local.session = attrdict()
 	local.dev_server = _dev_server
 	local.qb = get_query_builder(local.conf.db_type or "mariadb")
 	local.qb.engine = get_qb_engine()
@@ -319,7 +322,7 @@ def get_site_config(sites_path: str | None = None, site_path: str | None = None)
 		elif local.site and not local.flags.new_site:
 			raise IncorrectSitePath(f"{local.site} does not exist")
 
-	return _dict(config)
+	return attrdict(config)
 
 
 def get_conf(site: str | None = None) -> dict[str, Any]:
@@ -429,7 +432,7 @@ def msgprint(
 	from frappe.utils import strip_html_tags
 
 	msg = safe_decode(msg)
-	out = _dict(message=msg)
+	out = attrdict(message=msg)
 
 	@functools.lru_cache(maxsize=1024)
 	def _strip_html_tags(message):
@@ -550,9 +553,9 @@ def set_user(username: str):
 	local.session.user = username
 	local.session.sid = username
 	local.cache = {}
-	local.form_dict = _dict()
+	local.form_dict = attrdict()
 	local.jenv = None
-	local.session.data = _dict()
+	local.session.data = attrdict()
 	local.role_permissions = {}
 	local.new_doc_templates = {}
 	local.user_perms = None
@@ -846,12 +849,12 @@ def get_domain_data(module):
 	try:
 		domain_data = get_hooks("domains")
 		if module in domain_data:
-			return _dict(get_attr(get_hooks("domains")[module][0] + ".data"))
+			return attrdict(get_attr(get_hooks("domains")[module][0] + ".data"))
 		else:
-			return _dict()
+			return attrdict()
 	except ImportError:
 		if local.flags.in_test:
-			return _dict()
+			return attrdict()
 		else:
 			raise
 
@@ -1150,7 +1153,7 @@ def get_cached_value(
 
 	values = [doc.get(f) for f in fieldname]
 	if as_dict:
-		return _dict(zip(fieldname, values))
+		return attrdict(zip(fieldname, values))
 	return values
 
 
@@ -1461,7 +1464,7 @@ def _load_app_hooks(app_name: str | None = None):
 
 def get_hooks(
 	hook: str = None, default: Any | None = "_KEEP_DEFAULT_LIST", app_name: str = None
-) -> _dict:
+) -> attrdict:
 	"""Get hooks via `app/hooks.py`
 
 	:param hook: Name of the hook. Will gather all hooks for this name and return as a list.
@@ -1469,12 +1472,12 @@ def get_hooks(
 	:param app_name: Filter by app."""
 
 	if app_name:
-		hooks = _dict(_load_app_hooks(app_name))
+		hooks = attrdict(_load_app_hooks(app_name))
 	else:
 		if conf.developer_mode:
-			hooks = _dict(_load_app_hooks())
+			hooks = attrdict(_load_app_hooks())
 		else:
-			hooks = _dict(cache().get_value("app_hooks", _load_app_hooks))
+			hooks = attrdict(cache().get_value("app_hooks", _load_app_hooks))
 
 	if hook:
 		return hooks.get(hook, ([] if default == "_KEEP_DEFAULT_LIST" else default))
@@ -1630,7 +1633,7 @@ def make_property_setter(
 
 	If doctype is not specified, it will create a property setter for all fields with the
 	given fieldname"""
-	args = _dict(args)
+	args = attrdict(args)
 	if not args.doctype_or_field:
 		args.doctype_or_field = "DocField"
 		if not args.property_type:

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -221,7 +221,7 @@ def make_form_dict(request):
 	if not isinstance(args, dict):
 		frappe.throw(_("Invalid request arguments"))
 
-	frappe.local.form_dict = frappe._dict(args)
+	frappe.local.form_dict = frappe.attrdict(args)
 
 	if "_" in frappe.local.form_dict:
 		# _ is passed by $.ajax so that the request is not cached by the browser. So, remove _ from form_dict

--- a/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/test_auto_repeat.py
@@ -234,7 +234,7 @@ class TestAutoRepeat(FrappeTestCase):
 
 
 def make_auto_repeat(**args):
-	args = frappe._dict(args)
+	args = frappe.attrdict(args)
 	doc = frappe.get_doc(
 		{
 			"doctype": "Auto Repeat",

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -28,7 +28,7 @@ from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabl
 def get_bootinfo():
 	"""build and return boot info"""
 	frappe.set_user_lang(frappe.session.user)
-	bootinfo = frappe._dict()
+	bootinfo = frappe.attrdict()
 	hooks = frappe.get_hooks()
 	doclist = []
 
@@ -255,7 +255,7 @@ def load_translations(bootinfo):
 
 def get_user_info():
 	# get info for current user
-	user_info = frappe._dict()
+	user_info = frappe.attrdict()
 	add_user_info(frappe.session.user, user_info)
 
 	if frappe.session.user == "Administrator" and user_info.Administrator.email:
@@ -352,7 +352,7 @@ def get_link_preview_doctypes():
 
 
 def get_additional_filters_from_hooks():
-	filter_config = frappe._dict()
+	filter_config = frappe.attrdict()
 	filter_hooks = frappe.get_hooks("filters_config")
 	for hook in filter_hooks:
 		filter_config.update(frappe.get_attr(hook)())

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -46,7 +46,7 @@ def get_list(
 	if frappe.is_table(doctype):
 		check_parent_permission(parent, doctype)
 
-	args = frappe._dict(
+	args = frappe.attrdict(
 		doctype=doctype,
 		parent_doctype=parent,
 		fields=fields,
@@ -417,7 +417,7 @@ def validate_link(doctype: str, docname: str, fields=None):
 			frappe.PermissionError,
 		)
 
-	values = frappe._dict()
+	values = frappe.attrdict()
 	values.name = frappe.db.get_value(doctype, docname, cache=True)
 
 	fields = frappe.parse_json(fields)
@@ -445,7 +445,7 @@ def insert_doc(doc) -> "Document":
 
 	:param doc: doc to insert (dict)"""
 
-	doc = frappe._dict(doc)
+	doc = frappe.attrdict(doc)
 	if frappe.is_table(doc.doctype):
 		if not (doc.parenttype and doc.parent and doc.parentfield):
 			frappe.throw(_("Parenttype, Parent and Parentfield are required to insert a child record"))

--- a/frappe/commands/__init__.py
+++ b/frappe/commands/__init__.py
@@ -26,7 +26,7 @@ def pass_context(f):
 			pr.enable()
 
 		try:
-			ret = f(frappe._dict(ctx.obj), *args, **kwargs)
+			ret = f(frappe.attrdict(ctx.obj), *args, **kwargs)
 		except frappe.exceptions.SiteNotSpecifiedError as e:
 			click.secho(str(e), fg="yellow")
 			sys.exit(1)

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -990,9 +990,11 @@ def request(context, args=None, path=None):
 			frappe.connect()
 			if args:
 				if "?" in args:
-					frappe.local.form_dict = frappe._dict([a.split("=") for a in args.split("?")[-1].split("&")])
+					frappe.local.form_dict = frappe.attrdict(
+						[a.split("=") for a in args.split("?")[-1].split("&")]
+					)
 				else:
-					frappe.local.form_dict = frappe._dict()
+					frappe.local.form_dict = frappe.attrdict()
 
 				if args.startswith("/api/method"):
 					frappe.local.form_dict.cmd = args.split("?")[0].split("/")[-1]
@@ -1000,7 +1002,7 @@ def request(context, args=None, path=None):
 				with open(os.path.join("..", path)) as f:
 					args = json.loads(f.read())
 
-				frappe.local.form_dict = frappe._dict(args)
+				frappe.local.form_dict = frappe.attrdict(args)
 
 			frappe.handler.execute_cmd(frappe.form_dict.cmd)
 
@@ -1085,7 +1087,7 @@ def get_version(output):
 		module = frappe.get_module(app)
 		app_hooks = frappe.get_module(app + ".hooks")
 
-		app_info = frappe._dict()
+		app_info = frappe.attrdict()
 
 		try:
 			app_info.commit = Repo(frappe.get_app_path(app, "..")).head.object.hexsha[:7]

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -216,7 +216,7 @@ def get_address_templates(address):
 
 
 def get_company_address(company):
-	ret = frappe._dict()
+	ret = frappe.attrdict()
 	ret.company_address = get_default_address("Company", company)
 	ret.company_address_display = get_address_display(ret.company_address)
 

--- a/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py
+++ b/frappe/contacts/report/addresses_and_contacts/addresses_and_contacts.py
@@ -62,7 +62,7 @@ def get_data(filters):
 def get_reference_addresses_and_contact(reference_doctype, reference_name):
 	data = []
 	filters = None
-	reference_details = frappe._dict()
+	reference_details = frappe.attrdict()
 
 	if not reference_doctype:
 		return []
@@ -75,7 +75,7 @@ def get_reference_addresses_and_contact(reference_doctype, reference_name):
 	]
 
 	for d in reference_list:
-		reference_details.setdefault(d, frappe._dict())
+		reference_details.setdefault(d, frappe.attrdict())
 	reference_details = get_reference_details(
 		reference_doctype, "Address", reference_list, reference_details
 	)

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -13,7 +13,7 @@ def unzip_file(name: str):
 
 
 @frappe.whitelist()
-def get_attached_images(doctype: str, names: list[str]) -> frappe._dict:
+def get_attached_images(doctype: str, names: list[str]) -> frappe.attrdict:
 	"""get list of image urls attached in form
 	returns {name: ['image.jpg', 'image.png']}"""
 
@@ -30,7 +30,7 @@ def get_attached_images(doctype: str, names: list[str]) -> frappe._dict:
 		fields=["file_url", "attached_to_name as docname"],
 	)
 
-	out = frappe._dict()
+	out = frappe.attrdict()
 	for i in img_urls:
 		out[i.docname] = out.get(i.docname, [])
 		out[i.docname].append(i.file_url)

--- a/frappe/core/doctype/activity_log/feed.py
+++ b/frappe/core/doctype/activity_log/feed.py
@@ -25,7 +25,7 @@ def update_feed(doc, method=None):
 			if isinstance(feed, str):
 				feed = {"subject": feed}
 
-			feed = frappe._dict(feed)
+			feed = frappe.attrdict(feed)
 			doctype = feed.doctype or doc.doctype
 			name = feed.name or doc.name
 

--- a/frappe/core/doctype/activity_log/test_activity_log.py
+++ b/frappe/core/doctype/activity_log/test_activity_log.py
@@ -11,7 +11,7 @@ class TestActivityLog(FrappeTestCase):
 	def test_activity_log(self):
 
 		# test user login log
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{
 				"cmd": "login",
 				"sid": "Guest",
@@ -38,7 +38,7 @@ class TestActivityLog(FrappeTestCase):
 		auth_log = self.get_auth_log()
 		self.assertEqual(auth_log.status, "Failed")
 
-		frappe.local.form_dict = frappe._dict()
+		frappe.local.form_dict = frappe.attrdict()
 
 	def get_auth_log(self, operation="Login"):
 		names = frappe.get_all(
@@ -57,7 +57,7 @@ class TestActivityLog(FrappeTestCase):
 	def test_brute_security(self):
 		update_system_settings({"allow_consecutive_login_attempts": 3, "allow_login_after_fail": 5})
 
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{"cmd": "login", "sid": "Guest", "pwd": "admin", "usr": "Administrator"}
 		)
 
@@ -85,7 +85,7 @@ class TestActivityLog(FrappeTestCase):
 		time.sleep(5)
 		self.assertRaises(frappe.AuthenticationError, LoginManager)
 
-		frappe.local.form_dict = frappe._dict()
+		frappe.local.form_dict = frappe.attrdict()
 
 
 def update_system_settings(args):

--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -16,7 +16,7 @@ reflags = {"I": re.I, "L": re.L, "M": re.M, "U": re.U, "S": re.S, "X": re.X, "D"
 
 
 def get_data_keys():
-	return frappe._dict(
+	return frappe.attrdict(
 		{
 			"data_separator": _("Start entering data below this line"),
 			"main_table": _("Table") + ":",
@@ -219,7 +219,7 @@ class DataExporter:
 
 		tablecolumns.sort(key=lambda a: int(a.idx))
 
-		_column_start_end = frappe._dict(start=0)
+		_column_start_end = frappe.attrdict(start=0)
 
 		if dt == self.doctype:
 			if (meta.get("autoname") and meta.get("autoname").lower() == "prompt") or (self.with_data):
@@ -228,7 +228,7 @@ class DataExporter:
 			# if importing only child table for new record, add parent field
 			if meta.get("istable") and not self.with_data:
 				self.append_field_column(
-					frappe._dict(
+					frappe.attrdict(
 						{
 							"fieldname": "parent",
 							"parent": "",
@@ -241,9 +241,9 @@ class DataExporter:
 					True,
 				)
 
-			_column_start_end = frappe._dict(start=0)
+			_column_start_end = frappe.attrdict(start=0)
 		else:
-			_column_start_end = frappe._dict(start=len(self.columns))
+			_column_start_end = frappe.attrdict(start=len(self.columns))
 
 			if self.with_data:
 				self._append_name_column(dt)
@@ -449,7 +449,7 @@ class DataExporter:
 
 	def _append_name_column(self, dt=None):
 		self.append_field_column(
-			frappe._dict(
+			frappe.attrdict(
 				{
 					"fieldname": "name" if dt else self.name_field,
 					"parent": dt or "",

--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -55,7 +55,7 @@ class Exporter:
 		]
 
 		meta = frappe.get_meta(self.doctype)
-		exportable_fields = frappe._dict({})
+		exportable_fields = frappe.attrdict({})
 
 		for key, fieldnames in self.export_fields.items():
 			if key == self.doctype:
@@ -93,7 +93,7 @@ class Exporter:
 			return df and df.fieldtype not in (display_fieldtypes + no_value_fields)
 
 		# add name field
-		name_field = frappe._dict(
+		name_field = frappe.attrdict(
 			{
 				"fieldtype": "Data",
 				"fieldname": "name",

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -112,7 +112,7 @@ class Importer:
 		# get successfully imported rows
 		imported_rows = []
 		for log in import_log:
-			log = frappe._dict(log)
+			log = frappe.attrdict(log)
 			if log.success or len(import_log) < self.data_import.payload_count:
 				imported_rows += json.loads(log.row_indexes)
 
@@ -395,7 +395,9 @@ class Importer:
 class ImportFile:
 	def __init__(self, doctype, file, template_options=None, import_type=None):
 		self.doctype = doctype
-		self.template_options = template_options or frappe._dict(column_to_field_map=frappe._dict())
+		self.template_options = template_options or frappe.attrdict(
+			column_to_field_map=frappe.attrdict()
+		)
 		self.column_to_field_map = self.template_options.column_to_field_map
 		self.import_type = import_type
 		self.warnings = []
@@ -469,7 +471,7 @@ class ImportFile:
 	def get_data_for_import_preview(self):
 		"""Adds a serial number column as the first column"""
 
-		columns = [frappe._dict({"header_title": "Sr. No", "skip_import": True})]
+		columns = [frappe.attrdict({"header_title": "Sr. No", "skip_import": True})]
 		columns += [col.as_dict() for col in self.columns]
 		for col in columns:
 			# only pick useful fields in docfields to minimise the payload
@@ -489,7 +491,7 @@ class ImportFile:
 
 		warnings = self.get_warnings()
 
-		out = frappe._dict()
+		out = frappe.attrdict()
 		out.data = data
 		out.columns = columns
 		out.warnings = warnings
@@ -507,7 +509,7 @@ class ImportFile:
 		data = list(self.data)
 		while data:
 			doc, rows, data = self.parse_next_row_for_import(data)
-			payloads.append(frappe._dict(doc=doc, rows=rows))
+			payloads.append(frappe.attrdict(doc=doc, rows=rows))
 		return payloads
 
 	def parse_next_row_for_import(self, data):
@@ -640,7 +642,7 @@ class Row:
 		return doc
 
 	def _parse_doc(self, doctype, columns, values, parent_doc=None, table_df=None):
-		doc = frappe._dict()
+		doc = frappe.attrdict()
 		if self.import_type == INSERT:
 			# new_doc returns a dict with default values set
 			doc = frappe.new_doc(
@@ -804,7 +806,7 @@ class Header(Row):
 		self.row_number = index + 1
 		self.data = row
 		self.doctype = doctype
-		column_to_field_map = column_to_field_map or frappe._dict()
+		column_to_field_map = column_to_field_map or frappe.attrdict()
 
 		self.seen = []
 		self.columns = []
@@ -1044,7 +1046,7 @@ class Column:
 					)
 
 	def as_dict(self):
-		d = frappe._dict()
+		d = frappe.attrdict()
 		d.index = self.index
 		d.column_number = self.column_number
 		d.doctype = self.doctype
@@ -1091,7 +1093,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 
 		out = []
 		for df in standard_fields:
-			df = frappe._dict(df)
+			df = frappe.attrdict(df)
 			df.parent = doctype
 			out.append(df)
 		return out
@@ -1106,7 +1108,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 		translated_table_label = _(table_df.label) if table_df else None
 
 		# name field
-		name_df = frappe._dict(
+		name_df = frappe.attrdict(
 			{
 				"fieldtype": "Data",
 				"fieldname": "name",
@@ -1169,7 +1171,7 @@ def build_fields_dict_for_column_matching(parent_doctype):
 
 				# create a new df object to avoid mutation problems
 				if isinstance(df, dict):
-					new_df = frappe._dict(df.copy())
+					new_df = frappe.attrdict(df.copy())
 				else:
 					new_df = df.as_dict()
 
@@ -1220,7 +1222,7 @@ def get_id_field(doctype):
 	autoname_field = get_autoname_field(doctype)
 	if autoname_field:
 		return autoname_field
-	return frappe._dict({"label": "ID", "fieldname": "name", "fieldtype": "Data"})
+	return frappe.attrdict({"label": "ID", "fieldname": "name", "fieldtype": "Data"})
 
 
 def get_autoname_field(doctype):

--- a/frappe/core/doctype/log_settings/test_log_settings.py
+++ b/frappe/core/doctype/log_settings/test_log_settings.py
@@ -25,7 +25,7 @@ class TestLogSettings(FrappeTestCase):
 
 	def setUp(self) -> None:
 		if self._testMethodName == "test_delete_logs":
-			self.datetime = frappe._dict()
+			self.datetime = frappe.attrdict()
 			self.datetime.current = now_datetime()
 			self.datetime.past = add_to_date(self.datetime.current, days=-4)
 			setup_test_logs(self.datetime.past)

--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -136,7 +136,7 @@ class Page(Document):
 				with open(os.path.join(path, fname)) as f:
 					template = f.read()
 					if "<!-- jinja -->" in template:
-						context = frappe._dict({})
+						context = frappe.attrdict({})
 						try:
 							out = frappe.get_attr(
 								"{app}.{module}.page.{page}.{page}.get_context".format(

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -145,11 +145,11 @@ class Report(Document):
 		# report in python module
 		module = self.module or frappe.db.get_value("DocType", self.ref_doctype, "module")
 		method_name = get_report_module_dotted_path(module, self.name) + ".execute"
-		return frappe.get_attr(method_name)(frappe._dict(filters))
+		return frappe.get_attr(method_name)(frappe.attrdict(filters))
 
 	def execute_script(self, filters):
 		# server script
-		loc = {"filters": frappe._dict(filters), "data": None, "result": None}
+		loc = {"filters": frappe.attrdict(filters), "data": None, "result": None}
 		safe_exec(self.report_script, None, loc)
 		if loc["data"]:
 			return loc["data"]
@@ -177,7 +177,7 @@ class Report(Document):
 
 		for d in data.get("columns"):
 			if isinstance(d, dict):
-				col = frappe._dict(d)
+				col = frappe.attrdict(d)
 				if not col.fieldname:
 					col.fieldname = col.label
 				columns.append(col)
@@ -191,7 +191,7 @@ class Report(Document):
 							fieldtype, options = fieldtype.split("/")
 
 				columns.append(
-					frappe._dict(label=parts[0], fieldtype=fieldtype, fieldname=parts[0], options=options)
+					frappe.attrdict(label=parts[0], fieldtype=fieldtype, fieldname=parts[0], options=options)
 				)
 
 		result += data.get("result")
@@ -281,7 +281,7 @@ class Report(Document):
 
 		group_by = None
 		if params.get("group_by"):
-			group_by_args = frappe._dict(params["group_by"])
+			group_by_args = frappe.attrdict(params["group_by"])
 			group_by = group_by_args["group_by"]
 			order_by = "_aggregate_column desc"
 
@@ -301,7 +301,7 @@ class Report(Document):
 				else:
 					label = meta.get_label(fieldname)
 
-				field = frappe._dict(fieldname=fieldname, label=label)
+				field = frappe.attrdict(fieldname=fieldname, label=label)
 
 				# since name is the primary key for a document, it will always be a Link datatype
 				if fieldname == "name":
@@ -315,12 +315,12 @@ class Report(Document):
 		data = []
 		for row in result:
 			if isinstance(row, (list, tuple)):
-				_row = frappe._dict()
+				_row = frappe.attrdict()
 				for i, val in enumerate(row):
 					_row[columns[i].get("fieldname")] = val
 			elif isinstance(row, dict):
 				# no need to convert from dict to dict
-				_row = frappe._dict(row)
+				_row = frappe.attrdict(row)
 			data.append(_row)
 
 		return data

--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -117,7 +117,7 @@ class RQJob(Document):
 		pass
 
 
-def serialize_job(job: Job) -> frappe._dict:
+def serialize_job(job: Job) -> frappe.attrdict:
 	modified = job.last_heartbeat or job.ended_at or job.started_at or job.created_at
 	job_name = job.kwargs.get("kwargs", {}).get("job_type") or str(job.kwargs.get("job_name"))
 
@@ -126,7 +126,7 @@ def serialize_job(job: Job) -> frappe._dict:
 	if matches := re.match(r"<function (?P<func_name>.*) at 0x.*>", job_name):
 		job_name = matches.group("func_name")
 
-	return frappe._dict(
+	return frappe.attrdict(
 		name=job.id,
 		job_id=job.id,
 		queue=job.origin.rsplit(":", 1)[1],

--- a/frappe/core/doctype/rq_worker/rq_worker.py
+++ b/frappe/core/doctype/rq_worker/rq_worker.py
@@ -52,13 +52,13 @@ class RQWorker(Document):
 		pass
 
 
-def serialize_worker(worker: Worker) -> frappe._dict:
+def serialize_worker(worker: Worker) -> frappe.attrdict:
 	queue_names = worker.queue_names()
 
 	queue = ", ".join(queue_names)
 	queue_types = ",".join(q.rsplit(":", 1)[1] for q in queue_names)
 
-	return frappe._dict(
+	return frappe.attrdict(
 		name=worker.pid,
 		queue=queue,
 		queue_type=queue_types,

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -35,10 +35,10 @@ def create_translations(translation_map, language):
 	from frappe.frappeclient import FrappeClient
 
 	translation_map = json.loads(translation_map)
-	translation_map_to_send = frappe._dict({})
+	translation_map_to_send = frappe.attrdict({})
 	# first create / update local user translations
 	for source_id, translation_dict in translation_map.items():
-		translation_dict = frappe._dict(translation_dict)
+		translation_dict = frappe.attrdict(translation_dict)
 		existing_doc_name = frappe.get_all(
 			"Translation",
 			{

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -780,7 +780,7 @@ def ask_pass_update():
 
 def _get_user_for_update_password(key, old_password):
 	# verify old password
-	result = frappe._dict()
+	result = frappe.attrdict()
 	if key:
 		user = frappe.db.get_value(
 			"User", {"reset_password_key": key}, ["name", "last_reset_password_key_generated_on"]

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -89,7 +89,7 @@ def get_user_permissions(user=None):
 			out[perm.allow] = []
 
 		out[perm.allow].append(
-			frappe._dict(
+			frappe.attrdict(
 				{"doc": doc_name, "applicable_for": perm.get("applicable_for"), "is_default": is_default}
 			)
 		)
@@ -109,7 +109,7 @@ def get_user_permissions(user=None):
 				for doc in decendants:
 					add_doc_to_perm(perm, doc, False)
 
-		out = frappe._dict(out)
+		out = frappe.attrdict(out)
 		frappe.cache().hset("user_permissions", user, out)
 	except frappe.db.SQLError as e:
 		if frappe.db.is_table_missing(e):
@@ -224,7 +224,7 @@ def add_user_permissions(data):
 	frappe.only_for("System Manager")
 	if isinstance(data, str):
 		data = json.loads(data)
-	data = frappe._dict(data)
+	data = frappe.attrdict(data)
 
 	# get all doctypes on whom this permission is applied
 	perm_applied_docs = check_applicable_doc_perm(data.user, data.doctype, data.docname)

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -71,7 +71,7 @@ def get_diff(old, new, for_child=False):
 	data_import = new.flags.via_data_import
 	updater_reference = new.flags.updater_reference
 
-	out = frappe._dict(
+	out = frappe.attrdict(
 		changed=[],
 		added=[],
 		removed=[],

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -148,7 +148,7 @@ def get_fields_label(doctype=None):
 
 
 def create_custom_field_if_values_exist(doctype, df):
-	df = frappe._dict(df)
+	df = frappe.attrdict(df)
 	if df.fieldname in frappe.db.get_table_columns(doctype) and frappe.db.count(
 		dt=doctype, filters=IfNull(df.fieldname, "") != ""
 	):
@@ -156,7 +156,7 @@ def create_custom_field_if_values_exist(doctype, df):
 
 
 def create_custom_field(doctype, df, ignore_validate=False, is_system_generated=True):
-	df = frappe._dict(df)
+	df = frappe.attrdict(df)
 	if not df.fieldname and df.label:
 		df.fieldname = frappe.scrub(df.label)
 	if not frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": df.fieldname}):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -388,13 +388,13 @@ class Database:
 		):
 			raise ImplicitCommitError("This statement can cause implicit commit")
 
-	def fetch_as_dict(self) -> list[frappe._dict]:
+	def fetch_as_dict(self) -> list[frappe.attrdict]:
 		"""Internal. Converts results to dict."""
 		result = self.last_result
 		if result:
 			keys = [column[0] for column in self._cursor.description]
 
-		return [frappe._dict(zip(keys, row)) for row in result]
+		return [frappe.attrdict(zip(keys, row)) for row in result]
 
 	@staticmethod
 	def clear_db_table_cache(query):
@@ -633,7 +633,7 @@ class Database:
 				return r
 			if as_dict:
 				if r:
-					r = frappe._dict(r)
+					r = frappe.attrdict(r)
 					if update:
 						r.update(update)
 					return [r]
@@ -663,14 +663,14 @@ class Database:
 		).run(debug=debug)
 
 		if not cast:
-			return frappe._dict(queried_result)
+			return frappe.attrdict(queried_result)
 
 		try:
 			meta = frappe.get_meta(doctype)
 		except DoesNotExistError:
-			return frappe._dict(queried_result)
+			return frappe.attrdict(queried_result)
 
-		return_value = frappe._dict()
+		return_value = frappe.attrdict()
 
 		for fieldname, value in queried_result:
 			if df := meta.get_field(fieldname):

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -329,7 +329,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 
 	def get_column_index(
 		self, table_name: str, fieldname: str, unique: bool = False
-	) -> frappe._dict | None:
+	) -> frappe.attrdict | None:
 		"""Check if column exists for a specific fields in specified order.
 
 		This differs from db.has_index because it doesn't rely on index name but columns inside an

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -12,7 +12,7 @@ REQUIRED_MARIADB_CONFIG = {
 
 
 def get_mariadb_variables():
-	return frappe._dict(frappe.db.sql("show variables"))
+	return frappe.attrdict(frappe.db.sql("show variables"))
 
 
 def get_mariadb_version(version_string: str = ""):
@@ -24,7 +24,7 @@ def get_mariadb_version(version_string: str = ""):
 
 
 def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
-	frappe.local.session = frappe._dict({"user": "Administrator"})
+	frappe.local.session = frappe.attrdict({"user": "Administrator"})
 
 	db_name = frappe.local.conf.db_name
 	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -108,11 +108,12 @@ class DBTable:
 		self.setup_table_columns()
 
 		columns = [
-			frappe._dict({"fieldname": f, "fieldtype": "Data"}) for f in frappe.db.STANDARD_VARCHAR_COLUMNS
+			frappe.attrdict({"fieldname": f, "fieldtype": "Data"})
+			for f in frappe.db.STANDARD_VARCHAR_COLUMNS
 		]
 		if self.meta.get("istable"):
 			columns += [
-				frappe._dict({"fieldname": f, "fieldtype": "Data"}) for f in frappe.db.CHILD_TABLE_COLUMNS
+				frappe.attrdict({"fieldname": f, "fieldtype": "Data"}) for f in frappe.db.CHILD_TABLE_COLUMNS
 			]
 		columns += self.columns.values()
 

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -222,7 +222,7 @@ def get_defaults_for(parent="__default"):
 			.run(as_dict=True)
 		)
 
-		defaults = frappe._dict()
+		defaults = frappe.attrdict()
 		for d in res:
 			if d.defkey in defaults:
 				# listify

--- a/frappe/desk/calendar.py
+++ b/frappe/desk/calendar.py
@@ -10,8 +10,8 @@ from frappe import _
 @frappe.whitelist()
 def update_event(args, field_map):
 	"""Updates Event (called via calendar) based on passed `field_map`"""
-	args = frappe._dict(json.loads(args))
-	field_map = frappe._dict(json.loads(field_map))
+	args = frappe.attrdict(json.loads(args))
+	field_map = frappe.attrdict(json.loads(field_map))
 	w = frappe.get_doc(args.doctype, args.name)
 	w.set(field_map.start, args[field_map.start])
 	w.set(field_map.end, args.get(field_map.end))
@@ -30,7 +30,7 @@ def get_event_conditions(doctype, filters=None):
 
 @frappe.whitelist()
 def get_events(doctype, start, end, field_map, filters=None, fields=None):
-	field_map = frappe._dict(json.loads(field_map))
+	field_map = frappe.attrdict(json.loads(field_map))
 	fields = frappe.parse_json(fields)
 
 	doc_meta = frappe.get_meta(doctype)

--- a/frappe/desk/desk_page.py
+++ b/frappe/desk/desk_page.py
@@ -12,7 +12,7 @@ def get(name):
 	page = frappe.get_doc("Page", name)
 	if page.is_permitted():
 		page.load_assets()
-		docs = frappe._dict(page.as_dict())
+		docs = frappe.attrdict(page.as_dict())
 		if getattr(page, "_dynamic_page", None):
 			docs["_dynamic_page"] = 1
 

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -6,7 +6,7 @@ from functools import wraps
 from json import dumps, loads
 
 import frappe
-from frappe import DoesNotExistError, ValidationError, _, _dict
+from frappe import DoesNotExistError, ValidationError, _, attrdict
 from frappe.boot import get_allowed_pages, get_allowed_reports
 from frappe.cache_manager import (
 	build_domain_restriced_doctype_cache,
@@ -216,12 +216,12 @@ class Workspace:
 		new_data = []
 		for card in cards:
 			new_items = []
-			card = _dict(card)
+			card = attrdict(card)
 
 			links = card.get("links", [])
 
 			for item in links:
-				item = _dict(item)
+				item = attrdict(item)
 
 				# Condition: based on country
 				if item.country and item.country != default_country:
@@ -233,7 +233,7 @@ class Workspace:
 					new_items.append(prepared_item)
 
 			if new_items:
-				if isinstance(card, _dict):
+				if isinstance(card, attrdict):
 					new_card = card.copy()
 				else:
 					new_card = card.as_dict().copy()
@@ -414,8 +414,8 @@ def get_table_with_counts():
 
 def get_custom_reports_and_doctypes(module):
 	return [
-		_dict({"label": _("Custom Documents"), "links": get_custom_doctype_list(module)}),
-		_dict({"label": _("Custom Reports"), "links": get_custom_report_list(module)}),
+		attrdict({"label": _("Custom Documents"), "links": get_custom_doctype_list(module)}),
+		attrdict({"label": _("Custom Reports"), "links": get_custom_report_list(module)}),
 	]
 
 
@@ -464,7 +464,7 @@ def get_custom_report_list(module):
 
 def save_new_widget(doc, page, blocks, new_widgets):
 	if loads(new_widgets):
-		widgets = _dict(loads(new_widgets))
+		widgets = attrdict(loads(new_widgets))
 
 		if widgets.chart:
 			doc.charts.extend(new_widget(widgets.chart, "Workspace Chart", "charts"))

--- a/frappe/desk/doctype/dashboard/dashboard.py
+++ b/frappe/desk/doctype/dashboard/dashboard.py
@@ -79,7 +79,7 @@ def get_permitted_charts(dashboard_name):
 	dashboard = frappe.get_doc("Dashboard", dashboard_name)
 	for chart in dashboard.charts:
 		if frappe.has_permission("Dashboard Chart", doc=chart.chart):
-			chart_dict = frappe._dict()
+			chart_dict = frappe.attrdict()
 			chart_dict.update(chart.as_dict())
 
 			if dashboard.get("chart_options"):

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -112,7 +112,7 @@ def get(
 	if chart_name:
 		chart = frappe.get_doc("Dashboard Chart", chart_name)
 	else:
-		chart = frappe._dict(frappe.parse_json(chart))
+		chart = frappe.attrdict(frappe.parse_json(chart))
 
 	heatmap_year = heatmap_year or chart.heatmap_year
 	timespan = timespan or chart.timespan

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -171,7 +171,7 @@ def add_user_icon(_doctype, _report=None, label=None, link=None, type="link", st
 		)
 
 		if not module_icon:
-			module_icon = frappe._dict()
+			module_icon = frappe.attrdict()
 			opts = random.choice(palette)
 			module_icon.color = opts[0]
 			module_icon.reverse = 0 if (len(opts) > 1) else 1

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -228,7 +228,7 @@ def send_event_digest():
 
 
 @frappe.whitelist()
-def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[frappe._dict]:
+def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[frappe.attrdict]:
 	if not user:
 		user = frappe.session.user
 

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -63,7 +63,7 @@ def enqueue_create_notification(users: list[str] | str, doc: dict):
 	if frappe.flags.in_install:
 		return
 
-	doc = frappe._dict(doc)
+	doc = frappe.attrdict(doc)
 
 	if isinstance(users, str):
 		users = [user.strip() for user in users.split(",") if user.strip()]
@@ -149,7 +149,7 @@ def get_notification_logs(limit=20):
 
 	users = [log.from_user for log in notification_logs]
 	users = [*set(users)]  # remove duplicates
-	user_info = frappe._dict()
+	user_info = frappe.attrdict()
 
 	for user in users:
 		frappe.utils.add_user_info(user, user_info)

--- a/frappe/desk/doctype/workspace/test_workspace.py
+++ b/frappe/desk/doctype/workspace/test_workspace.py
@@ -40,7 +40,7 @@ def create_module(module_name):
 
 def create_workspace(**args):
 	workspace = frappe.new_doc("Workspace")
-	args = frappe._dict(args)
+	args = frappe.attrdict(args)
 
 	workspace.name = args.name or "Test Workspace"
 	workspace.label = args.label or "Test Workspace"

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -58,7 +58,7 @@ class Workspace(Document):
 
 	def get_link_groups(self):
 		cards = []
-		current_card = frappe._dict(
+		current_card = frappe.attrdict(
 			{
 				"label": "Link",
 				"type": "Card Break",

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -9,7 +9,7 @@ import frappe.defaults
 import frappe.desk.form.meta
 import frappe.share
 import frappe.utils
-from frappe import _, _dict
+from frappe import _, attrdict
 from frappe.desk.form.document_follow import is_document_followed
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.utils.user_settings import get_user_settings
@@ -52,7 +52,7 @@ def getdoc(doctype, name, user=None):
 	doc.add_seen()
 	set_link_titles(doc)
 	if frappe.response.docs is None:
-		frappe.local.response = _dict({"docs": []})
+		frappe.local.response = attrdict({"docs": []})
 	frappe.response.docs.append(doc)
 
 
@@ -102,7 +102,7 @@ def get_docinfo(doc=None, doctype=None, name=None):
 		msg for msg in all_communications if msg["communication_type"] != "Automated Message"
 	]
 
-	docinfo = frappe._dict(user_info={})
+	docinfo = frappe.attrdict(user_info={})
 
 	add_comments(doc, docinfo)
 
@@ -214,7 +214,7 @@ def get_communications(doctype, name, start=0, limit=20):
 
 def get_comments(
 	doctype: str, name: str, comment_type: str | list[str] = "Comment"
-) -> list[frappe._dict]:
+) -> list[frappe.attrdict]:
 	if isinstance(comment_type, list):
 		comment_types = comment_type
 
@@ -366,7 +366,7 @@ def get_badge_info(doctypes, filters):
 
 
 def run_onload(doc):
-	doc.set("__onload", frappe._dict())
+	doc.set("__onload", frappe.attrdict())
 	doc.run_method("onload")
 
 

--- a/frappe/desk/gantt.py
+++ b/frappe/desk/gantt.py
@@ -9,8 +9,8 @@ import frappe
 @frappe.whitelist()
 def update_task(args, field_map):
 	"""Updates Doc (called via gantt) based on passed `field_map`"""
-	args = frappe._dict(json.loads(args))
-	field_map = frappe._dict(json.loads(field_map))
+	args = frappe.attrdict(json.loads(args))
+	field_map = frappe.attrdict(json.loads(field_map))
 	d = frappe.get_doc(args.doctype, args.name)
 	d.set(field_map.start, args.start)
 	d.set(field_map.end, args.end)

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -209,7 +209,7 @@ def get_notification_config():
 
 	def _get():
 		subscribed_documents = get_subscribed_documents()
-		config = frappe._dict()
+		config = frappe.attrdict()
 		hooks = frappe.get_hooks()
 		if hooks:
 			for notification_config in hooks.notification_config:
@@ -219,7 +219,7 @@ def get_notification_config():
 					if key == "for_doctype":
 						if len(subscribed_documents) > 0:
 							key_config = nc.get(key, {})
-							subscribed_docs_config = frappe._dict()
+							subscribed_docs_config = frappe.attrdict()
 							for document in subscribed_documents:
 								if key_config.get(document):
 									subscribed_docs_config[document] = key_config.get(document)

--- a/frappe/desk/page/leaderboard/leaderboard.py
+++ b/frappe/desk/page/leaderboard/leaderboard.py
@@ -5,7 +5,7 @@ import frappe
 
 @frappe.whitelist()
 def get_leaderboard_config():
-	leaderboard_config = frappe._dict()
+	leaderboard_config = frappe.attrdict()
 	leaderboard_hooks = frappe.get_hooks("leaderboards")
 	for hook in leaderboard_hooks:
 		leaderboard_config.update(frappe.get_attr(hook)())

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -238,7 +238,7 @@ def parse_args(args):
 	if isinstance(args, str):
 		args = json.loads(args)
 
-	args = frappe._dict(args)
+	args = frappe.attrdict(args)
 
 	# strip the whitespace
 	for key, value in args.items():
@@ -400,7 +400,7 @@ def enable_twofactor_all_roles():
 
 
 def make_records(records, debug=False):
-	from frappe import _dict
+	from frappe import attrdict
 	from frappe.modules import scrub
 
 	if debug:
@@ -431,7 +431,7 @@ def make_records(records, debug=False):
 			frappe.db.rollback(save_point=savepoint)
 			exception = record.get("__exception")
 			if exception:
-				config = _dict(exception)
+				config = attrdict(exception)
 				if isinstance(e, config.exception):
 					config.handler()
 				else:

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -270,7 +270,7 @@ def export_query():
 	"""export from query reports"""
 	from frappe.desk.utils import get_csv_bytes, pop_csv_params, provide_binary_file
 
-	form_params = frappe._dict(frappe.local.form_dict)
+	form_params = frappe.attrdict(frappe.local.form_dict)
 	csv_params = pop_csv_params(form_params)
 	clean_params(form_params)
 	parse_json(form_params)
@@ -290,7 +290,7 @@ def export_query():
 		visible_idx = json.loads(visible_idx)
 
 	data = run(report_name, form_params.filters, custom_columns=custom_columns)
-	data = frappe._dict(data)
+	data = frappe.attrdict(data)
 	if not data.columns:
 		frappe.respond_as_web_page(
 			_("No data to export"),
@@ -313,7 +313,7 @@ def export_query():
 	provide_binary_file(report_name, file_extension, content)
 
 
-def format_duration_fields(data: frappe._dict) -> None:
+def format_duration_fields(data: frappe.attrdict) -> None:
 	for i, col in enumerate(data.columns):
 		if col.get("fieldtype") != "Duration":
 			continue
@@ -445,7 +445,7 @@ def get_data_for_custom_field(doctype, field):
 	if not frappe.has_permission(doctype, "read"):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 
-	value_map = frappe._dict(frappe.get_all(doctype, fields=["name", field], as_list=1))
+	value_map = frappe.attrdict(frappe.get_all(doctype, fields=["name", field], as_list=1))
 
 	return value_map
 
@@ -647,7 +647,7 @@ def get_columns_dict(columns):
 	The keys for the dict are both idx and fieldname,
 	so either index or fieldname can be used to search for a column's docfield properties
 	"""
-	columns_dict = frappe._dict()
+	columns_dict = frappe.attrdict()
 	for idx, col in enumerate(columns):
 		col_dict = get_column_as_dict(col)
 		columns_dict[idx] = col_dict
@@ -657,7 +657,7 @@ def get_columns_dict(columns):
 
 
 def get_column_as_dict(col):
-	col_dict = frappe._dict()
+	col_dict = frappe.attrdict()
 
 	# string
 	if isinstance(col, str):

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -66,7 +66,7 @@ def execute(doctype, *args, **kwargs):
 
 def get_form_params():
 	"""Stringify GET request parameters."""
-	data = frappe._dict(frappe.local.form_dict)
+	data = frappe.attrdict(frappe.local.form_dict)
 	clean_params(data)
 	validate_args(data)
 	return data

--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -81,4 +81,4 @@ def make_tree_args(**kwarg):
 
 	kwarg.update({parent_field: kwarg.get("parent") or kwarg.get(parent_field)})
 
-	return frappe._dict(kwarg)
+	return frappe.attrdict(kwarg)

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -117,7 +117,7 @@ class AutoEmailReport(Document):
 		)
 
 		# add serial numbers
-		columns.insert(0, frappe._dict(fieldname="idx", label="", width="30px"))
+		columns.insert(0, frappe.attrdict(fieldname="idx", label="", width="30px"))
 		for i in range(len(data)):
 			data[i]["idx"] = i + 1
 
@@ -130,7 +130,7 @@ class AutoEmailReport(Document):
 			return self.get_html_table(columns, data)
 
 		elif self.format == "XLSX":
-			report_data = frappe._dict()
+			report_data = frappe.attrdict()
 			report_data["columns"] = columns
 			report_data["result"] = data
 
@@ -139,7 +139,7 @@ class AutoEmailReport(Document):
 			return xlsx_file.getvalue()
 
 		elif self.format == "CSV":
-			report_data = frappe._dict()
+			report_data = frappe.attrdict()
 			report_data["columns"] = columns
 			report_data["result"] = data
 

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -188,7 +188,7 @@ class EmailAccount(Document):
 		if frappe.cache().get_value("workers:no-internet") == True:
 			return None
 
-		args = frappe._dict(
+		args = frappe.attrdict(
 			{
 				"email_account_name": self.email_account_name,
 				"email_account": self.name,
@@ -213,7 +213,7 @@ class EmailAccount(Document):
 		if not args.get("host"):
 			frappe.throw(_("{0} is required").format("Email Server"))
 
-		email_server = EmailServer(frappe._dict(args))
+		email_server = EmailServer(frappe.attrdict(args))
 		self.check_email_server_connection(email_server, in_receive)
 
 		if not in_receive and self.use_imap:

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -468,7 +468,7 @@ def get_context(doc):
 	return {
 		"doc": doc,
 		"nowdate": nowdate,
-		"frappe": frappe._dict(utils=get_safe_globals().get("frappe").get("utils")),
+		"frappe": frappe.attrdict(utils=get_safe_globals().get("frappe").get("utils")),
 	}
 
 

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -352,7 +352,7 @@ def get_formatted_html(
 	print_html=None,
 	email_account=None,
 	header=None,
-	unsubscribe_link: frappe._dict | None = None,
+	unsubscribe_link: frappe.attrdict | None = None,
 	sender=None,
 	with_container=False,
 ):

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -59,7 +59,7 @@ def get_emails_sent_today(email_account=None):
 
 def get_unsubscribe_message(
 	unsubscribe_message: str, expose_recipients: str
-) -> "frappe._dict[str, str]":
+) -> "frappe.attrdict[str, str]":
 	unsubscribe_message = unsubscribe_message or _("Unsubscribe")
 	unsubscribe_link = f'<a href="<!--unsubscribe_url-->" target="_blank">{unsubscribe_message}</a>'
 	unsubscribe_html = _("{0} to stop receiving emails of this type").format(unsubscribe_link)
@@ -74,7 +74,7 @@ def get_unsubscribe_message(
 	if expose_recipients == "footer":
 		text = f"\n<!--cc_message-->{text}"
 
-	return frappe._dict(html=html, text=text)
+	return frappe.attrdict(html=html, text=text)
 
 
 def get_unsubcribed_url(

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -71,7 +71,7 @@ class EmailServer:
 
 	def setup(self, args=None):
 		# overrride
-		self.settings = args or frappe._dict()
+		self.settings = args or frappe.attrdict()
 
 	def check_mails(self):
 		# overrride
@@ -677,7 +677,7 @@ class InboundMail(Email):
 		self._parent_communication = None
 		self._reference_document = None
 
-		self.flags = frappe._dict()
+		self.flags = frappe.attrdict()
 
 	def get_content(self):
 		if self.content_type == "text/html":
@@ -938,7 +938,7 @@ class InboundMail(Email):
 	@staticmethod
 	def get_email_fields(doctype):
 		"""Returns Email related fields of a doctype."""
-		fields = frappe._dict()
+		fields = frappe.attrdict()
 
 		email_fields = ["subject_field", "sender_field"]
 		meta = frappe.get_meta(doctype)

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -133,7 +133,7 @@ class FrappeClient:
 			verify=self.verify,
 			headers=self.headers,
 		)
-		return frappe._dict(self.post_process(res))
+		return frappe.attrdict(self.post_process(res))
 
 	def insert_many(self, docs):
 		"""Insert multiple documents to the remote server
@@ -149,7 +149,7 @@ class FrappeClient:
 		res = self.session.put(
 			url, data={"data": frappe.as_json(doc)}, verify=self.verify, headers=self.headers
 		)
-		return frappe._dict(self.post_process(res))
+		return frappe.attrdict(self.post_process(res))
 
 	def bulk_update(self, docs):
 		"""Bulk update documents remotely
@@ -263,12 +263,12 @@ class FrappeClient:
 
 		# build - attach children to parents
 		if tables:
-			docs = [frappe._dict(doc) for doc in docs]
+			docs = [frappe.attrdict(doc) for doc in docs]
 			docs_map = {doc.name: doc for doc in docs}
 
 			for fieldname in tables:
 				for child in tables[fieldname]:
-					child = frappe._dict(child)
+					child = frappe.attrdict(child)
 					if child.parent in docs_map:
 						docs_map[child.parent].setdefault(fieldname, []).append(child)
 

--- a/frappe/geo/country_info.py
+++ b/frappe/geo/country_info.py
@@ -12,7 +12,7 @@ from frappe.utils.momentjs import get_all_timezones
 
 def get_country_info(country=None):
 	data = get_all()
-	data = frappe._dict(data.get(country, {}))
+	data = frappe.attrdict(data.get(country, {}))
 	if "date_format" not in data:
 		data.date_format = "dd-mm-yyyy"
 	if "time_format" not in data:

--- a/frappe/geo/doctype/country/country.py
+++ b/frappe/geo/doctype/country/country.py
@@ -32,7 +32,7 @@ def get_countries_and_currencies():
 	added_currencies = set()
 
 	for name, country in data.items():
-		country = frappe._dict(country)
+		country = frappe.attrdict(country)
 		countries.append(
 			frappe.get_doc(
 				doctype="Country",

--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -160,7 +160,7 @@ def upload_from_folder(
 	if is_fresh_upload():
 		response = get_uploaded_files_meta(dropbox_folder, dropbox_client)
 	else:
-		response = frappe._dict({"entries": []})
+		response = frappe.attrdict({"entries": []})
 
 	path = str(path)
 
@@ -266,7 +266,7 @@ def get_uploaded_files_meta(dropbox_folder, dropbox_client):
 	except dropbox.exceptions.ApiError as e:
 		# folder not found
 		if isinstance(e.error, dropbox.files.ListFolderError):
-			return frappe._dict({"entries": []})
+			return frappe.attrdict({"entries": []})
 		else:
 			raise
 

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -250,7 +250,7 @@ def sync_events_from_google_calendar(g_calendar, method=None):
 		return
 
 	sync_token = account.get_password(fieldname="next_sync_token", raise_exception=False) or None
-	events = frappe._dict()
+	events = frappe.attrdict()
 	results = []
 	while True:
 		try:

--- a/frappe/integrations/doctype/google_contacts/google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.py
@@ -100,7 +100,7 @@ def sync_contacts_from_google_contacts(g_contact):
 	contacts_updated = 0
 
 	sync_token = account.get_password(fieldname="next_sync_token", raise_exception=False) or None
-	contacts = frappe._dict()
+	contacts = frappe.attrdict()
 
 	while True:
 		try:

--- a/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
+++ b/frappe/integrations/doctype/oauth_provider_settings/oauth_provider_settings.py
@@ -12,7 +12,7 @@ class OAuthProviderSettings(Document):
 
 def get_oauth_settings():
 	"""Returns oauth settings"""
-	out = frappe._dict(
+	out = frappe.attrdict(
 		{
 			"skip_authorization": frappe.db.get_single_value(
 				"OAuth Provider Settings", "skip_authorization"

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -102,7 +102,7 @@ def authorize(**kwargs):
 				frappe.local.response["location"] = success_url
 			else:
 				# Show Allow/Deny screen.
-				response_html_params = frappe._dict(
+				response_html_params = frappe.attrdict(
 					{
 						"client_id": frappe.db.get_value("OAuth Client", kwargs["client_id"], "app_name"),
 						"success_url": success_url,
@@ -125,7 +125,7 @@ def get_token(*args, **kwargs):
 		headers, body, status = get_oauth_server().create_token_response(
 			r.url, r.method, r.form, r.headers, frappe.flags.oauth_credentials
 		)
-		body = frappe._dict(json.loads(body))
+		body = frappe.attrdict(json.loads(body))
 
 		if body.error:
 			frappe.local.response = body
@@ -153,7 +153,7 @@ def revoke_token(*args, **kwargs):
 		pass
 
 	# status_code must be 200
-	frappe.local.response = frappe._dict({})
+	frappe.local.response = frappe.attrdict({})
 	frappe.local.response["http_status_code"] = status or 200
 	return
 
@@ -167,7 +167,7 @@ def openid_profile(*args, **kwargs):
 			headers=r.headers,
 			body=r.form,
 		)
-		body = frappe._dict(json.loads(body))
+		body = frappe.attrdict(json.loads(body))
 		frappe.local.response = body
 		return
 
@@ -178,7 +178,7 @@ def openid_profile(*args, **kwargs):
 @frappe.whitelist(allow_guest=True)
 def openid_configuration():
 	frappe_server_url = get_server_url()
-	frappe.local.response = frappe._dict(
+	frappe.local.response = frappe.attrdict(
 		{
 			"issuer": frappe_server_url,
 			"authorization_endpoint": f"{frappe_server_url}/api/method/frappe.integrations.oauth2.authorize",
@@ -213,7 +213,7 @@ def introspect_token(token=None, token_type_hint=None):
 
 		client = frappe.get_doc("OAuth Client", bearer_token.client)
 
-		token_response = frappe._dict(
+		token_response = frappe.attrdict(
 			{
 				"client_id": client.client_id,
 				"trusted_client": client.skip_authorization,
@@ -239,4 +239,4 @@ def introspect_token(token=None, token_type_hint=None):
 		frappe.local.response = token_response
 
 	except Exception:
-		frappe.local.response = frappe._dict({"active": False})
+		frappe.local.response = frappe.attrdict({"active": False})

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -4,7 +4,7 @@ import datetime
 import json
 
 import frappe
-from frappe import _, _dict
+from frappe import _, attrdict
 from frappe.model import (
 	child_table_fields,
 	datetime_fields,
@@ -23,11 +23,11 @@ from frappe.utils.html_utils import unescape_html
 max_positive_value = {"smallint": 2**15 - 1, "int": 2**31 - 1, "bigint": 2**63 - 1}
 
 DOCTYPE_TABLE_FIELDS = [
-	_dict(fieldname="fields", options="DocField"),
-	_dict(fieldname="permissions", options="DocPerm"),
-	_dict(fieldname="actions", options="DocType Action"),
-	_dict(fieldname="links", options="DocType Link"),
-	_dict(fieldname="states", options="DocType State"),
+	attrdict(fieldname="fields", options="DocField"),
+	attrdict(fieldname="permissions", options="DocPerm"),
+	attrdict(fieldname="actions", options="DocType Action"),
+	attrdict(fieldname="links", options="DocType Link"),
+	attrdict(fieldname="states", options="DocType State"),
 ]
 
 TABLE_DOCTYPES_FOR_DOCTYPE = {df["fieldname"]: df["options"] for df in DOCTYPE_TABLE_FIELDS}
@@ -294,7 +294,7 @@ class BaseDocument:
 	def get_valid_dict(
 		self, sanitize=True, convert_dates_to_str=False, ignore_nulls=False, ignore_virtual=False
 	) -> dict:
-		d = _dict()
+		d = attrdict()
 		for fieldname in self.meta.get_valid_columns():
 			# column is valid, we can use getattr
 			d[fieldname] = getattr(self, fieldname, None)
@@ -686,7 +686,7 @@ class BaseDocument:
 		if self.meta.istable:
 			for fieldname in ("parent", "parenttype"):
 				if not self.get(fieldname):
-					missing.append((fieldname, get_msg(_dict(label=fieldname))))
+					missing.append((fieldname, get_msg(attrdict(label=fieldname))))
 
 		return missing
 
@@ -733,7 +733,7 @@ class BaseDocument:
 				if not frappe.get_meta(doctype).get("is_virtual"):
 					if not fields_to_fetch:
 						# cache a single value type
-						values = _dict(name=frappe.db.get_value(doctype, docname, "name", cache=True))
+						values = attrdict(name=frappe.db.get_value(doctype, docname, "name", cache=True))
 					else:
 						values_to_fetch = ["name"] + [_df.fetch_from.split(".")[-1] for _df in fields_to_fetch]
 
@@ -1063,10 +1063,10 @@ class BaseDocument:
 		cache_key = parentfield or "main"
 
 		if not hasattr(self, "_precision"):
-			self._precision = _dict()
+			self._precision = attrdict()
 
 		if cache_key not in self._precision:
-			self._precision[cache_key] = _dict()
+			self._precision[cache_key] = attrdict()
 
 		if fieldname not in self._precision[cache_key]:
 			self._precision[cache_key][fieldname] = None

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -62,7 +62,7 @@ class DatabaseQuery:
 		self.fields = None
 		self.user = user or frappe.session.user
 		self.ignore_ifnull = False
-		self.flags = frappe._dict()
+		self.flags = frappe.attrdict()
 		self.reference_doctype = None
 
 	def execute(
@@ -225,7 +225,7 @@ class DatabaseQuery:
 		self.set_optional_columns()
 		self.build_conditions()
 
-		args = frappe._dict()
+		args = frappe.attrdict()
 
 		if self.with_childnames:
 			for t in self.tables:
@@ -458,7 +458,7 @@ class DatabaseQuery:
 
 		self.check_read_permission(doctype)
 		self.link_tables.append(
-			frappe._dict(doctype=doctype, fieldname=fieldname, table_name=f"`tab{doctype}`")
+			frappe.attrdict(doctype=doctype, fieldname=fieldname, table_name=f"`tab{doctype}`")
 		)
 
 	def check_read_permission(self, doctype):
@@ -1100,10 +1100,10 @@ def get_between_date_filter(value, df=None):
 
 def get_additional_filter_field(additional_filters_config, f, value):
 	additional_filter = additional_filters_config[f.operator.lower()]
-	f = frappe._dict(frappe.get_attr(additional_filter["get_field"])())
+	f = frappe.attrdict(frappe.get_attr(additional_filter["get_field"])())
 	if f.query_value:
 		for option in f.options:
-			option = frappe._dict(option)
+			option = frappe.attrdict(option)
 			if option.value == value:
 				f.value = option.query_value
 	return f

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -91,7 +91,7 @@ class Document(BaseDocument):
 		"""
 		self.doctype = None
 		self.name = None
-		self.flags = frappe._dict()
+		self.flags = frappe.attrdict()
 
 		if args and args[0]:
 			if isinstance(args[0], str):
@@ -1444,12 +1444,12 @@ class Document(BaseDocument):
 
 	def set_onload(self, key, value):
 		if not self.get("__onload"):
-			self.set("__onload", frappe._dict())
+			self.set("__onload", frappe.attrdict())
 		self.get("__onload")[key] = value
 
 	def get_onload(self, key=None):
 		if not key:
-			return self.get("__onload", frappe._dict())
+			return self.get("__onload", frappe.attrdict())
 
 		return self.get("__onload")[key]
 

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -29,7 +29,7 @@ def make_mapped_doc(method, source_name, selected_children=None, args=None):
 		selected_children = json.loads(selected_children)
 
 	if args:
-		frappe.flags.args = frappe._dict(json.loads(args))
+		frappe.flags.args = frappe.attrdict(json.loads(args))
 
 	frappe.flags.selected_children = selected_children or None
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -106,8 +106,8 @@ class Meta(Document):
 		"DocType State",
 	}
 	standard_set_once_fields = [
-		frappe._dict(fieldname="creation", fieldtype="Datetime"),
-		frappe._dict(fieldname="owner", fieldtype="Data"),
+		frappe.attrdict(fieldname="creation", fieldtype="Datetime"),
+		frappe.attrdict(fieldname="owner", fieldtype="Data"),
 	]
 
 	def __init__(self, doctype):
@@ -226,7 +226,7 @@ class Meta(Document):
 		"""Returns list of fields with `in_global_search` set and `name` if set"""
 		fields = self.get("fields", {"in_global_search": 1, "fieldtype": ["not in", no_value_fields]})
 		if getattr(self, "show_name_in_global_search", None):
-			fields.append(frappe._dict(fieldtype="Data", fieldname="name", label="Name"))
+			fields.append(frappe.attrdict(fieldtype="Data", fieldname="name", label="Name"))
 
 		return fields
 
@@ -521,7 +521,7 @@ class Meta(Document):
 		)
 
 		if self.name in user_permission_doctypes:
-			fields.append(frappe._dict({"label": "Name", "fieldname": "name", "options": self.name}))
+			fields.append(frappe.attrdict({"label": "Name", "fieldname": "name", "options": self.name}))
 
 		return fields
 
@@ -561,12 +561,12 @@ class Meta(Document):
 		file in the doctype's folder, along with any overrides or extensions
 		implemented in other Frappe applications via hooks.
 		"""
-		data = frappe._dict()
+		data = frappe.attrdict()
 		if not self.custom:
 			try:
 				module = load_doctype_module(self.name, suffix="_dashboard")
 				if hasattr(module, "get_data"):
-					data = frappe._dict(module.get_data())
+					data = frappe.attrdict(module.get_data())
 			except ImportError:
 				pass
 
@@ -574,7 +574,7 @@ class Meta(Document):
 
 		if not self.custom:
 			for hook in frappe.get_hooks("override_doctype_dashboards", {}).get(self.name, []):
-				data = frappe._dict(frappe.get_attr(hook)(data=data))
+				data = frappe.attrdict(frappe.get_attr(hook)(data=data))
 
 		return data
 
@@ -601,7 +601,7 @@ class Meta(Document):
 				continue
 
 			for group in data.transactions:
-				group = frappe._dict(group)
+				group = frappe.attrdict(group)
 
 				# For internal links parent doctype will be the key
 				doctype = link.parent_doctype or link.link_doctype
@@ -690,7 +690,7 @@ def get_field_currency(df, doc=None):
 		return None
 
 	if not getattr(frappe.local, "field_currency", None):
-		frappe.local.field_currency = frappe._dict()
+		frappe.local.field_currency = frappe.attrdict()
 
 	if not (
 		frappe.local.field_currency.get((doc.doctype, doc.name), {}).get(df.fieldname)
@@ -717,9 +717,9 @@ def get_field_currency(df, doc=None):
 						currency = frappe.db.get_value(doc.parenttype, doc.parent, df.get("options"))
 
 		if currency:
-			frappe.local.field_currency.setdefault((doc.doctype, ref_docname), frappe._dict()).setdefault(
-				df.fieldname, currency
-			)
+			frappe.local.field_currency.setdefault(
+				(doc.doctype, ref_docname), frappe.attrdict()
+			).setdefault(df.fieldname, currency)
 
 	return frappe.local.field_currency.get((doc.doctype, doc.name), {}).get(df.fieldname) or (
 		doc.get("parent")
@@ -748,12 +748,12 @@ def get_field_precision(df, doc=None, currency=None):
 def get_default_df(fieldname):
 	if fieldname in (default_fields + child_table_fields):
 		if fieldname in ("creation", "modified"):
-			return frappe._dict(fieldname=fieldname, fieldtype="Datetime")
+			return frappe.attrdict(fieldname=fieldname, fieldtype="Datetime")
 
 		elif fieldname in ("idx", "docstatus"):
-			return frappe._dict(fieldname=fieldname, fieldtype="Int")
+			return frappe.attrdict(fieldname=fieldname, fieldtype="Int")
 
-		return frappe._dict(fieldname=fieldname, fieldtype="Data")
+		return frappe.attrdict(fieldname=fieldname, fieldtype="Data")
 
 
 def trim_tables(doctype=None, dry_run=False, quiet=False):

--- a/frappe/model/utils/__init__.py
+++ b/frappe/model/utils/__init__.py
@@ -91,7 +91,7 @@ def get_fetch_values(doctype, fieldname, value):
 	:param value: Value selected
 	"""
 
-	result = frappe._dict()
+	result = frappe.attrdict()
 	meta = frappe.get_meta(doctype)
 
 	# fieldname in target doctype: fieldname in source doctype

--- a/frappe/model/utils/rename_doc.py
+++ b/frappe/model/utils/rename_doc.py
@@ -51,7 +51,7 @@ def get_fetch_fields(
 	product_list = product(master_list, linked_to_list)
 
 	for d in product_list:
-		linked_doctype_info = frappe._dict()
+		linked_doctype_info = frappe.attrdict()
 		if (
 			d[0]["parent"] == d[1]["parent"]
 			and (not ignore_doctypes or d[0]["parent"] not in ignore_doctypes)

--- a/frappe/model/virtual_doctype.py
+++ b/frappe/model/virtual_doctype.py
@@ -17,7 +17,7 @@ class VirtualDoctype(Protocol):
 	# ============ class/static methods ============
 
 	@staticmethod
-	def get_list(args) -> list[frappe._dict]:
+	def get_list(args) -> list[frappe.attrdict]:
 		"""Similar to reportview.get_list"""
 		...
 

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -76,10 +76,10 @@ def get_transitions(
 def get_workflow_safe_globals():
 	# access to frappe.db.get_value, frappe.db.get_list, and date time utils.
 	return dict(
-		frappe=frappe._dict(
-			db=frappe._dict(get_value=frappe.db.get_value, get_list=frappe.db.get_list),
+		frappe=frappe.attrdict(
+			db=frappe.attrdict(get_value=frappe.db.get_value, get_list=frappe.db.get_list),
 			session=frappe.session,
-			utils=frappe._dict(
+			utils=frappe.attrdict(
 				now_datetime=frappe.utils.now_datetime,
 				add_to_date=frappe.utils.add_to_date,
 				get_datetime=frappe.utils.get_datetime,

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -266,7 +266,9 @@ def get_app_publisher(module: str) -> str:
 
 
 def make_boilerplate(
-	template: str, doc: Union["Document", "frappe._dict"], opts: Union[dict, "frappe._dict"] = None
+	template: str,
+	doc: Union["Document", "frappe.attrdict"],
+	opts: Union[dict, "frappe.attrdict"] = None,
 ):
 	target_path = get_doc_path(doc.module, doc.doctype, doc.name)
 	template_name = template.replace("controller", scrub(doc.name))
@@ -281,8 +283,8 @@ def make_boilerplate(
 		print(f"{target_file_path} already exists, skipping...")
 		return
 
-	doc = doc or frappe._dict()
-	opts = opts or frappe._dict()
+	doc = doc or frappe.attrdict()
+	opts = opts or frappe.attrdict()
 	app_publisher = get_app_publisher(doc.module)
 	base_class = "Document"
 	base_class_import = "from frappe.model.document import Document"

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -41,7 +41,7 @@ class Monitor:
 
 	def __init__(self, transaction_type, method, kwargs):
 		try:
-			self.data = frappe._dict(
+			self.data = frappe.attrdict(
 				{
 					"site": frappe.local.site,
 					"timestamp": datetime.utcnow(),
@@ -58,7 +58,7 @@ class Monitor:
 			traceback.print_exc()
 
 	def collect_request_meta(self):
-		self.data.request = frappe._dict(
+		self.data.request = frappe.attrdict(
 			{
 				"ip": frappe.local.request_ip,
 				"method": frappe.request.method,
@@ -67,7 +67,7 @@ class Monitor:
 		)
 
 	def collect_job_meta(self, method, kwargs):
-		self.data.job = frappe._dict({"method": method, "scheduled": False, "wait": 0})
+		self.data.job = frappe.attrdict({"method": method, "scheduled": False, "wait": 0})
 		if "run_scheduled_job" in method:
 			self.data.job.method = kwargs["job_type"]
 			self.data.job.scheduled = True

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -576,7 +576,7 @@ def get_userinfo(user):
 		else:
 			picture = frappe_server_url + "/" + user.user_image
 
-	userinfo = frappe._dict(
+	userinfo = frappe.attrdict(
 		{
 			"sub": frappe.db.get_value(
 				"User Social Login",
@@ -602,9 +602,9 @@ def get_url_delimiter(separator_character=" "):
 
 def generate_json_error_response(e):
 	if not e:
-		e = frappe._dict({})
+		e = frappe.attrdict({})
 
-	frappe.local.response = frappe._dict(
+	frappe.local.response = frappe.attrdict(
 		{
 			"description": getattr(e, "description", "Internal Server Error"),
 			"status_code": getattr(e, "status_code", 500),

--- a/frappe/patches/v10_0/refactor_social_login_keys.py
+++ b/frappe/patches/v10_0/refactor_social_login_keys.py
@@ -130,7 +130,7 @@ def insert_user_social_login(user, modified_by, provider, idx, userid=None, user
 
 
 def get_provider_field_map():
-	return frappe._dict(
+	return frappe.attrdict(
 		{
 			"frappe": ["frappe_userid"],
 			"facebook": ["fb_userid", "fb_username"],

--- a/frappe/patches/v11_0/migrate_report_settings_for_new_listview.py
+++ b/frappe/patches/v11_0/migrate_report_settings_for_new_listview.py
@@ -18,7 +18,7 @@ def execute():
 		if not settings:
 			continue
 
-		settings = frappe._dict(json.loads(settings))
+		settings = frappe.attrdict(json.loads(settings))
 
 		# columns -> fields
 		settings.fields = settings.columns or []

--- a/frappe/patches/v12_0/delete_duplicate_indexes.py
+++ b/frappe/patches/v12_0/delete_duplicate_indexes.py
@@ -9,10 +9,10 @@ def execute():
 		return
 
 	all_tables = frappe.db.get_tables()
-	final_deletion_map = frappe._dict()
+	final_deletion_map = frappe.attrdict()
 
 	for table in all_tables:
-		indexes_to_keep_map = frappe._dict()
+		indexes_to_keep_map = frappe.attrdict()
 		indexes_to_delete = []
 		index_info = frappe.db.sql(
 			"""

--- a/frappe/patches/v14_0/reset_creation_datetime.py
+++ b/frappe/patches/v14_0/reset_creation_datetime.py
@@ -23,7 +23,7 @@ def execute():
 	for dt_path in doctype_jsons:
 		with open(dt_path) as f:
 			try:
-				file_schema = frappe._dict(json.load(f))
+				file_schema = frappe.attrdict(json.load(f))
 			except Exception:
 				continue
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -226,7 +226,7 @@ def get_role_permissions(doctype_meta, user=None, is_owner=None):
 		return allow_everything()
 
 	if not frappe.local.role_permissions.get(cache_key):
-		perms = frappe._dict(if_owner={})
+		perms = frappe.attrdict(if_owner={})
 
 		roles = frappe.get_roles(user)
 

--- a/frappe/search/full_text_search.py
+++ b/frappe/search/full_text_search.py
@@ -75,7 +75,7 @@ class FullTextSearch:
 
 		Args:
 		        self (object): FullTextSearch Instance
-		        document (_dict): A dictionary with title, path and content
+		        document (attrdict): A dictionary with title, path and content
 		"""
 		ix = self.get_index()
 
@@ -116,7 +116,7 @@ class FullTextSearch:
 		        limit (int, optional): Limit number of search results. Defaults to 20.
 
 		Returns:
-		        [List(_dict)]: Search results
+		        [List(attrdict)]: Search results
 		"""
 		ix = self.get_index()
 

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -57,7 +57,7 @@ class WebsiteSearch(FullTextSearch):
 		        path (str): route of the page to be parsed
 
 		Returns:
-		        document (_dict): A dictionary with title, path and content
+		        document (attrdict): A dictionary with title, path and content
 		"""
 		frappe.set_user("Guest")
 		frappe.local.no_cache = True
@@ -70,7 +70,7 @@ class WebsiteSearch(FullTextSearch):
 			text_content = page_content.text if page_content else ""
 			title = soup.title.text.strip() if soup.title else route
 
-			return frappe._dict(title=title, content=text_content, path=route)
+			return frappe.attrdict(title=title, content=text_content, path=route)
 		except Exception:
 			pass
 		finally:
@@ -80,7 +80,7 @@ class WebsiteSearch(FullTextSearch):
 		title_highlights = result.highlights("title")
 		content_highlights = result.highlights("content")
 
-		return frappe._dict(
+		return frappe.attrdict(
 			title=result["title"],
 			path=result["path"],
 			title_highlights=title_highlights,
@@ -104,7 +104,7 @@ def slugs_with_web_view(_items_to_index):
 					content = frappe.utils.md_to_html(getattr(doc, doctype.website_search_field))
 					soup = BeautifulSoup(content, "html.parser")
 					text_content = soup.text if soup else ""
-					_items_to_index += [frappe._dict(title=doc.title, content=text_content, path=doc.route)]
+					_items_to_index += [frappe.attrdict(title=doc.title, content=text_content, path=doc.route)]
 			else:
 				docs = frappe.get_all(doctype.name, filters=filters, fields=fields)
 				all_routes += [route.route for route in docs]

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -210,7 +210,7 @@ class Session:
 		self.user = user
 		self.user_type = user_type
 		self.full_name = full_name
-		self.data = frappe._dict({"data": frappe._dict({})})
+		self.data = frappe.attrdict({"data": frappe.attrdict({})})
 		self.time_diff = None
 
 		# set local session
@@ -312,7 +312,7 @@ class Session:
 
 	def get_session_data(self):
 		if self.sid == "Guest":
-			return frappe._dict({"user": "Guest"})
+			return frappe.attrdict({"user": "Guest"})
 
 		data = self.get_session_data_from_cache()
 		if not data:
@@ -322,7 +322,7 @@ class Session:
 	def get_session_data_from_cache(self):
 		data = frappe.cache().hget("session", self.sid)
 		if data:
-			data = frappe._dict(data)
+			data = frappe.attrdict(data)
 			session_data = data.get("data", {})
 
 			# set user for correct timezone
@@ -350,7 +350,7 @@ class Session:
 		)
 
 		if rec:
-			data = frappe._dict(frappe.safe_eval(rec and rec[0][1] or "{}"))
+			data = frappe.attrdict(frappe.safe_eval(rec and rec[0][1] or "{}"))
 			data.user = rec[0][0]
 		else:
 			self._delete_session()
@@ -439,7 +439,7 @@ def get_geo_from_ip(ip_addr):
 			reader = f.reader()
 			data = reader.get(ip_addr)
 
-			return frappe._dict(data)
+			return frappe.attrdict(data)
 	except ImportError:
 		return
 	except ValueError:

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -128,7 +128,7 @@ def get_notification_message(doc):
 
 
 def get_alert_dict(doc):
-	alert_dict = frappe._dict()
+	alert_dict = frappe.attrdict()
 	owner_name = get_fullname(doc.owner)
 	if doc.reference_doctype:
 		doc_link = get_link_to_form(doc.reference_doctype, doc.reference_name)
@@ -171,7 +171,7 @@ def get_alert_dict(doc):
 
 
 def create_energy_points_log(ref_doctype, ref_name, doc, apply_only_once=False):
-	doc = frappe._dict(doc)
+	doc = frappe.attrdict(doc)
 
 	log_exists = check_if_log_exists(
 		ref_doctype, ref_name, doc.rule, None if apply_only_once else doc.user
@@ -190,7 +190,7 @@ def create_energy_points_log(ref_doctype, ref_name, doc, apply_only_once=False):
 
 def check_if_log_exists(ref_doctype, ref_name, rule, user=None):
 	"""'Checks if Energy Point Log already exists"""
-	filters = frappe._dict(
+	filters = frappe.attrdict(
 		{"rule": rule, "reference_doctype": ref_doctype, "reference_name": ref_name, "reverted": 0}
 	)
 
@@ -226,14 +226,14 @@ def get_energy_points(user):
 	# 	lambda: get_user_energy_and_review_points(user))
 	# TODO: cache properly
 	points = get_user_energy_and_review_points(user)
-	return frappe._dict(points.get(user, {}))
+	return frappe.attrdict(points.get(user, {}))
 
 
 @frappe.whitelist()
 def get_user_energy_and_review_points(user=None, from_date=None, as_dict=True):
 	conditions = ""
 	given_points_condition = ""
-	values = frappe._dict()
+	values = frappe.attrdict()
 	if user:
 		conditions = "WHERE `user` = %(user)s"
 		values.user = user
@@ -268,7 +268,7 @@ def get_user_energy_and_review_points(user=None, from_date=None, as_dict=True):
 	if not as_dict:
 		return points_list
 
-	dict_to_return = frappe._dict()
+	dict_to_return = frappe.attrdict()
 	for d in points_list:
 		dict_to_return[d.pop("user")] = d
 	return dict_to_return
@@ -277,7 +277,7 @@ def get_user_energy_and_review_points(user=None, from_date=None, as_dict=True):
 @frappe.whitelist()
 def review(doc, points, to_user, reason, review_type="Appreciation"):
 	current_review_points = get_energy_points(frappe.session.user).review_points
-	doc = doc.as_dict() if hasattr(doc, "as_dict") else frappe._dict(json.loads(doc))
+	doc = doc.as_dict() if hasattr(doc, "as_dict") else frappe.attrdict(json.loads(doc))
 	points = abs(cint(points))
 	if current_review_points < points:
 		frappe.msgprint(_("You do not have enough review points"))

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -142,13 +142,13 @@ class TestResourceAPI(FrappeAPITestCase):
 	def test_get_list_dict(self):
 		# test 4: fetch response as (not) dict
 		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "as_dict": True})
-		json = frappe._dict(response.json)
+		json = frappe.attrdict(response.json)
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(json.data, list)
 		self.assertIsInstance(json.data[0], dict)
 
 		response = self.get(f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "as_dict": False})
-		json = frappe._dict(response.json)
+		json = frappe.attrdict(response.json)
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(json.data, list)
 		self.assertIsInstance(json.data[0], list)
@@ -167,7 +167,7 @@ class TestResourceAPI(FrappeAPITestCase):
 			f"/api/resource/{self.DOCTYPE}", {"sid": self.sid, "fields": '["description"]'}
 		)
 		self.assertEqual(response.status_code, 200)
-		json = frappe._dict(response.json)
+		json = frappe.attrdict(response.json)
 		self.assertIn("description", json.data[0])
 
 	def test_create_document(self):
@@ -241,7 +241,7 @@ class TestMethodAPI(FrappeAPITestCase):
 	def test_version(self):
 		# test 1: test for /api/method/version
 		response = self.get(f"{self.METHOD_PATH}/version")
-		json = frappe._dict(response.json)
+		json = frappe.attrdict(response.json)
 
 		self.assertEqual(response.status_code, 200)
 		self.assertIsInstance(json, dict)

--- a/frappe/tests/test_boilerplate.py
+++ b/frappe/tests/test_boilerplate.py
@@ -21,7 +21,7 @@ class TestBoilerPlate(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
-		cls.default_hooks = frappe._dict(
+		cls.default_hooks = frappe.attrdict(
 			{
 				"app_name": "test_app",
 				"app_title": "Test App",
@@ -33,7 +33,7 @@ class TestBoilerPlate(FrappeTestCase):
 			}
 		)
 
-		cls.default_user_input = frappe._dict(
+		cls.default_user_input = frappe.attrdict(
 			{
 				"title": "Test App",
 				"description": "This app's description contains 'single quotes' and \"double quotes\".",
@@ -111,7 +111,7 @@ class TestBoilerPlate(FrappeTestCase):
 	def test_create_app(self):
 		app_name = "test_app"
 
-		hooks = frappe._dict(
+		hooks = frappe.attrdict(
 			{
 				"app_name": app_name,
 				"app_title": "Test App",
@@ -134,7 +134,7 @@ class TestBoilerPlate(FrappeTestCase):
 	def test_create_app_without_git_init(self):
 		app_name = "test_app_no_git"
 
-		hooks = frappe._dict(
+		hooks = frappe.attrdict(
 			{
 				"app_name": app_name,
 				"app_title": "Test App",

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -42,7 +42,7 @@ class TestCachingUtils(FrappeTestCase):
 			range(10),
 			{"abc": "test-key"},
 			frappe.get_last_doc("DocType"),
-			frappe._dict(),
+			frappe.attrdict(),
 		]
 		same_output_received = lambda: all([x for x in set(retval) if x == retval[0]])
 

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -44,10 +44,10 @@ class TestClient(FrappeTestCase):
 
 		frappe.set_user("Administrator")
 
-		frappe.local.request = frappe._dict()
+		frappe.local.request = frappe.attrdict()
 		frappe.local.request.method = "POST"
 
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{"doc": dict(doctype="ToDo", description="Valid http method"), "cmd": "frappe.client.save"}
 		)
 		todo = execute_cmd("frappe.client.save")
@@ -61,10 +61,10 @@ class TestClient(FrappeTestCase):
 
 		frappe.set_user("Administrator")
 
-		frappe.local.request = frappe._dict()
+		frappe.local.request = frappe.attrdict()
 		frappe.local.request.method = "GET"
 
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{"doc": dict(doctype="ToDo", description="Invalid http method"), "cmd": "frappe.client.save"}
 		)
 
@@ -87,11 +87,11 @@ class TestClient(FrappeTestCase):
 		else:
 			report = frappe.get_doc("Report", "Test Run Doc Method")
 
-		frappe.local.request = frappe._dict()
+		frappe.local.request = frappe.attrdict()
 		frappe.local.request.method = "GET"
 
 		# Whitelisted, works as expected
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{
 				"dt": report.doctype,
 				"dn": report.name,
@@ -104,7 +104,7 @@ class TestClient(FrappeTestCase):
 		execute_cmd(frappe.local.form_dict.cmd)
 
 		# Not whitelisted, throws permission error
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{
 				"dt": report.doctype,
 				"dn": report.name,

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -36,7 +36,7 @@ from frappe.utils.jinja_globals import bundled_asset
 
 _result: Result | None = None
 TEST_SITE = "commands-site-O4PN2QKA.test"  # added random string tag to avoid collisions
-CLI_CONTEXT = frappe._dict(sites=[TEST_SITE])
+CLI_CONTEXT = frappe.attrdict(sites=[TEST_SITE])
 
 
 def clean(value) -> str:

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -743,10 +743,10 @@ class TestReportview(FrappeTestCase):
 
 		frappe.set_user(user.name)
 
-		frappe.local.request = frappe._dict()
+		frappe.local.request = frappe.attrdict()
 		frappe.local.request.method = "POST"
 
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{
 				"doctype": "Blog Post",
 				"fields": ["published", "title", "`tabTest Child`.`test_field`"],
@@ -756,7 +756,7 @@ class TestReportview(FrappeTestCase):
 		# even if * is passed, fields which are not accessible should be filtered out
 		response = execute_cmd("frappe.desk.reportview.get")
 		self.assertListEqual(response["keys"], ["title"])
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{
 				"doctype": "Blog Post",
 				"fields": ["*"],
@@ -773,7 +773,7 @@ class TestReportview(FrappeTestCase):
 		frappe.set_user("Administrator")
 
 		# Admin should be able to see access all fields
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{
 				"doctype": "Blog Post",
 				"fields": ["published", "title", "`tabTest Child`.`test_field`"],
@@ -789,7 +789,7 @@ class TestReportview(FrappeTestCase):
 
 	def test_reportview_get_aggregation(self):
 		# test aggregation based on child table field
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			{
 				"doctype": "DocType",
 				"fields": """["`tabDocField`.`label` as field_label","`tabDocField`.`name` as field_name"]""",

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -125,7 +125,7 @@ def get_other_fields_meta(meta):
 	optional_fields_map = {field: ("Text", 0) for field in optional_fields}
 	fields = dict(default_fields_map, **optional_fields_map, **child_table_fields_map)
 	field_map = [
-		frappe._dict({"fieldname": field, "fieldtype": _type, "length": _length})
+		frappe.attrdict({"fieldname": field, "fieldtype": _type, "length": _length})
 		for field, (_type, _length) in fields.items()
 	]
 

--- a/frappe/tests/test_formatter.py
+++ b/frappe/tests/test_formatter.py
@@ -5,9 +5,9 @@ from frappe.tests.utils import FrappeTestCase
 
 class TestFormatter(FrappeTestCase):
 	def test_currency_formatting(self):
-		df = frappe._dict({"fieldname": "amount", "fieldtype": "Currency", "options": "currency"})
+		df = frappe.attrdict({"fieldname": "amount", "fieldtype": "Currency", "options": "currency"})
 
-		doc = frappe._dict({"amount": 5})
+		doc = frappe.attrdict({"amount": 5})
 		frappe.db.set_default("currency", "INR")
 
 		# if currency field is not passed then default currency should be used.

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -13,7 +13,7 @@ class TestQueryReport(FrappeTestCase):
 		"""Test exporting report using rows with multiple datatypes (list, dict)"""
 
 		# Create mock data
-		data = frappe._dict()
+		data = frappe.attrdict()
 		data.columns = [
 			{"label": "Column A", "fieldname": "column_a", "fieldtype": "Float"},
 			{"label": "Column B", "fieldname": "column_b", "width": 100, "fieldtype": "Float"},
@@ -48,7 +48,7 @@ class TestQueryReport(FrappeTestCase):
 	def test_xlsx_export_with_composite_cell_value(self):
 		"""Test excel export using rows with composite cell value"""
 
-		data = frappe._dict()
+		data = frappe.attrdict()
 		data.columns = [
 			{"label": "Column A", "fieldname": "column_a", "fieldtype": "Float"},
 			{"label": "Column B", "fieldname": "column_b", "width": 150, "fieldtype": "Data"},
@@ -89,7 +89,7 @@ class TestQueryReport(FrappeTestCase):
 
 		for delimiter in (",", ";", "\t", "|"):
 			for quoting in (QUOTE_ALL, QUOTE_MINIMAL, QUOTE_NONE, QUOTE_NONNUMERIC):
-				frappe.local.form_dict = frappe._dict(
+				frappe.local.form_dict = frappe.attrdict(
 					{
 						"report_name": REPORT_NAME,
 						"file_format_type": "CSV",

--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -65,7 +65,7 @@ class TestRenameDoc(FrappeTestCase):
 			self.available_documents.append(doc.name)
 
 		#  data generation: for controllers tests
-		self.doctype = frappe._dict(
+		self.doctype = frappe.attrdict(
 			{
 				"old": "Test Rename Document Old",
 				"new": "Test Rename Document New",

--- a/frappe/tests/test_reportview.py
+++ b/frappe/tests/test_reportview.py
@@ -11,7 +11,7 @@ class TestReportview(FrappeTestCase):
 		from csv import QUOTE_ALL, QUOTE_MINIMAL, QUOTE_NONE, QUOTE_NONNUMERIC, DictReader
 		from io import StringIO
 
-		frappe.local.form_dict = frappe._dict(
+		frappe.local.form_dict = frappe.attrdict(
 			doctype="DocType",
 			file_format_type="CSV",
 			fields=("name", "module", "issingle"),

--- a/frappe/tests/test_virtual_doctype.py
+++ b/frappe/tests/test_virtual_doctype.py
@@ -68,7 +68,7 @@ class VirtualDoctypeTest(Document):
 	@staticmethod
 	def get_list(args):
 		data = VirtualDoctypeTest.get_current_data()
-		return [frappe._dict(doc) for name, doc in data.items()]
+		return [frappe.attrdict(doc) for name, doc in data.items()]
 
 	@staticmethod
 	def get_count(args):

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -339,7 +339,7 @@ class TestWebsite(FrappeTestCase):
 	def test_resolve_class(self):
 		from frappe.utils.jinja_globals import resolve_class
 
-		context = frappe._dict(primary=True)
+		context = frappe.attrdict(primary=True)
 		self.assertEqual(resolve_class("test"), "test")
 		self.assertEqual(resolve_class("test", "test-2"), "test test-2")
 		self.assertEqual(resolve_class("test", {"test-2": False, "test-3": True}), "test test-3")

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -29,7 +29,7 @@ def create_if_not_exists(doc):
 
 	names = []
 	for doc in docs:
-		doc = frappe._dict(doc)
+		doc = frappe.attrdict(doc)
 		filters = doc.copy()
 		filters.pop("doctype")
 		name = frappe.db.exists(doc.doctype, filters)

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -106,7 +106,7 @@ def _restore_thread_locals(flags):
 	frappe.local.message_log = []
 	frappe.local.debug_log = []
 	frappe.local.realtime_log = []
-	frappe.local.conf = frappe._dict(frappe.get_site_config())
+	frappe.local.conf = frappe.attrdict(frappe.get_site_config())
 	frappe.local.cache = {}
 	frappe.local.lang = "en"
 	frappe.local.preload_assets = {"style": [], "script": []}

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -747,7 +747,7 @@ def get_site_info():
 		del u["name"]
 
 	system_settings = frappe.db.get_singles_dict("System Settings")
-	space_usage = frappe._dict((frappe.local.conf.limits or {}).get("space_usage", {}))
+	space_usage = frappe.attrdict((frappe.local.conf.limits or {}).get("space_usage", {}))
 
 	kwargs = {
 		"fields": ["user", "creation", "full_name"],
@@ -787,7 +787,7 @@ def parse_json(val):
 	if isinstance(val, str):
 		val = json.loads(val)
 	if isinstance(val, dict):
-		val = frappe._dict(val)
+		val = frappe.attrdict(val)
 	return val
 
 
@@ -1022,7 +1022,7 @@ def dictify(arg):
 		for i, a in enumerate(arg):
 			arg[i] = dictify(a)
 	elif isinstance(arg, MutableMapping):
-		arg = frappe._dict(arg)
+		arg = frappe.attrdict(arg)
 
 	return arg
 
@@ -1033,9 +1033,9 @@ def add_user_info(user, user_info):
 			frappe.db.get_value(
 				"User", user, ["full_name", "user_image", "name", "email", "time_zone"], as_dict=True
 			)
-			or frappe._dict()
+			or frappe.attrdict()
 		)
-		user_info[user] = frappe._dict(
+		user_info[user] = frappe.attrdict(
 			fullname=info.full_name or user,
 			image=info.user_image,
 			name=user,

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -346,7 +346,7 @@ def get_redis_conn(username=None, password=None):
 
 	global redis_connection
 
-	cred = frappe._dict()
+	cred = frappe.attrdict()
 	if frappe.conf.get("use_rq_auth"):
 		if username:
 			cred["username"] = username

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -386,7 +386,7 @@ class BackupGenerator:
 		]
 
 		# escape reserved characters
-		args = frappe._dict(
+		args = frappe.attrdict(
 			[item[0], frappe.utils.esc(str(item[1]), "$ ")] for item in self.__dict__.copy().items()
 		)
 

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -29,7 +29,7 @@ def _get_user_inputs(app_name):
 	"""Prompt user for various inputs related to new app and return config."""
 	app_name = frappe.scrub(app_name)
 
-	hooks = frappe._dict()
+	hooks = frappe.attrdict()
 	hooks.app_name = app_name
 	app_title = hooks.app_name.replace("_", " ").title()
 

--- a/frappe/utils/change_log.py
+++ b/frappe/utils/change_log.py
@@ -17,7 +17,7 @@ def get_change_log(user=None):
 	if not user:
 		user = frappe.session.user
 
-	last_known_versions = frappe._dict(
+	last_known_versions = frappe.attrdict(
 		json.loads(frappe.db.get_value("User", user, "last_known_versions") or "{}")
 	)
 	current_versions = get_versions()
@@ -165,7 +165,7 @@ def get_app_last_commit_ref(app):
 
 
 def check_for_update():
-	updates = frappe._dict(major=[], minor=[], patch=[])
+	updates = frappe.attrdict(major=[], minor=[], patch=[])
 	apps = get_versions()
 
 	for app in apps:
@@ -184,7 +184,7 @@ def check_for_update():
 		for update_type in updates:
 			if github_version.__dict__[update_type] > instance_version.__dict__[update_type]:
 				updates[update_type].append(
-					frappe._dict(
+					frappe.attrdict(
 						current_version=str(instance_version),
 						available_version=str(github_version),
 						org_name=org_name,
@@ -291,7 +291,7 @@ def show_update_popup():
 		for update_type in updates:
 			release_links = ""
 			for app in updates[update_type]:
-				app = frappe._dict(app)
+				app = frappe.attrdict(app)
 				release_links += "<b>{title}</b>: <a href='https://github.com/{org_name}/{app_name}/releases/tag/v{available_version}'>v{available_version}</a><br>".format(
 					available_version=app.available_version,
 					org_name=app.org_name,

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -85,7 +85,7 @@ def send_csv_to_client(args):
 	if isinstance(args, str):
 		args = json.loads(args)
 
-	args = frappe._dict(args)
+	args = frappe.attrdict(args)
 
 	frappe.response["result"] = cstr(to_csv(args.data))
 	frappe.response["doctype"] = args.filename

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -37,7 +37,7 @@ def cache_source(function):
 
 def generate_and_cache_results(args, function, cache_key, chart):
 	try:
-		args = frappe._dict(args)
+		args = frappe.attrdict(args)
 		results = function(
 			chart_name=args.chart_name,
 			filters=args.filters or None,

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1721,8 +1721,8 @@ def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
 	return False
 
 
-def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "frappe._dict":
-	"""Returns a _dict like
+def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "frappe.attrdict":
+	"""Returns a attrdict like
 
 	{
 	        "doctype":
@@ -1750,7 +1750,7 @@ def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "fr
 			frappe._("Filter must have 4 values (doctype, fieldname, operator, value): {0}").format(str(f))
 		)
 
-	f = frappe._dict(doctype=f[0], fieldname=f[1], operator=f[2], value=f[3])
+	f = frappe.attrdict(doctype=f[0], fieldname=f[1], operator=f[2], value=f[3])
 
 	sanitize_column(f.fieldname)
 
@@ -1822,7 +1822,7 @@ def make_filter_dict(filters):
 	"""convert this [[doctype, key, operator, value], ..]
 	to this { key: (operator, value), .. }
 	"""
-	_filter = frappe._dict()
+	_filter = frappe.attrdict()
 	for f in filters:
 		_filter[f[1]] = (f[2], f[3])
 

--- a/frappe/utils/formatters.py
+++ b/frappe/utils/formatters.py
@@ -27,10 +27,10 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 	"""Format value based on given fieldtype, document reference, currency reference.
 	If docfield info (df) is not given, it will try and guess based on the datatype of the value"""
 	if isinstance(df, str):
-		df = frappe._dict(fieldtype=df)
+		df = frappe.attrdict(fieldtype=df)
 
 	if not df:
-		df = frappe._dict()
+		df = frappe.attrdict()
 		if isinstance(value, datetime.datetime):
 			df.fieldtype = "Datetime"
 		elif isinstance(value, datetime.date):
@@ -46,7 +46,7 @@ def format_value(value, df=None, doc=None, currency=None, translated=False, form
 
 	elif isinstance(df, dict):
 		# Convert dict to object if necessary
-		df = frappe._dict(df)
+		df = frappe.attrdict(df)
 
 	if value is None:
 		value = ""

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -74,7 +74,7 @@ def rebuild_for_doctype(doctype):
 		return
 
 	def _get_filters():
-		filters = frappe._dict({"docstatus": ["!=", 2]})
+		filters = frappe.attrdict({"docstatus": ["!=", 2]})
 		if meta.has_field("enabled"):
 			filters.enabled = 1
 		if meta.has_field("disabled"):
@@ -186,8 +186,8 @@ def get_children_data(doctype, meta):
 	}
 
 	"""
-	all_children = frappe._dict()
-	child_search_fields = frappe._dict()
+	all_children = frappe.attrdict()
+	child_search_fields = frappe.attrdict()
 
 	for child in meta.get_table_fields():
 		child_meta = frappe.get_meta(child.options)
@@ -200,7 +200,7 @@ def get_children_data(doctype, meta):
 			)
 
 			for record in child_records:
-				all_children.setdefault(record.parent, frappe._dict()).setdefault(child.options, []).append(
+				all_children.setdefault(record.parent, frappe.attrdict()).setdefault(child.options, []).append(
 					record
 				)
 

--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -39,7 +39,7 @@ def web_block(template, values=None, **kwargs):
 
 def web_blocks(blocks):
 	import frappe
-	from frappe import _, _dict, throw
+	from frappe import _, attrdict, throw
 	from frappe.website.doctype.web_page.web_page import get_web_blocks_html
 
 	web_blocks = []
@@ -47,7 +47,7 @@ def web_blocks(blocks):
 		if not block.get("template"):
 			throw(_("Web Template is not specified"))
 
-		doc = _dict(
+		doc = attrdict(
 			{
 				"doctype": "Web Page Block",
 				"web_template": block["template"],

--- a/frappe/utils/make_random.py
+++ b/frappe/utils/make_random.py
@@ -6,7 +6,7 @@ import frappe
 if TYPE_CHECKING:
 	from frappe.model.document import Document
 
-settings = frappe._dict(
+settings = frappe.attrdict(
 	prob={
 		"default": {"make": 0.6, "qty": (1, 5)},
 	}

--- a/frappe/utils/redis_queue.py
+++ b/frappe/utils/redis_queue.py
@@ -13,7 +13,7 @@ class RedisQueue:
 		password = password or self.conn.acl_genpass()
 		user_settings = self.get_new_user_settings(username, password)
 		is_created = self.conn.acl_setuser(**user_settings)
-		return frappe._dict(user_settings) if is_created else {}
+		return frappe.attrdict(user_settings) if is_created else {}
 
 	@classmethod
 	def get_connection(cls, username=None, password=None):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -32,7 +32,7 @@ class ServerScriptNotEnabled(frappe.PermissionError):
 	pass
 
 
-class NamespaceDict(frappe._dict):
+class NamespaceDict(frappe.attrdict):
 	"""Raise AttributeError if function not found in namespace"""
 
 	def __getattr__(self, key):
@@ -95,7 +95,7 @@ def safe_exec_flags():
 
 
 def get_safe_globals():
-	datautils = frappe._dict()
+	datautils = frappe.attrdict()
 
 	if frappe.db:
 		date_format = frappe.db.get_default("date_format") or "yyyy-mm-dd"
@@ -106,7 +106,7 @@ def get_safe_globals():
 
 	add_data_utils(datautils)
 
-	form_dict = getattr(frappe.local, "form_dict", frappe._dict())
+	form_dict = getattr(frappe.local, "form_dict", frappe.attrdict())
 
 	if "_" in form_dict:
 		del frappe.local.form_dict["_"]
@@ -119,13 +119,14 @@ def get_safe_globals():
 		as_json=frappe.as_json,
 		dict=dict,
 		log=frappe.log,
-		_dict=frappe._dict,
+		_dict=frappe.attrdict,
 		args=form_dict,
 		frappe=NamespaceDict(
 			call=call_whitelisted_function,
-			flags=frappe._dict(),
+			flags=frappe.attrdict(),
 			format=frappe.format_value,
 			format_value=frappe.format_value,
+			attrdict=frappe.attrdict,
 			date_format=date_format,
 			time_format=time_format,
 			format_date=frappe.utils.data.global_date_format,
@@ -160,7 +161,7 @@ def get_safe_globals():
 			if getattr(frappe.local, "session", None)
 			else "Guest",
 			request=getattr(frappe.local, "request", {}),
-			session=frappe._dict(
+			session=frappe.attrdict(
 				user=user,
 				csrf_token=frappe.local.session.data.csrf_token
 				if getattr(frappe.local, "session", None)
@@ -193,7 +194,7 @@ def get_safe_globals():
 			lang=getattr(frappe.local, "lang", "en"),
 		),
 		FrappeClient=FrappeClient,
-		style=frappe._dict(border_color="#d1d8dd"),
+		style=frappe.attrdict(border_color="#d1d8dd"),
 		get_toc=get_toc,
 		get_next_link=get_next_link,
 		_=frappe._,
@@ -270,7 +271,7 @@ def run_script(script, **kwargs):
 
 def call_with_form_dict(function, kwargs):
 	# temporarily update form_dict, to use inside below call
-	form_dict = getattr(frappe.local, "form_dict", frappe._dict())
+	form_dict = getattr(frappe.local, "form_dict", frappe.attrdict())
 	if kwargs:
 		frappe.local.form_dict = form_dict.copy().update(kwargs)
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import frappe
 import frappe.share
-from frappe import _dict
+from frappe import attrdict
 from frappe.boot import get_allowed_reports
 from frappe.core.doctype.domain_settings.domain_settings import get_active_modules
 from frappe.permissions import get_roles, get_valid_perms
@@ -271,11 +271,11 @@ def get_user_fullname(user: str) -> str:
 	)
 
 
-def get_fullname_and_avatar(user: str) -> _dict:
+def get_fullname_and_avatar(user: str) -> attrdict:
 	first_name, last_name, avatar, name = frappe.db.get_value(
 		"User", user, ["first_name", "last_name", "user_image", "name"], order_by=None
 	)
-	return _dict(
+	return attrdict(
 		{
 			"fullname": " ".join(list(filter(None, [first_name, last_name]))),
 			"avatar": avatar,

--- a/frappe/utils/weasyprint.py
+++ b/frappe/utils/weasyprint.py
@@ -69,7 +69,7 @@ class PrintFormatGenerator:
 			if self.print_settings.print_style
 			else None
 		)
-		context = frappe._dict(
+		context = frappe.attrdict(
 			{
 				"doc": self.doc,
 				"print_format": self.print_format,

--- a/frappe/website/dashboard_fixtures.py
+++ b/frappe/website/dashboard_fixtures.py
@@ -2,7 +2,7 @@ import frappe
 
 
 def get_data():
-	return frappe._dict(
+	return frappe.attrdict(
 		{
 			"dashboards": get_dashboards(),
 			"charts": get_charts(),

--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -196,7 +196,7 @@ class BlogPost(WebsiteGenerator):
 
 
 def get_list_context(context=None):
-	list_context = frappe._dict(
+	list_context = frappe.attrdict(
 		get_list=get_blog_list,
 		no_breadcrumbs=True,
 		hide_filters=True,

--- a/frappe/website/doctype/blog_post/test_blog_post.py
+++ b/frappe/website/doctype/blog_post/test_blog_post.py
@@ -84,7 +84,7 @@ class TestBlogPost(FrappeTestCase):
 			blog = make_test_blog(category_title)
 			blogs.append(blog)
 
-		filters = frappe._dict({"blog_category": scrub(category_title)})
+		filters = frappe.attrdict({"blog_category": scrub(category_title)})
 		# Assert that get_blog_list returns results as expected
 
 		self.assertEqual(len(get_blog_list(None, None, filters, 0, 3)), 3)

--- a/frappe/website/doctype/help_article/help_article.py
+++ b/frappe/website/doctype/help_article/help_article.py
@@ -56,7 +56,7 @@ def get_list_context(context=None):
 	if category:
 		filters["category"] = category
 
-	list_context = frappe._dict(
+	list_context = frappe.attrdict(
 		title=category or _("Knowledge Base"),
 		get_level_class=get_level_class,
 		show_sidebar=True,

--- a/frappe/website/doctype/help_category/help_category.py
+++ b/frappe/website/doctype/help_category/help_category.py
@@ -7,7 +7,7 @@ from frappe.website.website_generator import WebsiteGenerator
 
 
 class HelpCategory(WebsiteGenerator):
-	website = frappe._dict(condition_field="published", page_title_field="category_name")
+	website = frappe.attrdict(condition_field="published", page_title_field="category_name")
 
 	def before_insert(self):
 		self.published = 1

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -17,7 +17,7 @@ from frappe.website.website_generator import WebsiteGenerator
 
 
 class WebForm(WebsiteGenerator):
-	website = frappe._dict(no_cache=1)
+	website = frappe.attrdict(no_cache=1)
 
 	def onload(self):
 		super().onload()
@@ -367,7 +367,7 @@ def get_web_form_module(doc):
 @rate_limit(key="web_form", limit=5, seconds=60, methods=["POST"])
 def accept(web_form, data):
 	"""Save the web form"""
-	data = frappe._dict(json.loads(data))
+	data = frappe.attrdict(json.loads(data))
 
 	files = []
 	files_to_delete = []
@@ -515,7 +515,7 @@ def get_form_data(doctype, docname=None, web_form_name=None):
 	if web_form.login_required and frappe.session.user == "Guest":
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 
-	out = frappe._dict()
+	out = frappe.attrdict()
 	out.web_form = web_form
 
 	if frappe.session.user != "Guest" and not docname and not web_form.allow_multiple:

--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -45,7 +45,7 @@ class WebPage(WebsiteGenerator):
 		context.title = self.title
 
 		if self.context_script:
-			_locals = dict(context=frappe._dict())
+			_locals = dict(context=frappe.attrdict())
 			safe_exec(self.context_script, None, _locals)
 			context.update(_locals["context"])
 
@@ -205,7 +205,7 @@ def check_publish_status():
 def get_web_blocks_html(blocks):
 	"""Converts a list of blocks into Raw HTML and extracts out their scripts for deduplication"""
 
-	out = frappe._dict(html="", scripts={}, styles={})
+	out = frappe.attrdict(html="", scripts={}, styles={})
 	extracted_scripts = {}
 	extracted_styles = {}
 	for block in blocks:

--- a/frappe/website/doctype/website_meta_tag/website_meta_tag.py
+++ b/frappe/website/doctype/website_meta_tag/website_meta_tag.py
@@ -14,6 +14,6 @@ class WebsiteMetaTag(Document):
 		return {self.key: self.get_content()}
 
 	def set_in_context(self, context):
-		context.setdefault("metatags", frappe._dict({}))
+		context.setdefault("metatags", frappe.attrdict({}))
 		context.metatags[self.key] = self.get_content()
 		return context

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -114,7 +114,7 @@ class WebsiteSettings(Document):
 
 def get_website_settings(context=None):
 	hooks = frappe.get_hooks()
-	context = frappe._dict(context or {})
+	context = frappe.attrdict(context or {})
 	settings: "WebsiteSettings" = frappe.get_cached_doc("Website Settings")
 
 	context = context.update(
@@ -185,12 +185,12 @@ def get_website_settings(context=None):
 			context[key] = context[key][-1]
 
 	if context.disable_website_theme:
-		context.theme = frappe._dict()
+		context.theme = frappe.attrdict()
 
 	else:
 		from frappe.website.doctype.website_theme.website_theme import get_active_theme
 
-		context.theme = get_active_theme() or frappe._dict()
+		context.theme = get_active_theme() or frappe.attrdict()
 
 	if not context.get("favicon"):
 		context["favicon"] = "/assets/frappe/images/frappe-favicon.svg"

--- a/frappe/website/page_renderers/base_template_page.py
+++ b/frappe/website/page_renderers/base_template_page.py
@@ -11,7 +11,7 @@ class BaseTemplatePage(BaseRenderer):
 		self.source = ""
 
 	def init_context(self):
-		self.context = frappe._dict()
+		self.context = frappe.attrdict()
 		self.context.update(get_website_settings())
 		self.context.update(frappe.local.conf.get("website_context") or {})
 

--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -24,7 +24,7 @@ class PathResolver:
 
 	def resolve(self):
 		"""Returns endpoint and a renderer instance that can render the endpoint"""
-		request = frappe._dict()
+		request = frappe.attrdict()
 		if hasattr(frappe.local, "request"):
 			request = frappe.local.request or request
 

--- a/frappe/website/report/website_analytics/website_analytics.py
+++ b/frappe/website/report/website_analytics/website_analytics.py
@@ -15,7 +15,7 @@ def execute(filters=None):
 
 class WebsiteAnalytics:
 	def __init__(self, filters=None):
-		self.filters = frappe._dict(filters or {})
+		self.filters = frappe.attrdict(filters or {})
 
 		if not self.filters.to_date:
 			self.filters.to_date = datetime.now()

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -145,7 +145,7 @@ def get_page_info(path, app, start, basepath=None, app_path=None, fname=None):
 	page_name, extn = os.path.splitext(fname)
 
 	# add website route
-	page_info = frappe._dict()
+	page_info = frappe.attrdict()
 
 	page_info.basename = page_name if extn in ("html", "md") else fname
 	page_info.basepath = basepath

--- a/frappe/website/website_components/metatags.py
+++ b/frappe/website/website_components/metatags.py
@@ -7,7 +7,7 @@ class MetaTags:
 	def __init__(self, path, context):
 		self.path = path
 		self.context = context
-		self.tags = frappe._dict(self.context.get("metatags") or {})
+		self.tags = frappe.attrdict(self.context.get("metatags") or {})
 		self.init_metatags_from_context()
 		self.set_opengraph_tags()
 		self.set_twitter_tags()

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -9,7 +9,7 @@ from frappe.website.utils import cleanup_page_name, clear_cache
 
 
 class WebsiteGenerator(Document):
-	website = frappe._dict()
+	website = frappe.attrdict()
 
 	def __init__(self, *args, **kwargs):
 		self.route = None
@@ -112,7 +112,7 @@ class WebsiteGenerator(Document):
 		return condition_field
 
 	def get_page_info(self):
-		route = frappe._dict()
+		route = frappe.attrdict()
 		route.update(
 			{
 				"doc": self,

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -317,7 +317,7 @@ def get_users_next_action_data(transitions, doc):
 		filtered_users = filter_allowed_users(users, doc, transition)
 		for user in filtered_users:
 			if not user_data_map.get(user):
-				user_data_map[user] = frappe._dict(
+				user_data_map[user] = frappe.attrdict(
 					{
 						"possible_actions": [],
 						"email": frappe.db.get_value("User", user, "email"),
@@ -325,7 +325,7 @@ def get_users_next_action_data(transitions, doc):
 				)
 
 			user_data_map[user].get("possible_actions").append(
-				frappe._dict(
+				frappe.attrdict(
 					{
 						"action_name": transition.action,
 						"action_link": get_workflow_action_url(transition.action, doc, user),

--- a/frappe/www/_test/_test_no_context.py
+++ b/frappe/www/_test/_test_no_context.py
@@ -3,6 +3,6 @@ import frappe
 
 # no context object is accepted
 def get_context():
-	context = frappe._dict()
+	context = frappe.attrdict()
 	context.body = "Custom Content"
 	return context

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -27,7 +27,7 @@ def get_context(context):
 	try:
 		boot = frappe.sessions.get()
 	except Exception as e:
-		boot = frappe._dict(status="failed", error=str(e))
+		boot = frappe.attrdict(status="failed", error=str(e))
 		print(frappe.get_traceback())
 
 	# this needs commit

--- a/frappe/www/list.py
+++ b/frappe/www/list.py
@@ -49,7 +49,7 @@ def get(doctype, txt=None, limit_start=0, limit=20, pathname=None, **kwargs):
 
 	for doc in raw_result:
 		doc.doctype = doctype
-		new_context = frappe._dict(doc=doc, meta=meta, list_view_fields=list_view_fields)
+		new_context = frappe.attrdict(doc=doc, meta=meta, list_view_fields=list_view_fields)
 
 		if not list_context.get_list and not isinstance(new_context.doc, Document):
 			new_context.doc = frappe.get_doc(doc.doctype, doc.name)
@@ -91,7 +91,7 @@ def get_list_data(
 	meta = frappe.get_meta(doctype)
 
 	filters = prepare_filters(doctype, controller, kwargs)
-	list_context = get_list_context(frappe._dict(), doctype, web_form_name)
+	list_context = get_list_context(frappe.attrdict(), doctype, web_form_name)
 	list_context.title_field = getattr(controller, "website", {}).get(
 		"page_title_field", meta.title_field or "name"
 	)
@@ -140,7 +140,7 @@ def prepare_filters(doctype, controller, kwargs):
 			kwargs[key] = json.loads(kwargs[key])
 		except ValueError:
 			pass
-	filters = frappe._dict(kwargs)
+	filters = frappe.attrdict(kwargs)
 	meta = frappe.get_meta(doctype)
 
 	if hasattr(controller, "website") and controller.website.get("condition_field"):
@@ -165,14 +165,14 @@ def get_list_context(context, doctype, web_form_name=None):
 	from frappe.modules import load_doctype_module
 	from frappe.website.doctype.web_form.web_form import get_web_form_module
 
-	list_context = context or frappe._dict()
+	list_context = context or frappe.attrdict()
 	meta = frappe.get_meta(doctype)
 
 	def update_context_from_module(module, list_context):
 		# call the user defined method `get_list_context`
 		# from the python module
 		if hasattr(module, "get_list_context"):
-			out = frappe._dict(module.get_list_context(list_context) or {})
+			out = frappe.attrdict(module.get_list_context(list_context) or {})
 			if out:
 				list_context = out
 		return list_context
@@ -187,7 +187,7 @@ def get_list_context(context, doctype, web_form_name=None):
 	if meta.custom and web_form_name:
 		webform_list_contexts = frappe.get_hooks("webform_list_context")
 		if webform_list_contexts:
-			out = frappe._dict(frappe.get_attr(webform_list_contexts[0])(meta.module) or {})
+			out = frappe.attrdict(frappe.get_attr(webform_list_contexts[0])(meta.module) or {})
 			if out:
 				list_context = out
 

--- a/frappe/www/message.py
+++ b/frappe/www/message.py
@@ -8,7 +8,7 @@ no_cache = 1
 
 
 def get_context(context):
-	message_context = frappe._dict()
+	message_context = frappe.attrdict()
 	if hasattr(frappe.local, "message"):
 		message_context["header"] = frappe.local.message_title
 		message_context["title"] = strip_html_tags(frappe.local.message_title)

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -172,7 +172,7 @@ def get_rendered_template(
 	if template == "standard":
 		template = jenv.get_template(standard_format)
 
-	letter_head = frappe._dict(get_letter_head(doc, no_letterhead, letterhead) or {})
+	letter_head = frappe.attrdict(get_letter_head(doc, no_letterhead, letterhead) or {})
 
 	if letter_head.content:
 		letter_head.content = frappe.utils.jinja.render_template(
@@ -420,7 +420,7 @@ def make_layout(doc, meta, format_data=None):
 	for df in format_data or meta.fields:
 		if format_data:
 			# embellish df with original properties
-			df = frappe._dict(df)
+			df = frappe.attrdict(df)
 			if df.fieldname:
 				original = meta.get_field(df.fieldname)
 				if original:

--- a/frappe/www/search.py
+++ b/frappe/www/search.py
@@ -22,7 +22,7 @@ def get_context(context):
 @frappe.whitelist(allow_guest=True)
 def get_search_results(text, scope=None, start=0, as_html=False):
 	results = web_search(text, scope, start, limit=21)
-	out = frappe._dict()
+	out = frappe.attrdict()
 
 	if len(results) == 21:
 		out.has_more = 1


### PR DESCRIPTION
- This clearly indicates what the class does
- Underscore variables are supposed to be private use only, _dict is used everywhere.

Note: alias is added for backward compatibility. 

![image](https://user-images.githubusercontent.com/9079960/206459798-b733c0ef-4356-4896-b26a-4e2e7b2bb6bf.png)


If you like using `_dict` for some reason, keep doing it