### PR TITLE
chore(db): clarify root login code path

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -270,7 +270,8 @@ def connect(
 		host=local.conf.db_host,
 		port=local.conf.db_port,
 		user=db_name or local.conf.db_name,
-		password=None,
+		password=local.conf.db_password,
+		dbname=db_name or local.conf.db_name,
 	)
 	if set_admin_as_user:
 		set_user("Administrator")
@@ -290,7 +291,9 @@ def connect_replica() -> bool:
 		user = local.conf.replica_db_name
 		password = local.conf.replica_db_password
 
-	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)
+	local.replica_db = get_db(
+		host=local.conf.replica_host, user=user, password=password, port=port, dbname=user
+	)
 
 	# swap db connections
 	local.primary_db = local.db

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -7,18 +7,20 @@
 from frappe.database.database import savepoint
 
 
-def setup_database(force, source_sql=None, verbose=None, no_mariadb_socket=False):
+def setup_database(force, source_sql, verbose, root_login, root_password, no_mariadb_socket=False):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.setup_db
 
-		return frappe.database.postgres.setup_db.setup_database(force, source_sql, verbose)
+		return frappe.database.postgres.setup_db.setup_database(
+			force, source_sql, verbose, root_login, root_password
+		)
 	else:
 		import frappe.database.mariadb.setup_db
 
 		return frappe.database.mariadb.setup_db.setup_database(
-			force, source_sql, verbose, no_mariadb_socket=no_mariadb_socket
+			force, source_sql, verbose, root_login, root_password, no_mariadb_socket=no_mariadb_socket
 		)
 
 

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -39,14 +39,14 @@ def drop_user_and_database(db_name, root_login=None, root_password=None):
 		)
 
 
-def get_db(host=None, user=None, password=None, port=None):
+def get_db(host=None, user=None, password=None, port=None, dbname=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.database
 
-		return frappe.database.postgres.database.PostgresDatabase(host, user, password, port=port)
+		return frappe.database.postgres.database.PostgresDatabase(host, user, password, port, dbname)
 	else:
 		import frappe.database.mariadb.database
 
-		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port=port)
+		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port, dbname)

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -64,30 +64,23 @@ class Database:
 
 	def __init__(
 		self,
-		host=None,
-		user=None,
-		password=None,
-		ac_name=None,
-		use_default=0,
-		port=None,
+		host,
+		user,
+		password,
+		port,
+		cur_db_name,
 	):
 		self.setup_type_map()
-		self.host = host or frappe.conf.db_host
-		self.port = port or frappe.conf.db_port
-		self.user = user or frappe.conf.db_name
-		self.db_name = frappe.conf.db_name
+		self.host = host
+		self.port = port
+		self.user = user
+		self.password = password
+		self.cur_db_name = cur_db_name
 		self._conn = None
-
-		if ac_name:
-			self.user = ac_name or frappe.conf.db_name
-
-		if use_default:
-			self.user = frappe.conf.db_name
 
 		self.transaction_writes = 0
 		self.auto_commit_on_many_writes = 0
 
-		self.password = password or frappe.conf.db_password
 		self.value_cache = {}
 		self.logger = frappe.logger("database")
 		self.logger.setLevel("WARNING")
@@ -105,7 +98,6 @@ class Database:
 
 	def connect(self):
 		"""Connects to a database as set in `site_config.json`."""
-		self.cur_db_name = self.user
 		self._conn = self.get_connection()
 		self._cursor = self._conn.cursor()
 
@@ -123,6 +115,7 @@ class Database:
 	def use(self, db_name):
 		"""`USE` db_name."""
 		self._conn.select_db(db_name)
+		self.cur_db_name = db_name
 
 	def get_connection(self):
 		"""Returns a Database connection object that conforms with https://peps.python.org/pep-0249/#connection-objects"""

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -124,7 +124,7 @@ class MariaDBConnectionUtil:
 		}
 
 		if self.user not in (frappe.flags.root_login, "root"):
-			conn_settings["database"] = self.user
+			conn_settings["database"] = self.cur_db_name
 
 		if self.port:
 			conn_settings["port"] = int(self.port)
