### PR TITLE
fix: build_response for re.Match

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -159,6 +159,7 @@ def make_logs(response=None):
 def json_handler(obj):
 	"""serialize non-serializable data for json"""
 	from collections.abc import Iterable
+	from re import Match
 
 	if isinstance(obj, (datetime.date, datetime.datetime, datetime.time)):
 		return str(obj)
@@ -178,6 +179,9 @@ def json_handler(obj):
 
 	elif isinstance(obj, Iterable):
 		return list(obj)
+
+	elif isinstance(obj, Match):
+		return obj.string
 
 	elif type(obj) == type or isinstance(obj, Exception):
 		return repr(obj)


### PR DESCRIPTION
Updating password for a User document finishes successfully but logs an error in the logs. Adding support for `re.Match` objects in the `json_handler` makes our serializer more flexible 🎄 

```python
13:39:26 web.1            | During handling of the above exception, another exception occurred:
13:39:26 web.1            | 
13:39:26 web.1            | Traceback (most recent call last):
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/apps/frappe/frappe/middlewares.py", line 16, in __call__
13:39:26 web.1            |     return super().__call__(environ, start_response)
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/env/lib/python3.10/site-packages/werkzeug/middleware/shared_data.py", line 247, in __call__
13:39:26 web.1            |     return self.app(environ, start_response)
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/env/lib/python3.10/site-packages/werkzeug/middleware/shared_data.py", line 247, in __call__
13:39:26 web.1            |     return self.app(environ, start_response)
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/env/lib/python3.10/site-packages/werkzeug/local.py", line 237, in application
13:39:26 web.1            |     return ClosingIterator(app(environ, start_response), self.cleanup)
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/env/lib/python3.10/site-packages/werkzeug/wrappers/request.py", line 187, in application
13:39:26 web.1            |     resp = f(*args[:-2] + (request,))
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/apps/frappe/frappe/app.py", line 74, in application
13:39:26 web.1            |     response = handle_exception(e)
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/apps/frappe/frappe/app.py", line 251, in handle_exception
13:39:26 web.1            |     response = frappe.utils.response.report_error(http_status_code)
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/apps/frappe/frappe/utils/response.py", line 45, in report_error
13:39:26 web.1            |     response = build_response("json")
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/apps/frappe/frappe/utils/response.py", line 65, in build_response
13:39:26 web.1            |     return response_type_map[frappe.response.get("type") or response_type]()
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/apps/frappe/frappe/utils/response.py", line 113, in as_json
13:39:26 web.1            |     response.data = json.dumps(frappe.local.response, default=json_handler, separators=(",", ":"))
13:39:26 web.1            |   File "/usr/lib/python3.10/json/__init__.py", line 238, in dumps
13:39:26 web.1            |     **kw).encode(obj)
13:39:26 web.1            |   File "/usr/lib/python3.10/json/encoder.py", line 199, in encode
13:39:26 web.1            |     chunks = self.iterencode(o, _one_shot=True)
13:39:26 web.1            |   File "/usr/lib/python3.10/json/encoder.py", line 257, in iterencode
13:39:26 web.1            |     return _iterencode(o, 0)
13:39:26 web.1            |   File "/home/gavin/Desktop/projects-bench/apps/frappe/frappe/utils/response.py", line 189, in json_handler
13:39:26 web.1            |     raise TypeError(
13:39:26 web.1            | TypeError: Object of type <class 're.Match'> with value of <re.Match object; span=(8, 12), match='1997'> is not JSON serializable
```