### PR TITLE
refactor!: Use job_id for bg job deduplication

### DIFF
--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -9,7 +9,7 @@ from frappe.core.doctype.data_import.exporter import Exporter
 from frappe.core.doctype.data_import.importer import Importer
 from frappe.model.document import Document
 from frappe.modules.import_file import import_file_by_path
-from frappe.utils.background_jobs import enqueue, is_job_queued
+from frappe.utils.background_jobs import enqueue, is_job_enqueued
 from frappe.utils.csvutils import validate_google_sheets_url
 
 
@@ -64,13 +64,15 @@ class DataImport(Document):
 		if is_scheduler_inactive() and not frappe.flags.in_test:
 			frappe.throw(_("Scheduler is inactive. Cannot import data."), title=_("Scheduler Inactive"))
 
-		if not is_job_queued(self.name):
+		job_id = f"data_import::{self.name}"
+
+		if not is_job_enqueued(job_id):
 			enqueue(
 				start_import,
 				queue="default",
 				timeout=10000,
 				event="data_import",
-				job_name=self.name,
+				job_id=job_id,
 				data_import=self.name,
 				now=frappe.conf.developer_mode or frappe.flags.in_test,
 			)

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -11,7 +11,7 @@ import frappe
 from frappe.core.doctype.rq_job.rq_job import RQJob, remove_failed_jobs, stop_job
 from frappe.tests.utils import FrappeTestCase, timeout
 from frappe.utils import cstr, execute_in_shell
-from frappe.utils.background_jobs import is_job_enqueued, is_job_queued
+from frappe.utils.background_jobs import is_job_enqueued
 
 
 class TestRQJob(FrappeTestCase):
@@ -87,17 +87,6 @@ class TestRQJob(FrappeTestCase):
 		with self.assertRaises(rq_exc.NoSuchJobError):
 			job.refresh()
 
-	def test_is_enqueued(self):
-
-		dummy_job = frappe.enqueue(self.BG_JOB, sleep=10, queue="short")
-		job_name = "uniq_test_job"
-		actual_job = frappe.enqueue(self.BG_JOB, job_name=job_name, queue="short")
-
-		self.assertTrue(is_job_queued(job_name))
-		stop_job(dummy_job.id)
-		self.check_status(actual_job, "finished")
-		self.assertFalse(is_job_queued(job_name))
-
 	@timeout(20)
 	def test_multi_queue_burst_consumption(self):
 		for _ in range(3):
@@ -110,9 +99,10 @@ class TestRQJob(FrappeTestCase):
 	@timeout(20)
 	def test_job_id_dedup(self):
 		job_id = "test_dedup"
-		job = frappe.enqueue(self.BG_JOB, sleep=10, job_id=job_id)
+		job = frappe.enqueue(self.BG_JOB, sleep=5, job_id=job_id)
 		self.assertTrue(is_job_enqueued(job_id))
-		stop_job(job.id)
+		self.check_status(job, "finished")
+		self.assertFalse(is_job_enqueued(job_id))
 
 
 def test_func(fail=False, sleep=0):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -19,6 +19,7 @@ import frappe.monitor
 from frappe import _
 from frappe.utils import cstr, get_bench_id
 from frappe.utils.commands import log
+from frappe.utils.deprecations import deprecation_warning
 from frappe.utils.redis_queue import RedisQueue
 
 if TYPE_CHECKING:
@@ -76,7 +77,7 @@ def enqueue(
 	:param timeout: should be set according to the functions
 	:param event: this is passed to enable clearing of jobs from queues
 	:param is_async: if is_async=False, the method is executed immediately, else via a worker
-	:param job_name: can be used to name an enqueue call, which can be used to prevent duplicate calls
+	:param job_name: [DEPRECATED] can be used to name an enqueue call, which can be used to prevent duplicate calls
 	:param now: if now=True, the method is executed via frappe.call
 	:param kwargs: keyword arguments to be passed to the method
 	:param job_id: Assigning unique job id, which can be checked using `is_job_enqueued`
@@ -88,11 +89,12 @@ def enqueue(
 		# namespace job ids to sites
 		job_id = create_job_id(job_id)
 
+	if job_name:
+		deprecation_warning("Using enqueue with `job_name` is deprecated, use `job_id` instead.")
+
 	if not is_async and not frappe.flags.in_test:
-		print(
-			_(
-				"Using enqueue with is_async=False outside of tests is not recommended, use now=True instead."
-			)
+		deprecation_warning(
+			"Using enqueue with is_async=False outside of tests is not recommended, use now=True instead."
 		)
 
 	call_directly = now or (not is_async and not frappe.flags.in_test)
@@ -428,21 +430,6 @@ def test_job(s):
 
 	print("sleeping...")
 	time.sleep(s)
-
-
-def is_job_queued(job_name: str) -> bool:
-	"""Check if job exists with given job_name
-
-	DEPRECATED: Use `job_id` parameter while enqueueing job instead instead.
-	"""
-	for queue in get_queues():
-		for job_id in queue.get_job_ids():
-			if not job_id:
-				continue
-			job = queue.fetch_job(job_id)
-			if job.kwargs.get("job_name") == job_name and job.kwargs.get("site") == frappe.local.site:
-				return True
-	return False
 
 
 def create_job_id(job_id: str) -> str:


### PR DESCRIPTION
refer: https://github.com/frappe/frappe/pull/20937


`job_name` parameter is deprecated because the way it identifies duplicate jobs is very slow process. `job_id` is recommended over it. 



https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)#deprecation-of-job_name-parameter-in-frappeenqueue 