### PR TITLE
fix: handle `HTML` Code fieldtype's `has_content`

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -671,7 +671,11 @@ class BaseDocument:
 			value = cstr(self.get(df.fieldname))
 			has_text_content = strip_html(value).strip()
 			has_img_tag = "<img" in value
-			if df.fieldtype == "Text Editor" and (has_text_content or has_img_tag):
+			has_text_or_img_tag = has_text_content or has_img_tag
+
+			if df.fieldtype == "Text Editor" and has_text_or_img_tag:
+				return True
+			elif df.fieldtype == "Code" and df.options == "HTML" and has_text_or_img_tag:
 				return True
 			else:
 				return has_text_content


### PR DESCRIPTION
## Problem

### How to replicate?

In a `Code` field (with options set to 'HTML'), put the below content:

```html
<div style="display: flex;">
    <img style="height: 45px;" src="https://frappe.io/files/frappe.png" />
</div>
```

Try to save, it throws mandatory error.

### Why?

```python
def has_content(df):
	value = cstr(self.get(df.fieldname))
	has_text_content = strip_html(value).strip()
	has_img_tag = "<img" in value
	if df.fieldtype == "Text Editor" and (has_text_content or has_img_tag):
		return True
	else:
		return has_text_content
```

Observe, how the 'Text Editor' field is handled separately. Same behaviour is expected for a HTML code field.

## Solution

```python
def has_content(df):
	value = cstr(self.get(df.fieldname))
	has_text_content = strip_html(value).strip()
	has_img_tag = "<img" in value
	has_text_or_img_tag = (has_text_content or has_img_tag)

	if df.fieldtype == "Text Editor" and has_text_or_img_tag:
		return True
	elif df.fieldtype == "Code" and df.options == "HTML" and has_text_or_img_tag:
		return True
	else:
		return has_text_content
```