### PR TITLE
fix: use smaller font only if the report doesnt have a standard print format

### DIFF
--- a/frappe/public/html/print_template.html
+++ b/frappe/public/html/print_template.html
@@ -27,9 +27,11 @@
 			</div>
 		{% endif %}
 
-		<div class="print-format {% if landscape %} landscape {% endif %}"
+		<div class="print-format {% if landscape %}landscape{% endif %}"
 				{% if columns.length > 20 %}
-					style="font-size: 4.0pt"
+					{% if can_use_smaller_font %}
+						style="font-size: 4.0pt"
+					{% endif %}
 				{% endif %}
 			>
 			{% if print_settings.letter_head %}

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1371,6 +1371,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			columns: this.get_columns_for_print(print_settings, custom_format),
 			original_data: this.data,
 			report: this,
+			can_use_smaller_font: this.report_doc.is_standard === "Yes" && custom_format ? 0 : 1,
 		});
 	}
 
@@ -1407,6 +1408,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			columns: columns,
 			lang: frappe.boot.lang,
 			layout_direction: frappe.utils.is_rtl() ? "rtl" : "ltr",
+			can_use_smaller_font: this.report_doc.is_standard === "Yes" && custom_format ? 0 : 1,
 		});
 
 		let filter_values = [],

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1415,6 +1415,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							print_settings: print_settings,
 							columns: this.columns,
 							data: rows_in_order,
+							can_use_smaller_font: 1,
 						});
 					});
 				},


### PR DESCRIPTION
Internal Reference: ISS-23-24-00561

Change: don't control the font size of standard print formats of reports - ideally they should define their own font sizes