### PR TITLE
refactor: Namespace all RQ jobs

### DIFF
--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -240,14 +240,14 @@ def start_worker_pool(queue, quiet=False, num_workers=2, burst=False):
 @click.option("--site", help="site name")
 @pass_context
 def ready_for_migration(context, site=None):
-	from frappe.utils.doctor import get_pending_jobs
+	from frappe.utils.doctor import any_job_pending
 
 	if not site:
 		site = get_site(context)
 
 	try:
 		frappe.init(site=site)
-		pending_jobs = get_pending_jobs(site=site)
+		pending_jobs = any_job_pending(site=site)
 
 		if pending_jobs:
 			print(f"NOT READY for migration: site {site} has pending background jobs")

--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -63,23 +63,15 @@ class RQJob(Document):
 
 		order_desc = "desc" in args.get("order_by", "")
 
-		matched_job_ids = RQJob.get_matching_job_ids(args)
+		matched_job_ids = RQJob.get_matching_job_ids(args)[start : start + page_length]
 
-		jobs = []
-		for job_ids in create_batch(matched_job_ids, 100):
-			jobs.extend(
-				serialize_job(job)
-				for job in Job.fetch_many(job_ids=job_ids, connection=get_redis_conn())
-				if job and for_current_site(job)
-			)
-			if len(jobs) > start + page_length:
-				# we have fetched enough. This is inefficient but because of site filtering TINA
-				break
+		conn = get_redis_conn()
+		jobs = [serialize_job(job) for job in Job.fetch_many(job_ids=matched_job_ids, connection=conn)]
 
-		return sorted(jobs, key=lambda j: j.modified, reverse=order_desc)[start : start + page_length]
+		return sorted(jobs, key=lambda j: j.modified, reverse=order_desc)
 
 	@staticmethod
-	def get_matching_job_ids(args):
+	def get_matching_job_ids(args) -> list[str]:
 		filters = make_filter_dict(args.get("filters"))
 
 		queues = _eval_filters(filters.get("queue"), QUEUES)
@@ -92,7 +84,7 @@ class RQJob(Document):
 			for status in statuses:
 				matched_job_ids.extend(fetch_job_ids(queue, status))
 
-		return matched_job_ids
+		return filter_current_site_jobs(matched_job_ids)
 
 	@check_permissions
 	def delete(self):
@@ -155,6 +147,12 @@ def for_current_site(job: Job) -> bool:
 	return job.kwargs.get("site") == frappe.local.site
 
 
+def filter_current_site_jobs(job_ids: list[str]) -> list[str]:
+	site = frappe.local.site
+
+	return [j for j in job_ids if j.startswith(site)]
+
+
 def _eval_filters(filter, values: list[str]) -> list[str]:
 	if filter:
 		operator, operand = filter
@@ -186,10 +184,13 @@ def remove_failed_jobs():
 	frappe.only_for("System Manager")
 	for queue in get_queues():
 		fail_registry = queue.failed_job_registry
-		for job_ids in create_batch(fail_registry.get_job_ids(), 100):
-			for job in Job.fetch_many(job_ids=job_ids, connection=get_redis_conn()):
-				if job and for_current_site(job):
-					fail_registry.remove(job, delete_job=True)
+		failed_jobs = filter_current_site_jobs(fail_registry.get_job_ids())
+
+		# Delete in batches to avoid loading too many things in memory
+		conn = get_redis_conn()
+		for job_ids in create_batch(failed_jobs, 100):
+			for job in Job.fetch_many(job_ids=job_ids, connection=conn):
+				job and fail_registry.remove(job, delete_job=True)
 
 
 def get_all_queued_jobs():

--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -99,8 +99,7 @@ class RQJob(Document):
 
 	@staticmethod
 	def get_count(args) -> int:
-		# Can not be implemented efficiently due to site filtering hence ignored.
-		return 0
+		return len(RQJob.get_matching_job_ids(args))
 
 	# None of these methods apply to virtual job doctype, overriden for sanity.
 	@staticmethod

--- a/frappe/core/doctype/rq_job/rq_job_list.js
+++ b/frappe/core/doctype/rq_job/rq_job_list.js
@@ -15,7 +15,6 @@ frappe.listview_settings["RQ Job"] = {
 		);
 
 		if (listview.list_view_settings) {
-			listview.list_view_settings.disable_count = 1;
 			listview.list_view_settings.disable_sidebar_stats = 1;
 		}
 
@@ -57,6 +56,6 @@ frappe.listview_settings["RQ Job"] = {
 			}
 
 			listview.refresh();
-		}, 5000);
+		}, 15000);
 	},
 };

