### PR TITLE
fix(postgres): psql with remote databases

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -548,7 +548,13 @@ def _mariadb():
 
 def _psql():
 	psql = which("psql")
-	subprocess.run([psql, "-d", frappe.conf.db_name])
+
+	host = frappe.conf.db_host or "127.0.0.1"
+	port = frappe.conf.db_port or "5432"
+	env = os.environ.copy()
+	env["PGPASSWORD"] = frappe.conf.db_password
+	conn_string = f"postgresql://{frappe.conf.db_name}@{host}:{port}/{frappe.conf.db_name}"
+	subprocess.run([psql, conn_string], check=True, env=env)
 
 
 @click.command("jupyter")

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -532,7 +532,7 @@ def _mariadb():
 	command = [
 		mysql,
 		"--port",
-		frappe.conf.db_port or MariaDBDatabase.default_port,
+		str(frappe.conf.db_port or MariaDBDatabase.default_port),
 		"-u",
 		frappe.conf.db_name,
 		f"-p{frappe.conf.db_password}",

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -133,7 +133,7 @@ class Contact(Document):
 def get_default_contact(doctype, name):
 	"""Returns default contact for the given doctype, name"""
 	out = frappe.db.sql(
-		'''select parent,
+		"""select parent,
 			IFNULL((select is_primary_contact from tabContact c where c.name = dl.parent), 0)
 				as is_primary_contact
 		from
@@ -141,7 +141,7 @@ def get_default_contact(doctype, name):
 		where
 			dl.link_doctype=%s and
 			dl.link_name=%s and
-			dl.parenttype = 'Contact' ''',
+			dl.parenttype = 'Contact' """,
 		(doctype, name),
 		as_dict=True,
 	)

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -29,7 +29,7 @@ import frappe.recorder
 from frappe.installer import add_to_installed_apps, remove_app
 from frappe.query_builder.utils import db_type_is
 from frappe.tests.test_query_builder import run_only_if
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase, timeout
 from frappe.utils import add_to_date, get_bench_path, get_bench_relative_path, now
 from frappe.utils.backups import BackupGenerator, fetch_latest_backups
 from frappe.utils.jinja_globals import bundled_asset
@@ -763,3 +763,10 @@ class TestCommandUtils(FrappeTestCase):
 		app_groups = get_app_groups()
 		self.assertIn("frappe", app_groups)
 		self.assertIsInstance(app_groups["frappe"], click.Group)
+
+
+class TestDBCli(BaseTestCommands):
+	@timeout(10)
+	def test_db_cli(self):
+		self.execute("bench --site {site} db-console", kwargs={"cmd_input": rb"\q"})
+		self.assertEqual(self.returncode, 0)


### PR DESCRIPTION
- If you dont use unix socket psql command doesn't work.
- Also fixed maridab command which doesn't work with custom DB ports because of incorrect type.
