### PR TITLE
perf: Faster address query with explicit joins

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -254,10 +254,10 @@ def address_query(doctype, txt, searchfield, start, page_len, filters):
 		"""select
 			`tabAddress`.name, `tabAddress`.city, `tabAddress`.country
 		from
-			`tabAddress`, `tabDynamic Link`
+			`tabAddress`
+		join `tabDynamic Link`
+			on (`tabDynamic Link`.parent = `tabAddress`.name and `tabDynamic Link`.parenttype = 'Address')
 		where
-			`tabDynamic Link`.parent = `tabAddress`.name and
-			`tabDynamic Link`.parenttype = 'Address' and
 			`tabDynamic Link`.link_doctype = %(link_doctype)s and
 			`tabDynamic Link`.link_name = %(link_name)s and
 			ifnull(`tabAddress`.disabled, 0) = 0 and

--- a/frappe/contacts/doctype/address/test_address.py
+++ b/frappe/contacts/doctype/address/test_address.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+from functools import partial
+
 import frappe
-from frappe.contacts.doctype.address.address import get_address_display
+from frappe.contacts.doctype.address.address import address_query, get_address_display
 from frappe.tests.utils import FrappeTestCase
 
 
@@ -28,3 +30,29 @@ class TestAddress(FrappeTestCase):
 		address = frappe.get_list("Address")[0].name
 		display = get_address_display(frappe.get_doc("Address", address).as_dict())
 		self.assertTrue(display)
+
+	def test_address_query(self):
+		def query(doctype="Address", txt="", searchfield="name", start=0, page_len=20, filters=None):
+			if filters is None:
+				filters = {"link_doctype": "User", "link_name": "Administrator"}
+			return address_query(doctype, txt, searchfield, start, page_len, filters)
+
+		frappe.get_doc(
+			{
+				"address_type": "Billing",
+				"address_line1": "1",
+				"city": "Mumbai",
+				"state": "Maharashtra",
+				"country": "India",
+				"doctype": "Address",
+				"links": [
+					{
+						"link_doctype": "User",
+						"link_name": "Administrator",
+					}
+				],
+			}
+		).insert()
+
+		self.assertGreaterEqual(len(query(txt="admin")), 1)
+		self.assertEqual(len(query(txt="what_zyx")), 0)


### PR DESCRIPTION
This query is particularly problematic when there are `OR conditions` due to shared docs.

```sql
SELECT `tabAddress`.name,
       `tabAddress`.city,
       `tabAddress`.country
FROM `tabAddress`, `tabDynamic Link`
WHERE
  `tabDynamic Link`.parent = `tabAddress`.name 
  AND `tabDynamic Link`.parenttype = 'Address'
  AND `tabDynamic Link`.link_doctype = 'Customer'
  AND `tabDynamic Link`.link_name = 'CUSTOMER NAME'
  AND coalesce(`tabAddress`.disabled, 0) = 0
  AND (`tabAddress`.`country` like '%%'
       OR `tabAddress`.`state` like '%%'
       OR `tabAddress`.`name` like '%%'
       OR `tabAddress`.`name` like '%%')
  AND ((((coalesce(`tabAddress`.`branch`, '')=''
          OR `tabAddress`.`branch` in ('something')))))
  OR (`tabAddress`.name in ('SOME SHARED DOC'))
ORDER BY if(locate('', `tabAddress`.name), locate('', `tabAddress`.name), 99999),
         `tabAddress`.idx DESC,
         `tabAddress`.name
LIMIT 0, 20;
```

**Before:** Never terminates and reads entire table with millions of lines :LOL:

**After:** Reads ~100 rows max.

```
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: tabDynamic Link
         type: index_merge
possible_keys: parent,link_doctype_link_name_index,link_name
          key: link_name,link_doctype_link_name_index,parent
      key_len: 563,1126,563
          ref: NULL
         rows: 40
       r_rows: 79.00
     filtered: 100.00
   r_filtered: 100.00
        Extra: Using union(intersect(link_name,link_doctype_link_name_index),parent); Using where; Using temporary; Using filesort
*************************** 2. row ***************************
           id: 1
  select_type: SIMPLE
        table: tabAddress
         type: eq_ref
possible_keys: PRIMARY,selco_branch
          key: PRIMARY
      key_len: 562
          ref: _900a733bdc3bb9ed.tabDynamic Link.parent
         rows: 1
       r_rows: 1.00
     filtered: 100.00
   r_filtered: 100.00
        Extra: Using where
2 rows in set (0.001 sec)
```