### PR TITLE
fix: Set link title in PDF

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -40,6 +40,8 @@ def get_context(context):
 	else:
 		doc = frappe.get_doc(frappe.form_dict.doctype, frappe.form_dict.name)
 
+	set_link_titles(doc)
+
 	settings = frappe.parse_json(frappe.form_dict.settings)
 
 	letterhead = frappe.form_dict.letterhead or None


### PR DESCRIPTION
**Before:**
<img width="756" alt="Screenshot 2023-03-15 at 2 13 42 PM" src="https://user-images.githubusercontent.com/13928957/225255377-fd0071d6-bac6-453f-b5c3-e0b65dc42226.png">


**After:** 
<img width="682" alt="Screenshot 2023-03-15 at 2 13 26 PM" src="https://user-images.githubusercontent.com/13928957/225255399-9352f94a-485a-4a0c-9cd7-684584b7fe85.png">
