### PR TITLE
fix: DNR Operator - V13

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -106,6 +106,33 @@ class TestFilters(unittest.TestCase):
 			)
 		)
 
+	def test_date_time(self):
+		# date fields
+		self.assertTrue(
+			evaluate_filters(
+				{"doctype": "User", "birth_date": "2023-02-28"}, [("User", "birth_date", ">", "01-04-2022")]
+			)
+		)
+		self.assertFalse(
+			evaluate_filters(
+				{"doctype": "User", "birth_date": "2023-02-28"}, [("User", "birth_date", "<", "28-02-2023")]
+			)
+		)
+
+		# datetime fields
+		self.assertTrue(
+			evaluate_filters(
+				{"doctype": "User", "last_active": "2023-02-28 15:14:56"},
+				[("User", "last_active", ">", "01-04-2022 00:00:00")],
+			)
+		)
+		self.assertFalse(
+			evaluate_filters(
+				{"doctype": "User", "last_active": "2023-02-28 15:14:56"},
+				[("User", "last_active", "<", "28-02-2023 00:00:00")],
+			)
+		)
+
 
 class TestMoney(unittest.TestCase):
 	def test_money_in_words(self):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1530,14 +1530,14 @@ operator_map = {
 	"in": lambda a, b: operator.contains(b, a),
 	"not in": lambda a, b: not operator.contains(b, a),
 	# comparison operators
-	"=": lambda a, b: operator.eq(a, b),
-	"!=": lambda a, b: operator.ne(a, b),
-	">": lambda a, b: operator.gt(a, b),
-	"<": lambda a, b: operator.lt(a, b),
-	">=": lambda a, b: operator.ge(a, b),
-	"<=": lambda a, b: operator.le(a, b),
-	"not None": lambda a, b: a and True or False,
-	"None": lambda a, b: (not a) and True or False,
+	"=": operator.eq,
+	"!=": operator.ne,
+	">": operator.gt,
+	"<": operator.lt,
+	">=": operator.ge,
+	"<=": operator.le,
+	"not None": lambda a, b: a is not None,
+	"None": lambda a, b: a is None,
 }
 
 
@@ -1558,14 +1558,14 @@ def evaluate_filters(doc, filters: Union[Dict, List, Tuple]):
 	return True
 
 
-def compare(val1: Any, condition: str, val2: Any, fieldtype: Optional[str] = None):
-	ret = False
+def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
 	if fieldtype:
+		val1 = cast(fieldtype, val1)
 		val2 = cast(fieldtype, val2)
 	if condition in operator_map:
-		ret = operator_map[condition](val1, val2)
+		return operator_map[condition](val1, val2)
 
-	return ret
+	return False
 
 
 def get_filter(doctype: str, f: Union[Dict, List, Tuple], filters_config=None) -> "frappe._dict":

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1558,14 +1558,15 @@ def evaluate_filters(doc, filters: Union[Dict, List, Tuple]):
 	return True
 
 
-def compare(val1: Any, condition: str, val2: Any, fieldtype: str | None = None):
+def compare(val1: Any, condition: str, val2: Any, fieldtype: Optional[str] = None):
+	ret = False
 	if fieldtype:
 		val1 = cast(fieldtype, val1)
 		val2 = cast(fieldtype, val2)
 	if condition in operator_map:
-		return operator_map[condition](val1, val2)
+		ret = operator_map[condition](val1, val2)
 
-	return False
+	return ret
 
 
 def get_filter(doctype: str, f: Union[Dict, List, Tuple], filters_config=None) -> "frappe._dict":


### PR DESCRIPTION
**Version:**
ERPNext: v13.49.13 (version-13)
Frappe Framework: v13.55.0 (version-13)

fixes #20809
___
**Before:**

- when setting the document naming rule with the operator and creating a new transaction then faced an error.
```
TypeError: '>' not supported between instances of 'str' and 'datetime.timedelta'
```


https://user-images.githubusercontent.com/34390782/234180969-a1d2c70a-3a91-4b9b-bd2e-d52d59fa1498.mp4

<br>

**After:**

- After setting the `operator_map` and updating the `def compare` method. Then checking so the transaction will create successfully.


https://user-images.githubusercontent.com/34390782/234181381-eaf9571d-e055-4d8d-8bac-189e751686ef.mp4

<br>

Thanks and Regards,
Nihantra Patel (NCP)
Solufy

---

partial backport of: https://github.com/frappe/frappe/pull/17833
and full backport of: https://github.com/frappe/frappe/pull/20092