### PR TITLE
refactor: improve prepared report reporting

### DIFF
--- a/cypress/integration/socket_updates.js
+++ b/cypress/integration/socket_updates.js
@@ -65,6 +65,13 @@ context("Realtime updates", () => {
 			cy.get("@callback").should("be.called");
 		});
 	});
+
+	it("Progress bar", { scrollBehavior: false }, () => {
+		const title = "RealTime Progress";
+		cy.call("frappe.tests.ui_test_helpers.publish_progress", { title }).then(() => {
+			cy.contains(title).should("be.visible");
+		});
+	});
 });
 
 function publish_realtime(args) {

--- a/frappe/core/doctype/prepared_report/prepared_report.json
+++ b/frappe/core/doctype/prepared_report/prepared_report.json
@@ -35,7 +35,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Status",
-   "options": "Error\nQueued\nCompleted",
+   "options": "Error\nQueued\nCompleted\nStarted",
    "read_only": 1
   },
   {
@@ -104,7 +104,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2023-05-19 15:41:03.428589",
+ "modified": "2023-07-01 17:18:40.183106",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Prepared Report",

--- a/frappe/core/doctype/prepared_report/prepared_report.json
+++ b/frappe/core/doctype/prepared_report/prepared_report.json
@@ -25,7 +25,8 @@
    "fieldtype": "Data",
    "label": "Report Name",
    "read_only": 1,
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "default": "Queued",
@@ -36,7 +37,8 @@
    "in_standard_filter": 1,
    "label": "Status",
    "options": "Error\nQueued\nCompleted\nStarted",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_4",
@@ -104,7 +106,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2023-07-01 17:18:40.183106",
+ "modified": "2023-07-01 18:29:12.700239",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Prepared Report",

--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -13,8 +13,12 @@ from frappe.desk.form.load import get_attachments
 from frappe.desk.query_report import generate_report_result
 from frappe.model.document import Document
 from frappe.monitor import add_data_to_monitor
-from frappe.utils import gzip_compress, gzip_decompress
+from frappe.utils import add_to_date, gzip_compress, gzip_decompress, now
 from frappe.utils.background_jobs import enqueue
+
+# If prepared report runs for longer than this time it's automatically considered as failed
+FAILURE_THRESHOLD = 60 * 60
+REPORT_TIMEOUT = 25 * 60
 
 
 class PreparedReport(Document):
@@ -53,7 +57,7 @@ class PreparedReport(Document):
 			generate_report,
 			queue="long",
 			prepared_report=self.name,
-			timeout=1500,
+			timeout=REPORT_TIMEOUT,
 			enqueue_after_commit=True,
 		)
 
@@ -168,6 +172,21 @@ def get_completed_prepared_report(filters, user, report_name):
 			"owner": user,
 			"report_name": report_name,
 		},
+	)
+
+
+def expire_stalled_report():
+	frappe.db.set_value(
+		"Prepared Report",
+		{
+			"status": "Started",
+			"modified": ("<", add_to_date(now(), seconds=-FAILURE_THRESHOLD, as_datetime=True)),
+		},
+		{
+			"status": "Failed",
+			"error_message": frappe._("Report timed out."),
+		},
+		update_modified=False,
 	)
 
 

--- a/frappe/core/doctype/prepared_report/test_prepared_report.py
+++ b/frappe/core/doctype/prepared_report/test_prepared_report.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import json
 import time
+from contextlib import contextmanager
 
 import frappe
 from frappe.desk.query_report import generate_report_result, get_report_doc
@@ -17,7 +18,7 @@ class TestPreparedReport(FrappeTestCase):
 		frappe.db.commit()
 
 	@timeout(seconds=20)
-	def wait_for_completion(self, report, status="Completed"):
+	def wait_for_status(self, report, status):
 		frappe.db.commit()  # Flush changes first
 		while True:
 			frappe.db.rollback()  # read new data
@@ -27,11 +28,11 @@ class TestPreparedReport(FrappeTestCase):
 			# Cheap blocking behaviour
 			time.sleep(0.5)
 
-	def create_prepared_report(self, commit=True):
+	def create_prepared_report(self, report=None, commit=True):
 		doc = frappe.get_doc(
 			{
 				"doctype": "Prepared Report",
-				"report_name": "Database Storage Usage By Tables",
+				"report_name": report or "Database Storage Usage By Tables",
 			}
 		).insert()
 
