### PR TITLE
fix: better job naming for enqueue_doc

### DIFF
--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -115,7 +115,13 @@ class RQJob(Document):
 
 def serialize_job(job: Job) -> frappe._dict:
 	modified = job.last_heartbeat or job.ended_at or job.started_at or job.created_at
-	job_name = job.kwargs.get("kwargs", {}).get("job_type") or str(job.kwargs.get("job_name"))
+	job_kwargs = job.kwargs.get("kwargs", {})
+	job_name = job_kwargs.get("job_type") or str(job.kwargs.get("job_name"))
+	if job_name == "frappe.utils.background_jobs.run_doc_method":
+		doctype = job_kwargs.get("doctype")
+		doc_method = job_kwargs.get("doc_method")
+		if doctype and doc_method:
+			job_name = f"{doctype}.{doc_method}"
 
 	# function objects have this repr: '<function functionname at 0xmemory_address >'
 	# This regex just removes unnecessary things around it.


### PR DESCRIPTION
DocType.method instead of frappe.utils.background_jobs.run_doc_method

### Before

<img width="1440" alt="image" src="https://github.com/frappe/frappe/assets/9355208/f3b4d2d7-d2c8-41c9-adcb-94442a8e9c98">

### After
<img width="1440" alt="image" src="https://github.com/frappe/frappe/assets/9355208/af961315-6afa-49cc-b2f9-55abb6cd63d4">
