### PR TITLE
fix: strip comma, space from recipients before sending email for auto repeat

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -372,12 +372,10 @@ class AutoRepeat(Document):
 		elif "{" in self.message:
 			message = frappe.render_template(self.message, {"doc": new_doc})
 
-		recipients = self.recipients.split("\n")
-
 		frappe.sendmail(
 			reference_doctype=new_doc.doctype,
 			reference_name=new_doc.name,
-			recipients=recipients,
+			recipients=self.recipients,
 			subject=subject,
 			content=message,
 			attachments=attachments,


### PR DESCRIPTION
`QueueBuilder` by default splits the emails by comma, whitespace