### PR TITLE
fix: show workflow state in indicator if dont override status is set in workflow

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -712,9 +712,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	get_column_html(col, doc) {
 		if (col.type === "Status" || col.df?.options == "Workflow State") {
+			let show_workflow_state = col.df?.options == "Workflow State";
 			return `
 				<div class="list-row-col hidden-xs ellipsis">
-					${this.get_indicator_html(doc)}
+					${this.get_indicator_html(doc, show_workflow_state)}
 				</div>
 			`;
 		}
@@ -1014,8 +1015,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		return subject_html;
 	}
 
-	get_indicator_html(doc) {
-		const indicator = frappe.get_indicator(doc, this.doctype);
+	get_indicator_html(doc, show_workflow_state) {
+		const indicator = frappe.get_indicator(doc, this.doctype, show_workflow_state);
 		// sequence is important
 		const docstatus_description = [
 			__("Document is in draft state"),

--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -23,7 +23,7 @@ frappe.has_indicator = function (doctype) {
 	return false;
 };
 
-frappe.get_indicator = function (doc, doctype) {
+frappe.get_indicator = function (doc, doctype, show_workflow_state) {
 	if (doc.__unsaved) {
 		return [__("Not Saved"), "orange"];
 	}
@@ -40,7 +40,7 @@ frappe.get_indicator = function (doc, doctype) {
 		workflow_fieldname = frappe.workflow.get_state_fieldname(doctype);
 
 	// workflow
-	if (workflow_fieldname && !without_workflow) {
+	if (workflow_fieldname && (!without_workflow || show_workflow_state)) {
 		var value = doc[workflow_fieldname];
 		if (value) {
 			var colour = "";


### PR DESCRIPTION
Caused By: https://github.com/frappe/frappe/pull/21508

The above PR works fine if the **Don't Override Status** field is not set in the workflow, if it is set the indicator shows the status text

Before:
<img width="1058" alt="image" src="https://github.com/frappe/frappe/assets/30859809/f192ded1-c40f-4c5c-b655-09e144e5b268">


After:
<img width="1058" alt="image" src="https://github.com/frappe/frappe/assets/30859809/5b711903-5859-4b47-a72d-e35ef54e64de">
