### PR TITLE
fix: handle `tel:` links in emails

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -49,6 +49,7 @@ from frappe.utils.data import (
 	cast,
 	cstr,
 	duration_to_seconds,
+	expand_relative_urls,
 	get_datetime,
 	get_first_day_of_week,
 	get_time,
@@ -919,6 +920,21 @@ class TestMiscUtils(FrappeTestCase):
 		self.assertEqual(safe_json_loads("{}"), {})
 		self.assertEqual(safe_json_loads("{ /}"), "{ /}")
 		self.assertEqual(safe_json_loads("12"), 12)  # this is a quirk
+
+	def test_url_expansion(self):
+		unchanged_links = [
+			"<a href='tel:12345432'>My Phone</a>)",
+			"<a href='mailto:hello@example.com'>My Email</a>)",
+			"<a href='data:hello@example.com'>Data</a>)",
+		]
+		for link in unchanged_links:
+			self.assertEqual(link, expand_relative_urls(link))
+
+		site = get_url()
+
+		transforms = [("<a href='/about'>About</a>)", f"<a href='{site}/about'>About</a>)")]
+		for input, output in transforms:
+			self.assertEqual(output, expand_relative_urls(input))
 
 
 class TestTypingValidations(FrappeTestCase):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1885,7 +1885,7 @@ def expand_relative_urls(html: str) -> str:
 	def _expand_relative_urls(match):
 		to_expand = list(match.groups())
 
-		if not to_expand[2].startswith("mailto") and not to_expand[2].startswith("data:"):
+		if not to_expand[2].startswith(("mailto", "data:", "tel:")):
 			if not to_expand[2].startswith("/"):
 				to_expand[2] = "/" + to_expand[2]
 			to_expand.insert(2, url)


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/18853
