### PR TITLE
feat: added URL type in workspace shortcut

### DIFF
--- a/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
+++ b/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
@@ -7,6 +7,7 @@
  "field_order": [
   "type",
   "link_to",
+  "url",
   "doc_view",
   "column_break_4",
   "label",
@@ -24,16 +25,16 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Type",
-   "options": "DocType\nReport\nPage\nDashboard",
+   "options": "DocType\nReport\nPage\nDashboard\nURL",
    "reqd": 1
   },
   {
+   "depends_on": "eval:doc.type != \"URL\"",
    "fieldname": "link_to",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
    "label": "Link To",
-   "options": "type",
-   "reqd": 1
+   "options": "type"
   },
   {
    "depends_on": "eval:doc.type == \"DocType\"",
@@ -94,12 +95,20 @@
    "fieldname": "format",
    "fieldtype": "Data",
    "label": "Format"
+  },
+  {
+   "depends_on": "eval:doc.type == \"URL\"",
+   "fieldname": "url",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "URL",
+   "options": "URL"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-01-12 13:13:17.571324",
+ "modified": "2023-04-19 13:32:31.005443",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Shortcut",

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -35,6 +35,7 @@ frappe.form.formatters = {
 	},
 	Data: function (value, df) {
 		if (df && df.options == "URL") {
+			if (!value) return;
 			return `<a href="${value}" title="Open Link" target="_blank">${value}</a>`;
 		}
 		value = value == null ? "" : value;

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -20,6 +20,7 @@ export default class ShortcutWidget extends Widget {
 			restrict_to_domain: this.restrict_to_domain,
 			stats_filter: this.stats_filter,
 			type: this.type,
+			url: this.url,
 		};
 	}
 
@@ -43,6 +44,16 @@ export default class ShortcutWidget extends Widget {
 
 			if (e.ctrlKey || e.metaKey) {
 				frappe.open_in_new_tab = true;
+			}
+
+			if (this.type == "URL") {
+				if (frappe.open_in_new_tab) {
+					window.open(this.url, "_blank");
+					frappe.open_in_new_tab = false;
+				} else {
+					window.location.href = this.url;
+				}
+				return;
 			}
 
 			frappe.set_route(route);

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -510,8 +510,17 @@ class ShortcutDialog extends WidgetDialog {
 
 		data.label = data.label ? data.label : frappe.model.unscrub(data.link_to);
 
-		if (data.url && !data.label) {
-			data.label = "No Label (URL)";
+		if (data.url) {
+			!validate_url(data.url) &&
+				frappe.throw({
+					message: __("<b>{0}</b> is not a valid URL", [data.url]),
+					title: __("Invalid URL"),
+					indicator: "red",
+				});
+
+			if (!data.label) {
+				data.label = "No Label (URL)";
+			}
 		}
 
 		return data;

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -350,7 +350,7 @@ class ShortcutDialog extends WidgetDialog {
 				fieldname: "type",
 				label: "Type",
 				reqd: 1,
-				options: "DocType\nReport\nPage\nDashboard",
+				options: "DocType\nReport\nPage\nDashboard\nURL",
 				onchange: () => {
 					if (this.dialog.get_value("type") == "DocType") {
 						this.dialog.fields_dict.link_to.get_query = () => {
@@ -379,7 +379,6 @@ class ShortcutDialog extends WidgetDialog {
 				fieldtype: "Dynamic Link",
 				fieldname: "link_to",
 				label: "Link To",
-				reqd: 1,
 				options: "type",
 				onchange: () => {
 					const doctype = this.dialog.get_value("link_to");
@@ -404,6 +403,17 @@ class ShortcutDialog extends WidgetDialog {
 						this.hide_filters();
 					}
 				},
+				depends_on: (s) => s.type != "URL",
+				mandatory_depends_on: (s) => s.type != "URL",
+			},
+			{
+				fieldtype: "Data",
+				fieldname: "url",
+				label: "URL",
+				options: "URL",
+				default: "",
+				depends_on: (s) => s.type == "URL",
+				mandatory_depends_on: (s) => s.type == "URL",
 			},
 			{
 				fieldtype: "Select",
@@ -499,6 +509,10 @@ class ShortcutDialog extends WidgetDialog {
 		}
 
 		data.label = data.label ? data.label : frappe.model.unscrub(data.link_to);
+
+		if (data.url && !data.label) {
+			data.label = "No Label (URL)";
+		}
 
 		return data;
 	}


### PR DESCRIPTION
Now you will be able to add a complete URL in the shortcut block of the workspace to navigate to some external links.


https://user-images.githubusercontent.com/30859809/233012127-ae3a66ed-73be-4af9-b99f-af4f47f16279.mov


> no-docs