### PR TITLE
fix(print): Overflow wrap anywhere if a long word is found

### DIFF
--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -36,8 +36,8 @@
 			</td>
 			{% for col in columns %}
 				{% if col.name && col._id !== "_check" %}
-					{% var value = col.fieldname ? row[col.fieldname] : row[col.id] || "" %}
-					{% var longest_word = value.split(' ').reduce((longest, word) => word.length > longest.length ? word : longest, ''); %}
+					{% var value = col.fieldname ? row[col.fieldname] : row[col.id] %}
+					{% var longest_word = cstr(value).split(' ').reduce((longest, word) => word.length > longest.length ? word : longest, ''); %}
 					<td {% if row.bold == 1 %} style="font-weight: bold" {% endif %} {% if longest_word.length > 45 %} class="overflow-wrap-anywhere" {% endif %}>
 						<span {% if col._index == 0 %} style="padding-left: {%= cint(row.indent) * 2 %}em" {% endif %}>
 							{% format_data = row.is_total_row && ["Currency", "Float"].includes(col.fieldtype) ? data[0] : row %}

--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -36,10 +36,9 @@
 			</td>
 			{% for col in columns %}
 				{% if col.name && col._id !== "_check" %}
-
-					{% var value = col.fieldname ? row[col.fieldname] : row[col.id]; %}
-
-					<td {% if row.bold == 1 %} style="font-weight: bold" {% endif %}>
+					{% var value = col.fieldname ? row[col.fieldname] : row[col.id] || "" %}
+					{% var longest_word = value.split(' ').reduce((longest, word) => word.length > longest.length ? word : longest, ''); %}
+					<td {% if row.bold == 1 %} style="font-weight: bold" {% endif %} {% if longest_word.length > 45 %} class="overflow-wrap-anywhere" {% endif %}>
 						<span {% if col._index == 0 %} style="padding-left: {%= cint(row.indent) * 2 %}em" {% endif %}>
 							{% format_data = row.is_total_row && ["Currency", "Float"].includes(col.fieldtype) ? data[0] : row %}
 							{% if (row.is_total_row && col._index == 0) { %}

--- a/frappe/public/scss/print.bundle.scss
+++ b/frappe/public/scss/print.bundle.scss
@@ -35,3 +35,9 @@
 		margin: auto;
 	}
 }
+
+.overflow-wrap-anywhere {
+	* {
+		overflow-wrap: anywhere;
+	}
+}


### PR DESCRIPTION
**Before:**
<img width="1440" alt="Screenshot 2023-02-24 at 11 15 43 AM" src="https://user-images.githubusercontent.com/13928957/221101944-428eb491-05d9-4caa-a1a8-b1a794b53c32.png">

Print grid used to break-out when an unexpectedly long word is the content of table cell.

**After:**
<img width="1430" alt="Screenshot 2023-02-24 at 11 15 05 AM" src="https://user-images.githubusercontent.com/13928957/221102044-23a42377-e0c3-4cc5-881b-33c45d1198bd.png">


---

**Note:** Not applying `overflow-wrap: anywhere` for each table cell because then it starts breaking the table cell in weird places and it makes the print grid look ugly.
<img width="1422" alt="Screenshot 2023-02-24 at 11 16 33 AM" src="https://user-images.githubusercontent.com/13928957/221102070-ca22cadb-a4e8-4db7-8a96-a215b07dfc0f.png">
(with `overflow-wrap: anywhere` applied to each cell. Note that **ID**, "Priority", "Allocated To" column values are getting wrapped for no reason.)




**Ref:** https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap

