### PR TITLE
perf(DX): use cached `Meta` to create `FormMeta`

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -51,7 +51,7 @@ def get_meta(doctype, cached=True):
 
 class FormMeta(Meta):
 	def __init__(self, doctype):
-		super().__init__(doctype)
+		self.__dict__.update(frappe.get_meta(doctype).__dict__)
 		self.load_assets()
 
 	def load_assets(self):


### PR DESCRIPTION
FormMeta is primarily used for getting Meta + assets in the frontend. The reason why it's not cached in Developer Mode is to allow developer to change JS/CSS/other assets without clearing cache.

But Meta is still cached in developer mode, so there's nothing to prevent us from using the cached Meta returned by `frappe.get_meta` to build `FormMeta`.

## Before

![image](https://user-images.githubusercontent.com/16315650/214129046-34a1d806-d3e4-4d2c-aaa1-a06b9aa158d3.png)


## After

![Screenshot-2023-01-24-004244](https://user-images.githubusercontent.com/16315650/214129157-8ea985d9-1f50-42d9-89ff-15aff6a0f836.png)
