### PR TITLE
fix: setup wizard recursion in routing

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -49,19 +49,14 @@ frappe.pages["setup-wizard"].on_page_load = function (wrapper) {
 				};
 				frappe.wizard = new frappe.setup.SetupWizard(wizard_settings);
 				frappe.setup.run_event("after_load");
-				let route = frappe.get_route();
-				if (route) {
-					frappe.wizard.show_slide(route[1]);
-				}
+				frappe.wizard.show_slide(cint(frappe.get_route()[1]));
 			},
 		});
 	});
 };
 
 frappe.pages["setup-wizard"].on_page_show = function () {
-	if (frappe.get_route()[1]) {
-		frappe.wizard && frappe.wizard.show_slide(frappe.get_route()[1]);
-	}
+	frappe.wizard && frappe.wizard.show_slide(cint(frappe.get_route()[1]));
 };
 
 frappe.setup.on("before_load", function () {
@@ -125,7 +120,7 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 			return;
 		}
 		super.show_slide(id);
-		frappe.set_route(this.page_name, id + "");
+		frappe.set_route(this.page_name, cstr(id));
 	}
 
 	show_hide_prev_next(id) {


### PR DESCRIPTION
- setup wizard shows slide from index in route
- if you visit `/app/setup-wizard` then index in route is `undefined`
- because of hacky code for string conversion we do `id + ''` so `undefined` becomes `"undefined"` a truthy value

The recursion of undefined > 0 > undefined > 0 continues until browser intervenes and stops further routing. If your browser is dumb it just might crash. 
