### PR TITLE
chore: pin markupsafe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "ipython~=8.4.0",
     "ldap3~=2.9",
     "markdown2~=2.4.0",
+    "MarkupSafe>=2.1.0,<3",
     "maxminddb-geolite2==2018.703",
     "num2words~=0.5.10",
     "oauthlib~=3.2.1",


### PR DESCRIPTION
We depend on it for escaping. Currently this works because of indirect
dependencies:

```
λ pipdeptree -p MarkupSafe --reverse
MarkupSafe==2.1.1
  - Jinja2==3.1.2 [requires: MarkupSafe>=2.0]
    - frappe==15.0.0.dev0 [requires: Jinja2~=3.1.2]
  - Werkzeug==2.2.2 [requires: MarkupSafe>=2.1.1]
    - frappe==15.0.0.dev0 [requires: Werkzeug~=2.2.2]
```
