### PR TITLE
fix(minor): show 0 as comment count if _comment_count doesnt exist

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -896,7 +896,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		const comment_count = `<span class="comment-count">
 				${frappe.utils.icon("small-message")}
-				${doc._comment_count > 99 ? "99+" : doc._comment_count}
+				${doc._comment_count > 99 ? "99+" : doc._comment_count || 0}
 			</span>`;
 
 		html += `


### PR DESCRIPTION
comment counter now defaults to 0 if `_comment_count` property is undefined/not found

before:

![Screenshot from 2023-01-20 13-50-02](https://user-images.githubusercontent.com/32034600/213649135-b7fe496e-014f-480b-a560-7d9e24682cb4.png)


after:

![Screenshot from 2023-01-20 13-50-19](https://user-images.githubusercontent.com/32034600/213649164-5a36c7e0-0937-45b0-b1c5-a475a8661682.png)
