### PR TITLE
fix: allow user to send an email copy to themselves even if thread_notify is off

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -45,6 +45,7 @@ def make(
 	print_letterhead=True,
 	email_template=None,
 	communication_type=None,
+	filter_thread_notify=True,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -98,6 +99,7 @@ def make(
 		email_template=email_template,
 		communication_type=communication_type,
 		add_signature=False,
+		filter_thread_notify=filter_thread_notify,
 	)
 
 
@@ -123,6 +125,7 @@ def _make(
 	email_template=None,
 	communication_type=None,
 	add_signature=True,
+	filter_thread_notify=True,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -175,9 +178,12 @@ def _make(
 			print_format=print_format,
 			send_me_a_copy=send_me_a_copy,
 			print_letterhead=print_letterhead,
+			filter_thread_notify=cint(filter_thread_notify),
 		)
 
-	emails_not_sent_to = comm.exclude_emails_list(include_sender=send_me_a_copy)
+	emails_not_sent_to = comm.exclude_emails_list(
+		include_sender=send_me_a_copy, filter_thread_notify=cint(filter_thread_notify)
+	)
 
 	return {"name": comm.name, "emails_not_sent_to": ", ".join(emails_not_sent_to)}
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 from urllib.parse import quote
 
 import frappe
@@ -310,56 +312,74 @@ class TestCommunicationEmailMixin(FrappeTestCase):
 				"bcc": bcc,
 				"sender": "sender@test.com",
 			}
-		).insert(ignore_permissions=True)
-
-	def new_user(self, email, **user_data):
-		user_data.setdefault("first_name", "first_name")
-		user = frappe.new_doc("User")
-		user.email = email
-		user.update(user_data)
-		user.insert(ignore_permissions=True, ignore_if_duplicate=True)
-		return user
+		).insert(ignore_permissions=True, ignore_links=True)
 
 	def test_recipients(self):
 		to_list = ["to@test.com", "receiver <to+1@test.com>", "to@test.com"]
 		comm = self.new_communication(recipients=to_list)
 		res = comm.get_mail_recipients_with_displayname()
 		self.assertCountEqual(res, ["to@test.com", "receiver <to+1@test.com>"])
-		comm.delete()
 
-	def test_cc(self):
-		def test(assertion, cc_list=None, set_user_as=None, include_sender=False, thread_notify=False):
-			if set_user_as:
-				frappe.set_user(set_user_as)
+		# drop the "cached" recipients
+		delattr(comm, "_final_recipients")
 
-			user = self.new_user(email="cc+1@test.com", thread_notify=thread_notify)
-			comm = self.new_communication(recipients=["to@test.com"], cc=cc_list)
-			res = comm.get_mail_cc_with_displayname(include_sender=include_sender)
+		# test with assignments and owner for inbound communication for a document
+		with create_user("def@test.com", thread_notify=False), patch.object(
+			comm, "get_owner", return_value="to@test.com"
+		), patch.object(comm, "get_assignees", return_value=["abc@test.com", "def@test.com"]):
+			res = comm.get_mail_recipients_with_displayname(is_inbound_mail_communcation=True)
 
-			frappe.set_user("Administrator")
-			user.delete()
+			# cleanup
 			comm.delete()
 
-			self.assertEqual(res, assertion)
+			self.assertEqual(res, ["abc@test.com"])
 
-		# test filter_thread_notification_disbled_users and filter_mail_recipients
-		test(["cc <cc+2@test.com>"], cc_list=["cc+1@test.com", "cc <cc+2@test.com>", "to@test.com"])
+	def test_cc(self):
+		def _test(
+			assertion,
+			cc_list=None,
+			include_sender=False,
+			is_inbound_mail_communcation=False,
+			filter_thread_notify=True,
+		):
+			comm = self.new_communication(recipients=["to@test.com"], cc=cc_list)
+			res = comm.get_mail_cc_with_displayname(
+				include_sender=include_sender,
+				is_inbound_mail_communcation=is_inbound_mail_communcation,
+				filter_thread_notify=filter_thread_notify,
+			)
+			comm.delete()
+
+			self.assertEqual(sorted(res), sorted(assertion))
+
+		# test filter_mail_recipients
+		with create_user("cc+1@test.com", thread_notify=False):
+			_test(
+				["cc <cc+2@test.com>"],
+				cc_list=["cc+1@test.com", "cc <cc+2@test.com>", "to@test.com"],
+			)
+
+			# don't filter thread_notify disabled users
+			_test(
+				["cc+1@test.com", "cc <cc+2@test.com>"],
+				cc_list=["cc+1@test.com", "cc <cc+2@test.com>", "to@test.com"],
+				filter_thread_notify=False,
+			)
 
 		# test include_sender
-		test(["sender@test.com"], include_sender=True, thread_notify=True)
-		test(["cc+1@test.com"], include_sender=True, thread_notify=True, set_user_as="cc+1@test.com")
+		_test(["sender@test.com"], include_sender=True)
+
+		# test include sender with thread notify off
+		with create_user("cc+1@test.com", set_user=True, thread_notify=False):
+			_test(["cc+1@test.com"], include_sender=True)
 
 	def test_bcc(self):
-		bcc_list = [
-			"bcc+1@test.com",
-			"cc <bcc+2@test.com>",
-		]
-		user = self.new_user(email="bcc+2@test.com", enabled=0)
-		comm = self.new_communication(bcc=bcc_list)
+		email_list = ["bcc+1@test.com", "cc <bcc+2@test.com>", "bcc@test.com"]
+		comm = self.new_communication(recipients=[email_list[0]], cc=[email_list[1]], bcc=email_list)
 		res = comm.get_mail_bcc_with_displayname()
-		self.assertCountEqual(res, bcc_list)
-		user.delete()
 		comm.delete()
+
+		self.assertEqual(res, [email_list[2]])
 
 	def test_sendmail(self):
 		to_list = ["to <to@test.com>"]
@@ -407,3 +427,28 @@ def create_email_account() -> "EmailAccount":
 			"enable_automatic_linking": 1,
 		}
 	).insert(ignore_permissions=True)
+
+
+def new_user(email, **user_data):
+	user_data.setdefault("first_name", "first_name")
+	user = frappe.new_doc("User")
+	user.email = email
+	user.update(user_data)
+	user.insert(ignore_permissions=True, ignore_if_duplicate=True)
+	return user
+
+
+@contextmanager
+def create_user(user, set_user=False, **kwargs):
+	_user = new_user(email=user, **kwargs)
+
+	if set_user:
+		current_user = frappe.session.user
+		frappe.set_user(user)
+
+	try:
+		yield
+	finally:
+		if set_user:
+			frappe.set_user(current_user)
+		_user.delete(ignore_permissions=True, force=True)

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -648,6 +648,7 @@ frappe.views.CommunicationComposer = class {
 				attachments: selected_attachments,
 				read_receipt: form_values.send_read_receipt,
 				print_letterhead: me.is_print_letterhead_checked(),
+				filter_thread_notify: 0,
 			},
 			btn,
 			callback(r) {


### PR DESCRIPTION
Changes:
- allow people to send emails (via communication dialog) to people (self and others) even if thread notify is off (earlier we used to filter these off from CC and BCC)
- during inbound communication, attach doc owner/assignments to recipients/TO instead of CC. (TO used to come as blank)
- added filtering for thread_notify off users behind a param and added the same for recipients/TO