### PR TITLE
fix: Invalid Email throws an error exception.

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -467,7 +467,8 @@ def get_emails(email_strings: list[str]) -> list[str]:
 		if email_string:
 			result = getaddresses([email_string])
 			for email in result:
-				email_addrs.append(email[1])
+				if "@" in email[1]:
+					email_addrs.append(email[1])
 
 	return email_addrs
 


### PR DESCRIPTION
Ver 14

Invalid Email address throws an error exception.

If the option "Create Contacts from Incoming Emails" is enabled in the "Email Account" and if an incorrect address is specified by the sender of the letter, an error occurs: "Unable to add contact"
.......
  File "apps/frappe/frappe/__init__.py", line 442, in _raise_exception
    raise raise_exception(msg)
      inspect = <module 'inspect' from '/usr/lib/python3.10/inspect.py'>
      msg = 'Jon Dark is not a valid Email Address'
      raise_exception = <class 'frappe.exceptions.InvalidEmailAddressError'>
frappe.exceptions.InvalidEmailAddressError: Jon Dark is not a valid Email Address


email_strings: ['noreply@domain.com', 'Jon Dark', None, None] self.sender = 'noreply@domain.com.ru'
self.recipients = 'Jon Dark'
self.cc = None
self.bcc = None
auto_create_contact = create_contact_enabled

