### PR TITLE
refactor!: Remove dynamic addition of `_comments`

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -19,7 +19,6 @@ import frappe.recorder
 import frappe.utils.response
 from frappe import _
 from frappe.auth import SAFE_HTTP_METHODS, UNSAFE_HTTP_METHODS, HTTPRequest
-from frappe.core.doctype.comment.comment import update_comments_in_parent_after_request
 from frappe.middlewares import StaticDataMiddleware
 from frappe.utils import cint, get_site_name, sanitize_html
 from frappe.utils.error import make_error_snapshot
@@ -350,8 +349,6 @@ def sync_database(rollback: bool) -> bool:
 		if session.update():
 			frappe.db.commit()
 			rollback = False
-
-	update_comments_in_parent_after_request()
 
 	return rollback
 

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -152,14 +152,9 @@ def update_comments_in_parent(reference_doctype, reference_name, _comments):
 
 	except Exception as e:
 		if frappe.db.is_column_missing(e) and getattr(frappe.local, "request", None):
-			# missing column and in request, add column and update after commit
-			frappe.local._comments = getattr(frappe.local, "_comments", []) + [
-				(reference_doctype, reference_name, _comments)
-			]
-
+			pass
 		elif frappe.db.is_data_too_long(e):
 			raise frappe.DataTooLongException
-
 		else:
 			raise
 	else:
@@ -169,13 +164,3 @@ def update_comments_in_parent(reference_doctype, reference_name, _comments):
 		# Clear route cache
 		if route := frappe.get_cached_value(reference_doctype, reference_name, "route"):
 			clear_cache(route)
-
-
-def update_comments_in_parent_after_request():
-	"""update _comments in parent if _comments column is missing"""
-	if hasattr(frappe.local, "_comments"):
-		for (reference_doctype, reference_name, _comments) in frappe.local._comments:
-			add_column(reference_doctype, "_comments", "Text")
-			update_comments_in_parent(reference_doctype, reference_name, _comments)
-
-		frappe.db.commit()


### PR DESCRIPTION
This isn't required anymore, was added to handle old sites.
