### PR TITLE
fix: misc fixes related to setup etc

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -61,13 +61,13 @@ class PreparedReport(Document):
 		self.status = "Queued"
 
 	def on_trash(self):
-		# If job is running then send stop signal.
-		if self.status != "Started":
+		"""Remove pending job from queue, if already running then kill the job."""
+		if self.status not in ("Started", "Queued"):
 			return
 
 		with suppress(Exception):
 			job = frappe.get_doc("RQ Job", self.job_id)
-			job.stop_job()
+			job.stop_job() if self.status == "Started" else job.delete()
 
 	def after_insert(self):
 		enqueue(

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -31,6 +31,9 @@ frappe.setup = {
 };
 
 frappe.pages["setup-wizard"].on_page_load = function (wrapper) {
+	if (frappe.boot.setup_complete) {
+		window.location.href = "/app";
+	}
 	let requires = frappe.boot.setup_wizard_requires || [];
 	frappe.require(requires, function () {
 		frappe.call({

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -204,6 +204,8 @@ def update_user_name(args):
 				"last_name": last_name,
 			}
 		)
+
+		doc.append_roles(*_get_default_roles())
 		doc.flags.no_welcome_mail = True
 		doc.insert()
 		frappe.flags.mute_emails = _mute_emails
@@ -258,19 +260,21 @@ def parse_args(args):
 
 def add_all_roles_to(name):
 	user = frappe.get_doc("User", name)
-	for role in frappe.db.sql("""select name from tabRole"""):
-		if role[0] not in [
-			"Administrator",
-			"Guest",
-			"All",
-			"Customer",
-			"Supplier",
-			"Partner",
-			"Employee",
-		]:
-			d = user.append("roles")
-			d.role = role[0]
+	user.append_roles(*_get_default_roles())
 	user.save()
+
+
+def _get_default_roles() -> set[str]:
+	skip_roles = {
+		"Administrator",
+		"Guest",
+		"All",
+		"Customer",
+		"Supplier",
+		"Partner",
+		"Employee",
+	}
+	return set(frappe.get_all("Role", pluck="name")) - skip_roles
 
 
 def disable_future_access():

--- a/frappe/model/utils/link_count.py
+++ b/frappe/model/utils/link_count.py
@@ -5,11 +5,37 @@ from collections import defaultdict
 
 import frappe
 
-ignore_doctypes = ("DocType", "Print Format", "Role", "Module Def", "Communication", "ToDo")
+ignore_doctypes = {
+	"DocType",
+	"Print Format",
+	"Role",
+	"Module Def",
+	"Communication",
+	"ToDo",
+	"Version",
+	"Error Log",
+	"Scheduled Job Log",
+	"Event Sync Log",
+	"Event Update Log",
+	"Access Log",
+	"View Log",
+	"Activity Log",
+	"Energy Point Log",
+	"Notification Log",
+	"Email Queue",
+	"DocShare",
+	"Document Follow",
+	"Console Log",
+	"User",
+}
 
 
 def notify_link_count(doctype, name):
 	"""updates link count for given document"""
+
+	if doctype in ignore_doctypes or not frappe.request:
+		return
+
 	if not hasattr(frappe.local, "_link_count"):
 		frappe.local._link_count = defaultdict(int)
 		frappe.db.after_commit.add(flush_local_link_count)
@@ -41,13 +67,12 @@ def update_link_count():
 
 	if link_count:
 		for (doctype, name), count in link_count.items():
-			if doctype not in ignore_doctypes:
-				try:
-					table = frappe.qb.DocType(doctype)
-					frappe.qb.update(table).set(table.idx, table.idx + count).where(table.name == name).run()
-					frappe.db.commit()
-				except Exception as e:
-					if not frappe.db.is_table_missing(e):  # table not found, single
-						raise e
+			try:
+				table = frappe.qb.DocType(doctype)
+				frappe.qb.update(table).set(table.idx, table.idx + count).where(table.name == name).run()
+				frappe.db.commit()
+			except Exception as e:
+				if not frappe.db.is_table_missing(e):  # table not found, single
+					raise e
 	# reset the count
 	frappe.cache.delete_value("_link_count")


### PR DESCRIPTION
Recently after completing the setup wizard users kept getting this warning, which went away on first refresh:

<img width="640" alt="image" src="https://github.com/frappe/frappe/assets/9079960/85675aca-b70c-4379-8c83-28ab42b8b1d8">

The problem here is stale cache, but not _THAT_ simple. It's race condition between two workers when another worker ends up reading stale value and putting it in cache. 

Time | Web worker | Background worker | Database | Cache
-- | -- | -- | -- | --
  |   |   | 0 | 0
1 | SET TO 1 IN DB |   | 0 | 0
2 | CLEAR CACHE |   | 0 | -
3 |   | CACHE MISS | 0 | -
4 |   | FETCH FROM DB | 0 | -
5 | COMMIT |   | 1 | -
6 | CLEAR CACHE (after commit) |   | 1 | -
7 |   | PUT IN CACHE | 1 | 0
  |   |   |   | ^^^^^ Stale value






Many small unrelated fixes in same PR:
- perf: ignore log links and disable in background jobs
- fix: delete prepared report job from queue
- refactor: Add all roles when creating new user
