### PR TITLE
fix: allow external js script file links in web templates

### DIFF
--- a/frappe/utils/jinja_globals.py
+++ b/frappe/utils/jinja_globals.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import re
 
 
 def resolve_class(*classes):
@@ -75,7 +76,9 @@ def web_blocks(blocks):
 		# see render_dynamic method web_page.py
 		if template not in frappe.flags.web_block_scripts:
 			for script in scripts:
-				html += f"<script data-web-template='{template}'>{script}</script>"
+				html += re.sub(
+					"<script", f"<script data-web-template='{template}'", script, count=1, flags=re.I
+				)
 			frappe.flags.web_block_scripts[template] = True
 
 	for template, styles in out.styles.items():

--- a/frappe/website/doctype/web_page/templates/web_page.html
+++ b/frappe/website/doctype/web_page/templates/web_page.html
@@ -53,10 +53,8 @@
 	{%- endif -%}
 
 	{%- for web_template, scripts in (page_builder_scripts or {}).items() -%}
-	{%- if scripts -%}
 	{%- for script in scripts -%}
-	<script data-web-template="{{ web_template }}">{{ script }}</script>
+	{{ script }}
 	{%- endfor -%}
-	{%- endif -%}
 	{%- endfor -%}
 {% endblock %}

--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -239,8 +239,7 @@ def extract_script_and_style_tags(html):
 	styles = []
 
 	for script in soup.find_all("script"):
-		scripts.append(script.string)
-		script.extract()
+		scripts.append(str(script.extract()))
 
 	for style in soup.find_all("style"):
 		styles.append(style.string)


### PR DESCRIPTION
Current functionality only extracts the inline JS in-between `<script>JS HERE</script>` tags
Web templates may want to include external JS files like so:

`<script src="myscripts.js"></script>`

Tested and working for my use-case (a Web Template - Section) but needs review because I'm not sure of the scope of `web_blocks`. Do they *all* come from `extract_script_and_style_tags` in web_page.py?

version-14-hotfix