### PR TITLE
fix: Drop message_id index before migrating email queue

### DIFF
--- a/frappe/email/doctype/email_queue/patches/drop_search_index_on_message_id.py
+++ b/frappe/email/doctype/email_queue/patches/drop_search_index_on_message_id.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	"""Drop search index on message_id"""
+
+	if frappe.db.get_column_type("Email Queue", "message_id") == "text":
+		return
+
+	if index := frappe.db.get_column_index("tabEmail Queue", "message_id", unique=False):
+		frappe.db.sql(f"ALTER TABLE `tabEmail Queue` DROP INDEX `{index.Key_name}`")

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -183,6 +183,7 @@ frappe.patches.v13_0.encrypt_2fa_secrets
 frappe.patches.v13_0.reset_corrupt_defaults
 frappe.patches.v13_0.remove_share_for_std_users
 execute:frappe.reload_doc('custom', 'doctype', 'custom_field')
+frappe.email.doctype.email_queue.patches.drop_search_index_on_message_id
 frappe.patches.v14_0.update_workspace2 # 20.09.2021
 frappe.patches.v14_0.save_ratings_in_fraction #23-12-2021
 frappe.patches.v14_0.transform_todo_schema


### PR DESCRIPTION
caused by https://github.com/frappe/frappe/pull/20356 


