### PR TITLE
fix(db_query): Allow selecting string literals

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -488,14 +488,18 @@ class DatabaseQuery:
 		"""If there are more than one table, the fieldname must not be ambiguous.
 		If the fieldname is not explicitly mentioned, set the default table"""
 
-		def _in_standard_sql_methods(field):
+		def _in_standard_sql_methods(field: str) -> bool:
 			methods = ("count(", "avg(", "sum(", "extract(", "dayofyear(")
 			return field.lower().startswith(methods)
 
 		if len(self.tables) > 1 or len(self.link_tables) > 0:
 			for idx, field in enumerate(self.fields):
-				if field is not None and "." not in field and not _in_standard_sql_methods(field):
-					self.fields[idx] = f"{self.tables[0]}.{field}"
+				if field is not None:
+					# don't add table name if str literal
+					if field[0] in {"'", '"'}:
+						continue
+					if "." not in field and not _in_standard_sql_methods(field):
+						self.fields[idx] = f"{self.tables[0]}.{field}"
 
 	def cast_name_fields(self):
 		for i, field in enumerate(self.fields):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -166,6 +166,11 @@ class TestReportview(FrappeTestCase):
 		self.assertIn("parent 1 child record 2", parent1_children)
 		self.assertEqual(results2[0].child_title, "parent 2 child record 1")
 
+	def test_allow_select_const(self):
+		hide_name = frappe.get_all("DocType", fields=["name", "'name' as `name`"])
+		self.assertEqual(hide_name[0].name, "name")
+		self.assertSetEqual({x.name for x in hide_name}, {"name"})
+
 	def test_link_field_syntax(self):
 		todo = frappe.get_doc(
 			doctype="ToDo", description="Test ToDo", allocated_to="Administrator"


### PR DESCRIPTION
#### Before

```python
queries = frappe.get_all(
       "Table",
       filters={"table": self.name},
       fields=["*", "name as field_to_override"],
)
for qry in queries:
       qry.doctype = 'Fake DocType Label'
```

#### After

```python
queries = frappe.get_all(
       "Table",
       filters={"table": self.name},
       fields=["*", "name as field_to_override", "'Fake DocType Label' as doctype"],
)
```