### PR TITLE
fix: button link styling in quill

### DIFF
--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -20,7 +20,7 @@
 		margin-top: 0.5em;
 		margin-bottom: 0.25em;
 	}
-	a[href] {
+	a[href]:not(.btn) {
 		text-decoration: underline;
 	}
 	.ql-direction-rtl {


### PR DESCRIPTION
Since https://github.com/frappe/erpnext/pull/36353 we're injecting link buttons (`<a class="btn"></a>`) into **Email Templates**. The template can be created using the quill editor. Our stylesheet said to underline links in quill editor. This doesn't look good for buttons.

With this PR, we only underline links which don't have a "btn" class.

### Before
![Bildschirmfoto 2023-08-15 um 20 48 40](https://github.com/frappe/frappe/assets/14891507/545354e3-3b69-4e80-9da8-7a2b8c1f6017)


### After

![Bildschirmfoto 2023-08-15 um 20 47 58](https://github.com/frappe/frappe/assets/14891507/e76f716d-69c4-4cef-9a95-395d872ca2f0)
