### PR TITLE
feat!: populate fields from kwargs in `frappe.new_doc`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1049,18 +1049,26 @@ def reset_metadata_version():
 
 def new_doc(
 	doctype: str,
+	*,
 	parent_doc: Optional["Document"] = None,
 	parentfield: str | None = None,
 	as_dict: bool = False,
+	**kwargs,
 ) -> "Document":
 	"""Returns a new document of the given DocType with defaults set.
 
 	:param doctype: DocType of the new document.
 	:param parent_doc: [optional] add to parent document.
-	:param parentfield: [optional] add against this `parentfield`."""
+	:param parentfield: [optional] add against this `parentfield`.
+	:param as_dict: [optional] return as dictionary instead of Document.
+	:param kwargs: [optional] You can specify fields as field=value pairs in function call.
+	"""
+
 	from frappe.model.create_new import get_new_doc
 
-	return get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
+	new_doc = get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
+
+	return new_doc.update(kwargs)
 
 
 def set_value(doctype, docname, fieldname, value=None):

--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -259,7 +259,9 @@ def map_fetch_fields(target_doc, df, no_copy_fields):
 def map_child_doc(source_d, target_parent, table_map, source_parent=None):
 	target_child_doctype = table_map["doctype"]
 	target_parentfield = target_parent.get_parentfield_of_doctype(target_child_doctype)
-	target_d = frappe.new_doc(target_child_doctype, target_parent, target_parentfield)
+	target_d = frappe.new_doc(
+		target_child_doctype, parent_doc=target_parent, parentfield=target_parentfield
+	)
 
 	map_doc(source_d, target_d, table_map, source_parent)
 

--- a/frappe/patches/v11_0/apply_customization_to_custom_doctype.py
+++ b/frappe/patches/v11_0/apply_customization_to_custom_doctype.py
@@ -44,7 +44,7 @@ def execute():
 			if field:
 				field.update(cf)
 			else:
-				df = frappe.new_doc("DocField", meta, "fields")
+				df = frappe.new_doc("DocField", parent_doc=meta, parentfield="fields")
 				df.update(cf)
 				meta.fields.append(df)
 			frappe.db.delete("Custom Field", {"name": cf.name})

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -169,6 +169,10 @@ class TestDocument(FrappeTestCase):
 		with self.assertQueryCount(0):
 			user.db_set("user_type", "Magical Wizard")
 
+	def test_new_doc_with_fields(self):
+		user = frappe.new_doc("User", first_name="wizard")
+		self.assertEqual(user.first_name, "wizard")
+
 	def test_update_after_submit(self):
 		d = self.test_insert()
 		d.starts_on = "2014-09-09"


### PR DESCRIPTION
This makes it similar to `get_doc` API BUT still signifies intent that it's a "NEW" document.

Minor Breaking Change: positional arguments are now forcefully keyword arguments. Only seems to be used internally from what I can tell.

https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/frappe/.*+/frappe.new_doc%5C%28.*%3F%2C.*%3F%5C%29/+lang:python+&patternType=regexp&case=yes&sm=0&groupBy=repo


This is the change you need to make


```diff
- doc = frappe.new_doc(doctype, parent_doc, parentfield, False)
+ doc = frappe.new_doc(doctype, parent_doc=parent_doc, parentfield=parentfield, as_dict=False)
```





Refer https://github.com/frappe/semgrep-rules/issues/24



- [x] test
- [x] migration guide
- [ ] docs