### PR TITLE
ci: use multiple python version in patch test

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -62,9 +62,9 @@ jobs:
           fi
 
       - name: Setup Python
-        uses: "gabrielfalcao/pyenv-action@v10"
+        uses: "gabrielfalcao/pyenv-action@v14"
         with:
-          versions: 3.10:latest, 3.7:latest
+          versions: 3.10.11, 3.7.16
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Setup Python
         uses: "gabrielfalcao/pyenv-action@v14"
         with:
+          default: 3.10.11
           versions: 3.10.11, 3.7.16
 
       - name: Setup Node

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -68,6 +68,9 @@ jobs:
               3.7
               3.10
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -121,25 +121,25 @@ jobs:
 
           function update_to_version() {
             version=$1
+            py=$2
+
             branch_name="version-$version-hotfix"
             echo "Updating to v$version"
             git fetch --depth 1 upstream $branch_name:$branch_name
             git checkout -q -f $branch_name
-            pip install -U frappe-bench
 
             pgrep honcho | xargs kill
             rm -rf ~/frappe-bench/env
-            bench -v setup env
+            bench -v setup env --python $py
             bench start &> ~/frappe-bench/bench_start.log &
+
             bench --site test_site migrate
           }
 
-          alias python=python3.7
-          update_to_version 12
-          update_to_version 13
+          update_to_version 12 python3.7
+          update_to_version 13 python3.7
 
-          alias python=python3.10
-          update_to_version 14
+          update_to_version 14 python3.10
 
           echo "Updating to last commit"
           rm -rf ~/frappe-bench/env

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -61,18 +61,12 @@ jobs:
               exit 1
           fi
 
-      - name: Setup PyEnv
-        run: |
-            curl https://pyenv.run | bash
-            echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
-            echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-            echo 'eval "$(pyenv init -)"' >> ~/.bashrc
-            exec "$SHELL"
-
-      - name: Setup Python versions
-        run: |
-            pyenv install 3.10
-            pyenv install 3.7
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: |
+              3.7
+              3.10
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -68,9 +68,6 @@ jobs:
               3.7
               3.10
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -105,7 +105,6 @@ jobs:
         run: |
           bash ${GITHUB_WORKSPACE}/.github/helper/install_dependencies.sh
           pip install frappe-bench
-          pyenv global $(pyenv versions | grep '3.10')
           bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
           BEFORE: ${{ env.GITHUB_EVENT_PATH.before }}
@@ -138,11 +137,11 @@ jobs:
             bench --site test_site migrate
           }
 
-          pyenv global $(pyenv versions | grep '3.7')
+          alias python=python3.7
           update_to_version 12
           update_to_version 13
 
-          pyenv global $(pyenv versions | grep '3.10')
+          alias python=python3.10
           update_to_version 14
 
           echo "Updating to last commit"

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -61,11 +61,18 @@ jobs:
               exit 1
           fi
 
-      - name: Setup Python
-        uses: "gabrielfalcao/pyenv-action@v14"
-        with:
-          default: 3.10.11
-          versions: 3.10.11, 3.7.16
+      - name: Setup PyEnv
+        run: |
+            curl https://pyenv.run | bash
+            echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+            echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+            echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+            exec "$SHELL"
+
+      - name: Setup Python versions
+        run: |
+            pyenv install 3.10
+            pyenv install 3.7
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
- We were using pyenv action to install pyenv and then install 2 versions. 
- This started failing few days ago mysteriously, I didn't have patience to debug it.
- Moved to setup-python action which sets up multiple python versions (but doesn't put them in `$PATH`)
- Modified workflow to pick right python version during patch test. `bench setup env` takes optional `--python` flag to use python version which may not be default. 
- This is 4-5 minutes faster. Doesn't build python from source :moyai: 