### PR TITLE
fix(Database): clear background jobs and realtime logs on rollback

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -994,6 +994,9 @@ class Database:
 				if hasattr(obj, "on_rollback"):
 					obj.on_rollback()
 			frappe.local.rollback_observers = []
+		
+			frappe.local.realtime_log = []
+			frappe.flags.enqueue_after_commit = []
 
 	def field_exists(self, dt, fn):
 		"""Return true of field exists."""


### PR DESCRIPTION
**Problem**

Background Jobs to be enqueued after commit and Realtime Messages to be sent after commit are not cleared on rollback.

Sometimes we catch errors, rollback, and keep on working, so the enqueue and realtime logs will get flushed on the next commit.

```python
try:
    frappe.enqueue(..., enqueue_after_commit=True)
    frappe.publish_realtime(..., after_commit=True)
    frappe.throw("Some error occurred")
except Exception:
    frappe.db.rollback()
    # do some database work for ex. create an error log
    frappe.db.commit()  # will enqueue jobs and publish realtime messages even after rollback
```

**Solution**

Clear the logs!

```python
frappe.local.realtime_log = []
frappe.flags.enqueue_after_commit = []
```