### PR TITLE
fix: center notes text in FileUploader

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -70,7 +70,7 @@
 						<div class="mt-1">{{ __('Google Drive') }}</div>
 					</button>
 				</div>
-				<div class="text-muted text-medium">
+				<div class="text-muted text-medium text-center">
 					{{ upload_notes }}
 				</div>
 			</div>


### PR DESCRIPTION
Before

![Bildschirmfoto 2023-08-01 um 15 35 41](https://github.com/frappe/frappe/assets/14891507/dfbe67e4-be6e-45bd-9cec-87cdecf7407b)

After

![Bildschirmfoto 2023-08-01 um 15 35 51](https://github.com/frappe/frappe/assets/14891507/9098164a-4f7e-4bd4-90bf-6429119dccff)

> no-docs