### PR TITLE
fix: Report sidebar must consider Permission Query (backport #19588)

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -188,7 +188,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			& (hasRole.role.isin(roles))
 		)
 	)
-	pages_with_custom_roles = run_with_permission_query(parent, pages_with_custom_roles)
+	pages_with_custom_roles = _run_with_permission_query(pages_with_custom_roles, parent)
 
 	for p in pages_with_custom_roles:
 		has_role[p.name] = {"modified": p.modified, "title": p.title, "ref_doctype": p.ref_doctype}
@@ -214,7 +214,7 @@ def get_user_pages_or_reports(parent, cache=False):
 	if parent == "Report":
 		pages_with_standard_roles = pages_with_standard_roles.where(report.disabled == 0)
 
-	pages_with_standard_roles = run_with_permission_query(parent, pages_with_standard_roles)
+	pages_with_standard_roles = _run_with_permission_query(pages_with_standard_roles, parent)
 
 	for p in pages_with_standard_roles:
 		if p.name not in has_role:
@@ -233,7 +233,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			.select(parentTable.name, parentTable.modified, *columns)
 			.where(no_of_roles == 0)
 		)
-		pages_with_no_roles = run_with_permission_query(parent, pages_with_no_roles)
+		pages_with_no_roles = _run_with_permission_query(pages_with_no_roles, parent)
 
 		for p in pages_with_no_roles:
 			if p.name not in has_role:
@@ -254,7 +254,7 @@ def get_user_pages_or_reports(parent, cache=False):
 	return has_role
 
 
-def run_with_permission_query(doctype: str, query: "MySQLQueryBuilder") -> list[dict]:
+def _run_with_permission_query(query: "MySQLQueryBuilder", doctype: str) -> list[dict]:
 	"""
 	Adds Permission Query (Server Script) conditions and runs/executes modified query
 	Note: Works only if 'WHERE' is the last clause in the query
@@ -266,7 +266,7 @@ def run_with_permission_query(doctype: str, query: "MySQLQueryBuilder") -> list[
 	if permission_query:
 		query = query + " AND " + permission_query
 
-	return frappe.db.sql(query, as_dict=True)
+	return frappe.db.sql(query, as_dict=True)  # nosemgrep
 
 
 def load_translations(bootinfo):

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -174,6 +174,7 @@ def get_user_pages_or_reports(parent, cache=False):
 	parentTable = DocType(parent)
 
 	# get pages or reports set on custom role
+	# must end in a WHERE clause for `_run_with_permission_query`
 	pages_with_custom_roles = (
 		frappe.qb.from_(customRole)
 		.from_(hasRole)
@@ -199,6 +200,7 @@ def get_user_pages_or_reports(parent, cache=False):
 		.where(customRole[parent.lower()].isnotnull())
 	)
 
+	# must end in a WHERE clause for `_run_with_permission_query`
 	pages_with_standard_roles = (
 		frappe.qb.from_(hasRole)
 		.from_(parentTable)
@@ -228,6 +230,7 @@ def get_user_pages_or_reports(parent, cache=False):
 
 	# pages with no role are allowed
 	if parent == "Page":
+		# must end in a WHERE clause for `_run_with_permission_query`
 		pages_with_no_roles = (
 			frappe.qb.from_(parentTable)
 			.select(parentTable.name, parentTable.modified, *columns)

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -261,8 +261,8 @@ def _run_with_permission_query(query: Union[str, Postgres, MariaDB], doctype: st
 	Note: Works only if 'WHERE' is the last clause in the query
 	"""
 	permission_query = DatabaseQuery(doctype, frappe.session.user).get_permission_query_conditions()
-	if permission_query:
-		return frappe.db.sql(f"{query} AND {permission_query}", as_dict=True)  # nosemgrep
+	if permission_query and frappe.session.user != "Administrator":
+		return frappe.db.sql(f"{query} AND {permission_query}", as_dict=True)
 	return query.run(as_dict=True)
 
 

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -32,7 +32,7 @@ from frappe.utils.change_log import get_versions
 from frappe.website.doctype.web_page_view.web_page_view import is_tracking_enabled
 
 if TYPE_CHECKING:
-	from pypika.dialects import MySQLQueryBuilder
+	from frappe.database.utils import Query
 
 
 def get_bootinfo():
@@ -254,17 +254,14 @@ def get_user_pages_or_reports(parent, cache=False):
 	return has_role
 
 
-def _run_with_permission_query(query: "MySQLQueryBuilder", doctype: str) -> list[dict]:
+def _run_with_permission_query(query: "Query", doctype: str) -> list[dict]:
 	"""
 	Adds Permission Query (Server Script) conditions and runs/executes modified query
 	Note: Works only if 'WHERE' is the last clause in the query
 	"""
