### PR TITLE
fix: Reload form on "doc_update" trigger to avoid timestamp conflict

### DIFF
--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -91,9 +91,11 @@ frappe.ui.form.States = Class.extend({
 						// set the workflow_action for use in form scripts
 						me.frm.selected_workflow_action = d.action;
 						me.frm.script_manager.trigger('before_workflow_action').then(() => {
+							frappe.dom.freeze();
 							frappe.xcall('frappe.model.workflow.apply_workflow',
 								{doc: me.frm.doc, action: d.action})
 								.then((doc) => {
+									frappe.dom.unfreeze();
 									frappe.model.sync(doc);
 									me.frm.refresh();
 									me.frm.selected_workflow_action = null;

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -52,9 +52,13 @@ $.extend(frappe.model, {
 
 			if (doc) {
 				// current document is dirty, show message if its not me
-				if (frappe.get_route()[0] === "Form" && cur_frm.doc.doctype === doc.doctype && cur_frm.doc.name === doc.name) {
-					if (data.modified != cur_frm.doc.modified) {
-						if (!doc.__unsaved) {
+				if (
+					frappe.get_route()[0] === "Form" &&
+					cur_frm.doc.doctype === doc.doctype &&
+					cur_frm.doc.name === doc.name
+				) {
+					if (data.modified !== cur_frm.doc.modified) {
+						if (!cur_frm.is_dirty()) {
 							cur_frm.reload_doc();
 						} else if (!frappe.ui.form.is_saving) {
 							doc.__needs_refresh = true;

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -50,15 +50,19 @@ $.extend(frappe.model, {
 			frappe.views.ListView.trigger_list_update(data);
 			var doc = locals[data.doctype] && locals[data.doctype][data.name];
 
-			if(doc) {
+			if (doc) {
 				// current document is dirty, show message if its not me
-				if(frappe.get_route()[0]==="Form" && cur_frm.doc.doctype===doc.doctype && cur_frm.doc.name===doc.name) {
-					if(!frappe.ui.form.is_saving && data.modified!=cur_frm.doc.modified) {
-						doc.__needs_refresh = true;
-						cur_frm.check_doctype_conflict();
+				if (frappe.get_route()[0] === "Form" && cur_frm.doc.doctype === doc.doctype && cur_frm.doc.name === doc.name) {
+					if (data.modified != cur_frm.doc.modified) {
+						if (!doc.__unsaved) {
+							cur_frm.reload_doc();
+						} else if (!frappe.ui.form.is_saving) {
+							doc.__needs_refresh = true;
+							cur_frm.check_doctype_conflict();
+						}
 					}
 				} else {
-					if(!doc.__unsaved) {
+					if (!doc.__unsaved) {
 						// no local changes, remove from locals
 						frappe.model.remove_from_locals(doc.doctype, doc.name);
 					} else {


### PR DESCRIPTION
Form used to throw `Document has been modified after you have opened it` warning while approving documents (via workflow) multiple times without refreshing.
<img width="1437" alt="Screenshot 2023-02-22 at 2 38 43 PM" src="https://user-images.githubusercontent.com/13928957/220577712-204683aa-0e18-4403-a584-3faf115f0263.png">


This used happen if the document had email notification enabled for it. Email notification tends to update modified timestamp of a parent document but on client-side form, it was not getting synced realtime. We had a code to sync it (via realtime `doc_update` event) but it was not working as expected. Hence the changes in this PR. 

**Before:**

https://user-images.githubusercontent.com/13928957/220578049-685b1ba7-e2b4-4587-99b0-d95b4857b87a.mov


**After:**


https://user-images.githubusercontent.com/13928957/220578771-0a095653-afe6-4600-ad03-d07adac07baf.mov



> **Note:** My local was slow during testing so you can skip ahead in the video to check important content :p
