### PR TITLE
fix(commands): require ngrok auth token in `site_config.json` to use ngrok command

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -109,7 +109,8 @@ def new_site(
 	"--with-public-files", help="Restores the public files of the site, given path to its tar file"
 )
 @click.option(
-	"--with-private-files", help="Restores the private files of the site, given path to its tar file"
+	"--with-private-files",
+	help="Restores the private files of the site, given path to its tar file",
 )
 @click.option(
 	"--force",
@@ -191,7 +192,8 @@ def _restore(
 				fg="red",
 			)
 			click.secho(
-				"Use `bench partial-restore` to restore a partial backup to an existing site.", fg="yellow"
+				"Use `bench partial-restore` to restore a partial backup to an existing site.",
+				fg="yellow",
 			)
 			_backup.decryption_rollback()
 			sys.exit(1)
@@ -199,11 +201,15 @@ def _restore(
 	except UnicodeDecodeError:
 		_backup.decryption_rollback()
 		if encryption_key:
-			click.secho("Encrypted backup file detected. Decrypting using provided key.", fg="yellow")
+			click.secho(
+				"Encrypted backup file detected. Decrypting using provided key.", fg="yellow"
+			)
 			_backup.backup_decryption(encryption_key)
 
 		else:
-			click.secho("Encrypted backup file detected. Decrypting using site config.", fg="yellow")
+			click.secho(
+				"Encrypted backup file detected. Decrypting using site config.", fg="yellow"
+			)
 			encryption_key = get_or_generate_backup_encryption_key()
 			_backup.backup_decryption(encryption_key)
 
@@ -222,7 +228,8 @@ def _restore(
 				fg="red",
 			)
 			click.secho(
-				"Use `bench partial-restore` to restore a partial backup to an existing site.", fg="yellow"
+				"Use `bench partial-restore` to restore a partial backup to an existing site.",
+				fg="yellow",
 			)
 			_backup.decryption_rollback()
 			sys.exit(1)
@@ -324,7 +331,8 @@ def partial_restore(context, sql_file_path, verbose, encryption_key=None):
 			# Check for full backup file
 			if "Partial Backup" not in header:
 				click.secho(
-					"Full backup file detected.Use `bench restore` to restore a Frappe Site.", fg="red"
+					"Full backup file detected.Use `bench restore` to restore a Frappe Site.",
+					fg="red",
 				)
 				_backup.decryption_rollback()
 				sys.exit(1)
@@ -332,11 +340,15 @@ def partial_restore(context, sql_file_path, verbose, encryption_key=None):
 	except UnicodeDecodeError:
 		_backup.decryption_rollback()
 		if encryption_key:
-			click.secho("Encrypted backup file detected. Decrypting using provided key.", fg="yellow")
+			click.secho(
+				"Encrypted backup file detected. Decrypting using provided key.", fg="yellow"
+			)
 			key = encryption_key
 
 		else:
-			click.secho("Encrypted backup file detected. Decrypting using site config.", fg="yellow")
+			click.secho(
+				"Encrypted backup file detected. Decrypting using site config.", fg="yellow"
+			)
 			key = get_or_generate_backup_encryption_key()
 
 		_backup.backup_decryption(key)
@@ -355,7 +367,8 @@ def partial_restore(context, sql_file_path, verbose, encryption_key=None):
 			# Check for Full backup file.
 			if "Partial Backup" not in header:
 				click.secho(
-					"Full Backup file detected.Use `bench restore` to restore a Frappe Site.", fg="red"
+					"Full Backup file detected.Use `bench restore` to restore a Frappe Site.",
+					fg="red",
 				)
 				_backup.decryption_rollback()
 				sys.exit(1)
@@ -387,17 +400,26 @@ def reinstall(
 ):
 	"Reinstall site ie. wipe all data and start over"
 	site = get_site(context)
-	_reinstall(site, admin_password, db_root_username, db_root_password, yes, verbose=context.verbose)
+	_reinstall(
+		site, admin_password, db_root_username, db_root_password, yes, verbose=context.verbose
+	)
 
 
 def _reinstall(
-	site, admin_password=None, db_root_username=None, db_root_password=None, yes=False, verbose=False
+	site,
+	admin_password=None,
+	db_root_username=None,
+	db_root_password=None,
+	yes=False,
+	verbose=False,
 ):
 	from frappe.installer import _new_site
 	from frappe.utils.synchronization import filelock
 
 	if not yes:
-		click.confirm("This will wipe your database. Are you sure you want to reinstall?", abort=True)
+		click.confirm(
+			"This will wipe your database. Are you sure you want to reinstall?", abort=True
+		)
 	try:
 		frappe.init(site=site)
 		frappe.connect()
@@ -487,7 +509,9 @@ def list_apps(context, format):
 		apps = frappe.get_single("Installed Applications").installed_applications
 
 		if apps:
-			name_len, ver_len = (max(len(x.get(y)) for x in apps) for y in ["app_name", "app_version"])
+			name_len, ver_len = (
+				max(len(x.get(y)) for x in apps) for y in ["app_name", "app_version"]
+			)
 			template = f"{{0:{name_len}}} {{1:{ver_len}}} {{2}}"
 
 			installed_applications = [
@@ -528,7 +552,9 @@ def add_system_manager(context, email, first_name, last_name, send_welcome_email
 	for site in context.sites:
 		frappe.connect(site=site)
 		try:
-			frappe.utils.user.add_system_manager(email, first_name, last_name, send_welcome_email, password)
+			frappe.utils.user.add_system_manager(
+				email, first_name, last_name, send_welcome_email, password
+			)
 			frappe.db.commit()
 		finally:
 			frappe.destroy()
@@ -554,7 +580,9 @@ def add_user_for_sites(
 	for site in context.sites:
 		frappe.connect(site=site)
 		try:
-			add_new_user(email, first_name, last_name, user_type, send_welcome_email, password, add_role)
+			add_new_user(
+				email, first_name, last_name, user_type, send_welcome_email, password, add_role
+			)
 			frappe.db.commit()
 		finally:
 			frappe.destroy()
@@ -719,7 +747,10 @@ def use(site, sites_path="."):
 @click.option("--backup-path-private-files", default=None, help="Set path for saving private file")
 @click.option("--backup-path-conf", default=None, help="Set path for saving config file")
 @click.option(
-	"--ignore-backup-conf", default=False, is_flag=True, help="Ignore excludes/includes set in config"
+	"--ignore-backup-conf",
+	default=False,
+	is_flag=True,
+	help="Ignore excludes/includes set in config",
 )
 @click.option("--verbose", default=False, is_flag=True, help="Add verbosity")
 @click.option("--compress", default=False, is_flag=True, help="Compress private and public files")
@@ -772,9 +803,13 @@ def backup(
 				print(frappe.get_traceback())
 			exit_code = 1
 			continue
-		if frappe.get_system_settings("encrypt_backup") and frappe.get_site_config().encryption_key:
+		if (
+			frappe.get_system_settings("encrypt_backup")
+			and frappe.get_site_config().encryption_key
+		):
 			click.secho(
-				"Backup encryption is turned on. Please note the backup encryption key.", fg="yellow"
+				"Backup encryption is turned on. Please note the backup encryption key.",
+				fg="yellow",
 			)
 
 		odb.print_summary()
@@ -835,7 +870,9 @@ def uninstall(context, app, dry_run, yes, no_backup, force):
 			frappe.init(site=site)
 			frappe.connect()
 			with filelock("uninstall_app"):
-				remove_app(app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force)
+				remove_app(
+					app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force
+				)
 		finally:
 			frappe.destroy()
 	if not context.sites:
@@ -1128,13 +1165,14 @@ def start_ngrok(context, bind_tls):
 	site = get_site(context)
 	frappe.init(site=site)
 
-	ngrok_auth_token = frappe.conf.ngrok_auth_token
-	if not ngrok_auth_token:
-		frappe.errprint(
-			"'ngrok_auth_token' not found in site config. Please register for a free ngrok account at: https://dashboard.ngrok.com/signup and place the obtained authtoken in site_config.json file."
+	ngrok_authtoken = frappe.conf.ngrok_authtoken
+	if not ngrok_authtoken:
+		click.echo(
+			f"{click.style('ngrok_authtoken', bold=True)} not found in site config. Please register for a free ngrok account at: https://dashboard.ngrok.com/signup and place the obtained authtoken in site_config.json file.\n",
+			err=True,
 		)
-		exit(0)
-	ngrok.set_auth_token(ngrok_auth_token)
+		sys.exit(1)
+	ngrok.set_auth_token(ngrok_authtoken)
 
 	port = frappe.conf.http_port or frappe.conf.webserver_port
 	tunnel = ngrok.connect(addr=str(port), host_header=site, bind_tls=bind_tls)
@@ -1354,7 +1392,9 @@ def trim_tables(context, dry_run, format, no_backup):
 			trimmed_data = trim_tables(dry_run=dry_run, quiet=format == "json")
 
 			if format == "table" and not dry_run:
-				click.secho(f"The following data have been removed from {frappe.local.site}", fg="green")
+				click.secho(
+					f"The following data have been removed from {frappe.local.site}", fg="green"
+				)
 
 			handle_data(trimmed_data, format=format)
 		finally:
@@ -1369,7 +1409,9 @@ def handle_data(data: dict, format="json"):
 	else:
 		from frappe.utils.commands import render_table
 
-		data = [["DocType", "Fields"]] + [[table, ", ".join(columns)] for table, columns in data.items()]
+		data = [["DocType", "Fields"]] + [
+			[table, ", ".join(columns)] for table, columns in data.items()
+		]
 		render_table(data)
 
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -201,15 +201,11 @@ def _restore(
 	except UnicodeDecodeError:
 		_backup.decryption_rollback()
 		if encryption_key:
-			click.secho(
-				"Encrypted backup file detected. Decrypting using provided key.", fg="yellow"
-			)
+			click.secho("Encrypted backup file detected. Decrypting using provided key.", fg="yellow")
 			_backup.backup_decryption(encryption_key)
 
 		else:
-			click.secho(
-				"Encrypted backup file detected. Decrypting using site config.", fg="yellow"
-			)
+			click.secho("Encrypted backup file detected. Decrypting using site config.", fg="yellow")
 			encryption_key = get_or_generate_backup_encryption_key()
 			_backup.backup_decryption(encryption_key)
 
@@ -340,15 +336,11 @@ def partial_restore(context, sql_file_path, verbose, encryption_key=None):
 	except UnicodeDecodeError:
 		_backup.decryption_rollback()
 		if encryption_key:
-			click.secho(
-				"Encrypted backup file detected. Decrypting using provided key.", fg="yellow"
-			)
+			click.secho("Encrypted backup file detected. Decrypting using provided key.", fg="yellow")
 			key = encryption_key
 
 		else:
-			click.secho(
-				"Encrypted backup file detected. Decrypting using site config.", fg="yellow"
-			)
+			click.secho("Encrypted backup file detected. Decrypting using site config.", fg="yellow")
 			key = get_or_generate_backup_encryption_key()
 
 		_backup.backup_decryption(key)
@@ -400,9 +392,7 @@ def reinstall(
 ):
 	"Reinstall site ie. wipe all data and start over"
 	site = get_site(context)
-	_reinstall(
-		site, admin_password, db_root_username, db_root_password, yes, verbose=context.verbose
-	)
+	_reinstall(site, admin_password, db_root_username, db_root_password, yes, verbose=context.verbose)
 
 
 def _reinstall(
@@ -417,9 +407,7 @@ def _reinstall(
 	from frappe.utils.synchronization import filelock
 
 	if not yes:
-		click.confirm(
-			"This will wipe your database. Are you sure you want to reinstall?", abort=True
-		)
+		click.confirm("This will wipe your database. Are you sure you want to reinstall?", abort=True)
 	try:
 		frappe.init(site=site)
 		frappe.connect()
@@ -509,9 +497,7 @@ def list_apps(context, format):
 		apps = frappe.get_single("Installed Applications").installed_applications
 
 		if apps:
-			name_len, ver_len = (
-				max(len(x.get(y)) for x in apps) for y in ["app_name", "app_version"]
-			)
+			name_len, ver_len = (max(len(x.get(y)) for x in apps) for y in ["app_name", "app_version"])
 			template = f"{{0:{name_len}}} {{1:{ver_len}}} {{2}}"
 
 			installed_applications = [
@@ -552,9 +538,7 @@ def add_system_manager(context, email, first_name, last_name, send_welcome_email
 	for site in context.sites:
 		frappe.connect(site=site)
 		try:
-			frappe.utils.user.add_system_manager(
-				email, first_name, last_name, send_welcome_email, password
-			)
+			frappe.utils.user.add_system_manager(email, first_name, last_name, send_welcome_email, password)
 			frappe.db.commit()
 		finally:
 			frappe.destroy()
@@ -580,9 +564,7 @@ def add_user_for_sites(
 	for site in context.sites:
 		frappe.connect(site=site)
 		try:
-			add_new_user(
-				email, first_name, last_name, user_type, send_welcome_email, password, add_role
-			)
+			add_new_user(email, first_name, last_name, user_type, send_welcome_email, password, add_role)
 			frappe.db.commit()
 		finally:
 			frappe.destroy()
@@ -803,10 +785,7 @@ def backup(
 				print(frappe.get_traceback())
 			exit_code = 1
 			continue
-		if (
-			frappe.get_system_settings("encrypt_backup")
-			and frappe.get_site_config().encryption_key
-		):
+		if frappe.get_system_settings("encrypt_backup") and frappe.get_site_config().encryption_key:
 			click.secho(
 				"Backup encryption is turned on. Please note the backup encryption key.",
 				fg="yellow",
@@ -870,9 +849,7 @@ def uninstall(context, app, dry_run, yes, no_backup, force):
 			frappe.init(site=site)
 			frappe.connect()
 			with filelock("uninstall_app"):
-				remove_app(
-					app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force
-				)
+				remove_app(app_name=app, dry_run=dry_run, yes=yes, no_backup=no_backup, force=force)
 		finally:
 			frappe.destroy()
 	if not context.sites:
@@ -1392,9 +1369,7 @@ def trim_tables(context, dry_run, format, no_backup):
 			trimmed_data = trim_tables(dry_run=dry_run, quiet=format == "json")
 
 			if format == "table" and not dry_run:
-				click.secho(
-					f"The following data have been removed from {frappe.local.site}", fg="green"
-				)
+				click.secho(f"The following data have been removed from {frappe.local.site}", fg="green")
 
 			handle_data(trimmed_data, format=format)
 		finally:
@@ -1409,9 +1384,7 @@ def handle_data(data: dict, format="json"):
 	else:
 		from frappe.utils.commands import render_table
 
-		data = [["DocType", "Fields"]] + [
-			[table, ", ".join(columns)] for table, columns in data.items()
-		]
+		data = [["DocType", "Fields"]] + [[table, ", ".join(columns)] for table, columns in data.items()]
 		render_table(data)
 
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1128,6 +1128,14 @@ def start_ngrok(context, bind_tls):
 	site = get_site(context)
 	frappe.init(site=site)
 
+	ngrok_auth_token = frappe.conf.ngrok_auth_token
+	if not ngrok_auth_token:
+		frappe.errprint(
+			"'ngrok_auth_token' not found in site config. Please register for a free ngrok account at: https://dashboard.ngrok.com/signup and place the obtained authtoken in site_config.json file."
+		)
+		exit(0)
+	ngrok.set_auth_token(ngrok_auth_token)
+
 	port = frappe.conf.http_port or frappe.conf.webserver_port
 	tunnel = ngrok.connect(addr=str(port), host_header=site, bind_tls=bind_tls)
 	print(f"Public URL: {tunnel.public_url}")


### PR DESCRIPTION
**Problem**

The `ngrok` (`bench --site <site-name> ngrok`) feature had stopped working since **ngrok** requires **authtoken** if we want to use the `host_header` feature (which we use for setting it to the site name). Anyone can obtain a free token by signing up at https://dashboard.ngrok.com/signup. 

**Solution**

After this change, the user will be required to place the authtoken in site config under the key `ngrok_authtoken` in order to use this command. If the `ngrok_authtoken` is not present in the config, it will display a message and exit.

also, added a flag `--use-default-authtoken` to the command so that the default ngrok's authtoken can also be used