### PR TITLE
fix: date field shouldn't be formatted for TZ

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -186,7 +186,7 @@ frappe.form.formatters = {
 			return value;
 		}
 		if (value) {
-			value = frappe.datetime.str_to_user(value);
+			value = frappe.datetime.str_to_user(value, false, true);
 			// handle invalid date
 			if (value === "Invalid date") {
 				value = null;


### PR DESCRIPTION
Date fields aren't timezone aware.


ref: ISS-22-23-06237


closes https://github.com/frappe/frappe/issues/20485


steps to reproduce:

1. Set user tz which is behind system tz. E.g. system tz: Asia/Kolkata, user timezone: Asia/Dubai
2. Date fields will now show values 1 day before actual value. 