### PR TITLE
fix: can't sign out due to missing roles

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -570,7 +570,7 @@ def get_user():
 
 def get_roles(username=None) -> list[str]:
 	"""Returns roles of current user."""
-	if not local.session:
+	if not local.session or not local.session.user:
 		return ["Guest"]
 	import frappe.permissions
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -413,7 +413,7 @@ def get_roles(user=None, with_standard=True):
 	if not user:
 		user = frappe.session.user
 
-	if user == "Guest":
+	if user == "Guest" or not user:
 		return ["Guest"]
 
 	def get():


### PR DESCRIPTION
Happening after https://github.com/frappe/frappe/pull/19533

session isn't set so session.user is `None` and roles aren't found.

Fix: Assume *at least* `Guest` role by default.


```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 42, in application
    init_request(request)
  File "apps/frappe/frappe/app.py", line 120, in init_request
    frappe.local.http_request = HTTPRequest()
  File "apps/frappe/frappe/auth.py", line 36, in __init__
    self.set_session()
  File "apps/frappe/frappe/auth.py", line 72, in set_session
    frappe.local.login_manager = LoginManager()
  File "apps/frappe/frappe/auth.py", line 117, in __init__
    self.make_session(resume=True)
  File "apps/frappe/frappe/auth.py", line 205, in make_session
    frappe.local.session_obj = Session(
  File "apps/frappe/frappe/sessions.py", line 220, in __init__
    self.resume()
  File "apps/frappe/frappe/sessions.py", line 286, in resume
    data = self.get_session_record()
  File "apps/frappe/frappe/sessions.py", line 303, in get_session_record
    r = self.get_session_data()
  File "apps/frappe/frappe/sessions.py", line 319, in get_session_data
    data = self.get_session_data_from_db()
  File "apps/frappe/frappe/sessions.py", line 356, in get_session_data_from_db
    self._delete_session()
  File "apps/frappe/frappe/sessions.py", line 362, in _delete_session
    delete_session(self.sid, reason="Session Expired")
  File "apps/frappe/frappe/sessions.py", line 98, in delete_session
    logout_feed(user, reason)
  File "apps/frappe/frappe/core/doctype/activity_log/feed.py", line 20, in logout_feed
    add_authentication_log(subject, user, operation="Logout")
  File "apps/frappe/frappe/core/doctype/activity_log/activity_log.py", line 43, in add_authentication_log
    frappe.get_doc(
  File "apps/frappe/frappe/model/document.py", line 257, in insert
    self._set_defaults()
  File "apps/frappe/frappe/model/document.py", line 744, in _set_defaults
    new_doc = frappe.new_doc(self.doctype, as_dict=True)
  File "apps/frappe/frappe/__init__.py", line 1066, in new_doc
    return get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
  File "apps/frappe/frappe/model/create_new.py", line 22, in get_new_doc
    frappe.local.new_doc_templates[doctype] = make_new_doc(doctype)
  File "apps/frappe/frappe/model/create_new.py", line 42, in make_new_doc
    doc = doc.get_valid_dict(sanitize=False)
  File "apps/frappe/frappe/model/base_document.py", line 307, in get_valid_dict
    permitted_fields = get_permitted_fields(doctype=self.doctype)
  File "apps/frappe/frappe/model/__init__.py", line 210, in get_permitted_fields
    + meta.get_permitted_fieldnames(parenttype=parenttype, user=user)
  File "apps/frappe/frappe/model/meta.py", line 539, in get_permitted_fieldnames
    permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
  File "apps/frappe/frappe/model/meta.py", line 551, in get_permlevel_access
    if perm.role in roles and perm.get(permission_type):
TypeError: argument of type 'NoneType' is not iterable

```
