### PR TITLE
refactor: deprecate usage of set_value with None as docname

### DIFF
--- a/frappe/core/doctype/domain/domain.py
+++ b/frappe/core/doctype/domain/domain.py
@@ -85,8 +85,8 @@ class Domain(Document):
 	def set_default_portal_role(self):
 		"""Set default portal role based on domain"""
 		if self.data.get("default_portal_role"):
-			frappe.db.set_value(
-				"Portal Settings", None, "default_role", self.data.get("default_portal_role")
+			frappe.db.set_single_value(
+				"Portal Settings", "default_role", self.data.get("default_portal_role")
 			)
 
 	def setup_properties(self):

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -27,9 +27,9 @@ test_records = frappe.get_test_records("User")
 class TestUser(FrappeTestCase):
 	def tearDown(self):
 		# disable password strength test
-		frappe.db.set_value("System Settings", "System Settings", "enable_password_policy", 0)
-		frappe.db.set_value("System Settings", "System Settings", "minimum_password_score", "")
-		frappe.db.set_value("System Settings", "System Settings", "password_reset_limit", 3)
+		frappe.db.set_single_value("System Settings", "enable_password_policy", 0)
+		frappe.db.set_single_value("System Settings", "minimum_password_score", "")
+		frappe.db.set_single_value("System Settings", "password_reset_limit", 3)
 		frappe.set_user("Administrator")
 
 	def test_user_type(self):
@@ -111,7 +111,7 @@ class TestUser(FrappeTestCase):
 
 		self.assertEqual(frappe.db.get_value("User", "xxxtest@example.com"), None)
 
-		frappe.db.set_value("Website Settings", "Website Settings", "_test", "_test_val")
+		frappe.db.set_single_value("Website Settings", "_test", "_test_val")
 		self.assertEqual(frappe.db.get_value("Website Settings", None, "_test"), "_test_val")
 		self.assertEqual(
 			frappe.db.get_value("Website Settings", "Website Settings", "_test"), "_test_val"
@@ -179,15 +179,15 @@ class TestUser(FrappeTestCase):
 
 	def test_password_strength(self):
 		# Test Password without Password Strength Policy
-		frappe.db.set_value("System Settings", "System Settings", "enable_password_policy", 0)
+		frappe.db.set_single_value("System Settings", "enable_password_policy", 0)
 
 		# password policy is disabled, test_password_strength should be ignored
 		result = test_password_strength("test_password")
 		self.assertFalse(result.get("feedback", None))
 
 		# Test Password with Password Strenth Policy Set
-		frappe.db.set_value("System Settings", "System Settings", "enable_password_policy", 1)
-		frappe.db.set_value("System Settings", "System Settings", "minimum_password_score", 2)
+		frappe.db.set_single_value("System Settings", "enable_password_policy", 1)
+		frappe.db.set_single_value("System Settings", "minimum_password_score", 2)
 
 		# Score 1; should now fail
 		result = test_password_strength("bee2ve")
@@ -275,7 +275,7 @@ class TestUser(FrappeTestCase):
 
 	def test_rate_limiting_for_reset_password(self):
 		# Allow only one reset request for a day
-		frappe.db.set_value("System Settings", "System Settings", "password_reset_limit", 1)
+		frappe.db.set_single_value("System Settings", "password_reset_limit", 1)
 		frappe.db.commit()
 
 		url = get_url()
@@ -443,9 +443,7 @@ class TestUser(FrappeTestCase):
 	def test_reset_password_link_expiry(self):
 		new_password = "new_password"
 		# set the reset password expiry to 1 second
-		frappe.db.set_value(
-			"System Settings", "System Settings", "reset_password_link_expiry_duration", 1
-		)
+		frappe.db.set_single_value("System Settings", "reset_password_link_expiry_duration", 1)
 		frappe.set_user("testpassword@example.com")
 		test_user = frappe.get_doc("User", "testpassword@example.com")
 		test_user.reset_password()

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -32,7 +32,7 @@ from frappe.model.utils.link_count import flush_local_link_count
 from frappe.query_builder.functions import Count
 from frappe.utils import cast as cast_fieldtype
 from frappe.utils import cint, get_datetime, get_table_name, getdate, now, sbool
-from frappe.utils.deprecations import deprecated
+from frappe.utils.deprecations import deprecated, deprecation_warning
 
 IFNULL_PATTERN = re.compile(r"ifnull\(", flags=re.IGNORECASE)
 INDEX_PATTERN = re.compile(r"\s*\([^)]+\)\s*")
@@ -836,6 +836,11 @@ class Database:
 		"""
 		is_single_doctype = not (dn and dt != dn)
 		to_update = field if isinstance(field, dict) else {field: val}
+
+		if dn is None:
+			deprecation_warning(
+				"Calling db.set_value with no document name assumes a single doctype. This behaviour will be removed in version 15. Use db.set_single_value instead."
+			)
 
 		if update_modified:
 			modified = modified or now()

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -267,10 +267,10 @@ def add_all_roles_to(name):
 
 def disable_future_access():
 	frappe.db.set_default("desktop:home_page", "workspace")
-	frappe.db.set_value("System Settings", "System Settings", "setup_complete", 1)
+	frappe.db.set_single_value("System Settings", "setup_complete", 1)
 
 	# Enable onboarding after install
-	frappe.db.set_value("System Settings", "System Settings", "enable_onboarding", 1)
+	frappe.db.set_single_value("System Settings", "enable_onboarding", 1)
 
 	if not frappe.flags.in_test:
 		# remove all roles and add 'Administrator' to prevent future access

--- a/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
+++ b/frappe/integrations/doctype/dropbox_settings/dropbox_settings.py
@@ -393,7 +393,7 @@ def dropbox_auth_finish(return_access_token=False):
 
 
 def set_dropbox_access_token(access_token):
-	frappe.db.set_value("Dropbox Settings", None, "dropbox_access_token", access_token)
+	frappe.db.set_single_value("Dropbox Settings", "dropbox_access_token", access_token)
 	frappe.db.commit()
 
 

--- a/frappe/integrations/doctype/google_drive/google_drive.py
+++ b/frappe/integrations/doctype/google_drive/google_drive.py
@@ -54,7 +54,7 @@ def authorize_access(reauthorize=False, code=None):
 
 	if not oauth_code or reauthorize:
 		if reauthorize:
-			frappe.db.set_value("Google Drive", None, "backup_folder_id", "")
+			frappe.db.set_single_value("Google Drive", "backup_folder_id", "")
 		return oauth_obj.get_authentication_url(
 			{
 				"redirect": f"/app/Form/{quote('Google Drive')}",
@@ -62,8 +62,7 @@ def authorize_access(reauthorize=False, code=None):
 		)
 
 	r = oauth_obj.authorize(oauth_code)
-	frappe.db.set_value(
-		"Google Drive",
+	frappe.db.set_single_value(
 		"Google Drive",
 		{"authorization_code": oauth_code, "refresh_token": r.get("refresh_token")},
 	)
@@ -95,7 +94,7 @@ def check_for_folder_in_google_drive():
 
 		try:
 			folder = google_drive.files().create(body=file_metadata, fields="id").execute()
-			frappe.db.set_value("Google Drive", None, "backup_folder_id", folder.get("id"))
+			frappe.db.set_single_value("Google Drive", "backup_folder_id", folder.get("id"))
 			frappe.db.commit()
 		except HttpError as e:
 			frappe.throw(
@@ -120,7 +119,7 @@ def check_for_folder_in_google_drive():
 
 	for f in google_drive_folders.get("files"):
 		if f.get("name") == account.backup_folder_name:
-			frappe.db.set_value("Google Drive", None, "backup_folder_id", f.get("id"))
+			frappe.db.set_single_value("Google Drive", "backup_folder_id", f.get("id"))
 			frappe.db.commit()
 			backup_folder_exists = True
 			break
@@ -186,7 +185,7 @@ def upload_system_backup_to_google_drive():
 			send_email(False, "Google Drive", "Google Drive", "email", error_status=e)
 
 	set_progress(3, "Uploading successful.")
-	frappe.db.set_value("Google Drive", None, "last_backup_on", frappe.utils.now_datetime())
+	frappe.db.set_single_value("Google Drive", "last_backup_on", frappe.utils.now_datetime())
 	send_email(True, "Google Drive", "Google Drive", "email")
 	return _("Google Drive Backup Successful.")
 

--- a/frappe/integrations/doctype/google_settings/test_google_settings.py
+++ b/frappe/integrations/doctype/google_settings/test_google_settings.py
@@ -17,24 +17,24 @@ class TestGoogleSettings(FrappeTestCase):
 
 	def test_picker_disabled(self):
 		"""Google Drive Picker should be disabled if it is not enabled in Google Settings."""
-		frappe.db.set_value("Google Settings", None, "enable", 1)
-		frappe.db.set_value("Google Settings", None, "google_drive_picker_enabled", 0)
+		frappe.db.set_single_value("Google Settings", "enable", 1)
+		frappe.db.set_single_value("Google Settings", "google_drive_picker_enabled", 0)
 		settings = get_file_picker_settings()
 
 		self.assertEqual(settings, {})
 
 	def test_google_disabled(self):
 		"""Google Drive Picker should be disabled if Google integration is not enabled."""
-		frappe.db.set_value("Google Settings", None, "enable", 0)
-		frappe.db.set_value("Google Settings", None, "google_drive_picker_enabled", 1)
+		frappe.db.set_single_value("Google Settings", "enable", 0)
+		frappe.db.set_single_value("Google Settings", "google_drive_picker_enabled", 1)
 		settings = get_file_picker_settings()
 
 		self.assertEqual(settings, {})
 
 	def test_picker_enabled(self):
 		"""If picker is enabled, get_file_picker_settings should return the credentials."""
-		frappe.db.set_value("Google Settings", None, "enable", 1)
-		frappe.db.set_value("Google Settings", None, "google_drive_picker_enabled", 1)
+		frappe.db.set_single_value("Google Settings", "enable", 1)
+		frappe.db.set_single_value("Google Settings", "google_drive_picker_enabled", 1)
 		settings = get_file_picker_settings()
 
 		self.assertEqual(True, settings.get("enabled", False))

--- a/frappe/patches/v10_0/set_default_locking_time.py
+++ b/frappe/patches/v10_0/set_default_locking_time.py
@@ -6,4 +6,4 @@ import frappe
 
 def execute():
 	frappe.reload_doc("core", "doctype", "system_settings")
-	frappe.db.set_value("System Settings", None, "allow_login_after_fail", 60)
+	frappe.db.set_single_value("System Settings", "allow_login_after_fail", 60)

--- a/frappe/patches/v11_0/set_dropbox_file_backup.py
+++ b/frappe/patches/v11_0/set_dropbox_file_backup.py
@@ -6,4 +6,4 @@ def execute():
 	frappe.reload_doctype("Dropbox Settings")
 	check_dropbox_enabled = cint(frappe.db.get_single_value("Dropbox Settings", "enabled"))
 	if check_dropbox_enabled == 1:
-		frappe.db.set_value("Dropbox Settings", None, "file_backup", 1)
+		frappe.db.set_single_value("Dropbox Settings", "file_backup", 1)

--- a/frappe/patches/v12_0/set_default_password_reset_limit.py
+++ b/frappe/patches/v12_0/set_default_password_reset_limit.py
@@ -6,4 +6,4 @@ import frappe
 
 def execute():
 	frappe.reload_doc("core", "doctype", "system_settings", force=1)
-	frappe.db.set_value("System Settings", None, "password_reset_limit", 3)
+	frappe.db.set_single_value("System Settings", "password_reset_limit", 3)

--- a/frappe/patches/v13_0/set_first_day_of_the_week.py
+++ b/frappe/patches/v13_0/set_first_day_of_the_week.py
@@ -5,4 +5,4 @@ def execute():
 	frappe.reload_doctype("System Settings")
 	# setting first_day_of_the_week value as "Monday" to avoid breaking change
 	# because before the configuration was introduced, system used to consider "Monday" as start of the week
-	frappe.db.set_value("System Settings", "System Settings", "first_day_of_the_week", "Monday")
+	frappe.db.set_single_value("System Settings", "first_day_of_the_week", "Monday")

--- a/frappe/patches/v14_0/set_document_expiry_default.py
+++ b/frappe/patches/v14_0/set_document_expiry_default.py
@@ -2,8 +2,7 @@ import frappe
 
 
 def execute():
-	frappe.db.set_value(
-		"System Settings",
+	frappe.db.set_single_value(
 		"System Settings",
 		{"document_share_key_expiry": 30, "allow_older_web_view_links": 1},
 	)

--- a/frappe/patches/v14_0/update_auto_account_deletion_duration.py
+++ b/frappe/patches/v14_0/update_auto_account_deletion_duration.py
@@ -3,4 +3,4 @@ import frappe
 
 def execute():
 	days = frappe.db.get_single_value("Website Settings", "auto_account_deletion")
-	frappe.db.set_value("Website Settings", None, "auto_account_deletion", days * 24)
+	frappe.db.set_single_value("Website Settings", "auto_account_deletion", days * 24)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -1176,7 +1176,7 @@ def rename_language(old_name, new_name):
 
 	language_in_system_settings = frappe.db.get_single_value("System Settings", "language")
 	if language_in_system_settings == old_name:
-		frappe.db.set_value("System Settings", "System Settings", "language", new_name)
+		frappe.db.set_single_value("System Settings", "language", new_name)
 
 	frappe.db.sql(
 		"""update `tabUser` set language=%(new_name)s where language=%(old_name)s""",

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -446,7 +446,7 @@ def should_remove_barcode_image(barcode):
 
 
 def disable():
-	frappe.db.set_value("System Settings", None, "enable_two_factor_auth", 0)
+	frappe.db.set_single_value("System Settings", "enable_two_factor_auth", 0)
 
 
 @frappe.whitelist()

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -169,7 +169,7 @@ def before_tests():
 	if not int(frappe.db.get_single_value("System Settings", "setup_complete") or 0):
 		complete_setup_wizard()
 
-	frappe.db.set_value("Website Settings", "Website Settings", "disable_signup", 0)
+	frappe.db.set_single_value("Website Settings", "disable_signup", 0)
 	frappe.db.commit()
 	frappe.clear_cache()
 

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -121,7 +121,7 @@ def is_scheduler_disabled() -> bool:
 
 
 def toggle_scheduler(enable):
-	frappe.db.set_value("System Settings", None, "enable_scheduler", 1 if enable else 0)
+	frappe.db.set_single_value("System Settings", "enable_scheduler", int(enable))
 
 
 def enable_scheduler():

--- a/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/test_personal_data_deletion_request.py
@@ -59,7 +59,7 @@ class TestPersonalDataDeletionRequest(FrappeTestCase):
 		self.assertFalse(frappe.db.exists("Personal Data Deletion Request", self.delete_request.name))
 
 	def test_process_auto_request(self):
-		frappe.db.set_value("Website Settings", None, "auto_account_deletion", "1")
+		frappe.db.set_single_value("Website Settings", "auto_account_deletion", "1")
 		date_time_obj = datetime.strptime(
 			self.delete_request.creation, "%Y-%m-%d %H:%M:%S.%f"
 		) + timedelta(hours=-2)

--- a/frappe/website/doctype/website_settings/google_indexing.py
+++ b/frappe/website/doctype/website_settings/google_indexing.py
@@ -31,8 +31,7 @@ def authorize_access(reauthorize=False, code=None):
 		)
 
 	res = oauth_obj.authorize(oauth_code)
-	frappe.db.set_value(
-		"Website Settings",
+	frappe.db.set_single_value(
 		"Website Settings",
 		{"indexing_authorization_code": oauth_code, "indexing_refresh_token": res.get("refresh_token")},
 	)


### PR DESCRIPTION
This API is horrible cause:
1. It expects user to know that `None` needs to be specified to set single value - implicit information in code.
2. It expects user to retype doctype as docname... why?
3. It causes side effects like these https://github.com/frappe/frappe/issues/19471 when user mess up and add some incorrect value. These side-effects are easy to shoot yourself in foot with when you dynamically specify doctype and docname and somehow docname is `None`.

This deprecation is trivial to handle
```diff
- frappe.db.set_value("dt", None, "field", "value")
+ frappe.db.set_single_value("dt", "field", "value")
```

You'll get warning like this if you're using it wrong. This warning will become **ERROR** before next release. 
```
11:17:14 web.1            | /home/ankush/benches/develop/apps/erpnext/erpnext/controllers/selling_controller.py:24: DeprecationWarning: Calling db.set_value with no document name assumes a single doctype. This behaviour will be removed in version 15. Use db.set_single_value instead.
11:17:14 web.1            |   frappe.db.set_value("User", None, "what", "are you doing");
```

Alternatively use this semgrep rule to scan all instances: https://github.com/frappe/semgrep-rules/commit/41e336de05a92d45ec230896941498b5952f2c36


Closes https://github.com/frappe/frappe/issues/19471 

Migration guide: https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)#setting-single-value-using-dbset_value-is-deprecated