### PR TITLE
fix: login before check should be inclusive

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -307,7 +307,7 @@ class LoginManager:
 
 		current_hour = int(now_datetime().strftime("%H"))
 
-		if login_before and current_hour > login_before:
+		if login_before and current_hour >= login_before:
 			frappe.throw(_("Login not allowed at this time"), frappe.AuthenticationError)
 
 		if login_after and current_hour < login_after:


### PR DESCRIPTION
e.g. if login_before hour is 6 and it's 6:30 then it should be blocked.

related :) - https://fhur.me/posts/always-use-closed-open-intervals

