### PR TITLE
feat: formatter for `Attach` and `Attach Image` fields

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -365,7 +365,13 @@ frappe.form.formatters = {
 		</div>`
 			: "";
 	},
+	Attach: format_attachment_url,
+	AttachImage: format_attachment_url,
 };
+
+function format_attachment_url(url) {
+	return url ? `<a href="${url}" target="_blank">${url}</a>` : "";
+}
 
 frappe.form.get_formatter = function (fieldtype) {
 	if (!fieldtype) fieldtype = "Data";


### PR DESCRIPTION
### Issue

Attach fields weren't clickable for users with read-only access.

### Solution

![Peek 2023-06-02 14-12](https://github.com/frappe/frappe/assets/16315650/870fefca-88f7-4aba-a556-14ab243a3de7)


`no-docs`

Sponsored by @romlytech