### PR TITLE
fix: reload document naming rule before migrate

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -278,7 +278,7 @@ setup_wizard_exception = [
 	"frappe.desk.page.setup_wizard.setup_wizard.log_setup_wizard_exception",
 ]
 
-before_migrate = []
+before_migrate = ["frappe.patches.v13_0.sync_document_naming_rule.execute"]
 after_migrate = ["frappe.website.doctype.website_theme.website_theme.after_migrate"]
 
 otp_methods = ["OTP App", "Email", "SMS"]

--- a/frappe/patches/v13_0/sync_document_naming_rule.py
+++ b/frappe/patches/v13_0/sync_document_naming_rule.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+	frappe.reload_doc("core", "doctype", "document_naming_rule")


### PR DESCRIPTION
since we block users (via `block_user`) before running any patch, it sets some defaultvalues which use the `set_new_name` function which inturn uses the document naming rule.

reloading document naming rule before any patch runs should fix the problem