### PR TITLE
fix: log raw text reponse instead of parsing JSON

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -160,7 +160,7 @@ def log_request(
 			"url": url,
 			"headers": frappe.as_json(headers) if headers else None,
 			"data": frappe.as_json(data) if data else None,
-			"response": frappe.as_json(res.json()) if res else None,
+			"response": res and res.text,
 			"error": frappe.get_traceback(),
 		}
 	)


### PR DESCRIPTION
Not every service responds in JSON, we shouldn't expect a JSON response.

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/requests/models.py", line 910, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/rq/worker.py", line 1075, in perform_job
    rv = job.perform()
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/rq/job.py", line 854, in perform
    self._result = self._execute()
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/rq/job.py", line 877, in _execute
    result = self.func(*self.args, **self.kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 165, in execute_job
    retval = method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 140, in enqueue_webhook
    log_request(webhook.request_url, headers, data, r)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/integrations/doctype/webhook/webhook.py", line 156, in log_request
    "response": frappe.as_json(res.json()) if res else None,
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/requests/models.py", line 917, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: [Errno Expecting value] Message published.: 0
```


ref: ISS-22-23-05670