### PR TITLE
fix: prioritise user timezone over system

### DIFF
--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -152,13 +152,14 @@ $.extend(frappe.datetime, {
 			let date_obj = moment(val, frappe.defaultDateFormat);
 			return date_obj.format(user_date_fmt);
 		} else {
-			let date_obj = moment.tz(val, frappe.boot.time_zone.system);
+			let time_zone = frappe.boot.time_zone.user || frappe.boot.time_zone.system;
+			let date_obj = moment.tz(val, time_zone);
 			if (typeof val !== "string" || val.indexOf(" ") === -1) {
 				user_format = user_date_fmt;
 			} else {
 				user_format = user_date_fmt + " " + user_time_fmt;
 			}
-			return date_obj.clone().tz(frappe.boot.time_zone.user).format(user_format);
+			return date_obj.format(user_format);
 		}
 	},
 


### PR DESCRIPTION
![image_2023-05-09_17-53-22](https://github.com/frappe/frappe/assets/30859809/3d75ee61-ff91-49b7-9a6c-869040b36c7d)


In this example, we are first setting the timezone to `Asia/Singapore` and we again change the timezone with respect to `Asia/Singapore` timezone to `Asia/Kolkata` with gives the wrong date