### PR TITLE
fix: Don't show online/offline alerts when tab not active

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -405,6 +405,7 @@ frappe.create_shadow_element = function (wrapper, html, css, js) {
 
 // bind online/offline events
 $(window).on("online", function () {
+	if (document.hidden) return;
 	frappe.show_alert({
 		indicator: "green",
 		message: __("You are connected to internet."),
@@ -412,6 +413,7 @@ $(window).on("online", function () {
 });
 
 $(window).on("offline", function () {
+	if (document.hidden) return;
 	frappe.show_alert({
 		indicator: "orange",
 		message: __("Connection lost. Some features might not work."),


### PR DESCRIPTION
Coming back to an old tab can sometimes look like this:

![online-offline](https://github.com/frappe/frappe/assets/36654812/cd345bfd-15b9-4375-9ae6-55a477e75630)
