### PR TITLE
fix(setup_wizard): Don't try to send headers when exception happens on command line

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -377,7 +377,7 @@ def email_setup_wizard_exception(traceback, args):
 		traceback=traceback,
 		args="\n".join(pretty_args),
 		user=frappe.session.user,
-		headers=frappe.request.headers,
+		headers=frappe.request.headers if frappe.request else "[no request]",
 	)
 
 	frappe.sendmail(


### PR DESCRIPTION
There are no headers when running the setup wizard from the command line (e.g. in automated installs), which causes a `RuntimeError: object is not bound` in `email_setup_wizard_exception`.