### PR TITLE
fix: Only clear doctype cache if specified

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -120,13 +120,13 @@ def clear_defaults_cache(user=None):
 def clear_doctype_cache(doctype=None):
 	clear_controller_cache(doctype)
 
-	_clear_doctype_cache_form_redis()
+	_clear_doctype_cache_from_redis(doctype)
 	if hasattr(frappe.db, "after_commit"):
-		frappe.db.after_commit.add(_clear_doctype_cache_form_redis)
-		frappe.db.after_rollback.add(_clear_doctype_cache_form_redis)
+		frappe.db.after_commit.add(lambda: _clear_doctype_cache_from_redis(doctype))
+		frappe.db.after_rollback.add(lambda: _clear_doctype_cache_from_redis(doctype))
 
 
-def _clear_doctype_cache_form_redis(doctype: str | None = None):
+def _clear_doctype_cache_from_redis(doctype: str | None = None):
 	from frappe.desk.notifications import delete_notification_count_for
 
 	for key in ("is_table", "doctype_modules"):

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -46,7 +46,9 @@ class TestPerformance(FrappeTestCase):
 		self.reset_request_specific_caches()
 
 	def test_meta_caching(self):
+		frappe.clear_cache()
 		frappe.get_meta("User")
+		frappe.clear_cache(doctype="ToDo")
 
 		with self.assertQueryCount(0):
 			frappe.get_meta("User")
@@ -131,7 +133,6 @@ class TestPerformance(FrappeTestCase):
 			f"Possible performance regression in basic /api/Resource list  requests",
 		)
 
-	@unittest.skip("Not implemented")
 	def test_homepage_resolver(self):
 		paths = ["/", "/app"]
 		for path in paths:


### PR DESCRIPTION
- App install was suddenly feeling slow. 
- After initial investigation found out that the doctype cache is missed constantly.
- Put print_stack in rediswrapper and found that doctype is clearing all doctype cache instead of specific one since https://github.com/frappe/frappe/pull/21216
- Fixed and added perf test