### PR TITLE
fix!: inclusive descendants for tree link fields

### DIFF
--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -1,4 +1,3 @@
-import itertools
 import re
 from ast import literal_eval
 from types import BuiltinFunctionType
@@ -197,7 +196,6 @@ class Engine:
 				else OPERATOR_MAP["in"]
 			)
 			if result:
-				result = list(itertools.chain.from_iterable(result))
 				self.query = self.query.where(operator_fn(_field, result))
 			else:
 				self.query = self.query.where(operator_fn(_field, ("",)))
@@ -513,7 +511,7 @@ def has_function(field):
 			return True
 
 
-def get_nested_set_hierarchy_result(doctype: str, name: str, hierarchy: str):
+def get_nested_set_hierarchy_result(doctype: str, name: str, hierarchy: str) -> list[str]:
 	table = frappe.qb.DocType(doctype)
 	try:
 		lft, rgt = frappe.qb.from_(table).select("lft", "rgt").where(table.name == name).run()[0]
@@ -527,7 +525,7 @@ def get_nested_set_hierarchy_result(doctype: str, name: str, hierarchy: str):
 			.where(table.lft > lft)
 			.where(table.rgt < rgt)
 			.orderby(table.lft, order=Order.asc)
-			.run()
+			.run(pluck=True)
 		)
 	else:
 		# Get ancestor elements of a DocType with a tree structure
@@ -537,6 +535,6 @@ def get_nested_set_hierarchy_result(doctype: str, name: str, hierarchy: str):
 			.where(table.lft < lft)
 			.where(table.rgt > rgt)
 			.orderby(table.lft, order=Order.desc)
