### PR TITLE
fix: ignore virtual doctypes during data export

### DIFF
--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -9,6 +9,7 @@ import frappe
 import frappe.permissions
 from frappe import _
 from frappe.core.doctype.access_log.access_log import make_access_log
+from frappe.model.utils import is_virtual_doctype
 from frappe.utils import cint, cstr, format_datetime, format_duration, formatdate, parse_json
 from frappe.utils.csvutils import UnicodeWriter
 
@@ -390,6 +391,8 @@ class DataExporter:
 			if self.all_doctypes:
 				# add child tables
 				for c in self.child_doctypes:
+					if is_virtual_doctype(c["doctype"]):
+						continue
 					child_doctype_table = DocType(c["doctype"])
 					data_row = (
 						frappe.qb.from_(child_doctype_table)


### PR DESCRIPTION
Trying to export records for doctypes that have a child table as a virtual doctype raises the following error:

```python
ProgrammingError: (1146, "Table '_0ece7759525955dd.tab{redacted}' doesn't exist")
  File "frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "__init__.py", line 1585, in call
    return fn(*args, **newargs)
  File "frappe/core/doctype/data_export/exporter.py", line 61, in export_data
    exporter.build_response()
  File "frappe/core/doctype/data_export/exporter.py", line 141, in build_response
    self.add_data()
  File "frappe/core/doctype/data_export/exporter.py", line 379, in add_data
    for ci, child in enumerate(data_row.run(as_dict=True)):
  File "frappe/query_builder/utils.py", line 76, in execute_query
    return frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
  File "frappe/database/database.py", line 206, in sql
    self._cursor.execute(query, values)
  File "pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
```

In another iteration, we could use a common controller method to add the rows instead.