### PR TITLE
fix: Hide delete button for standard workspace if not in developer_mode

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.js
+++ b/frappe/desk/doctype/workspace/workspace.js
@@ -41,6 +41,10 @@ frappe.ui.form.on("Workspace", {
 			}
 		}
 
+		if (frappe.boot.developer_mode) {
+			frm.set_df_property("module", "read_only", 0);
+		}
+
 		frm.layout.show_message(message);
 	},
 

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -71,7 +71,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Module",
-   "options": "Module Def"
+   "options": "Module Def",
+   "read_only": 1
   },
   {
    "fieldname": "column_break_3",
@@ -177,7 +178,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2022-08-16 18:01:42.632238",
+ "modified": "2023-01-07 17:02:48.278025",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -719,13 +719,16 @@ frappe.views.Workspace = class Workspace {
 				icon: frappe.utils.icon("duplicate", "sm"),
 				action: () => this.duplicate_page(item),
 			},
-			{
+		];
+
+		if (this.is_item_deletable(item)) {
+			this.dropdown_list.push({
 				label: __("Delete"),
 				title: __("Delete Workspace"),
 				icon: frappe.utils.icon("delete-active", "sm"),
 				action: () => this.delete_page(item),
-			},
-		];
+			});
+		}
 
 		let $button = $(`
 			<div class="btn btn-secondary btn-xs setting-btn dropdown-btn" title="${__("Setting")}">
@@ -765,6 +768,19 @@ frappe.views.Workspace = class Workspace {
 				.filter(".dropdown-list")
 				.append(dropdown_item(i.label, i.title, i.icon, i.action));
 		});
+	}
+
+	is_item_deletable(item) {
+		// if item is private
+		// if item is public but doesn't have module set
+		// if item is public and has module set but developer mode is on
+		// then item is deletable
+		if (
+			!item.public ||
+			(item.public && (!item.module || (item.module && frappe.boot.developer_mode)))
+		)
+			return true;
+		return false;
 	}
 
 	delete_page(page) {

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -448,7 +448,7 @@ frappe.views.Workspace = class Workspace {
 			frappe.show_alert({ message: __("Customizations Discarded"), indicator: "info" });
 		});
 
-		if (page.name && frappe.perm.has_perm("Workspace", 0, "read")) {
+		if (page.name && this.has_access) {
 			this.page.add_inner_button(__("Settings"), () => {
 				frappe.set_route(`workspace/${page.name}`);
 			});


### PR DESCRIPTION
- [x] Hide the delete button for the standard workspace only if developer mode is not set
- [x] Do not allow to change module if not in developer mode
