### PR TITLE
refactor: frappe.cache() -> frappe.cache

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -380,7 +380,7 @@ def errprint(msg: str) -> None:
 
 
 def print_sql(enable: bool = True) -> None:
-	return cache().set_value("flag_print_sql", enable)
+	return cache.set_value("flag_print_sql", enable)
 
 
 def log(msg: str) -> None:
@@ -1016,7 +1016,7 @@ def is_table(doctype: str) -> bool:
 	def get_tables():
 		return db.get_values("DocType", filters={"istable": 1}, order_by=None, pluck=True)
 
-	tables = cache().get_value("is_table", get_tables)
+	tables = cache.get_value("is_table", get_tables)
 	return doctype in tables
 
 
@@ -1043,7 +1043,7 @@ def generate_hash(txt: str | None = None, length: int = 56) -> str:
 def reset_metadata_version():
 	"""Reset `metadata_version` (Client (Javascript) build ID) hash."""
 	v = generate_hash()
-	cache().set_value("metadata_version", v)
+	cache.set_value("metadata_version", v)
 	return v
 
 
@@ -1079,7 +1079,7 @@ def set_value(doctype, docname, fieldname, value=None):
 
 
 def get_cached_doc(*args, **kwargs) -> "Document":
-	if (key := can_cache_doc(args)) and (doc := cache().get_value(key)):
+	if (key := can_cache_doc(args)) and (doc := cache.get_value(key)):
 		return doc
 
 	# Not found in cache, fetch from DB
@@ -1095,7 +1095,7 @@ def get_cached_doc(*args, **kwargs) -> "Document":
 
 
 def _set_document_in_cache(key: str, doc: "Document") -> None:
-	cache().set_value(key, doc)
+	cache.set_value(key, doc)
 
 
 def can_cache_doc(args) -> str | None:
@@ -1122,9 +1122,9 @@ def get_document_cache_key(doctype: str, name: str):
 def clear_document_cache(doctype: str, name: str | None = None) -> None:
 	def clear_in_redis():
 		if name is not None:
-			cache().delete_value(get_document_cache_key(doctype, name))
+			cache.delete_value(get_document_cache_key(doctype, name))
 		else:
-			cache().delete_keys(get_document_cache_key(doctype, ""))
+			cache.delete_keys(get_document_cache_key(doctype, ""))
 
 	clear_in_redis()
 	if hasattr(db, "after_commit"):
@@ -1214,7 +1214,7 @@ def get_doc(*args, **kwargs):
 	doc = frappe.model.document.get_doc(*args, **kwargs)
 
 	# Replace cache if stale one exists
-	if (key := can_cache_doc(args)) and cache().exists(key):
+	if (key := can_cache_doc(args)) and cache.exists(key):
 		_set_document_in_cache(key, doc)
 
 	return doc
@@ -1448,13 +1448,13 @@ def get_installed_apps(sort=False, frappe_last=False, *, _ensure_on_bench=False)
 
 	if sort:
 		if not local.all_apps:
-			local.all_apps = cache().get_value("all_apps", get_all_apps)
+			local.all_apps = cache.get_value("all_apps", get_all_apps)
 
 		deprecation_warning("`sort` argument is deprecated and will be removed in v15.")
 		installed = [app for app in local.all_apps if app in installed]
 
 	if _ensure_on_bench:
-		all_apps = cache().get_value("all_apps", get_all_apps)
+		all_apps = cache.get_value("all_apps", get_all_apps)
 		installed = [app for app in installed if app in all_apps]
 
 	if frappe_last:
