### PR TITLE
refactor!: defer insert view log

### DIFF
--- a/frappe/core/doctype/view_log/test_view_log.py
+++ b/frappe/core/doctype/view_log/test_view_log.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
 import frappe
+from frappe.deferred_insert import save_to_db
 from frappe.tests.utils import FrappeTestCase
 
 
@@ -24,6 +25,10 @@ class TestViewLog(FrappeTestCase):
 
 		# load the form
 		getdoc("Event", ev.name)
+
+		# flush defered insert docs
+		save_to_db()
+
 		a = frappe.get_value(
 			doctype="View Log",
 			filters={"reference_doctype": "Event", "reference_name": ev.name},

--- a/frappe/core/doctype/view_log/view_log.py
+++ b/frappe/core/doctype/view_log/view_log.py
@@ -1,8 +1,28 @@
 # Copyright (c) 2018, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import frappe
 from frappe.model.document import Document
 
 
 class ViewLog(Document):
 	pass
+
+
+def make_view_log(doctype, docname, user=None, unique_views=False):
+	if not user:
+		user = frappe.session.user
+
+	if unique_views and frappe.db.exists(
+		"View Log", {"reference_doctype": doctype, "reference_name": docname, "viewed_by": user}
+	):
+		return
+
+	frappe.get_doc(
+		{
+			"doctype": "View Log",
+			"viewed_by": user,
+			"reference_doctype": doctype,
+			"reference_name": docname,
+		}
+	).deferred_insert()

--- a/frappe/core/doctype/view_log/view_log.py
+++ b/frappe/core/doctype/view_log/view_log.py
@@ -25,4 +25,4 @@ def make_view_log(doctype, docname, user=None, unique_views=False):
 			"reference_doctype": doctype,
 			"reference_name": docname,
 		}
-	).deferred_insert()
+	).deferred_insert(ignore_permissions=True)

--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -46,7 +46,7 @@ def save_to_db():
 def insert_record(record: Union[dict, "Document"], doctype: str):
 	try:
 		record.update({"doctype": doctype})
-		frappe.get_doc(record).insert()
+		frappe.get_doc(record).insert(ignore_permissions=record.pop("ignore_permissions", False))
 	except Exception as e:
 		frappe.logger().error(f"Error while inserting deferred {doctype} record: {e}")
 

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -10,6 +10,7 @@ import frappe.desk.form.meta
 import frappe.share
 import frappe.utils
 from frappe import _, _dict
+from frappe.core.doctype.view_log.view_log import make_view_log
 from frappe.desk.form.document_follow import is_document_followed
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.utils.user_settings import get_user_settings
@@ -42,8 +43,10 @@ def getdoc(doctype, name, user=None):
 	run_onload(doc)
 	doc.apply_fieldlevel_read_permissions()
 
-	# add file list
-	doc.add_viewed()
+	if hasattr(doc.meta, "track_views") and doc.meta.track_views:
+		# add log to communication when a user views a document
+		make_view_log(doc.doctype, doc.name)
+
 	get_docinfo(doc)
 
 	doc.add_seen()

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -378,13 +378,13 @@ def newsletter_email_read(recipient_email, reference_doctype, reference_name):
 	verify_request()
 	try:
 		doc = frappe.get_cached_doc("Newsletter", reference_name)
-		if doc.add_viewed(recipient_email, force=True, unique_views=True):
-			newsletter = frappe.qb.DocType("Newsletter")
-			(
-				frappe.qb.update(newsletter)
-				.set(newsletter.total_views, newsletter.total_views + 1)
-				.where(newsletter.name == doc.name)
-			).run()
+		doc.add_viewed(recipient_email, force=True, unique_views=True)
+		newsletter = frappe.qb.DocType("Newsletter")
+		(
+			frappe.qb.update(newsletter)
+			.set(newsletter.total_views, newsletter.total_views + 1)
+			.where(newsletter.name == doc.name)
+		).run()
 
 	except Exception:
 		doc.log_error(f"Unable to mark as viewed for {recipient_email}")

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1386,26 +1386,6 @@ class Document(BaseDocument):
 				frappe.db.set_value(self.doctype, self.name, "_seen", json.dumps(_seen), update_modified=False)
 				frappe.local.flags.commit = True
 
-	def add_viewed(self, user=None, force=False, unique_views=False):
-		"""add log to communication when a user views a document"""
-		if not user:
-			user = frappe.session.user
-
-		if unique_views and frappe.db.exists(
-			"View Log", {"reference_doctype": self.doctype, "reference_name": self.name, "viewed_by": user}
-		):
-			return
-
-		if (hasattr(self.meta, "track_views") and self.meta.track_views) or force:
-			frappe.get_doc(
-				{
-					"doctype": "View Log",
-					"viewed_by": user,
-					"reference_doctype": self.doctype,
-					"reference_name": self.name,
-				}
-			).deferred_insert()
-
 	def log_error(self, title=None, message=None):
 		"""Helper function to create an Error Log"""
 		return frappe.log_error(

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1397,21 +1397,14 @@ class Document(BaseDocument):
 			return
 
 		if (hasattr(self.meta, "track_views") and self.meta.track_views) or force:
-			view_log = frappe.get_doc(
+			frappe.get_doc(
 				{
 					"doctype": "View Log",
 					"viewed_by": user,
 					"reference_doctype": self.doctype,
 					"reference_name": self.name,
 				}
-			)
-			if frappe.flags.read_only:
-				view_log.deferred_insert()
-			else:
-				view_log.insert(ignore_permissions=True)
-				frappe.local.flags.commit = True
-
-			return view_log
+			).deferred_insert()
 
 	def log_error(self, title=None, message=None):
 		"""Helper function to create an Error Log"""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1533,7 +1533,7 @@ class Document(BaseDocument):
 
 		return DocTags(self.doctype).get_tags(self.name).split(",")[1:]
 
-	def deferred_insert(self) -> None:
+	def deferred_insert(self, ignore_permissions=False) -> None:
 		"""Push the document to redis temporarily and insert later.
 
 		WARN: This doesn't guarantee insertion as redis can be restarted
@@ -1545,6 +1545,7 @@ class Document(BaseDocument):
 		self.set_user_and_timestamp()
 
 		doc = self.get_valid_dict(convert_dates_to_str=True, ignore_virtual=True)
+		doc["ignore_permissions"] = ignore_permissions
 		deferred_insert(doctype=self.doctype, records=doc)
 
 	def __repr__(self):


### PR DESCRIPTION
Changes:
- removed `add_viewed` method from `Document` class (didn't really make sense why a doctype was added in document class :man_shrugging: ) - converted this into a simple function
- added `ignore_permissions` for deffered_insert
- `total_views` in newsletter will now track non-unique views