### PR TITLE
fix: reload document naming rule before migrate

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -289,7 +289,7 @@ setup_wizard_exception = [
 	"frappe.desk.page.setup_wizard.setup_wizard.log_setup_wizard_exception"
 ]
 
-before_migrate = ['frappe.patches.v11_0.sync_user_permission_doctype_before_migrate.execute']
+before_migrate = ['frappe.patches.v11_0.sync_user_permission_and_document_naming_rule.execute']
 after_migrate = ['frappe.website.doctype.website_theme.website_theme.after_migrate']
 
 otp_methods = ['OTP App','Email','SMS']

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -8,7 +8,6 @@ frappe.patches.v11_0.drop_column_apply_user_permissions
 execute:frappe.reload_doc('core', 'doctype', 'custom_docperm')
 execute:frappe.reload_doc('core', 'doctype', 'docperm') #2018-05-29
 execute:frappe.reload_doc('core', 'doctype', 'comment')
-execute:frappe.reload_doc('core', 'doctype', 'document_naming_rule', force=True)
 execute:frappe.reload_doc('core', 'doctype', 'module_def') #2020-08-28
 execute:frappe.reload_doc('core', 'doctype', 'version') #2017-04-01
 execute:frappe.reload_doc('email', 'doctype', 'document_follow')

--- a/frappe/patches/v11_0/sync_user_permission_and_document_naming_rule.py
+++ b/frappe/patches/v11_0/sync_user_permission_and_document_naming_rule.py
@@ -4,4 +4,5 @@ import frappe
 def execute():
 	frappe.flags.in_patch = True
 	frappe.reload_doc('core', 'doctype', 'user_permission')
+	frappe.reload_doc('core', 'doctype', 'document_naming_rule')
 	frappe.db.commit()


### PR DESCRIPTION
since we block users (via `block_user`) before running any patch, it sets some defaultvalues which use the `set_new_name` function which inturn uses the document naming rule.

reloading document naming rule before any patch runs should fix the problem