```
Traceback with variables (most recent call last):
  File "/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
      mod_name = 'frappe.utils.bench_helper'
      alter_argv = True
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f979e503dc0>, origin='/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py')
      code = <code object <module> at 0x7f979b54ca80, file "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 1>
      main_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x7f979e503dc0>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f979e503dc0>, origin='/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': '/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py', '__cached__': '/home/runner/frappe-bench/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc', 'importlib': <module 'importlib' from '/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/importlib/__init__.py'>, 'json': <module 'json' from '/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/json/__init__.py'>, 'os': <module 'os' from '/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/os.py'>,...
  File "/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
      code = <code object <module> at 0x7f979b54ca80, file "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 1>
      run_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x7f979e503dc0>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f979e503dc0>, origin='/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': '/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py', '__cached__': '/home/runner/frappe-bench/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc', 'importlib': <module 'importlib' from '/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/importlib/__init__.py'>, 'json': <module 'json' from '/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/json/__init__.py'>, 'os': <module 'os' from '/opt/hostedtoolcache/pyenv_root/2.2.4/x64/versions/3.10.2/lib/python3.10/os.py'>,...
      init_globals = None
      mod_name = '__main__'
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f979e503dc0>, origin='/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py')
      pkg_name = 'frappe.utils'
      script_name = None
      loader = <_frozen_importlib_external.SourceFileLoader object at 0x7f979e503dc0>
      fname = '/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py'
      cached = '/home/runner/frappe-bench/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc'
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
      ...skipped... 26 vars
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name="bench")
      commands = {'frappe': <Group frappe>, 'get-frappe-commands': <Command get-frappe-commands>, 'get-frappe-help': <Command get-frappe-help>}
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
      self = <Group None>
      args = ()
      kwargs = {'prog_name': 'bench'}
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
      self = <Group None>
      args = ['frappe', '--site', 'test_site', 'migrate']
      prog_name = 'bench'
      complete_var = None
      standalone_mode = True
      windows_expand_args = True
      extra = {}
      ctx = <click.core.Context object at 0x7f979cbe81c0>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x7f979b550dc0>
      args = ['migrate']
      cmd_name = 'frappe'
      cmd = <Group frappe>
      sub_ctx = <click.core.Context object at 0x7f979b5fd2a0>
      ctx = <click.core.Context object at 0x7f979cbe81c0>
      self = <Group None>
      __class__ = <class 'click.core.MultiCommand'>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x7f979b40c550>
      args = []
      cmd_name = 'migrate'
      cmd = <Command migrate>
      sub_ctx = <click.core.Context object at 0x7f979b5fd600>
      ctx = <click.core.Context object at 0x7f979b5fd2a0>
      self = <Group frappe>
      __class__ = <class 'click.core.MultiCommand'>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
Updating DocTypes for frappe..........................................................................................................................................................................................................Failed to alter schema using query: ALTER TABLE `tabEmail Queue` MODIFY `message_id` text


There was an issue while migrating the DocType: Email Queue

Queued rebuilding of search index for test_site

      self = <Command migrate>
      ctx = <click.core.Context object at 0x7f979b5fd600>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
      _Context__self = <click.core.Context object at 0x7f979b5fd600>
      _Context__callback = <function migrate at 0x7f979b5b8f70>
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      ctx = <click.core.Context object at 0x7f979b5fd600>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      f = <function migrate at 0x7f979b5b8d30>
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
      ctx = <click.core.Context object at 0x7f979b5fd600>
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      profile = False
      f = <function migrate at 0x7f979b5b8ca0>
  File "/home/runner/frappe-bench/apps/frappe/frappe/commands/site.py", line 605, in migrate
    SiteMigration(
      context = {'sites': ['test_site'], 'force': False, 'verbose': False, 'profile': False}
      skip_failing = False
      skip_search_index = False
      activate_by_import = <module 'traceback_with_variables.activate_by_import' from '/home/runner/frappe-bench/env/lib/python3.10/site-packages/traceback_with_variables/activate_by_import.py'>
      SiteMigration = <class 'frappe.migrate.SiteMigration'>
      site = 'test_site'
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 178, in run
    self.run_schema_updates()
      self = <frappe.migrate.SiteMigration object at 0x7f979b5fd6c0>
      site = 'test_site'
      filelock = <function filelock at 0x7f979b57a710>
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 41, in wrapper
    ret = method(*args, **kwargs)
      args = (<frappe.migrate.SiteMigration object at 0x7f979b5fd6c0>,)
      kwargs = {}
      method = <function SiteMigration.run_schema_updates at 0x7f97993f1ea0>
  File "/home/runner/frappe-bench/apps/frappe/frappe/migrate.py", line 113, in run_schema_updates
    frappe.model.sync.sync_all()
      self = <frappe.migrate.SiteMigration object at 0x7f979b5fd6c0>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/sync.py", line 19, in sync_all
    sync_for(app, force, reset_permissions=reset_permissions)
      force = 0
      reset_permissions = False
      app = 'frappe'
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/sync.py", line 81, in sync_for
    import_file_by_path(
      app_name = 'frappe'
      force = 0
      reset_permissions = False
      files = ['/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/docfield/docfield.json', '/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/docperm/docperm.json', '/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/doctype_action/doctype_action.json', '/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/doctype_link/doctype_link.json', '/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/doctype_state/doctype_state.json', '/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/role/role.json', '/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/has_role/has_role.json', '/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.json', '/home/runner/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.json', '/home/runner/frappe-bench/apps/frappe/frappe/custom/doctype/property_setter/property_setter.json', '/home/runner/frappe-bench/apps/frappe/frappe/website/doctype/web_form/web_form.json', '/home/runner/frappe-bench/a...
      FRAPPE_PATH = '/home/runner/frappe-bench/apps/frappe/frappe'
      core_module = 'doctype'
      custom_module = 'property_setter'
      website_module = 'portal_menu_item'
      desk_module = 'workspace'
      module_name = 'automation'
      folder = '/home/runner/frappe-bench/apps/frappe/frappe/automation'
      l = 320
      i = 202
      doc_path = '/home/runner/frappe-bench/apps/frappe/frappe/email/doctype/email_queue/email_queue.json'
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 145, in import_file_by_path
    import_doc(
      path = '/home/runner/frappe-bench/apps/frappe/frappe/email/doctype/email_queue/email_queue.json'
      force = 0
      data_import = False
      pre_process = None
      ignore_version = True
      reset_permissions = False
      docs = [{'actions': [], 'autoname': 'hash', 'creation': '2012-08-02 15:17:28', 'description': 'Email Queue records.', 'doctype': 'DocType', 'document_type': 'System', 'engine': 'InnoDB', 'fields': [{'fieldname': 'sender', 'fieldtype': 'Data', 'ignore_xss_filter': 1, 'label': 'Sender', 'options': 'Email', 'doctype': 'DocField'}, {'fieldname': 'recipients', 'fieldtype': 'Table', 'label': 'Recipient', 'options': 'Email Queue Recipient', 'doctype': 'DocField'}, {'fieldname': 'show_as_cc', 'fieldtype': 'Small Text', 'label': 'Show as cc', 'doctype': 'DocField'}, {'fieldname': 'message', 'fieldtype': 'Code', 'label': 'Message', 'doctype': 'DocField'}, {'default': 'Not Sent', 'fieldname': 'status', 'fieldtype': 'Select', 'in_list_view': 1, 'in_standard_filter': 1, 'label': 'Status', 'options': '\nNot Sent\nSending\nSent\nError\nExpired', 'doctype': 'DocField'}, {'fieldname': 'error', 'fieldtype': 'Code', 'label': 'Error', 'doctype': 'DocField'}, {'fieldname': 'message_id', 'fieldtype': 'Small Text',...
      calculated_hash = '89abb398753b095ba6858e249c174de4'
      doc = {'actions': [], 'autoname': 'hash', 'creation': '2012-08-02 15:17:28', 'description': 'Email Queue records.', 'doctype': 'DocType', 'document_type': 'System', 'engine': 'InnoDB', 'fields': [{'fieldname': 'sender', 'fieldtype': 'Data', 'ignore_xss_filter': 1, 'label': 'Sender', 'options': 'Email', 'doctype': 'DocField'}, {'fieldname': 'recipients', 'fieldtype': 'Table', 'label': 'Recipient', 'options': 'Email Queue Recipient', 'doctype': 'DocField'}, {'fieldname': 'show_as_cc', 'fieldtype': 'Small Text', 'label': 'Show as cc', 'doctype': 'DocField'}, {'fieldname': 'message', 'fieldtype': 'Code', 'label': 'Message', 'doctype': 'DocField'}, {'default': 'Not Sent', 'fieldname': 'status', 'fieldtype': 'Select', 'in_list_view': 1, 'in_standard_filter': 1, 'label': 'Status', 'options': '\nNot Sent\nSending\nSent\nError\nExpired', 'doctype': 'DocField'}, {'fieldname': 'error', 'fieldtype': 'Code', 'label': 'Error', 'doctype': 'DocField'}, {'fieldname': 'message_id', 'fieldtype': 'Small Text', ...
      db_modified_timestamp = datetime.datetime(2023, 3, 16, 23, 43, 5, 531685)
      is_db_timestamp_latest = True
      stored_hash = '5b7cbb6acbecc6bd0624c3b8f10b6c63'
  File "/home/runner/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 242, in import_doc
    doc.insert()
      docdict = {'actions': [], 'autoname': 'hash', 'creation': '2012-08-02 15:17:28', 'description': 'Email Queue records.', 'doctype': 'DocType', 'document_type': 'System', 'engine': 'InnoDB', 'fields': [{'fieldname': 'sender', 'fieldtype': 'Data', 'ignore_xss_filter': 1, 'label': 'Sender', 'options': 'Email', 'doctype': 'DocField'}, {'fieldname': 'recipients', 'fieldtype': 'Table', 'label': 'Recipient', 'options': 'Email Queue Recipient', 'doctype': 'DocField'}, {'fieldname': 'show_as_cc', 'fieldtype': 'Small Text', 'label': 'Show as cc', 'doctype': 'DocField'}, {'fieldname': 'message', 'fieldtype': 'Code', 'label': 'Message', 'doctype': 'DocField'}, {'default': 'Not Sent', 'fieldname': 'status', 'fieldtype': 'Select', 'in_list_view': 1, 'in_standard_filter': 1, 'label': 'Status', 'options': '\nNot Sent\nSending\nSent\nError\nExpired', 'doctype': 'DocField'}, {'fieldname': 'error', 'fieldtype': 'Code', 'label': 'Error', 'doctype': 'DocField'}, {'fieldname': 'message_id', 'fieldtype': 'Small Text', ...
      data_import = False
      pre_process = None
      ignore_version = True
      reset_permissions = False
      path = '/home/runner/frappe-bench/apps/frappe/frappe/email/doctype/email_queue/email_queue.json'
      controller = <class 'frappe.core.doctype.doctype.doctype.DocType'>
      doc = <DocType: Email Queue>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 292, in insert
    self.run_post_save_methods()
      self = <DocType: Email Queue>
      ignore_permissions = None
      ignore_links = None
      ignore_if_duplicate = False
      ignore_mandatory = None
      set_name = None
      set_child_names = True
      d = <DocPerm: 429168bcca parent=Email Queue>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1098, in run_post_save_methods
    self.run_method("on_update")
      self = <DocType: Email Queue>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 926, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
      self = <DocType: Email Queue>
      args = ()
      kwargs = {}
      fn = <function Document.run_method.<locals>.fn at 0x7f9797f4f250>
      method = 'on_update'
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1280, in composer
    return composed(self, method, *args, **kwargs)
      self = <DocType: Email Queue>
      args = ()
      kwargs = {}
      hooks = [<function build_domain_restriced_doctype_cache at 0x7f979b502950>, <function clear_doctype_notifications at 0x7f979b501d80>, <function process_workflow_actions at 0x7f9798dfb6d0>, <function apply at 0x7f9798d7dea0>, <function attach_files_to_document at 0x7f9798df9240>, <function update_due_date at 0x7f9798d7df30>, <function apply_permissions_for_non_standard_user_type at 0x7f9798d7f520>]
      method = 'on_update'
      doc_events = {'*': {'on_update': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.core.doctype.file.utils.attach_files_to_document', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type'], 'after_rename': ['frappe.desk.notifications.clear_doctype_notifications'], 'on_cancel': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions'], 'on_trash': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions'], 'on_update_after_submit': ['frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions'], 'on_change': ['frappe.social.doctype.energy_poin...
      handler = 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type'
      composed = <function Document.hook.<locals>.compose.<locals>.runner at 0x7f9797e0d7e0>
      compose = <function Document.hook.<locals>.compose at 0x7f9797fcff40>
      f = <function Document.run_method.<locals>.fn at 0x7f9797f4f250>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1262, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
      self = <DocType: Email Queue>
      method = 'on_update'
      args = ()
      kwargs = {}
      add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x7f9797fcdfc0>
      fn = <function Document.run_method.<locals>.fn at 0x7f9797f4f250>
      hooks = (<function build_domain_restriced_doctype_cache at 0x7f979b502950>, <function clear_doctype_notifications at 0x7f979b501d80>, <function process_workflow_actions at 0x7f9798dfb6d0>, <function apply at 0x7f9798d7dea0>, <function attach_files_to_document at 0x7f9798df9240>, <function update_due_date at 0x7f9798d7df30>, <function apply_permissions_for_non_standard_user_type at 0x7f9798d7f520>)
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 923, in fn
    return method_object(*args, **kwargs)
      self = <DocType: Email Queue>
      args = ()
      kwargs = {}
      method_object = <bound method DocType.on_update of <DocType: Email Queue>>
      method = 'on_update'
  File "/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 395, in on_update
    raise e
      self = <DocType: Email Queue>
  File "/home/runner/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 392, in on_update
    frappe.db.updatedb(self.name, Meta(self))
      self = <DocType: Email Queue>
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/mariadb/database.py", line 407, in updatedb
    db_table.sync()
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f9799299b10>
      doctype = 'Email Queue'
      meta = <Meta: Email Queue>
      res = ((0,),)
      db_table = <frappe.database.mariadb.schema.MariaDBTable object at 0x7f97983de740>
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/schema.py", line 44, in sync
    self.alter()
      self = <frappe.database.mariadb.schema.MariaDBTable object at 0x7f97983de740>
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/mariadb/schema.py", line 117, in alter
    frappe.db.sql(query)
      self = <frappe.database.mariadb.schema.MariaDBTable object at 0x7f97983de740>
      col = <frappe.database.schema.DbColumn object at 0x7f9797e3d7e0>
      add_column_query = ['ADD COLUMN `email_account` varchar(140)']
      modify_column_query = ['MODIFY `message_id` text']
      add_index_query = ['ADD INDEX `reference_name_index`(`reference_name`)']
      drop_index_query = []
      columns_to_modify = {<frappe.database.schema.DbColumn object at 0x7f9797e3f3a0>}
      current_column = {'name': 'status', 'type': 'varchar(140)', 'default': "'Not Sent'", 'index': 1, 'unique': 0}
      unique_constraint_changed = False
      index_constraint_changed = True
      index_record = None
      query_parts = ['MODIFY `message_id` text']
      query_body = 'MODIFY `message_id` text'
      query = 'ALTER TABLE `tabEmail Queue` MODIFY `message_id` text'
  File "/home/runner/frappe-bench/apps/frappe/frappe/database/database.py", line 222, in sql
    self._cursor.execute(query, values)
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f9799299b10>
      query = 'ALTER TABLE `tabEmail Queue` MODIFY `message_id` text'
      values = None
      as_dict = 0
      as_list = 0
      debug = False
      ignore_ddl = 0
      auto_commit = 0
      update = None
      explain = False
      run = True
      pluck = False
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
      self = <pymysql.cursors.Cursor object at 0x7f9799111b40>
      query = 'ALTER TABLE `tabEmail Queue` MODIFY `message_id` text'
      args = None
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
      self = <pymysql.cursors.Cursor object at 0x7f9799111b40>
      q = 'ALTER TABLE `tabEmail Queue` MODIFY `message_id` text'
      conn = <pymysql.connections.Connection object at 0x7f9799111840>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
      self = <pymysql.connections.Connection object at 0x7f9799111840>
      sql = b'ALTER TABLE `tabEmail Queue` MODIFY `message_id` text'
      unbuffered = False
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
      self = <pymysql.connections.Connection object at 0x7f9799111840>
      unbuffered = False
      result = <pymysql.connections.MySQLResult object at 0x7f9798387fd0>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
      self = <pymysql.connections.MySQLResult object at 0x7f9798387fd0>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
      self = <pymysql.connections.Connection object at 0x7f9799111840>
      packet_type = <class 'pymysql.protocol.MysqlPacket'>
      buff = bytearray(b"\xff\x92\x04#42000BLOB/TEXT column \'message_id\' used in key specification without a key length")
      packet_header = b'U\x00\x00\x01'
      btrl = 85
      btrh = 0
      packet_number = 1
      bytes_to_read = 85
      recv_data = b"\xff\x92\x04#42000BLOB/TEXT column 'message_id' used in key specification without a key length"
      packet = <pymysql.protocol.MysqlPacket object at 0x7f9797e3d1b0>
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
      self = <pymysql.protocol.MysqlPacket object at 0x7f9797e3d1b0>
      errno = 1170
  File "/home/runner/frappe-bench/env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
      data = b"\xff\x92\x04#42000BLOB/TEXT column 'message_id' used in key specification without a key length"
      errno = 1170
      errval = "BLOB/TEXT column 'message_id' used in key specification without a key length"
      errorclass = <class 'pymysql.err.OperationalError'>
pymysql.err.OperationalError: (1170, "BLOB/TEXT column 'message_id' used in key specification without a key length")
```