### PR TITLE
Fix set email subject

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -339,7 +339,7 @@ frappe.views.CommunicationComposer = class {
 			await this.dialog.set_value(fieldname, this[fieldname] || "");
 		}
 
-		const subject = frappe.utils.html2text(this.subject) || "";
+		const subject = this.subject ? frappe.utils.html2text(this.subject) : "";
 		await this.dialog.set_value("subject", subject);
 
 		await this.set_values_from_last_edited_communication();

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -326,7 +326,7 @@ frappe.provide("frappe.views");
 			store.watch((state, getters) => {
 				return state.empty_state;
 			}, show_empty_state);
-
+			make_columns();
 			store.dispatch("update_order");
 		}
 

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -326,7 +326,6 @@ frappe.provide("frappe.views");
 			store.watch((state, getters) => {
 				return state.empty_state;
 			}, show_empty_state);
-			make_columns();
 			store.dispatch("update_order");
 		}
 

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -326,6 +326,7 @@ frappe.provide("frappe.views");
 			store.watch((state, getters) => {
 				return state.empty_state;
 			}, show_empty_state);
+
 			store.dispatch("update_order");
 		}
 


### PR DESCRIPTION
**Description:**
`const subject = frappe.utils.html2text(this.subject) || "";`
the statement first formats whatever is `this.subject` to a string. When `this.subject` is `null` it will be "null" and thereby not empty. This leads to the issue, that "null" as a string will be shown as the email subject instead of an empty string.

<img width="417" alt="Bildschirmfoto 2023-04-17 um 12 58 14" src="https://user-images.githubusercontent.com/49870752/232465334-a729da53-f418-43d2-acdb-3c95f201265e.png">
