### PR TITLE
perf: accurate cache eviction for assets

### DIFF
--- a/frappe/public/js/frappe/assets.js
+++ b/frappe/public/js/frappe/assets.js
@@ -29,7 +29,7 @@ frappe.assets = {
 
 		if (localStorage._last_load) {
 			var not_updated_since = new Date() - new Date(localStorage._last_load);
-			if (not_updated_since < 10000 || not_updated_since > 86400000) {
+			if (not_updated_since > 86400000) {
 				frappe.assets.clear_local_storage();
 			}
 		} else {

--- a/frappe/public/js/frappe/assets.js
+++ b/frappe/public/js/frappe/assets.js
@@ -28,8 +28,11 @@ frappe.assets = {
 		}
 
 		if (localStorage._last_load) {
-			var not_updated_since = new Date() - new Date(localStorage._last_load);
-			if (not_updated_since > 86400000) {
+			let not_updated_since = new Date() - new Date(localStorage._last_load);
+			// Evict cache every 2 days
+			// Evict cache if page is reloaded within 10 seconds. Which could be user trying to
+			// refresh if things feel broken.
+			if ((not_updated_since < 10000 && is_reload()) || not_updated_since > 2 * 86400000) {
 				frappe.assets.clear_local_storage();
 			}
 		} else {
@@ -184,3 +187,15 @@ frappe.assets = {
 		return path;
 	},
 };
+
+function is_reload() {
+	try {
+		return window.performance
+			?.getEntriesByType("navigation")
+			.map((nav) => nav.type)
+			.includes("reload");
+	} catch (e) {
+		// Safari probably
+		return true;
+	}
+}

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -139,3 +139,8 @@ class TestPerformance(FrappeTestCase):
 			PathResolver(path).resolve()
 			with self.assertQueryCount(1):
 				PathResolver(path).resolve()
+
+	def test_consistent_build_version(self):
+		from frappe.utils import get_build_version
+
+		self.assertEqual(get_build_version(), get_build_version())

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -955,7 +955,7 @@ def get_file_size(path, format=False):
 
 def get_build_version():
 	try:
-		return str(os.path.getmtime(os.path.join(frappe.local.sites_path, ".build")))
+		return str(os.path.getmtime(os.path.join(frappe.local.sites_path, "assets/assets.json")))
 	except OSError:
 		# .build can sometimes not exist
 		# this is not a major problem so send fallback


### PR DESCRIPTION
- Build version wasn't correctly computed since v14 update of build system. This makes client side cache useless.
- Assuming rapid-reload ~= user frustrated with old assets. We weren't actually checking if load was "reload". This cleared cache when tabs were opened and effectively made cache useless.