### PR TITLE
fix(user profile): fix user profile queries to support postgresql

### DIFF
--- a/frappe/desk/page/user_profile/user_profile.py
+++ b/frappe/desk/page/user_profile/user_profile.py
@@ -12,11 +12,11 @@ def get_energy_points_heatmap_data(user, date):
 		date = getdate()
 
 	if frappe.db.db_type == "mariadb":
-		timestamp_field = f"unix_timestamp(date(creation))"
+		timestamp_field = "unix_timestamp(date(creation))"
 		subdate_field_year = f"subdate('{date}', interval 1 year)"
 		subdate_field_minus_year = f"subdate('{date}', interval -1 year)"
 	else:
-		timestamp_field = f"extract(epoch from date(creation))"
+		timestamp_field = "extract(epoch from date(creation))"
 		subdate_field_year = f"date('{date}') - INTERVAL '1' YEAR"
 		subdate_field_minus_year = f"date('{date}') - INTERVAL '-1' YEAR"
 
@@ -33,7 +33,7 @@ def get_energy_points_heatmap_data(user, date):
 		order by creation asc""".format(
 				timestamp_field=timestamp_field,
 				subdate_field_year=subdate_field_year,
-				subdate_field_minus_year=subdate_field_minus_year
+				subdate_field_minus_year=subdate_field_minus_year,
 			),
 			user,
 		)

--- a/frappe/query_builder/functions.py
+++ b/frappe/query_builder/functions.py
@@ -74,6 +74,22 @@ DateFormat = ImportMapper(
 )
 
 
+class _PostgresUnixTimestamp(Extract):
+	# Note: this is just a special case of "Extract" function with "epoch" hardcoded.
+	# Check super definition to see how it works.
+	def __init__(self, field, alias=None):
+		super().__init__("epoch", field=field, alias=alias)
+		self.field = field
+
+
+UnixTimestamp = ImportMapper(
+	{
+		db_type_is.MARIADB: CustomFunction("unix_timestamp", ["date"]),
+		db_type_is.POSTGRES: _PostgresUnixTimestamp,
+	}
+)
+
+
 class Cast_(Function):
 	def __init__(self, value, as_type, alias=None):
 		if frappe.db.db_type == "mariadb" and (

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import frappe
 from frappe.desk.form.assign_to import add as assign_to
+from frappe.desk.page.user_profile.user_profile import get_energy_points_heatmap_data
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.testutils import add_custom_field, clear_custom_fields
 
@@ -233,6 +234,10 @@ class TestEnergyPointLog(FrappeTestCase):
 		self.assertEqual(test_user_after_points, test_user_before_points + rule.points)
 
 		self.assertEqual(test2_user_after_points, test2_user_before_points + rule.points)
+
+	def test_eps_heatmap_query(self):
+		# Just asserts that query works, not correctness.
+		self.assertIsInstance(get_energy_points_heatmap_data(user="test@example.com", date=None), dict)
 
 	def test_points_on_field_value_change(self):
 		rule = create_energy_point_rule_for_todo(


### PR DESCRIPTION
## Problems:
- When loading user profile it calls function get_user_rank it contain two queries which group records by user in case of postgres the field user is capitalized  into 'USER' making it a different field than the one selected as in the following Image:
![rank_function_postgres](https://user-images.githubusercontent.com/52963581/211201428-6b6bb45e-7e88-47d4-86fd-1310087e81a2.PNG)
- In get_energy_points_heatmap_data function unix_timestamp, subdate don't exist in postgresql.

## Solutions:
- Include the table name with the user field so it wont be capitalized by postgresql engine.
- replace  unix_timestamp function with epoch in case of postgresql.
- remove subdate and used INTERVAL directly  in case of postgresql.