### PR TITLE
fix: doctype name localization in duplicate name message

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -530,7 +530,7 @@ class BaseDocument:
 
 				if not ignore_if_duplicate:
 					frappe.msgprint(
-						_("{0} {1} already exists").format(self.doctype, frappe.bold(self.name)),
+						_("{0} {1} already exists").format(_(self.doctype), frappe.bold(self.name)),
 						title=_("Duplicate Name"),
 						indicator="red",
 					)


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

This PR contains a fix for the doctype name localization in the duplicate name message, when you have a translation for the doctype name.

When a doctype has localized data in the CSV file or Translation doctype, the message will show without the translated data.

Using `_` function in the `self.doctype` will resolve this issue. 

![image](https://github.com/frappe/frappe/assets/30384731/9be94638-12f1-4b85-9b12-b34a75a1e982)
**This image shows shat DocType "Accreditation Response" is not translated even though the data is translated in the app.**

![image](https://github.com/frappe/frappe/assets/30384731/9b453cf0-f700-468d-9db2-ecba16fc537d)
**DocType is now translated with the translation data.**

![image](https://github.com/frappe/frappe/assets/30384731/b12ebc7e-8e2f-47e7-9f24-e2281348cbf6)
**Message in the default language.**

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
