### PR TITLE
perf: dont reload doc when already saving

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -149,10 +149,10 @@ $.extend(frappe.model, {
 					cur_frm.doc.doctype === doc.doctype &&
 					cur_frm.doc.name === doc.name
 				) {
-					if (data.modified !== cur_frm.doc.modified) {
+					if (data.modified !== cur_frm.doc.modified && !frappe.ui.form.is_saving) {
 						if (!cur_frm.is_dirty()) {
 							cur_frm.reload_doc();
-						} else if (!frappe.ui.form.is_saving) {
+						} else {
 							doc.__needs_refresh = true;
 							cur_frm.show_conflict_message();
 						}


### PR DESCRIPTION
### Issue

Document gets reloaded in the following code even though it's already saving:
https://github.com/frappe/frappe/blob/84188587fa330a05b4c717a25cf1474e55757dd4/frappe/public/js/frappe/model/model.js#L152-L154

Underlying problem is in following sequence:
- first the realtime update is received on commit
- then the save response is received

The problematic code was introduced in https://github.com/frappe/frappe/pull/20126 to ensure that workflows work as expected. But `frappe.ui.form.is_saving` should be `false` during that so it should still work as expected.

Additionally, the above code causes `refresh` event to get triggered twice:
- once after save
- once inside `reload_doc`

That leads to issues like this:

![image](https://github.com/frappe/frappe/assets/16315650/14eb2117-db27-4c15-9eb2-238effe63db1)


### Solution

Don't trigger reload if form is already saving.