### PR TITLE
fix: installation error, cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "markdownify~=0.11.6",
 
     # integration dependencies
-    "boto3~=1.18.49",
+    "boto3~=1.28.10",
     "dropbox~=11.36.0",
     "google-api-python-client~=2.2.0",
     "google-auth-oauthlib~=0.4.4",


### PR DESCRIPTION
Error at:
https://github.com/resilient-tech/india-compliance/actions/runs/5666166166/job/15352351580#step:11:1057

Fix Reference:
https://github.com/boto/boto3/issues/3714#issuecomment-1551798191