### PR TITLE
refactor: make the app source accessor explicit

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1414,6 +1414,14 @@ def get_app_path(app_name, *joins):
 	return get_pymodule_path(app_name, *joins)
 
 
+def get_app_source_path(app_name, *joins):
+	"""Return source path of given app.
+
+	:param app: App name.
+	:param *joins: Join additional path elements using `os.path.join`."""
+	return get_app_path(app_name, "..", *joins)
+
+
 def get_site_path(*joins):
 	"""Return path of current site.
 

--- a/frappe/build.py
+++ b/frappe/build.py
@@ -253,7 +253,7 @@ def bundle(
 		command += " --save-metafiles"
 
 	check_node_executable()
-	frappe_app_path = frappe.get_app_path("frappe", "..")
+	frappe_app_path = frappe.get_app_source_path("frappe")
 	frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env(), raise_err=True)
 
 
@@ -271,7 +271,7 @@ def watch(apps=None):
 		command += " --live-reload"
 
 	check_node_executable()
-	frappe_app_path = frappe.get_app_path("frappe", "..")
+	frappe_app_path = frappe.get_app_source_path("frappe")
 	frappe.commands.popen(command, cwd=frappe_app_path, env=get_node_env())
 
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -931,7 +931,7 @@ def _drop_site(
 	drop_user_and_database(frappe.conf.db_name, db_root_username, db_root_password)
 
 	archived_sites_path = archived_sites_path or os.path.join(
-		frappe.get_app_path("frappe"), "..", "..", "..", "archived", "sites"
+		frappe.utils.get_bench_path(), "archived", "sites"
 	)
 	archived_sites_path = os.path.realpath(archived_sites_path)
 

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -864,7 +864,7 @@ def run_ui_tests(
 ):
 	"Run UI tests"
 	site = get_site(context)
-	app_base_path = os.path.abspath(os.path.join(frappe.get_app_path(app), ".."))
+	app_base_path = frappe.get_app_source_path(app)
 	site_url = frappe.utils.get_site_url(site)
 	admin_password = frappe.get_conf(site).admin_password
 
@@ -1076,7 +1076,7 @@ def get_version(output):
 		app_info = frappe._dict()
 
 		try:
-			app_info.commit = Repo(frappe.get_app_path(app, "..")).head.object.hexsha[:7]
+			app_info.commit = Repo(frappe.get_app_source_path(app)).head.object.hexsha[:7]
 		except InvalidGitRepositoryError:
 			app_info.commit = ""
 

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -111,7 +111,7 @@ class WebsiteTheme(Document):
 		content = content.replace("\n", "\\n")
 		command = ["node", "generate_bootstrap_theme.js", output_path, content]
 
-		process = Popen(command, cwd=frappe.get_app_path("frappe", ".."), stdout=PIPE, stderr=PIPE)
+		process = Popen(command, cwd=frappe.get_app_source_path("frappe"), stdout=PIPE, stderr=PIPE)
 
 		stderr = process.communicate()[1]
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

The parent folder of a python module (inside `./site-packages`) can be
`./lib`. Separate code paths that depend on the app source into its own
getter so that patching that function becomes easier in those cases
where the python module is not served from the source checkout.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This PR only implements a code path separation in order to provide a different means of app source
injection when the site is served from regular python (not source) modules

This could be consider a stepping stone in [handling runtime packaging in tests on a read-only file system](https://github.com/blaggacao/frappix/blob/main/src/tests.md#todo-dynamically-generate-website-theme-bootstrap-assest).

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
