### PR TITLE
fix: clear contacts cache

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -63,6 +63,7 @@ user_cache_keys = (
 	"has_role:Page",
 	"has_role:Report",
 	"desk_sidebar_items",
+	"contacts",
 )
 
 doctype_cache_keys = (


### PR DESCRIPTION
Include the `"contacts"` key when clearing the user cache. Used in this file for caching contact email ids to be displayed in the email dialog:

https://github.com/frappe/frappe/blob/98006eb5fb3c74b42e8252052807c06667556ab1/frappe/email/__init__.py#L95-L118