### PR TITLE
fix(minor): typo in fixture syncing message

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -160,7 +160,7 @@ def sync_customizations_for_doctype(data: dict, folder: str, filename: str = "")
 
 	if not frappe.db.exists("DocType", doctype):
 		print(_("DocType {0} does not exist.").format(doctype))
-		print(_("Skipping fixture syncing for doctyoe {0} from file {1} ").format(doctype, filename))
+		print(_("Skipping fixture syncing for doctype {0} from file {1}").format(doctype, filename))
 		return
 
 	if data["custom_fields"]:


### PR DESCRIPTION
<img width="706" alt="image" src="https://user-images.githubusercontent.com/24353136/232987655-7ef52efd-9267-4837-8f86-c2d72783d7f4.png">
