### PR TITLE
feat: make workflow state translatable

### DIFF
--- a/frappe/workflow/doctype/workflow_state/workflow_state.json
+++ b/frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -40,10 +40,11 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2022-08-03 12:20:52.588427",
+ "modified": "2023-03-13 22:33:58.504532",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow State",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -66,5 +67,6 @@
  "sort_field": "modified",
  "sort_order": "ASC",
  "states": [],
- "track_changes": 1
+ "track_changes": 1,
+ "translated_doctype": 1
 }


### PR DESCRIPTION
Set `"translated_doctype": 1` for **Workflow State**. This way users can select a _Workflow State_ in their own language, in link fields and filters.

- _Workflow State_ is very similar to a _Status_ field, which is translated as well.
- I'm assuming that there won't be a great number of different **Workflow States**, so translation doesn't cause too much overhead.

> no-docs
