### PR TITLE
fix(Assignment Rule): also run `on_cancel` and `on_update_after_submit`

### DIFF
--- a/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/test_assignment_rule.py
@@ -274,6 +274,55 @@ class TestAutoAssign(FrappeTestCase):
 		assignment_rule.delete()
 		frappe.db.commit()  # undo changes commited by DDL
 
+	def test_submittable_assignment(self):
+		# create a submittable doctype
+		submittable_doctype = "Assignment Test Submittable"
+		create_test_doctype(submittable_doctype)
+		dt = frappe.get_doc("DocType", submittable_doctype)
+		dt.is_submittable = 1
+		dt.save()
+
+		# create a rule for the submittable doctype
+		assignment_rule = frappe.new_doc("Assignment Rule")
+		assignment_rule.name = f"For {submittable_doctype}"
+		assignment_rule.document_type = submittable_doctype
+		assignment_rule.rule = "Round Robin"
+		assignment_rule.extend("assignment_days", self.days)
+		assignment_rule.append("users", {"user": "test@example.com"})
+		assignment_rule.assign_condition = "docstatus == 1"
+		assignment_rule.unassign_condition = "docstatus == 2"
+		assignment_rule.save()
+
+		# create a submittable doc
+		doc = frappe.new_doc(submittable_doctype)
+		doc.save()
+		doc.submit()
+
+		# check if todo is created
+		todos = frappe.get_all(
+			"ToDo",
+			filters={
+				"reference_type": submittable_doctype,
+				"reference_name": doc.name,
+				"status": "Open",
+				"allocated_to": "test@example.com",
+			},
+		)
+		self.assertEqual(len(todos), 1)
+
+		# check if todo is closed on cancel
+		doc.cancel()
+		todos = frappe.get_all(
+			"ToDo",
+			filters={
+				"reference_type": submittable_doctype,
+				"reference_name": doc.name,
+				"status": "Cancelled",
+				"allocated_to": "test@example.com",
+			},
+		)
+		self.assertEqual(len(todos), 1)
+
 
 def clear_assignments():
 	frappe.db.delete("ToDo", {"reference_type": TEST_DOCTYPE})
@@ -335,7 +384,7 @@ def _make_test_record(**kwargs):
 
 def create_test_doctype(doctype: str):
 	"""Create custom doctype."""
-	frappe.db.delete("DocType", doctype)
+	frappe.delete_doc("DocType", doctype)
 
 	frappe.get_doc(
 		{

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -146,8 +146,8 @@ doc_events = {
 		"on_update": [
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
-			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
 			"frappe.core.doctype.file.utils.attach_files_to_document",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 			"frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type",
 		],
@@ -155,13 +155,16 @@ doc_events = {
 		"on_cancel": [
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
 		],
 		"on_trash": [
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
 		],
 		"on_update_after_submit": [
-			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions"
+			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 		],
 		"on_change": [
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -146,9 +146,7 @@ doc_events = {
 		"on_update": [
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
-			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
 			"frappe.core.doctype.file.utils.attach_files_to_document",
-			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 			"frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type",
 		],
 		"after_rename": "frappe.desk.notifications.clear_doctype_notifications",
@@ -166,6 +164,8 @@ doc_events = {
 		"on_change": [
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",
 			"frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 		],
 	},
 	"Event": {

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -146,7 +146,9 @@ doc_events = {
 		"on_update": [
 			"frappe.desk.notifications.clear_doctype_notifications",
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
 			"frappe.core.doctype.file.utils.attach_files_to_document",
+			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 			"frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type",
 		],
 		"after_rename": "frappe.desk.notifications.clear_doctype_notifications",
@@ -164,8 +166,6 @@ doc_events = {
 		"on_change": [
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",
 			"frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone",
-			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
-			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
 		],
 	},
 	"Event": {


### PR DESCRIPTION
### Issue

An **Assignment Rule** that is supposed to unassign on `docstatus == 2` has no effect.

### Cause

**Assignment Rule** only runs `on_update`. Other events like `on_cancel` and `on_update_after_submit` are ignored.

### Solution

Also run **Assignment Rule** `on_cancel` and `on_update_after_submit`.

Running `on_change` was dismissed because it triggers on every `db_set`, which is too low level and would be unexpected behavior.