### PR TITLE
fix(Email Search): cast iterator to list

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -35,7 +35,7 @@ def get_contact_list(txt, page_length=20):
 		{"txt": "%" + txt + "%", "page_length": page_length},
 		as_dict=True,
 	)
-	out = filter(None, out)
+	out = list(filter(None, out))
 
 	update_contact_cache(out)
 


### PR DESCRIPTION
The search functionality in the email modal uses the whitelisted method `get_contact_list`. Currently, in `version-13`, the search does not work, giving empty search results for valid queries.

### Problem

The `filter` function is used to get rid of any `None` values in the result. However, it returns a python iterator while the frontend expects a list of dictionaries.

### Solution

Cast the iterator to a list. This is already implemented in `develop` and `version-14`.