### PR TITLE
fix(UX): guess country on setup wizard

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -349,8 +349,6 @@ class CookieManager:
 		expires = datetime.datetime.now() + datetime.timedelta(days=3)
 		if frappe.session.sid:
 			self.set_cookie("sid", frappe.session.sid, expires=expires, httponly=True)
-		if frappe.session.session_country:
-			self.set_cookie("country", frappe.session.session_country)
 
 	def set_cookie(self, key, value, expires=None, secure=False, httponly=False, samesite="Lax"):
 		if not secure and hasattr(frappe.local, "request"):

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -545,15 +545,19 @@ frappe.setup.utils = {
 
 		slide.get_input("timezone").empty().add_options(data.all_timezones);
 
-		// set values if present
-		if (frappe.wizard.values.country) {
-			country_field.set_input(frappe.wizard.values.country);
-		} else if (data.default_country) {
-			country_field.set_input(data.default_country);
-		}
-
 		slide.get_field("currency").set_input(frappe.wizard.values.currency);
 		slide.get_field("timezone").set_input(frappe.wizard.values.timezone);
+
+		// set values if present
+		let country =
+			frappe.wizard.values.country ||
+			data.default_country ||
+			guess_country(frappe.setup.data.regional_data.country_info);
+
+		if (country) {
+			country_field.set_input(country);
+			$(country_field.input).change();
+		}
 	},
 
 	bind_language_events: function (slide) {
@@ -630,3 +634,16 @@ frappe.setup.utils = {
 		});
 	},
 };
+
+function guess_country(country_info) {
+	try {
+		const system_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+		for ([country, info] of Object.entries(country_info)) {
+			let possible_timezones = (info.timezones || []).filter((t) => t == system_timezone);
+			if (possible_timezones.length) return country;
+		}
+	} catch (e) {
+		console.log("Could not guess country", e);
+	}
+}

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -236,9 +236,6 @@ class Session:
 					"session_expiry": get_expiry_period(),
 					"full_name": self.full_name,
 					"user_type": self.user_type,
-					"session_country": get_geo_ip_country(frappe.local.request_ip)
-					if frappe.local.request_ip
-					else None,
 				}
 			)
 


### PR DESCRIPTION
Works in most popular countries with unique timezone. 

This just uses the browser's timezone, so not really reliable.

Alternates considered:
- geoip service - too much, network call to 3rd party.
- geolocation API - requires permission and we don't need pinpoint location so eh. 