### PR TITLE
fix: group buttons are overlapping

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -243,6 +243,8 @@ $input-height: 28px !default;
 	--highlight-color: var(--gray-50);
 	--yellow-highlight-color: var(--yellow-50);
 
+	--btn-group-border-color: var(--gray-300);
+
 	--field-placeholder-color: var(--gray-50);
 
 	--highlight-shadow: 1px 1px 10px var(--blue-50), 0px 0px 4px var(--blue-600);

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -100,6 +100,8 @@
 	--highlight-color: var(--gray-700);
 	--yellow-highlight-color: var(--yellow-700);
 
+	--btn-group-border-color: var(--gray-800);
+
 	--field-placeholder-color: var(--gray-700);
 
 	--highlight-shadow: 1px 1px 10px var(--blue-900), 0px 0px 4px var(--blue-500);

--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -234,6 +234,21 @@ h2 {
 	font-size: var(--text-md);
 }
 
+.btn-group {
+	.btn {
+		box-shadow: none;
+		outline: 1px solid var(--btn-group-border-color);
+
+		&:not(:first-child) {
+			margin-left: 1px;
+		}
+
+		&:focus {
+			outline: 2px solid var(--dark-border-color);
+		}
+	}
+}
+
 .btn-xs {
 	@extend .btn-sm;
 	line-height: 1.2;

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -189,29 +189,12 @@ $level-margin-right: 8px;
 .list-paging-area, .footnote-area {
 	border-top: 1px solid var(--border-color);
 
-	.btn-group {
-		box-shadow: var(--drop-shadow);
-		border-radius: var(--border-radius-md);
-
-		&> .btn:nth-child(2) {
-			border-left: none;
-			border-right: none;
-		}
-
-		.btn-paging {
-			box-shadow: none;
-			margin-left: 0px !important;
-			border: 1px solid var(--dark-border-color);
-
-			&.btn-info {
-				background-color: var(--gray-600);
-				border-color: var(--gray-600);
-				color: var(--white);
-				font-weight: var(--text-bold);
-			}
-		}
+	.btn-group .btn-paging.btn-info {
+		background-color: var(--gray-600);
+		border-color: var(--gray-600);
+		color: var(--white);
+		font-weight: var(--text-bold);
 	}
-
 }
 
 .frappe-card {


### PR DESCRIPTION
Before: 

https://user-images.githubusercontent.com/30859809/231439557-03cda4a9-d1c1-4ee9-a5b0-c49e1c7b57a4.mov

After:

https://user-images.githubusercontent.com/30859809/231439511-d49d859e-c970-4e23-a174-05d52c550fed.mov

