### PR TITLE
fix(UX): Leaderboard company field validation

### DIFF
--- a/frappe/desk/page/leaderboard/leaderboard.js
+++ b/frappe/desk/page/leaderboard/leaderboard.js
@@ -115,7 +115,6 @@ class Leaderboard {
 			default: frappe.defaults.get_default("company"),
 			reqd: 1,
 			change: (e) => {
-				this.options.selected_company = e.currentTarget.value;
 				this.make_request();
 			},
 		});
@@ -182,7 +181,9 @@ class Leaderboard {
 			let $li = $(e.currentTarget);
 			let doctype = $li.find(".doctype-text").attr("doctype-value");
 
-			this.options.selected_company = frappe.defaults.get_default("company");
+			this.company_select.set_value(
+				frappe.defaults.get_default("company") || this.company_select.get_value()
+			);
 			this.options.selected_doctype = doctype;
 			this.options.selected_filter = this.filters[doctype];
 			this.options.selected_filter_item = this.filters[doctype][0];
@@ -237,13 +238,16 @@ class Leaderboard {
 	}
 
 	get_leaderboard(notify) {
-		if (!this.options.selected_company) {
-			frappe.throw(__("Please select Company"));
+		let company = this.company_select.get_value();
+		if (!company && !this.leaderboard_config[this.options.selected_doctype].company_disabled) {
+			notify(this, null);
+			frappe.show_alert(__("Please select Company"));
+			return;
 		}
 		frappe
 			.call(this.leaderboard_config[this.options.selected_doctype].method, {
 				date_range: this.get_date_range(),
-				company: this.options.selected_company,
+				company: company,
 				field: this.options.selected_filter_item,
 				limit: this.leaderboard_limit,
 			})


### PR DESCRIPTION
- Company isn't really required in all leaderboards
- We already highlight field with red color if it's required. Throwing message repeatedly is just annoying.
- change event wasn't working.

If only frappe framework is installed OR company isn't in session defaults then it's quite annoying:


1. Throws error on first load.
![image](https://user-images.githubusercontent.com/9079960/211743811-b8d1ba3b-945d-48c3-b81d-b1eb3291f1a1.png)

2. Throws error where it's not even required
![image](https://user-images.githubusercontent.com/9079960/211744046-cb5eea00-1eda-48a3-914e-dce594e723f7.png)

