### PR TITLE
feat: add parameters language and letter_head to `download_pdf`

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -14,6 +14,7 @@ import json
 import operator
 import os
 import re
+from contextlib import contextmanager
 from csv import reader
 
 from babel.messages.extract import extract_python
@@ -1311,6 +1312,37 @@ def get_translated_doctypes():
 		"Property Setter", {"property": "translated_doctype", "value": "1"}, pluck="doc_type"
 	)
 	return unique(dts + custom_dts)
+
+
+@contextmanager
+def print_language(language: str):
+	"""Ensure correct globals for printing in a specific language.
+
+	Usage:
+
+	```
+	with print_language("de"):
+	    html = frappe.get_print( ... )
+	```
+	"""
+	if not language or language == frappe.local.lang:
+		# do nothing
+		yield
+		return
+
+	# remember original values
+	_lang = frappe.local.lang
+	_jenv = frappe.local.jenv
+
+	# set language, empty any existing lang_full_dict and jenv
+	frappe.local.lang = language
+	frappe.local.jenv = None
+
+	yield
+
+	# restore original values
+	frappe.local.lang = _lang
+	frappe.local.jenv = _jenv
 
 
 # Backward compatibility

--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -5,6 +5,7 @@ from PyPDF2 import PdfWriter
 import frappe
 from frappe import _
 from frappe.core.doctype.access_log.access_log import make_access_log
+from frappe.translate import print_language
 from frappe.utils.pdf import get_pdf
 
 no_cache = 1
@@ -118,15 +119,21 @@ def read_multi_pdf(output):
 
 
 @frappe.whitelist(allow_guest=True)
-def download_pdf(doctype, name, format=None, doc=None, no_letterhead=0):
+def download_pdf(
+	doctype, name, format=None, doc=None, no_letterhead=0, language=None, letter_head=None
+):
 	doc = doc or frappe.get_doc(doctype, name)
 	validate_print_permission(doc)
 
-	html = frappe.get_print(doctype, name, format, doc=doc, no_letterhead=no_letterhead)
+	with print_language(language):
+		pdf_file = frappe.get_print(
+			doctype, name, format, doc=doc, as_pdf=True, letterhead=letter_head, no_letterhead=no_letterhead
+		)
+
 	frappe.local.response.filename = "{name}.pdf".format(
 		name=name.replace(" ", "-").replace("/", "-")
 	)
-	frappe.local.response.filecontent = get_pdf(html)
+	frappe.local.response.filecontent = pdf_file
 	frappe.local.response.type = "pdf"
 
 


### PR DESCRIPTION
Allow to specify language and letter head when printing via `download_pdf()`.
Previously, it just used the default letter head and the current user's language, with no option to change that.

Required for https://github.com/frappe/erpnext/pull/33339

>no-docs