--- a/frappe/tests/test_background_jobs.py
+++ b/frappe/tests/test_background_jobs.py
@@ -10,6 +10,7 @@ from frappe.tests.utils import FrappeTestCase
 from frappe.utils.background_jobs import (
 	RQ_JOB_FAILURE_TTL,
 	RQ_RESULTS_TTL,
+	create_job_id,
 	execute_job,
 	generate_qname,
 	get_redis_conn,
@@ -54,11 +55,12 @@ class TestBackgroundJobs(FrappeTestCase):
 
 	def test_enqueue_call(self):
 		with patch.object(Queue, "enqueue_call") as mock_enqueue_call:
-			frappe.enqueue(
+			job = frappe.enqueue(
 				"frappe.handler.ping",
 				queue="short",
 				timeout=300,
 				kwargs={"site": frappe.local.site},
+				job_id="test",
 			)
 
 			mock_enqueue_call.assert_called_once_with(
@@ -78,7 +80,7 @@ class TestBackgroundJobs(FrappeTestCase):
 				at_front=False,
 				failure_ttl=RQ_JOB_FAILURE_TTL,
 				result_ttl=RQ_RESULTS_TTL,
-				job_id=None,
+				job_id=create_job_id("test"),
 			)
 
 	def test_job_hooks(self):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -66,6 +66,7 @@ def enqueue(
 	on_failure: Callable = None,
 	at_front: bool = False,
 	job_id: str = None,
+	deduplicate=False,
 	**kwargs,
 ) -> Job | Any:
 	"""
@@ -79,10 +80,25 @@ def enqueue(
 	:param job_name: [DEPRECATED] can be used to name an enqueue call, which can be used to prevent duplicate calls
 	:param now: if now=True, the method is executed via frappe.call
 	:param kwargs: keyword arguments to be passed to the method
+	:param deduplicate: do not re-queue job if it's already queued, requires job_id.
 	:param job_id: Assigning unique job id, which can be checked using `is_job_enqueued`
 	"""
 	# To handle older implementations
 	is_async = kwargs.pop("async", is_async)
+
+	if deduplicate:
+		if not job_id:
+			frappe.throw(_("`job_id` paramater is required for deduplication."))
+		job = get_job(job_id)
+		if job and job.get_status() in (JobStatus.QUEUED, JobStatus.STARTED):
+			frappe.logger().debug(f"Not queueing job {job.id} because it is in queue already")
+			return
+		elif job:
+			# delete job to avoid argument issues related to job args
+			# https://github.com/rq/rq/issues/793
+			job.delete()
+
+		# If job exists and is completed then delete it before re-queue
 
 	# namespace job ids to sites
 	job_id = create_job_id(job_id)
@@ -492,9 +508,13 @@ def is_job_enqueued(job_id: str) -> bool:
 
 def get_job_status(job_id: str) -> JobStatus | None:
 	"""Get RQ job status, returns None if job is not found."""
+	job = get_job(job_id)
+	if job:
+		return job.get_status()
+
+
+def get_job(job_id: str) -> Job:
 	try:
-		job = Job.fetch(create_job_id(job_id), connection=get_redis_conn())
+		return Job.fetch(create_job_id(job_id), connection=get_redis_conn())
 	except NoSuchJobError:
 		return None
-
-	return job.get_status()

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -84,9 +84,8 @@ def enqueue(
 	# To handle older implementations
 	is_async = kwargs.pop("async", is_async)
 
-	if job_id:
-		# namespace job ids to sites
-		job_id = create_job_id(job_id)
+	# namespace job ids to sites
+	job_id = create_job_id(job_id)
 
 	if job_name:
 		deprecation_warning("Using enqueue with `job_name` is deprecated, use `job_id` instead.")
@@ -481,6 +480,9 @@ def test_job(s):
 
 def create_job_id(job_id: str) -> str:
 	"""Generate unique job id for deduplication"""
+
+	if not job_id:
+		job_id = str(uuid4())
 	return f"{frappe.local.site}::{job_id}"
 
 

--- a/frappe/utils/doctor.py
+++ b/frappe/utils/doctor.py
@@ -79,6 +79,15 @@ def get_pending_jobs(site=None):
 	return jobs_per_queue
 
 
+def any_job_pending(site: str) -> bool:
+	for queue in get_queue_list():
+		q = get_queue(queue)
+		for job_id in q.get_job_ids():
+			if job_id.startswith(site):
+				return True
+	return False
+
+
 def check_number_of_workers():
 	return len(get_workers())
 


### PR DESCRIPTION
All RQ jobs have uuid4 as job id, this was rarely dependent by anyone.

If RQ job ids themselves can be namespaced then filtering jobs and ACL becomes much much simpler. This PR just adds site name to all job ids to simplify it.

Further changes
- `deduplicate` param added to `frappe.enqueue` to implement a sane version of deduplication that's O(1), don't use `job_name` ever now.
- RQ Job list view now loads much faster on multi-tenant sites. Doesn't hog resources if queue size has grown a lot.
- Count can now be implemented on RQ jobs as fetching job ids is not that expensive.
- Email queue deduplication is now O(1) instead O(jobs queued)
- `ready_for_migration` command now doesn't fetch all jobs in queues and just checks if there's even 1 queued job in queues. Much faster and less likely to blow up memory with large queues.  
