### PR TITLE
fix: multiple input element's in a single control

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -966,7 +966,7 @@ export default class GridRow {
 				let input_in_focus = false;
 
 				$(col)
-					.find("input[type='Text']")
+					.find("input[type='text']")
 					.each(function () {
 						if ($(this).is(":focus")) {
 							input_in_focus = true;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -965,8 +965,10 @@ export default class GridRow {
 				let first_input_field = $(col).find('input[type="Text"]:first');
 				let input_in_focus = false;
 
-				$(col).find("input[type='Text']").each(function () {
-						if($(this).is(":focus")) {
+				$(col)
+					.find("input[type='Text']")
+					.each(function () {
+						if ($(this).is(":focus")) {
 							input_in_focus = true;
 						}
 					});

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -963,7 +963,15 @@ export default class GridRow {
 				}
 				var col = this;
 				let first_input_field = $(col).find('input[type="Text"]:first');
-				first_input_field.trigger("focus");
+				let input_in_focus = false;
+
+				$(col).find("input[type='Text']").each(function () {
+						if($(this).is(":focus")) {
+							input_in_focus = true;
+						}
+					});
+
+				!input_in_focus && first_input_field.trigger("focus");
 
 				if (event.pointerType == "touch") {
 					first_input_field.length && on_input_focus(first_input_field);


### PR DESCRIPTION
While developing a custom control with multiple `input[type='text']` elements the grid row's column click handler creates an issue where anytime you click inside the column boundaries always the first input element is focused.

### Before PR
 
![before_pr-230605](https://github.com/frappe/frappe/assets/29856401/fdb04d29-3d5d-429d-bd2a-59e26e076edd)


### After PR
![after_pr-230605](https://github.com/frappe/frappe/assets/29856401/cea7005f-17fc-4796-b026-d14e2ebf06a0)
