### PR TITLE
perf(newsletter): query queued_recipients only once

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -143,7 +143,9 @@ class Newsletter(WebsiteGenerator):
 		"""Get list of pending recipients of the newsletter. These
 		recipients may not have receive the newsletter in the previous iteration.
 		"""
-		return [x for x in self.newsletter_recipients if x not in self.get_queued_recipients()]
+
+		queued_recipients = set(self.get_queued_recipients())
+		return [x for x in self.newsletter_recipients if x not in queued_recipients]
 
 	def queue_all(self):
 		"""Queue Newsletter to all the recipients generated from the `Email Group` table"""


### PR DESCRIPTION
O(N) -> O(1) check for queued recipients

Caused by https://github.com/frappe/frappe/pull/18044


Newsletter was taking forever to queue:

![image](https://github.com/frappe/frappe/assets/9079960/e6fd1b4e-fabe-4021-9eef-80ea8c95138c)
