### PR TITLE
chore(patch): send notification to system managers for resetup of oauth enabled email accounts

### DIFF
--- a/frappe/patches/v14_0/disable_email_accounts_with_oauth.py
+++ b/frappe/patches/v14_0/disable_email_accounts_with_oauth.py
@@ -1,15 +1,36 @@
-import click
-
 import frappe
+from frappe.desk.doctype.notification_log.notification_log import make_notification_logs
 
 
 def execute():
+	if not frappe.get_value("Email Account", {"auth_method": "OAuth"}):
+		return
+
 	# Setting awaiting password to 1 for email accounts where Oauth is enabled.
 	# This is done so that people can resetup their email accounts with connected app mechanism.
-	doctype = frappe.qb.DocType("Email Account")
-	frappe.qb.update(doctype).set(doctype.awaiting_password, 1).where(doctype.auth_mehtod == "OAuth")
+	frappe.db.set_value("Email Account", {"auth_method": "OAuth"}, "awaiting_password", 1)
 
-	click.secho(
-		"Email Accounts with auth method as OAuth have been disabled."
-		"Please re-setup your OAuth based email accounts with the connected app mechanism to re-enable them."
-	)
+	message = "Email Accounts with auth method as OAuth have been disabled.\
+	Please re-setup your OAuth based email accounts with the connected app mechanism to re-enable them."
+
+	if sysmanagers := get_system_managers():
+		make_notification_logs(
+			{
+				"type": "Alert",
+				"subject": frappe._(message),
+			},
+			sysmanagers,
+		)
+
+
+def get_system_managers():
+	user_doctype = frappe.qb.DocType("User").as_("user")
+	user_role_doctype = frappe.qb.DocType("Has Role").as_("user_role")
+	return (
+		frappe.qb.from_(user_doctype)
+		.from_(user_role_doctype)
+		.select(user_doctype.email)
+		.where(user_role_doctype.role == "System Manager")
+		.where(user_doctype.enabled == 1)
+		.where(user_role_doctype.parent == user_doctype.name)
+	).run(pluck=True)


### PR DESCRIPTION
updates `disable_email_accounts_with_oauth` patch with sending notification to system managers for updating the email accounts with OAuth enabled