### PR TITLE
refactor(money in words): translatable currency Name 

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1353,12 +1353,12 @@ def money_in_words(
 
 	# 0.00
 	if main == "0" and fraction in ["00", "000"]:
-		out = "{} {}".format(main_currency, _("Zero"))
+		out = "{} {}".format(_(main_currency), _("Zero"))
 	# 0.XX
 	elif main == "0":
 		out = _(in_words(fraction, in_million).title()) + " " + fraction_currency
 	else:
-		out = main_currency + " " + _(in_words(main, in_million).title())
+		out = _(main_currency) + " " + _(in_words(main, in_million).title())
 		if cint(fraction):
 			out = (
 				out

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1353,7 +1353,7 @@ def money_in_words(
 
 	# 0.00
 	if main == "0" and fraction in ["00", "000"]:
-		out = "{} {}".format(_(main_currency), _("Zero"))
+		out = _(main_currency, context="Currency") + " " + _("Zero")
 	# 0.XX
 	elif main == "0":
 		out = _(in_words(fraction, in_million).title()) + " " + fraction_currency

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1358,7 +1358,7 @@ def money_in_words(
 	elif main == "0":
 		out = _(in_words(fraction, in_million).title()) + " " + fraction_currency
 	else:
-		out = _(main_currency) + " " + _(in_words(main, in_million).title())
+		out = _(main_currency, context="Currency") + " " + _(in_words(main, in_million).title())
 		if cint(fraction):
 			out = (
 				out


### PR DESCRIPTION
When dealing with right to left languages and Currency name must be as standar in English ,  There will be problem formatting and text layout of money in words  for ex:
USD مائة و خمسة فقط. 
 
![money in words showing arabic layout ](https://github.com/frappe/frappe/assets/705960/6f4599c8-4ccb-4c55-a962-375a473dd3a1)
