### PR TITLE
test: Kanban Test fails to remove System Manager role

### DIFF
--- a/cypress/integration/kanban.js
+++ b/cypress/integration/kanban.js
@@ -98,19 +98,17 @@ context("Kanban Board", () => {
 	});
 
 	it("Checks if Kanban Board edits are blocked for non-System Manager and non-owner of the Board", () => {
-		// Add another System Manager so that the role can be removed from `frappe@example.com`
-		cy.call("frappe.tests.ui_test_helpers.create_test_user", {
-			username: "sysmanager@example.com",
-		});
-
-		cy.call("frappe.tests.ui_test_helpers.create_todo", { description: "Frappe User ToDo" });
-
 		cy.switch_to_user("Administrator");
-		cy.call("frappe.tests.ui_test_helpers.create_admin_kanban");
-		// remove sys manager
-		cy.remove_role("frappe@example.com", "System Manager");
 
-		cy.switch_to_user("frappe@example.com");
+		const noSystemManager = "nosysmanager@example.com";
+		cy.call("frappe.tests.ui_test_helpers.create_test_user", {
+			username: noSystemManager,
+		});
+		cy.remove_role(noSystemManager, "System Manager");
+		cy.call("frappe.tests.ui_test_helpers.create_todo", { description: "Frappe User ToDo" });
+		cy.call("frappe.tests.ui_test_helpers.create_admin_kanban");
+
+		cy.switch_to_user(noSystemManager);
 
 		cy.visit("/app/todo/view/kanban/Admin Kanban");
 
@@ -126,8 +124,8 @@ context("Kanban Board", () => {
 		// Column actions should be hidden (dropdown for 'Archive' and indicators)
 		cy.get(".kanban .column-options").should("have.length", 0);
 
-		cy.add_role("frappe@example.com", "System Manager");
-		cy.call("frappe.client.delete", { doctype: "User", name: "sysmanager@example.com" });
+		cy.switch_to_user("Administrator");
+		cy.call("frappe.client.delete", { doctype: "User", name: noSystemManager });
 	});
 
 	after(() => {

--- a/cypress/integration/kanban.js
+++ b/cypress/integration/kanban.js
@@ -98,7 +98,11 @@ context("Kanban Board", () => {
 	});
 
 	it("Checks if Kanban Board edits are blocked for non-System Manager and non-owner of the Board", () => {
-		// create admin kanban board
+		// Add another System Manager so that the role can be removed from `frappe@example.com`
+		cy.call("frappe.tests.ui_test_helpers.create_system_manager_user", {
+			username: "sysmanager@example.com",
+		});
+
 		cy.call("frappe.tests.ui_test_helpers.create_todo", { description: "Frappe User ToDo" });
 
 		cy.switch_to_user("Administrator");
@@ -123,6 +127,7 @@ context("Kanban Board", () => {
 		cy.get(".kanban .column-options").should("have.length", 0);
 
 		cy.add_role("frappe@example.com", "System Manager");
+		cy.call("frappe.client.delete", { doctype: "User", name: "sysmanager@example.com" });
 	});
 
 	after(() => {

--- a/cypress/integration/kanban.js
+++ b/cypress/integration/kanban.js
@@ -99,7 +99,7 @@ context("Kanban Board", () => {
 
 	it("Checks if Kanban Board edits are blocked for non-System Manager and non-owner of the Board", () => {
 		// Add another System Manager so that the role can be removed from `frappe@example.com`
-		cy.call("frappe.tests.ui_test_helpers.create_system_manager_user", {
+		cy.call("frappe.tests.ui_test_helpers.create_test_user", {
 			username: "sysmanager@example.com",
 		});
 

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -426,12 +426,15 @@ def create_blog_post():
 	return doc
 
 
-def create_test_user():
-	if frappe.db.exists("User", UI_TEST_USER):
+@whitelist_for_tests
+def create_test_user(username=None):
+	name = username or UI_TEST_USER
+
+	if frappe.db.exists("User", name):
 		return
 
 	user = frappe.new_doc("User")
-	user.email = UI_TEST_USER
+	user.email = name
 	user.first_name = "Frappe"
 	user.new_password = frappe.local.conf.admin_password
 	user.send_welcome_email = 0
@@ -622,28 +625,3 @@ def add_remove_role(action, user, role):
 		user_doc.remove_roles(role)
 	else:
 		user_doc.add_roles(role)
-
-
-@whitelist_for_tests
-def create_system_manager_user(username):
-	if frappe.db.exists("User", username):
-		return
-
-	user = frappe.new_doc("User")
-	user.email = username
-	user.first_name = "System Manager"
-	user.new_password = frappe.local.conf.admin_password
-	user.send_welcome_email = 0
-	user.time_zone = "Asia/Kolkata"
-	user.flags.ignore_password_policy = True
-	user.insert(ignore_if_duplicate=True)
-
-	user.reload()
-
-	blocked_roles = {"Administrator", "Guest", "All"}
-	all_roles = set(frappe.get_all("Role", pluck="name"))
-
-	for role in all_roles - blocked_roles:
-		user.append("roles", {"role": role})
-
-	user.save()


### PR DESCRIPTION
- As there's only one user with System Manager role, role removal is reverted
- Add another user with this role, so that role removal on test user works

UI test fails at https://github.com/frappe/frappe/pull/19375