### PR TITLE
perf: workflow transitions and bulk workflow

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -228,11 +228,7 @@ def send_email_alert(workflow_name):
 
 
 def get_workflow_field_value(workflow_name, field):
-	value = frappe.cache.hget("workflow_" + workflow_name, field)
-	if value is None:
-		value = frappe.db.get_value("Workflow", workflow_name, field)
-		frappe.cache.hset("workflow_" + workflow_name, field, value)
-	return value
+	return frappe.get_cached_value("Workflow", workflow_name, field)
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -545,7 +545,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (toggle) {
 			this.page.show_actions_menu();
 			this.page.clear_primary_action();
-			this.toggle_workflow_actions();
 		} else {
 			this.page.hide_actions_menu();
 			this.set_primary_action();
@@ -1313,6 +1312,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 			this.update_checkbox($target);
 		});
+
+		let me = this;
+		this.page.actions_btn_group.on("show.bs.dropdown", () => {
+			me.toggle_workflow_actions();
+		});
 	}
 
 	setup_like() {
@@ -1697,7 +1701,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	toggle_workflow_actions() {
 		if (!frappe.model.has_workflow(this.doctype)) return;
+
+		Object.keys(this.workflow_action_items).forEach((key) => {
+			this.workflow_action_items[key].addClass("disabled");
+		});
 		const checked_items = this.get_checked_items();
+
 		frappe
 			.xcall("frappe.model.workflow.get_common_transition_actions", {
 				docs: checked_items,
@@ -1705,6 +1714,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			})
 			.then((actions) => {
 				Object.keys(this.workflow_action_items).forEach((key) => {
+					this.workflow_action_items[key].removeClass("disabled");
 					this.workflow_action_items[key].toggle(actions.includes(key));
 				});
 			});

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -593,7 +593,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	render() {
 		this.render_list();
 		this.set_rows_as_checked();
-		this.on_row_checked();
 		this.render_count();
 	}
 

--- a/frappe/workflow/doctype/workflow/workflow.json
+++ b/frappe/workflow/doctype/workflow/workflow.json
@@ -54,7 +54,7 @@
    "label": "Don't Override Status"
   },
   {
-   "default": "1",
+   "default": "0",
    "description": "Emails will be sent with next possible workflow actions",
    "fieldname": "send_email_alert",
    "fieldtype": "Check",

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -17,7 +17,6 @@ class Workflow(Document):
 	def on_update(self):
 		self.update_doc_status()
 		frappe.clear_cache(doctype=self.document_type)
-		frappe.cache.delete_key("workflow_" + self.name)  # clear cache created in model/workflow.py
 
 	def create_custom_field_for_workflow_state(self):
 		frappe.clear_cache(doctype=self.document_type)


### PR DESCRIPTION
Problem: if someone has rows checked on list view and page refreshes it keeps calling (2x per refresh) `get_common_transitions` which has potential to block web workers entirely. 

Fixes:
- List view refresh was calling `on_row_checked` twice hence calling `get_common_transitions` twice
- Workflow caching had weird 2nd layer of cache. Just replaced with simpler `get_cached_value` now.
- Disabled list view updates while doing bulk workflow actions.
- Only compute common transactions when user expands "Actions"


towards https://github.com/frappe/frappe/issues/21742