### PR TITLE
fix: Load libs with frappe-web.bundle.js

### DIFF
--- a/frappe/public/js/frappe-web.bundle.js
+++ b/frappe/public/js/frappe-web.bundle.js
@@ -1,3 +1,4 @@
+import "./libs.bundle.js";
 import "./jquery-bootstrap";
 import "./frappe/class.js";
 import "./frappe/polyfill.js";


### PR DESCRIPTION
Fixes following error while loading webforms with grid.

![Screenshot 2023-01-23 at 12 13 03 PM](https://user-images.githubusercontent.com/13928957/213996527-d9e45959-17e7-4d4b-bcbf-82cc9b8bef25.png)

`Sortable` is used in web form which loaded via libs.bundle.js

Fixes: https://github.com/frappe/frappe/issues/19591


