### PR TITLE
fix: Migrate color fields to color doctype

### DIFF
--- a/frappe/patches/v13_0/generate_theme_files_in_public_folder.py
+++ b/frappe/patches/v13_0/generate_theme_files_in_public_folder.py
@@ -12,7 +12,6 @@ def execute():
 	for theme in themes:
 		doc = frappe.get_doc("Website Theme", theme.name)
 		try:
-			doc.generate_bootstrap_theme()
 			doc.save()
 		except Exception:
 			print("Ignoring....")

--- a/frappe/patches/v13_0/website_theme_custom_scss.py
+++ b/frappe/patches/v13_0/website_theme_custom_scss.py
@@ -8,21 +8,31 @@ def execute():
 
 	for theme in frappe.get_all("Website Theme"):
 		doc = frappe.get_doc("Website Theme", theme.name)
+		setup_color_record(doc)
 		if not doc.get("custom_scss") and doc.theme_scss:
 			# move old theme to new theme
 			doc.custom_scss = doc.theme_scss
-
-			if doc.background_color:
-				setup_color_record(doc.background_color)
-
 			doc.save()
 
 
-def setup_color_record(color):
-	frappe.get_doc(
-		{
-			"doctype": "Color",
-			"__newname": color,
-			"color": color,
-		}
-	).save()
+def setup_color_record(doc):
+	color_fields = [
+		"primary_color",
+		"text_color",
+		"light_color",
+		"dark_color",
+		"background_color",
+	]
+
+	for color_field in color_fields:
+		color_code = doc.get(color_field)
+		if not color_code or frappe.db.exists("Color", color_code):
+			continue
+
+		frappe.get_doc(
+			{
+				"doctype": "Color",
+				"__newname": color_code,
+				"color": color_code,
+			}
+		).insert()


### PR DESCRIPTION
fieldtype was changed from `Color` to `Link` with no patches here https://github.com/frappe/frappe/commit/e323441c1538b5e9bcfa964acefbd5d14524c462 which causes migration failures. 



```
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 110, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 31, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 433, in migrate
    migrate(context.verbose, skip_failing=skip_failing, skip_search_index=skip_search_index)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 91, in migrate
    frappe.get_attr(fn)()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/doctype/website_theme/website_theme.py", line 203, in after_migrate
    doc.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 312, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 348, in _save
    self._validate_links()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 910, in _validate_links
    frappe.throw(_("Could not find {0}").format(msg), frappe.LinkValidationError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 511, in throw
    as_list=as_list,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 479, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 434, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.LinkValidationError: Could not find Text Color: #000000, Background Color: #FFFFFF
```
