### PR TITLE
fix: add brackets for docshare or condition

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -779,7 +779,7 @@ class DatabaseQuery:
 
 			# share is an OR condition, if there is a role permission
 			if not only_if_shared and self.shared and conditions:
-				conditions = f"({conditions}) or ({self.get_share_condition()})"
+				conditions = f"(({conditions}) or ({self.get_share_condition()}))"
 
 			return conditions
 


### PR DESCRIPTION
**TL;DR**
In the SQL WHERE clause brackets are missing for the OR condition

**Summary:**
In our system we make use of the docshares to share documents on a single-document basis for users. We recently discovered some strange behavior with Contact link fields. Further debugging of the SQL statement lead to the following issue:
When the match condition is build up, the brackets around the OR statement are not sufficient. The statement in `contact_query` is not evaluated correctly, as displayed in the attached screenshot.

<img width="987" alt="Bildschirm­foto 2023-01-18 um 12 16 28" src="https://user-images.githubusercontent.com/49870752/213158662-1d0f573f-0887-4f97-b7b8-60ad275f5ee4.png">
