### PR TITLE
fix: hide toolbar label

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -265,7 +265,7 @@
    "default": "0",
    "fieldname": "hide_toolbar",
    "fieldtype": "Check",
-   "label": "Hide Sidebar and Menu",
+   "label": "Hide Sidebar Menu, and Comments",
    "oldfieldname": "hide_toolbar",
    "oldfieldtype": "Check"
   },
@@ -707,7 +707,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2022-10-12 14:13:27.315351",
+ "modified": "2022-12-13 15:50:27.315351",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",


### PR DESCRIPTION
After two years of `$(frm.wrapper).find('form-footer').remove()` stumped how other doctypes have hidden the comments for so long. I finally found the checkbox in doctype editor that hides the comment section. 