### PR TITLE
fix!: contact us email reply

### DIFF
--- a/frappe/templates/includes/contact.js
+++ b/frappe/templates/includes/contact.js
@@ -28,11 +28,8 @@ frappe.ready(function() {
 			sender: email,
 			message: message,
 			callback: function(r) {
-				if(r.message==="okay") {
+				if (!r.exc) {
 					frappe.msgprint('{{ _("Thank you for your message") }}');
-				} else {
-					frappe.msgprint('{{ _("There were errors") }}');
-					console.log(r.exc);
 				}
 				$(':input').val('');
 			}

--- a/frappe/templates/includes/contact.js
+++ b/frappe/templates/includes/contact.js
@@ -23,20 +23,22 @@ frappe.ready(function() {
 		}
 
 		$("#contact-alert").toggle(false);
-		frappe.send_message({
-			subject: $('[name="subject"]').val(),
-			sender: email,
-			message: message,
+		frappe.call({
+			type: "POST",
+			method: "frappe.www.contact.send_message",
+			args: {
+				subject: $('[name="subject"]').val(),
+				sender: email,
+				message: message,
+			},
 			callback: function(r) {
 				if (!r.exc) {
 					frappe.msgprint('{{ _("Thank you for your message") }}');
 				}
 				$(':input').val('');
-			}
-		}, this);
-		return false;
+			},
+		});
 	});
-
 });
 
 var msgprint = function(txt) {

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -213,15 +213,6 @@ $.extend(frappe, {
 			)
 			.appendTo(document.body);
 	},
-	send_message: function (opts, btn) {
-		return frappe.call({
-			type: "POST",
-			method: "frappe.www.contact.send_message",
-			btn: btn,
-			args: opts,
-			callback: opts.callback,
-		});
-	},
 	has_permission: function (doctype, docname, perm_type, callback) {
 		return frappe.call({
 			type: "GET",

--- a/frappe/www/contact.py
+++ b/frappe/www/contact.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.utils import now
+from frappe.rate_limiter import rate_limit
 
 sitemap = 1
 
@@ -22,38 +22,17 @@ def get_context(context):
 	return out
 
 
-max_communications_per_hour = 1000
-
-
 @frappe.whitelist(allow_guest=True)
-def send_message(subject="Website Query", message="", sender=""):
-	if not message:
-		frappe.response["message"] = "Please write something"
-		return
+@rate_limit(limit=1000, seconds=60 * 60, methods=["POST"])
+def send_message(sender, message, subject="Website Query"):
+	if forward_to_email := frappe.db.get_single_value("Contact Us Settings", "forward_to_email"):
+		frappe.sendmail(recipients=forward_to_email, reply_to=sender, content=message, subject=subject)
 
-	if not sender:
-		frappe.response["message"] = "Email Address Required"
-		return
-
-	# guest method, cap max writes per hour
-	if (
-		frappe.db.sql(
-			"""select count(*) from `tabCommunication`
-		where `sent_or_received`="Received"
-		and TIMEDIFF(%s, modified) < '01:00:00'""",
-			now(),
-		)[0][0]
-		> max_communications_per_hour
-	):
-		frappe.response[
-			"message"
-		] = "Sorry: we believe we have received an unreasonably high number of requests of this kind. Please try later"
-		return
-
-	# send email
-	forward_to_email = frappe.db.get_single_value("Contact Us Settings", "forward_to_email")
-	if forward_to_email:
-		frappe.sendmail(recipients=forward_to_email, sender=sender, content=message, subject=subject)
+	frappe.sendmail(
+		recipients=sender,
+		content="Thank you for reaching out to us. We will get back to you at the earliest.",
+		subject="We've received your query!",
+	)
 
 	# add to to-do ?
 	frappe.get_doc(
@@ -66,5 +45,3 @@ def send_message(subject="Website Query", message="", sender=""):
 			status="Open",
 		)
 	).insert(ignore_permissions=True)
-
-	return "okay"

--- a/frappe/www/contact.py
+++ b/frappe/www/contact.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from frappe.rate_limiter import rate_limit
+from frappe.utils import validate_email_address
 
 sitemap = 1
 
@@ -23,14 +24,15 @@ def get_context(context):
 
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=1000, seconds=60 * 60, methods=["POST"])
+@rate_limit(limit=1000, seconds=60 * 60)
 def send_message(sender, message, subject="Website Query"):
+	sender = validate_email_address(sender, throw=True)
 	if forward_to_email := frappe.db.get_single_value("Contact Us Settings", "forward_to_email"):
 		frappe.sendmail(recipients=forward_to_email, reply_to=sender, content=message, subject=subject)
 
 	frappe.sendmail(
 		recipients=sender,
-		content="Thank you for reaching out to us. We will get back to you at the earliest.",
+		content=f"<div style='white-space: pre-wrap'>Thank you for reaching out to us. We will get back to you at the earliest.\n\n\nYour query:\n\n{message}</div>",
 		subject="We've received your query!",
 	)
 


### PR DESCRIPTION
discovered by @casesolved-co-uk in #20382.

This PR tries to provide a better fix in terms of UX.

Sender/Contactee will now get a confirmation email that their query has been delivered *somewhere*.

![Screenshot from 2023-04-03 01-23-36](https://user-images.githubusercontent.com/32034600/229377025-bbdc6d81-a056-4478-bfc7-f9f40410bab6.png)

#

Other Changes:
- validation for sender email on server side
- removed `frappe.send_message` js util - this was overridden by erpnext for creating lead/opportunity (tackled here: https://github.com/frappe/erpnext/pull/34707)