### PR TITLE
fix: Support dynamic filters for Reports w/o js config

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -70,14 +70,18 @@ frappe.ui.form.on("Auto Email Report", {
 			frm.trigger("show_filters");
 		}
 	},
-	show_filters: function (frm) {
+	show_filters: async function (frm) {
 		var wrapper = $(frm.get_field("filters_display").wrapper);
 		wrapper.empty();
+		let reference_report = frappe.query_reports[frm.doc.report];
+		if (!reference_report || !reference_report.filters) {
+			reference_report = await frappe.model.with_doc("Report", frm.doc.report);
+		}
 		if (
 			frm.doc.report_type === "Custom Report" ||
 			(frm.doc.report_type !== "Report Builder" &&
-				frappe.query_reports[frm.doc.report] &&
-				frappe.query_reports[frm.doc.report].filters)
+				reference_report &&
+				reference_report.filters)
 		) {
 			// make a table to show filters
 			var table = $(
@@ -99,8 +103,8 @@ frappe.ui.form.on("Auto Email Report", {
 
 			if (
 				frm.doc.report_type === "Custom Report" &&
-				frappe.query_reports[frm.doc.reference_report] &&
-				frappe.query_reports[frm.doc.reference_report].filters
+				reference_report &&
+				reference_report.filters
 			) {
 				if (frm.doc.filters) {
 					filters = JSON.parse(frm.doc.filters);
@@ -115,7 +119,7 @@ frappe.ui.form.on("Auto Email Report", {
 				report_filters = frappe.query_reports[frm.doc.reference_report].filters;
 			} else {
 				filters = JSON.parse(frm.doc.filters || "{}");
-				report_filters = frappe.query_reports[frm.doc.report].filters;
+				report_filters = reference_report.filters;
 			}
 
 			if (report_filters && report_filters.length > 0) {


### PR DESCRIPTION
**Auto Email Report:** Dynamic date range filters were not supported for Report that did not have configuration script. This fix allows user to select "To" and "From" field from report filters set in report document.

**Before:**
<img width="1290" alt="Screenshot 2023-08-11 at 12 45 12 PM" src="https://github.com/frappe/frappe/assets/13928957/8d69f285-f91b-4ea7-9c79-e6c187735f25">
Option for To & From field were not getting populated. And on hitting "Send Now" it used to throw following error if "Period" is set.

### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 83, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1646, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 30, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 276, in send_now
    auto_email_report.send()
  File "apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 228, in send
    data = self.get_report_content()
  File "apps/frappe/frappe/email/doctype/auto_email_report/auto_email_report.py", line 142, in get_report_content
    columns, data = report.get_data(
  File "apps/frappe/frappe/core/doctype/report/report.py", line 202, in get_data
    columns, result = self.run_query_report(
  File "apps/frappe/frappe/core/doctype/report/report.py", line 217, in run_query_report
    data = frappe.desk.query_report.run(
  File "apps/frappe/frappe/utils/typing_validations.py", line 30, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 823, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 214, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 823, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 82, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 60, in get_report_result
    res = report.execute_query_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 150, in execute_query_report
    result = [list(t) for t in frappe.db.sql(self.query, filters)]
  File "apps/frappe/frappe/database/database.py", line 229, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 156, in execute
    query = self.mogrify(query, args)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 134, in mogrify
    query = query % self._escape_args(args, conn)
TypeError: format requires a mapping

```

**After:**
<img width="1308" alt="Screenshot 2023-08-11 at 12 43 03 PM" src="https://github.com/frappe/frappe/assets/13928957/2c201554-093e-4da3-88c1-fa74dbaadbc6">

<261>