### PR TITLE
fix: Convert extension to lowercase before comparison

### DIFF
--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -24,6 +24,8 @@ frappe.ui.form.on("File", {
 
 	preview_file: function (frm) {
 		let $preview = "";
+		let file_name = frm.doc.file_name.split("?")[0];
+		let file_extension = file_name.split(".").pop()?.toLowerCase();
 
 		if (frappe.utils.is_image_file(frm.doc.file_url)) {
 			$preview = $(`<div class="img_preview">
@@ -40,7 +42,7 @@ frappe.ui.form.on("File", {
 					${__("Your browser does not support the video element.")}
 				</video>
 			</div>`);
-		} else if (frm.doc.file_name.split("?")[0].endsWith(".pdf")) {
+		} else if (file_extension === "pdf") {
 			$preview = $(`<div class="img_preview">
 				<object style="background:#323639;" width="100%">
 					<embed
@@ -51,7 +53,7 @@ frappe.ui.form.on("File", {
 					>
 				</object>
 			</div>`);
-		} else if (frm.doc.file_name.split("?")[0].endsWith(".mp3")) {
+		} else if (file_extension === "mp3") {
 			$preview = $(`<div class="img_preview">
 				<audio width="480" height="60" controls>
 					<source src="${frm.doc.file_url}" type="audio/mpeg">


### PR DESCRIPTION
Backport of https://github.com/frappe/frappe/commit/551f58bde9efdad6895957e0d73e1b385b723964

fixes: https://github.com/frappe/frappe/issues/19596

<img width="1440" alt="Screenshot 2023-01-17 at 6 20 04 PM" src="https://user-images.githubusercontent.com/13928957/212903374-b3dc9f53-4f3a-44cc-ace3-99784a85fbf2.png">
