### PR TITLE
fix: checkbox is getting squeezed if label is long

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_column_selector.html
@@ -17,10 +17,10 @@
 				</div>
 				<div class="checkbox">
 					<label>
-						<input type="checkbox"
-							data-fieldname="{{ f.fieldname }}"
-							{{ selected ? "checked" : "" }}>
-							{{ __(f.label) }}
+						<span class="input-area">
+							<input type="checkbox" data-fieldname="{{ f.fieldname }}" {{ selected ? "checked" : "" }}>
+						</span>
+						<span class="label-area">{{ __(f.label) }}</span>
 					</label>
 				</div>
 			</div>


### PR DESCRIPTION
Before:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/30859809/218709402-9269824f-48bd-40ca-bdb6-94d5c0b35030.png">

After:
<img width="558" alt="image" src="https://user-images.githubusercontent.com/30859809/218709274-35827ee6-6e9e-4162-93c1-5d2b0d80346d.png">
