### PR TITLE
feat: let users modify hook resolution order

### DIFF
--- a/frappe/core/doctype/installed_applications/installed_applications.js
+++ b/frappe/core/doctype/installed_applications/installed_applications.js
@@ -2,6 +2,62 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Installed Applications", {
-	// refresh: function(frm) {
-	// }
+	refresh: function (frm) {
+		frm.add_custom_button(__("Update Hooks Resolution Order"), () => {
+			frm.trigger("show_update_order_dialog");
+		});
+	},
+
+	show_update_order_dialog() {
+		const dialog = new frappe.ui.Dialog({
+			title: __("Update Hooks Resolution Order"),
+			fields: [
+				{
+					fieldname: "apps",
+					fieldtype: "Table",
+					label: __("Installed Apps"),
+					cannot_add_rows: true,
+					cannot_delete_rows: true,
+					in_place_edit: true,
+					data: [],
+					fields: [
+						{
+							fieldtype: "Data",
+							fieldname: "app_name",
+							label: __("App Name"),
+							in_list_view: 1,
+							read_only: 1,
+						},
+					],
+				},
+			],
+			primary_action: function () {
+				const new_order = this.get_values()["apps"].map((row) => row.app_name);
+				frappe.call({
+					method: "frappe.core.doctype.installed_applications.installed_applications.update_installed_apps_order",
+					freeze: true,
+					args: {
+						new_order: new_order,
+					},
+				});
+				this.hide();
+			},
+			primary_action_label: __("Update Order"),
+		});
+
+		frappe
+			.xcall(
+				"frappe.core.doctype.installed_applications.installed_applications.get_installed_app_order"
+			)
+			.then((data) => {
+				data.forEach((app) => {
+					dialog.fields_dict.apps.df.data.push({
+						app_name: app,
+					});
+				});
+
+				dialog.fields_dict.apps.grid.refresh();
+				dialog.show();
+			});
+	},
 });

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -55,6 +55,18 @@ def update_installed_apps_order(new_order: list[str] | str):
 
 	frappe.db.set_global("installed_apps", json.dumps(new_order))
 
+	_create_version_log_for_change(existing_order, new_order)
+
+
+def _create_version_log_for_change(old, new):
+	version = frappe.new_doc("Version")
+	version.ref_doctype = "DefaultValue"
+	version.docname = "installed_apps"
+	version.data = frappe.as_json({"changed": [["current", json.dumps(old), json.dumps(new)]]})
+	version.flags.ignore_links = True  # This is a fake doctype
+	version.flags.ignore_permissions = True
+	version.insert()
+
 
 @frappe.whitelist()
 def get_installed_app_order() -> list[str]:

--- a/frappe/core/doctype/installed_applications/installed_applications.py
+++ b/frappe/core/doctype/installed_applications/installed_applications.py
@@ -1,8 +1,15 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import json
+
 import frappe
+from frappe import _
 from frappe.model.document import Document
+
+
+class InvalidAppOrder(frappe.ValidationError):
+	pass
 
 
 class InstalledApplications(Document):
@@ -18,3 +25,39 @@ class InstalledApplications(Document):
 				},
 			)
 		self.save()
+
+
+@frappe.whitelist()
+def update_installed_apps_order(new_order: list[str] | str):
+	"""Change the ordering of `installed_apps` global
+
+	This list is used to resolve hooks and by default it's order of installation on site.
+
+	Sometimes it might not be the ordering you want, so thie function is provided to override it.
+	"""
+	frappe.only_for("System Manager")
+
+	if isinstance(new_order, str):
+		new_order = json.loads(new_order)
+
+	frappe.local.request_cache and frappe.local.request_cache.clear()
+	existing_order = frappe.get_installed_apps(_ensure_on_bench=True)
+
+	if set(existing_order) != set(new_order) or not isinstance(new_order, list):
+		frappe.throw(
+			_("You are only allowed to update order, do not remove or add apps."), exc=InvalidAppOrder
+		)
+
+	# Ensure frappe is always first regardless of user's preference.
+	if "frappe" in new_order:
+		new_order.remove("frappe")
+	new_order.insert(0, "frappe")
+
+	frappe.db.set_global("installed_apps", json.dumps(new_order))
+
+
+@frappe.whitelist()
+def get_installed_app_order() -> list[str]:
+	frappe.only_for("System Manager")
+
+	return frappe.get_installed_apps(_ensure_on_bench=True)

--- a/frappe/core/doctype/installed_applications/test_installed_applications.py
+++ b/frappe/core/doctype/installed_applications/test_installed_applications.py
@@ -1,8 +1,16 @@
 # Copyright (c) 2020, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
-# import frappe
+
+import frappe
+from frappe.core.doctype.installed_applications.installed_applications import (
+	InvalidAppOrder,
+	update_installed_apps_order,
+)
 from frappe.tests.utils import FrappeTestCase
 
 
 class TestInstalledApplications(FrappeTestCase):
-	pass
+	def test_order_change(self):
+		update_installed_apps_order(["frappe"])
+		self.assertRaises(InvalidAppOrder, update_installed_apps_order, [])
+		self.assertRaises(InvalidAppOrder, update_installed_apps_order, ["frappe", "deepmind"])


### PR DESCRIPTION
Since hook resolution depends on the order in which apps were installed
on site, it should be made configurable as escape hatch in case a
different resolution order is desired.

Keep in mind that changing order affects every hook, page, customization
so you can't pick and choose priority for individual hooks as of now.

Separate proposals are welcome for such configurability.


Steps:
- Go to "Installed Applications" doctype > "Update Hooks Resolution Order"
- You will get table with apps in order, reorder child table rows and press update. 


Note:
- You need system manager role
- Removing/adding/changing names is not allowed. 
- frappe will always remain first, you can't modify it.

![image](https://user-images.githubusercontent.com/9079960/213181335-1189a6f4-c93e-4e1d-95a3-1f4b43835e56.png)


continues work started in https://github.com/frappe/frappe/pull/17869, https://github.com/frappe/frappe/issues/17762


docs: https://frappeframework.com/hooks#how-are-conflicting-hooks-resolved 