### PR TITLE
chore: pin `pip-audit` temporarily

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -82,5 +82,5 @@ jobs:
           python-version: '3.10'
       - uses: actions/checkout@v3
       - run: |
-          pip install pip-audit
+          pip install pip-audit==2.4.8
           pip-audit ${GITHUB_WORKSPACE}


### PR DESCRIPTION
The root issue is in [dropbox-sdk-python](https://github.com/dropbox/dropbox-sdk-python), but we can use `pip-audit 2.4.8` to keep checking for vulnerabilities till [the proposed fix](https://github.com/dropbox/dropbox-sdk-python/pull/456) is merged.