### PR TITLE
feat: track skipped patch with traceback

### DIFF
--- a/frappe/core/doctype/patch_log/patch_log.json
+++ b/frappe/core/doctype/patch_log/patch_log.json
@@ -7,7 +7,9 @@
  "document_type": "System",
  "engine": "InnoDB",
  "field_order": [
-  "patch"
+  "patch",
+  "skipped",
+  "traceback"
  ],
  "fields": [
   {
@@ -15,12 +17,24 @@
    "fieldtype": "Code",
    "label": "Patch",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "skipped",
+   "fieldtype": "Check",
+   "label": "Skipped"
+  },
+  {
+   "depends_on": "eval:doc.skipped == 1",
+   "fieldname": "traceback",
+   "fieldtype": "Code",
+   "label": "Traceback"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "links": [],
- "modified": "2023-01-17 15:35:11.688615",
+ "modified": "2023-05-04 23:56:02.270262",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Patch Log",
@@ -33,6 +47,14 @@
    "read": 1,
    "report": 1,
    "role": "Administrator"
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager"
   }
  ],
  "quick_entry": 1,

--- a/frappe/core/doctype/patch_log/patch_log.py
+++ b/frappe/core/doctype/patch_log/patch_log.py
@@ -12,4 +12,4 @@ class PatchLog(Document):
 
 
 def before_migrate():
-	frappe.reload_doc("core", "doctype", "patch_log", force=True)
+	frappe.reload_doc("core", "doctype", "patch_log")

--- a/frappe/core/doctype/patch_log/patch_log.py
+++ b/frappe/core/doctype/patch_log/patch_log.py
@@ -3,8 +3,13 @@
 
 # License: MIT. See LICENSE
 
+import frappe
 from frappe.model.document import Document
 
 
 class PatchLog(Document):
 	pass
+
+
+def before_migrate():
+	frappe.reload_doc("core", "doctype", "patch_log", force=True)

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -274,7 +274,7 @@ setup_wizard_exception = [
 	"frappe.desk.page.setup_wizard.setup_wizard.log_setup_wizard_exception",
 ]
 
-before_migrate = []
+before_migrate = ["frappe.core.doctype.patch_log.patch_log.before_migrate"]
 after_migrate = ["frappe.website.doctype.website_theme.website_theme.after_migrate"]
 
 otp_methods = ["OTP App", "Email", "SMS"]

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -68,7 +68,7 @@ def run_all(skip_failing: bool = False, patch_type: PatchType | None = None) -> 
 			else:
 				print("Failed to execute patch")
 				if skip_failing:
-					update_patch_log(patch, skip_failing)
+					update_patch_log(patch, skipped=True)
 
 	patches = get_all_patches(patch_type=patch_type)
 
@@ -188,7 +188,7 @@ def execute_patch(patchmodule: str, method=None, methodargs=None):
 					_patch()
 				else:
 					exec(patch, globals())
-				update_patch_log(patchmodule, False)
+				update_patch_log(patchmodule)
 
 		elif method:
 			method(**methodargs)
@@ -206,27 +206,16 @@ def execute_patch(patchmodule: str, method=None, methodargs=None):
 	return True
 
 
-def update_patch_log(patchmodule, skipped):
+def update_patch_log(patchmodule, skipped=False):
 	"""update patch_file in patch log"""
-	"""
-	skipped -> Patch failed
-	not skipped -> Patch executed successfully
-	"""
-	patch_log_exists = frappe.db.get_value("Patch Log", {"patch": patchmodule, "skipped": 1})
 
-	if patch_log_exists and not skipped:
-		frappe.db.set_value("Patch Log", {"patch": patchmodule}, "skipped", 0)
-	elif patch_log_exists:
+	patch = frappe.get_doc({"doctype": "Patch Log", "patch": patchmodule})
+
+	if skipped:
 		traceback = frappe.get_traceback(with_context=True)
-		frappe.db.set_value("Patch Log", {"patch": patchmodule}, "traceback", traceback)
-	else:
-		patch = frappe.get_doc({"doctype": "Patch Log", "patch": patchmodule})
-
-		if skipped:
-			traceback = frappe.get_traceback(with_context=True)
-			patch.skipped = 1
-			patch.traceback = traceback
-		patch.insert(ignore_permissions=True)
+		patch.skipped = 1
+		patch.traceback = traceback
+	patch.insert(ignore_permissions=True)
 
 
 def executed(patchmodule):

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -67,8 +67,7 @@ def run_all(skip_failing: bool = False, patch_type: PatchType | None = None) -> 
 				raise
 			else:
 				print("Failed to execute patch")
-				if skip_failing:
-					update_patch_log(patch, skipped=True)
+				update_patch_log(patch, skipped=True)
 
 	patches = get_all_patches(patch_type=patch_type)
 

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -223,7 +223,7 @@ def executed(patchmodule):
 	if patchmodule.startswith("finally:"):
 		# patches are saved without the finally: tag
 		patchmodule = patchmodule.replace("finally:", "")
-	return frappe.db.get_value("Patch Log", {"patch": patchmodule})
+	return frappe.db.get_value("Patch Log", {"patch": patchmodule, "skipped": 0})
 
 
 def _patch_mode(enable):

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -215,6 +215,7 @@ def update_patch_log(patchmodule, skipped=False):
 		traceback = frappe.get_traceback(with_context=True)
 		patch.skipped = 1
 		patch.traceback = traceback
+		print(traceback)
 	patch.insert(ignore_permissions=True)
 
 


### PR DESCRIPTION
### Changes:

* If migrate is executed with `--skip-failing` option, track all the failed patches with traceback.
* Allow system manager to view Patch Log (read only).

<img width="1208" alt="Screenshot 2023-05-09 at 3 49 32 PM" src="https://github.com/frappe/frappe/assets/30501401/a6b0ea8e-ac7c-4cec-9ac7-189a51e84fc1">


