### PR TITLE
fix: Dont throw back to `/` if desk page not found

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -168,7 +168,6 @@ frappe.Application = class Application {
 	}
 
 	set_route() {
-		frappe.flags.setting_original_route = true;
 		if (frappe.boot && localStorage.getItem("session_last_route")) {
 			frappe.set_route(localStorage.getItem("session_last_route"));
 			localStorage.removeItem("session_last_route");
@@ -176,7 +175,6 @@ frappe.Application = class Application {
 			// route to home page
 			frappe.router.route();
 		}
-		frappe.after_ajax(() => (frappe.flags.setting_original_route = false));
 		frappe.router.on("change", () => {
 			$(".tooltip").hide();
 		});

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -135,16 +135,11 @@ frappe.request.call = function (opts) {
 			}
 		},
 		404: function (xhr) {
-			if (frappe.flags.setting_original_route) {
-				// original route is wrong, redirect to login
-				frappe.app.redirect_to_login();
-			} else {
-				frappe.msgprint({
-					title: __("Not found"),
-					indicator: "red",
-					message: __("The resource you are looking for is not available"),
-				});
-			}
+			frappe.msgprint({
+				title: __("Not found"),
+				indicator: "red",
+				message: __("The resource you are looking for is not available"),
+			});
 		},
 		403: function (xhr) {
 			if (frappe.session.user === "Guest" && frappe.session.logged_in_user !== "Guest") {


### PR DESCRIPTION
- Try any path `/app/*` that doesn't exists
- You'll get thrown back to `/`, if you don't have superhuman eyes you might even miss the "not found" error message that vanishes in split second. 

If the desk SPA is loaded then let me just fix typo or go to wherever I want instead of reloading it again :pensive: 

Removed code that added this behaviour https://github.com/frappe/frappe/pull/12192 

towards https://github.com/frappe/frappe/issues/16721