### PR TITLE
fix: show file path instead of `file_url` in file exists validation error

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -299,7 +299,7 @@ class File(Document):
 			return True
 
 		if not os.path.exists(full_path):
-			frappe.throw(_("File {0} does not exist").format(self.file_url), IOError)
+			frappe.throw(_("File {0} does not exist").format(full_path), IOError)
 
 	def validate_duplicate_entry(self):
 		if not self.flags.ignore_duplicate_entry_error and not self.is_folder:


### PR DESCRIPTION
`self.file_url` is `None` while checking for existence of a local file on disk, making the error message less useful. Showing the path in this case is more useful for debugging purposes.
