### PR TITLE
feat: webhook timeout

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -17,6 +17,7 @@
   "html_condition",
   "sb_webhook",
   "request_url",
+  "timeout",
   "is_dynamic_url",
   "cb_webhook",
   "request_method",
@@ -204,6 +205,14 @@
    "fieldname": "is_dynamic_url",
    "fieldtype": "Check",
    "label": "Is Dynamic URL?"
+  },
+  {
+   "default": "5",
+   "description": "The number of seconds until the request expires",
+   "fieldname": "timeout",
+   "fieldtype": "Int",
+   "label": "Request Timeout",
+   "reqd": 1
   }
  ],
  "links": [
@@ -212,7 +221,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2023-06-02 17:25:12.598232",
+ "modified": "2023-06-16 10:21:00.971833",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -129,7 +129,7 @@ def enqueue_webhook(doc, webhook) -> None:
 				url=request_url,
 				data=json.dumps(data, default=str),
 				headers=headers,
-				timeout=5,
+				timeout=webhook.timeout,
 			)
 			r.raise_for_status()
 			frappe.logger().debug({"webhook_success": r.text})

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -129,7 +129,7 @@ def enqueue_webhook(doc, webhook) -> None:
 				url=request_url,
 				data=json.dumps(data, default=str),
 				headers=headers,
-				timeout=webhook.timeout,
+				timeout=webhook.timeout or 5,
 			)
 			r.raise_for_status()
 			frappe.logger().debug({"webhook_success": r.text})


### PR DESCRIPTION
In the case it is known a certain request will take more than 5 seconds to process the maintainer of the webhook can increase the timeout limit.

`no-docs`