### PR TITLE
fix: remove "All" permission for Workspace

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -177,7 +177,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2022-08-16 18:01:42.632238",
+ "modified": "2023-01-05 16:22:42.593601",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",
@@ -195,15 +195,6 @@
    "role": "Workspace Manager",
    "share": 1,
    "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -194,7 +194,7 @@ def save_page(title, public, new_widgets, blocks):
 
 	if not public:
 		filters = {"for_user": frappe.session.user, "label": title + "-" + frappe.session.user}
-	pages = frappe.get_list("Workspace", filters=filters)
+	pages = frappe.get_all("Workspace", filters=filters)
 	if pages:
 		doc = frappe.get_doc("Workspace", pages[0])
 
@@ -209,11 +209,7 @@ def save_page(title, public, new_widgets, blocks):
 @frappe.whitelist()
 def update_page(name, title, icon, parent, public):
 	public = frappe.parse_json(public)
-
 	doc = frappe.get_doc("Workspace", name)
-
-	filters = {"parent_page": doc.title, "public": doc.public}
-	child_docs = frappe.get_list("Workspace", filters=filters)
 
 	if doc:
 		doc.title = title
@@ -230,6 +226,9 @@ def update_page(name, title, icon, parent, public):
 			rename_doc("Workspace", name, new_name, force=True, ignore_permissions=True)
 
 		# update new name and public in child pages
+		child_docs = frappe.get_all(
+			"Workspace", filters={"parent_page": doc.title, "public": doc.public}
+		)
 		if child_docs:
 			for child in child_docs:
 				child_doc = frappe.get_doc("Workspace", child.name)
@@ -338,7 +337,7 @@ def last_sequence_id(doc):
 	if not doc_exists:
 		return 0
 
-	return frappe.db.get_list(
+	return frappe.get_all(
 		"Workspace",
 		fields=["sequence_id"],
 		filters={"public": doc.public, "for_user": doc.for_user},
@@ -347,7 +346,7 @@ def last_sequence_id(doc):
 
 
 def get_page_list(fields, filters):
-	return frappe.get_list("Workspace", fields=fields, filters=filters, order_by="sequence_id asc")
+	return frappe.get_all("Workspace", fields=fields, filters=filters, order_by="sequence_id asc")
 
 
 def is_workspace_manager():

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -448,10 +448,11 @@ frappe.views.Workspace = class Workspace {
 			frappe.show_alert({ message: __("Customizations Discarded"), indicator: "info" });
 		});
 
-		page.name &&
+		if (page.name && frappe.perm.has_perm("Workspace", 0, "read")) {
 			this.page.add_inner_button(__("Settings"), () => {
 				frappe.set_route(`workspace/${page.name}`);
 			});
+		}
 	}
 
 	show_sidebar_actions() {


### PR DESCRIPTION
Before:

- _All_ can access **Workspace** list and form view (but not do anything there)

After:

- Only _Workspace Manager_ can access **Workspace** list and form view

Everything else should remain unchanged.

---

"All" users were able to open the workspace list and see everyone else's workspace and, by extension, their email id's. This becomes a problem in big systems where users cannot, for legal reasons, see everybody's email ids.

We had some `get_list` calls that `workspace.py` uses internally, which I had to change to `get_all`. From a security perspective, this changes nothing (before, everyone had permissions, now they get ignored).

Internal reference: LAN-619