### PR TITLE
fix: child table not working

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -656,7 +656,7 @@ export default class GridRow {
 
 		this.grid.visible_columns.forEach((col, ci) => {
 			// to get update df for the row
-			let df = fields.find((field) => field.fieldname === col[0].fieldname);
+			let df = fields.find((field) => field?.fieldname === col[0].fieldname);
 
 			this.set_dependant_property(df);
 
@@ -1360,7 +1360,7 @@ export default class GridRow {
 				: this.docfields;
 
 		let df = fields.find((col) => {
-			return col.fieldname === fieldname;
+			return col?.fieldname === fieldname;
 		});
 
 		// format values if no frm


### PR DESCRIPTION
**Issue**

1. Add custom field in any child table doctype
2. Select the same field in the Gird View from the frontend
3. Remove that field from the doctype
4. Your child table will break 
<img width="1376" alt="Screenshot 2022-12-08 at 7 19 11 PM" src="https://user-images.githubusercontent.com/8780500/206463860-affdf97f-867a-4555-b7c8-02baeeeb01d1.png">
