### PR TITLE
feat: RQ WorkerPool support

### DIFF
--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -215,6 +215,27 @@ def start_worker(
 	)
 
 
+@click.command("worker-pool")
+@click.option(
+	"--queue",
+	type=str,
+	help="Queue to consume from. Multiple queues can be specified using comma-separated string. If not specified all queues are consumed.",
+)
+@click.option("--num-workers", type=int, default=2, help="Number of workers to spawn in pool.")
+@click.option("--quiet", is_flag=True, default=False, help="Hide Log Outputs")
+@click.option("--burst", is_flag=True, default=False, help="Run Worker in Burst mode.")
+def start_worker_pool(queue, quiet=False, num_workers=2, burst=False):
+	"""Start a backgrond worker"""
+	from frappe.utils.background_jobs import start_worker_pool
+
+	start_worker_pool(
+		queue=queue,
+		quiet=quiet,
+		burst=burst,
+		num_workers=num_workers,
+	)
+
+
 @click.command("ready-for-migration")
 @click.option("--site", help="site name")
 @pass_context
@@ -251,5 +272,6 @@ commands = [
 	show_pending_jobs,
 	start_scheduler,
 	start_worker,
+	start_worker_pool,
 	trigger_scheduler_event,
 ]

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -97,6 +97,17 @@ class TestRQJob(FrappeTestCase):
 		self.assertIn("quitting", cstr(stderr))
 
 	@timeout(20)
+	def test_multi_queue_burst_consumption_worker_pool(self):
+		for _ in range(3):
+			for q in ["default", "short"]:
+				frappe.enqueue(self.BG_JOB, sleep=1, queue=q)
+
+		_, stderr = execute_in_shell(
+			"bench worker-pool --queue short,default --burst --num-workers=4", check_exit_code=True
+		)
+		self.assertIn("quitting", cstr(stderr))
+
+	@timeout(20)
 	def test_job_id_dedup(self):
 		job_id = "test_dedup"
 		job = frappe.enqueue(self.BG_JOB, sleep=5, job_id=job_id)

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 import redis
 from redis.exceptions import BusyLoadingError, ConnectionError
-from rq import Connection, Queue, Worker
+from rq import Queue, Worker
 from rq.exceptions import NoSuchJobError
 from rq.job import Job, JobStatus
 from rq.logutils import setup_loghandlers
@@ -253,17 +253,16 @@ def start_worker(
 
 	WorkerKlass = DEQUEUE_STRATEGIES.get(strategy, Worker)
 
-	with Connection(redis_connection):
-		logging_level = "INFO"
-		if quiet:
-			logging_level = "WARNING"
-		worker = WorkerKlass(queues, name=get_worker_name(queue_name))
-		worker.work(
-			logging_level=logging_level,
-			burst=burst,
-			date_format="%Y-%m-%d %H:%M:%S",
-			log_format="%(asctime)s,%(msecs)03d %(message)s",
-		)
+	logging_level = "INFO"
+	if quiet:
+		logging_level = "WARNING"
+	worker = WorkerKlass(queues, name=get_worker_name(queue_name), connection=redis_connection)
+	worker.work(
+		logging_level=logging_level,
+		burst=burst,
+		date_format="%Y-%m-%d %H:%M:%S",
+		log_format="%(asctime)s,%(msecs)03d %(message)s",
+	)
 
 
 def get_worker_name(queue):


### PR DESCRIPTION
RQ now has experimental support for workerpools.

### When to use this?

Roughly when you have more than 2 workers a workerpool might make
sense, below 2 workers the overhead of the master "pool" process will likely make it less efficient.

### Why is it any better?

Currently, we just let supervisord duplicate the worker process N number
of times. This is inefficient from shared memory POV. Forking the
the original process to create workers enables sharing of more memory thus
leading upwards of 60-70% reduction in memory usage with a pool size of 8
workers.


![image](https://github.com/frappe/frappe/assets/9079960/fc96d670-4bbe-42b1-b4dd-78f41f434cb4)


---

`no-docs` - consider it **experimental** and don't use this for now. 

Not much to know about except how to start it:

```bash
bench worker-pool --num-workers=8
```