### PR TITLE
fix: offset log cleanup to avoid deadlocks

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -195,6 +195,14 @@ scheduler_events = {
 		"0/10 * * * *": [
 			"frappe.email.doctype.email_account.email_account.pull",
 		],
+		# Hourly but offset by 30 minutes
+		# "30 * * * *": [
+		#
+		# ],
+		# Daily but offset by 45 minutes
+		"45 0 * * *": [
+			"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",
+		],
 	},
 	"all": [
 		"frappe.email.queue.flush",
@@ -227,7 +235,6 @@ scheduler_events = {
 		"frappe.automation.doctype.auto_repeat.auto_repeat.make_auto_repeat_entry",
 		"frappe.automation.doctype.auto_repeat.auto_repeat.set_auto_repeat_as_completed",
 		"frappe.email.doctype.unhandled_email.unhandled_email.remove_old_unhandled_emails",
-		"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",
 	],
 	"daily_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily",


### PR DESCRIPTION
- Email queue is cleared at midnight
- Another worker at same time might be sending Email

This causes random failures almost daily.

Fix: offset log cleanup to 12:45


![image](https://github.com/frappe/frappe/assets/9079960/d42ab506-00e5-4818-97cf-c5fdb0803fce)
