### PR TITLE
fix: Delete module folder on Module Def deletion

### DIFF
--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import shutil
 
 import frappe
 from frappe.model.document import Document
@@ -64,6 +65,8 @@ class ModuleDef(Document):
 
 		modules = None
 		if frappe.local.module_app.get(frappe.scrub(self.name)):
+			module_path = frappe.get_app_path(self.app_name, self.name)
+			shutil.rmtree(module_path)
 			with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
 				content = f.read()
 				if self.name in content.splitlines():

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -3,7 +3,7 @@
 
 import json
 import os
-import shutil
+from frappe.modules.export_file import delete_folder
 
 import frappe
 from frappe.model.document import Document
@@ -66,9 +66,7 @@ class ModuleDef(Document):
 
         modules = None
         if frappe.local.module_app.get(frappe.scrub(self.name)):
-            module_path = frappe.get_app_path(self.app_name, self.name)
-            if os.path.exists(module_path):
-                shutil.rmtree(module_path)
+            delete_folder(self.module_name,"Module Def",self.name)
             with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
                 content = f.read()
                 if self.name in content.splitlines():

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -10,77 +10,79 @@ from frappe.model.document import Document
 
 
 class ModuleDef(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
 
-	from typing import TYPE_CHECKING
+    from typing import TYPE_CHECKING
 
-	if TYPE_CHECKING:
-		from frappe.types import DF
+    if TYPE_CHECKING:
+        from frappe.types import DF
 
-		app_name: DF.Literal
-		custom: DF.Check
-		module_name: DF.Data
-		package: DF.Link | None
-		restrict_to_domain: DF.Link | None
-	# end: auto-generated types
-	def on_update(self):
-		"""If in `developer_mode`, create folder for module and
-		add in `modules.txt` of app if missing."""
-		frappe.clear_cache()
-		if not self.custom and frappe.conf.get("developer_mode"):
-			self.create_modules_folder()
-			self.add_to_modules_txt()
+        app_name: DF.Literal
+        custom: DF.Check
+        module_name: DF.Data
+        package: DF.Link | None
+        restrict_to_domain: DF.Link | None
 
-	def create_modules_folder(self):
-		"""Creates a folder `[app]/[module]` and adds `__init__.py`"""
-		module_path = frappe.get_app_path(self.app_name, self.name)
-		if not os.path.exists(module_path):
-			os.mkdir(module_path)
-			with open(os.path.join(module_path, "__init__.py"), "w") as f:
-				f.write("")
+    # end: auto-generated types
+    def on_update(self):
+        """If in `developer_mode`, create folder for module and
+        add in `modules.txt` of app if missing."""
+        frappe.clear_cache()
+        if not self.custom and frappe.conf.get("developer_mode"):
+            self.create_modules_folder()
+            self.add_to_modules_txt()
 
-	def add_to_modules_txt(self):
-		"""Adds to `[app]/modules.txt`"""
-		modules = None
-		if not frappe.local.module_app.get(frappe.scrub(self.name)):
-			with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
-				content = f.read()
-				if not self.name in content.splitlines():
-					modules = list(filter(None, content.splitlines()))
-					modules.append(self.name)
+    def create_modules_folder(self):
+        """Creates a folder `[app]/[module]` and adds `__init__.py`"""
+        module_path = frappe.get_app_path(self.app_name, self.name)
+        if not os.path.exists(module_path):
+            os.mkdir(module_path)
+            with open(os.path.join(module_path, "__init__.py"), "w") as f:
+                f.write("")
 
-			if modules:
-				with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
-					f.write("\n".join(modules))
+    def add_to_modules_txt(self):
+        """Adds to `[app]/modules.txt`"""
+        modules = None
+        if not frappe.local.module_app.get(frappe.scrub(self.name)):
+            with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
+                content = f.read()
+                if not self.name in content.splitlines():
+                    modules = list(filter(None, content.splitlines()))
+                    modules.append(self.name)
 
-				frappe.clear_cache()
-				frappe.setup_module_map()
+            if modules:
+                with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
+                    f.write("\n".join(modules))
 
-	def on_trash(self):
-		"""Delete module name from modules.txt"""
+                frappe.clear_cache()
+                frappe.setup_module_map()
 
-		if not frappe.conf.get("developer_mode") or frappe.flags.in_uninstall or self.custom:
-			return
+    def on_trash(self):
+        """Delete module name from modules.txt"""
 
-		modules = None
-		if frappe.local.module_app.get(frappe.scrub(self.name)):
-			module_path = frappe.get_app_path(self.app_name, self.name)
-			shutil.rmtree(module_path)
-			with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
-				content = f.read()
-				if self.name in content.splitlines():
-					modules = list(filter(None, content.splitlines()))
-					modules.remove(self.name)
+        if not frappe.conf.get("developer_mode") or frappe.flags.in_uninstall or self.custom:
+            return
 
-			if modules:
-				with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
-					f.write("\n".join(modules))
+        modules = None
+        if frappe.local.module_app.get(frappe.scrub(self.name)):
+            module_path = frappe.get_app_path(self.app_name, self.name)
+            if os.path.exists(module_path):
+                shutil.rmtree(module_path)
+            with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
+                content = f.read()
+                if self.name in content.splitlines():
+                    modules = list(filter(None, content.splitlines()))
+                    modules.remove(self.name)
 
-				frappe.clear_cache()
-				frappe.setup_module_map()
+            if modules:
+                with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
+                    f.write("\n".join(modules))
+
+                frappe.clear_cache()
+                frappe.setup_module_map()
 
 
 @frappe.whitelist()
 def get_installed_apps():
-	return json.dumps(frappe.get_installed_apps())
+    return json.dumps(frappe.get_installed_apps())

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -3,10 +3,10 @@
 
 import json
 import os
-from frappe.modules.export_file import delete_folder
 
 import frappe
 from frappe.model.document import Document
+from frappe.modules.export_file import delete_folder
 
 
 class ModuleDef(Document):
@@ -66,7 +66,7 @@ class ModuleDef(Document):
 
 		modules = None
 		if frappe.local.module_app.get(frappe.scrub(self.name)):
-			delete_folder(self.module_name,"Module Def",self.name)
+			delete_folder(self.module_name, "Module Def", self.name)
 			with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
 				content = f.read()
 				if self.name in content.splitlines():

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -10,77 +10,77 @@ from frappe.model.document import Document
 
 
 class ModuleDef(Document):
-    # begin: auto-generated types
-    # This code is auto-generated. Do not modify anything in this block.
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
 
-    from typing import TYPE_CHECKING
+	from typing import TYPE_CHECKING
 
-    if TYPE_CHECKING:
-        from frappe.types import DF
+	if TYPE_CHECKING:
+		from frappe.types import DF
 
-        app_name: DF.Literal
-        custom: DF.Check
-        module_name: DF.Data
-        package: DF.Link | None
-        restrict_to_domain: DF.Link | None
+		app_name: DF.Literal
+		custom: DF.Check
+		module_name: DF.Data
+		package: DF.Link | None
+		restrict_to_domain: DF.Link | None
 
-    # end: auto-generated types
-    def on_update(self):
-        """If in `developer_mode`, create folder for module and
-        add in `modules.txt` of app if missing."""
-        frappe.clear_cache()
-        if not self.custom and frappe.conf.get("developer_mode"):
-            self.create_modules_folder()
-            self.add_to_modules_txt()
+	# end: auto-generated types
+	def on_update(self):
+		"""If in `developer_mode`, create folder for module and
+		add in `modules.txt` of app if missing."""
+		frappe.clear_cache()
+		if not self.custom and frappe.conf.get("developer_mode"):
+			self.create_modules_folder()
+			self.add_to_modules_txt()
 
-    def create_modules_folder(self):
-        """Creates a folder `[app]/[module]` and adds `__init__.py`"""
-        module_path = frappe.get_app_path(self.app_name, self.name)
-        if not os.path.exists(module_path):
-            os.mkdir(module_path)
-            with open(os.path.join(module_path, "__init__.py"), "w") as f:
-                f.write("")
+	def create_modules_folder(self):
+		"""Creates a folder `[app]/[module]` and adds `__init__.py`"""
+		module_path = frappe.get_app_path(self.app_name, self.name)
+		if not os.path.exists(module_path):
+			os.mkdir(module_path)
+			with open(os.path.join(module_path, "__init__.py"), "w") as f:
+				f.write("")
 
-    def add_to_modules_txt(self):
-        """Adds to `[app]/modules.txt`"""
-        modules = None
-        if not frappe.local.module_app.get(frappe.scrub(self.name)):
-            with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
-                content = f.read()
-                if not self.name in content.splitlines():
-                    modules = list(filter(None, content.splitlines()))
-                    modules.append(self.name)
+	def add_to_modules_txt(self):
+		"""Adds to `[app]/modules.txt`"""
+		modules = None
+		if not frappe.local.module_app.get(frappe.scrub(self.name)):
+			with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
+				content = f.read()
+				if not self.name in content.splitlines():
+					modules = list(filter(None, content.splitlines()))
+					modules.append(self.name)
 
-            if modules:
-                with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
-                    f.write("\n".join(modules))
+			if modules:
+				with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
+					f.write("\n".join(modules))
 
-                frappe.clear_cache()
-                frappe.setup_module_map()
+				frappe.clear_cache()
+				frappe.setup_module_map()
 
-    def on_trash(self):
-        """Delete module name from modules.txt"""
+	def on_trash(self):
+		"""Delete module name from modules.txt"""
 
-        if not frappe.conf.get("developer_mode") or frappe.flags.in_uninstall or self.custom:
-            return
+		if not frappe.conf.get("developer_mode") or frappe.flags.in_uninstall or self.custom:
+			return
 
-        modules = None
-        if frappe.local.module_app.get(frappe.scrub(self.name)):
-            delete_folder(self.module_name,"Module Def",self.name)
-            with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
-                content = f.read()
-                if self.name in content.splitlines():
-                    modules = list(filter(None, content.splitlines()))
-                    modules.remove(self.name)
+		modules = None
+		if frappe.local.module_app.get(frappe.scrub(self.name)):
+			delete_folder(self.module_name,"Module Def",self.name)
+			with open(frappe.get_app_path(self.app_name, "modules.txt")) as f:
+				content = f.read()
+				if self.name in content.splitlines():
+					modules = list(filter(None, content.splitlines()))
+					modules.remove(self.name)
 
-            if modules:
-                with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
-                    f.write("\n".join(modules))
+			if modules:
+				with open(frappe.get_app_path(self.app_name, "modules.txt"), "w") as f:
+					f.write("\n".join(modules))
 
-                frappe.clear_cache()
-                frappe.setup_module_map()
+				frappe.clear_cache()
+				frappe.setup_module_map()
 
 
 @frappe.whitelist()
 def get_installed_apps():
-    return json.dumps(frappe.get_installed_apps())
+	return json.dumps(frappe.get_installed_apps())


### PR DESCRIPTION
On deletion of the `Module Def`, entry from the Database is deleted, but folder is not removed. 

ISSUE: https://github.com/frappe/frappe/issues/14047