### PR TITLE
fix: prevent emails from being queued multiple times

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -131,9 +131,11 @@ def return_unsubscribed_page(email, doctype, name):
 
 def flush(from_test=False):
 	"""flush email queue, every time: called from scheduler"""
+	import rq.exceptions
+
 	from frappe.email.doctype.email_queue.email_queue import send_mail
 	from frappe.utils.background_jobs import get_jobs
-	import rq.exceptions
+
 	# To avoid running jobs inside unit tests
 	if frappe.are_emails_muted():
 		msgprint(_("Emails are muted"))
@@ -142,9 +144,11 @@ def flush(from_test=False):
 	if cint(frappe.db.get_default("suspend_email_queue")) == 1:
 		return
 	try:
-	    queued_jobs = get_jobs(site=frappe.local.site, key="job_name")[frappe.local.site]
+		queued_jobs = get_jobs(site=frappe.local.site, key="job_name")[frappe.local.site]
 	except rq.exceptions.NoSuchJobError as e:
-		frappe.logger().warn(f"Skipping the flush of emails because I could not get the queued jobs: {e}")
+		frappe.logger().warn(
+			f"Skipping the flush of emails because I could not get the queued jobs: {e}"
+		)
 		return
 
 	def run_in_bg_if_not_queued(**kwargs):

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -160,7 +160,7 @@ def flush(from_test=False):
 					queue="short",
 				)
 			else:
-				frappe.logger().info(f"Not queueing job {job_name} because it is in queueue already")
+				frappe.logger().debug(f"Not queueing job {job_name} because it is in queue already")
 		except Exception:
 			frappe.get_doc("Email Queue", row.name).log_error()
 

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -132,7 +132,8 @@ def return_unsubscribed_page(email, doctype, name):
 def flush(from_test=False):
 	"""flush email queue, every time: called from scheduler"""
 	from frappe.email.doctype.email_queue.email_queue import send_mail
-
+	from frappe.utils.background_jobs import get_jobs
+	import rq.exceptions
 	# To avoid running jobs inside unit tests
 	if frappe.are_emails_muted():
 		msgprint(_("Emails are muted"))
@@ -140,10 +141,22 @@ def flush(from_test=False):
 
 	if cint(frappe.db.get_default("suspend_email_queue")) == 1:
 		return
+	try:
+	    queued_jobs = get_jobs(site=frappe.local.site, key="job_name")[frappe.local.site]
+	except rq.exceptions.NoSuchJobError as e:
+		frappe.logger().warn(f"Skipping the flush of emails because I could not get the queued jobs: {e}")
+		return
+
+	def run_in_bg_if_not_queued(**kwargs):
+		job_name = "SendingEmail_" + kwargs["email_queue_name"]
+		if job_name not in queued_jobs:
+			return send_mail.enqueue(job_name=job_name, **kwargs)
+		else:
+			frappe.logger().debug(f"Not queueing job {job_name} because it is in queueue already")
 
 	for row in get_queue():
 		try:
-			func = send_mail if from_test else send_mail.enqueue
+			func = send_mail if from_test else run_in_bg_if_not_queued
 			is_background_task = not from_test
 			func(email_queue_name=row.name, is_background_task=is_background_task)
 		except Exception:

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -131,8 +131,6 @@ def return_unsubscribed_page(email, doctype, name):
 
 def flush(from_test=False):
 	"""flush email queue, every time: called from scheduler"""
-	import rq.exceptions
-
 	from frappe.email.doctype.email_queue.email_queue import send_mail
 	from frappe.utils.background_jobs import get_jobs
 
@@ -143,26 +141,26 @@ def flush(from_test=False):
 
 	if cint(frappe.db.get_default("suspend_email_queue")) == 1:
 		return
-	try:
-		queued_jobs = get_jobs(site=frappe.local.site, key="job_name")[frappe.local.site]
-	except rq.exceptions.NoSuchJobError as e:
-		frappe.logger().warn(
-			f"Skipping the flush of emails because I could not get the queued jobs: {e}"
-		)
-		return
 
-	def run_in_bg_if_not_queued(**kwargs):
-		job_name = "SendingEmail_" + kwargs["email_queue_name"]
-		if job_name not in queued_jobs:
-			return send_mail.enqueue(job_name=job_name, **kwargs)
-		else:
-			frappe.logger().debug(f"Not queueing job {job_name} because it is in queueue already")
+	try:
+		queued_jobs = set(get_jobs(site=frappe.local.site, key="job_name")[frappe.local.site])
+	except Exception:
+		queued_jobs = set()
 
 	for row in get_queue():
 		try:
-			func = send_mail if from_test else run_in_bg_if_not_queued
-			is_background_task = not from_test
-			func(email_queue_name=row.name, is_background_task=is_background_task)
+			job_name = f"email_queue_sendmail_{row.name}"
+			if job_name not in queued_jobs:
+				frappe.enqueue(
+					method=send_mail,
+					email_queue_name=row.name,
+					is_background_task=not from_test,
+					now=from_test,
+					job_name=job_name,
+					queue="short",
+				)
+			else:
+				frappe.logger().info(f"Not queueing job {job_name} because it is in queueue already")
 		except Exception:
 			frappe.get_doc("Email Queue", row.name).log_error()
 


### PR DESCRIPTION
We had problems sending out emails because of wrong credentials which made the sending of emails go into a timeout (which took a while)

the frappe.email.queue.flush runs every ~5 minutes but our emails were not nearly all sent which led to a HUGE job-queue, because the flush email jobs would see the same Email Queue documents again and again and always queue another sending job....

This attempts to fix this.