### PR TITLE
fix: set default user value only if enabled

### DIFF
--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -290,10 +290,9 @@ $.extend(frappe.perm, {
 		const allowed_docs = filtered_perms.map((perm) => perm.doc);
 
 		if (with_default_doc) {
-			const default_doc =
-				allowed_docs.length === 1
-					? allowed_docs
-					: filtered_perms.filter((perm) => perm.is_default).map((record) => record.doc);
+			const default_doc = filtered_perms
+				.filter((perm) => perm.is_default)
+				.map((record) => record.doc);
 
 			return {
 				allowed_records: allowed_docs,


### PR DESCRIPTION
Following is the screenshot of the setting in user permission:

![image](https://user-images.githubusercontent.com/10496564/232229505-e72bae0e-398b-4de3-9f5e-0398119b3866.png)

**Existing Behaviour:**
- If there is only one user permission (say for warehouse), its always set as default in all doctypes.
- If there are more than one permission for the warehouse, it will identify default as per settings.

**Issue:**
When there is more than one Warehouse field in a doctype, it sets the default for all the fields. Most of the time, it's not supposed to be the same. eg: from_warehouse has to be different from to_warehouse.