### PR TITLE
feat: log `pid` and `user` in request logs

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -157,6 +157,8 @@ def log_request(request, response):
 			{
 				"site": get_site_name(request.host),
 				"remote_addr": getattr(request, "remote_addr", "NOTFOUND"),
+				"pid": os.getpid(),
+				"user": getattr(frappe.local.session, "user", "NOTFOUND"),
 				"base_url": getattr(request, "base_url", "NOTFOUND"),
 				"full_path": getattr(request, "full_path", "NOTFOUND"),
 				"method": getattr(request, "method", "NOTFOUND"),


### PR DESCRIPTION
- Logging gunicorn worker PID can help kill resource-intensive workers if needed.
- Logging user can help with blame, etc.

<!-- no-docs -->

Tested Locally ✅ 