### PR TITLE
feat(Calendar): Add a new option `convertToUserTz` to address timezone inconsistencies

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -120,6 +120,7 @@ frappe.views.Calendar = class Calendar {
 			start: "start",
 			end: "end",
 			allDay: "all_day",
+			convertToUserTz: "convert_to_user_tz",
 		};
 		this.color_map = {
 			danger: "red",
@@ -372,10 +373,13 @@ frappe.views.Calendar = class Calendar {
 			});
 
 			if (!me.field_map.allDay) d.allDay = 1;
+			if (!me.field_map.convertToUserTz) d.convertToUserTz = 1;
 
 			// convert to user tz
-			d.start = frappe.datetime.convert_to_user_tz(d.start);
-			d.end = frappe.datetime.convert_to_user_tz(d.end);
+			if (d.convertToUserTz) {
+				d.start = frappe.datetime.convert_to_user_tz(d.start);
+				d.end = frappe.datetime.convert_to_user_tz(d.end);
+			}
 
 			// show event on single day if start or end date is invalid
 			if (!frappe.datetime.validate(d.start) && d.end) {


### PR DESCRIPTION
## Before

The calendar view converts the event's time to the user timezone if it's not the same as the system timezone:

https://github.com/frappe/frappe/blob/aae3bac0b11d9a896ff35a2e1aefd6e28ad6bcc5/frappe/public/js/frappe/views/calendar/calendar.js#L376-L378

The Time field is timezone unaware, unlike the DateTime field. The calendar config provided to the calendar view doesn't always get events from a DateTime field.

eg: In the case of shift calendar (Frappe HR), it maps a date field in config but returns a DateTime value by concatenating the date from shift assignment and time from shift type. 

This creates inconsistencies between the Form View and Calendar View. Form View still shows the time as per the system timezone but the calendar view converts it to the user timezone.

<img width="1326" alt="user-time" src="https://user-images.githubusercontent.com/24353136/219019519-166c06fa-c48f-4a9f-8dd8-d6ead8b0370c.png">

<img width="1326" alt="shift-calendar" src="https://user-images.githubusercontent.com/24353136/219019971-ac07e062-49a2-4839-9d55-8950d39cce5c.png">

## Example

<details>
<summary>Details</summary>

**System Timezone**: Asia/Kolkata

**User’s timezone**: Asia/Dubai

**Shift**: 18:30:00 - 22:00:00 in the system timezone (Asia/Kolkata)

<img width="1326" alt="shift" src="https://user-images.githubusercontent.com/24353136/219018936-d29f89ef-eb7b-45a5-b99c-35ed665d1144.png">

**The same time is shown to the user in the form view** (because time fields are timezone unaware)

<img width="1326" alt="user-time" src="https://user-images.githubusercontent.com/24353136/219019519-166c06fa-c48f-4a9f-8dd8-d6ead8b0370c.png">

**In the Calendar, time gets converted to the user timezone (Asia/Kolkata)** 
Making it 5p - 8:30p

<img width="1326" alt="shift-calendar" src="https://user-images.githubusercontent.com/24353136/219019971-ac07e062-49a2-4839-9d55-8950d39cce5c.png">

</details>

## Solution

**Solution 1**: Let the calendar view decide whether to convert to user timezone or not (won't work)

<details>
<summary>Details</summary>

- If we are able to determine the data type of the field mapped to the calendar view we can skip conversion for time and date fields. Only convert for DateTime fields (because they are timezone aware)
- The problem here is most calendar views don’t directly map to a DateTime field. 
   - In the case of Timesheet, it maps a date field but returns a DateTime field from the child table.
   - In the case of shift type, it maps a date field but returns a DateTime value by concatenating the date from shift assignment and time from shift type. 

This will work for the shift's case but the timesheet's case will stop working. 

</details>

**Solution 2**: Make time fields timezone aware

This might create data integrity issues without any control over conversion. It's an ideal long-term solution

**Solution 3**: Let the calendar config decide whether to convert to the user timezone or not with an option. 

Since the framework cannot accurately determine whether the field being mapped is a Date, Time, or DateTime field, let the calendar config pass a flag `convertToUserTz` to the calendar view to determine whether to convert time to user timezone or not. 

By default, it will be true to support the current behavior
It will be false in case of Shifts since time fields are timezone unaware.

P.S: `convertToUserTz` is named in camelCase to be consistent with other options like `allDay`

## After

<img width="1326" alt="after-fix" src="https://user-images.githubusercontent.com/24353136/219022679-5fccc3a6-7ba3-4c93-a567-7f77cece32d6.png">

