### PR TITLE
fix: log requests even if no response

### DIFF
--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -89,8 +89,11 @@ class Monitor:
 			self.data.duration = int(timediff.total_seconds() * 1000000)
 
 			if self.data.transaction_type == "request":
-				self.data.request.status_code = response.status_code
-				self.data.request.response_length = int(response.headers.get("Content-Length", 0))
+				if response:
+					self.data.request.status_code = response.status_code
+					self.data.request.response_length = int(response.headers.get("Content-Length", 0))
+				else:
+					self.data.request.status_code = 500
 
 				if hasattr(frappe.local, "rate_limiter"):
 					limiter = frappe.local.rate_limiter

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -33,6 +33,20 @@ class TestMonitor(FrappeTestCase):
 		self.assertEqual(log.transaction_type, "request")
 		self.assertEqual(log.request["method"], "GET")
 
+	def test_no_response(self):
+		set_request(method="GET", path="/api/method/frappe.ping")
+
+		frappe.monitor.start()
+		frappe.monitor.stop(response=None)
+
+		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		self.assertEqual(len(logs), 1)
+
+		log = frappe.parse_json(logs[0].decode())
+		self.assertEqual(log.request["status_code"], 500)
+		self.assertEqual(log.transaction_type, "request")
+		self.assertEqual(log.request["method"], "GET")
+
 	def test_job(self):
 		frappe.utils.background_jobs.execute_job(
 			frappe.local.site, "frappe.ping", None, None, {}, is_async=False


### PR DESCRIPTION
If web worker fails to respond or response is empty it should still be logged.


Failing right now


```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/monitor.py", line 82, in dump
    self.data.request.status_code = response.status_code
AttributeError: 'NoneType' object has no attribute 'status_code'
```
