### PR TITLE
ci: fix release notes generator

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -31,8 +31,8 @@ jobs:
       run: |
         NEW_NOTES=$(gh api --method POST -H "Accept: application/vnd.github+json"  /repos/frappe/frappe/releases/generate-notes  -f tag_name=$RELEASE_TAG | jq -r '.body' | sed  -E '/^\* (chore|ci|test|docs|style)/d' )
         RELEASE_ID=$(gh api -H "Accept: application/vnd.github+json" /repos/frappe/frappe/releases/tags/$RELEASE_TAG | jq -r '.id')
-        gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/frappe/frappe/releases/$RELEASE_ID -f body=$NEW_NOTES
+        gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/frappe/frappe/releases/$RELEASE_ID -f body="$NEW_NOTES"
 
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         RELEASE_TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}


### PR DESCRIPTION
Without quotes it gets splatted and treated as separate args. Yes, bash.
