### PR TITLE
fix(print): Language set in document should have higher precedence

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -347,7 +347,7 @@ frappe.ui.form.PrintView = class {
 	set_default_print_language() {
 		let print_format = this.get_print_format();
 		this.lang_code =
-			print_format.default_print_language || this.frm.doc.language || frappe.boot.lang;
+			this.frm.doc.language || print_format.default_print_language || frappe.boot.lang;
 		this.language_selector.val(this.lang_code);
 	}
 


### PR DESCRIPTION
**Issue:**
The system used to select "Default Print Language" set in print format even though language was set in document.

**Fix:**
Language set in document should have higher precedence than "Default Print Language" set in print format.