### PR TITLE
fix: handle fixtures & custom script syncing for missing doctypes

### DIFF
--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -44,18 +44,34 @@ def import_fixtures(app):
 
 def import_custom_scripts(app):
 	"""Import custom scripts from `[app]/fixtures/custom_scripts`"""
-	if os.path.exists(frappe.get_app_path(app, "fixtures", "custom_scripts")):
-		for fname in os.listdir(frappe.get_app_path(app, "fixtures", "custom_scripts")):
-			if fname.endswith(".js"):
-				with open(frappe.get_app_path(app, "fixtures", "custom_scripts") + os.path.sep + fname) as f:
-					doctype = fname.rsplit(".", 1)[0]
-					script = f.read()
-					if frappe.db.exists("Client Script", {"dt": doctype}):
-						custom_script = frappe.get_doc("Client Script", {"dt": doctype})
-						custom_script.script = script
-						custom_script.save()
-					else:
-						frappe.get_doc({"doctype": "Client Script", "dt": doctype, "script": script}).insert()
+	scripts_folder = frappe.get_app_path(app, "fixtures", "custom_scripts")
+	if not os.path.exists(scripts_folder):
+		return
+
+	for fname in os.listdir(scripts_folder):
+		if not fname.endswith(".js"):
+			continue
+
+		doctype = fname.rsplit(".", 1)[0]
+		if not frappe.db.exists("DocType", doctype):
+			print(
+				f"Skipping custom script fixture syncing for the missing doctype {doctype} from the file {fname}"
+			)
+			continue
+
+		# not using get_app_path here as it scrubs the fname (will not work for dt name with > 1 word)
+		file_path = scripts_folder + os.path.sep + fname
+
+		with open(file_path) as f:
+			script = f.read()
+			if frappe.db.exists("Client Script", {"dt": doctype}):
+				client_script = frappe.get_doc("Client Script", {"dt": doctype})
+				client_script.script = script
+				client_script.save()
+			else:
+				client_script = frappe.new_doc("Client Script")
+				client_script.update({"__newname": doctype, "dt": doctype, "script": script})
+				client_script.insert()
 
 
 def export_fixtures(app=None):

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -17,13 +17,29 @@ def sync_fixtures(app=None):
 	frappe.flags.in_fixtures = True
 
 	for app in apps:
-		fixtures_path = frappe.get_app_path(app, "fixtures")
-		if os.path.exists(fixtures_path):
-			import_doc(fixtures_path)
-
+		import_fixtures(app)
 		import_custom_scripts(app)
 
 	frappe.flags.in_fixtures = False
+
+
+def import_fixtures(app):
+	fixtures_path = frappe.get_app_path(app, "fixtures")
+	if not os.path.exists(fixtures_path):
+		return
+
+	fixture_files = os.listdir(fixtures_path)
+
+	for fname in fixture_files:
+		if not fname.endswith(".json"):
+			continue
+
+		file_path = frappe.get_app_path(app, "fixtures", fname)
+		try:
+			import_doc(file_path)
+		except (ImportError, frappe.DoesNotExistError) as e:
+			# fixture syncing for missing doctypes
+			print(f"Skipping fixture syncing from the file {fname}. Reason: {e}")
 
 
 def import_custom_scripts(app):


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/21324

**For fixture files:**

- Checking for `ImportError`/`DoesNotExistError`
- Not handling `LinkValidationError` because `import_doc` inserts the doc with `ignore_links = True`

**For Client Script fixtures:**

- The code was broken because of the missing name field for the client script. Fixed it and added an early return if it's trying to import a client script for a missing doctype.

Tested with some fixtures for a site that does not have HR installed:

<img width="337" alt="image" src="https://github.com/frappe/frappe/assets/24353136/e3e452e8-a77a-4560-9890-cd36bc32d133">

<img width="718" alt="fixture" src="https://github.com/frappe/frappe/assets/24353136/804a3837-f2cf-4c0b-a448-1a78ee75b744">

<hr>

Unrelated:
I am not sure how the DX for client script fixtures is supposed to be 🫠. It picks up the doctype name from the filename. So the fixture file should be named `Goal.js` not `goal.js`(Not intuitive?). Also, client scripts can simply be in a JSON file in fixtures. Don't know why is a separate folder needed with confusing DX.
