### PR TITLE
fix: use current redirect URIs instead of legacy ones

### DIFF
--- a/frappe/integrations/doctype/oauth_client/oauth_client.json
+++ b/frappe/integrations/doctype/oauth_client/oauth_client.json
@@ -76,7 +76,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.\n<br>e.g. http://hostname/api/method/frappe.www.login.login_via_facebook",
+   "description": "URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.\n<br>e.g. http://hostname/api/method/frappe.integrations.oauth2_logins.login_via_facebook",
    "fieldname": "redirect_uris",
    "fieldtype": "Text",
    "label": "Redirect URIs"
@@ -117,7 +117,7 @@
   }
  ],
  "links": [],
- "modified": "2023-04-07 07:06:35.765981",
+ "modified": "2023-07-17 07:06:35.765981",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "OAuth Client",

--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -96,7 +96,7 @@ class SocialLoginKey(Document):
 			"icon": "fa fa-github",
 			"authorize_url": "https://github.com/login/oauth/authorize",
 			"access_token_url": "https://github.com/login/oauth/access_token",
-			"redirect_url": "/api/method/frappe.www.login.login_via_github",
+			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_github",
 			"api_endpoint": "user",
 			"api_endpoint_args": None,
 			"auth_url_data": json.dumps({"scope": "user:email"}),
@@ -110,7 +110,7 @@ class SocialLoginKey(Document):
 			"icon": "fa fa-google",
 			"authorize_url": "https://accounts.google.com/o/oauth2/auth",
 			"access_token_url": "https://accounts.google.com/o/oauth2/token",
-			"redirect_url": "/api/method/frappe.www.login.login_via_google",
+			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_google",
 			"api_endpoint": "oauth2/v2/userinfo",
 			"api_endpoint_args": None,
 			"auth_url_data": json.dumps(
@@ -129,7 +129,7 @@ class SocialLoginKey(Document):
 			"icon": "fa fa-facebook",
 			"authorize_url": "https://www.facebook.com/dialog/oauth",
 			"access_token_url": "https://graph.facebook.com/oauth/access_token",
-			"redirect_url": "/api/method/frappe.www.login.login_via_facebook",
+			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_facebook",
 			"api_endpoint": "/v2.5/me",
 			"api_endpoint_args": json.dumps(
 				{"fields": "first_name,last_name,email,gender,location,verified,picture"}
@@ -144,7 +144,7 @@ class SocialLoginKey(Document):
 			"enable_social_login": 1,
 			"custom_base_url": 1,
 			"icon": "/assets/frappe/images/frappe-favicon.svg",
-			"redirect_url": "/api/method/frappe.www.login.login_via_frappe",
+			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_frappe",
 			"api_endpoint": "/api/method/frappe.integrations.oauth2.openid_profile",
 			"api_endpoint_args": None,
 			"authorize_url": "/api/method/frappe.integrations.oauth2.authorize",


### PR DESCRIPTION
in continuation of https://github.com/frappe/frappe/pull/19465