### PR TITLE
fix: allow rename for workflow action master

### DIFF
--- a/frappe/workflow/doctype/workflow_action_master/workflow_action_master.json
+++ b/frappe/workflow/doctype/workflow_action_master/workflow_action_master.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "autoname": "field:workflow_action_name",
+ "allow_rename": 1,
  "creation": "2012-12-28 10:49:56",
  "description": "Workflow Action Master",
  "doctype": "DocType",
@@ -21,7 +22,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2022-08-03 12:20:52.449982",
+ "modified": "2023-04-14 12:20:52.449982",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Action Master",


### PR DESCRIPTION
allow to rename work flow action masters will help to consolidate and make sure that typos can be corrected at ease
