### PR TITLE
fix: validate if doctype exists before syncing customisations

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -114,10 +114,10 @@ def sync_customizations(app=None):
 						with open(os.path.join(folder, fname)) as f:
 							data = json.loads(f.read())
 						if data.get("sync_on_migrate"):
-							sync_customizations_for_doctype(data, folder)
+							sync_customizations_for_doctype(data, folder, fname)
 
 
-def sync_customizations_for_doctype(data: dict, folder: str):
+def sync_customizations_for_doctype(data: dict, folder: str, fname: str):
 	"""Sync doctype customzations for a particular data set"""
 	from frappe.core.doctype.doctype.doctype import validate_fields_for_doctype
 
@@ -158,6 +158,11 @@ def sync_customizations_for_doctype(data: dict, folder: str):
 			if doc_type == doctype or not os.path.exists(os.path.join(folder, scrub(doc_type) + ".json")):
 				sync_single_doctype(doc_type)
 
+	if not frappe.db.exists("DocType", doctype):
+		print(_("DocType {0} does not exist.").format(doctype))
+		print(_("Skipping fixture syncing for doctyoe {0} from file {1} ").format(doctype, fname))
+		return
+
 	if data["custom_fields"]:
 		sync("custom_fields", "Custom Field", "dt")
 		update_schema = True
@@ -168,7 +173,6 @@ def sync_customizations_for_doctype(data: dict, folder: str):
 	if data.get("custom_perms"):
 		sync("custom_perms", "Custom DocPerm", "parent")
 
-	print(f"Updating customizations for {doctype}")
 	validate_fields_for_doctype(doctype)
 
 	if update_schema and not frappe.db.get_value("DocType", doctype, "issingle"):

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -117,7 +117,7 @@ def sync_customizations(app=None):
 							sync_customizations_for_doctype(data, folder, fname)
 
 
-def sync_customizations_for_doctype(data: dict, folder: str, fname: str):
+def sync_customizations_for_doctype(data: dict, folder: str, filename: str = ""):
 	"""Sync doctype customzations for a particular data set"""
 	from frappe.core.doctype.doctype.doctype import validate_fields_for_doctype
 
@@ -160,7 +160,7 @@ def sync_customizations_for_doctype(data: dict, folder: str, fname: str):
 
 	if not frappe.db.exists("DocType", doctype):
 		print(_("DocType {0} does not exist.").format(doctype))
-		print(_("Skipping fixture syncing for doctyoe {0} from file {1} ").format(doctype, fname))
+		print(_("Skipping fixture syncing for doctyoe {0} from file {1} ").format(doctype, filename))
 		return
 
 	if data["custom_fields"]:


### PR DESCRIPTION
### Before Fix

