### PR TITLE
fix: assertAlmostEqual with precision

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1068,7 +1068,7 @@ class BaseDocument:
 	def is_dummy_password(self, pwd):
 		return "".join(set(pwd)) == "*"
 
-	def precision(self, fieldname, parentfield=None):
+	def precision(self, fieldname, parentfield=None) -> int | None:
 		"""Returns float precision for a particular field (or get global default).
 
 		:param fieldname: Fieldname for which precision is required.

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -55,12 +55,14 @@ class FrappeTestCase(unittest.TestCase):
 			else:
 				self._compare_field(value, actual.get(field), actual, field)
 
-	def _compare_field(self, expected, actual, doc, field):
+	def _compare_field(self, expected, actual, doc: BaseDocument, field: str):
 		msg = f"{field} should be same."
 
 		if isinstance(expected, float):
 			precision = doc.precision(field)
-			self.assertAlmostEqual(expected, actual, f"{field} should be same to {precision} digits")
+			self.assertAlmostEqual(
+				expected, actual, places=precision, msg=f"{field} should be same to {precision} digits"
+			)
 		elif isinstance(expected, (bool, int)):
 			self.assertEqual(expected, cint(actual), msg=msg)
 		elif isinstance(expected, datetime_like_types):


### PR DESCRIPTION
`assertAlmostEqual` compares to a precision of 7 decimal places by default. We can use the `places` parameter to compare according to our desired precision.