### PR TITLE
fix: translate autocomplete options label

### DIFF
--- a/frappe/desk/utils.py
+++ b/frappe/desk/utils.py
@@ -53,6 +53,8 @@ def get_csv_bytes(data: list[list], csv_params: dict) -> bytes:
 
 def provide_binary_file(filename: str, extension: str, content: bytes) -> None:
 	"""Provide a binary file to the client."""
+	from frappe import _
+
 	frappe.response["type"] = "binary"
 	frappe.response["filecontent"] = content
-	frappe.response["filename"] = f"{filename}.{extension}"
+	frappe.response["filename"] = f"{_(filename)}.{extension}"

--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -177,7 +177,7 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 
 		options = options.map((o) => {
 			if (typeof o !== "string") {
-				o.label = cstr(o.label);
+				o.label = __(cstr(o.label));
 				o.value = cstr(o.value);
 			}
 			return o;


### PR DESCRIPTION
**Issues:**
1. The autocomplete options were not translated
2. While exporting to CSV or Excel the filename is not translated

Before:

https://github.com/frappe/frappe/assets/30859809/8a610c03-251f-4932-8254-d3486e38c879


https://github.com/frappe/frappe/assets/30859809/9ed0640f-2de1-4a9a-9f80-85e309f9c1f8



After:

https://github.com/frappe/frappe/assets/30859809/23c2c56b-e5b7-4784-b93b-c862a376e245


https://github.com/frappe/frappe/assets/30859809/7b53b3bd-20b8-44d2-811f-4b43b8dee883



