### PR TITLE
fix: skip InReadOnlyMode in error snapshots

### DIFF
--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -22,6 +22,7 @@ EXCLUDE_EXCEPTIONS = (
 	frappe.CSRFTokenError,  # CSRF covers OAuth too
 	frappe.SecurityException,
 	LDAPException,
+	frappe.InReadOnlyMode,
 )
 
 


### PR DESCRIPTION
This causes stale leftover snapshot files during migrate and messes up FC's
site clean up logic. Also in read only mode we shouldn't be touching file
system too.
