### PR TITLE
refactor: easier customization of Geolocation control

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -1,4 +1,4 @@
-frappe.provide("frappe.utils.utils");
+frappe.provide("frappe.utils");
 
 frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.form.ControlData {
 	static horizontal = false;

--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -138,7 +138,7 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 			},
 		});
 
-		L.Icon.Default.imagePath = "/assets/frappe/images/leaflet/";
+		L.Icon.Default.imagePath = frappe.utils.map_defaults.image_path;
 	}
 
 	bind_leaflet_map() {

--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -35,6 +35,7 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 	}
 
 	make_map(value) {
+		this.customize_draw_controls();
 		this.bind_leaflet_map();
 		if (this.disabled) {
 			this.map.dragging.disable();
@@ -113,7 +114,7 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 	 */
 	on_each_feature(feature, layer) {}
 
-	bind_leaflet_map() {
+	customize_draw_controls() {
 		const circleToGeoJSON = L.Circle.prototype.toGeoJSON;
 		L.Circle.include({
 			toGeoJSON: function () {
@@ -138,6 +139,9 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 		});
 
 		L.Icon.Default.imagePath = "/assets/frappe/images/leaflet/";
+	}
+
+	bind_leaflet_map() {
 		this.map = L.map(this.map_id);
 		this.map.setView(frappe.utils.map_defaults.center, frappe.utils.map_defaults.zoom);
 

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1203,6 +1203,7 @@ Object.assign(frappe.utils, {
 			attribution:
 				'&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
 		},
+		image_path: "/assets/frappe/images/leaflet/",
 	},
 
 	icon(icon_name, size = "sm", icon_class = "", icon_style = "", svg_class = "") {

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -32,7 +32,7 @@ frappe.views.MapView = class MapView extends frappe.views.ListView {
 
 		this.$result.html(`<div id="${this.map_id}" class="map-view-container"></div>`);
 
-		L.Icon.Default.imagePath = "/assets/frappe/images/leaflet/";
+		L.Icon.Default.imagePath = frappe.utils.map_defaults.image_path;
 		this.map = L.map(this.map_id).setView(
 			frappe.utils.map_defaults.center,
 			frappe.utils.map_defaults.zoom

--- a/frappe/public/js/frappe/views/map/map_view.js
+++ b/frappe/public/js/frappe/views/map/map_view.js
@@ -1,7 +1,7 @@
 /**
  * frappe.views.MapView
  */
-frappe.provide("frappe.utils.utils");
+frappe.provide("frappe.utils");
 frappe.provide("frappe.views");
 
 frappe.views.MapView = class MapView extends frappe.views.ListView {


### PR DESCRIPTION
Refactor the Geolocation control to make customization easier

- Extract a method `customize_draw_controls` from `bind_leaflet_map`. -> Can be overridden to create custom controls.
- Move the default path for icons to `map_defaults` instead of hardcoding it
in the control. -> Can be overridden to provide a custom image path.
- Remove one unused `"utils"` from `frappe.provide("frappe.utils.utils")`