### PR TITLE
feat: re-enable scheduler from desk

### DIFF
--- a/frappe/core/doctype/rq_job/rq_job_list.js
+++ b/frappe/core/doctype/rq_job/rq_job_list.js
@@ -4,11 +4,15 @@ frappe.listview_settings["RQ Job"] = {
 	onload(listview) {
 		if (!has_common(frappe.user_roles, ["Administrator", "System Manager"])) return;
 
-		listview.page.add_inner_button(__("Remove Failed Jobs"), () => {
-			frappe.confirm(__("Are you sure you want to remove all failed jobs?"), () => {
-				frappe.xcall("frappe.core.doctype.rq_job.rq_job.remove_failed_jobs");
-			});
-		});
+		listview.page.add_inner_button(
+			__("Remove Failed Jobs"),
+			() => {
+				frappe.confirm(__("Are you sure you want to remove all failed jobs?"), () => {
+					frappe.xcall("frappe.core.doctype.rq_job.rq_job.remove_failed_jobs");
+				});
+			},
+			__("Actions")
+		);
 
 		if (listview.list_view_settings) {
 			listview.list_view_settings.disable_count = 1;
@@ -20,6 +24,25 @@ frappe.listview_settings["RQ Job"] = {
 				listview.page.set_indicator(__("Scheduler: Active"), "green");
 			} else {
 				listview.page.set_indicator(__("Scheduler: Inactive"), "red");
+				listview.page.add_inner_button(
+					__("Enable Scheduler"),
+					() => {
+						frappe.confirm(__("Are you sure you want to re-enable scheduler?"), () => {
+							frappe
+								.xcall("frappe.utils.scheduler.activate_scheduler")
+								.then(() => {
+									frappe.show_alert(__("Enabled Scheduler"));
+								})
+								.catch((e) => {
+									frappe.show_alert({
+										message: __("Failed to enable scheduler: {0}", e),
+										indicator: "error",
+									});
+								});
+						});
+					},
+					__("Actions")
+				);
 			}
 		});
 

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -176,6 +176,11 @@ def _get_last_modified_timestamp(doctype):
 
 @frappe.whitelist()
 def activate_scheduler():
+	frappe.only_for("Administrator")
+
+	if frappe.local.conf.maintenance_mode:
+		frappe.throw(frappe._("Scheduler can not be re-enabled when maintenance mode is active."))
+
 	if is_scheduler_disabled():
 		enable_scheduler()
 	if frappe.conf.pause_scheduler:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9079960/227120609-59c34504-7f8c-408a-9fb3-1aa703004c93.png)



closes #20392 


`no-docs`