### PR TITLE
fix: raise_exception=False for has_permission in filter_allowed_users

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -444,7 +444,9 @@ def filter_allowed_users(users, doc, transition):
 
 	filtered_users = []
 	for user in users:
-		if has_approval_access(user, doc, transition) and has_permission(doctype=doc, user=user, raise_exception=False):
+		if has_approval_access(user, doc, transition) and has_permission(
+			doctype=doc, user=user, raise_exception=False
+		):
 			filtered_users.append(user)
 	return filtered_users
 

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -444,7 +444,7 @@ def filter_allowed_users(users, doc, transition):
 
 	filtered_users = []
 	for user in users:
-		if has_approval_access(user, doc, transition) and has_permission(doctype=doc, user=user):
+		if has_approval_access(user, doc, transition) and has_permission(doctype=doc, user=user, raise_exception=False):
 			filtered_users.append(user)
 	return filtered_users
 


### PR DESCRIPTION

**TL;DR**
We currently face an issue where users receive permission errors which are triggered by the `filter_allowed_users` function in `workflow_action.py`. Since this function only helps by filtering relevant users, it should not lead to permission errors coming back to the current user, therefore the `raise_exception=False` was added.

**More detailed explanation of the issue**
In the `filter_allowed_users` function in `workflow_action.py` it is checked whether users who have the required role for the workflow have permission for the current document. For all users who are not the current user, the `has_permission` fails, but it is not shown to the current user (see `print_has_permission_check_logs` in `frappe/permissions.py`). But if the current user also does not have access to the document (in our case we insert a new project from another document in the background and it can be the case, that the current user will not have access to this document), a permission error will be shown. This permission error is originating from the `has_permission` call in `workflow_action.py`.