### PR TITLE
fix: allow default for text and long text when altering table

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -247,7 +247,6 @@ class DbColumn:
 			self.default_changed(current_def)
 			and (self.default not in frappe.db.DEFAULT_SHORTCUTS)
 			and not cstr(self.default).startswith(":")
-			and not (column_type in ["text", "longtext"])
 		):
 			self.table.set_default.append(self)
 


### PR DESCRIPTION
missed in https://github.com/frappe/frappe/pull/21089
