### PR TITLE
fix: better fetch_if_empty (old fix #19586)

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -591,13 +591,19 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			let field_value = "";
 			for (const [target_field, source_field] of Object.entries(fetch_map)) {
 				if (value) field_value = response[source_field];
-				frappe.model.set_value(
-					df.parent,
-					docname,
-					target_field,
-					field_value,
-					df.fieldtype
-				);
+				let target_df = frappe.meta.get_docfield(df.parent, target_field);
+				let target_value = frappe.model.get_value(df.parent, docname, target_field);
+				if (target_df?.fetch_if_empty && target_value) {
+					continue;
+				} else {
+					frappe.model.set_value(
+						df.parent,
+						docname,
+						target_field,
+						field_value,
+						df.fieldtype
+					);
+				}
 			}
 		}
 

--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -213,12 +213,7 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 				df.read_only == 1 ||
 				df.is_virtual == 1;
 
-			if (
-				is_read_only_field &&
-				df.fetch_from &&
-				(!df.fetch_if_empty || (df.fetch_if_empty && !me.frm.doc[df.fieldname])) &&
-				df.fetch_from.indexOf(".") != -1
-			) {
+			if (is_read_only_field && df.fetch_from && df.fetch_from.indexOf(".") != -1) {
 				var parts = df.fetch_from.split(".");
 				me.frm.add_fetch(parts[0], parts[1], df.fieldname, df.parent);
 			}


### PR DESCRIPTION
There is a `fetch_dict` which gets created while we load the form and when a link field is updated we check if any of the field in the `fetch_dict` depends on it and if yes we update it.

But, In PR https://github.com/frappe/frappe/pull/19586 (old fix)
If `fetch_if_empty` is set and the field has value we do not add that field in `fetch_dict` but there is one problem
If we again make the field empty and now again set the link field since `fetch_dict` does not have the field in it it does not get updated even though it is empty. This PR solves this problem