### PR TITLE
refactor: normalize redis invocation and unblock unix domain socket conn

### DIFF
--- a/frappe/utils/redis_queue.py
+++ b/frappe/utils/redis_queue.py
@@ -17,10 +17,7 @@ class RedisQueue:
 
 	@classmethod
 	def get_connection(cls, username=None, password=None):
-		rq_url = frappe.local.conf.redis_queue
-		domain = rq_url.split("redis://", 1)[-1]
-		url = (username and f"redis://{username}:{password or ''}@{domain}") or rq_url
-		conn = redis.from_url(url)
+		conn = redis.from_url(frappe.conf.redis_queue, username=username, password=password)
 		conn.ping()
 		return conn
 


### PR DESCRIPTION
Prior to this change, given that a unix domain socket string was passed
as `frappe.conf.redis_queue`, then the url split would have failed.

With this change, the upstream API for `from_url` is invoked
transparently.

passing none values for username and password is inocuous; [proof](https://github.com/redis/redis-py/blob/d95d8a24ed2af3eae80b7b0f14cbccc9dbe86e96/redis/connection.py#L604) and
[proof](https://github.com/redis/redis-py/blob/d95d8a24ed2af3eae80b7b0f14cbccc9dbe86e96/redis/connection.py#L594)

The [entrypoint](https://github.com/redis/redis-py/blob/d95d8a24ed2af3eae80b7b0f14cbccc9dbe86e96/redis/client.py#L868) passes these parameters on transparently.
