### PR TITLE
fix: include all traceback frames

### DIFF
--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -45,7 +45,7 @@ def get_current_stack_frames():
 		current = inspect.currentframe()
 		frames = inspect.getouterframes(current, context=10)
 		for frame, filename, lineno, function, context, index in list(reversed(frames))[:-2]:
-			if "/apps/" in filename:
+			if "/apps/" in filename or "<serverscript>" in filename:
 				yield {
 					"filename": TRACEBACK_PATH_PATTERN.sub("", filename),
 					"lineno": lineno,


### PR DESCRIPTION
Recorder omits traceback frames which don't contain `/apps/`  in file, this is problematic when writes are made from server scripts.

This check was added when server scripts didn't exist, so omitting non-app frames was sensible. Not so much anymore.
