### PR TITLE
fix: TemplatePage.can_render

### DIFF
--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -331,6 +331,17 @@ class TestWebsite(FrappeTestCase):
 		self.assertIn("test.__test", content)
 		self.assertNotIn("frappe.exceptions.ValidationError: Illegal template", content)
 
+	def test_never_render(self):
+		from pathlib import Path
+		from random import choices
+
+		WWW = Path(frappe.get_app_path("frappe")) / "www"
+		FILES_TO_SKIP = choices(list(WWW.glob("**/*.py*")), k=10)
+
+		for suffix in FILES_TO_SKIP:
+			content = get_response_content(suffix.relative_to(WWW))
+			self.assertIn("404", content)
+
 	def test_metatags(self):
 		content = get_response_content("/_test/_test_metatags")
 		self.assertIn('<meta name="title" content="Test Title Metatag">', content)

--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -1,5 +1,5 @@
-import io
 import os
+from importlib.machinery import all_suffixes
 
 import click
 
@@ -16,6 +16,8 @@ from frappe.website.utils import (
 	get_toc,
 	is_binary_file,
 )
+
+PY_LOADER_SUFFIXES = tuple(all_suffixes())
 
 WEBPAGE_PY_MODULE_PROPERTIES = (
 	"base_template_path",
@@ -66,7 +68,11 @@ class TemplatePage(BaseTemplatePage):
 						return
 
 	def can_render(self):
-		return hasattr(self, "template_path") and bool(self.template_path)
+		return (
+			hasattr(self, "template_path")
+			and self.template_path
+			and not self.template_path.endswith(PY_LOADER_SUFFIXES)
+		)
 
 	@staticmethod
 	def get_index_path_options(search_path):


### PR DESCRIPTION
Don't render python executable/loadable files from the TemplatePage renderer. This restricts access to reading/downloading possibly private Python source code from Frappe applications

ref: https://discuss.frappe.io/t/many-python-files-in-www-directory/101938?u=gavindsouza