### PR TITLE
fix: do not rename select field options and values on doctype rename

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -390,11 +390,6 @@ def rename_doctype(doctype: str, old: str, new: str) -> None:
 	for fieldtype in fields_with_options:
 		update_options_for_fieldtype(fieldtype, old, new)
 
-	# change options where select options are hardcoded i.e. listed
-	select_fields = get_select_fields(old, new)
-	update_link_field_values(select_fields, old, new, doctype)
-	update_select_field_values(old, new)
-
 	# change parenttype for fieldtype Table
 	update_parenttype_values(old, new)
 


### PR DESCRIPTION
A user created a custom doctype named **Expense** and then renamed it **Custom Expense**
This activity caused all the select field options like **Expense** in **Root Type** field of **Account** doctype of ERPNext to be renamed to **Custom Expense**
Even the values of this field were renamed