### PR TITLE
fix: don't use default filters for auto-email report

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -157,10 +157,18 @@ class Report(Document):
 			return self.get_columns(), loc["result"]
 
 	def get_data(
-		self, filters=None, limit=None, user=None, as_dict=False, ignore_prepared_report=False
+		self,
+		filters=None,
+		limit=None,
+		user=None,
+		as_dict=False,
+		ignore_prepared_report=False,
+		are_default_filters=True,
 	):
 		if self.report_type in ("Query Report", "Script Report", "Custom Report"):
-			columns, result = self.run_query_report(filters, user, ignore_prepared_report)
+			columns, result = self.run_query_report(
+				filters, user, ignore_prepared_report, are_default_filters
+			)
 		else:
 			columns, result = self.run_standard_report(filters, limit, user)
 
@@ -169,10 +177,16 @@ class Report(Document):
 
 		return columns, result
 
-	def run_query_report(self, filters=None, user=None, ignore_prepared_report=False):
+	def run_query_report(
+		self, filters=None, user=None, ignore_prepared_report=False, are_default_filters=True
+	):
 		columns, result = [], []
 		data = frappe.desk.query_report.run(
-			self.name, filters=filters, user=user, ignore_prepared_report=ignore_prepared_report
+			self.name,
+			filters=filters,
+			user=user,
+			ignore_prepared_report=ignore_prepared_report,
+			are_default_filters=are_default_filters,
 		)
 
 		for d in data.get("columns"):

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -114,6 +114,7 @@ class AutoEmailReport(Document):
 			filters=self.filters,
 			as_dict=True,
 			ignore_prepared_report=True,
+			are_default_filters=False,
 		)
 
 		# add serial numbers


### PR DESCRIPTION
## Issue

When auto-email is setup for custom reports (with filters), they use default filters instead of filters specified in auto-email report.

![image](https://user-images.githubusercontent.com/10496564/235671575-79205c99-3e06-4bda-a125-dcc9afc73c64.png)

Reference where custom filters are set:
https://github.com/frappe/frappe/blob/develop/frappe/desk/query_report.py#L201

## Resolution

Give priority to filters specified in auto-email report

Added, `are_default_filters = False` in Auto-Email Report.

