### PR TITLE
fix: fair-er scheduling for multitenant deploys

### DIFF
--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -10,6 +10,7 @@ Events:
 
 # imports - standard imports
 import os
+import random
 import time
 from typing import NoReturn
 
@@ -51,6 +52,9 @@ def enqueue_events_for_all_sites() -> None:
 
 	with frappe.init_site():
 		sites = get_sites()
+
+	# Sites are sorted in alphabetical order, shuffle to randomize priorities
+	random.shuffle(sites)
 
 	for site in sites:
 		try:


### PR DESCRIPTION
By default, the scheduler loop gets sites and works on one site at a time. Sites that come first alphabetically automatically get higher priority. 

This PR just randomizes the behaviour so scheduling priorities are random and fair according to prng gods. 