### PR TITLE
fix: gently log the port on which the realtime service listens

### DIFF
--- a/realtime/index.js
+++ b/realtime/index.js
@@ -3,7 +3,7 @@ const { Server } = require("socket.io");
 const { get_conf, get_redis_subscriber } = require("../node_utils");
 const conf = get_conf();
 
-let io = new Server(conf.socketio_port, {
+let io = new Server({
 	cors: {
 		// Should be fine since we are ensuring whether hostname and origin are same before adding setting listeners for s socket
 		origin: true,
@@ -52,3 +52,7 @@ subscriber.on("message", function (_channel, message) {
 
 subscriber.subscribe("events");
 // =======================
+
+let port = conf.socketio_port;
+io.listen(port);
+console.log("Realtime service listening on: ", port);

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -1,13 +1,9 @@
 const { Server } = require("socket.io");
-const http = require("node:http");
 
 const { get_conf, get_redis_subscriber } = require("../node_utils");
 const conf = get_conf();
 
-const server = http.createServer();
-const port = conf.socketio_port;
-
-let io = new Server(server, {
+let io = new Server(conf.socketio_port, {
 	cors: {
 		// Should be fine since we are ensuring whether hostname and origin are same before adding setting listeners for s socket
 		origin: true,
@@ -56,7 +52,3 @@ subscriber.on("message", function (_channel, message) {
 
 subscriber.subscribe("events");
 // =======================
-
-server.listen(port, () => {
-	console.log("Realtime service listening on: ", port);
-});

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -1,9 +1,13 @@
 const { Server } = require("socket.io");
+const http = require("node:http");
 
 const { get_conf, get_redis_subscriber } = require("../node_utils");
 const conf = get_conf();
 
-let io = new Server(conf.socketio_port, {
+const server = http.createServer();
+const port = conf.socketio_port;
+
+let io = new Server(server, {
 	cors: {
 		// Should be fine since we are ensuring whether hostname and origin are same before adding setting listeners for s socket
 		origin: true,
@@ -52,3 +56,7 @@ subscriber.on("message", function (_channel, message) {
 
 subscriber.subscribe("events");
 // =======================
+
+server.listen(port, () => {
+	console.log("Realtime service listening on: ", port);
+});


### PR DESCRIPTION
without this, the service remains completely silent (e.g. in overmind) and it is hard to tell if it is even running
