### PR TITLE
perf: skip reset_seen for new doc

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1134,7 +1134,11 @@ class Document(BaseDocument):
 
 	def reset_seen(self):
 		"""Clear _seen property and set current user as seen"""
-		if getattr(self.meta, "track_seen", False) and not getattr(self.meta, "issingle", False):
+		if (
+			getattr(self.meta, "track_seen", False)
+			and not getattr(self.meta, "issingle", False)
+			and not self.is_new()
+		):
 			frappe.db.set_value(
 				self.doctype, self.name, "_seen", json.dumps([frappe.session.user]), update_modified=False
 			)


### PR DESCRIPTION
The query is fired but document doesn't exist yet, so it does nothing really.
