### PR TITLE
feat(minor): Webhook DocType enhancements

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -129,6 +129,7 @@
   },
   {
    "depends_on": "eval: doc.request_structure == \"JSON\"",
+   "description": "To add dynamic values from the document, use jinja tags like\n\n<div>\n<pre><code>{ \"id\": \"{{ doc.name }}\" }</code>\n</pre>\n</div>",
    "fieldname": "webhook_json",
    "fieldtype": "Code",
    "label": "JSON Request Body"

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -202,8 +202,13 @@
    "fieldtype": "Section Break"
   }
  ],
- "links": [],
- "modified": "2022-07-11 08:54:10.740512",
+ "links": [
+  {
+   "link_doctype": "Webhook Request Log",
+   "link_fieldname": "webhook"
+  }
+ ],
+ "modified": "2023-05-21 15:30:20.714582",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -132,7 +132,8 @@
    "description": "To add dynamic values from the document, use jinja tags like\n\n<div>\n<pre><code>{ \"id\": \"{{ doc.name }}\" }</code>\n</pre>\n</div>",
    "fieldname": "webhook_json",
    "fieldtype": "Code",
-   "label": "JSON Request Body"
+   "label": "JSON Request Body",
+   "options": "JSON"
   },
   {
    "fieldname": "naming_series",
@@ -209,7 +210,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2023-05-21 15:30:20.714582",
+ "modified": "2023-05-21 15:42:58.844826",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
+++ b/frappe/integrations/doctype/webhook_request_log/webhook_request_log.json
@@ -6,12 +6,12 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "user",
   "webhook",
   "reference_document",
   "headers",
   "data",
   "column_break_4",
+  "user",
   "url",
   "response",
   "error"
@@ -79,7 +79,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-04-12 11:50:01.702862",
+ "modified": "2023-05-21 15:50:10.414002",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook Request Log",


### PR DESCRIPTION
Add some "quality of life" enhancements to webhook doctype:

- feat(minor): add request log to connections
- fix(ux): add description for jinja support
- fix(ux): set language to enable syntax highlighting JSON
- fix(ui): rearrange field in webhook request log doctype

<img width="1320" alt="CleanShot 2023-05-21 at 15 52 34@2x" src="https://github.com/frappe/frappe/assets/34810212/da9a191d-71f9-4321-8ec9-8204a6e2f7cb">

`no-docs`

