### PR TITLE
fix: tree report has 2 total rows while printing it

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1534,7 +1534,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			})
 			.filter(Boolean);
 
-		if (this.raw_data.add_total_row) {
+		if (this.raw_data.add_total_row && !this.report_settings.tree) {
 			let totalRow = this.datatable.bodyRenderer.getTotalRow().reduce((row, cell) => {
 				row[cell.column.id] = cell.content;
 				row.is_total_row = true;


### PR DESCRIPTION
Before:

https://github.com/frappe/frappe/assets/30859809/07b7a0b4-e961-41fd-b680-f71d9e486b62


After:

https://github.com/frappe/frappe/assets/30859809/9ffbf8e6-d7ab-4e28-ab8f-48cef662de8e


Fixes: https://github.com/frappe/frappe/issues/22045