### PR TITLE
fix: false positive attr check while applying permlevel

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -676,7 +676,11 @@ class Document(BaseDocument):
 
 		for df in self.meta.fields:
 			if df.permlevel and hasattr(self, df.fieldname) and df.permlevel not in has_access_to:
-				delattr(self, df.fieldname)
+				try:
+					delattr(self, df.fieldname)
+				except AttributeError:
+					# hasattr might return True for class attribute which can't be delattr-ed.
+					continue
 
 		for table_field in self.meta.get_table_fields():
 			for df in frappe.get_meta(table_field.options).fields or []:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -675,8 +675,7 @@ class Document(BaseDocument):
 		has_access_to = self.get_permlevel_access("read")
 
 		for df in self.meta.fields:
-			# not using hasattr since it also contains attributes of super class
-			if df.permlevel and df.fieldname in self.__dict__ and df.permlevel not in has_access_to:
+			if df.permlevel and hasattr(self, df.fieldname) and df.permlevel not in has_access_to:
 				delattr(self, df.fieldname)
 
 		for table_field in self.meta.get_table_fields():

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -675,7 +675,8 @@ class Document(BaseDocument):
 		has_access_to = self.get_permlevel_access("read")
 
 		for df in self.meta.fields:
-			if df.permlevel and hasattr(self, df.fieldname) and df.permlevel not in has_access_to:
+			# not using hasattr since it also contains attributes of super class
+			if df.permlevel and df.fieldname in self.__dict__ and df.permlevel not in has_access_to:
 				delattr(self, df.fieldname)
 
 		for table_field in self.meta.get_table_fields():


### PR DESCRIPTION
## Problem

- Permlevel is applied on a section break field named `website`
- The Partner DocType's class inherits WebsiteGenerator which has a `website` attribute
- While applying permlevel, restricted fields/attributes are deleted after checking if attr exists using `hasattr(self, df.fieldname)`. 
- The instance (self) can access the superclass attributes but cannot delete them. That's why `hasattr` passes but `delattr` fails.

![attr](https://user-images.githubusercontent.com/24353136/219449316-80bd80a6-0b36-4f00-ada0-1666f53d170c.png)

## Fix

Ignore `AttributeError` while trying to pop perm-level fields

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/24353136/219451276-9d2b60b7-cfe3-49af-a23c-741d6fe9f4b3.png">

P.S. should we disallow setting perm levels on Section/Column/Tab break fields?


regression/triggered from https://github.com/frappe/frappe/pull/19533