### PR TITLE
perf: index for_user in Notification log

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -29,7 +29,8 @@
    "fieldtype": "Link",
    "hidden": 1,
    "label": "For User",
-   "options": "User"
+   "options": "User",
+   "search_index": 1
   },
   {
    "fieldname": "type",
@@ -64,8 +65,7 @@
    "fieldtype": "Link",
    "hidden": 1,
    "label": "From User",
-   "options": "User",
-   "search_index": 1
+   "options": "User"
   },
   {
    "default": "0",
@@ -96,7 +96,7 @@
  "hide_toolbar": 1,
  "in_create": 1,
  "links": [],
- "modified": "2022-09-13 16:08:48.153934",
+ "modified": "2023-06-14 21:20:51.197943",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Log",


### PR DESCRIPTION
Missed out before somehow: https://github.com/frappe/frappe/commit/3a5a45d8af6e86742b466e06702d74cc8bade7e3
