### PR TITLE
fix: Maintain listview checks after bulk update

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -908,7 +908,7 @@ def run_ui_tests(
 
 	os.chdir(app_base_path)
 
-	node_bin = subprocess.getoutput("npm bin")
+	node_bin = subprocess.getoutput("yarn bin")
 	cypress_path = f"{node_bin}/cypress"
 	drag_drop_plugin_path = f"{node_bin}/../@4tw/cypress-drag-drop"
 	real_events_plugin_path = f"{node_bin}/../cypress-real-events"

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1832,7 +1832,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					this.disable_list_update = true;
 					bulk_operations.edit(this.get_checked_items(true), field_mappings, () => {
 						this.disable_list_update = false;
-						this.clear_checked_items();
 						this.refresh();
 					});
 				},


### PR DESCRIPTION
Seems like the maintaining checkbox behaviour hasn't been a thing for some time.  Came across this when `Keep checkbox checked after Refresh` test was failing for https://github.com/frappe/frappe/pull/19895 which begged the question of why the test wasn't failing on v14 and develop.

#### Before

[Before Fix.webm](https://user-images.githubusercontent.com/36654812/218407710-bd25e658-2d50-42d7-baaa-583f81fb658a.webm)

#### After

[After Fix.webm](https://user-images.githubusercontent.com/36654812/218408978-16928c87-6d49-4db0-b718-1b69abdd289a.webm)
