### PR TITLE
fix: Many migration fixes

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -592,6 +592,8 @@ def disable_user(context, email):
 @pass_context
 def migrate(context, skip_failing=False, skip_search_index=False):
 	"Run patches, sync schema and rebuild files/translations"
+	from traceback_with_variables import activate_by_import
+
 	from frappe.migrate import SiteMigration
 
 	for site in context.sites:

--- a/frappe/desk/utils.py
+++ b/frappe/desk/utils.py
@@ -9,16 +9,14 @@ def validate_route_conflict(doctype, name):
 	Raises exception if name clashes with routes from other documents for /app routing
 	"""
 
+	if frappe.flags.in_migrate:
+		return
+
 	all_names = []
 	for _doctype in ["Page", "Workspace", "DocType"]:
-		try:
-			all_names.extend(
-				[
-					slug(d) for d in frappe.get_all(_doctype, pluck="name") if (doctype != _doctype and d != name)
-				]
-			)
-		except frappe.db.TableMissingError:
-			pass
+		all_names.extend(
+			[slug(d) for d in frappe.get_all(_doctype, pluck="name") if (doctype != _doctype and d != name)]
+		)
 
 	if slug(name) in all_names:
 		frappe.msgprint(frappe._("Name already taken, please set a new name"))

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -59,11 +59,11 @@ def import_controller(doctype):
 
 	module_name = "Core"
 	if doctype not in DOCTYPES_FOR_DOCTYPE:
-		meta = frappe.get_meta(doctype, cached=not frappe.flags.in_migrate)
-		if meta.custom:
-			return NestedSet if meta.get("is_tree") else Document
-
-		module_name = meta.module
+		doctype_info = frappe.db.get_value("DocType", doctype, fieldname="*")
+		if doctype_info:
+			if doctype_info.custom:
+				return NestedSet if doctype_info.is_tree else Document
+			module_name = doctype_info.module
 
 	module_path = None
 	class_overrides = frappe.get_hooks("override_doctype_class")

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -43,7 +43,7 @@ def get_controller(doctype):
 	:param doctype: DocType name as string.
 	"""
 
-	if frappe.local.dev_server:
+	if frappe.local.dev_server or frappe.flags.in_migrate:
 		return import_controller(doctype)
 
 	site_controllers = frappe.controllers.setdefault(frappe.local.site, {})
@@ -59,7 +59,7 @@ def import_controller(doctype):
 
 	module_name = "Core"
 	if doctype not in DOCTYPES_FOR_DOCTYPE:
-		meta = frappe.get_meta(doctype)
+		meta = frappe.get_meta(doctype, cached=not frappe.flags.in_migrate)
 		if meta.custom:
 			return NestedSet if meta.get("is_tree") else Document
 

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -232,7 +232,11 @@ def set_naming_from_document_naming_rule(doc):
 	"""
 	Evaluate rules based on "Document Naming Series" doctype
 	"""
