### PR TITLE
fix: misc migration related fixes

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1133,7 +1133,7 @@ def validate_fields(meta):
 					d.options = options
 
 	def check_hidden_and_mandatory(docname, d):
-		if d.hidden and d.reqd and not d.default:
+		if d.hidden and d.reqd and not d.default and not frappe.flags.in_migrate:
 			frappe.throw(
 				_("{0}: Field {1} in row {2} cannot be hidden and mandatory without default").format(
 					docname, d.label, d.idx

--- a/frappe/core/doctype/patch_log/patch_log.json
+++ b/frappe/core/doctype/patch_log/patch_log.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "PATCHLOG.#####",
+ "autoname": "hash",
  "creation": "2013-01-17 11:36:45",
  "description": "List of patches executed",
  "doctype": "DocType",
@@ -20,11 +20,11 @@
  "icon": "fa fa-cog",
  "idx": 1,
  "links": [],
- "modified": "2022-06-13 05:34:37.845368",
+ "modified": "2023-01-17 15:35:11.688615",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Patch Log",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
- [x] Disable check for hidden-mandatory fields during migrate. This is fine when developer/user is editing it from desk, not required during migrate.
- [x] change patch log naming to hash, naming series isn't required here.