### PR TITLE
fix: hide invalid filter conditions for 'HTML Editor' and 'Markdown Editor' (backport #20119)

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -47,6 +47,8 @@ frappe.ui.Filter = class {
 			Color: ['Between', 'Timespan'],
 			Check: this.conditions.map((c) => c[0]).filter((c) => c !== '='),
 			Code: ['Between', 'Timespan', '>', '<', '>=', '<=', 'in', 'not in'],
+			'HTML Editor': ['Between', 'Timespan', '>', '<', '>=', '<=', 'in', 'not in'],
+			'Markdown Editor': ['Between', 'Timespan', '>', '<', '>=', '<=', 'in', 'not in'],
 			Password: ['Between', 'Timespan', '>', '<', '>=', '<=', 'in', 'not in'],
 			Rating: ['like', 'not like', 'Between', 'in', 'not in', 'Timespan'],
 		};


### PR DESCRIPTION
backport #20119