### PR TITLE
fix: String formatting index in error message

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -207,7 +207,7 @@ class FormMeta(Meta):
 
 		if df.get("is_custom_field"):
 			custom_field_link = get_link_to_form("Custom Field", df.name)
-			msg += " " + _("Please delete the field from {2} or add the required doctype.").format(
+			msg += " " + _("Please delete the field from {0} or add the required doctype.").format(
 				custom_field_link
 			)
 


### PR DESCRIPTION
Introduced in https://github.com/frappe/frappe/pull/19744

Fixes the below issue while showing missing fields validation in Doctypes

<img width="1369" alt="image" src="https://user-images.githubusercontent.com/42651287/218147912-4b27b37d-10b4-40dc-8a65-3bc585b7bbd7.png">
