### PR TITLE
load defaults at the entrypoint

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -54,6 +54,7 @@ fi
 
 echo "Starting Bench..."
 
+bench use test_site
 bench start &> ~/frappe-bench/bench_start.log &
 
 if [ "$TYPE" == "server" ]

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -318,7 +318,7 @@ def get_site_config(sites_path: str | None = None, site_path: str | None = None)
 				click.secho(f"{local.site}/site_config.json is invalid", fg="red")
 				print(error)
 		elif local.site and not local.flags.new_site:
-			raise IncorrectSitePath(f"{local.site} does not exist")
+			raise IncorrectSitePath(local.site, f"Site {local.site} does not exist!")
 
 	return _dict(config)
 

--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -3,174 +3,130 @@ import sys
 import click
 
 import frappe
-from frappe.commands import get_site, pass_context
+from frappe.commands import profile, with_each_site, with_site
 from frappe.exceptions import SiteNotSpecifiedError
 
 
 @click.command("trigger-scheduler-event", help="Trigger a scheduler event")
 @click.argument("event")
-@pass_context
-def trigger_scheduler_event(context, event):
+@profile
+@with_each_site(lambda d: sys.exit(d.exit_code), {"exit_code": 0})
+def trigger_scheduler_event(site, context, event, exit_code):
 	import frappe.utils.scheduler
 
-	exit_code = 0
+	frappe.connect()
+	try:
+		frappe.get_doc("Scheduled Job Type", {"method": event}).execute()
+	except frappe.DoesNotExistError:
+		click.secho(f"Event {event} does not exist!", fg="red")
+		exit_code = 1
 
-	for site in context.sites:
-		try:
-			frappe.init(site=site)
-			frappe.connect()
-			try:
-				frappe.get_doc("Scheduled Job Type", {"method": event}).execute()
-			except frappe.DoesNotExistError:
-				click.secho(f"Event {event} does not exist!", fg="red")
-				exit_code = 1
-		finally:
-			frappe.destroy()
-
-	if not context.sites:
-		raise SiteNotSpecifiedError
-
-	sys.exit(exit_code)
+	return {"exit_code": exit_code}
 
 
 @click.command("enable-scheduler")
-@pass_context
-def enable_scheduler(context):
+@profile
+@with_each_site()
+def enable_scheduler(site, context):
 	"Enable scheduler"
 	import frappe.utils.scheduler
 
-	for site in context.sites:
-		try:
-			frappe.init(site=site)
-			frappe.connect()
-			frappe.utils.scheduler.enable_scheduler()
-			frappe.db.commit()
-			print("Enabled for", site)
-		finally:
-			frappe.destroy()
-	if not context.sites:
-		raise SiteNotSpecifiedError
+	frappe.connect()
+	frappe.utils.scheduler.enable_scheduler()
+	frappe.db.commit()
+	print("Enabled for", site)
 
 
 @click.command("disable-scheduler")
-@pass_context
-def disable_scheduler(context):
+@profile
+@with_each_site()
+def disable_scheduler(site, context):
 	"Disable scheduler"
 	import frappe.utils.scheduler
 
-	for site in context.sites:
-		try:
-			frappe.init(site=site)
-			frappe.connect()
-			frappe.utils.scheduler.disable_scheduler()
-			frappe.db.commit()
-			print("Disabled for", site)
-		finally:
-			frappe.destroy()
-	if not context.sites:
-		raise SiteNotSpecifiedError
+	frappe.connect()
+	frappe.utils.scheduler.disable_scheduler()
+	frappe.db.commit()
+	print("Disabled for", site)
 
 
 @click.command("scheduler")
-@click.option("--site", help="site name")
 @click.argument("state", type=click.Choice(["pause", "resume", "disable", "enable", "status"]))
 @click.option(
 	"--format", "-f", default="text", type=click.Choice(["json", "text"]), help="Output format"
 )
 @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
-@pass_context
-def scheduler(context, state: str, format: str, verbose: bool = False, site: str | None = None):
+@profile
+@with_site
+def scheduler(site, context, state: str, format: str, verbose: bool = False):
 	"""Control scheduler state."""
-	import frappe
 	from frappe.utils.scheduler import is_scheduler_inactive, toggle_scheduler
-
-	site = site or get_site(context)
 
 	output = {
 		"text": "Scheduler is {status} for site {site}",
 		"json": '{{"status": "{status}", "site": "{site}"}}',
 	}
