### PR TITLE
fix: correct condition check for dynamic filters

### DIFF
--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -203,9 +203,11 @@ frappe.dashboard_utils = {
 
 	get_all_filters(doc) {
 		let filters = doc.filters_json ? JSON.parse(doc.filters_json) : null;
-		let dynamic_filters = doc.dynamic_filters_json ? JSON.parse(doc.dynamic_filters_json) : [];
+		let dynamic_filters = doc.dynamic_filters_json
+			? JSON.parse(doc.dynamic_filters_json)
+			: null;
 
-		if (!Object.keys(dynamic_filters).length) {
+		if (!dynamic_filters || !Object.keys(dynamic_filters).length) {
 			return filters;
 		}
 

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -202,14 +202,14 @@ frappe.dashboard_utils = {
 	},
 
 	get_all_filters(doc) {
-		let filters = doc.filters_json ? JSON.parse(doc.filters_json) : [];
+		let filters = doc.filters_json ? JSON.parse(doc.filters_json) : null;
 		let dynamic_filters = doc.dynamic_filters_json ? JSON.parse(doc.dynamic_filters_json) : [];
 
 		if (!Object.keys(dynamic_filters).length) {
 			return filters;
 		}
 
-		if ($.isArray(dynamic_filters)) {
+		if (Array.isArray(dynamic_filters)) {
 			dynamic_filters.forEach((f) => {
 				try {
 					f[3] = eval(f[3]);

--- a/frappe/public/js/frappe/utils/dashboard_utils.js
+++ b/frappe/public/js/frappe/utils/dashboard_utils.js
@@ -202,10 +202,10 @@ frappe.dashboard_utils = {
 	},
 
 	get_all_filters(doc) {
-		let filters = JSON.parse(doc.filters_json || "null");
-		let dynamic_filters = JSON.parse(doc.dynamic_filters_json || "null");
+		let filters = doc.filters_json ? JSON.parse(doc.filters_json) : [];
+		let dynamic_filters = doc.dynamic_filters_json ? JSON.parse(doc.dynamic_filters_json) : [];
 
-		if (!dynamic_filters) {
+		if (!Object.keys(dynamic_filters).length) {
 			return filters;
 		}
 


### PR DESCRIPTION
Fixes the following error:

```
Uncaught (in promise) TypeError: filters is not iterable at line 220
```

filters are objects in some cases and arrays in other cases.

### Issue

`dynamic_filters_json` can be an empty array.
https://github.com/frappe/frappe/blob/develop/frappe/desk/doctype/dashboard_chart/dashboard_chart.js#L122

### Resolution

return if the length is zero