### PR TITLE
refactor: document caching and invalidation

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1125,6 +1125,7 @@ def clear_document_cache(doctype: str, name: str | None = None) -> None:
 	clear_in_redis()
 	if hasattr(db, "after_commit"):
 		db.after_commit.add(clear_in_redis)
+		db.after_rollback.add(clear_in_redis)
 
 	if doctype == "System Settings" and hasattr(local, "system_settings"):
 		delattr(local, "system_settings")

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1116,7 +1116,12 @@ def get_document_cache_key(doctype: str, name: str):
 
 
 def clear_document_cache(doctype, name):
-	cache().hdel("document_cache", get_document_cache_key(doctype, name))
+	def clear_in_redis():
+		cache().hdel("document_cache", get_document_cache_key(doctype, name))
+
+	clear_in_redis()
+	if hasattr(db, "after_commit"):
+		db.after_commit.add(clear_in_redis)
 
 	if doctype == "System Settings" and hasattr(local, "system_settings"):
 		delattr(local, "system_settings")

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1115,9 +1115,12 @@ def get_document_cache_key(doctype: str, name: str):
 	return f"document_cache::{doctype}::{name}"
 
 
-def clear_document_cache(doctype, name):
+def clear_document_cache(doctype: str, name: str | None = None) -> None:
 	def clear_in_redis():
-		cache().delete_value(get_document_cache_key(doctype, name))
+		if name is not None:
+			cache().delete_value(get_document_cache_key(doctype, name))
+		else:
+			cache().delete_keys(get_document_cache_key(doctype, ""))
 
 	clear_in_redis()
 	if hasattr(db, "after_commit"):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1116,7 +1116,6 @@ def get_document_cache_key(doctype: str, name: str):
 
 
 def clear_document_cache(doctype, name):
-	cache().hdel("last_modified", doctype)
 	cache().hdel("document_cache", get_document_cache_key(doctype, name))
 
 	if doctype == "System Settings" and hasattr(local, "system_settings"):

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -125,8 +125,9 @@ def clear_doctype_cache(doctype=None):
 	clear_controller_cache(doctype)
 	cache = frappe.cache()
 
-	for key in ("is_table", "doctype_modules", "document_cache"):
+	for key in ("is_table", "doctype_modules"):
 		cache.delete_value(key)
+	cache.delete_keys("document_cache")
 
 	def clear_single(dt):
 		for name in doctype_cache_keys:

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -123,13 +123,21 @@ def clear_defaults_cache(user=None):
 
 def clear_doctype_cache(doctype=None):
 	clear_controller_cache(doctype)
+
+	_clear_doctype_cache_form_redis()
+	if hasattr(frappe.db, "after_commit"):
+		frappe.db.after_commit.add(_clear_doctype_cache_form_redis)
+		frappe.db.after_rollback.add(_clear_doctype_cache_form_redis)
+
+
+def _clear_doctype_cache_form_redis(doctype: str | None = None):
 	cache = frappe.cache()
 
 	for key in ("is_table", "doctype_modules"):
 		cache.delete_value(key)
-	cache.delete_keys("document_cache")
 
 	def clear_single(dt):
+		frappe.clear_document_cache(dt)
 		for name in doctype_cache_keys:
 			cache.hdel(name, dt)
 
@@ -156,6 +164,7 @@ def clear_doctype_cache(doctype=None):
 		# clear all
 		for name in doctype_cache_keys:
 			cache.delete_value(name)
+		cache.delete_keys("document_cache::")
 
 
 def clear_controller_cache(doctype=None):

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -920,10 +920,8 @@ class Database:
 		if isinstance(dn, str):
 			frappe.clear_document_cache(dt, dn)
 		else:
-			# TODO: Fix this; doesn't work rn - gavin@frappe.io
-			# frappe.cache().hdel_keys(dt, "document_cache")
-			# Workaround: clear all document caches
-			frappe.cache().delete_value("document_cache")
+			# No way to guess which documents are modified, clear all of them
+			frappe.clear_document_cache(dt)
 
 		for column, value in to_update.items():
 			query = query.set(column, value)

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -6,8 +6,7 @@ from frappe.model.document import Document
 
 
 class ListViewSettings(Document):
-	def on_update(self):
-		frappe.clear_document_cache(self.doctype, self.name)
+	pass
 
 
 @frappe.whitelist()

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1122,7 +1122,14 @@ class Document(BaseDocument):
 			frappe.flags.currently_saving.remove((self.doctype, self.name))
 
 	def clear_cache(self):
+		# TODO: Remove this call after verifying,
+		# after commit call alone should be enough.
 		frappe.clear_document_cache(self.doctype, self.name)
+
+		# There's a possibility that another worker might read data after clearing cache and before
+		# changes are commited to DB, in which case stale doc can be read and stored in DB. So
+		# clear cache after commiting.
+		frappe.db.after_commit.add(lambda: frappe.clear_document_cache(self.doctype, self.name))
 
 	def reset_seen(self):
 		"""Clear _seen property and set current user as seen"""

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1207,7 +1207,6 @@ class Document(BaseDocument):
 		if notify:
 			self.notify_update()
 
-		self.clear_cache()
 		if commit:
 			frappe.db.commit()
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1122,14 +1122,7 @@ class Document(BaseDocument):
 			frappe.flags.currently_saving.remove((self.doctype, self.name))
 
 	def clear_cache(self):
-		# TODO: Remove this call after verifying,
-		# after commit call alone should be enough.
 		frappe.clear_document_cache(self.doctype, self.name)
