### PR TITLE
fix: Attempt to run after_hooks only if site is initialized

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -77,8 +77,9 @@ def application(request: Request):
 		if request.method in UNSAFE_HTTP_METHODS and frappe.db and rollback:
 			frappe.db.rollback()
 
-		for after_request_task in frappe.get_hooks("after_request"):
-			frappe.call(after_request_task, response=response, request=request)
+		if getattr(frappe.local, "initialised", False):
+			for after_request_task in frappe.get_hooks("after_request"):
+				frappe.call(after_request_task, response=response, request=request)
 
 		log_request(request, response)
 		process_response(response)


### PR DESCRIPTION
Raise correct HTTP Code & error when site not found 

### Before

![image](https://user-images.githubusercontent.com/36654812/222125842-88cd00a5-b085-4df4-b74e-961e40f983bd.png)

### After

![image](https://user-images.githubusercontent.com/36654812/222125884-beda2406-3c62-4215-9c3f-13f4cb82d110.png)

---

Introduced by #19971 