### PR TITLE
fix: ui tour popover when outside viewport

### DIFF
--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -82,11 +82,7 @@ frappe.Application = class Application {
 				frappe.boot.onboarding_tours.findIndex((tour) => {
 					frappe.boot.user.onboarding_status[tour[0]]?.is_complete == true;
 				}) == -1;
-			if (
-				document.documentElement.clientWidth >= 992 &&
-				pending_tours &&
-				frappe.boot.onboarding_tours.length > 0
-			) {
+			if (pending_tours && frappe.boot.onboarding_tours.length > 0) {
 				frappe.require("onboarding_tours.bundle.js", () => {
 					frappe.utils.sleep(1000).then(() => {
 						frappe.ui.init_onboarding_tour();

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -82,7 +82,11 @@ frappe.Application = class Application {
 				frappe.boot.onboarding_tours.findIndex((tour) => {
 					frappe.boot.user.onboarding_status[tour[0]]?.is_complete == true;
 				}) == -1;
-			if (pending_tours && frappe.boot.onboarding_tours.length > 0) {
+			if (
+				document.documentElement.clientWidth >= 992 &&
+				pending_tours &&
+				frappe.boot.onboarding_tours.length > 0
+			) {
 				frappe.require("onboarding_tours.bundle.js", () => {
 					frappe.utils.sleep(1000).then(() => {
 						frappe.ui.init_onboarding_tour();

--- a/frappe/public/js/onboarding_tours/onboarding_tours.js
+++ b/frappe/public/js/onboarding_tours/onboarding_tours.js
@@ -29,6 +29,13 @@ frappe.ui.OnboardingTour = class OnboardingTour {
 							step.popover.node.offsetTop + step.options.step_info.offset_y
 						}px`;
 					}
+					if (step.popover.node.offsetLeft < 0) {
+						step.popover.node.style.minWidth = "200px";
+						step.popover.node.style.maxWidth = `${
+							350 + step.popover.node.offsetLeft
+						}px`;
+						step.popover.node.style.left = "0px";
+					}
 					if (step.popover.closeBtnNode) {
 						step.popover.closeBtnNode.onclick = () => {
 							this.on_finish && this.on_finish();

--- a/frappe/public/js/onboarding_tours/onboarding_tours.js
+++ b/frappe/public/js/onboarding_tours/onboarding_tours.js
@@ -346,7 +346,7 @@ frappe.ui.init_onboarding_tour = () => {
 };
 // As of now Tours are only for desktop as it is annoying on mobile.
 // Also lot of elements are hidden on mobile so until we find a better way to do it.
-window.matchMedia("(min-device-width: 992px)").matches &&
+document.documentElement.clientWidth >= 992 &&
 	frappe.router.on("change", () => {
 		frappe.ui.init_onboarding_tour();
 	});

--- a/frappe/public/js/onboarding_tours/onboarding_tours.js
+++ b/frappe/public/js/onboarding_tours/onboarding_tours.js
@@ -346,7 +346,7 @@ frappe.ui.init_onboarding_tour = () => {
 };
 // As of now Tours are only for desktop as it is annoying on mobile.
 // Also lot of elements are hidden on mobile so until we find a better way to do it.
-document.documentElement.clientWidth >= 992 &&
+window.matchMedia("(min-device-width: 992px)").matches &&
 	frappe.router.on("change", () => {
 		frappe.ui.init_onboarding_tour();
 	});


### PR DESCRIPTION
There are times when popover will go outside viewport this updates the style on highlight to make sure it doesn't.

This fixes issue shared here : https://github.com/frappe/frappe/pull/21044#issuecomment-1566107530

https://github.com/frappe/frappe/assets/39730881/15865a2d-07d4-4c47-8ad3-069e9f0520ee

