### PR TITLE
fix(UI): page layout breaking after upgrading bootstrap to v4.6.2

### DIFF
--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -76,6 +76,7 @@
 
 .layout-main-section-wrapper {
 	margin-bottom: var(--page-bottom-margin);
+	min-width: 0;
 }
 
 .layout-main-section.frappe-card {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "air-datepicker": "github:frappe/air-datepicker",
     "autoprefixer": "10",
     "awesomplete": "^1.1.5",
-    "bootstrap": "4.5.0",
+    "bootstrap": "4.6.2",
     "chalk": "^2.3.2",
     "cliui": "^7.0.4",
     "cookie": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,10 +462,10 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-bootstrap@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.0.tgz#97d9dbcb5a8972f8722c9962483543b907d9b9ec"
-  integrity sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA==
+bootstrap@4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.2.tgz#8e0cd61611728a5bf65a3a2b8d6ff6c77d5d7479"
+  integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Before: 
<img width="1404" alt="image" src="https://github.com/frappe/frappe/assets/30859809/fd3fd5d2-d5b7-4b02-8268-466b1825dab0">

After:
<img width="1404" alt="image" src="https://github.com/frappe/frappe/assets/30859809/9886dd88-ab2a-4ebb-80a3-3a90cdcf9e6c">


What changed in bootstrap:
![image_2023-07-17_17-42-27](https://github.com/frappe/frappe/assets/30859809/db5c0fb4-0a15-4265-bdeb-9e06975d4ea9)
![image_2023-07-17_17-42-28](https://github.com/frappe/frappe/assets/30859809/0f78bc1e-24c0-4aff-8782-aec5df8d5148)


