### PR TITLE
fix: email forgery in contact page

### DIFF
--- a/frappe/www/contact.py
+++ b/frappe/www/contact.py
@@ -22,7 +22,7 @@ def get_context(context):
 	return out
 
 
-max_communications_per_hour = 1000
+max_communications_per_hour = 100
 
 
 @frappe.whitelist(allow_guest=True)
@@ -53,7 +53,9 @@ def send_message(subject="Website Query", message="", sender=""):
 	# send email
 	forward_to_email = frappe.db.get_single_value("Contact Us Settings", "forward_to_email")
 	if forward_to_email:
-		frappe.sendmail(recipients=forward_to_email, sender=sender, content=message, subject=subject)
+		frappe.sendmail(
+			recipients=sender, reply_to=sender, bcc=forward_to_email, content=message, subject=subject
+		)
 
 	# add to to-do ?
 	frappe.get_doc(


### PR DESCRIPTION
The contact page forges emails from the sender.
A properly configured email server will refuse to send the email, and it is extremely bad practice for many reasons.

Now:
- sends to the 'sender'
- reply-to is set to the 'sender'
- bcc is the configured contact page recipient
- sender is the frappe default

Also reduces the rate limit to 100 per hour from 1000

version-14-hotfix
version-13-hotfix
