### PR TITLE
fix(build): Exit build process instead of throwing an exception

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -89,7 +89,7 @@ execute()
 	.then(() => RUN_BUILD_COMMAND && run_build_command_for_apps(APPS))
 	.catch((e) => {
 		console.error(e);
-		throw e;
+		process.exit(1);
 	});
 
 if (WATCH_MODE) {


### PR DESCRIPTION
This was fixed with https://github.com/frappe/frappe/pull/21084, the fix only works on Node 15 and above

Consider the following snippet
```node
function alwaysErrors(){
    throw new Error('Uh oh!');
}

async function hello() {
    console.log('Hello');
}

hello().then(() => alwaysErrors())
.catch((err) => {
    console.error(err);
    throw err;
});
```
Returns exit code 1 on Node 15 and above
```
Hello
Error: Uh oh!
    at alwaysErrors (/home/aditya/Frappe/benches/press/example.js:2:11)
    at /home/aditya/Frappe/benches/press/example.js:9:20
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^

Error: Uh oh!
    at alwaysErrors (/home/aditya/Frappe/benches/press/example.js:2:11)
    at /home/aditya/Frappe/benches/press/example.js:9:20
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v18.12.1
```

Node 14 only shows a warning
```
Hello
Error: Uh oh!
    at alwaysErrors (/home/aditya/Frappe/benches/press/example.js:2:11)
    at /home/aditya/Frappe/benches/press/example.js:9:20
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
(node:445564) UnhandledPromiseRejectionWarning: Error: Uh oh!
    at alwaysErrors (/home/aditya/Frappe/benches/press/example.js:2:11)
    at /home/aditya/Frappe/benches/press/example.js:9:20
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:445564) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:445564) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

After the fix, fails with exit code 1 everywhere

```
Hello
Error: Uh oh!
    at alwaysErrors (/home/aditya/Frappe/benches/press/example.js:2:11)
    at /home/aditya/Frappe/benches/press/example.js:9:20
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

Reference: https://nodejs.org/docs/latest-v16.x/api/cli.html#--unhandled-rejectionsmode
Fixes: https://github.com/frappe/press/issues/874

