### PR TITLE
fix: frappe.clear_cache should drop all keys

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -914,11 +914,8 @@ def clear_cache(user: str | None = None, doctype: str | None = None):
 	elif user:
 		frappe.cache_manager.clear_user_cache(user)
 	else:  # everything
-		from frappe import translate
-
-		frappe.cache_manager.clear_user_cache()
-		frappe.cache_manager.clear_domain_cache()
-		translate.clear_cache()
+		# Delete ALL keys associated with this site.
+		frappe.cache.delete_keys("")
 		reset_metadata_version()
 		local.cache = {}
 		local.new_doc_templates = {}

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -163,6 +163,25 @@ class TestRedisCache(FrappeAPITestCase):
 		# kwargs should hit cache too
 		self.assertEqual(function_call_count, 4)
 
+	def test_global_clear_cache(self):
+		function_call_count = 0
+
+		@redis_cache()
+		def calculate_area(radius: float) -> float:
+			nonlocal function_call_count
+			function_call_count += 1
+			return 3.14 * radius**2
+
+		calculate_area(10)
+		calculate_area(10)
+		calculate_area(10)
+		self.assertEqual(function_call_count, 1)
+
+		# This is supposed to clear cache for the active site
+		frappe.clear_cache()
+		calculate_area(10)
+		self.assertEqual(function_call_count, 2)
+
 
 class TestDocumentCache(FrappeAPITestCase):
 	TEST_DOCTYPE = "User"


### PR DESCRIPTION
We are dropping some keys which are hardcoded in function.

- this over time might be out of sync with rest of the code.
- other apps cache stuff too.

Best fix: just clear everything.
