### PR TITLE
feat: let custom language on gantt view

### DIFF
--- a/frappe/public/js/frappe/views/gantt/gantt_view.js
+++ b/frappe/public/js/frappe/views/gantt/gantt_view.js
@@ -89,6 +89,7 @@ frappe.views.GanttView = class GanttView extends frappe.views.ListView {
 	render_gantt() {
 		const me = this;
 		const gantt_view_mode = this.view_user_settings.gantt_view_mode || "Day";
+		const gantt_language = this.calendar_settings.gantt_language || "en";
 		const field_map = this.calendar_settings.field_map;
 		const date_format = "YYYY-MM-DD";
 
@@ -103,6 +104,7 @@ frappe.views.GanttView = class GanttView extends frappe.views.ListView {
 			resize_handle_corner_radius: 3,
 			resize_handle_offset: 4,
 			view_mode: gantt_view_mode,
+			language: gantt_language,
 			date_format: "YYYY-MM-DD",
 			on_click: (task) => {
 				frappe.set_route("Form", task.doctype, task.id);

--- a/frappe/public/js/frappe/views/gantt/gantt_view.js
+++ b/frappe/public/js/frappe/views/gantt/gantt_view.js
@@ -89,8 +89,8 @@ frappe.views.GanttView = class GanttView extends frappe.views.ListView {
 	render_gantt() {
 		const me = this;
 		const gantt_view_mode = this.view_user_settings.gantt_view_mode || "Day";
-		const gantt_language = this.calendar_settings.gantt_language || "en";
-		const field_map = this.calendar_settings.field_map;
+		const gantt_language = this.calendar_settings.gantt.language || "en";
+		const field_map = this.calendar_settings.gantt.field_map;
 		const date_format = "YYYY-MM-DD";
 
 		this.$result.empty();


### PR DESCRIPTION
Month names are always offered in english. This PR add  language support on render_gantt method. 

`frappe.views.calendar` supports now `language` property on gantt object (even `frappe.boot.lang` could be used), but gantt component currently supports this options: en, es, ru, ptBr, fr, tr, zh, de, hu

xxx_calendar.js sample:

```
frappe.views.calendar["Task"] = {
	field_map: {
		"start": "exp_start_date",
		"end": "exp_end_date",
		"id": "name",
		"title": "subject",
		"allDay": "allDay",
		"progress": "progress",
		"project:": "project"
	
	},
	gantt: {
		field_map: {
			"start": "exp_start_date",
			"end": "exp_end_date",
			"id": "name",
			"title": "subject",
			"allDay": "allDay",
			"progress": "progress",
			"project:": "project"
		},
		language: "es"
	}
	,
	filters: [
		{
			"fieldtype": "Link",
			"fieldname": "project",
			"options": "Project",
			"label": __("Project")
		}
	],
	get_events_method: "frappe.desk.calendar.get_events"
}

```

