### PR TITLE
refactor: safe_eval to use same restictedpython library 

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2244,24 +2244,9 @@ def bold(text):
 def safe_eval(code, eval_globals=None, eval_locals=None):
 	"""A safer `eval`"""
 
-	from frappe.utils.safe_exec import UNSAFE_ATTRIBUTES
+	from frappe.utils.safe_exec import safe_eval
 
-	whitelisted_globals = {"int": int, "float": float, "long": int, "round": round}
-	code = unicodedata.normalize("NFKC", code)
-
-	for attribute in UNSAFE_ATTRIBUTES:
-		if attribute in code:
-			throw(f'Illegal rule {bold(code)}. Cannot use "{attribute}"')
-
-	if "__" in code:
-		throw(f'Illegal rule {bold(code)}. Cannot use "__"')
-
-	if not eval_globals:
-		eval_globals = {}
-
-	eval_globals["__builtins__"] = {}
-	eval_globals.update(whitelisted_globals)
-	return eval(code, eval_globals, eval_locals)
+	return safe_eval(code, eval_globals, eval_locals)
 
 
 def get_website_settings(key):

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -254,9 +254,8 @@ def execute(context, method, args=None, kwargs=None, profile=False):
 			try:
 				ret = frappe.get_attr(method)(*args, **kwargs)
 			except Exception:
-				ret = frappe.safe_eval(
-					method + "(*args, **kwargs)", eval_globals=globals(), eval_locals=locals()
-				)
+				# eval is safe here because input is from console
+				ret = eval(method + "(*args, **kwargs)", globals(), locals())  # nosemgrep
 
 			if profile:
 				import pstats

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -44,6 +44,9 @@ class TestSafeExec(FrappeTestCase):
 		)
 		self.assertEqual(1, frappe.safe_eval("int(enabled)", eval_locals=user.as_dict()))
 
+	def test_safe_eval_wal(self):
+		self.assertRaises(SyntaxError, frappe.safe_eval, "(x := (40+2))")
+
 	def test_sql(self):
 		_locals = dict(out=None)
 		safe_exec(

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -105,3 +105,10 @@ class TestSafeExec(FrappeTestCase):
 
 		# RestrictedPython
 		safe_exec("my_dict = _dict()")
+
+	def test_write_wrapper(self):
+		# Allow modifying _dict instance
+		safe_exec("_dict().x = 1")
+
+		# dont Allow modifying _dict class
+		self.assertRaises(Exception, safe_exec, "_dict.x = 1")

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -93,14 +93,6 @@ def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=Fals
 def safe_eval(code, eval_globals=None, eval_locals=None):
 	import unicodedata
 
-	whitelisted_globals = {
-		"int": int,
-		"float": float,
-		"long": int,
-		"round": round,
-		# RestrictedPython specific overrides
-		"_getattr_": _get_attr_for_eval,
-	}
 	code = unicodedata.normalize("NFKC", code)
 
 	for attribute in UNSAFE_ATTRIBUTES:
@@ -114,7 +106,7 @@ def safe_eval(code, eval_globals=None, eval_locals=None):
 		eval_globals = {}
 
 	eval_globals["__builtins__"] = {}
-	eval_globals.update(whitelisted_globals)
+	eval_globals.update(WHITELISTED_SAFE_EVAL_GLOBALS)
 
 	return eval(
 		compile_restricted(code, filename="<safe_eval>", policy=FrappeTransformer, mode="eval"),
@@ -595,3 +587,16 @@ VALID_UTILS = (
 	"get_user_info_for_avatar",
 	"get_abbr",
 )
+
+
+WHITELISTED_SAFE_EVAL_GLOBALS = {
+	"int": int,
+	"float": float,
+	"long": int,
+	"round": round,
+	# RestrictedPython specific overrides
+	"_getattr_": _get_attr_for_eval,
+	"_getitem_": _getitem,
+	"_getiter_": iter,
+	"_iter_unpack_sequence_": RestrictedPython.Guards.guarded_iter_unpack_sequence,
+}

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -456,7 +456,20 @@ def _validate_attribute_read(object, name):
 
 def _write(obj):
 	# guard function for RestrictedPython
-	# allow writing to any object
+	if isinstance(
+		obj,
+		(
+			types.ModuleType,
+			types.CodeType,
+			types.TracebackType,
+			types.FrameType,
+			type,
+			types.FunctionType,  # covers lambda
+			types.MethodType,
+			types.BuiltinFunctionType,  # covers methods
+		),
+	):
+		raise SyntaxError(f"Not allowed to write to object {obj} of type {type(obj)}")
 	return obj
 
 


### PR DESCRIPTION
Why?

- Same code used for exec/eval -> Makes it simpler to add validation and avoid duplication for the most part. 