### PR TITLE
fix: after login if redirect is used getting blank screen

### DIFF
--- a/frappe/website/page_renderers/not_permitted_page.py
+++ b/frappe/website/page_renderers/not_permitted_page.py
@@ -15,6 +15,8 @@ class NotPermittedPage(TemplatePage):
 
 	def render(self):
 		action = f"/login?redirect-to={frappe.request.path}"
+		if frappe.request.path.startswith("/app"):
+			action = "/login"
 		frappe.local.message_title = _("Not Permitted")
 		frappe.local.response["context"] = dict(
 			indicator_color="red", primary_action=action, primary_label=_("Login"), fullpage=True


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/18946

**Issue**: If we are logging in with some redirect arguments we are getting a blank screen
**Before:**

https://user-images.githubusercontent.com/30859809/210814539-6068317b-3015-4d6c-9775-512815b92bda.mov

**After:**

https://user-images.githubusercontent.com/30859809/210814098-6c6fe337-7779-4152-8713-d6be0a4b7972.mov

