### PR TITLE
fix: pull from email account every 10 mins instead of 4 mins (by default)

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -186,11 +186,13 @@ scheduler_events = {
 			"frappe.oauth.delete_oauth2_data",
 			"frappe.website.doctype.web_page.web_page.check_publish_status",
 			"frappe.twofactor.delete_all_barcodes_for_users",
-		]
+		],
+		"0/10 * * * *": [
+			"frappe.email.doctype.email_account.email_account.pull",
+		],
 	},
 	"all": [
 		"frappe.email.queue.flush",
-		"frappe.email.doctype.email_account.email_account.pull",
 		"frappe.email.doctype.email_account.email_account.notify_unreplied",
 		"frappe.utils.global_search.sync_global_search",
 		"frappe.monitor.flush",


### PR DESCRIPTION
reason for doing this: https://support.google.com/mail/?p=BadCredentials

> Make sure your mail app isn't set to check for new email too frequently. If your mail app checks for new messages more than once every 10 minutes, the app’s access to your account could be blocked

imo it doesnt matter much if we pull every 10 mins. Open to suggestions.