### PR TITLE
fix: handle multiple webform for same doctype

### DIFF
--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -31,6 +31,10 @@
   "allow_incomplete",
   "section_break_2",
   "max_attachment_size",
+  "section_break_xzqr",
+  "condition",
+  "column_break_tjgl",
+  "condition_description",
   "section_break_3",
   "list_setting_message",
   "show_list",
@@ -280,10 +284,6 @@
    "label": "Form"
   },
   {
-   "fieldname": "column_break_1",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "section_break_1",
    "fieldtype": "Section Break"
   },
@@ -297,7 +297,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "collapsible": 1,
    "fieldname": "section_break_2",
    "fieldtype": "Section Break"
   },
@@ -374,13 +373,33 @@
    "fieldname": "anonymous",
    "fieldtype": "Check",
    "label": "Anonymous"
+  },
+  {
+   "fieldname": "condition",
+   "fieldtype": "Code",
+   "label": "Condition",
+   "max_height": "150px"
+  },
+  {
+   "fieldname": "section_break_xzqr",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_tjgl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "condition_description",
+   "fieldtype": "HTML",
+   "label": "Condition Description",
+   "options": "<p>Multiple webforms can be created for a single doctype. Write a condition specific to this webform to display correct record after submission.</p><p>For Example:</p>\n<p>If you create a separate webform every year to capture feedback from employees add a \n field named year in doctype and add a condition <b>doc.year==\"2023\"</b></p>\n"
   }
  ],
  "has_web_view": 1,
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2023-04-20 17:24:42.657731",
+ "modified": "2023-06-03 19:18:56.760479",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -153,10 +153,16 @@ def get_context(context):
 			and not frappe.form_dict.name
 			and not frappe.form_dict.is_list
 		):
-			name = frappe.db.get_value(self.doc_type, {"owner": frappe.session.user}, "name")
-			if name:
-				context.in_view_mode = True
-				frappe.redirect(f"/{self.route}/{name}")
+			names = frappe.db.get_values(self.doc_type, {"owner": frappe.session.user}, pluck="name")
+			for name in names:
+				if self.condition:
+					doc = frappe.get_doc(self.doc_type, name)
+					if frappe.safe_eval(self.condition, None, {"doc": doc.as_dict()}):
+						context.in_view_mode = True
+						frappe.redirect(f"/{self.route}/{name}")
+				else:
+					context.in_view_mode = True
+					frappe.redirect(f"/{self.route}/{name}")
 
 		# Show new form when
 		# - User is Guest


### PR DESCRIPTION
If you want to create multiple web forms for the same doctype and `allow_multiple` is not set. 
If the user already submitted a web form before and now is asked to submit again for another webform for the same doctype he will not be able to since the old record already exists and it will be displayed if he tries to hit `/new`

E.g.
We create separate web forms to get a count of employees coming for the company offsite and we store all the data in the same doctype named Offsite.
At the start of the year, we went on our first trip and created a web form named Bhopal Offsite now again at the end of the year we are planning to go for another trip so need to create another web form named Igatpuri Offsite but since each employee have already submitted a response through Bhopal Offsite webform if we create a new web form for same doctype they will be not able to submit a new response since old offsite record already exist.

Now after the fix, we can add a condition in Webform which will be evaluated and if the record does not exist he/she will be able to submit a new response

<img width="1307" alt="image" src="https://github.com/frappe/frappe/assets/30859809/5dafc5cc-586e-4b2a-8808-9cd53b2be5e7">
