### PR TITLE
fix(workflow): Remove docstatus field from get_workflow_state_count

### DIFF
--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -136,7 +136,7 @@ def get_workflow_state_count(doctype, workflow_state_field, states):
 	states = frappe.parse_json(states)
 	result = frappe.get_all(
 		doctype,
-		fields=[workflow_state_field, "count(*) as count", "docstatus"],
+		fields=[workflow_state_field, "count(*) as count"],
 		filters={workflow_state_field: ["not in", states]},
 		group_by=workflow_state_field,
 	)


### PR DESCRIPTION
remove docstatus from get_workflow_state_count as it is not being used and causes error with PostgreSQL as it requires the selected column to either appear in the group by clause or an aggregate function

![postgresql_workfow](https://user-images.githubusercontent.com/52963581/208292612-dee025c4-517c-40fb-bdd6-3a5d3dee6add.PNG)

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

