### PR TITLE
fix: sanitize form dict in error logs

### DIFF
--- a/frappe/core/doctype/error_snapshot/test_error_snapshot.py
+++ b/frappe/core/doctype/error_snapshot/test_error_snapshot.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils.logger import sanitized_dict
 
 # test_records = frappe.get_test_records('Error Snapshot')
 
 
 class TestErrorSnapshot(FrappeTestCase):
-	pass
+	def test_form_dict_sanitization(self):
+		self.assertNotEqual(sanitized_dict({"pwd": "SECRET", "usr": "WHAT"}).get("pwd"), "SECRET")

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -305,7 +305,7 @@ def get_traceback(with_context=False) -> str:
 		return ""
 
 	if with_context:
-		trace_list = iter_exc_lines(fmt=_get_sanitizer())
+		trace_list = iter_exc_lines(fmt=_get_traceback_sanitizer())
 		tb = "\n".join(trace_list)
 	else:
 		trace_list = traceback.format_exception(exc_type, exc_value, exc_tb)
@@ -316,7 +316,7 @@ def get_traceback(with_context=False) -> str:
 
 
 @functools.lru_cache(maxsize=1)
-def _get_sanitizer():
+def _get_traceback_sanitizer():
 	from traceback_with_variables import Format
 
 	blocklist = [

--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -1,6 +1,7 @@
 # imports - standard imports
 import logging
 import os
+from copy import deepcopy
 from logging.handlers import RotatingFileHandler
 from typing import Literal
 
@@ -91,7 +92,7 @@ class SiteContextFilter(logging.Filter):
 	def filter(self, record) -> bool:
 		if "Form Dict" not in str(record.msg):
 			site = getattr(frappe.local, "site", None)
-			form_dict = getattr(frappe.local, "form_dict", None)
+			form_dict = sanitized_dict(getattr(frappe.local, "form_dict", None))
 			record.msg = str(record.msg) + f"\nSite: {site}\nForm Dict: {form_dict}"
 			return True
 
@@ -100,3 +101,25 @@ def set_log_level(level: Literal["ERROR", "WARNING", "WARN", "INFO", "DEBUG"]) -
 	"""Use this method to set log level to something other than the default DEBUG"""
 	frappe.log_level = getattr(logging, (level or "").upper(), None) or default_log_level
 	frappe.loggers = {}
+
+
+def sanitized_dict(form_dict):
+	if not isinstance(form_dict, dict):
+		return form_dict
+
+	sanitized_dict = deepcopy(form_dict)
+
+	blocklist = [
+		"password",
+		"passwd",
+		"secret",
+		"token",
+		"key",
+		"pwd",
+	]
+
+	for k in sanitized_dict:
+		for secret_kw in blocklist:
+			if secret_kw in k:
+				sanitized_dict[k] = "********"
+	return sanitized_dict


### PR DESCRIPTION
similar to https://github.com/frappe/frappe/pull/19805


Applied to form dicts which are logged as plain text.
