### PR TITLE
fix: duplicate unique indexes

### DIFF
--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -73,13 +73,19 @@ class MariaDBTable(DBTable):
 		add_index_query = []
 		drop_index_query = []
 
-		columns_to_modify = set(self.change_type + self.add_unique + self.set_default)
-
 		for col in self.add_column:
 			add_column_query.append(f"ADD COLUMN `{col.fieldname}` {col.get_definition()}")
 
+		columns_to_modify = set(self.change_type + self.set_default)
 		for col in columns_to_modify:
-			modify_column_query.append(f"MODIFY `{col.fieldname}` {col.get_definition()}")
+			modify_column_query.append(
+				f"MODIFY `{col.fieldname}` {col.get_definition(for_modification=True)}"
+			)
+
+		for col in self.add_unique:
+			modify_column_query.append(
+				f"ADD UNIQUE INDEX IF NOT EXISTS {col.fieldname} (`{col.fieldname}`)"
+			)
 
 		for col in self.add_index:
 			# if index key does not exists

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -17,18 +17,18 @@ class DBTable:
 		self.doctype = doctype
 		self.table_name = f"tab{doctype}"
 		self.meta = meta or frappe.get_meta(doctype, False)
-		self.columns = {}
+		self.columns: dict[str, DbColumn] = {}
 		self.current_columns = {}
 
 		# lists for change
-		self.add_column = []
-		self.change_type = []
-		self.change_name = []
-		self.add_unique = []
-		self.add_index = []
-		self.drop_unique = []
-		self.drop_index = []
-		self.set_default = []
+		self.add_column: list[DbColumn] = []
+		self.change_type: list[DbColumn] = []
+		self.change_name: list[DbColumn] = []
+		self.add_unique: list[DbColumn] = []
+		self.add_index: list[DbColumn] = []
+		self.drop_unique: list[DbColumn] = []
+		self.drop_index: list[DbColumn] = []
+		self.set_default: list[DbColumn] = []
 
 		# load
 		self.get_columns_from_docfields()

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -187,7 +187,7 @@ class DbColumn:
 		self.unique = unique
 		self.precision = precision
 
-	def get_definition(self, with_default=1):
+	def get_definition(self, for_modification=False):
 		column_def = get_definition(self.fieldtype, precision=self.precision, length=self.length)
 
 		if not column_def:
@@ -209,7 +209,7 @@ class DbColumn:
 		):
 			column_def += f" default {frappe.db.escape(self.default)}"
 
-		if self.unique and (column_def not in ("text", "longtext")):
+		if self.unique and not for_modification and (column_def not in ("text", "longtext")):
 			column_def += " unique"
 
 		return column_def

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -99,7 +99,7 @@ frappe.patches.v12_0.delete_feedback_request_if_exists #1
 frappe.patches.v12_0.rename_events_repeat_on
 frappe.patches.v12_0.fix_public_private_files
 frappe.patches.v12_0.move_email_and_phone_to_child_table
-frappe.patches.v12_0.delete_duplicate_indexes
+frappe.patches.v12_0.delete_duplicate_indexes  # 2022-12-15
 frappe.patches.v12_0.set_default_incoming_email_port
 frappe.patches.v12_0.update_global_search
 frappe.patches.v12_0.setup_tags

--- a/frappe/patches/v12_0/delete_duplicate_indexes.py
+++ b/frappe/patches/v12_0/delete_duplicate_indexes.py
@@ -15,39 +15,41 @@ def execute():
 		indexes_to_keep_map = frappe._dict()
 		indexes_to_delete = []
 		index_info = frappe.db.sql(
-			"""
-			SELECT
-				column_name,
-				index_name,
-				non_unique
-			FROM information_schema.STATISTICS
-			WHERE table_name=%s
-			AND column_name!='name'
-			AND non_unique=0
-			ORDER BY index_name;
-		""",
-			table,
+			f"""SHOW INDEX FROM `{table}`
+				WHERE Seq_in_index = 1
+				AND Non_unique=0""",
 			as_dict=1,
 		)
 
 		for index in index_info:
-			if not indexes_to_keep_map.get(index.column_name):
-				indexes_to_keep_map[index.column_name] = index
+			if not indexes_to_keep_map.get(index.Column_name):
+				indexes_to_keep_map[index.Column_name] = index
 			else:
-				indexes_to_delete.append(index.index_name)
+				indexes_to_delete.append(index.Key_name)
+
 		if indexes_to_delete:
 			final_deletion_map[table] = indexes_to_delete
 
