### PR TITLE
fix: enqueueing jobs from safe_exec and param clash in run_doc_method and frappe.enqueue

### DIFF
--- a/frappe/public/js/frappe/form/controls/button.js
+++ b/frappe/public/js/frappe/form/controls/button.js
@@ -36,7 +36,7 @@ frappe.ui.form.ControlButton = class ControlButton extends frappe.ui.form.Contro
 		if (this.frm && this.frm.docname) {
 			frappe.call({
 				method: "run_doc_method",
-				args: { docs: this.frm.doc, method: this.df.options },
+				args: { docs: this.frm.doc, doc_method: this.df.options },
 				btn: this.$input,
 				callback: function (r) {
 					if (!r.exc) {

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -65,7 +65,7 @@ frappe.call = function (opts) {
 		$.extend(args, {
 			cmd: "run_doc_method",
 			docs: frappe.get_doc(opts.doc.doctype, opts.doc.name),
-			method: opts.method,
+			doc_method: opts.method,
 			args: opts.args,
 		});
 	} else if (opts.method) {

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -73,6 +73,7 @@ class TestBackgroundJobs(FrappeTestCase):
 					"event": None,
 					"job_name": "frappe.handler.ping",
 					"is_async": True,
+					"from_safe_exec": None,
 					"kwargs": {"kwargs": {"site": frappe.local.site}},
 				},
 				at_front=False,

--- a/frappe/tests/test_client.py
+++ b/frappe/tests/test_client.py
@@ -95,7 +95,7 @@ class TestClient(FrappeTestCase):
 			{
 				"dt": report.doctype,
 				"dn": report.name,
-				"method": "toggle_disable",
+				"doc_method": "toggle_disable",
 				"cmd": "run_doc_method",
 				"args": 0,
 			}
@@ -108,7 +108,7 @@ class TestClient(FrappeTestCase):
 			{
 				"dt": report.doctype,
 				"dn": report.name,
-				"method": "create_report_py",
+				"doc_method": "create_report_py",
 				"cmd": "run_doc_method",
 				"args": 0,
 			}

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -108,6 +108,7 @@ def enqueue(
 		"event": event,
 		"job_name": job_name or cstr(method),
 		"is_async": is_async,
+		"from_safe_exec": frappe.flags.in_safe_exec,
 		"kwargs": kwargs,
 	}
 	if enqueue_after_commit:
@@ -151,7 +152,9 @@ def run_doc_method(doctype, name, doc_method, **kwargs):
 	getattr(frappe.get_doc(doctype, name), doc_method)(**kwargs)
 
 
-def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True, retry=0):
+def execute_job(
+	site, method, event, job_name, kwargs, user=None, is_async=True, retry=0, from_safe_exec=None
+):
 	"""Executes job in a worker, performs commit/rollback and logs if there is any error"""
 	retval = None
 	if is_async:
@@ -161,6 +164,8 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 
 		if user:
 			frappe.set_user(user)
+
+	frappe.flags.in_safe_exec = from_safe_exec
 
 	if isinstance(method, str):
 		method_name = method


### PR DESCRIPTION
Problem: Enqueue a whitelisted document method from server script with custom timeout and queue.

This can be achieved via `run_doc_method` but there are 2 problems with this:
1. `run_doc_method` and `frappe.enqueue` have the same param `method` which causes confusion for python
2. jobs are queued with `in_safe_exec` flag, but when the actual job runs, it's absent
 
This pr tries to address both these problems.