### PR TITLE
fix: prevent overwriting of the warnings by PyPDF2

### DIFF
--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -42,7 +42,7 @@ class TestPdf(FrappeTestCase):
 	def test_pdf_encryption(self):
 		password = "qwe"
 		pdf = pdfgen.get_pdf(self.html, options={"password": password})
-		reader = PdfReader(io.BytesIO(pdf))
+		reader = PdfReader(io.BytesIO(pdf), overwriteWarnings=False)
 		self.assertTrue(reader.isEncrypted)
 		self.assertTrue(reader.decrypt(password))
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -38,7 +38,7 @@ def get_pdf(html, options=None, output: PdfWriter | None = None):
 		filedata = pdfkit.from_string(html, options=options or {}, verbose=True)
 
 		# create in-memory binary streams from filedata and create a PdfReader object
-		reader = PdfReader(io.BytesIO(filedata))
+		reader = PdfReader(io.BytesIO(filedata), overwriteWarnings=False)
 	except OSError as e:
 		if any([error in str(e) for error in PDF_CONTENT_ERRORS]):
 			if not filedata:


### PR DESCRIPTION

When creating an Object of the class `PDFFileReader` from the package PyPDF2 the global warning function will be overwritten. This definitely happens in version 13, since it uses PyPDF2 in version 1.26.0 where it is done by the standard. 

This causes problems e.g. in unit tests when warnings are being thrown since some part of the handling in the PDFFileReader warning is incompatible with other warnings and causes an error. 

However, there is a simple solution to this because the constructor of the PDFFileReader accepts an argument to skip the overwriting of the warnings.

This problem is also known to PyPDF2 and also fixed in version 2 of PyPDF. Since frappe version 13 uses version 1.26.0 of PyPDF2 it is necessary to adapt to this problem.

For more information on PyPDF2 site check the following issue in their repository: https://github.com/py-pdf/pypdf/issues/67

In this issue there is also stated that the argument for the constructor is the correct and best way to solve this problem.