### PR TITLE
fix: clear all email_queue not with priority = 0

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -18,6 +18,8 @@ import frappe
 from frappe import _, enqueue, msgprint, safe_decode, safe_encode
 from frappe.email.email_body import add_attachment, get_email, get_formatted_html
 from frappe.email.smtp import SMTPServer, get_outgoing_email_account
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 from frappe.utils import (
 	add_days,
 	cint,
@@ -736,30 +738,25 @@ def clear_outbox(days=None):
 	"""Remove low priority older than 31 days in Outbox or configured in Log Settings.
 	Note: Used separate query to avoid deadlock
 	"""
-	if not days:
-		days = 31
+	days = days or 31
+	email_queue = frappe.qb.DocType("Email Queue")
+	email_recipient = frappe.qb.DocType("Email Queue Recipient")
 
-	email_queues = frappe.db.sql_list(
-		"""SELECT `name` FROM `tabEmail Queue`
-		WHERE `modified` < (NOW() - INTERVAL '{0}' DAY)""".format(
-			days
-		)
-	)
+	# Delete queue table
+	(
+		frappe.qb.from_(email_queue)
+		.delete()
+		.where(email_queue.modified < (Now() - Interval(days=days)))
+	).run()
 
-	if email_queues:
-		frappe.db.sql(
-			"""DELETE FROM `tabEmail Queue` WHERE `name` IN ({0})""".format(
-				",".join(["%s"] * len(email_queues))
-			),
-			tuple(email_queues),
-		)
-
-		frappe.db.sql(
-			"""DELETE FROM `tabEmail Queue Recipient` WHERE `parent` IN ({0})""".format(
-				",".join(["%s"] * len(email_queues))
-			),
-			tuple(email_queues),
-		)
+	# delete child tables, note that this has potential to leave some orphan
+	# child table behind if modified time was later than parent doc (rare).
+	# But it's safe since child table doesn't contain links.
+	(
+		frappe.qb.from_(email_recipient)
+		.delete()
+		.where(email_recipient.modified < (Now() - Interval(days=days)))
+	).run()
 
 
 def set_expiry_for_email_queue():

--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -741,7 +741,7 @@ def clear_outbox(days=None):
 
 	email_queues = frappe.db.sql_list(
 		"""SELECT `name` FROM `tabEmail Queue`
-		WHERE `priority`=0 AND `modified` < (NOW() - INTERVAL '{0}' DAY)""".format(
+		WHERE `modified` < (NOW() - INTERVAL '{0}' DAY)""".format(
 			days
 		)
 	)


### PR DESCRIPTION
Issue: Email Queue Log is not clearing queues with priority > 1.

NOTE: It was fixed in v14 & develop when the log settings was refactored