### PR TITLE
fix(UX): show perm server messages on file uploader

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -97,6 +97,7 @@ def has_permission(
 		if not perm:
 			push_perm_check_log(
 				_("User {0} does not have access to this document").format(frappe.bold(user))
+				+ f": {_(doc.doctype)} - {doc.name}"
 			)
 	else:
 		if ptype == "submit" and not cint(meta.is_submittable):

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -473,7 +473,20 @@ function upload_file(file, i) {
 				} else if (xhr.status === 403) {
 					file.failed = true;
 					let response = JSON.parse(xhr.responseText);
-					file.error_message = `Not permitted. ${response._error_message || ''}`;
+					file.error_message = `Not permitted. ${response._error_message || ''}.`;
+
+					try {
+						// Append server messages which are useful hint for perm issues
+						let server_messages = JSON.parse(response._server_messages);
+
+						server_messages.forEach((m) => {
+							m = JSON.parse(m);
+							file.error_message += `\n ${m.message} `
+						})
+					} catch (e) {
+						console.warning("Failed to parse server message", e)
+					}
+
 
 				} else if (xhr.status === 413) {
 					file.failed = true;


### PR DESCRIPTION
- File permission is dependent on document it's being attached to
- If user doesn't have perm to doc, the error still says "Insufficient permission for File"
- Useful info is sent in perm check logs, but not rendered on file uploader. 