### PR TITLE
feat: child_field syntax sugar for qb

### DIFF
--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -82,19 +82,26 @@ def patch_query_execute():
 
 	def execute_query(query, *args, **kwargs):
 		child_queries = query._child_queries if isinstance(query._child_queries, list) else []
-
 		query, params = prepare_query(query)
 		result = frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
-
-		if result and isinstance(result[0], dict) and result[0].name:
-			parent_names = [d.name for d in result]
-			for child_query in child_queries or []:
-				data = child_query.get_query(parent_names).run(as_dict=1)
-				for row in result:
-					row[child_query.fieldname] = [
-						d for d in data if str(d.parent) == str(row.name) and d.parentfield == child_query.fieldname
-					]
+		execute_child_queries(child_queries, result)
 		return result
+
+	def execute_child_queries(queries, result):
+		if not result or not isinstance(result[0], dict) or not result[0].name:
+			return
+		parent_names = [d.name for d in result]
+		for child_query in queries:
+			data = child_query.get_query(parent_names).run(as_dict=1)
+			for row in result:
+				row[child_query.fieldname] = []
+				for d in data:
+					if str(d.parent) == str(row.name) and d.parentfield == child_query.fieldname:
+						if "parent" not in child_query.fields:
+							del d["parent"]
+						if "parentfield" not in child_query.fields:
+							del d["parentfield"]
+						row[child_query.fieldname].append(d)
 
 	def prepare_query(query):
 		import inspect


### PR DESCRIPTION
Fetching child table rows in a `get_list` query was not possible without doing data manipulation before. Now, you can use the dictionary syntax. This only works in `frappe.qb.get_query`.

```py
result = frappe.qb.get_query(
	"Note",
	fields=["name", {"seen_by": ["*"]}]
).run(as_dict=1)

# result
[
  {'name': '123', 'seen_by': [{'name': '123fsdf', 'user': 'Administrator', 'idx: 1, ...}, ...]},
  {'name': '234', 'seen_by': [{'name': '788dddd', 'user': 'Administrator', 'idx: 1, ...}, ...]}
]
```

```py
result = frappe.qb.get_query(
	"Note",
	fields=["name", {"seen_by": ["user"]}]
).run(as_dict=1)

# result
[
  {'name': '123', 'seen_by': [{'user': 'Administrator'}, ...]},
  {'name': '234', 'seen_by': [{'user': 'Guest'}, ...]}
]
```


- [x] Test