### PR TITLE
Fix: 'TypeError' object has no attribute 'message'

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -368,7 +368,10 @@ class EmailServer:
 			self.seen_status.update({uid: "UNSEEN"})
 
 	def has_login_limit_exceeded(self, e):
-		return "-ERR Exceeded the login limit" in strip(cstr(e.message))
+		if hasattr(e, "message"):
+			return "-ERR Exceeded the login limit" in strip(cstr(e.message))
+		else: #'TypeError' object has no attribute 'message'
+			return ""
 
 	def is_temporary_system_problem(self, e):
 		messages = (


### PR DESCRIPTION
The generated error may not contain the 'message' attribute, which raises another error!