### PR TITLE
test: set `request_ip` when testing `reset_password`

### DIFF
--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -369,6 +369,7 @@ class TestUser(FrappeTestCase):
 		frappe.local.login_manager = LoginManager()
 		# used by rate limiter when calling reset_password
 		frappe.local.request_ip = "127.0.0.1"
+		frappe.db.set_single_value("System Settings", "password_reset_limit", 6)
 
 		frappe.set_user("testpassword@example.com")
 		test_user = frappe.get_doc("User", "testpassword@example.com")

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -367,6 +367,8 @@ class TestUser(FrappeTestCase):
 		set_request(path="/random")
 		frappe.local.cookie_manager = CookieManager()
 		frappe.local.login_manager = LoginManager()
+		# used by rate limiter when calling reset_password
+		frappe.local.request_ip = "127.0.0.1"
 
 		frappe.set_user("testpassword@example.com")
 		test_user = frappe.get_doc("User", "testpassword@example.com")


### PR DESCRIPTION
Fix required due to https://github.com/frappe/frappe/pull/21929

Alternate fixes:
- set a flag like `frappe.flags.ignore_rate_limiter`
- change rate limiter implementation to look for `frappe.local.http_request` instead