### PR TITLE
fix: set is_system_generated for exported custom fields & property setters

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -13,6 +13,10 @@ from frappe.utils import cstr, random_string
 
 
 class CustomField(Document):
+	def before_import(self):
+		if frappe.flags.in_fixtures:
+			self.is_system_generated = 1
+
 	def autoname(self):
 		self.set_fieldname()
 		self.name = self.dt + "-" + self.fieldname

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -9,6 +9,10 @@ not_allowed_fieldtype_change = ["naming_series"]
 
 
 class PropertySetter(Document):
+	def before_import(self):
+		if frappe.flags.in_fixtures:
+			self.is_system_generated = 1
+
 	def autoname(self):
 		self.name = "{doctype}-{field}-{property}".format(
 			doctype=self.doc_type, field=self.field_name or self.row_name or "main", property=self.property

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -133,6 +133,7 @@ def sync_customizations_for_doctype(data: dict, folder: str):
 				if data.get(doctype_fieldname) == doc_type:
 					data["doctype"] = custom_doctype
 					doc = frappe.get_doc(data)
+					doc.is_system_generated = 1
 					doc.db_insert()
 
 			if custom_doctype != "Custom Field":
@@ -150,6 +151,7 @@ def sync_customizations_for_doctype(data: dict, folder: str):
 					else:
 						custom_field = frappe.get_doc("Custom Field", field)
 						custom_field.flags.ignore_validate = True
+						custom_field.is_system_generated = 1
 						custom_field.update(d)
 						custom_field.db_update()
 


### PR DESCRIPTION
This pr sets the is_system_generated check for custom fields/property setters which were exported as fixtures/customizations

TODO:
- [ ] tests?
- [x] should only happen for customizations and fixtures 


this should not happen with `Packages` as they're for copying customizations from one site to another rather than exporting them to an app.