### PR TITLE
feat: get anonymous response from webform

### DIFF
--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -42,6 +42,12 @@ frappe.ui.form.on("Web Form", {
 		render_list_settings_message(frm);
 	},
 
+	anonymous: function (frm) {
+		if (frm.doc.anonymous) {
+			frm.set_value("login_required", 0);
+		}
+	},
+
 	validate: function (frm) {
 		if (!frm.doc.login_required) {
 			frm.set_value("allow_multiple", 0);

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -9,7 +9,7 @@
   "title",
   "route",
   "published",
-  "column_break_1",
+  "column_break_vdhm",
   "doc_type",
   "module",
   "is_standard",
@@ -21,6 +21,7 @@
   "allow_multiple",
   "allow_edit",
   "allow_delete",
+  "anonymous",
   "column_break_2",
   "apply_document_permissions",
   "allow_print",
@@ -96,10 +97,12 @@
    "default": "0",
    "fieldname": "published",
    "fieldtype": "Check",
+   "hidden": 1,
    "label": "Published"
   },
   {
    "default": "0",
+   "depends_on": "eval:!doc.anonymous",
    "fieldname": "login_required",
    "fieldtype": "Check",
    "label": "Login Required"
@@ -301,6 +304,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "show_list",
+   "depends_on": "eval:!doc.anonymous",
    "fieldname": "section_break_3",
    "fieldtype": "Section Break",
    "label": "List Settings"
@@ -308,6 +312,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "show_sidebar",
+   "depends_on": "eval:!doc.anonymous",
    "fieldname": "section_break_4",
    "fieldtype": "Section Break",
    "label": "Sidebar Settings"
@@ -358,13 +363,24 @@
    "fieldname": "meta_image",
    "fieldtype": "Attach Image",
    "label": "Meta Image"
+  },
+  {
+   "fieldname": "column_break_vdhm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Receive anonymous response",
+   "fieldname": "anonymous",
+   "fieldtype": "Check",
+   "label": "Anonymous"
   }
  ],
  "has_web_view": 1,
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2023-01-02 10:19:15.680960",
+ "modified": "2023-04-20 17:24:42.657731",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -387,6 +387,10 @@ def accept(web_form, data):
 
 	web_form = frappe.get_doc("Web Form", web_form)
 	doctype = web_form.doc_type
+	user = frappe.session.user
+
+	if web_form.anonymous and frappe.session.user != "Guest":
+		frappe.session.user = "Guest"
 
 	if data.name and not web_form.allow_edit:
 		frappe.throw(_("You are not allowed to update this Web Form Document"))
@@ -467,6 +471,9 @@ def accept(web_form, data):
 		for f in files_to_delete:
 			if f:
 				remove_file_by_url(f, doctype=doctype, name=doc.name)
+
+	if web_form.anonymous and frappe.session.user == "Guest" and user:
+		frappe.session.user = user
 
 	frappe.flags.web_form_doc = doc
 	return doc


### PR DESCRIPTION
Receive an anonymous response (as a Guest) from a web form

<img width="1301" alt="image" src="https://user-images.githubusercontent.com/30859809/233360295-3f75457e-3f67-4a35-b0fa-cd10a4ed0828.png">

docs: https://frappeframework.com/docs/v14/user/en/web-form/settings