### PR TITLE
fix: remove desk access for Guest in post_model_sync

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -168,7 +168,6 @@ execute:frappe.db.set_default('desktop:home_page', 'space')
 execute:frappe.delete_doc_if_exists('Page', 'workspace')
 execute:frappe.delete_doc_if_exists('Page', 'dashboard', force=1)
 frappe.core.doctype.page.patches.drop_unused_pages
-execute:frappe.get_doc('Role', 'Guest').save() # remove desk access
 frappe.patches.v13_0.remove_chat
 frappe.patches.v13_0.rename_desk_page_to_workspace # 02.02.2021
 frappe.patches.v13_0.delete_package_publish_tool
@@ -199,6 +198,7 @@ frappe.patches.v15_0.remove_event_streaming
 frappe.patches.v15_0.copy_disable_prepared_report_to_prepared_report
 
 [post_model_sync]
+execute:frappe.get_doc('Role', 'Guest').save() # remove desk access
 frappe.core.doctype.role.patches.v13_set_default_desk_properties
 frappe.patches.v14_0.drop_data_import_legacy
 frappe.patches.v14_0.copy_mail_data #08.03.21


### PR DESCRIPTION
since we added used_oauth column in User Email in v14, this patch fails as that column wasn't present in db in pre-model when migrating from v13 to v14