### PR TITLE
fix: login failing if user doesn't have access to the Report doctype

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -233,7 +233,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			if p.name not in has_role:
 				has_role[p.name] = {"modified": p.modified, "title": p.title}
 
-	elif parent == "Report":
+	elif parent == "Report" and frappe.has_permission("Report"):
 		reports = frappe.get_list(
 			"Report",
 			fields=["name", "report_type"],


### PR DESCRIPTION
## Problem:

User has no access to the "Report" doctype
   
<img width="1340" alt="image" src="https://user-images.githubusercontent.com/24353136/220148790-a4b58ec4-2297-4967-9913-15b8b495af0d.png">

Boot fails due to the `get_list` query on the Report doctype. Encountered after https://github.com/frappe/frappe/pull/19926 

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/24353136/220149105-e7dd82d2-dfed-4b7a-8042-121305608734.png">

**Note**: This might be working correctly in most cases because by default the ["All" role has access to the Report doctype](https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/report/report.json#L225-L231)

<details>
<summary>Traceback</summary>

```python
Traceback (most recent call last):
File "apps/frappe/frappe/www/app.py", line 28, in get_context
  boot = frappe.sessions.get()
File "apps/frappe/frappe/sessions.py", line 149, in get
  bootinfo = get_bootinfo()
File "apps/frappe/frappe/boot.py", line 36, in get_bootinfo
  get_user(bootinfo)
File "apps/frappe/frappe/boot.py", line 273, in get_user
  bootinfo.user = frappe.get_user().load_user()
File "apps/frappe/frappe/utils/user.py", line 255, in load_user
  d.all_reports = self.get_all_reports()File "apps/frappe/frappe/utils/user.py", line 259, in get_all_reports
  return get_allowed_reports()
File "apps/frappe/frappe/boot.py", line 141, in get_allowed_reports
  return get_user_pages_or_reports("Report", cache=cache)
File "apps/frappe/frappe/boot.py", line 237, in get_user_pages_or_reports
  reports = frappe.get_list(
File "apps/frappe/frappe/__init__.py", line 1854, in get_list
  return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
File "apps/frappe/frappe/model/db_query.py", line 121, in execute
  raise frappe.PermissionError(self.doctypefrappe.exceptions.PermissionError: Report
```

</details>

## Fix

Only check for permitted reports if the user has permission on the "Report" doctype

<img width="1340" alt="image" src="https://user-images.githubusercontent.com/24353136/220150123-833c2b97-e469-464f-9c0d-c80208f5e832.png">
