### PR TITLE
feat: Support ARIA engine on MariaDB

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -645,7 +645,7 @@ def console(context, autoreload=False):
 @click.option(
 	"--engine",
 	default=None,
-	type=click.Choice(["InnoDB", "MyISAM"]),
+	type=click.Choice(["InnoDB", "MyISAM", "ARIA"]),
 	help="Choice of storage engine for said table(s)",
 )
 @click.option(
@@ -695,6 +695,8 @@ def transform_database(context, table, engine, row_format, failfast):
 		values_to_set = ""
 		if engine:
 			values_to_set += f" ENGINE={engine}"
+		if engine == "ARIA":
+			values_to_set += " TRANSACTIONAL=1"  # crash safe
 		if row_format:
 			values_to_set += f" ROW_FORMAT={row_format}"
 

--- a/frappe/core/doctype/data_import_log/data_import_log.json
+++ b/frappe/core/doctype/data_import_log/data_import_log.json
@@ -3,7 +3,7 @@
  "creation": "2021-12-25 16:12:20.205889",
  "doctype": "DocType",
  "editable_grid": 1,
- "engine": "MyISAM",
+ "engine": "ARIA",
  "field_order": [
   "data_import",
   "row_indexes",

--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -457,7 +457,7 @@
    "fieldname": "engine",
    "fieldtype": "Select",
    "label": "Database Engine",
-   "options": "InnoDB\nMyISAM"
+   "options": "InnoDB\nMyISAM\nARIA"
   },
   {
    "default": "0",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -118,7 +118,7 @@ class DocType(Document):
 		documentation: DF.Data | None
 		editable_grid: DF.Check
 		email_append_to: DF.Check
-		engine: DF.Literal["InnoDB", "MyISAM"]
+		engine: DF.Literal["InnoDB", "MyISAM", "ARIA"]
 		fields: DF.Table[DocField]
 		force_re_route_to_default_view: DF.Check
 		has_web_view: DF.Check

--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -3,7 +3,7 @@
  "creation": "2013-01-16 13:09:40",
  "doctype": "DocType",
  "document_type": "System",
- "engine": "MyISAM",
+ "engine": "ARIA",
  "field_order": [
   "seen",
   "reference_doctype",

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -279,7 +279,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 				published int(1) not null default 0,
 				unique `doctype_name` (doctype, name))
 				COLLATE=utf8mb4_unicode_ci
-				ENGINE=MyISAM
+				ENGINE=ARIA TRANSACTIONAL=1
 				CHARACTER SET=utf8mb4""".format(
 					self.VARCHAR_LEN
 				)

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -49,6 +49,12 @@ class MariaDBTable(DBTable):
 
 		additional_definitions = ",\n".join(additional_definitions)
 
+		engine_params = ""
+		if engine == "ARIA":
+			engine_params += "TRANSACTIONAL=1"
+		else:
+			engine_params += "ROW_FORMAT=DYNAMIC"
+
 		# create table
 		query = f"""create table `{self.table_name}` (
 			{name_column},
@@ -60,7 +66,7 @@ class MariaDBTable(DBTable):
 			idx int(8) not null default '0',
 			{additional_definitions})
 			ENGINE={engine}
-			ROW_FORMAT=DYNAMIC
+			{engine_params}
 			CHARACTER SET=utf8mb4
 			COLLATE=utf8mb4_unicode_ci"""
 


### PR DESCRIPTION
ARIA is crash-safe alternate to MyISAM. Global Search and Error log
tablee frequently end up crashed and get auto-repaired. While both these
tables don't need serious data integrity, it would still be better to
not have crashes.

This doesn't apply to existing sites yet. If you want to migrate run:

```
bench --site sitename transform-database --table='tabError Log, __global_search` --engine='ARIA'
```

closes https://github.com/frappe/frappe/issues/21839
closes https://github.com/frappe/bench/issues/1470