### PR TITLE
fix: correctly return session usertype

### DIFF
--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -126,7 +126,7 @@ def can_subscribe_doctype(doctype: str) -> bool:
 def get_user_info():
 	return {
 		"user": frappe.session.user,
-		"user_type": frappe.session.user_type,
+		"user_type": frappe.session.data.user_type,
 	}
 
 


### PR DESCRIPTION
`user_type` is under data dict and not on session itself.



