### PR TITLE
feat: actually redirect to login

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -430,62 +430,12 @@ frappe.Application = class Application {
 		});
 	}
 	handle_session_expired() {
-		if (!frappe.app.session_expired_dialog) {
-			var dialog = new frappe.ui.Dialog({
-				title: __("Session Expired"),
-				keep_open: true,
-				fields: [
-					{
-						fieldtype: "Password",
-						fieldname: "password",
-						label: __("Please Enter Your Password to Continue"),
-					},
-				],
-				onhide: () => {
-					if (!dialog.logged_in) {
-						frappe.app.redirect_to_login();
-					}
-				},
-			});
-			dialog.get_field("password").disable_password_checks();
-			dialog.set_primary_action(__("Login"), () => {
-				dialog.set_message(__("Authenticating..."));
-				frappe.call({
-					method: "login",
-					args: {
-						usr: frappe.session.user,
-						pwd: dialog.get_values().password,
-					},
-					callback: (r) => {
-						if (r.message === "Logged In") {
-							dialog.logged_in = true;
-
-							// revert backdrop
-							$(".modal-backdrop").css({
-								opacity: "",
-								"background-color": "#334143",
-							});
-						}
-						dialog.hide();
-					},
-					statusCode: () => {
-						dialog.hide();
-					},
-				});
-			});
-			frappe.app.session_expired_dialog = dialog;
-		}
-		if (!frappe.app.session_expired_dialog.display) {
-			frappe.app.session_expired_dialog.show();
-			// add backdrop
-			$(".modal-backdrop").css({
-				opacity: 1,
-				"background-color": "#4B4C9D",
-			});
-		}
+		frappe.app.redirect_to_login();
 	}
 	redirect_to_login() {
-		window.location.href = "/";
+		window.location.href = `/login?redirect-to=${encodeURIComponent(
+			window.location.pathname + window.location.search
+		)}`;
 	}
 	set_favicon() {
 		var link = $('link[type="image/x-icon"]').remove().attr("href");


### PR DESCRIPTION
When session was expired, we used to get a blue screen with a password prompt. When the prompt was dismissed, we redirected to `/`, despite the function name being `redirect_to_login`.

Now we immediately redirect to the login page, passing the current page as the first target after login. This way users will see the usual login page, password managers will work normally, users will land exactly where they came from, and we don't have to maintain two login flows.