### PR TITLE
Revert "fix: handle additional width from scrollbar"

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -759,17 +759,11 @@ body {
 
 [data-page-route="Workspaces"] {
 	@media (min-width: map-get($grid-breakpoints, "lg")) {
-		.page-actions {
-			scrollbar-gutter: stable;
-			overflow: auto;
-			height: calc(var(--btn-height) + 2px);
-		}
 		.layout-main {
 			height: calc(100vh - var(--navbar-height) - var(--page-head-height) - 5px);
 			.layout-side-section, .layout-main-section-wrapper {
 				height: 100%;
 				overflow-y: auto;
-				scrollbar-gutter: stable;
 				scrollbar-color: var(--gray-200) transparent;
 				[data-theme="dark"] & {
 					scrollbar-color: var(--gray-800) transparent;


### PR DESCRIPTION
This commit improved looks for the standard view, but leads to a bug when clicking the menu in a customized workspace:

https://user-images.githubusercontent.com/14891507/216132590-49f65499-0c05-4cd6-aea8-0ab3a590b20a.mov

Only v13 is affected by this.
