### PR TITLE
feat: hook `ignore_links_on_delete` to skip doctypes on delete

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -366,3 +366,21 @@ override_whitelisted_methods = {
 	"frappe.core.doctype.file.file.move_file": "frappe.core.api.file.move_file",
 	"frappe.core.doctype.file.file.zip_files": "frappe.core.api.file.zip_files",
 }
+
+ignore_links_on_delete = [
+	"Communication",
+	"ToDo",
+	"DocShare",
+	"Email Unsubscribe",
+	"Activity Log",
+	"File",
+	"Version",
+	"Document Follow",
+	"Comment",
+	"View Log",
+	"Tag Link",
+	"Notification Log",
+	"Email Queue",
+	"Document Share Key",
+	"Integration Request",
+]

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -16,24 +16,6 @@ from frappe.utils.file_manager import remove_all
 from frappe.utils.global_search import delete_for_document
 from frappe.utils.password import delete_all_passwords_for
 
-doctypes_to_skip = (
-	"Communication",
-	"ToDo",
-	"DocShare",
-	"Email Unsubscribe",
-	"Activity Log",
-	"File",
-	"Version",
-	"Document Follow",
-	"Comment",
-	"View Log",
-	"Tag Link",
-	"Notification Log",
-	"Email Queue",
-	"Document Share Key",
-	"Integration Request",
-)
-
 
 def delete_doc(
 	doctype=None,
@@ -277,7 +259,7 @@ def check_if_doc_is_linked(doc, method="Delete"):
 				item_parent = getattr(item, "parent", None)
 				linked_doctype = item.parenttype if item_parent else link_dt
 
-				if linked_doctype in doctypes_to_skip or (
+				if linked_doctype in frappe.get_hooks("ignore_links_on_delete") or (
 					linked_doctype in ignore_linked_doctypes and method == "Cancel"
 				):
 					# don't check for communication and todo!
@@ -306,7 +288,9 @@ def check_if_doc_is_dynamically_linked(doc, method="Delete"):
 
 		ignore_linked_doctypes = doc.get("ignore_linked_doctypes") or []
 
-		if df.parent in doctypes_to_skip or (df.parent in ignore_linked_doctypes and method == "Cancel"):
+		if df.parent in frappe.get_hooks("ignore_links_on_delete") or (
+			df.parent in ignore_linked_doctypes and method == "Cancel"
+		):
 			# don't check for communication and todo!
 			continue
 

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -59,6 +59,55 @@ class TestHooks(FrappeTestCase):
 		address.flags.dont_touch_me = True
 		self.assertFalse(frappe.has_permission("Address", doc=address, user=username))
 
+	def test_ignore_links_on_delete(self):
+		customer = frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": "Test Customer",
+			}
+		)
+		customer.insert()
+
+		so = frappe.get_doc(
+			{
+				"doctype": "Sales Order",
+				"customer": customer.name,
+				"delivery_date": "2022-12-21",
+				"items": [
+					{
+						"item_code": frappe.get_last_doc("Item").name,
+						"qty": 1,
+						"rate": 100,
+					}
+				],
+			}
+		)
+		so.insert()
+
+		self.assertRaises(frappe.LinkExistsError, customer.delete)
+
+		event = frappe.get_doc(
+			{
+				"doctype": "Event",
+				"subject": "Test Event",
+				"starts_on": "2022-12-21",
+				"event_type": "Public",
+			}
+		)
+		event.insert()
+
+		todo = frappe.get_doc(
+			{
+				"doctype": "ToDo",
+				"description": "Test ToDo",
+				"reference_type": "Event",
+				"reference_name": event.name,
+			}
+		)
+		todo.insert()
+
+		event.delete()
+
 
 def custom_has_permission(doc, ptype, user):
 	if doc.flags.dont_touch_me:

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -342,7 +342,7 @@ app_license = "{app_license}"
 #
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
 
-# Ignore Links on Document deletion
+# Ignore links to specified DocTypes when deleting documents
 # --------------------------------
 
 # ignore_links_on_delete = ["Communication", "ToDo"]

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -342,6 +342,11 @@ app_license = "{app_license}"
 #
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
 
+# Ignore Links on Document deletion
+# --------------------------------
+
+# ignore_links_on_delete = ["Communication", "ToDo"]
+
 
 # User Data Protection
 # --------------------

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -343,7 +343,7 @@ app_license = "{app_license}"
 # auto_cancel_exempted_doctypes = ["Auto Repeat"]
 
 # Ignore links to specified DocTypes when deleting documents
-# --------------------------------
+# -----------------------------------------------------------
 
 # ignore_links_on_delete = ["Communication", "ToDo"]
 


### PR DESCRIPTION
This feature is primarily intended to be used by apps like India Compliance and e-Commerce Integrations to ignore links to log doctypes like e-Waybill log, e-Invoice log, e-Commerce integration log etc. on delete.

1. Added a new hook `ignore_links_on_delete` in `hooks.py`
2. Updated `hooks_template` in `boilerplate.py` 
3. Replace `doctypes_to_skip` with a new hook so that the user can ignore any doctypes by specifying it in the hook (for a custom app).

Docs: https://frappeframework.com/docs/v14/user/en/python-api/hooks/edit-wiki?wiki_page_patch=1b43df460e