### PR TITLE
fix: Permission error while processing role based notifications

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -64,13 +64,14 @@ class Role(Document):
 					user.save()
 
 
-def get_info_based_on_role(role, field="email"):
+def get_info_based_on_role(role, field="email", ignore_permissions=False):
 	"""Get information of all users that have been assigned this role"""
 	users = frappe.get_list(
 		"Has Role",
 		filters={"role": role, "parenttype": "User"},
 		parent_doctype="User",
 		fields=["parent as user_name"],
+		ignore_permissions=ignore_permissions,
 	)
 
 	return get_user_info(users, field)

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -298,7 +298,7 @@ def get_context(context):
 
 			# For sending emails to specified role
 			if recipient.receiver_by_role:
-				emails = get_info_based_on_role(recipient.receiver_by_role, "email")
+				emails = get_info_based_on_role(recipient.receiver_by_role, "email", ignore_permissions=True)
 
 				for email in emails:
 					recipients = recipients + email.split("\n")


### PR DESCRIPTION


closes https://github.com/frappe/frappe/issues/20185#issuecomment-1452233173


refer https://discuss.frappe.io/t/notification-not-send-on-new-document/99588/5


Summary: Dont check for permissions when getting users to send notifications. Notifications are configured by sys managers, so if they configure something stupid that leaks info to normal users it's on them. 

Also I don't see any reason to apply permissions while processing notifications. Notifications shouldn't really depend on which user is triggering it. 

```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/email/doctype/notification/notification.py", line 131, in send
    self.send_an_email(doc, context)
      self = <Notification: New Registered Device>
      doc = <Document: REG-DEVICE-0097>
      context = {'doc': <Document: REG-DEVICE-0097>, 'alert': <Notification: New Registered Device>, 'comments': None}
  File "apps/frappe/frappe/email/doctype/notification/notification.py", line 207, in send_an_email
    recipients, cc, bcc = self.get_list_of_recipients(doc, context)
      self = <Notification: New Registered Device>
      doc = <Document: REG-DEVICE-0097>
      context = {'doc': <Document: REG-DEVICE-0097>, 'alert': <Notification: New Registered Device>, 'comments': None}
      formataddr = <function formataddr at 0x7fa9671697e0>
      make_communication = <function _make at 0x7fa953f2ba30>
      subject = ' REG-DEVICE-0097 created by A User  '
      attachments = None
  File "apps/frappe/frappe/email/doctype/notification/notification.py", line 300, in get_list_of_recipients
    emails = get_info_based_on_role(recipient.receiver_by_role, "email")
      self = <Notification: New Registered Device>
      doc = <Document: REG-DEVICE-0097>
      context = {'doc': <Document: REG-DEVICE-0097>, 'alert': <Notification: New Registered Device>, 'comments': None}
      recipients = []
      cc = ['name@mymail.com']
      bcc = []
      recipient = <NotificationRecipient: ecac7ac57c parent=New Registered Device>
  File "apps/frappe/frappe/core/doctype/role/role.py", line 69, in get_info_based_on_role
    users = frappe.get_list(
      role = 'Website Manager'
      field = 'email'
  File "apps/frappe/frappe/__init__.py", line 1879, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
      doctype = 'Has Role'
      args = ()
      kwargs = {'filters': {'role': 'Website Manager', 'parenttype': 'User'}, 'parent_doctype': 'User', 'fields': ['parent as user_name']}
      frappe = <module 'frappe' from 'apps/frappe/frappe/init.py'>
  File "apps/frappe/frappe/model/db_query.py", line 112, in execute
    raise frappe.PermissionError(self.doctype)
      self = <frappe.model.db_query.DatabaseQuery object at 0x7fa953c72530>
      fields = ['parent as user_name']
      filters = {'role': 'Website Manager', 'parenttype': 'User'}
      or_filters = None
      docstatus = None
      group_by = None
      order_by = 'KEEP_DEFAULT_ORDERING'
      limit_start = False
      limit_page_length = None
      as_list = False
      with_childnames = False
      debug = False
      ignore_permissions = False
      user = None
      with_comment_count = False
      join = 'left join'
      distinct = False
      start = None
      page_length = None
      limit = None
      ignore_ifnull = False
      save_user_settings = False
      save_user_settings_fields = False
      update = None
      add_total_row = None
      user_settings = None
      reference_doctype = None
      run = True
      strict = True
      ignore_ddl = False
      parent_doctype = 'User'
      pluck = None
frappe.exceptions.PermissionError: Has role
```