@@ -45,7 +46,7 @@ class TestPreparedReport(FrappeTestCase):
 		self.assertEqual("Queued", doc.status)
 		self.assertTrue(doc.queued_at)
 
-		self.wait_for_completion(doc)
+		self.wait_for_status(doc, "Completed")
 
 		doc = frappe.get_last_doc("Prepared Report")
 		self.assertTrue(doc.job_id)
@@ -53,10 +54,33 @@ class TestPreparedReport(FrappeTestCase):
 
 	def test_prepared_data(self):
 		doc = self.create_prepared_report()
-		self.wait_for_completion(doc)
+		self.wait_for_status(doc, "Completed")
 
 		prepared_data = json.loads(doc.get_prepared_data().decode("utf-8"))
 		generated_data = generate_report_result(get_report_doc("Database Storage Usage By Tables"))
 		self.assertEqual(len(prepared_data["columns"]), len(generated_data["columns"]))
 		self.assertEqual(len(prepared_data["result"]), len(generated_data["result"]))
 		self.assertEqual(len(prepared_data), len(generated_data))
+
+	def test_start_status(self):
+		if frappe.db.db_type == "postgres":
+			return
+
+		with test_report(report_type="Query Report", query="select sleep(5)") as report:
+			doc = self.create_prepared_report(report.name)
+			self.wait_for_status(doc, "Started")
+
+
+@contextmanager
+def test_report(**args):
+	try:
+		report = frappe.new_doc("Report")
+		report.update(args)
+		if not report.report_name:
+			report.report_name = frappe.generate_hash()
+		if not report.ref_doctype:
+			report.ref_doctype = "ToDo"
+		report.insert()
+		yield report
+	finally:
+		report.delete()

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -49,6 +49,10 @@ class Report(Document):
 	def on_update(self):
 		self.export_doc()
 
+	def before_export(self):
+		self.letterhead = None
+		self.prepared_report = 0
+
 	def on_trash(self):
 		if (
 			self.is_standard == "Yes"

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -121,7 +121,7 @@ class Report(Document):
 
 	def execute_script_report(self, filters):
 		# save the timestamp to automatically set to prepared
-		threshold = 30
+		threshold = 15
 		res = []
 
 		start_time = datetime.datetime.now()

--- a/frappe/core/report/database_storage_usage_by_tables/database_storage_usage_by_tables.json
+++ b/frappe/core/report/database_storage_usage_by_tables/database_storage_usage_by_tables.json
@@ -9,7 +9,6 @@
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "abc",
  "modified": "2022-10-19 02:59:00.365307",
  "modified_by": "Administrator",
  "module": "Core",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -196,9 +196,9 @@ scheduler_events = {
 			"frappe.email.doctype.email_account.email_account.pull",
 		],
 		# Hourly but offset by 30 minutes
-		# "30 * * * *": [
-		#
-		# ],
+		"30 * * * *": [
+			"frappe.core.doctype.prepared_report.prepared_report.expire_stalled_report",
+		],
 		# Daily but offset by 45 minutes
 		"45 0 * * *": [
 			"frappe.core.doctype.log_settings.log_settings.run_log_clean_up",

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -642,3 +642,19 @@ def publish_realtime(
 		docname=docname,
 		task_id=task_id,
 	)
+
+
+@whitelist_for_tests
+def publish_progress(duration=3, title=None, doctype=None, docname=None):
+	# This should consider session user and only show it to current user.
+	frappe.enqueue(slow_task, duration=duration, title=title, doctype=doctype, docname=docname)
+
+
+def slow_task(duration, title, doctype, docname):
+	import time
+
+	steps = 10
+
+	for i in range(steps + 1):
+		frappe.publish_progress(i * 10, title=title, doctype=doctype, docname=docname)
+		time.sleep(int(duration) / steps)


### PR DESCRIPTION
- Reduced prepared report threshold to send things to background more aggressively.
- Removed "prepared_report" and letterhead during exporting of reports. Developers' preference shouldn't be exported in code.
- Added "Started" status which gets updated when report is started.
- On deletion of prepared report automatically kill running report job, if any.
- Expire all reports that fail to complete in 1 hour
- Unrelated socketio test that I forgot to put in previous PR

