### PR TITLE
feat: used cached version of document in mapper

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -62,6 +62,7 @@ def get_mapped_doc(
 	postprocess=None,
 	ignore_permissions=False,
 	ignore_child_tables=False,
+	cached=False,
 ):
 
 	apply_strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
@@ -79,7 +80,10 @@ def get_mapped_doc(
 	):
 		target_doc.raise_no_permission_to("create")
 
-	source_doc = frappe.get_cached_doc(from_doctype, from_docname)
+	if cached:
+		source_doc = frappe.get_cached_doc(from_doctype, from_docname)
+	else:
+		source_doc = frappe.get_doc(from_doctype, from_docname)
 
 	if not ignore_permissions:
 		if not source_doc.has_permission("read"):

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -79,7 +79,7 @@ def get_mapped_doc(
 	):
 		target_doc.raise_no_permission_to("create")
 
-	source_doc = frappe.get_doc(from_doctype, from_docname)
+	source_doc = frappe.get_cached_doc(from_doctype, from_docname)
 
 	if not ignore_permissions:
 		if not source_doc.has_permission("read"):


### PR DESCRIPTION
For each `get_mapped_doc` call the system calls get_doc internally. 

But there are cases where base doc remain same eg preparing salary slip from salary structure, in such cases calling get_doc is expensive.

Thus adding a provision to explicitly used cached version of source doc.

https://github.com/frappe/hrms/pull/470/commits/ea21f391306973c632322636dc12e190c253c42a