### PR TITLE
fix: don't stop next unattached file from being attached

### DIFF
--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -308,7 +308,7 @@ def attach_files_to_document(doc: "Document", event) -> None:
 		# we dont want the update to fail if file cannot be attached for some reason
 		value = doc.get(df.fieldname)
 		if not (value or "").startswith(("/files", "/private/files")):
-			return
+			continue
 
 		if frappe.db.exists(
 			"File",

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -319,7 +319,7 @@ def attach_files_to_document(doc: "Document", event) -> None:
 				"attached_to_field": df.fieldname,
 			},
 		):
-			return
+			continue
 
 		unattached_file = frappe.db.exists(
 			"File",
@@ -341,7 +341,7 @@ def attach_files_to_document(doc: "Document", event) -> None:
 					"attached_to_field": df.fieldname,
 				},
 			)
-			return
+			continue
 
 		file: "File" = frappe.get_doc(
 			doctype="File",


### PR DESCRIPTION
Currently `attach_files_to_document` ends execution if the first file's URL is invalid or if the first attached file is found or if the first unattached file is attached -- it doesn't handle the subsequent files.