### PR TITLE
fix: only load workspace skeleton on workspace body

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -1425,15 +1425,15 @@ frappe.views.Workspace = class Workspace {
 	}
 
 	create_page_skeleton() {
-		if ($(".layout-main-section").find(".workspace-skeleton").length) return;
+		if (this.body.find(".workspace-skeleton").length) return;
 
-		$(".layout-main-section").prepend(frappe.render_template("workspace_loading_skeleton"));
-		$(".layout-main-section").find(".codex-editor").addClass("hidden");
+		this.body.prepend(frappe.render_template("workspace_loading_skeleton"));
+		this.body.find(".codex-editor").addClass("hidden");
 	}
 
 	remove_page_skeleton() {
-		$(".layout-main-section").find(".codex-editor").removeClass("hidden");
-		$(".layout-main-section").find(".workspace-skeleton").remove();
+		this.body.find(".codex-editor").removeClass("hidden");
+		this.body.find(".workspace-skeleton").remove();
 	}
 
 	create_sidebar_skeleton() {

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -1437,15 +1437,15 @@ frappe.views.Workspace = class Workspace {
 	}
 
 	create_sidebar_skeleton() {
-		if ($(".list-sidebar").find(".workspace-sidebar-skeleton").length) return;
+		if (this.sidebar.find(".workspace-sidebar-skeleton").length) return;
 
-		$(".list-sidebar").prepend(frappe.render_template("workspace_sidebar_loading_skeleton"));
-		$(".desk-sidebar").addClass("hidden");
+		this.sidebar.prepend(frappe.render_template("workspace_sidebar_loading_skeleton"));
+		this.sidebar.find(".standard-sidebar-section").addClass("hidden");
 	}
 
 	remove_sidebar_skeleton() {
-		$(".desk-sidebar").removeClass("hidden");
-		$(".list-sidebar").find(".workspace-sidebar-skeleton").remove();
+		this.sidebar.find(".standard-sidebar-section").removeClass("hidden");
+		this.sidebar.find(".workspace-sidebar-skeleton").remove();
 	}
 
 	register_awesomebar_shortcut() {


### PR DESCRIPTION
If the network is slow sometimes the workspace skeleton bleeds on the list view body.
Can't reproduce but Rushabh has faced the problem (couple of ss from Rushabh)

![image](https://user-images.githubusercontent.com/30859809/222083566-d1c24538-62c3-454a-ac88-27033ac20ae8.png)


![image](https://user-images.githubusercontent.com/30859809/222083526-d5bf366f-8e6b-4683-aeb8-845b0979b593.png)
