### PR TITLE
Update standard web templates to support translations

### DIFF
--- a/frappe/website/web_template/section_with_cards/section_with_cards.html
+++ b/frappe/website/web_template/section_with_cards/section_with_cards.html
@@ -18,8 +18,8 @@
 		}) }}
 		{%- endif -%}
 		<div class="card-body">
-			<h3 class="card-title mt-0">{{ title or '' }}</h3>
-			<p class="card-text">{{ content or '' }}</p>
+			<h3 class="card-title mt-0">{{ _(title) or '' }}</h3>
+			<p class="card-text">{{ _(content) or '' }}</p>
 		</div>
 		<a href="{{ url or '#' }}" class="stretched-link"></a>
 	</div>
@@ -28,10 +28,10 @@
 
 <div class="section-with-cards">
 	{%- if title -%}
-	<h2 class="section-title">{{ title }}</h2>
+	<h2 class="section-title">{{ _(title) }}</h2>
 	{%- endif -%}
 	{%- if subtitle -%}
-	<p class="section-description">{{ subtitle }}</p>
+	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}
 	{%- set card_size = card_size or 'Small' -%}
 	<div class="{{ resolve_class({'mt-6': title}) }}">
@@ -42,7 +42,7 @@
 			{%- set url = values['card_' + index + '_url'] -%}
 			{%- set image = values['card_' + index + '_image'] -%}
 			{%- if title -%}
-			{{ card(title, content, url, image) }}
+			{{ card(_(title), _(content), url, image) }}
 			{%- endif -%}
 			{%- endfor -%}
 		</div>

--- a/frappe/website/web_template/section_with_testimonials/section_with_testimonials.html
+++ b/frappe/website/web_template/section_with_testimonials/section_with_testimonials.html
@@ -2,10 +2,10 @@
 
 <div class="section-with-features">
 	{%- if title -%}
-	<h2 class="section-title">{{ title }}</h2>
+	<h2 class="section-title">{{ _(title) }}</h2>
 	{%- endif -%}
 	{%- if subtitle -%}
-	<p class="section-description">{{ subtitle }}</p>
+	<p class="section-description">{{ _(subtitle) }}</p>
 	{%- endif -%}
 
 	<div class="section-features" data-columns="{{ columns or 3 }}">
@@ -13,15 +13,15 @@
 		<div class="section-feature">
 			<div>
 				{%- if testimonial.content -%}
-				<p class="feature-content">{{ testimonial.content }}</p>
+				<p class="feature-content">{{ _(testimonial.content) }}</p>
 				{%- endif -%}
 			</div>
 			<div class="testimonial-author">
 				{{  avatar(full_name=testimonial.full_name, image=testimonial.image, size='avatar-medium') }}
 				<p>
-					{{ testimonial.full_name }}
+					{{ _(testimonial.full_name) }}
 					{%- if testimonial.designation -%}
-					<br>{{ testimonial.designation }}
+					<br>{{ _(testimonial.designation) }}
 					{%- endif -%}
 				</p>
 			</div>

--- a/frappe/website/web_template/split_section_with_image/split_section_with_image.html
+++ b/frappe/website/web_template/split_section_with_image/split_section_with_image.html
@@ -15,9 +15,9 @@
 	</div>
 	{%- endif -%}
 	<div class="split-section-content col-12 {{ left_col if image_on_right else right_col }} {{ align_content }}">
-		<h2 class="mt-0">{{ title }}</h2>
+		<h2 class="mt-0">{{ _(title) }}</h2>
 		{%- if content -%}
-		<p>{{ content }}</p>
+		<p>{{ _(content) }}</p>
 		{%- endif -%}
 
 		{%- if link_label and link_url -%}


### PR DESCRIPTION
@shariquerik
I have updated the standard web templates to support translations by changing the HTML variables for the title, subtitle, and content from {{variable_name}} to {{_(variable_name)}}. This change will enable translators to localize the text for different languages.

Please review my changes and let me know if you have any feedback or concerns.

Changes made on these templates:

- Split Section with Image
- Section with Cards
- Section with Testimonials

Thank you for considering my contribution and I hope to add my fixes to the next release.