### PR TITLE
fix: `fetch_if_empty` not honoured on the client-side

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -213,7 +213,12 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 				df.read_only == 1 ||
 				df.is_virtual == 1;
 
-			if (is_read_only_field && df.fetch_from && df.fetch_from.indexOf(".") != -1) {
+			if (
+				is_read_only_field &&
+				df.fetch_from &&
+				(!df.fetch_if_empty || (df.fetch_if_empty && !me.frm.doc[df.fieldname])) &&
+				df.fetch_from.indexOf(".") != -1
+			) {
 				var parts = df.fetch_from.split(".");
 				me.frm.add_fetch(parts[0], parts[1], df.fieldname, df.parent);
 			}


### PR DESCRIPTION
## Problem:

`fetch_if_empty` is checked on the server side but not honored on the client side. Example:

- Fetch if Empty is enabled for the Image field in the employee master

   <img width="1311" alt="image" src="https://user-images.githubusercontent.com/24353136/212277253-9b3e4ee7-0c8c-414a-8d9b-bfe508deccd1.png">

- An image is already set for the employee. On selecting the user, the user's empty image is overwriting the employee's image on the client side.

   https://user-images.githubusercontent.com/24353136/212277143-3b0db476-a992-43de-a817-cedb083b1c65.mp4

## After:

https://user-images.githubusercontent.com/24353136/212278651-aea74098-65ff-450c-b209-4438a075c77d.mp4


