### PR TITLE
refactor!: Remove custom script import

### DIFF
--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -3,9 +3,10 @@
 
 import os
 
+import click
+
 import frappe
 from frappe.core.doctype.data_import.data_import import export_json, import_doc
-from frappe.utils.deprecations import deprecation_warning
 
 
 def sync_fixtures(app=None):
@@ -53,29 +54,10 @@ def import_custom_scripts(app):
 		if not fname.endswith(".js"):
 			continue
 
-		doctype = fname.rsplit(".", 1)[0]
-		if not frappe.db.exists("DocType", doctype):
-			print(
-				f"Skipping custom script fixture syncing for the missing doctype {doctype} from the file {fname}"
-			)
-			continue
-
-		# not using get_app_path here as it scrubs the fname (will not work for dt name with > 1 word)
-		file_path = scripts_folder + os.path.sep + fname
-		deprecation_warning(
-			f"Importing client script {fname} from {scripts_folder} is deprecated and will be removed in version-15. Use client scripts as fixtures directly."
+		click.secho(
+			f"Importing Client Script `{fname}` from `{scripts_folder}` is not supported. Convert the client script to fixture.",
+			fg="red",
 		)
-
-		with open(file_path) as f:
-			script = f.read()
-			if frappe.db.exists("Client Script", {"dt": doctype}):
-				client_script = frappe.get_doc("Client Script", {"dt": doctype})
-				client_script.script = script
-				client_script.save()
-			else:
-				client_script = frappe.new_doc("Client Script")
-				client_script.update({"__newname": doctype, "dt": doctype, "script": script})
-				client_script.insert()
 
 
 def export_fixtures(app=None):

--- a/frappe/utils/fixtures.py
+++ b/frappe/utils/fixtures.py
@@ -5,6 +5,7 @@ import os
 
 import frappe
 from frappe.core.doctype.data_import.data_import import export_json, import_doc
+from frappe.utils.deprecations import deprecation_warning
 
 
 def sync_fixtures(app=None):
@@ -61,6 +62,9 @@ def import_custom_scripts(app):
 
 		# not using get_app_path here as it scrubs the fname (will not work for dt name with > 1 word)
 		file_path = scripts_folder + os.path.sep + fname
+		deprecation_warning(
+			f"Importing client script {fname} from {scripts_folder} is deprecated and will be removed in version-15. Use client scripts as fixtures directly."
+		)
 
 		with open(file_path) as f:
 			script = f.read()


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/21353

Why?
- Fixtures achieve this purpose already
- `custom_script` didn't allow multiple scripts, so syncing them was easy. Now we allow multiple scripts, so the current behaviour of import is just picking last client script and overriding it. 

Breaking change:
- This PR removes this feature
- Existing synced things will continue to work
- New changes wont be synced. 


https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)#removal-of-custom-script-import-from-fixturescustom_scipts