-	db_query = DatabaseQuery(doctype, frappe.session.user)
-	permission_query = db_query.get_permission_query_conditions()
-
-	query = query.get_sql()
+	permission_query = DatabaseQuery(doctype, frappe.session.user).get_permission_query_conditions()
 	if permission_query:
-		query = query + " AND " + permission_query
+		query = f"{query.get_sql()} AND {permission_query}"
 
 	return frappe.db.sql(query, as_dict=True)  # nosemgrep
 

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -261,7 +261,7 @@ def _run_with_permission_query(query: "Query", doctype: str) -> list[dict]:
 	"""
 	permission_query = DatabaseQuery(doctype, frappe.session.user).get_permission_query_conditions()
 	if permission_query:
-		query = f"{query.get_sql()} AND {permission_query}"
+		query = f"{query} AND {permission_query}"
 
 	return frappe.db.sql(query, as_dict=True)  # nosemgrep
 

--- a/frappe/query_builder/terms.py
+++ b/frappe/query_builder/terms.py
@@ -99,8 +99,13 @@ class ParameterizedFunction(Function):
 
 		return function_sql
 
+
 class subqry(Criterion):
-	def __init__(self, subq: QueryBuilder, alias: Optional[str] = None,) -> None:
+	def __init__(
+		self,
+		subq: QueryBuilder,
+		alias: Optional[str] = None,
+	) -> None:
 		super().__init__(alias)
 		self.subq = subq
 

--- a/frappe/query_builder/terms.py
+++ b/frappe/query_builder/terms.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
 from typing import Any, Dict, Optional
 
-from pypika.terms import Function, ValueWrapper
+from pypika.queries import QueryBuilder
+from pypika.terms import Criterion, Function, ValueWrapper
 from pypika.utils import format_alias_sql
 
 from frappe.utils.data import format_timedelta
@@ -97,3 +98,12 @@ class ParameterizedFunction(Function):
 			return format_alias_sql(function_sql, self.alias, quote_char=quote_char, **kwargs)
 
 		return function_sql
+
+class subqry(Criterion):
+	def __init__(self, subq: QueryBuilder, alias: Optional[str] = None,) -> None:
+		super().__init__(alias)
+		self.subq = subq
+
+	def get_sql(self, **kwg: Any) -> str:
+		kwg["subquery"] = True
+		return self.subq.get_sql(**kwg)

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -1,0 +1,76 @@
+import frappe
+from frappe.boot import get_unseen_notes, get_user_pages_or_reports
+from frappe.desk.doctype.note.note import mark_as_seen
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestBootData(FrappeTestCase):
+	def test_get_unseen_notes(self):
+		frappe.db.delete("Note")
+		frappe.db.delete("Note Seen By")
+		note = frappe.get_doc(
+			{
+				"doctype": "Note",
+				"title": "Test Note",
+				"notify_on_login": 1,
+				"content": "Test Note 1",
+				"public": 1,
+			}
+		)
+		note.insert()
+
+		frappe.set_user("test@example.com")
+		unseen_notes = [d.title for d in get_unseen_notes()]
+		self.assertListEqual(unseen_notes, ["Test Note"])
+
+		mark_as_seen(note.name)
+		unseen_notes = [d.title for d in get_unseen_notes()]
+		self.assertListEqual(unseen_notes, [])
+
+	def test_get_user_pages_or_reports_with_permission_query(self):
+		try:
+			# Create a ToDo custom report with admin user
+			frappe.set_user("Administrator")
+			frappe.get_doc(
+				{
+					"doctype": "Report",
+					"ref_doctype": "ToDo",
+					"report_name": "Test Admin Report",
+					"report_type": "Report Builder",
+					"is_standard": "No",
+				}
+			).insert()
+
+			# Add permission query such that each user can only see their own custom reports
+			frappe.get_doc(
+				dict(
+					doctype="Server Script",
+					name="test_report_permission_query",
+					script_type="Permission Query",
+					reference_doctype="Report",
+					script="""conditions = f"(`tabReport`.is_standard = 'Yes' or `tabReport`.owner = '{frappe.session.user}')"
+					""",
+				)
+			).insert()
+
+			# Create a ToDo custom report with test user
+			frappe.set_user("test@example.com")
+			frappe.get_doc(
+				{
+					"doctype": "Report",
+					"ref_doctype": "ToDo",
+					"report_name": "Test User Report",
+					"report_type": "Report Builder",
+					"is_standard": "No",
+				}
+			).insert()
+
+			get_user_pages_or_reports("Report")
+			allowed_reports = frappe.cache().get_value("has_role:Report", user=frappe.session.user)
+
+			# Test user must not see admin user's report
+			self.assertNotIn("Test Admin Report", allowed_reports)
+			self.assertIn("Test User Report", allowed_reports)
+		finally:
+			frappe.db.rollback()
+			frappe.set_user("Administrator")

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -28,49 +28,48 @@ class TestBootData(FrappeTestCase):
 		self.assertListEqual(unseen_notes, [])
 
 	def test_get_user_pages_or_reports_with_permission_query(self):
-		try:
-			# Create a ToDo custom report with admin user
-			frappe.set_user("Administrator")
-			frappe.get_doc(
-				{
-					"doctype": "Report",
-					"ref_doctype": "ToDo",
-					"report_name": "Test Admin Report",
-					"report_type": "Report Builder",
-					"is_standard": "No",
-				}
-			).insert()
+		# Create a ToDo custom report with admin user
+		frappe.set_user("Administrator")
+		frappe.get_doc(
+			{
+				"doctype": "Report",
+				"ref_doctype": "ToDo",
+				"report_name": "Test Admin Report",
+				"report_type": "Report Builder",
+				"is_standard": "No",
+			}
+		).insert()
 
-			# Add permission query such that each user can only see their own custom reports
-			frappe.get_doc(
-				dict(
-					doctype="Server Script",
-					name="test_report_permission_query",
-					script_type="Permission Query",
-					reference_doctype="Report",
-					script="""conditions = f"(`tabReport`.is_standard = 'Yes' or `tabReport`.owner = '{frappe.session.user}')"
-					""",
-				)
-			).insert()
+		# Add permission query such that each user can only see their own custom reports
+		frappe.get_doc(
+			dict(
+				doctype="Server Script",
+				name="test_report_permission_query",
+				script_type="Permission Query",
+				reference_doctype="Report",
+				script="""conditions = f"(`tabReport`.is_standard = 'Yes' or `tabReport`.owner = '{frappe.session.user}')"
+				""",
+			)
+		).insert()
 
-			# Create a ToDo custom report with test user
-			frappe.set_user("test@example.com")
-			frappe.get_doc(
-				{
-					"doctype": "Report",
-					"ref_doctype": "ToDo",
-					"report_name": "Test User Report",
-					"report_type": "Report Builder",
-					"is_standard": "No",
-				}
-			).insert()
+		# Create a ToDo custom report with test user
+		frappe.set_user("test@example.com")
+		frappe.get_doc(
+			{
+				"doctype": "Report",
+				"ref_doctype": "ToDo",
+				"report_name": "Test User Report",
+				"report_type": "Report Builder",
+				"is_standard": "No",
+			}
+		).insert(ignore_permissions=True)
 
-			get_user_pages_or_reports("Report")
-			allowed_reports = frappe.cache().get_value("has_role:Report", user=frappe.session.user)
+		get_user_pages_or_reports("Report")
+		allowed_reports = frappe.cache().get_value("has_role:Report", user=frappe.session.user)
 
-			# Test user must not see admin user's report
-			self.assertNotIn("Test Admin Report", allowed_reports)
-			self.assertIn("Test User Report", allowed_reports)
-		finally:
-			frappe.db.rollback()
-			frappe.set_user("Administrator")
+		# Test user must not see admin user's report
+		self.assertNotIn("Test Admin Report", allowed_reports)
+		self.assertIn("Test User Report", allowed_reports)
+
+		self.addCleanup(frappe.db.rollback)
+		self.addCleanup(frappe.set_user, "Administrator")

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -70,6 +70,3 @@ class TestBootData(FrappeTestCase):
 		# Test user must not see admin user's report
 		self.assertNotIn("Test Admin Report", allowed_reports)
 		self.assertIn("Test User Report", allowed_reports)
-
-		self.addCleanup(frappe.db.rollback)
-		self.addCleanup(frappe.set_user, "Administrator")

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -15,6 +15,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import DocType
 
 
 class NestedSetRecursionError(frappe.ValidationError):
@@ -364,12 +365,8 @@ def get_root_of(doctype):
 	t1 = Table.as_("t1")
 	t2 = Table.as_("t2")
 
-	subq = frappe.qb.from_(t2).select(Count("*")).where(
-		(t2.lft < t1.lft) & (t2.rgt > t1.rgt)
-	)
-	result = frappe.qb.from_(t1).select(t1.name).where(
-		(subqry(subq) == 0) & (t1.rgt > t1.lft)
-	).run()
+	subq = frappe.qb.from_(t2).select(Count("*")).where((t2.lft < t1.lft) & (t2.rgt > t1.rgt))
+	result = frappe.qb.from_(t1).select(t1.name).where((subqry(subq) == 0) & (t1.rgt > t1.lft)).run()
 
 	return result[0][0] if result else None
 


### PR DESCRIPTION
Manual backport of #19588 

Additionally https://github.com/frappe/frappe/pull/16468/commits/2d806b5d6d0239fab096be351b0accb92f254ab9 has been cherry-pick as `subqry` (`SubQuery` in v14) is required for one of the queries