### PR TITLE
fix: Consistent buttons on login / error pages

### DIFF
--- a/frappe/www/message.html
+++ b/frappe/www/message.html
@@ -28,7 +28,7 @@ html, body {
 	{% block message_body %}
 		<p>{{ message or "" }}</p>
 		{% if primary_action %}
-		<div><a href='{{ primary_action or "/" }}' class='btn btn-primary btn-sm'>
+		<div><a href='{{ primary_action or "/" }}' class='btn btn-primary btn-sm btn-block'>
 			{{ primary_label or _("Home") }}</a></div>
 		{% endif %}
 	{% endblock %}


### PR DESCRIPTION
Action button was actually half the width of the button that's usually after it.

Screenshots:

![SCR-20230517-mjrg](https://github.com/frappe/frappe/assets/925613/1cb2fbdf-77f5-43fb-af21-16dd57c10aa2)
