### PR TITLE
fix: add missing parameters for search_widget

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -109,7 +109,17 @@ def search_widget(
 	elif not query and doctype in standard_queries:
 		# from standard queries
 		search_widget(
-			doctype, txt, standard_queries[doctype][0], searchfield, start, page_length, filters
+			doctype,
+			txt,
+			standard_queries[doctype][0],
+			searchfield,
+			start,
+			page_length,
+			filters,
+			filter_fields,
+			as_dict,
+			reference_doctype,
+			ignore_user_permissions,
 		)
 	else:
 		meta = frappe.get_meta(doctype)

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -109,17 +109,17 @@ def search_widget(
 	elif not query and doctype in standard_queries:
 		# from standard queries
 		search_widget(
-			doctype,
-			txt,
-			standard_queries[doctype][0],
-			searchfield,
-			start,
-			page_length,
-			filters,
-			filter_fields,
-			as_dict,
-			reference_doctype,
-			ignore_user_permissions,
+			doctype=doctype,
+			txt=txt,
+			query=standard_queries[doctype][0],
+			searchfield=searchfield,
+			start=start,
+			page_length=page_length,
+			filters=filters,
+			filter_fields=filter_fields,
+			as_dict=as_dict,
+			reference_doctype=reference_doctype,
+			ignore_user_permissions=ignore_user_permissions,
 		)
 	else:
 		meta = frappe.get_meta(doctype)


### PR DESCRIPTION
Before:
![image](https://github.com/frappe/frappe/assets/52111700/1721e48a-3a57-4e45-9d81-c8c91dfbee53)


After:
![image](https://github.com/frappe/frappe/assets/52111700/ca4629de-7d80-434e-8da2-1ca75f617f08)


How to replicate:
```
new frappe.ui.form.MultiSelectDialog({
    doctype: "Customer",
    target: null,
    setters: {"customer_name": null},
    action(selections) {
        console.log(selections);
    }
});
```
Run the above code in your browser console.

Reason:
Missing `as_dict` parameter in the subsequent call of `search_widget` caused the returned response to be list(by default).