### PR TITLE
feat: support reordering standard fields in Form Builder

### DIFF
--- a/frappe/public/js/form_builder/FormBuilder.vue
+++ b/frappe/public/js/form_builder/FormBuilder.vue
@@ -165,6 +165,10 @@ onMounted(() => {
 				color: var(--text-muted);
 			}
 		}
+
+		:deep([data-is-user-generated="1"]) {
+			background-color: var(--yellow-highlight-color);
+		}
 	}
 
 	:deep(.preview) {

--- a/frappe/public/js/form_builder/FormBuilder.vue
+++ b/frappe/public/js/form_builder/FormBuilder.vue
@@ -165,17 +165,12 @@ onMounted(() => {
 				color: var(--text-muted);
 			}
 		}
-
-		:deep([data-has-std-field="false"]),
-		:deep([data-is-custom="1"]) {
-			background-color: var(--yellow-highlight-color);
-		}
 	}
 
 	:deep(.preview) {
 		--field-placeholder-color: var(--fg-bg-color);
 
-		.tab, .column, .field, [data-is-custom="1"] {
+		.tab, .column, .field {
 			background-color: var(--fg-color);
 		}
 

--- a/frappe/public/js/form_builder/components/Column.vue
+++ b/frappe/public/js/form_builder/components/Column.vue
@@ -157,7 +157,7 @@ function move_columns_to_section() {
 				<Field
 					:column="column"
 					:field="element"
-					:data-is-custom="element.df.is_custom_field"
+					:data-is-user-generated="store.is_user_generated_field(element)"
 				/>
 			</template>
 		</draggable>

--- a/frappe/public/js/form_builder/components/Column.vue
+++ b/frappe/public/js/form_builder/components/Column.vue
@@ -148,8 +148,6 @@ function move_columns_to_section() {
 			:style="{ backgroundColor: column.fields.length ? '' : 'var(--field-placeholder-color)' }"
 			v-model="column.fields"
 			group="fields"
-			filter="[data-is-custom='0']"
-			:prevent-on-filter="false"
 			:animation="200"
 			:easing="store.get_animation"
 			item-key="id"
@@ -159,7 +157,6 @@ function move_columns_to_section() {
 				<Field
 					:column="column"
 					:field="element"
-					:data-is-custom="element.df.is_custom_field"
 				/>
 			</template>
 		</draggable>

--- a/frappe/public/js/form_builder/components/Column.vue
+++ b/frappe/public/js/form_builder/components/Column.vue
@@ -157,6 +157,7 @@ function move_columns_to_section() {
 				<Field
 					:column="column"
 					:field="element"
+					:data-is-custom="element.df.is_custom_field"
 				/>
 			</template>
 		</draggable>

--- a/frappe/public/js/form_builder/components/Section.vue
+++ b/frappe/public/js/form_builder/components/Section.vue
@@ -160,8 +160,6 @@ function move_sections_to_tab() {
 						backgroundColor: section.columns.length ? null : 'var(--field-placeholder-color)'
 					}"
 					v-model="section.columns"
-					filter="[data-has-std-field='true']"
-					:prevent-on-filter="false"
 					group="columns"
 					item-key="id"
 					:animation="200"
@@ -172,8 +170,6 @@ function move_sections_to_tab() {
 						<Column
 							:section="section"
 							:column="element"
-							:data-is-custom="element.df.is_custom_field"
-							:data-has-std-field="store.has_standard_field(element)"
 						/>
 					</template>
 				</draggable>

--- a/frappe/public/js/form_builder/components/Section.vue
+++ b/frappe/public/js/form_builder/components/Section.vue
@@ -170,7 +170,7 @@ function move_sections_to_tab() {
 						<Column
 							:section="section"
 							:column="element"
-							:data-is-custom="element.df.is_custom_field"
+							:data-is-user-generated="store.is_user_generated_field(element)"
 						/>
 					</template>
 				</draggable>

--- a/frappe/public/js/form_builder/components/Section.vue
+++ b/frappe/public/js/form_builder/components/Section.vue
@@ -170,6 +170,7 @@ function move_sections_to_tab() {
 						<Column
 							:section="section"
 							:column="element"
+							:data-is-custom="element.df.is_custom_field"
 						/>
 					</template>
 				</draggable>

--- a/frappe/public/js/form_builder/components/Tabs.vue
+++ b/frappe/public/js/form_builder/components/Tabs.vue
@@ -123,6 +123,7 @@ function delete_tab(with_children) {
 				<div
 					:class="['tab', store.form.active_tab == element.df.name ? 'active' : '']"
 					:title="element.df.fieldname"
+					:data-is-custom="element.df.is_custom_field"
 					@click.stop="activate_tab(element)"
 					@dragstart="dragged = true"
 					@dragend="dragged = false"
@@ -179,6 +180,7 @@ function delete_tab(with_children) {
 					<Section
 						:tab="tab"
 						:section="element"
+						:data-is-custom="element.df.is_custom_field"
 					/>
 				</template>
 			</draggable>

--- a/frappe/public/js/form_builder/components/Tabs.vue
+++ b/frappe/public/js/form_builder/components/Tabs.vue
@@ -114,8 +114,6 @@ function delete_tab(with_children) {
 			class="tabs"
 			v-model="store.form.layout.tabs"
 			group="tabs"
-			filter="[data-has-std-field='true']"
-			:prevent-on-filter="false"
 			:animation="200"
 			:easing="store.get_animation"
 			item-key="id"
@@ -125,8 +123,6 @@ function delete_tab(with_children) {
 				<div
 					:class="['tab', store.form.active_tab == element.df.name ? 'active' : '']"
 					:title="element.df.fieldname"
-					:data-is-custom="element.df.is_custom_field"
-					:data-has-std-field="store.has_standard_field(element)"
 					@click.stop="activate_tab(element)"
 					@dragstart="dragged = true"
 					@dragend="dragged = false"
@@ -174,8 +170,6 @@ function delete_tab(with_children) {
 				class="tab-content-container"
 				v-model="tab.sections"
 				group="sections"
-				filter="[data-has-std-field='true']"
-				:prevent-on-filter="false"
 				:animation="200"
 				:easing="store.get_animation"
 				item-key="id"
@@ -185,8 +179,6 @@ function delete_tab(with_children) {
 					<Section
 						:tab="tab"
 						:section="element"
-						:data-is-custom="element.df.is_custom_field"
-						:data-has-std-field="store.has_standard_field(element)"
 					/>
 				</template>
 			</draggable>

--- a/frappe/public/js/form_builder/components/Tabs.vue
+++ b/frappe/public/js/form_builder/components/Tabs.vue
@@ -123,7 +123,7 @@ function delete_tab(with_children) {
 				<div
 					:class="['tab', store.form.active_tab == element.df.name ? 'active' : '']"
 					:title="element.df.fieldname"
-					:data-is-custom="element.df.is_custom_field"
+					:data-is-user-generated="store.is_user_generated_field(element)"
 					@click.stop="activate_tab(element)"
 					@dragstart="dragged = true"
 					@dragend="dragged = false"
@@ -180,7 +180,7 @@ function delete_tab(with_children) {
 					<Section
 						:tab="tab"
 						:section="element"
-						:data-is-custom="element.df.is_custom_field"
+						:data-is-user-generated="store.is_user_generated_field(element)"
 					/>
 				</template>
 			</draggable>

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -64,6 +64,10 @@ export const useStore = defineStore("form-builder-store", () => {
 		});
 	}
 
+	function is_user_generated_field(field) {
+		return cint(field.df.is_custom_field && !field.df.is_system_generated);
+	}
+
 	async function fetch() {
 		await frappe.model.clear_doc("DocType", doctype.value);
 		await frappe.model.with_doctype(doctype.value);
@@ -320,6 +324,7 @@ export const useStore = defineStore("form-builder-store", () => {
 		selected,
 		get_df,
 		has_standard_field,
+		is_user_generated_field,
 		fetch,
 		reset_changes,
 		validate_fields,


### PR DESCRIPTION

https://github.com/frappe/frappe/assets/30859809/730256e1-39ca-41d3-b7e2-d221ed3e197a



### Changes Made

- remove background color distinction for custom fields (same as customize form).
- remove draggable filtering for custom fields and tabs / sections with std fields.
- remove attribute `data-has-std-field`. not used anymore.


`no-docs`