### PR TITLE
fix!: Dont implicitly assume default naming series

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -434,14 +434,9 @@ def revert_series_if_last(key, name, doc=None):
 
 
 def get_default_naming_series(doctype: str) -> str | None:
-	"""get default value for `naming_series` property"""
-	naming_series_options = frappe.get_meta(doctype).get_naming_series_options()
-
-	# Return first truthy options
-	# Empty strings are used to avoid populating forms by default
-	for option in naming_series_options:
-		if option:
-			return option
+	"""get default value for `naming_series` property from default set in docfield"""
+	if df := frappe.get_meta(doctype).get_field("naming_series"):
+		return df.default
 
 
 def validate_name(doctype: str, name: int | str):


### PR DESCRIPTION
Default naming series is assumed as first truthy value in options...
this is bad in multiple ways:

1. It breaks the otherwise consitent behaviour of picking default form
   "default" option of docfield.
2. Breaks "user must always select" configuration as user can choose to
   not select naming series and first one will get applied.
3. Implicit behaviour. Nothing much to do once naming is performed other
   than deleting and creating new doc.


breaking change:
- Default is only picked form "default" option in docfield. 

closes https://github.com/frappe/frappe/issues/20272 