### PR TITLE
fix: styling of group by button

### DIFF
--- a/frappe/public/scss/desk/report.scss
+++ b/frappe/public/scss/desk/report.scss
@@ -100,11 +100,11 @@
 
 .group-by-button {
 	margin: 5px;
-	max-width: 125px;
 }
 
 .group-by-button.btn-primary-light {
 	color: var(--text-on-blue);
+	outline: 1px solid var(--bg-dark-blue);
 }
 
 .group-by-icon.active {


### PR DESCRIPTION
### Before

![group_by_old](https://github.com/frappe/frappe/assets/14891507/856e578a-452e-42c0-bbe1-60c3936a0425)

### After

![group_by_new](https://github.com/frappe/frappe/assets/14891507/fb1fb7c3-ab40-43b3-8aa5-27044e1b4be5)

Responsiveness works fine as well