### PR TITLE
fix: migrate all workspaces

### DIFF
--- a/frappe/patches/v14_0/update_workspace2.py
+++ b/frappe/patches/v14_0/update_workspace2.py
@@ -26,8 +26,6 @@ def execute():
 
 def create_content(doc):
 	content = []
-	if doc.onboarding:
-		content.append({"type": "onboarding", "data": {"onboarding_name": doc.onboarding, "col": 12}})
 	if doc.charts:
 		invalid_links = []
 		for c in doc.charts:
@@ -44,7 +42,7 @@ def create_content(doc):
 		content.append(
 			{
 				"type": "header",
-				"data": {"text": doc.shortcuts_label or _("Your Shortcuts"), "level": 4, "col": 12},
+				"data": {"text": _("Your Shortcuts"), "level": 4, "col": 12},
 			}
 		)
 		for s in doc.shortcuts:
@@ -60,7 +58,7 @@ def create_content(doc):
 		content.append(
 			{
 				"type": "header",
-				"data": {"text": doc.cards_label or _("Reports & Masters"), "level": 4, "col": 12},
+				"data": {"text": _("Reports & Masters"), "level": 4, "col": 12},
 			}
 		)
 		for l in doc.links:
@@ -74,11 +72,11 @@ def create_content(doc):
 
 
 def update_workspace(doc, seq, content):
-	if not doc.title and not doc.content and not doc.is_standard and not doc.public:
+	if not doc.title and not doc.content and not doc.public:
 		doc.sequence_id = seq + 1
 		doc.content = json.dumps(content)
 		doc.public = 0 if doc.for_user else 1
-		doc.title = doc.extends or doc.label
+		doc.title = doc.label
 		doc.extends = ""
 		doc.category = ""
 		doc.onboarding = ""


### PR DESCRIPTION
There's no reason to ignore workspaces with `is_standard = 1`

Looks like the workspace2 doctype has changed since first implemented: no onboarding, shortcuts_label, cards_label or extends attributes

version-14-hotfix