-	if doc.doctype in log_types:
+	from frappe.model.base_document import DOCTYPES_FOR_DOCTYPE
+
+	IGNORED_DOCTYPES = {*log_types, *DOCTYPES_FOR_DOCTYPE, "DefaultValue", "Patch Log"}
+
+	if doc.doctype in IGNORED_DOCTYPES:
 		return
 
 	document_naming_rules = frappe.cache_manager.get_doctype_map(

--- a/frappe/patches/v13_0/rename_list_view_setting_to_list_view_settings.py
+++ b/frappe/patches/v13_0/rename_list_view_setting_to_list_view_settings.py
@@ -5,22 +5,27 @@ import frappe
 
 
 def execute():
-	if frappe.db.table_exists("List View Setting"):
-		if not frappe.db.table_exists("List View Settings"):
-			frappe.reload_doc("desk", "doctype", "List View Settings")
+	if not frappe.db.table_exists("List View Setting"):
+		return
+	if not frappe.db.exists("DocType", "List View Setting"):
+		return
 
-		existing_list_view_settings = frappe.get_all("List View Settings", as_list=True)
-		for list_view_setting in frappe.get_all(
-			"List View Setting",
-			fields=["disable_count", "disable_sidebar_stats", "disable_auto_refresh", "name"],
-		):
-			name = list_view_setting.pop("name")
-			if name not in [x[0] for x in existing_list_view_settings]:
-				list_view_setting["doctype"] = "List View Settings"
-				list_view_settings = frappe.get_doc(list_view_setting)
-				# setting name here is necessary because autoname is set as prompt
-				list_view_settings.name = name
-				list_view_settings.insert()
+	frappe.reload_doc("desk", "doctype", "List View Settings")
 
-		frappe.delete_doc("DocType", "List View Setting", force=True)
-		frappe.db.commit()
+	existing_list_view_settings = frappe.get_all(
+		"List View Settings", as_list=True, order_by="modified"
+	)
+	for list_view_setting in frappe.get_all(
+		"List View Setting",
+		fields=["disable_count", "disable_sidebar_stats", "disable_auto_refresh", "name"],
+		order_by="modified",
+	):
+		name = list_view_setting.pop("name")
+		if name not in [x[0] for x in existing_list_view_settings]:
+			list_view_setting["doctype"] = "List View Settings"
+			list_view_settings = frappe.get_doc(list_view_setting)
+			# setting name here is necessary because autoname is set as prompt
+			list_view_settings.name = name
+			list_view_settings.insert()
+
+	frappe.delete_doc("DocType", "List View Setting", force=True)


### PR DESCRIPTION
Continues https://github.com/frappe/frappe/pull/19874, https://github.com/frappe/frappe/pull/19725, https://github.com/frappe/frappe/pull/19623

1. Migration fails because doctype naming rule doesn't find itself while bootstrapping

![image](https://user-images.githubusercontent.com/9079960/216521996-2284cc2a-9505-400c-a888-8f285de36147.png)


When migrating base doctypes we need to insert docfield which triggers
 document naming rule code and document naming rule doesn't yet exists
 cause that's what we are trying to migrate.

Fix: skip naming rule on bootstrapped doctypes.


issue: ISS-22-23-03583


```
Executing execute:frappe.reload_doc('core', 'doctype', 'doctype_action', force=True) #2019-09-23 in ...

Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 110, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 31, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 433, in migrate
    migrate(context.verbose, skip_failing=skip_failing, skip_search_index=skip_search_index)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 69, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 47, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 36, in run_patch
    if not run_single(patchmodule=patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 81, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 103, in execute_patch
    exec(patchmodule.split("execute:")[1], globals())
  File "<string>", line 1, in <module>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1185, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/utils.py", line 199, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 54, in import_files
    module, dt, dn, force=force, pre_process=pre_process, reset_permissions=reset_permissions
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 62, in import_file
    path, force, pre_process=pre_process, reset_permissions=reset_permissions
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 153, in import_file_by_path
    path=path,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 275, in import_doc
    doc.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 258, in insert
    self.set_new_name(set_name=set_name, set_child_names=set_child_names)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 471, in set_new_name
    set_new_name(d)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 54, in set_new_name
    set_naming_from_document_naming_rule(doc)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/naming.py", line 111, in set_naming_from_document_naming_rule
    ignore_ddl=True,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1746, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1718, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 170, in execute
    result = self.build_and_run()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 187, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 223, in prepare_args
    self.build_conditions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 474, in build_conditions
    self.build_filter_conditions(self.filters, self.conditions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 495, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 505, in prepare_filter_condition
    f = get_filter(self.doctype, f, additional_filters_config)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/data.py", line 1641, in get_filter
    meta = frappe.get_meta(f.doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1111, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 49, in get_meta
    meta = Meta(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 106, in __init__
    super(Meta, self).__init__("DocType", doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 118, in __init__
    self.load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 111, in load_from_db
    super(Meta, self).load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 164, in load_from_db
    _("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 511, in throw
    as_list=as_list,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 479, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 434, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType Document Naming Rule not found
```


2. Route conflict checks fail during migrate cause new route doctypes might not exist. 
3. Controllers cache leads to invalid controller path like `frappe.core.doctype.DOCTYPE_NAME`, ignore cached values during migrations because things are changing constantly in migration so caching is just not a good idea here. 
4. List view setting patch fails because it tries to find order by field while migrating itself. 
5. ~~`rename_doctypes` fail when patches are attempted twice - Forcefully drop the target table when renaming~~ FC will handle this, in same way but better to handle where the cause of this problem lives.  https://github.com/frappe/press/issues/703 
6. Show locals when migration fails.