### PR TITLE
docs: clarify what s3 endpoint does

### DIFF
--- a/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
+++ b/frappe/integrations/doctype/s3_backup_settings/s3_backup_settings.json
@@ -71,6 +71,7 @@
   },
   {
    "default": "https://s3.amazonaws.com",
+   "description": "Only change this if you want to use other S3 compatible object storage backends.",
    "fieldname": "endpoint_url",
    "fieldtype": "Data",
    "label": "Endpoint URL"
@@ -129,7 +130,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-12-07 15:30:55.047689",
+ "modified": "2023-01-11 15:38:20.333833",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "S3 Backup Settings",
@@ -149,5 +150,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
Endpoint is used for using non-AWS s3 compatible backends. You dont
need to fiddle with this for AWS S3.

