### PR TITLE
fix: Handle JsBarcode exceptions

### DIFF
--- a/frappe/public/js/frappe/form/controls/barcode.js
+++ b/frappe/public/js/frappe/form/controls/barcode.js
@@ -27,6 +27,7 @@ frappe.ui.form.ControlBarcode = class ControlBarcode extends frappe.ui.form.Cont
 		let svg = value;
 		let barcode_value = "";
 
+		this.set_empty_description();
 		if (value && value.startsWith("<svg")) {
 			barcode_value = $(svg).attr("data-barcode-value");
 		}
@@ -44,10 +45,14 @@ frappe.ui.form.ControlBarcode = class ControlBarcode extends frappe.ui.form.Cont
 		if (value) {
 			// Get svg
 			const svg = this.barcode_area.find("svg")[0];
-			JsBarcode(svg, value, this.get_options(value));
-			$(svg).attr("data-barcode-value", value);
-			$(svg).attr("width", "100%");
-			return this.barcode_area.html();
+			try {
+				JsBarcode(svg, value, this.get_options(value));
+				$(svg).attr("data-barcode-value", value);
+				$(svg).attr("width", "100%");
+				return this.barcode_area.html();
+			} catch (e) {
+				this.set_description(`Invalid Barcode: ${String(e)}`);
+			}
 		}
 	}
 


### PR DESCRIPTION
JsBarcode exceptions prevent entire page from loading. Instead of that
catch error and show it in helpbox so user can correct the barcode if
required.

Steps to reproduce:
1. Add barcode field
2. Set barcode type in options
3. add invalid barcode and save

(cherry picked from commit 57d40b2614068c13b4b14f42438b46b22c0f5533)

