### PR TITLE
fix(Database): frappe.db.get_value/count not escaping filter values

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -819,7 +819,7 @@ class Database:
 		if fields == "*" and not isinstance(fields, (list, tuple)) and not isinstance(fields, Criterion):
 			as_dict = True
 
-		return self.sql(query, as_dict=as_dict, debug=debug, update=update, run=run, pluck=pluck)
+		return query.run(as_dict=as_dict, debug=debug, update=update, run=run, pluck=pluck)
 
 	def _get_value_for_many_names(
 		self,
@@ -1101,7 +1101,7 @@ class Database:
 		query = frappe.qb.engine.get_query(
 			table=dt, filters=filters, fields=Count("*"), distinct=distinct
 		)
-		count = self.sql(query, debug=debug)[0][0]
+		count = query.run(debug=debug)[0][0]
 		if not filters and cache:
 			frappe.cache().set_value(f"doctype:count:{dt}", count, expires_in_sec=86400)
 		return count


### PR DESCRIPTION
### Example Problem:
```
name = "Test Name \\"  # backslash is supposed to be escaped/sanitized
frappe.db.get_value("Customer", name)
```

will give an error

```
ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''Test\\' ORDER BY `modified` DESC LIMIT 1' at line 1")
```

because backslash `\` or any filter value is not being parsed and escaped/sanitized by `frappe.db.get_value` and `frappe.db.count`

### Root Problem:
Passing a QueryBuilder object in `frappe.db.sql` does not `walk` / `prepare_query` before running it!

Example:

```
c = frappe.qb.DocType("Customer")
query = frappe.qb.from_(c).select(c.name).where(c.name == "Test\\")
frappe.db.sql(query)  # ERROR because not sanitized!
```

### Hotfix Solution
Replace `frappe.db.sql(QueryBuilder)` with `QueryBuilder.run()` in `frappe.db.get_value` and `frappe.db.count`

### Observation
`develop` does not have this issue, only `version-14` has it