### PR TITLE
fix: trigger js hooks when setting values via grid upload

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1042,7 +1042,6 @@ export default class Grid {
 			};
 
 			// upload
-			frappe.flags.no_socketio = true;
 			$(this.wrapper)
 				.find(".grid-upload")
 				.removeClass("hidden")
@@ -1075,12 +1074,15 @@ export default class Grid {
 												me.df.options,
 												fieldname
 											);
-											if (df) {
-												d[fieldnames[ci]] = value_formatter_map[
-													df.fieldtype
-												]
-													? value_formatter_map[df.fieldtype](value)
-													: value;
+											if (df && !df.read_only) {
+												frappe.model.set_value(
+													d.doctype,
+													d.name,
+													fieldname,
+													value_formatter_map[df.fieldtype]
+														? value_formatter_map[df.fieldtype](value)
+														: value
+												);
 											}
 										});
 									}

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1089,7 +1089,6 @@ export default class Grid {
 								}
 							});
 
-							me.frm.refresh_field(me.df.fieldname);
 							frappe.msgprint({
 								message: __("Table updated"),
 								title: __("Success"),


### PR DESCRIPTION
This pr uses model.set_value to set values to fields when uploading data via grid upload. This is done so that the value based js controller hooks are triggered upon value set.

Also, ignore setting read-only fields values