### PR TITLE
feat(telemetry): allow users to send session recording

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -402,9 +402,17 @@ frappe.setup.slides_settings = [
 			},
 			{
 				fieldname: "enable_telemetry",
-				label: __("Allow Sending Usage Data for Improving Applications"),
+				label: __("Allow sending usage data for improving applications"),
 				fieldtype: "Check",
 				default: 1,
+				depends_on: "eval:frappe.telemetry.can_enable()",
+			},
+			{
+				fieldname: "allow_recording_first_session",
+				label: __("Allow recording my first session to improve user experience"),
+				fieldtype: "Check",
+				default: 0,
+				depends_on: "eval:frappe.telemetry.can_enable()",
 			},
 		],
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -6,7 +6,7 @@ import json
 import frappe
 from frappe.geo.country_info import get_country_info
 from frappe.translate import get_messages_for_boot, send_translations, set_default_language
-from frappe.utils import cint, strip
+from frappe.utils import cint, now, strip
 from frappe.utils.password import update_password
 
 from . import install_fixtures
@@ -184,6 +184,8 @@ def update_system_settings(args):
 		}
 	)
 	system_settings.save()
+	if args.get("allow_recording_first_session"):
+		frappe.db.set_default("session_recording_start", now())
 
 
 def update_user_name(args):

--- a/frappe/public/js/frappe/utils/datetime.js
+++ b/frappe/public/js/frappe/utils/datetime.js
@@ -82,6 +82,10 @@ $.extend(frappe.datetime, {
 		return moment(d1).diff(d2, "hours");
 	},
 
+	get_minute_diff: function (d1, d2) {
+		return moment(d1).diff(d2, "minutes");
+	},
+
 	get_day_diff: function (d1, d2) {
 		return moment(d1).diff(d2, "days");
 	},


### PR DESCRIPTION
- allows recording first session (assumed to be ~2 hours)
- only enabled with explicit **opt-in** from user. 

Other change:
- hide telemetry related fields where it's not configured (like self hosted sites)