### PR TITLE
fix: Close unclosed span tags and prevent extra refresh() calls in multicheck.js

### DIFF
--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -18,13 +18,11 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 		this.$checkbox_area = $(`<div class="checkbox-options ${row}"></div>`).appendTo(
 			this.wrapper
 		);
-		this.refresh();
 	}
 
 	refresh() {
 		this.set_options();
 		this.bind_checkboxes();
-		this.refresh_input();
 		super.refresh();
 	}
 

--- a/frappe/public/js/frappe/form/templates/form_links.html
+++ b/frappe/public/js/frappe/form/templates/form_links.html
@@ -5,7 +5,7 @@
 		{% } %}
 			<div class="col-md-4">
 				<div class="form-link-title">
-					<span>{{ __(transactions[i].label) }}<span>
+					<span>{{ __(transactions[i].label) }}</span>
 				</div>
 				{% for (let j=0; j < transactions[i].items.length; j++) { %}
 					{% let doctype = transactions[i].items[j]; %}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1029,7 +1029,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return `<span class="indicator-pill ${indicator[1]} filterable ellipsis"
 				data-filter='${indicator[2]}' title='${title}'>
 				<span class="ellipsis"> ${__(indicator[0])}</span>
-			<span>`;
+			</span>`;
 		}
 		return "";
 	}


### PR DESCRIPTION
This PR includes a fix in `frappe/public/js/frappe/list/list_view.js` and `frappe/templates/form_links.html` that closes `<span>` tags. 

It addresses two issues in the MultiCheck control:
1. Prevents an extra call to `refresh()` inside the `make()` function.
2. `refresh_input()` is being called twice. The first call is from `refresh()`, and then `refresh()` calls its super method from `base_control` which triggers the second call to `refresh_input()`.
