### PR TITLE
feat: rate limiting on server scripts

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -17,6 +17,10 @@
   "disabled",
   "section_break_8",
   "script",
+  "rate_limiting_section",
+  "enable_rate_limit",
+  "rate_limit_count",
+  "rate_limit_seconds",
   "help_section",
   "help_html"
  ],
@@ -102,6 +106,32 @@
    "fieldtype": "Link",
    "label": "Module (for export)",
    "options": "Module Def"
+  },
+  {
+   "depends_on": "eval:doc.script_type==='API'",
+   "fieldname": "rate_limiting_section",
+   "fieldtype": "Section Break",
+   "label": "Rate Limiting"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_rate_limit",
+   "fieldtype": "Check",
+   "label": "Enable Rate Limit"
+  },
+  {
+   "default": "5",
+   "depends_on": "enable_rate_limit",
+   "fieldname": "rate_limit_count",
+   "fieldtype": "Int",
+   "label": "Limit"
+  },
+  {
+   "default": "86400",
+   "depends_on": "enable_rate_limit",
+   "fieldname": "rate_limit_seconds",
+   "fieldtype": "Int",
+   "label": "Seconds"
   }
  ],
  "index_web_pages_for_search": 1,
@@ -111,7 +141,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2022-06-13 06:04:20.937969",
+ "modified": "2023-05-12 20:54:54.365266",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -206,6 +206,10 @@ def setup_scheduler_events(script_name, frequency):
 
 
 def execute_api_server_script(script=None, *args, **kwargs):
+	# These are only added for compatibility with rate limiter.
+	del args
+	del kwargs
+
 	if script.script_type != "API":
 		raise frappe.DoesNotExistError
 


### PR DESCRIPTION
- Support wrapping server script in `@rate_limit` decorator.
- The implementation looks magical but it works. It works by wrapping the server script in a new partial function and executing it at runtime.
https://github.com/frappe/frappe/blob/95287c060c0cf5e95ce16f16d55351a9dc1b5ac9/frappe/core/doctype/server_script/server_script.py#L89-L90

- This works because rate_limit decorator applies rate limiting on `cmd`
https://github.com/frappe/frappe/blob/9dc2a329523f1e431cbdca07e733a35d1067d3e7/frappe/rate_limiter.py#L138

![image](https://github.com/frappe/frappe/assets/9079960/d039f06e-fdb1-4903-a45b-2bd8cd15274b)


docs: https://frappeframework.com/docs/v14/user/en/desk/scripting/server-script