### PR TITLE
fix: Bench get-untranslated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 dynamic = ["version"]
 dependencies = [
     # core dependencies
-    "Babel~=2.9.0",
+    "Babel~=2.12.1",
     "Click~=8.1.3",
     "filelock~=3.8.0",
     "GitPython~=3.1.30",


### PR DESCRIPTION
**Problem**
`bench get-untranslated` is not working. 
![pr1](https://user-images.githubusercontent.com/100179677/222897186-5cf7413f-57b7-4580-8c06-72f7e06af602.png)
As the trackback, the problem is in Babel.

**Solution**
Upgrade Babel.
![pr2](https://user-images.githubusercontent.com/100179677/222897231-29a73693-a82c-47a9-a52c-3cb104cbe864.png)
