### PR TITLE
fix: error in frappe.db.get_value while marking communication as read

### DIFF
--- a/frappe/email/inbox.py
+++ b/frappe/email/inbox.py
@@ -54,8 +54,10 @@ def create_email_flag_queue(names, action):
 
 	for name in json.loads(names or []):
 		uid, seen_status, email_account = frappe.db.get_value(
-			"Communication", name, ["ifnull(uid, -1)", "ifnull(seen, 0)", "email_account"]
+			"Communication", name, ["uid", "seen", "email_account"]
 		)
+		uid = uid if uid else -1
+		seen_status = seen_status if seen_status else 0
 
 		# can not mark email SEEN or UNSEEN without uid
 		if not uid or uid == -1:


### PR DESCRIPTION
Screenshot of the error while marking email as read from Communication

![Screenshot from 2023-04-24 19-01-16](https://user-images.githubusercontent.com/48860013/234015990-1378d194-cdc3-4642-adce-ae6d5dc64c12.png)

Tried multiple times but the query was not working, made a simple change it started working.

Is it a database version dependency(as tried on multiple database versions) or any other dependency issue?