### PR TITLE
fix: support timespan filters for custom dashboard chart source

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -48,7 +48,6 @@ frappe.ui.form.on("Dashboard Chart", {
 		frm.set_df_property("dynamic_filters_section", "hidden", 1);
 
 		frm.trigger("set_parent_document_type");
-		frm.trigger("set_time_series");
 		frm.set_query("document_type", function () {
 			return {
 				filters: {

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -48,6 +48,7 @@ frappe.ui.form.on("Dashboard Chart", {
 		frm.set_df_property("dynamic_filters_section", "hidden", 1);
 
 		frm.trigger("set_parent_document_type");
+		frm.trigger("set_time_series");
 		frm.set_query("document_type", function () {
 			return {
 				filters: {
@@ -106,6 +107,8 @@ frappe.ui.form.on("Dashboard Chart", {
 		// set timeseries based on chart type
 		if (["Count", "Average", "Sum"].includes(frm.doc.chart_type)) {
 			frm.set_value("timeseries", 1);
+		} else if (frm.doc.chart_type == "Custom") {
+			return;
 		} else {
 			frm.set_value("timeseries", 0);
 		}

--- a/frappe/public/js/frappe/widgets/chart_widget.js
+++ b/frappe/public/js/frappe/widgets/chart_widget.js
@@ -103,7 +103,7 @@ export default class ChartWidget extends Widget {
 				this.action_area.empty();
 				this.prepare_chart_actions();
 
-				if (this.chart_doc.timeseries && this.chart_doc.chart_type !== "Custom") {
+				if (this.chart_doc.timeseries) {
 					this.render_time_series_filters();
 				}
 			}


### PR DESCRIPTION
## Feature Support Added

Support the following filters in a custom dashboard chart:

![image](https://github.com/frappe/frappe/assets/10496564/62e49bef-38d9-48d0-a28e-3a28ee450387)

This is already supported in most cases, just somehow not allowed for custom charts.

eg usages:
1. [ERPNext Report](https://github.com/frappe/erpnext/blob/develop/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py#L22)
2. [Fetch time series in Custom Dashboard Chart from Source](https://github.com/frappe/frappe/blob/develop/frappe/desk/doctype/dashboard_chart/dashboard_chart.js#L9)

## Issues Fixed

- Don't reset the time series on refresh
- Allow time-series in chart wizard even for custom dashboard chart if configured.