### PR TITLE
fix: field replace

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -191,12 +191,14 @@ frappe.ui.form.Layout = class Layout {
 	replace_field(fieldname, df, render) {
 		df.fieldname = fieldname; // change of fieldname is avoided
 		if (this.fields_dict[fieldname] && this.fields_dict[fieldname].df) {
-			const fieldobj = this.init_field(df, render);
+			let fieldobj = this.init_field(df, render);
+			const prev_fieldobj = this.fields_dict[fieldname];
+			const idx = this.fields_list.findIndex((e) => e == prev_fieldobj);
 			this.fields_dict[fieldname].$wrapper.remove();
-			this.fields_list.splice(this.fields_dict[fieldname], 1, fieldobj);
+			this.fields_list.splice(idx, 1, fieldobj);
 			this.fields_dict[fieldname] = fieldobj;
-			this.section.fields_list.splice(this.section.fields_dict[fieldname], 1, fieldobj);
-			this.section.fields_dict[fieldname] = fieldobj;
+			this.sections.forEach((section) => section.replace_field(fieldname, fieldobj));
+			prev_fieldobj.tab.replace_field(fieldobj);
 			this.refresh_fields([df]);
 		}
 	}

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -198,7 +198,7 @@ frappe.ui.form.Layout = class Layout {
 			this.fields_list.splice(idx, 1, fieldobj);
 			this.fields_dict[fieldname] = fieldobj;
 			this.sections.forEach((section) => section.replace_field(fieldname, fieldobj));
-			prev_fieldobj.tab.replace_field(fieldobj);
+			prev_fieldobj.tab?.replace_field(fieldobj);
 			this.refresh_fields([df]);
 		}
 	}

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -191,10 +191,10 @@ frappe.ui.form.Layout = class Layout {
 	replace_field(fieldname, df, render) {
 		df.fieldname = fieldname; // change of fieldname is avoided
 		if (this.fields_dict[fieldname] && this.fields_dict[fieldname].df) {
-			let fieldobj = this.init_field(df, render);
 			const prev_fieldobj = this.fields_dict[fieldname];
+			const fieldobj = this.init_field(df, prev_fieldobj.parent, render);
+			prev_fieldobj.$wrapper.replaceWith(fieldobj.$wrapper);
 			const idx = this.fields_list.findIndex((e) => e == prev_fieldobj);
-			this.fields_dict[fieldname].$wrapper.remove();
 			this.fields_list.splice(idx, 1, fieldobj);
 			this.fields_dict[fieldname] = fieldobj;
 			this.sections.forEach((section) => section.replace_field(fieldname, fieldobj));
@@ -207,7 +207,8 @@ frappe.ui.form.Layout = class Layout {
 		!this.section && this.make_section();
 		!this.column && this.make_column();
 
-		const fieldobj = this.init_field(df, render);
+		const parent = this.column.form.get(0);
+		const fieldobj = this.init_field(df, parent, render);
 		this.fields_list.push(fieldobj);
 		this.fields_dict[df.fieldname] = fieldobj;
 
@@ -219,11 +220,11 @@ frappe.ui.form.Layout = class Layout {
 		}
 	}
 
-	init_field(df, render = false) {
+	init_field(df, parent, render = false) {
 		const fieldobj = frappe.ui.form.make_control({
 			df: df,
 			doctype: this.doctype,
-			parent: this.column.form.get(0),
+			parent: parent,
 			frm: this.frm,
 			render_input: render,
 			doc: this.doc,

--- a/frappe/public/js/frappe/form/section.js
+++ b/frappe/public/js/frappe/form/section.js
@@ -82,6 +82,16 @@ export default class Section {
 		}
 	}
 
+	replace_field(fieldname, fieldobj) {
+		if (this.fields_dict[fieldname]?.df) {
+			const olfldobj = this.fields_dict[fieldname];
+			const idx = this.fields_list.findIndex((e) => e == olfldobj);
+			this.fields_list.splice(idx, 1, fieldobj);
+			this.fields_dict[fieldname] = fieldobj;
+			fieldobj.section = this;
+		}
+	}
+
 	add_field(fieldobj) {
 		this.fields_list.push(fieldobj);
 		this.fields_dict[fieldobj.df.fieldname] = fieldobj;

--- a/frappe/public/js/frappe/form/tab.js
+++ b/frappe/public/js/frappe/form/tab.js
@@ -76,6 +76,9 @@ export default class Tab {
 	add_field(fieldobj) {
 		fieldobj.tab = this;
 	}
+	replace_field(fieldobj) {
+		fieldobj.tab = this;
+	}
 
 	set_active() {
 		this.tab_link.find(".nav-link").tab("show");


### PR DESCRIPTION
- fix: section fields_dict
- fix: replace_field

Prior to this PR, replace_field did simply not work. Because:
- splice needs an (integer) index not an element
- also section field management must be taken into account for all sections

This PR uses the correct integer for splicing and also manages sections, columns and tabs
according to the original field that is being replaced so that the field remains at the same
location in the layout.

---

works blissfully in tandem with #21322 :
```js
	setup(frm) {
		df = frm.get_docfield("map");
		df["fieldtype"] = "GeolocationVRP";
		frm.layout.replace_field("map", df);
	},
	refresh(frm) {
		fld = frm.fields_dict["map"];
		fld.refresh(); // not sure why necessary, may be rather a bug in ControlGeolocation
	}
```

And a custom controller:
```js
frappe.ui.form.ControlGeolocationVRP = class ControlGeolocationVRP extends (
	frappe.ui.form.ControlGeolocation
) {
	point_to_layer(geoJsonPoint, latlng) {
		// Custom rules for how geojson data is rendered on the map
		if (geoJsonPoint.properties.point_type == "circle") {
			return L.circle(latlng, { radius: geoJsonPoint.properties.radius });
		} else if (geoJsonPoint.properties.point_type == "circlemarker") {
			return L.circleMarker(latlng, {
				radius: geoJsonPoint.properties.radius,
			});
		} else {
			// return L.marker(latlng);
			const homeIcon = L.divIcon({ className: "fa fa-home --blue" });
			return L.marker(latlng, { icon: homeIcon });
		}
	}
	setStyle(geoJsonFeature) {
		if (geoJsonFeature.geometry.type === "LineString") {
			return {
				color: geoJsonFeature.properties.stroke,
				weight: geoJsonFeature.properties["stroke-width"],
			};
		}
		return {};
	}
};
```
