### PR TITLE
fix: Activate tab when scrolling to field

### DIFF
--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -85,7 +85,7 @@ export default class Tab {
 	set_active() {
 		this.tab_link.find(".nav-link").tab("show");
 		this.wrapper.addClass("show");
-		this.frm.active_tab = this;
+		this.frm?.set_active_tab?.(this);
 	}
 
 	is_active() {


### PR DESCRIPTION
**Before**:

Tab not activated when using `scroll_to_field`. Fields get populated in the same tab


https://user-images.githubusercontent.com/24353136/210767957-a95e7b86-f27f-41d5-9c84-8c5f5023c9d2.mp4


**After**:


https://user-images.githubusercontent.com/24353136/210767711-75054d5d-ba5d-4a7e-b2fb-9d1d842046b0.mp4

