### PR TITLE
fix(translate.py): Filter out disabled languages

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -161,7 +161,7 @@ def set_default_language(lang):
 def get_lang_dict():
 	"""Returns all languages in dict format, full name is the key e.g. `{"english":"en"}`"""
 	return dict(
-		frappe.get_all("Language", fields=["language_name", "name"], order_by=None, as_list=True)
+		frappe.get_all("Language", fields=["language_name", "name"], filters={'enabled':True}, order_by=None, as_list=True)
 	)
 
 


### PR DESCRIPTION
Request:
We want to filter out disabled languages in the print format translation options

![image](https://github.com/frappe/frappe/assets/85614308/cf66b4fe-6c48-4a20-90e7-e5e5eba698a8)

![image](https://github.com/frappe/frappe/assets/85614308/beddad98-2dfd-4704-a97d-633653b58c08)
