### PR TITLE
fix(workflow): move dom unfreeze to `finally`

### DIFF
--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -112,10 +112,12 @@ frappe.ui.form.States = class FormStates {
 								})
 								.then((doc) => {
 									frappe.model.sync(doc);
+									me.frm.script_manager.trigger("after_workflow_action");
+								})
+								.finally(() => {
 									frappe.dom.unfreeze();
 									me.frm.refresh();
 									me.frm.selected_workflow_action = null;
-									me.frm.script_manager.trigger("after_workflow_action");
 								});
 						});
 					});

--- a/frappe/public/js/frappe/form/workflow.js
+++ b/frappe/public/js/frappe/form/workflow.js
@@ -112,12 +112,12 @@ frappe.ui.form.States = class FormStates {
 								})
 								.then((doc) => {
 									frappe.model.sync(doc);
+									me.frm.refresh();
+									me.frm.selected_workflow_action = null;
 									me.frm.script_manager.trigger("after_workflow_action");
 								})
 								.finally(() => {
 									frappe.dom.unfreeze();
-									me.frm.refresh();
-									me.frm.selected_workflow_action = null;
 								});
 						});
 					});


### PR DESCRIPTION
Why? DOM stays frozen if some exception is raised by the python function.