### PR TITLE
fix: disable activity log global search

### DIFF
--- a/frappe/core/doctype/activity_log/activity_log.json
+++ b/frappe/core/doctype/activity_log/activity_log.json
@@ -33,7 +33,6 @@
   {
    "fieldname": "subject",
    "fieldtype": "Small Text",
-   "in_global_search": 1,
    "in_list_view": 1,
    "label": "Subject",
    "reqd": 1


### PR DESCRIPTION
has millions of record that don't need to be searched "globally".

