### PR TITLE
fix: Unable to create doctype using 'Copy To Clipboard'

### DIFF
--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -71,7 +71,7 @@ export const useStore = defineStore("form-builder-store", () => {
 
 	async function fetch() {
 		doc.value = frm.value.doc;
-		if (doctype.value.startsWith("new-doctype-")) {
+		if (doctype.value.startsWith("new-doctype-") && !doc.value.fields) {
 			doc.value.fields = [get_df("Data", "", __("Title"))];
 		}
 
@@ -91,9 +91,11 @@ export const useStore = defineStore("form-builder-store", () => {
 		form.value.selected_field = null;
 
 		nextTick(() => {
-			dirty.value = false;
-			frm.value.doc.__unsaved = 0;
-			frm.value.page.clear_indicator();
+			if (!doctype.value.startsWith("new-doctype-")) {
+				dirty.value = false;
+				frm.value.doc.__unsaved = 0;
+				frm.value.page.clear_indicator();
+			}
 			read_only.value =
 				!is_customize_form.value && !frappe.boot.developer_mode && !doc.value.custom;
 			preview.value = false;


### PR DESCRIPTION
Was unable to create a doctype using `Copy To Clipboard` after moving the form builder inside the doctype form. All the meta info was getting copied but the form fields were not getting copied in the form builder.


https://github.com/frappe/frappe/assets/30859809/5edf54ad-526b-4d36-a9c1-b17bc7084c4b


fixes: https://github.com/frappe/frappe/issues/22131