+	match state:
+		case "status":
+			frappe.connect()
+			status = "disabled" if is_scheduler_inactive(verbose=verbose) else "enabled"
+			return print(output[format].format(status=status, site=site))
+		case "pause" | "resume":
+			from frappe.installer import update_site_config
 
-	with frappe.init_site(site=site):
-		match state:
-			case "status":
-				frappe.connect()
-				status = "disabled" if is_scheduler_inactive(verbose=verbose) else "enabled"
-				return print(output[format].format(status=status, site=site))
-			case "pause" | "resume":
-				from frappe.installer import update_site_config
+			update_site_config("pause_scheduler", state == "pause")
+		case "enable" | "disable":
+			frappe.connect()
+			toggle_scheduler(state == "enable")
+			frappe.db.commit()
 
-				update_site_config("pause_scheduler", state == "pause")
-			case "enable" | "disable":
-				frappe.connect()
-				toggle_scheduler(state == "enable")
-				frappe.db.commit()
-
-		print(output[format].format(status=f"{state}d", site=site))
+	print(output[format].format(status=f"{state}d", site=site))
 
 
 @click.command("set-maintenance-mode")
-@click.option("--site", help="site name")
 @click.argument("state", type=click.Choice(["on", "off"]))
-@pass_context
-def set_maintenance_mode(context, state, site=None):
+@profile
+@with_site
+def set_maintenance_mode(site, context, state):
 	"""Put the site in maintenance mode for upgrades."""
 	from frappe.installer import update_site_config
 
-	if not site:
-		site = get_site(context)
-
-	try:
-		frappe.init(site=site)
-		update_site_config("maintenance_mode", 1 if (state == "on") else 0)
-
-	finally:
-		frappe.destroy()
+	update_site_config("maintenance_mode", 1 if (state == "on") else 0)
 
 
-@click.command(
-	"doctor"
-)  # Passing context always gets a site and if there is no use site it breaks
-@click.option("--site", help="site name")
-@pass_context
-def doctor(context, site=None):
+@click.command("doctor")
+@profile
+@with_each_site()
+def doctor(site, context):
 	"Get diagnostic info about background workers"
 	from frappe.utils.doctor import doctor as _doctor
 
-	if not site:
-		site = get_site(context, raise_err=False)
-	return _doctor(site=site)
+	_doctor(site=site)
 
 
 @click.command("show-pending-jobs")
-@click.option("--site", help="site name")
-@pass_context
-def show_pending_jobs(context, site=None):
+@profile
+@with_site
+def show_pending_jobs(site, context):
 	"Get diagnostic info about background jobs"
 	from frappe.utils.doctor import pending_jobs as _pending_jobs
 
-	if not site:
-		site = get_site(context)
-
-	with frappe.init_site(site):
-		pending_jobs = _pending_jobs(site=site)
-
-	return pending_jobs
+	return _pending_jobs(site=site)
 
 
 @click.command("purge-jobs")
-@click.option("--site", help="site name")
 @click.option("--queue", default=None, help='one of "low", "default", "high')
 @click.option(
 	"--event",
 	default=None,
 	help='one of "all", "weekly", "monthly", "hourly", "daily", "weekly_long", "daily_long"',
 )
-def purge_jobs(site=None, queue=None, event=None):
+@profile
+@with_site
+def purge_jobs(site, queue=None, event=None):
 	"Purge any pending periodic tasks, if event option is not given, it will purge everything for the site"
 	from frappe.utils.doctor import purge_pending_jobs
 
-	frappe.init(site or "")
 	count = purge_pending_jobs(event=event, site=site, queue=queue)
 	print(f"Purged {count} jobs")
 
@@ -237,28 +193,19 @@ def start_worker_pool(queue, quiet=False, num_workers=2, burst=False):
 
 
 @click.command("ready-for-migration")
-@click.option("--site", help="site name")
-@pass_context
-def ready_for_migration(context, site=None):
+@profile
+@with_site
+def ready_for_migration(site, context):
 	from frappe.utils.doctor import any_job_pending
 
-	if not site:
-		site = get_site(context)
+	pending_jobs = any_job_pending(site=site)
+	if pending_jobs:
+		print(f"NOT READY for migration: site {site} has pending background jobs")
+		sys.exit(1)
 