-
-		# There's a possibility that another worker might read data after clearing cache and before
-		# changes are commited to DB, in which case stale doc can be read and stored in DB. So
-		# clear cache after commiting.
-		frappe.db.after_commit.add(lambda: frappe.clear_document_cache(self.doctype, self.name))
 
 	def reset_seen(self):
 		"""Clear _seen property and set current user as seen"""

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -210,3 +210,18 @@ class TestDocumentCache(FrappeAPITestCase):
 
 		with self.assertQueryCount(0):
 			frappe.get_cached_doc(self.TEST_DOCTYPE, self.TEST_DOCNAME)
+
+
+class TestRedisWrapper(FrappeAPITestCase):
+	def test_delete_keys(self):
+
+		c = frappe.cache()
+
+		prefix = "test_del_"
+
+		for i in range(5):
+			c.set_value(f"{prefix}{i}", 1)
+
+		self.assertEqual(len(c.get_keys(prefix)), 5)
+		c.delete_keys(prefix)
+		self.assertEqual(len(c.get_keys(prefix)), 0)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -802,7 +802,7 @@ class TestDBSetValue(FrappeTestCase):
 			"description",
 			f"{self.todo1.description}-edit by `test_for_update`",
 		)
-		query = frappe.db.last_query
+		query = str(frappe.db.last_query)
 
 		if frappe.conf.db_type == "postgres":
 			from frappe.database.postgres.database import modify_query

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -796,21 +796,20 @@ class TestDBSetValue(FrappeTestCase):
 	def test_set_value(self):
 		self.todo1.reload()
 
-		with patch.object(Database, "sql") as sql_called:
-			frappe.db.set_value(
-				self.todo1.doctype,
-				self.todo1.name,
-				"description",
-				f"{self.todo1.description}-edit by `test_for_update`",
-			)
-			first_query = sql_called.call_args_list[0].args[0]
+		frappe.db.set_value(
+			self.todo1.doctype,
+			self.todo1.name,
+			"description",
+			f"{self.todo1.description}-edit by `test_for_update`",
+		)
+		query = frappe.db.last_query
 
-			if frappe.conf.db_type == "postgres":
-				from frappe.database.postgres.database import modify_query
+		if frappe.conf.db_type == "postgres":
+			from frappe.database.postgres.database import modify_query
 
-				self.assertTrue(modify_query("UPDATE `tabToDo` SET") in first_query)
-			if frappe.conf.db_type == "mariadb":
-				self.assertTrue("UPDATE `tabToDo` SET" in first_query)
+			self.assertTrue(modify_query("UPDATE `tabToDo` SET") in query)
+		if frappe.conf.db_type == "mariadb":
+			self.assertTrue("UPDATE `tabToDo` SET" in query)
 
 	def test_cleared_cache(self):
 		self.todo2.reload()

--- a/frappe/tests/test_fixture_import.py
+++ b/frappe/tests/test_fixture_import.py
@@ -69,10 +69,12 @@ class TestFixtureImport(FrappeTestCase):
 
 		import_doc(path_to_exported_fixtures)
 
-		delete_doc("DocType", "temp_singles", delete_permanently=True)
-		os.remove(path_to_exported_fixtures)
-
 		data = frappe.db.get_single_value("temp_singles", "member_name")
 		truncate_query.run()
 
 		self.assertEqual(data, dummy_name_list[0])
+
+		delete_doc("DocType", "temp_singles", delete_permanently=True)
+		os.remove(path_to_exported_fixtures)
+
+		frappe.db.commit()

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -199,7 +199,11 @@ class RedisWrapper(redis.Redis):
 
 	def exists(self, *names: str, user=None, shared=None) -> int:
 		names = [self.make_key(n, user=user, shared=shared) for n in names]
-		return super().exists(*names)
+
+		try:
+			return super().exists(*names)
+		except redis.exceptions.ConnectionError:
+			return False
 
 	def hgetall(self, name):
 		value = super().hgetall(self.make_key(name))


### PR DESCRIPTION
This PR addresses many issues with cache invalidations and cache structure: 



1. In very rare cases `doc.save()` will still leave a stale document in the cache. Check illustration below to understand how this can happen. 
2. Duplicate cache clearing in following places:
    - List view settings
    - document.db_set -> db.set_value does it anyway. 
3. Change `document_cache` from hashes to strings. 
    - Hashes are supposed to be used for representing complex objects, not multiple documents of the same DocType.
    - Redis's auto cache clearing based on memory limit won't clear individual keys from hashes even if they are rarely used.
    - strings can have expiry.
    - string keys are easier to filter and remove in O(1) time instead of dropping all documents we can just drop individual doctype using prefix.
4. `db.set_value` now only evicts cache for doctype when it can't determine which document was affected. Earlier it used to drop ALL document cache. No more random slow down when set_value with filters is used. :rocket: 
5. Same as # 1 above but for transaction rollbacks. An uncommitted modification can still be cached which will stay there forever. 
6. `frappe.clear_cache` also clears it again after commit/rollback for better guarantees. 
7. `frappe.cache().delete_keys` is now O(1) operation instead of O(N) :rocket: 
8. `frappe.cache().exists` returns `False` when connection isn't available, consistent with other similar functions. 

TODO:
- [x] tests


depends on https://github.com/frappe/frappe/pull/21215/


```
                                   Time

              Worker 1              │              Worker 2
                                    │
                                    │          doc.save()
                                    │           │
                                    │           ├──► doc.db_update()
                                    │           │
                                    │           └──► doc.clear_cache()
                                    │
                                    │
      frappe.get_cached_doc(...)    │           # Some unrelated time consuming
                                    │           # action before db.commit()
      # Cache miss                  │
      frappe.get_doc(...)           │
                                    │
      # Put stale doc in cache      │
                                    │
                                    │           frappe.db.commit()
                                    │
                                    ▼
```
closes https://github.com/frappe/frappe/issues/21214

Why this happens: https://mariadb.com/kb/en/transactions-repeatable-read/ 
