### PR TITLE
feat: hooks added for print formats / pdf.

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -83,6 +83,11 @@ on_logout = (
 	"frappe.core.doctype.session_default_settings.session_default_settings.clear_session_defaults"
 )
 
+# PDF
+pdf_header_html = "frappe.utils.pdf.pdf_header_html"
+pdf_body_html = "frappe.utils.pdf.pdf_body_html"
+pdf_footer_html = "frappe.utils.pdf.pdf_footer_html"
+
 # permissions
 
 permission_query_conditions = {

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -23,6 +23,29 @@ PDF_CONTENT_ERRORS = [
 ]
 
 
+def pdf_header_html(head, content, styles, html_id, css):
+	return frappe.render_template(
+		"templates/print_formats/pdf_header_footer.html",
+		{
+			"head": head,
+			"content": content,
+			"styles": styles,
+			"html_id": html_id,
+			"css": css,
+			"lang": frappe.local.lang,
+			"layout_direction": "rtl" if is_rtl() else "ltr",
+		},
+	)
+
+
+def pdf_body_html(template, args, **kwargs):
+	return template.render(args, filters={"len": len})
+
+
+def pdf_footer_html(head, content, styles, html_id, css):
+	return pdf_header_html(head=head, content=content, styles=styles, html_id=html_id, css=css)
+
+
 def get_pdf(html, options=None, output: PdfWriter | None = None):
 	html = scrub_urls(html)
 	html, options = prepare_options(html, options)
@@ -196,17 +219,15 @@ def prepare_header_footer(soup):
 				tag.extract()
 
 			toggle_visible_pdf(content)
-			html = frappe.render_template(
-				"templates/print_formats/pdf_header_footer.html",
-				{
-					"head": head,
-					"content": content,
-					"styles": styles,
-					"html_id": html_id,
-					"css": css,
-					"lang": frappe.local.lang,
-					"layout_direction": "rtl" if is_rtl() else "ltr",
-				},
+			mapper = {"header-html": "pdf_header_html", "footer-html": "pdf_footer_html"}
+			hook_func = frappe.get_hooks(mapper.get(html_id))
+			html = frappe.get_attr(hook_func[-1])(
+				soup=soup,
+				head=head,
+				content=content,
+				styles=styles,
+				html_id=html_id,
+				css=css,
 			)
 
 			# create temp file

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -221,8 +221,8 @@ def prepare_header_footer(soup):
 				tag.extract()
 
 			toggle_visible_pdf(content)
-			mapper = {"header-html": "pdf_header_html", "footer-html": "pdf_footer_html"}
-			hook_func = frappe.get_hooks(mapper.get(html_id))
+			id_map = {"header-html": "pdf_header_html", "footer-html": "pdf_footer_html"}
+			hook_func = frappe.get_hooks(id_map.get(html_id))
 			html = frappe.get_attr(hook_func[-1])(
 				soup=soup,
 				head=head,

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -23,7 +23,7 @@ PDF_CONTENT_ERRORS = [
 ]
 
 
-def pdf_header_html(head, content, styles, html_id, css):
+def pdf_header_html(soup, head, content, styles, html_id, css):
 	return frappe.render_template(
 		"templates/print_formats/pdf_header_footer.html",
 		{
@@ -42,8 +42,10 @@ def pdf_body_html(template, args, **kwargs):
 	return template.render(args, filters={"len": len})
 
 
-def pdf_footer_html(head, content, styles, html_id, css):
-	return pdf_header_html(head=head, content=content, styles=styles, html_id=html_id, css=css)
+def pdf_footer_html(soup, head, content, styles, html_id, css):
+	return pdf_header_html(
+		soup=soup, head=head, content=content, styles=styles, html_id=html_id, css=css
+	)
 
 
 def get_pdf(html, options=None, output: PdfWriter | None = None):

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -208,8 +208,10 @@ def get_rendered_template(
 			"print_settings": print_settings,
 		}
 	)
-
-	html = template.render(args, filters={"len": len})
+	hook_func = frappe.get_hooks("pdf_body_html")
+	html = frappe.get_attr(hook_func[-1])(
+		jenv=jenv, template=template, print_format=print_format, args=args
+	)
 
 	if cint(trigger_print):
 		html += trigger_print_script


### PR DESCRIPTION
This will allow other apps to provide/alter HTML for print formats' header, body, and footer.
It is useful when developers want to manipulate print formats and/or pdf.
### Header / Footer Example
```
def pdf_header_footer_html(soup, head, content, styles, html_id, css):
	if soup.find(id="my_custom_id"):
		return frappe.render_template(
			"custom_app/page/custom_module/jinja/header_footer.html",
			{
				"head": head,
				"content": content,
				"styles": styles,
				"html_id": html_id,
				"css": css,
				"custom_arg": soup.find(id="some_element"),
				"lang": frappe.local.lang,
				"layout_direction": "rtl" if is_rtl() else "ltr",
			},)
	else:
		mapper = {
				"header-html": "pdf_header_html",
				"footer-html": "pdf_footer_html",
			}
		return frappe.get_attr('frappe.utils.pdf.{0}'.format(mapper.get(html_id)))(soup=soup, head=head, content=content, styles=styles, html_id=html_id, css=css)
```
###  HTML Body Example
```
def pdf_body_html(print_format, jenv, args, template):
	if print_format and print_format.some_custom_field:
		template = jenv.get_template("custom_app/page/custom_module/jinja/main.html")
		args.update(
			{
				"custom_args": json.loads(print_format.some_custom_field),
			}
		)
	return template.render(args, filters={"len": len})
```
`no-docs`