### PR TITLE
fix: Do not filter columns like "_assign" & "_user_tags"

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -644,7 +644,7 @@ class DatabaseQuery:
 					permitted_child_table_fields = get_permitted_fields(
 						doctype=ch_doctype, parenttype=self.doctype
 					)
-					if column in permitted_child_table_fields:
+					if column in permitted_child_table_fields or column in optional_fields:
 						continue
 					else:
 						self.remove_field(i)


### PR DESCRIPTION
**Before:**
 Assignments were not showing up even thought documents had assignments.
![Screenshot 2023-02-14 at 2 02 57 PM](https://user-images.githubusercontent.com/13928957/218681599-d36646fc-8278-4648-b952-d8961f392085.png)

**After:**
![Screenshot 2023-02-14 at 2 02 27 PM](https://user-images.githubusercontent.com/13928957/218681773-6e256bdd-1a4c-447d-bc2c-8674d9c2b03d.png)


Issue was introduced via https://github.com/frappe/frappe/pull/19533