### PR TITLE
fix: misc migration issues

### DIFF
--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -287,7 +287,7 @@ def user_linked_with_permission_on_doctype(doc, user):
 
 def apply_permissions_for_non_standard_user_type(doc, method=None):
 	"""Create user permission for the non standard user type"""
-	if not frappe.db.table_exists("User Type"):
+	if not frappe.db.table_exists("User Type") or frappe.flags.in_migrate:
 		return
 
 	user_types = frappe.cache().get_value(


### PR DESCRIPTION
1. Non-standard user permissions can be ignored in migrate because `migrate`
   happens as `administrator` user anyway.
2. When customization or apps are removed without cleaning up dead link fields
   they can make the original DocType basically unusable without letting user
   know how to fix it. While automatically fixing this hard, we can nudge
   towards a possible fix (removing the dead link fields)


Before:

![image](https://user-images.githubusercontent.com/9079960/214019459-a0872112-575b-4493-b768-24031dc39ac3.png)


After:

![image](https://user-images.githubusercontent.com/9079960/214019079-6506976c-6835-4db4-b15b-462ce91b8cd1.png)
