### PR TITLE
chore(Database): simplify condition

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -813,7 +813,8 @@ class Database:
 			distinct=distinct,
 			limit=limit,
 		)
-		if fields == "*" and not isinstance(fields, (list, tuple)) and not isinstance(fields, Criterion):
+
+		if fields == "*":
 			as_dict = True
 
 		return query.run(as_dict=as_dict, debug=debug, update=update, run=run, pluck=pluck)


### PR DESCRIPTION
If fields is a string, it can never be a list / tuple / Criterion.