### PR TITLE
fix: download upload button is hidden if grid row length is < 50

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -477,11 +477,16 @@ export default class Grid {
 					this.wrapper.find(".grid-add-multiple-rows").removeClass("hidden");
 				}
 			}
-		} else if (this.grid_rows.length < this.grid_pagination.page_length) {
+		} else if (
+			this.grid_rows.length < this.grid_pagination.page_length &&
+			!this.df.allow_bulk_edit
+		) {
 			this.wrapper.find(".grid-footer").toggle(false);
 		}
 
-		this.wrapper.find(".grid-add-row, .grid-add-multiple-rows").toggle(this.is_editable());
+		this.wrapper
+			.find(".grid-add-row, .grid-add-multiple-rows, .grid-upload")
+			.toggle(this.is_editable());
 	}
 
 	truncate_rows() {


### PR DESCRIPTION
Issue: For cancelled & submitted documents the download/upload button for the grid is only visible if the grid row length is more than 50.

**Before:** 
```
If 
	the grid is editable then all buttons are visible in the footer (Add, Add Multiple, Download & Upload)
else
	hide the footer if the grid row length is < 50 
```

**After:**
```
if 
	same as above
else
	hide the footer if grid row length < 50 & allow_bulk_edit is not set
```

Download & Upload is always shown if the footer is visible, it does not make sense to show the upload button if the grid is not editable.
Now Download button will always be visible if allow_bulk_edit is set and the Upload button will only be visible if the grid is editable