### PR TITLE
fix: user permission fixed

### DIFF
--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -230,8 +230,8 @@ class TestUserPermission(FrappeTestCase):
 			fields=["person_name"],
 		)
 
-		self.assertEqual(visible_names[0], {"person_name": "Child"}, {"person_name": "Parent"})
-		self.assertEqual(visible_names_after_hide_descendants[0], {"person_name": "Parent"})
+		self.assertEqual(visible_names, [{"person_name": "Child"}, {"person_name": "Parent"}])
+		self.assertEqual(visible_names_after_hide_descendants, [{"person_name": "Parent"}])
 
 	def test_user_perm_on_new_doc_with_field_default(self):
 		"""Test User Perm impact on frappe.new_doc. with *field* default value"""

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -998,6 +998,9 @@ class DatabaseQuery:
 		for df in doctype_link_fields:
 			if df.get("ignore_user_permissions"):
 				continue
+			if df.get("fieldname") != "name" and df.get("options") == self.doctype:
+				# if doctype is same as current doctype then ignore
+				continue
 
 			user_permission_values = user_permissions.get(df.get("options"), {})
 


### PR DESCRIPTION
When we give permission to a particular user of a particular Doctype(Department in this case)
<img width="1163" alt="image" src="https://github.com/frappe/frappe/assets/65544983/baeaf472-26d9-4495-89b9-26430ad2586b">

Department doesn't come in the Link Search field(Accounting Dimension Department in this case)
<img width="680" alt="image" src="https://github.com/frappe/frappe/assets/65544983/75b934c7-db58-4440-bd4d-bd145e373c20">

When we assign a user lets say "Arjun" to "only see MH Department and its child", the user Arjun is not able to see the neither the doctype nor the children of the department. 

and Arjun is shown nothing
<img width="680" alt="image" src="https://github.com/frappe/frappe/assets/65544983/75b934c7-db58-4440-bd4d-bd145e373c20">

So to solve this we add a check in db_query.py
```
			if df.get("fieldname") != "name" and df.get("options") == self.doctype:
				# if doctype is same as current doctype then ignore
				continue
```

so after adding the above code it is solved

