### PR TITLE
fix: error in workspace patch

### DIFF
--- a/frappe/patches/v14_0/update_workspace2.py
+++ b/frappe/patches/v14_0/update_workspace2.py
@@ -70,7 +70,7 @@ def update_workspace(doc, seq, content):
 		doc.sequence_id = seq + 1
 		doc.content = json.dumps(content)
 		doc.public = 0 if doc.for_user else 1
-		doc.title = doc.extends or doc.label
+		doc.title = doc.get("extends") or doc.get("label")
 		doc.extends = ""
 		doc.category = ""
 		doc.onboarding = ""


### PR DESCRIPTION
While migrating a v14 instance, I got `builtins.AttributeError: 'Workspace' object has no attribute 'extends'` caused by a workspace from a custom app. Using `doc.get("extends")` resolves this.