### PR TITLE
fix: process filters while making and getting prepared report missed in (#19565)

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -106,9 +106,7 @@ def make_prepared_report(report_name, filters=None):
 		{
 			"doctype": "Prepared Report",
 			"report_name": report_name,
-			# This looks like an insanity but, without this it'd be very hard to find Prepared Reports matching given condition
-			# We're ensuring that spacing is consistent. e.g. JS seems to put no spaces after ":", Python on the other hand does.
-			"filters": json.dumps(json.loads(filters)),
+			"filters": process_filters_for_prepared_report(filters),
 		}
 	).insert(ignore_permissions=True)
 
@@ -134,7 +132,7 @@ def get_completed_prepared_report(filters, user, report_name):
 		"Prepared Report",
 		filters={
 			"status": "Completed",
-			"filters": json.dumps(filters),
+			"filters": process_filters_for_prepared_report(filters),
 			"owner": user,
 			"report_name": report_name,
 		},


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/19565
This fix was implemented after the prepared report refactor was merged in this PR https://github.com/frappe/frappe/pull/19265 which was missed in the backport