### PR TITLE
fix: proper permission for submission queue

### DIFF
--- a/frappe/core/doctype/submission_queue/submission_queue.json
+++ b/frappe/core/doctype/submission_queue/submission_queue.json
@@ -88,7 +88,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-01-23 12:45:53.997708",
+ "modified": "2023-08-28 18:48:56.242178",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Submission Queue",
@@ -96,16 +96,6 @@
  "owner": "Administrator",
  "permissions": [
   {
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1
-  },
-  {
-   "if_owner": 1,
    "read": 1,
    "role": "All"
   }

--- a/frappe/core/doctype/submission_queue/submission_queue.py
+++ b/frappe/core/doctype/submission_queue/submission_queue.py
@@ -205,3 +205,7 @@ def format_tb(traceback: str | None = None):
 		return
 
 	return traceback.strip().split("\n")[-1]
+
+
+def has_permission(doc, ptype=None, user=None):
+	return frappe.get_cached_doc(doc.ref_doctype, doc.ref_docname).has_permission()

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -124,6 +124,7 @@ has_permission = {
 	"Workflow Action": "frappe.workflow.doctype.workflow_action.workflow_action.has_permission",
 	"File": "frappe.core.doctype.file.file.has_permission",
 	"Prepared Report": "frappe.core.doctype.prepared_report.prepared_report.has_permission",
+	"Submission Queue": "frappe.core.doctype.submission_queue.submission_queue.has_permission",
 }
 
 has_website_permission = {


### PR DESCRIPTION
allow user to read the submission queue doc if they have the perm for the reference doc