### PR TITLE
perf: use db.count() instead of len(get_all)

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -279,9 +279,9 @@ def get_open_count(doctype, name, items=None):
 			# get the fieldname for the current document
 			# we only need open documents related to the current document
 			filters[fieldname] = name
-			data["open_count"] = frappe.db.count(d, filters, cache=True, distinct=True)
+			data["open_count"] = frappe.db.count(d, filters, distinct=True)
 
-		data["count"] = frappe.db.count(d, {fieldname: name}, cache=True, distinct=True)
+		data["count"] = frappe.db.count(d, {fieldname: name}, distinct=True)
 		out.append(data)
 
 	out = {

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -279,17 +279,9 @@ def get_open_count(doctype, name, items=None):
 			# get the fieldname for the current document
 			# we only need open documents related to the current document
 			filters[fieldname] = name
-			total = len(
-				frappe.get_all(d, fields="name", filters=filters, limit=100, distinct=True, ignore_ifnull=True)
-			)
-			data["open_count"] = total
+			data["open_count"] = frappe.db.count(d, filters, cache=True, distinct=True)
 
-		total = len(
-			frappe.get_all(
-				d, fields="name", filters={fieldname: name}, limit=100, distinct=True, ignore_ifnull=True
-			)
-		)
-		data["count"] = total
+		data["count"] = frappe.db.count(d, {fieldname: name}, cache=True, distinct=True)
 		out.append(data)
 
 	out = {


### PR DESCRIPTION
Before:

```
%timeit -r 100 -n 100 get_open_count("My DocType", "My Docname")
2.14 ms ± 406 µs per loop (mean ± std. dev. of 100 runs, 100 loops each)
```

After:

```
%timeit -r 100 -n 100 get_open_count("My DocType", "My Docname")
1.72 ms ± 512 µs per loop (mean ± std. dev. of 100 runs, 100 loops each)
```

_My DocType_ has ~800 records, 20 of which are linked to _My Docname_.

### Thoughts

This function is leaking information (not introduced by this PR) since users will see the total number of records, not just of the ones they are permitted to see. Maybe a `frappe.get_list(dt, fields="COUNT(*)", filters=filters)` would be safer (but slower) here.