### PR TITLE
feat: allow configuring ttl for RQ job retention

### DIFF
--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -44,6 +44,12 @@ class TestRQJob(FrappeTestCase):
 		)
 		self.check_status(job, "finished")
 
+	def test_configurable_ttl(self):
+		frappe.conf.rq_job_failure_ttl = 600
+		job = frappe.enqueue(method=self.BG_JOB, queue="short")
+
+		self.assertEqual(job.failure_ttl, 600)
+
 	def test_func_obj_serialization(self):
 		job = frappe.enqueue(method=test_func, queue="short")
 		rq_job = frappe.get_doc("RQ Job", job.id)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1300,8 +1300,8 @@ def enqueue_jobs_after_commit():
 				execute_job,
 				timeout=job.get("timeout"),
 				kwargs=job.get("queue_args"),
-				failure_ttl=RQ_JOB_FAILURE_TTL,
-				result_ttl=RQ_RESULTS_TTL,
+				failure_ttl=frappe.conf.get("rq_job_failure_ttl") or RQ_JOB_FAILURE_TTL,
+				result_ttl=frappe.conf.get("rq_results_ttl") or RQ_RESULTS_TTL,
 			)
 		frappe.flags.enqueue_after_commit = []
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -126,8 +126,8 @@ def enqueue(
 		timeout=timeout,
 		kwargs=queue_args,
 		at_front=at_front,
-		failure_ttl=RQ_JOB_FAILURE_TTL,
-		result_ttl=RQ_RESULTS_TTL,
+		failure_ttl=frappe.conf.get("rq_job_failure_ttl") or RQ_JOB_FAILURE_TTL,
+		result_ttl=frappe.conf.get("rq_results_ttl") or RQ_RESULTS_TTL,
 	)
 
 


### PR DESCRIPTION
Some might want to keep them around for long, others might wanna get rid
of it to free up memory. Hardcoded defaults dont work for everyone hence
make it configurable.

`no-docs`

