### PR TITLE
chore: update deprecated deep selector syntax

### DIFF
--- a/frappe/public/js/print_format_builder/Preview.vue
+++ b/frappe/public/js/print_format_builder/Preview.vue
@@ -130,7 +130,7 @@ onMounted(() => {
 	margin-top: auto;
 	margin-bottom: 1.2rem;
 }
-.preview-control >>> .form-control {
+.preview-control :deep(.form-control) {
 	background: var(--control-bg-on-gray);
 }
 </style>

--- a/frappe/public/js/print_format_builder/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatControls.vue
@@ -332,7 +332,7 @@ watch(print_format, () => (store.dirty.value = true), { deep: true });
 	margin-bottom: 0;
 }
 
-.control-font >>> .frappe-control[data-fieldname="font"] label {
+.control-font :deep(.frappe-control[data-fieldname="font"] label) {
 	display: none;
 }
 </style>


### PR DESCRIPTION
`>>>` to `:deep`

Will make this warning go away.
<img width="842" alt="image" src="https://user-images.githubusercontent.com/9355208/233604382-4726a98c-df93-4e88-aa4b-181cd4fd21f1.png">


Ref: https://vuejs.org/api/sfc-css-features.html#scoped-css, https://stackoverflow.com/questions/48032006/how-do-i-use-deep-or-or-v-deep-in-vue-js