### PR TITLE
refactor(DX)!: `frappe.cache()` -> `frappe.cache`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -152,6 +152,7 @@ def set_user_lang(user: str, user_language: str | None = None) -> None:
 # local-globals
 
 db = local("db")
+cache = local("_redis_cache")
 qb = local("qb")
 conf = local("conf")
 form = form_dict = local("form_dict")
@@ -241,6 +242,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	local.dev_server = _dev_server
 	local.qb = get_query_builder(local.conf.db_type or "mariadb")
 	local.qb.get_query = get_query
+	local._redis_cache = _get_redis_cache()
 	setup_module_map()
 
 	if not _qb_patched.get(local.conf.db_type):
@@ -348,17 +350,17 @@ def destroy():
 	release_local(local)
 
 
-redis_server = None
+_redis_cache_conn = None
 
 
-def cache() -> "RedisWrapper":
+def _get_redis_cache() -> "RedisWrapper":
 	"""Returns redis connection."""
-	global redis_server
-	if not redis_server:
+	global _redis_cache_conn
+	if not _redis_cache_conn:
 		from frappe.utils.redis_wrapper import RedisWrapper
 
-		redis_server = RedisWrapper.from_url(conf.get("redis_cache") or "redis://localhost:11311")
-	return redis_server
+		_redis_cache_conn = RedisWrapper.from_url(conf.get("redis_cache") or "redis://localhost:11311")
+	return _redis_cache_conn
 
 
 def get_traceback(with_context: bool = False) -> str:

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -215,13 +215,14 @@ class TestDocumentCache(FrappeAPITestCase):
 class TestRedisWrapper(FrappeAPITestCase):
 	def test_delete_keys(self):
 
-		c = frappe.cache()
-
 		prefix = "test_del_"
 
 		for i in range(5):
-			c.set_value(f"{prefix}{i}", 1)
+			frappe.cache.set_value(f"{prefix}{i}", 1)
 
-		self.assertEqual(len(c.get_keys(prefix)), 5)
-		c.delete_keys(prefix)
-		self.assertEqual(len(c.get_keys(prefix)), 0)
+		self.assertEqual(len(frappe.cache.get_keys(prefix)), 5)
+		frappe.cache.delete_keys(prefix)
+		self.assertEqual(len(frappe.cache.get_keys(prefix)), 0)
+
+	def test_backward_compat_cache(self):
+		self.assertEqual(frappe.cache, frappe.cache())

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -34,6 +34,10 @@ class RedisWrapper(redis.Redis):
 		except redis.exceptions.ConnectionError:
 			return False
 
+	def __call__(self):
+		"""WARNING: Added for backward compatibility to support frappe.cache().method(...)"""
+		return self
+
 	def make_key(self, key, user=None, shared=False):
 		if shared:
 			return key


### PR DESCRIPTION
```diff
- frappe.cache().set_value(...)
+ frappe.cache.set_value(...)
```

This is more intuitive and consistent with other things like `frappe.db`.

`frappe.cache()` will continue to work because of this hack for backward compatibility. We will deprecate and remove this in v16 maybe.
https://github.com/frappe/frappe/blob/583cd27068f1248d0312d1b88dbed0dd1053384e/frappe/utils/redis_wrapper.py#L37-L39

PS: This is quite likely going to break some weird usage which I can't guess right now, but feel it. Normal usage inside request/job cycles will continue to work as it used to.

