### PR TITLE
fix(UX): Provision to ignore prepared report via route options

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -201,7 +201,7 @@ def run(
 	if sbool(are_default_filters) and report.custom_filters:
 		filters = report.custom_filters
 
-	if report.prepared_report and not ignore_prepared_report and not custom_columns:
+	if report.prepared_report and not sbool(ignore_prepared_report) and not custom_columns:
 		if filters:
 			if isinstance(filters, str):
 				filters = json.loads(filters)

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -57,6 +57,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		// throttle refresh for 300ms
 		this.refresh = frappe.utils.throttle(this.refresh, 300);
 
+		this.ignore_prepared_report = false;
 		this.menu_items = [];
 	}
 
@@ -592,6 +593,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				frappe.route_options = null;
 			});
 
+			this.ignore_prepared_report = route_options["ignore_prepared_report"] || false;
+
 			return frappe.run_serially(promises);
 		}
 	}
@@ -639,6 +642,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				args: {
 					report_name: this.report_name,
 					filters: filters,
+					ignore_prepared_report: this.ignore_prepared_report,
 					is_tree: this.report_settings.tree,
 					parent_field: this.report_settings.parent_field,
 					are_default_filters: are_default_filters,


### PR DESCRIPTION
Once a Script Report crosses a certain threshold limit it becomes a prepared report. Consider the General Ledger report in ERPNext as an example. When the report is generated for the entire fiscal year it might take a while to generate and the report becomes a Prepared Report.

This same report is very frequently accessed from the form view against each voucher. In such case, user has to do one extra  click to generate the report and if there are other reports pending this goes into a queue where the user has to wait just to see the report against a single voucher

A prepared report is not needed in such scenarios, this change allows app developers to ignore prepared report in certain scenarios by passing an argument in route options 