### PR TITLE
feat: before/after hooks for any app install/uninstall

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -287,6 +287,9 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 		if out is False:
 			return
 
+	for fn in frappe.get_hooks("before_app_install"):
+		frappe.get_attr(fn)(name)
+
 	if name != "frappe":
 		add_module_defs(name, ignore_if_duplicate=force)
 
@@ -301,6 +304,9 @@ def install_app(name, verbose=False, set_as_patched=True, force=False):
 
 	for after_install in app_hooks.after_install or []:
 		frappe.get_attr(after_install)()
+
+	for fn in frappe.get_hooks("after_app_install"):
+		frappe.get_attr(fn)(name)
 
 	sync_jobs()
 	sync_fixtures(name)
@@ -369,6 +375,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 	for before_uninstall in app_hooks.before_uninstall or []:
 		frappe.get_attr(before_uninstall)()
 
+	for fn in frappe.get_hooks("before_app_uninstall"):
+		frappe.get_attr(fn)(app_name)
+
 	modules = frappe.get_all("Module Def", filters={"app_name": app_name}, pluck="name")
 
 	drop_doctypes = _delete_modules(modules, dry_run=dry_run)
@@ -381,6 +390,9 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 
 	for after_uninstall in app_hooks.after_uninstall or []:
 		frappe.get_attr(after_uninstall)()
+
+	for fn in frappe.get_hooks("after_app_uninstall"):
+		frappe.get_attr(fn)(app_name)
 
 	click.secho(f"Uninstalled App {app_name} from Site {site}", fg="green")
 	frappe.flags.in_uninstall = False

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -372,6 +372,22 @@ app_license = "{app_license}"
 # before_uninstall = "{app_name}.uninstall.before_uninstall"
 # after_uninstall = "{app_name}.uninstall.after_uninstall"
 
+# Integration Setup
+# ------------------
+# To set up dependencies/integrations with other apps
+# Name of the app being installed is passed as an argument
+
+# before_app_install = "{app_name}.utils.before_app_install"
+# after_app_install = "{app_name}.utils.after_app_install"
+
+# Integration Cleanup
+# -------------------
+# To clean up dependencies/integrations with other apps
+# Name of the app being uninstalled is passed as an argument
+
+# before_app_uninstall = "{app_name}.utils.before_app_uninstall"
+# after_app_uninstall = "{app_name}.utils.after_app_uninstall"
+
 # Desk Notifications
 # ------------------
 # See frappe.core.notifications.get_notification_config


### PR DESCRIPTION
## Why

Currently, we have `before_install` / `after_install` hooks for setup or cleanup of the current app. As we split apps, multiple apps need to have soft dependencies/integrations with other apps. 

Ex: [Payroll in `hrms` uses loans from `erpnext`](https://github.com/frappe/hrms/pull/616). With the loan module separating out as the [lending app](https://github.com/frappe/lending), `hrms` needs to set up/clean up integration with loans (adding custom fields in hr/loan app doctypes), hooked on lending app installation/uninstallation.

## What

This PR adds 4 new hooks. 

Called when any app is installed, `app_name` is passed as an argument

`before_app_install`
`after_app_install`

Called when any app is uninstalled, `app_name` is passed as an argument

`before_app_uninstall`
`after_app_uninstall`

## Usage

`hrms/hooks.py`:

```python
after_app_install = "hrms.utils.after_app_install"
before_app_uninstall = "hrms.utils.before_app_uninstall"
```

```python
def after_app_install(app_name):
	"""Set up loan integration with payroll"""
	if app_name != "lending":
		return

	print("Updating payroll setup for loans")
	create_custom_fields(SALARY_SLIP_LOAN_FIELDS)


def before_app_uninstall(app_name):
	"""Clean up loan integration with payroll"""
	if app_name != "lending":
		return

	print("Updating payroll setup for loans")
	delete_custom_fields(SALARY_SLIP_LOAN_FIELDS)
```

## Caveats

Confusing DX:

Easy to get confused between `after_app_install` and `after_install` (or not). `after_install` is meant for the current app, and `after_app_install` is for any app.

The `after_install`, `before_install`... hooks sort of become redundant after this.

Alternatives:

Make it clearer with the word "any"
`after_any_app_install(app_name)` 

Change the behavior: Do not run hooks for the installing app. "other" means any app apart from the current one.
`after_other_app_install(app_name)` (sounds weird grammatically)

or a clearer usage like the `doc_events` hook (overkill ?):

```python
handle_app_dependencies: {
	"lending": {
		"after_install": "hrms.utils.create_loan_fields",
		"before_uninstall": "hrms.utils.delete_loan_fields",
	},
	"payments": {
		"after_install": "hrms.utils.create_payment_fields",
	}
}
```

Feedback welcome. Especially on naming.