### PR TITLE
fix: route to form if name has slashes in it

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -203,7 +203,7 @@ frappe.router = {
 						? meta.default_view
 						: null
 				);
-			} else if (route[1] && route[1] !== "view" && !route[2]) {
+			} else if (route[1] && route[1] !== "view") {
 				let docname = route[1];
 				if (route.length > 2) {
 					docname = route.slice(1).join("/");


### PR DESCRIPTION
Caused By: https://github.com/frappe/frappe/pull/18409

Issue: Cannot redirect to form view of any document if the name has slashes in it. e.g **MAT-2022-2023/0001**
It gets redirected back to the list view