@@ -198,7 +198,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			SUM(`data_length` + `index_length`) / 1024 / 1024 AS `database_size`
 			FROM information_schema.tables WHERE `table_schema` = %s GROUP BY `table_schema`
 			""",
-			self.db_name,
+			self.cur_db_name,
 			as_dict=True,
 		)
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -123,7 +123,7 @@ class MariaDBConnectionUtil:
 			"use_unicode": True,
 		}
 
-		if self.user not in (frappe.flags.root_login, "root"):
+		if self.cur_db_name:
 			conn_settings["database"] = self.cur_db_name
 
 		if self.port:

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -23,11 +23,11 @@ def get_mariadb_version(version_string: str = ""):
 	return version.rsplit(".", 1)
 
 
-def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
+def setup_database(force, source_sql, verbose, root_login, root_password, no_mariadb_socket=False):
 	frappe.local.session = frappe._dict({"user": "Administrator"})
 
 	db_name = frappe.local.conf.db_name
-	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
+	root_conn = get_root_connection(root_login, root_password)
 	dbman = DbManager(root_conn)
 	dbman_kwargs = {}
 	if no_mariadb_socket:
@@ -153,17 +153,17 @@ def check_compatible_versions():
 
 
 def get_root_connection(root_login, root_password):
-	import getpass
-
 	if not frappe.local.flags.root_connection:
 		if not root_login:
-			root_login = "root"
+			root_login = frappe.conf.get("root_login") or "root"
 
 		if not root_password:
 			root_password = frappe.conf.get("root_password") or None
 
 		if not root_password:
-			root_password = getpass.getpass("MySQL root password: ")
+			from getpass import getpass
+
+			root_password = getpass("MySQL root password: ")
 
 		frappe.local.flags.root_connection = frappe.database.get_db(
 			host=frappe.conf.db_host,

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -170,6 +170,7 @@ def get_root_connection(root_login, root_password):
 			port=frappe.conf.db_port,
 			user=root_login,
 			password=root_password,
+			dbname=None,
 		)
 
 	return frappe.local.flags.root_connection

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -160,11 +160,16 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		return LazyDecode(self._cursor.query)
 
 	def get_connection(self):
-		conn = psycopg2.connect(
-			"host='{}' dbname='{}' user='{}' password='{}' port={}".format(
-				self.host, self.cur_db_name, self.user, self.password, self.port
-			)
-		)
+		conn_settings = {
+			"user": self.user,
+			"dbname": self.cur_db_name,
+			"host": self.host,
+			"password": self.password,
+		}
+		if self.port:
+			conn_settings["port"] = self.port
+
+		conn = psycopg2.connect(**conn_settings)
 		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
 
 		return conn

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -162,7 +162,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 	def get_connection(self):
 		conn = psycopg2.connect(
 			"host='{}' dbname='{}' user='{}' password='{}' port={}".format(
-				self.host, self.user, self.user, self.password, self.port
+				self.host, self.cur_db_name, self.user, self.password, self.port
 			)
 		)
 		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
@@ -194,7 +194,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 	def get_database_size(self):
 		"""'Returns database size in MB"""
 		db_size = self.sql(
-			"SELECT (pg_database_size(%s) / 1024 / 1024) as database_size", self.db_name, as_dict=True
+			"SELECT (pg_database_size(%s) / 1024 / 1024) as database_size", self.cur_db_name, as_dict=True
 		)
 		return db_size[0].get("database_size")
 
@@ -214,7 +214,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			where table_catalog='{}'
 				and table_type = 'BASE TABLE'
 				and table_schema='{}'""".format(
-					frappe.conf.db_name, frappe.conf.get("db_schema", "public")
+					self.cur_db_name, frappe.conf.get("db_schema", "public")
 				)
 			)
 		]

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -96,6 +96,7 @@ def get_root_connection(root_login=None, root_password=None):
 			port=frappe.conf.db_port,
 			user=root_login,
 			password=root_password,
+			dbname=root_login,
 		)
 
 	return frappe.local.flags.root_connection

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -3,8 +3,8 @@ import os
 import frappe
 
 
-def setup_database(force, source_sql=None, verbose=False):
-	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
+def setup_database(force, source_sql, verbose, root_login, root_password):
+	root_conn = get_root_connection(root_login, root_password)
 	root_conn.commit()
 	root_conn.sql("end")
 	root_conn.sql(f"DROP DATABASE IF EXISTS `{frappe.conf.db_name}`")
@@ -78,10 +78,7 @@ def import_db_from_sql(source_sql=None, verbose=False):
 def get_root_connection(root_login=None, root_password=None):
 	if not frappe.local.flags.root_connection:
 		if not root_login:
-			root_login = frappe.conf.get("root_login") or None
-
-		if not root_login:
-			root_login = input("Enter postgres super user: ")
+			root_login = frappe.conf.get("root_login") or "postgres"
 
 		if not root_password:
 			root_password = frappe.conf.get("root_password") or None
@@ -103,9 +100,7 @@ def get_root_connection(root_login=None, root_password=None):
 
 
 def drop_user_and_database(db_name, root_login, root_password):
-	root_conn = get_root_connection(
-		frappe.flags.root_login or root_login, frappe.flags.root_password or root_password
-	)
+	root_conn = get_root_connection(root_login, root_password)
 	root_conn.commit()
 	root_conn.sql(
 		"SELECT pg_terminate_backend (pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = %s",

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -135,11 +135,6 @@ def install_db(
 	if not db_type:
 		db_type = frappe.conf.db_type
 
-	if not root_login and db_type == "mariadb":
-		root_login = "root"
-	elif not root_login and db_type == "postgres":
-		root_login = "postgres"
-
 	make_conf(
 		db_name,
 		site_config=site_config,
@@ -150,9 +145,7 @@ def install_db(
 	)
 	frappe.flags.in_install_db = True
 
-	frappe.flags.root_login = root_login
-	frappe.flags.root_password = root_password
-	setup_database(force, source_sql, verbose, no_mariadb_socket)
+	setup_database(force, source_sql, verbose, root_login, root_password, no_mariadb_socket)
 
 	frappe.conf.admin_password = frappe.conf.admin_password or admin_password
 


### PR DESCRIPTION
- ~~fix: procure db config from single authority~~
- ~~fix: revert unnecessary breaking changes~~
- fix: set defaults at the highest level interface
- chore: compose postgres conn settings in the same way as with mariadb
^^ part of https://github.com/frappe/frappe/pull/21779 which turned out to be a necessary cleanup of the (my) mental model prior to untangling this contrived root login code path. Please feel free to review independently or together in this PR according to your preferences.
---
- chore: normalize db root connection domain

> Please provide enough information so that others can review your pull request:

This PR clarifies the db root login code path by removing the need to pass connection
parameters through obscure and hard to trace global context flags.

This PR cleanly passes all connection parameters through the function stack so that every maintainer can clearly understand the code.

> Explain the **details** for making this change. What existing problem does the pull request solve?

- Removes the implementation that was based on `frappe.flags.root_{login,password}`
