### PR TITLE
fix: prepared report patch

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -772,7 +772,9 @@ class Database:
 
 		if not df:
 			frappe.throw(
-				_("Invalid field name: {0}").format(frappe.bold(fieldname)), self.InvalidColumnName
+				_("Field {0} does not exist on {1}").format(
+					frappe.bold(fieldname), frappe.bold(doctype), self.InvalidColumnName
+				)
 			)
 
 		val = cast_fieldtype(df.fieldtype, val)

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -196,7 +196,6 @@ frappe.patches.v14_0.setup_likes_from_feedback
 frappe.patches.v14_0.update_webforms
 frappe.patches.v14_0.delete_payment_gateways
 frappe.patches.v15_0.remove_event_streaming
-frappe.patches.v15_0.remove_prepared_report_settings_from_system_settings
 frappe.patches.v15_0.copy_disable_prepared_report_to_prepared_report
 
 [post_model_sync]
@@ -221,3 +220,4 @@ frappe.patches.v14_0.update_attachment_comment
 frappe.patches.v15_0.set_contact_full_name
 execute:frappe.delete_doc("Page", "activity", force=1)
 frappe.patches.v14_0.disable_email_accounts_with_oauth
+frappe.patches.v15_0.remove_prepared_report_settings_from_system_settings

--- a/frappe/patches/v15_0/remove_prepared_report_settings_from_system_settings.py
+++ b/frappe/patches/v15_0/remove_prepared_report_settings_from_system_settings.py
@@ -4,12 +4,6 @@ from frappe.utils import cint
 
 def execute():
 	expiry_period = (
-		cint(frappe.db.get_single_value("System Settings", "prepared_report_expiry_period")) or 30
+		cint(frappe.db.get_singles_dict("System Settings").get("prepared_report_expiry_period")) or 30
 	)
 	frappe.get_single("Log Settings").register_doctype("Prepared Report", expiry_period)
-
-	singles = frappe.qb.DocType("Singles")
-	frappe.qb.from_(singles).delete().where(
-		(singles.doctype == "System Settings")
-		& (singles.field.isin(["enable_prepared_report_auto_deletion", "prepared_report_expiry_period"]))
-	).run()


### PR DESCRIPTION
- the patch is failing if system setting is updated and column is gone
- the message is misleading "invalid column", it should be "missing field".


```
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 600, in migrate
    SiteMigration(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 178, in run
    self.run_schema_updates()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 41, in wrapper
    ret = method(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 110, in run_schema_updates
    frappe.modules.patch_handler.run_all(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 75, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 150, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 186, in execute_patch
    _patch()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/patches/v15_0/remove_prepared_report_settings_from_system_settings.py", line 7, in execute
    cint(frappe.db.get_single_value("System Settings", "prepared_report_expiry_period")) or 30
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 774, in get_single_value
    frappe.throw(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 523, in throw
    msgprint(
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 491, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 440, in _raise_exception
    raise raise_exception(msg)
frappe.database.database.Database.InvalidColumnName: Invalid field name: <strong>prepared_report_expiry_period</strong>
```