### PR TITLE
fix: removed canonical link

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -20,8 +20,6 @@
 	>
 	{% endblock %}
 
-	<link rel="canonical" href="{{ canonical }}">
-
 	{%- block head -%}
 		{% include "templates/includes/head.html" %}
 	{%- endblock -%}


### PR DESCRIPTION
1. Canonical link implementation is not well thought.
2. The logic just takes the route path and uses it as a canonical link
3. In the case of pages whose route is determined by the `website_route_rules` hook, the canonical link gets set as the file path.

### Example:

**The rule defined in website_route_rules:** 

`{"from_route": "/courses/<course>", "to_route": "courses/course"}`

**Canonical Link**

<img width="1440" alt="Screenshot 2023-05-18 at 3 37 43 PM" src="https://github.com/frappe/frappe/assets/31363128/7725d93d-5a48-42a2-b375-dda4ea7f39c6">

Check the canonical link in the image above.

**Preview**
When the URL of this page is shared on platforms that follow the open graph protocol, the preview of the link looks weird.

<img width="357" alt="Screenshot 2023-05-18 at 3 48 26 PM" src="https://github.com/frappe/frappe/assets/31363128/5385ac54-731c-454e-9fad-a8f657aa5522">

Checking the page URL on Meta's open graph debugger:

**Open Graph Debugger**
<img width="1440" alt="Screenshot 2023-05-18 at 3 46 47 PM" src="https://github.com/frappe/frappe/assets/31363128/ee39c031-6fbd-443f-8683-d4dac38b5826">

The protocol considers the canonical link and users that to render a preview of the URL. Hence the preview is broken.