### PR TITLE
fix: slug doctype when building url to report with filters

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1672,9 +1672,9 @@ def get_url_to_report(name, report_type: str | None = None, doctype: str | None 
 
 def get_url_to_report_with_filters(name, filters, report_type=None, doctype=None):
 	if report_type == "Report Builder":
-		return get_url(uri=f"/app/{quoted(doctype)}/view/report?{filters}")
-	else:
-		return get_url(uri=f"/app/query-report/{quoted(name)}?{filters}")
+		return get_url(uri=f"/app/{quoted(slug(doctype))}/view/report?{filters}")
+
+	return get_url(uri=f"/app/query-report/{quoted(name)}?{filters}")
 
 
 operator_map = {


### PR DESCRIPTION
slugs the doctype when creating link to the report - results in urls like `/app/Email%20Account` rather than `/app/email-account` when the report type is `Report Builder`

closes: https://github.com/frappe/frappe/issues/19580