### PR TITLE
fix: docshare on int pk doctype

### DIFF
--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -125,3 +125,17 @@ class TestDocShare(FrappeTestCase):
 		)
 
 		frappe.share.remove(doctype, submittable_doc.name, self.user)
+
+	def test_share_int_pk(self):
+		test_doc = frappe.new_doc("Console Log")
+
+		test_doc.insert()
+		frappe.share.add("Console Log", test_doc.name, self.user)
+
+		frappe.set_user(self.user)
+		self.assertIn(
+			str(test_doc.name), [str(name) for name in frappe.get_list("Console Log", pluck="name")]
+		)
+
+		test_doc.reload()
+		self.assertTrue(test_doc.has_permission("read"))

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -637,7 +637,7 @@ def get_linked_doctypes(dt: str) -> list:
 def get_doc_name(doc):
 	if not doc:
 		return None
-	return doc if isinstance(doc, str) else doc.name
+	return doc if isinstance(doc, str) else str(doc.name)
 
 
 def allow_everything():


### PR DESCRIPTION
DocShare doesn't work on doctypes which have int PKs, this PR fixes that.
