### PR TITLE
fix: support for different delimiter for timeline email linking

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -487,28 +487,32 @@ def parse_email(communication, email_strings):
 	"""
 	Parse email to add timeline links.
 	When automatic email linking is enabled, an email from email_strings can contain
-	a doctype and docname ie in the format `admin+doctype+docname@example.com`,
+	a doctype and docname ie in the format `admin+doctype+docname@example.com` or `admin+doctype=docname@example.com`,
 	the email is parsed and doctype and docname is extracted and timeline link is added.
 	"""
-	if not frappe.get_all("Email Account", filters={"enable_automatic_linking": 1}):
+	if not frappe.db.get_value("Email Account", filters={"enable_automatic_linking": 1}):
 		return
-
-	delimiter = "+"
 
 	for email_string in email_strings:
 		if email_string:
 			for email in email_string.split(","):
-				if delimiter in email:
-					email = email.split("@")[0]
-					email_local_parts = email.split(delimiter)
-					if not len(email_local_parts) == 3:
-						continue
-
+				email_username = email.split("@")[0]
+				email_local_parts = email_username.split("+")
+				docname = doctype = None
+				if len(email_local_parts) == 3:
 					doctype = unquote(email_local_parts[1])
 					docname = unquote(email_local_parts[2])
 
-					if doctype and docname and frappe.db.exists(doctype, docname):
-						communication.add_link(doctype, docname)
+				elif len(email_local_parts) == 2:
+					document_parts = email_local_parts[1].split("=", 1)
+					if len(document_parts) != 2:
+						continue
+
+					doctype = unquote(document_parts[0])
+					docname = unquote(document_parts[1])
+
+				if doctype and docname and frappe.db.get_value(doctype, docname, ignore=True):
+					communication.add_link(doctype, docname)
 
 
 def get_email_without_link(email):

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -219,17 +219,17 @@ class TestCommunication(FrappeTestCase):
 		self.assertIn(comm_note_2.name, data)
 
 	def test_link_in_email(self):
-		frappe.delete_doc_if_exists("Note", "test document link in email")
-
 		create_email_account()
 
-		note = frappe.get_doc(
-			{
-				"doctype": "Note",
-				"title": "test document link in email",
-				"content": "test document link in email",
-			}
-		).insert(ignore_permissions=True)
+		notes = {}
+		for i in range(2):
+			frappe.delete_doc_if_exists("Note", f"test document link in email {i}")
+			notes[i] = frappe.get_doc(
+				{
+					"doctype": "Note",
+					"title": f"test document link in email {i}",
+				}
+			).insert(ignore_permissions=True)
 
 		comm = frappe.get_doc(
 			{
@@ -237,14 +237,15 @@ class TestCommunication(FrappeTestCase):
 				"communication_medium": "Email",
 				"subject": "Document Link in Email",
 				"sender": "comm_sender@example.com",
-				"recipients": f'comm_recipient+{quote("Note")}+{quote(note.name)}@example.com',
+				"recipients": f'comm_recipient+{quote("Note")}+{quote(notes[0].name)}@example.com,comm_recipient+{quote("Note")}={quote(notes[1].name)}@example.com',
 			}
 		).insert(ignore_permissions=True)
 
 		doc_links = [
 			(timeline_link.link_doctype, timeline_link.link_name) for timeline_link in comm.timeline_links
 		]
-		self.assertIn(("Note", note.name), doc_links)
+		self.assertIn(("Note", notes[0].name), doc_links)
+		self.assertIn(("Note", notes[1].name), doc_links)
 
 	def test_parse_emails(self):
 		emails = get_emails(

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -406,7 +406,7 @@ def get_document_email(doctype, name):
 		return None
 
 	email = email.split("@")
-	return f"{email[0]}+{quote(doctype)}+{quote(cstr(name))}@{email[1]}"
+	return f"{email[0]}+{quote(doctype)}={quote(cstr(name))}@{email[1]}"
 
 
 def get_automatic_email_link():


### PR DESCRIPTION
adds support for `=` in email timeline linking for plus addressing.

TODO:
- [x] manual testing
- [x] test(s)

will hopefully close https://github.com/frappe/frappe/issues/16522