### PR TITLE
fix: Improve JSON export format readability

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1915,13 +1915,13 @@ def as_json(obj: dict | list, indent=1, separators=None) -> str:
 
 	try:
 		return json.dumps(
-			obj, indent=indent, sort_keys=True, default=json_handler, separators=separators
+			obj, indent=indent, sort_keys=True, default=json_handler, separators=separators, ensure_ascii=False
 		)
 	except TypeError:
 		# this would break in case the keys are not all os "str" type - as defined in the JSON
 		# adding this to ensure keys are sorted (expected behaviour)
 		sorted_obj = dict(sorted(obj.items(), key=lambda kv: str(kv[0])))
-		return json.dumps(sorted_obj, indent=indent, default=json_handler, separators=separators)
+		return json.dumps(sorted_obj, indent=indent, default=json_handler, separators=separators, ensure_ascii=False)
 
 
 def are_emails_muted():

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1915,13 +1915,24 @@ def as_json(obj: dict | list, indent=1, separators=None, ensure_ascii=True) -> s
 
 	try:
 		return json.dumps(
-			obj, indent=indent, sort_keys=True, default=json_handler, separators=separators, ensure_ascii=ensure_ascii
+			obj,
+			indent=indent,
+			sort_keys=True,
+			default=json_handler,
+			separators=separators,
+			ensure_ascii=ensure_ascii,
 		)
 	except TypeError:
 		# this would break in case the keys are not all os "str" type - as defined in the JSON
 		# adding this to ensure keys are sorted (expected behaviour)
 		sorted_obj = dict(sorted(obj.items(), key=lambda kv: str(kv[0])))
-		return json.dumps(sorted_obj, indent=indent, default=json_handler, separators=separators, ensure_ascii=ensure_ascii)
+		return json.dumps(
+			sorted_obj,
+			indent=indent,
+			default=json_handler,
+			separators=separators,
+			ensure_ascii=ensure_ascii,
+		)
 
 
 def are_emails_muted():

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1907,7 +1907,7 @@ def get_value(*args, **kwargs):
 	return db.get_value(*args, **kwargs)
 
 
-def as_json(obj: dict | list, indent=1, separators=None) -> str:
+def as_json(obj: dict | list, indent=1, separators=None, ensure_ascii=True) -> str:
 	from frappe.utils.response import json_handler
 
 	if separators is None:
@@ -1915,13 +1915,13 @@ def as_json(obj: dict | list, indent=1, separators=None) -> str:
 
 	try:
 		return json.dumps(
-			obj, indent=indent, sort_keys=True, default=json_handler, separators=separators, ensure_ascii=False
+			obj, indent=indent, sort_keys=True, default=json_handler, separators=separators, ensure_ascii=ensure_ascii
 		)
 	except TypeError:
 		# this would break in case the keys are not all os "str" type - as defined in the JSON
 		# adding this to ensure keys are sorted (expected behaviour)
 		sorted_obj = dict(sorted(obj.items(), key=lambda kv: str(kv[0])))
-		return json.dumps(sorted_obj, indent=indent, default=json_handler, separators=separators, ensure_ascii=False)
+		return json.dumps(sorted_obj, indent=indent, default=json_handler, separators=separators, ensure_ascii=ensure_ascii)
 
 
 def are_emails_muted():

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -260,7 +260,7 @@ def export_json(doctype, path, filters=None, or_filters=None, name=None, order_b
 		path = os.path.join("..", path)
 
 	with open(path, "w") as outfile:
-		outfile.write(frappe.as_json(out))
+		outfile.write(frappe.as_json(out, ensure_ascii=False))
 
 
 def export_csv(doctype, path):


### PR DESCRIPTION
# PR justification

By default, Python's `json.dumps()` method is run with `ensure_ascii = True` flag. This behavior makes exporting fixtures difficult to maintain and read by humans for data in languages other than english as the resulting JSON files gets ascii character codes instead of the corresponding unicode characters.
This PR resolves this by ensuring that the `frappe.as_json()` method runs with `ensure_ascii = False`

Another reason for this change is that the default behavior makes little sense as everything in Frappe is unicode based (database table collation, python strings, file encoding, etc.) so why fixtures content shouldn't be?

--------------

## Examples:

Exported fixture sample before this PR:
![image](https://user-images.githubusercontent.com/8353891/209904833-5919b6fc-3d8f-4ebe-bcc2-410ff504c1d1.png)

Exported fixture sample after this PR:
![image](https://user-images.githubusercontent.com/8353891/209905219-b04d531c-ec59-4153-b002-9ecafc0691ef.png)
