### PR TITLE
add translation to main_currency and fraction_currency on money_to_wo…

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1368,9 +1368,9 @@ def money_in_words(
 		out = "{} {}".format(main_currency, _("Zero"))
 	# 0.XX
 	elif main == "0":
-		out = _(in_words(fraction, in_million).title()) + " " + fraction_currency
+		out = _(in_words(fraction, in_million).title()) + " " + _(fraction_currency)
 	else:
-		out = main_currency + " " + _(in_words(main, in_million).title())
+		out = _(in_words(main, in_million).title()) + " " + _(main_currency)
 		if cint(fraction):
 			out = (
 				out
@@ -1379,7 +1379,7 @@ def money_in_words(
 				+ " "
 				+ _(in_words(fraction, in_million).title())
 				+ " "
-				+ fraction_currency
+				+ _(fraction_currency)
 			)
 
 	return out + " " + _("only.")


### PR DESCRIPTION
fix currency translation and position on money_to_word function:

Before on English language:
<img width="370" alt="before EN" src="https://github.com/frappe/frappe/assets/45880595/f4be2d06-3b25-48b3-a460-47380754c64d">

Before on Arabic language:
<img width="373" alt="before AR" src="https://github.com/frappe/frappe/assets/45880595/5a3a46c0-14ea-4b84-a235-9d9beb9df4c7">

After on English language:
<img width="374" alt="After EN" src="https://github.com/frappe/frappe/assets/45880595/3ff6e7bf-585b-4a05-a92f-6ab07c78dd03">

After on Arabic language:
<img width="376" alt="after AR" src="https://github.com/frappe/frappe/assets/45880595/b7c5f8b5-911f-4de6-af7f-5a17eb9a383e">
