### PR TITLE
fix: corrected whitelisted function `get_roles()`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -568,15 +568,6 @@ def get_user():
 	return local.user_perms
 
 
-def get_roles(username=None) -> list[str]:
-	"""Returns roles of current user."""
-	if not local.session or not local.session.user:
-		return ["Guest"]
-	import frappe.permissions
-
-	return frappe.permissions.get_roles(username or local.session.user)
-
-
 def get_request_header(key, default=None):
 	"""Return HTTP request header.
 
@@ -1050,6 +1041,16 @@ def reset_metadata_version():
 	v = generate_hash()
 	cache().set_value("metadata_version", v)
 	return v
+
+
+@whitelist()
+def get_roles(username=None) -> list[str]:
+	"""Returns roles of current user."""
+	if not local.session or not local.session.user:
+		return ["Guest"]
+	import frappe.permissions
+
+	return frappe.permissions.get_roles(username or local.session.user)
 
 
 def new_doc(

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -673,9 +673,9 @@ def get_all_roles(arg=None):
 
 
 @frappe.whitelist()
-def get_roles(arg=None):
+def get_roles(user: str | None = None) -> list[str]:
 	"""get roles for a user"""
-	return frappe.get_roles(frappe.form_dict["uid"])
+	return frappe.get_roles(user)
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -673,12 +673,6 @@ def get_all_roles(arg=None):
 
 
 @frappe.whitelist()
-def get_roles(user: str | None = None) -> list[str]:
-	"""get roles for a user"""
-	return frappe.get_roles(user)
-
-
-@frappe.whitelist()
 def get_perm_info(role):
 	"""get permission info"""
 	from frappe.permissions import get_all_perms


### PR DESCRIPTION
1. Removed a whitelisted function `get_roles()` from *user.py* which was throwing an error like: `KeyError: u'uid'`. Also this function is not being called anywhere.
2. Make `frappe.ger_roles` as whitelisted. It will be helpful to get user roles from client side.