### PR TITLE
fix: remove "All" permission on workspace (Backport #19496)

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -477,7 +477,7 @@ def get_custom_report_list(module):
 	return out
 
 
-def get_custom_workspace_for_user(page):
+def get_custom_workspace_for_user(page: str):
 	"""Get custom page from workspace if exists or create one
 
 	Args:
@@ -486,8 +486,7 @@ def get_custom_workspace_for_user(page):
 	Returns:
 	        Object: Document object
 	"""
-	filters = {"extends": page, "for_user": frappe.session.user}
-	pages = frappe.get_list("Workspace", filters=filters)
+	pages = frappe.get_all("Workspace", filters={"extends": page, "for_user": frappe.session.user})
 	if pages:
 		return frappe.get_doc("Workspace", pages[0])
 	doc = frappe.new_doc("Workspace")

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -209,16 +209,16 @@
    "options": "Workspace Link"
   },
   {
-    "default": "0",
-    "depends_on": "extends_another_page",
-    "description": "Sets the current page as default for all users",
-    "fieldname": "is_default",
-    "fieldtype": "Check",
-    "label": "Is Default"
-   }
+   "default": "0",
+   "depends_on": "extends_another_page",
+   "description": "Sets the current page as default for all users",
+   "fieldname": "is_default",
+   "fieldtype": "Check",
+   "label": "Is Default"
+  }
  ],
  "links": [],
- "modified": "2021-01-21 12:09:36.156614",
+ "modified": "2023-01-08 18:46:00.751741",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",
@@ -235,15 +235,6 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "share": 1
   }
  ],
  "sort_field": "modified",

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -18,7 +18,6 @@ frappe.views.Workspace = class Workspace {
 		this.wrapper = $(wrapper);
 		this.page = wrapper.page;
 		this.prepare_container();
-		this.show_or_hide_sidebar();
 		this.setup_dropdown();
 		this.pages = {};
 		this.sidebar_items = {};
@@ -190,23 +189,6 @@ frappe.views.Workspace = class Workspace {
 		this.page.add_menu_item(__('Reset Customizations'), () => {
 			this.current_page.reset_customization();
 		}, 1);
-
-		this.page.add_menu_item(__('Toggle Sidebar'), () => {
-			this.toggle_side_bar();
-		}, 1);
-	}
-
-	toggle_side_bar() {
-		let show_workspace_sidebar = JSON.parse(localStorage.show_workspace_sidebar || "true");
-		show_workspace_sidebar = !show_workspace_sidebar;
-		localStorage.show_workspace_sidebar = show_workspace_sidebar;
-		this.show_or_hide_sidebar();
-		$(document.body).trigger("toggleDeskSidebar");
-	}
-
-	show_or_hide_sidebar() {
-		let show_workspace_sidebar = JSON.parse(localStorage.show_workspace_sidebar || "true");
-		$('#page-workspace .layout-side-section').toggleClass('hidden', !show_workspace_sidebar);
 	}
 };
 

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -788,7 +788,8 @@ body {
 			}
 
 			.layout-side-section {
-				margin-right: 20px;
+				margin-right: 15px;
+				padding-right: 15px;
 			}
 
 			.desk-sidebar {

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -764,7 +764,6 @@ body {
 			.layout-side-section, .layout-main-section-wrapper {
 				height: 100%;
 				overflow-y: auto;
-				padding-right: 25px;
 				scrollbar-color: var(--gray-200) transparent;
 				[data-theme="dark"] & {
 					scrollbar-color: var(--gray-800) transparent;

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -759,11 +759,17 @@ body {
 
 [data-page-route="Workspaces"] {
 	@media (min-width: map-get($grid-breakpoints, "lg")) {
+		.page-actions {
+			scrollbar-gutter: stable;
+			overflow: auto;
+			height: calc(var(--btn-height) + 2px);
+		}
 		.layout-main {
 			height: calc(100vh - var(--navbar-height) - var(--page-head-height) - 5px);
 			.layout-side-section, .layout-main-section-wrapper {
 				height: 100%;
 				overflow-y: auto;
+				scrollbar-gutter: stable;
 				scrollbar-color: var(--gray-200) transparent;
 				[data-theme="dark"] & {
 					scrollbar-color: var(--gray-800) transparent;


### PR DESCRIPTION
- Backport of #19496: 38b0327
- The menu button "Toggle Sidebar" had no visible effect, therefore I removed it. Toggling the sidebar still works via the sandwich on the left. 3f070ad
- The menu buttons were not aligned with workspace content on large screens. Fixed this in ec6b89f. ~~Workspaces with scrollbar are still a bit off, due to the additional width of the scrollbar, but less than before.~~ (d202d10)
    Before:
    ![before](https://user-images.githubusercontent.com/14891507/211220823-94b5d120-ef39-4c98-b5f0-cb6f343e7a35.png)
    After:
    ![after](https://user-images.githubusercontent.com/14891507/211220821-36c95446-c39f-4459-a8da-f21a1a3818c1.png)


