### PR TITLE
fix: install cypress plugins in frappe namespace

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -908,7 +908,7 @@ def run_ui_tests(
 
 	os.chdir(app_base_path)
 
-	node_bin = subprocess.getoutput("yarn bin")
+	node_bin = subprocess.getoutput("(cd ../frappe && yarn bin)")
 	cypress_path = f"{node_bin}/cypress"
 	drag_drop_plugin_path = f"{node_bin}/../@4tw/cypress-drag-drop"
 	real_events_plugin_path = f"{node_bin}/../cypress-real-events"
@@ -935,7 +935,7 @@ def run_ui_tests(
 				"@cypress/code-coverage@^3",
 			]
 		)
-		frappe.commands.popen(f"yarn add {packages} --no-lockfile")
+		frappe.commands.popen(f"(cd ../frappe && yarn add {packages} --no-lockfile)")
 
 	# run for headless mode
 	run_or_open = "run --browser chrome --record" if headless else "open"


### PR DESCRIPTION
## Overview
When running UI tests on a custom app the cypress plugin packages are installed in the custom apps node_module folder, but when cypress is running the test it looks to resolve these plugins in frappe/node_modules.

```
Module not found: Error: Can't resolve '@4tw/cypress-drag-drop' in '/home/runner/frappe-bench/apps/frappe/cypress/support'
resolve '@4tw/cypress-drag-drop' in '/home/runner/frappe-bench/apps/frappe/cypress/support'
```

Note that the custom app includes https://github.com/frappe/frappe/blob/develop/cypress/support/e2e.js
so it will have access to the custom commands.

## Proposed Solution
Force the plugins to be installed in frappe node_module namespace.