### PR TITLE
style: use `set.isdisjoint` when comparing roles (+ minor refactor)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -845,7 +845,7 @@ def only_for(roles: list[str] | tuple[str] | str, message=False):
 	if isinstance(roles, str):
 		roles = (roles,)
 
-	if not set(roles).intersection(get_roles()):
+	if set(roles).isdisjoint(get_roles()):
 		if not message:
 			raise PermissionError
 

--- a/frappe/desk/desk_page.py
+++ b/frappe/desk/desk_page.py
@@ -37,13 +37,12 @@ def has_permission(page):
 	if frappe.session.user == "Administrator" or "System Manager" in frappe.get_roles():
 		return True
 
-	page_roles = [d.role for d in page.get("roles")]
-	if page_roles:
-		if frappe.session.user == "Guest" and "Guest" not in page_roles:
-			return False
-		elif not set(page_roles).intersection(set(frappe.get_roles())):
-			# check if roles match
-			return False
+	page_roles = {d.role for d in page.get("roles")}
+	if page_roles and (
+		(frappe.session.user == "Guest" and "Guest" not in page_roles)
+		or page_roles.isdisjoint(frappe.get_roles())
+	):
+		return False
 
 	if not frappe.has_permission("Page", ptype="read", doc=page):
 		# check if there are any user_permissions

--- a/frappe/desk/desk_page.py
+++ b/frappe/desk/desk_page.py
@@ -31,22 +31,3 @@ def getpage():
 	doc = get(page)
 
 	frappe.response.docs.append(doc)
-
-
-def has_permission(page):
-	if frappe.session.user == "Administrator" or "System Manager" in frappe.get_roles():
-		return True
-
-	page_roles = {d.role for d in page.get("roles")}
-	if page_roles and (
-		(frappe.session.user == "Guest" and "Guest" not in page_roles)
-		or page_roles.isdisjoint(frappe.get_roles())
-	):
-		return False
-
-	if not frappe.has_permission("Page", ptype="read", doc=page):
-		# check if there are any user_permissions
-		return False
-	else:
-		# hack for home pages! if no Has Roles, allow everyone to see!
-		return True

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -62,12 +62,11 @@ def get_permission_query_conditions(user):
 
 
 def has_permission(doc, user):
-
-	user_roles = set(frappe.get_roles(user))
+	if user == "Administrator":
+		return True
 
 	permitted_roles = {permitted_role.role for permitted_role in doc.permitted_roles}
-
-	return user == "Administrator" or user_roles.intersection(permitted_roles)
+	return not permitted_roles.isdisjoint(frappe.get_roles(user))
 
 
 def process_workflow_actions(doc, state):


### PR DESCRIPTION
reasons:
- [`set.isdisjoint`](https://docs.python.org/3/library/stdtypes.html#frozenset.isdisjoint) doesn't create a new set unlike `set.intersection`
- `set.isdisjoint` [exits early](https://github.com/python/cpython/blob/78942ecd9b1dbbd95e99cc298b0154fe126dac12/Lib/_collections_abc.py#L610)

Also removing `desk_page.has_permission`. It's dead code.
Read more: https://stackoverflow.com/a/17735466.