### PR TITLE
chore: make isort ignore posthog

### DIFF
--- a/frappe/utils/telemetry.py
+++ b/frappe/utils/telemetry.py
@@ -8,7 +8,8 @@ from contextlib import suppress
 import frappe
 from frappe.utils import getdate
 from frappe.utils.caching import site_cache
-from posthog import Posthog
+
+from posthog import Posthog  # isort: skip
 
 POSTHOG_PROJECT_FIELD = "posthog_project_id"
 POSTHOG_HOST_FIELD = "posthog_host"


### PR DESCRIPTION
Looks like this was intended in https://github.com/frappe/frappe/pull/21475 but did not get backported. Should prevent CI failures like this one: https://github.com/frappe/frappe/actions/runs/5444478017/jobs/9902391543?pr=21503