### PR TITLE
fix(delete_doc): Check ignore_links_on_delete with parent doctype

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -328,6 +328,13 @@ def check_if_doc_is_dynamically_linked(doc, method="Delete"):
 				):
 					reference_doctype = refdoc.parenttype if meta.istable else df.parent
 					reference_docname = refdoc.parent if meta.istable else refdoc.name
+
+					if reference_doctype in frappe.get_hooks("ignore_links_on_delete") or (
+						reference_doctype in ignore_linked_doctypes and method == "Cancel"
+					):
+						# don't check for communication and todo!
+						continue
+
 					at_position = f"at Row: {refdoc.idx}" if meta.istable else ""
 
 					raise_link_exists_exception(doc, reference_doctype, reference_docname, at_position)


### PR DESCRIPTION
**Problem:**
Communication dynamically linked to Lead
![image](https://user-images.githubusercontent.com/328330/236200611-7da5a5aa-e49b-4831-bc84-527e0d8b8d57.png)

Lead cannot be deleted
![image](https://user-images.githubusercontent.com/328330/236200782-a226138f-67fe-4036-af0e-e1b0310e7889.png)


**Solution:**
Ignore linked dynamically document based on parenttype