### PR TITLE
fix: remove unused variable and fetching of the "doc before save"

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1081,8 +1081,6 @@ class Document(BaseDocument):
 		- `on_cancel` for **Cancel**
 		- `update_after_submit` for **Update after Submit**"""
 
-		doc_before_save = self.get_doc_before_save()
-
 		if self._action == "save":
 			self.run_method("on_update")
 		elif self._action == "submit":


### PR DESCRIPTION
`get_doc_before_save` gets called and stored on a variable which is never used in this function and can thus be removed

I checked this in frappe 14 and this line doesn't exist there.