### PR TITLE
fix(MariaDBTable): dont attempt to drop index twice

### DIFF
--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -94,7 +94,7 @@ class MariaDBTable(DBTable):
 			if not frappe.db.get_column_index(self.table_name, col.fieldname, unique=False):
 				add_index_query.append(f"ADD INDEX `{col.fieldname}_index`(`{col.fieldname}`)")
 
-		for col in self.drop_index + self.drop_unique:
+		for col in {*self.drop_index, *self.drop_unique}:
 			if col.fieldname == "name":
 				continue
 


### PR DESCRIPTION
Prevent error when syncing columns that have both a unique index AND a non-unique one:

```py
In [1]: frappe.db.sql("alter table `tabInstalled Application` add index app_name
   ...: _index(app_name)")
Out[1]: ()

In [2]: frappe.db.sql("alter table `tabInstalled Application` add unique index a
   ...: pp_name_index_(app_name)")
Out[2]: ()

In [3]: from frappe.database.mariadb.schema import MariaDBTable

In [4]: x = MariaDBTable("Installed Application")

In [5]: x.validate()

In [6]: x.sync()
Failed to alter schema using query: ALTER TABLE `tabInstalled Application` DROP INDEX `app_name_index_`, DROP INDEX `app_name_index`, DROP INDEX `app_name_index_`, DROP INDEX `app_name_index`

--- snip traceback ---
```

_Issue encountered when upgrading a site to version 14._

