### PR TITLE
fix: load generic(doctype based) code files

### DIFF
--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -301,7 +301,11 @@ def get_code_files_via_hooks(hook, name):
 		if not isinstance(files, list):
 			files = [files]
 
-		for file in files:
+		generic_files = code_hook.get("*", [])
+		if not isinstance(generic_files, list):
+			generic_files = [generic_files]
+
+		for file in (files + generic_files):
 			path = frappe.get_app_path(app_name, *file.strip("/").split("/"))
 			code_files.append(path)
 


### PR DESCRIPTION
This PR lets users load js/css files via hooks in the following manner:

```
doctype_js = {
	"*": "public/js/generic_js_file.js",
}
```
