### PR TITLE
fix(ux): make webhook naming "prompt"

### DIFF
--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -14,7 +14,10 @@ from frappe.tests.utils import FrappeTestCase
 
 @contextmanager
 def get_test_webhook(config):
-	wh = frappe.get_doc(config).insert()
+	wh = frappe.get_doc(config)
+	if not wh.name:
+		wh.name = frappe.generate_hash()
+	wh.insert()
 	wh.reload()
 	try:
 		yield wh
@@ -37,6 +40,7 @@ class TestWebhook(FrappeTestCase):
 	def create_sample_webhooks(cls):
 		samples_webhooks_data = [
 			{
+				"name": frappe.generate_hash(),
 				"webhook_doctype": "User",
 				"webhook_docevent": "after_insert",
 				"request_url": "https://httpbin.org/post",
@@ -44,6 +48,7 @@ class TestWebhook(FrappeTestCase):
 				"enabled": True,
 			},
 			{
+				"name": frappe.generate_hash(),
 				"webhook_doctype": "User",
 				"webhook_docevent": "after_insert",
 				"request_url": "https://httpbin.org/post",

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -1,13 +1,12 @@
 {
  "actions": [],
- "autoname": "naming_series:",
+ "autoname": "prompt",
  "creation": "2017-09-08 16:16:13.060641",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "sb_doc_events",
-  "naming_series",
   "webhook_doctype",
   "cb_doc_events",
   "webhook_docevent",
@@ -46,6 +45,7 @@
   {
    "fieldname": "webhook_doctype",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "DocType",
    "options": "DocType",
    "reqd": 1,
@@ -137,12 +137,6 @@
    "options": "JSON"
   },
   {
-   "fieldname": "naming_series",
-   "fieldtype": "Select",
-   "label": "Naming Series",
-   "options": "\nHOOK-.####"
-  },
-  {
    "fieldname": "sb_security",
    "fieldtype": "Section Break",
    "label": "Webhook Security"
@@ -218,11 +212,11 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2023-05-22 16:30:10.740512",
+ "modified": "2023-06-02 17:25:12.598232",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",
- "naming_rule": "By \"Naming Series\" field",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -241,6 +235,5 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
- "title_field": "webhook_doctype",
  "track_changes": 1
 }


### PR DESCRIPTION
The naming series select field is unnecessary, anyways it only had 1 option 🤷🏼

Before:
<img width="1636" alt="CleanShot 2023-05-27 at 16 03 34@2x" src="https://github.com/frappe/frappe/assets/34810212/46d1774a-8503-4bc0-aecc-6fb69937ef84">


After:
<img width="1618" alt="CleanShot 2023-05-27 at 16 03 14@2x" src="https://github.com/frappe/frappe/assets/34810212/9603c3a7-09e4-4e1b-8cda-58d8d6ee7e1e">

