### PR TITLE
refactor: replace imghdr with filetype

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -17,6 +17,7 @@ from frappe.core.api.file import (
 	move_file,
 	unzip_file,
 )
+from frappe.core.doctype.file.utils import get_extension
 from frappe.exceptions import ValidationError
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_files_path
@@ -739,3 +740,10 @@ class TestFileOptimization(FrappeTestCase):
 			size_after_rollback = os.stat(image_path).st_size
 
 			self.assertEqual(size_before_optimization, size_after_rollback)
+
+	def test_image_header_guessing(self):
+		file_path = frappe.get_app_path("frappe", "tests/data/sample_image_for_optimization.jpg")
+		with open(file_path, "rb") as f:
+			file_content = f.read()
+
+		self.assertEqual(get_extension("", None, file_content), "jpeg")

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -76,11 +76,11 @@ def get_extension(
 
 		mimetype = mimetypes.guess_type(filename + "." + extn)[0]
 
-	if mimetype is None or not mimetype.startswith("image/") and content:
-		# detect file extension by reading image header properties
-		_type_info = filetype.image_match(content)
+	if mimetype is None and extn is None and content:
+		# detect file extension by using filetype matchers
+		_type_info = filetype.match(content)
 		if _type_info:
-			extn = _type_info.mime.split("/")[1]
+			extn = _type_info.extension
 
 	return extn
 

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -1,5 +1,4 @@
 import hashlib
-import imghdr
 import mimetypes
 import os
 import re
@@ -7,6 +6,7 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Optional
 from urllib.parse import unquote
 
+import filetype
 import requests
 import requests.exceptions
 from PIL import Image
@@ -78,7 +78,9 @@ def get_extension(
 
 	if mimetype is None or not mimetype.startswith("image/") and content:
 		# detect file extension by reading image header properties
-		extn = imghdr.what(filename + "." + (extn or ""), h=content)
+		_type_info = filetype.image_match(content)
+		if _type_info:
+			extn = _type_info.mime.split("/")[1]
 
 	return extn
 

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -3,7 +3,7 @@ import datetime
 import hashlib
 import re
 from http import cookies
-from urllib.parse import unquote, urlparse, urljoin
+from urllib.parse import unquote, urljoin, urlparse
 
 import jwt
 import pytz

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -126,7 +126,7 @@ class Workflow(Document):
 
 @frappe.whitelist()
 def get_workflow_state_count(doctype, workflow_state_field, states):
-	frappe.has_permission(doctype=doctype, ptype='read', throw=True)
+	frappe.has_permission(doctype=doctype, ptype="read", throw=True)
 	states = frappe.parse_json(states)
 	result = frappe.get_all(
 		doctype,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "Babel~=2.12.1",
     "Click~=8.1.3",
     "filelock~=3.8.0",
+    "filetype~=1.2.0",
     "GitPython~=3.1.30",
     "Jinja2~=3.1.2",
     "Pillow~=9.3.0",


### PR DESCRIPTION
- `imghdr` will be removed in python 3.12
- replaced it with `filetype`
- expand scope to more than just images. 