### PR TITLE
feat: `frappe.db.sql` results `as_iterator`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -142,6 +142,9 @@ class Database:
 	def _transform_result(self, result: list[tuple]) -> list[tuple]:
 		return result
 
+	def _clean_up(self):
+		pass
+
 	def sql(
 		self,
 		query: Query,
@@ -280,18 +283,21 @@ class Database:
 			)
 
 		if pluck:
-			return [r[0] for r in last_result]
+			last_result = [r[0] for r in last_result]
+			self._clean_up()
+			return last_result
 
 		# scrub output if required
 		if as_dict:
-			ret = self.fetch_as_dict(last_result)
+			last_result = self.fetch_as_dict(last_result)
 			if update:
-				for r in ret:
+				for r in last_result:
 					r.update(update)
-			return ret
+
 		elif as_list:
-			result = self.convert_to_lists(last_result)
-			return result
+			last_result = self.convert_to_lists(last_result)
+
+		self._clean_up()
 		return last_result
 
 	def _return_as_iterator(self, result, *, pluck, as_dict, as_list, update):
@@ -312,6 +318,8 @@ class Database:
 				yield list(row)
 		else:
 			frappe.throw(_("`as_iterator` only works with `as_list=True` or `as_dict=True`"))
+
+		self._clean_up()
 
 	def _log_query(
 		self,

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -10,7 +10,7 @@ import traceback
 from collections.abc import Iterable, Sequence
 from contextlib import contextmanager, suppress
 from time import time
-from typing import Any
+from typing import TYPE_CHECKING, Any, Union
 
 from pypika.dialects import MySQLQueryBuilder, PostgreSQLQueryBuilder
 
@@ -33,6 +33,13 @@ from frappe.utils import CallbackManager
 from frappe.utils import cast as cast_fieldtype
 from frappe.utils import cint, get_datetime, get_table_name, getdate, now, sbool
 from frappe.utils.deprecations import deprecation_warning
+
+if TYPE_CHECKING:
+	from psycopg2 import connection as PostgresConnection
+	from psycopg2 import cursor as PostgresCursor
+	from pymysql.connections import Connection as MariadbConnection
+	from pymysql.cursors import Cursor as MariadbCursor
+
 
 IFNULL_PATTERN = re.compile(r"ifnull\(", flags=re.IGNORECASE)
 INDEX_PATTERN = re.compile(r"\s*\([^)]+\)\s*")
@@ -103,8 +110,8 @@ class Database:
 
 	def connect(self):
 		"""Connects to a database as set in `site_config.json`."""
-		self._conn = self.get_connection()
-		self._cursor = self._conn.cursor()
+		self._conn: Union["MariadbConnection", "PostgresConnection"] = self.get_connection()
+		self._cursor: Union["MariadbCursor", "PostgresCursor"] = self._conn.cursor()
 
 		try:
 			if execution_timeout := get_query_execution_timeout():
@@ -149,6 +156,7 @@ class Database:
 		explain=False,
 		run=True,
 		pluck=False,
+		as_iterator=False,
 	):
 		"""Execute a SQL query and fetch all rows.
 
@@ -163,6 +171,7 @@ class Database:
 		:param run: Return query without executing it if False.
 		:param pluck: Get the plucked field only.
 		:param explain: Print `EXPLAIN` in error log.
+		:param as_iterator: Returns iterator over results instead of fetching all results at once.
 		Examples:
 
 		        # return customer names as dicts
@@ -264,21 +273,45 @@ class Database:
 		if not self._cursor.description:
 			return ()
 
-		self.last_result = self._transform_result(self._cursor.fetchall())
+		last_result = self._transform_result(self._cursor.fetchall())
+		if as_iterator:
+			return self._return_as_iterator(
+				last_result, pluck=pluck, as_dict=as_dict, as_list=as_list, update=update
+			)
 
 		if pluck:
-			return [r[0] for r in self.last_result]
+			return [r[0] for r in last_result]
 
 		# scrub output if required
 		if as_dict:
-			ret = self.fetch_as_dict()
+			ret = self.fetch_as_dict(last_result)
 			if update:
 				for r in ret:
 					r.update(update)
 			return ret
 		elif as_list:
-			return self.convert_to_lists(self.last_result)
-		return self.last_result
+			result = self.convert_to_lists(last_result)
+			return result
+		return last_result
+
+	def _return_as_iterator(self, result, *, pluck, as_dict, as_list, update):
+		if pluck:
+			for row in result:
+				yield row[0]
+
+		elif as_dict:
+			keys = [column[0] for column in self._cursor.description]
+			for row in result:
+				row = frappe._dict(zip(keys, row))
+				if update:
+					row.update(update)
+				yield row
+
+		elif as_list:
+			for row in result:
+				yield list(row)
+		else:
+			frappe.throw(_("`as_iterator` only works with `as_list=True` or `as_dict=True`"))
 
 	def _log_query(
 		self,
@@ -396,9 +429,8 @@ class Database:
 		):
 			raise ImplicitCommitError("This statement can cause implicit commit", query)
 
-	def fetch_as_dict(self) -> list[frappe._dict]:
+	def fetch_as_dict(self, result) -> list[frappe._dict]:
 		"""Internal. Convert results to dict."""
-		result = self.last_result
 		if result:
 			keys = [column[0] for column in self._cursor.description]
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -209,6 +209,13 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		self._log_query(self.last_query, debug, explain, query)
 		return self.last_query
 
+	def _clean_up(self):
+		# PERF: Erase internal references of pymysql to trigger GC as soon as
+		# results are consumed.
+		self._cursor._result = None
+		self._cursor._rows = None
+		self._cursor.connection._result = None
+
 	@staticmethod
 	def escape(s, percent=True):
 		"""Excape quotes and percent in given string."""

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -979,3 +979,31 @@ class TestReplicaConnections(FrappeTestCase):
 
 			outer()
 			self.assertEqual(write_connection, db_id())
+
+
+class TestSqlIterator(FrappeTestCase):
+	def test_db_sql_iterator(self):
+		test_queries = [
+			"select * from `tabCountry` order by name",
+			"select code from `tabCountry` order by name",
+			"select code from `tabCountry` order by name limit 5",
+		]
+
+		for query in test_queries:
+			self.assertEqual(
+				frappe.db.sql(query, as_dict=True),
+				list(frappe.db.sql(query, as_dict=True, as_iterator=True)),
+				msg=f"{query=} results not same as iterator",
+			)
+
+			self.assertEqual(
+				frappe.db.sql(query, pluck=True),
+				list(frappe.db.sql(query, pluck=True, as_iterator=True)),
+				msg=f"{query=} results not same as iterator",
+			)
+
+			self.assertEqual(
+				frappe.db.sql(query, as_list=True),
+				list(frappe.db.sql(query, as_list=True, as_iterator=True)),
+				msg=f"{query=} results not same as iterator",
+			)

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -16,6 +16,8 @@ query. This test can be written like this.
 >>> 		get_controller("User")
 
 """
