### PR TITLE
fix: restore missing `helpful` and `not_helpful` fields to help article doctype.

### DIFF
--- a/frappe/website/doctype/help_article/help_article.json
+++ b/frappe/website/doctype/help_article/help_article.json
@@ -15,7 +15,11 @@
   "section_break_7",
   "content",
   "likes",
-  "route"
+  "route",
+  "section_break_cww5",
+  "helpful",
+  "cb_00",
+  "not_helpful"
  ],
  "fields": [
   {
@@ -78,6 +82,30 @@
    "fieldtype": "Data",
    "in_global_search": 1,
    "label": "Route"
+  },
+  {
+   "default": "0",
+   "fieldname": "helpful",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Helpful",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cb_00",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "not_helpful",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Not Helpful",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_cww5",
+   "fieldtype": "Section Break"
   }
  ],
  "has_web_view": 1,
@@ -85,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2022-01-04 16:25:18.577325",
+ "modified": "2022-12-15 20:05:11.317400",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Help Article",
@@ -116,6 +144,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "title",
  "track_changes": 1
 }

--- a/frappe/website/doctype/help_article/test_help_article.py
+++ b/frappe/website/doctype/help_article/test_help_article.py
@@ -7,4 +7,35 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestHelpArticle(FrappeTestCase):
-	pass
+	@classmethod
+	def setUpClass(cls) -> None:
+		cls.help_category = frappe.get_doc({
+			"doctype": "Help Category",
+			"category_name": "_Test Help Category",
+		}).insert()
+
+		cls.help_article = frappe.get_doc({
+			"doctype": "Help Article",
+			"title": "_Test Article",
+			"category": cls.help_category.name,
+			"content": "_Test Article",
+		}).insert()
+
+	def test_article_is_helpful(self):
+		from frappe.website.doctype.help_article.help_article import add_feedback
+
+		self.help_article.load_from_db()
+		self.assertEqual(self.help_article.helpful, 0)
+		self.assertEqual(self.help_article.not_helpful, 0)
+
+		add_feedback(self.help_article.name, "Yes")
+		add_feedback(self.help_article.name, "No")
+
+		self.help_article.load_from_db()
+		self.assertEqual(self.help_article.helpful, 1)
+		self.assertEqual(self.help_article.not_helpful, 1)
+
+	@classmethod
+	def tearDownClass(cls) -> None:
+		frappe.delete_doc(cls.help_article.doctype, cls.help_article.name)
+		frappe.delete_doc(cls.help_category.doctype, cls.help_category.name)

--- a/frappe/website/doctype/help_article/test_help_article.py
+++ b/frappe/website/doctype/help_article/test_help_article.py
@@ -9,17 +9,21 @@ from frappe.tests.utils import FrappeTestCase
 class TestHelpArticle(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
-		cls.help_category = frappe.get_doc({
-			"doctype": "Help Category",
-			"category_name": "_Test Help Category",
-		}).insert()
+		cls.help_category = frappe.get_doc(
+			{
+				"doctype": "Help Category",
+				"category_name": "_Test Help Category",
+			}
+		).insert()
 
-		cls.help_article = frappe.get_doc({
-			"doctype": "Help Article",
-			"title": "_Test Article",
-			"category": cls.help_category.name,
-			"content": "_Test Article",
-		}).insert()
+		cls.help_article = frappe.get_doc(
+			{
+				"doctype": "Help Article",
+				"title": "_Test Article",
+				"category": cls.help_category.name,
+				"content": "_Test Article",
+			}
+		).insert()
 
 	def test_article_is_helpful(self):
 		from frappe.website.doctype.help_article.help_article import add_feedback


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/17192