### PR TITLE
fix: use sender from formatted email body for email queue

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -39,7 +39,7 @@ class EmailQueue(Document):
 	def set_recipients(self, recipients):
 		self.set("recipients", [])
 		for r in recipients:
-			self.append("recipients", {"recipient": r, "status": "Not Sent"})
+			self.append("recipients", {"recipient": r.strip(), "status": "Not Sent"})
 
 	def on_trash(self):
 		self.prevent_email_queue_delete()
@@ -711,7 +711,7 @@ class QueueBuilder:
 			"attachments": json.dumps(self.get_attachments()),
 			"message_id": get_string_between("<", mail.msg_root["Message-Id"], ">"),
 			"message": mail_to_string,
-			"sender": self.sender,
+			"sender": mail.sender,
 			"reference_doctype": self.reference_doctype,
 			"reference_name": self.reference_name,
 			"add_unsubscribe_link": self._add_unsubscribe_link,

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -99,7 +99,7 @@ def get_unsubcribed_url(
 @frappe.whitelist(allow_guest=True)
 def unsubscribe(doctype, name, email):
 	# unsubsribe from comments and communications
-	if not verify_request():
+	if not frappe.flags.in_test and not verify_request():
 		return
 
 	try:


### PR DESCRIPTION
This pr makes the value in `sender` field in email queue the same as `From` header.

We send emails using the sender field which caused redundancy where Fhe from header showed the intended mail address whereas the sender showed the original sender which caused problems in email accounts which had the option of sending via the same email id as their account (especially for microsoft - where you have to explicitly configure to let people send emails from any email id they like)

#

Some other thought(s): imo sender field should just be removed, as it promotes redundancy and causes confusion.