### PR TITLE
fix(list view): add link_field_title to group_by clause in list view

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1065,7 +1065,9 @@ class DatabaseQuery:
 
 			if full_field_name:
 				tbl = field.split(".", 1)[0]
-				if tbl not in self.tables:
+				if tbl not in self.tables and tbl not in  (
+					d.table_name for d in self.link_tables
+				):
 					if tbl.startswith("`"):
 						tbl = tbl[4:-1]
 					frappe.throw(_("Please select atleast 1 column from {0} to sort/group").format(tbl))

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1065,9 +1065,7 @@ class DatabaseQuery:
 
 			if full_field_name:
 				tbl = field.split(".", 1)[0]
-				if tbl not in self.tables and tbl not in  (
-					d.table_name for d in self.link_tables
-				):
+				if tbl not in self.tables and tbl not in (d.table_name for d in self.link_tables):
 					if tbl.startswith("`"):
 						tbl = tbl[4:-1]
 					frappe.throw(_("Please select atleast 1 column from {0} to sort/group").format(tbl))

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -180,6 +180,27 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			);
 	}
 
+	get_group_by() {
+		let group_by = [];
+		let group_by_name = super.get_group_by();
+		if (group_by_name) {
+			group_by.push(group_by_name);
+		}
+		Object.keys(this.link_field_title_fields || {}).forEach((link_field) => {
+			let df = frappe.meta.get_docfield(this.doctype, link_field);
+			let df_doctype = df.options;
+			let col = frappe.model.get_full_column_name(
+				this.link_field_title_fields[link_field],
+				df_doctype
+			);
+			group_by.push(col);
+		});
+		if (group_by.length) {
+			return group_by.join(",");
+		}
+		return null;
+	}
+
 	async set_fields() {
 		this.link_field_title_fields = {};
 		let fields = [].concat(


### PR DESCRIPTION
## Problem:
- When selecting a title field in a doctype A and using this doctype as a link in another doctype B, when trying to view the list of this doctype B it throws an error regarding postgres that requires the title field selected to either be in aggregate or group by.

## Solution:
- Add title fields to group by clause in list_view.js