### PR TITLE
fix(UX): OAuth confirm access screen

### DIFF
--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -101,6 +101,10 @@ def authorize(**kwargs):
 				frappe.local.response["type"] = "redirect"
 				frappe.local.response["location"] = success_url
 			else:
+				if "openid" in scopes:
+					scopes.remove("openid")
+					scopes.extend(["First Name", "Last Name", "Email", "Password", "User Image", "Roles"])
+
 				# Show Allow/Deny screen.
 				response_html_params = frappe._dict(
 					{

--- a/frappe/integrations/oauth2.py
+++ b/frappe/integrations/oauth2.py
@@ -113,7 +113,7 @@ def authorize(**kwargs):
 				resp_html = frappe.render_template(
 					"templates/includes/oauth_confirmation.html", response_html_params
 				)
-				frappe.respond_as_web_page("Confirm Access", resp_html)
+				frappe.respond_as_web_page("Confirm Access", resp_html, primary_action=None)
 		except (FatalClientError, OAuth2Error) as e:
 			return generate_json_error_response(e)
 

--- a/frappe/templates/includes/oauth_confirmation.html
+++ b/frappe/templates/includes/oauth_confirmation.html
@@ -1,22 +1,19 @@
 {% if not error %}
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h3 class="panel-title">{{ _("{} wants to access the following details from your account").format(client_id) }}</h3>
+    <div class="panel-title h3">{{ _(client_id) }}</div>
+    <p class="panel-subtitle">{{ _("wants to access the following details from your account") }}</p>
   </div>
   <div class="panel-body">
-      <ul class="list-group">
+      <ul>
       {% for dtl in details %}
-        <li class="list-group-item">{{ dtl.title() }}</li>
+        <li>{{ dtl.title() }}</li>
       {% endfor %}
       </ul>
-    <ul class="list-inline">
-      <li>
-        <button id="allow" class="btn btn-sm btn-primary">{{ _("Allow") }}</button>
-      </li>
-      <li>
-        <button id="deny" class="btn btn-sm btn-light">{{ _("Deny") }}</button>
-      </li>
-    </ul>
+    <div class="action-buttons d-flex">
+      <button id="deny" class="btn btn-sm btn-light btn-block mr-3">{{ _("Deny") }}</button>
+      <button id="allow" class="btn btn-sm btn-primary btn-block">{{ _("Allow") }}</button>
+    </div>
   </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
Before:
<img width="805" alt="image" src="https://github.com/frappe/frappe/assets/30859809/e765571b-a400-4852-83c9-c2eaeee2487e">

After:
<img width="1241" alt="image" src="https://github.com/frappe/frappe/assets/30859809/544bbfa6-8145-4b55-8658-93c918e5a81c">

Fixes: https://github.com/frappe/frappe/issues/21673
