### PR TITLE
    refactor!: Disable server scripts by default

### DIFF
--- a/frappe/core/doctype/report/test_report.py
+++ b/frappe/core/doctype/report/test_report.py
@@ -18,6 +18,11 @@ test_dependencies = ["User"]
 
 
 class TestReport(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls) -> None:
+		cls.enable_safe_exec()
+		return super().setUpClass()
+
 	def test_report_builder(self):
 		if frappe.db.exists("Report", "User Activity Report"):
 			frappe.delete_doc("Report", "User Activity Report")

--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -21,6 +21,20 @@ frappe.ui.form.on("Server Script", {
 			.then((items) => {
 				frm.set_df_property("script", "autocompletions", items);
 			});
+
+		frm.trigger("check_safe_exec");
+	},
+
+	check_safe_exec(frm) {
+		frappe.xcall("frappe.core.doctype.server_script.server_script.enabled").then((enabled) => {
+			if (enabled === false) {
+				frm.dashboard.clear_comment();
+				let msg = __("Server Scripts feature is not available on this site.") + " ";
+				msg += __("Please contact your system administrator to enable this feature.");
+				frm.dashboard.add_comment(msg, "yellow", true);
+				frm.disable_form();
+			}
+		});
 	},
 
 	setup_help(frm) {

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.rate_limiter import rate_limit
-from frappe.utils.safe_exec import NamespaceDict, get_safe_globals, safe_exec
+from frappe.utils.safe_exec import NamespaceDict, get_safe_globals, is_safe_exec_enabled, safe_exec
 
 
 class ServerScript(Document):
@@ -277,3 +277,9 @@ def execute_api_server_script(script=None, *args, **kwargs):
 	_globals, _locals = safe_exec(script.script)
 
 	return _globals.frappe.flags
+
+
+@frappe.whitelist()
+def enabled() -> bool | None:
+	if frappe.has_permission("Server Script"):
+		return is_safe_exec_enabled()

--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -97,8 +97,9 @@ class TestServerScript(FrappeTestCase):
 			script_doc = frappe.get_doc(doctype="Server Script")
 			script_doc.update(script)
 			script_doc.insert()
-
+		cls.enable_safe_exec()
 		frappe.db.commit()
+		return super().setUpClass()
 
 	@classmethod
 	def tearDownClass(cls):
@@ -269,13 +270,13 @@ frappe.qb.from_(todo).select(todo.name).where(todo.name == "{todo.name}").run()
 		site = frappe.utils.get_site_url(frappe.local.site)
 		client = FrappeClient(site)
 
-		# Exhaust rate limti
+		# Exhaust rate limit
 		for _ in range(5):
 			client.get_api(script1.api_method)
 
 		self.assertRaises(FrappeException, client.get_api, script1.api_method)
 
-		# Exhaust rate limti
+		# Exhaust rate limit
 		for _ in range(5):
 			client.get_api(script2.api_method)
 

--- a/frappe/desk/doctype/system_console/test_system_console.py
+++ b/frappe/desk/doctype/system_console/test_system_console.py
@@ -5,6 +5,11 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestSystemConsole(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls) -> None:
+		cls.enable_safe_exec()
+		return super().setUpClass()
+
 	def test_system_console(self):
 		system_console = frappe.get_doc("System Console")
 		system_console.console = 'log("hello")'

--- a/frappe/tests/test_boot.py
+++ b/frappe/tests/test_boot.py
@@ -27,6 +27,13 @@ class TestBootData(FrappeTestCase):
 		unseen_notes = [d.title for d in get_unseen_notes()]
 		self.assertListEqual(unseen_notes, [])
 
+
+class TestPermissionQueries(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls) -> None:
+		cls.enable_safe_exec()
+		return super().setUpClass()
+
 	def test_get_user_pages_or_reports_with_permission_query(self):
 		# Create a ToDo custom report with admin user
 		frappe.set_user("Administrator")

--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -2,10 +2,15 @@ import types
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils.safe_exec import get_safe_globals, safe_exec
+from frappe.utils.safe_exec import ServerScriptNotEnabled, get_safe_globals, safe_exec
 
 
 class TestSafeExec(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls) -> None:
+		cls.enable_safe_exec()
+		return super().setUpClass()
+
 	def test_import_fails(self):
 		self.assertRaises(ImportError, safe_exec, "import os")
 
@@ -115,3 +120,8 @@ class TestSafeExec(FrappeTestCase):
 
 		# dont Allow modifying _dict class
 		self.assertRaises(Exception, safe_exec, "_dict.x = 1")
+
+
+class TestNoSafeExec(FrappeTestCase):
+	def test_safe_exec_disabled_by_default(self):
+		self.assertRaises(ServerScriptNotEnabled, safe_exec, "pass")

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import os
 import signal
 import unittest
 from collections.abc import Sequence
@@ -112,6 +113,21 @@ class FrappeTestCase(unittest.TestCase):
 			self.assertLessEqual(rows_read, count, msg="Queries read more rows than expected")
 		finally:
 			frappe.db.sql = orig_sql
+
+	@classmethod
+	def enable_safe_exec(cls) -> None:
+		"""Enable safe exec and disable them after test case is completed."""
+		from frappe.installer import update_site_config
+		from frappe.utils.safe_exec import SAFE_EXEC_CONFIG_KEY
+
+		cls._common_conf = os.path.join(frappe.local.sites_path, "common_site_config.json")
+		update_site_config(SAFE_EXEC_CONFIG_KEY, 1, validate=False, site_config_path=cls._common_conf)
+
+		cls.addClassCleanup(
+			lambda: update_site_config(
+				SAFE_EXEC_CONFIG_KEY, 0, validate=False, site_config_path=cls._common_conf
+			)
+		)
 
 
 class MockedRequestTestCase(FrappeTestCase):

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -35,6 +35,8 @@ class ServerScriptNotEnabled(frappe.PermissionError):
 
 ARGUMENT_NOT_SET = object()
 
+SAFE_EXEC_CONFIG_KEY = "server_script_enabled"
+
 
 class NamespaceDict(frappe._dict):
 	"""Raise AttributeError if function not found in namespace"""
@@ -59,15 +61,11 @@ class FrappeTransformer(RestrictingNodeTransformer):
 
 
 def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=False):
-	# server scripts can be disabled via site_config.json
-	# they are enabled by default
-	if "server_script_enabled" in frappe.conf:
-		enabled = frappe.conf.server_script_enabled
-	else:
-		enabled = True
+	# server scripts can only be enabled via common_site_config.json
+	enabled = frappe.get_common_site_config().get(SAFE_EXEC_CONFIG_KEY)
 
 	if not enabled:
-		frappe.throw(_("Please Enable Server Scripts"), ServerScriptNotEnabled)
+		frappe.throw(_("Please Enable Server Scripts From Bench Config."), ServerScriptNotEnabled)
 
 	# build globals
 	exec_globals = get_safe_globals()

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -60,12 +60,18 @@ class FrappeTransformer(RestrictingNodeTransformer):
 		return super().check_name(node, name, *args, **kwargs)
 
 
-def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=False):
+def is_safe_exec_enabled() -> bool:
 	# server scripts can only be enabled via common_site_config.json
