### PR TITLE
fix: allow zero page length in `get_list` to return complete list

### DIFF
--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -106,7 +106,9 @@ class FrappeClient:
 			headers=self.headers,
 		)
 
-	def get_list(self, doctype, fields='["name"]', filters=None, limit_start=0, limit_page_length=None):
+	def get_list(
+		self, doctype, fields='["name"]', filters=None, limit_start=0, limit_page_length=None
+	):
 		"""Returns list of records of a particular type"""
 		if not isinstance(fields, str):
 			fields = json.dumps(fields)

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -106,7 +106,7 @@ class FrappeClient:
 			headers=self.headers,
 		)
 
-	def get_list(self, doctype, fields='["name"]', filters=None, limit_start=0, limit_page_length=0):
+	def get_list(self, doctype, fields='["name"]', filters=None, limit_start=0, limit_page_length=None):
 		"""Returns list of records of a particular type"""
 		if not isinstance(fields, str):
 			fields = json.dumps(fields)
@@ -115,7 +115,7 @@ class FrappeClient:
 		}
 		if filters:
 			params["filters"] = json.dumps(filters)
-		if limit_page_length:
+		if limit_page_length is not None:
 			params["limit_start"] = limit_start
 			params["limit_page_length"] = limit_page_length
 		res = self.session.get(


### PR DESCRIPTION
- fixes frappeclient to allow `0` value in limit_page_length  to be set explicitly.
- this would return a complete list.
