### PR TITLE
fix: option to disable page head scroll feature

### DIFF
--- a/cypress/integration/web_form.js
+++ b/cypress/integration/web_form.js
@@ -2,6 +2,9 @@ context("Web Form", () => {
 	before(() => {
 		cy.login("Administrator");
 		cy.visit("/app/");
+		cy.set_value("System Settings", "System Settings", {
+			disable_page_head_scroll: 1,
+		});
 		return cy
 			.window()
 			.its("frappe")

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -74,7 +74,9 @@
   "max_auto_email_report_per_user",
   "system_updates_section",
   "disable_system_update_notification",
-  "disable_change_log_notification"
+  "disable_change_log_notification",
+  "desk_section",
+  "disable_page_head_scroll"
  ],
  "fields": [
   {
@@ -520,12 +522,24 @@
    "fieldname": "login_with_email_link_expiry",
    "fieldtype": "Int",
    "label": "Login with email link expiry (in minutes)"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "desk_section",
+   "fieldtype": "Section Break",
+   "label": "Desk"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_page_head_scroll",
+   "fieldtype": "Check",
+   "label": "Disable Page Head Scroll"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2022-12-20 21:45:37.651668",
+ "modified": "2023-01-16 11:34:40.469450",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -49,14 +49,25 @@ frappe.ui.Page = class Page {
 		let last_scroll = 0;
 		$(window).scroll(
 			frappe.utils.throttle(() => {
-				$(".page-head").toggleClass("drop-shadow", !!document.documentElement.scrollTop);
-				let current_scroll = document.documentElement.scrollTop;
-				if (current_scroll > 0 && last_scroll <= current_scroll) {
-					$(".page-head").css("top", "-15px");
+				if (cint(frappe.boot.sysdefaults.disable_page_head_scroll)) {
+					if (document.documentElement.scrollTop) {
+						$(".page-head").toggleClass("drop-shadow", true);
+					} else {
+						$(".page-head").removeClass("drop-shadow");
+					}
 				} else {
-					$(".page-head").css("top", "var(--navbar-height)");
+					$(".page-head").toggleClass(
+						"drop-shadow",
+						!!document.documentElement.scrollTop
+					);
+					let current_scroll = document.documentElement.scrollTop;
+					if (current_scroll > 0 && last_scroll <= current_scroll) {
+						$(".page-head").css("top", "-15px");
+					} else {
+						$(".page-head").css("top", "var(--navbar-height)");
+					}
+					last_scroll = current_scroll;
 				}
-				last_scroll = current_scroll;
 			}, 500)
 		);
 	}


### PR DESCRIPTION
The page Head getting hidden when we scroll is a nice feature but sometimes it becomes annoying and some UI test also fails because the page head is hidden Save button is not visible.
Adding an option to enable or disable it in System Settings (default is enabled)

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/30859809/212609845-61885b4f-32dc-4898-ac80-31a1e25ffadb.png">

