### PR TITLE
fix: don't break link list in middle of link in table multiselect

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -353,9 +353,9 @@ frappe.form.formatters = {
 		const formatted_values = rows.map((row) => {
 			const value = row[link_field.fieldname];
 			return (
-				`<span style="white-space: nowrap;">` +
-				frappe.format(value, link_field, options, row) +
-				`</span>`
+				`<span class="text-nowrap">
+					${frappe.format(value, link_field, options, row)}
+				</span>`
 			);
 		});
 		return formatted_values.join(", ");

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -352,7 +352,11 @@ frappe.form.formatters = {
 		const link_field = meta.fields.find((df) => df.fieldtype === "Link");
 		const formatted_values = rows.map((row) => {
 			const value = row[link_field.fieldname];
-			return frappe.format(value, link_field, options, row);
+			return (
+				`<span style="white-space: nowrap;">` +
+				frappe.format(value, link_field, options, row) +
+				`</span>`
+			);
 		});
 		return formatted_values.join(", ");
 	},

--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -352,11 +352,9 @@ frappe.form.formatters = {
 		const link_field = meta.fields.find((df) => df.fieldtype === "Link");
 		const formatted_values = rows.map((row) => {
 			const value = row[link_field.fieldname];
-			return (
-				`<span class="text-nowrap">
-					${frappe.format(value, link_field, options, row)}
-				</span>`
-			);
+			return `<span class="text-nowrap">
+				${frappe.format(value, link_field, options, row)}
+			</span>`;
 		});
 		return formatted_values.join(", ");
 	},


### PR DESCRIPTION
**Previously:**
![image](https://github.com/frappe/frappe/assets/7548295/1a884bc2-af47-4a6b-8b19-c256c6f16823)

**After this PR:**
![image](https://github.com/frappe/frappe/assets/7548295/3579bba0-4b42-457b-b8ac-fae082e4cda4)
