### PR TITLE
refactor: pretty_date

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -611,12 +611,12 @@ class TestDateUtils(FrappeTestCase):
 		now = get_datetime()
 
 		test_cases = {
-			now: _("just now"),
+			now: _("1 second ago"),
 			add_to_date(now, minutes=-1): _("1 minute ago"),
 			add_to_date(now, minutes=-3): _("3 minutes ago"),
 			add_to_date(now, hours=-1): _("1 hour ago"),
 			add_to_date(now, hours=-2): _("2 hours ago"),
-			add_to_date(now, days=-1): _("Yesterday"),
+			add_to_date(now, days=-1): _("1 day ago"),
 			add_to_date(now, days=-5): _("5 days ago"),
 			add_to_date(now, days=-8): _("1 week ago"),
 			add_to_date(now, days=-14): _("2 weeks ago"),

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1518,51 +1518,16 @@ def pretty_date(iso_datetime: datetime.datetime | str) -> str:
 	long ago the date represents.
 	Ported from PrettyDate by John Resig
 	"""
-	from frappe import _
-
 	if not iso_datetime:
 		return ""
-	import math
+
+	from babel.dates import format_timedelta
 
 	if isinstance(iso_datetime, str):
 		iso_datetime = datetime.datetime.strptime(iso_datetime, DATETIME_FORMAT)
 	now_dt = datetime.datetime.strptime(now(), DATETIME_FORMAT)
-	dt_diff = now_dt - iso_datetime
-
-	# available only in python 2.7+
-	# dt_diff_seconds = dt_diff.total_seconds()
-
-	dt_diff_seconds = dt_diff.days * 86400.0 + dt_diff.seconds
-
-	dt_diff_days = math.floor(dt_diff_seconds / 86400.0)
-
-	# differnt cases
-	if dt_diff_seconds < 60.0:
-		return _("just now")
-	elif dt_diff_seconds < 120.0:
-		return _("1 minute ago")
-	elif dt_diff_seconds < 3600.0:
-		return _("{0} minutes ago").format(cint(math.floor(dt_diff_seconds / 60.0)))
-	elif dt_diff_seconds < 7200.0:
-		return _("1 hour ago")
-	elif dt_diff_seconds < 86400.0:
-		return _("{0} hours ago").format(cint(math.floor(dt_diff_seconds / 3600.0)))
-	elif dt_diff_days == 1.0:
-		return _("Yesterday")
-	elif dt_diff_days < 7.0:
-		return _("{0} days ago").format(cint(dt_diff_days))
-	elif dt_diff_days < 14:
-		return _("1 week ago")
-	elif dt_diff_days < 31.0:
-		return _("{0} weeks ago").format(dt_diff_days // 7)
-	elif dt_diff_days < 61.0:
-		return _("1 month ago")
-	elif dt_diff_days < 365.0:
-		return _("{0} months ago").format(dt_diff_days // 30)
-	elif dt_diff_days < 730.0:
-		return _("1 year ago")
-	else:
-		return _("{0} years ago").format(dt_diff_days // 365)
+	locale = frappe.local.lang.replace("-", "_") if frappe.local.lang else None
+	return format_timedelta(iso_datetime - now_dt, add_direction=True, locale=locale)
 
 
 def comma_or(some_list, add_quotes=True):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1514,9 +1514,9 @@ def escape_html(text: str) -> str:
 
 def pretty_date(iso_datetime: datetime.datetime | str) -> str:
 	"""
-	Takes an ISO time and returns a string representing how
-	long ago the date represents.
-	Ported from PrettyDate by John Resig
+	Return a localized string representation of the delta to the current system time.
+
+	For example, "1 hour ago", "2 days ago", "in 5 seconds", etc.
 	"""
 	if not iso_datetime:
 		return ""


### PR DESCRIPTION
- Use babel's `format_timedelta` instead of reinventing the wheel
- We gain perfect localization and looking into the future ("in 5 hours")
- We lose "Yesterday" and "just now" as special cases (becoming "1 day ago" and "1 second ago")