### PR TITLE
test: switch tests to supported methods

### DIFF
--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -255,10 +255,10 @@ class TestRenameDoc(FrappeTestCase):
 
 		with redirect_stdout(stdout), patch_db(["set_value"]):
 			get_fetch_fields("User", "ToDo", ["Activity Log"])
-			self.assertTrue("Function frappe.model.rename_doc.get_fetch_fields" in stdout.getvalue())
+			self.assertIn("Function frappe.model.rename_doc.get_fetch_fields", stdout.getvalue())
 
 			update_linked_doctypes("User", "ToDo", "str", "str")
-			self.assertTrue("Function frappe.model.rename_doc.update_linked_doctypes" in stdout.getvalue())
+			self.assertIn("Function frappe.model.rename_doc.update_linked_doctypes", stdout.getvalue())
 
 	def test_doc_rename_method(self):
 		name = choice(self.available_documents)

--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -9,14 +9,10 @@ from unittest.mock import patch
 
 import frappe
 from frappe.core.doctype.doctype.test_doctype import new_doctype
-from frappe.exceptions import DoesNotExistError, ValidationError
+from frappe.exceptions import DoesNotExistError
 from frappe.model.base_document import get_controller
-from frappe.model.rename_doc import (
-	bulk_rename,
-	get_fetch_fields,
-	update_document_title,
-	update_linked_doctypes,
-)
+from frappe.model.rename_doc import bulk_rename, update_document_title
+from frappe.model.utils.rename_doc import get_fetch_fields, update_linked_doctypes
 from frappe.modules.utils import get_doc_path
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now

--- a/frappe/tests/test_rename_doc.py
+++ b/frappe/tests/test_rename_doc.py
@@ -12,7 +12,6 @@ from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.exceptions import DoesNotExistError
 from frappe.model.base_document import get_controller
 from frappe.model.rename_doc import bulk_rename, update_document_title
-from frappe.model.utils.rename_doc import get_fetch_fields, update_linked_doctypes
 from frappe.modules.utils import get_doc_path
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_to_date, now
@@ -251,6 +250,8 @@ class TestRenameDoc(FrappeTestCase):
 			)
 
 	def test_deprecated_utils(self):
+		from frappe.model.rename_doc import get_fetch_fields, update_linked_doctypes
+
 		stdout = StringIO()
 
 		with redirect_stdout(stdout), patch_db(["set_value"]):


### PR DESCRIPTION
Switch tests to the implementation in `frappe.model.utils.rename_doc`.
The one in `frappe.model.rename_doc` has been deprecated two years ago.