### PR TITLE
fix(socketio): Event list_update > doctype_subscribe

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1321,7 +1321,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (this.list_view_settings && this.list_view_settings.disable_auto_refresh) {
 			return;
 		}
-		frappe.socketio.list_subscribe(this.doctype);
+		frappe.socketio.doctype_subscribe(this.doctype);
 		frappe.realtime.on("list_update", (data) => {
 			if (!frappe.get_doc(data?.doctype, data?.name)?.__unsaved) {
 				frappe.model.remove_from_locals(data.doctype, data.name);

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -129,8 +129,8 @@ frappe.socketio = {
 	task_unsubscribe: function (task_id) {
 		frappe.socketio.socket.emit("task_unsubscribe", task_id);
 	},
-	list_subscribe: function (doctype) {
-		frappe.socketio.socket.emit("list_update", doctype);
+	doctype_subscribe: function (doctype) {
+		frappe.socketio.socket.emit("doctype_subscribe", doctype);
 	},
 	doc_subscribe: function (doctype, docname) {
 		if (frappe.flags.doc_subscribe) {

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -56,7 +56,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		if (this.list_view_settings?.disable_auto_refresh) {
 			return;
 		}
-		frappe.socketio.list_subscribe(this.doctype);
+		frappe.socketio.doctype_subscribe(this.doctype);
 		frappe.realtime.on("list_update", (data) => this.on_update(data));
 	}
 

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -115,7 +115,7 @@ def can_subscribe_doc(doctype: str, docname: str) -> bool:
 
 
 @frappe.whitelist(allow_guest=True)
-def can_subscribe_list(doctype: str) -> bool:
+def can_subscribe_doctype(doctype: str) -> bool:
 	from frappe.exceptions import PermissionError
 
 	if not frappe.has_permission(user=frappe.session.user, doctype=doctype, ptype="read"):

--- a/socketio.js
+++ b/socketio.js
@@ -58,8 +58,8 @@ io.on("connection", function (socket) {
 		socket.join(get_site_room(socket));
 	}
 
-	socket.on("list_update", function (doctype) {
-		can_subscribe_list({
+	socket.on("doctype_subscribe", function (doctype) {
+		can_subscribe_doctype({
 			socket,
 			doctype,
 			callback: () => {
@@ -286,11 +286,11 @@ function can_subscribe_doc(args) {
 		});
 }
 
-function can_subscribe_list(args) {
+function can_subscribe_doctype(args) {
 	if (!args) return;
 	if (!args.doctype) return;
 	request
-		.get(get_url(args.socket, "/api/method/frappe.realtime.can_subscribe_list"))
+		.get(get_url(args.socket, "/api/method/frappe.realtime.can_subscribe_doctype"))
 		.type("form")
 		.query({
 			sid: args.socket.sid,
@@ -306,7 +306,7 @@ function can_subscribe_list(args) {
 				args.callback && args.callback(err, res);
 				return true;
 			}
-			log("ERROR (can_subscribe_list): ", err, res);
+			log("ERROR (can_subscribe_doctype): ", err, res);
 		});
 }
 


### PR DESCRIPTION
Renamed internal methods (added via https://github.com/frappe/frappe/pull/18875) to subscribe to doctype list updates, the underlying event & API for consistency