### PR TITLE
build: bump pyyaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     # core dependencies
     "Babel~=2.9.0",
     "Click~=8.1.3",
-    "Cython~=0.29.32",
     "filelock~=3.8.0",
     "GitPython~=3.1.14",
     "Jinja2~=3.1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     # core dependencies
     "Babel~=2.9.0",
     "Click~=8.1.3",
+    "Cython~=0.29.32",
     "filelock~=3.8.0",
     "GitPython~=3.1.14",
     "Jinja2~=3.1.2",
@@ -20,7 +21,7 @@ dependencies = [
     "PyPDF2~=2.1.0",
     "PyPika~=0.48.9",
     "PyQRCode~=1.2.1",
-    "PyYAML~=5.4.1",
+    "PyYAML~=6.0",
     "RestrictedPython~=6.0",
     "WeasyPrint==52.5",
     "Werkzeug~=2.2.2",


### PR DESCRIPTION
compatible version for rhel based os
tested on Almalinux and Rockylinux 8
got error for PyYAML==5.4.0
change to PyYAML==6.0
