### PR TITLE
fix: Refresh Counter Dialog in Document Naming Rule

### DIFF
--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.js
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.js
@@ -53,6 +53,7 @@ frappe.ui.form.on("Document Naming Rule", {
 					callback: function () {
 						frm.set_value("counter", fields.new_counter);
 						dialog.hide();
+						frm.reload_doc();
 					},
 				});
 			};

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.js
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.js
@@ -53,7 +53,6 @@ frappe.ui.form.on("Document Naming Rule", {
 					callback: function () {
 						frm.set_value("counter", fields.new_counter);
 						dialog.hide();
-						frm.reload_doc();
 					},
 				});
 			};

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -52,4 +52,4 @@ class DocumentNamingRule(Document):
 @frappe.whitelist()
 def update_current(name, new_counter):
 	frappe.only_for("System Manager")
-	frappe.db.set_value("Document Naming Rule", name, "counter", new_counter)
+	frappe.db.set_value("Document Naming Rule", name, "counter", new_counter, update_modified=False)


### PR DESCRIPTION
**Version:**

ERPNext: v14.22.2 (version-14)
Frappe Framework: v14.33.1 (version-14)
___
**Before:**

- When opening the counter dialog and adding a new counter then saving the dialog then the value is set properly in the counter but the form doesn't save.


https://user-images.githubusercontent.com/34390782/233904939-820ed427-de87-4f5a-8f3e-40cb4fc0d5dc.mp4

<br>

**After:**

- After adding an `frm.reload_doc()` in document_naming_rule.js then check so the counter will update with refresh form/page.


https://user-images.githubusercontent.com/34390782/233905402-243e06d0-9b86-4dd7-b97f-027480af28f0.mp4

<br>

Thanks and Regards,
Nihantra Patel (NCP)
Solufy