### PR TITLE
fix: data-import command fails with local files (#20521)

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -386,7 +386,14 @@ def import_doc(context, path, force=False):
 
 @click.command("data-import")
 @click.option(
-	"--file", "file_path", type=click.Path(), required=True, help="Path to import file (.csv, .xlsx)"
+	"--file",
+ 	"file_path",
+	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
+	required=True,
+ 	help=(
+		"Path to import file (.csv, .xlsx)."
+		"Consider that relative paths will resolve from 'sites' directory"
+	)
 )
 @click.option("--doctype", type=str, required=True)
 @click.option(
@@ -408,6 +415,9 @@ def data_import(
 	from frappe.core.doctype.data_import.data_import import import_file
 
 	site = get_site(context)
+
+	if "~" in file_path:
+		file_path = os.path.expanduser(file_path)
 
 	frappe.init(site=site)
 	frappe.connect()

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -387,13 +387,13 @@ def import_doc(context, path, force=False):
 @click.command("data-import")
 @click.option(
 	"--file",
- 	"file_path",
+	"file_path",
 	type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 	required=True,
- 	help=(
+	help=(
 		"Path to import file (.csv, .xlsx)."
 		"Consider that relative paths will resolve from 'sites' directory"
-	)
+	),
 )
 @click.option("--doctype", type=str, required=True)
 @click.option(
@@ -415,9 +415,6 @@ def data_import(
 	from frappe.core.doctype.data_import.data_import import import_file
 
 	site = get_site(context)
-
-	if "~" in file_path:
-		file_path = os.path.expanduser(file_path)
 
 	frappe.init(site=site)
 	frappe.connect()

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -576,14 +576,7 @@ class ImportFile:
 
 	def read_file(self, file_path: str):
 		extn = os.path.splitext(file_path)[1][1:]
-
-		file_content = None
-
-		file_name = frappe.db.get_value("File", {"file_url": file_path})
-		if file_name:
-			file = frappe.get_doc("File", file_name)
-			file_content = file.get_content()
-
+		file_content = frappe.read_file(file_path, True)
 		return file_content, extn
 
 	def read_content(self, content, extension):

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -576,7 +576,14 @@ class ImportFile:
 
 	def read_file(self, file_path: str):
 		extn = os.path.splitext(file_path)[1][1:]
-		file_content = frappe.read_file(file_path, True)
+
+		file_content = None
+
+		file_name = frappe.db.get_value("File", {"file_url": file_path})
+		if file_name:
+			file = frappe.get_doc("File", file_name)
+			file_content = file.get_content()
+
 		return file_content, extn
 
 	def read_content(self, content, extension):

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -579,6 +579,10 @@ class ImportFile:
 
 		file_content = None
 
+		if self.console:
+			file_content = frappe.read_file(file_path, True)
+			return file_content, extn
+
 		file_name = frappe.db.get_value("File", {"file_url": file_path})
 		if file_name:
 			file = frappe.get_doc("File", file_name)


### PR DESCRIPTION
This PR closes #20521

- `Importer.read_file()` method is trying to retrieve data from database which doesn't makes sense as it is being used on local file use cases
- `data-import` cli command fails with a generic file import error if relative file path does not resolves. Checking if path exists before trying to import file improves the message to the user
- Also added a note on the command help to beware the user on using relative paths, improving the user experience on how to use the command