```
frappetech@Saurabhs-MacBook-Pro frappe % bench --site test.erpnext migrate
Migrating test.erpnext
Updating DocTypes for frappe        : [========================================] 100%
Updating DocTypes for erpnext       : [========================================] 100%
Updating DocTypes for journeys      : [========================================] 100%
Updating DocTypes for ********       : [========================================] 100%
Updating Dashboard for frappe
Updating Dashboard for erpnext
Updating Dashboard for journeys
Updating Dashboard for *******
Updating customizations for Address
Updating customizations for Contact
Updating customizations for Employee Benefit Claim
Queued rebuilding of search index for test.erpnext

Traceback with variables (most recent call last):
  File "/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
      mod_name = 'frappe.utils.bench_helper'
      alter_argv = True
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10bf7b280>, origin='/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py')
      code = <code object <module> at 0x10fedd2c0, file "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 1>
      main_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x10bf7b280>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10bf7b280>, origin='/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': '/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py', '__cached__': '/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc', 'importlib': <module 'importlib' from '/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/importlib/__init__.py'>, 'json': <module 'json' from '/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/json/__init__.py'>, 'os': <module 'os' from '/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/os.py'>, 'traceback'...
  File "/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
      code = <code object <module> at 0x10fedd2c0, file "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 1>
      run_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x10bf7b280>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10bf7b280>, origin='/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': '/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py', '__cached__': '/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc', 'importlib': <module 'importlib' from '/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/importlib/__init__.py'>, 'json': <module 'json' from '/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/json/__init__.py'>, 'os': <module 'os' from '/Users/frappetech/.pyenv/versions/3.10.0/lib/python3.10/os.py'>, 'traceback'...
      init_globals = None
      mod_name = '__main__'
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x10bf7b280>, origin='/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py')
      pkg_name = 'frappe.utils'
      script_name = None
      loader = <_frozen_importlib_external.SourceFileLoader object at 0x10bf7b280>
      fname = '/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py'
      cached = '/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-310.pyc'
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
      ...skipped... 26 vars
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name="bench")
      commands = {'frappe': <Group frappe>, 'get-frappe-commands': <Command get-frappe-commands>, 'get-frappe-help': <Command get-frappe-help>}
  File "/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
      self = <Group None>
      args = ()
      kwargs = {'prog_name': 'bench'}
  File "/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
      self = <Group None>
      args = ['frappe', '--site', 'kartoza.erpnext', 'migrate']
      prog_name = 'bench'
      complete_var = None
      standalone_mode = True
      windows_expand_args = True
      extra = {}
      ctx = <click.core.Context object at 0x10ff9a470>
  File "/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x1101b75b0>
      args = ['migrate']
      cmd_name = 'frappe'
      cmd = <Group frappe>
      sub_ctx = <click.core.Context object at 0x11040fe80>
      ctx = <click.core.Context object at 0x10ff9a470>
      self = <Group None>
      __class__ = <class 'click.core.MultiCommand'>
  File "/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x10fee57e0>
      args = []
      cmd_name = 'migrate'
      cmd = <Command migrate>
      sub_ctx = <click.core.Context object at 0x11238d120>
      ctx = <click.core.Context object at 0x11040fe80>
      self = <Group frappe>
      __class__ = <class 'click.core.MultiCommand'>
  File "/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
      self = <Command migrate>
      ctx = <click.core.Context object at 0x11238d120>
  File "/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
      _Context__self = <click.core.Context object at 0x11238d120>
      _Context__callback = <function migrate at 0x10ff420e0>
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      ctx = <click.core.Context object at 0x11238d120>
  File "/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      f = <function migrate at 0x10ff41ea0>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
      ctx = <click.core.Context object at 0x11238d120>
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      profile = False
      f = <function migrate at 0x10ff41e10>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/commands/site.py", line 605, in migrate
    SiteMigration(
      context = {'sites': ['kartoza.erpnext'], 'force': False, 'verbose': False, 'profile': False}
      skip_failing = False
      skip_search_index = False
      activate_by_import = <module 'traceback_with_variables.activate_by_import' from '/Users/frappetech/Workdesk/develop-bench/env/lib/python3.10/site-packages/traceback_with_variables/activate_by_import.py'>
      SiteMigration = <class 'frappe.migrate.SiteMigration'>
      site = 'kartoza.erpnext'
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/migrate.py", line 179, in run
    self.post_schema_updates()
      self = <frappe.migrate.SiteMigration object at 0x11238d1e0>
      site = 'kartoza.erpnext'
      filelock = <function filelock at 0x10ff07130>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/migrate.py", line 41, in wrapper
    ret = method(*args, **kwargs)
      args = (<frappe.migrate.SiteMigration object at 0x11238d1e0>,)
      kwargs = {}
      method = <function SiteMigration.post_schema_updates at 0x113b5e050>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/migrate.py", line 135, in post_schema_updates
    sync_customizations()
      self = <frappe.migrate.SiteMigration object at 0x11238d1e0>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/modules/utils.py", line 117, in sync_customizations
    sync_customizations_for_doctype(data, folder)
      app = None
      apps = ['frappe', 'erpnext', 'journeys', 'kartoza']
      app_name = 'kartoza'
      module_name = 'kartoza'
      folder = '/Users/frappetech/Workdesk/develop-bench/apps/kartoza/kartoza/kartoza/custom'
      fname = 'employee_benefit_claim.json'
      f = <_io.TextIOWrapper name='/Users/frappetech/Workdesk/develop-bench/apps/kartoza/kartoza/kartoza/custom/employee_benefit_claim.json' mode='r' encoding='UTF-8'>
      data = {'custom_fields': [{'_assign': None, '_comments': None, '_liked_by': None, '_user_tags': None, 'allow_in_quick_entry': 0, 'allow_on_submit': 0, 'bold': 0, 'collapsible': 0, 'collapsible_depends_on': None, 'columns': 0, 'creation': '2022-08-18 10:41:57.128390', 'default': None, 'depends_on': None, 'description': None, 'docstatus': 0, 'dt': 'Employee Benefit Claim', 'fetch_from': None, 'fetch_if_empty': 0, 'fieldname': 'kilometer', 'fieldtype': 'Float', 'hidden': 0, 'hide_border': 0, 'hide_days': 0, 'hide_seconds': 0, 'idx': 12, 'ignore_user_permissions': 0, 'ignore_xss_filter': 0, 'in_global_search': 0, 'in_list_view': 0, 'in_preview': 0, 'in_standard_filter': 0, 'insert_after': 'pay_against_benefit_claim', 'label': 'Kilometer', 'length': 0, 'mandatory_depends_on': None, 'modified': '2022-08-18 10:41:57.128390', 'modified_by': 'Administrator', 'name': 'Employee Benefit Claim-kilometer', 'no_copy': 0, 'non_negative': 0, 'options': None, 'owner': 'Administrator', 'parent': None, 'parentfi...
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/modules/utils.py", line 172, in sync_customizations_for_doctype
    validate_fields_for_doctype(doctype)
      validate_fields_for_doctype = <function validate_fields_for_doctype at 0x11403b760>
      update_schema = True
      sync = <function sync_customizations_for_doctype.<locals>.sync at 0x116042ef0>
      data = {'custom_fields': [{'_assign': None, '_comments': None, '_liked_by': None, '_user_tags': None, 'allow_in_quick_entry': 0, 'allow_on_submit': 0, 'bold': 0, 'collapsible': 0, 'collapsible_depends_on': None, 'columns': 0, 'creation': '2022-08-18 10:41:57.128390', 'default': None, 'depends_on': None, 'description': None, 'docstatus': 0, 'dt': 'Employee Benefit Claim', 'fetch_from': None, 'fetch_if_empty': 0, 'fieldname': 'kilometer', 'fieldtype': 'Float', 'hidden': 0, 'hide_border': 0, 'hide_days': 0, 'hide_seconds': 0, 'idx': 12, 'ignore_user_permissions': 0, 'ignore_xss_filter': 0, 'in_global_search': 0, 'in_list_view': 0, 'in_preview': 0, 'in_standard_filter': 0, 'insert_after': 'pay_against_benefit_claim', 'label': 'Kilometer', 'length': 0, 'mandatory_depends_on': None, 'modified': '2022-08-18 10:41:57.128390', 'modified_by': 'Administrator', 'name': 'Employee Benefit Claim-kilometer', 'no_copy': 0, 'non_negative': 0, 'options': None, 'owner': 'Administrator', 'parent': None, 'parentfi...
      doctype = 'Employee Benefit Claim'
      folder = '/Users/frappetech/Workdesk/develop-bench/apps/kartoza/kartoza/kartoza/custom'
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 1040, in validate_fields_for_doctype
    meta = frappe.get_meta(doctype, cached=False)
      doctype = 'Employee Benefit Claim'
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/__init__.py", line 1195, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
      doctype = 'Employee Benefit Claim'
      cached = False
      frappe = <module 'frappe' from '/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/__init__.py'>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/model/meta.py", line 60, in get_meta
    return Meta(doctype)
      doctype = 'Employee Benefit Claim'
      cached = False
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/model/meta.py", line 117, in __init__
    super().__init__("DocType", doctype)
      self = <Meta: Employee Benefit Claim>
      doctype = 'Employee Benefit Claim'
      __class__ = <class 'frappe.model.meta.Meta'>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/model/document.py", line 107, in __init__
    self.load_from_db()
      self = <Meta: Employee Benefit Claim>
      args = ('DocType', 'Employee Benefit Claim')
      kwargs = {}
      __class__ = <class 'frappe.model.document.Document'>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/model/meta.py", line 123, in load_from_db
    super().load_from_db()
      self = <Meta: Employee Benefit Claim>
      __class__ = <class 'frappe.model.meta.Meta'>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/model/document.py", line 159, in load_from_db
    frappe.throw(
      self = <Meta: Employee Benefit Claim>
      get_value_kwargs = {'for_update': None, 'as_dict': True, 'order_by': None}
      d = None
      __class__ = <class 'frappe.model.document.Document'>
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/__init__.py", line 523, in throw
    msgprint(
      msg = 'DocType Employee Benefit Claim not found'
      exc = <class 'frappe.exceptions.DoesNotExistError'>
      title = None
      is_minimizable = False
      wide = False
      as_list = False
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/__init__.py", line 491, in msgprint
    _raise_exception()
      title = None
      as_table = False
      as_list = False
      indicator = 'red'
      alert = False
      primary_action = None
      is_minimizable = False
      wide = False
      sys = <module 'sys' (built-in)>
      out = {'message': 'DocType Employee Benefit Claim not found', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1}
      _raise_exception = <function msgprint.<locals>._raise_exception at 0x116043f40>
      _strip_html_tags = <functools._lru_cache_wrapper object at 0x1160ece00>
      msg = 'DocType Employee Benefit Claim not found'
      raise_exception = <class 'frappe.exceptions.DoesNotExistError'>
      strip_html_tags = <function strip_html_tags at 0x10d523d00>
      ...skipped... 1 vars
  File "/Users/frappetech/Workdesk/develop-bench/apps/frappe/frappe/__init__.py", line 440, in _raise_exception
    raise raise_exception(msg)
      msg = 'DocType Employee Benefit Claim not found'
      raise_exception = <class 'frappe.exceptions.DoesNotExistError'>
      ...skipped... 1 vars
frappe.exceptions.DoesNotExistError: DocType Employee Benefit Claim not found
```

### After fix

<img width="739" alt="Screenshot 2023-04-10 at 11 15 47 AM" src="https://user-images.githubusercontent.com/3784093/230835003-4b02a798-f9b9-4b72-82fa-a164ecc382c0.png">
