### PR TITLE
fix: event date exception

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -363,7 +363,7 @@ def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[
 				# last day of month issue, start from prev month!
 				try:
 					getdate(date)
-				except ValueError:
+				except Exception:
 					date = date.split("-")
 					date = date[0] + "-" + str(cint(date[1]) - 1) + "-" + date[2]
 


### PR DESCRIPTION
## Issue

<img width="1399" alt="Screenshot 2023-02-08 at 11 58 24 AM" src="https://user-images.githubusercontent.com/31363128/217451778-44335f11-6c95-49b5-b08e-515a6af54658.png">

A user created an event that started on 30-04-2022 and was monthly. Till now the event notification was triggering just fine every month. In February the scheduled job started failing. Because the notification trigger date now becomes 30-02-2023 which is not a valid date.

There is an exception in the code to handle this scenario, but the exception was not getting executed. The exception type was set as ValueError. The issue was causing a ValueError but in turn, was also throwing ValidationError. So the logic in exception did not execute.

```
Traceback (most recent call last):
  File "/Users/jannatpatel/Documents/frappe-bench/env/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 649, in parse
    ret = self._build_naive(res, default)
  File "/Users/jannatpatel/Documents/frappe-bench/env/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 1235, in _build_naive
    naive = default.replace(**repl)
ValueError: day is out of range for month

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/utils/data.py", line 97, in getdate
    return parser.parse(string_date, dayfirst=parse_day_first).date()
  File "/Users/jannatpatel/Documents/frappe-bench/env/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 1368, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/Users/jannatpatel/Documents/frappe-bench/env/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 651, in parse
    six.raise_from(ParserError(str(e) + ": %s", timestr), e)
  File "<string>", line 3, in raise_from
dateutil.parser._parser.ParserError: day is out of range for month: 2023-02-30

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/commands/utils.py", line 262, in execute
    ret = frappe.get_attr(method)(*args, **kwargs)
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/desk/doctype/event/event.py", line 210, in send_event_digest
    events = get_events(today, today, user.name, for_reminder=True)
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/desk/doctype/event/event.py", line 365, in get_events
    getdate(date)
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/utils/data.py", line 99, in getdate
    frappe.throw(
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/__init__.py", line 523, in throw
    msgprint(
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/__init__.py", line 491, in msgprint
    _raise_exception()
  File "/Users/jannatpatel/Documents/frappe-bench/apps/frappe/frappe/__init__.py", line 440, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: 2023-02-30 is not a valid date string.
```
