### PR TITLE
perf: Faster report exporting logic

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -349,6 +349,13 @@ def build_xlsx_data(data, visible_idx, include_indentation, ignore_visible_idx=F
 		datetime.timedelta,
 	)
 
+	if len(visible_idx) == len(data.result):
+		# It's not possible to have same length and different content.
+		ignore_visible_idx = True
+	else:
+		# Note: converted for faster lookups
+		visible_idx = set(visible_idx)
+
 	result = [[]]
 	column_widths = []
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1466,7 +1466,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				}
 
 				const visible_idx = this.datatable.bodyRenderer.visibleRowIndices;
-				if (visible_idx.length + 1 === this.data.length) {
+				// data.length will be +1 if add total row is enabled.
+				if (this.report_doc.add_total_row) {
 					visible_idx.push(visible_idx.length);
 				}
 


### PR DESCRIPTION
Try exporting report with 100K rows, most likely it fails or takes a really long time.

Root causes:
- visible_idx was a list, lookups are SLOW AF when lists grow to 100k+. Converted this to set which is one time cost but lookups are O(1) after that. 
- visible_idx check is not required when I am exporting entire report. If length matches then ignore visible IDs completely and just send everything. 



|         | Before | After | Improvement |
| ---     | ---    | ---   | ---         |
| Export 85K rows  | 25.99  | 0.77  | ~33x faster |