### PR TITLE
perf: lower web worker memory usage

### DIFF
--- a/frappe/build.py
+++ b/frappe/build.py
@@ -9,7 +9,6 @@ from tempfile import mkdtemp, mktemp
 from urllib.parse import urlparse
 
 import click
-import psutil
 from semantic_version import Version
 
 import frappe
@@ -288,6 +287,8 @@ def get_node_env():
 
 
 def get_safe_max_old_space_size():
+	import psutil
+
 	safe_max_old_space_size = 0
 	try:
 		total_memory = psutil.virtual_memory().total / (1024 * 1024)

--- a/frappe/core/doctype/error_log/test_error_log.py
+++ b/frappe/core/doctype/error_log/test_error_log.py
@@ -1,7 +1,10 @@
 # Copyright (c) 2015, Frappe Technologies and Contributors
 # License: MIT. See LICENSE
+from ldap3.core.exceptions import LDAPException, LDAPInappropriateAuthenticationResult
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils.error import _is_ldap_exception
 
 # test_records = frappe.get_test_records('Error Log')
 
@@ -12,3 +15,9 @@ class TestErrorLog(FrappeTestCase):
 		doc = frappe.new_doc("Error Log")
 		error = doc.log_error("This is an error")
 		self.assertEqual(error.doctype, "Error Log")
+
+	def test_ldap_exceptions(self):
+		exc = [LDAPException, LDAPInappropriateAuthenticationResult]
+
+		for e in exc:
+			self.assertTrue(_is_ldap_exception(e()))

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING, Optional
 from urllib.parse import unquote
 
 import filetype
-import requests
-import requests.exceptions
 from PIL import Image
 
 import frappe
@@ -116,6 +114,9 @@ def get_local_image(file_url: str) -> tuple["ImageFile", str, str]:
 
 
 def get_web_image(file_url: str) -> tuple["ImageFile", str, str]:
+	import requests
+	import requests.exceptions
+
 	# download
 	file_url = frappe.utils.get_url(file_url)
 	r = requests.get(file_url, stream=True)

--- a/frappe/frappeclient.py
+++ b/frappe/frappeclient.py
@@ -4,8 +4,6 @@ FrappeClient is a library that helps you connect with other frappe systems
 import base64
 import json
 
-import requests
-
 import frappe
 from frappe.utils.data import cstr
 
@@ -37,6 +35,8 @@ class FrappeClient:
 		api_secret=None,
 		frappe_authorization_source=None,
 	):
