### PR TITLE
feat: Apply permlevel restrictions in Document, DatabaseQuery API Calls [v13]

### DIFF
--- a/frappe/api.py
+++ b/frappe/api.py
@@ -78,6 +78,8 @@ def handle():
 					doc = frappe.get_doc(doctype, name)
 					if not doc.has_permission("read"):
 						raise frappe.PermissionError
+					if frappe.get_system_settings("apply_perm_level_on_api_calls"):
+						doc.apply_fieldlevel_read_permissions()
 					frappe.local.response.update({"data": doc})
 
 				if frappe.local.request.method == "PUT":
@@ -90,8 +92,10 @@ def handle():
 
 					# Not checking permissions here because it's checked in doc.save
 					doc.update(data)
-
-					frappe.local.response.update({"data": doc.save().as_dict()})
+					doc.save()
+					if frappe.get_system_settings("apply_perm_level_on_api_calls"):
+						doc.apply_fieldlevel_read_permissions()
+					frappe.local.response.update({"data": doc})
 
 					if doc.parenttype and doc.parent:
 						frappe.get_doc(doc.parenttype, doc.parent).save()

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -86,6 +86,10 @@ def get(doctype, name=None, filters=None, parent=None):
 		doc = frappe.get_doc(doctype)  # single
 
 	doc.check_permission()
+
+	if frappe.get_system_settings("apply_perm_level_on_api_calls"):
+		doc.apply_fieldlevel_read_permissions()
+
 	return doc.as_dict()
 
 

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -42,6 +42,7 @@
   "allow_error_traceback",
   "strip_exif_metadata_from_uploaded_images",
   "allow_older_web_view_links",
+  "apply_perm_level_on_api_calls",
   "password_settings",
   "logout_on_password_reset",
   "force_user_to_reset_password",
@@ -518,12 +519,18 @@
    "fieldname": "email_retry_limit",
    "fieldtype": "Int",
    "label": "Email Retry Limit"
