### PR TITLE
fix: correct exit code on missing app failure

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1474,9 +1474,7 @@ def _load_app_hooks(app_name: str | None = None):
 				# if app is not installed while restoring
 				# ignore it
 				pass
-			print(e)
-			if not request:
-				raise SystemExit
+			print(f'Could not find app "{app}": \n{e}')
 			raise
 
 		def _is_valid_hook(obj):


### PR DESCRIPTION
Exit code should be 1 to indicate that command failed, just raising exception back should do the job, idk why explicit SystemExit is required here? :thinking: 
