### PR TITLE
fix(Contact): use existing full name

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -217,18 +217,15 @@ def invite_user(contact):
 @frappe.whitelist()
 def get_contact_details(contact):
 	contact = frappe.get_doc("Contact", contact)
-	out = {
+	return {
 		"contact_person": contact.get("name"),
-		"contact_display": " ".join(
-			filter(None, [contact.get("salutation"), contact.get("first_name"), contact.get("last_name")])
-		),
+		"contact_display": contact.get("full_name"),
 		"contact_email": contact.get("email_id"),
 		"contact_mobile": contact.get("mobile_no"),
 		"contact_phone": contact.get("phone"),
 		"contact_designation": contact.get("designation"),
 		"contact_department": contact.get("department"),
 	}
-	return out
 
 
 def update_contact(doc, method):


### PR DESCRIPTION
The full name is already available, no need to recompute it:

https://github.com/frappe/frappe/blob/4a476217f28ca9a3c5eab8acc0fedc4110b7b07d/frappe/contacts/doctype/contact/contact.py#L61-L62