### PR TITLE
fix(patch): only run disable_email_accounts_with_oauth if connected user is not set

### DIFF
--- a/frappe/patches/v14_0/disable_email_accounts_with_oauth.py
+++ b/frappe/patches/v14_0/disable_email_accounts_with_oauth.py
@@ -3,7 +3,9 @@ from frappe.desk.doctype.notification_log.notification_log import make_notificat
 
 
 def execute():
-	if not frappe.get_value("Email Account", {"auth_method": "OAuth"}):
+	if frappe.get_all(
+		"Email Account", {"auth_method": "OAuth", "connected_user": ["is", "set"]}, limit=1
+	):
 		return
 
 	# Setting awaiting password to 1 for email accounts where Oauth is enabled.


### PR DESCRIPTION
needs this check after: https://github.com/frappe/frappe/pull/20790