### PR TITLE
fix: use frappe.log_error in EmailServer exception handling

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -151,7 +151,7 @@ class EmailServer:
 
 		except _socket.error:
 			# log performs rollback and logs error in Error Log
-			self.log_error("POP: Unable to connect")
+			frappe.log_error("POP: Unable to connect")
 
 			# Invalid mail server -- due to refusing connection
 			frappe.msgprint(_("Invalid Mail Server. Please rectify and try again."))
@@ -332,7 +332,7 @@ class EmailServer:
 
 			else:
 				# log performs rollback and logs error in Error Log
-				self.log_error("Unable to fetch email", self.make_error_msg(msg_num, incoming_mail))
+				frappe.log_error("Unable to fetch email", self.make_error_msg(msg_num, incoming_mail))
 				self.errors = True
 				frappe.db.rollback()
 


### PR DESCRIPTION
Fixes following exception 
```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/email/doctype/email_account/email_account.py", line 504, in get_inbound_mails
    messages = email_server.get_messages() or {}
      process_mail = <function EmailAccount.get_inbound_mails.<locals>.process_mail at 0x7eff20aecc10>
      email_sync_rule = 'UNSEEN'
      email_server = <frappe.email.receive.EmailServer object at 0x7eff20df2620>
      mails = []
  File "apps/frappe/frappe/email/receive.py", line 213, in get_messages
 File "apps/frappe/frappe/email/receive.py", line 335, in retrieve_message
    self.log_error("Unable to fetch email", self.make_error_msg(msg_num, incoming_mail))
      self = <frappe.email.receive.EmailServer object at 0x7eff20df2620>
      message_meta = b'1 76271'
      msg_num = 1
      incoming_mail = None
builtins.AttributeError: 'EmailServer' object has no attribute 'log_error'
```

Bug got introduced via https://github.com/frappe/frappe/pull/16653