### PR TITLE
feat: use Etc/UTC as system timezone for new sites

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.js
+++ b/frappe/core/doctype/system_settings/system_settings.js
@@ -3,10 +3,7 @@ frappe.ui.form.on("System Settings", {
 		frappe.call({
 			method: "frappe.core.doctype.system_settings.system_settings.load",
 			callback: function (data) {
-				frappe.all_timezones = data.message.timezones;
-				frm.set_df_property("time_zone", "options", frappe.all_timezones);
-
-				$.each(data.message.defaults, function (key, val) {
+				$.each(data.message, function (key, val) {
 					frm.set_value(key, val, null, true);
 					frappe.sys_defaults[key] = val;
 				});

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -100,11 +100,12 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "Etc/UTC",
    "fieldname": "time_zone",
    "fieldtype": "Select",
    "label": "Time Zone",
-   "read_only": 1,
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "default": "0",
@@ -525,7 +526,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2022-12-20 21:45:37.651668",
+ "modified": "2023-02-05 19:40:35.044872",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -8,7 +8,6 @@ from frappe.model.document import Document
 from frappe.translate import set_default_language
 from frappe.twofactor import toggle_two_factor_auth
 from frappe.utils import cint, today
-from frappe.utils.momentjs import get_all_timezones
 
 
 class SystemSettings(Document):
@@ -92,14 +91,11 @@ def update_last_reset_password_date():
 
 @frappe.whitelist()
 def load():
-	if not "System Manager" in frappe.get_roles():
-		frappe.throw(_("Not permitted"), frappe.PermissionError)
+	frappe.only_for("System Manager")
 
 	all_defaults = frappe.db.get_defaults()
-	defaults = {}
-
-	for df in frappe.get_meta("System Settings").get("fields"):
-		if df.fieldtype in ("Select", "Data"):
-			defaults[df.fieldname] = all_defaults.get(df.fieldname)
-
-	return {"timezones": get_all_timezones(), "defaults": defaults}
+	return {
+		df.fieldname: all_defaults.get(df.fieldname)
+		for df in frappe.get_meta("System Settings").get("fields")
+		if df.fieldtype in ("Select", "Data")
+	}

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -163,7 +163,6 @@ def update_system_settings(args):
 		{
 			"country": args.get("country"),
 			"language": get_language_code(args.get("language")) or "en",
-			"time_zone": args.get("timezone"),
 			"float_precision": 3,
 			"date_format": frappe.db.get_value("Country", args.get("country"), "date_format"),
 			"time_format": frappe.db.get_value("Country", args.get("country"), "time_format"),

--- a/frappe/geo/country_info.py
+++ b/frappe/geo/country_info.py
@@ -2,10 +2,8 @@
 # License: MIT. See LICENSE
 
 import json
-
-# all country info
 import os
-from functools import lru_cache
+from pathlib import Path
 
 import frappe
 from frappe.utils.momentjs import get_all_timezones
@@ -22,20 +20,10 @@ def get_country_info(country=None):
 	return data
 
 
-def get_all():
-	with open(os.path.join(os.path.dirname(__file__), "country_info.json")) as local_info:
-		all_data = json.loads(local_info.read())
-	return all_data
-
-
 @frappe.whitelist(allow_guest=True)
-def get_country_timezone_info():
-	return _get_country_timezone_info()
-
-
-@lru_cache(maxsize=2)
-def _get_country_timezone_info():
-	return {"country_info": get_all(), "all_timezones": get_all_timezones()}
+def get_all():
+	with open(Path(__file__).parent / "country_info.json") as country_info:
+		return json.load(country_info)
 
 
 def get_translated_dict():

--- a/frappe/public/js/frappe/form/controls/phone.js
+++ b/frappe/public/js/frappe/form/controls/phone.js
@@ -15,8 +15,7 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 		if (data) {
 			this.country_codes = data;
 		} else {
-			const data = await frappe.xcall("frappe.geo.country_info.get_country_timezone_info");
-			this.country_codes = data?.country_info;
+			this.country_codes = await frappe.xcall("frappe.geo.country_info.get_all");
 			localforage.setItem(key, this.country_codes);
 		}
 	}

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -318,7 +318,7 @@ def get_eta(from_time, percent_complete):
 
 
 def _get_time_zone():
-	return frappe.db.get_system_setting("time_zone") or "Asia/Kolkata"  # Default to India ?!
+	return frappe.db.get_system_setting("time_zone") or "Etc/UTC"
 
 
 def get_time_zone():

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -9,6 +9,7 @@ from frappe import _
 from frappe.core.utils import find
 from frappe.model.document import Document
 from frappe.utils import get_datetime, get_fullname, time_diff_in_hours
+from frappe.utils.data import add_days, now_datetime
 from frappe.utils.user import get_system_managers
 from frappe.utils.verified_command import get_signed_params, verify_request
 
@@ -352,11 +353,12 @@ def process_data_deletion_request():
 
 
 def remove_unverified_record():
-	frappe.db.sql(
-		"""
-		DELETE FROM `tabPersonal Data Deletion Request`
-		WHERE `status` = 'Pending Verification'
-		AND `creation` < (NOW() - INTERVAL '7' DAY)"""
+	frappe.db.delete(
+		"Personal Data Deletion Request",
+		{
+			"status": "Pending Verification",
+			"creation": ("<", add_days(now_datetime(), -7)),
+		},
 	)
 
 


### PR DESCRIPTION
- New sites get `"Etc/UTC"` set as timezone in **System Settings**
    - Because this is constant now, it is no longer needed in the Setup Wizard
- If no timezone is set in **System Settings**, `frappe.utils.data.get_time_zone` returns `"Etc/UTC"` instead of `"Asia/Kolkata"`. (This applies to code that runs before **System Settings** exist.)
- Existing sites continue to use their prior timezone from **System Settings**

Todo:

- [ ] allow setting a different timezone for scheduler events (for example, backups should run at midnight of the timezone where the most users are)

Resolves #17524