### PR TITLE
fix(role): Set desk properties (e.g. search_bar) to 1 for roles with desk_access

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1679,7 +1679,9 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 
 		for role in list(set(roles)):
 			if frappe.db.table_exists("Role", cached=False) and not frappe.db.exists("Role", role):
-				r = frappe.get_doc(dict(doctype="Role", role_name=role, desk_access=1))
+				r = frappe.new_doc("Role")
+				r.role_name = role
+				r.desk_access = 1
 				r.flags.ignore_mandatory = r.flags.ignore_permissions = True
 				r.insert()
 	except frappe.DoesNotExistError as e:


### PR DESCRIPTION
### Issue

I noticed that auto-generated<sup>1</sup> roles such as `Sales Master Manager` (ERPNext) did not have access to the full experience of the desk : no seach bar, no sidebar, ...

Indeed, the "desk properties" have a default value of 1, but this default value is not retrieved when creating these roles.

A previous patch ([v13_set_default_desk_properties.py](https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/role/patches/v13_set_default_desk_properties.py)) tried to address this issue but I think that new installations do not benefit from it.


### Fix


Replace `get_doc` with `new_doc`, because default values are not retrieved when using `get_doc(dict(...))`.

---

1. https://github.com/frappe/frappe/blob/95fc535f1a58ce7e72b2d9eb721e27eedbd94af2/frappe/core/doctype/doctype/doctype.py#L1680-L1684