### PR TITLE
feat: Bump dropbox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
 
     # integration dependencies
     "boto3~=1.18.49",
-    "dropbox~=11.7.0",
+    "dropbox~=11.36.0",
     "google-api-python-client~=2.2.0",
     "google-auth-oauthlib~=0.4.4",
     "google-auth~=1.29.0",


### PR DESCRIPTION
Bump dropbox library from 11.7.0 to 11.36.0.

My motivation is to resolve this [failure of Vulnerably Dependency Checker](https://github.com/frappe/frappe/actions/runs/3989324644/jobs/6841611664), which complains a dependency of the dropbox library.

Refactored to explicitly import classes from dropbox in order to make it easier to spot things that went missing in newer versions.

I'm not using dropbox. Somebody who does should test this PR.

> no-docs