### PR TITLE
perf: faster newsletter view logging

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.json
+++ b/frappe/email/doctype/newsletter/newsletter.json
@@ -234,7 +234,6 @@
    "default": "0",
    "fieldname": "total_views",
    "fieldtype": "Int",
-   "is_virtual": 1,
    "label": "Total Views",
    "no_copy": 1,
    "read_only": 1
@@ -246,7 +245,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2023-03-16 19:04:47.242884",
+ "modified": "2023-02-23 12:53:18.478018",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Newsletter",

--- a/frappe/email/doctype/newsletter/newsletter.json
+++ b/frappe/email/doctype/newsletter/newsletter.json
@@ -234,6 +234,7 @@
    "default": "0",
    "fieldname": "total_views",
    "fieldtype": "Int",
+   "is_virtual": 1,
    "label": "Total Views",
    "no_copy": 1,
    "read_only": 1
@@ -245,7 +246,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2023-02-23 12:53:18.478018",
+ "modified": "2023-03-16 19:04:47.242884",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Newsletter",

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -27,6 +27,14 @@ class Newsletter(WebsiteGenerator):
 			self._recipients = self.get_recipients()
 		return self._recipients
 
+	@property
+	def total_views(self) -> list[str]:
+		if getattr(self, "_total_viewed", None) is None:
+			self._total_viewed = frappe.db.count(
+				"View Log", {"reference_doctype": self.doctype, "reference_name": self.name}
+			)
+		return self._total_viewed
+
 	@frappe.whitelist()
 	def get_sending_status(self):
 		count_by_status = frappe.get_all(
@@ -376,15 +384,13 @@ def send_scheduled_email():
 @frappe.whitelist(allow_guest=True)
 def newsletter_email_read(recipient_email, reference_doctype, reference_name):
 	verify_request()
+	frappe.enqueue(_track_newsletter_view, recipient_email=recipient_email, newsletter=reference_name)
+	frappe.response.update(frappe.utils.get_imaginary_pixel_response())
+
+
+def _track_newsletter_view(recipient_email, newsletter):
 	try:
-		doc = frappe.get_doc(reference_doctype, reference_name)
-		if doc.add_viewed(recipient_email, force=True, unique_views=True):
-			doc.db_set("total_views", frappe.utils.cint(doc.total_views) + 1, update_modified=False)
-
+		doc = frappe.get_cached_doc("Newsletter", newsletter)
+		doc.add_viewed(recipient_email, force=True, unique_views=True)
 	except Exception:
-		frappe.log_error(
-			f"Unable to mark as viewed for {recipient_email}", None, reference_doctype, reference_name
-		)
-
-	finally:
-		frappe.response.update(frappe.utils.get_imaginary_pixel_response())
+		doc.log_error(f"Unable to mark as viewed for {recipient_email}")


### PR DESCRIPTION
```
         10801625 function calls (10757122 primitive calls) in 11.146 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   11.146   11.146 {built-in method builtins.exec}
        1    0.000    0.000   11.146   11.146 <string>:1(<module>)
        1    0.000    0.000   11.146   11.146 <ipython-input-6-123326dc520d>:1(view)
        1    0.000    0.000   11.131   11.131 document.py:1153(db_set)
        2    0.000    0.000   11.113    5.557 document.py:914(run_method)
        2    0.000    0.000   11.113    5.556 document.py:1270(composer)
        2    0.000    0.000   11.113    5.556 document.py:1261(runner)
        2    0.000    0.000   11.112    5.556 document.py:917(fn)
        1    0.000    0.000   11.112   11.112 website_generator.py:87(on_change)
        1    0.000    0.000   11.112   11.112 website_generator.py:167(update_website_search_index)
        1    0.019    0.019   11.112   11.112 website_search.py:138(remove_document_from_index)
        1    0.001    0.001   11.093   11.093 full_text_search.py:57(remove_document_from_index)
        1    0.000    0.000   11.078   11.078 writing.py:1035(commit)
        1    0.000    0.000   11.078   11.078 writing.py:892(commit)
        1    0.001    0.001    6.107    6.107 writing.py:864(_finalize_segment)
        1    0.000    0.000    6.094    6.094 writing.py:829(_flush_segment)
        1    0.347    0.347    5.981    5.981 base.py:162(add_postings)
        1    0.001    0.001    4.970    4.970 writing.py:806(_merge_segments)
        1    0.000    0.000    4.970    4.970 writing.py:108(OPTIMIZE)
        1    0.000    0.000    4.967    4.967 writing.py:702(add_reader)
        1    0.110    0.110    4.747    4.747 writing.py:644(add_postings_to_pool)
   161703    0.189    0.000    3.913    0.000 writing.py:581(_process_posts)
   161703    0.385    0.000    3.540    0.000 reading.py:421(iter_postings)
    21801    0.066    0.000    2.866    0.000 whoosh3.py:326(finish_term)
    21801    0.102    0.000    2.111    0.000 whoosh3.py:715(finish_postings)
    22058    0.261    0.000    1.994    0.000 whoosh3.py:750(_write_block)
    21801    0.174    0.000    1.741    0.000 reading.py:809(postings)
   163805    0.320    0.000    1.468    0.000 whoosh3.py:416(doc_field_length)
    21801    0.042    0.000    1.412    0.000 whoosh3.py:633(matcher)
   161702    0.115    0.000    1.073    0.000 whoosh3.py:323(add)
   161702    0.567    0.000    0.958    0.000 whoosh3.py:684(add_posting)
   162403    0.180    0.000    0.869    0.000 columns.py:699(__getitem__)
    21801    0.051    0.000    0.795    0.000 whoosh3.py:618(term_info)
   161702    0.073    0.000    0.760    0.000 whoosh3.py:975(id)
   161702    0.553    0.000    0.725    0.000 writing.py:156(add)
    22058    0.095    0.000    0.687    0.000 whoosh3.py:1079(_read_ids)
   162403    0.164    0.000    0.637    0.000 columns.py:431(__getitem__)
    22759    0.624    0.000    0.624    0.000 {built-in method zlib.compress}

```