### PR TITLE
feat: `bulk_update` query to update records in chunks

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -443,7 +443,7 @@ def update_link_field_values(link_fields: list[dict], old: str, new: str, doctyp
 			if parent == new and doctype == "DocType":
 				parent = old
 
-			frappe.db.set_value(parent, {docfield: old}, docfield, new, update_modified=False)
+			frappe.db.bulk_update(parent, {docfield: old}, docfield, new)
 
 		# update cached link_fields as per new
 		if doctype == "DocType" and field["parent"] == old:


### PR DESCRIPTION
## Motivation
There are times when we require to update too many records. However, as the no of records increases, it uses more ram if not committed in chunks.

## Usecase
- Rename docs used at almost all places like company (added support for rename in bulk with bulk_update)
- Patches to update too many values (eg: https://github.com/resilient-tech/india-compliance/pull/816/files#diff-dd65c624b95d18f222c1941a5130e2ddbc59ba694b716c3b1329fdaf497e3fa8R118)

Could help resolve the frappe issue: https://frappe.io/app/issue/ISS-23-24-01827