### PR TITLE
fix: system language to calendar

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -104,7 +104,7 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 			"assets/frappe/js/lib/fullcalendar/fullcalendar.min.css",
 			"assets/frappe/js/lib/fullcalendar/fullcalendar.min.js",
 		];
-		let user_language = frappe.boot.user.language || frappe.boot.lang;
+		let user_language = frappe.boot.lang;
 		if (user_language && user_language !== "en") {
 			assets.push("assets/frappe/js/lib/fullcalendar/locale-all.js");
 		}
@@ -250,7 +250,7 @@ frappe.views.Calendar = class Calendar {
 		var me = this;
 		defaults.meridiem = "false";
 		this.cal_options = {
-			locale: frappe.boot.user.language || frappe.boot.lang || "en",
+			locale: frappe.boot.lang,
 			header: {
 				left: "prev, title, next",
 				right: "today, month, agendaWeek, agendaDay",

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -104,7 +104,7 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 			"assets/frappe/js/lib/fullcalendar/fullcalendar.min.css",
 			"assets/frappe/js/lib/fullcalendar/fullcalendar.min.js",
 		];
-		let user_language = frappe.boot.user.language;
+		let user_language = frappe.boot.user.language || frappe.boot.lang;
 		if (user_language && user_language !== "en") {
 			assets.push("assets/frappe/js/lib/fullcalendar/locale-all.js");
 		}
@@ -250,7 +250,7 @@ frappe.views.Calendar = class Calendar {
 		var me = this;
 		defaults.meridiem = "false";
 		this.cal_options = {
-			locale: frappe.boot.user.language || "en",
+			locale: frappe.boot.user.language || frappe.boot.lang || "en",
 			header: {
 				left: "prev, title, next",
 				right: "today, month, agendaWeek, agendaDay",


### PR DESCRIPTION
Each site will have a default language, and each user can work in the same language or choose a specific language in the user's registration, if the user does not have any language in the registration, the system must use the default language configured for that site.

Following the order for language:
**User** or **System Settings** or **English**