### PR TITLE
fix: route to workspace when on "/app"

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -248,9 +248,7 @@ frappe.views.Workspace = class Workspace {
 		this.update_selected_sidebar(page, true); //add selected on new page
 
 		if (!frappe.router.current_route[0]) {
-			frappe.router.current_route = !page.public
-				? ["Workspaces", "private", page.name]
-				: ["Workspaces", page.name];
+			frappe.set_route(frappe.router.slug(page.public ? page.name : "private/" + page.name));
 		}
 
 		this.show_page(page);


### PR DESCRIPTION
By default, when you visit "/app" it shows the workspace but the same is not reflected on the frappe.router.current_path. we can't set the route before because the workspace is decided after all the workspaces are loaded and setting it after that will not trigger the router's change event also it makes sense to route to the correct URL.