### PR TITLE
fix: don't enqueue sendmail jobs

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -382,7 +382,12 @@ def send_workflow_action_email(users_data, doc):
 			"reference_doctype": doc.doctype,
 		}
 		email_args.update(common_args)
-		enqueue(method=frappe.sendmail, queue="short", **email_args)
+		try:
+			frappe.sendmail(**email_args)
+		except frappe.OutgoingEmailError:
+			# Emails config broken, don't bother retrying next user.
+			frappe.log_error("Failed to send workflow action email")
+			return
 
 
 def deduplicate_actions(action_list):


### PR DESCRIPTION
- sendmail just creates email queue, it should be done on the fly.
- if OutgoingEmailError occurs then skip all future ones.
