### PR TITLE
feat(util): `get_table_name`: wrap in backticks

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -1031,8 +1031,13 @@ def groupby_metric(iterable: dict[str, list], key: str):
 	return records
 
 
-def get_table_name(table_name: str) -> str:
-	return f"tab{table_name}" if not table_name.startswith("__") else table_name
+def get_table_name(table_name: str, wrap_in_backticks: bool = False) -> str:
+	name = f"tab{table_name}" if not table_name.startswith("__") else table_name
+
+	if wrap_in_backticks:
+		return f"`{name}`"
+
+	return name
 
 
 def squashify(what):


### PR DESCRIPTION
`utils/get_table_name` can be used to eliminate some magic strings, but it is not usable in some cases

#### Example
get_table_name("Foo Bar") -> `tabFoo Bar` which can not be used in SQL queries

#### Solution
`` `tabFoo Bar` `` is usable since it is wrapped in backticks. This PR adds an optional keyword, `wrap_in_backticks` (defaults to `False`), to achieve this