### PR TITLE
fix: setup_likes_from_feedback patch

### DIFF
--- a/frappe/patches/v14_0/setup_likes_from_feedback.py
+++ b/frappe/patches/v14_0/setup_likes_from_feedback.py
@@ -4,7 +4,7 @@ import frappe
 def execute():
 	frappe.reload_doctype("Comment")
 
-	if not frappe.db.exists("Feedback"):
+	if not frappe.db.table_exists("Feedback"):
 		return
 
 	if frappe.db.count("Feedback") > 20000:

--- a/frappe/patches/v14_0/setup_likes_from_feedback.py
+++ b/frappe/patches/v14_0/setup_likes_from_feedback.py
@@ -4,6 +4,9 @@ import frappe
 def execute():
 	frappe.reload_doctype("Comment")
 
+	if not frappe.db.exists("Feedback"):
+		return
+
 	if frappe.db.count("Feedback") > 20000:
 		frappe.db.auto_commit_on_many_writes = True
 


### PR DESCRIPTION
execute patch only if doctype feedback exists