### PR TITLE
fix: Notification JS relied on leaked locals

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -1,16 +1,6 @@
 // Copyright (c) 2018, Frappe Technologies and contributors
 // For license information, please see license.txt
 
-this.frm.add_fetch("sender", "email_id", "sender_email");
-
-this.frm.fields_dict.sender.get_query = function () {
-	return {
-		filters: {
-			enable_outgoing: 1,
-		},
-	};
-};
-
 frappe.notification = {
 	setup_fieldname_select: function (frm) {
 		// get the doctype to update fields
@@ -156,6 +146,15 @@ frappe.ui.form.on("Notification", {
 	refresh: function (frm) {
 		frappe.notification.setup_fieldname_select(frm);
 		frappe.notification.setup_example_message(frm);
+
+		frm.add_fetch("sender", "email_id", "sender_email");
+		frm.set_query("sender", () => {
+			return {
+				filters: {
+					enable_outgoing: 1,
+				},
+			};
+		});
 		frm.get_field("is_standard").toggle(frappe.boot.developer_mode);
 		frm.trigger("event");
 	},


### PR DESCRIPTION
this breaks after https://github.com/frappe/frappe/pull/19882

