### PR TITLE
fix: Avoid list update if user is doing some bulk operation

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -54,12 +54,8 @@ context("List View", () => {
 					method: "POST",
 					url: "api/method/frappe.model.workflow.bulk_workflow_approval",
 				}).as("bulk-approval");
-				cy.intercept({
-					method: "POST",
-					url: "api/method/frappe.desk.reportview.get",
-				}).as("real-time-update");
 				cy.wrap(elements).contains("Approve").click();
-				cy.wait(["@bulk-approval", "@real-time-update"]);
+				cy.wait("@bulk-approval");
 				cy.wait(300);
 				cy.get_open_dialog().find(".btn-modal-close").click();
 				cy.reload();

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1339,6 +1339,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				return;
 			}
 
+			// if some bulk operation is happening by selecting list items, don't refresh
+			if (this.$checks && this.$checks.length) {
+				return;
+			}
+
 			if (!frappe.get_doc(data?.doctype, data?.name)?.__unsaved) {
 				frappe.model.remove_from_locals(data.doctype, data.name);
 			}


### PR DESCRIPTION
**Issue:** If the user is selecting items in the list view to do some bulk operation and some new records are created/updated by some API or other user the list gets refreshed and all the selection is lost.