### PR TITLE
perf: set lower priority for background processes

### DIFF
--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -16,7 +16,7 @@ from typing import NoReturn
 # imports - module imports
 import frappe
 from frappe.utils import cint, get_datetime, get_sites, now_datetime
-from frappe.utils.background_jobs import get_jobs
+from frappe.utils.background_jobs import set_niceness
 
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
@@ -35,6 +35,7 @@ def start_scheduler() -> NoReturn:
 	Specify scheduler_interval in seconds in common_site_config.json"""
 
 	tick = cint(frappe.get_conf().scheduler_tick_interval) or 60
+	set_niceness()
 
 	while True:
 		time.sleep(tick)


### PR DESCRIPTION
https://github.com/frappe/frappe/issues/21838

Alternate to https://github.com/frappe/bench/pull/1445 


Defaulting to nice value of 10 which roughly means 50% less CPU time for background processes when CPU is fully utilized. Otherwise, doesn't matter much.`*`