### PR TITLE
fix: add freeze message for bulk delete

### DIFF
--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -147,7 +147,9 @@ export default class BulkOperations {
 				method: "frappe.desk.reportview.delete_items",
 				freeze: true,
 				freeze_message:
-					docnames.length <= 10 ? __("Deleting {0}...", [docnames.join(", ")]) : null,
+					docnames.length <= 10
+						? __("Deleting {0} records...", [docnames.length])
+						: null,
 				args: {
 					items: docnames,
 					doctype: this.doctype,

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -146,6 +146,8 @@ export default class BulkOperations {
 			.call({
 				method: "frappe.desk.reportview.delete_items",
 				freeze: true,
+				freeze_message:
+					docnames.length <= 10 ? __("Deleting {0}...", [docnames.join(", ")]) : null,
 				args: {
 					items: docnames,
 					doctype: this.doctype,


### PR DESCRIPTION
We used to freeze on bulk delete, without any feedback.
With this PR we show the same freeze message as when deleting a single record.

If `docnames.length > 10` the backend enqueues the deletion and returns immediately. A freeze message doesn't make sense here because the user has no time to read it.