@@ -1525,7 +1525,7 @@ def get_hooks(
 		if conf.developer_mode:
 			hooks = _dict(_load_app_hooks())
 		else:
-			hooks = _dict(cache().get_value("app_hooks", _load_app_hooks))
+			hooks = _dict(cache.get_value("app_hooks", _load_app_hooks))
 
 	if hook:
 		return hooks.get(hook, ([] if default == "_KEEP_DEFAULT_LIST" else default))
@@ -1555,11 +1555,9 @@ def append_hook(target, key, value):
 
 def setup_module_map():
 	"""Rebuild map of all modules (internal)."""
-	_cache = cache()
-
 	if conf.db_name:
-		local.app_modules = _cache.get_value("app_modules")
-		local.module_app = _cache.get_value("module_app")
+		local.app_modules = cache.get_value("app_modules")
+		local.module_app = cache.get_value("module_app")
 
 	if not (local.app_modules and local.module_app):
 		local.module_app, local.app_modules = {}, {}
@@ -1571,8 +1569,8 @@ def setup_module_map():
 				local.app_modules[app].append(module)
 
 		if conf.db_name:
-			_cache.set_value("app_modules", local.app_modules)
-			_cache.set_value("module_app", local.module_app)
+			cache.set_value("app_modules", local.app_modules)
+			cache.set_value("module_app", local.module_app)
 
 
 def get_file_items(path, raise_not_found=False, ignore_empty_lines=True):
@@ -1861,7 +1859,7 @@ def redirect_to_message(title, html, http_status_code=None, context=None, indica
 	if indicator_color:
 		message["context"].update({"indicator_color": indicator_color})
 
-	cache().set_value(f"message_id:{message_id}", message, expires_in_sec=60)
+	cache.set_value(f"message_id:{message_id}", message, expires_in_sec=60)
 	location = f"/message?id={message_id}"
 
 	if not getattr(local, "is_ajax", False):

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -188,10 +188,10 @@ class LoginManager:
 			frappe.response["full_name"] = self.full_name
 
 		# redirect information
-		redirect_to = frappe.cache().hget("redirect_after_login", self.user)
+		redirect_to = frappe.cache.hget("redirect_after_login", self.user)
 		if redirect_to:
 			frappe.local.response["redirect_to"] = redirect_to
-			frappe.cache().hdel("redirect_after_login", self.user)
+			frappe.cache.hdel("redirect_after_login", self.user)
 
 		frappe.local.cookie_manager.set_cookie("full_name", self.full_name)
 		frappe.local.cookie_manager.set_cookie("user_id", self.user)
@@ -482,15 +482,15 @@ class LoginAttemptTracker:
 
 	@property
 	def login_failed_count(self):
-		return frappe.cache().hget("login_failed_count", self.user_name)
+		return frappe.cache.hget("login_failed_count", self.user_name)
 
 	@login_failed_count.setter
 	def login_failed_count(self, count):
-		frappe.cache().hset("login_failed_count", self.user_name, count)
+		frappe.cache.hset("login_failed_count", self.user_name, count)
 
 	@login_failed_count.deleter
 	def login_failed_count(self):
-		frappe.cache().hdel("login_failed_count", self.user_name)
+		frappe.cache.hdel("login_failed_count", self.user_name)
 
 	@property
 	def login_failed_time(self):
@@ -498,15 +498,15 @@ class LoginAttemptTracker:
 
 		For every user we track only First failed login attempt time within lock interval of time.
 		"""
-		return frappe.cache().hget("login_failed_time", self.user_name)
+		return frappe.cache.hget("login_failed_time", self.user_name)
 
 	@login_failed_time.setter
 	def login_failed_time(self, timestamp):
-		frappe.cache().hset("login_failed_time", self.user_name, timestamp)
+		frappe.cache.hset("login_failed_time", self.user_name, timestamp)
 
 	@login_failed_time.deleter
 	def login_failed_time(self):
-		frappe.cache().hdel("login_failed_time", self.user_name)
+		frappe.cache.hdel("login_failed_time", self.user_name)
 
 	def add_failure_attempt(self):
 		"""Log user failure attempts into the system.

--- a/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/test_milestone_tracker.py
@@ -9,7 +9,7 @@ class TestMilestoneTracker(FrappeTestCase):
 	def test_milestone(self):
 		frappe.db.delete("Milestone Tracker")
 
-		frappe.cache().delete_key("milestone_tracker_map")
+		frappe.cache.delete_key("milestone_tracker_map")
 
 		milestone_tracker = frappe.get_doc(
 			dict(doctype="Milestone Tracker", document_type="ToDo", track_field="status")

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -149,10 +149,8 @@ def get_allowed_report_names(cache=False) -> set[str]:
 
 
 def get_user_pages_or_reports(parent, cache=False):
-	_cache = frappe.cache()
-
 	if cache:
-		has_role = _cache.get_value("has_role:" + parent, user=frappe.session.user)
+		has_role = frappe.cache.get_value("has_role:" + parent, user=frappe.session.user)
 		if has_role:
 			return has_role
 
@@ -254,7 +252,7 @@ def get_user_pages_or_reports(parent, cache=False):
 			has_role.pop(r, None)
 
 	# Expire every six hours
-	_cache.set_value("has_role:" + parent, has_role, frappe.session.user, 21600)
+	frappe.cache.set_value("has_role:" + parent, has_role, frappe.session.user, 21600)
 	return has_role
 
 

--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -79,28 +79,25 @@ doctype_cache_keys = (
 
 
 def clear_user_cache(user=None):
-	cache = frappe.cache()
-
 	# this will automatically reload the global cache
 	# so it is important to clear this first
 	clear_notifications(user)
 
 	if user:
 		for name in user_cache_keys:
-			cache.hdel(name, user)
-		cache.delete_keys("user:" + user)
+			frappe.cache.hdel(name, user)
+		frappe.cache.delete_keys("user:" + user)
 		clear_defaults_cache(user)
 	else:
 		for name in user_cache_keys:
-			cache.delete_key(name)
+			frappe.cache.delete_key(name)
 		clear_defaults_cache()
 		clear_global_cache()
 
 
 def clear_domain_cache(user=None):
-	cache = frappe.cache()
 	domain_cache_keys = ("domain_restricted_doctypes", "domain_restricted_pages")
-	cache.delete_value(domain_cache_keys)
+	frappe.cache.delete_value(domain_cache_keys)
 
 
 def clear_global_cache():
@@ -108,17 +105,17 @@ def clear_global_cache():
 
 	clear_doctype_cache()
 	clear_website_cache()
-	frappe.cache().delete_value(global_cache_keys)
-	frappe.cache().delete_value(bench_cache_keys)
+	frappe.cache.delete_value(global_cache_keys)
+	frappe.cache.delete_value(bench_cache_keys)
 	frappe.setup_module_map()
 
 
 def clear_defaults_cache(user=None):
 	if user:
 		for p in [user] + common_default_keys:
-			frappe.cache().hdel("defaults", p)
+			frappe.cache.hdel("defaults", p)
 	elif frappe.flags.in_install != "frappe":
-		frappe.cache().delete_key("defaults")
+		frappe.cache.delete_key("defaults")
 
 
 def clear_doctype_cache(doctype=None):
@@ -131,15 +128,13 @@ def clear_doctype_cache(doctype=None):
 
 
 def _clear_doctype_cache_form_redis(doctype: str | None = None):
-	cache = frappe.cache()
-
 	for key in ("is_table", "doctype_modules"):
-		cache.delete_value(key)
+		frappe.cache.delete_value(key)
 
 	def clear_single(dt):
 		frappe.clear_document_cache(dt)
 		for name in doctype_cache_keys:
-			cache.hdel(name, dt)
+			frappe.cache.hdel(name, dt)
 
 	if doctype:
 		clear_single(doctype)
@@ -163,8 +158,8 @@ def _clear_doctype_cache_form_redis(doctype: str | None = None):
 	else:
 		# clear all
 		for name in doctype_cache_keys:
-			cache.delete_value(name)
-		cache.delete_keys("document_cache::")
+			frappe.cache.delete_value(name)
+		frappe.cache.delete_keys("document_cache::")
 
 
 def clear_controller_cache(doctype=None):
@@ -177,7 +172,7 @@ def clear_controller_cache(doctype=None):
 
 
 def get_doctype_map(doctype, name, filters=None, order_by=None):
-	return frappe.cache().hget(
+	return frappe.cache.hget(
 		get_doctype_map_key(doctype),
 		name,
 		lambda: frappe.get_all(doctype, filters=filters, order_by=order_by, ignore_ddl=True),
@@ -185,7 +180,7 @@ def get_doctype_map(doctype, name, filters=None, order_by=None):
 
 
 def clear_doctype_map(doctype, name):
-	frappe.cache().hdel(frappe.scrub(doctype) + "_map", name)
+	frappe.cache.hdel(frappe.scrub(doctype) + "_map", name)
 
 
 def build_table_count_cache():
@@ -198,7 +193,6 @@ def build_table_count_cache():
 	):
 		return
 
-	_cache = frappe.cache()
 	table_name = frappe.qb.Field("table_name").as_("name")
 	table_rows = frappe.qb.Field("table_rows").as_("count")
 	information_schema = frappe.qb.Schema("information_schema")
@@ -207,7 +201,7 @@ def build_table_count_cache():
 		as_dict=True
 	)
 	counts = {d.get("name").replace("tab", "", 1): d.get("count", None) for d in data}
-	_cache.set_value("information_schema:counts", counts)
+	frappe.cache.set_value("information_schema:counts", counts)
 
 	return counts
 
@@ -221,11 +215,10 @@ def build_domain_restriced_doctype_cache(*args, **kwargs):
 		or frappe.flags.in_setup_wizard
 	):
 		return
-	_cache = frappe.cache()
 	active_domains = frappe.get_active_domains()
 	doctypes = frappe.get_all("DocType", filters={"restrict_to_domain": ("IN", active_domains)})
 	doctypes = [doc.name for doc in doctypes]
-	_cache.set_value("domain_restricted_doctypes", doctypes)
+	frappe.cache.set_value("domain_restricted_doctypes", doctypes)
 
 	return doctypes
 
@@ -239,10 +232,9 @@ def build_domain_restriced_page_cache(*args, **kwargs):
 		or frappe.flags.in_setup_wizard
 	):
 		return
-	_cache = frappe.cache()
 	active_domains = frappe.get_active_domains()
 	pages = frappe.get_all("Page", filters={"restrict_to_domain": ("IN", active_domains)})
 	pages = [page.name for page in pages]
-	_cache.set_value("domain_restricted_pages", pages)
+	frappe.cache.set_value("domain_restricted_pages", pages)
 
 	return pages

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -62,7 +62,7 @@ class Importer:
 
 	def before_import(self):
 		# set user lang for translations
-		frappe.cache().hdel("lang", frappe.session.user)
+		frappe.cache.hdel("lang", frappe.session.user)
 		frappe.set_user_lang(frappe.session.user)
 
 		# set flags
@@ -1207,7 +1207,7 @@ def get_df_for_column_header(doctype, header):
 	def build_fields_dict_for_doctype():
 		return build_fields_dict_for_column_matching(doctype)
 
-	df_by_labels_and_fieldname = frappe.cache().hget(
+	df_by_labels_and_fieldname = frappe.cache.hget(
 		"data_import_column_header_map", doctype, generator=build_fields_dict_for_doctype
 	)
 	return df_by_labels_and_fieldname.get(header)

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1710,7 +1710,7 @@ def check_fieldname_conflicts(docfield):
 
 
 def clear_linked_doctype_cache():
-	frappe.cache().delete_value("linked_doctypes_without_ignore_user_permissions_enabled")
+	frappe.cache.delete_value("linked_doctypes_without_ignore_user_permissions_enabled")
 
 
 def check_email_append_to(doc):

--- a/frappe/core/doctype/domain_settings/domain_settings.py
+++ b/frappe/core/doctype/domain_settings/domain_settings.py
@@ -73,7 +73,7 @@ def get_active_domains():
 		active_domains.append("")
 		return active_domains
 
-	return frappe.cache().get_value("active_domains", _get_active_domains)
+	return frappe.cache.get_value("active_domains", _get_active_domains)
 
 
 def get_active_modules():
@@ -87,4 +87,4 @@ def get_active_modules():
 				active_modules.append(m.name)
 		return active_modules
 
-	return frappe.cache().get_value("active_modules", _get_active_modules)
+	return frappe.cache.get_value("active_modules", _get_active_modules)

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -137,7 +137,7 @@ class Report(Document):
 		if execution_time > threshold and not self.prepared_report:
 			self.db_set("prepared_report", 1)
 
-		frappe.cache().hset("report_execution_time", self.name, execution_time)
+		frappe.cache.hset("report_execution_time", self.name, execution_time)
 
 		return res
 

--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -24,7 +24,7 @@ class Role(Document):
 			frappe.throw(frappe._("Standard roles cannot be renamed"))
 
 	def after_insert(self):
-		frappe.cache().hdel("roles", "Administrator")
+		frappe.cache.hdel("roles", "Administrator")
 
 	def validate(self):
 		if self.disabled:

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -19,7 +19,7 @@ class ServerScript(Document):
 		self.check_if_compilable_in_restricted_context()
 
 	def on_update(self):
-		frappe.cache().delete_value("server_script_map")
+		frappe.cache.delete_value("server_script_map")
 		self.sync_scheduler_events()
 
 	def on_trash(self):
@@ -168,11 +168,11 @@ class ServerScript(Document):
 					out.append([key, score])
 			return out
 
-		items = frappe.cache().get_value("server_script_autocompletion_items")
+		items = frappe.cache.get_value("server_script_autocompletion_items")
 		if not items:
 			items = get_keys(get_safe_globals())
 			items = [{"value": d[0], "score": d[1]} for d in items]
-			frappe.cache().set_value("server_script_autocompletion_items", items)
+			frappe.cache.set_value("server_script_autocompletion_items", items)
 		return items
 
 

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -55,7 +55,7 @@ def get_server_script_map():
 	if frappe.flags.in_patch and not frappe.db.table_exists("Server Script"):
 		return {}
 
-	script_map = frappe.cache().get_value("server_script_map")
+	script_map = frappe.cache.get_value("server_script_map")
 	if script_map is None:
 		script_map = {"permission_query": {}}
 		enabled_server_scripts = frappe.get_all(
@@ -73,6 +73,6 @@ def get_server_script_map():
 			else:
 				script_map.setdefault("_api", {})[script.api_method] = script.name
 
-		frappe.cache().set_value("server_script_map", script_map)
+		frappe.cache.set_value("server_script_map", script_map)
 
 	return script_map

--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -104,10 +104,10 @@ class TestServerScript(FrappeTestCase):
 	def tearDownClass(cls):
 		frappe.db.commit()
 		frappe.db.truncate("Server Script")
-		frappe.cache().delete_value("server_script_map")
+		frappe.cache.delete_value("server_script_map")
 
 	def setUp(self):
-		frappe.cache().delete_value("server_script_map")
+		frappe.cache.delete_value("server_script_map")
 
 	def test_doctype_event(self):
 		todo = frappe.get_doc(dict(doctype="ToDo", description="hello")).insert()

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -64,8 +64,8 @@ class SystemSettings(Document):
 	def on_update(self):
 		self.set_defaults()
 
-		frappe.cache().delete_value("system_settings")
-		frappe.cache().delete_value("time_zone")
+		frappe.cache.delete_value("system_settings")
+		frappe.cache.delete_value("time_zone")
 
 		if frappe.flags.update_last_reset_password_date:
 			update_last_reset_password_date()

--- a/frappe/core/doctype/translation/translation.py
+++ b/frappe/core/doctype/translation/translation.py
@@ -89,5 +89,5 @@ def create_translations(translation_map, language):
 
 
 def clear_user_translation_cache(lang):
-	frappe.cache().hdel(USER_TRANSLATION_KEY, lang)
-	frappe.cache().hdel(MERGED_TRANSLATION_KEY, lang)
+	frappe.cache.hdel(USER_TRANSLATION_KEY, lang)
+	frappe.cache.hdel(MERGED_TRANSLATION_KEY, lang)

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -283,7 +283,7 @@ class TestUser(FrappeTestCase):
 
 		# Clear rate limit tracker to start fresh
 		key = f"rl:{data['cmd']}:{data['user']}"
-		frappe.cache().delete(key)
+		frappe.cache.delete(key)
 
 		c = FrappeClient(url)
 		res1 = c.session.post(url, data=data, verify=c.verify, headers=c.headers)
@@ -330,7 +330,7 @@ class TestUser(FrappeTestCase):
 			sign_up(random_user, random_user_name, "/welcome"),
 			(1, "Please check your email for verification"),
 		)
-		self.assertEqual(frappe.cache().hget("redirect_after_login", random_user), "/welcome")
+		self.assertEqual(frappe.cache.hget("redirect_after_login", random_user), "/welcome")
 
 		# re-register
 		self.assertTupleEqual(

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -60,8 +60,8 @@ class User(Document):
 
 	def after_insert(self):
 		create_notification_settings(self.name)
-		frappe.cache().delete_key("users_for_mentions")
-		frappe.cache().delete_key("enabled_users")
+		frappe.cache.delete_key("users_for_mentions")
+		frappe.cache.delete_key("enabled_users")
 
 	def validate(self):
 		# clear new password
@@ -143,10 +143,10 @@ class User(Document):
 			frappe.defaults.set_default("time_zone", self.time_zone, self.name)
 
 		if self.has_value_changed("enabled"):
-			frappe.cache().delete_key("users_for_mentions")
-			frappe.cache().delete_key("enabled_users")
+			frappe.cache.delete_key("users_for_mentions")
+			frappe.cache.delete_key("enabled_users")
 		elif self.has_value_changed("allow_in_mentions") or self.has_value_changed("user_type"):
-			frappe.cache().delete_key("users_for_mentions")
+			frappe.cache.delete_key("users_for_mentions")
 
 	def has_website_permission(self, ptype, user, verbose=False):
 		"""Returns true if current user is the session user"""
@@ -462,9 +462,9 @@ class User(Document):
 		frappe.delete_doc("Notification Settings", self.name, ignore_permissions=True)
 
 		if self.get("allow_in_mentions"):
-			frappe.cache().delete_key("users_for_mentions")
+			frappe.cache.delete_key("users_for_mentions")
 
-		frappe.cache().delete_key("enabled_users")
+		frappe.cache.delete_key("enabled_users")
 
 		# delete user permissions
 		frappe.db.delete("User Permission", {"user": self.name})
@@ -760,10 +760,10 @@ def update_password(
 	user_doc, redirect_url = reset_user_data(user)
 
 	# get redirect url from cache
-	redirect_to = frappe.cache().hget("redirect_after_login", user)
+	redirect_to = frappe.cache.hget("redirect_after_login", user)
 	if redirect_to:
 		redirect_url = redirect_to
-		frappe.cache().hdel("redirect_after_login", user)
+		frappe.cache.hdel("redirect_after_login", user)
 
 	frappe.local.login_manager.login_as(user)
 
@@ -921,7 +921,7 @@ def sign_up(email: str, full_name: str, redirect_to: str) -> tuple[int, str]:
 			user.add_roles(default_role)
 
 		if redirect_to:
-			frappe.cache().hset("redirect_after_login", user.name, redirect_to)
+			frappe.cache.hset("redirect_after_login", user.name, redirect_to)
 
 		if user.flags.email_sent:
 			return 1, _("Please check your email for verification")
@@ -1234,4 +1234,4 @@ def get_enabled_users():
 		enabled_users = frappe.get_all("User", filters={"enabled": "1"}, pluck="name")
 		return enabled_users
 
-	return frappe.cache().get_value("enabled_users", _get_enabled_users)
+	return frappe.cache.get_value("enabled_users", _get_enabled_users)

--- a/frappe/core/doctype/user_group/user_group.py
+++ b/frappe/core/doctype/user_group/user_group.py
@@ -9,7 +9,7 @@ from frappe.model.document import Document
 
 class UserGroup(Document):
 	def after_insert(self):
-		frappe.cache().delete_key("user_groups")
+		frappe.cache.delete_key("user_groups")
 
 	def on_trash(self):
-		frappe.cache().delete_key("user_groups")
+		frappe.cache.delete_key("user_groups")

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -178,7 +178,7 @@ class TestUserPermission(FrappeTestCase):
 		frappe.db.set_value(
 			"User Permission", {"allow": "Person", "for_value": parent_record.name}, "hide_descendants", 1
 		)
-		frappe.cache().delete_value("user_permissions")
+		frappe.cache.delete_value("user_permissions")
 
 		# check if adding perm on a group record with hide_descendants enabled,
 		# hides child records

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -17,11 +17,11 @@ class UserPermission(Document):
 		self.validate_default_permission()
 
 	def on_update(self):
-		frappe.cache().hdel("user_permissions", self.user)
+		frappe.cache.hdel("user_permissions", self.user)
 		frappe.publish_realtime("update_user_permissions", user=self.user, after_commit=True)
 
 	def on_trash(self):
-		frappe.cache().hdel("user_permissions", self.user)
+		frappe.cache.hdel("user_permissions", self.user)
 		frappe.publish_realtime("update_user_permissions", user=self.user, after_commit=True)
 
 	def validate_user_permission(self):
@@ -74,7 +74,7 @@ def get_user_permissions(user=None):
 	if not user or user in ("Administrator", "Guest"):
 		return {}
 
-	cached_user_permissions = frappe.cache().hget("user_permissions", user)
+	cached_user_permissions = frappe.cache.hget("user_permissions", user)
 
 	if cached_user_permissions is not None:
 		return cached_user_permissions
@@ -110,7 +110,7 @@ def get_user_permissions(user=None):
 					add_doc_to_perm(perm, doc, False)
 
 		out = frappe._dict(out)
-		frappe.cache().hset("user_permissions", user, out)
+		frappe.cache.hset("user_permissions", user, out)
 	except frappe.db.SQLError as e:
 		if frappe.db.is_table_missing(e):
 			# called from patch

--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -18,7 +18,7 @@ class UserType(Document):
 		super().clear_cache()
 
 		if not self.is_standard:
-			frappe.cache().delete_value("non_standard_user_types")
+			frappe.cache.delete_value("non_standard_user_types")
 
 	def on_update(self):
 		if self.is_standard:
@@ -290,7 +290,7 @@ def apply_permissions_for_non_standard_user_type(doc, method=None):
 	if not frappe.db.table_exists("User Type") or frappe.flags.in_migrate:
 		return
 
-	user_types = frappe.cache().get_value(
+	user_types = frappe.cache.get_value(
 		"non_standard_user_types",
 		get_non_standard_user_types,
 	)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -302,7 +302,7 @@ class Database:
 		"""Takes the query and logs it to various interfaces according to the settings."""
 		_query = None
 
-		if frappe.conf.allow_tests and frappe.cache().get_value("flag_print_sql"):
+		if frappe.conf.allow_tests and frappe.cache.get_value("flag_print_sql"):
 			_query = _query or str(mogrified_query)
 			print(_query)
 
@@ -419,7 +419,7 @@ class Database:
 	@staticmethod
 	def clear_db_table_cache(query):
 		if query and is_query_type(query, ("drop", "create")):
-			frappe.cache().delete_key("db_tables")
+			frappe.cache.delete_key("db_tables")
 
 	def get_description(self):
 		"""Returns result metadata."""
@@ -1067,7 +1067,7 @@ class Database:
 	def count(self, dt, filters=None, debug=False, cache=False, distinct: bool = True):
 		"""Returns `COUNT(*)` for given DocType and filters."""
 		if cache and not filters:
-			cache_count = frappe.cache().get_value(f"doctype:count:{dt}")
+			cache_count = frappe.cache.get_value(f"doctype:count:{dt}")
 			if cache_count is not None:
 				return cache_count
 		count = frappe.qb.get_query(
@@ -1078,7 +1078,7 @@ class Database:
 			validate_filters=True,
 		).run(debug=debug)[0][0]
 		if not filters and cache:
-			frappe.cache().set_value(f"doctype:count:{dt}", count, expires_in_sec=86400)
+			frappe.cache.set_value(f"doctype:count:{dt}", count, expires_in_sec=86400)
 		return count
 
 	@staticmethod
@@ -1109,7 +1109,7 @@ class Database:
 
 	def get_db_table_columns(self, table) -> list[str]:
 		"""Returns list of column names from given table."""
-		columns = frappe.cache().hget("table_columns", table)
+		columns = frappe.cache.hget("table_columns", table)
 		if columns is None:
 			information_schema = frappe.qb.Schema("information_schema")
 
@@ -1121,7 +1121,7 @@ class Database:
 			)
 
 			if columns:
-				frappe.cache().hset("table_columns", table, columns)
+				frappe.cache.hset("table_columns", table, columns)
 
 		return columns
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -435,7 +435,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		to_query = not cached
 
 		if cached:
-			tables = frappe.cache().get_value("db_tables")
+			tables = frappe.cache.get_value("db_tables")
 			to_query = not tables
 
 		if to_query:
@@ -447,7 +447,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 				.where(information_schema.tables.table_schema != "information_schema")
 				.run(pluck=True)
 			)
-			frappe.cache().set_value("db_tables", tables)
+			frappe.cache.set_value("db_tables", tables)
 
 		return tables
 

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -40,7 +40,7 @@ class DBTable:
 		if self.is_new():
 			self.create()
 		else:
-			frappe.cache().hdel("table_columns", self.table_name)
+			frappe.cache.hdel("table_columns", self.table_name)
 			self.alter()
 
 	def create(self):

--- a/frappe/defaults.py
+++ b/frappe/defaults.py
@@ -230,7 +230,7 @@ def clear_default(key=None, value=None, parent=None, name=None, parenttype=None)
 
 def get_defaults_for(parent="__default"):
 	"""get all defaults"""
-	defaults = frappe.cache().hget("defaults", parent)
+	defaults = frappe.cache.hget("defaults", parent)
 
 	if defaults is None:
 		# sort descending because first default must get precedence
@@ -256,7 +256,7 @@ def get_defaults_for(parent="__default"):
 			elif d.defvalue is not None:
 				defaults[d.defkey] = d.defvalue
 
-		frappe.cache().hset("defaults", parent, defaults)
+		frappe.cache.hset("defaults", parent, defaults)
 
 	return defaults
 

--- a/frappe/deferred_insert.py
+++ b/frappe/deferred_insert.py
@@ -19,20 +19,20 @@ def deferred_insert(doctype: str, records: list[Union[dict, "Document"]] | str):
 		_records = records
 
 	try:
-		frappe.cache().rpush(f"{queue_prefix}{doctype}", _records)
+		frappe.cache.rpush(f"{queue_prefix}{doctype}", _records)
 	except redis.exceptions.ConnectionError:
 		for record in records:
 			insert_record(record, doctype)
 
 
 def save_to_db():
-	queue_keys = frappe.cache().get_keys(queue_prefix)
+	queue_keys = frappe.cache.get_keys(queue_prefix)
 	for key in queue_keys:
 		record_count = 0
 		queue_key = get_key_name(key)
 		doctype = get_doctype_name(key)
-		while frappe.cache().llen(queue_key) > 0 and record_count <= 500:
-			records = frappe.cache().lpop(queue_key)
+		while frappe.cache.llen(queue_key) > 0 and record_count <= 500:
+			records = frappe.cache.lpop(queue_key)
 			records = json.loads(records.decode("utf-8"))
 			if isinstance(records, dict):
 				record_count += 1

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -62,10 +62,10 @@ class Workspace:
 
 			self.table_counts = get_table_with_counts()
 		self.restricted_doctypes = (
-			frappe.cache().get_value("domain_restricted_doctypes") or build_domain_restriced_doctype_cache()
+			frappe.cache.get_value("domain_restricted_doctypes") or build_domain_restriced_doctype_cache()
 		)
 		self.restricted_pages = (
-			frappe.cache().get_value("domain_restricted_pages") or build_domain_restriced_page_cache()
+			frappe.cache.get_value("domain_restricted_pages") or build_domain_restriced_page_cache()
 		)
 
 	def is_permitted(self):
@@ -88,16 +88,14 @@ class Workspace:
 			return True
 
 	def get_cached(self, cache_key, fallback_fn):
-		_cache = frappe.cache()
-
-		value = _cache.get_value(cache_key, user=frappe.session.user)
+		value = frappe.cache.get_value(cache_key, user=frappe.session.user)
 		if value:
 			return value
 
 		value = fallback_fn()
 
 		# Expire every six hour
-		_cache.set_value(cache_key, value, frappe.session.user, 21600)
+		frappe.cache.set_value(cache_key, value, frappe.session.user, 21600)
 		return value
 
 	def get_can_read_items(self):
@@ -469,7 +467,7 @@ def get_workspace_sidebar_items():
 
 
 def get_table_with_counts():
-	counts = frappe.cache().get_value("information_schema:counts")
+	counts = frappe.cache.get_value("information_schema:counts")
 	if not counts:
 		counts = build_table_count_cache()
 

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -340,7 +340,7 @@ def get_charts_for_user(doctype, txt, searchfield, start, page_len, filters):
 
 class DashboardChart(Document):
 	def on_update(self):
-		frappe.cache().delete_key(f"chart-data:{self.name}")
+		frappe.cache.delete_key(f"chart-data:{self.name}")
 		if frappe.conf.developer_mode and self.is_standard:
 			export_to_files(record_list=[["Dashboard Chart", self.name]], record_module=self.module)
 

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -28,7 +28,7 @@ def get_desktop_icons(user=None):
 	if not user:
 		user = frappe.session.user
 
-	user_icons = frappe.cache().hget("desktop_icons", user)
+	user_icons = frappe.cache.hget("desktop_icons", user)
 
 	if not user_icons:
 		fields = [
@@ -120,7 +120,7 @@ def get_desktop_icons(user=None):
 			if d.label:
 				d.label = _(d.label)
 
-		frappe.cache().hset("desktop_icons", user, user_icons)
+		frappe.cache.hset("desktop_icons", user, user_icons)
 
 	return user_icons
 
@@ -313,8 +313,8 @@ def get_all_icons():
 
 
 def clear_desktop_icons_cache(user=None):
-	frappe.cache().hdel("desktop_icons", user or frappe.session.user)
-	frappe.cache().hdel("bootinfo", user or frappe.session.user)
+	frappe.cache.hdel("desktop_icons", user or frappe.session.user)
+	frappe.cache.hdel("bootinfo", user or frappe.session.user)
 
 
 def get_user_copy(module_name, user=None):
@@ -445,7 +445,7 @@ def get_module_icons(user=None):
 	if not user:
 		icons = frappe.get_all("Desktop Icon", fields="*", filters={"standard": 1}, order_by="idx")
 	else:
-		frappe.cache().hdel("desktop_icons", user)
+		frappe.cache.hdel("desktop_icons", user)
 		icons = get_user_icons(user)
 
 	for icon in icons:

--- a/frappe/desk/doctype/form_tour/form_tour.py
+++ b/frappe/desk/doctype/form_tour/form_tour.py
@@ -34,13 +34,13 @@ class FormTour(Document):
 					step.fieldtype = field_df.fieldtype
 
 	def on_update(self):
-		frappe.cache().delete_key("bootinfo")
+		frappe.cache.delete_key("bootinfo")
 
 		if frappe.conf.developer_mode and self.is_standard:
 			export_to_files([["Form Tour", self.name]], self.module)
 
 	def on_trash(self):
-		frappe.cache().delete_key("bootinfo")
+		frappe.cache.delete_key("bootinfo")
 
 
 @frappe.whitelist()
@@ -51,7 +51,7 @@ def reset_tour(tour_name):
 		frappe.db.set_value(
 			"User", user, "onboarding_status", frappe.as_json(onboarding_status), update_modified=False
 		)
-		frappe.cache().hdel("bootinfo", user)
+		frappe.cache.hdel("bootinfo", user)
 
 	frappe.msgprint(_("Successfully reset onboarding status for all users."), alert=True)
 
@@ -72,7 +72,7 @@ def update_user_status(value, step):
 		"User", frappe.session.user, "onboarding_status", value, update_modified=False
 	)
 
-	frappe.cache().hdel("bootinfo", frappe.session.user)
+	frappe.cache.hdel("bootinfo", frappe.session.user)
 
 
 def get_onboarding_ui_tours():

--- a/frappe/desk/doctype/global_search_settings/global_search_settings.py
+++ b/frappe/desk/doctype/global_search_settings/global_search_settings.py
@@ -28,7 +28,7 @@ class GlobalSearchSettings(Document):
 			frappe.throw(_("Document Type {0} has been repeated.").format(repeated_dts))
 
 		# reset cache
-		frappe.cache().hdel("global_search", "search_priorities")
+		frappe.cache.hdel("global_search", "search_priorities")
 
 
 def get_doctypes_for_global_search():
@@ -36,7 +36,7 @@ def get_doctypes_for_global_search():
 		doctypes = frappe.get_all("Global Search DocType", fields=["document_type"], order_by="idx ASC")
 		return [d.document_type for d in doctypes] or []
 
-	return frappe.cache().hget("global_search", "search_priorities", get_from_db)
+	return frappe.cache.hget("global_search", "search_priorities", get_from_db)
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -14,7 +14,7 @@ class KanbanBoard(Document):
 
 	def on_change(self):
 		frappe.clear_cache(doctype=self.reference_doctype)
-		frappe.cache().delete_keys("_user_settings")
+		frappe.cache.delete_keys("_user_settings")
 
 	def before_insert(self):
 		for column in self.columns:

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -531,13 +531,13 @@ def get_linked_doctypes(doctype, without_ignore_user_permissions_enabled=False):
 	        {"Address": {"fieldname": "customer"}..}
 	"""
 	if without_ignore_user_permissions_enabled:
-		return frappe.cache().hget(
+		return frappe.cache.hget(
 			"linked_doctypes_without_ignore_user_permissions_enabled",
 			doctype,
 			lambda: _get_linked_doctypes(doctype, without_ignore_user_permissions_enabled),
 		)
 	else:
-		return frappe.cache().hget("linked_doctypes", doctype, lambda: _get_linked_doctypes(doctype))
+		return frappe.cache.hget("linked_doctypes", doctype, lambda: _get_linked_doctypes(doctype))
 
 
 def _get_linked_doctypes(doctype, without_ignore_user_permissions_enabled=False):

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -37,10 +37,10 @@ ASSET_KEYS = (
 def get_meta(doctype, cached=True):
 	# don't cache for developer mode as js files, templates may be edited
 	if cached and not frappe.conf.developer_mode:
-		meta = frappe.cache().hget("doctype_form_meta", doctype)
+		meta = frappe.cache.hget("doctype_form_meta", doctype)
 		if not meta:
 			meta = FormMeta(doctype)
-			frappe.cache().hset("doctype_form_meta", doctype, meta)
+			frappe.cache.hset("doctype_form_meta", doctype, meta)
 	else:
 		meta = FormMeta(doctype)
 

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -34,13 +34,12 @@ def get_notifications():
 		return out
 
 	groups = list(config.get("for_doctype")) + list(config.get("for_module"))
-	cache = frappe.cache()
 
 	notification_count = {}
 	notification_percent = {}
 
 	for name in groups:
-		count = cache.hget("notification_count:" + name, frappe.session.user)
+		count = frappe.cache.hget("notification_count:" + name, frappe.session.user)
 		if count is not None:
 			notification_count[name] = count
 
@@ -83,7 +82,7 @@ def get_notifications_for_doctypes(config, notification_count):
 
 				else:
 					open_count_doctype[d] = result
-					frappe.cache().hset("notification_count:" + d, frappe.session.user, result)
+					frappe.cache.hset("notification_count:" + d, frappe.session.user, result)
 
 	return open_count_doctype
 
@@ -139,7 +138,6 @@ def get_notifications_for_targets(config, notification_percent):
 def clear_notifications(user=None):
 	if frappe.flags.in_install:
 		return
-	cache = frappe.cache()
 	config = get_notification_config()
 
 	if not config:
@@ -151,17 +149,17 @@ def clear_notifications(user=None):
 
 	for name in groups:
 		if user:
-			cache.hdel("notification_count:" + name, user)
+			frappe.cache.hdel("notification_count:" + name, user)
 		else:
-			cache.delete_key("notification_count:" + name)
+			frappe.cache.delete_key("notification_count:" + name)
 
 
 def clear_notification_config(user):
-	frappe.cache().hdel("notification_config", user)
+	frappe.cache.hdel("notification_config", user)
 
 
 def delete_notification_count_for(doctype):
-	frappe.cache().delete_key("notification_count:" + doctype)
+	frappe.cache.delete_key("notification_count:" + doctype)
 
 
 def clear_doctype_notifications(doc, method=None, *args, **kwargs):
@@ -230,7 +228,7 @@ def get_notification_config():
 						config[key].update(nc.get(key, {}))
 		return config
 
-	return frappe.cache().hget("notification_config", user, _get)
+	return frappe.cache.hget("notification_config", user, _get)
 
 
 def get_filters_for(doctype):

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -325,8 +325,8 @@ def load_country():
 @frappe.whitelist()
 def load_user_details():
 	return {
-		"full_name": frappe.cache().hget("full_name", "signup"),
-		"email": frappe.cache().hget("email", "signup"),
+		"full_name": frappe.cache.hget("full_name", "signup"),
+		"email": frappe.cache.hget("email", "signup"),
 	}
 
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -119,7 +119,7 @@ def generate_report_result(
 		"report_summary": report_summary,
 		"skip_total_row": skip_total_row or 0,
 		"status": None,
-		"execution_time": frappe.cache().hget("report_execution_time", report.name) or 0,
+		"execution_time": frappe.cache.hget("report_execution_time", report.name) or 0,
 	}
 
 
@@ -170,7 +170,7 @@ def get_script(report_name):
 	return {
 		"script": render_include(script),
 		"html_format": html_format,
-		"execution_time": frappe.cache().hget("report_execution_time", report_name) or 0,
+		"execution_time": frappe.cache.hget("report_execution_time", report_name) or 0,
 	}
 
 

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -311,8 +311,8 @@ def validate_and_sanitize_search_inputs(fn):
 
 @frappe.whitelist()
 def get_names_for_mentions(search_term):
-	users_for_mentions = frappe.cache().get_value("users_for_mentions", get_users_for_mentions)
-	user_groups = frappe.cache().get_value("user_groups", get_user_groups)
+	users_for_mentions = frappe.cache.get_value("users_for_mentions", get_users_for_mentions)
+	user_groups = frappe.cache.get_value("user_groups", get_user_groups)
 
 	filtered_mentions = []
 	for mention_data in users_for_mentions + user_groups:

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -96,7 +96,7 @@ def get_communication_doctype(doctype, txt, searchfield, start, page_len, filter
 
 
 def get_cached_contacts(txt):
-	contacts = frappe.cache().hget("contacts", frappe.session.user) or []
+	contacts = frappe.cache.hget("contacts", frappe.session.user) or []
 
 	if not contacts:
 		return
@@ -113,9 +113,9 @@ def get_cached_contacts(txt):
 
 
 def update_contact_cache(contacts):
-	cached_contacts = frappe.cache().hget("contacts", frappe.session.user) or []
+	cached_contacts = frappe.cache.hget("contacts", frappe.session.user) or []
 
 	uncached_contacts = [d for d in contacts if d not in cached_contacts]
 	cached_contacts.extend(uncached_contacts)
 
-	frappe.cache().hset("contacts", frappe.session.user, cached_contacts)
+	frappe.cache.hset("contacts", frappe.session.user, cached_contacts)

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -176,7 +176,7 @@ class EmailAccount(Document):
 
 	def get_incoming_server(self, in_receive=False, email_sync_rule="UNSEEN"):
 		"""Returns logged in POP3/IMAP connection object."""
-		if frappe.cache().get_value("workers:no-internet") == True:
+		if frappe.cache.get_value("workers:no-internet") == True:
 			return None
 
 		oauth_token = self.get_oauth_token()
@@ -253,7 +253,7 @@ class EmailAccount(Document):
 					if self.no_failed > 2:
 						self.handle_incoming_connect_error(description=description)
 				else:
-					frappe.cache().set_value("workers:no-internet", True)
+					frappe.cache.set_value("workers:no-internet", True)
 				return None
 			else:
 				raise
@@ -436,13 +436,13 @@ class EmailAccount(Document):
 			else:
 				self.set_failed_attempts_count(self.get_failed_attempts_count() + 1)
 		else:
-			frappe.cache().set_value("workers:no-internet", True)
+			frappe.cache.set_value("workers:no-internet", True)
 
 	def set_failed_attempts_count(self, value):
-		frappe.cache().set(f"{self.name}:email-account-failed-attempts", value)
+		frappe.cache.set(f"{self.name}:email-account-failed-attempts", value)
 
 	def get_failed_attempts_count(self):
-		return cint(frappe.cache().get(f"{self.name}:email-account-failed-attempts"))
+		return cint(frappe.cache.get(f"{self.name}:email-account-failed-attempts"))
 
 	def receive(self):
 		"""Called by scheduler to receive emails from this EMail account using POP3/IMAP."""
@@ -766,9 +766,9 @@ def pull(now=False):
 	"""Will be called via scheduler, pull emails from all enabled Email accounts."""
 	from frappe.integrations.doctype.connected_app.connected_app import has_token
 
-	if frappe.cache().get_value("workers:no-internet") == True:
+	if frappe.cache.get_value("workers:no-internet") == True:
 		if test_internet():
-			frappe.cache().set_value("workers:no-internet", False)
+			frappe.cache.set_value("workers:no-internet", False)
 		return
 
 	doctype = frappe.qb.DocType("Email Account")

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -42,10 +42,10 @@ class Notification(Document):
 		self.validate_forbidden_types()
 		self.validate_condition()
 		self.validate_standard()
-		frappe.cache().hdel("notifications", self.document_type)
+		frappe.cache.hdel("notifications", self.document_type)
 
 	def on_update(self):
-		frappe.cache().hdel("notifications", self.document_type)
+		frappe.cache.hdel("notifications", self.document_type)
 		path = export_module_json(self, self.is_standard, self.module)
 		if path:
 			# js
@@ -378,7 +378,7 @@ def get_context(context):
 			self.message = frappe.utils.md_to_html(self.message)
 
 	def on_trash(self):
-		frappe.cache().hdel("notifications", self.document_type)
+		frappe.cache.hdel("notifications", self.document_type)
 
 
 @frappe.whitelist()

--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -119,7 +119,7 @@ def authorize_access(g_calendar, reauthorize=None):
 	)
 
 	if not google_calendar.authorization_code or reauthorize:
-		frappe.cache().hset("google_calendar", "google_calendar", google_calendar.name)
+		frappe.cache.hset("google_calendar", "google_calendar", google_calendar.name)
 		return get_authentication_url(client_id=google_settings.client_id, redirect_uri=redirect_uri)
 	else:
 		try:
@@ -163,7 +163,7 @@ def google_callback(code=None):
 	"""
 	Authorization code is sent to callback as per the API configuration
 	"""
-	google_calendar = frappe.cache().hget("google_calendar", "google_calendar")
+	google_calendar = frappe.cache.hget("google_calendar", "google_calendar")
 	frappe.db.set_value("Google Calendar", google_calendar, "authorization_code", code)
 	frappe.db.commit()
 

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -20,7 +20,7 @@ def run_webhooks(doc, method):
 	# TODO: remove this hazardous unnecessary cache in flags
 	if frappe.flags.webhooks is None:
 		# load webhooks from cache
-		webhooks = frappe.cache().get_value("webhooks")
+		webhooks = frappe.cache.get_value("webhooks")
 		if webhooks is None:
 			# query webhooks
 			webhooks_list = frappe.get_all(
@@ -33,7 +33,7 @@ def run_webhooks(doc, method):
 			webhooks = {}
 			for w in webhooks_list:
 				webhooks.setdefault(w.webhook_doctype, []).append(w)
-			frappe.cache().set_value("webhooks", webhooks)
+			frappe.cache.set_value("webhooks", webhooks)
 
 		frappe.flags.webhooks = webhooks
 

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -102,7 +102,7 @@ class TestWebhook(FrappeTestCase):
 	def test_webhook_trigger_with_enabled_webhooks(self):
 		"""Test webhook trigger for enabled webhooks"""
 
-		frappe.cache().delete_value("webhooks")
+		frappe.cache.delete_value("webhooks")
 		frappe.flags.webhooks = None
 
 		# Insert the user to db

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -29,7 +29,7 @@ class Webhook(Document):
 		self.preview_document = None
 
 	def on_update(self):
-		frappe.cache().delete_value("webhooks")
+		frappe.cache.delete_value("webhooks")
 
 	def validate_docevent(self):
 		if self.webhook_doctype:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -959,9 +959,7 @@ class Document(BaseDocument):
 					filters={"enabled": 1, "document_type": self.doctype},
 				)
 
-			self.flags.notifications = frappe.cache().hget(
-				"notifications", self.doctype, _get_notifications
-			)
+			self.flags.notifications = frappe.cache.hget("notifications", self.doctype, _get_notifications)
 
 		if not self.flags.notifications:
 			return

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -59,11 +59,11 @@ def get_meta(doctype, cached=True) -> "Meta":
 	if not cached:
 		return Meta(doctype)
 
-	if meta := frappe.cache().hget("doctype_meta", doctype):
+	if meta := frappe.cache.hget("doctype_meta", doctype):
 		return meta
 
 	meta = Meta(doctype)
-	frappe.cache().hset("doctype_meta", doctype, meta)
+	frappe.cache.hset("doctype_meta", doctype, meta)
 	return meta
 
 
@@ -814,7 +814,7 @@ def trim_tables(doctype=None, dry_run=False, quiet=False):
 
 
 def trim_table(doctype, dry_run=True):
-	frappe.cache().hdel("table_columns", f"tab{doctype}")
+	frappe.cache.hdel("table_columns", f"tab{doctype}")
 	ignore_fields = default_fields + optional_fields + child_table_fields
 	columns = frappe.db.get_table_columns(doctype)
 	fields = frappe.get_meta(doctype, cached=False).get_fieldnames_with_value()

--- a/frappe/model/utils/link_count.py
+++ b/frappe/model/utils/link_count.py
@@ -23,7 +23,7 @@ def flush_local_link_count():
 	if not new_links:
 		return
 
-	link_count = frappe.cache().get_value("_link_count") or {}
+	link_count = frappe.cache.get_value("_link_count") or {}
 
 	for key, value in new_links.items():
 		if key in link_count:
@@ -31,13 +31,13 @@ def flush_local_link_count():
 		else:
 			link_count[key] = value
 
-	frappe.cache().set_value("_link_count", link_count)
+	frappe.cache.set_value("_link_count", link_count)
 	new_links.clear()
 
 
 def update_link_count():
 	"""increment link count in the `idx` column for the given document"""
-	link_count = frappe.cache().get_value("_link_count")
+	link_count = frappe.cache.get_value("_link_count")
 
 	if link_count:
 		for (doctype, name), count in link_count.items():
@@ -50,4 +50,4 @@ def update_link_count():
 					if not frappe.db.is_table_missing(e):  # table not found, single
 						raise e
 	# reset the count
-	frappe.cache().delete_value("_link_count")
+	frappe.cache.delete_value("_link_count")

--- a/frappe/model/utils/user_settings.py
+++ b/frappe/model/utils/user_settings.py
@@ -11,7 +11,7 @@ filter_dict = {"doctype": 0, "docfield": 1, "operator": 2, "value": 3}
 
 
 def get_user_settings(doctype, for_update=False):
-	user_settings = frappe.cache().hget("_user_settings", f"{doctype}::{frappe.session.user}")
+	user_settings = frappe.cache.hget("_user_settings", f"{doctype}::{frappe.session.user}")
 
 	if user_settings is None:
 		user_settings = frappe.db.sql(
@@ -41,12 +41,12 @@ def update_user_settings(doctype, user_settings, for_update=False):
 
 		current.update(user_settings)
 
-	frappe.cache().hset("_user_settings", f"{doctype}::{frappe.session.user}", json.dumps(current))
+	frappe.cache.hset("_user_settings", f"{doctype}::{frappe.session.user}", json.dumps(current))
 
 
 def sync_user_settings():
 	"""Sync from cache to database (called asynchronously via the browser)"""
-	for key, data in frappe.cache().hgetall("_user_settings").items():
+	for key, data in frappe.cache.hgetall("_user_settings").items():
 		key = safe_decode(key)
 		doctype, user = key.split("::")  # WTF?
 		frappe.db.multisql(
@@ -99,4 +99,4 @@ def update_user_settings_data(
 			)
 
 			# clear that user settings from the redis cache
-			frappe.cache().hset("_user_settings", f"{user_setting.doctype}::{user_setting.user}", None)
+			frappe.cache.hset("_user_settings", f"{user_setting.doctype}::{user_setting.user}", None)

--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -26,12 +26,12 @@ class WorkflowPermissionError(frappe.ValidationError):
 
 
 def get_workflow_name(doctype):
-	workflow_name = frappe.cache().hget("workflow", doctype)
+	workflow_name = frappe.cache.hget("workflow", doctype)
 	if workflow_name is None:
 		workflow_name = frappe.db.get_value(
 			"Workflow", {"document_type": doctype, "is_active": 1}, "name"
 		)
-		frappe.cache().hset("workflow", doctype, workflow_name or "")
+		frappe.cache.hset("workflow", doctype, workflow_name or "")
 
 	return workflow_name
 
@@ -228,10 +228,10 @@ def send_email_alert(workflow_name):
 
 
 def get_workflow_field_value(workflow_name, field):
-	value = frappe.cache().hget("workflow_" + workflow_name, field)
+	value = frappe.cache.hget("workflow_" + workflow_name, field)
 	if value is None:
 		value = frappe.db.get_value("Workflow", workflow_name, field)
-		frappe.cache().hset("workflow_" + workflow_name, field, value)
+		frappe.cache.hset("workflow_" + workflow_name, field, value)
 	return value
 
 

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -214,7 +214,7 @@ def export_doc(doctype, name, module=None):
 
 def get_doctype_module(doctype: str) -> str:
 	"""Returns **Module Def** name of given doctype."""
-	doctype_module_map = frappe.cache().get_value(
+	doctype_module_map = frappe.cache.get_value(
 		"doctype_modules",
 		generator=lambda: dict(frappe.qb.from_("DocType").select("name", "module").run()),
 	)

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -106,22 +106,22 @@ class Monitor:
 			traceback.print_exc()
 
 	def store(self):
-		if frappe.cache().llen(MONITOR_REDIS_KEY) > MONITOR_MAX_ENTRIES:
-			frappe.cache().ltrim(MONITOR_REDIS_KEY, 1, -1)
+		if frappe.cache.llen(MONITOR_REDIS_KEY) > MONITOR_MAX_ENTRIES:
+			frappe.cache.ltrim(MONITOR_REDIS_KEY, 1, -1)
 		serialized = json.dumps(self.data, sort_keys=True, default=str, separators=(",", ":"))
-		frappe.cache().rpush(MONITOR_REDIS_KEY, serialized)
+		frappe.cache.rpush(MONITOR_REDIS_KEY, serialized)
 
 
 def flush():
 	try:
 		# Fetch all the logs without removing from cache
-		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		logs = frappe.cache.lrange(MONITOR_REDIS_KEY, 0, -1)
 		if logs:
 			logs = list(map(frappe.safe_decode, logs))
 			with open(log_file(), "a", os.O_NONBLOCK) as f:
 				f.write("\n".join(logs))
 				f.write("\n")
 			# Remove fetched entries from cache
-			frappe.cache().ltrim(MONITOR_REDIS_KEY, len(logs) - 1, -1)
+			frappe.cache.ltrim(MONITOR_REDIS_KEY, len(logs) - 1, -1)
 	except Exception:
 		traceback.print_exc()

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -433,7 +433,7 @@ def get_roles(user=None, with_standard=True):
 			)
 			return roles + ["All", "Guest"]
 
-	roles = frappe.cache().hget("roles", user, get)
+	roles = frappe.cache.hget("roles", user, get)
 
 	# filter standard if required
 	if not with_standard:

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -38,8 +38,8 @@ class RateLimiter:
 		timestamp = int(frappe.utils.now_datetime().timestamp())
 
 		self.window_number, self.spent = divmod(timestamp, self.window)
-		self.key = frappe.cache().make_key(f"rate-limit-counter-{self.window_number}")
-		self.counter = cint(frappe.cache().get(self.key))
+		self.key = frappe.cache.make_key(f"rate-limit-counter-{self.window_number}")
+		self.counter = cint(frappe.cache.get(self.key))
 		self.remaining = max(self.limit - self.counter, 0)
 		self.reset = self.window - self.spent
 
@@ -59,7 +59,7 @@ class RateLimiter:
 		self.end = datetime.utcnow()
 		self.duration = int((self.end - self.start).total_seconds() * 1000000)
 
-		pipeline = frappe.cache().pipeline()
+		pipeline = frappe.cache.pipeline()
 		pipeline.incrby(self.key, self.duration)
 		pipeline.expire(self.key, self.window)
 		pipeline.execute()
@@ -137,11 +137,11 @@ def rate_limit(
 
 			cache_key = f"rl:{frappe.form_dict.cmd}:{identity}"
 
-			value = frappe.cache().get(cache_key) or 0
+			value = frappe.cache.get(cache_key) or 0
 			if not value:
-				frappe.cache().setex(cache_key, seconds, 0)
+				frappe.cache.setex(cache_key, seconds, 0)
 
-			value = frappe.cache().incrby(cache_key, 1)
+			value = frappe.cache.incrby(cache_key, 1)
 			if value > _limit:
 				frappe.throw(
 					_("You hit the rate limit because of too many requests. Please try after sometime.")

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -65,7 +65,7 @@ def get_current_stack_frames():
 
 def record(force=False):
 	if __debug__:
-		if frappe.cache().get_value(RECORDER_INTERCEPT_FLAG) or force:
+		if frappe.cache.get_value(RECORDER_INTERCEPT_FLAG) or force:
 			frappe.local._recorder = Recorder()
 
 
@@ -109,7 +109,7 @@ class Recorder:
 			"duration": float(f"{(datetime.datetime.now() - self.time).total_seconds() * 1000:0.3f}"),
 			"method": self.method,
 		}
-		frappe.cache().hset(RECORDER_REQUEST_SPARSE_HASH, self.uuid, request_data)
+		frappe.cache.hset(RECORDER_REQUEST_SPARSE_HASH, self.uuid, request_data)
 		frappe.publish_realtime(
 			event="recorder-dump-event",
 			message=json.dumps(request_data, default=str),
@@ -121,7 +121,7 @@ class Recorder:
 		request_data["calls"] = self.calls
 		request_data["headers"] = self.headers
 		request_data["form_dict"] = self.form_dict
-		frappe.cache().hset(RECORDER_REQUEST_HASH, self.uuid, request_data)
+		frappe.cache.hset(RECORDER_REQUEST_HASH, self.uuid, request_data)
 
 	def mark_duplicates(self):
 		counts = Counter([call["query"] for call in self.calls])
@@ -162,21 +162,21 @@ def administrator_only(function):
 @do_not_record
 @administrator_only
 def status(*args, **kwargs):
-	return bool(frappe.cache().get_value(RECORDER_INTERCEPT_FLAG))
+	return bool(frappe.cache.get_value(RECORDER_INTERCEPT_FLAG))
 
 
 @frappe.whitelist()
 @do_not_record
 @administrator_only
 def start(*args, **kwargs):
-	frappe.cache().set_value(RECORDER_INTERCEPT_FLAG, 1)
+	frappe.cache.set_value(RECORDER_INTERCEPT_FLAG, 1)
 
 
 @frappe.whitelist()
 @do_not_record
 @administrator_only
 def stop(*args, **kwargs):
-	frappe.cache().delete_value(RECORDER_INTERCEPT_FLAG)
+	frappe.cache.delete_value(RECORDER_INTERCEPT_FLAG)
 
 
 @frappe.whitelist()
@@ -184,9 +184,9 @@ def stop(*args, **kwargs):
 @administrator_only
 def get(uuid=None, *args, **kwargs):
 	if uuid:
-		result = frappe.cache().hget(RECORDER_REQUEST_HASH, uuid)
+		result = frappe.cache.hget(RECORDER_REQUEST_HASH, uuid)
 	else:
-		result = list(frappe.cache().hgetall(RECORDER_REQUEST_SPARSE_HASH).values())
+		result = list(frappe.cache.hgetall(RECORDER_REQUEST_SPARSE_HASH).values())
 	return result
 
 
@@ -194,15 +194,15 @@ def get(uuid=None, *args, **kwargs):
 @do_not_record
 @administrator_only
 def export_data(*args, **kwargs):
-	return list(frappe.cache().hgetall(RECORDER_REQUEST_HASH).values())
+	return list(frappe.cache.hgetall(RECORDER_REQUEST_HASH).values())
 
 
 @frappe.whitelist()
 @do_not_record
 @administrator_only
 def delete(*args, **kwargs):
-	frappe.cache().delete_value(RECORDER_REQUEST_SPARSE_HASH)
-	frappe.cache().delete_value(RECORDER_REQUEST_HASH)
+	frappe.cache.delete_value(RECORDER_REQUEST_SPARSE_HASH)
+	frappe.cache.delete_value(RECORDER_REQUEST_HASH)
 
 
 def record_queries(func: Callable):

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -38,7 +38,7 @@ class EnergyPointLog(Document):
 				"energy_point_alert", message=alert_dict, user=self.user, after_commit=True
 			)
 
-		frappe.cache().hdel("energy_points", self.user)
+		frappe.cache.hdel("energy_points", self.user)
 
 		if self.type != "Review" and frappe.get_cached_value(
 			"Notification Settings", self.user, "energy_points_system_notifications"
@@ -222,9 +222,6 @@ def add_review_points(user, points):
 
 @frappe.whitelist()
 def get_energy_points(user):
-	# points = frappe.cache().hget('energy_points', user,
-	# 	lambda: get_user_energy_and_review_points(user))
-	# TODO: cache properly
 	points = get_user_energy_and_review_points(user)
 	return frappe._dict(points.get(user, {}))
 

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -26,13 +26,13 @@ class TestEnergyPointLog(FrappeTestCase):
 		settings.save()
 
 	def setUp(self):
-		frappe.cache().delete_value("energy_point_rule_map")
+		frappe.cache.delete_value("energy_point_rule_map")
 
 	def tearDown(self):
 		frappe.set_user("Administrator")
 		frappe.db.delete("Energy Point Log")
 		frappe.db.delete("Energy Point Rule")
-		frappe.cache().delete_value("energy_point_rule_map")
+		frappe.cache.delete_value("energy_point_rule_map")
 
 	def test_user_energy_point(self):
 		frappe.set_user("test@example.com")

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -65,7 +65,7 @@ class TestBootData(FrappeTestCase):
 		).insert(ignore_permissions=True)
 
 		get_user_pages_or_reports("Report")
-		allowed_reports = frappe.cache().get_value("has_role:Report", user=frappe.session.user)
+		allowed_reports = frappe.cache.get_value("has_role:Report", user=frappe.session.user)
 
 		# Test user must not see admin user's report
 		self.assertNotIn("Test Admin Report", allowed_reports)

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -26,7 +26,7 @@ class TestHooks(FrappeTestCase):
 		hooks.override_doctype_class = {"ToDo": ["frappe.tests.test_hooks.CustomToDo"]}
 
 		# Clear cache
-		frappe.cache().delete_value("app_hooks")
+		frappe.cache.delete_value("app_hooks")
 		clear_controller_cache("ToDo")
 
 		todo = frappe.get_doc(doctype="ToDo", description="asdf")
@@ -45,7 +45,7 @@ class TestHooks(FrappeTestCase):
 		hooks.has_permission["Address"] = address_has_permission_hook
 
 		# Clear cache
-		frappe.cache().delete_value("app_hooks")
+		frappe.cache.delete_value("app_hooks")
 
 		# Init User and Address
 		username = "test@example.com"

--- a/frappe/tests/test_monitor.py
+++ b/frappe/tests/test_monitor.py
@@ -12,7 +12,7 @@ from frappe.utils.response import build_response
 class TestMonitor(FrappeTestCase):
 	def setUp(self):
 		frappe.conf.monitor = 1
-		frappe.cache().delete_value(MONITOR_REDIS_KEY)
+		frappe.cache.delete_value(MONITOR_REDIS_KEY)
 
 	def test_enable_monitor(self):
 		set_request(method="GET", path="/api/method/frappe.ping")
@@ -21,7 +21,7 @@ class TestMonitor(FrappeTestCase):
 		frappe.monitor.start()
 		frappe.monitor.stop(response)
 
-		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		logs = frappe.cache.lrange(MONITOR_REDIS_KEY, 0, -1)
 		self.assertEqual(len(logs), 1)
 
 		log = frappe.parse_json(logs[0].decode())
@@ -39,7 +39,7 @@ class TestMonitor(FrappeTestCase):
 		frappe.monitor.start()
 		frappe.monitor.stop(response=None)
 
-		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		logs = frappe.cache.lrange(MONITOR_REDIS_KEY, 0, -1)
 		self.assertEqual(len(logs), 1)
 
 		log = frappe.parse_json(logs[0].decode())
@@ -52,7 +52,7 @@ class TestMonitor(FrappeTestCase):
 			frappe.local.site, "frappe.ping", None, None, {}, is_async=False
 		)
 
-		logs = frappe.cache().lrange(MONITOR_REDIS_KEY, 0, -1)
+		logs = frappe.cache.lrange(MONITOR_REDIS_KEY, 0, -1)
 		self.assertEqual(len(logs), 1)
 		log = frappe.parse_json(logs[0].decode())
 		self.assertEqual(log.transaction_type, "job")
@@ -79,4 +79,4 @@ class TestMonitor(FrappeTestCase):
 
 	def tearDown(self):
 		frappe.conf.monitor = 0
-		frappe.cache().delete_value(MONITOR_REDIS_KEY)
+		frappe.cache.delete_value(MONITOR_REDIS_KEY)

--- a/frappe/tests/test_rate_limiter.py
+++ b/frappe/tests/test_rate_limiter.py
@@ -20,7 +20,7 @@ class TestRateLimiter(FrappeTestCase):
 		self.assertTrue(hasattr(frappe.local, "rate_limiter"))
 		self.assertIsInstance(frappe.local.rate_limiter, RateLimiter)
 
-		frappe.cache().delete(frappe.local.rate_limiter.key)
+		frappe.cache.delete(frappe.local.rate_limiter.key)
 		delattr(frappe.local, "rate_limiter")
 
 	def test_apply_without_limit(self):
@@ -53,8 +53,8 @@ class TestRateLimiter(FrappeTestCase):
 		self.assertEqual(int(headers["X-RateLimit-Limit"]), 10000)
 		self.assertEqual(int(headers["X-RateLimit-Remaining"]), 0)
 
-		frappe.cache().delete(limiter.key)
-		frappe.cache().delete(frappe.local.rate_limiter.key)
+		frappe.cache.delete(limiter.key)
+		frappe.cache.delete(frappe.local.rate_limiter.key)
 		delattr(frappe.local, "rate_limiter")
 
 	def test_respond_under_limit(self):
@@ -64,7 +64,7 @@ class TestRateLimiter(FrappeTestCase):
 		response = frappe.rate_limiter.respond()
 		self.assertEqual(response, None)
 
-		frappe.cache().delete(frappe.local.rate_limiter.key)
+		frappe.cache.delete(frappe.local.rate_limiter.key)
 		delattr(frappe.local, "rate_limiter")
 
 	def test_headers_under_limit(self):
@@ -79,7 +79,7 @@ class TestRateLimiter(FrappeTestCase):
 		self.assertEqual(int(headers["X-RateLimit-Limit"]), 10000)
 		self.assertEqual(int(headers["X-RateLimit-Remaining"]), 10000)
 
-		frappe.cache().delete(frappe.local.rate_limiter.key)
+		frappe.cache.delete(frappe.local.rate_limiter.key)
 		delattr(frappe.local, "rate_limiter")
 
 	def test_reject_over_limit(self):
@@ -90,7 +90,7 @@ class TestRateLimiter(FrappeTestCase):
 		limiter = RateLimiter(0.01, 86400)
 		self.assertRaises(frappe.TooManyRequestsError, limiter.apply)
 
-		frappe.cache().delete(limiter.key)
+		frappe.cache.delete(limiter.key)
 
 	def test_do_not_reject_under_limit(self):
 		limiter = RateLimiter(0.01, 86400)
@@ -100,13 +100,13 @@ class TestRateLimiter(FrappeTestCase):
 		limiter = RateLimiter(0.02, 86400)
 		self.assertEqual(limiter.apply(), None)
 
-		frappe.cache().delete(limiter.key)
+		frappe.cache.delete(limiter.key)
 
 	def test_update_method(self):
 		limiter = RateLimiter(0.01, 86400)
 		time.sleep(0.01)
 		limiter.update()
 
-		self.assertEqual(limiter.duration, cint(frappe.cache().get(limiter.key)))
+		self.assertEqual(limiter.duration, cint(frappe.cache.get(limiter.key)))
 
-		frappe.cache().delete(limiter.key)
+		frappe.cache.delete(limiter.key)

--- a/frappe/tests/test_twofactor.py
+++ b/frappe/tests/test_twofactor.py
@@ -61,7 +61,7 @@ class TestTwoFactor(FrappeTestCase):
 		self.assertTrue(verification_obj)
 		self.assertTrue(tmp_id)
 		for k in ["_usr", "_pwd", "_otp_secret"]:
-			self.assertTrue(frappe.cache().get(f"{tmp_id}{k}"), f"{k} not available")
+			self.assertTrue(frappe.cache.get(f"{tmp_id}{k}"), f"{k} not available")
 
 	def test_two_factor_is_enabled(self):
 		"""

--- a/frappe/tests/test_webform.py
+++ b/frappe/tests/test_webform.py
@@ -80,4 +80,4 @@ def set_webform_hook(key, value):
 			delattr(hooks, hook)
 
 	setattr(hooks, key, value)
-	frappe.cache().delete_key("app_hooks")
+	frappe.cache.delete_key("app_hooks")

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -46,7 +46,7 @@ class TestWebsite(FrappeTestCase):
 		frappe.db.set_value("Portal Settings", None, "default_portal_home", "test-portal-home")
 
 		frappe.set_user("test-user-for-home-page@example.com")
-		frappe.cache().hdel("home_page", frappe.session.user)
+		frappe.cache.hdel("home_page", frappe.session.user)
 		self.assertEqual(get_home_page(), "test-portal-home")
 
 		frappe.db.set_value("Portal Settings", None, "default_portal_home", "")
@@ -210,7 +210,7 @@ class TestWebsite(FrappeTestCase):
 		self.assertEqual(response.headers.get("Location"), "/courses/data")
 
 		delattr(frappe.hooks, "website_redirects")
-		frappe.cache().delete_key("app_hooks")
+		frappe.cache.delete_key("app_hooks")
 
 	def test_custom_page_renderer(self):
 		from frappe import get_hooks

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -125,7 +125,7 @@ def get_parent_language(lang: str) -> str:
 def get_user_lang(user: str = None) -> str:
 	"""Set frappe.local.lang from user preferences on session beginning or resumption"""
 	user = user or frappe.session.user
-	lang = frappe.cache().hget("lang", user)
+	lang = frappe.cache.hget("lang", user)
 
 	if not lang:
 		# User.language => Session Defaults => frappe.local.lang => 'en'
@@ -136,7 +136,7 @@ def get_user_lang(user: str = None) -> str:
 			or "en"
 		)
 
-		frappe.cache().hset("lang", user, lang)
+		frappe.cache.hset("lang", user, lang)
 
 	return lang
 
@@ -168,9 +168,8 @@ def get_dict(fortype: str, name: str | None = None) -> dict[str, str]:
 	:param name: name of the document for which assets are to be returned.
 	"""
 	fortype = fortype.lower()
-	cache = frappe.cache()
 	asset_key = fortype + ":" + (name or "-")
-	translation_assets = cache.hget("translation_assets", frappe.local.lang) or {}
+	translation_assets = frappe.cache.hget("translation_assets", frappe.local.lang) or {}
 
 	if asset_key not in translation_assets:
 		messages = []
@@ -210,7 +209,7 @@ def get_dict(fortype: str, name: str | None = None) -> dict[str, str]:
 		# remove untranslated
 		message_dict = {k: v for k, v in message_dict.items() if k != v}
 		translation_assets[asset_key] = message_dict
-		cache.hset("translation_assets", frappe.local.lang, translation_assets)
+		frappe.cache.hset("translation_assets", frappe.local.lang, translation_assets)
 
 	translation_map: dict = translation_assets[asset_key]
 
@@ -292,7 +291,7 @@ def get_all_translations(lang: str) -> dict[str, str]:
 		return all_translations
 
 	try:
-		return frappe.cache().hget(MERGED_TRANSLATION_KEY, lang, generator=_merge_translations)
+		return frappe.cache.hget(MERGED_TRANSLATION_KEY, lang, generator=_merge_translations)
 	except Exception:
 		# People mistakenly call translation function on global variables
 		# where locals are not initalized, translations dont make much sense there
@@ -361,19 +360,18 @@ def get_user_translations(lang):
 			user_translations[key] = value
 		return user_translations
 
-	return frappe.cache().hget(USER_TRANSLATION_KEY, lang, generator=_read_from_db)
+	return frappe.cache.hget(USER_TRANSLATION_KEY, lang, generator=_read_from_db)
 
 
 def clear_cache():
 	"""Clear all translation assets from :meth:`frappe.cache`"""
-	cache = frappe.cache()
-	cache.delete_key("langinfo")
+	frappe.cache.delete_key("langinfo")
 
 	# clear translations saved in boot cache
-	cache.delete_key("bootinfo")
-	cache.delete_key("translation_assets")
-	cache.delete_key(USER_TRANSLATION_KEY)
-	cache.delete_key(MERGED_TRANSLATION_KEY)
+	frappe.cache.delete_key("bootinfo")
+	frappe.cache.delete_key("translation_assets")
+	frappe.cache.delete_key(USER_TRANSLATION_KEY)
+	frappe.cache.delete_key(MERGED_TRANSLATION_KEY)
 
 
 def get_messages_for_app(app, deduplicate=True):
@@ -1273,9 +1271,9 @@ def get_all_languages(with_language_name: bool = False) -> list:
 		frappe.connect()
 
 	if with_language_name:
-		return frappe.cache().get_value("languages_with_name", get_all_language_with_name)
+		return frappe.cache.get_value("languages_with_name", get_all_language_with_name)
 	else:
-		return frappe.cache().get_value("languages", get_language_codes)
+		return frappe.cache.get_value("languages", get_language_codes)
 
 
 @frappe.whitelist(allow_guest=True)

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -74,8 +74,8 @@ def get_cached_user_pass():
 	user = pwd = None
 	tmp_id = frappe.form_dict.get("tmp_id")
 	if tmp_id:
-		user = frappe.safe_decode(frappe.cache().get(tmp_id + "_usr"))
-		pwd = frappe.safe_decode(frappe.cache().get(tmp_id + "_pwd"))
+		user = frappe.safe_decode(frappe.cache.get(tmp_id + "_usr"))
+		pwd = frappe.safe_decode(frappe.cache.get(tmp_id + "_pwd"))
 	return (user, pwd)
 
 
@@ -101,13 +101,13 @@ def cache_2fa_data(user, token, otp_secret, tmp_id):
 	# set increased expiry time for SMS and Email
 	if verification_method in ["SMS", "Email"]:
 		expiry_time = frappe.flags.token_expiry or 300
-		frappe.cache().set(tmp_id + "_token", token)
-		frappe.cache().expire(tmp_id + "_token", expiry_time)
+		frappe.cache.set(tmp_id + "_token", token)
+		frappe.cache.expire(tmp_id + "_token", expiry_time)
 	else:
 		expiry_time = frappe.flags.otp_expiry or 180
 	for k, v in {"_usr": user, "_pwd": pwd, "_otp_secret": otp_secret}.items():
-		frappe.cache().set(f"{tmp_id}{k}", v)
-		frappe.cache().expire(f"{tmp_id}{k}", expiry_time)
+		frappe.cache.set(f"{tmp_id}{k}", v)
+		frappe.cache.expire(f"{tmp_id}{k}", expiry_time)
 
 
 def two_factor_is_enabled_for_(user):
@@ -160,8 +160,8 @@ def confirm_otp_token(login_manager, otp=None, tmp_id=None):
 		return True
 	if not tmp_id:
 		tmp_id = frappe.form_dict.get("tmp_id")
-	hotp_token = frappe.cache().get(tmp_id + "_token")
-	otp_secret = frappe.cache().get(tmp_id + "_otp_secret")
+	hotp_token = frappe.cache.get(tmp_id + "_token")
+	otp_secret = frappe.cache.get(tmp_id + "_otp_secret")
 	if not otp_secret:
 		raise ExpiredLoginException(_("Login session expired, refresh page to retry"))
 
@@ -170,7 +170,7 @@ def confirm_otp_token(login_manager, otp=None, tmp_id=None):
 	hotp = pyotp.HOTP(otp_secret)
 	if hotp_token:
 		if hotp.verify(otp, int(hotp_token)):
-			frappe.cache().delete(tmp_id + "_token")
+			frappe.cache.delete(tmp_id + "_token")
 			tracker.add_success_attempt()
 			return True
 		else:
@@ -308,8 +308,8 @@ def get_link_for_qrcode(user, totp_uri):
 	key_user = f"{key}_user"
 	key_uri = f"{key}_uri"
 	lifespan = int(frappe.db.get_single_value("System Settings", "lifespan_qrcode_image")) or 240
-	frappe.cache().set_value(key_uri, totp_uri, expires_in_sec=lifespan)
-	frappe.cache().set_value(key_user, user, expires_in_sec=lifespan)
+	frappe.cache.set_value(key_uri, totp_uri, expires_in_sec=lifespan)
+	frappe.cache.set_value(key_user, user, expires_in_sec=lifespan)
 	return get_url(f"/qrcode?k={key}")
 
 

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -970,7 +970,7 @@ def get_assets_json():
 
 	if not hasattr(frappe.local, "assets_json"):
 		if not frappe.conf.developer_mode:
-			frappe.local.assets_json = frappe.cache().get_value(
+			frappe.local.assets_json = frappe.cache.get_value(
 				"assets_json",
 				_get_assets,
 				shared=True,

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -143,7 +143,7 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None) -> Calla
 		func_key = f"{func.__module__}.{func.__qualname__}"
 
 		def clear_cache():
-			frappe.cache().delete_keys(func_key)
+			frappe.cache.delete_keys(func_key)
 
 		func.clear_cache = clear_cache
 		func.ttl = ttl if not callable(ttl) else 3600
@@ -151,12 +151,12 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None) -> Calla
 		@wraps(func)
 		def redis_cache_wrapper(*args, **kwargs):
 			func_call_key = func_key + "::" + str(__generate_request_cache_key(args, kwargs))
-			if frappe.cache().exists(func_call_key):
-				return frappe.cache().get_value(func_call_key, user=user)
+			if frappe.cache.exists(func_call_key):
+				return frappe.cache.get_value(func_call_key, user=user)
 			else:
 				val = func(*args, **kwargs)
 				ttl = getattr(func, "ttl", 3600)
-				frappe.cache().set_value(func_call_key, val, expires_in_sec=ttl, user=user)
+				frappe.cache.set_value(func_call_key, val, expires_in_sec=ttl, user=user)
 				return val
 
 		return redis_cache_wrapper

--- a/frappe/utils/change_log.py
+++ b/frappe/utils/change_log.py
@@ -267,19 +267,17 @@ def check_release_on_github(app: str):
 def add_message_to_redis(update_json):
 	# "update-message" will store the update message string
 	# "update-user-set" will be a set of users
-	cache = frappe.cache()
-	cache.set_value("update-info", json.dumps(update_json))
+	frappe.cache.set_value("update-info", json.dumps(update_json))
 	user_list = [x.name for x in frappe.get_all("User", filters={"enabled": True})]
 	system_managers = [user for user in user_list if "System Manager" in frappe.get_roles(user)]
-	cache.sadd("update-user-set", *system_managers)
+	frappe.cache.sadd("update-user-set", *system_managers)
 
 
 @frappe.whitelist()
 def show_update_popup():
-	cache = frappe.cache()
 	user = frappe.session.user
 
-	update_info = cache.get_value("update-info")
+	update_info = frappe.cache.get_value("update-info")
 	if not update_info:
 		return
 
@@ -287,7 +285,7 @@ def show_update_popup():
 
 	# Check if user is int the set of users to send update message to
 	update_message = ""
-	if cache.sismember("update-user-set", user):
+	if frappe.cache.sismember("update-user-set", user):
 		for update_type in updates:
 			release_links = ""
 			for app in updates[update_type]:
@@ -308,4 +306,4 @@ def show_update_popup():
 
 	if update_message:
 		frappe.msgprint(update_message, title=_("New updates are available"), indicator="green")
-		cache.srem("update-user-set", user)
+		frappe.cache.srem("update-user-set", user)

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -25,7 +25,7 @@ def cache_source(function):
 		if int(kwargs.get("refresh") or 0):
 			results = generate_and_cache_results(kwargs, function, cache_key, chart)
 		else:
-			cached_results = frappe.cache().get_value(cache_key)
+			cached_results = frappe.cache.get_value(cache_key)
 			if cached_results:
 				results = frappe.parse_json(frappe.safe_decode(cached_results))
 			else:

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -326,7 +326,7 @@ def get_system_timezone():
 	if frappe.local.flags.in_test:
 		return _get_system_timezone()
 
-	return frappe.cache().get_value("time_zone", _get_system_timezone)
+	return frappe.cache.get_value("time_zone", _get_system_timezone)
 
 
 def convert_utc_to_timezone(utc_timestamp, time_zone):

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -61,7 +61,7 @@ def get_doctypes_with_global_search(with_child_tables=True):
 
 		return doctypes
 
-	return frappe.cache().get_value("doctypes_with_global_search", _get)
+	return frappe.cache.get_value("doctypes_with_global_search", _get)
 
 
 def rebuild_for_doctype(doctype):
@@ -371,17 +371,17 @@ def sync_global_search():
 	:param flags:
 	:return:
 	"""
-	while frappe.cache().llen("global_search_queue") > 0:
+	while frappe.cache.llen("global_search_queue") > 0:
 		# rpop to follow FIFO
 		# Last one should override all previous contents of same document
-		value = json.loads(frappe.cache().rpop("global_search_queue").decode("utf-8"))
+		value = json.loads(frappe.cache.rpop("global_search_queue").decode("utf-8"))
 		sync_value(value)
 
 
 def sync_value_in_queue(value):
 	try:
 		# append to search queue if connected
-		frappe.cache().lpush("global_search_queue", json.dumps(value))
+		frappe.cache.lpush("global_search_queue", json.dumps(value))
 	except redis.exceptions.ConnectionError:
 		# not connected, sync directly
 		sync_value(value)

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -210,7 +210,7 @@ def login_oauth_user(
 
 	if frappe.utils.cint(generate_login_token):
 		login_token = frappe.generate_hash(length=32)
-		frappe.cache().set_value(
+		frappe.cache.set_value(
 			f"login_token:{login_token}", frappe.local.session.sid, expires_in_sec=120
 		)
 

--- a/frappe/utils/password.py
+++ b/frappe/utils/password.py
@@ -128,9 +128,9 @@ def check_password(user, pwd, doctype="User", fieldname="password", delete_track
 
 
 def delete_login_failed_cache(user):
-	frappe.cache().hdel("last_login_tried", user)
-	frappe.cache().hdel("login_failed_count", user)
-	frappe.cache().hdel("locked_account_time", user)
+	frappe.cache.hdel("last_login_tried", user)
+	frappe.cache.hdel("login_failed_count", user)
+	frappe.cache.hdel("locked_account_time", user)
 
 
 def update_password(user, pwd, doctype="User", fieldname="password", logout_all_sessions=False):

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -273,13 +273,13 @@ def toggle_visible_pdf(soup):
 
 
 def get_wkhtmltopdf_version():
-	wkhtmltopdf_version = frappe.cache().hget("wkhtmltopdf_version", None)
+	wkhtmltopdf_version = frappe.cache.hget("wkhtmltopdf_version", None)
 
 	if not wkhtmltopdf_version:
 		try:
 			res = subprocess.check_output(["wkhtmltopdf", "--version"])
 			wkhtmltopdf_version = res.decode("utf-8").split(" ")[1]
-			frappe.cache().hset("wkhtmltopdf_version", None, wkhtmltopdf_version)
+			frappe.cache.hset("wkhtmltopdf_version", None, wkhtmltopdf_version)
 		except Exception:
 			pass
 

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -251,7 +251,7 @@ class RedisWrapper(redis.Redis):
 
 	def hdel_keys(self, name_starts_with, key):
 		"""Delete hash names with wildcard `*` and key"""
-		for name in frappe.cache().get_keys(name_starts_with):
+		for name in self.get_keys(name_starts_with):
 			name = name.split("|", 1)[1]
 			self.hdel(name, key)
 

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -59,7 +59,7 @@ class UserPermissions:
 			return user
 
 		if not frappe.flags.in_install_db and not frappe.flags.in_test:
-			user_doc = frappe.cache().hget("user_doc", self.name, get_user_doc)
+			user_doc = frappe.cache.hget("user_doc", self.name, get_user_doc)
 			if user_doc:
 				self.doc = frappe.get_doc(user_doc)
 
@@ -186,7 +186,7 @@ class UserPermissions:
 				filters={"property": "allow_import", "value": "1"},
 			)
 
-		frappe.cache().hset("can_import", frappe.session.user, self.can_import)
+		frappe.cache.hset("can_import", frappe.session.user, self.can_import)
 
 	def get_defaults(self):
 		import frappe.defaults

--- a/frappe/website/doctype/help_article/help_article.py
+++ b/frappe/website/doctype/help_article/help_article.py
@@ -93,7 +93,7 @@ def get_sidebar_items():
 			as_dict=True,
 		)
 
-	return frappe.cache().get_value("knowledge_base:category_sidebar", _get)
+	return frappe.cache.get_value("knowledge_base:category_sidebar", _get)
 
 
 def clear_cache():
@@ -105,8 +105,8 @@ def clear_cache():
 
 
 def clear_website_cache(path=None):
-	frappe.cache().delete_value("knowledge_base:category_sidebar")
-	frappe.cache().delete_value("knowledge_base:faq")
+	frappe.cache.delete_value("knowledge_base:category_sidebar")
+	frappe.cache.delete_value("knowledge_base:faq")
 
 
 @frappe.whitelist(allow_guest=True)

--- a/frappe/website/page_renderers/not_found_page.py
+++ b/frappe/website/page_renderers/not_found_page.py
@@ -21,7 +21,7 @@ class NotFoundPage(TemplatePage):
 
 	def render(self):
 		if self.can_cache_404():
-			frappe.cache().hset("website_404", self.request_url, True)
+			frappe.cache.hset("website_404", self.request_url, True)
 		return super().render()
 
 	def can_cache_404(self):

--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -29,7 +29,7 @@ class PathResolver:
 			request = frappe.local.request or request
 
 		# check if the request url is in 404 list
-		if request.url and can_cache() and frappe.cache().hget("website_404", request.url):
+		if request.url and can_cache() and frappe.cache.hget("website_404", request.url):
 			return self.path, NotFoundPage(self.path)
 
 		try:
@@ -110,7 +110,7 @@ def resolve_redirect(path, query_string=None):
 	if not redirects:
 		return
 
-	redirect_to = frappe.cache().hget("website_redirects", path)
+	redirect_to = frappe.cache.hget("website_redirects", path)
 
 	if redirect_to:
 		frappe.flags.redirect_location = redirect_to
@@ -130,7 +130,7 @@ def resolve_redirect(path, query_string=None):
 		if match:
 			redirect_to = re.sub(pattern, rule["target"], path_to_match)
 			frappe.flags.redirect_location = redirect_to
-			frappe.cache().hset("website_redirects", path_to_match, redirect_to)
+			frappe.cache.hset("website_redirects", path_to_match, redirect_to)
 			raise frappe.Redirect
 
 
@@ -177,4 +177,4 @@ def get_website_rules():
 		# dont cache in development
 		return _get()
 
-	return frappe.cache().get_value("website_route_rules", _get)
+	return frappe.cache.get_value("website_route_rules", _get)

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -100,7 +100,7 @@ def get_pages(app=None):
 
 		return pages
 
-	return frappe.cache().get_value("website_pages", lambda: _build(app))
+	return frappe.cache.get_value("website_pages", lambda: _build(app))
 
 
 def get_pages_from_path(start, app, app_path):
@@ -310,7 +310,7 @@ def get_doctypes_with_web_view():
 		]
 		return doctypes
 
-	return frappe.cache().get_value("doctypes_with_web_view", _get)
+	return frappe.cache.get_value("doctypes_with_web_view", _get)
 
 
 def get_start_folders():

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -23,15 +23,14 @@ CLEANUP_PATTERN_3 = re.compile(r"(-)\1+")
 
 
 def delete_page_cache(path):
-	cache = frappe.cache()
-	cache.delete_value("full_index")
+	frappe.cache.delete_value("full_index")
 	groups = ("website_page", "page_context")
 	if path:
 		for name in groups:
-			cache.hdel(name, path)
+			frappe.cache.hdel(name, path)
 	else:
 		for name in groups:
-			cache.delete_key(name)
+			frappe.cache.delete_key(name)
 
 
 def find_first_image(html):
@@ -127,7 +126,7 @@ def get_home_page():
 		# dont return cached homepage in development
 		return _get_home_page()
 
-	return frappe.cache().hget("home_page", frappe.session.user, _get_home_page)
+	return frappe.cache.hget("home_page", frappe.session.user, _get_home_page)
 
 
 def get_home_page_via_hooks():
@@ -296,7 +295,7 @@ def get_full_index(route=None, app=None):
 
 			return children_map
 
-		children_map = frappe.cache().get_value("website_full_index", _build)
+		children_map = frappe.cache.get_value("website_full_index", _build)
 
 		frappe.local.flags.children_map = children_map
 
@@ -363,13 +362,13 @@ def clear_cache(path=None):
 	from frappe.website.router import clear_routing_cache
 
 	for key in ("website_generator_routes", "website_pages", "website_full_index", "sitemap_routes"):
-		frappe.cache().delete_value(key)
+		frappe.cache.delete_value(key)
 
 	clear_routing_cache()
 
-	frappe.cache().delete_value("website_404")
+	frappe.cache.delete_value("website_404")
 	if path:
-		frappe.cache().hdel("website_redirects", path)
+		frappe.cache.hdel("website_redirects", path)
 		delete_page_cache(path)
 	else:
 		clear_sitemap()
@@ -383,7 +382,7 @@ def clear_cache(path=None):
 			"page_context",
 			"website_page",
 		):
-			frappe.cache().delete_value(key)
+			frappe.cache.delete_value(key)
 
 	for method in frappe.get_hooks("website_clear_cache"):
 		frappe.get_attr(method)(path)
@@ -439,7 +438,7 @@ def get_sidebar_items(parent_sidebar, basepath=None):
 
 
 def get_portal_sidebar_items():
-	sidebar_items = frappe.cache().hget("portal_menu_items", frappe.session.user)
+	sidebar_items = frappe.cache.hget("portal_menu_items", frappe.session.user)
 	if sidebar_items is None:
 		sidebar_items = []
 		roles = frappe.get_roles()
@@ -462,7 +461,7 @@ def get_portal_sidebar_items():
 				i["enabled"] = 1
 			add_items(sidebar_items, items_via_hooks)
 
-		frappe.cache().hset("portal_menu_items", frappe.session.user, sidebar_items)
+		frappe.cache.hset("portal_menu_items", frappe.session.user, sidebar_items)
 
 	return sidebar_items
 
@@ -507,7 +506,7 @@ def cache_html(func):
 	def cache_html_decorator(*args, **kwargs):
 		if can_cache():
 			html = None
-			page_cache = frappe.cache().hget("website_page", args[0].path)
+			page_cache = frappe.cache.hget("website_page", args[0].path)
 			if page_cache and frappe.local.lang in page_cache:
 				html = page_cache[frappe.local.lang]
 			if html:
@@ -516,9 +515,9 @@ def cache_html(func):
 		html = func(*args, **kwargs)
 		context = args[0].context
 		if can_cache(context.no_cache):
-			page_cache = frappe.cache().hget("website_page", args[0].path) or {}
+			page_cache = frappe.cache.hget("website_page", args[0].path) or {}
 			page_cache[frappe.local.lang] = html
-			frappe.cache().hset("website_page", args[0].path, page_cache)
+			frappe.cache.hset("website_page", args[0].path, page_cache)
 
 		return html
 

--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -33,7 +33,7 @@ class TestWorkflow(FrappeTestCase):
 						"postgres": 'ALTER TABLE "tabWorkflow Action" ADD COLUMN "user" varchar(140)',
 					}
 				)
