### PR TITLE
fix: hard link with environment variable

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -24,7 +24,11 @@ EXTRA_ARGS_CTX = {"ignore_unknown_options": True, "allow_extra_args": True}
 @click.option("--app", help="Build assets for app")
 @click.option("--apps", help="Build assets for specific apps")
 @click.option(
-	"--hard-link", is_flag=True, default=False, help="Copy the files instead of symlinking"
+	"--hard-link",
+	is_flag=True,
+	default=False,
+	help="Copy the files instead of symlinking",
+	envvar="FRAPPE_HARD_LINK_ASSETS",
 )
 @click.option(
 	"--make-copy",


### PR DESCRIPTION
On docker based deploys symlinking inside volume doesn't work.

[skip ci]

