### PR TITLE
fix(safe_eval): Normalize `code` before validating `code`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -16,6 +16,7 @@ import inspect
 import json
 import os
 import re
+import unicodedata
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, TypeAlias, overload
 
@@ -2271,6 +2272,7 @@ def bold(text):
 def safe_eval(code, eval_globals=None, eval_locals=None):
 	"""A safer `eval`"""
 	whitelisted_globals = {"int": int, "float": float, "long": int, "round": round}
+	code = unicodedata.normalize("NFKC", code)
 
 	UNSAFE_ATTRIBUTES = {
 		# Generator Attributes


### PR DESCRIPTION
Make sure code is normalised before validating the code

<!-- SECR-369683 -->