### PR TITLE
feat: added email template customization option for welcome and passw…

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -72,6 +72,8 @@
   "disable_standard_email_footer",
   "hide_footer_in_auto_email_reports",
   "attach_view_link",
+  "welcome_email_template",
+  "reset_password_template",
   "prepared_report_section",
   "max_auto_email_report_per_user",
   "system_updates_section",
@@ -549,12 +551,24 @@
    "fieldname": "enable_telemetry",
    "fieldtype": "Check",
    "label": "Allow Sending Usage Data for Improving Applications"
+  },
+  {
+   "fieldname": "welcome_email_template",
+   "fieldtype": "Link",
+   "label": "Welcome Email Template",
+   "options": "Email Template"
+  },
+  {
+   "fieldname": "reset_password_template",
+   "fieldtype": "Link",
+   "label": "Reset Password Template",
+   "options": "Email Template"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2023-04-23 11:14:59.302851",
+ "modified": "2023-05-25 13:02:54.808773",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -325,7 +325,10 @@ class User(Document):
 		return (self.first_name or "") + (self.first_name and " " or "") + (self.last_name or "")
 
 	def password_reset_mail(self, link):
-		self.send_login_mail(_("Password Reset"), "password_reset", {"link": link}, now=True)
+
+		reset_password_template = frappe.db.get_system_setting("reset_password_template")
+
+		self.send_login_mail(_("Password Reset"), "password_reset", {"link": link}, now=True, custom_template=reset_password_template)
 
 	def send_welcome_mail_to_user(self):
 		from frappe.utils import get_url
@@ -342,16 +345,19 @@ class User(Document):
 			else:
 				subject = _("Complete Registration")
 
+		welcome_email_template = frappe.db.get_system_setting("welcome_email_template")
+
 		self.send_login_mail(
 			subject,
 			"new_user",
-			dict(
+			   dict(
 				link=link,
 				site_url=get_url(),
 			),
+			custom_template=welcome_email_template,
 		)
 
-	def send_login_mail(self, subject, template, add_args, now=None):
+	def send_login_mail(self, subject, template, add_args, now=None, custom_template=None):
 		"""send mail with login details"""
 		from frappe.utils import get_url
 		from frappe.utils.user import get_user_fullname
@@ -374,11 +380,18 @@ class User(Document):
 			frappe.session.user not in STANDARD_USERS and get_formatted_email(frappe.session.user) or None
 		)
 
+		if custom_template:
+			from frappe.email.doctype.email_template.email_template import get_email_template
+			email_template = get_email_template(custom_template, args)
+			subject = email_template.get("subject")
+			content = email_template.get("message")
+
 		frappe.sendmail(
 			recipients=self.email,
 			sender=sender,
 			subject=subject,
-			template=template,
+			template=template if not custom_template else None,
+			content=content if custom_template else None,
 			args=args,
 			header=[subject, "green"],
 			delayed=(not now) if now is not None else self.flags.delay_emails,


### PR DESCRIPTION
### Added Email template customization option for Welcome Email and Reset Password.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Explain the **details** for making this change. What existing problem does the pull request solve?

When a new user is created or user is onboarded via Email link, the Email (template) received is hardcoded in the Frappe codebase. There's no way to customize the template design.

With this PR, one can select the customized Email template from the 'Email Template' list (with the required standard variables). This customization can be done for both Welcome Email & Reset Password Email. If you do not select any template then the default one will be used.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

I've added two fields in **System Settings** DocType's Email Section.

The two fields are as follows:
1. Welcome Email Template - a Link field linked to Email Template DocType
2. Reset Password Template - a Link field linked to Email Template DocType

Also I've added an optional agrument `custom_template` in the `send_login_mail` method defined in the _user.py_ file.
In the method, I've used Frappe's `get_email_template` method to get the `subject` & `content` from the custom template. Then passed them to `frappe.sendmail` method conditionally checking if the the custom template is there or not.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

<img width="1426" alt="image" src="https://github.com/frappe/frappe/assets/59502942/21591324-2fe9-49a6-9e22-6267fc9c0b82">

<img width="1434" alt="image" src="https://github.com/frappe/frappe/assets/59502942/f616bfcb-48c9-483a-93f9-288811e17968">

<img width="1433" alt="image" src="https://github.com/frappe/frappe/assets/59502942/16a2d305-f8e0-4385-a6a1-1c06e96c13cb">

