### PR TITLE
fix: show document title instead of name in like notification email

### DIFF
--- a/frappe/templates/includes/likes/likes.py
+++ b/frappe/templates/includes/likes/likes.py
@@ -26,7 +26,8 @@ def like(reference_doctype, reference_name, like, route=""):
 		clear_cache(route)
 
 	if like and ref_doc.enable_email_notification:
-		subject = _("Like on {0}: {1}").format(reference_doctype, reference_name)
+		ref_doc_title = ref_doc.get_title()
+		subject = _("Like on {0}: {1}").format(reference_doctype, ref_doc_title)
 		content = _("You have received a ❤️ like on your blog post")
 		message = f"<p>{content} <b>{reference_name}</b></p>"
 		message = message + "<p><a href='{}/{}#likes' style='font-size: 80%'>{}</a></p>".format(

--- a/frappe/templates/includes/likes/likes.py
+++ b/frappe/templates/includes/likes/likes.py
@@ -29,7 +29,7 @@ def like(reference_doctype, reference_name, like, route=""):
 		ref_doc_title = ref_doc.get_title()
 		subject = _("Like on {0}: {1}").format(reference_doctype, ref_doc_title)
 		content = _("You have received a ❤️ like on your blog post")
-		message = f"<p>{content} <b>{reference_name}</b></p>"
+		message = f"<p>{content} <b>{ref_doc_title}</b></p>"
 		message = message + "<p><a href='{}/{}#likes' style='font-size: 80%'>{}</a></p>".format(
 			frappe.utils.get_request_site_address(), ref_doc.route, _("View Blog Post")
 		)


### PR DESCRIPTION
**Before:**

<img width="1284" alt="CleanShot 2022-12-31 at 20 06 11@2x" src="https://user-images.githubusercontent.com/34810212/210140358-abe5a680-3e49-42b6-8da4-64581e55d3d8.png">


**After:**

<img width="1129" alt="CleanShot 2022-12-31 at 20 05 53@2x" src="https://user-images.githubusercontent.com/34810212/210140360-d8e5ed44-aaf7-4bc0-8ca1-c39043c7484a.png">

Better IMO. Of course will fall back to name if no title field is set. 

`no-docs`
