### PR TITLE
fix: consider default value for content in update_workspace2 patch

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -211,7 +211,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2023-05-17 14:52:38.110224",
+ "modified": "2023-06-08 14:52:38.110224",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -183,7 +183,6 @@ frappe.patches.v13_0.reset_corrupt_defaults
 frappe.patches.v13_0.remove_share_for_std_users
 execute:frappe.reload_doc('custom', 'doctype', 'custom_field')
 frappe.email.doctype.email_queue.patches.drop_search_index_on_message_id
-frappe.patches.v14_0.update_workspace2 # 20.09.2021
 frappe.patches.v14_0.save_ratings_in_fraction #23-12-2021
 frappe.patches.v14_0.transform_todo_schema
 frappe.patches.v14_0.remove_post_and_post_comment
@@ -201,6 +200,7 @@ execute:frappe.reload_doc("desk", "doctype", "Form Tour")
 [post_model_sync]
 execute:frappe.get_doc('Role', 'Guest').save() # remove desk access
 frappe.core.doctype.role.patches.v13_set_default_desk_properties
+frappe.patches.v14_0.update_workspace2 # 06.06.2023
 frappe.patches.v14_0.drop_data_import_legacy
 frappe.patches.v14_0.copy_mail_data #08.03.21
 frappe.patches.v14_0.update_github_endpoints #08-11-2021

--- a/frappe/patches/v14_0/update_workspace2.py
+++ b/frappe/patches/v14_0/update_workspace2.py
@@ -5,28 +5,15 @@ from frappe import _
 
 
 def execute():
-	frappe.reload_doc("desk", "doctype", "workspace", force=True)
-
-	child_tables = frappe.get_all(
-		"DocField",
-		pluck="options",
-		filters={"fieldtype": ["in", frappe.model.table_fields], "parent": "Workspace"},
-	)
-
-	for child_table in child_tables:
-		if child_table != "Has Role":
-			frappe.reload_doc("desk", "doctype", child_table, force=True)
-
-	for seq, workspace in enumerate(frappe.get_all("Workspace", order_by="name asc")):
+	for seq, workspace in enumerate(frappe.get_all("Workspace")):
 		doc = frappe.get_doc("Workspace", workspace.name)
 		content = create_content(doc)
 		update_workspace(doc, seq, content)
-	frappe.db.commit()
 
 
 def create_content(doc):
 	content = []
-	if doc.onboarding:
+	if doc.get("onboarding"):
 		content.append({"type": "onboarding", "data": {"onboarding_name": doc.onboarding, "col": 12}})
 	if doc.charts:
 		invalid_links = []
@@ -44,7 +31,7 @@ def create_content(doc):
 		content.append(
 			{
 				"type": "header",
-				"data": {"text": doc.shortcuts_label or _("Your Shortcuts"), "level": 4, "col": 12},
+				"data": {"text": doc.get("shortcuts_label") or _("Your Shortcuts"), "level": 4, "col": 12},
 			}
 		)
 		for s in doc.shortcuts:
@@ -60,7 +47,7 @@ def create_content(doc):
 		content.append(
 			{
 				"type": "header",
-				"data": {"text": doc.cards_label or _("Reports & Masters"), "level": 4, "col": 12},
+				"data": {"text": doc.get("cards_label") or _("Reports & Masters"), "level": 4, "col": 12},
 			}
 		)
 		for l in doc.links:
@@ -74,7 +61,12 @@ def create_content(doc):
 
 
 def update_workspace(doc, seq, content):
-	if not doc.title and not doc.content and not doc.is_standard and not doc.public:
+	if (
+		not doc.title
+		and (not doc.content or doc.content == "[]")
+		and not doc.get("is_standard")
+		and not doc.public
+	):
 		doc.sequence_id = seq + 1
 		doc.content = json.dumps(content)
 		doc.public = 0 if doc.for_user else 1


### PR DESCRIPTION
Since we reloaded the workspace doctype at the start of the patch, we get the content field with default value as `"[]"` (as seen over [here](https://github.com/frappe/frappe/blob/094b8589f750b660d169d136ce0747240471d3dd/frappe/desk/doctype/workspace/workspace.json#L149)).

the condition `not doc.content` was always `False` as `doc.content` with the value `"[]"` is truthy

Moved the patch to post sync as we reloaded most of the stuff associated with workspace anyway.

caused by: https://github.com/frappe/frappe/pull/21109