### PR TITLE
fix: Database error when joining a link field from the same doctype

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -273,7 +273,7 @@ class DatabaseQuery:
 
 		# left join link tables
 		for link in self.link_tables:
-			args.tables += f" {self.join} `tab{link.doctype}` on (`tab{link.doctype}`.`name` = {self.tables[0]}.`{link.fieldname}`)"
+			args.tables += f" {self.join} `tab{link.doctype}` as linkDT on (linkDT.`name` = {self.tables[0]}.`{link.fieldname}`)"
 
 		if self.grouped_or_conditions:
 			self.conditions.append(f"({' or '.join(self.grouped_or_conditions)})")


### PR DESCRIPTION
Problem: When a doctype has a link field which reference the same doctype, for example a task linked to its parent task, 
an error occured when `in list view` property  of linked field is check. 

![image](https://user-images.githubusercontent.com/58433943/237055915-77e1b8fe-4fb7-4e4b-a628-c306fe09b9eb.png)

Indeed the sql query that loads the report view is the following:
```sql
select `tabTask`.`name`, `tabTask`.`owner`, `tabTask`.`creation`, [...]
from `tabTask`
left join `tabTask` on (`tabTask`.`name` = `tabTask`.`parent_task`)
group by `tabTask`.`name` order by `tabTask`.`modified` desc limit 20 offset 0
```
So `left join` refer to the same table without beeing aliased. 
To prevent this error I add an alias on link table.
