### PR TITLE
fix: Doctype connection tab & close form message

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -91,7 +91,8 @@
   "column_break_51",
   "email_append_to",
   "sender_field",
-  "subject_field"
+  "subject_field",
+  "connections_tab"
  ],
  "fields": [
   {
@@ -653,6 +654,12 @@
    "fieldname": "fields_section",
    "fieldtype": "Section Break",
    "label": "Fields"
+  },
+  {
+   "fieldname": "connections_tab",
+   "fieldtype": "Tab Break",
+   "label": "Connections",
+   "show_dashboard": 1
   }
  ],
  "icon": "fa fa-bolt",
@@ -735,7 +742,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2023-08-14 17:32:23.824794",
+ "modified": "2023-08-23 15:09:08.789467",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -102,6 +102,7 @@ frappe.ui.form.Layout = class Layout {
 			// remove previous color
 			this.message.removeClass(this.message_color);
 		}
+		let close_message = $(`<div class="close-message">${frappe.utils.icon("close")}</div>`);
 		this.message_color =
 			color && ["yellow", "blue", "red", "green", "orange"].includes(color) ? color : "blue";
 		if (html) {
@@ -111,6 +112,8 @@ frappe.ui.form.Layout = class Layout {
 			}
 			this.message.removeClass("hidden").addClass(this.message_color);
 			$(html).appendTo(this.message);
+			close_message.appendTo(this.message);
+			close_message.on("click", () => this.message.empty().addClass("hidden"));
 		} else {
 			this.message.empty().addClass("hidden");
 		}

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -282,6 +282,7 @@
 }
 
 .form-message {
+	position: relative;
 	border-radius: var(--border-radius);
 	padding: var(--padding-md) var(--padding-xl);
 	font-size: var(--text-md, 13px);
@@ -305,6 +306,15 @@
 
 	&.red {
 		@include form-message-background("red");
+	}
+
+	.close-message {
+		position: absolute;
+		top: 0;
+		right: 0;
+		padding-top: var(--padding-sm);
+		padding-right: var(--padding-sm);
+		cursor: pointer;
 	}
 }
 


### PR DESCRIPTION
1. Moved the connections to a separate tab in Doctype
<img width="1342" alt="image" src="https://github.com/frappe/frappe/assets/30859809/ba8369ae-8135-44bb-8543-7ef4fb945412">

3. Added close button on form message

https://github.com/frappe/frappe/assets/30859809/9ff5b924-a851-495c-a042-a2f20777c63b

