### PR TITLE
Revert "feat: search all emails, not just the primary one"

### DIFF
--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -16,15 +16,15 @@ def get_contact_list(txt, page_length=20) -> list[dict]:
 	if cached_contacts := get_cached_contacts(txt):
 		return cached_contacts[:page_length]
 
-	fields = ["name", "first_name", "middle_name", "last_name", "company_name"]
+	search_condition = ("like", f"%{txt}%")
+	fields = ["name", "first_name", "middle_name", "last_name", "company_name", "email_id"]
 	contacts = frappe.get_list(
 		"Contact",
-		fields=fields + ["`tabContact Email`.email_id"],
-		filters=[
-			["Contact Email", "email_id", "is", "set"],
-		],
-		or_filters=[[field, "like", f"%{txt}%"] for field in fields]
-		+ [["Contact Email", "email_id", "like", f"%{txt}%"]],
+		fields=fields,
+		filters={
+			"email_id": ("is", "set"),
+		},
+		or_filters={field: search_condition for field in fields},
 		limit_page_length=page_length,
 	)
 


### PR DESCRIPTION
This reverts commit dba4a6b9f856fcbd41fb34394449a8fe83251530.

Missed an edge case there that needs to be addressed first: If Contacts have multiple Email IDs, the results show up as duplicates of the primary id.