### PR TITLE
fix: js issue if no message returned for xhr callback

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -145,7 +145,7 @@ frappe.Application = class Application {
 							user: frappe.session.user,
 						},
 						callback: function (r) {
-							if (r.message.show_alert) {
+							if (r.message && r.message.show_alert) {
 								frappe.show_alert({
 									indicator: "red",
 									message: r.message.message,


### PR DESCRIPTION
Fix js issue if no error logs pending to be viewed when "frappe.core.doctype.log_settings.log_settings.has_unseen_error_log" within desk.js.

Just added (r.message && ...) as most callback response functions.

```js
TypeError: Cannot read properties of undefined (reading 'show_alert')
    at Object.callback (desk.bundle.JGEXYTL7.js:2823:2771)
    at Object.e [as success_callback] (desk.bundle.JGEXYTL7.js:440:1208)
    at 200 (desk.bundle.JGEXYTL7.js:440:1775)
    at Object.<anonymous> (desk.bundle.JGEXYTL7.js:440:4840)
    at R (libs.bundle.YZMCKPNH.js:1:30299)
    at Object.fireWith [as resolveWith] (libs.bundle.YZMCKPNH.js:1:31091)
    at Oe (libs.bundle.YZMCKPNH.js:4:6046)
    at XMLHttpRequest.<anonymous> (libs.bundle.YZMCKPNH.js:4:8531)
```
