### PR TITLE
fix: misc UX fixes

### DIFF
--- a/frappe/desk/form_tour/main_workspace_tour/main_workspace_tour.json
+++ b/frappe/desk/form_tour/main_workspace_tour/main_workspace_tour.json
@@ -8,7 +8,7 @@
  "include_name_field": 0,
  "is_standard": 1,
  "list_name": "",
- "modified": "2023-05-24 12:43:43.741781",
+ "modified": "2023-08-24 11:01:18.688875",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Main Workspace Tour",
@@ -22,7 +22,7 @@
  "steps": [
   {
    "description": "This is Awesomebar, it helps you to navigate anywhere in the system, find documents, reports, settings, create new records and many more things.",
-   "element_selector": "#navbar-search",
+   "element_selector": "#navbar-search[aria-expanded=\"true\"]",
    "fieldtype": "0",
    "has_next_condition": 0,
    "hide_buttons": 0,

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -584,21 +584,19 @@ frappe.request.report_error = function (xhr, request_opts) {
 		if (!frappe.error_dialog) {
 			frappe.error_dialog = new frappe.ui.Dialog({
 				title: __("Server Error"),
-				primary_action_label: __("Report"),
-				primary_action: () => {
-					if (error_report_email) {
-						show_communication();
-					} else {
-						frappe.msgprint(__("Support Email Address Not Specified"));
-					}
+			});
+
+			if (error_report_email) {
+				frappe.error_dialog.set_primary_action(__("Report"), () => {
+					show_communication();
 					frappe.error_dialog.hide();
-				},
-				secondary_action_label: __("Copy error to clipboard"),
-				secondary_action: () => {
+				});
+			} else {
+				frappe.error_dialog.set_primary_action(__("Copy error to clipboard"), () => {
 					copy_markdown_to_clipboard();
 					frappe.error_dialog.hide();
-				},
-			});
+				});
+			}
 			frappe.error_dialog.wrapper.classList.add("msgprint-dialog");
 		}
 

--- a/frappe/public/js/frappe/views/workspace/blocks/onboarding.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/onboarding.js
@@ -106,6 +106,8 @@ export default class Onboarding extends Block {
 	}
 
 	render() {
+		if (frappe.is_mobile()) return;
+
 		this.wrapper = document.createElement("div");
 		this.new("onboarding");
 


### PR DESCRIPTION
1. Onboarding widgets are disabled on mobile because they are not quite usable. 
2. Awesomebar tour is deferred till user clicks on awesomebar (arid-expanded=true)
3. Error report button isn't shown unless support email is configured. 

closes https://github.com/frappe/frappe/issues/22172