### PR TITLE
fix: debounce form refresh from realtime events

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -41,6 +41,7 @@ frappe.ui.form.Form = class FrappeForm {
 		this.doctype_layout = frappe.get_doc("DocType Layout", doctype_layout_name);
 		this.undo_manager = new UndoManager({ frm: this });
 		this.setup_meta(doctype);
+		this.debounced_reload_doc = frappe.utils.debounce(this.reload_doc.bind(this), 1000);
 
 		this.beforeUnloadListener = (event) => {
 			event.preventDefault();
@@ -543,7 +544,7 @@ frappe.ui.form.Form = class FrappeForm {
 			this.doc.__last_sync_on &&
 			new Date() - this.doc.__last_sync_on > this.refresh_if_stale_for * 1000
 		) {
-			this.reload_doc();
+			this.debounced_reload_doc();
 			return true;
 		}
 	}
@@ -1132,7 +1133,7 @@ frappe.ui.form.Form = class FrappeForm {
 					"alert-warning"
 				);
 			} else {
-				this.reload_doc();
+				this.debounced_reload_doc();
 			}
 		}
 	}

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -151,7 +151,7 @@ $.extend(frappe.model, {
 				) {
 					if (data.modified !== cur_frm.doc.modified && !frappe.ui.form.is_saving) {
 						if (!cur_frm.is_dirty()) {
-							cur_frm.reload_doc();
+							cur_frm.debounced_reload_doc();
 						} else {
 							doc.__needs_refresh = true;
 							cur_frm.show_conflict_message();


### PR DESCRIPTION
refer https://github.com/frappe/hrms/issues/755



before
![image](https://github.com/frappe/frappe/assets/9079960/0a7a0195-3918-4aa5-aef8-b64628fa192d)


after
![image](https://github.com/frappe/frappe/assets/9079960/b6ac6ec1-e8c6-482d-b1e2-dc05f6c58a16)
