### PR TITLE
fix: missing report permission stops boot

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -12,6 +12,7 @@ from frappe.desk.doctype.route_history.route_history import frequently_visited_l
 from frappe.desk.form.load import get_meta_bundle
 from frappe.email.inbox import get_email_accounts
 from frappe.model.base_document import get_controller
+from frappe.permissions import has_permission
 from frappe.query_builder import DocType
 from frappe.query_builder.functions import Count
 from frappe.query_builder.terms import ParameterizedValueWrapper, SubQuery
@@ -234,6 +235,9 @@ def get_user_pages_or_reports(parent, cache=False):
 				has_role[p.name] = {"modified": p.modified, "title": p.title}
 
 	elif parent == "Report":
+		if not has_permission("Report", raise_exception=False):
+			return {}
+
 		reports = frappe.get_list(
 			"Report",
 			fields=["name", "report_type"],

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -244,6 +244,10 @@ class InReadOnlyMode(ValidationError):
 	http_status_code = 503  # temporarily not available
 
 
+class SessionBootFailed(ValidationError):
+	http_status_code = 500
+
+
 class TooManyWritesError(Exception):
 	pass
 

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -34,15 +34,6 @@ frappe.Application = class Application {
 		frappe.socketio.init();
 		frappe.model.init();
 
-		if (frappe.boot.status === "failed") {
-			frappe.msgprint({
-				message: frappe.boot.error,
-				title: __("Session Start Failed"),
-				indicator: "red",
-			});
-			throw "boot failed";
-		}
-
 		this.load_bootinfo();
 		this.load_user_permissions();
 		this.make_nav_bar();

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -27,8 +27,7 @@ def get_context(context):
 	try:
 		boot = frappe.sessions.get()
 	except Exception as e:
-		boot = frappe._dict(status="failed", error=str(e))
-		print(frappe.get_traceback())
+		raise frappe.SessionBootFailed from e
 
 	# this needs commit
 	csrf_token = frappe.sessions.get_csrf_token()


### PR DESCRIPTION
If you don't have report read permissions (enabled by default but some sites have removed it) then session boot fails with no traceback and just JS errors. 

- fix: Don't fetch report if not permitted
- fix: show proper error with traceback when boot fails


After fix: Clearly see the traceback :eyes: 

```
Traceback (most recent call last):
  File "apps/frappe/frappe/www/app.py", line 28, in get_context
    boot = frappe.sessions.get()
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/sessions.py", line 149, in get
    bootinfo = get_bootinfo()
               ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/boot.py", line 37, in get_bootinfo
    get_user(bootinfo)
  File "apps/frappe/frappe/boot.py", line 275, in get_user
    bootinfo.user = frappe.get_user().load_user()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/user.py", line 253, in load_user
    d.all_reports = self.get_all_reports()
                    ^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/user.py", line 257, in get_all_reports
    return get_allowed_reports()
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/boot.py", line 142, in get_allowed_reports
    return get_user_pages_or_reports("Report", cache=cache)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/boot.py", line 239, in get_user_pages_or_reports
    reports = frappe.get_list(
              ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1854, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/db_query.py", line 121, in execute
    raise frappe.PermissionError(self.doctype)
frappe.exceptions.PermissionError: Report

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "apps/frappe/frappe/website/serve.py", line 18, in get_response
    response = renderer_instance.render()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 78, in render
    html = self.get_html()
           ^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/website/utils.py", line 512, in cache_html_decorator
    html = func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 89, in get_html
    self.update_context()
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 157, in update_context
    data = self.run_pymodule_method("get_context")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 219, in run_pymodule_method
    return method(self.context)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/www/app.py", line 30, in get_context
    raise frappe.SessionBootFailed from e
frappe.exceptions.SessionBootFailed
```