### PR TITLE
fix: naming part should be empty if field is empty 

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -336,10 +336,8 @@ def parse_naming_series(
 			part = str(today)
 		elif e == "FY":
 			part = frappe.defaults.get_user_default("fiscal_year")
-		elif e.startswith("{") and doc:
+		elif doc and (e.startswith("{") or hasattr(doc, e)):
 			e = e.replace("{", "").replace("}", "")
-			part = doc.get(e)
-		elif doc and doc.get(e):
 			part = doc.get(e)
 		else:
 			part = e
@@ -550,9 +548,7 @@ def _format_autoname(autoname, doc):
 
 	def get_param_value_for_match(match):
 		param = match.group()
-		# trim braces
-		trimmed_param = param[1:-1]
-		return parse_naming_series([trimmed_param], doc=doc)
+		return parse_naming_series([param[1:-1]], doc=doc)
 
 	# Replace braced params with their parsed value
 	name = BRACED_PARAMS_PATTERN.sub(get_param_value_for_match, autoname_value)

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -369,6 +369,15 @@ class TestNaming(FrappeTestCase):
 			name.startswith("KOOH-"), f"incorrect name generated {name}, missing field value"
 		)
 
+	def test_naming_with_empty_field(self):
+		# check naming with empty field value
+
+		webhook = frappe.new_doc("Webhook")
+		series = "KOOH-.{request_structure}.-.request_structure.-.####"
+
+		name = parse_naming_series(series, doc=webhook)
+		self.assertTrue(name.startswith("KOOH---"), f"incorrect name generated {name}")
+
 
 def make_invalid_todo():
 	frappe.get_doc({"doctype": "ToDo", "description": "Test"}).insert(set_name="ToDo")


### PR DESCRIPTION
Currently, 2 different behaviors with respect to fields are there in naming series/expressions

1) if fields are wrapped in `{}`, then no matter if the field's value is None, we get an empty string
2) if fields aren't wrapped in `{}`, then if the field didnt have any value, it would be considered to be just a simple string i.e the fieldname would get attached to the doc name instead of an empty string

This pr tries to make the point 2's behavior consistent with point 1.

closes: https://github.com/frappe/frappe/issues/20926