### PR TITLE
fix: letterhead not working for multiple doc print

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -17,7 +17,9 @@ from frappe.www.printview import validate_print_permission
 
 
 @frappe.whitelist()
-def download_multi_pdf(doctype, name, format=None, no_letterhead=False, options=None):
+def download_multi_pdf(
+	doctype, name, format=None, no_letterhead=False, letterhead=None, options=None
+):
 	"""
 	Concatenate multiple docs as PDF .
 
@@ -76,6 +78,7 @@ def download_multi_pdf(doctype, name, format=None, no_letterhead=False, options=
 				as_pdf=True,
 				output=output,
 				no_letterhead=no_letterhead,
+				letterhead=letterhead,
 				pdf_options=options,
 			)
 		frappe.local.response.filename = "{doctype}.pdf".format(
@@ -92,6 +95,7 @@ def download_multi_pdf(doctype, name, format=None, no_letterhead=False, options=
 						as_pdf=True,
 						output=output,
 						no_letterhead=no_letterhead,
+						letterhead=letterhead,
 						pdf_options=options,
 					)
 				except Exception:


### PR DESCRIPTION
Issue: If we print from list view for multiple records and select Letter Head it does not use that letterhead it picks the default letterhead