### PR TITLE
feat: added specific kanban board as quick link in workspace

### DIFF
--- a/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
+++ b/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
@@ -9,6 +9,7 @@
   "link_to",
   "url",
   "doc_view",
+  "kanban_board",
   "column_break_4",
   "label",
   "icon",
@@ -43,7 +44,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "DocType View",
-   "options": "\nList\nReport Builder\nDashboard\nTree\nNew\nCalendar"
+   "options": "\nList\nReport Builder\nDashboard\nTree\nNew\nCalendar\nKanban"
   },
   {
    "fieldname": "column_break_4",
@@ -103,12 +104,19 @@
    "in_list_view": 1,
    "label": "URL",
    "options": "URL"
+  },
+  {
+   "depends_on": "eval:doc.doc_view == \"Kanban\"",
+   "fieldname": "kanban_board",
+   "fieldtype": "Link",
+   "label": "Kanban Board",
+   "options": "Kanban Board"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-04-19 13:32:31.005443",
+ "modified": "2023-07-18 16:12:53.546430",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Shortcut",
@@ -117,5 +125,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1295,6 +1295,9 @@ Object.assign(frappe.utils, {
 							break;
 						case "Kanban":
 							route = `${doctype_slug}/view/kanban`;
+							if (item.kanban_board) {
+								route += `/${item.kanban_board}`;
+							}
 							break;
 						default:
 							route = doctype_slug;

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -21,6 +21,7 @@ export default class ShortcutWidget extends Widget {
 			stats_filter: this.stats_filter,
 			type: this.type,
 			url: this.url,
+			kanban_board: this.kanban_board,
 		};
 	}
 
@@ -35,6 +36,7 @@ export default class ShortcutWidget extends Widget {
 				is_query_report: this.is_query_report,
 				doctype: this.ref_doctype,
 				doc_view: this.doc_view,
+				kanban_board: this.kanban_board,
 			});
 
 			let filters = frappe.utils.get_filter_from_json(this.stats_filter);

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -381,23 +381,29 @@ class ShortcutDialog extends WidgetDialog {
 				fieldname: "link_to",
 				label: "Link To",
 				options: "type",
-				onchange: () => {
+				onchange: async () => {
 					const doctype = this.dialog.get_value("link_to");
 					if (doctype && this.dialog.get_value("type") == "DocType") {
-						frappe.model.with_doctype(doctype, () => {
+						frappe.model.with_doctype(doctype, async () => {
 							let meta = frappe.get_meta(doctype);
-
+				
 							if (doctype && frappe.boot.single_types.includes(doctype)) {
 								this.hide_filters();
 							} else if (doctype) {
 								this.setup_filter(doctype);
 								this.show_filters();
 							}
-
+				
 							const views = ["List", "Report Builder", "Dashboard", "New"];
 							if (meta.is_tree === "Tree") views.push("Tree");
 							if (frappe.boot.calendars.includes(doctype)) views.push("Calendar");
 
+							const response = await frappe.db.get_value("Kanban Board", { reference_doctype: doctype }, "name");
+
+							if (response && response.message.name) {
+								views.push("Kanban");
+							}
+							
 							this.dialog.set_df_property("doc_view", "options", views.join("\n"));
 						});
 					} else {
@@ -426,13 +432,40 @@ class ShortcutDialog extends WidgetDialog {
 				),
 				default: "List",
 				depends_on: (state) => {
-					if (this.dialog) {
+					if (this.dialog && this.dialog.get_value("link_to")) {
 						let doctype = this.dialog.get_value("link_to");
 						let is_single = frappe.boot.single_types.includes(doctype);
 						return state.type == "DocType" && !is_single;
 					}
 
 					return false;
+				},
+				onchange: () => {
+					if (this.dialog.get_value("doc_view") == "Kanban") {
+						this.dialog.fields_dict.kanban_board.get_query = () => {
+							return {
+								filters: {
+									reference_doctype: this.dialog.get_value("link_to"),
+								},
+							};
+						};
+					} else {
+						this.dialog.fields_dict.link_to.get_query = null;
+					}
+				}
+			},
+			{
+				fieldtype: "Link",
+				fieldname: "kanban_board",
+				label: "Kanban Board",
+				options: "Kanban Board",
+				depends_on: () => {
+					let doc_view = this.dialog?.get_value("doc_view");
+					return doc_view == "Kanban";
+				},
+				mandatory_depends_on: () => {
+					let doc_view = this.dialog?.get_value("doc_view");
+					return doc_view == "Kanban";
 				},
 			},
 			{

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -398,9 +398,13 @@ class ShortcutDialog extends WidgetDialog {
 							if (meta.is_tree === "Tree") views.push("Tree");
 							if (frappe.boot.calendars.includes(doctype)) views.push("Calendar");
 
-							const response = await frappe.db.get_value("Kanban Board", { reference_doctype: doctype }, "name");
+							const response = await frappe.db.get_value(
+								"Kanban Board",
+								{ reference_doctype: doctype },
+								"name"
+							);
 							if (response?.message?.name) views.push("Kanban");
-							
+
 							this.dialog.set_df_property("doc_view", "options", views.join("\n"));
 						});
 					} else {
@@ -449,7 +453,7 @@ class ShortcutDialog extends WidgetDialog {
 					} else {
 						this.dialog.fields_dict.link_to.get_query = null;
 					}
-				}
+				},
 			},
 			{
 				fieldtype: "Link",

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -381,28 +381,25 @@ class ShortcutDialog extends WidgetDialog {
 				fieldname: "link_to",
 				label: "Link To",
 				options: "type",
-				onchange: async () => {
+				onchange: () => {
 					const doctype = this.dialog.get_value("link_to");
 					if (doctype && this.dialog.get_value("type") == "DocType") {
 						frappe.model.with_doctype(doctype, async () => {
 							let meta = frappe.get_meta(doctype);
-				
+
 							if (doctype && frappe.boot.single_types.includes(doctype)) {
 								this.hide_filters();
 							} else if (doctype) {
 								this.setup_filter(doctype);
 								this.show_filters();
 							}
-				
+
 							const views = ["List", "Report Builder", "Dashboard", "New"];
 							if (meta.is_tree === "Tree") views.push("Tree");
 							if (frappe.boot.calendars.includes(doctype)) views.push("Calendar");
 
 							const response = await frappe.db.get_value("Kanban Board", { reference_doctype: doctype }, "name");
-
-							if (response && response.message.name) {
-								views.push("Kanban");
-							}
+							if (response?.message?.name) views.push("Kanban");
 							
 							this.dialog.set_df_property("doc_view", "options", views.join("\n"));
 						});
@@ -432,10 +429,10 @@ class ShortcutDialog extends WidgetDialog {
 				),
 				default: "List",
 				depends_on: (state) => {
-					if (this.dialog && this.dialog.get_value("link_to")) {
+					if (this.dialog) {
 						let doctype = this.dialog.get_value("link_to");
 						let is_single = frappe.boot.single_types.includes(doctype);
-						return state.type == "DocType" && !is_single;
+						return doctype && state.type == "DocType" && !is_single;
 					}
 
 					return false;


### PR DESCRIPTION
Pull Request Description:

This pull request introduces a new feature that allows users to add shortcuts for specific Kanban Boards in workspaces. Currently, there is no direct way to add a specific Kanban Board as a shortcut in workspaces. To address this limitation, I have made the following changes:

1. Added a new field: I have included a new field that enables users to select a specific Kanban Board when the 'doc_view' parameter is set to 'Kanban'. This new field provides a way to associate a Kanban Board with a workspace shortcut.

2. File modifications: I have edited the relevant files that are necessary to implement this feature. These modifications ensure that the new field is properly integrated into the workspace functionality and that the selected Kanban Board is correctly associated with the workspace shortcut.

To provide more information and demonstrate the feature in action, I have attached a GIF below. The GIF visually showcases the process of adding a shortcut for a specific Kanban Board in a workspace.

These changes aim to enhance the usability and flexibility of the workspace feature by allowing users to conveniently access specific Kanban Boards directly from their workspaces.

![kanban shorcuts](https://github.com/frappe/frappe/assets/40702858/a73eca4d-a7ab-4493-b47b-6e1f1351f900)


>no-docs
