### PR TITLE
feat(DX): PEP517 compatible build in new apps

### DIFF
--- a/frappe/tests/test_boilerplate.py
+++ b/frappe/tests/test_boilerplate.py
@@ -56,9 +56,8 @@ class TestBoilerPlate(unittest.TestCase):
 		cls.git_folder = ".git"
 
 		cls.root_paths = [
-			"requirements.txt",
 			"README.md",
-			"setup.py",
+			"pyproject.toml",
 			"license.txt",
 			cls.git_folder,
 			cls.gitignore_file,

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -106,6 +106,9 @@ def _create_app_boilerplate(dest, hooks, no_git=False):
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "__init__.py"), "w") as f:
 		f.write(frappe.as_unicode(init_template))
 
+	with open(os.path.join(dest, hooks.app_name, "pyproject.toml"), "w") as f:
+		f.write(frappe.as_unicode(pyproject_template.format(**hooks)))
+
 	with open(os.path.join(dest, hooks.app_name, "README.md"), "w") as f:
 		f.write(
 			frappe.as_unicode(
@@ -268,6 +271,28 @@ class PatchCreator:
 init_template = """
 __version__ = '0.0.1'
 
+"""
+
+pyproject_template = """[project]
+name = "{app_name}"
+authors = [
+    {{ name = "{app_publisher}", email = "{app_email}"}}
+]
+description = "{app_description}"
+requires-python = ">=3.10"
+readme = "README.md"
+dynamic = ["version"]
+dependencies = [
+    # "frappe~=15.0.0" # Installed and managed by bench.
+]
+
+[build-system]
+requires = ["flit_core >=3.4,<4"]
+build-backend = "flit_core.buildapi"
+
+# These dependencies are only installed when developer mode is enabled
+[tool.bench.dev-dependencies]
+# package_name = "~=1.1.0"
 """
 
 hooks_template = """app_name = "{app_name}"

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -106,12 +106,6 @@ def _create_app_boilerplate(dest, hooks, no_git=False):
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "__init__.py"), "w") as f:
 		f.write(frappe.as_unicode(init_template))
 
-	with open(os.path.join(dest, hooks.app_name, "MANIFEST.in"), "w") as f:
-		f.write(frappe.as_unicode(manifest_template.format(**hooks)))
-
-	with open(os.path.join(dest, hooks.app_name, "requirements.txt"), "w") as f:
-		f.write("# frappe -- https://github.com/frappe/frappe is installed via 'bench init'")
-
 	with open(os.path.join(dest, hooks.app_name, "README.md"), "w") as f:
 		f.write(
 			frappe.as_unicode(
@@ -131,9 +125,6 @@ def _create_app_boilerplate(dest, hooks, no_git=False):
 	# So escaping them before setting variables in setup.py and hooks.py
 	for key in ("app_publisher", "app_description", "app_license"):
 		hooks[key] = hooks[key].replace("\\", "\\\\").replace("'", "\\'").replace('"', '\\"')
-
-	with open(os.path.join(dest, hooks.app_name, "setup.py"), "w") as f:
-		f.write(frappe.as_unicode(setup_template.format(**hooks)))
 
 	with open(os.path.join(dest, hooks.app_name, hooks.app_name, "hooks.py"), "w") as f:
 		f.write(frappe.as_unicode(hooks_template.format(**hooks)))
@@ -273,25 +264,6 @@ class PatchCreator:
 		init_py = self.patch_dir / "__init__.py"
 		init_py.touch()
 
-
-manifest_template = """include MANIFEST.in
-include requirements.txt
-include *.json
-include *.md
-include *.py
-include *.txt
-recursive-include {app_name} *.css
-recursive-include {app_name} *.csv
-recursive-include {app_name} *.html
-recursive-include {app_name} *.ico
-recursive-include {app_name} *.js
-recursive-include {app_name} *.json
-recursive-include {app_name} *.md
-recursive-include {app_name} *.png
-recursive-include {app_name} *.py
-recursive-include {app_name} *.svg
-recursive-include {app_name} *.txt
-recursive-exclude {app_name} *.pyc"""
 
 init_template = """
 __version__ = '0.0.1'
@@ -514,27 +486,6 @@ app_license = "{app_license}"
 # auth_hooks = [
 #	"{app_name}.auth.validate"
 # ]
-"""
-
-setup_template = """from setuptools import setup, find_packages
-
-with open("requirements.txt") as f:
-	install_requires = f.read().strip().split("\\n")
-
-# get version from __version__ variable in {app_name}/__init__.py
-from {app_name} import __version__ as version
-
-setup(
-	name="{app_name}",
-	version=version,
-	description="{app_description}",
-	author="{app_publisher}",
-	author_email="{app_email}",
-	packages=find_packages(),
-	zip_safe=False,
-	include_package_data=True,
-	install_requires=install_requires
-)
 """
 
 gitignore_template = """.DS_Store


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/21612

PIP will overtime move away from setup.py installs completely, so if you maintain Frappe app it's wise to add `pyproject.toml` file. Copy Frappe's and modify values if you're unsure how to do it. 

https://github.com/frappe/frappe/blob/e38078a69f07e71422697b8730735940c0677dc0/pyproject.toml#L1-L87


ref: 
- https://peps.python.org/pep-0517/
- https://github.com/frappe/frappe/pull/17174


docs: https://frappeframework.com/docs/v14/user/en/tutorial/create-an-app