### PR TITLE
fix: Password strength check for long passwords

### DIFF
--- a/frappe/tests/test_password_strength.py
+++ b/frappe/tests/test_password_strength.py
@@ -1,0 +1,18 @@
+import random
+from string import printable
+from time import time
+from unittest import TestCase
+
+from frappe.utils.password_strength import test_password_strength
+
+
+class TestPasswordStrength(TestCase):
+	def test_long_password(self):
+		password = "".join(random.choice(printable) for _ in range(600))
+
+		start_second = time()
+		result = test_password_strength(password)
+		end_second = time()
+
+		self.assertLess(end_second - start_second, 10)
+		self.assertIn("feedback", result)

--- a/frappe/utils/password_strength.py
+++ b/frappe/utils/password_strength.py
@@ -12,6 +12,12 @@ from frappe import _
 
 def test_password_strength(password, user_inputs=None):
 	"""Wrapper around zxcvbn.password_strength"""
+	if len(password) > 128:
+		# zxcvbn takes forever when checking long, random passwords.
+		# repetion patterns or user inputs in the first 128 characters
+		# will still be checked.
+		password = password[:128]
+
 	result = zxcvbn(password, user_inputs)
 	result.update({"feedback": get_feedback(result.get("score"), result.get("sequence"))})
 	return result

--- a/frappe/utils/password_strength.py
+++ b/frappe/utils/password_strength.py
@@ -17,7 +17,7 @@ def test_password_strength(password, user_inputs=None):
 		password = password[:128]
 
 	result = zxcvbn(password, user_inputs)
-	result.update({"feedback": get_feedback(result.get("score"), result.get("sequence"))})
+	result["feedback"] = get_feedback(result.get("score"), result.get("sequence"))
 	return result
 
 

--- a/frappe/utils/password_strength.py
+++ b/frappe/utils/password_strength.py
@@ -1,10 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-try:
-	from zxcvbn import zxcvbn
-except Exception:
-	import zxcvbn
+from zxcvbn import zxcvbn
+from zxcvbn.scoring import ALL_UPPER, START_UPPER
 
 import frappe
 from frappe import _
@@ -27,13 +25,7 @@ def test_password_strength(password, user_inputs=None):
 # -------------------------------------------
 # feedback functionality code from https://github.com/sans-serif/python-zxcvbn/blob/master/zxcvbn/feedback.py
 # see license for feedback code at https://github.com/sans-serif/python-zxcvbn/blob/master/LICENSE.txt
-
-# Used for regex matching capitalization
-import re
-
-# Used to get the regex patterns for capitalization
-# (Used the same way in the original zxcvbn)
-from zxcvbn import scoring
+# -------------------------------------------
 
 # Default feedback value
 default_feedback = {
@@ -183,9 +175,9 @@ def get_dictionary_match_feedback(match, is_sole_match):
 
 	word = match.get("token")
 	# Variations of the match like UPPERCASES
-	if scoring.START_UPPER.match(word):
+	if START_UPPER.match(word):
 		suggestions.append(_("Capitalization doesn't help very much."))
-	elif scoring.ALL_UPPER.match(word):
+	elif ALL_UPPER.match(word):
 		suggestions.append(_("All-uppercase is almost as easy to guess as all-lowercase."))
 
 	# Match contains l33t speak substitutions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "terminaltables~=3.1.0",
     "traceback-with-variables~=2.0.4",
     "xlrd~=2.0.1",
-    "zxcvbn-python~=4.4.28",
+    "zxcvbn~=4.4.28",
     "markdownify~=0.11.2",
 
     # integration dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "terminaltables~=3.1.0",
     "traceback-with-variables~=2.0.4",
     "xlrd~=2.0.1",
-    "zxcvbn-python~=4.4.24",
+    "zxcvbn-python~=4.4.28",
     "markdownify~=0.11.2",
 
     # integration dependencies


### PR DESCRIPTION
I have a long API Key (>600) characters that fails to save because of the password check.

The zxcvbn version we are using at the moment produces an `OverflowError`. That was fixed in https://github.com/dwolfhub/zxcvbn-python/pull/35 . -> Bumped from 4.4.24 to 4.4.28. [zxcvbn-python](https://pypi.org/project/zxcvbn-python/) is not maintained anymore. It has moved to [zxcvbn](https://pypi.org/project/zxcvbn/).

However, checking a password this long still took way too much time. I canceled the check after running for half a minute. -> For long passwords, only check the first 128 characters. This way we can still detect user inputs and repeating patterns in the first part, but it's reasonably quick.

To reproduce the problem, you can try this:

```
>>> from zxcvbn import zxcvbn
>>> import random
>>> import string
>>> password = ''.join(random.choice(string.printable) for i in range(600))
>>> zxcvbn(password)
```

With `zxcvbn==4.4.24` you should get an `OverflowError`. With `zxcvbn==4.4.28` you should have to wait for a long time.