### PR TITLE
feat(dx): Run gunicorn in development setup

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -401,11 +401,7 @@ def serve(
 		application = ProfilerMiddleware(application, sort_by=("cumtime", "calls"))
 
 	if not os.environ.get("NO_STATICS"):
-		application = SharedDataMiddleware(
-			application, {"/assets": str(os.path.join(sites_path, "assets"))}
-		)
-
-		application = StaticDataMiddleware(application, {"/files": str(os.path.abspath(sites_path))})
+		application = application_with_statics()
 
 	application.debug = True
 	application.config = {"SERVER_NAME": "localhost:8000"}
@@ -427,6 +423,18 @@ def serve(
 		use_evalex=not in_test_env,
 		threaded=not no_threading,
 	)
+
+
+def application_with_statics():
+	global application, _sites_path
+
+	application = SharedDataMiddleware(
+		application, {"/assets": str(os.path.join(_sites_path, "assets"))}
+	)
+
+	application = StaticDataMiddleware(application, {"/files": str(os.path.abspath(_sites_path))})
+
+	return application
 
 
 # Remove references to pattern that are pre-compiled and loaded to global scopes.


### PR DESCRIPTION
This lets developer run gunicorn in development setup while still being
able to use statics/assets without using dedicated web server for it (nginx).

While this is not "first class" support, it's usable for me. I don't see
need for more right now. Making this default in developer mode isn't
ideal IMO as it's quite heavy compared to werkzeug (and no debugger or
decent request logging)

To use in development mode swap `bench serve` with gunicorn command,
refer gunicorn config docs for more info.

```diff
- web: bench serve --port 8000
+ unicorn: gunicorn -b 127.0.0.1:8000 -w 1 --chdir /home/user/benches/develop/sites 'frappe.app:application_with_statics()' --preload
```

`no-docs`
