### PR TITLE
fix: using 'Equals' and 'Is' on multiselect throws error if 'get_filters_cond' is used for formating filters

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -679,6 +679,7 @@ def get_filters_cond(
 				if isinstance(f[1], str) and f[1][0] == "!":
 					flt.append([doctype, f[0], "!=", f[1][1:]])
 				elif isinstance(f[1], (list, tuple)) and f[1][0].lower() in (
+					"=",
 					">",
 					"<",
 					">=",
@@ -689,6 +690,7 @@ def get_filters_cond(
 					"in",
 					"not in",
 					"between",
+					"is",
 				):
 
 					flt.append([doctype, f[0], f[1][0], f[1][1]])


### PR DESCRIPTION
Sales Invoice -> Get Items from -> Delivery Note uses MultiSelect Dialog box. Filters generated from this dialog box is formatted using [`get_fiters_cond`](https://github.com/frappe/frappe/blob/a96aadc10bf98cac486ffdbc93d707e0c42daec5/frappe/desk/reportview.py#L667-L710) in `reportview.py` which doesn't handle 'Equal' and 'Is' properly.

<img width="1431" alt="Screenshot 2023-05-18 at 4 49 50 PM" src="https://github.com/frappe/frappe/assets/3272205/fb91c8e1-05eb-4c35-af25-7258ea17ae97">

Internal Reference: ISS-22-23-05732
