### PR TITLE
chore: remove code for handling old dict-based meta cache

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -129,7 +129,7 @@ class Meta(Document):
 
 	def process(self):
 		# don't process for special doctypes
-		# prevent's circular dependency
+		# prevents circular dependency
 		if self.name in self.special_doctypes:
 			self.init_field_caches()
 			return

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -111,12 +111,6 @@ class Meta(Document):
 	]
 
 	def __init__(self, doctype):
-		# from cache
-		if isinstance(doctype, dict):
-			super().__init__(doctype)
-			self.init_field_caches()
-			return
-
 		if isinstance(doctype, Document):
 			super().__init__(doctype.as_dict())
 		else:


### PR DESCRIPTION
### Before

A dict gets treated as "processed" meta. This was useful when we were caching Meta as dict.

### After

In absence of special treatment, a dict will get treated as filters for DocType. This doesn't matter much because it isn't used like this at all with direct caching of `Meta` objects.