### PR TITLE
refactor(minor): remove update counter dialog and make counter editable by default

### DIFF
--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.js
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.js
@@ -4,6 +4,24 @@
 frappe.ui.form.on("Document Naming Rule", {
 	refresh: function (frm) {
 		frm.trigger("document_type");
+		frm.last_counter_value = frm.doc.counter;
+		frm.skip_before_save = false;
+	},
+	before_save: function (frm) {
+		if (frm.is_new() || frm.skip_before_save || frm.last_counter_value === frm.doc.counter)
+			return;
+
+		frappe.validated = false;
+		frappe.warn(
+			__("Are you sure?"),
+			__("Updating counter may lead to document name conflicts if not done properly"),
+			() => {
+				frm.skip_before_save = true;
+				frm.save();
+			},
+			__("Proceed"),
+			false
+		);
 	},
 	document_type: (frm) => {
 		// update the select field options with fieldnames

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.js
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.js
@@ -4,7 +4,6 @@
 frappe.ui.form.on("Document Naming Rule", {
 	refresh: function (frm) {
 		frm.trigger("document_type");
-		if (!frm.doc.__islocal) frm.trigger("add_update_counter_button");
 	},
 	document_type: (frm) => {
 		// update the select field options with fieldnames
@@ -25,46 +24,5 @@ frappe.ui.form.on("Document Naming Rule", {
 				);
 			});
 		}
-	},
-	add_update_counter_button: (frm) => {
-		frm.add_custom_button(__("Update Counter"), function () {
-			const fields = [
-				{
-					fieldtype: "Data",
-					fieldname: "new_counter",
-					label: __("New Counter"),
-					default: frm.doc.counter,
-					reqd: 1,
-					description: __(
-						"Warning: Updating counter may lead to document name conflicts if not done properly"
-					),
-				},
-			];
-
-			let primary_action_label = __("Save");
-
-			let primary_action = (fields) => {
-				frappe.call({
-					method: "frappe.core.doctype.document_naming_rule.document_naming_rule.update_current",
-					args: {
-						name: frm.doc.name,
-						new_counter: fields.new_counter,
-					},
-					callback: function () {
-						frm.set_value("counter", fields.new_counter);
-						dialog.hide();
-					},
-				});
-			};
-
-			const dialog = new frappe.ui.Dialog({
-				title: __("Update Counter Value for Prefix: {0}", [frm.doc.prefix]),
-				fields,
-				primary_action_label,
-				primary_action,
-			});
-
-			dialog.show();
-		});
 	},
 });

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.json
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.json
@@ -23,7 +23,8 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Document Type",
-   "options": "DocType"
+   "options": "DocType",
+   "reqd": 1
   },
   {
    "default": "0",
@@ -86,7 +87,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-04-24 13:06:20.992011",
+ "modified": "2023-04-24 15:14:32.054272",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Document Naming Rule",

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.json
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.json
@@ -12,8 +12,9 @@
   "conditions",
   "naming_section",
   "prefix",
-  "prefix_digits",
-  "counter"
+  "counter",
+  "column_break_xfqa",
+  "prefix_digits"
  ],
  "fields": [
   {
@@ -38,11 +39,12 @@
    "reqd": 1
   },
   {
+   "default": "0",
+   "description": "Warning: Updating counter may lead to document name conflicts if not done properly",
    "fieldname": "counter",
    "fieldtype": "Int",
    "label": "Counter",
-   "no_copy": 1,
-   "read_only": 1
+   "no_copy": 1
   },
   {
    "default": "5",
@@ -76,11 +78,15 @@
    "fieldname": "priority",
    "fieldtype": "Int",
    "label": "Priority"
+  },
+  {
+   "fieldname": "column_break_xfqa",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-09-13 20:07:47.617615",
+ "modified": "2023-04-24 13:06:20.992011",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Document Naming Rule",
@@ -102,6 +108,7 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "document_type",
  "track_changes": 1
 }

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.py
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.py
@@ -47,9 +47,3 @@ class DocumentNamingRule(Document):
 
 		doc.name = naming_series + ("%0" + str(self.prefix_digits) + "d") % (counter + 1)
 		frappe.db.set_value(self.doctype, self.name, "counter", counter + 1)
-
-
-@frappe.whitelist()
-def update_current(name, new_counter):
-	frappe.only_for("System Manager")
-	frappe.db.set_value("Document Naming Rule", name, "counter", new_counter)


### PR DESCRIPTION
reasons for doing this:
- there is no validation present for this in document naming rule controller - which either means means we always meant to allow this or we forgot to add validation for this :P
- even after updating the counter in dialog, one had to save/reload the form (as we made the form dirty) which is bad UX - even though it was updated in the db directly
- this makes this field compliant with our permission system and not only relies on system manager for updation