### PR TITLE
fix: if file is a URL then email attachment throwing error

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -23,6 +23,9 @@ from frappe.utils.image import optimize_image, strip_exif_data
 from .exceptions import AttachmentLimitReached, FolderNotEmpty, MaxFileSizeReachedError
 from .utils import *
 
+import tempfile
+import urllib.request
+
 exclude_from_linked_with = True
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 URL_PREFIXES = ("http://", "https://")
@@ -457,10 +460,15 @@ class File(Document):
 
 		if self.file_url:
 			self.validate_file_url()
+			tmp_file = None
+			if(self.file_url.startswith(URL_PREFIXES)):
+				with urllib.request.urlopen(self.file_url) as response:
+					with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+						shutil.copyfileobj(response, tmp_file)
 		file_path = self.get_full_path()
 
 		# read the file
-		with open(file_path, mode="rb") as f:
+		with open(tmp_file or file_path, mode="rb") as f:
 			self._content = f.read()
 			try:
 				# for plain text files


### PR DESCRIPTION
fix: if file is a URL then email attachment throwing error

If URL attachment is added in an email
![Screenshot from 2023-03-22 15-12-51](https://user-images.githubusercontent.com/48860013/231442600-d81fabcc-f373-4f91-a4d7-4ed69f2bb1aa.png)

Although don't know if this is the right way to implement it, do let me know the same.
The pull request is against issue: #20430 and as we all know the Pull request is the fastest way to get a reply from Frappe instead of raising the Issue.