### PR TITLE
fix(UI): if grid custom button is not set grid has some extra space on top

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -402,6 +402,10 @@
 	display: inline-flex;
 }
 
+.grid-custom-buttons:empty {
+	padding: 0;
+}
+
 .grid-footer, .grid-custom-buttons {
 	padding: var(--padding-sm) 0px;
 	background-color: var(--fg-color);


### PR DESCRIPTION
Missed in PR: https://github.com/frappe/frappe/pull/19012

Before:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/30859809/207590474-d570b247-dd31-4b3c-9da3-082ab91f61da.png">

After:
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/30859809/207590229-37b00108-4e12-4f39-89da-4ae269d46013.png">
