### PR TITLE
fix: allow `reset_otp_secret` only if Two Factor Auth is enabled

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -219,9 +219,10 @@ frappe.ui.form.on("User", {
 				});
 			}
 
-			if (cint(frappe.boot.sysdefaults.enable_two_factor_auth) && (
-				frappe.session.user == doc.name || frappe.user.has_role("System Manager")
-			)) {
+			if (
+				cint(frappe.boot.sysdefaults.enable_two_factor_auth) &&
+				(frappe.session.user == doc.name || frappe.user.has_role("System Manager"))
+			) {
 				frm.add_custom_button(
 					__("Reset OTP Secret"),
 					function () {

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -219,7 +219,9 @@ frappe.ui.form.on("User", {
 				});
 			}
 
-			if (frappe.session.user == doc.name || frappe.user.has_role("System Manager")) {
+			if (cint(frappe.boot.sysdefaults.enable_two_factor_auth) && (
+				frappe.session.user == doc.name || frappe.user.has_role("System Manager")
+			)) {
 				frm.add_custom_button(
 					__("Reset OTP Secret"),
 					function () {

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -450,12 +450,20 @@ def disable():
 
 
 @frappe.whitelist()
-def reset_otp_secret(user):
+def reset_otp_secret(user: str):
 	if frappe.session.user != user:
 		frappe.only_for("System Manager", message=True)
 
-	otp_issuer = frappe.db.get_single_value("System Settings", "otp_issuer_name")
-	user_email = frappe.db.get_value("User", user, "email")
+	settings = frappe.get_cached_doc("System Settings")
+
+	if not settings.enable_two_factor_auth:
+		frappe.throw(
+			_("You have to enable Two Factor Auth from System Settings."),
+			title=_("Enable Two Factor Auth"),
+		)
+
+	otp_issuer = settings.otp_issuer_name or "Frappe Framework"
+	user_email = frappe.get_cached_value("User", user, "email")
 
 	clear_default(user + "_otplogin")
 	clear_default(user + "_otpsecret")
@@ -463,10 +471,10 @@ def reset_otp_secret(user):
 	email_args = {
 		"recipients": user_email,
 		"sender": None,
-		"subject": _("OTP Secret Reset - {0}").format(otp_issuer or "Frappe Framework"),
+		"subject": _("OTP Secret Reset - {0}").format(otp_issuer),
 		"message": _(
 			"<p>Your OTP secret on {0} has been reset. If you did not perform this reset and did not request it, please contact your System Administrator immediately.</p>"
-		).format(otp_issuer or "Frappe Framework"),
+		).format(otp_issuer),
 		"delayed": False,
 		"retry": 3,
 	}
@@ -482,4 +490,6 @@ def reset_otp_secret(user):
 		**email_args,
 	)
 
-	frappe.msgprint(_("OTP Secret has been reset. Re-registration will be required on next login."))
+	frappe.msgprint(
+		_("OTP Secret has been reset. Re-registration will be required on next login.")
+	)

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -490,6 +490,4 @@ def reset_otp_secret(user: str):
 		**email_args,
 	)
 
-	frappe.msgprint(
-		_("OTP Secret has been reset. Re-registration will be required on next login.")
-	)
+	frappe.msgprint(_("OTP Secret has been reset. Re-registration will be required on next login."))


### PR DESCRIPTION
**Fix**

In `user.js`
1. Display `Reset OTP Secret` button only if **Two Factor Auth** is enabled from System Settings.

Whitelisted function `reset_otp_secret` In `twofactor.py`
1. Added type hint
2. validate **Two Factor Auth** from settings
3. Use of  `get_cached_doc` and `get_cached_value`