### PR TITLE
fix(build):Use NamedTemporaryFile instead of insecure mktemp function

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import subprocess
 from subprocess import getoutput
-from tempfile import mkdtemp, NamedTemporaryFile
+from tempfile import NamedTemporaryFile, mkdtemp
 from urllib.parse import urlparse
 
 import click

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import subprocess
 from subprocess import getoutput
-from tempfile import mkdtemp, mktemp
+from tempfile import mkdtemp, NamedTemporaryFile
 from urllib.parse import urlparse
 
 import click
@@ -184,7 +184,7 @@ def symlink(target, link_name, overwrite=False):
 
 	# Create link to target with temporary filename
 	while True:
-		temp_link_name = mktemp(dir=link_dir)
+		temp_link_name = NamedTemporaryFile(dir=link_dir)
 
 		# os.* functions mimic as closely as possible system functions
 		# The POSIX symlink() returns EEXIST if link_name already exists


### PR DESCRIPTION
As mktemp introduces security vulnerabilities because there is no guarantee that the creation and open operations will happen atomically, we can use either NamedTemporaryFile or TemporaryFile from the tempfile module in python.

https://codeql.github.com/codeql-query-help/python/py-insecure-temporary-file/