### PR TITLE
chore(UX): reorder customize form actions (+ one rename)

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -111,17 +111,17 @@ frappe.ui.form.on("Customize Form", {
 				);
 
 				frm.add_custom_button(
-					__("Reload"),
+					__("Set Permissions"),
 					function () {
-						frm.script_manager.trigger("doc_type");
+						frappe.set_route("permission-manager", frm.doc.doc_type);
 					},
 					__("Actions")
 				);
 
 				frm.add_custom_button(
-					__("Reset to defaults"),
+					__("Reload"),
 					function () {
-						frappe.customize_form.confirm(__("Remove all customizations?"), frm);
+						frm.script_manager.trigger("doc_type");
 					},
 					__("Actions")
 				);
@@ -135,9 +135,9 @@ frappe.ui.form.on("Customize Form", {
 				);
 
 				frm.add_custom_button(
-					__("Set Permissions"),
+					__("Reset All Customizations"),
 					function () {
-						frappe.set_route("permission-manager", frm.doc.doc_type);
+						frappe.customize_form.confirm(__("Remove all customizations?"), frm);
 					},
 					__("Actions")
 				);


### PR DESCRIPTION
- Renamed **Reset to defaults** to **Reset All Customizations** (less confusing when read together with **Reset Layout**)
- Moved desctructive actions to the end
- Moved **Reset Layout** above **Reset All Customizations** (less destructive first)

### Before 

![image](https://github.com/frappe/frappe/assets/16315650/f90e131e-2c57-45ab-a6a0-161284043fa1)

### After

![image](https://github.com/frappe/frappe/assets/16315650/f9d7ce64-55de-4a95-b122-bc36107cf37b)
