### PR TITLE
perf: get all Scheduled Job Types in one query

### DIFF
--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -83,9 +83,9 @@ def enqueue_events_for_site(site: str) -> None:
 def enqueue_events(site: str) -> list[str] | None:
 	if schedule_jobs_based_on_activity():
 		enqueued_jobs = []
-		for job_type in frappe.get_all("Scheduled Job Type", ("name", "method"), {"stopped": 0}):
-			job_type = frappe.get_cached_doc("Scheduled Job Type", job_type.name)
-			if _enqueued := job_type.enqueue():
+		for job_type in frappe.get_all("Scheduled Job Type", filters={"stopped": 0}, fields="*"):
+			job_type = frappe.get_doc(doctype="Scheduled Job Type", **job_type)
+			if job_type.enqueue():
 				enqueued_jobs.append(job_type.method)
 
 		return enqueued_jobs


### PR DESCRIPTION
Similar to https://github.com/frappe/frappe/pull/20856

Note: this kind of optimisation works best for limited rows & doctypes without child tables.