### PR TITLE
fix: Dashboard shortcuts - Tree view missing

### DIFF
--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -395,7 +395,7 @@ class ShortcutDialog extends WidgetDialog {
 							}
 
 							const views = ["List", "Report Builder", "Dashboard", "New"];
-							if (meta.is_tree === "Tree") views.push("Tree");
+							if (meta.is_tree === 1) views.push("Tree");
 							if (frappe.boot.calendars.includes(doctype)) views.push("Calendar");
 
 							const response = await frappe.db.get_value(


### PR DESCRIPTION
**Version:**

ERPNext: v14.33.2 (version-14)
Frappe Framework: v14.43.1 (version-14)

fixes : https://discuss.frappe.io/t/dashboard-shortcuts-tree-view-missing/108298
___

**Before:**

- When selecting Tree structures related doctype then does not show the Tree option in Shortcut.


https://github.com/frappe/frappe/assets/141945075/0f446773-14ab-4424-b474-3d0a7cba4a95

<br>

**After:**
- If you check the below code, the condition is wrong.
https://github.com/frappe/frappe/blob/b2cc015f233b494f380d73be8aaf171d9db59c00/frappe/public/js/frappe/widgets/widget_dialog.js#L398

Actual conditions like if Tree structures doctype means 
```
is_tree === 1
```
Then will show the Tree option in the Dashboard shortcuts.


https://github.com/frappe/frappe/assets/141945075/be1ffd29-19ba-41dc-88a0-3be94372bd1b

<br>

Thank You!