### PR TITLE
feat: show db table utilization on doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -33,7 +33,7 @@ from frappe.model.meta import Meta
 from frappe.modules import get_doc_path, make_boilerplate
 from frappe.modules.import_file import get_file_path
 from frappe.query_builder.functions import Concat
-from frappe.utils import cint, random_string
+from frappe.utils import cint, flt, random_string
 from frappe.website.utils import clear_cache
 
 if TYPE_CHECKING:
@@ -1751,3 +1751,14 @@ def get_field(doc, fieldname):
 	for field in doc.fields:
 		if field.fieldname == fieldname:
 			return field
+
+
+@frappe.whitelist()
+def get_row_size_utilization(doctype: str) -> float:
+	"""Get row size utilization in percentage"""
+
+	frappe.has_permission("DocType", throw=True)
+	try:
+		return flt(frappe.db.get_row_size(doctype) / frappe.db.MAX_ROW_SIZE_LIMIT * 100, 2)
+	except Exception:
+		return 0.0

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -172,7 +172,18 @@ class CustomizeForm(Document):
 		check_email_append_to(self)
 
 		if self.flags.update_db:
-			frappe.db.updatedb(self.doc_type)
+			try:
+				frappe.db.updatedb(self.doc_type)
+			except Exception as e:
+				if frappe.db.is_db_table_size_limit(e):
+					frappe.throw(
+						_("You have hit the row size limit on database table: {0}").format(
+							"<a href='https://docs.erpnext.com/docs/v14/user/manual/en/customize-erpnext/articles/maximum-number-of-fields-in-a-form'>"
+							"Maximum Number of Fields in a Form</a>"
+						),
+						title=_("Database Table Row Size Limit"),
+					)
+				raise
 
 		if not hasattr(self, "hide_success") or not self.hide_success:
 			frappe.msgprint(_("{0} updated").format(_(self.doc_type)), alert=True)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1283,6 +1283,10 @@ class Database:
 
 		return get_next_val(*args, **kwargs)
 
+	def get_row_size(self, doctype: str) -> int:
+		"""Get estimated max row size of any table in bytes."""
+		raise NotImplementedError
+
 
 def enqueue_jobs_after_commit():
 	from frappe.utils.background_jobs import (

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -145,6 +145,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		UnicodeWithAttrs: escape_string,
 	}
 	default_port = "3306"
+	MAX_ROW_SIZE_LIMIT = 65_535  # bytes
 
 	def setup_type_map(self):
 		self.db_type = "mariadb"
@@ -445,3 +446,56 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			frappe.cache().set_value("db_tables", tables)
 
 		return tables
