### PR TITLE
refactor: use `urljoin` to build oauth picture path

### DIFF
--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -3,7 +3,7 @@ import datetime
 import hashlib
 import re
 from http import cookies
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote, urlparse, urljoin
 
 import jwt
 import pytz
@@ -575,7 +575,7 @@ def get_userinfo(user):
 		if frappe.utils.validate_url(user.user_image, valid_schemes=valid_url_schemes):
 			picture = user.user_image
 		else:
-			picture = frappe_server_url + "/" + user.user_image
+			picture = urljoin(frappe_server_url, user.user_image)
 
 	userinfo = frappe._dict(
 		{


### PR DESCRIPTION
In OAuth reponse:

![CleanShot 2023-04-12 at 11 58 49@2x](https://user-images.githubusercontent.com/34810212/231370257-db56e7d0-ca1a-4e22-b160-7b7a1922b4ef.png)
