### PR TITLE
fix(Query Report): no double translation

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1224,7 +1224,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 			return Object.assign(column, {
 				id: column.fieldname,
-				name: __(column.label, null, `Column of report '${this.report_name}'`), // context has to match context in   get_messages_from_report in translate.py
+				// The column label should have already been translated in the
+				// backend. Translating it again would cause unexpected behaviour.
+				name: column.label,
 				width: parseInt(column.width) || null,
 				editable: false,
 				compareValue: compareFn,


### PR DESCRIPTION
For illustration purposes, I renamed the"Description" column of the [report "ToDo"](https://github.com/frappe/frappe/blob/60b7b85341c2a8b3698e84c975a2c491988261db/frappe/desk/report/todo/todo.py):

```diff
columns = [
	_("ID") + ":Link/ToDo:90",
	_("Priority") + "::60",
	_("Date") + ":Date",
-	_("Description") + "::150",
+	_("Poison") + "::150",
	_("Assigned To/Owner") + ":Data:120",
	_("Assigned By") + ":Data:120",
	_("Reference") + "::200",
]
```

![en](https://github.com/frappe/frappe/assets/14891507/269f1b5a-ca08-4559-9fe4-c49211de947a)

The German translation of "Poison" is "Gift". We already ensure [via semgrep](https://github.com/frappe/semgrep-rules/blob/c0a1c4fcc4eb9fd7813187fa2420872cba8a3770/rules/report.py) that this first translation always happens in the backend.

If "Gift", assumed to be English, is translated again in the frontend, the resulting German word will be "Geschenk" (totally different meaning):

![before_de](https://github.com/frappe/frappe/assets/14891507/0e03fbf2-e08a-4aa5-b049-9d5e1f3dd54c)

There are many such toxic combinations, for example:

| (en) | (de + en) | (de) |
| --- | --- | --- |
| Poison | Gift | Geschenk |
| Child | Kind | Art |
| Kind | Art | Kunst |
| Advice | Rat | Ratte |
| Soon | Bald | Glatzköpfig |
| Lake | See | Sehen |
| Boat | Boot | Schuh |
| Letter | Brief | Kurz |
| Mobile Phone | Handy | Nützlich |
| Dung | Mist | Nebel |
| Skirt | Rock | Fels |
| Boss | Chef | Koch |
| Almost | Fast | Schnell |

This PR removes the double translation:
![after_de](https://github.com/frappe/frappe/assets/14891507/640230bc-2684-4070-9945-c983ab9c3626)
