### PR TITLE
fix: duplicate website theme generation

### DIFF
--- a/frappe/website/doctype/website_theme/test_website_theme.py
+++ b/frappe/website/doctype/website_theme/test_website_theme.py
@@ -1,40 +1,53 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import os
+from contextlib import contextmanager
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.website.doctype.website_theme.website_theme import (
+	after_migrate,
+	get_active_theme,
+	get_scss_paths,
+)
 
-from .website_theme import get_scss_paths
+
+@contextmanager
+def website_theme_fixture(**theme):
+	test_theme = "test-theme"
+
+	frappe.delete_doc_if_exists("Website Theme", test_theme)
+	theme = frappe.get_doc(doctype="Website Theme", theme=test_theme, **theme)
+	theme.insert()
+	yield theme
+	theme.delete(force=True)
 
 
 class TestWebsiteTheme(FrappeTestCase):
 	def test_website_theme(self):
-		frappe.delete_doc_if_exists("Website Theme", "test-theme")
-		theme = frappe.get_doc(
-			dict(
-				doctype="Website Theme",
-				theme="test-theme",
-				google_font="Inter",
-				custom_scss="body { font-size: 16.5px; }",  # this will get minified!
-			)
-		).insert()
+		with website_theme_fixture(
+			google_font="Inter",
+			custom_scss="body { font-size: 16.5px; }",  # this will get minified!
+		) as theme:
 
-		theme_path = frappe.get_site_path("public", theme.theme_url[1:])
-		with open(theme_path) as theme_file:
-			css = theme_file.read()
+			theme_path = frappe.get_site_path("public", theme.theme_url[1:])
+			with open(theme_path) as theme_file:
+				css = theme_file.read()
 
-		self.assertTrue("body{font-size:16.5px}" in css)
-		self.assertTrue("fonts.googleapis.com" in css)
+			self.assertTrue("body{font-size:16.5px}" in css)
+			self.assertTrue("fonts.googleapis.com" in css)
 
 	def test_get_scss_paths(self):
 		self.assertIn("frappe/public/scss/website.bundle", get_scss_paths())
 
 	def test_imports_to_ignore(self):
-		frappe.delete_doc_if_exists("Website Theme", "test-theme")
-		theme = frappe.get_doc(
-			dict(doctype="Website Theme", theme="test-theme", ignored_apps=[{"app": "frappe"}])
-		).insert()
+		with website_theme_fixture(ignored_apps=[{"app": "frappe"}]) as theme:
+			self.assertTrue('@import "frappe/public/scss/website"' not in theme.theme_scss)
 
-		self.assertTrue('@import "frappe/public/scss/website"' not in theme.theme_scss)
+	def test_after_migrate_hook(self):
+		with website_theme_fixture(google_font="Inter") as theme:
+			theme.set_as_default()
+			before = get_active_theme().theme_url
+			after_migrate()
+			after = get_active_theme().theme_url
+			self.assertNotEqual(before, after)

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -99,18 +99,8 @@ class WebsiteTheme(Document):
 			if fname.startswith(frappe.scrub(self.name) + "_") and fname.endswith(".css"):
 				os.remove(os.path.join(folder_path, fname))
 
-	def generate_theme_if_not_exist(self):
-		bench_path = frappe.utils.get_bench_path()
-		if self.theme_url:
-			theme_path = join_path(bench_path, "sites", self.theme_url[1:])
-			if not path_exists(theme_path):
-				self.generate_bootstrap_theme()
-		else:
-			self.generate_bootstrap_theme()
-
 	@frappe.whitelist()
 	def set_as_default(self):
-		self.generate_bootstrap_theme()
 		self.save()
 		website_settings = frappe.get_doc("Website Settings")
 		website_settings.website_theme = self.name
@@ -133,6 +123,7 @@ def get_active_theme() -> Optional["WebsiteTheme"]:
 		try:
 			return frappe.get_cached_doc("Website Theme", website_theme)
 		except frappe.DoesNotExistError:
+			frappe.clear_last_message()
 			pass
 
 
@@ -187,5 +178,4 @@ def after_migrate():
 		return
 
 	doc = frappe.get_doc("Website Theme", website_theme)
-	doc.generate_bootstrap_theme()
-	doc.save()
+	doc.save()  # Just re-saving re-generates the theme.


### PR DESCRIPTION
Website theme is getting regenerated twice during migrate

steps to reproduce:

1. Edit code to pause after_migrate hook of theme
2. Begin migrate, when paused visit site. CSS will be broken.
3. Continue execution. CSS *might be* broken still.
