### PR TITLE
feat: fields for attaching (html) meta tags in web form

### DIFF
--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -1,5 +1,9 @@
 {% extends "templates/web.html" %}
 
+{% block meta_block %}
+	{% include "templates/includes/meta_block.html" %}
+{% endblock %}
+
 {% block breadcrumbs %}{% endblock %}
 
 {% block header %}

--- a/frappe/website/doctype/web_form/test_records.json
+++ b/frappe/website/doctype/web_form/test_records.json
@@ -14,6 +14,9 @@
  "published": 1,
  "success_url": "/manage-events",
  "title": "Manage Events",
+ "meta_title": "Test Meta Form Title",
+ "meta_description": "Test Meta Form Description",
+ "meta_image": "https://frappe.io/files/frappe.png",
  "web_form_fields": [
   {
    "doctype": "Web Form Field",

--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -75,3 +75,11 @@ class TestWebForm(FrappeTestCase):
 		self.assertIn('data-doctype="Web Form"', content)
 		self.assertIn('data-path="manage-events/new"', content)
 		self.assertIn('source-type="Generator"', content)
+	
+	def test_webform_html_meta_is_added(self):
+		set_request(method="GET", path="manage-events/new")
+		content = get_response_content("manage-events/new")
+
+		self.assertIn('<meta name="name" content="Test Meta Form Title">', content)
+		self.assertIn('<meta property="og:description" content="Test Meta Form Description">', content)
+		self.assertIn('<meta property="og:image" content="https://frappe.io/files/frappe.png">', content)

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -48,6 +48,11 @@
   "success_url",
   "column_break_4",
   "success_message",
+  "meta_section",
+  "meta_title",
+  "meta_description",
+  "column_break_khxs",
+  "meta_image",
   "section_break_6",
   "client_script",
   "custom_css"
@@ -328,13 +333,38 @@
    "fieldname": "section_break_6",
    "fieldtype": "Section Break",
    "label": "Scripting / Style"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "meta_section",
+   "fieldtype": "Section Break",
+   "label": "Meta"
+  },
+  {
+   "fieldname": "meta_title",
+   "fieldtype": "Data",
+   "label": "Meta Title"
+  },
+  {
+   "fieldname": "meta_description",
+   "fieldtype": "Small Text",
+   "label": "Meta Description"
+  },
+  {
+   "fieldname": "column_break_khxs",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "meta_image",
+   "fieldtype": "Attach Image",
+   "label": "Meta Image"
   }
  ],
  "has_web_view": 1,
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2022-08-17 18:58:49.451658",
+ "modified": "2022-12-15 17:14:44.939645",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -191,9 +191,22 @@ def get_context(context):
 
 		self.add_custom_context_and_script(context)
 		self.load_translations(context)
+		self.add_metatags(context)
 
 		context.boot = get_boot_data()
 		context.boot["link_title_doctypes"] = frappe.boot.get_link_title_doctypes()
+
+	def add_metatags(self, context):
+		description = self.meta_description
+
+		if not description and self.introduction_text:
+			description = self.introduction_text[:140]
+
+		context.metatags = {
+			"name": self.meta_title,
+			"description": description,
+			"image": self.meta_image
+		}
 
 	def load_translations(self, context):
 		translated_messages = frappe.translate.get_dict("doctype", self.doc_type)

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -203,7 +203,7 @@ def get_context(context):
 			description = self.introduction_text[:140]
 
 		context.metatags = {
-			"name": self.meta_title,
+			"name": self.meta_title or self.title,
 			"description": description,
 			"image": self.meta_image
 		}


### PR DESCRIPTION
Added a meta section in **Web Form** doctype, identical to the one present in **Web Page** doctype:

![Meta Section in Web from screen shot](https://user-images.githubusercontent.com/34810212/207875466-7cc0ee93-cdbc-4ec4-bdd5-675b8e9e8768.png)

- [x] add title, description and image fields
- [x] use form title as meta title if `meta_title` not provided
- [x] use form introduction (first 140 chars) as meta descriptions if `meta_description` is not set
- [x] add tests

`no-docs`