### PR TITLE
fix: Get translated value for child tables in print format

### DIFF
--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -56,9 +56,9 @@
 							<td class="{{ get_align_class(tdf) }}" {{ fieldmeta(df) }}>
 							{% if doc.child_print_templates %}
 								{%- set child_templates = doc.child_print_templates.get(df.fieldname) -%}
-								<div class="value">{{ print_value(tdf, d, doc, visible_columns, child_templates) }}</div></td>
+								<div class="value">{{ _(print_value(tdf, d, doc, visible_columns, child_templates)) }}</div></td>
 							{% else %}
-								<div class="value">{{ print_value(tdf, d, doc, visible_columns) }}</div></td>
+								<div class="value">{{ _(print_value(tdf, d, doc, visible_columns)) }}</div></td>
 							{% endif %}
 						{% endfor %}
 					</tr>


### PR DESCRIPTION
Child Table values are not getting translated into print format
I have added a translation **HDFC - HDFC** --> **SBI - SBI** & **My Bank** --> **Your Bank**
Before:
<img width="692" alt="image" src="https://user-images.githubusercontent.com/30859809/227128000-af1fc68d-baea-4aa8-b0d9-bbefad2dc82e.png">

After:
<img width="692" alt="image" src="https://user-images.githubusercontent.com/30859809/227127944-3995dbcb-0142-4525-b2bf-2c8a1109598b.png">
