### PR TITLE
fix(UI): align link cards & charts on workspace

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -208,7 +208,6 @@ body {
 	// Overrides for each widgets
 	&.dashboard-widget-box {
 		min-height: 240px;
-		padding: var(--padding-md) var(--padding-lg);
 
 		.filter-chart {
 			background-color: var(--control-bg);
@@ -238,11 +237,14 @@ body {
 		}
 
 		.widget-head {
-			padding: var(--padding-sm);
 			display: flex;
 			justify-content: space-between;
 			flex-wrap: wrap;
 			gap: 6px;
+		}
+
+		.widget-body {
+			padding-top: 7px;
 		}
 
 		.widget-control {
@@ -560,7 +562,7 @@ body {
 	}
 
 	&.links-widget-box {
-		padding: 18px 12px;
+		padding: 12px 7px;
 
 		.link-item {
 			display: flex;


### PR DESCRIPTION
Charts
| Before | After |
| ------ | ----- |
| <img width="1048" alt="image" src="https://user-images.githubusercontent.com/30859809/229343386-006cc308-9004-4d92-9c65-b7f6dde0bc87.png"> | <img width="1048" alt="image" src="https://user-images.githubusercontent.com/30859809/229343312-a468f0ce-58ba-4f8b-b434-7ffe99cb337d.png"> |

Link Cards

| Before | After |
| ------ | ----- |
| <img width="1048" alt="image" src="https://user-images.githubusercontent.com/30859809/229343458-a8e8757a-8a0b-42e5-a705-cf4a4f16fd75.png"> | <img width="1048" alt="image" src="https://user-images.githubusercontent.com/30859809/229343504-b55e2908-6e94-4359-9969-5e70426c7c35.png"> |
