### PR TITLE
feat: wkhtmltopdf logging

### DIFF
--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -1,6 +1,8 @@
 # imports - standard imports
 import logging
 import os
+import sys
+from contextlib import contextmanager
 from copy import deepcopy
 from logging.handlers import RotatingFileHandler
 from typing import Literal
@@ -123,3 +125,29 @@ def sanitized_dict(form_dict):
 			if secret_kw in k:
 				sanitized_dict[k] = "********"
 	return sanitized_dict
+
+
+@contextmanager
+def pipe_to_log(logger_fn=None, stream=None):
+	"Pass an existing logger function e.g. logger.info. Stream defaults to stdout"
+	# late bind source
+	if stream is None:
+		stream = sys.stdout
+
+	stream_int = stream.fileno()
+	r_int, w_int = os.pipe()
+
+	# copy stream_fd before it is overwritten
+	with os.fdopen(os.dup(stream_int), "wb") as copied:
+		stream.flush()
+		os.dup2(w_int, stream_int)  # $ exec >&pipe
+		try:
+			with os.fdopen(w_int, "wb"):
+				yield stream
+		finally:
+			# restore stream to its previous value
+			stream.flush()
+			os.dup2(copied.fileno(), stream_int)  # $ exec >&copied
+			with os.fdopen(r_int, newline="") as r:
+				text = r.read()
+			logger_fn(text)

--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -128,7 +128,7 @@ def sanitized_dict(form_dict):
 
 
 @contextmanager
-def pipe_to_log(logger_fn=None, stream=None):
+def pipe_to_log(logger_fn, stream=None):
 	"Pass an existing logger function e.g. logger.info. Stream defaults to stdout"
 	# late bind source
 	if stream is None:

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -14,6 +14,7 @@ import frappe
 from frappe import _
 from frappe.utils import scrub_urls
 from frappe.utils.jinja_globals import bundled_asset, is_rtl
+from frappe.utils.logger import pipe_to_log
 
 PDF_CONTENT_ERRORS = [
 	"ContentNotFoundError",
@@ -21,6 +22,9 @@ PDF_CONTENT_ERRORS = [
 	"UnknownContentError",
 	"RemoteHostClosedError",
 ]
+
+logger = frappe.logger("wkhtmltopdf", max_size=100000, file_count=3)
+logger.setLevel("INFO")
 
 
 def pdf_header_html(soup, head, content, styles, html_id, css):
@@ -59,8 +63,13 @@ def get_pdf(html, options=None, output: PdfWriter | None = None):
 		options.update({"disable-smart-shrinking": ""})
 
 	try:
+		# wkhtmltopdf writes the pdf to stdout and errors to stderr
+		# pdfkit v1.0.0 writes the pdf to file or returns it
+		# stderr is written to sys.stdout if verbose=True is supplied
 		# Set filename property to false, so no file is actually created
-		filedata = pdfkit.from_string(html, options=options or {}, verbose=True)
+		# defaults to redirecting stdout
+		with pipe_to_log(logger.info):
+			filedata = pdfkit.from_string(html, False, options=options or {}, verbose=True)
 
 		# create in-memory binary streams from filedata and create a PdfReader object
 		reader = PdfReader(io.BytesIO(filedata))
@@ -118,7 +127,6 @@ def prepare_options(html, options):
 			"print-media-type": None,
 			"background": None,
 			"images": None,
-			"quiet": None,
 			# 'no-outline': None,
 			"encoding": "UTF-8",
 			# 'load-error-handling': 'ignore'


### PR DESCRIPTION
PDF logging to pick up problems:

> 2022-12-05 08:17:06,942 INFO wkhtmltopdf Loading pages (1/6)
> Warning: Failed to load http://testing/assets/css/printview.css (ignore)
> Warning: Failed to load http://testing/assets/css/printview.css (ignore)
> Counting pages (2/6)                                               
> Resolving links (4/6)                                                       
> Loading headers and footers (5/6)                                           
> Warning: Failed to load http://testing/assets/css/printview.css (%
> ignore)
> Printing pages (6/6)                                               
> Done                                                                      
> 
> Loading pages (1/6)
> Warning: Failed to load http://localhost/assets/frappe/bg.jpg (ignore)
> Warning: Failed to load http://localhost/assets/frappe/test.jpg (ignore)
> Counting pages (2/6)                                               
> Resolving links (4/6)                                                       
> Loading headers and footers (5/6)                                           
> Printing pages (6/6)
> Done
> 

no-docs
version-14-hotfix