### PR TITLE
test: rollback test transaction after executing cmd

### DIFF
--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -143,6 +143,9 @@ class BaseTestCommands(FrappeTestCase):
 
 	@classmethod
 	def execute(self, command, kwargs=None):
+		# tests might have written to DB which wont be visible to commands until we end current transaction
+		frappe.db.commit()
+
 		site = {"site": frappe.local.site}
 		cmd_input = None
 		if kwargs:
@@ -164,6 +167,9 @@ class BaseTestCommands(FrappeTestCase):
 		self.stdout = clean(self._proc.stdout)
 		self.stderr = clean(self._proc.stderr)
 		self.returncode = clean(self._proc.returncode)
+
+		# Commands might have written to DB which wont be visible until we end current transaction
+		frappe.db.rollback()
 
 	@classmethod
 	def setup_test_site(cls):
@@ -407,24 +413,17 @@ class TestCommands(BaseTestCommands):
 
 		self.execute("bench --site {site} set-password Administrator test1")
 		self.assertEqual(self.returncode, 0)
-		frappe.db.rollback()
 		self.assertEqual(check_password("Administrator", "test1"), "Administrator")
-		# to release the lock taken by check_password
-		frappe.db.rollback()
 
 		self.execute("bench --site {site} set-admin-password test2")
 		self.assertEqual(self.returncode, 0)
-		frappe.db.rollback()
 		self.assertEqual(check_password("Administrator", "test2"), "Administrator")
-		frappe.db.rollback()
 
 		# Reset it back to original password
 		original_password = frappe.conf.admin_password or "admin"
 		self.execute("bench --site {site} set-admin-password %s" % original_password)
 		self.assertEqual(self.returncode, 0)
-		frappe.db.rollback()
 		self.assertEqual(check_password("Administrator", original_password), "Administrator")
-		frappe.db.rollback()
 
 	@skipIf(
 		not (


### PR DESCRIPTION
In command tests if connection is active then due to repeatable read
isolation you will continue to read old data which might be modified by
the command you're trying to test.

It makes sense to:
1. Commit changes before executing.
2. End transaction after executing.

