### PR TITLE
fix: don't underline links in dropdown

### DIFF
--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -331,6 +331,7 @@ select.input-xs {
 	a {
 		transition: none;
 		cursor: pointer;
+		text-decoration: none;
 	}
 	a:active {
 		--icon-stroke: #{$component-active-color};


### PR DESCRIPTION
Before

![Bildschirmfoto 2023-08-23 um 12 26 58](https://github.com/frappe/frappe/assets/14891507/9b95bade-8015-471e-b50b-f262ac036d90)


After

![Bildschirmfoto 2023-08-23 um 12 27 26](https://github.com/frappe/frappe/assets/14891507/becbbe61-78b0-4201-a278-a564c6437876)


Not sure if this was caused by frappe or, accidentally, some other app, but can't hurt to make this explicit.