### PR TITLE
perf: remove localproxy for `frappe.cache`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -179,6 +179,7 @@ if TYPE_CHECKING:
 
 	db: MariaDBDatabase | PostgresDatabase
 	qb: MariaDB | Postgres
+	cache: RedisWrapper
 
 
 # end: static analysis hack
@@ -350,7 +351,7 @@ def destroy():
 	release_local(local)
 
 
-def setup_redis_cache_connection() -> "RedisWrapper":
+def setup_redis_cache_connection():
 	"""Defines `frappe.cache` as `RedisWrapper` instance"""
 	global cache
 


### PR DESCRIPTION
localproxy is not needed, connection is multitenancy-safe.

### Before

```py
In [2]: %timeit frappe.cache.get_value
1.39 µs ± 10.1 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

### After (97% better)

```py
In [1]: %timeit frappe.cache.get_value
35.1 ns ± 0.315 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```
