### PR TITLE
fix: not able to make delivery note from pick list

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -193,7 +193,7 @@ class Document(BaseDocument):
 		self.load_from_db()
 
 	def get_latest(self):
-		if not hasattr(self, "_doc_before_save"):
+		if not getattr(self, "_doc_before_save", None):
 			self.load_doc_before_save()
 
 		return self._doc_before_save


### PR DESCRIPTION
**Issue**

While making delivery note from pick list getting an error

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 38, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 76, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1457, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/model/mapper.py", line 41, in make_mapped_doc
    return method(source_name)
  File "apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 521, in create_delivery_note
    delivery_note = create_dn_with_so(sales_dict, pick_list)
  File "apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 573, in create_dn_with_so
    delivery_note.save()
  File "apps/frappe/frappe/model/document.py", line 311, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 346, in _save
    self.validate_higher_perm_levels()
  File "apps/frappe/frappe/model/document.py", line 697, in validate_higher_perm_levels
    self.reset_values_if_no_permlevel_access(has_access_to, high_permlevel_fields)
  File "apps/frappe/frappe/model/base_document.py", line 1073, in reset_values_if_no_permlevel_access
    self.set(df.fieldname, ref_doc.get(df.fieldname))
AttributeError: 'NoneType' object has no attribute 'get'
```