### PR TITLE
fix: dont retry if redis not available for realtime

### DIFF
--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -100,10 +100,10 @@ def emit_via_redis(event, message, room):
 	:param event: Event name, like `task_progress` etc.
 	:param message: JSON message object. For async must contain `task_id`
 	:param room: name of the room"""
-	from frappe.utils.background_jobs import get_redis_conn
+	from frappe.utils.background_jobs import get_redis_connection_without_auth
 
 	with suppress(redis.exceptions.ConnectionError):
-		r = get_redis_conn()
+		r = get_redis_connection_without_auth()
 		r.publish("events", frappe.as_json({"event": event, "message": message, "room": room}))
 
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -394,8 +394,8 @@ def validate_queue(queue, default_queue_list=None):
 
 
 @retry(
-	retry=retry_if_exception_type(BusyLoadingError) | retry_if_exception_type(ConnectionError),
-	stop=stop_after_attempt(10),
+	retry=retry_if_exception_type((BusyLoadingError, ConnectionError)),
+	stop=stop_after_attempt(5),
 	wait=wait_fixed(1),
 	reraise=True,
 )

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -423,9 +423,7 @@ def get_redis_conn(username=None, password=None):
 
 	try:
 		if not cred:
-			if not _redis_queue_conn:
-				_redis_queue_conn = RedisQueue.get_connection()
-			return _redis_queue_conn
+			return get_redis_connection_without_auth()
 		else:
 			return RedisQueue.get_connection(**cred)
 	except (redis.exceptions.AuthenticationError, redis.exceptions.ResponseError):
@@ -438,6 +436,14 @@ def get_redis_conn(username=None, password=None):
 	except Exception:
 		log(f"Please make sure that Redis Queue runs @ {frappe.get_conf().redis_queue}", colour="red")
 		raise
+
+
+def get_redis_connection_without_auth():
+	global _redis_queue_conn
+
+	if not _redis_queue_conn:
+		_redis_queue_conn = RedisQueue.get_connection()
+	return _redis_queue_conn
 
 
 def get_queues() -> list[Queue]:


### PR DESCRIPTION
caused by https://github.com/frappe/frappe/pull/21317


RQ attempts to retry because reliability is required there and workers NEED the connection, for realtime we've always ignored redis connection failures. 