### PR TITLE
fix(UX): Warn users if "Repeat Header and Footer" is disabled

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -245,6 +245,7 @@
    "default": "14",
    "fieldname": "font_size",
    "fieldtype": "Int",
+   "hidden": 1,
    "label": "Font Size"
   },
   {
@@ -258,7 +259,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2022-11-09 15:29:46.709305",
+ "modified": "2023-05-31 15:40:52.919029",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_settings/print_settings.json
+++ b/frappe/printing/doctype/print_settings/print_settings.json
@@ -47,7 +47,7 @@
    "default": "1",
    "fieldname": "repeat_header_footer",
    "fieldtype": "Check",
-   "label": "Repeat Header and Footer in PDF"
+   "label": "Repeat Header and Footer"
   },
   {
    "fieldname": "column_break_4",
@@ -176,7 +176,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-17 12:59:14.783694",
+ "modified": "2023-05-30 14:55:25.740691",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Settings",
@@ -193,5 +193,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -114,7 +114,7 @@ frappe.ui.form.PrintView = class {
 			description =
 				"<div class='form-message yellow p-3 mt-3'>" +
 				__("Footer might not be visible as {0} option is disabled</div>", [
-					`<a href="/app/print-settings/Print Settings#repeat_header_footer">${__(
+					`<a href="/app/print-settings/Print Settings">${__(
 						"Repeat Header and Footer"
 					)}</a>`,
 				]);

--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -91,7 +91,7 @@ frappe.ui.form.PrintView = class {
 			fieldtype: "Link",
 			fieldname: "print_format",
 			options: "Print Format",
-			placeholder: __("Print Format"),
+			label: __("Print Format"),
 			get_query: () => {
 				return { filters: { doc_type: this.frm.doctype } };
 			},
@@ -101,7 +101,7 @@ frappe.ui.form.PrintView = class {
 		this.language_selector = this.add_sidebar_item({
 			fieldtype: "Link",
 			fieldname: "language",
-			placeholder: __("Language"),
+			label: __("Language"),
 			options: "Language",
 			change: () => {
 				this.set_user_lang();
@@ -109,12 +109,27 @@ frappe.ui.form.PrintView = class {
 			},
 		}).$input;
 
+		let description = "";
+		if (!cint(this.print_settings.repeat_header_footer)) {
+			description =
+				"<div class='form-message yellow p-3 mt-3'>" +
+				__("Footer might not be visible as {0} option is disabled</div>", [
+					`<a href="/app/print-settings/Print Settings#repeat_header_footer">${__(
+						"Repeat Header and Footer"
+					)}</a>`,
+				]);
+		}
+		const print_view = this;
 		this.letterhead_selector = this.add_sidebar_item({
 			fieldtype: "Link",
 			fieldname: "letterhead",
 			options: "Letter Head",
-			placeholder: __("Letter Head"),
-			change: () => this.preview(),
+			label: __("Letter Head"),
+			description: description,
+			change: function () {
+				this.set_description(this.get_value() ? description : "");
+				print_view.preview();
+			},
 		}).$input;
 		this.sidebar_dynamic_section = $(`<div class="dynamic-settings"></div>`).appendTo(
 			this.sidebar

--- a/frappe/public/scss/desk/print_preview.scss
+++ b/frappe/public/scss/desk/print_preview.scss
@@ -45,9 +45,6 @@
 .layout-side-section.print-preview-sidebar {
 	padding-right: var(--padding-md);
 
-	.clearfix {
-		display: none;
-	}
 
 	.label-area {
 		white-space: nowrap;


### PR DESCRIPTION
When "Repeat Header and Footer" is disabled, print view does not show footer even if Letterhead is set (yeah its all UX mess). For starters, we are showing warning that a specific setting is affecting the visibility of the footer.

- Also, added labels to the print view options.

**Before:**
![Screenshot 2023-05-31 at 8 50 24 AM](https://github.com/frappe/frappe/assets/13928957/14771a8f-616b-469b-92bc-bcb6a8be2e96)

**After:**
![Screenshot 2023-05-31 at 8 48 58 AM](https://github.com/frappe/frappe/assets/13928957/4c339581-c6d2-48e7-873e-93d32b31960a)

- Hide "Font Size" from Print Format form since it is only by [new print format builder](https://github.com/frappe/frappe/pull/14134) and the font-size can be set via new print format builder's interface.