-				frappe.cache().delete_value("table_columns")
+				frappe.cache.delete_value("table_columns")
 
 	def tearDown(self):
 		frappe.delete_doc("Workflow", "Test ToDo")
@@ -49,7 +49,7 @@ class TestWorkflow(FrappeTestCase):
 						"postgres": 'ALTER TABLE "tabWorkflow Action" DROP COLUMN "user"',
 					}
 				)
-				frappe.cache().delete_value("table_columns")
+				frappe.cache.delete_value("table_columns")
 
 	def test_default_condition(self):
 		"""test default condition is set"""

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -17,7 +17,7 @@ class Workflow(Document):
 	def on_update(self):
 		self.update_doc_status()
 		frappe.clear_cache(doctype=self.document_type)
-		frappe.cache().delete_key("workflow_" + self.name)  # clear cache created in model/workflow.py
+		frappe.cache.delete_key("workflow_" + self.name)  # clear cache created in model/workflow.py
 
 	def create_custom_field_for_workflow_state(self):
 		frappe.clear_cache(doctype=self.document_type)

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -104,7 +104,7 @@ def get_context(context):
 
 @frappe.whitelist(allow_guest=True)
 def login_via_token(login_token: str):
-	sid = frappe.cache().get_value(f"login_token:{login_token}", expires=True)
+	sid = frappe.cache.get_value(f"login_token:{login_token}", expires=True)
 	if not sid:
 		frappe.respond_as_web_page(_("Invalid Request"), _("Invalid Login Token"), http_status_code=417)
 		return
