### PR TITLE
fix!: eval client scripts with immediately invoked `Function()` constructor

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -176,12 +176,12 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 		}
 
 		if (client_script) {
-			eval(client_script);
+			new Function(client_script)();
 		}
 
 		if (!this.frm.doctype_layout && doctype.__custom_js) {
 			try {
-				eval(doctype.__custom_js);
+				new Function(doctype.__custom_js)();
 			} catch (e) {
 				frappe.msgprint({
 					title: __("Error in Client Script"),

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -274,21 +274,18 @@ $.extend(frappe.model, {
 
 	init_doctype: function (doctype) {
 		var meta = locals.DocType[doctype];
-		if (meta.__list_js) {
-			eval(meta.__list_js);
+		for (const asset_key of [
+			"__list_js",
+			"__custom_list_js",
+			"__calendar_js",
+			"__map_js",
+			"__tree_js",
+		]) {
+			if (meta[asset_key]) {
+				new Function(meta[asset_key])();
+			}
 		}
-		if (meta.__custom_list_js) {
-			eval(meta.__custom_list_js);
-		}
-		if (meta.__calendar_js) {
-			eval(meta.__calendar_js);
-		}
-		if (meta.__map_js) {
-			eval(meta.__map_js);
-		}
-		if (meta.__tree_js) {
-			eval(meta.__tree_js);
-		}
+
 		if (meta.__templates) {
 			$.extend(frappe.templates, meta.__templates);
 		}


### PR DESCRIPTION
This helps in two ways:
- **avoid inadvertent access to local scope:** access to local scope was causing [minified variable names to conflict with legit global variable names](https://github.com/resilient-tech/india-compliance/issues/203).
- **avoid pollution of global scope:** same as esbuild. I am intending this to be a non-breaking alternative to [using strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!).

I don't think this is breaking:
- access to local variables was never intended in these contexts.
- global scope pollution didn't happen earlier anyway.

This is similar to the technique used in [`frappe.utils.eval`](https://github.com/frappe/frappe/blob/f1ffc1967388e9f7b2ea88f5a446e9dce421e735/frappe/public/js/frappe/utils/utils.js#L1080)

Closes https://github.com/resilient-tech/india-compliance/issues/203