+		import requests
+
 		self.headers = {
 			"Accept": "application/json",
 			"content-type": "application/x-www-form-urlencoded",
@@ -390,42 +390,13 @@ class FrappeClient:
 
 class FrappeOAuth2Client(FrappeClient):
 	def __init__(self, url, access_token, verify=True):
+		import requests
+
 		self.access_token = access_token
 		self.headers = {
 			"Authorization": "Bearer " + access_token,
 			"content-type": "application/x-www-form-urlencoded",
 		}
 		self.verify = verify
-		self.session = OAuth2Session(self.headers)
+		self.session = requests.session()
 		self.url = url
-
-	def get_request(self, params):
-		res = requests.get(
-			self.url, params=self.preprocess(params), headers=self.headers, verify=self.verify
-		)
-		res = self.post_process(res)
-		return res
-
-	def post_request(self, data):
-		res = requests.post(
-			self.url, data=self.preprocess(data), headers=self.headers, verify=self.verify
-		)
-		res = self.post_process(res)
-		return res
-
-
-class OAuth2Session:
-	def __init__(self, headers):
-		self.headers = headers
-
-	def get(self, url, params, verify):
-		res = requests.get(url, params=params, headers=self.headers, verify=verify)
-		return res
-
-	def post(self, url, data, verify):
-		res = requests.post(url, data=data, headers=self.headers, verify=verify)
-		return res
-
-	def put(self, url, data, verify):
-		res = requests.put(url, data=data, headers=self.headers, verify=verify)
-		return res

--- a/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py
+++ b/frappe/integrations/doctype/slack_webhook_url/slack_webhook_url.py
@@ -3,8 +3,6 @@
 
 import json
 
-import requests
-
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -24,6 +22,8 @@ class SlackWebhookURL(Document):
 
 
 def send_slack_message(webhook_url, message, reference_doctype, reference_name):
+	import requests
+
 	data = {"text": message, "attachments": []}
 
 	slack_url, show_link = frappe.db.get_value(

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -5,10 +5,9 @@ import base64
 import hashlib
 import hmac
 import json
+import typing
 from time import sleep
 from urllib.parse import urlparse
-
-import requests
 
 import frappe
 from frappe import _
@@ -17,6 +16,9 @@ from frappe.utils.jinja import validate_template
 from frappe.utils.safe_exec import get_safe_globals
 
 WEBHOOK_SECRET_HEADER = "X-Frappe-Webhook-Signature"
+
+if typing.TYPE_CHECKING:
+	import requests
 
 
 class Webhook(Document):
@@ -112,6 +114,8 @@ def get_context(doc):
 
 
 def enqueue_webhook(doc, webhook) -> None:
+	import requests
+
 	webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
 	headers = get_webhook_headers(doc, webhook)
 	data = get_webhook_data(doc, webhook)
@@ -154,7 +158,7 @@ def log_request(
 	url: str,
 	headers: dict,
 	data: dict,
-	res: requests.Response | None = None,
+	res: typing.Optional["requests.Response"] = None,
 ):
 	request_log = frappe.get_doc(
 		{

--- a/frappe/integrations/google_oauth.py
+++ b/frappe/integrations/google_oauth.py
@@ -2,7 +2,6 @@ import json
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
-from requests import get, post
 
 import frappe
 from frappe.utils import get_request_site_address
@@ -56,6 +55,8 @@ class GoogleOAuth:
 			frappe.throw(frappe._("Please update {} before continuing.").format(google_settings))
 
 	def authorize(self, oauth_code: str) -> dict[str, str | int]:
+		import requests
+
 		"""Returns a dict with access and refresh token.
 
 		:param oauth_code: code got back from google upon successful auhtorization
@@ -73,13 +74,14 @@ class GoogleOAuth:
 		}
 
 		return handle_response(
-			post(self.OAUTH_URL, data=data).json(),
+			requests.post(self.OAUTH_URL, data=data).json(),
 			"Google Oauth Authorization Error",
 			"Something went wrong during the authorization.",
 		)
 
 	def refresh_access_token(self, refresh_token: str) -> dict[str, str | int]:
 		"""Refreshes google access token using refresh token"""
+		import requests
 
 		data = {
 			"client_id": self.google_settings.client_id,
@@ -92,7 +94,7 @@ class GoogleOAuth:
 		}
 
 		return handle_response(
-			post(self.OAUTH_URL, data=data).json(),
+			requests.post(self.OAUTH_URL, data=data).json(),
 			"Google Oauth Access Token Refresh Error",
 			"Something went wrong during the access token generation.",
 			raise_err=True,
@@ -158,7 +160,9 @@ def handle_response(
 
 
 def is_valid_access_token(access_token: str) -> bool:
-	response = get(
+	import requests
+
+	response = requests.get(
 		"https://oauth2.googleapis.com/tokeninfo", params={"access_token": access_token}
 	).json()
 

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -5,7 +5,6 @@ from base64 import b32encode, b64encode
 from io import BytesIO
 
 import pyotp
-from pyqrcode import create as qrcreate
 
 import frappe
 import frappe.defaults
@@ -387,6 +386,8 @@ def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, mess
 
 def get_qr_svg_code(totp_uri):
 	"""Get SVG code to display Qrcode for OTP."""
+	from pyqrcode import create as qrcreate
+
 	url = qrcreate(totp_uri)
 	svg = ""
 	stream = BytesIO()

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -4,8 +4,6 @@ import csv
 import json
 from io import StringIO
 
-import requests
-
 import frappe
 from frappe import _, msgprint
 from frappe.utils import cint, comma_or, cstr, flt
@@ -178,6 +176,8 @@ def getlink(doctype, name):
 
 
 def get_csv_content_from_google_sheets(url):
+	import requests
+
 	# https://docs.google.com/spreadsheets/d/{sheetid}}/edit#gid={gid}
 	validate_google_sheets_url(url)
 	# get gid, defaults to first sheet

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -7,7 +7,6 @@ import inspect
 import json
 import linecache
 import os
-import pydoc
 import sys
 import traceback
 
@@ -69,6 +68,8 @@ def make_error_snapshot(exception):
 
 
 def get_snapshot(exception, context=10):
+	import pydoc
+
 	"""
 	Return a dict describing a given traceback (based on cgitb.text)
 	"""

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -11,8 +11,6 @@ import pydoc
 import sys
 import traceback
 
-from ldap3.core.exceptions import LDAPException
-
 import frappe
 from frappe.utils import cstr, encode
 
@@ -20,16 +18,31 @@ EXCLUDE_EXCEPTIONS = (
 	frappe.AuthenticationError,
 	frappe.CSRFTokenError,  # CSRF covers OAuth too
 	frappe.SecurityException,
-	LDAPException,
 	frappe.InReadOnlyMode,
 )
+
+LDAP_BASE_EXCEPTION = "LDAPException"
+
+
+def _is_ldap_exception(e):
+	"""Check if exception is from LDAP library.
+
+	This is a hack but ensures that LDAP is not imported unless it's required. This is tested in
+	unittests in case the exception changes in future.
+	"""
+
+	for t in type(e).__mro__:
+		if t.__name__ == LDAP_BASE_EXCEPTION:
+			return True
+
+	return False
 
 
 def make_error_snapshot(exception):
 	if frappe.conf.disable_error_snapshot:
 		return
 
-	if isinstance(exception, EXCLUDE_EXCEPTIONS):
+	if isinstance(exception, EXCLUDE_EXCEPTIONS) or _is_ldap_exception(exception):
 		return
 
 	logger = frappe.logger(with_more_info=True)

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -5,7 +5,6 @@ from urllib.parse import quote
 
 import frappe
 from frappe import _
-from frappe.integrations.google_oauth import GoogleOAuth
 from frappe.model.document import Document
 from frappe.utils import encode, get_request_site_address
 from frappe.website.utils import get_boot_data
@@ -100,6 +99,8 @@ class WebsiteSettings(Document):
 		frappe.clear_cache()
 
 	def get_access_token(self):
+		from frappe.integrations.google_oauth import GoogleOAuth
+
 		if not self.indexing_refresh_token:
 			button_label = frappe.bold(_("Allow API Indexing Access"))
 			raise frappe.ValidationError(_("Click on {0} to generate Refresh Token.").format(button_label))


### PR DESCRIPTION
Almost same as https://github.com/frappe/frappe/pull/21467 but for web workers. 

~18-20MB of junk imports removed. These included:
- `requests`
- `GoogleOauath`
- `ldap3`
- `psutil`
- `pydoc`
- `pyqrcode` 

AFAIK All of these are rarely used in prod and since we auto-restart workers after some time the cost of importing these isn't worth keeping them around in memory since start.

Before:
![image](https://github.com/frappe/frappe/assets/9079960/577405e0-c0ea-4fc3-b9b2-d175ba83f96a)


After:

![image](https://github.com/frappe/frappe/assets/9079960/94b76be7-d648-4265-a82d-5df93d49b19d)




Some more possilibilies:
- Consider utilising `--preload` for sharing some commonly used imported code (Think doctypes, modules..) will have to profile in prod to identify this using `memray attach`
- Clearly find out what's being shared and what isn't. Revisit https://github.com/frappe/frappe/issues/18927 spun off into separate PR: https://github.com/frappe/frappe/pull/21474 



---


Two huge but non-removable imports right now are:
- ~6mb `bs4` via markdownify. Used in html2text so can't remove
- ~2mb `yaml`, used in frontmatter code