### PR TITLE
feat: Disable Sharing globally (#20318) [backport]

### DIFF
--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -8,6 +8,7 @@ import unittest
 import frappe
 import frappe.share
 from frappe.automation.doctype.auto_repeat.test_auto_repeat import create_submittable_doctype
+from frappe.tests.utils import change_settings
 
 test_dependencies = ["User"]
 
@@ -128,3 +129,66 @@ class TestDocShare(unittest.TestCase):
 		)
 
 		frappe.share.remove(doctype, submittable_doc.name, self.user)
+
+	@change_settings("System Settings", {"disable_document_sharing": 1})
+	def test_share_disabled_add(self):
+		"Test if user loses share access on disabling share globally."
+		frappe.share.add("Event", self.event.name, self.user, share=1)  # Share as admin
+		frappe.set_user(self.user)
+
+		# User does not have share access although given to them
+		self.assertFalse(self.event.has_permission("share"))
+		self.assertRaises(
+			frappe.PermissionError, frappe.share.add, "Event", self.event.name, "test1@example.com"
+		)
+
+	@change_settings("System Settings", {"disable_document_sharing": 1})
+	def test_share_disabled_add_with_ignore_permissions(self):
+		frappe.share.add("Event", self.event.name, self.user, share=1)
+		frappe.set_user(self.user)
+
+		# User does not have share access although given to them
+		self.assertFalse(self.event.has_permission("share"))
+
+		# Test if behaviour is consistent for developer overrides
+		frappe.share.add_docshare(
+			"Event", self.event.name, "test1@example.com", flags={"ignore_share_permission": True}
+		)
+
+	@change_settings("System Settings", {"disable_document_sharing": 1})
+	def test_share_disabled_set_permission(self):
+		frappe.share.add("Event", self.event.name, self.user, share=1)
+		frappe.set_user(self.user)
+
+		# User does not have share access although given to them
+		self.assertFalse(self.event.has_permission("share"))
+		self.assertRaises(
+			frappe.PermissionError,
+			frappe.share.set_permission,
+			"Event",
+			self.event.name,
+			"test1@example.com",
+			"read",
+		)
+
+	@change_settings("System Settings", {"disable_document_sharing": 1})
+	def test_share_disabled_assign_to(self):
+		"""
+		Assigning a document to a user without access must not share the document,
+		if sharing disabled.
+		"""
+		from frappe.desk.form.assign_to import add, get
+
+		frappe.share.add("Event", self.event.name, self.user, share=1)
+		frappe.set_user(self.user)
+
+		# Assign to 'test1@example.com'
+		add({"doctype": "Event", "name": self.event.name, "assign_to": ["test1@example.com"]})
+
+		# Check if assigned to 'test1@example.com'
+		assignments = get(dict(doctype="Event", name=self.event.name))
+		self.assertEqual(len(assignments), 1)
+
+		# Check if not shared with 'test1@example.com'
+		shared_users = [x.user for x in frappe.share.get_users("Event", self.event.name)]
+		self.assertNotIn("test1@example.com", shared_users)

--- a/frappe/core/doctype/docshare/test_docshare.py
+++ b/frappe/core/doctype/docshare/test_docshare.py
@@ -151,7 +151,7 @@ class TestDocShare(unittest.TestCase):
 		self.assertFalse(self.event.has_permission("share"))
 
 		# Test if behaviour is consistent for developer overrides
