### PR TITLE
fix: grid don't remove search if filters are applied.

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -762,7 +762,8 @@ export default class GridRow {
 
 	show_search_row() {
 		// show or remove search columns based on grid rows
-		this.show_search = this.show_search && this.grid?.data?.length >= 20;
+		this.show_search =
+			this.show_search && (this.grid?.data?.length >= 20 || this.grid.filter_applied);
 		!this.show_search && this.wrapper.remove();
 		return this.show_search;
 	}


### PR DESCRIPTION
If grid is filtered don't remove search even if length is less than 20.

## Before

https://github.com/frappe/frappe/assets/39730881/e5826fee-c131-42ce-93a3-b7e57fa6bc2e

## After

https://github.com/frappe/frappe/assets/39730881/56b9ee24-6a0f-4c32-b82b-9980eda7a51d

