### PR TITLE
fix!: create property setters for system generated custom fields

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -25,6 +25,27 @@ frappe.ui.form.on("Custom Field", {
 		frm.toggle_enable("dt", frm.doc.__islocal);
 		frm.trigger("dt");
 		frm.toggle_reqd("label", !frm.doc.fieldname);
+
+		if (frm.doc.is_system_generated) {
+			frm.dashboard.add_comment(
+				__(
+					"<strong>Warning:</strong> This field is system generated and may be overwritten by a future update. Modify it using {0} instead.",
+					[
+						frappe.utils.get_form_link(
+							"Customize Form",
+							"Customize Form",
+							true,
+							__("Customize Form"),
+							{
+								doc_type: frm.doc.dt,
+							}
+						),
+					]
+				),
+				"yellow",
+				true
+			);
+		}
 	},
 	dt: function (frm) {
 		if (!frm.doc.dt) {

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -89,7 +89,7 @@ frappe.ui.form.on("Customize Form", {
 
 	setup_sortable: function (frm) {
 		frm.doc.fields.forEach(function (f) {
-			if (!f.is_custom_field) {
+			if (!f.is_custom_field || f.is_system_generated) {
 				f._sortable = false;
 			}
 

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -251,10 +251,23 @@ frappe.ui.form.on("Customize Form", {
 // can't delete standard fields
 frappe.ui.form.on("Customize Form Field", {
 	before_fields_remove: function (frm, doctype, name) {
-		var row = frappe.get_doc(doctype, name);
+		let row = frappe.get_doc(doctype, name);
+
+		if (row.is_system_generated) {
+			frappe.throw(
+				__(
+					"Cannot delete system generated field <strong>{0}</strong>. You can hide it instead.",
+					[__(row.label) || row.fieldname]
+				)
+			);
+		}
+
 		if (!(row.is_custom_field || row.__islocal)) {
-			frappe.msgprint(__("Cannot delete standard field. You can hide it if you want"));
-			throw "cannot delete standard field";
+			frappe.throw(
+				__("Cannot delete standard field <strong>{0}</strong>. You can hide it instead.", [
+					__(row.label) || row.fieldname,
+				])
+			);
 		}
 	},
 	fields_add: function (frm, cdt, cdn) {

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -251,7 +251,7 @@ frappe.ui.form.on("Customize Form", {
 // can't delete standard fields
 frappe.ui.form.on("Customize Form Field", {
 	before_fields_remove: function (frm, doctype, name) {
-		let row = frappe.get_doc(doctype, name);
+		const row = frappe.get_doc(doctype, name);
 
 		if (row.is_system_generated) {
 			frappe.throw(

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -403,3 +403,25 @@ class TestCustomizeForm(FrappeTestCase):
 
 		with self.assertRaises(frappe.ValidationError):
 			d.run_method("save_customization")
+
+	def test_system_generated_fields(self):
+		doctype = "Event"
+		custom_field_name = "test_custom_field"
+
+		custom_field = frappe.get_doc("Custom Field", {"dt": doctype, "fieldname": custom_field_name})
+		custom_field.is_system_generated = 1
+		custom_field.save()
+
+		d = self.get_customize_form(doctype)
+		custom_field = d.getone("fields", {"fieldname": custom_field_name})
+		custom_field.description = "Test Description"
+		d.run_method("save_customization")
+
+		property_setter_filters = {
+			"doc_type": doctype,
+			"field_name": custom_field_name,
+			"property": "description",
+		}
+		self.assertEqual(
+			frappe.db.get_value("Property Setter", property_setter_filters, "value"), "Test Description"
+		)


### PR DESCRIPTION
This is an important breaking change introduced to fix the following behaviour:

- System generated field `gstin` created when installing app.
- Field modified by user using **Customize Form**
- Field updated when updating the app to a newer version.
- User customisation overwritten / lost.

## Changes made

- System generated fields are now treated same as standard fields for the purpose of **Customize Form**
  - Modifications are stored as property setters instead of updating custom fields
  - They cannot be deleted, only hidden

- Warn users when they try to modify system generated fields from the **Custom Field** form
  
  ![image](https://user-images.githubusercontent.com/16315650/221547739-3550a13b-2a69-48d2-851d-b03b03721f91.png)
  
  (We can make the whole form read-only if needed)
