### PR TITLE
feat: `frappe.alert`

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -396,6 +396,14 @@ def log(msg: str) -> None:
 	debug_log.append(as_unicode(msg))
 
 
+def alert(
+	msg: str,
+	*,
+	indicator: Literal["blue", "green", "orange", "red", "yellow"] | None = None,
+):
+	return msgprint(msg, indicator=indicator, alert=True)
+
+
 def msgprint(
 	msg: str,
 	title: str | None = None,


### PR DESCRIPTION
Using `frappe.msgprint(..., alert=True)` feels awkward. Also we have
`frappe.alert` on the client but not on backend.
