### PR TITLE
fix: query SQL error not unique table/alias when have a link field reference to the same doctype

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -241,8 +241,13 @@ class DatabaseQuery:
 			args.tables += f" {self.join} {child} on ({child}.parent = {parent_name})"
 
 		# left join link tables
-		for link in self.link_tables:
-			args.tables += f" {self.join} `tab{link.doctype}` on (`tab{link.doctype}`.`name` = {self.tables[0]}.`{link.fieldname}`)"
+		for i, link in enumerate(self.link_tables):
+			if link.doctype == self.doctype:
+				table_alias = f"tab{link.doctype}{i}"
+				args.tables += f" {self.join} `tab{link.doctype}` as `{table_alias}` on (`{table_alias}`.`name` = {self.tables[0]}.`{link.fieldname}`)"
+			else:
+				table_alias = f"tab{link.doctype}"
+				args.tables += f" {self.join} {table_alias} on (`{table_alias}`.`name` = {self.tables[0]}.`{link.fieldname}`)"
 
 		if self.grouped_or_conditions:
 			self.conditions.append(f"({' or '.join(self.grouped_or_conditions)})")
@@ -259,7 +264,15 @@ class DatabaseQuery:
 
 		# Wrapping fields with grave quotes to allow support for sql keywords
 		# TODO: Add support for wrapping fields with sql functions and distinct keyword
-		for field in self.fields:
+		for field in self.fields:		
+			if field.startswith("`tab") and 'as' in field.lower().split():					
+				linked_table = field.split('.', 1)[0]
+				if linked_table == f"`tab{self.doctype}`":																
+					for i, item in enumerate(self.link_tables):					
+						if item.table_name == linked_table:
+							linked_table_alias = f"{linked_table[:len(linked_table) - 1]}{i}`"						
+							field = field.replace(linked_table, linked_table_alias)				
+							break
 			stripped_field = field.strip().lower()
 			skip_wrapping = any(
 				[


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

I tested with list view and it works. The issue only happen if you have a link field same doctype. Access list view will show error popup.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

I create an alias for join table by concat index to current table name. So, it make sure all alias table will unique. Base on current source code, I tried to apply change in last steps generate query string, all logic functions about check permission, access field of doctype... still working.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
