### PR TITLE
fix(db_query): apply_fieldlevel_read_permissions

### DIFF
--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -199,14 +199,13 @@ def get_permitted_fields(
 	if doctype in core_doctypes_list:
 		return valid_columns
 
-	meta_fields = meta.default_fields.copy()
-	optional_meta_fields = [x for x in optional_fields if x in valid_columns]
+	if permitted_fields := meta.get_permitted_fieldnames(parenttype=parenttype, user=user):
+		meta_fields = meta.default_fields.copy()
+		optional_meta_fields = [x for x in optional_fields if x in valid_columns]
 
-	if meta.istable:
-		meta_fields.extend(child_table_fields)
+		if meta.istable:
+			meta_fields.extend(child_table_fields)
 
-	return (
-		meta_fields
-		+ meta.get_permitted_fieldnames(parenttype=parenttype, user=user)
-		+ optional_meta_fields
-	)
+		return meta_fields + permitted_fields + optional_meta_fields
+
+	return []

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -95,6 +95,7 @@ optional_fields = ("_user_tags", "_comments", "_assign", "_liked_by", "_seen")
 table_fields = ("Table", "Table MultiSelect")
 
 core_doctypes_list = (
+	"DefaultValue",
 	"DocType",
 	"DocField",
 	"DocPerm",

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -163,6 +163,7 @@ class DatabaseQuery:
 		self.run = run
 		self.strict = strict
 		self.ignore_ddl = ignore_ddl
+		self.parent_doctype = parent_doctype
 
 		# for contextual user permission check
 		# to determine which user permission is applicable on link field of specific doctype
@@ -577,7 +578,7 @@ class DatabaseQuery:
 			return
 
 		asterisk_fields = []
-		permitted_fields = get_permitted_fields(doctype=self.doctype)
+		permitted_fields = get_permitted_fields(doctype=self.doctype, parenttype=self.parent_doctype)
 
 		for i, field in enumerate(self.fields):
 			if "distinct" in field.lower():

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -583,8 +583,12 @@ class DatabaseQuery:
 			if "distinct" in field.lower():
 				# field: 'count(distinct `tabPhoto`.name) as total_count'
 				# column: 'tabPhoto.name'
-				self.distinct = True
-				column = field.split(" ", 2)[1].replace("`", "").replace(")", "")
+				if _fn := FN_PARAMS_PATTERN.findall(field):
+					column = _fn[0].replace("distinct ", "").replace("DISTINCT ", "").replace("`", "")
+				# field: 'distinct name'
+				# column: 'name'
+				else:
+					column = field.split(" ", 2)[1].replace("`", "")
 			else:
 				# field: 'count(`tabPhoto`.name) as total_count'
 				# column: 'tabPhoto.name'

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -589,7 +589,18 @@ class DatabaseQuery:
 			self.fields.pop(idx)
 
 	def apply_fieldlevel_read_permissions(self):
-		"""Apply fieldlevel read permissions to the query"""
+		"""Apply fieldlevel read permissions to the query
+
+		Note: Does not apply to `frappe.model.core_doctype_list`
+
+		Remove fields that user is not allowed to read. If `fields=["*"]` is passed, only permitted fields will
+		be returned.
+
+		Example:
+		        - User has read permission only on `title` for DocType `Note`
+		        - Query: fields=["*"]
+		        - Result: fields=["title", ...] // will also include Frappe's meta field like `name`, `owner`, etc.
+		"""
 		if self.flags.ignore_permissions:
 			return
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -539,6 +539,9 @@ class Meta(Document):
 		"""
 		permitted_fieldnames = []
 
+		if self.istable and not parenttype:
+			return permitted_fieldnames
+
 		if not self.get_permissions(parenttype=parenttype):
 			return self.get_fieldnames_with_value()
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -533,8 +533,15 @@ class Meta(Document):
 		return self.high_permlevel_fields
 
 	def get_permitted_fieldnames(self, parenttype=None, *, user=None):
-		"""Build list of `fieldname` with read perm level and all the higher perm levels defined."""
+		"""Build list of `fieldname` with read perm level and all the higher perm levels defined.
+
+		Note: If permissions are not defined for DocType, return all the fields with value.
+		"""
 		permitted_fieldnames = []
+
+		if not self.get_permissions(parenttype=parenttype):
+			return self.get_fieldnames_with_value()
+
 		permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
 
 		for df in self.get_fieldnames_with_value(with_field_meta=True, with_virtual_fields=True):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -534,15 +534,14 @@ class Meta(Document):
 
 	def get_permitted_fieldnames(self, parenttype=None, *, user=None):
 		"""Build list of `fieldname` with read perm level and all the higher perm levels defined."""
-		if not hasattr(self, "permitted_fieldnames"):
-			self.permitted_fieldnames = []
-			permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
+		permitted_fieldnames = []
+		permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
 
-			for df in self.get_fieldnames_with_value(with_field_meta=True, with_virtual_fields=True):
-				if df.permlevel in permlevel_access:
-					self.permitted_fieldnames.append(df.fieldname)
+		for df in self.get_fieldnames_with_value(with_field_meta=True, with_virtual_fields=True):
+			if df.permlevel in permlevel_access:
+				permitted_fieldnames.append(df.fieldname)
 
-		return self.permitted_fieldnames
+		return permitted_fieldnames
 
 	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
 		has_access_to = []

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -986,6 +986,46 @@ class TestDBQuery(FrappeTestCase):
 
 
 class TestReportView(FrappeTestCase):
+	def test_get_count(self):
+		frappe.local.request = frappe._dict()
+		frappe.local.request.method = "GET"
+
+		# test with data check field
+		frappe.local.form_dict = frappe._dict(
+			{
+				"doctype": "DocType",
+				"filters": [["DocType", "show_title_field_in_link", "=", 1]],
+				"fields": [],
+				"distinct": "false",
+			}
+		)
+		list_filter_response = execute_cmd("frappe.desk.reportview.get_count")
+		frappe.local.form_dict = frappe._dict(
+			{"doctype": "DocType", "filters": {"show_title_field_in_link": 1}, "distinct": "true"}
+		)
+		dict_filter_response = execute_cmd("frappe.desk.reportview.get_count")
+		self.assertIsInstance(list_filter_response, int)
+		self.assertEqual(list_filter_response, dict_filter_response)
+
+		# test with child table filter
+		frappe.local.form_dict = frappe._dict(
+			{
+				"doctype": "DocType",
+				"filters": [["DocField", "fieldtype", "=", "Data"]],
+				"fields": [],
+				"distinct": "true",
+			}
+		)
+		child_filter_response = execute_cmd("frappe.desk.reportview.get_count")
+		current_value = frappe.db.sql(
+			# the below query is equivalent to the one in reportview.get_count
+			"select distinct count(distinct `tabDocType`.name) as total_count"
+			" from `tabDocType` left join `tabDocField`"
+			" on (`tabDocField`.parenttype = 'DocType' and `tabDocField`.parent = `tabDocType`.name)"
+			" where `tabDocField`.`fieldtype` = 'Data'"
+		)[0][0]
+		self.assertEqual(child_filter_response, current_value)
+
 	def test_reportview_get(self):
 		user = frappe.get_doc("User", "test@example.com")
 		add_child_table_to_blog_post()

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -36,11 +36,10 @@ class TestModelUtils(FrappeTestCase):
 		todo_all_columns = frappe.get_meta("ToDo").get_valid_columns()
 		self.assertListEqual(todo_all_fields, todo_all_columns)
 
-		# Guest should have access to only default fields in ToDo
+		# Guest should have access to no fields in ToDo
 		with set_user("Guest"):
 			guest_permitted_fields = get_permitted_fields("ToDo")
-			self.assertSequenceSubset(todo_all_fields, guest_permitted_fields)
-			self.assertNotEqual(len(todo_all_fields), len(guest_permitted_fields))
+			self.assertEqual(guest_permitted_fields, [])
 
 		# everyone should have access to all fields of core doctypes
 		with set_user("Guest"):
@@ -58,6 +57,13 @@ class TestModelUtils(FrappeTestCase):
 			child_all_fields = frappe.get_meta("Installed Application").get_valid_columns()
 			self.assertLess(len(without_parent_fields), len(with_parent_fields))
 			self.assertSequenceEqual(set(with_parent_fields), set(child_all_fields))
+
+		# guest has access to no fields
+		with set_user("Guest"):
+			self.assertEqual(get_permitted_fields("Installed Application"), [])
+			self.assertEqual(
+				get_permitted_fields("Installed Application", parenttype="Installed Applications"), []
+			)
 
 
 @contextmanager

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -48,13 +48,14 @@ class TestModelUtils(FrappeTestCase):
 			picked_doctype_all_columns = frappe.get_meta(picked_doctype).get_valid_columns()
 			self.assertSequenceEqual(core_permitted_fields, picked_doctype_all_columns)
 
-		# access to child tables' fields is restricted to default fields unless parent is passed & permitted
+		# access to child tables' fields is restricted to no fields unless parent is passed & permitted
 		with set_user("Administrator"):
 			without_parent_fields = get_permitted_fields("Installed Application")
 			with_parent_fields = get_permitted_fields(
 				"Installed Application", parenttype="Installed Applications"
 			)
 			child_all_fields = frappe.get_meta("Installed Application").get_valid_columns()
+			self.assertEqual(without_parent_fields, [])
 			self.assertLess(len(without_parent_fields), len(with_parent_fields))
 			self.assertSequenceEqual(set(with_parent_fields), set(child_all_fields))
 

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -49,6 +49,16 @@ class TestModelUtils(FrappeTestCase):
 			picked_doctype_all_columns = frappe.get_meta(picked_doctype).get_valid_columns()
 			self.assertSequenceEqual(core_permitted_fields, picked_doctype_all_columns)
 
+		# access to child tables' fields is restricted to default fields unless parent is passed & permitted
+		with set_user("Administrator"):
+			without_parent_fields = get_permitted_fields("Installed Application")
+			with_parent_fields = get_permitted_fields(
+				"Installed Application", parenttype="Installed Applications"
+			)
+			child_all_fields = frappe.get_meta("Installed Application").get_valid_columns()
+			self.assertLess(len(without_parent_fields), len(with_parent_fields))
+			self.assertSequenceEqual(set(with_parent_fields), set(child_all_fields))
+
 
 @contextmanager
 def set_user(user: str):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -15,10 +15,7 @@ class TestSearch(FrappeTestCase):
 	def setUp(self):
 		if self._testMethodName == "test_link_field_order":
 			setup_test_link_field_order(self)
-
-	def tearDown(self):
-		if self._testMethodName == "test_link_field_order":
-			teardown_test_link_field_order(self)
+			self.addCleanup(teardown_test_link_field_order, self)
 
 	def test_search_field_sanitizer(self):
 		# pass
@@ -146,24 +143,28 @@ def setup_test_link_field_order(TestCase):
 	TestCase.parent_doctype_name = "All Territories"
 
 	# Create Tree doctype
-	TestCase.tree_doc = frappe.get_doc(
-		{
-			"doctype": "DocType",
-			"name": TestCase.tree_doctype_name,
-			"module": "Custom",
-			"custom": 1,
-			"is_tree": 1,
-			"autoname": "field:random",
-			"fields": [{"fieldname": "random", "label": "Random", "fieldtype": "Data"}],
-		}
-	).insert()
-	TestCase.tree_doc.search_fields = "parent_test_tree_order"
-	TestCase.tree_doc.save()
+	if not frappe.db.exists("DocType", TestCase.tree_doctype_name):
+		TestCase.tree_doc = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": TestCase.tree_doctype_name,
+				"module": "Custom",
+				"custom": 1,
+				"is_tree": 1,
+				"autoname": "field:random",
+				"fields": [{"fieldname": "random", "label": "Random", "fieldtype": "Data"}],
+			}
+		).insert()
+		TestCase.tree_doc.search_fields = "parent_test_tree_order"
+		TestCase.tree_doc.save()
+	else:
+		TestCase.tree_doc = frappe.get_doc("DocType", TestCase.tree_doctype_name)
 
 	# Create root for the tree doctype
-	frappe.get_doc(
-		{"doctype": TestCase.tree_doctype_name, "random": TestCase.parent_doctype_name, "is_group": 1}
-	).insert()
+	if not frappe.db.exists(TestCase.tree_doctype_name, {"random": TestCase.parent_doctype_name}):
+		frappe.get_doc(
+			{"doctype": TestCase.tree_doctype_name, "random": TestCase.parent_doctype_name, "is_group": 1}
+		).insert(ignore_if_duplicate=True)
 
 	# Create children for the root
 	for child_name in TestCase.child_doctypes_names:
@@ -173,7 +174,7 @@ def setup_test_link_field_order(TestCase):
 				"random": child_name,
 				"parent_test_tree_order": TestCase.parent_doctype_name,
 			}
-		).insert()
+		).insert(ignore_if_duplicate=True)
 		TestCase.child_doctype_list.append(temp)
 
 

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -3,6 +3,7 @@ import datetime
 import signal
 import unittest
 from contextlib import contextmanager
+from typing import Sequence
 
 import frappe
 from frappe.model.base_document import BaseDocument
@@ -38,6 +39,10 @@ class FrappeTestCase(unittest.TestCase):
 		cls.addClassCleanup(_rollback_db)
 
 		return super().setUpClass()
+
+	def assertSequenceSubset(self, larger: Sequence, smaller: Sequence, msg=None):
+		"""Assert that `expected` is a subset of `actual`."""
+		self.assertTrue(set(smaller).issubset(set(larger)), msg=msg)
 
 	# --- Frappe Framework specific assertions
 	def assertDocumentEqual(self, expected, actual):


### PR DESCRIPTION
Handle cases missed & bugs (caused by|in) #19533. Added more tests 

---

* Allow access to all fields in DocType if permissions are not defined
* Add DefaultValue to `frappe.model.core_doctypes_list`
* reportview's get_count API 

```python
12:10:14 web.1            |     self.apply_fieldlevel_read_permissions()
12:10:14 web.1            |   File "apps/frappe/frappe/model/db_query.py", line 629, in apply_fieldlevel_read_permissions
12:10:14 web.1            |     table, column = column.split(".", 1)
12:10:14 web.1            | ValueError: not enough values to unpack (expected 2, got 1)
```

* Pass parent_doctype to get_permitted_fields to fetch fields

> frappe.client.get_value("Logs To Clear", "days", {"ref_doctype": "Email Queue"}, parent="Log Settings")
> frappe.get_list("Material", fields="*", limit=1, parent_doctype="Cloth")

```python
Syntax error in query:
select 
			from `tabLogs To Clear`
			where `tabLogs To Clear`.`ref_doctype` = 'Email Queue'
			
			
			limit 1 offset 0 
---------------------------------------------------------------------------
...
File ~/Desktop/projects-bench/env/lib/python3.10/site-packages/pymysql/err.py:143, in raise_mysql_exception(data)
    141 if errorclass is None:
    142     errorclass = InternalError if errno < 1000 else OperationalError
--> 143 raise errorclass(errno, errval)

ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'from `tabLogs To Clear`\n\t\t\twhere `tabLogs To Clear`.`ref_doctype` = 'Email Qu...' at line 2")
```

* Return empty list if user doesn't have access at least to one field
* Remove faulty code that cached meta property without respecting user parameter
