### PR TITLE
fix: allow 5 column layout in doctype form

### DIFF
--- a/frappe/public/js/frappe/form/column.js
+++ b/frappe/public/js/frappe/form/column.js
@@ -38,7 +38,12 @@ export default class Column {
 
 	resize_all_columns() {
 		// distribute all columns equally
-		let colspan = cint(12 / this.section.wrapper.find(".form-column").length);
+		let columns = this.section.wrapper.find(".form-column").length;
+		let colspan = cint(12 / columns);
+
+		if (columns == 5) {
+			colspan = 20;
+		}
 
 		this.section.wrapper
 			.find(".form-column")

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -409,6 +409,21 @@
 	}
 }
 
+// handle 5 columns in form
+.form-column.col-sm-20 {
+	position: relative;
+	width: 100%;
+	padding-right: 15px;
+	padding-left: 15px;
+}
+
+@media (min-width: map-get($grid-breakpoints, "sm")) {
+	.form-column.col-sm-20 {
+		flex: 0 0 20%;
+		max-width: 20%;
+	}
+}
+
 // above mobile
 @media (min-width: map-get($grid-breakpoints, "md")) {
 	.layout-main .form-column.col-sm-12 > form > .input-max-width {


### PR DESCRIPTION
Fixes: https://github.com/frappe/frappe/issues/19958

**Before:** Extra space after on the right
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/30859809/225608074-7d3f198b-4ab5-479a-af66-67d32c94fee7.png">

**After:** No Extra space
<img width="1303" alt="image" src="https://user-images.githubusercontent.com/30859809/225607987-003106e7-c44e-4c5d-8c30-c11daefc75f3.png">
