### PR TITLE
perf: Faster scheduled job deduplication

### DIFF
--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -11,7 +11,7 @@ import frappe
 from frappe.core.doctype.rq_job.rq_job import RQJob, remove_failed_jobs, stop_job
 from frappe.tests.utils import FrappeTestCase, timeout
 from frappe.utils import cstr, execute_in_shell
-from frappe.utils.background_jobs import is_job_queued
+from frappe.utils.background_jobs import is_job_enqueued, is_job_queued
 
 
 class TestRQJob(FrappeTestCase):
@@ -106,6 +106,13 @@ class TestRQJob(FrappeTestCase):
 
 		_, stderr = execute_in_shell("bench worker --queue short,default --burst", check_exit_code=True)
 		self.assertIn("quitting", cstr(stderr))
+
+	@timeout(20)
+	def test_job_id_dedup(self):
+		job_id = "test_dedup"
+		job = frappe.enqueue(self.BG_JOB, sleep=10, job_id=job_id)
+		self.assertTrue(is_job_enqueued(job_id))
+		stop_job(job.id)
 
 
 def test_func(fail=False, sleep=0):

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -10,7 +10,7 @@ from croniter import croniter
 import frappe
 from frappe.model.document import Document
 from frappe.utils import get_datetime, now_datetime
-from frappe.utils.background_jobs import enqueue, get_jobs
+from frappe.utils.background_jobs import enqueue, is_job_enqueued
 
 
 class ScheduledJobType(Document):
@@ -41,16 +41,12 @@ class ScheduledJobType(Document):
 		return self.get_next_execution() <= (current_time or now_datetime())
 
 	def is_job_in_queue(self) -> bool:
-		try:
-			job = frappe.get_doc("RQ Job", self.rq_job_id)
-			return job.status in ("queued", "started")
-		except frappe.DoesNotExistError:
-			return False
+		return is_job_enqueued(self.rq_job_id)
 
 	@property
 	def rq_job_id(self):
 		"""Unique ID created to deduplicate jobs with single RQ call."""
-		return f"scheduled_job::{frappe.local.site}::{self.method}"
+		return f"scheduled_job::{self.method}"
 
 	@property
 	def next_execution(self):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1302,6 +1302,7 @@ def enqueue_jobs_after_commit():
 				kwargs=job.get("queue_args"),
 				failure_ttl=frappe.conf.get("rq_job_failure_ttl") or RQ_JOB_FAILURE_TTL,
 				result_ttl=frappe.conf.get("rq_results_ttl") or RQ_RESULTS_TTL,
+				job_id=job.get("job_id"),
 			)
 		frappe.flags.enqueue_after_commit = []
 

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -78,6 +78,7 @@ class TestBackgroundJobs(FrappeTestCase):
 				at_front=False,
 				failure_ttl=RQ_JOB_FAILURE_TTL,
 				result_ttl=RQ_RESULTS_TTL,
+				job_id=None,
 			)
 
 	def test_job_hooks(self):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -19,7 +19,6 @@ import frappe.monitor
 from frappe import _
 from frappe.utils import cstr, get_bench_id
 from frappe.utils.commands import log
-from frappe.utils.deprecations import deprecation_warning
 from frappe.utils.redis_queue import RedisQueue
 
 if TYPE_CHECKING:
@@ -452,9 +451,11 @@ def create_job_id(job_id: str) -> str:
 
 
 def is_job_enqueued(job_id: str) -> str:
+	from rq.job import Job
+
 	try:
-		job = Job.fetch(job_id, connection=get_redis_conn())
+		job = Job.fetch(create_job_id(job_id), connection=get_redis_conn())
 	except NoSuchJobError:
 		return False
 
-	return job.status in ("queued", "started")
+	return job.get_status() in ("queued", "started")

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -64,6 +64,7 @@ def enqueue(
 	enqueue_after_commit=False,
 	*,
 	at_front=False,
+	job_id=None,
 	**kwargs,
 ) -> Union["Job", Any]:
 	"""
@@ -118,7 +119,13 @@ def enqueue(
 			frappe.flags.enqueue_after_commit = []
 
 		frappe.flags.enqueue_after_commit.append(
-			{"queue": queue, "is_async": is_async, "timeout": timeout, "queue_args": queue_args}
+			{
+				"queue": queue,
+				"is_async": is_async,
+				"timeout": timeout,
+				"queue_args": queue_args,
+				"job_id": job_id,
+			}
 		)
 		return frappe.flags.enqueue_after_commit
 
@@ -131,6 +138,7 @@ def enqueue(
 		at_front=at_front,
 		failure_ttl=frappe.conf.get("rq_job_failure_ttl") or RQ_JOB_FAILURE_TTL,
 		result_ttl=frappe.conf.get("rq_results_ttl") or RQ_RESULTS_TTL,
+		job_id=job_id,
 	)
 
 


### PR DESCRIPTION
O(n) to O(1) dedup by specifying unique IDs on scheduled RQ jobs.

Problem:
- scheduler read all queued jobs to avoid re-queueing duplicate
- This is mostly fine, except when queue is large, in which case it can end up reading GBs of jobs in memory only to decide if next job should be scheduler or not


![image](https://github.com/frappe/frappe/assets/9079960/dc2f0992-0595-4c61-acbf-8d2db9733830)


Fix:
The simple solution is to have unique job ID for each name so we can find if job exists or not from single redis call to fetch that job. 


Closes https://github.com/frappe/frappe/issues/18980
