### PR TITLE
fix: report print view not working

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1349,8 +1349,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			.map((f) => {
 				const [doctype, fieldname, condition, value] = f;
 				if (condition !== "=") return "";
+				const label = frappe.meta.get_label(doctype, fieldname);
 				const docfield = frappe.meta.get_docfield(doctype, fieldname);
-				return `<h6>${__(docfield.label)}: ${frappe.format(value, docfield)}</h6>`;
+				return `<h6>${__(label)}: ${frappe.format(value, docfield)}</h6>`;
 			})
 			.join("");
 	}


### PR DESCRIPTION

```
report_view.js:1353 Uncaught TypeError: Cannot read properties of undefined (reading 'label')
    at report_view.js:1353:31
    at Array.map (<anonymous>)
    at frappe.views.ReportView.get_filters_html_for_print (report_view.js:1349:5)
    at report_view.js:1414:23
    at print_utils.js:67:4
    at frappe.ui.Dialog.<anonymous> (messages.js:104:4)
    at HTMLButtonElement.<anonymous> (dialog.js:165:20)
    at HTMLButtonElement.dispatch (jquery.js:5430:27)
    at c1.handle (jquery.js:5234:28)
```

caused by https://github.com/frappe/frappe/pull/20717

partially reverted PR