### PR TITLE
fix(UI): Miscellaneous

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -48,6 +48,7 @@ frappe.ui.form.on("DocType", {
 				true
 			);
 		} else if (frappe.boot.developer_mode) {
+			frm.dashboard.clear_comment();
 			let msg = __(
 				"This site is running in developer mode. Any change made here will be updated in code."
 			);

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -40,7 +40,7 @@ export default class GridRow {
 			render_row = this.render_row();
 		}
 
-		if (!this.render_row) return;
+		if (!render_row) return;
 
 		this.set_data();
 		this.wrapper.appendTo(this.parent);
@@ -762,7 +762,8 @@ export default class GridRow {
 
 	show_search_row() {
 		// show or remove search columns based on grid rows
-		this.show_search = this.show_search && this.grid?.data?.length >= 20;
+		this.show_search =
+			this.show_search && (this.grid?.data?.length >= 20 || this.grid.filter_applied);
 		!this.show_search && this.wrapper.remove();
 		return this.show_search;
 	}

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -48,6 +48,8 @@ $.extend(frappe.model, {
 			// set title field / name as name
 			if (meta.autoname && meta.autoname.indexOf("field:") !== -1) {
 				doc[meta.autoname.substr(6)] = frappe.route_options.name_field;
+			} else if (meta.autoname && meta.autoname === "prompt") {
+				doc.__newname = frappe.route_options.name_field;
 			} else if (meta.title_field) {
 				doc[meta.title_field] = frappe.route_options.name_field;
 			}


### PR DESCRIPTION
- Clear dashboard comment to avoid duplicate message
- Fill partially entered data to quick entry. It used to not work if the linked doctype had "prompt" set as autoname
	**Before:**

	https://user-images.githubusercontent.com/13928957/225514155-f3ac2283-c0f6-4b3c-a101-3938978ce00a.mov

	**After:**

	https://user-images.githubusercontent.com/13928957/225514174-ccb58279-ac3c-4612-8e8b-682e8fc13564.mov

- With filter applied, grid filter was not showing up on page switch.

	**Before:**

	https://user-images.githubusercontent.com/13928957/225516775-30646c89-8804-4646-ab8d-acb6e2be5c6c.mov

	**After:**

	https://user-images.githubusercontent.com/13928957/225516762-057cff11-3cb1-4b70-87ef-b0ff97b52d36.mov



