### PR TITLE
fix(UX): Miscellaneous

### DIFF
--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -205,9 +205,11 @@ class Exporter:
 		for df in self.fields:
 			is_parent = not df.is_child_table_field
 			if is_parent:
-				label = _(df.label)
+				label = _(df.label or df.fieldname)
 			else:
-				label = f"{_(df.label)} ({_(df.child_table_df.label)})"
+				label = (
+					f"{_(df.label or df.fieldname)} ({_(df.child_table_df.label or df.child_table_df.fieldname)})"
+				)
 
 			if label in header:
 				# this label is already in the header,

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -223,4 +223,4 @@ frappe.patches.v14_0.disable_email_accounts_with_oauth
 execute:frappe.delete_doc("Page", "translation-tool", force=1)
 frappe.patches.v15_0.remove_prepared_report_settings_from_system_settings
 frappe.patches.v14_0.remove_manage_subscriptions_from_navbar
-frappe.patches.v15_0.update_background_jobs_url
+frappe.patches.v15_0.remove_background_jobs_from_dropdown

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -223,3 +223,4 @@ frappe.patches.v14_0.disable_email_accounts_with_oauth
 execute:frappe.delete_doc("Page", "translation-tool", force=1)
 frappe.patches.v15_0.remove_prepared_report_settings_from_system_settings
 frappe.patches.v14_0.remove_manage_subscriptions_from_navbar
+frappe.patches.v15_0.update_background_jobs_url

--- a/frappe/patches/v15_0/remove_background_jobs_from_dropdown.py
+++ b/frappe/patches/v15_0/remove_background_jobs_from_dropdown.py
@@ -6,4 +6,4 @@ def execute():
 	if not item:
 		return
 
-	frappe.set_value("Navbar Item", item, "route", "/app/rq-job")
+	frappe.delete_doc("Navbar Item", item)

--- a/frappe/patches/v15_0/update_background_jobs_url.py
+++ b/frappe/patches/v15_0/update_background_jobs_url.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	item = frappe.db.exists("Navbar Item", {"item_label": "Background Jobs"})
+	if not item:
+		return
+
+	frappe.set_value("Navbar Item", item, "route", "/app/rq-job")

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -34,9 +34,7 @@ $.extend(frappe.perm, {
 
 	doctype_perm: {},
 
-	has_perm: (doctype, permlevel, ptype, doc) => {
-		if (!permlevel) permlevel = 0;
-
+	has_perm: (doctype, permlevel = 0, ptype = "read", doc) => {
 		const perms = frappe.perm.get_perm(doctype, doc);
 		return !!perms?.[permlevel]?.[ptype];
 	},

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -13,6 +13,9 @@ frappe.ui.toolbar.Toolbar = class {
 			})
 		);
 		$(".dropdown-toggle").dropdown();
+		$("#toolbar-user a[href]").click(function () {
+			$(this).closest(".dropdown-menu").prev().dropdown("toggle");
+		});
 
 		this.setup_awesomebar();
 		this.setup_notifications();

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -137,9 +137,11 @@ frappe.ui.toolbar.Toolbar = class {
 				__("Generate Tracking URL")
 			);
 
-			frappe.search.utils.make_function_searchable(function () {
-				frappe.set_route("List", "RQ Job");
-			}, __("Background Jobs"));
+			if (frappe.perm.has_perm("RQ Job")) {
+				frappe.search.utils.make_function_searchable(function () {
+					frappe.set_route("List", "RQ Job");
+				}, __("Background Jobs"));
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -133,6 +133,10 @@ frappe.ui.toolbar.Toolbar = class {
 				frappe.utils.generate_tracking_url,
 				__("Generate Tracking URL")
 			);
+
+			frappe.search.utils.make_function_searchable(function () {
+				frappe.set_route("List", "RQ Job");
+			}, __("Background Jobs"));
 		}
 	}
 


### PR DESCRIPTION
- Use fieldname if label is not set while exporting data as a template to avoid issues like (https://github.com/frappe/erpnext/pull/34860)
- Redirect "Background Jobs" to "RQ Jobs"
After [this awesome change](https://github.com/frappe/frappe/pull/18086), there's bit of a confusion as to where is  background jobs list... better to redirect "Background Jobs" to "RQ Jobs" instead of removing it completely 

https://user-images.githubusercontent.com/13928957/232406851-3c484e7e-b4ce-4b72-bfca-4aea1aeab7d9.mov


- Remove "Background Jobs" from Navbar Dropdown (as it has no permission check).
<img width="268" alt="Screenshot 2023-04-17 at 11 48 11 AM" src="https://user-images.githubusercontent.com/13928957/232405849-dda3f5ba-49e7-42cc-bce7-3dfc14514705.png">

