### PR TITLE
fix: only allow system manager to create/edit email templates by default

### DIFF
--- a/frappe/email/doctype/email_template/email_template.json
+++ b/frappe/email/doctype/email_template/email_template.json
@@ -57,18 +57,16 @@
  ],
  "icon": "fa fa-comment",
  "links": [],
- "modified": "2022-01-04 14:12:50.321633",
+ "modified": "2023-01-02 03:56:48.437280",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Template",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
-   "create": 1,
    "read": 1,
-   "role": "All",
-   "share": 1,
-   "write": 1
+   "role": "All"
   },
   {
    "create": 1,
@@ -85,5 +83,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
Everyone can still select pre-existing email templates:

![Screenshot-2023-01-02-152945](https://user-images.githubusercontent.com/16315650/210216807-546da693-2d26-4f96-8885-987f50e13844.png)
