### PR TITLE
fix: use document title instead of name in subject

### DIFF
--- a/frappe/templates/includes/comments/comments.py
+++ b/frappe/templates/includes/comments/comments.py
@@ -54,9 +54,12 @@ def add_comment(comment, comment_email, comment_by, reference_doctype, reference
 		pass
 	else:
 		# notify creator
+		creator_email = frappe.db.get_value("User", doc.owner, "email") or doc.owner
+		subject = _("New Comment on {0}: {1}").format(doc.doctype, doc.get_title())
+
 		frappe.sendmail(
-			recipients=frappe.db.get_value("User", doc.owner, "email") or doc.owner,
-			subject=_("New Comment on {0}: {1}").format(doc.doctype, doc.name),
+			recipients=creator_email,
+			subject=subject,
 			message=content,
 			reference_doctype=doc.doctype,
 			reference_name=doc.name,


### PR DESCRIPTION
Before:

![CleanShot 2023-01-20 at 18 34 22@2x](https://user-images.githubusercontent.com/34810212/213701560-de0fd6fc-a735-4777-a6f5-530acf4a073d.png)


After:

![CleanShot 2023-01-20 at 18 33 16@2x](https://user-images.githubusercontent.com/34810212/213701576-bd30c018-9e91-4060-9f9a-f5f02b359a20.png)


