### PR TITLE
perf: Cache Docstatus check in invalid links

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -785,7 +785,8 @@ class BaseDocument:
 						df.fieldname != "amended_from"
 						and (is_submittable or self.meta.is_submittable)
 						and frappe.get_meta(doctype).is_submittable
-						and cint(frappe.db.get_value(doctype, docname, "docstatus")) == DocStatus.cancelled()
+						and cint(frappe.db.get_value(doctype, docname, "docstatus"), cache=True)
+						== DocStatus.cancelled()
 					):
 
 						cancelled_links.append((df.fieldname, docname, get_msg(df, docname)))


### PR DESCRIPTION
If same document occurs multiple times then we end up checking docstatus multiple times
