### PR TITLE
fix: permissions checking if multiple same-target link fields exists …

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -275,7 +275,6 @@ def has_user_permission(doc, user=None):
 	# check user permissions on self
 	if doctype in user_permissions:
 		allowed_docs = get_allowed_docs_for_doctype(user_permissions.get(doctype, []), doctype)
-
 		# if allowed_docs is empty it states that there is no applicable permission under the current doctype
 
 		# only check if allowed_docs is not empty
@@ -341,6 +340,7 @@ def has_user_permission(doc, user=None):
 				push_perm_check_log(msg)
 
 				return False
+			return True
 
 		return True
 


### PR DESCRIPTION
If you have two link fields to the same doctype in a document, only the last link field will be evaluated for the user permissions check because the for will walk until it finds a link field that does NOT satisfy the userpermission and returns false if it finds one.

That means the logic was the following: A user permission applies only IF ALL the link fields that apply point to the allowed  value


This changes this to "A user permission applies only IF ANY of the link fields point to the allowed value"