### PR TITLE
fix(UX): Do not add signature if it already exists

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -747,7 +747,10 @@ frappe.views.CommunicationComposer = class {
 			this.content_set = true;
 		}
 
-		message += await this.get_signature(sender_email || null);
+		const signature = await this.get_signature(sender_email || "");
+		if (!this.content_set || !strip_html(message).includes(strip_html(signature))) {
+			message += signature;
+		}
 
 		if (this.is_a_reply && !this.reply_set) {
 			message += this.get_earlier_reply();


### PR DESCRIPTION
When an email is in draft and user reloads the page, the footer duplicates itself multiple time.

**Before:**

https://github.com/frappe/frappe/assets/13928957/9a3f387b-2b9d-4197-a7cc-35038fc5e45c



**After:**

https://github.com/frappe/frappe/assets/13928957/26daf101-cc08-431d-a65c-0734ed36c2cc


> Note: In rare case the check in the fix can cause false positives.