### PR TITLE
perf(DX): Reduce recorder overhead

### DIFF
--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -27,19 +27,11 @@ def sql(*args, **kwargs):
 	end_time = time.monotonic()
 
 	stack = list(get_current_stack_frames())
-	query = sqlparse.format(str(frappe.db.last_query).strip(), keyword_case="upper", reindent=True)
-
-	# Collect EXPLAIN for executed query
-	if is_query_type(query, ("select", "update", "delete")):
-		# Only SELECT/UPDATE/DELETE queries can be "EXPLAIN"ed
-		explain_result = frappe.db._sql(f"EXPLAIN {query}", as_dict=True)
-	else:
-		explain_result = []
 
 	data = {
-		"query": query,
+		"query": str(frappe.db.last_query),
 		"stack": stack,
-		"explain_result": explain_result,
+		"explain_result": [],
 		"time": start_time,
 		"duration": float(f"{(end_time - start_time) * 1000:.3f}"),
 	}
@@ -61,6 +53,43 @@ def get_current_stack_frames():
 				}
 	except Exception:
 		pass
+
+
+def post_process():
+	"""post process all recorded values.
+
+	Any processing that can be done later should be done here to avoid overhead while
+	profiling. As of now following values are post-processed:
+	        - `EXPLAIN` output of queries.
+	        - SQLParse reformatting of queries
+	        - Mark duplicates
+	"""
+	frappe.db.rollback()
+	frappe.db.begin(read_only=True)  # Explicitly start read only transaction
+
+	result = list(frappe.cache.hgetall(RECORDER_REQUEST_HASH).values())
+
+	for request in result:
+		for call in request["calls"]:
+			formatted_query = sqlparse.format(call["query"].strip(), keyword_case="upper", reindent=True)
+			call["query"] = formatted_query
+
+			# Collect EXPLAIN for executed query
+			if is_query_type(formatted_query, ("select", "update", "delete")):
+				# Only SELECT/UPDATE/DELETE queries can be "EXPLAIN"ed
+				try:
+					call["explain_result"] = frappe.db.sql(f"EXPLAIN {formatted_query}", as_dict=True)
+				except Exception:
+					pass
+		mark_duplicates(request)
+		frappe.cache.hset(RECORDER_REQUEST_HASH, request["uuid"], request)
+
+
+def mark_duplicates(request):
+	counts = Counter([call["query"] for call in request["calls"]])
+	for index, call in enumerate(request["calls"]):
+		call["index"] = index
+		call["exact_copies"] = counts[call["query"]]
 
 
 def record(force=False):
@@ -116,18 +145,10 @@ class Recorder:
 			user="Administrator",
 		)
 
-		self.mark_duplicates()
-
 		request_data["calls"] = self.calls
 		request_data["headers"] = self.headers
 		request_data["form_dict"] = self.form_dict
 		frappe.cache.hset(RECORDER_REQUEST_HASH, self.uuid, request_data)
-
-	def mark_duplicates(self):
-		counts = Counter([call["query"] for call in self.calls])
-		for index, call in enumerate(self.calls):
-			call["index"] = index
-			call["exact_copies"] = counts[call["query"]]
 
 
 def _patch():
@@ -177,6 +198,7 @@ def start(*args, **kwargs):
 @administrator_only
 def stop(*args, **kwargs):
 	frappe.cache.delete_value(RECORDER_INTERCEPT_FLAG)
+	frappe.enqueue(post_process)
 
 
 @frappe.whitelist()
@@ -215,6 +237,7 @@ def record_queries(func: Callable):
 		ret = func(*args, **kwargs)
 		dump()
 		_unpatch()
+		post_process()
 		print("Recorded queries, open recorder to view them.")
 		return ret
 

--- a/frappe/tests/test_recorder.py
+++ b/frappe/tests/test_recorder.py
@@ -70,6 +70,7 @@ class TestRecorder(FrappeTestCase):
 		frappe.db.sql("SELECT * FROM tabDocType")
 		frappe.db.sql("COMMIT")
 		frappe.recorder.dump()
+		frappe.recorder.post_process()
 
 		requests = frappe.recorder.get()
 		request = frappe.recorder.get(requests[0]["uuid"])
@@ -89,6 +90,7 @@ class TestRecorder(FrappeTestCase):
 			frappe.db.sql(query[sql_dialect])
 
 		frappe.recorder.dump()
+		frappe.recorder.post_process()
 
 		requests = frappe.recorder.get()
 		request = frappe.recorder.get(requests[0]["uuid"])
@@ -113,6 +115,7 @@ class TestRecorder(FrappeTestCase):
 			frappe.db.sql(query[0])
 
 		frappe.recorder.dump()
+		frappe.recorder.post_process()
 
 		requests = frappe.recorder.get()
 		request = frappe.recorder.get(requests[0]["uuid"])


### PR DESCRIPTION
Recorder has performance penalty while running in prod. This PR attempts to reduce it a little by:
- deferring `EXPLAIN` of queries
- deferring duplicate counts
- deferring query formatting with sqlparse


No scientific way to measure it but general but overhead should go down by 20-60% depending upon usage. 

| action | without recorder | w/ Recorder before | w/ recorder now | reduction in overhead |
| --- | --- | ---| ---| --- |
| loading `/` | 160ms | 300 ms | 225ms | ~50% |