### PR TITLE
fix: removed unnecessary usage of `@frappe.whitelist`

### DIFF
--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -169,7 +169,6 @@ class ServerScript(Document):
 		return items
 
 
-@frappe.whitelist()
 def setup_scheduler_events(script_name, frequency):
 	"""Creates or Updates Scheduled Job Type documents based on the specified script name and frequency
 


### PR DESCRIPTION
No need of whitelisting the function `setup_scheduler_events()` in `server_script.py`.