### PR TITLE
fix: don't translate before unscrubbing

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -348,11 +348,9 @@ $.extend(frappe.model, {
 	},
 
 	unscrub: function (txt) {
-		return __(txt || "")
-			.replace(/-|_/g, " ")
-			.replace(/\w*/g, function (keywords) {
-				return keywords.charAt(0).toUpperCase() + keywords.substr(1).toLowerCase();
-			});
+		return (txt || "").replace(/-|_/g, " ").replace(/\w*/g, function (keywords) {
+			return keywords.charAt(0).toUpperCase() + keywords.substr(1).toLowerCase();
+		});
 	},
 
 	can_create: function (doctype) {


### PR DESCRIPTION
`__(txt || "")` becomes `(txt || "")`, the rest is formatting by pre-commit.

It makes no sense to translate the scrubbed string, then unscrub it. This leads to confusing behavior:

- strings that happen to have a translation for the scrubbed version get translated by `unscrub`
   - if the translation contains dashes, these get removed
- strings that have a translation for the unscrubbed version don't get translated

Old behavior:

1. `__(frappe.unscrub("email"))`
2. `unscrub` translates "email" to german -> "E-Mail"
4. `unscrub` remove dashes and converts to title case -> "E Mail"
5. There is no translation for "E Mail"
6. The resulting string is incorrect

New behavior:

1. `__(frappe.unscrub("email"))`
3. `unscrub` remove dashes and converts to title case -> "Email"
3. Translate "Email" to german -> "E-Mail"
5. The result is correct