### PR TITLE
fix: maintain frappe.router.current_router

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -247,6 +247,12 @@ frappe.views.Workspace = class Workspace {
 		this.update_selected_sidebar(this.current_page, false); //remove selected from old page
 		this.update_selected_sidebar(page, true); //add selected on new page
 
+		if (!frappe.router.current_route[0]) {
+			frappe.router.current_route = !page.public
+				? ["Workspaces", "private", page.name]
+				: ["Workspaces", page.name];
+		}
+
 		this.show_page(page);
 	}
 


### PR DESCRIPTION
If we route to `/app` we get routed to the last opened workspace but `frappe.router.current_route` stays empty. This PR fix that.