### PR TITLE
perf: Dont update list view data if list view not active

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1354,6 +1354,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	process_document_refreshes() {
 		if (!this.pending_document_refreshes.length) return;
 
+		const route = frappe.get_route() || [];
+		if (!cur_list || route[0] != "List" || cur_list.doctype != route[1]) {
+			// wait till user is back on list view before refreshing
+			this.pending_document_refreshes = [];
+			return;
+		}
+
 		const names = this.pending_document_refreshes.map((d) => d.name);
 		this.pending_document_refreshes = this.pending_document_refreshes.filter(
 			(d) => names.indexOf(d.name) === -1


### PR DESCRIPTION
Steps to reproduce:
1. visit a list view that's quite active
2. move to some other page
3. list view data keeps getting refreshed in background

Fix: Only refresh when user is back on list view

