### PR TITLE
perf: enable gc freezing by default

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -57,7 +57,7 @@ re._MAXCACHE = (
 	50  # reduced from default 512 given we are already maintaining this on parent worker
 )
 
-_tune_gc = bool(os.environ.get("FRAPPE_TUNE_GC", False))
+_tune_gc = bool(sbool(os.environ.get("FRAPPE_TUNE_GC", True)))
 
 if _dev_server:
 	warnings.simplefilter("always", DeprecationWarning)


### PR DESCRIPTION
ref: https://github.com/frappe/frappe/pull/21474 This is running on several prod site without any noticeable problems, so
making it default behaviour.

Opt out by setting env variable `FRAPPE_TUNE_GC=False`


v14 port of a63398778eb88c43a26f5985f40adbbcdd59e712