### PR TITLE
fix: Parameter {function} get translated and format doesn't work

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -411,8 +411,8 @@ def get_group_by_column_label(args, meta):
 	else:
 		sql_fn_map = {"avg": "Average", "sum": "Sum"}
 		aggregate_on_label = meta.get_label(args.aggregate_on)
-		label = _("{function} of {fieldlabel}").format(
-			function=sql_fn_map[args.aggregate_function], fieldlabel=aggregate_on_label
+		label = _("{0} of {1}").format(
+			_(sql_fn_map[args.aggregate_function]), _(aggregate_on_label)
 		)
 	return label
 

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -411,9 +411,7 @@ def get_group_by_column_label(args, meta):
 	else:
 		sql_fn_map = {"avg": "Average", "sum": "Sum"}
 		aggregate_on_label = meta.get_label(args.aggregate_on)
-		label = _("{0} of {1}").format(
-			_(sql_fn_map[args.aggregate_function]), _(aggregate_on_label)
-		)
+		label = _("{0} of {1}").format(_(sql_fn_map[args.aggregate_function]), _(aggregate_on_label))
 	return label
 
 


### PR DESCRIPTION
_("{**function**} of {fieldlabel}").format(**function**=sql_fn_map[args.aggregate_function], fieldlabel=aggregate_on_label)

I work with ERPNext in pt-BR and parameter **{function}** get translated and format doesn't work, because {function} is changed to {função} on my language.

parameter named was changed to numbers.