### PR TITLE
perf: faster docshare queries

### DIFF
--- a/frappe/core/doctype/docshare/docshare.json
+++ b/frappe/core/doctype/docshare/docshare.json
@@ -67,7 +67,8 @@
    "default": "0",
    "fieldname": "everyone",
    "fieldtype": "Check",
-   "label": "Everyone"
+   "label": "Everyone",
+   "search_index": 1
   },
   {
    "default": "1",
@@ -85,10 +86,11 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2021-04-04 11:38:50.813312",
+ "modified": "2023-06-15 18:02:51.877533",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocShare",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -106,5 +108,6 @@
  "read_only": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -161,7 +161,7 @@ def get_shared(doctype, user=None, rights=None):
 		or_filters += [["everyone", "=", 1]]
 
 	shared_docs = frappe.get_all(
-		"DocShare", fields=["share_name"], filters=filters, or_filters=or_filters
+		"DocShare", fields=["share_name"], filters=filters, or_filters=or_filters, order_by=None
 	)
 
 	return [doc.share_name for doc in shared_docs]


### PR DESCRIPTION
A typical share query looks like this.

```sql
select `share_name` 
from `tabDocShare` 
where `tabDocShare`.`read` = 1.0 
  and `tabDocShare`.`share_doctype` = 'Pick List' 
  and (`tabDocShare`.`user` = 'username' or `tabDocShare`.`everyone` = 1.0) 
  order by `tabDocShare`.`modified` DESC;
```

None of existing indexes provide `everyone` values quickly, so `OR`
clause effectively clauses full table scan ALL THE TIME.

Also `order by` is meaningless here and confuses query planner/causes extra work. 