### PR TITLE
fix: removed the output field from the console log

### DIFF
--- a/frappe/desk/doctype/console_log/console_log.json
+++ b/frappe/desk/doctype/console_log/console_log.json
@@ -6,8 +6,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "script",
-  "output"
+  "script"
  ],
  "fields": [
   {
@@ -16,20 +15,15 @@
    "in_list_view": 1,
    "label": "Script",
    "read_only": 1
-  },
-  {
-   "fieldname": "output",
-   "fieldtype": "Code",
-   "label": "Output",
-   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-08-18 20:07:57.587344",
+ "modified": "2023-07-05 22:16:02.823955",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Console Log",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -48,5 +42,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -26,7 +26,7 @@ class SystemConsole(Document):
 		else:
 			frappe.db.rollback()
 
-		frappe.get_doc(dict(doctype="Console Log", script=self.console, output=self.output)).insert()
+		frappe.get_doc(dict(doctype="Console Log", script=self.console)).insert()
 		frappe.db.commit()
 
 


### PR DESCRIPTION
Users on FC use the system console to test the SQL query of the report. While testing the SQL query using the system console, the system generates a console log containing the executed query and its output. The output field stores the actual data resulting from the query, which can be extensive. As users run the SQL query multiple times, the system creates a new console log record each time, which cause the database size limit issue.

As this logs are needed for the security reason and user won't able to delete it, it's better to not store the "Output" of the query in the database.

<img width="570" alt="Screenshot 2023-07-05 at 10 29 16 PM" src="https://github.com/frappe/frappe/assets/8780500/5f4b0973-f245-40f3-a088-2c720f8b8c1d">

