### PR TITLE
fix: pin pymysql to avoid breaking behaviour

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "Jinja2~=3.1.2",
     "Pillow~=9.3.0",
     "PyJWT~=2.4.0",
-    "PyMySQL~=1.0.2",
+    "PyMySQL==1.0.2",
     "PyPDF2~=2.1.0",
     "PyPika~=0.48.9",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
```
  File "/home/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 920, in get_default
    d = self.get_defaults(key, parent)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 936, in get_defaults
    defaults = frappe.defaults.get_defaults_for(parent)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/defaults.py", line 222, in get_defaults_for
    .run(as_dict=True)
     ^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/query_builder/utils.py", line 85, in execute_query
    return frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 264, in sql
    self.log_query(query, values, debug, explain)
  File "/home/ankush/benches/develop/apps/frappe/frappe/database/mariadb/database.py", line 203, in log_query
    self.last_query = query = self._cursor._last_executed
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Cursor' object has no attribute '_last_executed'. Did you mean: '_check_executed'?
```

