### PR TITLE
fix(pretty-date): plural form when the value is 1

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1551,15 +1551,15 @@ def pretty_date(iso_datetime: datetime.datetime | str) -> str:
 		return _("Yesterday")
 	elif dt_diff_days < 7.0:
 		return _("{0} days ago").format(cint(dt_diff_days))
-	elif dt_diff_days < 12:
+	elif dt_diff_days < 14:
 		return _("1 week ago")
 	elif dt_diff_days < 31.0:
 		return _("{0} weeks ago").format(dt_diff_days // 7)
-	elif dt_diff_days < 46:
+	elif dt_diff_days < 61.0:
 		return _("1 month ago")
 	elif dt_diff_days < 365.0:
 		return _("{0} months ago").format(dt_diff_days // 30)
-	elif dt_diff_days < 550.0:
+	elif dt_diff_days < 730.0:
 		return _("1 year ago")
 	else:
 		return _("{0} years ago").format(dt_diff_days // 365)


### PR DESCRIPTION
Fix the pretty_date utility function providing plural form of units with value 1

![image](https://user-images.githubusercontent.com/63963181/230591059-49b95f0d-c0e4-4987-b20b-4cebdbb8b2cf.png)
