### PR TITLE
fix(test): use app path directly without looping over bench path

### DIFF
--- a/frappe/tests/test_patches.py
+++ b/frappe/tests/test_patches.py
@@ -4,7 +4,6 @@ from unittest.mock import mock_open, patch
 import frappe
 from frappe.modules import patch_handler
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import get_bench_path
 
 EMTPY_FILE = ""
 EMTPY_SECTION = """
@@ -169,9 +168,9 @@ def check_patch_files(app):
 
 
 def _get_dotted_path(file: Path, app) -> str:
-	app_path = Path(get_bench_path()) / "apps" / app
+	app_path = Path(frappe.get_app_path(app))
 
 	*path, filename = file.relative_to(app_path).parts
 	base_filename = Path(filename).stem
 
-	return ".".join(path + [base_filename])
+	return ".".join([app] + path + [base_filename])

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -17,10 +17,10 @@ from frappe.translate import (
 	get_parent_language,
 	get_translation_dict_from_file,
 )
-from frappe.utils import set_request
+from frappe.utils import get_bench_path, set_request
 
 dirname = os.path.dirname(__file__)
-translation_string_file = os.path.join(dirname, "translation_test_file.txt")
+translation_string_file = os.path.abspath(os.path.join(dirname, "translation_test_file.txt"))
 first_lang, second_lang, third_lang, fourth_lang, fifth_lang = choices(
 	# skip "en*" since it is a default language
 	frappe.get_all("Language", pluck="name", filters=[["name", "not like", "en%"]]),
@@ -45,7 +45,9 @@ class TestTranslate(FrappeTestCase):
 
 	def test_extract_message_from_file(self):
 		data = frappe.translate.get_messages_from_file(translation_string_file)
-		exp_filename = "apps/frappe/frappe/tests/translation_test_file.txt"
+		bench_path = get_bench_path()
+		file_path = frappe.get_app_path("frappe", "tests", "translation_test_file.txt")
+		exp_filename = os.path.relpath(file_path, bench_path)
 
 		self.assertEqual(
 			len(data),

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -422,9 +422,11 @@ class TestValidationUtils(FrappeTestCase):
 
 class TestImage(FrappeTestCase):
 	def test_strip_exif_data(self):
-		original_image = Image.open("../apps/frappe/frappe/tests/data/exif_sample_image.jpg")
+		original_image = Image.open(
+			frappe.get_app_path("frappe", "tests", "data", "exif_sample_image.jpg")
+		)
 		original_image_content = open(
-			"../apps/frappe/frappe/tests/data/exif_sample_image.jpg", mode="rb"
+			frappe.get_app_path("frappe", "tests", "data", "exif_sample_image.jpg"), mode="rb"
 		).read()
 
 		new_image_content = strip_exif_data(original_image_content, "image/jpeg")
@@ -434,7 +436,9 @@ class TestImage(FrappeTestCase):
 		self.assertNotEqual(original_image._getexif(), new_image._getexif())
 
 	def test_optimize_image(self):
-		image_file_path = "../apps/frappe/frappe/tests/data/sample_image_for_optimization.jpg"
+		image_file_path = frappe.get_app_path(
+			"frappe", "tests", "data", "sample_image_for_optimization.jpg"
+		)
 		content_type = guess_type(image_file_path)[0]
 		original_content = open(image_file_path, mode="rb").read()
 

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -10,7 +10,6 @@ from typing import Optional
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import get_path
 
 
 class WebsiteTheme(Document):
@@ -181,15 +180,13 @@ def get_scss_paths():
 	returned set will contain 'frappe/public/scss/website[.bundle]'.
 	"""
 	import_path_list = []
-	bench_path = frappe.utils.get_bench_path()
 
 	scss_files = ["public/scss/website.scss", "public/scss/website.bundle.scss"]
 	for app in frappe.get_installed_apps():
 		for scss_file in scss_files:
-			relative_path = join_path(app, scss_file)
-			full_path = get_path("apps", app, relative_path, base=bench_path)
+			full_path = frappe.get_app_path(app, scss_file)
 			if path_exists(full_path):
-				import_path = splitext(relative_path)[0]
+				import_path = splitext(join_path(app, scss_file))[0]
 				import_path_list.append(import_path)
 
 	return import_path_list


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

The bench path heuristic is flawed when apps are installed as python modules.

Forthemore the current code is an unnecessary indirection (over that flawed code path).

> Explain the **details** for making this change. What existing problem does the pull request solve?

By avoiding this unnecessary indirection, these particular code paths are fixed in those scenarios.

It also simplifies the implementation a bit.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

cc @teutat3s
