### PR TITLE
fix: add card shadow to onboarding widget

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -342,6 +342,7 @@ body {
 		margin-bottom: var(--margin-2xl);
 		padding: var(--padding-lg) !important;
 		background-color: var(--bg-color);
+		box-shadow: var(--card-shadow) ;
 
 		&.edit-mode:hover {
 			background-color: var(--fg-color);


### PR DESCRIPTION
The contrast between bg and widget was very low, added shadow so it's slightly more noticeable. It ain't much but looks better. 

Before:

![image](https://github.com/frappe/frappe/assets/9079960/3ab7d3a8-f8b4-4a5f-b711-a1ace7fd8816)


After:

![image](https://github.com/frappe/frappe/assets/9079960/40cb647c-a68c-4c42-a298-e3014a460a7b)

