### PR TITLE
build(deps): Bump frappe-datatable to 1.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fast-deep-equal": "^2.0.1",
     "fast-glob": "^3.2.5",
     "frappe-charts": "2.0.0-rc22",
-    "frappe-datatable": "^1.16.4",
+    "frappe-datatable": "^1.17.0",
     "frappe-gantt": "^0.6.0",
     "highlight.js": "^10.4.1",
     "html5-qrcode": "^2.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,10 +1435,10 @@ frappe-charts@2.0.0-rc22:
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc22.tgz#9a5a747febdc381a1d4d7af96e89cf519dfba8c0"
   integrity sha512-N7f/8979wJCKjusOinaUYfMxB80YnfuVLrSkjpj4LtyqS0BGS6SuJxUnb7Jl4RWUFEIs7zEhideIKnyLeFZF4Q==
 
-frappe-datatable@^1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.16.4.tgz#cb26f197c3cd404a5b13f016ef81c394e06f56fe"
-  integrity sha512-VoiTLnkuObMa3FxITrvP32UYN9v4WQ0j4qlCiDuqdXha9/BVSxwDt2BTK+cvaRloGcds5G2Hm9IRbltRRGGhxA==
+frappe-datatable@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.0.tgz#bf13553320408acdc3b491049e05c040ea74cab8"
+  integrity sha512-QstM7Qg9ZLOxBidU1LBzKEjzAIQBmRmtLakRfqEsrlH4snbeKbcNFIAhiHSOe28d49gEsE3p0kLW3KU0ByID4g==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
Latest version has two fixes

1. https://github.com/frappe/datatable/pull/161
2. https://github.com/frappe/datatable/pull/166