### PR TITLE
fix: set proper fqdn name to starttls

### DIFF
--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -2,7 +2,7 @@
 # License: MIT. See LICENSE
 
 import smtplib
-
+import socket
 import frappe
 from frappe import _
 from frappe.email.oauth import Oauth
@@ -54,10 +54,14 @@ class SMTPServer:
 
 	def secure_session(self, conn):
 		"""Secure the connection incase of TLS."""
+		fqdn_name = ""
+		fqdn_name = socket.getfqdn()
+		if fqdn_name.endswith("."):
+			fqdn_name = fqdn_name + "local"
 		if self.use_tls:
-			conn.ehlo()
+			conn.ehlo(fqdn_name)
 			conn.starttls()
-			conn.ehlo()
+			conn.ehlo(fqdn_name)
 
 	@property
 	def session(self):


### PR DESCRIPTION
Fix #22123

stmp servers with starttls needs a proper FQDN name for `helo`/`ehlo` messages. 

Currently, we don't pass local_hostname to the methods `smtp.helo` and `smtp.ehlo` . 
So `smtplib` uses socket.getfqdn to get it, but if is not defined, receive just the "single" hostname with a final dot  ...

With this PR. we check hostname, add "local" if not valid fqdn and pass it to the methods.
