### PR TITLE
Revert "chore: typo"

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1021,7 +1021,7 @@ def reset_password(user: str) -> str:
 		user.reset_password(send_email=True)
 
 		return frappe.msgprint(
-			msg=_("Password reset instructions have been sent to user's email"),
+			msg=_("Password reset instructions have been sent to your email"),
 			title=_("Password Email Sent"),
 		)
 	except frappe.DoesNotExistError:


### PR DESCRIPTION
This reverts commit 3784ce850755b8b2dece1be3a1f1760af7be0951 / https://github.com/frappe/frappe/pull/22107.

Above PR is breaking a test and existing translations have not been removed or updated.