### PR TITLE
fix!: Dont show bold fields in quick entry.

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -60,11 +60,8 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 		this.meta = frappe.get_meta(this.doctype);
 		let fields = this.meta.fields;
 
-		// prepare a list of mandatory, bold and allow in quick entry fields
 		this.mandatory = fields.filter((df) => {
-			return (
-				(df.reqd || df.bold || df.allow_in_quick_entry) && !df.read_only && !df.is_virtual
-			);
+			return (df.reqd || df.allow_in_quick_entry) && !df.read_only && !df.is_virtual;
 		});
 	}
 


### PR DESCRIPTION
IDK if "BOLD" implies it should be shown in quick entry. All it implies is to add `strong` tag to the label. (IDK why even that is required :woozy_face: )

Frequent misunderstanding: https://github.com/frappe/frappe/issues/21726
