### PR TITLE
perf: unsubscribe from list_update events

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -308,6 +308,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.render_header(refresh_header);
 			this.update_checkbox();
 			this.update_url_with_filters();
+			this.setup_realtime_updates();
 		});
 	}
 
@@ -1329,7 +1330,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	setup_realtime_updates() {
 		this.pending_document_refreshes = [];
 
-		if (this.list_view_settings && this.list_view_settings.disable_auto_refresh) {
+		if (this.list_view_settings?.disable_auto_refresh || this.realtime_events_setup) {
 			return;
 		}
 		frappe.socketio.doctype_subscribe(this.doctype);
@@ -1349,6 +1350,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.pending_document_refreshes.push(data);
 			frappe.utils.debounce(this.process_document_refreshes.bind(this), 1000)();
 		});
+		this.realtime_events_setup = true;
+	}
+
+	disable_realtime_updates() {
+		frappe.socketio.doctype_unsubscribe(this.doctype);
+		this.realtime_events_setup = false;
 	}
 
 	process_document_refreshes() {
@@ -1358,6 +1365,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (!cur_list || route[0] != "List" || cur_list.doctype != route[1]) {
 			// wait till user is back on list view before refreshing
 			this.pending_document_refreshes = [];
+			this.disable_realtime_updates();
 			return;
 		}
 

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -132,6 +132,9 @@ frappe.socketio = {
 	doctype_subscribe: function (doctype) {
 		frappe.socketio.socket.emit("doctype_subscribe", doctype);
 	},
+	doctype_unsubscribe: function (doctype) {
+		frappe.socketio.socket.emit("doctype_unsubscribe", doctype);
+	},
 	doc_subscribe: function (doctype, docname) {
 		if (frappe.flags.doc_subscribe) {
 			console.log("throttled");

--- a/socketio.js
+++ b/socketio.js
@@ -68,6 +68,10 @@ io.on("connection", function (socket) {
 		});
 	});
 
+	socket.on("doctype_unsubscribe", function (doctype) {
+		socket.leave(get_doctype_room(socket, doctype));
+	});
+
 	socket.on("task_subscribe", function (task_id) {
 		var room = get_task_room(socket, task_id);
 		socket.join(room);


### PR DESCRIPTION
continues https://github.com/frappe/frappe/pull/20396


Completely unsubscribe doctype room when moving away from list view page to avoid receiving messages via socket too. 