### PR TITLE
fix: fetch the outerHTML of text-editor and remove unecessary is_quill_dirty check

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -97,7 +97,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 
 	bind_events() {
 		this.quill.on('text-change', frappe.utils.debounce((delta, oldDelta, source) => {
-			if (!this.is_quill_dirty(source)) return;
+			if (source === 'api') return;
 
 			const input_value = this.get_input_value();
 			this.parse_validate_and_set_in_model(input_value);
@@ -154,12 +154,6 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 			$font_size_label.attr('data-value', '---');
 			$default_font_size.attr('data-value', '---');
 		}
-	},
-
-	is_quill_dirty(source) {
-		if (source === 'api') return false;
-		let input_value = this.get_input_value();
-		return this.value !== input_value;
 	},
 
 	get_quill_options() {
@@ -232,7 +226,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 		} catch(e) {
 			value = `<div class="ql-editor read-mode">${value}</div>`;
 		}
-		
+
 		// quill keeps ol as a common container for both type of lists
 		// and uses css for appearances, this is not semantic
 		// so we convert ol to ul if it is unordered
@@ -244,7 +238,7 @@ frappe.ui.form.ControlTextEditor = frappe.ui.form.ControlCode.extend({
 			let $ul = $('<ul>').append($children);
 			$parent.replaceWith($ul);
 		});
-		value = $value.html();
+		value = $value.prop("outerHTML");
 		return value;
 	},
 


### PR DESCRIPTION
caused by: https://github.com/frappe/frappe/pull/19531

we try to wrap the text in a text-editor control inside `<div class="ql-editor read-mode"></div>`. However `.html()` provides us with the `innerHTMl` of the element and that div is not included in that ([ref](https://www.w3schools.com/jquery/html_html.asp)). Hence, we explicitly get the `outerHTML` property of the element


before:

https://user-images.githubusercontent.com/32034600/220074577-ac4a2e7b-75ee-45d9-9ddb-20f65ede3e5b.mp4

after:

https://user-images.githubusercontent.com/32034600/220075905-be8b7e8e-7be1-4294-9043-f81e239e4b4b.mp4

