### PR TITLE
chore(file): better error msg for file_upload

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -329,7 +329,9 @@ class File(Document):
 					self.file_url = duplicate_file.file_url
 
 	def set_file_name(self):
-		if not self.file_name and self.file_url:
+		if not self.file_name and not self.file_url:
+			frappe.throw(_("No `file` or `file_url` field found in form-data"))
+		elif not self.file_name and self.file_url:
 			self.file_name = self.file_url.split("/")[-1]
 		else:
 			self.file_name = re.sub(r"/", "", self.file_name)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -330,7 +330,7 @@ class File(Document):
 
 	def set_file_name(self):
 		if not self.file_name and not self.file_url:
-			frappe.throw(_("No `file` or `file_url` field found in form-data"))
+			frappe.throw(_("Fields `file_name` or `file_url` must be set for File", exc=frappe.MandatoryError)
 		elif not self.file_name and self.file_url:
 			self.file_name = self.file_url.split("/")[-1]
 		else:

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -330,7 +330,7 @@ class File(Document):
 
 	def set_file_name(self):
 		if not self.file_name and not self.file_url:
-			frappe.throw(_("Fields `file_name` or `file_url` must be set for File", exc=frappe.MandatoryError)
+			frappe.throw(_("Fields `file_name` or `file_url` must be set for File"), exc=frappe.MandatoryError)
 		elif not self.file_name and self.file_url:
 			self.file_name = self.file_url.split("/")[-1]
 		else:


### PR DESCRIPTION
current, if No `file` or `file_url` field set in form-data, err is cryptic:
```
172.19.0.1 - - [16/Jan/2023 16:52:27] "POST /api/method/upload_file HTTP/1.1" 403 -
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1590, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/handler.py", line 221, in upload_file
    return frappe.get_doc(
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 327, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 253, in insert
    self.run_method("before_insert")
  File "apps/frappe/frappe/model/document.py", line 909, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1259, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1241, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 906, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/core/doctype/file/file.py", line 61, in before_insert
    self.set_file_name()
  File "apps/frappe/frappe/core/doctype/file/file.py", line 335, in set_file_name
    self.file_name = re.sub(r"/", "", self.file_name)
  File "/home/frappe/.pyenv/versions/3.10.5/lib/python3.10/re.py", line 209, in sub
    return _compile(pattern, flags).sub(repl, string, count)
TypeError: expected string or bytes-like object
```

this pr make it understandable
