### PR TITLE
test: skip tests on RO app paths which require write access

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
+import os
 import random
 import string
+import unittest
 from unittest.mock import patch
 
 import frappe
@@ -172,6 +174,9 @@ class TestDocType(FrappeTestCase):
 				if condition:
 					self.assertFalse(re.match(pattern, condition))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_sync_field_order(self):
 		import os
 
@@ -648,6 +653,9 @@ class TestDocType(FrappeTestCase):
 	def test_no_delete_doc(self):
 		self.assertRaises(frappe.ValidationError, frappe.delete_doc, "DocType", "Address")
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_export_types(self):
 		"""Export python types."""
@@ -686,6 +694,9 @@ class TestDocType(FrappeTestCase):
 		doctype.delete()
 		frappe.db.commit()
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_custom_field_deletion(self):
 		"""Custom child tables whose doctype doesn't exist should be auto deleted."""
@@ -698,6 +709,9 @@ class TestDocType(FrappeTestCase):
 		frappe.delete_doc("DocType", child)
 		self.assertFalse(frappe.get_meta(doctype).get_field(field))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	@patch.dict(frappe.conf, {"developer_mode": 1})
 	def test_delete_doctype_with_customization(self):
 		from frappe.custom.doctype.property_setter.property_setter import make_property_setter

--- a/frappe/printing/doctype/print_format/test_print_format.py
+++ b/frappe/printing/doctype/print_format/test_print_format.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 import os
 import re
+import unittest
 from typing import TYPE_CHECKING
 
 import frappe
@@ -36,6 +37,9 @@ class TestPrintFormat(FrappeTestCase):
 		print_html = self.test_print_user("Classic")
 		self.assertTrue("/* classic format: for-test */" in print_html)
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_export_doc(self):
 		doc: "PrintFormat" = frappe.get_doc("Print Format", test_records[0]["name"])
 

--- a/frappe/tests/test_boilerplate.py
+++ b/frappe/tests/test_boilerplate.py
@@ -111,6 +111,9 @@ class TestBoilerPlate(unittest.TestCase):
 	def test_valid_ci_yaml(self):
 		yaml.safe_load(github_workflow_template.format(**self.default_hooks))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_create_app(self):
 		app_name = "test_app"
 
@@ -142,6 +145,9 @@ class TestBoilerPlate(unittest.TestCase):
 
 		self.assertEqual(parse_as_configfile(patches_file), [])
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_create_app_without_git_init(self):
 		app_name = "test_app_no_git"
 
@@ -192,6 +198,9 @@ class TestBoilerPlate(unittest.TestCase):
 				except Exception as e:
 					self.fail(f"Can't parse python file in new app: {python_file}\n" + str(e))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_new_patch_util(self):
 		user_inputs = {
 			"app_name": "frappe",

--- a/frappe/tests/test_modules.py
+++ b/frappe/tests/test_modules.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import unittest
 
 import frappe
 from frappe import scrub
@@ -82,6 +83,9 @@ class TestUtils(FrappeTestCase):
 		doc = frappe.get_last_doc("DocType")
 		self.assertIsNone(export_module_json(doc=doc, is_standard=True, module=doc.module))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_export_module_json(self):
 		doc = frappe.get_last_doc("DocType", {"issingle": 0, "custom": 0})
 		export_doc_path = os.path.join(
@@ -107,12 +111,18 @@ class TestUtils(FrappeTestCase):
 
 		self.assertTrue(last_modified_after > last_modified_before)
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_export_customizations(self):
 		file_path = export_customizations(module="Custom", doctype="Note")
 		self.addCleanup(delete_file, path=file_path)
 		self.assertTrue(file_path.endswith("/custom/custom/note.json"))
 		self.assertTrue(os.path.exists(file_path))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_sync_customizations(self):
 		custom_field = frappe.get_doc(
 			"Custom Field", {"dt": "Note", "fieldname": "test_export_customizations_field"}
@@ -157,6 +167,9 @@ class TestUtils(FrappeTestCase):
 		)
 		self.assertTrue(frappe.db.get_value("DocType", "Note", "migration_hash"))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_export_doc(self):
 		exported_doc_path = frappe.get_app_path(
 			"frappe", "desk", "note", self.note.name, f"{self.note.name}.json"
@@ -166,6 +179,9 @@ class TestUtils(FrappeTestCase):
 		self.addCleanup(delete_path, path=folder_path)
 		self.assertTrue(os.path.exists(exported_doc_path))
 
+	@unittest.skipUnless(
+		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
+	)
 	def test_make_boilerplate(self):
 		scrubbed = frappe.scrub(self.doctype.name)
 		self.assertFalse(


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

In a production-like staging environment where the app source tree is immutable (read only),
these tests would fail the staging validation pipeline.

> Explain the **details** for making this change. What existing problem does the pull request solve?

We skip these test if their assumptions (of a mutable frappe source tree) is not met.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
