### PR TITLE
fix: Hide perm level field for Section, Column and Tab Breaks

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -304,6 +304,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
    "fieldname": "permlevel",
    "fieldtype": "Int",
    "label": "Perm Level",
@@ -555,7 +556,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-01-11 20:46:43.164926",
+ "modified": "2023-02-20 12:07:29.552523",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -212,6 +212,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break'], doc.fieldtype)",
    "fieldname": "permlevel",
    "fieldtype": "Int",
    "in_list_view": 1,
@@ -467,7 +468,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-11-30 14:25:50.649449",
+ "modified": "2023-02-20 12:07:40.242470",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",


### PR DESCRIPTION
Hide perm level field in DocType and Customize Form for Section, Column, and Tab Breaks since we don't restrict access for the entire section/tab/column

Discussed here: https://github.com/frappe/frappe/pull/20069

