### PR TITLE
fix: remove guest permission from language

### DIFF
--- a/frappe/core/doctype/language/language.json
+++ b/frappe/core/doctype/language/language.json
@@ -51,7 +51,7 @@
  "icon": "fa fa-globe",
  "in_create": 1,
  "links": [],
- "modified": "2023-04-12 19:39:06.158183",
+ "modified": "2023-04-13 12:18:38.127995",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Language",
@@ -64,6 +64,10 @@
    "read": 1,
    "role": "System Manager",
    "write": 1
+  },
+  {
+   "role": "All",
+   "select": 1
   }
  ],
  "search_fields": "language_name",

--- a/frappe/core/doctype/language/language.json
+++ b/frappe/core/doctype/language/language.json
@@ -51,7 +51,7 @@
  "icon": "fa fa-globe",
  "in_create": 1,
  "links": [],
- "modified": "2023-04-13 12:18:38.127995",
+ "modified": "2023-04-13 13:48:38.127995",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Language",
@@ -67,7 +67,7 @@
   },
   {
    "role": "All",
-   "select": 1
+   "read": 1
   }
  ],
  "search_fields": "language_name",

--- a/frappe/core/doctype/language/language.json
+++ b/frappe/core/doctype/language/language.json
@@ -51,7 +51,7 @@
  "icon": "fa fa-globe",
  "in_create": 1,
  "links": [],
- "modified": "2022-08-14 18:54:03.490836",
+ "modified": "2023-04-12 19:39:06.158183",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Language",
@@ -64,15 +64,6 @@
    "read": 1,
    "role": "System Manager",
    "write": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Guest",
-   "share": 1
   }
  ],
  "search_fields": "language_name",


### PR DESCRIPTION
I don't see a reason why we need this. The language picker on the website works without permissions. Any other use cases?

