### PR TITLE
fix(WebForm): auto-increment link field

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -182,7 +182,7 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 			}
 			return o;
 		});
-		
+
 		return options;
 	}
 

--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -174,6 +174,15 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 		if (typeof options[0] === "string") {
 			options = options.map((o) => ({ label: o, value: o }));
 		}
+
+		options = options.map((o) => {
+			if (typeof o !== "string") {
+				o.label = o.label.toString();
+				o.value = o.value.toString();
+			}
+			return o;
+		});
+		
 		return options;
 	}
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -631,7 +631,7 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 		if title_field and show_title_field_in_link:
 			return json.dumps(link_options, default=str)
 		else:
-			return "\n".join([doc.value for doc in link_options])
+			return "\n".join([str(doc.value) for doc in link_options])
 
 	else:
 		raise frappe.PermissionError(


### PR DESCRIPTION
> Passenger and Debug Test fields are link to a DocType with naming rule set to `Autoincrement`


**Problem**

![CleanShot 2023-06-27 at 17 14 02](https://github.com/frappe/frappe/assets/34810212/ddcf9b3d-6d30-4b12-9c4e-e7fe359c18ad)


**Solved**

Parsing to and from int to string does the trick here.

![CleanShot 2023-06-27 at 17 13 27](https://github.com/frappe/frappe/assets/34810212/e295b211-413c-4dea-b6d3-a755780548b6)
