### PR TITLE
fix: Setting default print format

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -40,20 +40,23 @@ frappe.ui.form.on("Print Format", {
 				frm.set_df_property("html", "reqd", 1);
 			}
 			if (frappe.model.can_write("Customize Form")) {
-				frappe.db.get_value("DocType", frm.doc.doc_type, "default_print_format", (r) => {
-					if (r.default_print_format != frm.doc.name) {
-						frm.add_custom_button(__("Set as Default"), function () {
-							frappe.call({
-								method: "frappe.printing.doctype.print_format.print_format.make_default",
-								args: {
-									name: frm.doc.name,
-								},
-								callback: function () {
-									frm.refresh();
-								},
-							});
-						});
+				frappe.model.with_doctype(frm.doc.doc_type, function () {
+					let current_format = frappe.get_meta(frm.doc.DocType).default_print_format;
+					if (current_format == frm.doc.name) {
+						return;
 					}
+
+					frm.add_custom_button(__("Set as Default"), function () {
+						frappe.call({
+							method: "frappe.printing.doctype.print_format.print_format.make_default",
+							args: {
+								name: frm.doc.name,
+							},
+							callback: function () {
+								frm.refresh();
+							},
+						});
+					});
 				});
 			}
 		}

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -109,13 +109,12 @@ def make_default(name):
 
 	print_format = frappe.get_doc("Print Format", name)
 
-	if (frappe.conf.get("developer_mode") or 0) == 1:
-		# developer mode, set it default in doctype
-		doctype = frappe.get_doc("DocType", print_format.doc_type)
+	doctype = frappe.get_doc("DocType", print_format.doc_type)
+	if doctype.custom:
 		doctype.default_print_format = name
 		doctype.save()
 	else:
-		# customization
+		# "Customize form"
 		frappe.make_property_setter(
 			{
 				"doctype_or_field": "DocType",


### PR DESCRIPTION
- Remove check for developer mode, it's not even valid as we dont allow
  setting default print format like this
- Set in custom doctype if custom doctype else prop setter.
- query meta instead of doctype.

better fix for https://github.com/frappe/frappe/pull/19856