### PR TITLE
fix: strength check on password control

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -447,6 +447,7 @@ frappe.Application = class Application {
 					}
 				},
 			});
+			dialog.get_field("password").disable_password_checks();
 			dialog.set_primary_action(__("Login"), () => {
 				dialog.set_message(__("Authenticating..."));
 				frappe.call({

--- a/frappe/public/js/frappe/form/controls/password.js
+++ b/frappe/public/js/frappe/form/controls/password.js
@@ -32,13 +32,9 @@ frappe.ui.form.ControlPassword = class ControlPassword extends frappe.ui.form.Co
 				new_password: value || "",
 			},
 			callback: function (r) {
-				if (r.message && r.message.entropy) {
-					var score = r.message.score,
-						feedback = r.message.feedback;
-
-					feedback.crack_time_display = r.message.crack_time_display;
-
-					var indicators = ["grey", "red", "orange", "yellow", "green"];
+				if (r.message) {
+					let score = r.message.score;
+					var indicators = ["red", "red", "orange", "yellow", "green"];
 					me.set_strength_indicator(indicators[score]);
 				}
 			},
@@ -47,6 +43,6 @@ frappe.ui.form.ControlPassword = class ControlPassword extends frappe.ui.form.Co
 	set_strength_indicator(color) {
 		var message = __("Include symbols, numbers and capital letters in the password");
 		this.indicator.removeClass().addClass("password-strength-indicator indicator " + color);
-		this.message.html(message).removeClass("hidden");
+		this.message.html(message).toggleClass("hidden", color == "green");
 	}
 };

--- a/frappe/public/js/frappe/form/controls/password.js
+++ b/frappe/public/js/frappe/form/controls/password.js
@@ -2,6 +2,7 @@ frappe.ui.form.ControlPassword = class ControlPassword extends frappe.ui.form.Co
 	static input_type = "password";
 	make() {
 		super.make();
+		this.enable_password_checks = true;
 	}
 	make_input() {
 		var me = this;
@@ -23,7 +24,15 @@ frappe.ui.form.ControlPassword = class ControlPassword extends frappe.ui.form.Co
 			}, 500);
 		});
 	}
+
+	disable_password_checks() {
+		this.enable_password_checks = false;
+	}
+
 	get_password_strength(value) {
+		if (!this.enable_password_checks) {
+			return;
+		}
 		var me = this;
 		frappe.call({
 			type: "POST",

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -161,11 +161,10 @@ frappe.ready(function() {
 						.text("{{ _('Invalid Password') }}");
 				},
 				200: function(r) {
-					if (r.message && r.message.score) {
+					if (r.message && r.message) {
 						var score = r.message.score,
 							feedback = r.message.feedback;
 
-						feedback.crack_time_display = r.message.crack_time_display;
 						feedback.score = score;
 
 						if(feedback.password_policy_validation_passed){

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -161,7 +161,7 @@ frappe.ready(function() {
 						.text("{{ _('Invalid Password') }}");
 				},
 				200: function(r) {
-					if (r.message && r.message) {
+					if (r.message) {
 						var score = r.message.score,
 							feedback = r.message.feedback;
 


### PR DESCRIPTION
1. Fix password control to reflect changed APIs of zxcvbn response + some misc UX fixes.
2. Disable strength checks on re-login dialog... doesn't make sense here.


2 is required because the password strength check API call is done with guest user and response will set Guest cookie, if in meantime you send login request based on order of execution your browser will log in and log back out. Throttle browser's network speed to reproduce.

Extends https://github.com/frappe/frappe/pull/18943