+
+	def get_row_size(self, doctype: str) -> int:
+		"""Get estimated max row size of any table in bytes."""
+
+		# Query reused from this answer: https://dba.stackexchange.com/a/313889/274503
+		# Modification: get values for particular table instead of full summary.
+		# Reference: https://mariadb.com/kb/en/data-type-storage-requirements/
+
+		est_row_size = frappe.db.sql(
+			"""
+			SELECT SUM(col_sizes.col_size) AS EST_MAX_ROW_SIZE
+			FROM (
+				SELECT
+					cols.COLUMN_NAME,
+					CASE cols.DATA_TYPE
+						WHEN 'tinyint' THEN 1
+						WHEN 'smallint' THEN 2
+						WHEN 'mediumint' THEN 3
+						WHEN 'int' THEN 4
+						WHEN 'bigint' THEN 8
+						WHEN 'float' THEN IF(cols.NUMERIC_PRECISION > 24, 8, 4)
+						WHEN 'double' THEN 8
+						WHEN 'decimal' THEN ((cols.NUMERIC_PRECISION - cols.NUMERIC_SCALE) DIV 9)*4  + (cols.NUMERIC_SCALE DIV 9)*4 + CEIL(MOD(cols.NUMERIC_PRECISION - cols.NUMERIC_SCALE,9)/2) + CEIL(MOD(cols.NUMERIC_SCALE,9)/2)
+						WHEN 'bit' THEN (cols.NUMERIC_PRECISION + 7) DIV 8
+						WHEN 'year' THEN 1
+						WHEN 'date' THEN 3
+						WHEN 'time' THEN 3 + CEIL(cols.DATETIME_PRECISION /2)
+						WHEN 'datetime' THEN 5 + CEIL(cols.DATETIME_PRECISION /2)
+						WHEN 'timestamp' THEN 4 + CEIL(cols.DATETIME_PRECISION /2)
+						WHEN 'char' THEN cols.CHARACTER_OCTET_LENGTH
+						WHEN 'binary' THEN cols.CHARACTER_OCTET_LENGTH
+						WHEN 'varchar' THEN IF(cols.CHARACTER_OCTET_LENGTH > 255, 2, 1) + cols.CHARACTER_OCTET_LENGTH
+						WHEN 'varbinary' THEN IF(cols.CHARACTER_OCTET_LENGTH > 255, 2, 1) + cols.CHARACTER_OCTET_LENGTH
+						WHEN 'tinyblob' THEN 9
+						WHEN 'tinytext' THEN 9
+						WHEN 'blob' THEN 10
+						WHEN 'text' THEN 10
+						WHEN 'mediumblob' THEN 11
+						WHEN 'mediumtext' THEN 11
+						WHEN 'longblob' THEN 12
+						WHEN 'longtext' THEN 12
+						WHEN 'enum' THEN 2
+						WHEN 'set' THEN 8
+						ELSE 0
+					END AS col_size
+				FROM INFORMATION_SCHEMA.COLUMNS cols
+				WHERE cols.TABLE_NAME = %s
+			) AS col_sizes;""",
+			(get_table_name(doctype),),
+		)
+
+		if est_row_size:
+			return int(est_row_size[0][0])

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -77,6 +77,10 @@ class MariaDBExceptionUtil:
 		return e.args[0] == ER.DATA_TOO_LONG
 
 	@staticmethod
+	def is_db_table_size_limit(e: pymysql.Error) -> bool:
+		return e.args[0] == ER.TOO_BIG_ROWSIZE
+
+	@staticmethod
 	def is_primary_key_violation(e: pymysql.Error) -> bool:
 		return (
 			MariaDBDatabase.is_duplicate_entry(e)

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -107,6 +107,10 @@ class PostgresExceptionUtil:
 	def is_data_too_long(e):
 		return getattr(e, "pgcode", None) == STRING_DATA_RIGHT_TRUNCATION
 
+	@staticmethod
+	def is_db_table_size_limit(e) -> bool:
+		return False
+
 
 class PostgresDatabase(PostgresExceptionUtil, Database):
 	REGEX_CHARACTER = "~"

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -22,6 +22,29 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 		};
 	}
 
+	refresh() {
+		this.show_db_utilization();
+	}
+
+	show_db_utilization() {
+		const doctype = this.frm.doc.doc_type || this.frm.doc.name;
+		frappe
+			.xcall("frappe.core.doctype.doctype.doctype.get_row_size_utilization", {
+				doctype,
+			})
+			.then((r) => {
+				if (r < 50.0) return;
+				this.frm.dashboard.show_progress(
+					__("Database Row Size Utilization"),
+					r,
+					__(
+						"Database Table Row Size Utilization: {0}%, this limits number of fields you can add.",
+						[r]
+					)
+				);
+			});
+	}
+
 	max_attachments() {
 		if (!this.frm.doc.max_attachments) {
 			return;


### PR DESCRIPTION
Show utilization of max row size on doctype and customize form. This makes it clear why adding a new field is suddenly throwing the error "max row size reached".


Note: 
1. Utilization is hidden by default and only shown when you hit >50%. This right now only happens on very few core DocTypes.
2. This is estimation so off by +/-5 % I guess. 

Sales Invoice vanilla:
![image](https://github.com/frappe/frappe/assets/9079960/a9ff1b7c-a2c3-4801-8f20-a4bf97535d2e)


Sales Invoice with half dozen giant varchar fields:
![image](https://github.com/frappe/frappe/assets/9079960/79012dd0-afc7-4414-aefb-618bc4b7c7df)





ref: https://docs.erpnext.com/docs/v13/user/manual/en/customize-erpnext/articles/maximum-number-of-fields-in-a-form

`no-docs`


