### PR TITLE
fix: multiple assignments to the same person

### DIFF
--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -147,35 +147,36 @@ def add_multiple(args=None):
 def close_all_assignments(doctype, name):
 	assignments = frappe.get_all(
 		"ToDo",
-		fields=["allocated_to"],
+		fields=["allocated_to", "name"],
 		filters=dict(reference_type=doctype, reference_name=name, status=("!=", "Cancelled")),
 	)
 	if not assignments:
 		return False
 
 	for assign_to in assignments:
-		set_status(doctype, name, assign_to.allocated_to, status="Closed")
+		set_status(doctype, name, todo=assign_to.name, assign_to=assign_to.allocated_to, status="Closed")
 
 	return True
 
 
 @frappe.whitelist()
 def remove(doctype, name, assign_to):
-	return set_status(doctype, name, assign_to, status="Cancelled")
+	return set_status(doctype, name, "", assign_to, status="Cancelled")
 
 
-def set_status(doctype, name, assign_to, status="Cancelled"):
+def set_status(doctype, name, todo=None, assign_to=None, status="Cancelled"):
 	"""remove from todo"""
 	try:
-		todo = frappe.db.get_value(
-			"ToDo",
-			{
-				"reference_type": doctype,
-				"reference_name": name,
-				"allocated_to": assign_to,
-				"status": ("!=", status),
-			},
-		)
+		if not todo:
+			todo = frappe.db.get_value(
+				"ToDo",
+				{
+					"reference_type": doctype,
+					"reference_name": name,
+					"allocated_to": assign_to,
+					"status": ("!=", status),
+				},
+			)
 		if todo:
 			todo = frappe.get_doc("ToDo", todo)
 			todo.status = status
@@ -197,13 +198,17 @@ def clear(doctype, name):
 	Clears assignments, return False if not assigned.
 	"""
 	assignments = frappe.get_all(
-		"ToDo", fields=["allocated_to"], filters=dict(reference_type=doctype, reference_name=name)
+		"ToDo",
+		fields=["allocated_to", "name"],
+		filters=dict(reference_type=doctype, reference_name=name),
 	)
 	if not assignments:
 		return False
 
 	for assign_to in assignments:
-		set_status(doctype, name, assign_to.allocated_to, "Cancelled")
+		set_status(
+			doctype, name, todo=assign_to.name, assign_to=assign_to.allocated_to, status="Cancelled"
+		)
 
 	return True
 


### PR DESCRIPTION
Issue: When the doc status is changed to completed or closed if a user is already assigned same user is again assigned showing the user avatar twice.

Before:

https://user-images.githubusercontent.com/30859809/233912775-d877c37e-e992-4839-aa7a-699068cb0a1e.mov


After:

https://user-images.githubusercontent.com/30859809/233912746-52f9b4ca-05a6-4323-a328-ea813f265f27.mov