+  },
+  {
+   "default": "0",
+   "fieldname": "apply_perm_level_on_api_calls",
+   "fieldtype": "Check",
+   "label": "Apply Perm Level on API calls (Recommended)"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2022-06-21 13:55:04.796152",
+ "modified": "2023-03-03 11:47:24.867356",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -514,14 +514,18 @@ class DatabaseQuery(object):
 		        - Query: fields=["*"]
 		        - Result: fields=["title", ...] // will also include Frappe's meta field like `name`, `owner`, etc.
 		"""
-		if self.flags.ignore_permissions or not frappe.get_system_settings(
-			"apply_perm_level_on_api_calls",
-			ignore_if_not_exists=True,
+		if (
+			self.flags.ignore_permissions
+			or not frappe.get_system_settings(
+				"apply_perm_level_on_api_calls",
+				ignore_if_not_exists=True,
+			)
+			or frappe.get_meta(self.doctype).istable
 		):
 			return
 
 		asterisk_fields = []
-		permitted_fields = get_permitted_fields(doctype=self.doctype, parenttype=self.parent_doctype)
+		permitted_fields = get_permitted_fields(doctype=self.doctype)
 
 		for i, field in enumerate(self.fields):
 			if "distinct" in field.lower():
@@ -557,7 +561,7 @@ class DatabaseQuery(object):
 				table, column = column.split(".", 1)
 				ch_doctype = table.replace("`", "").replace("tab", "", 1)
 
-				if wrap_grave_quotes(table) in self.query_tables:
+				if wrap_grave_quotes(table) in self.tables:
 					permitted_child_table_fields = get_permitted_fields(
 						doctype=ch_doctype, parenttype=self.doctype
 					)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -515,7 +515,8 @@ class DatabaseQuery(object):
 		        - Result: fields=["title", ...] // will also include Frappe's meta field like `name`, `owner`, etc.
 		"""
 		if self.flags.ignore_permissions or not frappe.get_system_settings(
-			"apply_perm_level_on_api_calls"
+			"apply_perm_level_on_api_calls",
+			ignore_if_not_exists=True,
 		):
 			return
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -19,7 +19,7 @@ import frappe.permissions
 import frappe.share
 from frappe import _
 from frappe.core.doctype.server_script.server_script_utils import get_server_script_map
-from frappe.model import optional_fields
+from frappe.model import get_permitted_fields, optional_fields
 from frappe.model.meta import get_table_columns
 from frappe.model.utils.user_settings import get_user_settings, update_user_settings
 from frappe.utils import (
@@ -33,6 +33,8 @@ from frappe.utils import (
 	make_filter_tuple,
 )
 
+SPECIAL_FIELD_CHARS = frozenset(("(", "`", ".", "'", '"', "*"))
+
 SUB_QUERY_PATTERN = re.compile("^.*[,();@].*")
 IS_QUERY_PATTERN = re.compile(r"^(select|delete|update|drop|create)\s")
 IS_QUERY_PREDICATE_PATTERN = re.compile(
@@ -43,6 +45,7 @@ FIELD_COMMA_PATTERN = re.compile(r"[0-9a-zA-Z]+\s*,")
 STRICT_FIELD_PATTERN = re.compile(r".*/\*.*")
 STRICT_UNION_PATTERN = re.compile(r".*\s(union).*\s")
 ORDER_GROUP_PATTERN = re.compile(r".*[^a-z0-9-_ ,`'\"\.\(\)].*")
+FN_PARAMS_PATTERN = re.compile(r".*?\((.*)\).*")
 
 
 class DatabaseQuery(object):
@@ -221,6 +224,7 @@ class DatabaseQuery(object):
 		self.extract_tables()
 		self.set_optional_columns()
 		self.build_conditions()
+		self.apply_fieldlevel_read_permissions()
 
 		args = frappe._dict()
 
@@ -493,6 +497,104 @@ class DatabaseQuery(object):
 				conditions.append(f)
 			else:
 				conditions.append(self.prepare_filter_condition(f))
+
+	def remove_field(self, idx: int):
+		if self.as_list:
+			self.fields[idx] = None
+		else:
+			self.fields.pop(idx)
+
+	def apply_fieldlevel_read_permissions(self):
+		"""Apply fieldlevel read permissions to the query
+		Note: Does not apply to `frappe.model.core_doctype_list`
+		Remove fields that user is not allowed to read. If `fields=["*"]` is passed, only permitted fields will
+		be returned.
+		Example:
+		        - User has read permission only on `title` for DocType `Note`
+		        - Query: fields=["*"]
+		        - Result: fields=["title", ...] // will also include Frappe's meta field like `name`, `owner`, etc.
+		"""
+		if self.flags.ignore_permissions or not frappe.get_system_settings(
+			"apply_perm_level_on_api_calls"
+		):
+			return
+
+		asterisk_fields = []
+		permitted_fields = get_permitted_fields(doctype=self.doctype, parenttype=self.parent_doctype)
+
+		for i, field in enumerate(self.fields):
+			if "distinct" in field.lower():
+				# field: 'count(distinct `tabPhoto`.name) as total_count'
+				# column: 'tabPhoto.name'
+				_fn = FN_PARAMS_PATTERN.findall(field)
+				if _fn:
+					column = _fn[0].replace("distinct ", "").replace("DISTINCT ", "").replace("`", "")
+				# field: 'distinct name'
+				# column: 'name'
+				else:
+					column = field.split(" ", 2)[1].replace("`", "")
+			else:
+				# field: 'count(`tabPhoto`.name) as total_count'
+				# column: 'tabPhoto.name'
+				column = field.split("(")[-1].split(")", 1)[0]
+				column = strip_alias(column).replace("`", "")
+
+			if column == "*" and not in_function("*", field):
+				asterisk_fields.append(i)
+				continue
+
+			# handle pseudo columns
+			elif not column or column.isnumeric():
+				continue
+
+			# labels / pseudo columns or frappe internals
+			elif column[0] in {"'", '"'} or column in optional_fields:
+				continue
+
+			# handle child / joined table fields
+			elif "." in field:
+				table, column = column.split(".", 1)
+				ch_doctype = table.replace("`", "").replace("tab", "", 1)
+
+				if wrap_grave_quotes(table) in self.query_tables:
+					permitted_child_table_fields = get_permitted_fields(
+						doctype=ch_doctype, parenttype=self.doctype
+					)
+					if column in permitted_child_table_fields or column in optional_fields:
+						continue
+					else:
+						self.remove_field(i)
+				else:
+					raise frappe.PermissionError(ch_doctype)
+
+			elif column in permitted_fields:
+				continue
+
+			# field inside function calls / * handles things like count(*)
+			elif "(" in field:
+				if "*" in field:
+					continue
+				_params = FN_PARAMS_PATTERN.findall(field)
+				if _params:
+					params = (x.strip() for x in _params[0].split(","))
+					for param in params:
+						if not (
+							not param or param in permitted_fields or param.isnumeric() or "'" in param or '"' in param
+						):
+							self.remove_field(i)
+							break
+					continue
+				self.remove_field(i)
+
+			# remove if access not allowed
+			else:
+				self.remove_field(i)
+
+		# handle * fields
+		j = 0
+		for i in asterisk_fields:
+			self.fields[i + j : i + j + 1] = permitted_fields
+			j = j + len(permitted_fields) - 1
 
 	def prepare_filter_condition(self, f):
 		"""Returns a filter condition in the format:
@@ -1075,3 +1177,30 @@ def requires_owner_constraint(role_permissions):
 	# not checking if either select or read if present in if_owner_perms
 	# because either of those is required to perform a query
 	return True
+
+
+def wrap_grave_quotes(table: str) -> str:
+	if table[0] != "`":
+		table = f"`{table}`"
+	return table
+
+
+def is_plain_field(field: str) -> bool:
+	for char in field:
+		if char in SPECIAL_FIELD_CHARS:
+			return False
+	return True
+
+
+def in_function(substr: str, field: str) -> bool:
+	try:
+		return substr in field and field.index("(") < field.index(substr) < field.index(")")
+	except ValueError:
+		return False
+
+
+def strip_alias(field: str) -> str:
+	# Note: Currently only supports aliases that use the " AS " syntax
+	if " as " in field.lower():
+		return field.split(" as ", 1)[0]
+	return field

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -867,8 +867,12 @@ def setup_patched_blog_post():
 
 @contextmanager
 def enable_permlevel_restrictions():
+	frappe.local.system_settings = {}
 	frappe.db.set_single_value("System Settings", "apply_perm_level_on_api_calls", 1)
+
 	yield
+
+	frappe.local.system_settings = {}
 	frappe.db.set_single_value("System Settings", "apply_perm_level_on_api_calls", 0)
 
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -788,15 +788,6 @@ class TestDatabaseQuery(unittest.TestCase):
 			self.assertTrue("count" in data[0])
 			self.assertEqual(len(data[0]), 2)
 
-			data = frappe.get_list(
-				"Blog Post",
-				fields=["name", "blogger.full_name as blogger_full_name", "blog_category.description"],
-				limit=1,
-			)
-			self.assertTrue("name" in data[0])
-			self.assertTrue("blogger_full_name" in data[0])
-			self.assertTrue("description" not in data[0])  # field does not exist
-
 	def test_reportview_get_permlevel_system_users(self):
 		with enable_permlevel_restrictions(), setup_patched_blog_post(), setup_test_user(set_user=True):
 			frappe.local.request = frappe._dict(method="POST")

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -2,7 +2,9 @@
 # MIT License. See license.txt
 from __future__ import unicode_literals
 
+import datetime
 import unittest
+from contextlib import contextmanager
 
 import frappe
 from frappe.core.page.permission_manager.permission_manager import add, reset, update
@@ -693,6 +695,176 @@ class TestReportview(unittest.TestCase):
 		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", ["a"])}, return_query=1))
 		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", [])}, return_query=1))
 		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", [""])}, return_query=1))
+
+
+class TestDatabaseQuery(unittest.TestCase):
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def test_permlevel_fields(self):
+		with enable_permlevel_restrictions(), setup_patched_blog_post(), setup_test_user(set_user=True):
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "published"], limit=1
+			)
+			self.assertFalse("published" in data[0])
+			self.assertTrue("name" in data[0])
+			self.assertEqual(len(data[0]), 1)
+
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "`published`"], limit=1
+			)
+			self.assertFalse("published" in data[0])
+			self.assertTrue("name" in data[0])
+			self.assertEqual(len(data[0]), 1)
+
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "`tabBlog Post`.`published`"], limit=1
+			)
+			self.assertFalse("published" in data[0])
+			self.assertTrue("name" in data[0])
+			self.assertEqual(len(data[0]), 1)
+
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "`tabTest Child`.`test_field`"], limit=1
+			)
+			self.assertFalse("test_field" in data[0])
+			self.assertTrue("name" in data[0])
+			self.assertEqual(len(data[0]), 1)
+
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "MAX(`published`)"], limit=1
+			)
+			self.assertTrue("name" in data[0])
+			self.assertEqual(len(data[0]), 1)
+
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "LAST(published)"], limit=1
+			)
+			self.assertTrue("name" in data[0])
+			self.assertEqual(len(data[0]), 1)
+
+			data = frappe.get_list(
+				"Blog Post",
+				filters={"published": 1},
+				fields=["name", "MAX(`modified`)"],
+				limit=1,
+				order_by=None,
+				group_by="name",
+			)
+			self.assertEqual(len(data[0]), 2)
+
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "now() abhi"], limit=1
+			)
+			self.assertIsInstance(data[0]["abhi"], datetime.datetime)
+			self.assertEqual(len(data[0]), 2)
+
+			data = frappe.get_list(
+				"Blog Post", filters={"published": 1}, fields=["name", "'LABEL'"], limit=1
+			)
+			self.assertTrue("name" in data[0])
+			self.assertTrue("LABEL" in data[0].values())
+			self.assertEqual(len(data[0]), 2)
+
+			data = frappe.get_list(
+				"Blog Post",
+				filters={"published": 1},
+				fields=["name", "COUNT(*) as count"],
+				limit=1,
+				order_by=None,
+				group_by="name",
+			)
+			self.assertTrue("count" in data[0])
+			self.assertEqual(len(data[0]), 2)
+
+			data = frappe.get_list(
+				"Blog Post",
+				filters={"published": 1},
+				fields=["name", "COUNT(*) count"],
+				limit=1,
+				order_by=None,
+				group_by="name",
+			)
+			self.assertTrue("count" in data[0])
+			self.assertEqual(len(data[0]), 2)
+
+			data = frappe.get_list(
+				"Blog Post",
+				fields=["name", "blogger.full_name as blogger_full_name", "blog_category.description"],
+				limit=1,
+			)
+			self.assertTrue("name" in data[0])
+			self.assertTrue("blogger_full_name" in data[0])
+			self.assertTrue("description" not in data[0])  # field does not exist
+
+	def test_reportview_get_permlevel_system_users(self):
+		with enable_permlevel_restrictions(), setup_patched_blog_post(), setup_test_user(set_user=True):
+			frappe.local.request = frappe._dict(method="POST")
+			frappe.local.form_dict = frappe._dict(
+				{
+					"doctype": "Blog Post",
+					"fields": ["published", "title", "`tabTest Child`.`test_field`"],
+				}
+			)
+
+			# even if * is passed, fields which are not accessible should be filtered out
+			response = execute_cmd("frappe.desk.reportview.get")
+			self.assertListEqual(response["keys"], ["title"])
+			frappe.local.form_dict = frappe._dict(
+				{
+					"doctype": "Blog Post",
+					"fields": ["*"],
+				}
+			)
+
+			response = execute_cmd("frappe.desk.reportview.get")
+			self.assertNotIn("published", response["keys"])
+
+	def test_reportview_get_admin(self):
+		# Admin should be able to see access all fields
+		with enable_permlevel_restrictions(), setup_patched_blog_post():
+			frappe.local.request = frappe._dict(method="GET")
+			frappe.local.form_dict = frappe._dict(
+				{
+					"doctype": "Blog Post",
+					"fields": ["published", "title", "`tabTest Child`.`test_field`"],
+				}
+			)
+			response = execute_cmd("frappe.desk.reportview.get")
+			self.assertListEqual(response["keys"], ["published", "title", "test_field"])
+
+
+@contextmanager
+def setup_test_user(set_user=False):
+	test_user = frappe.get_doc("User", "test@example.com")
+	user_roles = frappe.get_roles()
+	test_user.remove_roles(*user_roles)
+	test_user.add_roles("Blogger")
+
+	if set_user:
+		frappe.set_user(test_user.name)
+
+	yield test_user
+
+	test_user.remove_roles("Blogger")
+	test_user.add_roles(*user_roles)
+
+
+@contextmanager
+def setup_patched_blog_post():
+	add_child_table_to_blog_post()
+	make_property_setter("Blog Post", "published", "permlevel", 1, "Int")
+	reset("Blog Post")
+	add("Blog Post", "Website Manager", 1)
+	update("Blog Post", "Website Manager", 1, "write", 1)
+	yield
+
+
+@contextmanager
+def enable_permlevel_restrictions():
+	frappe.db.set_single_value("System Settings", "apply_perm_level_on_api_calls", 1)
+	yield
+	frappe.db.set_single_value("System Settings", "apply_perm_level_on_api_calls", 0)
 
 
 def add_child_table_to_blog_post():

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -827,7 +827,21 @@ class TestDatabaseQuery(unittest.TestCase):
 
 @contextmanager
 def setup_test_user(set_user=False):
-	test_user = frappe.get_doc("User", "test@example.com")
+	DB_QUERY_TEST_USER = "test_db_query@example.com"
+	if not frappe.db.exists("User", DB_QUERY_TEST_USER):
+		test_user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": DB_QUERY_TEST_USER,
+				"first_name": "Test",
+				"last_name": "User",
+				"enabled": 1,
+				"send_welcome_email": 0,
+			}
+		).insert(ignore_permissions=True)
+	else:
+		test_user = frappe.get_doc("User", DB_QUERY_TEST_USER)
+
 	user_roles = frappe.get_roles()
 	test_user.remove_roles(*user_roles)
 	test_user.add_roles("Blogger")


### PR DESCRIPTION


_Note: Backporting only the permlevel changes introduced in `develop` via #19533. Unlike #20244, this PR doesn't backport the other supplementary corrective changes from v15 or the relevant history._