### PR TITLE
ci: use `$GITHUB_OUTPUT` instead of `set-output`

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
 	# this is a push build, run all builds
 	if not pr_number:
-		os.system('echo "build=strawberry" >> $GITHUB_OUTPUT'')
+		os.system('echo "build=strawberry" >> $GITHUB_OUTPUT')
 		sys.exit(0)
 
 	files_list = files_list or get_files_list(pr_number=pr_number, repo=repo)

--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
 	# this is a push build, run all builds
 	if not pr_number:
-		os.system('echo "::set-output name=build::strawberry"')
+		os.system('echo "build=strawberry" >> $GITHUB_OUTPUT'')
 		sys.exit(0)
 
 	files_list = files_list or get_files_list(pr_number=pr_number, repo=repo)
@@ -122,4 +122,4 @@ if __name__ == "__main__":
 		print("Only Python code was updated, stopping Cypress build process.")
 		sys.exit(0)
 
-	os.system('echo "::set-output name=build::strawberry"')
+	os.system('echo "build=strawberry" >> $GITHUB_OUTPUT')

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -475,7 +475,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
+        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
 
       - uses: actions/cache@v3
         id: yarn-cache


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.