### PR TITLE
refactor: Deprecate broken-img mixin

### DIFF
--- a/frappe/public/scss/common/mixins.scss
+++ b/frappe/public/scss/common/mixins.scss
@@ -45,42 +45,5 @@
 	$background-color: var(--bg-color),
 	$border-radius: var(--border-radius),
 ) {
-
-	@if $content {
-		img:after {
-			content: url($content);
-		}
-	} @else {
-		img:after {
-			content: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='lightgrey' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-image'><rect x='3' y='3' width='18' height='18' rx='2' ry='2'/><circle cx='8.5' cy='8.5' r='1.5'/><polyline points='21 15 16 10 5 21'/></svg>");
-		}
-	}
-
-	img[alt]:after {
-		height: $height;
-		top: $top;
-		left: $left;
-		background-color: $background-color;
-		border-radius: $border-radius;
-		width: 100%;
-		position: absolute;
-		@include flex();
-		z-index: 1;
-	}
+	// Deprecated: Does not work as expected anymore. Also, this never worked in Safari.
 }
-
-// @mixin img-foreground() {
-// 	content: "\f1c5";
-// 	display: block;
-// 	font-style: normal;
-// 	font-family: FontAwesome;
-// 	font-size: 32px;
-// 	color: var(--text-muted);
-
-// 	position: absolute;
-// 	top: 50%;
-// 	transform: translateY(-50%);
-// 	left: 0;
-// 	width: 100%;
-// 	text-align: center;
-// }

--- a/frappe/public/scss/desk/file_view.scss
+++ b/frappe/public/scss/desk/file_view.scss
@@ -97,11 +97,6 @@
 						color: transparent;
 						position: relative;
 					}
-
-					@include broken-img(
-						$height: 70px,
-						$top: -15px,
-					);
 				}
 			}
 

--- a/frappe/public/scss/desk/image_view.scss
+++ b/frappe/public/scss/desk/image_view.scss
@@ -153,11 +153,6 @@
 				position: relative;
 				width: 100%;
 			}
-
-			@include broken-img(
-				$height: 175px,
-				$border-radius: 0
-			);
 		}
 
 		.image-title {

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -181,11 +181,6 @@
 							color: transparent;
 							position: relative;
 						}
-
-						@include broken-img(
-							$height: 125px,
-							$top: -4px,
-						)
 					}
 
 					.kanban-card-body {


### PR DESCRIPTION
- It does not work as expected. For the broken image it used to show blank space instead of a fallback image.

	![Screenshot 2023-06-28 at 10 35 38 AM](https://github.com/frappe/frappe/assets/13928957/228f07bb-ce30-4d7b-b746-9a79604fcc72)
	On chrome browser

- Also, it never used to work in safari and it occasionally overlays actual non-broken image on scrolling (mostly due to "z-index" set on the fallback and some weird rendering done by Safari).

	<img src="https://github.com/frappe/frappe/assets/13928957/2d63ed6e-6f58-4bce-bf15-c03c84387ff4" width="300">
	
	on Safari browser (iOS)

---

The better way to handle broken images is to use "onerror" attribute of the image.



