### PR TITLE
fix: translate values of sidebar filters

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -214,14 +214,17 @@ frappe.views.ListGroupBy = class ListGroupBy {
 	}
 
 	get_dropdown_html(field, fieldtype, applied = false) {
-		let label = field.name == null ? __("Not Set") : field.name;
-		if (label === frappe.session.user) {
+		let label;
+		if (field.name == null) {
+			label = __("Not Set");
+		} else if (field.name === frappe.session.user) {
 			label = __("Me");
 		} else if (fieldtype && fieldtype == "Check") {
-			label = label == "0" ? __("No") : __("Yes");
+			label = field.name == "0" ? __("No") : __("Yes");
+		} else {
+			label = __(field.name);
 		}
 		let value = field.name == null ? "" : encodeURIComponent(field.name);
-
 		let applied_html = applied
 			? `<span class="applied"> ${frappe.utils.icon("tick", "xs")} </span>`
 			: "";


### PR DESCRIPTION
Sidebar filters show untranslated values ...

Before:
![image](https://github.com/frappe/frappe/assets/94137451/0e04f477-78a1-4ae7-b09a-2db9ccb59318)

After:
![image](https://github.com/frappe/frappe/assets/94137451/ff5906dd-7085-4156-b6b3-8ce6497d3a52)

@barredterra , since you have vast experience on translations, could you check this? I'm afraid of any collateral damages 