### PR TITLE
fix: Validate default values

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1434,9 +1434,7 @@ def validate_fields(meta):
 	def validate_default_values(docfield):
 		if docfield.get("default"):
 			if docfield.fieldtype == "Int":
-				try:
-					int(docfield.default)
-				except ValueError:
+				if not isinstance(docfield.default, int):
 					frappe.throw(
 						_("Default value for field {0} must be an integer").format(frappe.bold(docfield.label)),
 						title=_("Invalid Value"),

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1188,6 +1188,21 @@ def validate_fields(meta):
 					_("Default value for {0} must be in the list of options.").format(frappe.bold(d.fieldname))
 				)
 
+		if d.default and d.fieldtype == "Int":
+			if not isinstance(d.default, int):
+				frappe.throw(
+					_("Default value for field {0} must be an integer").format(frappe.bold(d.label)),
+					title=_("Invalid Value"),
+				)
+		if d.default and d.fieldtype in ["Percent", "Float"]:
+			try:
+				float(d.default)
+			except ValueError:
+				frappe.throw(
+					_("Default value for field {0} must be a number").format(frappe.bold(d.label)),
+					title=_("Invalid Value"),
+				)
+
 	def check_unique_and_text(docname, d):
 		if meta.is_virtual:
 			return
@@ -1431,23 +1446,6 @@ def validate_fields(meta):
 			if docfield.options and (int(docfield.options) > 10 or int(docfield.options) < 3):
 				frappe.throw(_("Options for Rating field can range from 3 to 10"))
 
-	def validate_default_values(docfield):
-		if docfield.get("default"):
-			if docfield.fieldtype == "Int":
-				if not isinstance(docfield.default, int):
-					frappe.throw(
-						_("Default value for field {0} must be an integer").format(frappe.bold(docfield.label)),
-						title=_("Invalid Value"),
-					)
-			elif docfield.fieldtype in ["Percent", "Float"]:
-				try:
-					float(docfield.default)
-				except ValueError:
-					frappe.throw(
-						_("Default value for field {0} must be a number").format(frappe.bold(docfield.label)),
-						title=_("Invalid Value"),
-					)
-
 	fields = meta.get("fields")
 	fieldname_list = [d.fieldname for d in fields]
 
@@ -1471,7 +1469,6 @@ def validate_fields(meta):
 		scrub_options_in_select(d)
 		scrub_fetch_from(d)
 		validate_data_field_type(d)
-		validate_default_values(d)
 
 		if not frappe.flags.in_migrate:
 			check_link_table_options(meta.get("name"), d)

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -719,7 +719,7 @@ class TestDocType(FrappeTestCase):
 		self.assertTrue(doctype.fields[1].in_list_view)
 		frappe.delete_doc("DocType", doctype.name)
 
-	def test_default_value_validate(self):
+	def test_validate_default_value(self):
 		"""Test default value validation."""
 		doctype = new_doctype(
 			fields=[

--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -719,6 +719,34 @@ class TestDocType(FrappeTestCase):
 		self.assertTrue(doctype.fields[1].in_list_view)
 		frappe.delete_doc("DocType", doctype.name)
 
+	def test_default_value_validate(self):
+		"""Test default value validation."""
+		doctype = new_doctype(
+			fields=[
+				{
+					"fieldname": "some_field",
+					"fieldtype": "Float",
+					"label": "Some Field",
+					"default": "100%",
+				},
+			],
+		)
+
+		self.assertRaises(frappe.ValidationError, doctype.insert)
+
+		doctype = new_doctype(
+			fields=[
+				{
+					"fieldname": "some_field",
+					"fieldtype": "Int",
+					"label": "Some Field",
+					"default": 99.5,
+				},
+			],
+		)
+
+		self.assertRaises(frappe.ValidationError, doctype.insert)
+
 
 def new_doctype(
 	name: str | None = None,

--- a/frappe/custom/doctype/property_setter/property_setter.py
+++ b/frappe/custom/doctype/property_setter/property_setter.py
@@ -16,7 +16,6 @@ class PropertySetter(Document):
 
 	def validate(self):
 		self.validate_fieldtype_change()
-		self.validate_default_value()
 
 		if self.is_new():
 			delete_property_setter(self.doc_type, self.property, self.field_name, self.row_name)
@@ -25,29 +24,6 @@ class PropertySetter(Document):
 	def validate_fieldtype_change(self):
 		if self.property == "fieldtype" and self.field_name in not_allowed_fieldtype_change:
 			frappe.throw(_("Field type cannot be changed for {0}").format(self.field_name))
-
-	def validate_default_value(self):
-		if self.property == "default":
-			field_meta = frappe.get_meta(self.doc_type).get_field(self.field_name)
-			fieldtype = field_meta.fieldtype
-			label = field_meta.label
-
-			if fieldtype == "Int":
-				try:
-					int(self.value)
-				except ValueError:
-					frappe.throw(
-						_("Default value for field {0} must be an integer").format(frappe.bold(label)),
-						title=_("Invalid Value"),
-					)
-			elif fieldtype in ["Percent", "Float"]:
-				try:
-					float(self.value)
-				except ValueError:
-					frappe.throw(
-						_("Default value for field {0} must be a number").format(frappe.bold(label)),
-						title=_("Invalid Value"),
-					)
 
 	def on_update(self):
 		if frappe.flags.in_patch:


### PR DESCRIPTION
Recipe to break your site migration: Go and set a string value as Default for any Int or Float field, now whenever the doctype is synced again (reloaded) migrate will fail

<img width="713" alt="image" src="https://user-images.githubusercontent.com/42651287/230616743-bdc9b90b-43d4-4dbc-8e0f-016c4b22c2d3.png">

Right now there aren't many validations on the default value based on the field type. Staring by adding some basic validation for numeric fields