### PR TITLE
feat(DX): return absolute path

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1426,9 +1426,12 @@ def get_pymodule_path(modulename, *joins):
 
 	:param modulename: Python module name.
 	:param *joins: Join additional path elements using `os.path.join`."""
-	if not "public" in joins:
+	from os.path import abspath, dirname, join
+
+	if "public" not in joins:
 		joins = [scrub(part) for part in joins]
-	return os.path.join(os.path.dirname(get_module(scrub(modulename)).__file__ or ""), *joins)
+
+	return abspath(join(dirname(get_module(scrub(modulename)).__file__ or ""), *joins))
 
 
 def get_module_list(app_name):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1438,7 +1438,7 @@ def get_pymodule_path(modulename, *joins):
 
 def get_module_list(app_name):
 	"""Get list of modules for given all via `app/modules.txt`."""
-	return get_file_items(os.path.join(os.path.dirname(get_module(app_name).__file__), "modules.txt"))
+	return get_file_items(get_app_path(app_name, "modules.txt"))
 
 
 def get_all_apps(with_internal_apps=True, sites_path=None):

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1418,7 +1418,9 @@ def get_site_path(*joins):
 	"""Return path of current site.
 
 	:param *joins: Join additional path elements using `os.path.join`."""
-	return os.path.join(local.site_path, *joins)
+	from os.path import abspath, join
+
+	return abspath(join(local.site_path, *joins))
 
 
 def get_pymodule_path(modulename, *joins):

--- a/frappe/modules/patch_handler.py
+++ b/frappe/modules/patch_handler.py
@@ -100,8 +100,7 @@ def get_patches_from_app(app: str, patch_type: PatchType | None = None) -> list[
 	        1. ini like file with section for different patch_type
 	        2. plain text file with each line representing a patch.
 	"""
-
-	patches_file = frappe.get_pymodule_path(app, "patches.txt")
+	patches_file = frappe.get_app_path(app, "patches.txt")
 
 	try:
 		return parse_as_configfile(patches_file, patch_type)

--- a/frappe/parallel_test_runner.py
+++ b/frappe/parallel_test_runner.py
@@ -97,7 +97,7 @@ class ParallelTestRunner:
 					make_test_records(doctype, commit=True)
 
 	def get_module(self, path, filename):
-		app_path = frappe.get_pymodule_path(self.app)
+		app_path = frappe.get_app_path(self.app)
 		relative_path = os.path.relpath(path, app_path)
 		if relative_path == ".":
 			module_name = self.app
@@ -217,7 +217,7 @@ class ParallelTestResult(unittest.TextTestResult):
 
 def get_all_tests(app):
 	test_file_list = []
-	for path, folders, files in os.walk(frappe.get_pymodule_path(app)):
+	for path, folders, files in os.walk(frappe.get_app_path(app)):
 		for dontwalk in ("locals", ".git", "public", "__pycache__"):
 			if dontwalk in folders:
 				folders.remove(dontwalk)

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -157,7 +157,7 @@ def run_all_tests(app=None, verbose=False, profile=False, failfast=False, junit_
 
 	test_suite = unittest.TestSuite()
 	for app in apps:
-		for path, folders, files in os.walk(frappe.get_pymodule_path(app)):
+		for path, folders, files in os.walk(frappe.get_app_path(app)):
 			for dontwalk in ("locals", ".git", "public", "__pycache__"):
 				if dontwalk in folders:
 					folders.remove(dontwalk)
@@ -312,7 +312,7 @@ def _add_test(app, path, filename, verbose, test_suite=None):
 		# in /doctype/doctype/boilerplate/
 		return
 
-	app_path = frappe.get_pymodule_path(app)
+	app_path = frappe.get_app_path(app)
 	relative_path = os.path.relpath(path, app_path)
 	if relative_path == ".":
 		module_name = app

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -306,7 +306,7 @@ def get_translations_from_apps(lang, apps=None):
 
 	translations = {}
 	for app in apps or frappe.get_installed_apps(_ensure_on_bench=True):
-		path = os.path.join(frappe.get_pymodule_path(app), "translations", lang + ".csv")
+		path = frappe.get_app_path(app, "translations", lang + ".csv")
 		translations.update(get_translation_dict_from_file(path, lang, app) or {})
 	if "-" in lang:
 		parent = lang.split("-", 1)[0]
@@ -639,7 +639,7 @@ def get_server_messages(app):
 	inside an app"""
 	messages = []
 	file_extensions = (".py", ".html", ".js", ".vue")
-	app_walk = os.walk(frappe.get_pymodule_path(app))
+	app_walk = os.walk(frappe.get_app_path(app))
 
 	for basepath, folders, files in app_walk:
 		folders[:] = [folder for folder in folders if folder not in {".git", "__pycache__"}]
@@ -1128,8 +1128,8 @@ def migrate_translations(source_app, target_app):
 
 	languages = frappe.translate.get_all_languages()
 
-	source_app_translations_dir = os.path.join(frappe.get_pymodule_path(source_app), "translations")
-	target_app_translations_dir = os.path.join(frappe.get_pymodule_path(target_app), "translations")
+	source_app_translations_dir = frappe.get_app_path(source_app, "translations")
+	target_app_translations_dir = frappe.get_app_path(target_app, "translations")
 
 	if not os.path.exists(target_app_translations_dir):
 		os.makedirs(target_app_translations_dir)
@@ -1181,7 +1181,7 @@ def write_translations_file(app, lang, full_dict=None, app_messages=None):
 	if not app_messages:
 		return
 
-	tpath = frappe.get_pymodule_path(app, "translations")
+	tpath = frappe.get_app_path(app, "translations")
 	frappe.create_folder(tpath)
 	write_csv_file(
 		os.path.join(tpath, lang + ".csv"), app_messages, full_dict or get_all_translations(lang)


### PR DESCRIPTION
- Make `get_pymodule_path` and `get_site_path` return absolute paths

    Before:
    ```python
    In [1]: frappe.get_pymodule_path("frappe", "..", "..", "..", "sites", "my-site")
    Out[1]: '/path/to/my-bench/apps/frappe/frappe/../../../sites/my_site'
    ```

    After:
    ```python
    In [1]: frappe.get_pymodule_path("frappe", "..", "..", "..", "sites", "my-site")
    Out[1]: '/path/to/my-bench/sites/my_site'
    ```

- Refactor code to use `get_app_path` instead of `get_pymodule_path`

    It's technically the same, but nicer to read; less mental load.

- Refactor `get_module_list` to use `get_app_path`

> no-docs