### PR TITLE
feat: allow 'content' attribute for website structured data schema

### DIFF
--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -424,6 +424,7 @@ acceptable_attributes = [
 	"cols",
 	"colspan",
 	"compact",
+	"content",
 	"contenteditable",
 	"controls",
 	"coords",


### PR DESCRIPTION
feat: allow 'content' attribute for website structured data schema

version-14-hotfix