### PR TITLE
fix: pass reference_doctype to search query methods

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -81,7 +81,15 @@ def search_widget(
 		try:
 			is_whitelisted(frappe.get_attr(query))
 			frappe.response["values"] = frappe.call(
-				query, doctype, txt, searchfield, start, page_length, filters, as_dict=as_dict
+				query,
+				doctype,
+				txt,
+				searchfield,
+				start,
+				page_length,
+				filters,
+				as_dict=as_dict,
+				reference_doctype=reference_doctype,
 			)
 		except frappe.exceptions.PermissionError as e:
 			if frappe.local.conf.developer_mode:

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -130,10 +130,30 @@ class TestSearch(FrappeTestCase):
 		search_link("User", "user@random", searchfield="name")
 		self.assertListEqual(frappe.response["results"], [])
 
+	def test_reference_doctype(self):
+		"""search query methods should get reference_doctype if they want"""
+		search_link(
+			doctype="User",
+			txt="",
+			filters=None,
+			page_length=20,
+			reference_doctype="ToDo",
+			query="frappe.tests.test_search.query_with_reference_doctype",
+		)
+		self.assertListEqual(frappe.response["results"], [])
+
 
 @frappe.validate_and_sanitize_search_inputs
 def get_data(doctype, txt, searchfield, start, page_len, filters):
 	return [doctype, txt, searchfield, start, page_len, filters]
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def query_with_reference_doctype(
+	doctype, txt, searchfield, start, page_len, filters, reference_doctype=None
+):
+	return []
 
 
 def setup_test_link_field_order(TestCase):


### PR DESCRIPTION
Isssue: If you create user permissions with "applicable_for" it's supposed to apply those UP to queries when link field is getting queries, however, the reference doctype isn't passed at all to custom queries so there's no way for them to know where it's being linked. 

refer:

- https://github.com/frappe/frappe/blob/e6279e08f28f4b970d474bb8b7e4e0b0637b955b/frappe/model/db_query.py#L174-L176
- https://github.com/frappe/frappe/blob/e6279e08f28f4b970d474bb8b7e4e0b0637b955b/frappe/model/db_query.py#L962-L969

Fix: pass reference_doctype to queries. `frappe.call` ensures that it's only passed to functions which can accept it, so nothing to worry about ~ backward compatible change.



dependent PR: https://github.com/frappe/erpnext/pull/35038

ref: ISS-23-24-00271