### PR TITLE
fix: show/hide tab content when we switch tab

### DIFF
--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -81,7 +81,7 @@ export default class Tab {
 
 	set_active() {
 		this.parent.find(".nav-link").tab("show");
-		this.wrapper.addClass("active");
+		this.wrapper.addClass("show");
 		this.frm?.set_active_tab?.(this);
 	}
 


### PR DESCRIPTION
While jumping to the field in a different tab the content (tab fields) is still visible and is at bottom of the page hence it scrolls to the bottom. Now the fields will only be visible after a tab is switched completely and the content of the previous tab is hidden.