### PR TITLE
Fix possible none value evaluation in get_formatted function

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1109,7 +1109,8 @@ class BaseDocument:
 			df = get_default_df(fieldname)
 
 		if (
-			df.fieldtype == "Currency"
+			df
+			and df.fieldtype == "Currency"
 			and not currency
 			and (currency_field := df.get("options"))
 			and (currency_value := self.get(currency_field))


### PR DESCRIPTION
I found this problem in the erpnext app, and this is the cause for this problem.
The return value of get_default_df can be a none value and in the next line it gets evaluated which is an error.

This is related to my issue report [#33657](https://github.com/frappe/erpnext/issues/33657) in erpnext.

Before:
![before](https://user-images.githubusercontent.com/8073152/215897551-822d79b7-0e20-49fe-80a3-7fb626edfb14.png)

After:
![after](https://user-images.githubusercontent.com/8073152/215897545-cb7c8c05-b063-4060-ae8a-5af306bc5303.png)
