### PR TITLE
fix: Dont setup socketio events on new doc

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1934,7 +1934,9 @@ frappe.ui.form.Form = class FrappeForm {
 		let doctype = this.doctype;
 		let docname = this.docname;
 
-		frappe.socketio.doc_subscribe(doctype, docname);
+		if (this.doc && !this.is_new()) {
+			frappe.socketio.doc_subscribe(doctype, docname);
+		}
 		frappe.realtime.off("docinfo_update");
 		frappe.realtime.on("docinfo_update", ({ doc, key, action = "update" }) => {
 			if (

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -216,7 +216,7 @@ frappe.socketio = {
 					}
 				});
 
-				if (cur_frm && cur_frm.doc) {
+				if (cur_frm && cur_frm.doc && !cur_frm.is_new()) {
 					frappe.socketio.doc_open(cur_frm.doc.doctype, cur_frm.doc.name);
 				}
 			}, 5000);


### PR DESCRIPTION
```
18:39:50 socketio.1       | Error: Not Found
18:39:50 socketio.1       |     at Request.callback (/home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/index.js:706:15)
18:39:50 socketio.1       |     at /home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/index.js:916:18
18:39:50 socketio.1       |     at IncomingMessage.<anonymous> (/home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/parsers/json.js:19:7)
18:39:50 socketio.1       |     at IncomingMessage.emit (node:events:525:35)
18:39:50 socketio.1       |     at endReadableNT (node:internal/streams/readable:1358:12)
18:39:50 socketio.1       |     at processTicksAndRejections (node:internal/process/task_queues:83:21) {
18:39:50 socketio.1       |   status: 404,
18:39:50 socketio.1       |   response: <ref *1> Response {
18:39:50 socketio.1       |     _events: [Object: null prototype] {},
18:39:50 socketio.1       |     _eventsCount: 0,
18:39:50 socketio.1       |     _maxListeners: undefined,
18:39:50 socketio.1       |     res: IncomingMessage {
18:39:50 socketio.1       |       _readableState: [ReadableState],
18:39:50 socketio.1       |       _events: [Object: null prototype],
18:39:50 socketio.1       |       _eventsCount: 4,
18:39:50 socketio.1       |       _maxListeners: undefined,
18:39:50 socketio.1       |       socket: [Socket],
18:39:50 socketio.1       |       httpVersionMajor: 1,
18:39:50 socketio.1       |       httpVersionMinor: 1,
18:39:50 socketio.1       |       httpVersion: '1.1',
18:39:50 socketio.1       |       complete: true,
18:39:50 socketio.1       |       rawHeaders: [Array],
18:39:50 socketio.1       |       rawTrailers: [],
18:39:50 socketio.1       |       aborted: false,
18:39:50 socketio.1       |       upgrade: false,
18:39:50 socketio.1       |       url: '',
18:39:50 socketio.1       |       method: null,
18:39:50 socketio.1       |       statusCode: 404,
18:39:50 socketio.1       |       statusMessage: 'NOT FOUND',
18:39:50 socketio.1       |       client: [Socket],
18:39:50 socketio.1       |       _consuming: false,
18:39:50 socketio.1       |       _dumped: false,
18:39:50 socketio.1       |       req: [ClientRequest],
18:39:50 socketio.1       |       text: '{"exc_type":"DoesNotExistError","_server_messages":"[\\"{\\\\\\"message\\\\\\": \\\\\\"User new-user-1 not found\\\\\\", \\\\\\"title\\\\\\": \\\\\\"Message\\\\\\", \\\\\\"indicator\\\\\\": \\\\\\"red\\\\\\", \\\\\\"raise_exception\\\\\\": 1}\\"]"}',
18:39:50 socketio.1       |       [Symbol(kCapture)]: false,
18:39:50 socketio.1       |       [Symbol(kHeaders)]: [Object],
18:39:50 socketio.1       |       [Symbol(kHeadersCount)]: 20,
18:39:50 socketio.1       |       [Symbol(kTrailers)]: null,
18:39:50 socketio.1       |       [Symbol(kTrailersCount)]: 0,
18:39:50 socketio.1       |       [Symbol(RequestTimeout)]: undefined
18:39:50 socketio.1       |     },
18:39:50 socketio.1       |     request: Request {
18:39:50 socketio.1       |       _events: [Object: null prototype] {},
18:39:50 socketio.1       |       _eventsCount: 0,
18:39:50 socketio.1       |       _maxListeners: undefined,
18:39:50 socketio.1       |       _agent: false,
18:39:50 socketio.1       |       _formData: null,
18:39:50 socketio.1       |       method: 'GET',
18:39:50 socketio.1       |       url: 'http://dev.localhost:8000/api/method/frappe.realtime.can_subscribe_doc?sid=f97c73753354488821716263cd6fb24067cbeb6866fa060799d4f99b&doctype=User&docname=new-user-1',
18:39:50 socketio.1       |       _header: [Object],
18:39:50 socketio.1       |       header: [Object],
18:39:50 socketio.1       |       writable: true,
18:39:50 socketio.1       |       _redirects: 0,
18:39:50 socketio.1       |       _maxRedirects: 5,
18:39:50 socketio.1       |       cookies: '',
18:39:50 socketio.1       |       qs: {},
18:39:50 socketio.1       |       _query: [],
18:39:50 socketio.1       |       qsRaw: [],
18:39:50 socketio.1       |       _redirectList: [],
18:39:50 socketio.1       |       _streamRequest: false,
18:39:50 socketio.1       |       req: [ClientRequest],
18:39:50 socketio.1       |       protocol: 'http:',
18:39:50 socketio.1       |       host: 'dev.localhost:8000',
18:39:50 socketio.1       |       _endCalled: true,
18:39:50 socketio.1       |       _callback: [Function (anonymous)],
18:39:50 socketio.1       |       res: [IncomingMessage],
18:39:50 socketio.1       |       response: [Circular *1],
18:39:50 socketio.1       |       called: true,
18:39:50 socketio.1       |       [Symbol(kCapture)]: false
18:39:50 socketio.1       |     },
18:39:50 socketio.1       |     req: ClientRequest {
18:39:50 socketio.1       |       _events: [Object: null prototype],
18:39:50 socketio.1       |       _eventsCount: 3,
18:39:50 socketio.1       |       _maxListeners: undefined,
18:39:50 socketio.1       |       outputData: [],
18:39:50 socketio.1       |       outputSize: 0,
18:39:50 socketio.1       |       writable: true,
18:39:50 socketio.1       |       destroyed: false,
18:39:50 socketio.1       |       _last: true,
18:39:50 socketio.1       |       chunkedEncoding: false,
18:39:50 socketio.1       |       shouldKeepAlive: false,
18:39:50 socketio.1       |       maxRequestsOnConnectionReached: false,
18:39:50 socketio.1       |       _defaultKeepAlive: true,
18:39:50 socketio.1       |       useChunkedEncodingByDefault: false,
18:39:50 socketio.1       |       sendDate: false,
18:39:50 socketio.1       |       _removedConnection: false,
18:39:50 socketio.1       |       _removedContLen: false,
18:39:50 socketio.1       |       _removedTE: false,
18:39:50 socketio.1       |       strictContentLength: false,
18:39:50 socketio.1       |       _contentLength: 0,
18:39:50 socketio.1       |       _hasBody: true,
18:39:50 socketio.1       |       _trailer: '',
18:39:50 socketio.1       |       finished: true,
18:39:50 socketio.1       |       _headerSent: true,
18:39:50 socketio.1       |       _closed: false,
18:39:50 socketio.1       |       socket: [Socket],
18:39:50 socketio.1       |       _header: 'GET /api/method/frappe.realtime.can_subscribe_doc?sid=f97c73753354488821716263cd6fb24067cbeb6866fa060799d4f99b&doctype=User&docname=new-user-1 HTTP/1.1\r\n' +
18:39:50 socketio.1       |         'Host: dev.localhost:8000\r\n' +
18:39:50 socketio.1       |         'Accept-Encoding: gzip, deflate\r\n' +
18:39:50 socketio.1       |         'User-Agent: node-superagent/3.8.3\r\n' +
18:39:50 socketio.1       |         'Content-Type: application/x-www-form-urlencoded\r\n' +
18:39:50 socketio.1       |         'Connection: close\r\n' +
18:39:50 socketio.1       |         '\r\n',
18:39:50 socketio.1       |       _keepAliveTimeout: 0,
18:39:50 socketio.1       |       _onPendingData: [Function: nop],
18:39:50 socketio.1       |       agent: [Agent],
18:39:50 socketio.1       |       socketPath: undefined,
18:39:50 socketio.1       |       method: 'GET',
18:39:50 socketio.1       |       maxHeaderSize: undefined,
18:39:50 socketio.1       |       insecureHTTPParser: undefined,
18:39:50 socketio.1       |       path: '/api/method/frappe.realtime.can_subscribe_doc?sid=f97c73753354488821716263cd6fb24067cbeb6866fa060799d4f99b&doctype=User&docname=new-user-1',
18:39:50 socketio.1       |       _ended: true,
18:39:50 socketio.1       |       res: [IncomingMessage],
18:39:50 socketio.1       |       aborted: false,
18:39:50 socketio.1       |       timeoutCb: null,
18:39:50 socketio.1       |       upgradeOrConnect: false,
18:39:50 socketio.1       |       parser: null,
18:39:50 socketio.1       |       maxHeadersCount: null,
18:39:50 socketio.1       |       reusedSocket: false,
18:39:50 socketio.1       |       host: 'dev.localhost',
18:39:50 socketio.1       |       protocol: 'http:',
18:39:50 socketio.1       |       [Symbol(kCapture)]: false,
18:39:50 socketio.1       |       [Symbol(kBytesWritten)]: 0,
18:39:50 socketio.1       |       [Symbol(kEndCalled)]: true,
18:39:50 socketio.1       |       [Symbol(kNeedDrain)]: false,
18:39:50 socketio.1       |       [Symbol(corked)]: 0,
18:39:50 socketio.1       |       [Symbol(kOutHeaders)]: [Object: null prototype],
18:39:50 socketio.1       |       [Symbol(kUniqueHeaders)]: null
18:39:50 socketio.1       |     },
18:39:50 socketio.1       |     text: '{"exc_type":"DoesNotExistError","_server_messages":"[\\"{\\\\\\"message\\\\\\": \\\\\\"User new-user-1 not found\\\\\\", \\\\\\"title\\\\\\": \\\\\\"Message\\\\\\", \\\\\\"indicator\\\\\\": \\\\\\"red\\\\\\", \\\\\\"raise_exception\\\\\\": 1}\\"]"}',
18:39:50 socketio.1       |     body: {
18:39:50 socketio.1       |       exc_type: 'DoesNotExistError',
18:39:50 socketio.1       |       _server_messages: '["{\\"message\\": \\"User new-user-1 not found\\", \\"title\\": \\"Message\\", \\"indicator\\": \\"red\\", \\"raise_exception\\": 1}"]'
18:39:50 socketio.1       |     },
18:39:50 socketio.1       |     files: undefined,
18:39:50 socketio.1       |     buffered: true,
18:39:50 socketio.1       |     headers: {
18:39:50 socketio.1       |       server: 'Werkzeug/2.2.2 Python/3.11.0',
18:39:50 socketio.1       |       date: 'Tue, 31 Jan 2023 13:09:50 GMT',
18:39:50 socketio.1       |       'content-type': 'application/json',
18:39:50 socketio.1       |       'content-length': '204',
18:39:50 socketio.1       |       'set-cookie': [Array],
18:39:50 socketio.1       |       connection: 'close'
18:39:50 socketio.1       |     },
18:39:50 socketio.1       |     header: {
18:39:50 socketio.1       |       server: 'Werkzeug/2.2.2 Python/3.11.0',
18:39:50 socketio.1       |       date: 'Tue, 31 Jan 2023 13:09:50 GMT',
18:39:50 socketio.1       |       'content-type': 'application/json',
18:39:50 socketio.1       |       'content-length': '204',
18:39:50 socketio.1       |       'set-cookie': [Array],
18:39:50 socketio.1       |       connection: 'close'
18:39:50 socketio.1       |     },
18:39:50 socketio.1       |     statusCode: 404,
18:39:50 socketio.1       |     status: 404,
18:39:50 socketio.1       |     statusType: 4,
18:39:50 socketio.1       |     info: false,
18:39:50 socketio.1       |     ok: false,
18:39:50 socketio.1       |     redirect: false,
18:39:50 socketio.1       |     clientError: true,
18:39:50 socketio.1       |     serverError: false,
18:39:50 socketio.1       |     error: Error: cannot GET /api/method/frappe.realtime.can_subscribe_doc?sid=f97c73753354488821716263cd6fb24067cbeb6866fa060799d4f99b&doctype=User&docname=new-user-1 (404)
18:39:50 socketio.1       |         at Response.toError (/home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/response.js:94:15)
18:39:50 socketio.1       |         at ResponseBase._setStatusProperties (/home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/response-base.js:123:16)
18:39:50 socketio.1       |         at new Response (/home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/response.js:41:8)
18:39:50 socketio.1       |         at Request._emitResponse (/home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/index.js:752:20)
18:39:50 socketio.1       |         at /home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/index.js:916:38
18:39:50 socketio.1       |         at IncomingMessage.<anonymous> (/home/ankush/benches/develop/apps/frappe/node_modules/superagent/lib/node/parsers/json.js:19:7)
18:39:50 socketio.1       |         at IncomingMessage.emit (node:events:525:35)
18:39:50 socketio.1       |         at endReadableNT (node:internal/streams/readable:1358:12)
18:39:50 socketio.1       |         at processTicksAndRejections (node:internal/process/task_queues:83:21) {
18:39:50 socketio.1       |       status: 404,
18:39:50 socketio.1       |       text: '{"exc_type":"DoesNotExistError","_server_messages":"[\\"{\\\\\\"message\\\\\\": \\\\\\"User new-user-1 not found\\\\\\", \\\\\\"title\\\\\\": \\\\\\"Message\\\\\\", \\\\\\"indicator\\\\\\": \\\\\\"red\\\\\\", \\\\\\"raise_exception\\\\\\": 1}\\"]"}',
18:39:50 socketio.1       |       method: 'GET',
18:39:50 socketio.1       |       path: '/api/method/frappe.realtime.can_subscribe_doc?sid=f97c73753354488821716263cd6fb24067cbeb6866fa060799d4f99b&doctype=User&docname=new-user-1'
18:39:50 socketio.1       |     },
18:39:50 socketio.1       |     created: false,
18:39:50 socketio.1       |     accepted: false,
18:39:50 socketio.1       |     noContent: false,
18:39:50 socketio.1       |     badRequest: false,
18:39:50 socketio.1       |     unauthorized: false,
18:39:50 socketio.1       |     notAcceptable: false,
18:39:50 socketio.1       |     forbidden: false,
18:39:50 socketio.1       |     notFound: true,
18:39:50 socketio.1       |     unprocessableEntity: false,
18:39:50 socketio.1       |     type: 'application/json',
18:39:50 socketio.1       |     links: {},
18:39:50 socketio.1       |     setEncoding: [Function: bound ],
18:39:50 socketio.1       |     redirects: [],
18:39:50 socketio.1       |     [Symbol(kCapture)]: false
18:39:50 socketio.1       |   }
18:39:50 socketio.1       | }
```