### PR TITLE
fix: `re` module cache settings - purge & cache size

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -53,12 +53,8 @@ local = Local()
 cache = None
 STANDARD_USERS = ("Guest", "Administrator")
 
-_dev_server = int(sbool(os.environ.get("DEV_SERVER", False)))
 _qb_patched = {}
-re._MAXCACHE = (
-	50  # reduced from default 512 given we are already maintaining this on parent worker
-)
-
+_dev_server = int(sbool(os.environ.get("DEV_SERVER", False)))
 _tune_gc = bool(sbool(os.environ.get("FRAPPE_TUNE_GC", True)))
 
 if _dev_server:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2446,3 +2446,6 @@ if _tune_gc:
 	# everything else.
 	g0, g1, g2 = gc.get_threshold()  # defaults are 700, 10, 10.
 	gc.set_threshold(g0 * 10, g1 * 2, g2 * 2)
+
+# Remove references to pattern that are pre-compiled and loaded to global scopes.
+re.purge()

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -4,6 +4,7 @@
 import gc
 import logging
 import os
+import re
 
 from werkzeug.exceptions import HTTPException, NotFound
 from werkzeug.local import LocalManager
@@ -427,6 +428,9 @@ def serve(
 		threaded=not no_threading,
 	)
 
+
+# Remove references to pattern that are pre-compiled and loaded to global scopes.
+re.purge()
 
 # Both Gunicorn and RQ use forking to spawn workers. In an ideal world, the fork should be sharing
 # most of the memory if there are no writes made to data because of Copy on Write, however,


### PR DESCRIPTION
Best to leave re to maintain its own caching. Reducing the `_MAXCACHE` interferes with managing other compiled patterns during runtime.

This felt like a concern after seeing the `re` module in 3.12 has had some more deliberate choices made regarding its cache management. (ref: https://github.com/python/cpython/blob/3d15c8b84b334658a5476a9cbf2626fe15fc7344/Lib/re/__init__.py#L271-L278)