### PR TITLE
fix(DX): better error message for notification from reference doctype

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -453,16 +453,17 @@ def evaluate_alert(doc: Document, alert, event):
 			doc.reload()
 		alert.send(doc)
 	except TemplateError:
-		frappe.throw(
-			_("Error while evaluating Notification {0}. Please fix your template.").format(alert)
+		message = _("Error while evaluating Notification {0}. Please fix your template.").format(
+			frappe.utils.get_link_to_form("Notification", alert.name)
 		)
+		frappe.throw(message, title=_("Error in Notification"))
 	except Exception as e:
-		error_log = frappe.log_error(message=frappe.get_traceback(), title=str(e))
-		frappe.throw(
-			_("Error in Notification: {}").format(
-				frappe.utils.get_link_to_form("Error Log", error_log.name)
-			)
-		)
+		title = str(e)
+		message = frappe.get_traceback()
+		frappe.log_error(message=message, title=title)
+
+		msg = f"<details><summary>{title}</summary>{message}</details>"
+		frappe.throw(msg, title=_("Error in Notification"))
 
 
 def get_context(doc):


### PR DESCRIPTION
**Before:**
<img width="594" alt="image" src="https://user-images.githubusercontent.com/30859809/222448381-07e8a3c6-b083-4e09-87ce-55548204b4cc.png">

**After:**
<img width="591" alt="image" src="https://user-images.githubusercontent.com/30859809/222447498-cab299e6-aae1-447c-9f4f-306b12a51847.png">

<img width="589" alt="image" src="https://user-images.githubusercontent.com/30859809/222447545-11d8d3ff-cf7f-4a5d-8751-d42c790592a4.png">

----

**Before:** Template Error
<img width="597" alt="image" src="https://user-images.githubusercontent.com/30859809/222448653-1b74262d-00b1-4996-8ee4-a0267104bb70.png">

**After:** Template Error
<img width="590" alt="image" src="https://user-images.githubusercontent.com/30859809/222448985-007a9209-1608-46d4-b05e-1caab825286f.png">
