### PR TITLE
fix: Allow array in API request

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -218,14 +218,13 @@ def make_form_dict(request):
 		args.update(request.args or {})
 		args.update(request.form or {})
 
-	if not isinstance(args, dict):
-		frappe.throw(_("Invalid request arguments"))
+	if isinstance(args, dict):
+		
+		frappe.local.form_dict = frappe._dict(args)
 
-	frappe.local.form_dict = frappe._dict(args)
-
-	if "_" in frappe.local.form_dict:
-		# _ is passed by $.ajax so that the request is not cached by the browser. So, remove _ from form_dict
-		frappe.local.form_dict.pop("_")
+		if "_" in frappe.local.form_dict:
+			# _ is passed by $.ajax so that the request is not cached by the browser. So, remove _ from form_dict
+			frappe.local.form_dict.pop("_")
 
 
 def handle_exception(e):


### PR DESCRIPTION
Array is not allowed in API request, only python dict is allowed.
If we need to pass array of object, frappe doesn't allow this, This has to be wrapped in object first.
Ex: 
`[
    {
        "test": "test"
    },
    {
        "test": "test"
    }
]`
This above request is not allowed.