### PR TITLE
fix(cli): trim-tables, new-site

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -44,7 +44,7 @@ from frappe.exceptions import SiteNotSpecifiedError
 @click.option(
 	"--force", help="Force restore if site/database already exists", is_flag=True, default=False
 )
-@click.option("--source_sql", help="Initiate database with a SQL file")
+@click.option("--source-sql", "--source_sql", help="Initiate database with a SQL file")
 @click.option("--install-app", multiple=True, help="Install app after installation")
 @click.option(
 	"--set-default", is_flag=True, default=False, help="Set the new site as default site"
@@ -67,9 +67,12 @@ def new_site(
 	set_default=False,
 ):
 	"Create a new site"
-	from frappe.installer import _new_site
+	from frappe.installer import _new_site, extract_sql_from_archive
 
 	frappe.init(site=site, new_site=True)
+
+	if source_sql:
+		source_sql = extract_sql_from_archive(source_sql)
 
 	_new_site(
 		db_name,

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -772,7 +772,7 @@ def trim_tables(doctype=None, dry_run=False, quiet=False):
 	delete the db field.
 	"""
 	UPDATED_TABLES = {}
-	filters = {"issingle": 0}
+	filters = {"issingle": 0, "is_virtual": 0}
 	if doctype:
 		filters["name"] = doctype
 


### PR DESCRIPTION
### Changes

* Add `--source-sql` as alias of `--source_sql` for consistency [new-site]
* Allow compressed `.sql.gz` files for --source-sql option [new-site]
* Skip trimming check for virtual doctypes [trim-tables]