### PR TITLE
fix: TypeError when msgprint() receives lists

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -453,7 +453,10 @@ def msgprint(
 		out.as_list = 1
 
 	if sys.stdin and sys.stdin.isatty():
-		msg = _strip_html_tags(out.message)
+		if out.as_list:
+			msg = [_strip_html_tags(msg) for msg in out.message]
+		else:
+			msg = _strip_html_tags(out.message)
 
 	if flags.print_messages and out.message:
 		print(f"Message: {_strip_html_tags(out.message)}")


### PR DESCRIPTION
This fix, strips HTML tags for each message received in list by msgprint, avoiding a TypeError caused by the `_strip_html_tags()` function
