### PR TITLE
fix: ignore permission for marking Note as seen

### DIFF
--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -30,7 +30,7 @@ def mark_as_seen(note):
 	note = frappe.get_doc("Note", note)
 	if frappe.session.user not in [d.user for d in note.seen_by]:
 		note.append("seen_by", {"user": frappe.session.user})
-		note.save(ignore_version=True)
+		note.save(ignore_version=True, ignore_permissions=True)
 
 
 def get_permission_query_conditions(user):


### PR DESCRIPTION
This way, the access to **Notes** can be restricted via Roles and Permissions, without interfering with the "Notification" feature.