### PR TITLE
chore(docstring): fix docstring to match the value of `MAX_WRITES_PER_TRANSACTION`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -362,7 +362,7 @@ class Database:
 		self.sql(query, debug=debug)
 
 	def check_transaction_status(self, query):
-		"""Raises exception if more than 20,000 `INSERT`, `UPDATE` queries are
+		"""Raises exception if more than 200,000 `INSERT`, `UPDATE` queries are
 		executed in one transaction. This is to ensure that writes are always flushed otherwise this
 		could cause the system to hang."""
 		self.check_implicit_commit(query)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -55,7 +55,7 @@ class Database:
 	STANDARD_VARCHAR_COLUMNS = ("name", "owner", "modified_by")
 	DEFAULT_COLUMNS = ["name", "creation", "modified", "modified_by", "owner", "docstatus", "idx"]
 	CHILD_TABLE_COLUMNS = ("parent", "parenttype", "parentfield")
-	MAX_WRITES_PER_TRANSACTION = 200_000
+	MAX_WRITES_PER_TRANSACTION = 20_000
 
 	# NOTE:
 	# FOR MARIADB - using no cache - as during backup, if the sequence was used in anyform,

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -55,7 +55,7 @@ class Database:
 	STANDARD_VARCHAR_COLUMNS = ("name", "owner", "modified_by")
 	DEFAULT_COLUMNS = ["name", "creation", "modified", "modified_by", "owner", "docstatus", "idx"]
 	CHILD_TABLE_COLUMNS = ("parent", "parenttype", "parentfield")
-	MAX_WRITES_PER_TRANSACTION = 20_000
+	MAX_WRITES_PER_TRANSACTION = 200_000
 
 	# NOTE:
 	# FOR MARIADB - using no cache - as during backup, if the sequence was used in anyform,


### PR DESCRIPTION


**Update**: Confirmed that it was not a bug, but just a typo in the docstring

> 
> ## Fixes:
>  - constant value of `MAX_WRITES_PER_TRANSACTION` as per the docstring.
> 
> As per the docstring of `check_transaction_status`, the correct value should be `20_000` instead of `200_000`
> 
> https://github.com/frappe/frappe/blob/0898ac2a0eb401871f789a5f9d368bb5649192d6/frappe/database/database.py#L364-L367
> 
> This wrong value (extra zero) was added in this [commit](https://github.com/frappe/frappe/commit/5214bb286a9a23a2c9b21398ff45073d9e1fee96) (8 Years ago) and never fixed since then.
> 
> PS: not sure about the correct value - but as per the history of changes of this value, `20_000` seems to be valid to me.
> 