### PR TITLE
docs: fix typo in `database.py`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1222,7 +1222,7 @@ class Database:
 			# multi_word_regex is designed to match following patterns
 			# `tabXxx Xxx` and "tabXxx Xxx"
 
-			# ([`"]?) Captures " or ` at the begining of the table name (if provided)
+			# ([`"]?) Captures " or ` at the beginning of the table name (if provided)
 			# \1 matches the first captured group (quote character) at the end of the table name
 			# multi word table name must have surrounding quotes.
 


### PR DESCRIPTION
begining -> beginning
