### PR TITLE
fix: Wrap identifier alias with backticks to allow reserved words as key name

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -272,7 +272,7 @@ class DatabaseQuery:
 				fields.append(field)
 			elif "as" in field.lower().split(" "):
 				col, _, new = field.split()
-				fields.append(f"`{col}` as {new}")
+				fields.append(f"`{col}` as `{new}`")
 			else:
 				fields.append(f"`{field}`")
 


### PR DESCRIPTION
if you try to add a field that is reserved-words in mariadb for example like 'continue' this query will failed and stopped
for example
SELECT `continue` as continue 

you can try 

>>> these are the reserved-words for mariadb https://mariadb.com/kb/en/reserved-words/

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
