### PR TITLE
fix(meta): Revert to using conf over _dev_server for cache

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -36,7 +36,7 @@ ASSET_KEYS = (
 
 def get_meta(doctype, cached=True) -> "FormMeta":
 	# don't cache for developer mode as js files, templates may be edited
-	cached = cached and not frappe._dev_server
+	cached = cached and not frappe.conf.developer_mode
 	if cached:
 		meta = frappe.cache.hget("doctype_form_meta", doctype)
 		if not meta:


### PR DESCRIPTION
Reverting change that hath broken my workflow via https://github.com/frappe/frappe/commit/8a30667a97992784c8681949c1c92ff6ef902ba2