### PR TITLE
Dedupe timeline links in Communication

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -377,6 +377,7 @@ class Communication(Document, CommunicationEmailMixin):
 
 	def add_link(self, link_doctype, link_name, autosave=False):
 		self.append("timeline_links", {"link_doctype": link_doctype, "link_name": link_name})
+		self.deduplicate_timeline_links()
 
 		if autosave:
 			self.save(ignore_permissions=True)


### PR DESCRIPTION
Timeline links are deduplicated in Communication, only for communication medium Email. This allows duplicate to be created in case of Event. Each time an Event is saved, timeline links are doubled (in sync_communication)

https://github.com/frappe/frappe/blob/d5a296a7cac31425b26f0c504e62c29636998cd1/frappe/desk/doctype/event/event.py#L90

