### PR TITLE
fix(error snapshot): fix seen update query in error snapshot to work with postgres

### DIFF
--- a/frappe/core/doctype/error_snapshot/error_snapshot.py
+++ b/frappe/core/doctype/error_snapshot/error_snapshot.py
@@ -12,10 +12,10 @@ class ErrorSnapshot(Document):
 
 	def onload(self):
 		if not self.parent_error_snapshot:
-			self.db_set("seen", True, update_modified=False)
+			self.db_set("seen", 1, update_modified=False)
 
 			for relapsed in frappe.get_all("Error Snapshot", filters={"parent_error_snapshot": self.name}):
-				frappe.db.set_value("Error Snapshot", relapsed.name, "seen", True, update_modified=False)
+				frappe.db.set_value("Error Snapshot", relapsed.name, "seen", 1, update_modified=False)
 
 			frappe.local.flags.commit = True
 
@@ -32,7 +32,7 @@ class ErrorSnapshot(Document):
 			self.update({"parent_error_snapshot": parent["name"]})
 			frappe.db.set_value("Error Snapshot", parent["name"], "relapses", parent["relapses"] + 1)
 			if parent["seen"]:
-				frappe.db.set_value("Error Snapshot", parent["name"], "seen", False)
+				frappe.db.set_value("Error Snapshot", parent["name"], "seen", 0)
 
 	@staticmethod
 	def clear_old_logs(days=30):


### PR DESCRIPTION
## problem:
- When trying to view an error from error snapshot it will try to update the seen field of the record with true value , but it will give the following error in case of postgres because the type of seen field is int not boolean, it will work with mariadb but not postgres.

![postgresql_errorsnapshot](https://user-images.githubusercontent.com/52963581/208663460-2cc832c6-3a32-47bf-81d4-43c086a5b871.PNG)

## solution:
- Change update value from True to 1,  False to 0 so it works with mariadb and posgres