### PR TITLE
fix: don't mutate notification when getting cc and bcc

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -282,19 +282,8 @@ def get_context(context):
 						email_ids = email_ids_value.replace(",", "\n")
 						recipients = recipients + email_ids.split("\n")
 
-			if recipient.cc and "{" in recipient.cc:
-				recipient.cc = frappe.render_template(recipient.cc, context)
-
-			if recipient.cc:
-				recipient.cc = recipient.cc.replace(",", "\n")
-				cc = cc + recipient.cc.split("\n")
-
-			if recipient.bcc and "{" in recipient.bcc:
-				recipient.bcc = frappe.render_template(recipient.bcc, context)
-
-			if recipient.bcc:
-				recipient.bcc = recipient.bcc.replace(",", "\n")
-				bcc = bcc + recipient.bcc.split("\n")
+			cc.extend(get_emails_from_template(recipient.cc, context))
+			bcc.extend(get_emails_from_template(recipient.bcc, context))
 
 			# For sending emails to specified role
 			if recipient.receiver_by_role:
@@ -485,3 +474,11 @@ def get_assignees(doc):
 	recipients = [d.allocated_to for d in assignees]
 
 	return recipients
+
+
+def get_emails_from_template(template, context):
+	if not template:
+		return ()
+
+	emails = frappe.render_template(template, context) if "{" in template else template
+	return filter(None, emails.replace(",", "\n").split("\n"))


### PR DESCRIPTION
### Issue

This applies only to Notifications which -
 - trigger daily (**Days Before** / **Days After** event)
 - have a template in CC / BCC fields of Recipients child table

For such cases, the [same Notification doc is used](https://github.com/frappe/frappe/blob/2eca7b483760020d276cd1674b6cae6bec390959/frappe/email/doctype/notification/notification.py#L416) to trigger alerts for all matching documents.
Let's say 3 documents get matched (in order of modified desc): A, B and C.

Document A has 3 CC email IDs. Document B has 0 CC email IDs. Document C has 2 CC email IDs.
Because the `recipient.cc` value was earlier [getting mutated](https://github.com/frappe/frappe/blob/1eabd21bb8719e5f23989d8bf4865fc83cb168a7/frappe/email/doctype/notification/notification.py#L286), the 3 email IDs in document A would get CC'd even for the alerts of Document B and C. The actual email IDs for Document C would never get CC'd.

---


Tested Locally ✅ 