-	try:
-		frappe.init(site=site)
-		pending_jobs = any_job_pending(site=site)
-
-		if pending_jobs:
-			print(f"NOT READY for migration: site {site} has pending background jobs")
-			sys.exit(1)
-
-		else:
-			print(f"READY for migration: site {site} does not have any background jobs")
-			return 0
-
-	finally:
-		frappe.destroy()
+	else:
+		print(f"READY for migration: site {site} does not have any background jobs")
+		return 0
 
 
 commands = [

--- a/frappe/commands/translate.py
+++ b/frappe/commands/translate.py
@@ -1,40 +1,31 @@
 import click
 
-from frappe.commands import get_site, pass_context
+from frappe.commands import profile, with_each_site, with_site
 from frappe.exceptions import SiteNotSpecifiedError
 
 
 # translation
 @click.command("build-message-files")
-@pass_context
-def build_message_files(context):
+@profile
+@with_each_site()
+def build_message_files(site, context):
 	"Build message files for translation"
 	import frappe.translate
 
-	for site in context.sites:
-		try:
-			frappe.init(site=site)
-			frappe.connect()
-			frappe.translate.rebuild_all_translation_files()
-		finally:
-			frappe.destroy()
-	if not context.sites:
-		raise SiteNotSpecifiedError
+	frappe.connect()
+	frappe.translate.rebuild_all_translation_files()
 
 
 @click.command("new-language")  # , help="Create lang-code.csv for given app")
-@pass_context
 @click.argument("lang_code")  # , help="Language code eg. en")
 @click.argument("app")  # , help="App name eg. frappe")
-def new_language(context, lang_code, app):
+@profile
+@with_site
+def new_language(site, context, lang_code, app):
 	"""Create lang-code.csv for given app"""
 	import frappe.translate
 
-	if not context["sites"]:
-		raise Exception("--site is required")
-
-	# init site
-	frappe.connect(site=context["sites"][0])
+	frappe.connect()
 	frappe.translate.write_translations_file(app, lang_code)
 
 	print(
@@ -52,18 +43,14 @@ def new_language(context, lang_code, app):
 @click.argument("lang")
 @click.argument("untranslated_file")
 @click.option("--all", default=False, is_flag=True, help="Get all message strings")
-@pass_context
-def get_untranslated(context, lang, untranslated_file, app="_ALL_APPS", all=None):
+@profile
+@with_site
+def get_untranslated(site, context, lang, untranslated_file, app="_ALL_APPS", all=None):
 	"Get untranslated strings for language"
 	import frappe.translate
 
-	site = get_site(context)
-	try:
-		frappe.init(site=site)
-		frappe.connect()
-		frappe.translate.get_untranslated(lang, untranslated_file, get_all=all, app=app)
-	finally:
-		frappe.destroy()
+	frappe.connect()
+	frappe.translate.get_untranslated(lang, untranslated_file, get_all=all, app=app)
 
 
 @click.command("update-translations")
@@ -71,52 +58,40 @@ def get_untranslated(context, lang, untranslated_file, app="_ALL_APPS", all=None
 @click.argument("lang")
 @click.argument("untranslated_file")
 @click.argument("translated-file")
-@pass_context
-def update_translations(context, lang, untranslated_file, translated_file, app="_ALL_APPS"):
+@profile
+@with_site
+def update_translations(site, context, lang, untranslated_file, translated_file, app="_ALL_APPS"):
 	"Update translated strings"
 	import frappe.translate
 
-	site = get_site(context)
-	try:
-		frappe.init(site=site)
-		frappe.connect()
-		frappe.translate.update_translations(lang, untranslated_file, translated_file, app=app)
-	finally:
-		frappe.destroy()
+	frappe.connect()
+	frappe.translate.update_translations(lang, untranslated_file, translated_file, app=app)
 
 
 @click.command("import-translations")
 @click.argument("lang")
 @click.argument("path")
-@pass_context
-def import_translations(context, lang, path):
+@profile
+@with_site
+def import_translations(site, context, lang, path):
 	"Update translated strings"
 	import frappe.translate
 
-	site = get_site(context)
-	try:
-		frappe.init(site=site)
-		frappe.connect()
-		frappe.translate.import_translations(lang, path)
-	finally:
-		frappe.destroy()
+	frappe.connect()
+	frappe.translate.import_translations(lang, path)
 
 
 @click.command("migrate-translations")
 @click.argument("source-app")
 @click.argument("target-app")
-@pass_context
-def migrate_translations(context, source_app, target_app):
+@profile
+@with_site
+def migrate_translations(site, context, source_app, target_app):
 	"Migrate target-app-specific translations from source-app to target-app"
 	import frappe.translate
 
-	site = get_site(context)
-	try:
-		frappe.init(site=site)
-		frappe.connect()
-		frappe.translate.migrate_translations(source_app, target_app)
-	finally:
-		frappe.destroy()
+	frappe.connect()
+	frappe.translate.migrate_translations(source_app, target_app)
 
 
 commands = [

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -181,7 +181,9 @@ class AppNotInstalledError(ValidationError):
 
 
 class IncorrectSitePath(NotFound):
-	pass
+	def __init__(self, site, *args, **kwargs):
+		self.site = site
+		super(NotFound, self).__init__(*args, **kwargs)
 
 
 class ImplicitCommitError(ValidationError):

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -176,18 +176,13 @@ class BaseTestCommands(FrappeTestCase):
 
 	@classmethod
 	def setup_test_site(cls):
-		cmd_config = {
-			"test_site": TEST_SITE,
-			"admin_password": frappe.conf.admin_password,
-			"root_login": frappe.conf.root_login,
-			"root_password": frappe.conf.root_password,
-			"db_type": frappe.conf.db_type,
-		}
-
 		if not os.path.exists(os.path.join(TEST_SITE, "site_config.json")):
 			cls.execute(
-				"bench new-site {test_site} --admin-password {admin_password} --db-type" " {db_type}",
-				cmd_config,
+				f"bench new-site {TEST_SITE} "
+				f"--admin-password {frappe.conf.admin_password} "
+				f"--db-root-username {frappe.conf.root_login} "
+				f"--db-root-password {frappe.conf.root_password} "
+				f"--db-type {frappe.conf.db_type}",
 			)
 
 	def _formatMessage(self, msg, standardMsg):
@@ -441,12 +436,17 @@ class TestCommands(BaseTestCommands):
 		self.execute(
 			f"bench new-site {site} --force --verbose "
 			f"--admin-password {frappe.conf.admin_password} "
+			f"--mariadb-root-username {frappe.conf.root_login} "
 			f"--mariadb-root-password {frappe.conf.root_password} "
 			f"--db-type {frappe.conf.db_type or 'mariadb'} "
 		)
 		self.assertEqual(self.returncode, 0)
 
-		self.execute(f"bench drop-site {site} --force --root-password {frappe.conf.root_password}")
+		self.execute(
+			f"bench drop-site {site} --force "
+			f"--root-login {frappe.conf.root_login} "
+			f"--root-password {frappe.conf.root_password}"
+		)
 		self.assertEqual(self.returncode, 0)
 
 		bench_path = get_bench_path()
@@ -466,6 +466,7 @@ class TestCommands(BaseTestCommands):
 			self.execute(
 				f"bench new-site {TEST_SITE} --verbose "
 				f"--admin-password {frappe.conf.admin_password} "
+				f"--mariadb-root-username {frappe.conf.root_login} "
 				f"--mariadb-root-password {frappe.conf.root_password} "
 				f"--db-type {frappe.conf.db_type or 'mariadb'} "
 			)

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -423,6 +423,21 @@ class TestCommands(BaseTestCommands):
 		self.assertEqual(self.returncode, 0)
 		self.assertEqual(check_password("Administrator", original_password), "Administrator")
 
+	def test_root_login_defaults(self):
+		self.execute(
+			"bench new-site {site} --force --verbose " f"--admin-password {frappe.conf.admin_password} "
+			# # defaults we'll test:
+			# #  - root_login is set and defaulted from `frappe.conf`
+			# f"--mariadb-root-username {frappe.conf.root_login} "
+			# #  - root_password is set and defaulted from `frappe.conf`
+			# f"--mariadb-root-password {frappe.conf.root_password} "
+			# #  - only specify if it's not the default we want to test
+			f"--db-type {frappe.conf.db_type} "
+			if frappe.conf.db_type != "mariadb"
+			else ""
+		)
+		self.assertEqual(self.returncode, 0)
+
 	@skipIf(
 		not (
 			frappe.conf.root_password and frappe.conf.admin_password and frappe.conf.db_type == "mariadb"


### PR DESCRIPTION
- test: fully spec command invokations for test commands
- test: add dedicated unit tests to assert the defaulting heuristics
- feat(cli): load default map config values from site config
- refactor(cli): provide a site context manager via cli context
- refactor(cli): use site context manager decorators
