### PR TITLE
fix: Use `word-break` property for print media to avoid overflow

### DIFF
--- a/frappe/public/scss/print.scss
+++ b/frappe/public/scss/print.scss
@@ -17,6 +17,11 @@
 	.print-hide {
 		display: none !important;
 	}
+	.overflow-wrap-anywhere {
+		* {
+			word-break: break-all;
+		}
+	}
 }
 
 .action-banner {


### PR DESCRIPTION
Continuation of https://github.com/frappe/frappe/pull/20152

Although the previous fix worked for print view but it did not work for PDFs mostly because wkhtmltopdf is using very old QTWebkit version which did not support [`overflow-wrap`](https://caniuse.com/?search=overflow-wrap) hence using `word-break` in print media as it works in a similar way.

**Before:**
<img width="1420" alt="Screenshot 2023-03-02 at 10 56 05 AM" src="https://user-images.githubusercontent.com/13928957/222340737-8f349af4-a3cb-4e18-aa52-ad294541311c.png">

**After:**
<img width="1423" alt="Screenshot 2023-03-02 at 10 55 52 AM" src="https://user-images.githubusercontent.com/13928957/222340766-1e74dd47-85a0-4964-9dac-0efcd59d22a9.png">
