### PR TITLE
feat: Add HEAD method to whitelist in init.py

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -732,7 +732,7 @@ def whitelist(allow_guest=False, xss_safe=False, methods=None):
 	"""
 
 	if not methods:
-		methods = ["GET", "POST", "PUT", "DELETE"]
+		methods = ["GET", "POST", "PUT", "DELETE", "HEAD"]
 
 	def innerfn(fn):
 		from frappe.utils.typing_validations import validate_argument_types


### PR DESCRIPTION
Description:

This pull request aims to update the Frappe repository's whitelist decorator in the __init__.py file to include the HEAD HTTP method. Currently, the decorator only allows "GET," "POST," "PUT," and "DELETE" methods. By adding support for the HEAD method, it enables access to functions via HTTP with the HEAD request.

Changes Made:

Modified the whitelist decorator in __init__.py to include the HEAD method in the list of allowed methods.
Updated the methods list to ["GET", "POST", "PUT", "DELETE", "HEAD"].
Motivation:

The addition of the HEAD method to the whitelist decorator is necessary to provide comprehensive HTTP access to functions in Frappe. This change ensures that developers can utilise the HEAD method in their APIs and perform the necessary head-based requests.