### PR TITLE
refactor: Let search queries omit unnecessary args

### DIFF
--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -529,7 +529,7 @@ def make_auto_repeat(doctype, docname, frequency="Daily", start_date=None, end_d
 # method for reference_doctype filter
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_auto_repeat_doctypes(doctype, txt, searchfield, start, page_len, filters):
+def get_auto_repeat_doctypes():
 	res = frappe.get_all(
 		"Property Setter",
 		{

--- a/frappe/contacts/address_and_contact.py
+++ b/frappe/contacts/address_and_contact.py
@@ -113,9 +113,7 @@ def delete_contact_and_address(doctype: str, docname: str) -> None:
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def filter_dynamic_link_doctypes(
-	doctype, txt: str, searchfield, start, page_len, filters: dict
-) -> list[list[str]]:
+def filter_dynamic_link_doctypes(txt: str, filters: dict) -> list[list[str]]:
 	from frappe.permissions import get_doctypes_with_read
 
 	txt = txt or ""

--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -263,7 +263,7 @@ def get_company_address(company):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def address_query(doctype, txt, searchfield, start, page_len, filters):
+def address_query(txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 
 	doctype = "Address"

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -245,7 +245,7 @@ def update_contact(doc, method):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def contact_query(doctype, txt, searchfield, start, page_len, filters):
+def contact_query(txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 
 	doctype = "Contact"

--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -143,7 +143,7 @@ def has_unseen_error_log():
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_log_doctypes(doctype, txt, searchfield, start, page_len, filters):
+def get_log_doctypes(txt, start, page_len, filters):
 
 	filters = filters or {}
 

--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -123,7 +123,7 @@ def get_users(role):
 # searches for active employees
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def role_query(doctype, txt, searchfield, start, page_len, filters):
+def role_query(txt, start, page_len, filters):
 	report_filters = [["Role", "name", "like", f"%{txt}%"], ["Role", "is_custom", "=", 0]]
 	if filters and isinstance(filters, list):
 		report_filters.extend(filters)

--- a/frappe/core/doctype/user_permission/user_permission.py
+++ b/frappe/core/doctype/user_permission/user_permission.py
@@ -154,7 +154,7 @@ def user_permission_exists(user, allow, for_value, applicable_for=None):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_applicable_for_doctype_list(doctype, txt, searchfield, start, page_len, filters):
+def get_applicable_for_doctype_list(doctype, txt, start, page_len):
 	linked_doctypes_map = get_linked_doctypes(doctype, True)
 
 	linked_doctypes = []

--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -223,7 +223,7 @@ def get_non_standard_user_types():
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_user_linked_doctypes(doctype, txt, searchfield, start, page_len, filters):
+def get_user_linked_doctypes(txt, start, page_len, filters):
 	modules = [d.get("module_name") for d in get_modules_from_app("frappe")]
 
 	filters = [

--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -47,7 +47,7 @@ def get_columns_and_fields(doctype):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def query_doctypes(doctype, txt, searchfield, start, page_len, filters):
+def query_doctypes(txt,  filters):
 	user = filters.get("user")
 	user_perms = frappe.utils.user.UserPermissions(user)
 	user_perms.build_permissions()

--- a/frappe/desk/doctype/custom_html_block/custom_html_block.py
+++ b/frappe/desk/doctype/custom_html_block/custom_html_block.py
@@ -26,7 +26,7 @@ class CustomHTMLBlock(Document):
 
 
 @frappe.whitelist()
-def get_custom_blocks_for_user(doctype, txt, searchfield, start, page_len, filters):
+def get_custom_blocks_for_user():
 	# return logged in users private blocks and all public blocks
 	customHTMLBlock = DocType("Custom HTML Block")
 

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -331,7 +331,7 @@ def get_result(data, timegrain, from_date, to_date, chart_type):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_charts_for_user(doctype, txt, searchfield, start, page_len, filters):
+def get_charts_for_user(filters):
 	or_filters = {"owner": frappe.session.user, "is_public": 1}
 	return frappe.db.get_list(
 		"Dashboard Chart", fields=["name"], filters=filters, or_filters=or_filters, as_list=1

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -217,7 +217,7 @@ def create_number_card(args):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
+def get_cards_for_user(doctype, txt, filters):
 	meta = frappe.get_meta(doctype)
 	searchfields = meta.get_search_fields()
 	search_conditions = []

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -81,15 +81,17 @@ def search_widget(
 	if query and query.split(maxsplit=1)[0].lower() != "select":
 		# by method
 		try:
-			is_whitelisted(frappe.get_attr(query))
+			method = frappe.get_attr(query)
+			is_whitelisted(method)
 			frappe.response["values"] = frappe.call(
-				query,
-				doctype,
-				txt,
-				searchfield,
-				start,
-				page_length,
-				filters,
+				method,
+				doctype=doctype,
+				txt=txt,
+				searchfield=searchfield,
+				start=start,
+				page_length=page_length,
+				page_len=page_length,  # backward compatbility
+				filters=filters,
 				as_dict=as_dict,
 				reference_doctype=reference_doctype,
 			)

--- a/frappe/email/__init__.py
+++ b/frappe/email/__init__.py
@@ -72,7 +72,7 @@ def relink(name, reference_doctype=None, reference_name=None):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_communication_doctype(doctype, txt, searchfield, start, page_len, filters):
+def get_communication_doctype(txt):
 	user_perms = frappe.utils.user.UserPermissions(frappe.session.user)
 	user_perms.build_permissions()
 	can_read = user_perms.can_read

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -732,9 +732,7 @@ class EmailAccount(Document):
 
 
 @frappe.whitelist()
-def get_append_to(
-	doctype=None, txt=None, searchfield=None, start=None, page_len=None, filters=None
-):
+def get_append_to(txt=None, filters=None):
 	txt = txt if txt else ""
 	email_append_to_list = []
 

--- a/frappe/utils/diff.py
+++ b/frappe/utils/diff.py
@@ -47,7 +47,7 @@ def _get_value_from_version(version_name: int | str, fieldname: str):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def version_query(doctype, txt, searchfield, start, page_len, filters):
+def version_query(start, page_len, filters):
 	results = frappe.get_list(
 		"Version",
 		fields=["name", "modified"],


### PR DESCRIPTION
Most queries don't need `doctype` or some other field depending on context. There's no real need to force these 5 arguments on every custom search query. 

`frappe.call` removes kwargs that function doesn't support. This lets developers switch order and/or omit unnecessary arguments. Much simpler.

Another unrelated change:
- `page_len` -> `page_length`. 


```diff
- def get_log_doctypes(doctype, txt, searchfield, start, page_len, filters):
+ def get_log_doctypes(txt, start, page_len, filters):
```


closes https://github.com/frappe/frappe/issues/21882



TODO:
- [ ] reliably support diff arg name with previous order. 