### PR TITLE
fix: permission check before loading document

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -28,14 +28,10 @@ def getdoc(doctype, name, user=None):
 	if not (doctype and name):
 		raise Exception("doctype and name required!")
 
-	if not name:
-		name = doctype
-
 	if not is_virtual_doctype(doctype) and not frappe.db.exists(doctype, name):
 		return []
 
 	doc = frappe.get_doc(doctype, name)
-	run_onload(doc)
 
 	if not doc.has_permission("read"):
 		frappe.flags.error_message = _("Insufficient Permission for {0}").format(
@@ -43,6 +39,8 @@ def getdoc(doctype, name, user=None):
 		)
 		raise frappe.PermissionError(("read", doctype, name))
 
+	
+	run_onload(doc)
 	doc.apply_fieldlevel_read_permissions()
 
 	# add file list


### PR DESCRIPTION
Removed redundant code [name check twice] and document load will happen post Permission Check.

Fixes #11774