### PR TITLE
fix: ignore naming series validation when generating repeated address name

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -27,7 +27,8 @@ class Address(Document):
 			self.name = cstr(self.address_title).strip() + "-" + cstr(_(self.address_type)).strip()
 			if frappe.db.exists("Address", self.name):
 				self.name = make_autoname(
-					cstr(self.address_title).strip() + "-" + cstr(self.address_type).strip() + "-.#"
+					cstr(self.address_title).strip() + "-" + cstr(self.address_type).strip() + "-.#",
+					ignore_validate=True,
 				)
 		else:
 			throw(_("Address Title is mandatory."))

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -64,8 +64,10 @@ class NamingSeries:
 				exc=InvalidNamingSeriesError,
 			)
 
-	def generate_next_name(self, doc: "Document") -> str:
-		self.validate()
+	def generate_next_name(self, doc: "Document", *, ignore_validate=False) -> str:
+		if not ignore_validate:
+			self.validate()
+
 		parts = self.series.split(".")
 		return parse_naming_series(parts, doc=doc)
 
@@ -264,7 +266,7 @@ def set_name_by_naming_series(doc):
 	doc.name = make_autoname(doc.naming_series + ".#####", "", doc)
 
 
-def make_autoname(key="", doctype="", doc=""):
+def make_autoname(key="", doctype="", doc="", *, ignore_validate=False):
 	"""
 	     Creates an autoname from the given key:
 
@@ -286,7 +288,7 @@ def make_autoname(key="", doctype="", doc=""):
 		return frappe.generate_hash(length=10)
 
 	series = NamingSeries(key)
-	return series.generate_next_name(doc)
+	return series.generate_next_name(doc, ignore_validate=ignore_validate)
 
 
 def parse_naming_series(


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/21442

Tested Locally ✅ 

![image](https://github.com/frappe/frappe/assets/16315650/da8a5783-db35-403b-b44b-40dd2ca634a0)
