### PR TITLE
fix: make sure number is not zero for `bankers_rounding`

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -1096,6 +1096,8 @@ class TestRounding(FrappeTestCase):
 		rounding_method = "Banker's Rounding"
 
 		self.assertEqual(rounded(0, 0, rounding_method=rounding_method), 0)
+		self.assertEqual(rounded(5.551115123125783e-17, 2, rounding_method=rounding_method), 0.0)
+
 		self.assertEqual(flt("0.5", 0, rounding_method=rounding_method), 0)
 		self.assertEqual(flt("0.3", rounding_method=rounding_method), 0.3)
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1116,11 +1116,11 @@ def _round_away_from_zero(num, precision):
 
 
 def _bankers_rounding(num, precision):
-	if num == 0:
-		return 0.0
-
 	multiplier = 10**precision
 	num = round(num * multiplier, 12)
+
+	if num == 0:
+		return 0.0
 
 	floor_num = math.floor(num)
 	decimal_part = num - floor_num


### PR DESCRIPTION
## Reason for error
Input Number:  -5.551115123125783e-17
The number after the multiplier is: 0


## Traceback
```
request.js:457 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 53, in application
    response = frappe.api.handle()
               ^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1586, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/e_invoice.py", line 99, in generate_e_invoice
    data = EInvoiceData(doc).get_data()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/e_invoice.py", line 318, in get_data
    self.set_transaction_details()
  File "apps/india_compliance/india_compliance/gst_india/utils/transaction_data.py", line 50, in set_transaction_details
    rounding_adjustment = self.get_adjusted_rounding(tds_amount)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/transaction_data.py", line 100, in get_adjusted_rounding
    rounding_adjustment = self.rounded(
                          ^^^^^^^^^^^^^
  File "apps/india_compliance/india_compliance/gst_india/utils/transaction_data.py", line 526, in rounded
    return rounded(value, precision)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/data.py", line 1064, in rounded
    return _bankers_rounding(num, precision)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/data.py", line 1131, in _bankers_rounding
    epsilon = 2.0 ** (math.log(abs(num), 2) - 52.0)
                      ^^^^^^^^^^^^^^^^^^^^^
ValueError: math domain error
```