### PR TITLE
perf!: `frappe.db.exists` without `order_by`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1046,7 +1046,7 @@ class Database:
 			dt = dt.copy()  # don't modify the original dict
 			dt, dn = dt.pop("doctype"), dt
 
-		return self.get_value(dt, dn, ignore=True, cache=cache)
+		return self.get_value(dt, dn, ignore=True, cache=cache, order_by=None)
 
 	def count(self, dt, filters=None, debug=False, cache=False, distinct: bool = True):
 		"""Returns `COUNT(*)` for given DocType and filters."""


### PR DESCRIPTION
`frappe.db.exists` is meant to be used to check if at least 1 row exists with given filters.

Ordering should not make any difference here but it surely makes things slower in some cases because it confuses query planner.


Potentially Breaking: Some have written code to use frappe.db.exists as frappe.db.get_value, there change of ordering might give different results.
