### PR TITLE
fix: Check links and abandon /before/ starting to delete.

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -108,15 +108,15 @@ def delete_doc(
 				update_flags(doc, flags, ignore_permissions)
 				check_permission_and_not_submitted(doc)
 
-				if not ignore_on_trash:
-					doc.run_method("on_trash")
-					doc.flags.in_delete = True
-					doc.run_method("on_change")
-
 				# check if links exist
 				if not force:
 					check_if_doc_is_linked(doc)
 					check_if_doc_is_dynamically_linked(doc)
+
+				if not ignore_on_trash:
+					doc.run_method("on_trash")
+					doc.flags.in_delete = True
+					doc.run_method("on_change")
 
 			update_naming_series(doc)
 			delete_from_table(doctype, name, ignore_doctypes, doc)


### PR DESCRIPTION
Re [frappe/erpnext:36406](https://github.com/frappe/frappe/issues/22046).

Deleting a module def may fail because there are referenced DocTypes.

In this case, the installation is left in an at least slightly disorderly state as the deletion has already started before being abandoned:

https://github.com/frappe/erpnext/assets/46800703/af7b9ef9-bc63-4b2c-93e7-7cce07d4826f

Enclosed PR fixes this problem, ensuring referenced DocTypes are checked before any event handlers are being called or flags being set.