### PR TITLE
fix: Use double quotes in template to avoid failure

### DIFF
--- a/frappe/public/js/frappe/views/reports/print_grid.html
+++ b/frappe/public/js/frappe/views/reports/print_grid.html
@@ -37,7 +37,7 @@
 			{% for col in columns %}
 				{% if col.name && col._id !== "_check" %}
 					{% var value = col.fieldname ? row[col.fieldname] : row[col.id] %}
-					{% var longest_word = cstr(value).split(' ').reduce((longest, word) => word.length > longest.length ? word : longest, ''); %}
+					{% var longest_word = cstr(value).split(" ").reduce((longest, word) => word.length > longest.length ? word : longest, ""); %}
 					<td {% if row.bold == 1 %} style="font-weight: bold" {% endif %} {% if longest_word.length > 45 %} class="overflow-wrap-anywhere" {% endif %}>
 						<span {% if col._index == 0 %} style="padding-left: {%= cint(row.indent) * 2 %}em" {% endif %}>
 							{% format_data = row.is_total_row && ["Currency", "Float"].includes(col.fieldtype) ? data[0] : row %}


### PR DESCRIPTION
<img width="1431" alt="Screenshot 2023-03-01 at 12 26 06 PM" src="https://user-images.githubusercontent.com/13928957/222069665-e9720ff9-576c-4ee6-ad27-07e39bb1dacc.png">

Fails in v13