### PR TITLE
fix: use `DOMParser` instead of `createElement` to remove script and style

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -34,35 +34,28 @@ frappe.dom = {
 	},
 	remove_script_and_style: function (txt) {
 		const evil_tags = ["script", "style", "noscript", "title", "meta", "base", "head"];
-		const regex = new RegExp(evil_tags.map((tag) => `<${tag}>.*<\\/${tag}>`).join("|"), "s");
-		if (!regex.test(txt)) {
-			// no evil tags found, skip the DOM method entirely!
-			return txt;
-		}
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(txt, "text/html");
+		const body = doc.body;
+		let found = !!doc.head.innerHTML;
 
-		var div = document.createElement("div");
-		div.innerHTML = txt;
-		var found = false;
-		evil_tags.forEach(function (e) {
-			var elements = div.getElementsByTagName(e);
-			i = elements.length;
-			while (i--) {
+		for (const tag of evil_tags) {
+			for (const element of body.getElementsByTagName(tag)) {
 				found = true;
-				elements[i].parentNode.removeChild(elements[i]);
-			}
-		});
-
-		// remove links with rel="stylesheet"
-		var elements = div.getElementsByTagName("link");
-		var i = elements.length;
-		while (i--) {
-			if (elements[i].getAttribute("rel") == "stylesheet") {
-				found = true;
-				elements[i].parentNode.removeChild(elements[i]);
+				element.parentNode.removeChild(element);
 			}
 		}
+
+		for (const element of body.getElementsByTagName("link")) {
+			const relation = element.getAttribute("rel");
+			if (relation && relation.toLowerCase().trim() === "stylesheet") {
+				found = true;
+				element.parentNode.removeChild(element);
+			}
+		}
+
 		if (found) {
-			return div.innerHTML;
+			return body.innerHTML;
 		} else {
 			// don't disturb
 			return txt;


### PR DESCRIPTION
The behaviour in my testing was exactly the same as before.