### PR TITLE
fix!: Drop unused link_doctype, link_name

### DIFF
--- a/frappe/core/doctype/comment/comment.json
+++ b/frappe/core/doctype/comment/comment.json
@@ -14,8 +14,6 @@
   "column_break_5",
   "reference_doctype",
   "reference_name",
-  "link_doctype",
-  "link_name",
   "reference_owner",
   "section_break_10",
   "content",
@@ -77,18 +75,6 @@
    "options": "reference_doctype"
   },
   {
-   "fieldname": "link_doctype",
-   "fieldtype": "Link",
-   "label": "Link DocType",
-   "options": "DocType"
-  },
-  {
-   "fieldname": "link_name",
-   "fieldtype": "Dynamic Link",
-   "label": "Link Name",
-   "options": "link_doctype"
-  },
-  {
    "fieldname": "reference_owner",
    "fieldtype": "Data",
    "label": "Reference Owner",
@@ -113,7 +99,7 @@
   }
  ],
  "links": [],
- "modified": "2022-07-12 17:35:31.774137",
+ "modified": "2023-07-24 13:52:55.651462",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Comment",

--- a/frappe/desk/like.py
+++ b/frappe/desk/like.py
@@ -88,20 +88,4 @@ def remove_like(doctype, name):
 
 def add_comment(doctype, name):
 	doc = frappe.get_doc(doctype, name)
-
-	if doctype == "Communication" and doc.reference_doctype and doc.reference_name:
-		link = get_link_to_form(
-			doc.reference_doctype,
-			doc.reference_name,
-			f"{_(doc.reference_doctype)} {doc.reference_name}",
-		)
-
-		doc.add_comment(
-			"Like",
-			_("{0}: {1} in {2}").format(_(doc.communication_type), "<b>" + doc.subject + "</b>", link),
-			link_doctype=doc.reference_doctype,
-			link_name=doc.reference_name,
-		)
-
-	else:
-		doc.add_comment("Like", _("Liked"))
+	doc.add_comment("Like", _("Liked"))

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1361,8 +1361,6 @@ class Document(BaseDocument):
 		comment_type="Comment",
 		text=None,
 		comment_email=None,
-		link_doctype=None,
-		link_name=None,
 		comment_by=None,
 	):
 		"""Add a comment to this document.
@@ -1378,8 +1376,6 @@ class Document(BaseDocument):
 				"reference_doctype": self.doctype,
 				"reference_name": self.name,
 				"content": text or comment_type,
-				"link_doctype": link_doctype,
-				"link_name": link_name,
 			}
 		).insert(ignore_permissions=True)
 		return out


### PR DESCRIPTION
identified here: https://github.com/frappe/frappe/issues/21785

doesn't seem to be used anywhere from what I can tell. 