### PR TITLE
fix: Remove unnecessary code to avoid timestamp conflict

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -554,9 +554,6 @@ def update_parent_document_on_communication(doc):
 			parent.db_set("status", "Open")
 			parent.run_method("handle_hold_time", "Replied")
 			apply_assignment_rule(parent)
-		else:
-			# update the modified date for document
-			parent.update_modified()
 
 	update_first_response_time(parent, doc)
 	set_avg_response_time(parent, doc)


### PR DESCRIPTION
Can't think of a reason why creation of comment/notification needs to update parent's `modified`.

--

This will avoid issues [like this](https://github.com/frappe/frappe/pull/20126) in different scenarios. 

--

The solution that the  original PR introduced should work even without this removed code.
https://github.com/frappe/frappe/pull/4295