### PR TITLE
fix: delete feedback doctype after patch is completed

### DIFF
--- a/frappe/patches/v14_0/setup_likes_from_feedback.py
+++ b/frappe/patches/v14_0/setup_likes_from_feedback.py
@@ -28,3 +28,5 @@ def execute():
 	# clean up
 	frappe.db.delete("Feedback")
 	frappe.db.commit()
+
+	frappe.delete_doc("DocType", "Feedback")


### PR DESCRIPTION
missed in https://github.com/frappe/frappe/pull/17479