### PR TITLE
fix(Data Import): cast selected value to string

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -690,7 +690,7 @@ class Row:
 		df = col.df
 		if df.fieldtype == "Select":
 			select_options = get_select_options(df)
-			if select_options and value not in select_options:
+			if select_options and cstr(value) not in select_options:
 				options_string = ", ".join(frappe.bold(d) for d in select_options)
 				msg = _("Value must be one of {0}").format(options_string)
 				self.warnings.append(


### PR DESCRIPTION
`select_options` is always a list of strings, while a number value coming from Excel might be an integer. So the validation always fails for cases like this: `2023 in ("2022", "2023", "2023")`, despite being a valid value. The data import would cast the value in the end, but the validation fails before that.

Reproduce: Create a doctype where you can select a year, create an Excel file with a year column (formatted as number), try to import.