### PR TITLE
fix: unsubscribe from list_update before resubbing

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1334,6 +1334,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return;
 		}
 		frappe.socketio.doctype_subscribe(this.doctype);
+		frappe.realtime.off("list_update");
 		frappe.realtime.on("list_update", (data) => {
 			if (data?.doctype !== this.doctype) {
 				return;


### PR DESCRIPTION
resubbing can result in multiple events being fired, so unsubscribe all
of them before re-subscribing.

missed in https://github.com/frappe/frappe/pull/20423
