### PR TITLE
feat: show if address is "Disabled"

### DIFF
--- a/frappe/public/js/frappe/form/templates/address_list.html
+++ b/frappe/public/js/frappe/form/templates/address_list.html
@@ -8,6 +8,8 @@
 		<span class="text-muted">({%= __("Primary") %})</span>{% } %}
 		{% if(addr_list[i].is_shipping_address) { %}
 		<span class="text-muted">({%= __("Shipping") %})</span>{% } %}
+		{% if(addr_list[i].disabled) { %}
+		<span class="text-muted">({%= __("Disabled") %})</span>{% } %}
 
 		<a href="/app/Form/Address/{%= encodeURIComponent(addr_list[i].name) %}" class="btn btn-default btn-xs pull-right"
 			style="margin-top:-3px; margin-right: -5px;">


### PR DESCRIPTION
After being used in a document, the address can no longer be "Deleted" and it is mandatory to deactivate it.

In several cases, the customer may have more than 2 addresses in their registration, in the customer registration as an example, the address, even if disabled, is presented in the customer registration,
I believe this is correct, so I've added some code just to point out to users that the address has been deactivated.

![image](https://user-images.githubusercontent.com/25017988/227209095-3f11b0b6-5946-4ad0-b236-ae9be8a0e69a.png)
