### PR TITLE
feat: allow no_smtp_authentication to be set from site config

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -384,6 +384,10 @@ class EmailAccount(Document):
 			"name": {"conf_names": ("email_sender_name",), "default": "Frappe"},
 			"auth_method": {"conf_names": ("auth_method"), "default": "Basic"},
 			"from_site_config": {"default": True},
+			"no_smtp_authentication": {
+				"conf_names": ("disable_mail_smtp_authentication",),
+			    "default": 0,
+			},
 		}
 
 		account_details = {}


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
#### Problem
When adding an email account in frappe there is an option to `Disable SMTP server authentication`.
Below are the mail related config options available. As we are able to add mail port and server, It seems logical to have option to set Disable SMTP server authentication from site config too.

![Screenshot 2023-06-07 at 2 33 04 PM](https://github.com/frappe/frappe/assets/42698742/0c21bd3f-a478-4bd9-80b0-1d81a2dfd0c7)

#### Solution
Mapping a setting named `disable_mail_smtp_authentication` in `get_account_details_from_site_config` function in EmailAccount class. Allows you to set `disable_mail_smtp_authentication` in config file.

Ref - https://github.com/frappe/frappe/issues/21273

### Backport to v14 ###