### PR TITLE
fix: Remove language selector in email modal

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -130,11 +130,6 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "Select",
 				fieldname: "select_print_format",
 			},
-			{
-				label: __("Select Languages"),
-				fieldtype: "Select",
-				fieldname: "language_sel",
-			},
 			{ fieldtype: "Column Break" },
 			{
 				label: __("Select Attachments"),
@@ -183,7 +178,6 @@ frappe.views.CommunicationComposer = class {
 	prepare() {
 		this.setup_multiselect_queries();
 		this.setup_subject_and_recipients();
-		this.setup_print_language();
 		this.setup_print();
 		this.setup_attach();
 		this.setup_email();
@@ -295,7 +289,6 @@ frappe.views.CommunicationComposer = class {
 				args: {
 					template_name: email_template,
 					doc: me.doc,
-					_lang: me.dialog.get_value("language_sel"),
 				},
 				callback(r) {
 					prepend_reply(r.message);
@@ -400,29 +393,6 @@ frappe.views.CommunicationComposer = class {
 			return locals["Print Format"][format];
 		} else {
 			return {};
-		}
-	}
-
-	setup_print_language() {
-		const fields = this.dialog.fields_dict;
-
-		//Load default print language from doctype
-		this.lang_code =
-			this.doc.language ||
-			this.get_print_format().default_print_language ||
-			frappe.boot.lang;
-
-		//On selection of language retrieve language code
-		const me = this;
-		$(fields.language_sel.input).change(function () {
-			me.lang_code = this.value;
-		});
-
-		// Load all languages in the select field language_sel
-		$(fields.language_sel.input).empty().add_options(frappe.get_languages());
-
-		if (this.lang_code) {
-			$(fields.language_sel.input).val(this.lang_code);
 		}
 	}
 
@@ -676,7 +646,6 @@ frappe.views.CommunicationComposer = class {
 				sender_full_name: form_values.sender ? frappe.user.full_name() : undefined,
 				email_template: form_values.email_template,
 				attachments: selected_attachments,
-				_lang: me.lang_code,
 				read_receipt: form_values.send_read_receipt,
 				print_letterhead: me.is_print_letterhead_checked(),
 			},


### PR DESCRIPTION
<img width="796" alt="Screenshot 2023-03-16 at 11 41 12 AM" src="https://user-images.githubusercontent.com/13928957/225530637-3cf6e78b-54ff-49bb-b74b-10f8f2c03625.png">

---

Removed language selector in communication to avoid confusion since the feature is not functional and no wiring has been done to support this feature.
