### PR TITLE
perf: lower limit for global search

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -51,7 +51,7 @@ frappe.search.SearchDialog = class {
 				no_results_status: () => __("No Results found"),
 				get_results: (keywords, callback) => {
 					let start = 0,
-						limit = 1000;
+						limit = 100;
 					let results = frappe.search.utils.get_nav_results(keywords);
 					frappe.search.utils.get_global_results(keywords, start, limit).then(
 						(global_results) => {


### PR DESCRIPTION
No one asks for 1000 results. This is a bad default. Lowered it to 100 for now. IMO should be somewhere between 20-100. 