### PR TITLE
perf: get all file data at once when downloading private file

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -224,16 +224,16 @@ def download_private_file(path: str) -> Response:
 	"""Checks permissions and sends back private file"""
 
 	can_access = False
-	files = frappe.get_all("File", filters={"file_url": path}, pluck="name")
+	files = frappe.get_all("File", filters={"file_url": path}, fields="*")
 	# this file might be attached to multiple documents
 	# if the file is accessible from any one of those documents
 	# then it should be downloadable
-	for fname in files:
-		file: "File" = frappe.get_doc("File", fname)
-		if can_access := file.is_downloadable():
+	for file_data in files:
+		file: "File" = frappe.get_doc(doctype="File", **file_data)
+		if file.is_downloadable():
 			break
 
-	if not can_access:
+	else:
 		raise Forbidden(_("You don't have permission to access this file"))
 
 	make_access_log(doctype="File", document=file.name, file_type=os.path.splitext(path)[-1][1:])


### PR DESCRIPTION
Get all private files in one query to avoid O(n) DB calls.

_Optionally, we can also set a limit of maximum number of files to check permissions for, before giving up. Like maybe 1000 files._

## When getting a file URL present in 5500 files without permission

### Before

```python

In [18]: %timeit download_private_file("/private/files/500x500.png")
6.03 s ± 39.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```


### After (>90% improvement)

```python

In [19]: %timeit download_private_file("/private/files/500x500.png")
329 ms ± 2.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```

---

Partly helps fix https://github.com/frappe/frappe/issues/20821

Only partly, because we're still doing queries via `get_doc` inside `file.has_permission`:
https://github.com/frappe/frappe/blob/9cf7f2b31100e15677412343b1fcd609d3ca0ff3/frappe/core/doctype/file/file.py#L720