### PR TITLE
fix: Do not consider priority while clearing email queue

### DIFF
--- a/frappe/email/queue.py
+++ b/frappe/email/queue.py
@@ -733,33 +733,26 @@ def prepare_message(email, recipient, recipients_list):
 
 
 def clear_outbox(days=None):
-	"""Remove low priority older than 31 days in Outbox or configured in Log Settings.
-	Note: Used separate query to avoid deadlock
-	"""
-	if not days:
-		days = 31
+	from frappe.query_builder import Interval
+	from frappe.query_builder.functions import Now
 
-	email_queues = frappe.db.sql_list(
-		"""SELECT `name` FROM `tabEmail Queue`
-		WHERE `priority`=0 AND `modified` < (NOW() - INTERVAL '{0}' DAY)""".format(
-			days
-		)
-	)
+	days = days or 31
+	email_queue = frappe.qb.DocType("Email Queue")
+	email_recipient = frappe.qb.DocType("Email Queue Recipient")
 
-	if email_queues:
-		frappe.db.sql(
-			"""DELETE FROM `tabEmail Queue` WHERE `name` IN ({0})""".format(
-				",".join(["%s"] * len(email_queues))
-			),
-			tuple(email_queues),
-		)
+	# Delete queue table
+	(
+		frappe.qb.from_(email_queue).delete().where(email_queue.modified < (Now() - Interval(days=days)))
+	).run()
 
-		frappe.db.sql(
-			"""DELETE FROM `tabEmail Queue Recipient` WHERE `parent` IN ({0})""".format(
-				",".join(["%s"] * len(email_queues))
-			),
-			tuple(email_queues),
-		)
+	# delete child tables, note that this has potential to leave some orphan
+	# child table behind if modified time was later than parent doc (rare).
+	# But it's safe since child table doesn't contain links.
+	(
+		frappe.qb.from_(email_recipient)
+		.delete()
+		.where(email_recipient.modified < (Now() - Interval(days=days)))
+	).run()
 
 
 def set_expiry_for_email_queue():

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -190,3 +190,4 @@ frappe.patches.v13_0.reset_corrupt_defaults
 frappe.patches.v13_0.payment_gateways_deprecation_warning
 frappe.patches.v13_0.set_suspend_email_queue_default
 frappe.patches.v13_0.remove_share_for_std_users
+frappe.patches.v13_0.clear_large_email_queues

--- a/frappe/patches/v13_0/clear_large_email_queues.py
+++ b/frappe/patches/v13_0/clear_large_email_queues.py
@@ -1,0 +1,71 @@
+import os
+
+import frappe
+from frappe.utils import add_to_date, today
+
+
+def execute():
+	"""Due to large size of log tables on old sites some table cleanups never
+	finished during daily log clean up. This patch discards such data by using
+	"big delete" code.
+
+
+	This is "special" version of generic patch found in v14
+
+	https://github.com/frappe/frappe/blob/develop/frappe/patches/v14_0/clear_long_pending_stale_logs.py
+	"""
+
+	retention = get_current_setting("clear_email_queue_after") or 30
+
+	if not is_log_cleanup_stuck("Email Queue", retention):
+		return
+
+	clear_log_table("Email Queue", retention)
+	clear_log_table("Email Queue Recipient", retention)
+
+
+def clear_log_table(doctype, days=90):
+	"""If any logtype table grows too large then clearing it with DELETE query
+	is not feasible in reasonable time. This command copies recent data to new
+	table and replaces current table with new smaller table.
+	ref: https://mariadb.com/kb/en/big-deletes/#deleting-more-than-half-a-table
+	"""
+	from frappe.utils import get_table_name
+
+	original = get_table_name(doctype)
+	temporary = f"{original} temp_table"
+	backup = f"{original} backup_table"
+
+	try:
+		frappe.db.sql_ddl(f"CREATE TABLE `{temporary}` LIKE `{original}`")
+
+		# Copy all recent data to new table
+		frappe.db.sql(
+			f"""INSERT INTO `{temporary}`
+				SELECT * FROM `{original}`
+				WHERE `{original}`.`modified` > NOW() - INTERVAL '{days}' DAY"""
+		)
+		frappe.db.sql_ddl(f"RENAME TABLE `{original}` TO `{backup}`, `{temporary}` TO `{original}`")
+	except Exception:
+		frappe.db.rollback()
+		frappe.db.sql_ddl(f"DROP TABLE IF EXISTS `{temporary}`")
+		raise
+	else:
+		frappe.db.sql_ddl(f"DROP TABLE `{backup}`")
+
+
+def is_log_cleanup_stuck(doctype, retention):
+	"""Check if doctype has data significantly older than configured cleanup period"""
+	threshold = add_to_date(today(), days=retention * -2)
+
+	in_patch_test = os.environ.get("CI")
+
+	return bool(frappe.db.get_value(doctype, {"modified": ("<", threshold)})) or bool(in_patch_test)
+
+
+def get_current_setting(fieldname):
+	try:
+		return frappe.db.get_single_value("Log Settings", fieldname)
+	except Exception:
+		# Field might be gone if patch is reattempted
+		pass


### PR DESCRIPTION
It makes no sense to skip email queues with priority 1 while clearing logs since the default priority is 1 and most of the email queue documents are left undeleted.

porting part of https://github.com/frappe/frappe/commit/ea416f9d6bd5312e48ca030ad915f01ad8434d40 to resolve the specific issue
