### PR TITLE
fix(translations)!: load translation in installed app order

### DIFF
--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe import _
 from frappe.tests.utils import FrappeTestCase
-from frappe.translate import APP_TRANSLATION_KEY, clear_cache
+from frappe.translate import clear_cache
 
 
 class TestTranslation(FrappeTestCase):
@@ -37,20 +37,16 @@ class TestTranslation(FrappeTestCase):
 
 		frappe.local.lang = "es"
 
-		clear_translation_cache()
 		self.assertTrue(_(data[0][0]), data[0][1])
 
-		clear_translation_cache()
 		self.assertTrue(_(data[1][0]), data[1][1])
 
 		frappe.local.lang = "es-MX"
 
 		# different translation for es-MX
-		clear_translation_cache()
 		self.assertTrue(_(data[2][0]), data[2][1])
 
 		# from spanish (general)
-		clear_translation_cache()
 		self.assertTrue(_(data[1][0]), data[1][1])
 
 	def test_multi_language_translations(self):
@@ -112,7 +108,3 @@ def create_translation(key, val):
 	translation.translated_text = val[1]
 	translation.save()
 	return translation
-
-
-def clear_translation_cache():
-	frappe.cache().delete_key(APP_TRANSLATION_KEY)

--- a/frappe/core/doctype/translation/test_translation.py
+++ b/frappe/core/doctype/translation/test_translation.py
@@ -3,7 +3,7 @@
 import frappe
 from frappe import _
 from frappe.tests.utils import FrappeTestCase
-from frappe.translate import clear_cache
+from frappe.translate import APP_TRANSLATION_KEY, clear_cache
 
 
 class TestTranslation(FrappeTestCase):
@@ -115,4 +115,4 @@ def create_translation(key, val):
 
 
 def clear_translation_cache():
-	frappe.cache().delete_key("translations_from_apps", shared=True)
+	frappe.cache().delete_key(APP_TRANSLATION_KEY)

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 import frappe
 import frappe.translate
 from frappe import _
-from frappe.core.doctype.translation.test_translation import clear_translation_cache
 from frappe.tests.utils import FrappeTestCase
 from frappe.translate import (
 	extract_javascript,
@@ -39,14 +38,10 @@ class TestTranslate(FrappeTestCase):
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Guest")
 
-		clear_translation_cache()
-
 	def tearDown(self):
 		frappe.form_dict.pop("_lang", None)
 		if self._testMethodName in self.guest_sessions_required:
 			frappe.set_user("Administrator")
-
-		clear_translation_cache()
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)


### PR DESCRIPTION
- translations are loaded in apps.txt order this doesnt make much sense.
- translations are loaded from apps which aren't even installed, again
  doesn't make sense.

Breaking but necessary change.

closes https://github.com/frappe/frappe/issues/20621



This order can be changed on site: https://github.com/frappe/frappe/pull/19653