### PR TITLE
feat: virtual child doctypes

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -168,8 +168,13 @@ class Document(BaseDocument):
 			# During frappe is installed, the property "is_virtual" is not available in tabDocType, so
 			# we need to filter those cases for the access to frappe.db.get_value() as it would crash otherwise.
 			if hasattr(self, "doctype") and not hasattr(self, "module") and is_virtual_doctype(df.options):
-				self.set(df.fieldname, [])
-				continue
+				# find controller of virtual table and fetch
+				# unlike the regular API, add the parent here. The controller has no other way to figure it 
+				# out, without risking a loop.				
+				controller = get_controller(df.options)
+				data = controller.get_list({'parent_doc': self})  				
+				self.set(df.fieldname, data)
+				continue		
 
 			children = (
 				frappe.db.get_values(


### PR DESCRIPTION
allow virtual child tables by looking up child doctypes controller class an call its get_list

It is actually a small change that FMO dramatically increases the usefulness of virtual doctypes, which can now be child tables too.
I came across two small design issues (not really related to this)
* The handover of the parent into the get_list method (or any other child table controller method) is useful, as the (static) child controller has otherwise no way to figure out its parent (without risking a loop).
* the (boiler plate) virtual child table controller has all methods of a regular controller, - all of them are not used for a child table, so perhaps the boilerplate can be shrinked in case of child doc types to just that `get_list(parent).`



