### PR TITLE
fix: avoid internal arrays in get_all_docs

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -64,7 +64,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 
 			const is_empty_row = function (cells) {
 				for (let i = 0; i < cells.length; i++) {
-					if (locals[doc.doctype][doc.name][cells[i].fieldname]) {
+					if (locals[doc.doctype][doc.name] && locals[doc.doctype][doc.name][cells[i].fieldname]) {
 						return false;
 					}
 				}

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -791,7 +791,7 @@ $.extend(frappe.model, {
 	get_all_docs: function (doc) {
 		var all = [doc];
 		for (var key in doc) {
-			if ($.isArray(doc[key])) {
+			if ($.isArray(doc[key]) && !key.startsWith("_")) {
 				var children = doc[key];
 				for (var i = 0, l = children.length; i < l; i++) {
 					all.push(children[i]);


### PR DESCRIPTION
**Issue:** When you create a new Purchase Order (It doesn't matter if you use Tab to add a new row just add a new row and delete it) then save

Will get an error (This is not an actual problem ignore this)
<img width="297" alt="image" src="https://github.com/frappe/frappe/assets/30859809/b8f51fba-ff91-4233-b280-c5520d8b6cc9">

After resolving the above error Mandatory fields required in row 2 error pop up

It is happening because in erpnext `_items` Array is getting created which is a duplicate of `items` and while deleting the value from it is not removed