### PR TITLE
feat: helper method for address display

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -129,7 +129,7 @@ def get_default_address(doctype, name, sort_key="is_primary_address"):
 
 
 @frappe.whitelist()
-def get_address_display(address_dict):
+def get_address_display(address_dict: dict | str) -> str:
 	if not address_dict:
 		return
 

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -42,4 +42,23 @@ $.extend(frappe.contacts, {
 			docname,
 		};
 	},
+	get_address_display: function (frm, address_field, display_field) {
+		if (frm.updating_party_details) {
+			return;
+		}
+
+		let _address_field = address_field || "address";
+		let _display_field = display_field || "address_display";
+
+		if (!frm.doc[_address_field]) {
+			frm.set_value(_display_field, "");
+			return;
+		}
+
+		frappe
+			.xcall("frappe.contacts.doctype.address.address.get_address_display", {
+				address_dict: frm.doc[_address_field],
+			})
+			.then((address_display) => frm.set_value(_display_field, address_display));
+	},
 });


### PR DESCRIPTION
The frontend helper method `get_address_display` was part of erpnext only. I think this should be a part of the framework. After this is merged, we can start to replace and phase out the implementation in erpnext.

> no-docs