### PR TITLE
fix: frappe.route_options in quick_list_widget

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -241,9 +241,6 @@ export default class QuickListWidget extends Widget {
 		this.footer.empty();
 
 		let filters = frappe.utils.get_filter_from_json(this.quick_list_filter);
-		if (filters) {
-			frappe.route_options = filters;
-		}
 		let route = frappe.utils.generate_route({ type: "doctype", name: this.document_type });
 		this.see_all_button = $(`
 			<div class="see-all btn btn-xs">${__("View List")}</div>
@@ -252,6 +249,9 @@ export default class QuickListWidget extends Widget {
 		this.see_all_button.click((e) => {
 			if (e.ctrlKey || e.metaKey) {
 				frappe.open_in_new_tab = true;
+			}
+			if (filters) {
+				frappe.route_options = filters;
 			}
 			frappe.set_route(route);
 		});


### PR DESCRIPTION
**Issue description:**
When adding multiple `quick_list_widgets` in a workspace with different filters, the filter of the last widget is globally added to `frappe.route_options`. Clicking on any of the View List buttons of the other widgets always pre-filters the list based on the last `quick_list_widget` that was added. To avoid this behavior, the `frappe.route_options` should be set within the click handler.

**Steps to reproduce:**
- Create a new workspace
- A Quick List Widget, e.g. Sales Invoice DocType with filter on status Paid
- A Quick List Widget, e.g. Timesheet DocType with filter on status Draft
- Save
- When you click on View List for the Sales Invoice Quick List it will be filtered on status Draft instead of Paid