### PR TITLE
fix: compare with content value for Link fieldtypes

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1204,7 +1204,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				width: parseInt(column.width) || null,
 				editable: false,
 				compareValue: compareFn,
-				format: (value, row, column, data) => {
+				format: (value, row, column, data, for_filter = false) => {
+					if (for_filter && column?.fieldtype === "Link") {
+						return value || "";
+					}
 					if (this.report_settings.formatter) {
 						return this.report_settings.formatter(
 							value,


### PR DESCRIPTION
Depends on PR: https://github.com/frappe/datatable/pull/169

**Issue:** While filtering we always compare the filter string with the formatted value of the cell but some cell takes too much time to get the formatted value which results in a broken page.

For some field types like the Link field we do not have to get formatted value, we can check with the content value which will fix the problem.