### PR TITLE
perf(desk): reduce unnecessary requests on first load

### DIFF
--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -60,6 +60,10 @@ class UserPermission(Document):
 			frappe.throw(_("{0} has already assigned default value for {1}.").format(ref_link, self.allow))
 
 
+def send_user_permissions(bootinfo):
+	bootinfo.user["user_permissions"] = get_user_permissions()
+
+
 @frappe.whitelist()
 def get_user_permissions(user=None):
 	"""Get all users permissions for the user as a dict of doctype"""

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -427,4 +427,5 @@ after_job = [
 
 extend_bootinfo = [
 	"frappe.utils.telemetry.add_bootinfo",
+	"frappe.core.doctype.user_permission.user_permission.send_user_permissions",
 ]

--- a/frappe/public/js/frappe/assets.js
+++ b/frappe/public/js/frappe/assets.js
@@ -32,7 +32,7 @@ frappe.assets = {
 			// Evict cache every 2 days
 			// Evict cache if page is reloaded within 10 seconds. Which could be user trying to
 			// refresh if things feel broken.
-			if ((not_updated_since < 10000 && is_reload()) || not_updated_since > 2 * 86400000) {
+			if ((not_updated_since < 5000 && is_reload()) || not_updated_since > 2 * 86400000) {
 				frappe.assets.clear_local_storage();
 			}
 		} else {

--- a/frappe/public/js/frappe/defaults.js
+++ b/frappe/public/js/frappe/defaults.js
@@ -130,4 +130,12 @@ frappe.defaults = {
 			}
 		});
 	},
+
+	load_user_permission_from_boot: function () {
+		if (frappe.boot.user.user_permissions) {
+			this._user_permissions = Object.assign({}, frappe.boot.user.user_permissions);
+		} else {
+			frappe.defaults.update_user_permissions();
+		}
+	},
 };

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -277,7 +277,7 @@ frappe.Application = class Application {
 	}
 
 	load_user_permissions() {
-		frappe.defaults.update_user_permissions();
+		frappe.defaults.load_user_permission_from_boot();
 
 		frappe.realtime.on(
 			"update_user_permissions",

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -127,7 +127,6 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			}
 		});
 		frappe.search.utils.setup_recent();
-		frappe.tags.utils.fetch_tags();
 	}
 
 	add_help() {

--- a/frappe/public/js/frappe/ui/toolbar/tag_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/tag_utils.js
@@ -8,6 +8,11 @@ frappe.tags.utils = {
 		txt = txt.slice(1);
 		let out = [];
 
+		if (!frappe.tags.tags) {
+			frappe.tags.utils.fetch_tags();
+			return [];
+		}
+
 		for (let i in frappe.tags.tags) {
 			let tag = frappe.tags.tags[i];
 			let level = frappe.search.utils.fuzzy_search(txt, tag);


### PR DESCRIPTION
- perf: eliminate request for user permissions, send it with the boot. 
- perf: lazy load tag list for awesome bar, no one uses this feature, so why load it by default? 
- fix: lower rapid-reload threshold 10s -> 5s.

Continues https://github.com/frappe/frappe/pull/21693, https://github.com/frappe/frappe/pull/21683

Related PR on ERPNext: https://github.com/frappe/erpnext/pull/36150
