### PR TITLE
feat: Apply permlevel restrictions in Document, DatabaseQuery API Calls [v14]

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -77,7 +77,8 @@ def handle():
 					doc = frappe.get_doc(doctype, name)
 					if not doc.has_permission("read"):
 						raise frappe.PermissionError
-					doc.apply_fieldlevel_read_permissions()
+					if frappe.get_system_settings("apply_perm_level_on_api_calls"):
+						doc.apply_fieldlevel_read_permissions()
 					frappe.local.response.update({"data": doc})
 
 				if frappe.local.request.method == "PUT":
@@ -91,8 +92,9 @@ def handle():
 					# Not checking permissions here because it's checked in doc.save
 					doc.update(data)
 					doc.save()
-					doc.apply_fieldlevel_read_permissions()
-					frappe.local.response.update({"data": doc.as_dict()})
+					if frappe.get_system_settings("apply_perm_level_on_api_calls"):
+						doc.apply_fieldlevel_read_permissions()
+					frappe.local.response.update({"data": doc})
 
 					# check for child table doctype
 					if doc.get("parenttype"):

--- a/frappe/api.py
+++ b/frappe/api.py
@@ -77,6 +77,7 @@ def handle():
 					doc = frappe.get_doc(doctype, name)
 					if not doc.has_permission("read"):
 						raise frappe.PermissionError
+					doc.apply_fieldlevel_read_permissions()
 					frappe.local.response.update({"data": doc})
 
 				if frappe.local.request.method == "PUT":
@@ -89,8 +90,9 @@ def handle():
 
 					# Not checking permissions here because it's checked in doc.save
 					doc.update(data)
-
-					frappe.local.response.update({"data": doc.save().as_dict()})
+					doc.save()
+					doc.apply_fieldlevel_read_permissions()
+					frappe.local.response.update({"data": doc.as_dict()})
 
 					# check for child table doctype
 					if doc.get("parenttype"):

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -86,6 +86,8 @@ def get(doctype, name=None, filters=None, parent=None):
 		doc = frappe.get_doc(doctype)  # single
 
 	doc.check_permission()
+	doc.apply_fieldlevel_read_permissions()
+
 	return doc.as_dict()
 
 

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -86,7 +86,9 @@ def get(doctype, name=None, filters=None, parent=None):
 		doc = frappe.get_doc(doctype)  # single
 
 	doc.check_permission()
-	doc.apply_fieldlevel_read_permissions()
+
+	if frappe.get_system_settings("apply_perm_level_on_api_calls"):
+		doc.apply_fieldlevel_read_permissions()
 
 	return doc.as_dict()
 

--- a/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
+++ b/frappe/contacts/report/addresses_and_contacts/test_addresses_and_contacts.py
@@ -112,6 +112,3 @@ class TestAddressesAndContacts(FrappeTestCase):
 				1,
 			]
 			self.assertListEqual(test_item, report_data[idx])
-
-	def tearDown(self):
-		frappe.db.rollback()

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -43,6 +43,7 @@
   "allow_error_traceback",
   "strip_exif_metadata_from_uploaded_images",
   "allow_older_web_view_links",
+  "apply_perm_level_on_api_calls",
   "password_settings",
   "logout_on_password_reset",
   "force_user_to_reset_password",
@@ -533,12 +534,18 @@
    "fieldname": "disable_user_pass_login",
    "fieldtype": "Check",
    "label": "Disable Username/Password Login"
+  },
+  {
+   "default": "0",
+   "fieldname": "apply_perm_level_on_api_calls",
+   "fieldtype": "Check",
+   "label": "Apply Perm Level on API calls (Recommended)"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2022-10-30 12:02:46.639170",
+ "modified": "2023-03-03 11:47:24.867356",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -219,7 +219,7 @@ class Database:
 			self._cursor.execute(query, values)
 		except Exception as e:
 			if self.is_syntax_error(e):
-				frappe.errprint(f"Syntax error in query:\n{query} {values}")
+				frappe.errprint(f"Syntax error in query:\n{query} {values or ''}")
 
 			elif self.is_deadlocked(e):
 				raise frappe.QueryDeadlockError(e) from e

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -43,7 +43,8 @@ def getdoc(doctype, name, user=None):
 		)
 		raise frappe.PermissionError(("read", doctype, name))
 
-	doc.apply_fieldlevel_read_permissions()
+	if frappe.get_system_settings("apply_perm_level_on_api_calls"):
+		doc.apply_fieldlevel_read_permissions()
 
 	# add file list
 	doc.add_viewed()

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -43,8 +43,8 @@ def getdoc(doctype, name, user=None):
 		)
 		raise frappe.PermissionError(("read", doctype, name))
 
-	if frappe.get_system_settings("apply_perm_level_on_api_calls"):
-		doc.apply_fieldlevel_read_permissions()
+	# ignores system setting (apply_perm_level_on_api_calls) unconditionally to maintain backward compatibility
+	doc.apply_fieldlevel_read_permissions()
 
 	# add file list
 	doc.add_viewed()

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -151,13 +151,13 @@ def setup_group_by(data):
 			frappe.throw(_("Invalid aggregate function"))
 
 		if frappe.db.has_column(data.aggregate_on_doctype, data.aggregate_on_field):
-			data.fields.append(
-				"{aggregate_function}(`tab{aggregate_on_doctype}`.`{aggregate_on_field}`) AS _aggregate_column".format(
-					**data
-				)
-			)
+			column = f"`tab{data.aggregate_on_doctype}`.`{data.aggregate_on_field}`"
+			aggregate_function = data.aggregate_function
+
+			data.fields.append(f"{aggregate_function}({column}) AS _aggregate_column")
 			if data.aggregate_on_field:
-				data.fields.append(f"`tab{data.aggregate_on_doctype}`.`{data.aggregate_on_field}`")
+				data.fields.append(column)
+			data.group_by += f", {column}"
 		else:
 			raise_invalid_field(data.aggregate_on_field)
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -151,13 +151,9 @@ def setup_group_by(data):
 			frappe.throw(_("Invalid aggregate function"))
 
 		if frappe.db.has_column(data.aggregate_on_doctype, data.aggregate_on_field):
-			column = f"`tab{data.aggregate_on_doctype}`.`{data.aggregate_on_field}`"
-			aggregate_function = data.aggregate_function
-
-			data.fields.append(f"{aggregate_function}({column}) AS _aggregate_column")
-			if data.aggregate_on_field:
-				data.fields.append(column)
-			data.group_by += f", {column}"
+			data.fields.append(
+				f"{data.aggregate_function}(`tab{data.aggregate_on_doctype}`.`{data.aggregate_on_field}`) AS _aggregate_column"
+			)
 		else:
 			raise_invalid_field(data.aggregate_on_field)
 

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -186,3 +186,25 @@ def delete_fields(args_dict, delete=0):
 		if frappe.db.db_type == "postgres":
 			# commit the results to db
 			frappe.db.commit()
