### PR TITLE
refactor: filter on `name` while fetching custom column in report

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -459,12 +459,16 @@ def add_total_row(result, columns, meta=None, is_tree=False, parent_field=None):
 
 
 @frappe.whitelist()
-def get_data_for_custom_field(doctype, field):
+def get_data_for_custom_field(doctype, field, names=None):
 
 	if not frappe.has_permission(doctype, "read"):
 		frappe.throw(_("Not Permitted to read {0}").format(doctype), frappe.PermissionError)
 
-	return frappe._dict(frappe.get_all(doctype, fields=["name", field], as_list=1))
+	filters = {}
+	if names:
+		filters.update({"name": ["in", json.loads(names)]})
+
+	return frappe._dict(frappe.get_list(doctype, filters=filters, fields=["name", field], as_list=1))
 
 
 def get_data_for_custom_report(columns):

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1697,10 +1697,14 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								args: {
 									field: values.field,
 									doctype: values.doctype,
+									names: Array.from(
+										this.doctype_field_map[values.doctype].names
+									),
 								},
 								callback: (r) => {
 									const custom_data = r.message;
-									const link_field = this.doctype_field_map[values.doctype];
+									const link_field =
+										this.doctype_field_map[values.doctype].fieldname;
 
 									this.add_custom_column(
 										custom_columns,
@@ -1838,7 +1842,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		);
 
 		doctypes.forEach((doc) => {
-			this.doctype_field_map[doc.doctype] = doc.fieldname;
+			this.doctype_field_map[doc.doctype] = { fieldname: doc.fieldname, names: new Set() };
+		});
+
+		this.data.forEach((row) => {
+			doctypes.forEach((doc) => {
+				this.doctype_field_map[doc.doctype].names.add(row[doc.fieldname]);
+			});
 		});
 
 		return doctypes;


### PR DESCRIPTION
`Add Column` option
<img width="1440" alt="Screenshot 2023-08-21 at 11 14 46 AM" src="https://github.com/frappe/frappe/assets/3272205/4e7383fa-32aa-4f7f-b869-60ad3926f4b6">

 times out on large databases. This is caused by inefficient [`get_data_for_custom_field`](https://github.com/frappe/frappe/blob/2a086cf9c61ab7cc45d6be432c6060d12e91d432/frappe/desk/query_report.py#L467) which fetches all records by default.

Adding `name` filter to query, so only the displayed record's custom field is fetched.

before:

https://github.com/frappe/frappe/assets/3272205/2bbfe121-d714-4e5d-9f79-a73416fe8113

after:

https://github.com/frappe/frappe/assets/3272205/e708cd70-ca66-4a10-b30d-69f252ea3a5e


