### PR TITLE
perf: drop `ifnull` from `IS SET` filter

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -815,14 +815,19 @@ class DatabaseQuery:
 			elif f.operator.lower() == "is":
 				if f.value == "set":
 					f.operator = "!="
+					# Value can technically be null, but comparing with null will always be falsy
+					# Not using coalesce here is faster because indexes can be used.
+					# null != '' -> null ~ falsy
+					# '' != '' -> false
+					can_be_null = False
 				elif f.value == "not set":
 					f.operator = "="
+					fallback = "''"
+					can_be_null = True
 
 				value = ""
-				fallback = "''"
-				can_be_null = True
 
-				if "ifnull" not in column_name.lower():
+				if can_be_null and "ifnull" not in column_name.lower():
 					column_name = f"ifnull({column_name}, {fallback})"
 
 			elif df and df.fieldtype == "Date":

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -704,6 +704,11 @@ class TestDBQuery(FrappeTestCase):
 		self.assertTrue({"name": "Prepared Report"} in res)
 		self.assertFalse({"name": "Property Setter"} in res)
 
+		frappe.db.set_value("DocType", "Property Setter", "autoname", None, update_modified=False)
+
+		res = DatabaseQuery("DocType").execute(filters={"autoname": ["is", "set"]})
+		self.assertFalse({"name": "Property Setter"} in res)
+
 	def test_set_field_tables(self):
 		# Tests _in_standard_sql_methods method in test_set_field_tables
 		# The following query will break if the above method is broken

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -158,3 +158,8 @@ class TestPerformance(FrappeTestCase):
 		frappe.get_list("User")
 		with self.assertQueryCount(1):
 			frappe.get_list("User")
+
+	def test_no_ifnull_checks(self):
+		query = frappe.get_all("DocType", {"autoname": ("is", "set")}, run=0).lower()
+		self.assertNotIn("coalesce", query)
+		self.assertNotIn("ifnull", query)


### PR DESCRIPTION
- Kinda confuses query planner (idk why it's not smart enough to
  understand but there are probably edge cases where it can't be done)
- `null != ''` and `'' != ''` both yield `null` which is falsy and
  won't be shown in results.


| value type | is it "set"? | `coelsce(value, '') != ''` | `value != ''` |
| --- | --- | --- | --- |
| `'some string or truthy value'` | yes | true | true
| `''` (empty string) | no | false | false |
| `null` | no | false | null (falsy) |

Alternate fix to https://github.com/frappe/frappe/pull/21817


Query: `frappe.get_all("Sales Invoice", {"batch_no": ("is", "set")})` (batch_no is in child table)

Before:

Full table scan:
```
+------+-------------+-----------------------+------+---------------+--------+---------+----------------------------------------+-------+----------+----------+------------+->
| id   | select_type | table                 | type | possible_keys | key    | key_len | ref                                    | rows  | r_rows   | filtered | r_filtered | >
+------+-------------+-----------------------+------+---------------+--------+---------+----------------------------------------+-------+----------+----------+------------+->
|    1 | SIMPLE      | tabSales Invoice      | ALL  | NULL          | NULL   | NULL    | NULL                                   | 23680 | 38389.00 |   100.00 |     100.00 | >
|    1 | SIMPLE      | tabSales Invoice Item | ref  | parent        | parent | 1023    | H1kokdjKldJPtTkh.tabSales Invoice.name | 1     | 1.01     |   100.00 |      98.56 | >
+------+-------------+-----------------------+------+---------------+--------+---------+----------------------------------------+-------+----------+----------+------------+->
```

After:

uses the index and doesn't read anything. 

```
+------+-------------+-----------------------+--------+-----------------------+----------------+---------+-----------------------------------------------+------+--------+--->
| id   | select_type | table                 | type   | possible_keys         | key            | key_len | ref                                           | rows | r_rows | fi>
+------+-------------+-----------------------+--------+-----------------------+----------------+---------+-----------------------------------------------+------+--------+--->
|    1 | SIMPLE      | tabSales Invoice Item | range  | parent,batch_no_index | batch_no_index | 563     | NULL                                          | 2    | 0.00   |   >
|    1 | SIMPLE      | tabSales Invoice      | eq_ref | PRIMARY               | PRIMARY        | 1022    | H1kokdjKldJPtTkh.tabSales Invoice Item.parent | 1    | NULL   |   >
+------+-------------+-----------------------+--------+-----------------------+----------------+---------+-----------------------------------------------+------+--------+--->
```