### PR TITLE
fix: Fetch non-cached version of Meta on Customize Form.

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -80,7 +80,7 @@ def get_meta_bundle(doctype):
 	bundle = [frappe.desk.form.meta.get_meta(doctype)]
 	for df in bundle[0].fields:
 		if df.fieldtype in frappe.model.table_fields:
-			bundle.append(frappe.desk.form.meta.get_meta(df.options, not frappe.conf.developer_mode))
+			bundle.append(frappe.desk.form.meta.get_meta(df.options))
 	return bundle
 
 

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -34,12 +34,14 @@ ASSET_KEYS = (
 )
 
 
-def get_meta(doctype, cached=True):
+def get_meta(doctype, cached=True) -> "FormMeta":
 	# don't cache for developer mode as js files, templates may be edited
-	if cached and not frappe.conf.developer_mode:
+	cached = cached and not frappe.conf.developer_mode
+	if cached:
 		meta = frappe.cache.hget("doctype_form_meta", doctype)
 		if not meta:
-			meta = FormMeta(doctype)
+			# Cache miss - explicitly get meta from DB to avoid
+			meta = FormMeta(doctype, cached=False)
 			frappe.cache.hset("doctype_form_meta", doctype, meta)
 	else:
 		meta = FormMeta(doctype)
@@ -51,8 +53,8 @@ def get_meta(doctype, cached=True):
 
 
 class FormMeta(Meta):
-	def __init__(self, doctype):
-		self.__dict__.update(frappe.get_meta(doctype).__dict__)
+	def __init__(self, doctype, cached=True):
+		self.__dict__.update(frappe.get_meta(doctype, cached=cached).__dict__)
 		self.load_assets()
 
 	def load_assets(self):

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -36,7 +36,7 @@ ASSET_KEYS = (
 
 def get_meta(doctype, cached=True) -> "FormMeta":
 	# don't cache for developer mode as js files, templates may be edited
-	cached = cached and not frappe.conf.developer_mode
+	cached = cached and not frappe._dev_server
 	if cached:
 		meta = frappe.cache.hget("doctype_form_meta", doctype)
 		if not meta:
@@ -53,7 +53,7 @@ def get_meta(doctype, cached=True) -> "FormMeta":
 
 
 class FormMeta(Meta):
-	def __init__(self, doctype, cached=True):
+	def __init__(self, doctype, *, cached=True):
 		self.__dict__.update(frappe.get_meta(doctype, cached=cached).__dict__)
 		self.load_assets()
 

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -56,14 +56,12 @@ DEFAULT_FIELD_LABELS = {
 
 
 def get_meta(doctype, cached=True) -> "Meta":
-	if not cached:
-		return Meta(doctype)
-
-	if meta := frappe.cache.hget("doctype_meta", doctype):
+	cached = cached and isinstance(doctype, str)
+	if cached and (meta := frappe.cache.hget("doctype_meta", doctype)):
 		return meta
 
 	meta = Meta(doctype)
-	frappe.cache.hset("doctype_meta", doctype, meta)
+	frappe.cache.hset("doctype_meta", meta.name, meta)
 	return meta
 
 


### PR DESCRIPTION
maybe closes #21268 

Sometimes even after using customize form the form meta is still containing old meta. This PR attempts to fix it. I am not entirely sure if it fixes but not using cached version here makes sense to me. 


Rationale/hypothesis: When there's cache-miss for form-meta most likely meta is invalid, hence load it from DB instead of Redis. 


Thanks to @sagarvora for this hypothesis. 