### PR TITLE
fix: permission error for child doctype based chart

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -278,15 +278,14 @@ def get_group_by_chart_config(chart, filters):
 	group_by_field = chart.group_by_based_on
 	doctype = chart.document_type
 
-	data = frappe.db.get_list(
+	data = frappe.get_list(
 		doctype,
 		fields=[
 			f"{group_by_field} as name",
-			"{aggregate_function}({value_field}) as count".format(
-				aggregate_function=aggregate_function, value_field=value_field
-			),
+			f"{aggregate_function}({value_field}) as count",
 		],
 		filters=filters,
+		parent_doctype=chart.parent_document_type,
 		group_by=group_by_field,
 		order_by="count desc",
 		ignore_ifnull=True,


### PR DESCRIPTION
Created chart against the doctype `Timesheet Detail` but system throwing permission error even though user has permission to access the timesheet 

<img width="578" alt="image" src="https://user-images.githubusercontent.com/8780500/220588136-182ce16f-4e01-43b0-8bd3-0bd55263052e.png">
