### PR TITLE
refactor: set docfield options without method

### DIFF
--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -40,17 +40,21 @@ frappe.ui.form.on("Workflow", {
 	},
 	update_field_options: function (frm) {
 		var doc = frm.doc;
-		if (doc.document_type) {
-			const get_field_method =
-				"frappe.workflow.doctype.workflow.workflow.get_fieldnames_for";
-			frappe.xcall(get_field_method, { doctype: doc.document_type }).then((resp) => {
-				frm.fields_dict.states.grid.update_docfield_property(
-					"update_field",
-					"options",
-					[""].concat(resp)
-				);
-			});
+		if (!doc.document_type) {
+			return;
 		}
+		frappe.model.with_doctype(doc.document_type, () => {
+			const fieldnames = frappe
+				.get_meta(doc.document_type)
+				.fields.filter((field) => !frappe.model.no_value_type.includes(field.fieldtype))
+				.map((field) => field.fieldname);
+
+			frm.fields_dict.states.grid.update_docfield_property(
+				"update_field",
+				"options",
+				[""].concat(fieldnames)
+			);
+		});
 	},
 	create_warning_dialog: function (frm) {
 		const warning_html = `<p class="bold">

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -125,14 +125,6 @@ class Workflow(Document):
 
 
 @frappe.whitelist()
-def get_fieldnames_for(doctype):
-	frappe.has_permission(doctype=doctype, ptype='read', throw=True)
-	return [
-		f.fieldname for f in frappe.get_meta(doctype).fields if f.fieldname not in no_value_fields
-	]
-
-
-@frappe.whitelist()
 def get_workflow_state_count(doctype, workflow_state_field, states):
 	frappe.has_permission(doctype=doctype, ptype='read', throw=True)
 	states = frappe.parse_json(states)


### PR DESCRIPTION
- the whitelisted method is not required, all this data is available on client side. 
- f.fieldname is checked against no value "types" it never worked the way it's supposed to. 