### PR TITLE
chore(flake8): ignore B028

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -69,6 +69,7 @@ ignore =
     F841,
     E713,
     E712,
+    B028,
 
 max-line-length = 200
 exclude=,test_*.py


### PR DESCRIPTION
This has very high false positive ratio, not suitable for our codebase.
