### PR TITLE
feat!: DB hooks to run things before/after commit/rollback

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -207,7 +207,6 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 			"read_only": False,
 		}
 	)
-	local.rollback_observers = []
 	local.locked_documents = []
 	local.test_objects = {}
 

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -231,7 +231,6 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	local.role_permissions = {}
 	local.valid_columns = {}
 	local.new_doc_templates = {}
-	local.link_count = {}
 
 	local.jenv = None
 	local.jloader = None

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -209,7 +209,6 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	)
 	local.rollback_observers = []
 	local.locked_documents = []
-	local.before_commit = []
 	local.test_objects = {}
 
 	local.site = site

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -190,7 +190,6 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	local.error_log = []
 	local.message_log = []
 	local.debug_log = []
-	local.realtime_log = []
 	local.flags = _dict(
 		{
 			"currently_saving": [],

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -623,7 +623,7 @@ frappe.db.connect()
 
 
 def _console_cleanup():
-	# Execute rollback_observers on console close
+	# Execute after_rollback on console close
 	frappe.db.rollback()
 	frappe.destroy()
 

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -17,7 +17,7 @@ from frappe.core.api.file import (
 	move_file,
 	unzip_file,
 )
-from frappe.core.doctype.file.utils import get_extension
+from frappe.core.doctype.file.utils import delete_file, get_extension
 from frappe.exceptions import ValidationError
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_files_path
@@ -75,6 +75,16 @@ class TestSimpleFile(FrappeTestCase):
 		_file = frappe.get_doc("File", {"file_url": self.saved_file_url})
 		content = _file.get_content()
 		self.assertEqual(content, self.test_content)
+
+
+class TestFSRollbacks(FrappeTestCase):
+	def test_rollback_from_file_system(self):
+		file_name = content = frappe.generate_hash()
+		file = frappe.new_doc("File", file_name=file_name, content=content).insert()
+		self.assertTrue(file.exists_on_disk())
+
+		frappe.db.rollback()
+		self.assertFalse(file.exists_on_disk())
 
 
 class TestBase64File(FrappeTestCase):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -987,7 +987,6 @@ class Database:
 		self.after_commit.run()
 
 		self.flush_realtime_log()
-		flush_local_link_count()
 
 	def rollback(self, *, save_point=None):
 		"""`ROLLBACK` current transaction. Optionally rollback to a known save_point."""

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -986,8 +986,6 @@ class Database:
 
 		self.after_commit.run()
 
-		self.flush_realtime_log()
-
 	def rollback(self, *, save_point=None):
 		"""`ROLLBACK` current transaction. Optionally rollback to a known save_point."""
 		if save_point:
@@ -1002,15 +1000,6 @@ class Database:
 			self.begin()
 
 			self.after_rollback.run()
-
-			frappe.local.realtime_log = []
-
-	@staticmethod
-	def flush_realtime_log():
-		for args in frappe.local.realtime_log:
-			frappe.realtime.emit_via_redis(*args)
-
-		frappe.local.realtime_log = []
 
 	def savepoint(self, save_point):
 		"""Savepoints work as a nested transaction.

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -29,7 +29,6 @@ from frappe.database.utils import (
 	is_query_type,
 )
 from frappe.exceptions import DoesNotExistError, ImplicitCommitError
-from frappe.model.utils.link_count import flush_local_link_count
 from frappe.query_builder.functions import Count
 from frappe.utils import CallbackManager
 from frappe.utils import cast as cast_fieldtype

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -977,9 +977,6 @@ class Database:
 
 	def commit(self):
 		"""Commit current transaction. Calls SQL `COMMIT`."""
-		for method in frappe.local.before_commit:
-			frappe.call(method[0], *(method[1] or []), **(method[2] or {}))
-
 		# Invalidated by a commit.
 		self.before_rollback.reset()
 		self.after_rollback.reset()
@@ -1018,9 +1015,6 @@ class Database:
 
 			frappe.local.realtime_log = []
 			frappe.flags.enqueue_after_commit = []
-
-	def add_before_commit(self, method, args=None, kwargs=None):
-		frappe.local.before_commit.append([method, args, kwargs])
 
 	@staticmethod
 	def flush_realtime_log():

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -976,7 +976,6 @@ class Database:
 
 	def commit(self):
 		"""Commit current transaction. Calls SQL `COMMIT`."""
-		# Invalidated by a commit.
 		self.before_rollback.reset()
 		self.after_rollback.reset()
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -125,7 +125,6 @@ class Database:
 		self.cur_db_name = self.user
 		self._conn = self.get_connection()
 		self._cursor = self._conn.cursor()
-		frappe.local.rollback_observers = []
 
 		try:
 			if execution_timeout := get_query_execution_timeout():
@@ -988,7 +987,6 @@ class Database:
 
 		self.after_commit.run()
 
-		frappe.local.rollback_observers = []
 		self.flush_realtime_log()
 		enqueue_jobs_after_commit()
 		flush_local_link_count()
@@ -1007,11 +1005,6 @@ class Database:
 			self.begin()
 
 			self.after_rollback.run()
-
-			for obj in dict.fromkeys(frappe.local.rollback_observers):
-				if hasattr(obj, "on_rollback"):
-					obj.on_rollback()
-			frappe.local.rollback_observers = []
 
 			frappe.local.realtime_log = []
 			frappe.flags.enqueue_after_commit = []

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -32,7 +32,7 @@ class FrappeTestCase(unittest.TestCase):
 		# flush changes done so far to avoid flake
 		frappe.db.commit()
 		if cls.SHOW_TRANSACTION_COMMIT_WARNINGS:
-			frappe.db.add_before_commit(_commit_watcher)
+			frappe.db.before_commit.add(_commit_watcher)
 
 		# enqueue teardown actions (executed in LIFO order)
 		cls.addClassCleanup(_restore_thread_locals, copy.deepcopy(frappe.local.flags))

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -101,7 +101,6 @@ def _commit_watcher():
 
 
 def _rollback_db():
-	frappe.local.rollback_observers = []
 	frappe.db.value_cache = {}
 	frappe.db.rollback()
 

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -101,7 +101,6 @@ def _commit_watcher():
 
 
 def _rollback_db():
-	frappe.local.before_commit = []
 	frappe.local.rollback_observers = []
 	frappe.db.value_cache = {}
 	frappe.db.rollback()

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -110,7 +110,6 @@ def _restore_thread_locals(flags):
 	frappe.local.error_log = []
 	frappe.local.message_log = []
 	frappe.local.debug_log = []
-	frappe.local.realtime_log = []
 	frappe.local.conf = frappe._dict(frappe.get_site_config())
 	frappe.local.cache = {}
 	frappe.local.lang = "en"

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -3,13 +3,14 @@ import socket
 import time
 from collections import defaultdict
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, Union
+from typing import Any, Callable, Literal, NoReturn
 from uuid import uuid4
 
 import redis
 from redis.exceptions import BusyLoadingError, ConnectionError
 from rq import Connection, Queue, Worker
 from rq.exceptions import NoSuchJobError
+from rq.job import Job, JobStatus
 from rq.logutils import setup_loghandlers
 from rq.worker import RandomWorker, RoundRobinWorker
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -21,10 +22,6 @@ from frappe.utils import cstr, get_bench_id
 from frappe.utils.commands import log
 from frappe.utils.deprecations import deprecation_warning
 from frappe.utils.redis_queue import RedisQueue
-
-if TYPE_CHECKING:
-	from rq.job import Job
-
 
 # TTL to keep RQ job logs in redis for.
 RQ_JOB_FAILURE_TTL = 7 * 24 * 60 * 60  # 7 days instead of 1 year (default)
@@ -54,21 +51,21 @@ redis_connection = None
 
 
 def enqueue(
-	method,
-	queue="default",
-	timeout=None,
-	on_success=None,
-	on_failure=None,
+	method: str | Callable,
+	queue: str = "default",
+	timeout: int | None = None,
 	event=None,
-	is_async=True,
-	job_name=None,
-	now=False,
-	enqueue_after_commit=False,
+	is_async: bool = True,
+	job_name: str | None = None,
+	now: bool = False,
+	enqueue_after_commit: bool = False,
 	*,
-	at_front=False,
-	job_id=None,
+	on_success: Callable = None,
+	on_failure: Callable = None,
+	at_front: bool = False,
+	job_id: str = None,
 	**kwargs,
-) -> Union["Job", Any]:
+) -> Job | Any:
 	"""
 	Enqueue method to be executed using a background worker
 
@@ -431,12 +428,15 @@ def create_job_id(job_id: str) -> str:
 	return f"{frappe.local.site}::{job_id}"
 
 
-def is_job_enqueued(job_id: str) -> str:
-	from rq.job import Job
+def is_job_enqueued(job_id: str) -> bool:
+	return get_job_status(job_id) in (JobStatus.QUEUED, JobStatus.STARTED)
 
+
+def get_job_status(job_id: str) -> JobStatus | None:
+	"""Get RQ job status, returns None if job is not found."""
 	try:
 		job = Job.fetch(create_job_id(job_id), connection=get_redis_conn())
 	except NoSuchJobError:
-		return False
+		return None
 
-	return job.get_status() in ("queued", "started")
+	return job.get_status()


### PR DESCRIPTION
This is a common pattern which is implemented in inconsistent and undocumented ways using these:

- `frappe.local.rollback_observers`
- `frappe.flags.enqueue_after_commit`
- `frappe.local.realtime_log`
- `frappe.local.before_commit`
- `flush_local_link_count`

Instead new simple api:

- Simple function call `frappe.db.after_commit.add(function)`
- If you need args just pass partial function `frappe.db.after_commit.add(lambda: frappe.clear_cache(doctype, name)`


Planned breaking change:
- All other local and flags used for same purposes will be deprecated and removed.


TODO:
- [x] Migrate `frappe.local.before_commit` - Unused completely - https://sourcegraph.com/search?q=context:global+before_commit+repo:%5Egithub%5C.com/frappe/.*&patternType=standard&sm=0&groupBy=repo
- [x] Migrate `frappe.flags.enqueue_after_commit` - is internal.
- [x] Migrate `frappe.local.rollback_observers` - https://sourcegraph.com/search?q=context:global+rollback_observers+repo:%5Egithub%5C.com/frappe/.*&patternType=standard&sm=0&groupBy=repo  cc: @uhrjun 
- [x] Migrate `flush_local_link_count`
- [x] Migrate `frappe.local.realtime_log`
- [x] Test
- [x] Docs: https://frappeframework.com/docs/v14/user/en/api/database#database-transaction-hooks
- [x] update migration guide: https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)#frappe-db-transaction-hooks