### PR TITLE
fix(UX): Notify if newly created user has no roles

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -212,6 +212,7 @@
    "read_only": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "role_profile_name",
    "fieldtype": "Link",
    "label": "Role Profile",
@@ -761,7 +762,7 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2023-05-24 15:20:06.434506",
+ "modified": "2023-06-05 17:26:04.127555",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -75,6 +75,7 @@ class User(Document):
 			self.validate_email_type(self.email)
 			self.validate_email_type(self.name)
 		self.add_system_manager_role()
+		self.check_roles_added()
 		self.set_system_user()
 		self.set_full_name()
 		self.check_enable_disable()
@@ -672,6 +673,21 @@ class User(Document):
 	def set_time_zone(self):
 		if not self.time_zone:
 			self.time_zone = get_system_timezone()
+
+	def check_roles_added(self):
+		if self.user_type != "System User" or self.roles or not self.is_new():
+			return
+
+		frappe.msgprint(
+			_("Newly created user {0} has no roles enabled.").format(frappe.bold(self.name)),
+			title=_("No Roles Specified"),
+			indicator="orange",
+			primary_action={
+				"label": _("Add Roles"),
+				"client_action": "frappe.set_route",
+				"args": ["Form", self.doctype, self.name],
+			},
+		)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
- System user with no role is useless, it's most likely a mistake or missed out.
- By default adding a new system user doesn't give them ANY role so
they can't really access desk even if they have system user role.


PS: We'll be adding some role profiles by default to ease up onboarding (in ERPNext and other apps)

