### PR TITLE
fix: configurable rename queue

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -65,6 +65,8 @@ def update_document_title(
 	)
 	name_updated = updated_name and (updated_name != doc.name)
 
+	queue = kwargs.get("queue") or "default"
+
 	if name_updated:
 		if action_enqueued:
 			current_name = doc.name
@@ -86,7 +88,7 @@ def update_document_title(
 				save_point=True,
 			)
 
-			doc.queue_action("rename", name=transformed_name, merge=merge)
+			doc.queue_action("rename", name=transformed_name, merge=merge, queue=queue)
 		else:
 			doc.rename(updated_name, merge=merge)
 

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -98,6 +98,10 @@ frappe.ui.form.Toolbar = class Toolbar {
 		const docname = this.frm.doc.name;
 		const title_field = this.frm.meta.title_field || "";
 		const doctype = this.frm.doctype;
+		let queue;
+		if (this.frm.__rename_queue) {
+			queue = this.frm.__rename_queue;
+		}
 
 		if (input_name) {
 			const warning = __("This cannot be undone");
@@ -120,6 +124,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 					merge,
 					freeze: true,
 					freeze_message: __("Updating related fields..."),
+					queue,
 				})
 				.then((new_docname) => {
 					const reload_form = (input_name) => {


### PR DESCRIPTION
When trying to rename company the job constantly fails.

possibly alternate fix to https://github.com/frappe/frappe/pull/21995

Job timed out because of 300 seconds timeout, no amount of optimization
will fix this because it's rewriting practically every row in every transaction on DB.



![image](https://github.com/frappe/frappe/assets/9079960/6da2c4c3-ff33-4d1f-83ff-cf8c3c6b83d8)
