### PR TITLE
fix(Email Inline Embed): escape regex expression

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -513,7 +513,7 @@ def replace_filename_with_cid(message):
 
 		filecontent = get_filecontent_from_path(img_path)
 		if not filecontent:
-			message = re.sub(f"""embed=['"]{img_path}['"]""", "", message)
+			message = re.sub(f"""embed=['"]{re.escape(img_path)}['"]""", "", message)
 			continue
 
 		content_id = random_string(10)
@@ -522,7 +522,7 @@ def replace_filename_with_cid(message):
 			{"filename": filename, "filecontent": filecontent, "content_id": content_id}
 		)
 
-		message = re.sub(f"""embed=['"]{img_path}['"]""", f'src="cid:{content_id}"', message)
+		message = re.sub(f"""embed=['"]{re.escape(img_path)}['"]""", f'src="cid:{content_id}"', message)
 
 	return (message, inline_images)
 


### PR DESCRIPTION
**Problem:**

Regex substituion is being done, however, written in a naive way, the regex does not work when special regex characters are included for example `<img embed="/private/files/test-(abc)-image.jpg">`.

Since the method is written inside a `while True` loop this is a critical bug leading to memory leak and consuming all available memory until process is killed or until server crashes.

**Solution:**

Escape user string parts of regex expressions!