### PR TITLE
fix: guess_country backward timezone issue for india.

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -640,8 +640,11 @@ frappe.setup.utils = {
 
 function guess_country(country_info) {
 	try {
-		const system_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-
+		let system_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+		// https://github.com/eggert/tz/blob/main/backward add more when encountered.
+		if (system_timezone == "Asia/Calcutta") {
+			system_timezone = "Asia/Kolkata";
+		}
 		for (let [country, info] of Object.entries(country_info)) {
 			let possible_timezones = (info.timezones || []).filter((t) => t == system_timezone);
 			if (possible_timezones.length) return country;

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -638,13 +638,16 @@ frappe.setup.utils = {
 	},
 };
 
+// https://github.com/eggert/tz/blob/main/backward add more if required.
+const TZ_BACKWARD_COMPATBILITY_MAP = {
+	"Asia/Calcutta": "Asia/Kolkata",
+};
+
 function guess_country(country_info) {
 	try {
 		let system_timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-		// https://github.com/eggert/tz/blob/main/backward add more when encountered.
-		if (system_timezone == "Asia/Calcutta") {
-			system_timezone = "Asia/Kolkata";
-		}
+		system_timezone = TZ_BACKWARD_COMPATBILITY_MAP[system_timezone] || system_timezone;
+
 		for (let [country, info] of Object.entries(country_info)) {
 			let possible_timezones = (info.timezones || []).filter((t) => t == system_timezone);
 			if (possible_timezones.length) return country;


### PR DESCRIPTION
In some cases ( mac ) where Asia/Calcutta is used as timezone guessing didn't work. This can be improved over time. i don't have the data right now but better solution will be to have dict for all such timezones.