### PR TITLE
chore: remove deprecated check_admin_or_system_manager function

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -27,22 +27,6 @@ rights = (
 )
 
 
-def check_admin_or_system_manager(user=None):
-	from frappe.utils.commands import warn
-
-	warn(
-		"The function check_admin_or_system_manager will be deprecated in version 15."
-		'Please use frappe.only_for("System Manager") instead.',
-		category=PendingDeprecationWarning,
-	)
-
-	if not user:
-		user = frappe.session.user
-
-	if ("System Manager" not in frappe.get_roles(user)) and (user != "Administrator"):
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
-
-
 def print_has_permission_check_logs(func):
 	def inner(*args, **kwargs):
 		frappe.flags["has_permission_check_logs"] = []


### PR DESCRIPTION
deprecated in https://github.com/frappe/frappe/pull/17682, but wasn't removed in develop.