### PR TITLE
fix(types): Exporter unconditionally marks fields as Nullable

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -36,7 +36,7 @@ class AssignmentRule(Document):
 		priority: DF.Int
 		rule: DF.Literal["Round Robin", "Load Balancing", "Based on Field"]
 		unassign_condition: DF.Code | None
-		users: DF.TableMultiSelect[AssignmentRuleUser] | None
+		users: DF.TableMultiSelect[AssignmentRuleUser]
 	# end: auto-generated types
 	def validate(self):
 		self.validate_document_types()

--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -45,8 +45,6 @@ class Comment(Document):
 		]
 		content: DF.HTMLEditor | None
 		ip_address: DF.Data | None
-		link_doctype: DF.Link | None
-		link_name: DF.DynamicLink | None
 		published: DF.Check
 		reference_doctype: DF.Link | None
 		reference_name: DF.DynamicLink | None

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -23,7 +23,6 @@ class ModuleDef(Document):
 		module_name: DF.Data
 		package: DF.Link | None
 		restrict_to_domain: DF.Link | None
-
 	# end: auto-generated types
 	def on_update(self):
 		"""If in `developer_mode`, create folder for module and

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -56,6 +56,7 @@ class SystemSettings(Document):
 		]
 		float_precision: DF.Literal["", "2", "3", "4", "5", "6", "7", "8", "9"]
 		force_user_to_reset_password: DF.Int
+		force_web_capture_mode_for_uploads: DF.Check
 		hide_footer_in_auto_email_reports: DF.Check
 		language: DF.Link
 		lifespan_qrcode_image: DF.Int

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -54,7 +54,7 @@ class User(Document):
 		api_key: DF.Data | None
 		api_secret: DF.Password | None
 		banner_image: DF.AttachImage | None
-		bio: DF.Text | None
+		bio: DF.SmallText | None
 		birth_date: DF.Date | None
 		block_modules: DF.Table[BlockModule]
 		bypass_restrict_ip_check_if_2fa_enabled: DF.Check

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -26,7 +26,7 @@ class NotificationSettings(Document):
 		enabled: DF.Check
 		energy_points_system_notifications: DF.Check
 		seen: DF.Check
-		subscribed_documents: DF.TableMultiSelect[NotificationSubscribedDocument] | None
+		subscribed_documents: DF.TableMultiSelect[NotificationSubscribedDocument]
 		user: DF.Link | None
 	# end: auto-generated types
 	def on_update(self):

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -44,7 +44,7 @@ non_nullable_types = {
 	"Rating",
 	"Select",
 	"Table",
-	"TableMultiSelect",
+	"Table MultiSelect",
 }
 
 
@@ -155,7 +155,7 @@ class TypeExporter:
 	def _is_nullable(self, field) -> bool:
 		"""If value can be `None`"""
 
-		if field.fieldtype.replace(" ", "") in non_nullable_types:
+		if field.fieldtype in non_nullable_types:
 			return False
 
 		return not bool(field.reqd)

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -155,7 +155,7 @@ class TypeExporter:
 	def _is_nullable(self, field) -> bool:
 		"""If value can be `None`"""
 
-		if field.fieldtype in non_nullable_types:
+		if field.fieldtype.replace(" ", "") in non_nullable_types:
 			return False
 
 		return not bool(field.reqd)

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -36,7 +36,7 @@ class WorkflowAction(Document):
 
 		completed_by: DF.Link | None
 		completed_by_role: DF.Link | None
-		permitted_roles: DF.TableMultiSelect[WorkflowActionPermittedRole] | None
+		permitted_roles: DF.TableMultiSelect[WorkflowActionPermittedRole]
 		reference_doctype: DF.Link | None
 		reference_name: DF.DynamicLink | None
 		status: DF.Literal["Open", "Completed"]


### PR DESCRIPTION
This happened because:

**Expectation:** `SmallText`, `TableMultiSelect`
**Reality:** `Small Text`, `Table MultiSelect`