### PR TITLE
fix: focus on first input only if needed

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -655,10 +655,10 @@ frappe.ui.form.Form = class FrappeForm {
 			return;
 		}
 
-		const first_input = layout_wrapper.find(":input:visible:first");
-		if (!in_list(["Date", "Datetime"], first_input.attr("data-fieldtype"))) {
-			first_input.trigger("focus");
-		}
+		layout_wrapper
+			.find(":input:visible:first")
+			.not("[data-fieldtype^='Date']")
+			.trigger("focus");
 	}
 
 	run_after_load_hook() {

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -647,9 +647,17 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	focus_on_first_input() {
-		let first = this.form_wrapper.find(".form-layout :input:visible:first");
-		if (!in_list(["Date", "Datetime"], first.attr("data-fieldtype"))) {
-			first.focus();
+		const layout_wrapper = this.layout.wrapper;
+
+		// dont do anything if the current active element is inside the form
+		// user must have clicked on some element before this function trigerred
+		if (!layout_wrapper || layout_wrapper.has(":focus").length) {
+			return;
+		}
+
+		const first_input = layout_wrapper.find(":input:visible:first");
+		if (!in_list(["Date", "Datetime"], first_input.attr("data-fieldtype"))) {
+			first_input.trigger("focus");
 		}
 	}
 


### PR DESCRIPTION
### Before

![fix focus before](https://github.com/frappe/frappe/assets/16315650/ce096aef-f81e-46b8-aa01-d46de0f8f634)

### After

![fix focus after](https://github.com/frappe/frappe/assets/16315650/accc4c6d-c6ef-4689-9f81-501c0d17da7c)

Also fixed Cypress issue detailed here:
https://discuss.frappe.io/t/how-do-i-randomly-select-from-a-link-field-in-a-cypress-test/109068