### PR TITLE
fix: Quality Inspection fails because of incorrect str to float conversion

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -939,6 +939,15 @@ def flt(s: NumericType | str, precision: int | None = None) -> float:
 	>>> flt("a")
 	0.0
 	"""
+
+	#Get current decimal string and convert it to usual one.
+	number_format = frappe.db.get_default("number_format") or "#,###.##"
+	decimal_str, comma_str, number_format_precision = get_number_format_info(number_format)
+	if isinstance(s, str) and decimal_str == "," and comma_str == ".":
+		s = s.replace(",", "*") #Saving as temp
+		s = s.replace(".", ",")
+		s = s.replace("*", ".")
+
 	if isinstance(s, str):
 		s = s.replace(",", "")
 


### PR DESCRIPTION
Numeric format in Turkey is #.###,## . When saving quality inspections ERPNext sets the value as Rejected although given numbers are in the correct range.

Before:

![before_fix](https://user-images.githubusercontent.com/79133506/220991517-d1feb46a-95b9-42cb-913c-0e150bdb81f9.gif)

After:

![after_fix](https://user-images.githubusercontent.com/79133506/220991543-1aa381d0-59af-4e4b-9089-e454e65a1cac.gif)


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
