### PR TITLE
fix: postgres query

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -141,7 +141,7 @@ def get_default_contact(doctype, name):
 		where
 			dl.link_doctype=%s and
 			dl.link_name=%s and
-			dl.parenttype = "Contact"''',
+			dl.parenttype = 'Contact' ''',
 		(doctype, name),
 		as_dict=True,
 	)


### PR DESCRIPTION
Double quotes are supposed to be used for table/columns only in
postgres. Mariadb is fine with either.

Broken since https://github.com/frappe/frappe/pull/19347 but not because of it


```
======================================================================
 ERROR  test_ignore_links_on_delete (frappe.tests.test_hooks.TestHooks.test_ignore_links_on_delete)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/frappe/frappe/tests/test_hooks.py", line 80, in test_ignore_links_on_delete
    ).insert()
      ^^^^^^^^
    email_unsubscribe = <EmailUnsubscribe: a4e3488b25>
    self = <frappe.tests.test_hooks.TestHooks testMethod=test_ignore_links_on_delete>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 268, in insert
    self.run_before_save_methods()
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <Event: EV00053>
    set_child_names = True
    set_name = None
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1056, in run_before_save_methods
    self.run_method("before_save")
    self = <Event: EV00053>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 920, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7f680add1e40>
    args = ()
    kwargs = {'as_dict': True}
    query = 'select parent,\n\t\t\tIFNULL((select is_primary_contact from tabContact c where c.name = dl.parent), 0)\n\t\t\t\tas is_primary_contact\n\t\tfrom\n\t\t\t`tabDynamic Link` dl\n\t\twhere\n\t\t\tdl.link_doctype=%s and\n\t\t\tdl.link_name=%s and\n\t\t\tdl.parenttype = "Contact"'
    self = <frappe.database.postgres.database.PostgresDatabase object at 0x7f68128aca50>
    values = ('Email Unsubscribe', 'a4e3488b25')
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/database.py", line 221, in sql
    self._cursor.execute(query, values)
    as_dict = True
    as_list = 0
    auto_commit = 0
    debug = False
    explain = False
    ignore_ddl = 0
    pluck = False
    query = 'select parent,\n\t\t\tcoalesce((select is_primary_contact from "tabContact" c where c.name = dl.parent), 0)\n\t\t\t\tas is_primary_contact\n\t\tfrom\n\t\t\t"tabDynamic Link" dl\n\t\twhere\n\t\t\tdl.link_doctype=%s and\n\t\t\tdl.link_name=%s and\n\t\t\tdl.parenttype = "Contact"'
    run = True
    self = <frappe.database.postgres.database.PostgresDatabase object at 0x7f68128aca50>
    update = None
    values = ['Email Unsubscribe', 'a4e3488b25']
psycopg2.errors.UndefinedColumn: column "Contact" does not exist
LINE 9:    dl.parenttype = "Contact"
                           ^
```
