### PR TITLE
Revert "fix: Report sidebar must consider Permission Query (backport #19588)"

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -3,16 +3,15 @@
 """
 bootstrap client session
 """
+
 import frappe
 import frappe.defaults
 import frappe.desk.desk_page
 from frappe.core.doctype.navbar_settings.navbar_settings import get_app_logo, get_navbar_settings
-from frappe.database.utils import Query
 from frappe.desk.doctype.route_history.route_history import frequently_visited_links
 from frappe.desk.form.load import get_meta_bundle
 from frappe.email.inbox import get_email_accounts
 from frappe.model.base_document import get_controller
-from frappe.model.db_query import DatabaseQuery
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
 from frappe.query_builder.terms import ParameterizedValueWrapper, SubQuery
@@ -170,7 +169,6 @@ def get_user_pages_or_reports(parent, cache=False):
 	parentTable = DocType(parent)
 
 	# get pages or reports set on custom role
-	# must end in a WHERE clause for `_run_with_permission_query`
 	pages_with_custom_roles = (
 		frappe.qb.from_(customRole)
 		.from_(hasRole)
@@ -184,8 +182,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			& (customRole[parent.lower()].isnotnull())
 			& (hasRole.role.isin(roles))
 		)
-	)
-	pages_with_custom_roles = _run_with_permission_query(pages_with_custom_roles, parent)
+	).run(as_dict=True)
 
 	for p in pages_with_custom_roles:
 		has_role[p.name] = {"modified": p.modified, "title": p.title, "ref_doctype": p.ref_doctype}
@@ -196,7 +193,6 @@ def get_user_pages_or_reports(parent, cache=False):
 		.where(customRole[parent.lower()].isnotnull())
 	)
 
-	# must end in a WHERE clause for `_run_with_permission_query`
 	pages_with_standard_roles = (
 		frappe.qb.from_(hasRole)
 		.from_(parentTable)
@@ -212,7 +208,7 @@ def get_user_pages_or_reports(parent, cache=False):
 	if parent == "Report":
 		pages_with_standard_roles = pages_with_standard_roles.where(report.disabled == 0)
 
-	pages_with_standard_roles = _run_with_permission_query(pages_with_standard_roles, parent)
+	pages_with_standard_roles = pages_with_standard_roles.run(as_dict=True)
 
 	for p in pages_with_standard_roles:
 		if p.name not in has_role:
@@ -226,13 +222,12 @@ def get_user_pages_or_reports(parent, cache=False):
 
 	# pages with no role are allowed
 	if parent == "Page":
-		# must end in a WHERE clause for `_run_with_permission_query`
+
 		pages_with_no_roles = (
 			frappe.qb.from_(parentTable)
 			.select(parentTable.name, parentTable.modified, *columns)
 			.where(no_of_roles == 0)
-		)
-		pages_with_no_roles = _run_with_permission_query(pages_with_no_roles, parent)
+		).run(as_dict=True)
 
 		for p in pages_with_no_roles:
 			if p.name not in has_role:
@@ -251,17 +246,6 @@ def get_user_pages_or_reports(parent, cache=False):
 	# Expire every six hours
 	_cache.set_value("has_role:" + parent, has_role, frappe.session.user, 21600)
 	return has_role
-
-
-def _run_with_permission_query(query: "Query", doctype: str) -> list[dict]:
-	"""
-	Adds Permission Query (Server Script) conditions and runs/executes modified query
-	Note: Works only if 'WHERE' is the last clause in the query
-	"""
-	permission_query = DatabaseQuery(doctype, frappe.session.user).get_permission_query_conditions()
-	if permission_query and frappe.session.user != "Administrator":
-		return frappe.db.sql(f"{query} AND {permission_query}", as_dict=True)
-	return query.run(as_dict=True)
 
 
 def load_translations(bootinfo):

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -1,5 +1,5 @@
 import frappe
-from frappe.boot import get_unseen_notes, get_user_pages_or_reports
+from frappe.boot import get_unseen_notes
 from frappe.desk.doctype.note.note import mark_as_seen
 from frappe.tests.utils import FrappeTestCase
 
@@ -26,47 +26,3 @@ class TestBootData(FrappeTestCase):
 		mark_as_seen(note.name)
 		unseen_notes = [d.title for d in get_unseen_notes()]
 		self.assertListEqual(unseen_notes, [])
-
-	def test_get_user_pages_or_reports_with_permission_query(self):
-		# Create a ToDo custom report with admin user
-		frappe.set_user("Administrator")
-		frappe.get_doc(
-			{
-				"doctype": "Report",
-				"ref_doctype": "ToDo",
-				"report_name": "Test Admin Report",
-				"report_type": "Report Builder",
-				"is_standard": "No",
-			}
-		).insert()
-
-		# Add permission query such that each user can only see their own custom reports
-		frappe.get_doc(
-			dict(
-				doctype="Server Script",
-				name="test_report_permission_query",
-				script_type="Permission Query",
-				reference_doctype="Report",
-				script="""conditions = f"(`tabReport`.is_standard = 'Yes' or `tabReport`.owner = '{frappe.session.user}')"
-				""",
-			)
-		).insert()
-
-		# Create a ToDo custom report with test user
-		frappe.set_user("test@example.com")
-		frappe.get_doc(
-			{
-				"doctype": "Report",
-				"ref_doctype": "ToDo",
-				"report_name": "Test User Report",
-				"report_type": "Report Builder",
-				"is_standard": "No",
-			}
-		).insert(ignore_permissions=True)
-
-		get_user_pages_or_reports("Report")
-		allowed_reports = frappe.cache().get_value("has_role:Report", user=frappe.session.user)
-
-		# Test user must not see admin user's report
-		self.assertNotIn("Test Admin Report", allowed_reports)
-		self.assertIn("Test User Report", allowed_reports)


### PR DESCRIPTION
Reverts frappe/frappe#19847


Permission query can practically prevent users from even logging into site if it's broken. Needs better alternative. 

Also perm query is expected to run with `get_list` like queries but boot queries are slightly different and hence can cause alias conflicts. 


```
pymysql.err.OperationalError: (1052, "Column 'name' in where clause is ambiguous")
```

query condition

```
name in ('some', 'values')
```