### PR TITLE
fix: only run migrations for apps present on the bench

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1386,7 +1386,7 @@ def get_installed_apps(sort=False, frappe_last=False, *, _ensure_on_bench=False)
 
 	:param sort: [DEPRECATED] Sort installed apps based on the sequence in sites/apps.txt
 	:param frappe_last: [DEPRECATED] Keep frappe last. Do not use this, reverse the app list instead.
-	:param ensure_on_bench: Only return apps that are present on bench.
+	:param _ensure_on_bench: Only return apps that are present on bench.
 	"""
 	from frappe.utils.deprecations import deprecation_warning
 

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -100,7 +100,7 @@ class SiteMigration:
 	@atomic
 	def pre_schema_updates(self):
 		"""Executes `before_migrate` hooks"""
-		for app in frappe.get_installed_apps():
+		for app in frappe.get_installed_apps(_ensure_on_bench=True):
 			for fn in frappe.get_hooks("before_migrate", app_name=app):
 				frappe.get_attr(fn)()
 
@@ -139,7 +139,7 @@ class SiteMigration:
 		frappe.get_single("Portal Settings").sync_menu()
 		frappe.get_single("Installed Applications").update_versions()
 
-		for app in frappe.get_installed_apps():
+		for app in frappe.get_installed_apps(_ensure_on_bench=True):
 			for fn in frappe.get_hooks("after_migrate", app_name=app):
 				frappe.get_attr(fn)()
 

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -86,7 +86,7 @@ def get_all_patches(patch_type: PatchType | None = None) -> list[str]:
 		frappe.throw(f"Unsupported patch type specified: {patch_type}")
 
 	patches = []
-	for app in frappe.get_installed_apps():
+	for app in frappe.get_installed_apps(_ensure_on_bench=True):
 		patches.extend(get_patches_from_app(app, patch_type=patch_type))
 
 	return patches

--- a/frappe/search/website_search.py
+++ b/frappe/search/website_search.py
@@ -114,10 +114,8 @@ def slugs_with_web_view(_items_to_index):
 def get_static_pages_from_all_apps():
 	from glob import glob
 
-	apps = frappe.get_installed_apps()
-
 	routes_to_index = []
-	for app in apps:
+	for app in frappe.get_installed_apps(_ensure_on_bench=True):
 		path_to_index = frappe.get_app_path(app, "www")
 
 		files_to_index = glob(path_to_index + "/**/*.html", recursive=True)

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -12,7 +12,7 @@ def sync_fixtures(app=None):
 	if app:
 		apps = [app]
 	else:
-		apps = frappe.get_installed_apps()
+		apps = frappe.get_installed_apps(_ensure_on_bench=True)
 
 	frappe.flags.in_fixtures = True
 


### PR DESCRIPTION
Trying to migrate a restored v13 database on a v14 bench. On v13, it had an app installed that has been renamed for v14+ (erpnext_datev_uo -> erpnext_datev). The migration failed with errors like the one below:

<details>

<summary>Log</summary>

```
bench migrate                                           
Migrating erpnext14
Could not find app "erpnext_datev_uo": 
No module named 'erpnext_datev_uo'
Building search index for erpnext14

Traceback with variables (most recent call last):
  File "/usr/local/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
      mod_name = 'frappe.utils.bench_helper'
      alter_argv = True
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10188b190>, origin='version-14/apps/frappe/frappe/utils/bench_helper.py')
      code = <code object <module> at 0x105b90710, file "version-14/apps/frappe/frappe/utils/bench_helper.py", line 1>
      main_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x10188b190>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10188b190>, origin='version-14/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': 'version-14/apps/frappe/frappe/utils/bench_helper.py', '__cached__': 'version-14/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc', 'importlib': <module 'importlib' from '/usr/local/python3.10/importlib/__init__.py'>, 'json': <module 'json' from '/usr/local/python3.10/json/__init__.py'>, 'os': <module 'os' from '/usr/local/C...
  File "/usr/local/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
      code = <code object <module> at 0x105b90710, file "version-14/apps/frappe/frappe/utils/bench_helper.py", line 1>
      run_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x10188b190>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10188b190>, origin='version-14/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': 'version-14/apps/frappe/frappe/utils/bench_helper.py', '__cached__': 'version-14/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc', 'importlib': <module 'importlib' from '/usr/local/python3.10/importlib/__init__.py'>, 'json': <module 'json' from '/usr/local/python3.10/json/__init__.py'>, 'os': <module 'os' from '/usr/local/C...
      init_globals = None
      mod_name = '__main__'
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10188b190>, origin='version-14/apps/frappe/frappe/utils/bench_helper.py')
      pkg_name = 'frappe.utils'
      script_name = None
      loader = <_frozen_importlib_external.SourceFileLoader object at 0x10188b190>
      fname = 'version-14/apps/frappe/frappe/utils/bench_helper.py'
      cached = 'version-14/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc'
  File "version-14/apps/frappe/frappe/utils/bench_helper.py", line 109, in <module>
    main()
      ...skipped... 25 vars
  File "version-14/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name="bench")
      commands = {'frappe': <Group frappe>, 'get-frappe-commands': <Command get-frappe-commands>, 'get-frappe-help': <Command get-frappe-help>}
  File "version-14/env/lib/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
      self = <Group None>
      args = ()
      kwargs = {'prog_name': 'bench'}
  File "version-14/env/lib/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
      self = <Group None>
      args = ['frappe', 'migrate']
      prog_name = 'bench'
      complete_var = None
      standalone_mode = True
      extra = {}
      ctx = <click.core.Context object at 0x1033b06d0>
  File "version-14/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x105b94160>
      args = ['migrate']
      cmd_name = 'frappe'
      cmd = <Group frappe>
      sub_ctx = <click.core.Context object at 0x105b79cc0>
      ctx = <click.core.Context object at 0x1033b06d0>
      self = <Group None>
  File "version-14/env/lib/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x105c39e10>
      args = []
      cmd_name = 'migrate'
      cmd = <Command migrate>
      sub_ctx = <click.core.Context object at 0x105c2f4f0>
      ctx = <click.core.Context object at 0x105b79cc0>
      self = <Group frappe>
  File "version-14/env/lib/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
      self = <Command migrate>
      ctx = <click.core.Context object at 0x105c2f4f0>
  File "version-14/env/lib/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      self = <click.core.Context object at 0x105c2f4f0>
      callback = <function migrate at 0x105bde680>
      ctx = <click.core.Context object at 0x105c2f4f0>
  File "version-14/env/lib/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      f = <function migrate at 0x105bde440>
  File "version-14/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
      ctx = <click.core.Context object at 0x105c2f4f0>
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      profile = False
      f = <function migrate at 0x105bde3b0>
  File "version-14/apps/frappe/frappe/commands/site.py", line 554, in migrate
    SiteMigration(
      context = {'sites': ['erpnext14'], 'force': False, 'verbose': False, 'profile': False}
      skip_failing = False
      skip_search_index = False
      activate_by_import = <module 'traceback_with_variables.activate_by_import' from 'version-14/env/lib/python3.10/site-packages/traceback_with_variables/activate_by_import.py'>
      SiteMigration = <class 'frappe.migrate.SiteMigration'>
      site = 'erpnext14'
  File "version-14/apps/frappe/frappe/migrate.py", line 178, in run
    self.tearDown()
      self = <frappe.migrate.SiteMigration object at 0x105c2f7f0>
      site = 'erpnext14'
  File "version-14/apps/frappe/frappe/migrate.py", line 94, in tearDown
    build_index_for_all_routes()
      self = <frappe.migrate.SiteMigration object at 0x105c2f7f0>
      f = <_io.TextIOWrapper name='./erpnext14/touched_tables.json' mode='w' encoding='UTF-8'>
  File "version-14/apps/frappe/frappe/search/website_search.py", line 145, in build_index_for_all_routes
    return ws.build()
      ws = <frappe.search.website_search.WebsiteSearch object at 0x108dfb640>
  File "version-14/apps/frappe/frappe/search/full_text_search.py", line 41, in build
    self.documents = self.get_items_to_index()
      self = <frappe.search.website_search.WebsiteSearch object at 0x108dfb640>
  File "version-14/apps/frappe/frappe/search/website_search.py", line 42, in get_items_to_index
    routes = get_static_pages_from_all_apps() + slugs_with_web_view(self._items_to_index)
      self = <frappe.search.website_search.WebsiteSearch object at 0x108dfb640>
  File "version-14/apps/frappe/frappe/search/website_search.py", line 121, in get_static_pages_from_all_apps
    path_to_index = frappe.get_app_path(app, "www")
      glob = <function glob at 0x102f9c700>
      apps = ['frappe', 'erpnext', 'erpnext_datev_uo']
      routes_to_index = ['message', 'qrcode', 'printview', 'me', 'unsubscribe', 'about', 'contact', 'modified_doc_alert', 'list', 'third_party_apps', '404', 'login', 'update-password', 'printpreview', 'complete_signup', 'search', 'app', 'confirm_workflow_action', 'error', '_test/_test_safe_render_on', '_test/_test_custom_base', '_test/_test_metatags', '_test/', '_test/problematic_page', '_test/_test_no_context', '_test/_test_safe_render_off', '_test/_test_folder/_test_page', '_test/_test_folder/new', '_test/_test_folder/', '_test/_test_folder/_test_toc', 'payment_setup_certification', 'book_appointment/', 'book_appointment/verify/', 'shop-by-category/', 'shop-by-category/category_card_section', 'support/', 'all-products/', 'all-products/not_found']
      app = 'erpnext_datev_uo'
      path_to_index = 'version-14/apps/sipgate/sipgate/www'
      files_to_index = []
      file = 'version-14/apps/erpnext/erpnext/www/all-products/not_found.html'
      route = 'all-products/not_found'
  File "version-14/apps/frappe/frappe/__init__.py", line 1356, in get_app_path
    return get_pymodule_path(app_name, *joins)
      app_name = 'erpnext_datev_uo'
      joins = ('www',)
  File "version-14/apps/frappe/frappe/__init__.py", line 1373, in get_pymodule_path
    return os.path.join(os.path.dirname(get_module(scrub(modulename)).__file__ or ""), *joins)
      modulename = 'erpnext_datev_uo'
      joins = ['www']
  File "version-14/apps/frappe/frappe/__init__.py", line 1327, in get_module
    return importlib.import_module(modulename)
      modulename = 'erpnext_datev_uo'
  File "/usr/local/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
      name = 'erpnext_datev_uo'
      package = None
      level = 0
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
      name = 'erpnext_datev_uo'
      package = None
      level = 0
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
      name = 'erpnext_datev_uo'
      import_ = <function _gcd_import at 0x1016ab400>
      module = <object object at 0x1016d0060>
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
      name = 'erpnext_datev_uo'
      import_ = <function _gcd_import at 0x1016ab400>
      path = None
      parent = ''
      spec = None
builtins.ModuleNotFoundError: No module named 'erpnext_datev_uo'
```

</details>

Apparently it tried to migrate files that were no longer there. Setting the `_ensure_on_bench` parameter in these places resolved the problem.