### PR TITLE
fix: validate email on setup wizard

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -441,7 +441,7 @@ frappe.setup.slides_settings = [
 	{
 		// Profile slide
 		name: "user",
-		title: __("Let's setup your account"),
+		title: __("Let's set up your account"),
 		icon: "fa fa-user",
 		fields: [
 			{

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -490,12 +490,6 @@ frappe.setup.slides_settings = [
 			if (frappe.setup.data.email) {
 				let email = frappe.setup.data.email;
 				slide.form.fields_dict.email.set_input(email);
-				if (frappe.get_gravatar(email, 200)) {
-					let $attach_user_image = slide.form.fields_dict.attach_user_image.$wrapper;
-					$attach_user_image.find(".missing-image").toggle(false);
-					$attach_user_image.find("img").attr("src", frappe.get_gravatar(email, 200));
-					$attach_user_image.find(".img-container").toggle(true);
-				}
 			}
 		},
 	},

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -85,9 +85,11 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 		return this.fields_dict[fieldname];
 	}
 
-	get_values(ignore_errors) {
+	get_values(ignore_errors, check_invalid) {
 		var ret = {};
 		var errors = [];
+		let invalid = [];
+
 		for (var key in this.fields_dict) {
 			var f = this.fields_dict[key];
 			if (f.get_value) {
@@ -104,7 +106,12 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 			if (this.is_dialog && f.df.reqd && !f.value) {
 				f.refresh_input();
 			}
+
+			if (f.df.invalid) {
+				invalid.push(__(f.df.label));
+			}
 		}
+
 		if (errors.length && !ignore_errors) {
 			frappe.msgprint({
 				title: __("Missing Values Required"),
@@ -112,6 +119,19 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 					__("Following fields have missing values:") +
 					"<br><br><ul><li>" +
 					errors.join("<li>") +
+					"</ul>",
+				indicator: "orange",
+			});
+			return null;
+		}
+
+		if (invalid.length && check_invalid) {
+			frappe.msgprint({
+				title: __("Inavlid Values"),
+				message:
+					__("Following fields have invalid values:") +
+					"<br><br><ul><li>" +
+					invalid.join("<li>") +
 					"</ul>",
 				indicator: "orange",
 			});

--- a/frappe/public/js/frappe/ui/slides.js
+++ b/frappe/public/js/frappe/ui/slides.js
@@ -106,7 +106,7 @@ frappe.ui.Slide = class Slide {
 	}
 
 	set_values(ignore_errors) {
-		this.values = this.form.get_values(ignore_errors);
+		this.values = this.form.get_values(ignore_errors, true);
 		if (this.values === null) {
 			return false;
 		}


### PR DESCRIPTION
As of now you can proceed with invalid values on setup wizard. This PR
basically checks all fields which are marked `invalid` as per df options.


Some misc unrelated changes also part of same PR:
- dead code related to gravatar
- typo `setup` -> `set up`


