### PR TITLE
fix(DX): hide irrelevant sections in DocType if it's a child table

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -231,6 +231,7 @@
   },
   {
    "collapsible": 1,
+   "depends_on": "eval:!doc.istable",
    "fieldname": "form_settings_section",
    "fieldtype": "Section Break",
    "label": "Form Settings"
@@ -304,6 +305,7 @@
   },
   {
    "collapsible": 1,
+   "depends_on": "eval:!doc.istable",
    "fieldname": "view_settings",
    "fieldtype": "Section Break",
    "label": "View Settings"
@@ -414,7 +416,7 @@
    "oldfieldtype": "Check"
   },
   {
-   "depends_on": "eval:doc.custom===0",
+   "depends_on": "eval:doc.custom===0 && !doc.istable",
    "fieldname": "web_view",
    "fieldtype": "Section Break",
    "label": "Web View"
@@ -482,6 +484,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "actions",
+   "depends_on": "eval:!doc.istable",
    "fieldname": "actions_section",
    "fieldtype": "Section Break",
    "label": "Actions"
@@ -495,6 +498,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "links",
+   "depends_on": "eval:!doc.istable",
    "fieldname": "links_section",
    "fieldtype": "Section Break",
    "label": "Linked Documents"
@@ -526,6 +530,7 @@
   },
   {
    "collapsible": 1,
+   "depends_on": "eval:!doc.istable",
    "fieldname": "email_settings_sb",
    "fieldtype": "Section Break",
    "label": "Email Settings"
@@ -578,6 +583,7 @@
   },
   {
    "collapsible": 1,
+   "depends_on": "eval:!doc.istable",
    "fieldname": "document_states_section",
    "fieldtype": "Section Break",
    "label": "Document States"
@@ -729,7 +735,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2023-07-12 13:56:26.185637",
+ "modified": "2023-08-14 17:32:23.824794",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",


### PR DESCRIPTION
If the DocType is a child table, hide sections "Form Settings", "View Settings", "Web View", "Actions", "Linked Documents", "Email Settings" and "Document States".