-			.run()
+			.run(pluck=True)
 		)
 	return result

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -23,6 +23,7 @@ NestedSetHierarchy = (
 	"descendants of",
 	"not ancestors of",
 	"not descendants of",
+	"descendants of (inclusive)",
 )
 
 

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -678,7 +678,9 @@ class FilterArea {
 			if (
 				fields_dict[fieldname] &&
 				(condition === "=" ||
-					(condition === "like" && fields_dict[fieldname]?.df?.fieldtype != "Link"))
+					(condition === "like" && fields_dict[fieldname]?.df?.fieldtype != "Link") ||
+					(condition === "descendants of (inclusive)" &&
+						fields_dict[fieldname]?.df?.fieldtype == "Link"))
 			) {
 				// standard filter
 				out.promise = out.promise.then(() => fields_dict[fieldname].set_value(value));
@@ -787,6 +789,13 @@ class FilterArea {
 							options.unshift("");
 							options = options.join("\n");
 						}
+					}
+					if (
+						df.fieldtype == "Link" &&
+						df.options &&
+						frappe.boot.treeviews.includes(df.options)
+					) {
+						condition = "descendants of (inclusive)";
 					}
 
 					return {

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -30,6 +30,7 @@ frappe.ui.Filter = class {
 
 		this.nested_set_conditions = [
 			["descendants of", __("Descendants Of")],
+			["descendants of (inclusive)", __("Descendants Of (inclusive)")],
 			["not descendants of", __("Not Descendants Of")],
 			["ancestors of", __("Ancestors Of")],
 			["not ancestors of", __("Not Ancestors Of")],
@@ -524,6 +525,7 @@ frappe.ui.filter_utils = {
 				"=",
 				"!=",
 				"descendants of",
+				"descendants of (inclusive)",
 				"ancestors of",
 				"not descendants of",
 				"not ancestors of",

--- a/frappe/tests/test_nestedset.py
+++ b/frappe/tests/test_nestedset.py
@@ -51,35 +51,35 @@ records = [
 	},
 ]
 
+TEST_DOCTYPE = "Test Tree DocType"
+
 
 class NestedSetTestUtil:
 	def setup_test_doctype(self):
-		frappe.db.sql("delete from `tabDocType` where `name` = 'Test Tree DocType'")
-		frappe.db.sql_ddl("drop table if exists `tabTest Tree DocType`")
+		frappe.db.delete("DocType", TEST_DOCTYPE)
+		frappe.db.sql_ddl(f"drop table if exists `{TEST_DOCTYPE}`")
 
-		self.tree_doctype = new_doctype(
-			"Test Tree DocType", is_tree=True, autoname="field:some_fieldname"
-		)
+		self.tree_doctype = new_doctype(TEST_DOCTYPE, is_tree=True, autoname="field:some_fieldname")
 		self.tree_doctype.insert()
 
 		for record in records:
-			d = frappe.new_doc("Test Tree DocType")
+			d = frappe.new_doc(TEST_DOCTYPE)
 			d.update(record)
 			d.insert()
 
 	def teardown_test_doctype(self):
 		self.tree_doctype.delete()
-		frappe.db.sql_ddl("drop table if exists `tabTest Tree DocType`")
+		frappe.db.sql_ddl(f"drop table if exists `{TEST_DOCTYPE}`")
 
 	def move_it_back(self):
-		parent_1 = frappe.get_doc("Test Tree DocType", "Parent 1")
+		parent_1 = frappe.get_doc(TEST_DOCTYPE, "Parent 1")
 		parent_1.parent_test_tree_doctype = "Root Node"
 		parent_1.save()
 
 	def get_no_of_children(self, record_name: str) -> int:
 		if not record_name:
-			return frappe.db.count("Test Tree DocType")
-		return len(get_descendants_of("Test Tree DocType", record_name, ignore_permissions=True))
+			return frappe.db.count(TEST_DOCTYPE)
+		return len(get_descendants_of(TEST_DOCTYPE, record_name, ignore_permissions=True))
 
 
 class TestNestedSet(FrappeTestCase):
@@ -101,18 +101,18 @@ class TestNestedSet(FrappeTestCase):
 		global records
 
 		min_lft = 1
-		max_rgt = frappe.qb.from_("Test Tree DocType").select(Max(Field("rgt"))).run(pluck=True)[0]
+		max_rgt = frappe.qb.from_(TEST_DOCTYPE).select(Max(Field("rgt"))).run(pluck=True)[0]
 
 		for record in records:
 			lft, rgt, parent_test_tree_doctype = frappe.db.get_value(
-				"Test Tree DocType",
+				TEST_DOCTYPE,
 				record["some_fieldname"],
 				["lft", "rgt", "parent_test_tree_doctype"],
 			)
 
 			if parent_test_tree_doctype:
 				parent_lft, parent_rgt = frappe.db.get_value(
-					"Test Tree DocType", parent_test_tree_doctype, ["lft", "rgt"]
+					TEST_DOCTYPE, parent_test_tree_doctype, ["lft", "rgt"]
 				)
 			else:
 				# root
@@ -138,19 +138,19 @@ class TestNestedSet(FrappeTestCase):
 			self.assertTrue(parent_rgt == (parent_lft + 1 + (2 * no_of_children)))
 
 	def test_recursion(self):
-		leaf_node = frappe.get_doc("Test Tree DocType", {"some_fieldname": "Parent 2"})
+		leaf_node = frappe.get_doc(TEST_DOCTYPE, {"some_fieldname": "Parent 2"})
 		leaf_node.parent_test_tree_doctype = "Child 3"
 		self.assertRaises(NestedSetRecursionError, leaf_node.save)
 		leaf_node.reload()
 
 	def test_rebuild_tree(self):
-		rebuild_tree("Test Tree DocType", "parent_test_tree_doctype")
+		rebuild_tree(TEST_DOCTYPE, "parent_test_tree_doctype")
 		self.test_basic_tree()
 
 	def test_move_group_into_another(self):
-		old_lft, old_rgt = frappe.db.get_value("Test Tree DocType", "Parent 2", ["lft", "rgt"])
+		old_lft, old_rgt = frappe.db.get_value(TEST_DOCTYPE, "Parent 2", ["lft", "rgt"])
 
-		parent_1 = frappe.get_doc("Test Tree DocType", "Parent 1")
+		parent_1 = frappe.get_doc(TEST_DOCTYPE, "Parent 1")
 		lft, rgt = parent_1.lft, parent_1.rgt
 
 		parent_1.parent_test_tree_doctype = "Parent 2"
@@ -158,7 +158,7 @@ class TestNestedSet(FrappeTestCase):
 		self.test_basic_tree()
 
 		# after move
-		new_lft, new_rgt = frappe.db.get_value("Test Tree DocType", "Parent 2", ["lft", "rgt"])
+		new_lft, new_rgt = frappe.db.get_value(TEST_DOCTYPE, "Parent 2", ["lft", "rgt"])
 
 		# lft should reduce
 		self.assertEqual(old_lft - new_lft, rgt - lft + 1)
@@ -170,12 +170,10 @@ class TestNestedSet(FrappeTestCase):
 		self.test_basic_tree()
 
 	def test_move_leaf_into_another_group(self):
-		child_2 = frappe.get_doc("Test Tree DocType", "Child 2")
+		child_2 = frappe.get_doc(TEST_DOCTYPE, "Child 2")
 
 		# assert that child 2 is not already under parent 1
-		parent_lft_old, parent_rgt_old = frappe.db.get_value(
-			"Test Tree DocType", "Parent 2", ["lft", "rgt"]
-		)
+		parent_lft_old, parent_rgt_old = frappe.db.get_value(TEST_DOCTYPE, "Parent 2", ["lft", "rgt"])
 		self.assertTrue((parent_lft_old > child_2.lft) and (parent_rgt_old > child_2.rgt))
 
 		child_2.parent_test_tree_doctype = "Parent 2"
@@ -183,22 +181,20 @@ class TestNestedSet(FrappeTestCase):
 		self.test_basic_tree()
 
 		# assert that child 2 is under parent 1
-		parent_lft_new, parent_rgt_new = frappe.db.get_value(
-			"Test Tree DocType", "Parent 2", ["lft", "rgt"]
-		)
+		parent_lft_new, parent_rgt_new = frappe.db.get_value(TEST_DOCTYPE, "Parent 2", ["lft", "rgt"])
 		self.assertFalse((parent_lft_new > child_2.lft) and (parent_rgt_new > child_2.rgt))
 
 	def test_delete_leaf(self):
 		global records
 		el = {"some_fieldname": "Child 1", "parent_test_tree_doctype": "Parent 1", "is_group": 0}
 
-		child_1 = frappe.get_doc("Test Tree DocType", "Child 1")
+		child_1 = frappe.get_doc(TEST_DOCTYPE, "Child 1")
 		child_1.delete()
 		records.remove(el)
 
 		self.test_basic_tree()
 
-		n = frappe.new_doc("Test Tree DocType")
+		n = frappe.new_doc(TEST_DOCTYPE)
 		n.update(el)
 		n.insert()
 		records.append(el)
@@ -208,10 +204,10 @@ class TestNestedSet(FrappeTestCase):
 	def test_delete_group(self):
 		# cannot delete group with child, but can delete leaf
 		with self.assertRaises(NestedSetChildExistsError):
-			frappe.delete_doc("Test Tree DocType", "Parent 1")
+			frappe.delete_doc(TEST_DOCTYPE, "Parent 1")
 
 	def test_remove_subtree(self):
-		remove_subtree("Test Tree DocType", "Parent 2")
+		remove_subtree(TEST_DOCTYPE, "Parent 2")
 		self.test_basic_tree()
 
 	def test_rename_nestedset(self):
@@ -223,7 +219,7 @@ class TestNestedSet(FrappeTestCase):
 	def test_merge_groups(self):
 		global records
 		el = {"some_fieldname": "Parent 2", "parent_test_tree_doctype": "Root Node", "is_group": 1}
-		frappe.rename_doc("Test Tree DocType", "Parent 2", "Parent 1", merge=True)
+		frappe.rename_doc(TEST_DOCTYPE, "Parent 2", "Parent 1", merge=True)
 		records.remove(el)
 		self.test_basic_tree()
 
@@ -232,7 +228,7 @@ class TestNestedSet(FrappeTestCase):
 		el = {"some_fieldname": "Child 3", "parent_test_tree_doctype": "Parent 2", "is_group": 0}
 
 		frappe.rename_doc(
-			"Test Tree DocType",
+			TEST_DOCTYPE,
 			"Child 3",
 			"Child 2",
 			merge=True,
@@ -242,17 +238,17 @@ class TestNestedSet(FrappeTestCase):
 
 	def test_merge_leaf_into_group(self):
 		with self.assertRaises(NestedSetInvalidMergeError):
-			frappe.rename_doc("Test Tree DocType", "Child 1", "Parent 1", merge=True)
+			frappe.rename_doc(TEST_DOCTYPE, "Child 1", "Parent 1", merge=True)
 
 	def test_merge_group_into_leaf(self):
 		with self.assertRaises(NestedSetInvalidMergeError):
-			frappe.rename_doc("Test Tree DocType", "Parent 1", "Child 1", merge=True)
+			frappe.rename_doc(TEST_DOCTYPE, "Parent 1", "Child 1", merge=True)
 
 	def test_root_deletion(self):
 		for doc in ["Child 3", "Child 2", "Child 1", "Parent 2", "Parent 1"]:
-			frappe.delete_doc("Test Tree DocType", doc)
+			frappe.delete_doc(TEST_DOCTYPE, doc)
 
-		root_node = frappe.get_doc("Test Tree DocType", "Root Node")
+		root_node = frappe.get_doc(TEST_DOCTYPE, "Root Node")
 
 		# root deletion with allow_root_deletion
 		# patched as delete_doc create a new instance of Root Node (using get_doc)
@@ -263,4 +259,4 @@ class TestNestedSet(FrappeTestCase):
 
 		# root deletion without allow_root_deletion
 		root_node.delete()
-		self.assertFalse(frappe.db.exists("Test Tree DocType", "Root Node"))
+		self.assertFalse(frappe.db.exists(TEST_DOCTYPE, "Root Node"))

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1766,6 +1766,7 @@ def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "fr
 	        "fieldtype":
 	}
 	"""
+	from frappe.database.utils import NestedSetHierarchy
 	from frappe.model import child_table_fields, default_fields, optional_fields
 
 	if isinstance(f, dict):
@@ -1805,14 +1806,10 @@ def get_filter(doctype: str, f: dict | list | tuple, filters_config=None) -> "fr
 		"not in",
 		"is",
 		"between",
-		"descendants of",
-		"ancestors of",
-		"not descendants of",
-		"not ancestors of",
 		"timespan",
 		"previous",
 		"next",
-	)
+	) + NestedSetHierarchy
 
 	if filters_config:
 		additional_operators = []


### PR DESCRIPTION
Changes:

1. `descendants of (inclusive)` operator which just self to list of children. Nothing complex. We've spent months on deciding name for this, lets just roll. Labels can be changed in future if something better is available. Rarely anyone uses this in code directly. :eyes:  


2. **Breaking change:** These filters will now default to including all children. 

![image](https://github.com/frappe/frappe/assets/9079960/008a0775-0da2-4442-9457-07f71691272b)


re of https://github.com/frappe/frappe/pull/15360


closes https://github.com/frappe/frappe/issues/17394 


permanent fix for long pending issue: https://github.com/frappe/erpnext/pull/25838 