### PR TITLE
fix: format filter values in report print view

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1424,9 +1424,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		const applied_filters = this.get_filter_values();
 		return Object.keys(applied_filters)
 			.map((fieldname) => {
-				const label = frappe.query_report.get_filter(fieldname).df.label;
+				const docfield = frappe.query_report.get_filter(fieldname).df;
 				const value = applied_filters[fieldname];
-				return `<h6>${__(label)}: ${value}</h6>`;
+				return `<h6>${__(docfield.label)}: ${frappe.format(value, docfield)}</h6>`;
 			})
 			.join("");
 	}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1349,9 +1349,8 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			.map((f) => {
 				const [doctype, fieldname, condition, value] = f;
 				if (condition !== "=") return "";
-
-				const label = frappe.meta.get_label(doctype, fieldname);
-				return `<h6>${__(label)}: ${value}</h6>`;
+				const docfield = frappe.meta.get_docfield(doctype, fieldname);
+				return `<h6>${__(docfield.label)}: ${frappe.format(value, docfield)}</h6>`;
 			})
 			.join("");
 	}


### PR DESCRIPTION
#### Existing behavior:
Currently, when printing a report, the values of the filter overview at the top of the document don't get formatted but inserted as raw values.

#### Changes in `query_report.js` and `report_view.js`:
The filter's values now get formatted with `frappe.format()` when generating the html for the print view. This should handle all fieldtypes accordingly (I haven't tested it with all fieldtypes though).

In the before/after screenshots below you can see that:
- Select and data fields get translated, if there is a translation for the string.
- Link fields resolve the doc's title correctly
- Date and time fields get localized

Before:
<img width="178" alt="Screenshot 2023-04-15 232157" src="https://user-images.githubusercontent.com/60393001/232254367-92b5eda3-8489-4ee6-8f01-c49f2407fd3a.png">

After:
<img width="178" alt="Screenshot 2023-04-15 232224" src="https://user-images.githubusercontent.com/60393001/232254372-2c5e87fb-063b-4a03-a74b-aef97e3bd942.png">
