### PR TITLE
fix: fallback to unscrubbed table fieldname if label not found

### DIFF
--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -157,7 +157,6 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 				let meta = frappe.get_meta(doc.doctype);
 				if (meta.istable) {
 					const table_field = frappe.meta.docfield_map[doc.parenttype][doc.parentfield];
-					
 					const table_label = __(
 						table_field.label || frappe.unscrub(table_field.fieldname)
 					).bold();

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -161,7 +161,6 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 					const table_label = __(
 						table_field.label || frappe.unscrub(table_field.fieldname)
 					).bold();
-					
 					var message = __('Mandatory fields required in table {0}, Row {1}', [table_label, doc.idx]);
 				} else {
 					var message = __('Mandatory fields required in {0}', [__(doc.doctype)]);

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -156,7 +156,12 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 			if (error_fields.length) {
 				let meta = frappe.get_meta(doc.doctype);
 				if (meta.istable) {
-					const table_label = __(frappe.meta.docfield_map[doc.parenttype][doc.parentfield].label).bold();
+					const table_field = frappe.meta.docfield_map[doc.parenttype][doc.parentfield];
+					
+					const table_label = __(
+						table_field.label || frappe.unscrub(table_field.fieldname)
+					).bold();
+					
 					var message = __('Mandatory fields required in table {0}, Row {1}', [table_label, doc.idx]);
 				} else {
 					var message = __('Mandatory fields required in {0}', [__(doc.doctype)]);


### PR DESCRIPTION
The problem was solved in PR #17599 and the backport to 13 was asked for in #21571

### Before 
There was a problem with missing mandatory fields in a child table without a label. The error thrown looked something like this: 
```
form.js:757 TypeError: Cannot read properties of undefined (reading 'bold')
    at Object.<anonymous> (save.js:159:92)
    at Function.each (jquery.js:385:19)
    at check_mandatory (save.js:120:5)
    at save (save.js:24:48)
    at frappe.ui.form.save (save.js:266:3)
    at form.js:778:21
``` 

### After
The correct error message will be thrown:
![image](https://github.com/frappe/frappe/assets/63648645/95908902-a85e-4c27-a66b-559809fb1aa5)
