### PR TITLE
fix: Exclude Geolocation from "hide empty read-only field"

### DIFF
--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -125,7 +125,7 @@ frappe.ui.form.Control = class BaseControl {
 			status === "Read" &&
 			!this.only_input &&
 			is_null(value) &&
-			!in_list(["HTML", "Image", "Button"], this.df.fieldtype)
+			!in_list(["HTML", "Image", "Button", "Geolocation"], this.df.fieldtype)
 		) {
 			// eslint-disable-next-line
 			if (explain) console.log("By Hide Read-only, null fields: None"); // eslint-disable-line no-console


### PR DESCRIPTION
Fixes part of https://github.com/frappe/frappe/pull/16561/

**Issue:**
- Add a geolocation field and make it read-only
  <img width="1301" alt="Screenshot 2023-05-23 at 4 20 00 PM" src="https://github.com/frappe/frappe/assets/25857446/32c90b05-da12-47fe-9d0b-2ab142355345">

- When the read-only field has no value it is hidden as many other fields such as Data, Link, etc.
   ![2023-05-23 16 24 57](https://github.com/frappe/frappe/assets/25857446/e7ad5f45-4987-4a60-967f-29b2f4fffc1d)

**Fix:**
- Exclude it from field to be hidden on empty value
   ![2023-05-23 16 26 12](https://github.com/frappe/frappe/assets/25857446/f753a16c-a943-436a-b81c-5dc201ae43b6)
