### PR TITLE
fix(email): unintended emails sent as cc for todo allocated_to users

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -70,7 +70,7 @@ class CommunicationEmailMixin:
 		if include_sender:
 			cc.append(self.sender_mailid)
 		if is_inbound_mail_communcation:
-			if (doc_owner := self.get_owner()) not in frappe.STANDARD_USERS:
+			if (doc_owner := self.get_owner()) and (doc_owner not in frappe.STANDARD_USERS):
 				cc.append(doc_owner)
 			cc = set(cc) - {self.sender_mailid}
 			cc.update(self.get_assignees())

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -217,7 +217,7 @@ class CommunicationEmailMixin:
 			"reference_type": self.reference_doctype,
 		}
 		
-		if self.reference_doctype == "ToDo" and self.reference_name != None:
+		if self.reference_doctype and self.reference_name:
 			return ToDo.get_owners(filters)
 		else:
 			return []

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -216,7 +216,11 @@ class CommunicationEmailMixin:
 			"reference_name": self.reference_name,
 			"reference_type": self.reference_doctype,
 		}
-		return ToDo.get_owners(filters)
+		
+		if self.reference_doctype == "ToDo" and self.reference_name != None:
+			return ToDo.get_owners(filters)
+		else:
+			return []
 
 	@staticmethod
 	def filter_thread_notification_disbled_users(emails):


### PR DESCRIPTION
We have found that every incoming email is unintentionally and automatically forwarded to several users in CC directly.

For a reason I don't understand, logic was added within https://github.com/frappe/frappe/pull/13816, which determines all "allocated_to" users of all ToDos based on faulty filtering and adds them as CC recipients for all incoming emails.

Additionally, the wrong usage of the walrus operator was corrected in the PR because, up to now, a "None" entry was unintentionally inserted into the CC list.

<redacted>

This PR does **NOT** contain the refactoring of the implementation mentioned above. I don't know the business background, but the design needs improvement because the ToDo-Doctype is imported manually in the Communication-mixin, and special logic is implemented. Once it is clear why this was done in the first place, the logic needs to be replaced by a generic implementation that refers to "self.reference_doctype" or similar. I have created a discuss thread to get more background on that: https://discuss.frappe.io/t/todo-specific-logic-in-communication-mixin/101461
