### PR TITLE
fix: invalid "empty form" message

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -621,10 +621,6 @@ frappe.ui.form.Form = class FrappeForm {
 
 		this.$wrapper.trigger("render_complete");
 
-		if (!this.hidden) {
-			this.layout.show_empty_form_message();
-		}
-
 		frappe.after_ajax(() => {
 			$(document).ready(() => {
 				this.scroll_to_element();

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -52,17 +52,6 @@ frappe.ui.form.Layout = class Layout {
 		this.setup_events();
 	}
 
-	show_empty_form_message() {
-		if (
-			!(
-				this.wrapper.find(".frappe-control:visible").length ||
-				this.wrapper.find(".section-head.collapsed").length
-			)
-		) {
-			this.show_message(__("This form does not have any input"));
-		}
-	}
-
 	get_doctype_fields() {
 		let fields = [this.get_new_name_field()];
 		if (this.doctype_layout) {


### PR DESCRIPTION
This happens on...

- form with tabs
- where first tab loaded is dashboard so doesn't have any field or section visible yet. 



![image](https://user-images.githubusercontent.com/9079960/213703982-96fc9dc2-45ec-48ce-9310-633a7c5c7b11.png)


Fix:
- ~~Run this check at very end of form rendering process, cause there is no need to run it this early?~~ :thinking: 


Remove this completely, this is a weird edge case that's rarely if ever encountered. 

TODO:
- [ ] ~make this less hacky? what happens if current selected tab has no field/sections but other tabs do?~


