### PR TITLE
feat: Customizable Scheduler Job Frequency

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -14,9 +14,13 @@
   "stopped",
   "method",
   "server_script",
+  "create_log",
+  "frequency_section",
   "frequency",
   "cron_format",
-  "create_log",
+  "column_break_6bvj",
+  "custom_frequency",
+  "custom_cron_format",
   "status_section",
   "last_execution",
   "column_break_9",
@@ -55,7 +59,7 @@
    "depends_on": "eval:doc.frequency==='Cron'",
    "fieldname": "cron_format",
    "fieldtype": "Data",
-   "label": "Cron Format",
+   "label": "Standard Cron Format",
    "read_only": 1
   },
   {
@@ -63,7 +67,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Frequency",
+   "label": "Standard Frequency",
    "options": "All\nHourly\nHourly Long\nDaily\nDaily Long\nWeekly\nWeekly Long\nMonthly\nMonthly Long\nCron\nYearly\nAnnual",
    "read_only": 1,
    "reqd": 1
@@ -91,6 +95,28 @@
   {
    "fieldname": "column_break_9",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:!doc.server_script",
+   "fieldname": "custom_frequency",
+   "fieldtype": "Select",
+   "label": "Custom Frequency",
+   "options": "All\nHourly\nHourly Long\nDaily\nDaily Long\nWeekly\nWeekly Long\nMonthly\nMonthly Long\nCron\nYearly\nAnnual"
+  },
+  {
+   "depends_on": "eval:doc.custom_frequency==='Cron'",
+   "fieldname": "custom_cron_format",
+   "fieldtype": "Data",
+   "label": "Custom Cron Format"
+  },
+  {
+   "fieldname": "column_break_6bvj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "frequency_section",
+   "fieldtype": "Section Break",
+   "label": "Frequency"
   }
  ],
  "in_create": 1,
@@ -100,7 +126,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2022-06-28 02:55:12.470915",
+ "modified": "2023-06-20 18:34:59.280833",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",


### PR DESCRIPTION
This change lets user configure scheduler frequency on particular site for individual jobs. 

Why is this required? 
- Many jobs implement hackety-hacks to run at different configurable periods. E.g. If I want to run something every 5, 15, 60 minutes I'll have to add 5 minute job and see at every execution if configured time has elapsed.
- Some things are best left to the end user. e.g. When emails should be sent. 
- Examples: https://github.com/frappe/ecommerce_integrations/blob/1bb9198e92a39df741c1a376ed0556c6c70e5a3d/ecommerce_integrations/controllers/scheduling.py#L5-L25 https://github.com/frappe/erpnext/blob/9d27a25e5f2335386402f96f83a10729695b20c8/erpnext/utilities/doctype/video/video.py#L57-L75

Implementation:

- Add custom frequency and corn fields. 
- At runtime pick the effective field. Custom ones take precedence. 
 
![image](https://github.com/frappe/frappe/assets/9079960/5c87e1e9-8907-41a6-a535-eb023aa71591)




TODO:
- [ ] test (haven't used this at all, just poc)
- [ ] check how the migration of jobs and changes in core will work.
- [ ] document