### PR TITLE
chore(db): ensure db obtains defaults from the calling site

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -270,7 +270,8 @@ def connect(
 		host=local.conf.db_host,
 		port=local.conf.db_port,
 		user=db_name or local.conf.db_name,
-		password=None,
+		password=local.conf.db_password,
+		dbname=db_name or local.conf.db_name,
 	)
 	if set_admin_as_user:
 		set_user("Administrator")
@@ -290,7 +291,9 @@ def connect_replica() -> bool:
 		user = local.conf.replica_db_name
 		password = local.conf.replica_db_password
 
-	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)
+	local.replica_db = get_db(
+		host=local.conf.replica_host, user=user, password=password, port=port, dbname=user
+	)
 
 	# swap db connections
 	local.primary_db = local.db

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -39,14 +39,14 @@ def drop_user_and_database(db_name, root_login=None, root_password=None):
 		)
 
 
-def get_db(host=None, user=None, password=None, port=None):
+def get_db(host=None, user=None, password=None, port=None, dbname=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.database
 
-		return frappe.database.postgres.database.PostgresDatabase(host, user, password, port=port)
+		return frappe.database.postgres.database.PostgresDatabase(host, user, password, port, dbname)
 	else:
 		import frappe.database.mariadb.database
 
-		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port=port)
+		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port, dbname)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -64,30 +64,23 @@ class Database:
 
 	def __init__(
 		self,
-		host=None,
-		user=None,
-		password=None,
-		ac_name=None,
-		use_default=0,
-		port=None,
+		host,
+		user,
+		password,
+		port,
+		cur_db_name,
 	):
 		self.setup_type_map()
-		self.host = host or frappe.conf.db_host
-		self.port = port or frappe.conf.db_port
-		self.user = user or frappe.conf.db_name
-		self.db_name = frappe.conf.db_name
+		self.host = host
+		self.port = port
+		self.user = user
+		self.password = password
+		self.cur_db_name = cur_db_name
 		self._conn = None
-
-		if ac_name:
-			self.user = ac_name or frappe.conf.db_name
-
-		if use_default:
-			self.user = frappe.conf.db_name
 
 		self.transaction_writes = 0
 		self.auto_commit_on_many_writes = 0
 
-		self.password = password or frappe.conf.db_password
 		self.value_cache = {}
 		self.logger = frappe.logger("database")
 		self.logger.setLevel("WARNING")
@@ -105,7 +98,6 @@ class Database:
 
 	def connect(self):
 		"""Connects to a database as set in `site_config.json`."""
-		self.cur_db_name = self.user
 		self._conn = self.get_connection()
 		self._cursor = self._conn.cursor()
 
@@ -123,6 +115,7 @@ class Database:
 	def use(self, db_name):
 		"""`USE` db_name."""
 		self._conn.select_db(db_name)
+		self.cur_db_name = db_name
 
 	def get_connection(self):
 		"""Returns a Database connection object that conforms with https://peps.python.org/pep-0249/#connection-objects"""

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -124,7 +124,7 @@ class MariaDBConnectionUtil:
 		}
 
 		if self.user not in (frappe.flags.root_login, "root"):
-			conn_settings["database"] = self.user
+			conn_settings["database"] = self.cur_db_name
 
 		if self.port:
 			conn_settings["port"] = int(self.port)
@@ -198,7 +198,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			SUM(`data_length` + `index_length`) / 1024 / 1024 AS `database_size`
 			FROM information_schema.tables WHERE `table_schema` = %s GROUP BY `table_schema`
 			""",
-			self.db_name,
+			self.cur_db_name,
 			as_dict=True,
 		)
 

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -170,6 +170,7 @@ def get_root_connection(root_login, root_password):
 			port=frappe.conf.db_port,
 			user=root_login,
 			password=root_password,
+			dbname=None,
 		)
 
 	return frappe.local.flags.root_connection

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -160,11 +160,16 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		return LazyDecode(self._cursor.query)
 
 	def get_connection(self):
-		conn = psycopg2.connect(
-			"host='{}' dbname='{}' user='{}' password='{}' port={}".format(
-				self.host, self.cur_db_name, self.user, self.password, self.port
-			)
-		)
+		conn_settings = {
+			"user": self.user,
+			"dbname": self.cur_db_name,
+			"host": self.host,
+			"password": self.password,
+		}
+		if self.port:
+			conn_settings["port"] = self.port
+
+		conn = psycopg2.connect(**conn_settings)
 		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
 
 		return conn

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -162,7 +162,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 	def get_connection(self):
 		conn = psycopg2.connect(
 			"host='{}' dbname='{}' user='{}' password='{}' port={}".format(
-				self.host, self.user, self.user, self.password, self.port
+				self.host, self.cur_db_name, self.user, self.password, self.port
 			)
 		)
 		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
@@ -194,7 +194,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 	def get_database_size(self):
 		"""'Returns database size in MB"""
 		db_size = self.sql(
-			"SELECT (pg_database_size(%s) / 1024 / 1024) as database_size", self.db_name, as_dict=True
+			"SELECT (pg_database_size(%s) / 1024 / 1024) as database_size", self.cur_db_name, as_dict=True
 		)
 		return db_size[0].get("database_size")
 
@@ -214,7 +214,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			where table_catalog='{}'
 				and table_type = 'BASE TABLE'
 				and table_schema='{}'""".format(
-					frappe.conf.db_name, frappe.conf.get("db_schema", "public")
+					self.cur_db_name, frappe.conf.get("db_schema", "public")
 				)
 			)
 		]

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -96,6 +96,7 @@ def get_root_connection(root_login=None, root_password=None):
 			port=frappe.conf.db_port,
 			user=root_login,
 			password=root_password,
+			dbname=root_login,
 		)
 
 	return frappe.local.flags.root_connection


### PR DESCRIPTION
- ~~fix: procure db config from single authority~~
- ~~fix: revert unnecessary breaking changes~~
^^ part of: https://github.com/frappe/frappe/pull/21578 which tries to maintain a trivial diff. But depending on review preference, this slightly bigger PR can be reviewed, instead. If this PR has controversial changes, please review that linked PR, in a first pass.

---

- fix: set defaults at the highest level interface
- chore: compose postgres conn settings in the same way as with mariadb

> Please provide enough information so that others can review your pull request:

This PR moves the defaulting of db connection values to the calling site so that it becomes easier to understand where values come from.
This removes another (complex) layer of defaulting logic and increases the maintainability of the code further.

> Explain the **details** for making this change. What existing problem does the pull request solve?

- The (low level) database object ceases to implement `user == dbname` and now simply operates on `cur_db_name`, instead.
- The datbase object now avoids defaulting on its own terms and therefore must be supplied with a fully specified configuration.
  This ensures that configuration and defaulting heuristics happen closer to the internal configuraion object (`frappe.conf`),
  instead in more obscure places, like the database interface.

