### PR TITLE
fix(minor): grid row layout on small viewport

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -338,7 +338,7 @@ export default class GridRow {
 					this.open_form_button = $(`
 						<div class="btn-open-row">
 							<a>${frappe.utils.icon("edit", "xs")}</a>
-							<div class="hidden-xs edit-grid-row">${__("Edit")}</div>
+							<div class="hidden-md edit-grid-row">${__("Edit")}</div>
 						</div>
 					`)
 						.appendTo(this.open_form_button)

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -150,6 +150,7 @@
 .grid-row > .row {
 	.col:last-child {
 		border-right: none;
+		min-width: 50px;
 	}
 
 	.col {

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -150,7 +150,7 @@
 .grid-row > .row {
 	.col:last-child {
 		border-right: none;
-		min-width: 50px;
+		min-width: 0;
 	}
 
 	.col {


### PR DESCRIPTION
on small viewports header and body rows were not aligned due to "Edit" text.
fix: added min-width of 50px so header's last col will be same size as body.

### Before
<img width="933" alt="Grid Before" src="https://github.com/frappe/frappe/assets/39730881/f2b064ac-e3bf-4128-b8c3-a345c3318995">

### After
<img width="933" alt="Grid After" src="https://github.com/frappe/frappe/assets/39730881/5a63edd3-5f1a-43b1-8191-2e970e4e7d41">
