### PR TITLE
chore: Remove duplicated Oauth2 whitelisted APIs

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -356,6 +356,7 @@ global_search_doctypes = {
 }
 
 override_whitelisted_methods = {
+	# Legacy File APIs
 	"frappe.core.doctype.file.file.download_file": "download_file",
 	"frappe.core.doctype.file.file.unzip_file": "frappe.core.api.file.unzip_file",
 	"frappe.core.doctype.file.file.get_attached_images": "frappe.core.api.file.get_attached_images",
@@ -365,6 +366,14 @@ override_whitelisted_methods = {
 	"frappe.core.doctype.file.file.create_new_folder": "frappe.core.api.file.create_new_folder",
 	"frappe.core.doctype.file.file.move_file": "frappe.core.api.file.move_file",
 	"frappe.core.doctype.file.file.zip_files": "frappe.core.api.file.zip_files",
+	# Legacy (& Consistency) OAuth2 APIs
+	"frappe.www.login.login_via_google": "frappe.integrations.oauth2_logins.login_via_google",
+	"frappe.www.login.login_via_github": "frappe.integrations.oauth2_logins.login_via_github",
+	"frappe.www.login.login_via_facebook": "frappe.integrations.oauth2_logins.login_via_facebook",
+	"frappe.www.login.login_via_frappe": "frappe.integrations.oauth2_logins.login_via_frappe",
+	"frappe.www.login.login_via_office365": "frappe.integrations.oauth2_logins.login_via_office365",
+	"frappe.www.login.login_via_salesforce": "frappe.integrations.oauth2_logins.login_via_salesforce",
+	"frappe.www.login.login_via_fairlogin": "frappe.integrations.oauth2_logins.login_via_fairlogin",
 }
 
 ignore_links_on_delete = [

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -11,13 +11,7 @@ from frappe.rate_limiter import rate_limit
 from frappe.utils import cint, get_url
 from frappe.utils.html_utils import get_icon_html
 from frappe.utils.jinja import guess_is_path
-from frappe.utils.oauth import (
-	get_oauth2_authorize_url,
-	get_oauth_keys,
-	login_via_oauth2,
-	login_via_oauth2_id_token,
-	redirect_post_login,
-)
+from frappe.utils.oauth import get_oauth2_authorize_url, get_oauth_keys, redirect_post_login
 from frappe.utils.password import get_decrypted_password
 from frappe.website.utils import get_home_page
 
@@ -106,31 +100,6 @@ def get_context(context):
 	context["login_with_email_link"] = frappe.get_system_settings("login_with_email_link")
 
 	return context
-
-
-@frappe.whitelist(allow_guest=True)
-def login_via_google(code: str, state: str):
-	login_via_oauth2("google", code, state, decoder=decoder_compat)
-
-
-@frappe.whitelist(allow_guest=True)
-def login_via_github(code: str, state: str):
-	login_via_oauth2("github", code, state)
-
-
-@frappe.whitelist(allow_guest=True)
-def login_via_facebook(code: str, state: str):
-	login_via_oauth2("facebook", code, state, decoder=decoder_compat)
-
-
-@frappe.whitelist(allow_guest=True)
-def login_via_frappe(code: str, state: str):
-	login_via_oauth2("frappe", code, state, decoder=decoder_compat)
-
-
-@frappe.whitelist(allow_guest=True)
-def login_via_office365(code: str, state: str):
-	login_via_oauth2_id_token("office_365", code, state, decoder=decoder_compat)
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
Better to maintain just routes instead of redefining similar API methods in two different modules. Maintain routes via the `override_whitelisted_methods` hook.

Ref: https://github.com/frappe/frappe/pull/19421#issuecomment-1369541106