### PR TITLE
fix: exception handling for bulk email sending

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -5,6 +5,7 @@ import json
 import quopri
 import smtplib
 import traceback
+from contextlib import suppress
 from email.parser import Parser
 from email.policy import SMTPUTF8
 
@@ -704,7 +705,10 @@ class QueueBuilder:
 			if not smtp_server_instance:
 				email_account = q.get_email_account()
 				smtp_server_instance = email_account.get_smtp_server()
-			q.send(smtp_server_instance=smtp_server_instance)
+
+			with suppress(Exception):
+				q.send(smtp_server_instance=smtp_server_instance)
+
 		smtp_server_instance.quit()
 
 	def as_dict(self, include_recipients=True):


### PR DESCRIPTION
There is no exception handling present when bulk sending emails in batches. So if an email was failed to send, the whole batch fails.

This is not an ideal solution, as the reason why this was added was to reuse smtp connection, having a try except won't help in that but this does log an email queue doc which will be retried on next iteration.

#

TODO:
- [x] manual testing