### PR TITLE
refactor(minor): no need for setting session defaults when migrating site

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -8,7 +8,6 @@ import frappe.utils
 import frappe.utils.user
 from frappe import _, conf
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
-from frappe.modules.patch_handler import check_session_stopped
 from frappe.sessions import Session, clear_sessions, delete_session
 from frappe.translate import get_language
 from frappe.twofactor import (
@@ -44,9 +43,6 @@ class HTTPRequest:
 
 		# write out latest cookies
 		frappe.local.cookie_manager.init_cookies()
-
-		# check session status
-		check_session_stopped()
 
 	@property
 	def domain(self):

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -110,7 +110,6 @@ Otherwise, check the server logs and ensure that all the required services are r
 
 def run_before_migrate_hooks():
 	for app in frappe.get_installed_apps():
-		frappe.db.begin()
 		try:
 			for fn in frappe.get_hooks("before_migrate", app_name=app):
 				frappe.get_attr(fn)()

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -63,11 +63,7 @@ Otherwise, check the server logs and ensure that all the required services are r
 		frappe.flags.in_migrate = True
 
 		clear_global_cache()
-
-		# run before_migrate hooks
-		for app in frappe.get_installed_apps():
-			for fn in frappe.get_hooks("before_migrate", app_name=app):
-				frappe.get_attr(fn)()
+		run_before_migrate_hooks()
 
 		# run patches
 		frappe.modules.patch_handler.run_all(skip_failing)
@@ -110,3 +106,16 @@ Otherwise, check the server logs and ensure that all the required services are r
 		with open(touched_tables_file, "w") as f:
 			json.dump(list(frappe.flags.touched_tables), f, sort_keys=True, indent=4)
 		frappe.flags.touched_tables.clear()
+
+
+def run_before_migrate_hooks():
+	for app in frappe.get_installed_apps():
+		frappe.db.begin()
+		try:
+			for fn in frappe.get_hooks("before_migrate", app_name=app):
+				frappe.get_attr(fn)()
+		except Exception:
+			frappe.db.rollback()
+			raise
+		else:
+			frappe.db.commit()

--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -11,18 +11,16 @@ import os
 
 import frappe
 from frappe.modules.import_file import import_file_by_path
-from frappe.modules.patch_handler import block_user
 from frappe.utils import update_progress_bar
 
 
 def sync_all(force=0, verbose=False, reset_permissions=False):
-	block_user(True)
+	frappe.local.flags.in_patch = True
 
 	for app in frappe.get_installed_apps():
 		sync_for(app, force, verbose=verbose, reset_permissions=reset_permissions)
 
-	block_user(False)
-
+	frappe.local.flags.in_patch = False
 	frappe.clear_cache()
 
 

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -136,21 +136,10 @@ def executed(patchmodule):
 	return done
 
 
-def block_user(block, msg=None):
+def block_user(block):
 	"""stop/start execution till patch is run"""
 	frappe.local.flags.in_patch = block
-	frappe.db.begin()
-	if not msg:
-		msg = "Patches are being executed in the system. Please try again in a few moments."
-	frappe.db.set_global("__session_status", block and "stop" or None)
-	frappe.db.set_global("__session_status_message", block and msg or None)
 	frappe.db.commit()
-
-
-def check_session_stopped():
-	if frappe.db.get_global("__session_status") == "stop":
-		frappe.msgprint(frappe.db.get_global("__session_status_message"))
-		raise frappe.SessionStopped("Session Stopped")
 
 
 def log(msg):

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -85,7 +85,7 @@ def run_single(patchmodule=None, method=None, methodargs=None, force=False):
 
 def execute_patch(patchmodule, method=None, methodargs=None):
 	"""execute the patch"""
-	block_user(True)
+	frappe.local.flags.in_patch = True
 	frappe.db.begin()
 	start_time = time.time()
 	try:
@@ -114,7 +114,7 @@ def execute_patch(patchmodule, method=None, methodargs=None):
 	else:
 		frappe.db.commit()
 		end_time = time.time()
-		block_user(False)
+		frappe.local.flags.in_patch = False
 		log("Success: Done in {time}s".format(time=round(end_time - start_time, 3)))
 
 	return True
@@ -134,12 +134,6 @@ def executed(patchmodule):
 	# if done:
 	# 	print "Patch %s already executed in %s" % (patchmodule, frappe.db.cur_db_name)
 	return done
-
-
-def block_user(block):
-	"""stop/start execution till patch is run"""
-	frappe.local.flags.in_patch = block
-	frappe.db.commit()
 
 
 def log(msg):

--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -232,7 +232,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 		} catch(e) {
 			value = `<div class="ql-editor read-mode">${value}</div>`;
 		}
-		
+
 		// quill keeps ol as a common container for both type of lists
 		// and uses css for appearances, this is not semantic
 		// so we convert ol to ul if it is unordered


### PR DESCRIPTION
This change removes `block_user` as it’s primarily unnecessary as we set maintenance mode when migrating.

What triggered this: 

debugging an issue while migrating a v12 site to v13 - document Naming Rule was added in v13 but before running any patch we go through the `block_user` function which basically sets some session variables in defaultvalue table. This utilizes `doc.insert` which uses `set_new_name` and consecutively checks for document naming rule first and since the doctype wasn’t registered in the system/db *yet*, the migration failed


Some additional context:

- Every request goes through the `application` method which triggers `init_request` function - this function check if the site is in maintenance mode or not and based on that gives session error

- Previously we were unnecessarily checking if the session is stopped when initializing `HTTPRequest` class - we won’t do this now since maintenance mode is enough for that


Other Changes:
- added transaction handling for before_migrate hook