### PR TITLE
perf: lazy load sidebar tag stats

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -525,47 +525,47 @@ def get_stats(stats, doctype, filters=None):
 
 	if filters is None:
 		filters = []
-	tags = json.loads(stats)
+	columns = json.loads(stats)
 	if filters:
 		filters = json.loads(filters)
-	stats = {}
+	results = {}
 
 	try:
-		columns = frappe.db.get_table_columns(doctype)
+		db_columns = frappe.db.get_table_columns(doctype)
 	except (frappe.db.InternalError, frappe.db.ProgrammingError):
 		# raised when _user_tags column is added on the fly
 		# raised if its a virtual doctype
-		columns = []
+		db_columns = []
 
-	for tag in tags:
-		if tag not in columns:
+	for column in columns:
+		if column not in db_columns:
 			continue
 		try:
 			tag_count = frappe.get_list(
 				doctype,
-				fields=[tag, "count(*)"],
-				filters=filters + [[tag, "!=", ""]],
-				group_by=tag,
+				fields=[column, "count(*)"],
+				filters=filters + [[column, "!=", ""]],
+				group_by=column,
 				as_list=True,
 				distinct=1,
 			)
 
-			if tag == "_user_tags":
-				stats[tag] = scrub_user_tags(tag_count)
+			if column == "_user_tags":
+				results[column] = scrub_user_tags(tag_count)
 				no_tag_count = frappe.get_list(
 					doctype,
-					fields=[tag, "count(*)"],
-					filters=filters + [[tag, "in", ("", ",")]],
+					fields=[column, "count(*)"],
+					filters=filters + [[column, "in", ("", ",")]],
 					as_list=True,
-					group_by=tag,
-					order_by=tag,
+					group_by=column,
+					order_by=column,
 				)
 
 				no_tag_count = no_tag_count[0][1] if no_tag_count else 0
 
-				stats[tag].append([_("No Tags"), no_tag_count])
+				results[column].append([_("No Tags"), no_tag_count])
 			else:
-				stats[tag] = tag_count
+				results[column] = tag_count
 
 		except frappe.db.SQLError:
 			pass
@@ -573,7 +573,7 @@ def get_stats(stats, doctype, filters=None):
 			# raised when _user_tags column is added on the fly
 			pass
 
-	return stats
+	return results
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -187,6 +187,10 @@ frappe.views.ListSidebar = class ListSidebar {
 
 	get_stats() {
 		var me = this;
+
+		let dropdown_options = me.sidebar.find(".list-stats-dropdown .stat-result");
+		this.set_loading_state(dropdown_options);
+
 		frappe.call({
 			method: "frappe.desk.reportview.get_sidebar_stats",
 			type: "GET",
@@ -206,6 +210,14 @@ frappe.views.ListSidebar = class ListSidebar {
 				frappe.utils.setup_search(stats_dropdown, ".stat-link", ".stat-label");
 			},
 		});
+	}
+
+	set_loading_state(dropdown) {
+		dropdown.html(`<li>
+			<div class="empty-state">
+				${__("Loading...")}
+			</div>
+		</li>`);
 	}
 
 	render_stat(stats) {

--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -34,7 +34,7 @@ frappe.views.ListSidebar = class ListSidebar {
 		) {
 			this.sidebar.find(".list-tags").remove();
 		} else {
-			this.sidebar.find(".list-stats").on("click", (e) => {
+			this.sidebar.find(".list-stats").on("show.bs.dropdown", (e) => {
 				this.reload_stats();
 			});
 		}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -587,9 +587,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			</div>
 		`);
 		this.setup_new_doc_event();
-		if (this.list_view_settings && !this.list_view_settings.disable_sidebar_stats) {
-			this.list_sidebar && this.list_sidebar.reload_stats();
-		}
 		this.toggle_paging && this.$paging_area.toggle(true);
 	}
 


### PR DESCRIPTION
We load sidebar tag count by default, though very few people actually use this feature. Every list view reload triggers tag stats reload which on large sites can block the web workers and make everything less responsive. We have a hack "Disable sidebar stats" to fix this in list view settings. That however is not easily discoverable and needs to be enabled manually. 


Changes:
- Removed auto-loading of tag info. Instead, load when the user clicks on tags. 
- Added loading state on tags dropdown similar to "assigned to" and filter dropdowns. This will only be shown on large tables usually. 

closes https://github.com/frappe/frappe/issues/21624

Thanks to @surajshetty3416 for the idea. 


Fun fact: This change will save **~1500 compute hours** per month on FC with current usage patterns.