### PR TITLE
fix: help-icon taking space if doc url is not set

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -17,7 +17,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 				<div class="form-group">
 					<div class="clearfix">
 						<label class="control-label" style="padding-right: 0px;"></label>
-						<span class="ml-1 help"></span>
+						<span class="help"></span>
 					</div>
 					<div class="control-input-wrapper">
 						<div class="control-input"></div>

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -63,7 +63,7 @@ export default class Grid {
 		let template = `
 			<div class="grid-field">
 				<label class="control-label">${__(this.df.label || "")}</label>
-				<span class="ml-1 help"></span>
+				<span class="help"></span>
 				<p class="text-muted small grid-description"></p>
 				<div class="grid-custom-buttons"></div>
 				<div class="form-grid-container">

--- a/frappe/public/scss/common/controls.scss
+++ b/frappe/public/scss/common/controls.scss
@@ -135,6 +135,9 @@ select.form-control {
 		content: ' *';
 		color: var(--red-400);
 	}
+	.help:empty {
+		display: none;
+	}
 	.ql-editor:not(.read-mode) {
 		background-color: var(--control-bg);
 	}

--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -36,6 +36,10 @@
 			top: 5px;
 			right: 10px;
 		}
+
+		.help {
+			display: none;
+		}
 	}
 
 	.dt-header {
@@ -67,6 +71,10 @@
 
 	.checkbox {
 		margin: 7px 0 7px 8px;
+
+		.label-area {
+			display: none;
+		}
 	}
 
 	[data-fieldtype="Color"] .control-input {


### PR DESCRIPTION
Before:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/30859809/219315328-d19dad27-657e-4c4f-829b-b2c9874de514.png">

After:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/30859809/219315080-38729f5c-c9de-49b2-bf1b-eb643c209ace.png">
