### PR TITLE
fix: pass email as value

### DIFF
--- a/frappe/contacts/doctype/contact/test_contact.py
+++ b/frappe/contacts/doctype/contact/test_contact.py
@@ -49,11 +49,13 @@ class TestContact(FrappeTestCase):
 		# First time from database
 		results = get_contact_list("_Test Supplier")
 		self.assertEqual(results[0].label, "test_contact@example.com")
+		self.assertEqual(results[0].value, "test_contact@example.com")
 		self.assertEqual(results[0].description, "_Test Contact For _Test Supplier")
 
 		# Second time from cache
 		results = get_contact_list("_Test Supplier")
 		self.assertEqual(results[0].label, "test_contact@example.com")
+		self.assertEqual(results[0].value, "test_contact@example.com")
 		self.assertEqual(results[0].description, "_Test Contact For _Test Supplier")
 
 

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -16,7 +16,7 @@ def get_contact_list(txt, page_length=20) -> list[dict]:
 	if cached_contacts := get_cached_contacts(txt):
 		return cached_contacts[:page_length]
 
-	fields = ["name", "first_name", "middle_name", "last_name", "company_name"]
+	fields = ["first_name", "middle_name", "last_name", "company_name"]
 	contacts = frappe.get_list(
 		"Contact",
 		fields=fields + ["`tabContact Email`.email_id"],
@@ -33,7 +33,7 @@ def get_contact_list(txt, page_length=20) -> list[dict]:
 	# https://github.com/frappe/frappe/blob/6c6a89bcdd9454060a1333e23b855d0505c9ebc2/frappe/public/js/frappe/form/controls/autocomplete.js#L29-L35
 	result = [
 		frappe._dict(
-			value=d.name,
+			value=d.email_id,
 			label=d.email_id,
 			description=get_full_name(d.first_name, d.middle_name, d.last_name, d.company_name),
 		)


### PR DESCRIPTION
Scenario: two contacts with three email ids each.

### Before

Two email ids show up as duplicates of the first one.

![Bildschirmfoto 2023-07-24 um 16 04 43](https://github.com/frappe/frappe/assets/14891507/d14b65b6-06e9-4de3-9f77-6636cccdf739)

### After

Each email id is shown correctly

![Bildschirmfoto 2023-07-24 um 15 43 56](https://github.com/frappe/frappe/assets/14891507/f07e0494-0096-4aec-bb32-d451beee9a0b)

![Bildschirmfoto 2023-07-24 um 15 44 26](https://github.com/frappe/frappe/assets/14891507/af2ed933-ceb4-4d04-944a-0c56fbcb1abc)

Values are propagated correctly to Email Queue:

![Bildschirmfoto 2023-07-24 um 15 46 07](https://github.com/frappe/frappe/assets/14891507/3503b5ed-4f84-4b28-9bb7-9edf2d93ca21)
