### PR TITLE
fix: deduplicate timeline links while adding links

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -377,6 +377,7 @@ class Communication(Document, CommunicationEmailMixin):
 
 	def add_link(self, link_doctype, link_name, autosave=False):
 		self.append("timeline_links", {"link_doctype": link_doctype, "link_name": link_name})
+		self.deduplicate_timeline_links()
 
 		if autosave:
 			self.save(ignore_permissions=True)


### PR DESCRIPTION
Timeline links are deduplicated in Communication in validate but only for communication medium Email. 

Issue:
Each time an Event is saved, timeline links are doubled (in sync_communication) https://github.com/frappe/frappe/blob/9608c32db7dd90a485b20a60f86ea899003b65db/frappe/desk/doctype/event/event.py#L114

Solution:
Deduplicate timeline links after add_link. it fixes duplicates created through add_link.
