### PR TITLE
fix(DX): Wrap print format errors

### DIFF
--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -252,6 +252,10 @@ class SessionBootFailed(ValidationError):
 	http_status_code = 500
 
 
+class PrintFormatError(ValidationError):
+	pass
+
+
 class TooManyWritesError(Exception):
 	pass
 

--- a/frappe/utils/error.py
+++ b/frappe/utils/error.py
@@ -157,5 +157,5 @@ def guess_exception_source(exception: str) -> str | None:
 				app_name = matches.group("app_name")
 				apps[app_name] += app_priority.get(app_name, 0)
 
-		if probably_source := apps.most_common(1):
+		if (probably_source := apps.most_common(1)) and probably_source[0][0] != "frappe":
 			return f"{probably_source[0][0]} (app)"


### PR DESCRIPTION
![image](https://github.com/frappe/frappe/assets/9079960/11562c54-e200-4451-ae2b-03ae82f57d4c)


closes #21939 



Jinja template or runtime errors are 5xx, even though technically they are 4xx. This change wraps print format rendering and gives proper error message when print formats fail. 