### PR TITLE
feat(DX): load python startup in `bench console`

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -613,9 +613,14 @@ def console(context, autoreload=False):
 	register(_console_cleanup)
 
 	terminal = InteractiveShellEmbed()
+
 	if autoreload:
 		terminal.extension_manager.load_extension("autoreload")
 		terminal.run_line_magic("autoreload", "2")
+
+	python_startup = os.environ.get("PYTHONSTARTUP", False)
+	if python_startup and frappe.conf.developer_mode:
+		terminal.safe_execfile(python_startup, terminal.user_ns, raise_exceptions=True)
 
 	all_apps = frappe.get_installed_apps()
 	failed_to_import = []


### PR DESCRIPTION
Ipython has vast ecosystem of extensions which speeds up workflow. The ones I like quite a bit it are automatic imports and `rich` pretty prints.

Set `PYTHONSTARTUP` in your shell rc file to auto source python startup files.

You can use it to import things, load ipy magics etc. 


Mine:

```python
from contextlib import suppress

with suppress(Exception):
	from IPython import get_ipython

	get_ipython().run_line_magic("load_ext", "ipython_autoimport")

with suppress(Exception):
	from rich import pretty

	pretty.install()

```