### PR TITLE
feat: migrate translations command

### DIFF
--- a/frappe/commands/translate.py
+++ b/frappe/commands/translate.py
@@ -102,10 +102,28 @@ def import_translations(context, lang, path):
 		frappe.destroy()
 
 
+@click.command("migrate-translations")
+@click.argument("source-app")
+@click.argument("target-app")
+@pass_context
+def migrate_translations(context, source_app, target_app):
+	"Migrate target-app-specific translations from source-app to target-app"
+	import frappe.translate
+
+	site = get_site(context)
+	try:
+		frappe.init(site=site)
+		frappe.connect()
+		frappe.translate.migrate_translations(source_app, target_app)
+	finally:
+		frappe.destroy()
+
+
 commands = [
 	build_message_files,
 	get_untranslated,
 	import_translations,
 	new_language,
 	update_translations,
+	migrate_translations,
 ]

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -1125,7 +1125,9 @@ def migrate_translations(source_app, target_app):
 	strings_in_source_app = [m[1] for m in frappe.translate.get_messages_for_app(source_app)]
 	strings_in_target_app = [m[1] for m in frappe.translate.get_messages_for_app(target_app)]
 
-	strings_in_target_app_but_not_in_source_app = list(set(strings_in_target_app) - set(strings_in_source_app))
+	strings_in_target_app_but_not_in_source_app = list(
+		set(strings_in_target_app) - set(strings_in_source_app)
+	)
 
 	languages = frappe.translate.get_all_languages()
 
@@ -1144,10 +1146,10 @@ def migrate_translations(source_app, target_app):
 		target_csv = os.path.join(target_app_translations_dir, lang + ".csv")
 		temp_csv = os.path.join(source_app_translations_dir, "_temp.csv")
 
-		with open(source_csv, "r") as s, open(target_csv, "a+") as t, open(temp_csv, "a+") as temp:
-			source_reader = reader(s, lineterminator = "\n")
-			target_writer = writer(t, lineterminator = "\n")
-			temp_writer = writer(temp, lineterminator = "\n")
+		with open(source_csv) as s, open(target_csv, "a+") as t, open(temp_csv, "a+") as temp:
+			source_reader = reader(s, lineterminator="\n")
+			target_writer = writer(t, lineterminator="\n")
+			temp_writer = writer(temp, lineterminator="\n")
 
 			for row in source_reader:
 				if row[0] in strings_in_target_app_but_not_in_source_app:

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -15,7 +15,7 @@ import operator
 import os
 import re
 from contextlib import contextmanager
-from csv import reader
+from csv import reader, writer
 
 from babel.messages.extract import extract_python
 from babel.messages.jslexer import Token, tokenize, unquote_string
@@ -999,7 +999,6 @@ def write_csv_file(path, app_messages, lang_dict):
 	:param lang_dict: Full translated dict.
 	"""
 	app_messages.sort(key=lambda x: x[1])
-	from csv import writer
 
 	with open(path, "w", newline="") as msgfile:
 		w = writer(msgfile, lineterminator="\n")
@@ -1118,6 +1117,48 @@ def import_translations(lang, path):
 
 	for app in frappe.get_all_apps(True):
 		write_translations_file(app, lang, full_dict)
+
+
+def migrate_translations(source_app, target_app):
+	"""Migrate target-app-specific translations from source-app to target-app"""
+	clear_cache()
+	strings_in_source_app = [m[1] for m in frappe.translate.get_messages_for_app(source_app)]
+	strings_in_target_app = [m[1] for m in frappe.translate.get_messages_for_app(target_app)]
+
+	strings_in_target_app_but_not_in_source_app = list(set(strings_in_target_app) - set(strings_in_source_app))
+
+	languages = frappe.translate.get_all_languages()
+
+	source_app_translations_dir = os.path.join(frappe.get_pymodule_path(source_app), "translations")
+	target_app_translations_dir = os.path.join(frappe.get_pymodule_path(target_app), "translations")
+
+	if not os.path.exists(target_app_translations_dir):
+		os.makedirs(target_app_translations_dir)
+
+	for lang in languages:
+		source_csv = os.path.join(source_app_translations_dir, lang + ".csv")
+
+		if not os.path.exists(source_csv):
+			continue
+
+		target_csv = os.path.join(target_app_translations_dir, lang + ".csv")
+		temp_csv = os.path.join(source_app_translations_dir, "_temp.csv")
+
+		with open(source_csv, "r") as s, open(target_csv, "a+") as t, open(temp_csv, "a+") as temp:
+			source_reader = reader(s, lineterminator = "\n")
+			target_writer = writer(t, lineterminator = "\n")
+			temp_writer = writer(temp, lineterminator = "\n")
+
+			for row in source_reader:
+				if row[0] in strings_in_target_app_but_not_in_source_app:
+					target_writer.writerow(row)
+				else:
+					temp_writer.writerow(row)
+
+		if not os.path.getsize(target_csv):
+			os.remove(target_csv)
+		os.remove(source_csv)
+		os.rename(temp_csv, source_csv)
 
 
 def rebuild_all_translation_files():


### PR DESCRIPTION
Helps with migrating target-app-specific translations from source-app to target-app.

Example:

Migrate all lending-specific translations from erpnext to lending using:
`bench --site kina migrate-translations erpnext lending`

Results:

ERPNext translations: https://github.com/frappe/erpnext/pull/35522/commits/2afc5ea1b46e67a3951581b5352dfa5180a4bebe
Lending translations: https://github.com/frappe/lending/commit/441ad19d6265daea6ee728a78c288821936feaba