### PR TITLE
fix: otp and ldap not working together

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -233,7 +233,8 @@ class LoginManager:
 			self.fail(_("Incomplete login details"), user=user)
 
 		_raw_user_name = user
-		user = User.find_by_credentials(user, pwd)
+		validate = not frappe.form_dict.get("tmp_id", False)
+		user = User.find_by_credentials(user, pwd, validate_password=validate)
 
 		if not user:
 			self.fail("Invalid login credentials", user=_raw_user_name)


### PR DESCRIPTION
after a OTP login auth tries to re-autenticate but with LDAP dat is not possible (since user is not in Auth-DB).  so reverting to v12 use-case for skipping pwd check on ldap (but still using cached credentials)