### PR TITLE
perf!: ignore permission in get_list for `Administrator`

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -117,6 +117,9 @@ class DatabaseQuery:
 	) -> list:
 
 		if not ignore_permissions:
+			ignore_permissions = frappe.session.user == "Administrator"
+
+		if not ignore_permissions:
 			self.check_read_permission(self.doctype, parent_doctype=parent_doctype)
 
 		# filters and fields swappable

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -108,10 +108,14 @@ class TestPerformance(FrappeTestCase):
 			f"Possible performance regression in basic /api/Resource list  requests",
 		)
 
-	@unittest.skip("Not implemented")
 	def test_homepage_resolver(self):
-		paths = ["/", "/app"]
+		paths = ["/", "/app", "/contact"]
 		for path in paths:
 			PathResolver(path).resolve()
 			with self.assertQueryCount(1):
 				PathResolver(path).resolve()
+
+	def test_get_list_single_query(self):
+		frappe.get_list("User")
+		with self.assertQueryCount(1):
+			frappe.get_list("User")


### PR DESCRIPTION
- This is consistent with rest of permission system
- backgound jobs needlessly check permission, shared documents etc even
  when user is admin i.e. full access to everything.




Potentially problematic:
- [ ] perm queries used as "business logic"
