### PR TITLE
fix(Workspace): ignore `is_hidden` when importing standard workspaces

### DIFF
--- a/frappe/modules/import_file.py
+++ b/frappe/modules/import_file.py
@@ -34,6 +34,7 @@ ignore_values = {
 	"Print Style": ["disabled"],
 	"Module Onboarding": ["is_complete"],
 	"Onboarding Step": ["is_complete", "is_skipped"],
+	"Workspace": ["is_hidden"],
 }
 
 ignore_doctypes = [""]


### PR DESCRIPTION
### Issue

If a Workspace gets updated in any app after being [hidden](https://github.com/frappe/frappe/pull/19539) by Workspace Manager, the truthy value for `is_hidden` gets lost when updated Workspace gets imported during any subsequent migration.