### PR TITLE
fix: ensure correct return value for `get_values_from_single`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -617,10 +617,10 @@ class Database:
 						return []
 
 			if as_dict:
-				return values and [values] or []
+				return [values] if values else []
 
 			if isinstance(fields, list):
-				return [map(values.get, fields)]
+				return [list(map(values.get, fields))]
 
 		else:
 			r = frappe.qb.get_query(


### PR DESCRIPTION
The return value needs to be evaluated instead of iterator.

### Before

```py
In [5]: frappe.db.get_values_from_single(["name"], {}, "Selling Settings")
Out[5]: [<map at 0x7fc4011f87f0>]

```

### After

```py
In [4]: frappe.db.get_values_from_single(["name"], {}, "Selling Settings")
Out[4]: [['Selling Settings']]
```