### PR TITLE
feat(ops): add environment variable to set bench root / workdir

### DIFF
--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -509,7 +509,9 @@ def get_files_path(*path, **kwargs):
 
 
 def get_bench_path():
-	return os.path.realpath(os.path.join(os.path.dirname(frappe.__file__), "..", "..", ".."))
+	return os.environ.get("FRAPPE_BENCH_ROOT") or os.path.realpath(
+		os.path.join(os.path.dirname(frappe.__file__), "..", "..", "..")
+	)
 
 
 def get_bench_id():


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

In the case of serving frappe from a regular python module, the bench root heurisic
ends up somewhere around `lib/site-packages`.

> Explain the **details** for making this change. What existing problem does the pull request solve?

In such operational scenarios, this PR allows to normatively declare the bench root and bypass the flawed heuristic.

The heuristic is still valid in local dev environments and operational scenarios that can affort to comply with the eagerly opinionated folder layout.

Examples when this previously failed in production if modules are installed as python modules:
```
frappe/integrations/doctype/google_drive/google_drive.py
19:from frappe.utils import get_backups_path, get_bench_path
226:	return f"{get_bench_path()}/sites/{file_path}"

frappe/utils/synchronization.py
11:from frappe.utils import get_bench_path, get_site_path
37:		lock_path = os.path.abspath(os.path.join(get_bench_path(), "config", lock_filename))

frappe/monitor.py
36:	return os.path.join(frappe.utils.get_bench_path(), "logs", "monitor.json.log
```

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

cc @teutat3s
