### PR TITLE
fix: print preview no letterhead selected

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -657,7 +657,7 @@ frappe.ui.form.PrintView = class {
 	}
 
 	get_letterhead() {
-		return this.letterhead_selector.val() || "No Letterhead";
+		return this.letterhead_selector.val() || __("No Letterhead");
 	}
 
 	get_no_preview_html() {

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -657,7 +657,7 @@ frappe.ui.form.PrintView = class {
 	}
 
 	get_letterhead() {
-		return this.letterhead_selector.val();
+		return this.letterhead_selector.val() || "No Letterhead";
 	}
 
 	get_no_preview_html() {


### PR DESCRIPTION
### Overview
When no letter head is selected, the letter head is still rendered on the print preview.

**Before PR**
![image](https://user-images.githubusercontent.com/29856401/223835657-7930a8d6-f5fa-459a-9ba9-e9ecaf55a9b6.png)


**After PR**
![image](https://user-images.githubusercontent.com/29856401/223835413-075f597b-ac95-45ce-a4fb-a81ef01517e7.png)
