### PR TITLE
perf: ~20% Faster web routing :rocket: 

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -875,6 +875,7 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 	:param doctype: If doctype is given, only DocType cache is cleared."""
 	import frappe.cache_manager
 	import frappe.utils.caching
+	from frappe.website.page_renderers.document_page import clear_routing_cache
 
 	if doctype:
 		frappe.cache_manager.clear_doctype_cache(doctype)
@@ -902,6 +903,8 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 		del local.system_settings
 	if hasattr(local, "website_settings"):
 		del local.website_settings
+
+	clear_routing_cache()
 
 
 def only_has_select_perm(doctype, user=None, ignore_permissions=False):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -875,7 +875,7 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 	:param doctype: If doctype is given, only DocType cache is cleared."""
 	import frappe.cache_manager
 	import frappe.utils.caching
-	from frappe.website.page_renderers.document_page import clear_routing_cache
+	from frappe.website.router import clear_routing_cache
 
 	if doctype:
 		frappe.cache_manager.clear_doctype_cache(doctype)

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -150,7 +150,7 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None) -> Calla
 
 		@wraps(func)
 		def redis_cache_wrapper(*args, **kwargs):
-			func_call_key = func_key + str(__generate_request_cache_key(args, kwargs))
+			func_call_key = func_key + "::" + str(__generate_request_cache_key(args, kwargs))
 			if frappe.cache().exists(func_call_key):
 				return frappe.cache().get_value(func_call_key, user=user)
 			else:

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -12,15 +12,13 @@ from frappe.desk.form.meta import get_code_files_via_hooks
 from frappe.modules.utils import export_module_json, get_doc_module
 from frappe.rate_limiter import rate_limit
 from frappe.utils import cstr, dict_with_keys, strip_html
+from frappe.utils.caching import redis_cache
 from frappe.website.utils import get_boot_data, get_comment_list, get_sidebar_items
 from frappe.website.website_generator import WebsiteGenerator
 
 
 class WebForm(WebsiteGenerator):
 	website = frappe._dict(no_cache=1)
-
-	def onload(self):
-		super().onload()
 
 	def validate(self):
 		super().validate()
@@ -639,3 +637,8 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 		raise frappe.PermissionError(
 			_("You don't have permission to access the {0} DocType.").format(doctype)
 		)
+
+
+@redis_cache(ttl=60 * 60)
+def get_published_web_forms() -> dict[str, str]:
+	return frappe.get_all("Web Form", ["name", "route", "modified"], {"published": 1})

--- a/frappe/website/doctype/web_page/web_page.py
+++ b/frappe/website/doctype/web_page/web_page.py
@@ -31,10 +31,6 @@ class WebPage(WebsiteGenerator):
 		if not self.dynamic_route:
 			self.route = quoted(self.route)
 
-	def clear_cache(self):
-		super().clear_cache()
-		get_dynamic_web_pages.clear_cache()
-
 	def get_context(self, context):
 		context.main_section = get_html_content_based_on_type(self, "main_section", self.content_type)
 		context.source_content_type = self.content_type

