### PR TITLE
fix: Buggy Mariadb version check

### DIFF
--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -17,15 +17,16 @@ expected_settings_10_3_later = {
 }
 
 
-def get_mariadb_versions():
+def get_mariadb_variables():
+	return frappe._dict(frappe.db.sql("show variables"))
+
+
+def get_mariadb_version(version_string: str = ""):
 	# MariaDB classifies their versions as Major (1st and 2nd number), and Minor (3rd number)
 	# Example: Version 10.3.13 is Major Version = 10.3, Minor Version = 13
-	mariadb_variables = frappe._dict(frappe.db.sql("""show variables"""))
-	version_string = mariadb_variables.get("version").split("-")[0]
-	versions = {}
-	versions["major"] = version_string.split(".")[0] + "." + version_string.split(".")[1]
-	versions["minor"] = version_string.split(".")[2]
-	return versions
+	version_string = version_string or get_mariadb_variables().get("version")
+	version = version_string.split("-")[0]
+	return version.rsplit(".", 1)
 
 
 def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
@@ -125,13 +126,13 @@ def import_db_from_sql(source_sql=None, verbose=False):
 
 
 def check_database_settings():
-	versions = get_mariadb_versions()
-	if versions["major"] <= "10.2":
+	mariadb_variables = get_mariadb_variables()
+	versions = get_mariadb_version(mariadb_variables.get("version"))
+	if versions[0] <= "10.2":
 		expected_variables = expected_settings_10_2_earlier
 	else:
 		expected_variables = expected_settings_10_3_later
 
-	mariadb_variables = frappe._dict(frappe.db.sql("show variables"))
 	# Check each expected value vs. actuals:
 	result = True
 	for key, expected_value in expected_variables.items():
@@ -141,18 +142,16 @@ def check_database_settings():
 				% (key, expected_value, mariadb_variables.get(key))
 			)
 			result = False
+
 	if not result:
 		print(
 			(
-				"=" * 80 + "\n"
-				"Creation of your site - {x} failed because MariaDB is not properly {sep}"
+				"{sep2}Creation of your site - {site} failed because MariaDB is not properly {sep}"
 				"configured.  If using version 10.2.x or earlier, make sure you use the {sep}"
-				"the Barracuda storage engine. {sep}{sep}"
-				"Please verify the settings above in MariaDB's my.cnf.  Restart MariaDB.  And {sep}"
-				"then run `bench new-site {x}` again.{sep2}"
-				""
-				"=" * 80
-			).format(x=frappe.local.site, sep2="\n" * 2, sep="\n")
+				"the Barracuda storage engine.{sep2}"
+				"Please verify the above settings in MariaDB's my.cnf.  Restart MariaDB.{sep}"
+				"And then run `bench new-site {site}` again.{sep2}"
+			).format(site=frappe.local.site, sep2="\n\n", sep="\n")
 		)
 
 	return result

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -1,5 +1,7 @@
 import os
 
+import click
+
 import frappe
 from frappe.database.db_manager import DbManager
 
@@ -118,9 +120,11 @@ def import_db_from_sql(source_sql=None, verbose=False):
 
 
 def check_database_settings():
-	mariadb_variables = get_mariadb_variables()
+
+	check_compatible_versions()
 
 	# Check each expected value vs. actuals:
+	mariadb_variables = get_mariadb_variables()
 	result = True
 	for key, expected_value in REQUIRED_MARIADB_CONFIG.items():
 		if mariadb_variables.get(key) != expected_value:
@@ -141,6 +145,28 @@ def check_database_settings():
 		)
 
 	return result
+
+
+def check_compatible_versions():
+	try:
+		version = get_mariadb_version()
+		version_tuple = tuple(int(v) for v in version[0].split("."))
+
+		if version_tuple < (10, 3):
+			click.secho(
+				f"Warning: MariaDB version {version} is less than 10.3 which is not supported by Frappe",
+				fg="yellow",
+			)
+		elif version_tuple >= (10, 9):
+			click.secho(
+				f"Warning: MariaDB version {version} is more than 10.8 which is not yet tested with Frappe Framework.",
+				fg="yellow",
+			)
+	except Exception:
+		click.secho(
+			"MariaDB version compatibility checks failed, make sure you're running a supported version.",
+			fg="yellow",
+		)
 
 
 def get_root_connection(root_login, root_password):

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -3,15 +3,7 @@ import os
 import frappe
 from frappe.database.db_manager import DbManager
 
-expected_settings_10_2_earlier = {
-	"innodb_file_format": "Barracuda",
-	"innodb_file_per_table": "ON",
-	"innodb_large_prefix": "ON",
-	"character_set_server": "utf8mb4",
-	"collation_server": "utf8mb4_unicode_ci",
-}
-
-expected_settings_10_3_later = {
+REQUIRED_MARIADB_CONFIG = {
 	"character_set_server": "utf8mb4",
 	"collation_server": "utf8mb4_unicode_ci",
 }
@@ -127,15 +119,10 @@ def import_db_from_sql(source_sql=None, verbose=False):
 
 def check_database_settings():
 	mariadb_variables = get_mariadb_variables()
-	versions = get_mariadb_version(mariadb_variables.get("version"))
-	if versions[0] <= "10.2":
-		expected_variables = expected_settings_10_2_earlier
-	else:
-		expected_variables = expected_settings_10_3_later
 
 	# Check each expected value vs. actuals:
 	result = True
-	for key, expected_value in expected_variables.items():
+	for key, expected_value in REQUIRED_MARIADB_CONFIG.items():
 		if mariadb_variables.get(key) != expected_value:
 			print(
 				"For key %s. Expected value %s, found value %s"
@@ -147,8 +134,7 @@ def check_database_settings():
 		print(
 			(
 				"{sep2}Creation of your site - {site} failed because MariaDB is not properly {sep}"
-				"configured.  If using version 10.2.x or earlier, make sure you use the {sep}"
-				"the Barracuda storage engine.{sep2}"
+				"configured.{sep2}"
 				"Please verify the above settings in MariaDB's my.cnf.  Restart MariaDB.{sep}"
 				"And then run `bench new-site {site}` again.{sep2}"
 			).format(site=frappe.local.site, sep2="\n\n", sep="\n")


### PR DESCRIPTION
If mariadb version is 10.10, `bench new-site <site_name>` fails with:
```
For key innodb_file_format. Expected value Barracuda, found value None
For key innodb_large_prefix. Expected value ON, found value None
================================================================================
Creation of your site - mariadb-2 failed because MariaDB is not properly
configured.  If using version 10.2.x or earlier, make sure you use the
the Barracuda storage engine.

Please verify the settings above in MariaDB's my.cnf.  Restart MariaDB.  And
then run `bench new-site mariadb-2` again.
```

This is because `check_database_settings` wrongly performs:
<img width="564" alt="Screenshot 2023-02-16 at 1 40 13 PM" src="https://user-images.githubusercontent.com/25857446/219305566-ed9a4422-fd6b-46d4-9232-9ffea2aadfbf.png">

<hr>
This is fixed in develop and v13/v14 do not support a version lower than 10.3

> Needs to be backported to v13, if we can't for whatever reason I'll raise a fix using `semantic_version` for version comparison