### PR TITLE
fix: sync importable doctype before documents

### DIFF
--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -11,6 +11,28 @@ from frappe.modules.import_file import import_file_by_path
 from frappe.modules.patch_handler import _patch_mode
 from frappe.utils import update_progress_bar
 
+IMPORTABLE_DOCTYPES = [
+	("core", "doctype"),
+	("core", "page"),
+	("core", "report"),
+	("desk", "dashboard_chart_source"),
+	("printing", "print_format"),
+	("website", "web_page"),
+	("website", "website_theme"),
+	("website", "web_form"),
+	("website", "web_template"),
+	("email", "notification"),
+	("printing", "print_style"),
+	("desk", "workspace"),
+	("desk", "onboarding_step"),
+	("desk", "module_onboarding"),
+	("desk", "form_tour"),
+	("custom", "client_script"),
+	("core", "server_script"),
+	("custom", "custom_field"),
+	("custom", "property_setter"),
+]
+
 
 def sync_all(force=0, reset_permissions=False):
 	_patch_mode(True)
@@ -71,6 +93,11 @@ def sync_for(app_name, force=0, reset_permissions=False):
 		]:
 			files.append(os.path.join(FRAPPE_PATH, "desk", "doctype", desk_module, f"{desk_module}.json"))
 
+		for module_name, document_type in IMPORTABLE_DOCTYPES:
+			file = os.path.join(FRAPPE_PATH, module_name, "doctype", document_type, f"{document_type}.json")
+			if file not in files:
+				files.append(file)
+
 	for module_name in frappe.local.app_modules.get(app_name) or []:
 		folder = os.path.dirname(frappe.get_module(app_name + "." + module_name).__file__)
 		files = get_doc_files(files=files, start_path=folder)
@@ -97,29 +124,7 @@ def get_doc_files(files, start_path):
 
 	files = files or []
 
-	# load in sequence - warning for devs
-	document_types = [
-		"doctype",
-		"page",
-		"report",
-		"dashboard_chart_source",
-		"print_format",
-		"web_page",
-		"website_theme",
-		"web_form",
-		"web_template",
-		"notification",
-		"print_style",
-		"workspace",
-		"onboarding_step",
-		"module_onboarding",
-		"form_tour",
-		"client_script",
-		"server_script",
-		"custom_field",
-		"property_setter",
-	]
-	for doctype in document_types:
+	for _module, doctype in IMPORTABLE_DOCTYPES:
 		doctype_path = os.path.join(start_path, doctype)
 		if os.path.exists(doctype_path):
 			for docname in os.listdir(doctype_path):


### PR DESCRIPTION
Problem:

1. Add some field to form tour
2. Create a form tour in core module
3. Migrate on another site
4. Form tour will migrate but new field wont be there.

This is because doctype itself isn't migrated before inserting the document. This PR just fixes it by migrating all importable doctypes before migrating their documents.

PS: Some more thought needs to be given to import order.
