### PR TITLE
fix(UX): dont let users select child table in ref_doctype

### DIFF
--- a/frappe/core/doctype/report/report.js
+++ b/frappe/core/doctype/report/report.js
@@ -44,6 +44,14 @@ frappe.ui.form.on("Report", {
 				doc.disabled ? "fa fa-check" : "fa fa-off"
 			);
 		}
+
+		frm.set_query("ref_doctype", () => {
+			return {
+				filters: {
+					istable: 0,
+				},
+			};
+		});
 	},
 
 	ref_doctype: function (frm) {


### PR DESCRIPTION
Child doctypes have no concept of permission so when ref_doctype is
child doctype it will always fail. You should pick ref_doctype that's
typical parent used for perm checks.

ref: ISS-22-23-05771