+import gc
+import sys
 import time
 from unittest.mock import patch
 
@@ -176,3 +178,18 @@ class TestPerformance(FrappeTestCase):
 		query = frappe.get_all("DocType", {"autoname": ("is", "set")}, run=0).lower()
 		self.assertNotIn("coalesce", query)
 		self.assertNotIn("ifnull", query)
+
+	def test_no_stale_ref_sql(self):
+		"""frappe.db.sql should not hold any internal references to result set.
+
+		pymysql stores results internally. If your code reads a lot and doesn't make another
+		query, for that entire duration there's copy of result consuming memory in internal
+		attributes of pymysql.
+		We clear it manually, this test ensures that it actually works.
+		"""
+
+		query = "select * from tabUser"
+		for kwargs in ({}, {"as_dict": True}, {"as_list": True}):
+			result = frappe.db.sql(query, **kwargs)
+			self.assertEqual(sys.getrefcount(result), 2)  # Note: This always returns +1
+			self.assertFalse(gc.get_referrers(result))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "Jinja2~=3.1.2",
     "Pillow~=10.0.1",
     "PyJWT~=2.8.0",
+    # We depend on internal attributes,
+    # do NOT add loose requirements on PyMySQL versions.
     "PyMySQL==1.1.0",
     "pypdf~=3.17.0",
     "PyPika~=0.48.9",


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/18826

This PR roughly halves the memory usage while operating on large result sets. This is because:
1. pymysql - internally fetches entire result. 1st copy of data. 
2. Frappe fetches entire data  and stores in self.last_result - This is a reference only to same data. 
3. Same data is processed and converted if as_list/as_dict are true. - 2nd copy.


Note: 
- IDK how suitable this is for absolutely large tables. You should be converting business logic to SQL queries directly in that cases.




Before:
```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
   974    104.5 MiB    104.5 MiB           1    @profile
   975                                          def test_run_memory_profile(self):
   976    104.5 MiB      0.0 MiB           1            frappe.db.sql("select * from `tabGL Entry` limit 1")  # warmup
   977    271.6 MiB    165.2 MiB       50001            for gl in frappe.db.sql("select * from `tabGL Entry` order by modified limit 50000", as_dict=True):
   978    271.6 MiB      0.0 MiB       50000                    continue  # consume iterator
   979
   980    269.6 MiB     -2.0 MiB           1            pass
```



After:


```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
  1008    104.5 MiB    104.5 MiB           1    @profile
  1009                                          def test_run_memory_profile(self):
  1010    104.5 MiB      0.0 MiB           1            frappe.db.sql("select * from `tabGL Entry` limit 1")  # warmup
  1011    195.5 MiB      91 MiB       50001            for gl in frappe.db.sql("select * from `tabGL Entry` order by modified limit 50000", as_dict=True, as_iterator=True):
  1012    195.5 MiB      0.0 MiB       50000                    continue  # consume iterator
  1013
  1014    109.0 MiB    -86.5 MiB           1            pass # notice drop due to gc trigger
```