-	enabled = frappe.get_common_site_config().get(SAFE_EXEC_CONFIG_KEY)
+	return bool(frappe.get_common_site_config().get(SAFE_EXEC_CONFIG_KEY))
 
-	if not enabled:
-		frappe.throw(_("Please Enable Server Scripts From Bench Config."), ServerScriptNotEnabled)
+
+def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=False):
+	if not is_safe_exec_enabled():
+
+		msg = _("Server Scripts are disabled. Please enable server scripts from bench configuration.")
+		docs_cta = _("Read the documentation to know")
+		msg += f"<br><a href='https://frappeframework.com/docs/user/en/desk/scripting/server-script'>{docs_cta}</a>"
+		frappe.throw(msg, ServerScriptNotEnabled, title="Server Scripts Disabled")
 
 	# build globals
 	exec_globals = get_safe_globals()


### PR DESCRIPTION
- Disables server script / safe exec by default. Note: this also disables context script in web page, python system console and custom python script report.
- Move the config to bench level and not site level because server script "threat model" requires consent from a bench owner and not individual site.
- While this is a breaking change which people may not like, we believe it's essential to improve the security model of Frappe.



Execute this to enable.

```bash
bench set-config -g server_script_enabled 1
```


TODO:
- [X] migration guide -  https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version-(future-v15)#safe-exec-restrictions
- [x] FC changes