### PR TITLE
perf: pre-load common modules to reduce memory usage

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -54,6 +54,8 @@ fi
 
 echo "Starting Bench..."
 
+export FRAPPE_TUNE_GC=True
+
 bench start &> ~/frappe-bench/bench_start.log &
 
 if [ "$TYPE" == "server" ]

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -31,6 +31,30 @@ _site = None
 _sites_path = os.environ.get("SITES_PATH", ".")
 
 
+# If gc.freeze is done then importing modules before forking allows us to share the memory
+if frappe._tune_gc:
+	import frappe.boot
+	import frappe.client
+	import frappe.core.doctype.user.user
+	import frappe.database.mariadb.database  # Load database related utils
+	import frappe.database.query
+	import frappe.desk.desktop  # workspace
+	import frappe.model.db_query
+	import frappe.query_builder
+	import frappe.utils.background_jobs  # Enqueue is very common
+	import frappe.utils.data  # common utils
+	import frappe.utils.jinja  # web page rendering
+	import frappe.utils.jinja_globals
+	import frappe.utils.redis_wrapper  # Exact redis_wrapper
+	import frappe.utils.safe_exec
+	import frappe.utils.typing_validations  # any whitelisted method uses this
+	import frappe.website.path_resolver  # all the page types and resolver
+	import frappe.website.router  # Website router
+	import frappe.website.website_generator  # web page doctypes
+
+# end: module pre-loading
+
+
 @local_manager.middleware
 @Request.application
 def application(request: Request):

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -4,7 +4,6 @@
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, urljoin, urlparse
 
-import jwt
 import requests
 from werkzeug.test import TestResponse
 
@@ -362,6 +361,8 @@ class TestOAuth20(FrappeRequestTestCase):
 		self.assertTrue(payload.get("nonce") == nonce)
 
 	def decode_id_token(self, id_token):
+		import jwt
+
 		return jwt.decode(
 			id_token,
 			audience=self.client_id,

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -15,6 +15,9 @@ from typing import Any, Literal, Optional, TypeVar, Union
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlunparse
 
 from click import secho
+from dateutil import parser
+from dateutil.parser import ParserError
+from dateutil.relativedelta import relativedelta
 
 import frappe
 from frappe.desk.utils import slug
@@ -80,9 +83,6 @@ def getdate(
 	Converts string date (yyyy-mm-dd) to datetime.date object.
 	If no input is provided, current date is returned.
 	"""
-	from dateutil import parser
-	from dateutil.parser._parser import ParserError
-
 	if not string_date:
 		return get_datetime().date()
 	if isinstance(string_date, datetime.datetime):
@@ -105,7 +105,6 @@ def getdate(
 def get_datetime(
 	datetime_str: Optional["DateTimeLikeObject"] = None,
 ) -> datetime.datetime | None:
-	from dateutil import parser
 
 	if datetime_str is None:
 		return now_datetime()
@@ -141,9 +140,6 @@ def get_timedelta(time: str | None = None) -> datetime.timedelta | None:
 	Returns:
 	        datetime.timedelta: Timedelta object equivalent of the passed `time` string
 	"""
-	from dateutil import parser
-	from dateutil.parser import ParserError
-
 	time = time or "0:0:0"
 
 	try:
@@ -161,8 +157,6 @@ def get_timedelta(time: str | None = None) -> datetime.timedelta | None:
 
 
 def to_timedelta(time_str: str | datetime.time) -> datetime.timedelta:
-	from dateutil import parser
-
 	if isinstance(time_str, datetime.time):
 		time_str = str(time_str)
 
@@ -237,9 +231,6 @@ def add_to_date(
 	as_datetime=False,
 ) -> DateTimeLikeObject:
 	"""Adds `days` to the given date"""
-	from dateutil import parser
-	from dateutil.parser._parser import ParserError
-	from dateutil.relativedelta import relativedelta
 
 	if date is None:
 		date = now_datetime()
@@ -500,9 +491,6 @@ def get_year_ending(date) -> datetime.date:
 
 
 def get_time(time_str: str) -> datetime.time:
-	from dateutil import parser
-	from dateutil.parser import ParserError
-
 	if isinstance(time_str, datetime.datetime):
 		return time_str.time()
 	elif isinstance(time_str, datetime.time):

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -5,8 +5,6 @@ import base64
 import json
 from typing import TYPE_CHECKING, Callable
 
-import jwt
-
 import frappe
 import frappe.utils
 from frappe import _
@@ -126,6 +124,9 @@ def login_via_oauth2_id_token(
 def get_info_via_oauth(
 	provider: str, code: str, decoder: Callable | None = None, id_token: bool = False
 ):
+
+	import jwt
+
 	flow = get_oauth2_flow(provider)
 	oauth2_providers = get_oauth2_providers()
 

--- a/frappe/utils/telemetry.py
+++ b/frappe/utils/telemetry.py
@@ -8,7 +8,9 @@ from contextlib import suppress
 import frappe
 from frappe.utils import getdate
 from frappe.utils.caching import site_cache
-from posthog import Posthog
+
+from posthog import Posthog  # isort: skip
+
 
 POSTHOG_PROJECT_FIELD = "posthog_project_id"
 POSTHOG_HOST_FIELD = "posthog_host"


### PR DESCRIPTION
Continues #21474


| Metric                    | before   | after #21474 | after preloading modules | total reduction |
| ---                       | ---      | ---          | ----                     | ---             |
| 24 Worker total PSS       | 1791.518 | 1236.89      | 1166.879                 | 34.8%           |

Pretty much everything I've added to preload list gets imported in minutes on the active site. So upfront memory cost is worth it as it lets us share it when using multiple workers. 