### PR TITLE
ci: use GITHUB_TOKEN for roulette api calls

### DIFF
--- a/.github/helper/roulette.py
+++ b/.github/helper/roulette.py
@@ -23,10 +23,15 @@ def fetch_pr_data(pr_number, repo, endpoint=""):
 
 def req(url):
 	"Simple resilient request call to handle rate limits."
+	headers = None
+	token = os.environ.get("GITHUB_TOKEN")
+	if token:
+		headers = {"authorization": f"Bearer {token}"}
+
 	retries = 0
 	while True:
 		try:
-			req = urllib.request.Request(url)
+			req = urllib.request.Request(url, headers=headers)
 			return urllib.request.urlopen(req)
 		except HTTPError as exc:
 			if exc.code == 403 and retries < 5:

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -9,6 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # Do not change this as GITHUB_TOKEN is being used by roulette
   contents: read
 
 jobs:
@@ -31,6 +32,7 @@ jobs:
           TYPE: "server"
           PR_NUMBER: ${{ github.event.number }}
           REPO_NAME: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     name: Patch

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -12,6 +12,7 @@ concurrency:
 
 
 permissions:
+  # Do not change this as GITHUB_TOKEN is being used by roulette
   contents: read
 
 jobs:
@@ -34,6 +35,7 @@ jobs:
           TYPE: "server"
           PR_NUMBER: ${{ github.event.number }}
           REPO_NAME: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     name: Unit Tests

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # Do not change this as GITHUB_TOKEN is being used by roulette
   contents: read
 
 jobs:
@@ -33,6 +34,7 @@ jobs:
           TYPE: "ui"
           PR_NUMBER: ${{ github.event.number }}
           REPO_NAME: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is safe cuz we set read only permission on this token in workflows.

NOTE: Changing permission type is dangerous here!

This should hopefully put an end to rate limits ._.

