### PR TITLE
fix: "Remember Last Selected Value" not working (frappe#21364)

### DIFF
--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -163,7 +163,8 @@ $.extend(frappe.model, {
 
 				if (!user_default) {
 					user_default = frappe.defaults.get_user_default(df.fieldname);
-				} else if (
+				} 
+				if (
 					!user_default &&
 					df.remember_last_selected_value &&
 					frappe.boot.user.last_selected_values


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:
Setting flag remember_last_selected_value on docfield doesn't bring last selected value on Create New action.
Explanation details in frappe#21364

> Explain the **details** for making this change. What existing problem does the pull request solve?
This changes the logic to allow the docfield to be filled if it wasn't previously filled by user defaults. It will be filled with the last selected value for the field.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
