### PR TITLE
fix: fetch portal sidebar items

### DIFF
--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -109,8 +109,7 @@ class TemplatePage(BaseTemplatePage):
 		super().post_process_context()
 
 	def add_sidebar_and_breadcrumbs(self):
-		if self.basepath:
-			self.context.sidebar_items = get_sidebar_items(self.context.website_sidebar, self.basepath)
+		self.context.sidebar_items = get_sidebar_items(self.context.website_sidebar, self.basepath)
 
 		if self.context.add_breadcrumbs and not self.context.parents:
 			parent_path = os.path.dirname(self.path)


### PR DESCRIPTION
The `get_sidebar_items` method was not getting called for routes with no basepath set, resulting in `get_portal_sidebar_items` never getting called. 

Removed the check for ensuring `self.basepath` is not None. In all the cases, the `get_sidebar_items` method gets called. The case with basepath not set is already handled within the method and the portal sidebar items are returned.

The portal sidebar items are now fetched correctly for the above routes.

<img width="1220" alt="Screenshot 2023-07-17 at 11 02 12 AM" src="https://github.com/frappe/frappe/assets/40693548/df3cf02d-f5ee-4839-be2b-65508571a69c">

<br>

Closes #16818