### PR TITLE
fix: Made Set Password Page Better

### DIFF
--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -45,7 +45,7 @@
 frappe.ready(function() {
 	// URL args
 	const key = frappe.utils.get_url_arg('key');
-	const pasword_expired = frappe.utils.get_url_arg('password_expired');
+	const password_expired = frappe.utils.get_url_arg('password_expired');
 	// inputs, paragraphs and button elements
 	const old_password = $('#old_password');
 	const new_password = $('#new_password');
@@ -63,7 +63,7 @@ frappe.ready(function() {
 		old_password.parent().toggle();
 	}
 
-	if(pasword_expired) {
+	if(password_expired) {
 		$(".password-box").html("{{ _('The password of your account has expired.') }}");
 	}
 
@@ -193,8 +193,8 @@ frappe.ready(function() {
 			password_strength_message.addClass("hidden");
 		}
 		if ((key || (!key && old_password.val() && password_mismatch_message.text() !== password_not_same_as_old_password )) && common_conditions ) {
-            update_button.prop("disabled", false).css("cursor", "pointer");
-        }
+			update_button.prop("disabled", false).css("cursor", "pointer");
+		}
 		else {
 			update_button.prop("disabled", true).css("cursor", "not-allowed");
 		}

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -84,6 +84,7 @@ frappe.ready(function() {
 		if (args.new_password !== confirm_password) {
 			$('.password-mismatch-message').text("{{ _('Passwords do not match') }}")
 				.removeClass('hidden text-muted').addClass('text-danger');
+			$('.password-strength-message').addClass('hidden');
 			return false;
 		}
 
@@ -198,6 +199,7 @@ frappe.ready(function() {
 				message.push("{{ _('Success! You are good to go 👍') }}");
 			}
 		}
+		$('.password-mismatch-message').text("").addClass('hidden');
 		strength_message.html(message.join(' ') || '').removeClass('hidden');
 	}
 

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -199,7 +199,8 @@ frappe.ready(function() {
 				message.push("{{ _('Success! You are good to go 👍') }}");
 			}
 		}
-		$('.password-mismatch-message').text("").addClass('hidden');
+		$('.password-mismatch-message').addClass('hidden');
+
 		strength_message.html(message.join(' ') || '').removeClass('hidden');
 	}
 

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -143,9 +143,24 @@ frappe.ready(function() {
 	window.strength_message = $('.password-strength-message');
 
 	$('#new_password').on('keyup', function() {
+		if ($('#confirm_password').val() && $('new_password').val() === $('#confirm_password').val()) {
+			$('#update').prop('disabled', false).css('cursor', 'pointer');
+		}
 		window.clear_timeout();
 		window.timout_password_strength = setTimeout(window.test_password_strength, 200);
 	});
+
+	$('#new_password').on('keyup', frappe.utils.debounce(function() {
+		if ($('#old_password').val() === $('#new_password').val()) {
+			$('.password-strength-message').text("{{ _('New password cannot be same as old password') }}")
+				.removeClass('hidden text-muted').addClass('text-danger');
+			$('.password-strength-indicator').addClass('hidden');
+			$('#update').prop('disabled', true).css('cursor', 'not-allowed');
+		}
+		else {
+			$('.password-strength-message').removeClass('text-danger')
+		}
+	}, 500));
 
 
 	$("#old_password, #new_password, #confirm_password").on("keyup", function () {
@@ -180,7 +195,7 @@ frappe.ready(function() {
 
 
 
-	$('#confirm_password').on('keyup', function() {
+	$('#confirm_password, #new_password').on('keyup', function() {
 		if ($('#confirm_password').val() && $('#new_password').val() !== $('#confirm_password').val()) {
 			$('.password-mismatch-message').text("{{ _('Passwords do not match') }}")
 				.removeClass('hidden text-muted').addClass('text-danger');

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -43,12 +43,27 @@
 <script>
 
 frappe.ready(function() {
+	// URL args
+	const key = frappe.utils.get_url_arg('key');
+	const pasword_expired = frappe.utils.get_url_arg('password_expired');
+	// inputs and button elements
+	const old_password = $('#old_password');
+	const new_password = $('#new_password');
+	const confirm_password = $('#confirm_password');
+	const update_button = $('#update');
+	const password_strength_indicator = $('.password-strength-indicator');
+	const password_strength_message =$('.password-strength-message');
+	const password_mismatch_message = $('.password-mismatch-message');
+	// Span text
+	const password_not_same_as_old_password = "{{ _('New password cannot be same as old password') }}";
+	const password_mismatch = "{{ _('Passwords do not match') }}";
+	const password_strength_message_success = "{{ _('Success! You are good to go 👍') }}";
 
-	if(frappe.utils.get_url_arg("key")) {
-		$("#old_password").parent().toggle();
+	if(key) {
+		old_password.parent().toggle();
 	}
 
-	if(frappe.utils.get_url_arg("password_expired")) {
+	if(pasword_expired) {
 		$(".password-box").html("{{ _('The password of your account has expired.') }}");
 	}
 
@@ -56,18 +71,17 @@ frappe.ready(function() {
 		return false;
 	});
 
-	$("#new_password").on("keypress", function(e) {
-		if(e.which===13) $("#update").click();
+	new_password.on("keypress", function(e) {
+		if(e.which===13) update_button.click();
 	})
 
-	$("#update").click(function() {
+	update_button.click(function() {
 		var args = {
-			key: frappe.utils.get_url_arg("key") || "",
-			old_password: $("#old_password").val(),
-			new_password: $("#new_password").val(),
+			key: key || "",
+			old_password: old_password.val(),
+			new_password: new_password.val(),
 			logout_all_sessions: 1
 		}
-		const confirm_password = $('#confirm_password').val()
 		if (!args.old_password && !args.key) {
 			frappe.msgprint({
 				title: "{{ _('Missing Value') }}",
@@ -85,16 +99,16 @@ frappe.ready(function() {
 		if (args.old_password === args.new_password) {
 			frappe.msgprint({
 				title: "{{ _('Invalid Password') }}",
-				message: "{{ _('New password cannot be same as old password') }}",
+				message: password_not_same_as_old_password,
 			});
-			$('.password-strength-message').addClass('hidden');
+			password_strength_message.addClass('hidden');
 			return;
 		}
 
 		if (args.new_password !== confirm_password) {
-			$('.password-mismatch-message').text("{{ _('Passwords do not match') }}")
+			password_mismatch_message.text(password_mismatch)
 				.removeClass('hidden text-muted').addClass('text-danger');
-			$('.password-strength-message').addClass('hidden');
+			password_strength_message.addClass('hidden');
 			return false;
 
 		}
@@ -102,7 +116,7 @@ frappe.ready(function() {
 		frappe.call({
 			type: "POST",
 			method: "frappe.core.doctype.user.user.update_password",
-			btn: $("#update"),
+			btn: update_button,
 			args: args,
 			statusCode: {
 				401: function() {
@@ -139,81 +153,55 @@ frappe.ready(function() {
 		return false;
 	});
 
-	window.strength_indicator = $('.password-strength-indicator');
-	window.strength_message = $('.password-strength-message');
+	window.strength_indicator = password_strength_indicator;
+	window.strength_message = password_strength_message;
 
-	$('#new_password').on('keyup', function() {
-		if ($('#confirm_password').val() && $('new_password').val() === $('#confirm_password').val()) {
-			$('#update').prop('disabled', false).css('cursor', 'pointer');
-		}
+	new_password.on('keyup', function() {
 		window.clear_timeout();
 		window.timout_password_strength = setTimeout(window.test_password_strength, 200);
 	});
 
-	$('#new_password').on('keyup', frappe.utils.debounce(function() {
-		if ($('#old_password').val() === $('#new_password').val()) {
-			$('.password-strength-message').text("{{ _('New password cannot be same as old password') }}")
-				.removeClass('hidden text-muted').addClass('text-danger');
-			$('.password-strength-indicator').addClass('hidden');
-			$('#update').prop('disabled', true).css('cursor', 'not-allowed');
+	$("#old_password, #new_password, #confirm_password").on("keyup", frappe.utils.debounce(function () {
+		let common_conditions = new_password.val() && confirm_password.val() && new_password.val() === confirm_password.val() &&
+		password_strength_message.text() === password_strength_message_success
+
+		if (new_password.val() && old_password.val() === new_password.val()) {
+			password_mismatch_message.text(password_not_same_as_old_password)
+				.removeClass("hidden text-muted").addClass("text-danger");
+
+			password_strength_message.addClass("hidden");
 		}
+		if ((new_password.val() || old_password.val) && old_password.val() !== new_password.val()) {
+			password_mismatch_message.addClass("hidden");
+			password_strength_message.removeClass("hidden");
+			password_mismatch_message.text('')
+		}
+
+		if (new_password.val() === confirm_password.val() && old_password.val() !== new_password.val() ) {
+			password_mismatch_message.addClass("hidden");
+			password_strength_message.removeClass("hidden");
+		}
+		if (confirm_password.val() &&  new_password.val() !== confirm_password.val()) {
+			password_mismatch_message.text(password_mismatch)
+				.removeClass("hidden text-muted").addClass("text-danger");
+			password_strength_message.addClass("hidden");
+		}
+		if ((key || (!key && old_password.val() && password_mismatch_message.text() !== password_not_same_as_old_password )) && common_conditions ) {
+            update_button.prop("disabled", false).css("cursor", "pointer");
+        }
 		else {
-			$('.password-strength-message').removeClass('text-danger')
+			update_button.prop("disabled", true).css("cursor", "not-allowed");
 		}
-	}, 500));
-
-
-	$("#old_password, #new_password, #confirm_password").on("keyup", function () {
-
-		if (!frappe.utils.get_url_arg("key")) {
-			if (
-				$("#old_password").val() &&
-				$("#new_password").val() &&
-				$("#confirm_password").val() &&
-				$("#new_password").val() === $("#confirm_password").val() &&
-				$(".password-strength-message").text() ===
-					"{{_('Success! You are good to go 👍')}}"
-			) {
-				$("#update").prop("disabled", false).css("cursor", "pointer");
-			} else {
-				$("#update").prop("disabled", true).css("cursor", "not-allowed");
-			}
-		} else {
-			if (
-				$("#new_password").val() &&
-				$("#confirm_password").val() &&
-				$("#new_password").val() === $("#confirm_password").val() &&
-				$(".password-strength-message").text() ===
-					"{{_('Success! You are good to go 👍')}}"
-			) {
-				$("#update").prop("disabled", false).css("cursor", "pointer");
-			} else {
-				$("#update").prop("disabled", true).css("cursor", "not-allowed");
-			}
-		}
-	});
-
-
-
-	$('#confirm_password, #new_password').on('keyup', function() {
-		if ($('#confirm_password').val() && $('#new_password').val() !== $('#confirm_password').val()) {
-			$('.password-mismatch-message').text("{{ _('Passwords do not match') }}")
-				.removeClass('hidden text-muted').addClass('text-danger');
-			$('.password-strength-message').addClass('hidden');
-		}
-		else {
-			$('.password-mismatch-message').addClass('hidden');
-			$('.password-strength-message').removeClass('hidden');
-		}
-	});
+		},500)
+	)
 
 	window.test_password_strength = function() {
 		window.timout_password_strength = null;
 
 		var args = {
-			key: frappe.utils.get_url_arg("key") || "",
-			old_password: $("#old_password").val(),
-			new_password: $("#new_password").val()
+			key: key || "",
+			old_password: old_password.val(),
+			new_password: new_password.val()
 		}
 
 		if (!args.new_password) {
@@ -267,10 +255,10 @@ frappe.ready(function() {
 				message.push(feedback.help_msg);
 
 			} else {
-				message.push("{{ _('Success! You are good to go 👍') }}");
+				message.push(password_strength_message_success);
 			}
 		}
-		$('.password-mismatch-message').addClass('hidden');
+		password_mismatch_message.addClass('hidden');
 
 		strength_message.html(message.join(' ') || '').removeClass('hidden');
 	}

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -26,7 +26,7 @@
 				<p class="password-mismatch-message text-muted small hidden mt-2"></p>
 			</div>
 			<p class='password-strength-message text-muted small hidden'></p>
-			<button type="submit" id="update"
+			<button type="submit" id="update" disabled = true style="cursor: not-allowed;"
 				class="btn btn-primary btn-block btn-update">{{_("Confirm")}}</button>
 		</form>
 		{%- if not disable_signup -%}
@@ -43,6 +43,7 @@
 <script>
 
 frappe.ready(function() {
+
 	if(frappe.utils.get_url_arg("key")) {
 		$("#old_password").parent().toggle();
 	}
@@ -134,6 +135,50 @@ frappe.ready(function() {
 	$('#new_password').on('keyup', function() {
 		window.clear_timeout();
 		window.timout_password_strength = setTimeout(window.test_password_strength, 200);
+	});
+
+
+	$("#old_password, #new_password, #confirm_password").on("keyup", function () {
+		if (!frappe.utils.get_url_arg("key")) {
+			if (
+				$("#old_password").val() &&
+				$("#new_password").val() &&
+				$("#confirm_password").val() &&
+				$("#new_password").val() === $("#confirm_password").val() &&
+				$(".password-strength-message").text() ===
+					"{{_('Success! You are good to go 👍')}}"
+			) {
+				$("#update").prop("disabled", false).css("cursor", "pointer");
+			} else {
+				$("#update").prop("disabled", true).css("cursor", "not-allowed");
+			}
+		} else {
+			if (
+				$("#new_password").val() &&
+				$("#confirm_password").val() &&
+				$("#new_password").val() === $("#confirm_password").val() &&
+				$(".password-strength-message").text() ===
+					"{{_('Success! You are good to go 👍')}}"
+			) {
+				$("#update").prop("disabled", false).css("cursor", "pointer");
+			} else {
+				$("#update").prop("disabled", true).css("cursor", "not-allowed");
+			}
+		}
+	});
+
+
+
+	$('#confirm_password').on('keyup', function() {
+		if ($('#confirm_password').val() && $('#new_password').val() !== $('#confirm_password').val()) {
+			$('.password-mismatch-message').text("{{ _('Passwords do not match') }}")
+				.removeClass('hidden text-muted').addClass('text-danger');
+			$('.password-strength-message').addClass('hidden');
+		}
+		else {
+			$('.password-mismatch-message').addClass('hidden');
+			$('.password-strength-message').removeClass('hidden');
+		}
 	});
 
 	window.test_password_strength = function() {

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -23,9 +23,9 @@
 				<input id="confirm_password" type="password"
 					class="form-control" placeholder="{{ _('Confirm Password') }}" autocomplete="new-password">
 
-				<p class="password-mismatch-message text-muted small hidden mt-2"></p>
 			</div>
-			<p class='password-strength-message text-muted small hidden'></p>
+			<p class="password-mismatch-message text-muted small hidden mt-2"></p>
+			<p class='password-strength-message text-muted small mt-2 hidden'></p>
 			<button type="submit" id="update" disabled = true style="cursor: not-allowed;"
 				class="btn btn-primary btn-block btn-update">{{_("Confirm")}}</button>
 		</form>
@@ -46,7 +46,7 @@ frappe.ready(function() {
 	// URL args
 	const key = frappe.utils.get_url_arg('key');
 	const pasword_expired = frappe.utils.get_url_arg('password_expired');
-	// inputs and button elements
+	// inputs, paragraphs and button elements
 	const old_password = $('#old_password');
 	const new_password = $('#new_password');
 	const confirm_password = $('#confirm_password');
@@ -54,7 +54,7 @@ frappe.ready(function() {
 	const password_strength_indicator = $('.password-strength-indicator');
 	const password_strength_message =$('.password-strength-message');
 	const password_mismatch_message = $('.password-mismatch-message');
-	// Span text
+	// Info text
 	const password_not_same_as_old_password = "{{ _('New password cannot be same as old password') }}";
 	const password_mismatch = "{{ _('Passwords do not match') }}";
 	const password_strength_message_success = "{{ _('Success! You are good to go 👍') }}";
@@ -80,6 +80,7 @@ frappe.ready(function() {
 			key: key || "",
 			old_password: old_password.val(),
 			new_password: new_password.val(),
+			confirm_password: confirm_password.val(),
 			logout_all_sessions: 1
 		}
 		if (!args.old_password && !args.key) {
@@ -105,12 +106,11 @@ frappe.ready(function() {
 			return;
 		}
 
-		if (args.new_password !== confirm_password.val()) {
+		if (args.new_password !== args.confirm_password) {
 			password_mismatch_message.text(password_mismatch)
 				.removeClass('hidden text-muted').addClass('text-danger');
 			password_strength_message.addClass('hidden');
-			return false;
-
+			return;
 		}
 
 		frappe.call({

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -105,7 +105,7 @@ frappe.ready(function() {
 			return;
 		}
 
-		if (args.new_password !== confirm_password) {
+		if (args.new_password !== confirm_password.val()) {
 			password_mismatch_message.text(password_mismatch)
 				.removeClass('hidden text-muted').addClass('text-danger');
 			password_strength_message.addClass('hidden');
@@ -121,6 +121,12 @@ frappe.ready(function() {
 			statusCode: {
 				401: function() {
 					$(".page-card-head .reset-password-heading").text("{{ _('Invalid Password') }}");
+					frappe.msgprint({
+						title: "{{ _('Invalid Password') }}",
+						message: "{{ _('Your old password is incorrect.') }}",
+						// clear any server message
+						clear: true
+					});
 				},
 				410: function({ responseJSON }) {
 					const title = "{{ _('Invalid Link') }}";

--- a/frappe/www/update-password.html
+++ b/frappe/www/update-password.html
@@ -82,11 +82,21 @@ frappe.ready(function() {
 				clear: true
 			});
 		}
+		if (args.old_password === args.new_password) {
+			frappe.msgprint({
+				title: "{{ _('Invalid Password') }}",
+				message: "{{ _('New password cannot be same as old password') }}",
+			});
+			$('.password-strength-message').addClass('hidden');
+			return;
+		}
+
 		if (args.new_password !== confirm_password) {
 			$('.password-mismatch-message').text("{{ _('Passwords do not match') }}")
 				.removeClass('hidden text-muted').addClass('text-danger');
 			$('.password-strength-message').addClass('hidden');
 			return false;
+
 		}
 
 		frappe.call({
@@ -139,6 +149,7 @@ frappe.ready(function() {
 
 
 	$("#old_password, #new_password, #confirm_password").on("keyup", function () {
+
 		if (!frappe.utils.get_url_arg("key")) {
 			if (
 				$("#old_password").val() &&


### PR DESCRIPTION
**Issue:**
![image](https://github.com/frappe/frappe/assets/65544983/1ada3f62-c303-492e-91a9-9a2f407d321b)

Both good to go & password does not match messages were shown at the same time in the "Set Password Page", which is a bad UX as it tells us everything is good even though the passwords aren't same.



**Solution:**
<img width="491" alt="image" src="https://github.com/frappe/frappe/assets/65544983/64950d92-d590-46a4-9a12-48eaab7e8290">

https://github.com/frappe/frappe/assets/65544983/68afb9d0-8645-423b-bc2f-4660f04a5969




**Functionalities:**
1.  Old Password and New password can't be same, if same error msg will be shown
2. New password Strength Feedback
3. New Password ≠ Confirm Password then passwords don't match error will be shown.
4. If New Password ==  Confirm password and old password ≠ new password then Submit button will be enabled else it will be disabled.

