### PR TITLE
fix: Propogate exit code from yarn build to bench build

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -87,7 +87,10 @@ const NODE_PATHS = [].concat(
 
 execute()
 	.then(() => RUN_BUILD_COMMAND && run_build_command_for_apps(APPS))
-	.catch((e) => console.error(e));
+	.catch((e) => {
+		console.error(e);
+		throw e;
+	});
 
 if (WATCH_MODE) {
 	// listen for open files in editor event


### PR DESCRIPTION
When `yarn build` fails `bench build` ignores the error and exits with exit code 0

Reference: https://frappecloud.com/dashboard/benches/bench-1816/deploys/deploy-1816-000215

`bench get-app` in this case should've failed but silently ignored the error and carried on.

```shell
Getting insights
$ git clone /home/aditya/Frappe/benches/press/insights --branch develop --depth 1 --origin upstream
Cloning into 'insights'...
warning: --depth is ignored in local clones; use file:// instead.
done.
Ignoring dependencies of /home/aditya/Frappe/benches/press/insights. To install dependencies use --resolve-deps
Installing insights
$ /home/aditya/Frappe/benches/press/env/bin/python -m pip install --quiet --upgrade -e /home/aditya/Frappe/benches/press/apps/insights 
$ yarn install
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...

success Saved lockfile.
$ cd frontend && yarn install --ignore-engines
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
warning "frappe-ui > @tiptap/extension-color@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-highlight@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-image@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-link@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-mention@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-placeholder@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-table@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-table-cell@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-table-header@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-table-row@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-text-align@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-text-style@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/extension-typography@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/pm@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/prosemirror-tables@1.1.4" has unmet peer dependency "prosemirror-keymap@^1.1.2".
warning "frappe-ui > @tiptap/prosemirror-tables@1.1.4" has unmet peer dependency "prosemirror-model@^1.8.1".
warning "frappe-ui > @tiptap/prosemirror-tables@1.1.4" has unmet peer dependency "prosemirror-state@^1.3.1".
warning "frappe-ui > @tiptap/prosemirror-tables@1.1.4" has unmet peer dependency "prosemirror-transform@^1.2.1".
warning "frappe-ui > @tiptap/prosemirror-tables@1.1.4" has unmet peer dependency "prosemirror-view@^1.13.3".
warning "frappe-ui > @tiptap/suggestion@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/vue-3@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/vue-3 > @tiptap/extension-bubble-menu@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "frappe-ui > @tiptap/vue-3 > @tiptap/extension-floating-menu@2.0.1" has unmet peer dependency "@tiptap/core@^2.0.0".
warning "vue3-drr-grid-layout > @interactjs/actions@1.10.17" has unmet peer dependency "@interactjs/core@1.10.17".
warning "vue3-drr-grid-layout > @interactjs/actions@1.10.17" has unmet peer dependency "@interactjs/utils@1.10.17".
warning "vue3-drr-grid-layout > @interactjs/auto-start@1.10.17" has unmet peer dependency "@interactjs/core@1.10.17".
warning "vue3-drr-grid-layout > @interactjs/auto-start@1.10.17" has unmet peer dependency "@interactjs/utils@1.10.17".
warning "vue3-drr-grid-layout > @interactjs/dev-tools@1.10.17" has unmet peer dependency "@interactjs/utils@1.10.17".
warning "vue3-drr-grid-layout > @interactjs/modifiers@1.10.17" has unmet peer dependency "@interactjs/core@1.10.17".
warning "vue3-drr-grid-layout > @interactjs/modifiers@1.10.17" has unmet peer dependency "@interactjs/utils@1.10.17".
warning "vue3-drr-grid-layout > @interactjs/modifiers > @interactjs/snappers@1.10.17" has unmet peer dependency "@interactjs/utils@1.10.17".
[4/4] Building fresh packages...
Done in 5.64s.
Done in 6.09s.
$ bench build --app insights
✔ Application Assets Linked                                                                                                                                                         


yarn run v1.22.19
$ node esbuild --apps insights --run-build-command
File                                                        Size

 DONE  Total Build Time: 317.298ms

 WARN  Cannot connect to redis_cache to update assets_json
 WARN  Cannot connect to redis_cache to update assets_json
 WARN  Cannot connect to redis_cache to update assets_json

Running build command for insights
$ cd frontend && yarn build
$ vite build --base=/assets/insights/frontend/ && yarn copy-html-entry
vite v4.2.1 building for production...
transforming (1981) node_modules/zrender/lib/contain/cubic.jsError when using sourcemap for reporting an error: Can't resolve original location of error.
✓ 1984 modules transformed.
✓ built in 14.67s
"getShortNumber" is not exported by "src/utils/index.js", imported by "src/widgets/Progress/Progress.vue".
file: /home/aditya/Frappe/benches/press/apps/insights/frontend/src/widgets/Progress/Progress.vue:15:9
13: 
14: import { computed } from 'vue'
15: import { getShortNumber } from '@/utils'
             ^
error during build:
RollupError: "getShortNumber" is not exported by "src/utils/index.js", imported by "src/widgets/Progress/Progress.vue".
    at error (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:2128:30)
    at Module.error (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:13322:16)
    at Module.traceVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:13707:29)
    at ModuleScope.findVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:12210:39)
    at FunctionScope.findVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:6953:38)
    at ChildScope.findVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:6953:38)
    at FunctionScope.findVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:6953:38)
    at ChildScope.findVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:6953:38)
    at TrackingScope.findVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:6953:38)
    at BlockScope.findVariable (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:6953:38)
    at Identifier.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:8103:40)
    at CallExpression.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5749:23)
    at CallExpression.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:9630:15)
    at ReturnStatement.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5749:23)
    at BlockStatement.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5745:28)
    at IfStatement.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5749:23)
    at BlockStatement.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5745:28)
    at FunctionDeclaration.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5749:23)
    at BlockStatement.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5745:28)
    at FunctionExpression.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5749:23)
    at Property.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5749:23)
    at ObjectExpression.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5745:28)
    at VariableDeclarator.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5749:23)
    at VariableDeclaration.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5745:28)
    at Program.bind (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:5745:28)
    at Module.bindReferences (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:13318:18)
    at Graph.sortModules (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:24704:20)
    at Graph.build (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:24588:14)
    at async file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:25605:13
    at async catchUnfinishedHookActions (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:24758:20)
    at async rollupInternal (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/rollup/dist/es/shared/node-entry.js:25600:5)
    at async build (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/vite/dist/node/chunks/dep-79892de8.js:46240:18)
    at async CAC.<anonymous> (file:///home/aditya/Frappe/benches/press/apps/insights/frontend/node_modules/vite/dist/node/cli.js:813:9)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Command failed: yarn build
    at checkExecSyncError (node:child_process:871:11)
    at execSync (node:child_process:943:15)
    at run_build_command_for_apps (/home/aditya/Frappe/benches/press/apps/frappe/esbuild/esbuild.js:436:5)
    at /home/aditya/Frappe/benches/press/apps/frappe/esbuild/esbuild.js:89:35
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 36090,
  stdout: null,
  stderr: null
}
Done in 20.49s.
aditya yarn run build --apps insights --run-build-command 0 True
WARN: restart failed: Couldn't find supervisorctl in PATH
```


