### PR TITLE
fix: repeat title value in description of link field.

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -243,16 +243,17 @@ def search_widget(
 def get_std_fields_list(meta, key):
 	# get additional search fields
 	sflist = ["name"]
-	if meta.search_fields:
-		for d in meta.search_fields.split(","):
-			if d.strip() not in sflist:
-				sflist.append(d.strip())
 
 	if meta.title_field and meta.title_field not in sflist:
 		sflist.append(meta.title_field)
 
 	if key not in sflist:
 		sflist.append(key)
+
+	if meta.search_fields:
+		for d in meta.search_fields.split(","):
+			if d.strip() not in sflist:
+				sflist.append(d.strip())
 
 	return sflist
 


### PR DESCRIPTION
If a link field has search fields setting and tick check show title in link field will repeat title in the last item of description.

I found that, before return data to render, will check if item in the second position same as value, it will be removed. But, when include search fields, second position not always the title field, it can be another. My solution is append list value of the fields at the end array.

Before:

![Screenshot 2023-06-22 at 18 17 02](https://github.com/frappe/frappe/assets/31474164/92a54eee-9705-4527-b12d-61aec8722908)

After:

![Screenshot 2023-06-22 at 18 16 27](https://github.com/frappe/frappe/assets/31474164/586c1f60-ac92-48a5-8ce5-53f8a8a6c471)
