### PR TITLE
fix: workspace blank after login

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -22,7 +22,6 @@ frappe.views.Workspace = class Workspace {
 		this.page = wrapper.page;
 		this.blocks = frappe.workspace_block.blocks;
 		this.is_read_only = true;
-		this.is_page_loaded = false;
 		this.pages = {};
 		this.sorted_public_items = [];
 		this.sorted_private_items = [];
@@ -243,20 +242,17 @@ frappe.views.Workspace = class Workspace {
 		}
 
 		let page = this.get_page_to_show();
-		this.page.set_title(__(page.name));
-
-		this.update_selected_sidebar(this.current_page, false); //remove selected from old page
-		this.update_selected_sidebar(page, true); //add selected on new page
 
 		if (!frappe.router.current_route[0]) {
-			this.is_page_loaded = true;
+			frappe.route_flags.replace_route = true;
 			frappe.set_route(frappe.router.slug(page.public ? page.name : "private/" + page.name));
+			return;
 		}
 
-		if (!this.is_page_loaded) {
-			this.show_page(page);
-			this.is_page_loaded = false;
-		}
+		this.page.set_title(__(page.name));
+		this.update_selected_sidebar(this.current_page, false); //remove selected from old page
+		this.update_selected_sidebar(page, true); //add selected on new page
+		this.show_page(page);
 	}
 
 	update_selected_sidebar(page, add) {
@@ -335,12 +331,9 @@ frappe.views.Workspace = class Workspace {
 			default_page = { name: "Build", public: true };
 		}
 
-		let page =
-			(frappe.get_route()[1] == "private" ? frappe.get_route()[2] : frappe.get_route()[1]) ||
-			default_page.name;
-		let is_public = frappe.get_route()[1]
-			? frappe.get_route()[1] != "private"
-			: default_page.public;
+		const route = frappe.get_route();
+		const page = (route[1] == "private" ? route[2] : route[1]) || default_page.name;
+		const is_public = route[1] ? route[1] != "private" : default_page.public;
 		return { name: page, public: is_public };
 	}
 


### PR DESCRIPTION
Fixes issues mentioned in https://github.com/frappe/frappe/pull/21042 and https://github.com/frappe/frappe/pull/21252 properly

### Summary of Changes

- Revert `is_page_loaded` logic defined in https://github.com/frappe/frappe/pull/21252. Causes blank page when opening `site.localhost/app`. This is because `is_page_loaded`  is set to true and so `show_page` never gets called.
- Alternative to above revert, we are now returning early if re-routing to specific workspace page. That way `show_page` only gets called once - as intended. This returning logic has been moved to as early in the `show` function as possible.
- Other minor perf: call `frappe.get_route` only once in `get_page_to_show`.
- Important: set `frappe.route_flags.replace_route` as `true` in case of re-route from `/app` to avoid recursively going back to workspace ([similar example detailed here](https://github.com/frappe/frappe/pull/15539)).