### PR TITLE
chore: remove unnecessary query condition from get_other_system_managers

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -305,12 +305,10 @@ class User(Document):
 			.from_(user_role_doctype)
 			.select(user_doctype.name)
 			.where(user_role_doctype.role == "System Manager")
-			.where(user_doctype.docstatus < 2)
 			.where(user_doctype.enabled == 1)
 			.where(user_role_doctype.parent == user_doctype.name)
 			.where(user_role_doctype.parent.notin(["Administrator", self.name]))
 			.limit(1)
-			.distinct()
 		).run()
 
 	def get_fullname(self):


### PR DESCRIPTION
removes distinct and docstatus condition from `get_other_system_managers` query

name is always distinct (primary key)
and docstatus is always 0 (as it's not a submmittable doctype)