### PR TITLE
fix: content_type can be `None` during file upload

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -198,7 +198,7 @@ def upload_file():
 		filename = file.filename
 
 		content_type = guess_type(filename)[0]
-		if optimize and content_type.startswith("image/"):
+		if optimize and content_type and content_type.startswith("image/"):
 			args = {"content": content, "content_type": content_type}
 			if frappe.form_dict.max_width:
 				args["max_width"] = int(frappe.form_dict.max_width)


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/20571

