### PR TITLE
feat: Multi-line Python conditions in Notifications and more with `safe_block_eval`

### DIFF
--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -180,7 +180,8 @@
    "fieldtype": "Code",
    "ignore_xss_filter": 1,
    "in_list_view": 1,
-   "label": "Condition"
+   "label": "Condition",
+   "options": "PythonBlock"
   },
   {
    "fieldname": "column_break_6",
@@ -282,7 +283,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-05-04 11:17:11.882314",
+ "modified": "2023-06-27 17:36:38.694880",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -14,6 +14,7 @@ from frappe.model.document import Document
 from frappe.modules.utils import export_module_json, get_doc_module
 from frappe.utils import add_to_date, cast, is_html, nowdate, validate_email_address
 from frappe.utils.jinja import validate_template
+from frappe.utils.safe_block_eval import safe_block_eval
 from frappe.utils.safe_exec import get_safe_globals
 
 
@@ -75,7 +76,7 @@ def get_context(context):
 		temp_doc = frappe.new_doc(self.document_type)
 		if self.condition:
 			try:
-				frappe.safe_eval(self.condition, None, get_context(temp_doc.as_dict()))
+				safe_block_eval(self.condition, None, get_context(temp_doc.as_dict()))
 			except Exception:
 				frappe.throw(_("The Condition '{0}' is invalid").format(self.condition))
 
@@ -110,7 +111,7 @@ def get_context(context):
 		for d in doc_list:
 			doc = frappe.get_doc(self.document_type, d.name)
 
-			if self.condition and not frappe.safe_eval(self.condition, None, get_context(doc)):
+			if self.condition and not safe_block_eval(self.condition, None, get_context(doc)):
 				continue
 
 			docs.append(doc)
@@ -265,7 +266,7 @@ def get_context(context):
 		bcc = []
 		for recipient in self.recipients:
 			if recipient.condition:
-				if not frappe.safe_eval(recipient.condition, None, context):
+				if not safe_block_eval(recipient.condition, None, context):
 					continue
 			if recipient.receiver_by_document_field:
 				fields = recipient.receiver_by_document_field.split(",")
@@ -302,7 +303,7 @@ def get_context(context):
 		receiver_list = []
 		for recipient in self.recipients:
 			if recipient.condition:
-				if not frappe.safe_eval(recipient.condition, None, context):
+				if not safe_block_eval(recipient.condition, None, context):
 					continue
 
 			# For sending messages to the owner's mobile phone number
@@ -419,7 +420,7 @@ def evaluate_alert(doc: Document, alert, event):
 		context = get_context(doc)
 
 		if alert.condition:
-			if not frappe.safe_eval(alert.condition, None, context):
+			if not safe_block_eval(alert.condition, None, context):
 				return
 
 		if event == "Value Change" and not doc.is_new():

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -145,6 +145,23 @@ class TestNotification(FrappeTestCase):
 		self.assertRaises(frappe.ValidationError, notification.save)
 		notification.delete()
 
+	def test_multiline_condition(self):
+		frappe.set_user("Administrator")
+		notification = frappe.new_doc("Notification")
+		notification.subject = "test"
+		notification.document_type = "ToDo"
+		notification.send_alert_on = "New"
+		notification.message = "test"
+
+		recipent = frappe.new_doc("Notification Recipient")
+		recipent.receiver_by_document_field = "owner"
+
+		notification.recipents = recipent
+		notification.condition = "if 1 == 1:\n\treturn True\nelse:\n\treturn False"
+
+		notification.save()
+		notification.delete()
+
 	def test_value_changed(self):
 		event = frappe.new_doc("Event")
 		event.subject = "test"

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -133,7 +133,7 @@ class TestNotification(FrappeTestCase):
 		notification = frappe.new_doc("Notification")
 		notification.subject = "test"
 		notification.document_type = "ToDo"
-		notification.send_alert_on = "New"
+		notification.event = "New"
 		notification.message = "test"
 
 		recipent = frappe.new_doc("Notification Recipient")
@@ -150,7 +150,7 @@ class TestNotification(FrappeTestCase):
 		notification = frappe.new_doc("Notification")
 		notification.subject = "test"
 		notification.document_type = "ToDo"
-		notification.send_alert_on = "New"
+		notification.event = "New"
 		notification.message = "test"
 
 		recipent = frappe.new_doc("Notification Recipient")

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -942,6 +942,11 @@ class BaseDocument:
 			elif language == "PythonExpression":
 				frappe.utils.validate_python_code(code_string, fieldname=field.label)
 
+			elif language == "PythonBlock":
+				from frappe.utils.safe_block_eval import validate
+
+				validate(code_string, fieldname=field.label)
+
 	def _sync_autoname_field(self):
 		"""Keep autoname field in sync with `name`"""
 		autoname = self.meta.autoname or ""

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -152,6 +152,8 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 			Javascript: "ace/mode/javascript",
 			JS: "ace/mode/javascript",
 			Python: "ace/mode/python",
+			PythonExpression: "ace/mode/python",
+			PythonBlock: "ace/mode/python",
 			Py: "ace/mode/python",
 			HTML: "ace/mode/html",
 			CSS: "ace/mode/css",

--- a/frappe/utils/safe_block_eval.py
+++ b/frappe/utils/safe_block_eval.py
@@ -18,6 +18,12 @@ def safe_block_eval(script: str, _globals=None, _locals=None, output_var=None, *
 	        any: The result of the evaluation of the code.
 	"""
 
+	if not script:
+		return
+
+	if not isinstance(script, str):
+		raise TypeError(f"safe_block_eval: Code must be a string, got {type(script)}")
+
 	output_var = output_var or "evaluated_code_output_" + frappe.generate_hash(length=5)
 	_locals = _locals or {}
 	script = _wrap_in_function(script, output_var=output_var, local_vars=_locals)
@@ -69,6 +75,12 @@ def _wrap_in_function(
 def validate(code_string: str, fieldname: str):
 	"""Validate a block of code by first wrapping it in a function and then compiling it."""
 	from frappe.utils import validate_python_code
+
+	if not code_string:
+		return
+
+	if not isinstance(code_string, str):
+		raise TypeError(f"Code must be a string, got {type(code_string)}")
 
 	code_string = _wrap_in_function(code_string)
 	return validate_python_code(code_string, fieldname=fieldname, is_expression=False)

--- a/frappe/utils/safe_block_eval.py
+++ b/frappe/utils/safe_block_eval.py
@@ -1,0 +1,74 @@
+import frappe
+from frappe.utils.safe_exec import safe_exec
+
+
+def safe_block_eval(script: str, _globals=None, _locals=None, output_var=None, **kwargs):
+	"""Evaluate a block of code and return the result.
+
+	Allows `return` statements and `yield` expressions in the code to make it easier to write code that should return a value.
+
+	Args:
+	        script (str): The code to evaluate. Will be wrapped in a function.
+	        _globals (dict, optional): Globals
+	        _locals (dict, optional): Locals
+	        output_var (str, optional): The name of the variable to store the result in. Randomly generated if not provided.
+	        restrict_commit_rollback (bool, optional)
+
+	Returns:
+	        any: The result of the evaluation of the code.
+	"""
+
+	output_var = output_var or "evaluated_code_output_" + frappe.generate_hash(length=5)
+	_locals = _locals or {}
+	script = _wrap_in_function(script, output_var=output_var, local_vars=_locals)
+	safe_exec(script, _globals, _locals, **kwargs)
+	return _locals[output_var]
+
+
+def _wrap_in_function(
+	code: str,
+	*,
+	output_var: str = "evaluated_code_output_var_",
+	local_vars: dict[str, None] | None = None,
+	function_name: str = "evaluated_code_wrapper_function_",
+) -> str:
+	"""Wrap code in a function so that it can contain `return` statements."""
+	import textwrap
+
+	# Convert newlines to \n and remove leading/trailing newlines
+	code = (
+		code.replace("\r\n", "\n")
+		.replace("\r", "")
+		.replace("\u2028", "\n")
+		.replace("\u2029", "\n")
+		.strip("\n")
+	)
+
+	# If code is a single line, and does not contain a return statement, then prepend one
+	if "\n" not in code and " = " not in code:
+		start_keywords = {"return ", "raise ", "assert ", "yield "}
+		if not any(code.startswith(keyword) for keyword in start_keywords):
+			code = f"return {code}"
+
+	# Detect the indentation to avoid mixing tabs and spaces.
+	# Any amount of leading spaces is accepted as long as it is consistent.
+	indent = "\t" if "\t" in code else "    "
+
+	# Indent the code
+	code = textwrap.indent(code, indent)
+
+	args = ", ".join(
+		key
+		for key in (local_vars or {}).keys()
+		if key != output_var and not key.startswith("_") and key.isidentifier()
+	)
+	code = f"def {function_name}({args}):\n{code}\n\n{output_var} = {function_name}({args})"
+	return code
+
+
+def validate(code_string: str, fieldname: str):
+	"""Validate a block of code by first wrapping it in a function and then compiling it."""
+	from frappe.utils import validate_python_code
+
+	code_string = _wrap_in_function(code_string)
+	return validate_python_code(code_string, fieldname=fieldname, is_expression=False)


### PR DESCRIPTION
> # TODO: does not work if server scripts are disabled

# Multi-line conditions

Currently, it is possible to add Python conditions on documents for a number of doctypes such as Notifications, Workflow Transitions, Assignment Rules, etc.

**However, these conditions must be one liners to work with `frappe.safe_eval`. This is not really convenient.**

---

## A new method, `safe_block_eval`

This PR introduces a new method called `safe_block_eval`, which is backwards-compatible with `safe_eval`, and which can evaluate multi-line code and return its return value. Thus, `safe_block_eval` is a general purpose alternative to `safe_eval` (which only evaluates one-liners) and `safe_exec` (which has no *clean* -- this is my opinion -- concept of return values).

Needless to say, this change could be a welcome addition, as it is currently difficult to write **maintainable** conditions in workflow transitions for instance.

Moreover, this feature is not limited to binary conditions, but can also be used in more advanced computations, for instance in **virtual fields** or in other use cases (e.g. a custom formula for a Shipping Rule's fee, etc.).

## How does it work?
**Basically, it wraps the body of the condition in a function.**

The following condition (value of the `condition` field):
```python
if doc.owner == "Administrator":
    return False
return True
```

is transformed into:
```python
def evaluated_code_wrapper_function_(doc)
    if doc.owner == "Administrator":
        if doc.field == "value":
            return False
    return True

evaluated_code_output_var_ = evaluated_code_wrapper_function_(doc=doc)
```

<details><summary>Details about indentation and avoiding edge case mayhem</summary>
<p>

To wrap it in the function, the original code is indented once. Because mixing space-based indentation levels is allowed in a line (2 spaces then 4 spaces then 2 again for instance) as long as it's consistent across lines, it's not that difficult to handle code originally indented with spaces. Tab-based indentation even more straightforward.

Yet, the indentation code **does not handle some edge cases** (tab characters in code such as string literals but with space-based indentation, mixed indentation which is illegal anyway), but I didn't want to over-engineer the code with indent type detection or even a regex such as `r"^\t"` which does the job almost perfectly (safe for multi-line literals containing tab characters but this is a convoluted edge case anyway).

Let me tell you that I carefully read PEP 8 and it's legal to have inconsistent spaces in a line  
(try it out with `exec("if 1:\n  if 2:\n                          print('ok')")`)

</p>
</details> 

Once transformed, the generated code is executed with `safe_exec`, then the value of `evaluated_code_output_var_` is grabbed from the evaluation context, and returned by `safe_block_eval` to the calling method.

I'm not entirely _satisfied_ with the **locals-passing mechanism** but it is generally limited to values such as the `doc`, and so I think this is a reasonable way of doing it (another way is to merge "globals" and "locals" into the "globals" but it isn't cleaner).


One-liners still work for backwards-compatibility and developer experience's sake. For instance:
```python
doc.owner == "Administrator" and doc.field == "value"
```

is transformed into:
```python
def evaluated_code_wrapper_function_(doc)
    return doc.owner == "Administrator" and doc.field == "value"

evaluated_code_output_var_ = evaluated_code_wrapper_function_(doc=doc)
```

## Converting to this new system
I only migrated Notifications to this new system, but it should be easy to upgrade other DocTypes.

## Final remarks

I am open to discussion on this system, but I think it would be nice to have multi-line code as an option. I believe that this method (using a "hidden" function-wrapping mechanism) is the cleanest way of doing this, and the easiest for end users, even though it's not legal Python code verbatim.

<small>no-docs</small>