### PR TITLE
fix: allow users having access to email queue to bulk retry sending

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue_list.js
+++ b/frappe/email/doctype/email_queue/email_queue_list.js
@@ -44,8 +44,6 @@ function show_toggle_sending_button(list_view) {
 }
 
 function add_bulk_retry_button_to_actions(list_view) {
-	if (!has_common(frappe.user_roles, ["Administrator", "System Manager"])) return;
-
 	list_view.page.add_actions_menu_item(__("Retry Sending"), () => {
 		frappe.call({
 			method: "frappe.email.doctype.email_queue.email_queue.bulk_retry",


### PR DESCRIPTION
Don't restrict the bulk retry button for just system managers