### PR TITLE
fix: cast label to string before comparing

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -382,7 +382,7 @@ frappe.ui.GroupBy = class {
 			const child_table_fields = frappe.meta
 				.get_docfields(cdt)
 				.filter(standard_fields_filter)
-				.sort((a, b) => __(a.label).localeCompare(__(b.label)));
+				.sort((a, b) => __(cstr(a.label)).localeCompare(__(cstr(b.label))));
 			this.group_by_fields[cdt] = child_table_fields;
 			this.all_fields[cdt] = child_table_fields;
 		});


### PR DESCRIPTION
Sometimes if label is undefined then sorting doesn't work as `undefined` doesn't have `localCompare`. 


```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'localeCompare')
    at group_by.js:385:31
    at Array.sort (<anonymous>)
    at group_by.js:385:6
    at Array.forEach (<anonymous>)
    at frappe.ui.GroupBy.get_group_by_fields (group_by.js:380:16)
    at frappe.ui.GroupBy.init_group_by_popover (group_by.js:27:31)
    at frappe.ui.GroupBy.make (group_by.js:13:8)
    at new frappe.ui.GroupBy (group_by.js:8:8)
    at frappe.views.ReportView.setup_sort_selector (report_view.js:112:27)

```

triggered by (but not root cause) https://github.com/frappe/frappe/pull/21394 