### PR TITLE
fix: avoid loading workspace content if already loaded

### DIFF
--- a/frappe/core/doctype/doctype/doctype_list.js
+++ b/frappe/core/doctype/doctype/doctype_list.js
@@ -7,14 +7,14 @@ frappe.listview_settings["DocType"] = {
 	setup_select_primary_button: function (me) {
 		let actions = [
 			{
-				label: __("Add DocType"),
-				description: __("Create a new DocType"),
-				action: () => frappe.new_doc("DocType"),
-			},
-			{
 				label: __("Add DocType (Form Builder)"),
 				description: __("Use the form builder to create a new DocType"),
 				action: () => frappe.set_route("form-builder", "new-doctype"),
+			},
+			{
+				label: __("Add DocType"),
+				description: __("Create a new DocType"),
+				action: () => frappe.new_doc("DocType"),
 			},
 		];
 

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -22,6 +22,7 @@ frappe.views.Workspace = class Workspace {
 		this.page = wrapper.page;
 		this.blocks = frappe.workspace_block.blocks;
 		this.is_read_only = true;
+		this.is_page_loaded = false;
 		this.pages = {};
 		this.sorted_public_items = [];
 		this.sorted_private_items = [];
@@ -248,10 +249,14 @@ frappe.views.Workspace = class Workspace {
 		this.update_selected_sidebar(page, true); //add selected on new page
 
 		if (!frappe.router.current_route[0]) {
+			this.is_page_loaded = true;
 			frappe.set_route(frappe.router.slug(page.public ? page.name : "private/" + page.name));
 		}
 
-		this.show_page(page);
+		if (!this.is_page_loaded) {
+			this.show_page(page);
+			this.is_page_loaded = false;
+		}
 	}
 
 	update_selected_sidebar(page, add) {


### PR DESCRIPTION
Caused by: https://github.com/frappe/frappe/pull/21042

https://github.com/frappe/frappe/assets/30859809/3b0d2f47-a024-48bf-9ca7-63931ac6fad0

