### PR TITLE
fix: do not allow to create dashboard chart, number card if doesn't have access

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -287,7 +287,7 @@
   }
  ],
  "links": [],
- "modified": "2022-07-27 11:09:09.203236",
+ "modified": "2023-08-14 16:33:30.172798",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",
@@ -319,7 +319,6 @@
    "write": 1
   },
   {
-   "create": 1,
    "email": 1,
    "export": 1,
    "print": 1,

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -175,12 +175,14 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 	}
 
 	add_card_button_to_toolbar() {
+		if (!frappe.model.can_create("Number Card")) return;
 		this.page.add_inner_button(__("Create Card"), () => {
 			this.add_card_to_dashboard();
 		});
 	}
 
 	add_chart_buttons_to_toolbar(show) {
+		if (!frappe.model.can_create("Dashboard Chart")) return;
 		if (show) {
 			this.create_chart_button && this.create_chart_button.remove();
 			this.create_chart_button = this.page.add_button(__("Set Chart"), () => {


### PR DESCRIPTION
User with only read access to the report was able to see the **Set Chart**, and **Create Card** button on the report
Only show button if they have access to create Number Card or Dashboard Chart
By default, Dashboard Chart has the `create` role set for `All` so removed that

Before:
<img width="1301" alt="image" src="https://github.com/frappe/frappe/assets/30859809/b71e98c6-7d66-4dad-aeab-61a7a70a212d">


After:
<img width="1301" alt="image" src="https://github.com/frappe/frappe/assets/30859809/adb19e9d-c47a-4dc2-a93f-11f8d6ac2983">
