### PR TITLE
fix: handle image extraction while editing comment

### DIFF
--- a/frappe/desk/form/utils.py
+++ b/frappe/desk/form/utils.py
@@ -57,7 +57,14 @@ def update_comment(name, content):
 	if frappe.session.user not in ["Administrator", doc.owner]:
 		frappe.throw(_("Comment can only be edited by the owner"), frappe.PermissionError)
 
-	doc.content = content
+	if doc.reference_doctype and doc.reference_name:
+		reference_doc = frappe.get_doc(doc.reference_doctype, doc.reference_name)
+		reference_doc.check_permission()
+
+		doc.content = extract_images_from_html(reference_doc, content, is_private=True)
+	else:
+		doc.content = content
+
 	doc.save(ignore_permissions=True)
 
 


### PR DESCRIPTION
Fixes: https://github.com/frappe/frappe/issues/12283


https://user-images.githubusercontent.com/30859809/225591933-dba33603-9350-43bf-a833-3e12985b420d.mov

