### PR TITLE
fix(UX): Sort case-insensitive where it makes sense

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -62,8 +62,8 @@ def get_roles_and_doctypes():
 	roles_list = [{"label": _(d.get("name")), "value": d.get("name")} for d in roles]
 
 	return {
-		"doctypes": sorted(doctypes_list, key=lambda d: d["label"]),
-		"roles": sorted(roles_list, key=lambda d: d["label"]),
+		"doctypes": sorted(doctypes_list, key=lambda d: d["label"].casefold()),
+		"roles": sorted(roles_list, key=lambda d: d["label"].casefold()),
 	}
 
 

--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -59,7 +59,7 @@ def get_tags(doctype, txt):
 	tag = frappe.get_list("Tag", filters=[["name", "like", f"%{txt}%"]])
 	tags = [t.name for t in tag]
 
-	return sorted(filter(lambda t: t and txt.lower() in t.lower(), list(set(tags))))
+	return sorted(filter(lambda t: t and txt.casefold() in t.casefold(), list(set(tags))))
 
 
 class DocTags:

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -282,7 +282,7 @@ def scrub_custom_query(query, key, txt):
 
 def relevance_sorter(key, query, as_dict):
 	value = _(key.name if as_dict else key[0])
-	return (cstr(value).lower().startswith(query.lower()) is not True, value)
+	return (cstr(value).casefold().startswith(query.casefold()) is not True, value)
 
 
 def validate_and_sanitize_search_inputs(fn):


### PR DESCRIPTION
Role permission manager sorts doctype without ignoring case, so lower cased doctype go to bottom. 

Similar issue with tags. Case-insensitive sort makes sense in both cases. 

![image](https://user-images.githubusercontent.com/9079960/220040358-d4429df1-3195-489d-a1ce-3cb4959d367c.png)
