### PR TITLE
chore: add methodname to monitor log

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -12,6 +12,7 @@ import frappe.sessions
 import frappe.utils
 from frappe import _, is_whitelisted
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
+from frappe.monitor import add_data_to_monitor
 from frappe.utils import cint
 from frappe.utils.csvutils import build_csv_response
 from frappe.utils.image import optimize_image
@@ -319,6 +320,8 @@ def run_doc_method(method, docs=None, dt=None, dn=None, arg=None, args=None):
 		return
 
 	frappe.response["message"] = response
+
+	add_data_to_monitor(methodname=method)
 
 
 # for backwards compatibility

--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -26,7 +26,7 @@ export default class QuickListWidget extends Widget {
 
 	setup_add_new_button() {
 		this.add_new_button = $(
-			`<div class="add-new btn btn-xs pull-right" 
+			`<div class="add-new btn btn-xs pull-right"
 			title="${__("Add New")}  ${__(this.document_type)}
 			">
 				${frappe.utils.icon("add", "sm")}


### PR DESCRIPTION
Log `methodname` while logging `run_doc_method` requests