### PR TITLE
fix: improved implementation of `between` filter

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1070,13 +1070,7 @@ class Database:
 		if not datetime:
 			return FallBackDateTimeStr
 
-		if isinstance(datetime, str):
-			if ":" not in datetime:
-				datetime = datetime + " 00:00:00.000000"
-		else:
-			datetime = datetime.strftime("%Y-%m-%d %H:%M:%S.%f")
-
-		return datetime
+		return get_datetime(datetime).strftime("%Y-%m-%d %H:%M:%S.%f")
 
 	def get_creation_count(self, doctype, minutes):
 		"""Get count of records created in the last x minutes"""

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -762,6 +762,7 @@ class DatabaseQuery:
 				value = "('')"
 
 		else:
+			escape = True
 			df = meta.get("fields", {"fieldname": f.fieldname})
 			df = df[0] if df else None
 
@@ -783,6 +784,7 @@ class DatabaseQuery:
 				or (df and (df.fieldtype == "Date" or df.fieldtype == "Datetime"))
 			):
 
+				escape = False
 				value = get_between_date_filter(f.value, df)
 				fallback = f"'{FallBackDateTimeStr}'"
 
@@ -842,7 +844,7 @@ class DatabaseQuery:
 				value = f"{tname}.{quote}{f.value.name}{quote}"
 
 			# escape value
-			elif isinstance(value, str) and f.operator.lower() != "between":
+			elif escape and isinstance(value, str):
 				value = f"{frappe.db.escape(value, percent=False)}"
 
 		if (


### PR DESCRIPTION
In lieu of https://github.com/frappe/frappe/pull/19626 by @Aradhya-Tripathi 

**Note:** This PR restricts the **between** filter to Date and Datetime values. FWIW, this has been the UI behaviour since a long time anyway.

**Changes tested locally ✅** 