### PR TITLE
fix: consider user email if send me a copy is checked

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -66,11 +66,16 @@ class CommunicationEmailMixin:
 
 		cc = self.cc_list()
 
-		# Need to inform parent document owner incase communication is created through inbound mail
 		if include_sender:
-			cc.append(self.sender_mailid)
+			sender = self.sender_mailid
+			# if user has selected send_me_a_copy, use their email as sender
+			if frappe.session.user not in frappe.STANDARD_USERS:
+				sender = frappe.db.get_value("User", frappe.session.user, "email")
+			cc.append(sender)
+
 		if is_inbound_mail_communcation:
-			if (doc_owner := self.get_owner()) and (doc_owner not in frappe.STANDARD_USERS):
+			# inform parent document owner incase communication is created through inbound mail
+			if doc_owner := self.get_owner():
 				cc.append(doc_owner)
 			cc = set(cc) - {self.sender_mailid}
 			cc.update(self.get_assignees())
@@ -82,7 +87,7 @@ class CommunicationEmailMixin:
 		if is_inbound_mail_communcation:
 			cc = cc - set(self.cc_list() + self.to_list())
 
-		self._final_cc = [m for m in cc if m not in frappe.STANDARD_USERS]
+		self._final_cc = [m for m in cc if m and m not in frappe.STANDARD_USERS]
 		return self._final_cc
 
 	def get_mail_cc_with_displayname(self, is_inbound_mail_communcation=False, include_sender=False):


### PR DESCRIPTION
Considers user's email by default when they have checked "Send Me a Copy" in Communications/Email dialog.