### PR TITLE
fix: include languages when clearing website cache

### DIFF
--- a/frappe/core/doctype/language/language.py
+++ b/frappe/core/doctype/language/language.py
@@ -16,6 +16,10 @@ class Language(Document):
 	def before_rename(self, old, new, merge=False):
 		validate_with_regex(new, "Name")
 
+	def on_update(self):
+		frappe.cache.delete_value("languages_with_name")
+		frappe.cache.delete_value("languages")
+
 
 def validate_with_regex(name, label):
 	pattern = re.compile("^[a-zA-Z]+[-_]*[a-zA-Z]+$")

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -357,7 +357,14 @@ def clear_cache(path=None):
 	:param path: (optional) for the given path"""
 	from frappe.website.router import clear_routing_cache
 
-	for key in ("website_generator_routes", "website_pages", "website_full_index", "sitemap_routes"):
+	for key in (
+		"website_generator_routes",
+		"website_pages",
+		"website_full_index",
+		"sitemap_routes",
+		"languages_with_name",
+		"languages",
+	):
 		frappe.cache.delete_value(key)
 
 	clear_routing_cache()


### PR DESCRIPTION
We cache the languages shown in the website language picker:

https://github.com/frappe/frappe/blob/9c481cfd68d71b979e64678e78dc11b957bd22ba/frappe/translate.py#L1304-L1320

But marking a **Language** as _Disabled_ has no effect, since they are served from the cache. Running clear_cache also had no effect, since it didn't include the "languages" keys.

Proposed solution:

- Clear language cache on update of **Language**
- Clear language cache during "clear website cache"