### PR TITLE
wip: use http2 for socketio and allow to use unix socket

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -28,16 +28,13 @@ from frappe.exceptions import SiteNotSpecifiedError
 @click.option(
 	"--db-root-username",
 	"--mariadb-root-username",
-	help='Root username for MariaDB or PostgreSQL, Default is "root"',
+	help='Root username for MariaDB or PostgreSQL, Default is current user',
 )
 @click.option(
 	"--db-root-password", "--mariadb-root-password", help="Root password for MariaDB or PostgreSQL"
 )
 @click.option(
-	"--no-mariadb-socket",
-	is_flag=True,
-	default=False,
-	help="Set MariaDB host to % and use TCP/IP Socket instead of using the UNIX Socket",
+	"--db-socket", "--mariadb-db-socket", help="Database socket for MariaDB or PostgreSQL"
 )
 @click.option("--admin-password", help="Administrator password for new site", default=None)
 @click.option("--verbose", is_flag=True, default=False, help="Verbose")
@@ -57,11 +54,11 @@ def new_site(
 	verbose=False,
 	source_sql=None,
 	force=None,
-	no_mariadb_socket=False,
 	install_app=None,
 	db_name=None,
 	db_password=None,
 	db_type=None,
+	db_socket=None,
 	db_host=None,
 	db_port=None,
 	set_default=False,
@@ -84,9 +81,9 @@ def new_site(
 		install_apps=install_app,
 		source_sql=source_sql,
 		force=force,
-		no_mariadb_socket=no_mariadb_socket,
 		db_password=db_password,
 		db_type=db_type,
+		db_socket=db_socket,
 		db_host=db_host,
 		db_port=db_port,
 	)
@@ -867,7 +864,7 @@ def uninstall(context, app, dry_run, yes, no_backup, force):
 	"--db-root-username",
 	"--mariadb-root-username",
 	"--root-login",
-	help='Root username for MariaDB or PostgreSQL, Default is "root"',
+	help='Root username for MariaDB or PostgreSQL, Default is current user',
 )
 @click.option(
 	"--db-root-password",
@@ -926,7 +923,14 @@ def _drop_site(
 			sys.exit(1)
 
 	click.secho("Dropping site database and user", fg="green")
-	drop_user_and_database(frappe.conf.db_name, db_root_username, db_root_password)
+	drop_user_and_database(
+		frappe.conf.db_name,
+		socket=frappe.conf.db_socket,
+		host=frappe.conf.db_host,
+		port=frappe.conf.db_port,
+		user=db_root_username,
+		password=db_root_password,
+	)
 
 	archived_sites_path = archived_sites_path or os.path.join(
 		frappe.get_app_path("frappe"), "..", "..", "..", "archived", "sites"

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -538,17 +538,24 @@ def _mariadb(extra_args=None):
 	mysql = which("mysql")
 	command = [
 		mysql,
-		"--port",
-		str(frappe.conf.db_port or MariaDBDatabase.default_port),
-		"-u",
-		frappe.conf.db_name,
-		f"-p{frappe.conf.db_password}",
-		frappe.conf.db_name,
-		"-h",
-		frappe.conf.db_host or "localhost",
 		"--pager=less -SFX",
 		"--safe-updates",
-		"-A",
+		"--no-auto-rehash",
+	]
+	if frappe.conf.db_socket:
+		command += [
+			f"--socket={frappe.conf.db_socket}"
+		]
+	else:
+		port = str(frappe.conf.db_port or MariaDBDatabase.default_port)
+		command = [
+			f"--port={port}",
+			f"--host={frappe.conf.db_host}",
+		]
+	command += [
+		f"--user={frappe.conf.db_name}",
+		f"--password={frappe.conf.db_password}",
+		frappe.conf.db_name,
 	]
 	if extra_args:
 		command += list(extra_args)

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -533,33 +533,24 @@ def postgres(context, extra_args):
 
 
 def _mariadb(extra_args=None):
-	from frappe.database.mariadb.database import MariaDBDatabase
-
-	mysql = which("mysql")
-	command = [
-		mysql,
+	from frappe.database import get_command_args
+	extra = [
 		"--pager=less -SFX",
 		"--safe-updates",
 		"--no-auto-rehash",
 	]
-	if frappe.conf.db_socket:
-		command += [
-			f"--socket={frappe.conf.db_socket}"
-		]
-	else:
-		port = str(frappe.conf.db_port or MariaDBDatabase.default_port)
-		command = [
-			f"--port={port}",
-			f"--host={frappe.conf.db_host}",
-		]
-	command += [
-		f"--user={frappe.conf.db_name}",
-		f"--password={frappe.conf.db_password}",
-		frappe.conf.db_name,
-	]
+	bin, command = get_command_args(
+		socket=frappe.conf.db_socket,
+		host=frappe.conf.db_host,
+		port=frappe.conf.db_port,
+		user=frappe.conf.db_name,
+		password=frappe.conf.db_password,
+		db_name=frappe.conf.db_name,
+		extra=extra,
+	)
 	if extra_args:
-		command += list(extra_args)
-	os.execv(mysql, command)
+		command.extend(list(extra_args))
+	os.execv(bin, command)
 
 
 def _psql(extra_args=None):

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -3,50 +3,71 @@
 
 # Database Module
 # --------------------
+import os
 
 from frappe.database.database import savepoint
 
-
-def setup_database(force, source_sql=None, verbose=None, no_mariadb_socket=False):
+def setup_database(force, source_sql=None, verbose=None, socket=None, host=None, port=None, user=None, password=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.setup_db
 
-		return frappe.database.postgres.setup_db.setup_database(force, source_sql, verbose)
+		return frappe.database.postgres.setup_db.setup_database(
+			force, socket, host, user, password, port, source_sql, verbose
+		)
 	else:
 		import frappe.database.mariadb.setup_db
 
 		return frappe.database.mariadb.setup_db.setup_database(
-			force, source_sql, verbose, no_mariadb_socket=no_mariadb_socket
+			force, socket, host, user, password, port, source_sql, verbose
 		)
 
 
-def drop_user_and_database(db_name, root_login=None, root_password=None):
+def drop_user_and_database(db_name, socket=None, host=None, port=None, user=None, password=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.setup_db
 
 		return frappe.database.postgres.setup_db.drop_user_and_database(
-			db_name, root_login, root_password
+			db_name, socket, host, user, password, port
 		)
 	else:
 		import frappe.database.mariadb.setup_db
 
 		return frappe.database.mariadb.setup_db.drop_user_and_database(
-			db_name, root_login, root_password
+			db_name, socket, host, user, password, port
 		)
 
 
-def get_db(host=None, user=None, password=None, port=None):
+def get_db(socket=None, host=None, port=None, user=None, password=None, cur_db_name=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.database
 
-		return frappe.database.postgres.database.PostgresDatabase(host, user, password, port=port)
+		return frappe.database.postgres.database.PostgresDatabase(
+			socket=socket,
+			host=host,
+			port=port,
+			user=user,
+			password=password,
+			cur_db_name=cur_db_name,
+		)
 	else:
 		import frappe.database.mariadb.database
 
-		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port=port)
+		# Defaults for MySQL
+		if not socket:
+			socket = os.environ.get('MYSQL_UNIX_PORT')
+		if not socket and not host:
+			host = '127.0.0.1'
+		return frappe.database.mariadb.database.MariaDBDatabase(
+			socket=socket,
+			host=host,
+			port=port,
+			user=user,
+			password=password,
+			cur_db_name=cur_db_name,
+		)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -43,8 +43,8 @@ MULTI_WORD_PATTERN = re.compile(r'([`"])(tab([A-Z]\w+)( [A-Z]\w+)+)\1')
 
 class Database:
 	"""
-	Open a database connection with the given parmeters, if use_default is True, use the
-	login details from `conf.py`. This is called by the request handler and is accessible using
+	Open a database connection with the given parmeters.
+	This is called by the request handler and is accessible using
 	the `db` global variable. the `sql` method is also global to run queries
 	"""
 
@@ -80,30 +80,25 @@ class Database:
 
 	def __init__(
 		self,
+		socket=None,
 		host=None,
 		user=None,
 		password=None,
-		ac_name=None,
-		use_default=0,
 		port=None,
+		cur_db_name=None,
 	):
 		self.setup_type_map()
-		self.host = host or frappe.conf.db_host or "127.0.0.1"
-		self.port = port or frappe.conf.db_port or ""
-		self.user = user or frappe.conf.db_name
-		self.db_name = frappe.conf.db_name
+		self.socket = socket
+		self.host = host
+		self.port = port
+		self.user = user
+		self.password = password
+		self.cur_db_name = cur_db_name
 		self._conn = None
-
-		if ac_name:
-			self.user = ac_name or frappe.conf.db_name
-
-		if use_default:
-			self.user = frappe.conf.db_name
 
 		self.transaction_writes = 0
 		self.auto_commit_on_many_writes = 0
 
-		self.password = password or frappe.conf.db_password
 		self.value_cache = {}
 		# self.db_type: str
 		# self.last_query (lazy) attribute of last sql query executed
@@ -113,7 +108,6 @@ class Database:
 
 	def connect(self):
 		"""Connects to a database as set in `site_config.json`."""
-		self.cur_db_name = self.user
 		self._conn = self.get_connection()
 		self._cursor = self._conn.cursor()
 		frappe.local.rollback_observers = []
@@ -132,6 +126,7 @@ class Database:
 	def use(self, db_name):
 		"""`USE` db_name."""
 		self._conn.select_db(db_name)
+		self.cur_db_name = db_name
 
 	def get_connection(self):
 		"""Returns a Database connection object that conforms with https://peps.python.org/pep-0249/#connection-objects"""

--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -68,18 +68,26 @@ class DbManager:
 		if pipe:
 			print("Restoring Database file...")
 
-		command = (
-			"{pipe} mysql -u {user} -p{password} -h{host} "
-			+ ("-P{port}" if frappe.db.port else "")
-			+ " {target} {source}"
-		)
-		command = command.format(
-			pipe=pipe,
-			user=esc(user),
-			password=esc(password),
-			host=esc(frappe.db.host),
-			target=esc(target),
-			source=source,
-			port=frappe.db.port,
-		)
-		os.system(command)
+		args = {
+			"pipe": pipe,
+			"user": esc(user),
+			"password": esc(password),
+			"target": esc(target),
+			"source": source,
+		}
+
+		command = "{pipe} mysql -u {user} -p{password} "
+		if frappe.db.socket:
+			command += " -S{socket} "
+			args["socket"] = esc(frappe.db.socket)
+		elif frappe.db.port:
+			command += " -h{host} "
+			command += " -p{host} "
+			args["host"] = esc(frappe.db.host)
+			args["port"] = esc(frappe.db.port)
+		else:
+			command += " -h{host} "
+			args["host"] = esc(frappe.db.host)
+
+		command += " {target} {source}"
+		os.system(command.format(**args))

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -23,16 +23,14 @@ def get_mariadb_version(version_string: str = ""):
 	return version.rsplit(".", 1)
 
 
-def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
+def setup_database(force, source_sql, verbose, socket, host, port, user, password):
 	frappe.local.session = frappe._dict({"user": "Administrator"})
 
+	root_conn = get_root_connection(socket, host, port, user, password)
+
 	db_name = frappe.local.conf.db_name
-	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
 	dbman = DbManager(root_conn)
 	dbman_kwargs = {}
-	if no_mariadb_socket:
-		dbman_kwargs["host"] = "%"
-
 	if force or (db_name not in dbman.get_database_list()):
 		dbman.delete_user(db_name, **dbman_kwargs)
 		dbman.drop_database(db_name)
@@ -58,8 +56,8 @@ def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
 	bootstrap_database(db_name, verbose, source_sql)
 
 
-def drop_user_and_database(db_name, root_login, root_password):
-	frappe.local.db = get_root_connection(root_login, root_password)
+def drop_user_and_database(db_name, socket, host, port, user, password):
+	frappe.local.db = get_root_connection(socket, host, port, user, password)
 	dbman = DbManager(frappe.local.db)
 	dbman.drop_database(db_name)
 	dbman.delete_user(db_name, host="%")
@@ -152,21 +150,17 @@ def check_compatible_versions():
 		)
 
 
-def get_root_connection(root_login, root_password):
-	import getpass
+def get_root_connection(socket, host, port, user, password):
 
 	if not frappe.local.flags.root_connection:
-		if not root_login:
-			root_login = "root"
+		if not user:
+			user = frappe.conf.get("root_login") or os.getlogin()
 
-		if not root_password:
-			root_password = frappe.conf.get("root_password") or None
-
-		if not root_password:
-			root_password = getpass.getpass("MySQL root password: ")
+		if not password:
+			password = frappe.conf.get("root_password") or None
 
 		frappe.local.flags.root_connection = frappe.database.get_db(
-			user=root_login, password=root_password
+			socket, host, port, user, password
 		)
 
 	return frappe.local.flags.root_connection

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -97,8 +97,7 @@ def get_redis_server():
 	global redis_server
 	if not redis_server:
 		from redis import Redis
-
-		redis_server = Redis.from_url(frappe.conf.redis_socketio or "redis://localhost:12311")
+		redis_server = Redis.from_url(frappe.conf.redis_socketio)
 	return redis_server
 
 

--- a/frappe/utils/connections.py
+++ b/frappe/utils/connections.py
@@ -1,4 +1,5 @@
 import socket
+import os
 from urllib.parse import urlparse
 
 from frappe import get_conf
@@ -6,11 +7,16 @@ from frappe import get_conf
 REDIS_KEYS = ("redis_cache", "redis_queue", "redis_socketio")
 
 
-def is_open(ip, port, timeout=10):
-	s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+def is_open(scheme, hostname, port, path, timeout=10):
+	if scheme == 'unix':
+		s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+		conn = path
+	else:
+		s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		conn = (hostname, port)
 	s.settimeout(timeout)
 	try:
-		s.connect((ip, int(port)))
+		s.connect(conn)
 		s.shutdown(socket.SHUT_RDWR)
 		return True
 	except OSError:
@@ -21,20 +27,21 @@ def is_open(ip, port, timeout=10):
 
 def check_database():
 	config = get_conf()
+	if config.get("db_socket"):
+		return {db_type: is_open('unix', None, None, config.get("db_socket"))}
 	db_type = config.get("db_type", "mariadb")
 	db_host = config.get("db_host", "localhost")
 	db_port = config.get("db_port", 3306 if db_type == "mariadb" else 5432)
-	return {db_type: is_open(db_host, db_port)}
+	return {db_type: is_open('other', db_host, db_port, None)}
 
 
 def check_redis(redis_services=None):
 	config = get_conf()
 	services = redis_services or REDIS_KEYS
 	status = {}
-	for conn in services:
-		redis_url = urlparse(config.get(conn)).netloc
-		redis_host, redis_port = redis_url.split(":")
-		status[conn] = is_open(redis_host, redis_port)
+	for srv in services:
+		url = urlparse(config[srv])
+		status[conn] = is_open(url.scheme, url.hostname, url.port, url.path)
 	return status
 
 

--- a/frappe/utils/logger.py
+++ b/frappe/utils/logger.py
@@ -19,7 +19,7 @@ def get_logger(
 	filter=None,
 	max_size=100_000,
 	file_count=20,
-	stream_only=False,
+	stream_only=os.environ.get("FRAPPE_STREAM_LOGGING"),
 ) -> "logging.Logger":
 	"""Application Logger for your given module
 

--- a/frappe/utils/redis_queue.py
+++ b/frappe/utils/redis_queue.py
@@ -17,10 +17,10 @@ class RedisQueue:
 
 	@classmethod
 	def get_connection(cls, username=None, password=None):
-		rq_url = frappe.local.conf.redis_queue
-		domain = rq_url.split("redis://", 1)[-1]
-		url = (username and f"redis://{username}:{password or ''}@{domain}") or rq_url
-		conn = redis.from_url(url)
+		if username and password:
+			conn = redis.from_url(frappe.conf.redis_queue, username=username, password=password)
+		else:
+			conn = redis.from_url(frappe.conf.redis_queue)
 		conn.ping()
 		return conn
 

--- a/node_utils.js
+++ b/node_utils.js
@@ -40,8 +40,20 @@ function get_conf() {
 
 function get_redis_subscriber(kind = "redis_socketio", options = {}) {
 	const conf = get_conf();
-	const host = conf[kind] || conf.redis_async_broker_port;
-	return redis.createClient({ url: host, ...options });
+	let redisSock = {
+	    redis_cache:
+	    	process.env.FRAPPE_REDIS_CACHE_SOCKET || conf[kind] || conf.redis_async_broker_port,
+	    redis_queue:
+	    	process.env.FRAPPE_REDIS_QUEUE_SOCKET || conf[kind] || conf.redis_async_broker_port,
+	    redis_socketio:
+	    	process.env.FRAPPE_REDIS_SOCKETIO_SOCKET || conf[kind] || conf.redis_async_broker_port,
+	};
+	const sockStr = redisSock[kind];
+	if socketStr.startsWith("/") {
+		return redis.createClient({ socket: { path: sockStr }, ...options });
+	} else {
+		return redis.createClient({ url: sockStr, ...options });
+	}
 }
 
 module.exports = {

--- a/node_utils.js
+++ b/node_utils.js
@@ -41,15 +41,15 @@ function get_conf() {
 function get_redis_subscriber(kind = "redis_socketio", options = {}) {
 	const conf = get_conf();
 	let redisSock = {
-	    redis_cache:
-	    	process.env.FRAPPE_REDIS_CACHE_SOCKET || conf[kind] || conf.redis_async_broker_port,
-	    redis_queue:
-	    	process.env.FRAPPE_REDIS_QUEUE_SOCKET || conf[kind] || conf.redis_async_broker_port,
-	    redis_socketio:
-	    	process.env.FRAPPE_REDIS_SOCKETIO_SOCKET || conf[kind] || conf.redis_async_broker_port,
+		redis_cache:
+			process.env.FRAPPE_REDIS_CACHE_SOCKET || conf[kind] || conf.redis_async_broker_port,
+		redis_queue:
+			process.env.FRAPPE_REDIS_QUEUE_SOCKET || conf[kind] || conf.redis_async_broker_port,
+		redis_socketio:
+			process.env.FRAPPE_REDIS_SOCKETIO_SOCKET || conf[kind] || conf.redis_async_broker_port,
 	};
-	const sockStr = redisSock[kind];
-	if socketStr.startsWith("/") {
+	let sockStr = redisSock[kind];
+	if (sockStr.startsWith("/")) {
 		return redis.createClient({ socket: { path: sockStr }, ...options });
 	} else {
 		return redis.createClient({ url: sockStr, ...options });

--- a/socketio.js
+++ b/socketio.js
@@ -1,12 +1,18 @@
 const cookie = require("cookie");
 const request = require("superagent");
+const http = require("node:http");
 
 const { get_conf, get_redis_subscriber } = require("./node_utils");
 const conf = get_conf();
 const log = console.log; // eslint-disable-line
 const subscriber = get_redis_subscriber();
 
-const io = require("socket.io")(conf.socketio_port, {
+const unix = process.env.FRAPPE_SOCKETIO_SOCKET;
+const port = process.env.FRAPPE_SOCKETIO_PORT || conf.socketio_port;
+
+const server = http.createServer();
+
+const io = require("socket.io")(server, {
 	cors: {
 		// Should be fine since we are ensuring whether hostname and origin are same before adding setting listeners for s socket
 		origin: true,
@@ -197,6 +203,10 @@ subscriber.on("message", function (_channel, message) {
 });
 
 subscriber.subscribe("events");
+
+server.listen(unix || port, () => {
+	log("Listening on", unix || port);
+});
 
 function get_doc_room(socket, doctype, docname) {
 	return get_site_name(socket) + ":doc:" + doctype + "/" + docname;


### PR DESCRIPTION
Rationale:
- http2 is more effecient
- unix socket is more effecient
- unix socket can be named with the bench project name and it is hence
  easier to avoid port conflicts when used in conjunction with nginx for
  multiple bench projects, e.g. `/run/frappe/${projName}-socketio.sock`
  instead of having to take care that `3000` (the default) doesn't start
  conflicting

In order to use unix sockets, the node:http* module needs to be used
to create a http server that can be passed to socketio, see:
https://socket.io/docs/v4/server-initialization/#with-an-http2-server

(secure server is not necessary, here as `nginx` terminates TLS already)
