### PR TITLE
fix: incorrect doctype map key in cache

### DIFF
--- a/frappe/cache_manager.py
+++ b/frappe/cache_manager.py
@@ -9,7 +9,7 @@ doctypes_for_mapping = {
 	"Energy Point Rule",
 	"Assignment Rule",
 	"Milestone Tracker",
-	"Event Consumer Document",
+	"Event Consumer Document Type",
 	"Document Naming Rule",
 }
 


### PR DESCRIPTION
Doctype name is Event Consumer Document Type
Ref: https://github.com/frappe/frappe/pull/21408