### PR TITLE
feat: Optimize Table after clearing logs to reclaim space

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.json
+++ b/frappe/core/doctype/log_settings/log_settings.json
@@ -5,7 +5,9 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "logs_to_clear"
+  "logs_to_clear",
+  "miscellaneous_section",
+  "optimize_tables"
  ],
  "fields": [
   {
@@ -13,12 +15,24 @@
    "fieldtype": "Table",
    "label": "Logs to Clear",
    "options": "Logs To Clear"
+  },
+  {
+   "fieldname": "miscellaneous_section",
+   "fieldtype": "Section Break",
+   "label": "Miscellaneous"
+  },
+  {
+   "default": "0",
+   "description": "Databases usually do not reclaim space immediately after rows are deleted. Checking this will explicitly attempt to optimize tables every few days.",
+   "fieldname": "optimize_tables",
+   "fieldtype": "Check",
+   "label": "Optimize Tables After Clearing"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-06-11 02:17:30.803721",
+ "modified": "2023-02-03 22:37:05.536427",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Log Settings",

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -116,6 +116,23 @@ def run_log_clean_up():
 	doc.clear_logs()
 
 
+def optimize_log_tables():
+	if frappe.db.db_type != "mariadb":
+		return
+
+	doc = frappe.get_doc("Log Settings")
+	if not doc.get("optimize_tables"):
+		return
+
+	for entry in doc.logs_to_clear:
+		if not frappe.db.table_exists(entry.ref_doctype):
+			continue
+
+		table = f"`tab{entry.ref_doctype}`"
+		frappe.db.sql(f"ANALYZE TABLE {table}")
+		frappe.db.sql(f"OPTIMIZE TABLE {table}")
+
+
 @frappe.whitelist()
 def has_unseen_error_log():
 	if frappe.get_all("Error Log", filters={"seen": 0}, limit=1):

--- a/frappe/core/doctype/log_settings/test_log_settings.py
+++ b/frappe/core/doctype/log_settings/test_log_settings.py
@@ -4,7 +4,11 @@
 from datetime import datetime
 
 import frappe
-from frappe.core.doctype.log_settings.log_settings import _supports_log_clearing, run_log_clean_up
+from frappe.core.doctype.log_settings.log_settings import (
+	_supports_log_clearing,
+	optimize_log_tables,
+	run_log_clean_up,
+)
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now_datetime
 
@@ -72,6 +76,13 @@ class TestLogSettings(FrappeTestCase):
 		unsupported_types = ["DocType", "User", "Non Existing dt"]
 		for dt in unsupported_types:
 			self.assertFalse(_supports_log_clearing(dt), f"{dt} shouldn't be recognized as log type")
+
+	def test_optimize(self):
+		log_settings = frappe.get_doc("Log Settings")
+		log_settings.optimize_tables = True
+		log_settings.save()
+
+		optimize_log_tables()  # nothing to assert
 
 
 def setup_test_logs(past: datetime) -> None:

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -233,6 +233,7 @@ scheduler_events = {
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_weekly",
 		"frappe.integrations.doctype.s3_backup_settings.s3_backup_settings.take_backups_weekly",
 		"frappe.desk.form.document_follow.send_weekly_updates",
+		"frappe.core.doctype.log_settings.log_settings.optimize_log_tables",
 		"frappe.social.doctype.energy_point_log.energy_point_log.send_weekly_summary",
 		"frappe.integrations.doctype.google_drive.google_drive.weekly_backup",
 	],


### PR DESCRIPTION
Once a week run `analyze table` and `optimize table` on log setting doctypes.

Why? MariaDB (MySQL) doesn't immediately reclaim disk space so even if you delete old logs they will still consume some amount of space to be reused in future. `optimize` can reclaim some of that

requirements: `innodb_file_per_table` should be enabled. This is enabled on Frappe Cloud by default. ref: https://github.com/frappe/press/blob/eef3dacb76ea94a733225f08990eedf750cc120c/press/playbooks/roles/mariadb/templates/mariadb.cnf#L43

pro: *some* disk space can be reclaimed.
con: expensive operation.

Tip: Enable it and try it directly once by using `Execute Job` if it doesn't help then disable it back.

On some tables I was able to recover up to 10-20% of storage space while in one case it added 10%. MariaDB works in mysterious ways :shrug: 



`no-docs`
