### PR TITLE
fix: hide or show button to load more

### DIFF
--- a/frappe/public/js/frappe/form/link_selector.js
+++ b/frappe/public/js/frappe/form/link_selector.js
@@ -146,9 +146,11 @@ frappe.ui.form.LinkSelector = class LinkSelector {
 						});
 				}
 
+				var more_btn = me.dialog.fields_dict.more.$wrapper;
 				if (r.values.length < 20) {
-					var more_btn = me.dialog.fields_dict.more.$wrapper;
 					more_btn.hide();
+				} else {
+					more_btn.show();
 				}
 			},
 			this.dialog.get_primary_btn()


### PR DESCRIPTION
When I do a search that returns less than 20 records, the button to load more records was hidden, but if I changed the search keywords, the button to load more was not shown again, even though my new combination had more than 20 records

This source is used when u try to add multiple itens on sales invoice, sales order, POS Invoice...

![button_load_more](https://github.com/frappe/frappe/assets/25017988/84635b66-cdfb-46ea-984c-49e1dfa7da8e)
