### PR TITLE
fix: only generate fieldname for inconsequential fields

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -366,8 +366,10 @@ class DocType(Document):
 							d.fieldname = d.fieldname + "_column"
 						elif d.fieldtype == "Tab Break":
 							d.fieldname = d.fieldname + "_tab"
-					else:
+					elif d.fieldtype in ("Section Break", "Column Break", "Tab Break"):
 						d.fieldname = d.fieldtype.lower().replace(" ", "_") + "_" + str(random_string(4))
+					else:
+						frappe.throw(_("Row #{}: Fieldname is required").format(d.idx), title="Missing Fieldname")
 				else:
 					if d.fieldname in restricted:
 						frappe.throw(_("Fieldname {0} is restricted").format(d.fieldname), InvalidFieldNameError)

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -330,7 +330,9 @@ class File(Document):
 
 	def set_file_name(self):
 		if not self.file_name and not self.file_url:
-			frappe.throw(_("Fields `file_name` or `file_url` must be set for File"), exc=frappe.MandatoryError)
+			frappe.throw(
+				_("Fields `file_name` or `file_url` must be set for File"), exc=frappe.MandatoryError
+			)
 		elif not self.file_name and self.file_url:
 			self.file_name = self.file_url.split("/")[-1]
 		else:


### PR DESCRIPTION
Creating columns that are altered in DB on save automatically is kinda
bad and will leave unnecessary columns in DB if user makes a mistake or
forgets to add a fieldname explicitly.

The default generated names are meaningless like "float_asdx", there is
no use case for this.

closes https://github.com/frappe/frappe/issues/19336

