### PR TITLE
fix: unable to access url file from the timeline section

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -638,7 +638,10 @@ class File(Document):
 
 	def create_attachment_record(self):
 		icon = ' <i class="fa fa-lock text-warning"></i>' if self.is_private else ""
-		file_url = quote(frappe.safe_encode(self.file_url), safe="/:") if self.file_url else self.file_name
+		if self.file_url:
+			quote(frappe.safe_encode(self.file_url), safe="/:")
+		else:
+			self.file_name
 		file_name = self.file_name or self.file_url
 
 		self.add_comment_in_reference_doc(

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -638,7 +638,7 @@ class File(Document):
 
 	def create_attachment_record(self):
 		icon = ' <i class="fa fa-lock text-warning"></i>' if self.is_private else ""
-		file_url = quote(frappe.safe_encode(self.file_url)) if self.file_url else self.file_name
+		file_url = quote(frappe.safe_encode(self.file_url), safe="/:") if self.file_url else self.file_name
 		file_name = self.file_name or self.file_url
 
 		self.add_comment_in_reference_doc(

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -638,10 +638,9 @@ class File(Document):
 
 	def create_attachment_record(self):
 		icon = ' <i class="fa fa-lock text-warning"></i>' if self.is_private else ""
-		if self.file_url:
-			quote(frappe.safe_encode(self.file_url), safe="/:")
-		else:
-			self.file_name
+		file_url = (
+			quote(frappe.safe_encode(self.file_url), safe="/:") if self.file_url else self.file_name
+		)
 		file_name = self.file_name or self.file_url
 
 		self.add_comment_in_reference_doc(


### PR DESCRIPTION
when a user tries to access URL based Attachment from the timeline section then the resource not found error is shown, please see the below video for more information.

[Kooha-2023-04-24-21-15-44.webm](https://user-images.githubusercontent.com/48860013/234221526-7c26963d-1810-442c-80b5-80ac43995d2a.webm)

In the file: file.py
`file_url = quote(frappe.safe_encode(self.file_url)) if self.file_url else self.file_name`
if self.file_url = 'https://sgp1.digitaloceanspaces.com/cdn.extension/Extension-ERP-06-32.png'
then out => 'https%3A//sgp1.digitaloceanspaces.com/cdn.extension/Extension-ERP-06-32.png'
here => `:` is translated to `%3A`

As per the doc of [urllib.parse](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote): 
_Replace special characters in the string using the %xx escape. Letters, digits, and the characters '\_.-~' are never quoted. By default, this function is intended for quoting the path section of a URL. The optional safe parameter specifies additional ASCII characters that should not be quoted — its default value is '/'._

It should mainly be used for quoting paths, but as we are also quoting a full URL, we should pass `:` as a safe character.

So after the change:
`file_url = quote(frappe.safe_encode(self.file_url), safe="/:") if self.file_url else self.file_name`
with the same input out is => 'https://sgp1.digitaloceanspaces.com/cdn.extension/Extension-ERP-06-32.png'

and with input(normal system file): '/files/download.pdf'
out =>  '/files/download.pdf'