### PR TITLE
fix: Keep raw query params string formatted.

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -436,11 +436,14 @@ frappe.router = {
 	},
 
 	make_url(params) {
-		let path_string = $.map(params, function (a) {
+		let path_string = $.map(params, function (a, i) {
 			if ($.isPlainObject(a)) {
 				frappe.route_options = a;
 				return null;
 			} else {
+				if (a.startsWith('?') && i == params.length - 1) {
+					return a;
+				}
 				return encodeURIComponent(String(a));
 			}
 		}).join("/");


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Current frappe.set_route function will encode each param through make_url function. But, when the last param is a query params string created by frappe.utils.make_query_string function, it will be encoded too. Since '?' , '&' , ' ' characters won't be recognized as query string begin, separator or equal sign. So, frappe.utils.get_url_arg function will return undefined.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> The solution is keep raw value the param of frappe.set_route if it starts with the '?' character and is the last one.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Before:

https://github.com/frappe/frappe/assets/31474164/f623340e-f878-403e-b063-26df40ca0f68

After:

https://github.com/frappe/frappe/assets/31474164/32e790e0-a17e-430b-8cdd-96398d82baeb

<!-- Add images/recordings to better visualize the change: expected/current behviour -->



