### PR TITLE
fix(translation): empty string

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -142,7 +142,7 @@ def get_fields_label(doctype=None):
 		return frappe.msgprint(_("Custom Fields can only be added to a standard DocType."))
 
 	return [
-		{"value": df.fieldname or "", "label": _(df.label or "")}
+		{"value": df.fieldname or "", "label": _(df.label) if df.label else ""}
 		for df in frappe.get_meta(doctype).get("fields")
 	]
 


### PR DESCRIPTION
It is reserved by GNU gettext: gettext("") returns the header entry with meta information, not the empty string

rel: https://github.com/frappe/frappe/pull/19655