### PR TITLE
fix(Workspace): Clear bootinfo cache when creating a new workspace

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -64,6 +64,13 @@ class Workspace(Document):
 		except Exception:
 			frappe.throw(_("Content data shoud be a list"))
 
+	def clear_cache(self):
+		super().clear_cache()
+		if self.for_user:
+			frappe.cache.hdel("bootinfo", self.for_user)
+		else:
+			frappe.cache.delete_key("bootinfo")
+
 	def on_update(self):
 		if disable_saving_as_public():
 			return


### PR DESCRIPTION
# Description

Just after creating a new Workspace, it suddenly seemed to not exist when reloading the page.

Indeed, available workspaces are **not** fetched directly from the database, but instead are found, when reloading, in _bootinfo_ : `frappe.boot.allowed_workspaces`. However, because of a missing _cache invalidation_ of `bootinfo` for the user, it becomes out-of-sync with the actual Workspaces, because the _bootinfo_ is cached.

A partial fix (https://github.com/frappe/frappe/commit/e4c45dd719cf9fe3ef754e96746cf87ea8fd0391) was recently merged, but it is more of a workaround, using localStorage.

# Solution

Clear the bootinfo cache for the user when creating a private Workspace. (Could also do it when deleting/updating one?)

# Drawbacks

I'm not sure if I should add some conditions like `if frappe.flags.in_install:`, I'm open to suggestions