### PR TITLE
fix: Avoid doc caching if `for_update` is set

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1253,6 +1253,9 @@ def get_doc(*args, **kwargs):
 
 	doc = frappe.model.document.get_doc(*args, **kwargs)
 
+	if "for_update" in kwargs and kwargs["for_update"]:
+		return doc
+
 	# Replace cache if stale one exists
 	if (key := can_cache_doc(args)) and cache.exists(key):
 		_set_document_in_cache(key, doc)

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1253,11 +1253,8 @@ def get_doc(*args, **kwargs):
 
 	doc = frappe.model.document.get_doc(*args, **kwargs)
 
-	if "for_update" in kwargs and kwargs["for_update"]:
-		return doc
-
 	# Replace cache if stale one exists
-	if (key := can_cache_doc(args)) and cache.exists(key):
+	if not kwargs.get("for_update") and (key := can_cache_doc(args)) and cache.exists(key):
 		_set_document_in_cache(key, doc)
 
 	return doc


### PR DESCRIPTION
fixes : https://github.com/frappe/frappe/issues/21655