### PR TITLE
chore: remove `get_docname`

### DIFF
--- a/frappe/website/doctype/discussion_topic/discussion_topic.py
+++ b/frappe/website/doctype/discussion_topic/discussion_topic.py
@@ -39,10 +39,3 @@ def save_message(reply, topic):
 	frappe.get_doc({"doctype": "Discussion Reply", "reply": reply, "topic": topic}).save(
 		ignore_permissions=True
 	)
-
-
-@frappe.whitelist(allow_guest=True)
-def get_docname(route):
-	if not route:
-		route = frappe.db.get_single_value("Website Settings", "home_page")
-	return frappe.db.get_value("Web Page", {"route": route}, ["name"])


### PR DESCRIPTION
A whitelisted method `get_docname` was not accessed from UI. Also removed this method because I couldn't find any usage of it.