--- a/frappe/website/page_renderers/document_page.py
+++ b/frappe/website/page_renderers/document_page.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.model.document import get_controller
+from frappe.utils.caching import redis_cache
 from frappe.website.page_renderers.base_template_page import BaseTemplatePage
 from frappe.website.router import (
 	get_doctypes_with_web_view,
@@ -22,22 +23,9 @@ class DocumentPage(BaseTemplatePage):
 		return False
 
 	def search_in_doctypes_with_web_view(self):
-		for doctype in get_doctypes_with_web_view():
-			filters = dict(route=self.path)
-			meta = frappe.get_meta(doctype)
-			condition_field = self.get_condition_field(meta)
-
-			if condition_field:
-				filters[condition_field] = 1
-
-			try:
-				self.docname = frappe.db.get_value(doctype, filters, "name")
-				if self.docname:
-					self.doctype = doctype
-					return True
-			except Exception as e:
-				if not frappe.db.is_missing_column(e):
-					raise e
+		if document := _find_matching_document_webview(self.path):
+			self.doctype, self.docname = document
+			return True
 
 	def search_web_page_dynamic_routes(self):
 		d = get_page_info_from_web_page_with_dynamic_routes(self.path)
@@ -83,7 +71,8 @@ class DocumentPage(BaseTemplatePage):
 			if prop not in self.context:
 				self.context[prop] = getattr(self.doc, prop, False)
 
-	def get_condition_field(self, meta):
+	@staticmethod
+	def get_condition_field(meta):
 		condition_field = None
 		if meta.is_published_field:
 			condition_field = meta.is_published_field
@@ -92,3 +81,26 @@ class DocumentPage(BaseTemplatePage):
 			condition_field = controller.website.condition_field
 
 		return condition_field
+
+
+@redis_cache(ttl=60 * 60)
+def _find_matching_document_webview(route: str) -> tuple[str, str] | None:
+	for doctype in get_doctypes_with_web_view():
+		filters = dict(route=route)
+		meta = frappe.get_meta(doctype)
+		condition_field = DocumentPage.get_condition_field(meta)
+
+		if condition_field:
+			filters[condition_field] = 1
+
+		try:
+			docname = frappe.db.get_value(doctype, filters, "name")
+			if docname:
+				return (doctype, docname)
+		except Exception as e:
+			if not frappe.db.is_missing_column(e):
+				raise e
+
+
+def clear_routing_cache():
+	_find_matching_document_webview.clear_cache()

--- a/frappe/website/page_renderers/document_page.py
+++ b/frappe/website/page_renderers/document_page.py
@@ -100,10 +100,3 @@ def _find_matching_document_webview(route: str) -> tuple[str, str] | None:
 		except Exception as e:
 			if not frappe.db.is_missing_column(e):
 				raise e
-
-
-def clear_routing_cache():
-	from frappe.website.doctype.web_page.web_page import get_dynamic_web_pages
-
-	_find_matching_document_webview.clear_cache()
-	get_dynamic_web_pages.clear_cache()

--- a/frappe/website/page_renderers/document_page.py
+++ b/frappe/website/page_renderers/document_page.py
@@ -103,4 +103,7 @@ def _find_matching_document_webview(route: str) -> tuple[str, str] | None:
 
 
 def clear_routing_cache():
+	from frappe.website.doctype.web_page.web_page import get_dynamic_web_pages
+
 	_find_matching_document_webview.clear_cache()
+	get_dynamic_web_pages.clear_cache()

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -16,12 +16,11 @@ def get_page_info_from_web_page_with_dynamic_routes(path):
 	"""
 	Query Web Page with dynamic_route = 1 and evaluate if any of the routes match
 	"""
+	from frappe.website.doctype.web_page.web_page import get_dynamic_web_pages
+
 	rules, page_info = [], {}
 
-	# build rules from all web page with `dynamic_route = 1`
-	for d in frappe.get_all(
-		"Web Page", fields=["name", "route", "modified"], filters=dict(published=1, dynamic_route=1)
-	):
+	for d in get_dynamic_web_pages():
 		rules.append(Rule("/" + d.route, endpoint=d.name))
 		d.doctype = "Web Page"
 		page_info[d.name] = d

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -32,9 +32,10 @@ def get_page_info_from_web_page_with_dynamic_routes(path):
 
 def get_page_info_from_web_form(path):
 	"""Query published web forms and evaluate if the route matches"""
+	from frappe.website.doctype.web_form.web_form import get_published_web_forms
+
 	rules, page_info = [], {}
-	web_forms = frappe.get_all("Web Form", ["name", "route", "modified"], {"published": 1})
-	for d in web_forms:
+	for d in get_published_web_forms():
 		rules.append(Rule(f"/{d.route}", endpoint=d.name))
 		rules.append(Rule(f"/{d.route}/list", endpoint=d.name))
 		rules.append(Rule(f"/{d.route}/new", endpoint=d.name))
@@ -314,3 +315,13 @@ def get_doctypes_with_web_view():
 
 def get_start_folders():
 	return frappe.local.flags.web_pages_folders or ("www", "templates/pages")
+
+
+def clear_routing_cache():
+	from frappe.website.doctype.web_form.web_form import get_published_web_forms
+	from frappe.website.doctype.web_page.web_page import get_dynamic_web_pages
+	from frappe.website.page_renderers.document_page import _find_matching_document_webview
+
+	_find_matching_document_webview.clear_cache()
+	get_dynamic_web_pages.clear_cache()
+	get_published_web_forms.clear_cache()

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -360,7 +360,7 @@ def get_html_content_based_on_type(doc, fieldname, content_type):
 def clear_cache(path=None):
 	"""Clear website caches
 	:param path: (optional) for the given path"""
-	from frappe.website.page_renderers.document_page import clear_routing_cache
+	from frappe.website.router import clear_routing_cache
 
 	for key in ("website_generator_routes", "website_pages", "website_full_index", "sitemap_routes"):
 		frappe.cache().delete_value(key)

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -360,8 +360,12 @@ def get_html_content_based_on_type(doc, fieldname, content_type):
 def clear_cache(path=None):
 	"""Clear website caches
 	:param path: (optional) for the given path"""
+	from frappe.website.page_renderers.document_page import clear_routing_cache
+
 	for key in ("website_generator_routes", "website_pages", "website_full_index", "sitemap_routes"):
 		frappe.cache().delete_value(key)
+
+	clear_routing_cache()
 
 	frappe.cache().delete_value("website_404")
 	if path:


### PR DESCRIPTION
Context / closes: https://github.com/frappe/frappe/issues/18047


Before:
```
λ wrk -t10 -c20 -d30s http://erp.localhost:8000/
Running 30s test @ http://erp.localhost:8000/
  10 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   516.99ms   70.62ms 750.57ms   72.31%
    Req/Sec     4.51      2.94    10.00     73.74%
  1152 requests in 30.03s, 160.90MB read
Requests/sec:     38.36
Transfer/sec:      5.36MB
```

After:
```
λ wrk -t10 -c20 -d30s http://erp.localhost:8000/
Running 30s test @ http://erp.localhost:8000/
  10 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   428.96ms   60.97ms 680.33ms   69.19%
    Req/Sec     5.35      2.91    10.00     64.72%
  1389 requests in 30.03s, 194.00MB read
Requests/sec:     46.26
Transfer/sec:      6.46MB
```


Primarily achieved by caching following queries.

- Web view evaluations (we evaluate EACH webview doctype)
- Dynamic web page list, published web form list.

Note: This doesn't improve `/app` as it's already hardcoded to avoid this routing dance. https://github.com/frappe/frappe/pull/17891 
