### PR TITLE
fix(getdoctype): make sure cached_timestamp and modified date of doctype are same type

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -70,7 +70,7 @@ def getdoctype(doctype, with_parent=False, cached_timestamp=None):
 
 	frappe.response["user_settings"] = get_user_settings(parent_dt or doctype)
 
-	if cached_timestamp and docs[0].modified == cached_timestamp:
+	if cached_timestamp and str(docs[0].modified) == cached_timestamp:
 		return "use_cache"
 
 	frappe.response.docs.extend(docs)


### PR DESCRIPTION
## Problem:
- When getdoctype method is called to load a doctype it has a cached_timestamp which is string and in backed is compared with modified date of the doctype which is type date, so the comparison fails and cached doctype is not used.

## Solution:
- Cast modified date of doctype to string 
