### PR TITLE
fix: cast primary value in compare util if fieldtype is present

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -142,6 +142,33 @@ class TestFilters(FrappeTestCase):
 			)
 		)
 
+	def test_date_time(self):
+		# date fields
+		self.assertTrue(
+			evaluate_filters(
+				{"doctype": "User", "birth_date": "2023-02-28"}, [("User", "birth_date", ">", "01-04-2022")]
+			)
+		)
+		self.assertFalse(
+			evaluate_filters(
+				{"doctype": "User", "birth_date": "2023-02-28"}, [("User", "birth_date", "<", "28-02-2023")]
+			)
+		)
+
+		# datetime fields
+		self.assertTrue(
+			evaluate_filters(
+				{"doctype": "User", "last_active": "2023-02-28 15:14:56"},
+				[("User", "last_active", ">", "01-04-2022 00:00:00")],
+			)
+		)
+		self.assertFalse(
+			evaluate_filters(
+				{"doctype": "User", "last_active": "2023-02-28 15:14:56"},
+				[("User", "last_active", "<", "28-02-2023 00:00:00")],
+			)
+		)
+
 
 class TestMoney(FrappeTestCase):
 	def test_money_in_words(self):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1714,6 +1714,7 @@ def evaluate_filters(doc, filters: dict | list | tuple):
 
 def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
 	if fieldtype:
+		val1 = cast(fieldtype, val1)
 		val2 = cast(fieldtype, val2)
 	if condition in operator_map:
 		return operator_map[condition](val1, val2)


### PR DESCRIPTION
Problem: 
create a document naming rule with a date (or datetime) field as the condition. now when we try to create a document of the doctyppe on which document naming rule is defined, it fails with the following error ->

![Screenshot from 2023-02-28 15-57-14](https://user-images.githubusercontent.com/32034600/221827225-8744feb8-6f2b-44bb-9c00-918356251fa5.png)

This is due to the fact that date and datetime fields aren't converted to appropriate datetime objects when inserting a document and remain as string. Hence when comparing with str and datetime object, that error is raised.

This fix casts the document value to it's appropriate type in order to make the comparision proper.