### PR TITLE
fix: email linking and message_id indexing

### DIFF
--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -318,7 +318,7 @@
   },
   {
    "fieldname": "message_id",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "ignore_xss_filter": 1,
    "label": "Message ID",
    "length": 995,
@@ -395,7 +395,7 @@
  "icon": "fa fa-comment",
  "idx": 1,
  "links": [],
- "modified": "2022-05-09 00:13:45.310564",
+ "modified": "2023-03-16 12:04:18.113817",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Communication",

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -397,6 +397,7 @@ def on_doctype_update():
 	"""Add indexes in `tabCommunication`"""
 	frappe.db.add_index("Communication", ["reference_doctype", "reference_name"])
 	frappe.db.add_index("Communication", ["status", "communication_type"])
+	frappe.db.add_index("Communication", ["message_id(140)"])
 
 
 def has_permission(doc, ptype, user):

--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -67,10 +67,9 @@
   },
   {
    "fieldname": "message_id",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Message ID",
-   "read_only": 1,
-   "search_index": 1
+   "read_only": 1
   },
   {
    "fieldname": "reference_doctype",
@@ -153,7 +152,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2022-07-12 15:17:37.934316",
+ "modified": "2023-03-16 12:15:17.850292",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -407,6 +407,8 @@ def on_doctype_update():
 		"Email Queue", ("status", "send_after", "priority", "creation"), "index_bulk_flush"
 	)
 
+	frappe.db.add_index("Email Queue", ["message_id(140)"])
+
 
 def get_email_retry_limit():
 	return cint(frappe.db.get_system_setting("email_retry_limit")) or 3

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -795,17 +795,15 @@ class InboundMail(Email):
 		if not self.is_reply():
 			return ""
 
-		communication = None
-		communication = Communication.find_one_by_filters(
-			message_id=self.in_reply_to, creation=[">=", self.get_relative_dt(-30)]
-		)
-		if not communication and self.parent_email_queue() and self.parent_email_queue().communication:
-			communication = Communication.find(self.parent_email_queue().communication, ignore_error=True)
-		else:
-			reference = self.in_reply_to
-			if "@" in self.in_reply_to:
-				reference, _ = self.in_reply_to.split("@", 1)
-			communication = Communication.find(reference, ignore_error=True)
+		communication = Communication.find_one_by_filters(message_id=self.in_reply_to)
+		if not communication:
+			if self.parent_email_queue() and self.parent_email_queue().communication:
+				communication = Communication.find(self.parent_email_queue().communication, ignore_error=True)
+			else:
+				reference = self.in_reply_to
+				if "@" in self.in_reply_to:
+					reference, _ = self.in_reply_to.split("@", 1)
+				communication = Communication.find(reference, ignore_error=True)
 
 		self._parent_communication = communication or ""
 		return self._parent_communication

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -782,7 +782,7 @@ class InboundMail(Email):
 
 		Here are the cases to handle:
 		1. If mail is a reply to already sent mail, then we can get parent communicaion from
-		        Email Queue record.
+		        Email Queue record or message_id on communication.
 		2. Sometimes we send communication name in message-ID directly, use that to get parent communication.
 		3. Sender sent a reply but reply is on top of what (s)he sent before,
 		        then parent record exists directly in communication.
@@ -795,11 +795,11 @@ class InboundMail(Email):
 		if not self.is_reply():
 			return ""
 
-		if not self.is_reply_to_system_sent_mail():
-			communication = Communication.find_one_by_filters(
-				message_id=self.in_reply_to, creation=[">=", self.get_relative_dt(-30)]
-			)
-		elif self.parent_email_queue() and self.parent_email_queue().communication:
+		communication = None
+		communication = Communication.find_one_by_filters(
+			message_id=self.in_reply_to, creation=[">=", self.get_relative_dt(-30)]
+		)
+		if not communication and self.parent_email_queue() and self.parent_email_queue().communication:
 			communication = Communication.find(self.parent_email_queue().communication, ignore_error=True)
 		else:
 			reference = self.in_reply_to


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/20352


- changes mesage_id from varchar(~900) to small text. 
- Add prefix index for comparison and finding `reply to` messages for linking. 
- While finding parent communication we now ignore check if it's not reply to system generated email. Both email queue and communication maintain message_id on user generated outgoing emails. The problem is email queue is cleared to save storage space on most sites. So communication is more reliable. 

TODO:

- [x] confirm that prefix index actually works. 


index works fine

![image](https://user-images.githubusercontent.com/9079960/225542500-0869d9f4-643f-4ff8-a929-53836e5a332e.png)


ref:
- https://mariadb.com/kb/en/innodb-limitations/