### PR TITLE
build: bump pymysql

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -200,7 +200,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		return db_size[0].get("database_size")
 
 	def log_query(self, query, values, debug, explain):
-		self.last_query = query = self._cursor._last_executed
+		self.last_query = query = self._cursor._executed
 		self._log_query(query, debug, explain)
 		return self.last_query
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "Jinja2~=3.1.2",
     "Pillow~=9.3.0",
     "PyJWT~=2.4.0",
-    "PyMySQL==1.0.2",
+    "PyMySQL==1.0.3",
     "PyPDF2~=2.1.0",
     "PyPika~=0.48.9",
     "PyQRCode~=1.2.1",


### PR DESCRIPTION
Actual fix for this bandaid fix: https://github.com/frappe/frappe/pull/20475

Keeping pymysql hard pinned until we have better way to get last full query.

