### PR TITLE
fix: hooks boilerplate

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -304,6 +304,7 @@ app_publisher = "{app_publisher}"
 app_description = "{app_description}"
 app_email = "{app_email}"
 app_license = "{app_license}"
+# required_apps = []
 
 # Includes in <head>
 # ------------------

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -298,9 +298,7 @@ __version__ = '0.0.1'
 
 """
 
-hooks_template = """from . import __version__ as app_version
-
-app_name = "{app_name}"
+hooks_template = """app_name = "{app_name}"
 app_title = "{app_title}"
 app_publisher = "{app_publisher}"
 app_description = "{app_description}"


### PR DESCRIPTION
- fix: remove `from . import __version__ as app_version` from hooks boilerplate

    It's not used by any frappe/erpnext code and linters complain about the
unused import

- fix: add `required_apps` to hooks boilerplate