@@ -150,7 +150,7 @@ def _generate_temporary_login_link(email: str, expiry: int):
 			_("User with email address {0} does not exist").format(email), frappe.DoesNotExistError
 		)
 	key = frappe.generate_hash()
-	frappe.cache().set_value(f"one_time_login_key:{key}", email, expires_in_sec=expiry * 60)
+	frappe.cache.set_value(f"one_time_login_key:{key}", email, expires_in_sec=expiry * 60)
 
 	return get_url(f"/api/method/frappe.www.login.login_via_key?key={key}")
 
@@ -159,10 +159,10 @@ def _generate_temporary_login_link(email: str, expiry: int):
 @rate_limit(limit=5, seconds=60 * 60)
 def login_via_key(key: str):
 	cache_key = f"one_time_login_key:{key}"
-	email = frappe.cache().get_value(cache_key)
+	email = frappe.cache.get_value(cache_key)
 
 	if email:
-		frappe.cache().delete_value(cache_key)
+		frappe.cache.delete_value(cache_key)
 
 		frappe.local.login_manager.login_as(email)
 

--- a/frappe/www/message.py
+++ b/frappe/www/message.py
@@ -20,7 +20,7 @@ def get_context(context):
 	elif frappe.local.form_dict.id:
 		message_id = frappe.local.form_dict.id
 		key = f"message_id:{message_id}"
