### PR TITLE
fix: handle `SMTPRecipientsRefused` retries

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -213,7 +213,6 @@ class SendMailContext:
 		exceptions = [
 			smtplib.SMTPServerDisconnected,
 			smtplib.SMTPAuthenticationError,
-			smtplib.SMTPRecipientsRefused,
 			smtplib.SMTPConnectError,
 			smtplib.SMTPHeloError,
 			JobTimeoutException,

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -203,7 +203,7 @@ class SendMailContext:
 		# Note: smtp session will have to be manually closed
 		self.retain_smtp_session = bool(smtp_server_instance)
 
-		self.sent_to = [rec.recipient for rec in self.queue_doc.recipients if rec.is_main_sent()]
+		self.sent_to = [rec.recipient for rec in self.queue_doc.recipients if rec.is_mail_sent()]
 
 	def __enter__(self):
 		self.queue_doc.update_status(status="Sending", commit=True)

--- a/frappe/email/doctype/email_queue_recipient/email_queue_recipient.py
+++ b/frappe/email/doctype/email_queue_recipient/email_queue_recipient.py
@@ -11,7 +11,7 @@ class EmailQueueRecipient(Document):
 	def is_mail_to_be_sent(self):
 		return self.status == "Not Sent"
 
-	def is_main_sent(self):
+	def is_mail_sent(self):
 		return self.status == "Sent"
 
 	def update_db(self, commit=False, **kwargs):

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -217,7 +217,7 @@ def split_emails(txt):
 	# emails can be separated by comma or newline
 	s = WHITESPACE_PATTERN.sub(" ", cstr(txt))
 	for email in MULTI_EMAIL_STRING_PATTERN.split(s):
-		email = strip(cstr(email))
+		email = strip(cstr(email), chars="'\"").strip()
 		if email:
 			email_list.append(email)
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -217,7 +217,7 @@ def split_emails(txt):
 	# emails can be separated by comma or newline
 	s = WHITESPACE_PATTERN.sub(" ", cstr(txt))
 	for email in MULTI_EMAIL_STRING_PATTERN.split(s):
-		email = strip(cstr(email), chars="'\"").strip()
+		email = strip(cstr(email))
 		if email:
 			email_list.append(email)
 


### PR DESCRIPTION
```
smtplib.SMTPRecipientsRefused: {"'user@email.com'": (553, b"5.1.3 The recipient address <'user@email.com'> is not a valid
5.1.3 RFC-5321 address. Learn more at
5.1.3  https://support.google.com/mail/answer/6596 me18-20020a17090b17d200b00244991b3f7asm8850490pjb.1 - gsmtp")}
```


This error is retried infinitely as if it's gonna change anything. 

Changes:
- don't retry infinitely, those retries are only applicable to SMTP connection related errors and not email validation failing on smtpserver side. 