### PR TITLE
fix: Updated Translations bug in MultiSelectDialog

### DIFF
--- a/frappe/public/js/frappe/form/multi_select_dialog.js
+++ b/frappe/public/js/frappe/form/multi_select_dialog.js
@@ -72,8 +72,8 @@ frappe.ui.form.MultiSelectDialog = class MultiSelectDialog {
 	}
 
 	make() {
-		let doctype_plural = this.doctype.plural();
-		let title = __("Select {0}", [this.for_select ? __("value") : __(doctype_plural)]);
+		let doctype_plural = __(this.doctype).plural();
+		let title = __("Select {0}", [this.for_select ? __("value") : doctype_plural]);
 
 		this.dialog = new frappe.ui.Dialog({
 			title: title,


### PR DESCRIPTION
Updated Translations bug in title of MultiSelectDialog

Case: when we click on "Get Items from" or use the MultiSelectDialog then the "Change label" or other translations doesn't work for MultiSelectDialog

1. The Quotation label changed to "Bargain":
![Screenshot from 2023-02-01 00-54-46](https://user-images.githubusercontent.com/48860013/215867549-61955186-7cf6-45ed-b604-821bf2b13110.png)

2. The MultiSelectDialog in Sales Order without the fix saying "Select Quotations":
![Screenshot from 2023-02-01 00-52-47](https://user-images.githubusercontent.com/48860013/215867701-09fb179d-adf0-47c4-9c16-745beaad4362.png)

3. The MultiSelectDialog in Sales Order after the fix saying "Select Bargains":
![Screenshot from 2023-02-01 01-05-20](https://user-images.githubusercontent.com/48860013/215867836-6e4b5827-e7b3-4032-a637-28b66a7acd42.png)