### PR TITLE
fix(DX): Print alter query if it fails during migration

### DIFF
--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -1,3 +1,5 @@
+from pymysql.constants.ER import DUP_ENTRY
+
 import frappe
 from frappe import _
 from frappe.database.schema import DBTable
@@ -115,17 +117,15 @@ class MariaDBTable(DBTable):
 					frappe.db.sql(query)
 
 		except Exception as e:
-			# sanitize
-			if e.args[0] == 1060:
-				frappe.throw(str(e))
-			elif e.args[0] == 1062:
+			if query := locals().get("query"):  # this weirdness is to avoid potentially unbounded vars
+				print(f"Failed to alter schema using query: {query}")
+
+			if e.args[0] == DUP_ENTRY:
 				fieldname = str(e).split("'")[-2]
 				frappe.throw(
 					_("{0} field cannot be set as unique in {1}, as there are non-unique existing values").format(
 						fieldname, self.table_name
 					)
 				)
-			elif e.args[0] == 1067:
-				frappe.throw(str(e.args[1]))
-			else:
-				raise e
+
+			raise


### PR DESCRIPTION
When db.alter fails it shows pymysql error which dont really help much as they dont have any info about WHICH column it failed on or which query caused it.

Printing query is sufficient to guess the root cause.
