### PR TITLE
fix(subscription): Allow remote_login even if subscription.expiry is not set

### DIFF
--- a/frappe/utils/subscription.py
+++ b/frappe/utils/subscription.py
@@ -9,7 +9,7 @@ import frappe
 def remote_login():
 	try:
 		login_url = frappe.conf.subscription["login_url"]
-		if frappe.conf.subscription["expiry"] and login_url:
+		if login_url:
 			resp = requests.post(login_url)
 
 			if resp.status_code != 200:


### PR DESCRIPTION
If `subscription.expiry` is not set in `site_config.json` then remote_login always responds with `False`. 

Clicking on **Navbar Dropdown** > **Manage Subscription** fails with 
```
No active subscriptions found
```