### PR TITLE
feat: Custom naming series parser via hooks

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -428,3 +428,7 @@ after_job = [
 extend_bootinfo = [
 	"frappe.utils.telemetry.add_bootinfo",
 ]
+
+naming_series_variables = {
+	"PM": "frappe.tests.test_naming.parse_naming_series_variable",
+}

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -339,11 +339,12 @@ def parse_naming_series(
 			part = determine_consecutive_week_number(today)
 		elif e == "timestamp":
 			part = str(today)
-		elif e == "FY":
-			part = frappe.defaults.get_user_default("fiscal_year")
 		elif doc and (e.startswith("{") or doc.get(e, _sentinel) is not _sentinel):
 			e = e.replace("{", "").replace("}", "")
 			part = doc.get(e)
+		elif has_custom_parser(e):
+			method = frappe.get_hooks("naming_series_variables", {}).get(e)
+			part = frappe.get_attr(method[0])(doc, e)
 		else:
 			part = e
 
@@ -353,6 +354,11 @@ def parse_naming_series(
 			name += cstr(part).strip()
 
 	return name
+
+
+def has_custom_parser(e):
+	"""Returns true if the naming series part has a custom parser"""
+	return frappe.get_hooks("naming_series_variables", {}).get(e)
 
 
 def determine_consecutive_week_number(datetime):

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -342,8 +342,7 @@ def parse_naming_series(
 		elif doc and (e.startswith("{") or doc.get(e, _sentinel) is not _sentinel):
 			e = e.replace("{", "").replace("}", "")
 			part = doc.get(e)
-		elif has_custom_parser(e):
-			method = frappe.get_hooks("naming_series_variables", {}).get(e)
+		elif method := has_custom_parser(e):
 			part = frappe.get_attr(method[0])(doc, e)
 		else:
 			part = e

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -375,6 +375,19 @@ class TestNaming(FrappeTestCase):
 		name = parse_naming_series(series, doc=webhook)
 		self.assertTrue(name.startswith("KOOH---"), f"incorrect name generated {name}")
 
+	def test_custom_parser(self):
+		# check naming with custom parser
+		todo = frappe.new_doc("ToDo")
+		series = "TODO-.PM.-.####"
+		name = parse_naming_series(series, doc=todo)
+		expected_name = "TODO-" + nowdate().split("-")[1] + "-" + "0001"
+		self.assertEqual(name, expected_name)
+
+
+def parse_naming_series_variable(doc, variable):
+	if variable == "PM":
+		return nowdate().split("-")[1]
+
 
 def make_invalid_todo():
 	frappe.get_doc({"doctype": "ToDo", "description": "Test"}).insert(set_name="ToDo")


### PR DESCRIPTION
Fiscal Year is an ERPNext app doctype so having a naming series variable handled here didn't make much sense

Implemented a hook via https://github.com/frappe/erpnext/pull/35960 to handle this scenario
This will allow app owners to define their custom naming series variable and use it

This also solves the scenario where users wanted the fiscal year to be set based on the documents posting date instead of default or current fiscal year

`no-docs`