### PR TITLE
feat: display Edit button in workspace only if the workspace page is editable

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -412,18 +412,20 @@ frappe.views.Workspace = class Workspace {
 
 		this.clear_page_actions();
 
-		this.page.set_secondary_action(__("Edit"), async () => {
-			if (!this.editor || !this.editor.readOnly) return;
-			this.is_read_only = false;
-			this.toggle_hidden_workspaces(true);
-			await this.editor.readOnly.toggle();
-			this.editor.isReady.then(() => {
-				this.initialize_editorjs_undo();
-				this.setup_customization_buttons(current_page);
-				this.show_sidebar_actions();
-				this.make_blocks_sortable();
+		if (current_page.is_editable) {
+			this.page.set_secondary_action(__("Edit"), async () => {
+				if (!this.editor || !this.editor.readOnly) return;
+				this.is_read_only = false;
+				this.toggle_hidden_workspaces(true);
+				await this.editor.readOnly.toggle();
+				this.editor.isReady.then(() => {
+					this.initialize_editorjs_undo();
+					this.setup_customization_buttons(current_page);
+					this.show_sidebar_actions();
+					this.make_blocks_sortable();
+				});
 			});
-		});
+		}
 
 		this.page.add_inner_button(__("Create Workspace"), () => {
 			this.initialize_new_page();


### PR DESCRIPTION


https://user-images.githubusercontent.com/818803/232070494-cdd1a043-a964-4c6b-85e8-90613cd6c81a.mp4

This should fix #20712 such that user's will only see the "Edit" workspace button only if they are allowed to. Hopefully, I didn't miss something obvious.
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
