### PR TITLE
fix!: Correct resolution order for template page

### DIFF
--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -50,7 +50,7 @@ class TemplatePage(BaseTemplatePage):
 		and /templates/pages folders and sets path if match is found
 		"""
 		folders = get_start_folders()
-		for app in frappe.get_installed_apps(frappe_last=True):
+		for app in reversed(frappe.get_installed_apps()):
 			app_path = frappe.get_app_path(app)
 
 			for dirname in folders:


### PR DESCRIPTION
Current resolution is confusing mess:

1. Evaluation is done in order of installed app, **first install wins**
2. Except frappe, frappe is treated with lowest priority.

Following same principle of "last write wins" everywhere similar to
previous PRs:

- https://github.com/frappe/frappe/pull/17869
- https://github.com/frappe/frappe/pull/20648
- https://github.com/frappe/frappe/pull/19653

Closes https://github.com/frappe/frappe/issues/20377

