### PR TITLE
Fix exporter name type

### DIFF
--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -197,7 +197,7 @@ class Exporter:
 		# Group children data by parent name
 		grouped_children_data = self.group_children_data_by_parent(child_data)
 		for doc in parent_data:
-			related_children_docs = grouped_children_data.get(doc.name, {})
+			related_children_docs = grouped_children_data.get(str(doc.name), {})
 			yield {**doc, **related_children_docs}
 
 	def add_header(self):


### PR DESCRIPTION
This PR fixes CSV/Excel exporting Child Tables when the Document  name is set to Autoincrement.

With autoincrement, the type of the name is casted to integer and the dict key is always a string, which caused exporter to always return empty Child Tables.

In order to reproduce a simple document with autoincrement can be created with a Child Table and try exporting all data.

