### PR TITLE
fix: duplicate email pull hook

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -209,7 +209,6 @@ scheduler_events = {
 	},
 	"all": [
 		"frappe.email.queue.flush",
-		"frappe.email.doctype.email_account.email_account.pull",
 		"frappe.email.doctype.email_account.email_account.notify_unreplied",
 		"frappe.utils.global_search.sync_global_search",
 		"frappe.monitor.flush",


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/our/frappe-bench/apps/frappe/frappe/model/base_document.py", line 502, in db_insert
    frappe.db.sql(
  File "/home/our/frappe-bench/apps/frappe/frappe/database/database.py", line 219, in sql
    self._cursor.execute(query, values)
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 158, in execute
    result = self._query(query)
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 325, in _query
    conn.query(q)
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 549, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 779, in _read_query_result
    result.read()
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 1157, in read
    first_packet = self.connection._read_packet()
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 729, in _read_packet
    packet.raise_for_error()
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.IntegrityError: (1062, "Duplicate entry 'email_account.pull' for key 'PRIMARY'")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/our/frappe-bench/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 209, in insert_single_event
    doc.insert()
  File "/home/our/frappe-bench/apps/frappe/frappe/model/document.py", line 270, in insert
    self.db_insert(ignore_if_duplicate=ignore_if_duplicate)
  File "/home/our/frappe-bench/apps/frappe/frappe/model/base_document.py", line 529, in db_insert
    raise frappe.DuplicateEntryError(self.doctype, self.name, e)
frappe.exceptions.DuplicateEntryError: ('Scheduled Job Type', 'email_account.pull', IntegrityError(1062, "Duplicate entry 'email_account.pull' for key 'PRIMARY'"))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/redis/connection.py", line 559, in connect
    sock = self._connect()
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/redis/connection.py", line 615, in _connect
    raise err
  File "/home/our/frappe-bench/env/lib/python3.10/site-packages/redis/connection.py", line 603, in _connect
    sock.connect(socket_address)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

```