### PR TITLE
refactor!: Drop support for currentsite.txt

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -700,9 +700,12 @@ def _use(site, sites_path="."):
 
 
 def use(site, sites_path="."):
+	from frappe.installer import update_site_config
+
 	if os.path.exists(os.path.join(sites_path, site)):
-		with open(os.path.join(sites_path, "currentsite.txt"), "w") as sitefile:
-			sitefile.write(site)
+		sites_path = os.getcwd()
+		conifg = os.path.join(sites_path, "common_site_config.json")
+		update_site_config("default_site", site, validate=False, site_config_path=conifg)
 		print(f"Current Site set to {site}")
 	else:
 		print(f"Site {site} does not exist")

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -4,6 +4,7 @@ import os
 import traceback
 import warnings
 from pathlib import Path
+from textwrap import dedent
 
 import click
 
@@ -54,6 +55,17 @@ def get_sites(site_arg: str) -> list[str]:
 		return [os.environ.get("FRAPPE_SITE")]
 	elif default_site := frappe.get_conf().default_site:
 		return [default_site]
+	# This is not supported, just added here for warning.
+	elif (site := frappe.read_file("currentsite.txt")) and site.strip():
+		click.secho(
+			dedent(
+				f"""
+			WARNING: currentsite.txt is not supported anymore for setting default site. Use following command to set it as default site.
+			$ bench use {site}"""
+			),
+			fg="red",
+		)
+
 	return []
 
 

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -52,10 +52,8 @@ def get_sites(site_arg: str) -> list[str]:
 		return [site_arg]
 	elif os.environ.get("FRAPPE_SITE"):
 		return [os.environ.get("FRAPPE_SITE")]
-	elif os.path.exists("currentsite.txt"):
-		with open("currentsite.txt") as f:
-			if site := f.read().strip():
-				return [site]
+	elif default_site := frappe.get_conf().default_site:
+		return [default_site]
 	return []
 
 

--- a/node_utils.js
+++ b/node_utils.js
@@ -31,10 +31,6 @@ function get_conf() {
 	if (process.env.FRAPPE_SITE) {
 		conf.default_site = process.env.FRAPPE_SITE;
 	}
-	if (fs.existsSync("sites/currentsite.txt")) {
-		conf.default_site = fs.readFileSync("sites/currentsite.txt").toString().trim();
-	}
-
 	return conf;
 }
 


### PR DESCRIPTION
This is confusing and can be easily merged with `common_site_config.json` so moved it to common conf. 

- `bench use` will continue to work.
- Instead of txt file use common_site_config to set default site using `default_site` key.
- `FRAPPE_SITE` environment variable also works

You'll get a nice warning and way to migrate if you were using this. 
```
λ bench console

WARNING: currentsite.txt is not supported anymore for setting default site. Use following command to set it as default site.
$ bench use frappe.cloud

Please specify --site sitename
```

TODO:
- [x] migration guide
- [x] docs