### PR TITLE
fix: incorrect caching of `is_owner` permissions

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -206,7 +206,7 @@ def get_role_permissions(doctype_meta, user=None, is_owner=None):
 	if not user:
 		user = frappe.session.user
 
-	cache_key = (doctype_meta.name, user)
+	cache_key = (doctype_meta.name, user, bool(is_owner))
 
 	if user == "Administrator":
 		return allow_everything()


### PR DESCRIPTION
- Create a doctype
- Pick any role and only allow owner to create, read, write.
- after_insert hook re-save the document
- This will fail because there's a function call to `frappe.only_has_select_perm` which doesn't pass the is_owner, this is likely acceptable if document is not available.

Fix: cache should be separate for is_owner

Triggered from but not caused by https://github.com/frappe/frappe/pull/20810

