### PR TITLE
fix: `connect_replica` and `read_only` should be idempotent

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -817,14 +817,14 @@ def read_only():
 
 			# frappe.read_only could be called from nested functions, in such cases don't swap the
 			# connection again.
-			switchd_connection = False
+			switched_connection = False
 			if conf.read_from_replica:
-				switchd_connection = connect_replica()
+				switched_connection = connect_replica()
 
 			try:
 				retval = fn(*args, **get_newargs(fn, kwargs))
 			finally:
-				if switchd_connection and local and hasattr(local, "primary_db"):
+				if switched_connection and local and hasattr(local, "primary_db"):
 					local.db.close()
 					local.db = local.primary_db
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -930,3 +930,34 @@ class TestTransactionManagement(FrappeTestCase):
 
 		frappe.db.commit()
 		self.assertEqual(_get_transaction_id(), _get_transaction_id())
+
+
+# Treat same DB as replica for tests, a separate connection will be opened
+class TestReplicaConnections(FrappeTestCase):
+	def test_switching_to_replica(self):
+		with patch.dict(frappe.local.conf, {"read_from_replica": 1, "replica_host": "localhost"}):
+
+			def db_id():
+				return id(frappe.local.db)
+
+			write_connection = db_id()
+			read_only_connection = None
+
+			@frappe.read_only()
+			def outer():
+				nonlocal read_only_connection
+				read_only_connection = db_id()
+
+				# A new connection should be opened
+				self.assertNotEqual(read_only_connection, write_connection)
+				inner()
+				# calling nested read only function shouldn't change connection
+				self.assertEqual(read_only_connection, db_id())
+
+			@frappe.read_only()
+			def inner():
+				# calling nested read only function shouldn't change connection
+				self.assertEqual(read_only_connection, db_id())
+
+			outer()
+			self.assertEqual(write_connection, db_id())


### PR DESCRIPTION
Calling `connect_replica` multiple times or `@frappe.read_only` in nested functions results in original writable connection being lost completely.

Fix: Added check to not switch connections more than once. Also added a test for replicas.


closes https://github.com/frappe/frappe/issues/21619

alt/correct fix to https://github.com/frappe/frappe/pull/21621