### PR TITLE
fix: actually debounce list view updates

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -24,6 +24,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	constructor(opts) {
 		super(opts);
 		this.show();
+		this.debounced_refresh = frappe.utils.debounce(
+			this.process_document_refreshes.bind(this),
+			2000
+		);
 	}
 
 	has_permissions() {
@@ -1377,7 +1381,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			}
 
 			this.pending_document_refreshes.push(data);
-			frappe.utils.debounce(this.process_document_refreshes.bind(this), 1000)();
+			this.debounced_refresh();
 		});
 		this.realtime_events_setup = true;
 	}


### PR DESCRIPTION
Immediately debouncing and executing creates a new function everytime and doesn't actually "debounce" it just "delays". :moyai:

So 10 calls to this function will result in 10 actual calls, just delayed by 1 second.


Towards https://github.com/frappe/frappe/issues/21742