### PR TITLE
fix: print format doctype contains two fields with same name

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -138,12 +138,6 @@
    "label": "Show Line Breaks after Sections"
   },
   {
-   "default": "0",
-   "fieldname": "absolute_value",
-   "fieldtype": "Check",
-   "label": "Show Absolute Values"
-  },
-  {
    "fieldname": "column_break_11",
    "fieldtype": "Column Break"
   },
@@ -213,7 +207,7 @@
  ],
  "icon": "fa fa-print",
  "idx": 1,
- "modified": "2020-12-14 11:38:49.132061",
+ "modified": "2022-03-07 11:38:49.132061",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

**Print Format** doctype has two fields with same name
