### PR TITLE
ci: print any vulnerabilities found by pip-audit

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -96,4 +96,4 @@ jobs:
           pip install pip-audit
           cd ${GITHUB_WORKSPACE}
           sed -i '/dropbox/d' pyproject.toml   # Remove dropbox temporarily https://github.com/dropbox/dropbox-sdk-python/pull/456
-          pip-audit .
+          pip-audit --desc on .


### PR DESCRIPTION
Include a description for each vulnerability, so we can immediately judge from the output without running `pip-audit` locally a second time.

```bash
> pip-audit --help
  # ...
  --desc [{on,off,auto}]
       include a description for each vulnerability; `auto` defaults to `on` for the `json` format.
       This flag has no effect on the `cyclonedx-json` or `cyclonedx-xml` formats. (default: auto)
```