### PR TITLE
chore: ignore vuln `GHSA-hcpj-qp55-gfph` during pip audit

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -83,4 +83,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: |
           pip install pip-audit
-          pip-audit ${GITHUB_WORKSPACE}
+          pip-audit ${GITHUB_WORKSPACE} --ignore-vuln GHSA-hcpj-qp55-gfph


### PR DESCRIPTION
The affected endpoint isn't used by Frappe.