-	# build drop index query
-	for (table_name, index_list) in final_deletion_map.items():
-		query_list = []
-		alter_query = f"ALTER TABLE `{table_name}`"
-
+	for table_name, index_list in final_deletion_map.items():
 		for index in index_list:
-			query_list.append(f"{alter_query} DROP INDEX `{index}`")
-
-		for query in query_list:
 			try:
-				frappe.db.sql(query)
-			except frappe.db.InternalError:
-				pass
+				if is_clustered_index(table_name, index):
+					continue
+				frappe.db.sql_ddl(f"ALTER TABLE `{table_name}` DROP INDEX `{index}`")
+			except Exception as e:
+				frappe.log_error("Failed to drop index")
+				print(f"x Failed to drop index {index} from {table_name}\n {str(e)}")
+			else:
+				print(f"✓ dropped {index} index from {table}")
+
+
+def is_clustered_index(table, index_name):
+	return bool(
+		frappe.db.sql(
+			f"""SHOW INDEX FROM `{table}`
+			WHERE Key_name = "{index_name}"
+				AND Seq_in_index = 2
+			""",
+			as_dict=True,
+		)
+	)

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.utils import find
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.tests.utils import FrappeTestCase
@@ -86,6 +87,36 @@ class TestDBUpdate(FrappeTestCase):
 		frappe.db.updatedb(doctype)
 		email_sig_column = get_table_column("User", "email_signature")
 		self.assertEqual(email_sig_column.index, 1)
+
+	def check_unique_indexes(self, doctype: str, field: str):
+		indexes = frappe.db.sql(
+			f"""show index from `tab{doctype}` where column_name = '{field}' and Non_unique = 0""",
+			as_dict=1,
+		)
+		self.assertEqual(
+			len(indexes), 1, msg=f"There should be 1 index on {doctype}.{field}, found {indexes}"
+		)
+
+	def test_unique_index_on_install(self):
+		"""Only one unique index should be added"""
+		for dt in frappe.get_all("DocType", {"is_virtual": 0, "issingle": 0}, pluck="name"):
+			doctype = frappe.get_meta(dt)
+			fields = doctype.get("fields", filters={"unique": 1})
+			for field in fields:
+				with self.subTest(f"Checking index {doctype.name} - {field.fieldname}"):
+					self.check_unique_indexes(doctype.name, field.fieldname)
+
+	def test_unique_index_on_alter(self):
+		"""Only one unique index should be added"""
+
+		doctype = new_doctype(unique=1).insert()
+		field = "some_fieldname"
+
+		doctype.fields[0].length = 142
+		doctype.save()
+
+		doctype.delete()
+		self.check_unique_indexes(doctype.name, field)
 
 
 def get_fieldtype_from_def(field_def):

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -2,6 +2,8 @@ import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.utils import find
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.query_builder.utils import db_type_is
+from frappe.tests.test_query_builder import run_only_if
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cstr
 
@@ -97,6 +99,7 @@ class TestDBUpdate(FrappeTestCase):
 			len(indexes), 1, msg=f"There should be 1 index on {doctype}.{field}, found {indexes}"
 		)
 
+	@run_only_if(db_type_is.MARIADB)
 	def test_unique_index_on_install(self):
 		"""Only one unique index should be added"""
 		for dt in frappe.get_all("DocType", {"is_virtual": 0, "issingle": 0}, pluck="name"):
@@ -106,17 +109,26 @@ class TestDBUpdate(FrappeTestCase):
 				with self.subTest(f"Checking index {doctype.name} - {field.fieldname}"):
 					self.check_unique_indexes(doctype.name, field.fieldname)
 
+	@run_only_if(db_type_is.MARIADB)
 	def test_unique_index_on_alter(self):
 		"""Only one unique index should be added"""
 
 		doctype = new_doctype(unique=1).insert()
 		field = "some_fieldname"
 
+		self.check_unique_indexes(doctype.name, field)
 		doctype.fields[0].length = 142
 		doctype.save()
 
-		doctype.delete()
+		doctype.fields[0].unique = 0
+		doctype.save()
+
+		doctype.fields[0].unique = 1
+		doctype.save()
 		self.check_unique_indexes(doctype.name, field)
+
+		doctype.delete()
+		frappe.db.commit()
 
 
 def get_fieldtype_from_def(field_def):


### PR DESCRIPTION
There should always be 1 unique index. Right now every time a column is modified we do `alter table <tablename> modify column <datatype definition> [unique]` which implicitly creates a new index everytime it runs.

Fix:
- move unique definition out of column def while modifing 
- Add explicitly named unique index that doesn't implicitly keep creating duplicates like `index_1`, `index_2` etc. 


closes https://github.com/frappe/frappe/issues/19172

