### PR TITLE
fix: Workspaces missing fixes

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -153,6 +153,8 @@ class Workspace:
 			return True
 		if item_type == "dashboard":
 			return True
+		if item_type == "url":
+			return True
 
 		return False
 

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -158,7 +158,7 @@ frappe.views.Workspace = class Workspace {
 		}
 
 		if (
-			sidebar_section.find("sidebar-item-container").length &&
+			sidebar_section.find(".sidebar-item-container").length &&
 			sidebar_section.find("> [item-is-hidden='0']").length == 0
 		) {
 			sidebar_section.addClass("hidden show-in-edit-mode");


### PR DESCRIPTION
1. Allow URL-type shortcuts from the backend. Missed in PR https://github.com/frappe/frappe/pull/20769
2. Do not show section if it only contains hidden workspaces Missed in PR https://github.com/frappe/frappe/pull/20346