### PR TITLE
ci: bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,8 +48,8 @@ repos:
             )$
 
 
-  - repo: https://github.com/timothycrosley/isort
-    rev: 5.9.1
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -39,7 +39,6 @@ def getdoc(doctype, name, user=None):
 		)
 		raise frappe.PermissionError(("read", doctype, name))
 
-	
 	run_onload(doc)
 	doc.apply_fieldlevel_read_permissions()
 


### PR DESCRIPTION
Should resolve these CI failures:

- https://github.com/frappe/frappe/actions/runs/4038132291/jobs/6941915466
- https://github.com/frappe/frappe/actions/runs/4042290456/jobs/6949819483
- https://github.com/frappe/frappe/actions/runs/4032314826/jobs/6932115087
- ...

The cause of this error has been resolved [in this commit](https://github.com/PyCQA/isort/commit/0d219a6e0b49b7f84ef0702b2387d5e14299bb8e), which was released with isort [5.12.0](https://github.com/PyCQA/isort/releases/tag/5.12.0).

Also, the repo owner/org changed from "timothycrosley" to "PyCQA" (the original repo redirects there).