### PR TITLE
perf: preload more modules

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -33,14 +33,17 @@ _sites_path = os.environ.get("SITES_PATH", ".")
 
 # If gc.freeze is done then importing modules before forking allows us to share the memory
 if frappe._tune_gc:
+	import bleach
 	import pydantic
 
 	import frappe.boot
 	import frappe.client
+	import frappe.core.doctype.file.file
 	import frappe.core.doctype.user.user
 	import frappe.database.mariadb.database  # Load database related utils
 	import frappe.database.query
 	import frappe.desk.desktop  # workspace
+	import frappe.desk.form.save
 	import frappe.model.db_query
 	import frappe.query_builder
 	import frappe.utils.background_jobs  # Enqueue is very common

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -74,6 +74,9 @@ class TestPerformance(FrappeTestCase):
 	def test_get_value_limits(self):
 		# check both dict and list style filters
 		filters = [{"enabled": 1}, [["enabled", "=", 1]]]
+
+		# Warm up code
+		frappe.db.get_values("User", filters=filters[0], limit=1)
 		for filter in filters:
 			with self.assertRowsRead(1):
 				self.assertEqual(1, len(frappe.db.get_values("User", filters=filter, limit=1)))


### PR DESCRIPTION
- bleach is used frequently for sanitization
- File gets imported anytime a private file is viewed. Indirect import
  of PIL is costly in each worker.
- save is very common operation and triggers indirect imports which are costly.


continues https://github.com/frappe/frappe/pull/21467 