### PR TITLE
fix: set system manager as default permissions while creating from form builder

### DIFF
--- a/frappe/desk/page/form_builder/form_builder.js
+++ b/frappe/desk/page/form_builder/form_builder.js
@@ -85,6 +85,7 @@ function load_form_builder(wrapper) {
 			},
 			secondary_action_label: __("Create New DocType"),
 			secondary_action() {
+				let doctype = d.get_value("doctype") || "";
 				d.hide();
 				let new_d = new frappe.ui.Dialog({
 					title: __("Create New DocType"),
@@ -93,6 +94,7 @@ function load_form_builder(wrapper) {
 							label: __("DocType Name"),
 							fieldname: "doctype_name",
 							fieldtype: "Data",
+							default: doctype,
 							reqd: 1,
 						},
 						{ fieldtype: "Column Break" },

--- a/frappe/desk/page/form_builder/form_builder.js
+++ b/frappe/desk/page/form_builder/form_builder.js
@@ -155,6 +155,20 @@ function load_form_builder(wrapper) {
 								issingle: values.issingle,
 								custom: values.custom,
 								is_submittable: values.is_submittable,
+								permissions: [
+									{
+										create: 1,
+										delete: 1,
+										email: 1,
+										export: 1,
+										print: 1,
+										read: 1,
+										report: 1,
+										role: "System Manager",
+										share: 1,
+										write: 1,
+									},
+								],
 								fields: [
 									{
 										label: "Title",


### PR DESCRIPTION
1. Set `System Manager` as default permission while creating a new doctype from the form builder similar to default doctype creation.
2. If `Select DocType` is set and `Create New DocType` is clicked populate the `DocType Name` from `Select DocType` field value