### PR TITLE
fix: only call background job synchronously as fallback during migration

### DIFF
--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -95,9 +95,12 @@ def enqueue(
 	try:
 		q = get_queue(queue, is_async=is_async)
 	except ConnectionError:
-		# If redis is not available for queueing execute the job directly
-		print(f"Redis queue is unreachable: Executing {method} synchronously")
-		return frappe.call(method, **kwargs)
+		if frappe.local.flags.in_migrate:
+			# If redis is not available during migration, execute the job directly
+			print(f"Redis queue is unreachable: Executing {method} synchronously")
+			return frappe.call(method, **kwargs)
+
+		raise
 
 	if not timeout:
 		timeout = get_queues_timeout().get(queue) or 300


### PR DESCRIPTION
Restores [earlier behaviour](https://github.com/frappe/frappe/pull/17974/files#diff-c3003a6f894d7b130a27e37eae5d5ce386a1c63b38d9d85bfd9636d020a0b232L81) of failing explicitly for scenarios except migration.

