### PR TITLE
test: cleanup some tests

### DIFF
--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -176,18 +176,13 @@ class BaseTestCommands(FrappeTestCase):
 
 	@classmethod
 	def setup_test_site(cls):
-		cmd_config = {
-			"test_site": TEST_SITE,
-			"admin_password": frappe.conf.admin_password,
-			"root_login": frappe.conf.root_login,
-			"root_password": frappe.conf.root_password,
-			"db_type": frappe.conf.db_type,
-		}
-
 		if not os.path.exists(os.path.join(TEST_SITE, "site_config.json")):
 			cls.execute(
-				"bench new-site {test_site} --admin-password {admin_password} --db-type" " {db_type}",
-				cmd_config,
+				f"bench new-site {TEST_SITE} "
+				f"--admin-password {frappe.conf.admin_password} "
+				f"--db-root-username {frappe.conf.root_login} "
+				f"--db-root-password {frappe.conf.root_password} "
+				f"--db-type {frappe.conf.db_type}",
 			)
 
 	def _formatMessage(self, msg, standardMsg):
@@ -441,12 +436,17 @@ class TestCommands(BaseTestCommands):
 		self.execute(
 			f"bench new-site {site} --force --verbose "
 			f"--admin-password {frappe.conf.admin_password} "
+			f"--mariadb-root-username {frappe.conf.root_login} "
 			f"--mariadb-root-password {frappe.conf.root_password} "
 			f"--db-type {frappe.conf.db_type or 'mariadb'} "
 		)
 		self.assertEqual(self.returncode, 0)
 
-		self.execute(f"bench drop-site {site} --force --root-password {frappe.conf.root_password}")
+		self.execute(
+			f"bench drop-site {site} --force "
+			f"--root-login {frappe.conf.root_login} "
+			f"--root-password {frappe.conf.root_password}"
+		)
 		self.assertEqual(self.returncode, 0)
 
 		bench_path = get_bench_path()
@@ -466,6 +466,7 @@ class TestCommands(BaseTestCommands):
 			self.execute(
 				f"bench new-site {TEST_SITE} --verbose "
 				f"--admin-password {frappe.conf.admin_password} "
+				f"--mariadb-root-username {frappe.conf.root_login} "
 				f"--mariadb-root-password {frappe.conf.root_password} "
 				f"--db-type {frappe.conf.db_type or 'mariadb'} "
 			)

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -423,6 +423,21 @@ class TestCommands(BaseTestCommands):
 		self.assertEqual(self.returncode, 0)
 		self.assertEqual(check_password("Administrator", original_password), "Administrator")
 
+	def test_root_login_defaults(self):
+		self.execute(
+			"bench new-site {site} --force --verbose " f"--admin-password {frappe.conf.admin_password} "
+			# # defaults we'll test:
+			# #  - root_login is set and defaulted from `frappe.conf`
+			# f"--mariadb-root-username {frappe.conf.root_login} "
+			# #  - root_password is set and defaulted from `frappe.conf`
+			# f"--mariadb-root-password {frappe.conf.root_password} "
+			# #  - only specify if it's not the default we want to test
+			f"--db-type {frappe.conf.db_type} "
+			if frappe.conf.db_type != "mariadb"
+			else ""
+		)
+		self.assertEqual(self.returncode, 0)
+
 	@skipIf(
 		not (
 			frappe.conf.root_password and frappe.conf.admin_password and frappe.conf.db_type == "mariadb"


### PR DESCRIPTION
- tests: fully spec command invokations for test commands
- tests: add dedicated unit tests to assert the defaulting heuristics

---
This PR makes 'unit' tests test the 'unit' and not something else (i.e. defaulting heuristics).

I have an idea for some default heuristic cleanups, but first it is worth establishing a test case baseline for it. :smile: 