-		message = frappe.cache().get_value(key, expires=True)
+		message = frappe.cache.get_value(key, expires=True)
 		if message:
 			message_context.update(message.get("context", {}))
 			if message.get("http_status_code"):

--- a/frappe/www/qrcode.py
+++ b/frappe/www/qrcode.py
@@ -29,8 +29,8 @@ def get_query_key():
 def get_user_svg_from_cache():
 	"""Get User and SVG code from cache."""
 	key = get_query_key()
-	totp_uri = frappe.cache().get_value(f"{key}_uri")
-	user = frappe.cache().get_value(f"{key}_user")
+	totp_uri = frappe.cache.get_value(f"{key}_uri")
+	user = frappe.cache.get_value(f"{key}_user")
 	if not totp_uri or not user:
 		frappe.throw(_("Page has expired!"), frappe.PermissionError)
 	if not frappe.db.exists("User", user):

--- a/frappe/www/sitemap.py
+++ b/frappe/www/sitemap.py
@@ -69,4 +69,4 @@ def get_public_pages_from_doctypes():
 
 		return routes
 
-	return frappe.cache().get_value("sitemap_routes", get_sitemap_routes)
+	return frappe.cache.get_value("sitemap_routes", get_sitemap_routes)


### PR DESCRIPTION
continues https://github.com/frappe/frappe/pull/21279 and https://github.com/frappe/frappe/pull/21281



This is slightly faster too :pinched_fingers:   

Before:
```
In [2]: %timeit frappe.cache().set_value
66 ns ± 1.76 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```

After:
```
In [1]: %timeit frappe.cache.set_value
41.3 ns ± 0.521 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```