### PR TITLE
fix: make operator in link filters translatable

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -475,7 +475,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 			let value = filter[3] == null || filter[3] === "" ? __("empty") : String(filter[3]);
 
-			return [__(label).bold(), filter[2], value.bold()].join(" ");
+			return [__(label).bold(), __(frappe.model.unscrub(filter[2])), value.bold()].join(" ");
 		}
 
 		let filter_string = filter_array.map(get_filter_description).join(", ");


### PR DESCRIPTION
Translate operators such as "in", "not in", "descendents of", etc. in link field filters.

Translations already exist for the unscrubbed version, therefore we unscrub before translating.