+
+
+def get_permitted_fields(
+	doctype: str, parenttype: str | None = None, user: str | None = None
+) -> list[str]:
+	meta = frappe.get_meta(doctype)
+	valid_columns = meta.get_valid_columns()
+
+	if doctype in core_doctypes_list:
+		return valid_columns
+
+	meta_fields = meta.default_fields.copy()
+	optional_meta_fields = [x for x in optional_fields if x in valid_columns]
+
+	if meta.istable:
+		meta_fields.extend(child_table_fields)
+
+	return (
+		meta_fields
+		+ meta.get_permitted_fieldnames(parenttype=parenttype, user=user)
+		+ optional_meta_fields
+	)

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -95,6 +95,7 @@ optional_fields = ("_user_tags", "_comments", "_assign", "_liked_by", "_seen")
 table_fields = ("Table", "Table MultiSelect")
 
 core_doctypes_list = (
+	"DefaultValue",
 	"DocType",
 	"DocField",
 	"DocPerm",

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -197,14 +197,13 @@ def get_permitted_fields(
 	if doctype in core_doctypes_list:
 		return valid_columns
 
-	meta_fields = meta.default_fields.copy()
-	optional_meta_fields = [x for x in optional_fields if x in valid_columns]
+	if permitted_fields := meta.get_permitted_fieldnames(parenttype=parenttype, user=user):
+		meta_fields = meta.default_fields.copy()
+		optional_meta_fields = [x for x in optional_fields if x in valid_columns]
 
-	if meta.istable:
-		meta_fields.extend(child_table_fields)
+		if meta.istable:
+			meta_fields.extend(child_table_fields)
 
-	return (
-		meta_fields
-		+ meta.get_permitted_fieldnames(parenttype=parenttype, user=user)
-		+ optional_meta_fields
-	)
+		return meta_fields + permitted_fields + optional_meta_fields
+
+	return []

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -32,6 +32,7 @@ DOCTYPE_TABLE_FIELDS = [
 
 TABLE_DOCTYPES_FOR_DOCTYPE = {df["fieldname"]: df["options"] for df in DOCTYPE_TABLE_FIELDS}
 DOCTYPES_FOR_DOCTYPE = {"DocType", *TABLE_DOCTYPES_FOR_DOCTYPE.values()}
+_DOC_DELETED_ATTR = object()
 
 
 def get_controller(doctype):
@@ -298,8 +299,14 @@ class BaseDocument:
 	) -> dict:
 		d = _dict()
 		for fieldname in self.meta.get_valid_columns():
+			field_value = getattr(self, fieldname, _DOC_DELETED_ATTR)
+
+			# don't set if field is deleted
+			if field_value is _DOC_DELETED_ATTR:
+				continue
+
 			# column is valid, we can use getattr
-			d[fieldname] = getattr(self, fieldname, None)
+			d[fieldname] = field_value
 
 			# if no need for sanitization and value is None, continue
 			if not sanitize and d[fieldname] is None:

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -353,7 +353,7 @@ class BaseDocument:
 
 			if ignore_nulls and d[fieldname] is None:
 				del d[fieldname]
-			if not is_virtual_field and field_value is _DOC_DELETED_ATTR:
+			elif not is_virtual_field and field_value is _DOC_DELETED_ATTR:
 				del d[fieldname]
 
 		return d

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -613,6 +613,7 @@ class DatabaseQuery:
 			# handle child / joined table fields
 			elif "." in field:
 				table, column = column.split(".", 1)
+				ch_doctype = table.replace("`", "").replace("tab", "", 1)
 
 				if wrap_grave_quotes(table) in self.tables:
 					ch_doctype = table.replace("`", "").replace("tab", "", 1)
@@ -623,6 +624,8 @@ class DatabaseQuery:
 						continue
 					else:
 						self.fields.remove(field)
+				else:
+					raise frappe.PermissionError(ch_doctype)
 
 			elif column in permitted_fields:
 				continue

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -603,7 +603,9 @@ class DatabaseQuery:
 		        - Query: fields=["*"]
 		        - Result: fields=["title", ...] // will also include Frappe's meta field like `name`, `owner`, etc.
 		"""
-		if self.flags.ignore_permissions:
+		if self.flags.ignore_permissions or not frappe.get_system_settings(
+			"apply_perm_level_on_api_calls"
+		):
 			return
 
 		asterisk_fields = []

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -56,7 +56,6 @@ ORDER_GROUP_PATTERN = re.compile(r".*[^a-z0-9-_ ,`'\"\.\(\)].*")
 class DatabaseQuery:
 	def __init__(self, doctype, user=None):
 		self.doctype = doctype
-		self.doctype_meta = frappe.get_meta(doctype)
 		self.tables = []
 		self.link_tables = []
 		self.conditions = []
@@ -66,6 +65,12 @@ class DatabaseQuery:
 		self.ignore_ifnull = False
 		self.flags = frappe._dict()
 		self.reference_doctype = None
+
+	@property
+	def doctype_meta(self):
+		if not hasattr(self, "_doctype_meta"):
+			self._doctype_meta = frappe.get_meta(self.doctype)
+		return self._doctype_meta
 
 	def execute(
 		self,

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -14,7 +14,7 @@ import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr
-from frappe.model import core_doctypes_list, optional_fields
+from frappe.model import child_table_fields, core_doctypes_list, optional_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
@@ -52,6 +52,7 @@ STRICT_FIELD_PATTERN = re.compile(r".*/\*.*")
 STRICT_UNION_PATTERN = re.compile(r".*\s(union).*\s")
 ORDER_GROUP_PATTERN = re.compile(r".*[^a-z0-9-_ ,`'\"\.\(\)].*")
 FN_PARAMS_PATTERN = re.compile(r".*?\((.*)\).*")
+SPECIAL_FIELD_CHARS = frozenset(("(", "`", ".", "'", '"', "*"))
 
 
 class DatabaseQuery:
@@ -1267,7 +1268,7 @@ def get_permitted_fields(doctype, parenttype=None):
 		meta_fields.remove("docstatus")
 
 	if meta.istable:
-		meta_fields.extend(["parent", "parenttype", "parentfield"])
+		meta_fields.extend(child_table_fields)
 	else:
 		meta_fields.remove("idx")
 
@@ -1282,7 +1283,7 @@ def wrap_grave_quotes(table: str) -> str:
 
 def is_plain_field(field: str) -> bool:
 	for char in field:
-		if char in ("(", "`", ".", "'", '"', "*"):
+		if char in SPECIAL_FIELD_CHARS:
 			return False
 	return True
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -164,6 +164,7 @@ class DatabaseQuery:
 		self.run = run
 		self.strict = strict
 		self.ignore_ddl = ignore_ddl
+		self.parent_doctype = parent_doctype
 
 		# for contextual user permission check
 		# to determine which user permission is applicable on link field of specific doctype
@@ -593,7 +594,7 @@ class DatabaseQuery:
 			return
 
 		asterisk_fields = []
-		permitted_fields = get_permitted_fields(doctype=self.doctype)
+		permitted_fields = get_permitted_fields(doctype=self.doctype, parenttype=self.parent_doctype)
 
 		for i, field in enumerate(self.fields):
 			if "distinct" in field.lower():

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -240,6 +240,7 @@ class DatabaseQuery:
 		self.extract_tables()
 		self.set_optional_columns()
 		self.build_conditions()
+		self.apply_fieldlevel_read_permissions()
 
 		args = frappe._dict()
 
@@ -566,6 +567,27 @@ class DatabaseQuery:
 				conditions.append(f)
 			else:
 				conditions.append(self.prepare_filter_condition(f))
+
+	def apply_fieldlevel_read_permissions(self):
+		"""Apply fieldlevel read permissions to the query"""
+		if self.flags.ignore_permissions:
+			return
+
+		accessible_fields = {
+			x.fieldname for x in frappe.get_meta(self.doctype).get_permlevel_read_fields()
+		}
+
+		for i, field in enumerate(self.fields):
+			if field == "*":
+				self.fields.pop(i)
+				for f in accessible_fields:
+					self.fields.insert(i, f"`tab{self.doctype}`.`{f}`")
+
+			elif field[0] in {"'", '"', "_"} or "(" in field or "." in field or field in accessible_fields:
+				continue
+
+			else:
+				self.fields.remove(field)
 
 	def prepare_filter_condition(self, f):
 		"""Returns a filter condition in the format:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -632,8 +632,6 @@ class DatabaseQuery:
 			elif "(" in field:
 				if "*" in field:
 					continue
-				elif any(x for x in permitted_fields if x in field):
-					continue
 				elif _params := FN_PARAMS_PATTERN.findall(column):
 					params = (x for x in _params[0].split(","))
 					for param in params:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -580,7 +580,7 @@ class DatabaseQuery:
 		if self.flags.ignore_permissions:
 			return
 
-		available_fields = get_available_fields(doctype=self.doctype)
+		available_fields = get_permitted_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
 			column = field.split(" ", 1)[0].replace("`", "")
@@ -599,7 +599,7 @@ class DatabaseQuery:
 
 				if table in self.tables:
 					ch_doctype = table.replace("`", "").replace("tab", "", 1)
-					available_child_table_fields = get_available_fields(
+					available_child_table_fields = get_permitted_fields(
 						doctype=ch_doctype, parenttype=self.doctype
 					)
 					if column in available_child_table_fields:
@@ -616,7 +616,9 @@ class DatabaseQuery:
 				elif _params := FN_PARAMS_PATTERN.findall(column):
 					params = (x for x in _params[0].split(","))
 					for param in params:
-						if param in available_fields or param.isnumeric() or "'" in param or '"' in param:
+						if (
+							not param or param in available_fields or param.isnumeric() or "'" in param or '"' in param
+						):
 							continue
 						else:
 							self.fields.remove(field)
@@ -1230,7 +1232,7 @@ def requires_owner_constraint(role_permissions):
 	return True
 
 
-def get_available_fields(doctype, parenttype=None):
+def get_permitted_fields(doctype, parenttype=None):
 	meta = frappe.get_meta(doctype)
 
 	if doctype in core_doctypes_list:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -580,28 +580,41 @@ class DatabaseQuery:
 		if self.flags.ignore_permissions:
 			return
 
-		available_fields = get_permitted_fields(doctype=self.doctype)
+		permitted_fields = get_permitted_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
-			if "distinct" in field:
-				self.distinct = True
-				column = field.split(" ", 2)[1].replace("`", "")
-			else:
-				column = field.split(" ", 1)[0].replace("`", "")
+			# field: like 'name', 'published'
+			if is_plain_field(field) and field not in permitted_fields:
+				self.fields.remove(field)
+				continue
 
-			if column == "*":
-				self.fields[i : i + 1] = available_fields
+			if "distinct" in field.lower():
+				# field: 'count(distinct `tabPhoto`.name) as total_count'
+				# column: 'tabPhoto.name'
+				self.distinct = True
+				column = field.split(" ", 2)[1].replace("`", "").replace(")", "")
+			else:
+				# field: 'count(`tabPhoto`.name) as total_count'
+				# column: 'tabPhoto.name'
+				column = field.split("(")[-1].split(")", 1)[0]
+				column = strip_alias(column).replace("`", "")
+
+			if column == "*" and not in_function("*", field):
+				self.fields[i : i + 1] = permitted_fields
+
+			# handle pseudo columns
+			elif not column:
+				continue
 
 			# labels / pseudo columns or frappe internals
-			elif column[0] in {"'", '"', "_"} or column in available_fields:
+			elif column[0] in {"'", '"', "_"}:
 				continue
 
 			# handle child / joined table fields
 			elif "." in field:
-				table, _column = field.split(".", 1)
-				column = _column.lower().split(" ", 1)[0].replace("`", "")
+				table, column = column.split(".", 1)
 
-				if table in self.tables:
+				if wrap_grave_quotes(table) in self.tables:
 					ch_doctype = table.replace("`", "").replace("tab", "", 1)
 					available_child_table_fields = get_permitted_fields(
 						doctype=ch_doctype, parenttype=self.doctype
@@ -611,21 +624,23 @@ class DatabaseQuery:
 					else:
 						self.fields.remove(field)
 
+			elif column in permitted_fields:
+				continue
+
 			# field inside function calls / * handles things like count(*)
 			elif "(" in field:
 				if "*" in field:
 					continue
-				elif any(x for x in available_fields if x in field):
+				elif any(x for x in permitted_fields if x in field):
 					continue
 				elif _params := FN_PARAMS_PATTERN.findall(column):
 					params = (x for x in _params[0].split(","))
 					for param in params:
 						if (
-							not param or param in available_fields or param.isnumeric() or "'" in param or '"' in param
+							not param or param in permitted_fields or param.isnumeric() or "'" in param or '"' in param
 						):
 							continue
-						else:
-							self.fields.remove(field)
+				self.fields.remove(field)
 
 			# remove if access not allowed
 			else:
@@ -1258,3 +1273,30 @@ def get_permitted_fields(doctype, parenttype=None):
 		meta_fields.remove("idx")
 
 	return meta_fields + accessible_fields + optional_meta_fields
+
+
+def wrap_grave_quotes(table: str) -> str:
+	if table[0] != "`":
+		table = f"`{table}`"
+	return table
+
+
+def is_plain_field(field: str) -> bool:
+	for char in field:
+		if char in ("(", "`", ".", "'", '"', "*"):
+			return False
+	return True
+
+
+def in_function(substr: str, field: str) -> bool:
+	try:
+		return substr in field and field.index("(") < field.index(substr) < field.index(")")
+	except ValueError:
+		return False
+
+
+def strip_alias(field: str) -> str:
+	# Note: Currently only supports aliases that use the " AS " syntax
+	if " as " in field.lower():
+		return field.split(" as ", 1)[0]
+	return field

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -574,13 +574,32 @@ class DatabaseQuery:
 		if self.flags.ignore_permissions:
 			return
 
-		accessible_fields = {x.fieldname for x in self.doctype_meta.get_permlevel_read_fields()}
+		accessible_fields = [x.fieldname for x in self.doctype_meta.get_permlevel_read_fields()]
+		meta_fields = self.doctype_meta.default_fields.copy()
+		optional_meta_fields = list(optional_fields)
+
+		if not self.doctype_meta.track_seen:
+			optional_meta_fields.remove("_seen")
+
+		if not self.doctype_meta.is_submittable:
+			meta_fields.remove("docstatus")
+
+		if self.doctype_meta.istable:
+			meta_fields.append("parent")
+			meta_fields.append("parenttype")
+			meta_fields.append("parentfield")
+		else:
+			meta_fields.remove("idx")
+
+		available_fields = meta_fields + accessible_fields + optional_meta_fields
 
 		for i, field in enumerate(self.fields):
 			if field == "*":
 				self.fields.pop(i)
-				for f in accessible_fields:
-					self.fields.insert(i, f"`tab{self.doctype}`.`{f}`")
+				k = i
+				for f in available_fields:
+					self.fields.insert(k, f"`tab{self.doctype}`.`{f}`")
+					k += 1
 
 			elif field[0] in {"'", '"', "_"} or "(" in field or "." in field or field in accessible_fields:
 				continue

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -594,7 +594,7 @@ class DatabaseQuery:
 			return
 
 		asterisk_fields = []
-		permitted_fields = get_permitted_fields(doctype=self.doctype, parenttype=self.parent_doctype)
+		permitted_fields = get_permitted_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
 			if "distinct" in field.lower():
@@ -612,16 +612,11 @@ class DatabaseQuery:
 				column = field.split("(")[-1].split(")", 1)[0]
 				column = strip_alias(column).replace("`", "")
 
-			if column == "*" and not in_function("*", field):
-				asterisk_fields.append(i)
-				continue
-
-			# handle pseudo columns
-			elif not column or column.isnumeric():
-				continue
+			if column == "*":
+				self.fields[i : i + 1] = permitted_fields
 
 			# labels / pseudo columns or frappe internals
-			elif column[0] in {"'", '"'} or column in optional_fields:
+			elif column[0] in {"'", '"', "_"} or column in permitted_fields:
 				continue
 
 			# handle child / joined table fields
@@ -631,10 +626,10 @@ class DatabaseQuery:
 
 				if wrap_grave_quotes(table) in self.tables:
 					ch_doctype = table.replace("`", "").replace("tab", "", 1)
-					available_child_table_fields = get_permitted_fields(
+					permitted_child_table_fields = get_permitted_fields(
 						doctype=ch_doctype, parenttype=self.doctype
 					)
-					if column in available_child_table_fields:
+					if column in permitted_child_table_fields:
 						continue
 					else:
 						self.remove_field(i)
@@ -648,10 +643,12 @@ class DatabaseQuery:
 			elif "(" in field:
 				if "*" in field:
 					continue
-				elif _params := FN_PARAMS_PATTERN.findall(field):
-					params = (x.strip() for x in _params[0].split(","))
+				elif any(x for x in permitted_fields if x in field):
+					continue
+				elif _params := FN_PARAMS_PATTERN.findall(column):
+					params = (x for x in _params[0].split(","))
 					for param in params:
-						if not (
+						if (
 							not param or param in permitted_fields or param.isnumeric() or "'" in param or '"' in param
 						):
 							self.remove_field(i)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -583,11 +583,6 @@ class DatabaseQuery:
 		permitted_fields = get_permitted_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
-			# field: like 'name', 'published'
-			if is_plain_field(field) and field not in permitted_fields:
-				self.fields.remove(field)
-				continue
-
 			if "distinct" in field.lower():
 				# field: 'count(distinct `tabPhoto`.name) as total_count'
 				# column: 'tabPhoto.name'
@@ -601,9 +596,10 @@ class DatabaseQuery:
 
 			if column == "*" and not in_function("*", field):
 				self.fields[i : i + 1] = permitted_fields
+				continue
 
 			# handle pseudo columns
-			elif not column:
+			elif not column or column.isnumeric():
 				continue
 
 			# labels / pseudo columns or frappe internals

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -632,13 +632,15 @@ class DatabaseQuery:
 			elif "(" in field:
 				if "*" in field:
 					continue
-				elif _params := FN_PARAMS_PATTERN.findall(column):
-					params = (x for x in _params[0].split(","))
+				elif _params := FN_PARAMS_PATTERN.findall(field):
+					params = (x.strip() for x in _params[0].split(","))
 					for param in params:
-						if (
+						if not (
 							not param or param in permitted_fields or param.isnumeric() or "'" in param or '"' in param
 						):
-							continue
+							self.fields.remove(field)
+							break
+					continue
 				self.fields.remove(field)
 
 			# remove if access not allowed

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -247,8 +247,8 @@ class DatabaseQuery:
 
 		if self.with_childnames:
 			for t in self.tables:
-				if t != "`tab" + self.doctype + "`":
-					self.fields.append(t + ".name as '%s:name'" % t[4:-1])
+				if t != f"`tab{self.doctype}`":
+					self.fields.append(f"{t}.name as '{t[4:-1]}:name'")
 
 		# query dict
 		args.tables = self.tables[0]
@@ -555,7 +555,7 @@ class DatabaseQuery:
 			if match_conditions:
 				self.conditions.append(f"({match_conditions})")
 
-	def build_filter_conditions(self, filters, conditions, ignore_permissions=None):
+	def build_filter_conditions(self, filters, conditions: list, ignore_permissions=None):
 		"""build conditions from user filters"""
 		if ignore_permissions is not None:
 			self.flags.ignore_permissions = ignore_permissions
@@ -585,9 +585,7 @@ class DatabaseQuery:
 			meta_fields.remove("docstatus")
 
 		if self.doctype_meta.istable:
-			meta_fields.append("parent")
-			meta_fields.append("parenttype")
-			meta_fields.append("parentfield")
+			meta_fields.extend(["parent", "parenttype", "parentfield"])
 		else:
 			meta_fields.remove("idx")
 
@@ -595,11 +593,7 @@ class DatabaseQuery:
 
 		for i, field in enumerate(self.fields):
 			if field == "*":
-				self.fields.pop(i)
-				k = i
-				for f in available_fields:
-					self.fields.insert(k, f"`tab{self.doctype}`.`{f}`")
-					k += 1
+				self.fields[i : i + 1] = available_fields
 
 			elif field[0] in {"'", '"', "_"} or "(" in field or "." in field or field in accessible_fields:
 				continue

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -277,16 +277,14 @@ class DatabaseQuery:
 		# TODO: Add support for wrapping fields with sql functions and distinct keyword
 		for field in self.fields:
 			stripped_field = field.strip().lower()
-			skip_wrapping = any(
-				[
-					stripped_field.startswith(("`", "*", '"', "'")),
-					"(" in stripped_field,
-					"distinct" in stripped_field,
-				]
-			)
-			if skip_wrapping:
+
+			if (
+				stripped_field[0] in {"`", "*", '"', "'"}
+				or "(" in stripped_field
+				or "distinct" in stripped_field
+			):
 				fields.append(field)
-			elif "as" in field.lower().split(" "):
+			elif "as" in stripped_field.split(" "):
 				col, _, new = field.split()
 				fields.append(f"`{col}` as {new}")
 			else:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -56,6 +56,7 @@ ORDER_GROUP_PATTERN = re.compile(r".*[^a-z0-9-_ ,`'\"\.\(\)].*")
 class DatabaseQuery:
 	def __init__(self, doctype, user=None):
 		self.doctype = doctype
+		self.doctype_meta = frappe.get_meta(doctype)
 		self.tables = []
 		self.link_tables = []
 		self.conditions = []
@@ -338,7 +339,7 @@ class DatabaseQuery:
 				if " as " in field:
 					field, alias = field.split(" as ", 1)
 				linked_fieldname, fieldname = field.split(".", 1)
-				linked_field = frappe.get_meta(self.doctype).get_field(linked_fieldname)
+				linked_field = self.doctype_meta.get_field(linked_fieldname)
 				# this is not a link field
 				if not linked_field:
 					continue
@@ -573,9 +574,7 @@ class DatabaseQuery:
 		if self.flags.ignore_permissions:
 			return
 
-		accessible_fields = {
-			x.fieldname for x in frappe.get_meta(self.doctype).get_permlevel_read_fields()
-		}
+		accessible_fields = {x.fieldname for x in self.doctype_meta.get_permlevel_read_fields()}
 
 		for i, field in enumerate(self.fields):
 			if field == "*":
@@ -784,12 +783,11 @@ class DatabaseQuery:
 		if not self.tables:
 			self.extract_tables()
 
-		meta = frappe.get_meta(self.doctype)
-		role_permissions = frappe.permissions.get_role_permissions(meta, user=self.user)
+		role_permissions = frappe.permissions.get_role_permissions(self.doctype_meta, user=self.user)
 		self.shared = frappe.share.get_shared(self.doctype, self.user)
 
 		if (
-			not meta.istable
+			not self.doctype_meta.istable
 			and not (role_permissions.get("select") or role_permissions.get("read"))
 			and not self.flags.ignore_permissions
 			and not has_any_user_permission_for_doctype(self.doctype, self.user, self.reference_doctype)
@@ -839,9 +837,8 @@ class DatabaseQuery:
 		)
 
 	def add_user_permissions(self, user_permissions):
-		meta = frappe.get_meta(self.doctype)
 		doctype_link_fields = []
-		doctype_link_fields = meta.get_link_fields()
+		doctype_link_fields = self.doctype_meta.get_link_fields()
 
 		# append current doctype with fieldname as 'name' as first link field
 		doctype_link_fields.append(
@@ -916,8 +913,6 @@ class DatabaseQuery:
 		return " and ".join(conditions) if conditions else ""
 
 	def set_order_by(self, args):
-		meta = frappe.get_meta(self.doctype)
-
 		if self.order_by and self.order_by != DefaultOrderBy:
 			args.order_by = self.order_by
 		else:
@@ -936,7 +931,7 @@ class DatabaseQuery:
 
 			if not group_function_without_group_by:
 				sort_field = sort_order = None
-				if meta.sort_field and "," in meta.sort_field:
+				if self.doctype_meta.sort_field and "," in self.doctype_meta.sort_field:
 					# multiple sort given in doctype definition
 					# Example:
 					# `idx desc, modified desc`
@@ -944,17 +939,17 @@ class DatabaseQuery:
 					# `tabItem`.`idx` desc, `tabItem`.`modified` desc
 					args.order_by = ", ".join(
 						f"`tab{self.doctype}`.`{f_split[0].strip()}` {f_split[1].strip()}"
-						for f in meta.sort_field.split(",")
+						for f in self.doctype_meta.sort_field.split(",")
 						if (f_split := f.split(maxsplit=2))
 					)
 				else:
-					sort_field = meta.sort_field or "modified"
-					sort_order = (meta.sort_field and meta.sort_order) or "desc"
+					sort_field = self.doctype_meta.sort_field or "modified"
+					sort_order = (self.doctype_meta.sort_field and self.doctype_meta.sort_order) or "desc"
 					if self.order_by:
 						args.order_by = f"`tab{self.doctype}`.`{sort_field or 'modified'}` {sort_order or 'desc'}"
 
 				# draft docs always on top
-				if hasattr(meta, "is_submittable") and meta.is_submittable:
+				if hasattr(self.doctype_meta, "is_submittable") and self.doctype_meta.is_submittable:
 					if self.order_by:
 						args.order_by = f"`tab{self.doctype}`.docstatus asc, {args.order_by}"
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -574,30 +574,34 @@ class DatabaseQuery:
 		if self.flags.ignore_permissions:
 			return
 
-		accessible_fields = [x.fieldname for x in self.doctype_meta.get_permlevel_read_fields()]
-		meta_fields = self.doctype_meta.default_fields.copy()
-		optional_meta_fields = list(optional_fields)
-
-		if not self.doctype_meta.track_seen:
-			optional_meta_fields.remove("_seen")
-
-		if not self.doctype_meta.is_submittable:
-			meta_fields.remove("docstatus")
-
-		if self.doctype_meta.istable:
-			meta_fields.extend(["parent", "parenttype", "parentfield"])
-		else:
-			meta_fields.remove("idx")
-
-		available_fields = meta_fields + accessible_fields + optional_meta_fields
+		available_fields = get_available_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
 			if field == "*":
 				self.fields[i : i + 1] = available_fields
 
-			elif field[0] in {"'", '"', "_"} or "(" in field or "." in field or field in accessible_fields:
+			# labels / pseudo columns or frappe internals
+			elif field[0] in {"'", '"', "_"} or field in available_fields:
 				continue
 
+			# handle child / joined table fields
+			elif "." in field:
+				table, _column = field.split(".", 1)
+				column = _column.lower().split(" ", 1)[0].replace("`", "")
+
+				if table in self.tables:
+					ch_doctype = table.replace("`", "").replace("tab", "", 1)
+					available_child_table_fields = get_available_fields(doctype=ch_doctype)
+					if column in available_child_table_fields:
+						continue
+					else:
+						self.fields.remove(field)
+
+			# field inside function calls
+			elif "(" in field and any(x for x in available_fields if x in field):
+				continue
+
+			# remove if access not allowed
 			else:
 				self.fields.remove(field)
 
@@ -1204,3 +1208,23 @@ def requires_owner_constraint(role_permissions):
 	# not checking if either select or read if present in if_owner_perms
 	# because either of those is required to perform a query
 	return True
+
+
+def get_available_fields(doctype):
+	meta = frappe.get_meta(doctype)
+	accessible_fields = [x.fieldname for x in meta.get_permlevel_read_fields()]
+	meta_fields = meta.default_fields.copy()
+	optional_meta_fields = list(optional_fields)
+
+	if not meta.track_seen:
+		optional_meta_fields.remove("_seen")
+
+	if not meta.is_submittable:
+		meta_fields.remove("docstatus")
+
+	if meta.istable:
+		meta_fields.extend(["parent", "parenttype", "parentfield"])
+	else:
+		meta_fields.remove("idx")
+
+	return meta_fields + accessible_fields + optional_meta_fields

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1257,7 +1257,6 @@ def get_permitted_fields(doctype, parenttype=None):
 	if doctype in core_doctypes_list:
 		return meta.get_valid_columns()
 
-	accessible_fields = [x.fieldname for x in meta.get_permlevel_read_fields(parenttype=parenttype)]
 	meta_fields = meta.default_fields.copy()
 	optional_meta_fields = list(optional_fields)
 
@@ -1272,7 +1271,7 @@ def get_permitted_fields(doctype, parenttype=None):
 	else:
 		meta_fields.remove("idx")
 
-	return meta_fields + accessible_fields + optional_meta_fields
+	return meta_fields + meta.get_permitted_fieldnames(parenttype=parenttype) + optional_meta_fields
 
 
 def wrap_grave_quotes(table: str) -> str:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -640,7 +640,7 @@ class DatabaseQuery:
 					permitted_child_table_fields = get_permitted_fields(
 						doctype=ch_doctype, parenttype=self.doctype
 					)
-					if column in permitted_child_table_fields:
+					if column in permitted_child_table_fields or column in optional_fields:
 						continue
 					else:
 						self.remove_field(i)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -74,6 +74,10 @@ class DatabaseQuery:
 			self._doctype_meta = frappe.get_meta(self.doctype)
 		return self._doctype_meta
 
+	@property
+	def query_tables(self):
+		return self.tables + [d.table_name for d in self.link_tables]
+
 	def execute(
 		self,
 		fields=None,
@@ -472,9 +476,7 @@ class DatabaseQuery:
 					table_name = table_name[13:]
 				if not table_name[0] == "`":
 					table_name = f"`{table_name}`"
-				if table_name not in self.tables and table_name not in (
-					d.table_name for d in self.link_tables
-				):
+				if table_name not in self.query_tables:
 					self.append_table(table_name)
 
 	def append_table(self, table_name):
@@ -635,8 +637,7 @@ class DatabaseQuery:
 				table, column = column.split(".", 1)
 				ch_doctype = table.replace("`", "").replace("tab", "", 1)
 
-				if wrap_grave_quotes(table) in self.tables:
-					ch_doctype = table.replace("`", "").replace("tab", "", 1)
+				if wrap_grave_quotes(table) in self.query_tables:
 					permitted_child_table_fields = get_permitted_fields(
 						doctype=ch_doctype, parenttype=self.doctype
 					)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -285,6 +285,10 @@ class DatabaseQuery:
 		# Wrapping fields with grave quotes to allow support for sql keywords
 		# TODO: Add support for wrapping fields with sql functions and distinct keyword
 		for field in self.fields:
+			if field is None:
+				fields.append("NULL")
+				continue
+
 			stripped_field = field.strip().lower()
 
 			if (
@@ -506,12 +510,13 @@ class DatabaseQuery:
 
 		if len(self.tables) > 1 or len(self.link_tables) > 0:
 			for idx, field in enumerate(self.fields):
-				if "." not in field and not _in_standard_sql_methods(field):
+				if field is not None and "." not in field and not _in_standard_sql_methods(field):
 					self.fields[idx] = f"{self.tables[0]}.{field}"
 
 	def cast_name_fields(self):
 		for i, field in enumerate(self.fields):
-			self.fields[i] = cast_name(field)
+			if field is not None:
+				self.fields[i] = cast_name(field)
 
 	def get_table_columns(self):
 		try:
@@ -576,6 +581,12 @@ class DatabaseQuery:
 			else:
 				conditions.append(self.prepare_filter_condition(f))
 
+	def remove_field(self, idx: int):
+		if self.as_list:
+			self.fields[idx] = None
+		else:
+			self.fields.pop(idx)
+
 	def apply_fieldlevel_read_permissions(self):
 		"""Apply fieldlevel read permissions to the query"""
 		if self.flags.ignore_permissions:
@@ -621,7 +632,7 @@ class DatabaseQuery:
 					if column in available_child_table_fields:
 						continue
 					else:
-						self.fields.remove(field)
+						self.remove_field(i)
 				else:
 					raise frappe.PermissionError(ch_doctype)
 
@@ -638,14 +649,14 @@ class DatabaseQuery:
 						if not (
 							not param or param in permitted_fields or param.isnumeric() or "'" in param or '"' in param
 						):
-							self.fields.remove(field)
+							self.remove_field(i)
 							break
 					continue
-				self.fields.remove(field)
+				self.remove_field(i)
 
 			# remove if access not allowed
 			else:
-				self.fields.remove(field)
+				self.remove_field(i)
 
 		# handle * fields
 		j = 0

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -269,7 +269,7 @@ class DatabaseQuery:
 		# left join parent, child tables
 		for child in self.tables[1:]:
 			parent_name = cast_name(f"{self.tables[0]}.name")
-			args.tables += f" {self.join} {child} on ({child}.parent = {parent_name})"
+			args.tables += f" {self.join} {child} on ({child}.parenttype = {frappe.db.escape(self.doctype)} and {child}.parent = {parent_name})"
 
 		# left join link tables
 		for link in self.link_tables:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -600,8 +600,12 @@ class DatabaseQuery:
 			if "distinct" in field.lower():
 				# field: 'count(distinct `tabPhoto`.name) as total_count'
 				# column: 'tabPhoto.name'
-				self.distinct = True
-				column = field.split(" ", 2)[1].replace("`", "").replace(")", "")
+				if _fn := FN_PARAMS_PATTERN.findall(field):
+					column = _fn[0].replace("distinct ", "").replace("DISTINCT ", "").replace("`", "")
+				# field: 'distinct name'
+				# column: 'name'
+				else:
+					column = field.split(" ", 2)[1].replace("`", "")
 			else:
 				# field: 'count(`tabPhoto`.name) as total_count'
 				# column: 'tabPhoto.name'

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -589,7 +589,18 @@ class DatabaseQuery:
 			self.fields.pop(idx)
 
 	def apply_fieldlevel_read_permissions(self):
-		"""Apply fieldlevel read permissions to the query"""
+		"""Apply fieldlevel read permissions to the query
+
+		Note: Does not apply to `frappe.model.core_doctype_list`
+
+		Remove fields that user is not allowed to read. If `fields=["*"]` is passed, only permitted fields will
+		be returned.
+
+		Example:
+		        - User has read permission only on `title` for DocType `Note`
+		        - Query: fields=["*"]
+		        - Result: fields=["title", ...] // will also include Frappe's meta field like `name`, `owner`, etc.
+		"""
 		if self.flags.ignore_permissions:
 			return
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -581,6 +581,7 @@ class DatabaseQuery:
 		if self.flags.ignore_permissions:
 			return
 
+		asterisk_fields = []
 		permitted_fields = get_permitted_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
@@ -596,7 +597,7 @@ class DatabaseQuery:
 				column = strip_alias(column).replace("`", "")
 
 			if column == "*" and not in_function("*", field):
-				self.fields[i : i + 1] = permitted_fields
+				asterisk_fields.append(i)
 				continue
 
 			# handle pseudo columns
@@ -645,6 +646,12 @@ class DatabaseQuery:
 			# remove if access not allowed
 			else:
 				self.fields.remove(field)
+
+		# handle * fields
+		j = 0
+		for i in asterisk_fields:
+			self.fields[i + j : i + j + 1] = permitted_fields
+			j = j + len(permitted_fields) - 1
 
 	def prepare_filter_condition(self, f):
 		"""Returns a filter condition in the format:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -51,6 +51,7 @@ FIELD_COMMA_PATTERN = re.compile(r"[0-9a-zA-Z]+\s*,")
 STRICT_FIELD_PATTERN = re.compile(r".*/\*.*")
 STRICT_UNION_PATTERN = re.compile(r".*\s(union).*\s")
 ORDER_GROUP_PATTERN = re.compile(r".*[^a-z0-9-_ ,`'\"\.\(\)].*")
+FN_PARAMS_PATTERN = re.compile(r".*?\((.*)\).*")
 
 
 class DatabaseQuery:
@@ -582,11 +583,13 @@ class DatabaseQuery:
 		available_fields = get_available_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
-			if field == "*":
+			column = field.split(" ", 1)[0].replace("`", "")
+
+			if column == "*":
 				self.fields[i : i + 1] = available_fields
 
 			# labels / pseudo columns or frappe internals
-			elif field[0] in {"'", '"', "_"} or field in available_fields:
+			elif column[0] in {"'", '"', "_"} or column in available_fields:
 				continue
 
 			# handle child / joined table fields
@@ -605,8 +608,18 @@ class DatabaseQuery:
 						self.fields.remove(field)
 
 			# field inside function calls / * handles things like count(*)
-			elif "(" in field and ("*" in field or any(x for x in available_fields if x in field)):
-				continue
+			elif "(" in field:
+				if "*" in field:
+					continue
+				elif any(x for x in available_fields if x in field):
+					continue
+				elif _params := FN_PARAMS_PATTERN.findall(column):
+					params = (x for x in _params[0].split(","))
+					for param in params:
+						if param in available_fields or param.isnumeric() or "'" in param or '"' in param:
+							continue
+						else:
+							self.fields.remove(field)
 
 			# remove if access not allowed
 			else:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -583,7 +583,11 @@ class DatabaseQuery:
 		available_fields = get_permitted_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
-			column = field.split(" ", 1)[0].replace("`", "")
+			if "distinct" in field:
+				self.distinct = True
+				column = field.split(" ", 2)[1].replace("`", "")
+			else:
+				column = field.split(" ", 1)[0].replace("`", "")
 
 			if column == "*":
 				self.fields[i : i + 1] = available_fields

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -14,7 +14,7 @@ import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
 from frappe.database.utils import DefaultOrderBy, FallBackDateTimeStr
-from frappe.model import child_table_fields, core_doctypes_list, optional_fields
+from frappe.model import get_permitted_fields, optional_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
@@ -1254,29 +1254,6 @@ def requires_owner_constraint(role_permissions):
 	# not checking if either select or read if present in if_owner_perms
 	# because either of those is required to perform a query
 	return True
-
-
-def get_permitted_fields(doctype, parenttype=None):
-	meta = frappe.get_meta(doctype)
-
-	if doctype in core_doctypes_list:
-		return meta.get_valid_columns()
-
-	meta_fields = meta.default_fields.copy()
-	optional_meta_fields = list(optional_fields)
-
-	if not meta.track_seen:
-		optional_meta_fields.remove("_seen")
-
-	if not meta.is_submittable:
-		meta_fields.remove("docstatus")
-
-	if meta.istable:
-		meta_fields.extend(child_table_fields)
-	else:
-		meta_fields.remove("idx")
-
-	return meta_fields + meta.get_permitted_fieldnames(parenttype=parenttype) + optional_meta_fields
 
 
 def wrap_grave_quotes(table: str) -> str:

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -604,7 +604,7 @@ class DatabaseQuery:
 				continue
 
 			# labels / pseudo columns or frappe internals
-			elif column[0] in {"'", '"', "_"}:
+			elif column[0] in {"'", '"'} or column in optional_fields:
 				continue
 
 			# handle child / joined table fields

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -664,7 +664,11 @@ class Document(BaseDocument):
 
 		for df in self.meta.fields:
 			if df.permlevel and hasattr(self, df.fieldname) and df.permlevel not in has_access_to:
-				delattr(self, df.fieldname)
+				try:
+					delattr(self, df.fieldname)
+				except AttributeError:
+					# hasattr might return True for class attribute which can't be delattr-ed.
+					continue
 
 		for table_field in self.meta.get_table_fields():
 			for df in frappe.get_meta(table_field.options).fields or []:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -663,14 +663,15 @@ class Document(BaseDocument):
 		has_access_to = self.get_permlevel_access("read")
 
 		for df in self.meta.fields:
-			if df.permlevel and df.permlevel not in has_access_to:
+			if df.permlevel and hasattr(self, df.fieldname) and df.permlevel not in has_access_to:
 				delattr(self, df.fieldname)
 
 		for table_field in self.meta.get_table_fields():
 			for df in frappe.get_meta(table_field.options).fields or []:
 				if df.permlevel and df.permlevel not in has_access_to:
 					for child in self.get(table_field.fieldname) or []:
-						delattr(child, df.fieldname)
+						if hasattr(child, df.fieldname):
+							delattr(child, df.fieldname)
 
 	def validate_higher_perm_levels(self):
 		"""If the user does not have permissions at permlevel > 0, then reset the values to original / default"""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -663,14 +663,14 @@ class Document(BaseDocument):
 		has_access_to = self.get_permlevel_access("read")
 
 		for df in self.meta.fields:
-			if df.permlevel and not df.permlevel in has_access_to:
-				self.set(df.fieldname, None)
+			if df.permlevel and df.permlevel not in has_access_to:
+				delattr(self, df.fieldname)
 
 		for table_field in self.meta.get_table_fields():
 			for df in frappe.get_meta(table_field.options).fields or []:
-				if df.permlevel and not df.permlevel in has_access_to:
+				if df.permlevel and df.permlevel not in has_access_to:
 					for child in self.get(table_field.fieldname) or []:
-						child.set(df.fieldname, None)
+						delattr(child, df.fieldname)
 
 	def validate_higher_perm_levels(self):
 		"""If the user does not have permissions at permlevel > 0, then reset the values to original / default"""

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -535,15 +535,14 @@ class Meta(Document):
 
 	def get_permitted_fieldnames(self, parenttype=None, *, user=None):
 		"""Build list of `fieldname` with read perm level and all the higher perm levels defined."""
-		if not hasattr(self, "permitted_fieldnames"):
-			self.permitted_fieldnames = []
-			permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
+		permitted_fieldnames = []
+		permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
 
-			for df in self.get_fieldnames_with_value(with_field_meta=True, with_virtual_fields=True):
-				if df.permlevel in permlevel_access:
-					self.permitted_fieldnames.append(df.fieldname)
+		for df in self.get_fieldnames_with_value(with_field_meta=True, with_virtual_fields=True):
+			if df.permlevel in permlevel_access:
+				permitted_fieldnames.append(df.fieldname)
 
-		return self.permitted_fieldnames
+		return permitted_fieldnames
 
 	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
 		has_access_to = []

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -496,9 +496,11 @@ class Meta(Document):
 			if custom_perms:
 				self.permissions = [Document(d) for d in custom_perms]
 
-	def get_fieldnames_with_value(self, with_field_meta=False):
+	def get_fieldnames_with_value(self, with_field_meta=False, with_virtual_fields=False):
 		def is_value_field(docfield):
-			return not (docfield.get("is_virtual") or docfield.fieldtype in no_value_fields)
+			return not (
+				not with_virtual_fields and docfield.get("is_virtual") or docfield.fieldtype in no_value_fields
+			)
 
 		if with_field_meta:
 			return [df for df in self.fields if is_value_field(df)]
@@ -537,7 +539,7 @@ class Meta(Document):
 			self.permitted_fieldnames = []
 			permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
 
-			for df in self.get_fieldnames_with_value(with_field_meta=True):
+			for df in self.get_fieldnames_with_value(with_field_meta=True, with_virtual_fields=True):
 				if df.permlevel in permlevel_access:
 					self.permitted_fieldnames.append(df.fieldname)
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -531,17 +531,17 @@ class Meta(Document):
 
 		return self.high_permlevel_fields
 
-	def get_permlevel_read_fields(self, parenttype=None, *, user=None):
-		"""Build list of fields with read perm level and all the higher perm levels defined."""
-		if not hasattr(self, "permlevel_read_fields"):
-			self.permlevel_read_fields = []
+	def get_permitted_fieldnames(self, parenttype=None, *, user=None):
+		"""Build list of `fieldname` with read perm level and all the higher perm levels defined."""
+		if not hasattr(self, "permitted_fieldnames"):
+			self.permitted_fieldnames = []
 			permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
 
 			for df in self.get_fieldnames_with_value(with_field_meta=True):
 				if df.permlevel in permlevel_access:
-					self.permlevel_read_fields.append(df)
+					self.permitted_fieldnames.append(df.fieldname)
 
-		return self.permlevel_read_fields
+		return self.permitted_fieldnames
 
 	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
 		has_access_to = []

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -534,8 +534,15 @@ class Meta(Document):
 		return self.high_permlevel_fields
 
 	def get_permitted_fieldnames(self, parenttype=None, *, user=None):
-		"""Build list of `fieldname` with read perm level and all the higher perm levels defined."""
+		"""Build list of `fieldname` with read perm level and all the higher perm levels defined.
+
+		Note: If permissions are not defined for DocType, return all the fields with value.
+		"""
 		permitted_fieldnames = []
+
+		if not self.get_permissions(parenttype=parenttype):
+			return self.get_fieldnames_with_value()
+
 		permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
 
 		for df in self.get_fieldnames_with_value(with_field_meta=True, with_virtual_fields=True):

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -540,6 +540,9 @@ class Meta(Document):
 		"""
 		permitted_fieldnames = []
 
+		if self.istable and not parenttype:
+			return permitted_fieldnames
+
 		if not self.get_permissions(parenttype=parenttype):
 			return self.get_fieldnames_with_value()
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -531,6 +531,18 @@ class Meta(Document):
 
 		return self.high_permlevel_fields
 
+	def get_permlevel_read_fields(self, parenttype=None, *, user=None):
+		"""Build list of fields with read perm level and all the higher perm levels defined."""
+		if not hasattr(self, "permlevel_read_fields"):
+			self.permlevel_read_fields = []
+			permlevel_access = set(self.get_permlevel_access("read", parenttype, user=user))
+
+			for df in self.get_fieldnames_with_value(with_field_meta=True):
+				if df.permlevel in permlevel_access:
+					self.permlevel_read_fields.append(df)
+
+		return self.permlevel_read_fields
+
 	def get_permlevel_access(self, permission_type="read", parenttype=None, *, user=None):
 		has_access_to = []
 		roles = frappe.get_roles(user)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -861,7 +861,7 @@ class TestReportview(FrappeTestCase):
 			)
 			self.assertTrue("name" in data[0])
 			self.assertTrue("blogger_full_name" in data[0])
-			self.assertTrue("description" in data[0])
+			self.assertTrue("description" not in data[0])  # field does not exist
 
 	def test_reportview_get_permlevel_system_users(self):
 		with setup_patched_blog_post(), setup_test_user(set_user=True):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -46,6 +46,13 @@ def setup_patched_blog_post():
 	yield
 
 
+@contextmanager
+def enable_permlevel_restrictions():
+	frappe.db.set_single_value("System Settings", "apply_perm_level_on_api_calls", 1)
+	yield
+	frappe.db.set_single_value("System Settings", "apply_perm_level_on_api_calls", 0)
+
+
 class TestReportview(FrappeTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
@@ -761,7 +768,7 @@ class TestReportview(FrappeTestCase):
 		self.assertNotEqual(users_edited[0].modified, users_edited[0].creation)
 
 	def test_permlevel_fields(self):
-		with setup_patched_blog_post(), setup_test_user(set_user=True):
+		with enable_permlevel_restrictions(), setup_patched_blog_post(), setup_test_user(set_user=True):
 			data = frappe.get_list(
 				"Blog Post", filters={"published": 1}, fields=["name", "published"], limit=1
 			)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -81,6 +81,94 @@ class TestReportview(FrappeTestCase):
 		self.assertEqual(result[0].seen_by, "Administrator")
 		note.delete()
 
+	def test_child_table_join(self):
+		frappe.delete_doc_if_exists("DocType", "Parent DocType 1")
+		frappe.delete_doc_if_exists("DocType", "Parent DocType 2")
+		frappe.delete_doc_if_exists("DocType", "Child DocType")
+		# child table
+		frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "Child DocType",
+				"module": "Custom",
+				"custom": 1,
+				"istable": 1,
+				"fields": [
+					{"label": "Title", "fieldname": "title", "fieldtype": "Data"},
+				],
+			}
+		).insert()
+		# doctype 1
+		frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "Parent DocType 1",
+				"module": "Custom",
+				"custom": 1,
+				"fields": [
+					{"label": "Title", "fieldname": "title", "fieldtype": "Data"},
+					{
+						"label": "Table Field 1",
+						"fieldname": "child",
+						"fieldtype": "Table",
+						"options": "Child DocType",
+					},
+				],
+				"permissions": [{"role": "System Manager"}],
+			}
+		).insert()
+		# doctype 2
+		frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "Parent DocType 2",
+				"module": "Custom",
+				"custom": 1,
+				"fields": [
+					{"label": "Title", "fieldname": "title", "fieldtype": "Data"},
+					{
+						"label": "Table Field 1",
+						"fieldname": "child",
+						"fieldtype": "Table",
+						"options": "Child DocType",
+					},
+				],
+				"permissions": [{"role": "System Manager"}],
+			}
+		).insert()
+
+		# clear records
+		frappe.db.delete("Parent DocType 1")
+		frappe.db.delete("Parent DocType 2")
+		frappe.db.delete("Child DocType")
+
+		# insert records
+		frappe.get_doc(
+			doctype="Parent DocType 1",
+			title="test",
+			child=[{"title": "parent 1 child record 1"}, {"title": "parent 1 child record 2"}],
+			__newname="test_parent",
+		).insert(ignore_if_duplicate=True)
+		frappe.get_doc(
+			doctype="Parent DocType 2",
+			title="test",
+			child=[{"title": "parent 2 child record 1"}],
+			__newname="test_parent",
+		).insert(ignore_if_duplicate=True)
+
+		# test query
+		results1 = frappe.get_all("Parent DocType 1", fields=["name", "child.title as child_title"])
+		results2 = frappe.get_all("Parent DocType 2", fields=["name", "child.title as child_title"])
+		# check both parents have same name
+		self.assertEqual(results1[0].name, results2[0].name)
+		# check both parents have different number of child records
+		self.assertEqual(len(results1), 2)
+		self.assertEqual(len(results2), 1)
+		parent1_children = [result.child_title for result in results1]
+		self.assertIn("parent 1 child record 1", parent1_children)
+		self.assertIn("parent 1 child record 2", parent1_children)
+		self.assertEqual(results2[0].child_title, "parent 2 child record 1")
+
 	def test_link_field_syntax(self):
 		todo = frappe.get_doc(
 			doctype="ToDo", description="Test ToDo", allocated_to="Administrator"

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1050,6 +1050,46 @@ class TestReportview(FrappeTestCase):
 
 
 class TestReportView(FrappeTestCase):
+	def test_get_count(self):
+		frappe.local.request = frappe._dict()
+		frappe.local.request.method = "GET"
+
+		# test with data check field
+		frappe.local.form_dict = frappe._dict(
+			{
+				"doctype": "DocType",
+				"filters": [["DocType", "show_title_field_in_link", "=", 1]],
+				"fields": [],
+				"distinct": "false",
+			}
+		)
+		list_filter_response = execute_cmd("frappe.desk.reportview.get_count")
+		frappe.local.form_dict = frappe._dict(
+			{"doctype": "DocType", "filters": {"show_title_field_in_link": 1}, "distinct": "true"}
+		)
+		dict_filter_response = execute_cmd("frappe.desk.reportview.get_count")
+		self.assertIsInstance(list_filter_response, int)
+		self.assertEqual(list_filter_response, dict_filter_response)
+
+		# test with child table filter
+		frappe.local.form_dict = frappe._dict(
+			{
+				"doctype": "DocType",
+				"filters": [["DocField", "fieldtype", "=", "Data"]],
+				"fields": [],
+				"distinct": "true",
+			}
+		)
+		child_filter_response = execute_cmd("frappe.desk.reportview.get_count")
+		current_value = frappe.db.sql(
+			# the below query is equivalent to the one in reportview.get_count
+			"select distinct count(distinct `tabDocType`.name) as total_count"
+			" from `tabDocType` left join `tabDocField`"
+			" on (`tabDocField`.parenttype = 'DocType' and `tabDocField`.parent = `tabDocType`.name)"
+			" where `tabDocField`.`fieldtype` = 'Data'"
+		)[0][0]
+		self.assertEqual(child_filter_response, current_value)
+
 	def test_reportview_get(self):
 		user = frappe.get_doc("User", "test@example.com")
 		add_child_table_to_blog_post()

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -715,7 +715,12 @@ class TestReportview(FrappeTestCase):
 			self.assertEqual(len(data[0]), 1)
 
 			data = frappe.get_list(
-				"Blog Post", filters={"published": 1}, fields=["name", "MAX(`modified`)"], limit=1
+				"Blog Post",
+				filters={"published": 1},
+				fields=["name", "MAX(`modified`)"],
+				limit=1,
+				order_by=None,
+				group_by="name",
 			)
 			self.assertEqual(len(data[0]), 2)
 
@@ -729,17 +734,27 @@ class TestReportview(FrappeTestCase):
 				"Blog Post", filters={"published": 1}, fields=["name", "'LABEL'"], limit=1
 			)
 			self.assertTrue("name" in data[0])
-			self.assertTrue("LABEL" in data[0])
+			self.assertTrue("LABEL" in data[0].values())
 			self.assertEqual(len(data[0]), 2)
 
 			data = frappe.get_list(
-				"Blog Post", filters={"published": 1}, fields=["name", "COUNT(*) as count"], limit=1
+				"Blog Post",
+				filters={"published": 1},
+				fields=["name", "COUNT(*) as count"],
+				limit=1,
+				order_by=None,
+				group_by="name",
 			)
 			self.assertTrue("count" in data[0])
 			self.assertEqual(len(data[0]), 2)
 
 			data = frappe.get_list(
-				"Blog Post", filters={"published": 1}, fields=["name", "COUNT(*) count"], limit=1
+				"Blog Post",
+				filters={"published": 1},
+				fields=["name", "COUNT(*) count"],
+				limit=1,
+				order_by=None,
+				group_by="name",
 			)
 			self.assertTrue("count" in data[0])
 			self.assertEqual(len(data[0]), 2)

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -847,6 +847,12 @@ class TestReportview(FrappeTestCase):
 			self.assertTrue("count" in data[0])
 			self.assertEqual(len(data[0]), 2)
 
+			with self.assertRaises(frappe.PermissionError):
+				frappe.get_list(
+					"Blog Post",
+					fields=["blog_category.description"],
+				)
+
 	def test_reportview_get_permlevel_system_users(self):
 		with setup_patched_blog_post(), setup_test_user(set_user=True):
 			frappe.local.request = frappe._dict()

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -913,9 +913,7 @@ class TestReportview(FrappeTestCase):
 		)
 
 		response = execute_cmd("frappe.desk.reportview.get")
-		self.assertListEqual(
-			response["keys"], ["field_label", "field_name", "_aggregate_column", "columns"]
-		)
+		self.assertListEqual(response["keys"], ["field_label", "field_name", "_aggregate_column"])
 
 	def test_cast_name(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -847,11 +847,14 @@ class TestReportview(FrappeTestCase):
 			self.assertTrue("count" in data[0])
 			self.assertEqual(len(data[0]), 2)
 
-			with self.assertRaises(frappe.PermissionError):
-				frappe.get_list(
-					"Blog Post",
-					fields=["blog_category.description"],
-				)
+			data = frappe.get_list(
+				"Blog Post",
+				fields=["name", "blogger.full_name as blogger_full_name", "blog_category.description"],
+				limit=1,
+			)
+			self.assertTrue("name" in data[0])
+			self.assertTrue("blogger_full_name" in data[0])
+			self.assertTrue("description" in data[0])
 
 	def test_reportview_get_permlevel_system_users(self):
 		with setup_patched_blog_post(), setup_test_user(set_user=True):

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -901,30 +901,6 @@ class TestReportview(FrappeTestCase):
 			response = execute_cmd("frappe.desk.reportview.get")
 			self.assertListEqual(response["keys"], ["published", "title", "test_field"])
 
-	def test_reportview_get_aggregation(self):
-		# test aggregation based on child table field
-		frappe.local.request = frappe._dict()
-		frappe.local.request.method = "POST"
-		frappe.local.form_dict = frappe._dict(
-			{
-				"doctype": "DocType",
-				"fields": """["`tabDocField`.`label` as field_label","`tabDocField`.`name` as field_name"]""",
-				"filters": "[]",
-				"order_by": "_aggregate_column desc",
-				"start": 0,
-				"page_length": 20,
-				"view": "Report",
-				"with_comment_count": 0,
-				"group_by": "field_label, field_name",
-				"aggregate_on_field": "columns",
-				"aggregate_on_doctype": "DocField",
-				"aggregate_function": "sum",
-			}
-		)
-
-		response = execute_cmd("frappe.desk.reportview.get")
-		self.assertListEqual(response["keys"], ["field_label", "field_name", "_aggregate_column"])
-
 	def test_cast_name(self):
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
@@ -1161,6 +1137,7 @@ class TestReportView(FrappeTestCase):
 
 	def test_reportview_get_aggregation(self):
 		# test aggregation based on child table field
+		frappe.local.request = frappe._dict()
 		frappe.local.form_dict = frappe._dict(
 			{
 				"doctype": "DocType",

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -56,6 +56,7 @@ def enable_permlevel_restrictions():
 class TestReportview(FrappeTestCase):
 	def setUp(self):
 		frappe.set_user("Administrator")
+		return super().setUp()
 
 	def test_basic(self):
 		self.assertTrue({"name": "DocType"} in DatabaseQuery("DocType").execute(limit_page_length=None))
@@ -222,8 +223,6 @@ class TestReportview(FrappeTestCase):
 
 		self.assertEqual(build_match_conditions(as_condition=True), assertion_string)
 
-		frappe.set_user("Administrator")
-
 	def test_fields(self):
 		self.assertTrue(
 			{"name": "DocType", "issingle": 0}
@@ -332,7 +331,6 @@ class TestReportview(FrappeTestCase):
 		frappe.set_user("test2@example.com")
 		self.assertRaises(frappe.PermissionError, get_filters_cond, "DocType", dict(istable=1), [])
 		self.assertTrue(get_filters_cond("DocType", dict(istable=1), [], ignore_permissions=True))
-		frappe.set_user("Administrator")
 
 	def test_query_fields_sanitizer(self):
 		self.assertRaises(
@@ -495,7 +493,6 @@ class TestReportview(FrappeTestCase):
 			)
 
 	def test_nested_permission(self):
-		frappe.set_user("Administrator")
 		create_nested_doctype()
 		create_nested_doctype_records()
 		clear_user_permissions_for_doctype("Nested DocType")
@@ -519,7 +516,6 @@ class TestReportview(FrappeTestCase):
 		self.assertFalse({"name": "Level 1 B"} in data)
 		self.assertFalse({"name": "Level 2 B"} in data)
 		update("Nested DocType", "All", 0, "if_owner", 1)
-		frappe.set_user("Administrator")
 
 	def test_filter_sanitizer(self):
 		self.assertRaises(
@@ -630,7 +626,6 @@ class TestReportview(FrappeTestCase):
 			)
 
 	def test_of_not_of_descendant_ancestors(self):
-		frappe.set_user("Administrator")
 		clear_user_permissions_for_doctype("Nested DocType")
 
 		# in descendants filter
@@ -1036,6 +1031,10 @@ class TestReportview(FrappeTestCase):
 
 
 class TestReportView(FrappeTestCase):
+	def setUp(self) -> None:
+		frappe.set_user("Administrator")
+		return super().setUp()
+
 	def test_get_count(self):
 		frappe.local.request = frappe._dict()
 		frappe.local.request.method = "GET"
@@ -1116,9 +1115,6 @@ class TestReportView(FrappeTestCase):
 
 		frappe.set_user("Administrator")
 		user.add_roles("Website Manager")
-		frappe.set_user(user.name)
-
-		frappe.set_user("Administrator")
 
 		# Admin should be able to see access all fields
 		frappe.local.form_dict = frappe._dict(
@@ -1137,7 +1133,7 @@ class TestReportView(FrappeTestCase):
 
 	def test_reportview_get_aggregation(self):
 		# test aggregation based on child table field
-		frappe.local.request = frappe._dict()
+		frappe.local.request = frappe._dict(method="GET")
 		frappe.local.form_dict = frappe._dict(
 			{
 				"doctype": "DocType",
@@ -1156,9 +1152,7 @@ class TestReportView(FrappeTestCase):
 		)
 
 		response = execute_cmd("frappe.desk.reportview.get")
-		self.assertListEqual(
-			response["keys"], ["field_label", "field_name", "_aggregate_column", "columns"]
-		)
+		self.assertListEqual(response["keys"], ["field_label", "field_name", "_aggregate_column"])
 
 
 def add_child_table_to_blog_post():

--- a/frappe/tests/test_form_load.py
+++ b/frappe/tests/test_form_load.py
@@ -50,7 +50,8 @@ class TestFormLoad(FrappeTestCase):
 		frappe.set_user(user.name)
 		blog_doc = get_blog(blog.name)
 
-		self.assertEqual(blog_doc.published, None)
+		with self.assertRaises(AttributeError):
+			blog_doc.published
 
 		# this will be ignored because user does not
 		# have write access on `published` field (or on permlevel 1 fields)
@@ -70,7 +71,8 @@ class TestFormLoad(FrappeTestCase):
 
 		self.assertEqual(blog_doc.name, blog.name)
 		# since published field has higher permlevel
-		self.assertEqual(blog_doc.published, None)
+		with self.assertRaises(AttributeError):
+			blog_doc.published
 
 		# this will be ignored because user does not
 		# have write access on `published` field (or on permlevel 1 fields)

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -36,11 +36,10 @@ class TestModelUtils(FrappeTestCase):
 		todo_all_columns = frappe.get_meta("ToDo").get_valid_columns()
 		self.assertListEqual(todo_all_fields, todo_all_columns)
 
-		# Guest should have access to only default fields in ToDo
+		# Guest should have access to no fields in ToDo
 		with set_user("Guest"):
 			guest_permitted_fields = get_permitted_fields("ToDo")
-			self.assertSequenceSubset(todo_all_fields, guest_permitted_fields)
-			self.assertNotEqual(len(todo_all_fields), len(guest_permitted_fields))
+			self.assertEqual(guest_permitted_fields, [])
 
 		# everyone should have access to all fields of core doctypes
 		with set_user("Guest"):
@@ -58,6 +57,13 @@ class TestModelUtils(FrappeTestCase):
 			child_all_fields = frappe.get_meta("Installed Application").get_valid_columns()
 			self.assertLess(len(without_parent_fields), len(with_parent_fields))
 			self.assertSequenceEqual(set(with_parent_fields), set(child_all_fields))
+
+		# guest has access to no fields
+		with set_user("Guest"):
+			self.assertEqual(get_permitted_fields("Installed Application"), [])
+			self.assertEqual(
+				get_permitted_fields("Installed Application", parenttype="Installed Applications"), []
+			)
 
 
 @contextmanager

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -48,13 +48,14 @@ class TestModelUtils(FrappeTestCase):
 			picked_doctype_all_columns = frappe.get_meta(picked_doctype).get_valid_columns()
 			self.assertSequenceEqual(core_permitted_fields, picked_doctype_all_columns)
 
-		# access to child tables' fields is restricted to default fields unless parent is passed & permitted
+		# access to child tables' fields is restricted to no fields unless parent is passed & permitted
 		with set_user("Administrator"):
 			without_parent_fields = get_permitted_fields("Installed Application")
 			with_parent_fields = get_permitted_fields(
 				"Installed Application", parenttype="Installed Applications"
 			)
 			child_all_fields = frappe.get_meta("Installed Application").get_valid_columns()
+			self.assertEqual(without_parent_fields, [])
 			self.assertLess(len(without_parent_fields), len(with_parent_fields))
 			self.assertSequenceEqual(set(with_parent_fields), set(child_all_fields))
 

--- a/frappe/tests/test_model_utils.py
+++ b/frappe/tests/test_model_utils.py
@@ -49,6 +49,16 @@ class TestModelUtils(FrappeTestCase):
 			picked_doctype_all_columns = frappe.get_meta(picked_doctype).get_valid_columns()
 			self.assertSequenceEqual(core_permitted_fields, picked_doctype_all_columns)
 
+		# access to child tables' fields is restricted to default fields unless parent is passed & permitted
+		with set_user("Administrator"):
+			without_parent_fields = get_permitted_fields("Installed Application")
+			with_parent_fields = get_permitted_fields(
+				"Installed Application", parenttype="Installed Applications"
+			)
+			child_all_fields = frappe.get_meta("Installed Application").get_valid_columns()
+			self.assertLess(len(without_parent_fields), len(with_parent_fields))
+			self.assertSequenceEqual(set(with_parent_fields), set(child_all_fields))
+
 
 @contextmanager
 def set_user(user: str):

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -15,10 +15,7 @@ class TestSearch(FrappeTestCase):
 	def setUp(self):
 		if self._testMethodName == "test_link_field_order":
 			setup_test_link_field_order(self)
-
-	def tearDown(self):
-		if self._testMethodName == "test_link_field_order":
-			teardown_test_link_field_order(self)
+			self.addCleanup(teardown_test_link_field_order, self)
 
 	def test_search_field_sanitizer(self):
 		# pass
@@ -146,24 +143,28 @@ def setup_test_link_field_order(TestCase):
 	TestCase.parent_doctype_name = "All Territories"
 
 	# Create Tree doctype
-	TestCase.tree_doc = frappe.get_doc(
-		{
-			"doctype": "DocType",
-			"name": TestCase.tree_doctype_name,
-			"module": "Custom",
-			"custom": 1,
-			"is_tree": 1,
-			"autoname": "field:random",
-			"fields": [{"fieldname": "random", "label": "Random", "fieldtype": "Data"}],
-		}
-	).insert()
-	TestCase.tree_doc.search_fields = "parent_test_tree_order"
-	TestCase.tree_doc.save()
+	if not frappe.db.exists("DocType", TestCase.tree_doctype_name):
+		TestCase.tree_doc = frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": TestCase.tree_doctype_name,
+				"module": "Custom",
+				"custom": 1,
+				"is_tree": 1,
+				"autoname": "field:random",
+				"fields": [{"fieldname": "random", "label": "Random", "fieldtype": "Data"}],
+			}
+		).insert()
+		TestCase.tree_doc.search_fields = "parent_test_tree_order"
+		TestCase.tree_doc.save()
+	else:
+		TestCase.tree_doc = frappe.get_doc("DocType", TestCase.tree_doctype_name)
 
 	# Create root for the tree doctype
-	frappe.get_doc(
-		{"doctype": TestCase.tree_doctype_name, "random": TestCase.parent_doctype_name, "is_group": 1}
-	).insert()
+	if not frappe.db.exists(TestCase.tree_doctype_name, {"random": TestCase.parent_doctype_name}):
+		frappe.get_doc(
+			{"doctype": TestCase.tree_doctype_name, "random": TestCase.parent_doctype_name, "is_group": 1}
+		).insert(ignore_if_duplicate=True)
 
 	# Create children for the root
 	for child_name in TestCase.child_doctypes_names:
@@ -173,7 +174,7 @@ def setup_test_link_field_order(TestCase):
 				"random": child_name,
 				"parent_test_tree_order": TestCase.parent_doctype_name,
 			}
-		).insert()
+		).insert(ignore_if_duplicate=True)
 		TestCase.child_doctype_list.append(temp)
 
 

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -3,6 +3,7 @@ import datetime
 import signal
 import unittest
 from contextlib import contextmanager
+from typing import Sequence
 
 import frappe
 from frappe.model.base_document import BaseDocument
@@ -37,6 +38,10 @@ class FrappeTestCase(unittest.TestCase):
 		cls.addClassCleanup(_rollback_db)
 
 		return super().setUpClass()
+
+	def assertSequenceSubset(self, larger: Sequence, smaller: Sequence, msg=None):
+		"""Assert that `expected` is a subset of `actual`."""
+		self.assertTrue(set(smaller).issubset(set(larger)), msg=msg)
 
 	# --- Frappe Framework specific assertions
 	def assertDocumentEqual(self, expected, actual):


### PR DESCRIPTION
Apart from the changes introduced on develop/v15, this backport contains a switch [`Apply Perm Level on API calls (Recommended)`] to optionally enable the permlevel restrictions on Frappe Sites. We're not unconditionally applying them given they introduce breaking changes that may disrupt flows that depend on them.

![image](https://user-images.githubusercontent.com/36654812/222646935-10568082-4754-478b-aeea-a8418a6360b1.png)

---

Cherrypicked changes from the following PRs, and made more to accommodate to v14 branch:

- https://github.com/frappe/frappe/pull/19533
- https://github.com/frappe/frappe/pull/19916
- https://github.com/frappe/frappe/pull/20024
- https://github.com/frappe/frappe/pull/20069
- https://github.com/frappe/frappe/pull/20085
- https://github.com/frappe/frappe/pull/17865