### PR TITLE
fix!: Change scheduled job type naming to hash

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -14,9 +14,6 @@ from frappe.utils.background_jobs import enqueue, is_job_enqueued
 
 
 class ScheduledJobType(Document):
-	def autoname(self):
-		self.name = ".".join(self.method.split(".")[-2:])
-
 	def validate(self):
 		if self.frequency != "All":
 			# force logging for all events other than continuous ones (ALL)


### PR DESCRIPTION
- This naming is prone to colission between apps
- This naming also doesn't allow using same method in multiple hooks.

root cause of problems like https://github.com/frappe/frappe/pull/21539



Possible problems: linking between jobs will be lost when they are modified. (Not that serious? it's just logs)