### PR TITLE
fix: thread-unsafe shared class attribute on QB engine

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -184,7 +184,8 @@ OPERATOR_MAP: dict[str, Callable] = {
 
 
 class Engine:
-	tables: dict[str, str] = {}
+	def __init__(self):
+		self.tables: dict[str, str] = {}
 
 	@cached_property
 	def OPERATOR_MAP(self):


### PR DESCRIPTION
`Engine.tables` when used with `gthreaded` workers causes race condition.

E.g.

Request 1: Generating query on User doctype and puts it in tables.
Request 2: Generating query on Batch doctype and puts it in tables.

Both if on same worker are modifying same class's attribute and hence
generated query will have implicit join in it.


Example: (these two tables are never joined in code afaik, many such examples)
![image](https://user-images.githubusercontent.com/9079960/219042277-1a08f536-3456-44c6-a0d3-5520f94e2884.png)

![image](https://github.com/user-attachments/assets/fa1143b6-7e10-4e76-bff6-e8563e6cb5cb)


references:

- `ISS-22-23-05064`
- `ISS-22-23-05071`

Exact affected version: 14.22.0, 14.25.1