### PR TITLE
fix(UX): Highlight prepared reports older than 1 day

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -748,9 +748,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				);
 			});
 
-			const part1 = __("This report was generated {0}.", [
-				frappe.datetime.comment_when(doc.report_end_time),
-			]);
+			let pretty_diff = frappe.datetime.comment_when(doc.report_end_time);
+			const days_old = frappe.datetime.get_day_diff(
+				frappe.datetime.now_datetime(),
+				doc.report_end_time
+			);
+			if (days_old > 1) {
+				pretty_diff = `<span style="color:var(--red-600)">${pretty_diff}</span>`;
+			}
+			const part1 = __("This report was generated {0}.", [pretty_diff]);
 			const part2 = __("To get the updated report, click on {0}.", [__("Rebuild")]);
 			const part3 = __("See all past reports.");
 


### PR DESCRIPTION
In MOST cases prepared report that are older than 1 day are considered "stale".




![image](https://github.com/frappe/frappe/assets/9079960/a1fcfb7a-e0e4-4fa9-b37f-a18922b82fc0)

![image](https://github.com/frappe/frappe/assets/9079960/3a665745-cb49-41bb-a015-cfc646319fa0)

