### PR TITLE
ci: use node18 for releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: Setup dependencies
         run: |
           npm install @semantic-release/git @semantic-release/exec --no-save


### PR DESCRIPTION
Node <18 isn't supported anymore

> [semantic-release]: node version >=18 is required. Found v14.21.1.

> See https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md for more details and solutions.

[skip ci]

