### PR TITLE
chore: add ascending order to querybuilder

### DIFF
--- a/frappe/query_builder/builder.py
+++ b/frappe/query_builder/builder.py
@@ -12,6 +12,7 @@ from frappe.utils import get_table_name
 class Base:
 	terms = terms
 	desc = Order.desc
+	asc = Order.asc
 	Schema = Schema
 	Table = Table
 


### PR DESCRIPTION
Added the missing ascending order_by filter to query builder