### PR TITLE
fix: change page title to app name.

### DIFF
--- a/frappe/www/app.html
+++ b/frappe/www/app.html
@@ -15,7 +15,7 @@
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-status-bar-style" content="white">
 		<meta name="mobile-web-app-capable" content="yes">
-		<title>Frappe</title>
+		<title>{{ app_name }}</title>
 		<link rel="shortcut icon"
 			href="{{ favicon or "/assets/frappe/images/frappe-favicon.svg" }}" type="image/x-icon">
 		<link rel="icon"

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -62,6 +62,7 @@ def get_context(context):
 			"google_analytics_id": frappe.conf.get("google_analytics_id"),
 			"google_analytics_anonymize_ip": frappe.conf.get("google_analytics_anonymize_ip"),
 			"mixpanel_id": frappe.conf.get("mixpanel_id"),
+			"app_name": frappe.get_website_settings("app_name") or frappe.get_system_settings("app_name") or "Frappe",
 		}
 	)
 


### PR DESCRIPTION
For a few seconds after login before the home page fully loads the document title reads 'Frappe'. This changes it to the app's name.