-		frappe.share.add_docshare(
+		frappe.share.add(
 			"Event", self.event.name, "test1@example.com", flags={"ignore_share_permission": True}
 		)
 
@@ -177,18 +177,13 @@ class TestDocShare(unittest.TestCase):
 		Assigning a document to a user without access must not share the document,
 		if sharing disabled.
 		"""
-		from frappe.desk.form.assign_to import add, get
+		from frappe.desk.form.assign_to import add
 
 		frappe.share.add("Event", self.event.name, self.user, share=1)
 		frappe.set_user(self.user)
 
-		# Assign to 'test1@example.com'
-		add({"doctype": "Event", "name": self.event.name, "assign_to": ["test1@example.com"]})
-
-		# Check if assigned to 'test1@example.com'
-		assignments = get(dict(doctype="Event", name=self.event.name))
-		self.assertEqual(len(assignments), 1)
-
-		# Check if not shared with 'test1@example.com'
-		shared_users = [x.user for x in frappe.share.get_users("Event", self.event.name)]
-		self.assertNotIn("test1@example.com", shared_users)
+		self.assertRaises(
+			frappe.ValidationError,
+			add,
+			{"doctype": "Event", "name": self.event.name, "assign_to": ["test1@example.com"]},
+		)

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -14,6 +14,7 @@
   "is_first_startup",
   "enable_onboarding",
   "setup_complete",
+  "disable_document_sharing",
   "date_and_number_format",
   "date_format",
   "time_format",
@@ -525,12 +526,18 @@
    "fieldname": "apply_perm_level_on_api_calls",
    "fieldtype": "Check",
    "label": "Apply Perm Level on API calls (Recommended)"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_document_sharing",
+   "fieldtype": "Check",
+   "label": "Disable Document Sharing"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2023-03-03 11:47:24.867356",
+ "modified": "2023-03-14 11:30:56.465653",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -93,10 +93,17 @@ def add(args=None):
 
 			doc = frappe.get_doc(args["doctype"], args["name"])
 
-			# if assignee does not have permissions, share
+			# if assignee does not have permissions, share or inform
 			if not frappe.has_permission(doc=doc, user=assign_to):
-				frappe.share.add(doc.doctype, doc.name, assign_to)
-				shared_with_users.append(assign_to)
+				if frappe.get_system_settings("disable_document_sharing"):
+					msg = _("User {0} is not permitted to access this document.").format(frappe.bold(assign_to))
+					msg += "<br>" + _(
+						"As document sharing is disabled, please give them the required permissions before assigning."
+					)
+					frappe.throw(msg, title=_("Missing Permission"))
+				else:
+					frappe.share.add(doc.doctype, doc.name, assign_to)
+					shared_with_users.append(assign_to)
 
 			# make this document followed by assigned user
 			follow_document(args["doctype"], args["name"], assign_to)

--- a/frappe/model/__init__.py
+++ b/frappe/model/__init__.py
@@ -190,7 +190,7 @@ def get_permitted_fields(
 
 	if doctype in core_doctypes_list:
 		return valid_columns
-	
+
 	# DocType has only fields of type Table (Table, Table MultiSelect)
 	if set(valid_columns).issubset(default_fields):
 		return valid_columns

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -86,6 +86,9 @@ def has_permission(
 	if user == "Administrator":
 		return True
 
+	if ptype == "share" and frappe.get_system_settings("disable_document_sharing"):
+		return False
+
 	meta = frappe.get_meta(doctype)
 
 	if doc:

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -348,8 +348,14 @@ $.extend(frappe.model, {
 		return frappe.boot.user.can_email.indexOf(doctype)!==-1;
 	},
 
-	can_share: function(doctype, frm) {
-		if(frm) {
+	can_share: function (doctype, frm) {
+		let disable_sharing = cint(frappe.sys_defaults.disable_document_sharing);
+
+		if (disable_sharing && frappe.session.user !== "Administrator") {
+			return false;
+		}
+
+		if (frm) {
 			return frm.perm[0].share===1;
 		}
 		return frappe.boot.user.can_share.indexOf(doctype)!==-1;

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -44,7 +44,7 @@ def change_settings(doctype, settings_dict):
 		# change setting
 		for key, value in settings_dict.items():
 			setattr(settings, key, value)
-		settings.save()
+		settings.save(ignore_permissions=True)
 		# singles are cached by default, clear to avoid flake
 		frappe.db.value_cache[settings] = {}
 		yield  # yield control to calling function
@@ -54,7 +54,7 @@ def change_settings(doctype, settings_dict):
 		settings = frappe.get_doc(doctype)
 		for key, value in previous_settings.items():
 			setattr(settings, key, value)
-		settings.save()
+		settings.save(ignore_permissions=True)
 		frappe.db.value_cache[settings] = {}
 
 


### PR DESCRIPTION
Port of https://github.com/frappe/frappe/pull/20318

Docs: https://docs.erpnext.com/docs/v13/user/manual/en/setting-up/settings/system-settings/edit-wiki?wiki_page_patch=301c81b67e

The following is tested on a **v13** site and the screenshots belong to the same:

### Enable or Disable document sharing system wide
1. Checkbox in System Settings which is unchecked by default to maintain old behaviour
    <img width="1322" alt="Screenshot 2023-03-29 at 1 05 46 PM" src="https://user-images.githubusercontent.com/25857446/228460410-e5545e16-c68c-4319-af82-764601aaed8d.png">

2. If enabled, system wide, no user will have share access to any document
3. The share button will be read only, no action (no share access). Although users can see who the doc is shared with (consistent with old behaviour)
     ![2023-03-29 12 58 54](https://user-images.githubusercontent.com/25857446/228460497-5c7c2564-946c-44ee-88f0-8d4b8aa76338.gif)

4. On invoking the share API **without** `ignore_share_permissions` (from the browser), a perm error is thrown
    ![2023-03-29 12 57 24](https://user-images.githubusercontent.com/25857446/228460792-ab64201a-5bb3-47bd-b977-f958764c4abf.gif)

5. If any share API is invoked **with** `ignore_share_permissions` it will go through (consistent with old behaviour). [Creating a user, doc must be shared with the user themselves]
   ![2023-03-29 13 08 53](https://user-images.githubusercontent.com/25857446/228461211-3ba42ef3-d7db-470f-8f32-8cc8129f79f1.gif)

6. `assign_to` is handled as a special case, where assigning a doc to a user **will block** the assignment if the user does not have access already. The assignee is expected to have access to the document otherwise assignments can be misused
    <img width="1220" alt="Screenshot 2023-03-29 at 12 59 55 PM" src="https://user-images.githubusercontent.com/25857446/228461291-12cdbf6f-0d5e-4ab9-bb11-048b97f0911a.png">

