### PR TITLE
fix: removing website theme breaks website

### DIFF
--- a/frappe/templates/includes/head.html
+++ b/frappe/templates/includes/head.html
@@ -2,8 +2,9 @@
 {{ head_html or "" }}
 {%- endif %}
 
-{%- if theme.name != 'Standard' -%}
+{%- if theme && theme.name != 'Standard' -%}
 <link type="text/css" rel="stylesheet" href="{{ theme.theme_url }}">
+
 {%- else -%}
 {{ include_style('website.bundle.css') }}
 {%- endif -%}


### PR DESCRIPTION
1. create website theme
2. set it as default in website settings
3. remove the theme
4. no CSS is loaded on website now because `None != "standard"` it thinks website theme is present. 