### PR TITLE
fix: removed duplicate doctype_properties from customize form

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -707,7 +707,6 @@ doctype_properties = {
 	"naming_rule": "Data",
 	"autoname": "Data",
 	"show_title_field_in_link": "Check",
-	"translate_link_fields": "Check",
 	"is_calendar_and_gantt": "Check",
 	"default_view": "Select",
 	"force_re_route_to_default_view": "Check",


### PR DESCRIPTION
In `doctype_properties` field `translate_link_fields` and `translated_doctype` both exist which are same 
`Translate Link Fields` is the label and `translated_doctype` is the fieldname