### PR TITLE
fix: make text smaller and reduced some spacings for webform for mobile view

### DIFF
--- a/frappe/public/scss/website/web_form.scss
+++ b/frappe/public/scss/website/web_form.scss
@@ -28,6 +28,10 @@
 					margin-top: 0;
 					margin-bottom: 0;
 					padding-bottom: 2px;
+
+					@include media-breakpoint-down(sm) {
+						font-size: 1.25rem;
+					}
 				}
 
 				.web-form-header {
@@ -37,6 +41,10 @@
 					border-top-right-radius: var(--border-radius-md);
 					background-color: var(--fg-color);
 					padding: 2rem 2rem 0;
+
+					@include media-breakpoint-down(sm) {
+						padding: 1.5rem 1.5rem 0;
+					}
 
 					.breadcrumb-container {
 						padding: 0px;
@@ -83,6 +91,10 @@
 
 							p {
 								color: var(--text-muted);
+
+								@include media-breakpoint-down(sm) {
+									font-size: var(--text-xs);
+								}
 							}
 						}
 					}
@@ -96,10 +108,18 @@
 					border-bottom-left-radius: var(--border-radius);
 					border-bottom-right-radius: var(--border-radius);
 
+					@include media-breakpoint-down(sm) {
+						padding: 1rem 1.5rem 1.5rem;
+					}
+
 					.web-form-wrapper {
 						.form-control {
 							color: var(--text-color);
 							background-color: var(--control-bg);
+
+							@include media-breakpoint-down(sm) {
+								font-size: var(--text-sm);
+							}
 						}
 
 						.form-section {
@@ -113,8 +133,18 @@
 						.form-column {
 							padding: 0 var(--padding-sm);
 
+							.form-group {
+								@include media-breakpoint-down(sm) {
+									margin-bottom: 0.5rem;
+								}
+							}
+
 							.frappe-control {
 								position: relative;
+
+								@include media-breakpoint-down(sm) {
+									font-size: var(--text-sm);
+								}
 
 								&[data-fieldtype="Rating"] {
 									.like-disabled-input {
@@ -194,6 +224,10 @@
 					.web-form-footer {
 						margin-top: 1rem;
 
+						@include media-breakpoint-down(sm) {
+							margin-top: 0.5rem;
+						}
+
 						.web-form-actions {
 							display: flex;
 							justify-content: space-between;
@@ -201,6 +235,10 @@
 
 							.btn {
 								font-size: var(--text-base);
+
+								@include media-breakpoint-down(sm) {
+									font-size: var(--text-sm);
+								}
 							}
 
 							.btn-link {
@@ -294,6 +332,10 @@
 									width: 100%;
 									justify-content: center;
 									margin-bottom: 1.5rem;
+
+									&:empty {
+										margin: 0;
+									}
 								}
 							}
 


### PR DESCRIPTION
| Before | After |
|-------|-------|
| <img width="300" alt="image" src="https://github.com/frappe/frappe/assets/30859809/adf7b5e4-f05d-45f3-b713-19250be4de28"> | <img width="300" alt="image" src="https://github.com/frappe/frappe/assets/30859809/e57161e7-aa20-47ba-8517-f041dfbb5f41"> |

| Before | After |
|-------|-------|
| <img width="300" alt="image" src="https://github.com/frappe/frappe/assets/30859809/ea02b648-8cd1-43be-82cf-aa77a9a34964"> | <img width="300" alt="image" src="https://github.com/frappe/frappe/assets/30859809/c1347951-af7e-4bdd-a49f-73e3ff87213a"> |
