### PR TITLE
fix: set-config without `-g` must specify site

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -1071,6 +1071,8 @@ def set_config(context, key, value, global_=False, parse=False, as_dict=False):
 		common_site_config_path = os.path.join(sites_path, "common_site_config.json")
 		update_site_config(key, value, validate=False, site_config_path=common_site_config_path)
 	else:
+		if not context.sites:
+			raise SiteNotSpecifiedError
 		for site in context.sites:
 			frappe.init(site=site)
 			update_site_config(key, value, validate=False)


### PR DESCRIPTION
`bench set-config key value` assumes it's for individual sites but if no site is specified then it does nothing.

Even docs are misleading on this, e.g. `bench set-config developer_mode 1` does NOTHING.

