### PR TITLE
fix(desk): Auto-Reload after changing User time_zone

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -114,12 +114,16 @@ frappe.ui.form.on("User", {
 			return;
 		}
 
+		function hasChanged(doc_attr, boot_attr) {
+			return (doc_attr || boot_attr) && doc_attr !== boot_attr;
+		}
+
 		if (
 			doc.name === frappe.session.user &&
 			!doc.__unsaved &&
 			frappe.all_timezones &&
-			(doc.language || frappe.boot.user.language) &&
-			doc.language !== frappe.boot.user.language
+			(hasChanged(doc.language, frappe.boot.user.language) ||
+				hasChanged(doc.time_zone, frappe.boot.time_zone.user))
 		) {
 			frappe.msgprint(__("Refreshing..."));
 			window.location.reload();


### PR DESCRIPTION
Avoid the following situation by reloading

![image](https://user-images.githubusercontent.com/36654812/227520603-5af62689-2b10-4017-a9d7-116de56a6b98.png)
