### PR TITLE
fix(UX): workspace breadcrumbs based on history

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -130,7 +130,7 @@ def load_desktop_data(bootinfo):
 	from frappe.desk.desktop import get_workspace_sidebar_items
 
 	bootinfo.allowed_workspaces = get_workspace_sidebar_items().get("pages")
-	bootinfo.module_page_map = get_controller("Workspace").get_module_page_map()
+	bootinfo.module_wise_workspaces = get_controller("Workspace").get_module_wise_workspaces()
 	bootinfo.dashboards = frappe.get_all("Dashboard")
 
 

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+from collections import defaultdict
 from json import loads
 
 import frappe
@@ -49,12 +50,22 @@ class Workspace(Document):
 			delete_folder(self.module, "Workspace", self.title)
 
 	@staticmethod
-	def get_module_page_map():
-		pages = frappe.get_all(
-			"Workspace", fields=["name", "module"], filters={"for_user": ""}, as_list=1
+	def get_module_wise_workspaces():
+		workspaces = frappe.get_all(
+			"Workspace",
+			fields=["name", "module"],
+			filters={"for_user": "", "public": 1},
+			order_by="creation",
 		)
 
-		return {page[1]: page[0] for page in pages if page[1]}
+		module_workspaces = defaultdict(list)
+
+		for workspace in workspaces:
+			if not workspace.module:
+				continue
+			module_workspaces[workspace.module].append(workspace.name)
+
+		return module_workspaces
 
 	def get_link_groups(self):
 		cards = []

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -82,25 +82,38 @@ frappe.breadcrumbs = {
 		this.$breadcrumbs.append(html);
 	},
 
+	get last_route() {
+		return frappe.route_history.slice(-2)[0];
+	},
+
 	set_workspace_breadcrumb(breadcrumbs) {
-		// get preferred module for breadcrumbs, based on sent via module
+		// get preferred module for breadcrumbs, based on history and module
 
 		if (!breadcrumbs.workspace) {
-			this.set_workspace(breadcrumbs);
-		}
-
-		if (breadcrumbs.workspace) {
-			if (
-				!breadcrumbs.module_info.blocked &&
-				frappe.visible_modules.includes(breadcrumbs.module_info.module)
-			) {
-				$(
-					`<li><a href="/app/${frappe.router.slug(breadcrumbs.workspace)}">${__(
-						breadcrumbs.workspace
-					)}</a></li>`
-				).appendTo(this.$breadcrumbs);
+			// guess from last route
+			if (this.last_route?.[0] == "Workspaces") {
+				breadcrumbs.workspace = this.last_route[1];
+			} else {
+				this.set_workspace(breadcrumbs);
 			}
 		}
+		if (!breadcrumbs.workspace) {
+			return;
+		}
+
+		if (
+			breadcrumbs.module_info &&
+			(breadcrumbs.module_info.blocked ||
+				!frappe.visible_modules.includes(breadcrumbs.module_info.module))
+		) {
+			return;
+		}
+
+		$(
+			`<li><a href="/app/${frappe.router.slug(breadcrumbs.workspace)}">${__(
+				breadcrumbs.workspace
+			)}</a></li>`
+		).appendTo(this.$breadcrumbs);
 	},
 
 	set_workspace(breadcrumbs) {

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -90,12 +90,7 @@ frappe.breadcrumbs = {
 		// get preferred module for breadcrumbs, based on history and module
 
 		if (!breadcrumbs.workspace) {
-			// guess from last route
-			if (this.last_route?.[0] == "Workspaces") {
-				breadcrumbs.workspace = this.last_route[1];
-			} else {
-				this.set_workspace(breadcrumbs);
-			}
+			this.set_workspace(breadcrumbs);
 		}
 		if (!breadcrumbs.workspace) {
 			return;
@@ -130,6 +125,19 @@ frappe.breadcrumbs = {
 			breadcrumbs.module = this.preferred[breadcrumbs.doctype];
 		}
 
+		// guess from last route
+		if (this.last_route?.[0] == "Workspaces") {
+			let last_workspace = this.last_route[1];
+
+			if (
+				breadcrumbs.module &&
+				frappe.boot.module_wise_workspaces[breadcrumbs.module]?.includes(last_workspace)
+			) {
+				breadcrumbs.workspace = last_workspace;
+				return;
+			}
+		}
+
 		if (breadcrumbs.module) {
 			if (this.module_map[breadcrumbs.module]) {
 				breadcrumbs.module = this.module_map[breadcrumbs.module];
@@ -138,8 +146,11 @@ frappe.breadcrumbs = {
 			breadcrumbs.module_info = frappe.get_module(breadcrumbs.module);
 
 			// set workspace
-			if (breadcrumbs.module_info && frappe.boot.module_page_map[breadcrumbs.module]) {
-				breadcrumbs.workspace = frappe.boot.module_page_map[breadcrumbs.module];
+			if (
+				breadcrumbs.module_info &&
+				frappe.boot.module_wise_workspaces[breadcrumbs.module]
+			) {
+				breadcrumbs.workspace = frappe.boot.module_wise_workspaces[breadcrumbs.module][0];
 			}
 		}
 	},


### PR DESCRIPTION
Summary: When navigating from desk, use last route to render workspace breadcrumbs instead of guessing.

E.g.
- Go to selling workspace  and open sales order analytics
- Workspace is shown as "Retail" in breadcrumbs, even though retail module doesn't even have this report.
