### PR TITLE
 feat: `Desk User` role

### DIFF
--- a/frappe/automation/doctype/reminder/reminder.json
+++ b/frappe/automation/doctype/reminder/reminder.json
@@ -66,7 +66,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-24 13:47:50.419648",
+ "modified": "2023-08-28 22:17:18.351025",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Reminder",
@@ -78,7 +78,7 @@
    "delete": 1,
    "if_owner": 1,
    "read": 1,
-   "role": "All",
+   "role": "Desk User",
    "write": 1
   }
  ],

--- a/frappe/core/doctype/activity_log/activity_log.json
+++ b/frappe/core/doctype/activity_log/activity_log.json
@@ -158,7 +158,7 @@
  "icon": "fa fa-comment",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-28 13:26:32.281278",
+ "modified": "2023-08-28 20:22:10.992615",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Activity Log",
@@ -169,16 +169,6 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
-   "share": 1
-  },
-  {
-   "email": 1,
-   "export": 1,
-   "if_owner": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
    "share": 1
   }
  ],

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -32,6 +32,7 @@ from frappe.model.document import Document
 from frappe.model.meta import Meta
 from frappe.modules import get_doc_path, make_boilerplate
 from frappe.modules.import_file import get_file_path
+from frappe.permissions import ALL_USER_ROLE, AUTOMATIC_ROLES, SYSTEM_USER_ROLE
 from frappe.query_builder.functions import Concat
 from frappe.utils import cint, flt, is_a_property, random_string
 from frappe.website.utils import clear_cache
@@ -1695,7 +1696,7 @@ def validate_permissions(doctype, for_remove=False, alert=False):
 			)
 
 	def check_level_zero_is_set(d):
-		if cint(d.permlevel) > 0 and d.role != "All":
+		if cint(d.permlevel) > 0 and d.role not in (ALL_USER_ROLE, SYSTEM_USER_ROLE):
 			has_zero_perm = False
 			for p in permissions:
 				if p.role == d.role and (p.permlevel or 0) == 0 and p != d:
@@ -1747,10 +1748,10 @@ def validate_permissions(doctype, for_remove=False, alert=False):
 			return
 
 		if doctype.custom:
-			if d.role == "All":
+			if d.role in AUTOMATIC_ROLES:
 				frappe.throw(
 					_("Row # {0}: Non administrator user can not set the role {1} to the custom doctype").format(
-						d.idx, frappe.bold(_("All"))
+						d.idx, frappe.bold(_(d.role))
 					),
 					title=_("Permissions Error"),
 				)
@@ -1801,8 +1802,7 @@ def make_module_and_roles(doc, perm_fieldname="permissions"):
 				m.custom = 1
 			m.insert()
 
-		default_roles = ["Administrator", "Guest", "All"]
-		roles = [p.role for p in doc.get("permissions") or []] + default_roles
+		roles = [p.role for p in doc.get("permissions") or []] + list(AUTOMATIC_ROLES)
 
 		for role in list(set(roles)):
 			if frappe.db.table_exists("Role", cached=False) and not frappe.db.exists("Role", role):

--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -231,7 +231,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "show_name_in_global_search": 1,

--- a/frappe/core/doctype/role/role.js
+++ b/frappe/core/doctype/role/role.js
@@ -5,7 +5,12 @@ frappe.ui.form.on("Role", {
 	refresh: function (frm) {
 		if (frm.doc.name === "All") {
 			frm.dashboard.add_comment(
-				__("Role 'All' will be given to all System Users."),
+				__("Role 'All' will be given to all system + website users."),
+				"yellow"
+			);
+		} else if (frm.doc.name === "Desk User") {
+			frm.dashboard.add_comment(
+				__("Role 'Desk User' will be given to all system users."),
 				"yellow"
 			);
 		}

--- a/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
+++ b/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.core.doctype.report.report import is_prepared_report_enabled
 from frappe.model.document import Document
+from frappe.permissions import ALL_USER_ROLE
 from frappe.utils import cint
 
 
@@ -96,7 +97,9 @@ class RolePermissionforPageandReport(Document):
 
 	def get_roles(self):
 		return [
-			{"role": data.role, "parenttype": "Custom Role"} for data in self.roles if data.role != "All"
+			{"role": data.role, "parenttype": "Custom Role"}
+			for data in self.roles
+			if data.role != ALL_USER_ROLE
 		]
 
 	def update_status(self):

--- a/frappe/core/doctype/submission_queue/submission_queue.json
+++ b/frappe/core/doctype/submission_queue/submission_queue.json
@@ -88,7 +88,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-01-23 12:45:53.997708",
+ "modified": "2023-08-28 22:25:55.480699",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Submission Queue",
@@ -107,7 +107,7 @@
   {
    "if_owner": 1,
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "sort_field": "modified",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -781,7 +781,10 @@ def get_all_roles(arg=None):
 
 	roles = frappe.get_all(
 		"Role",
-		filters={"name": ("not in", "Administrator,Guest,All"), "disabled": 0},
+		filters={
+			"name": ("not in", frappe.permissions.AUTOMATIC_ROLES),
+			"disabled": 0,
+		},
 		or_filters={"ifnull(restrict_to_domain, '')": "", "restrict_to_domain": ("in", active_domains)},
 		order_by="name",
 	)

--- a/frappe/core/doctype/user_group/user_group.json
+++ b/frappe/core/doctype/user_group/user_group.json
@@ -19,10 +19,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-04-15 16:12:31.455401",
+ "modified": "2023-08-28 22:25:16.941457",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Group",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -39,10 +40,11 @@
   },
   {
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -12,6 +12,7 @@ from frappe.core.doctype.doctype.doctype import (
 from frappe.exceptions import DoesNotExistError
 from frappe.modules.import_file import get_file_path, read_doc_from_file
 from frappe.permissions import (
+	AUTOMATIC_ROLES,
 	add_permission,
 	get_all_perms,
 	get_linked_doctypes,
@@ -44,7 +45,7 @@ def get_roles_and_doctypes():
 	if frappe.session.user != "Administrator":
 		custom_user_type_roles = frappe.get_all("User Type", filters={"is_standard": 0}, fields=["role"])
 		restricted_roles.extend(row.role for row in custom_user_type_roles)
-		restricted_roles.append("All")
+		restricted_roles.extend(AUTOMATIC_ROLES)
 
 	roles = frappe.get_all(
 		"Role",

--- a/frappe/custom/doctype/doctype_layout/doctype_layout.json
+++ b/frappe/custom/doctype/doctype_layout/doctype_layout.json
@@ -43,7 +43,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-02-14 17:53:24.486171",
+ "modified": "2023-08-28 22:24:08.103972",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "DocType Layout",
@@ -64,7 +64,7 @@
   },
   {
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "route": "doctype-layout",

--- a/frappe/desk/doctype/calendar_view/calendar_view.json
+++ b/frappe/desk/doctype/calendar_view/calendar_view.json
@@ -53,10 +53,11 @@
   }
  ],
  "links": [],
- "modified": "2020-09-18 17:26:09.703215",
+ "modified": "2023-08-28 22:29:39.662726",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Calendar View",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -73,9 +74,10 @@
   },
   {
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappe/desk/doctype/custom_html_block/custom_html_block.json
+++ b/frappe/desk/doctype/custom_html_block/custom_html_block.json
@@ -93,7 +93,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-05-30 14:33:31.994738",
+ "modified": "2023-08-28 20:25:00.740795",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Custom HTML Block",
@@ -106,7 +106,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1
   },
   {
@@ -118,7 +118,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1,
    "write": 1
   },

--- a/frappe/desk/doctype/dashboard/dashboard.json
+++ b/frappe/desk/doctype/dashboard/dashboard.json
@@ -67,7 +67,7 @@
   }
  ],
  "links": [],
- "modified": "2020-07-23 11:05:41.890459",
+ "modified": "2023-08-28 22:35:02.993039",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard",
@@ -103,13 +103,14 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1
   }
  ],
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "dashboard_name",
  "track_changes": 1
 }

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -287,7 +287,7 @@
   }
  ],
  "links": [],
- "modified": "2023-08-14 16:33:30.172798",
+ "modified": "2023-08-28 20:20:54.186299",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",
@@ -324,7 +324,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1
   }
  ],

--- a/frappe/desk/doctype/dashboard_settings/dashboard_settings.json
+++ b/frappe/desk/doctype/dashboard_settings/dashboard_settings.json
@@ -27,10 +27,11 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-04-01 00:07:26.489561",
+ "modified": "2023-08-28 22:23:42.722543",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Settings",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -39,7 +40,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1,
    "write": 1
   }
@@ -47,5 +48,6 @@
  "read_only": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/desk/doctype/form_tour/form_tour.json
+++ b/frappe/desk/doctype/form_tour/form_tour.json
@@ -178,7 +178,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-05-25 11:30:44.396248",
+ "modified": "2023-08-28 20:24:42.594360",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Form Tour",
@@ -199,7 +199,7 @@
   },
   {
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "sort_field": "modified",

--- a/frappe/desk/doctype/kanban_board/kanban_board.json
+++ b/frappe/desk/doctype/kanban_board/kanban_board.json
@@ -84,7 +84,7 @@
   }
  ],
  "links": [],
- "modified": "2022-04-13 12:10:20.284367",
+ "modified": "2023-08-28 22:29:29.569670",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Kanban Board",
@@ -93,14 +93,14 @@
  "permissions": [
   {
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   },
   {
    "create": 1,
    "delete": 1,
    "if_owner": 1,
    "read": 1,
-   "role": "All",
+   "role": "Desk User",
    "write": 1
   },
   {

--- a/frappe/desk/doctype/list_filter/list_filter.json
+++ b/frappe/desk/doctype/list_filter/list_filter.json
@@ -36,7 +36,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2022-08-03 12:20:50.889979",
+ "modified": "2023-08-28 22:32:51.465521",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "List Filter",
@@ -50,7 +50,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1,
    "write": 1
   }

--- a/frappe/desk/doctype/module_onboarding/module_onboarding.json
+++ b/frappe/desk/doctype/module_onboarding/module_onboarding.json
@@ -82,7 +82,7 @@
   }
  ],
  "links": [],
- "modified": "2020-06-08 15:36:04.701049",
+ "modified": "2023-08-28 22:24:02.233272",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Module Onboarding",
@@ -106,12 +106,13 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1
   }
  ],
  "read_only": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/desk/doctype/note/note.json
+++ b/frappe/desk/doctype/note/note.json
@@ -86,7 +86,7 @@
  "icon": "fa fa-file-text",
  "idx": 1,
  "links": [],
- "modified": "2023-04-24 16:07:03.281184",
+ "modified": "2023-08-28 20:23:59.424943",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Note",
@@ -122,21 +122,21 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All"
+   "role": "Desk User"
   },
   {
    "create": 1,
    "delete": 1,
    "email": 1,
    "if_owner": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1,
    "write": 1
   },
   {
    "permlevel": 1,
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "quick_entry": 1,

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -113,6 +113,21 @@ def get_permission_query_conditions(user):
 	return f"""(`tabNotification Settings`.name = {frappe.db.escape(user)})"""
 
 
+def has_permission(doc, ptype="read", user=None):
+	# - Administrator can access everything.
+	# - System managers can access everything except admin.
+	# - Everyone else can only access their document.
+	user = user or frappe.session.user
+
+	if user == "Administrator":
+		return True
+
+	if "System Manager" in frappe.get_roles(user):
+		return doc.name != "Administrator"
+
+	return doc.name == user
+
+
 @frappe.whitelist()
 def set_seen_value(value, user):
 	if frappe.flags.read_only:

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -191,8 +191,8 @@
    "options": "Sum\nAverage\nMinimum\nMaximum"
   },
   {
-   "description": "The document type selected is a child table, so the parent document type is required.",
    "depends_on": "eval: doc.type === 'Document Type'",
+   "description": "The document type selected is a child table, so the parent document type is required.",
    "fieldname": "parent_document_type",
    "fieldtype": "Link",
    "label": "Parent Document Type",
@@ -200,7 +200,7 @@
   }
  ],
  "links": [],
- "modified": "2022-06-12 15:34:38.210910",
+ "modified": "2023-08-28 22:23:56.286804",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",
@@ -236,7 +236,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1
   }
  ],

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.json
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.json
@@ -217,7 +217,7 @@
   }
  ],
  "links": [],
- "modified": "2021-12-02 10:56:04.448580",
+ "modified": "2023-08-28 22:23:48.174317",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Onboarding Step",
@@ -242,7 +242,7 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1
   }
  ],
@@ -250,5 +250,6 @@
  "read_only": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -5,6 +5,7 @@ import json
 
 import frappe
 from frappe.model.document import Document
+from frappe.permissions import AUTOMATIC_ROLES
 from frappe.utils import get_fullname, parse_addr
 
 exclude_from_linked_with = True
@@ -150,8 +151,7 @@ def get_permission_query_conditions(user):
 		user = frappe.session.user
 
 	todo_roles = frappe.permissions.get_doctype_roles("ToDo")
-	if "All" in todo_roles:
-		todo_roles.remove("All")
+	todo_roles = set(todo_roles) - set(AUTOMATIC_ROLES)
 
 	if any(check in todo_roles for check in frappe.get_roles(user)):
 		return None
@@ -164,8 +164,7 @@ def get_permission_query_conditions(user):
 def has_permission(doc, ptype="read", user=None):
 	user = user or frappe.session.user
 	todo_roles = frappe.permissions.get_doctype_roles("ToDo", ptype)
-	if "All" in todo_roles:
-		todo_roles.remove("All")
+	todo_roles = set(todo_roles) - set(AUTOMATIC_ROLES)
 
 	if any(check in todo_roles for check in frappe.get_roles(user)):
 		return True

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -5,6 +5,7 @@ import json
 
 import frappe
 from frappe.geo.country_info import get_country_info
+from frappe.permissions import AUTOMATIC_ROLES
 from frappe.translate import get_messages_for_boot, send_translations, set_default_language
 from frappe.utils import cint, now, strip
 from frappe.utils.password import update_password
@@ -272,13 +273,11 @@ def add_all_roles_to(name):
 def _get_default_roles() -> set[str]:
 	skip_roles = {
 		"Administrator",
-		"Guest",
-		"All",
 		"Customer",
 		"Supplier",
 		"Partner",
 		"Employee",
-	}
+	}.union(AUTOMATIC_ROLES)
 	return set(frappe.get_all("Role", pluck="name")) - skip_roles
 
 

--- a/frappe/email/doctype/document_follow/document_follow.json
+++ b/frappe/email/doctype/document_follow/document_follow.json
@@ -41,7 +41,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-09-17 09:19:28.496453",
+ "modified": "2023-08-28 22:34:53.394652",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Document Follow",
@@ -67,12 +67,13 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1,
    "write": 1
   }
  ],
  "read_only": 1,
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappe/email/doctype/email_template/email_template.json
+++ b/frappe/email/doctype/email_template/email_template.json
@@ -57,7 +57,7 @@
  ],
  "icon": "fa fa-comment",
  "links": [],
- "modified": "2023-01-02 03:56:48.437280",
+ "modified": "2023-08-28 22:29:04.457992",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Template",
@@ -66,7 +66,7 @@
  "permissions": [
   {
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   },
   {
    "create": 1,

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -124,6 +124,7 @@ has_permission = {
 	"Workflow Action": "frappe.workflow.doctype.workflow_action.workflow_action.has_permission",
 	"File": "frappe.core.doctype.file.file.has_permission",
 	"Prepared Report": "frappe.core.doctype.prepared_report.prepared_report.has_permission",
+	"Notification Settings": "frappe.desk.doctype.notification_settings.notification_settings.has_permission",
 }
 
 has_website_permission = {

--- a/frappe/integrations/doctype/google_calendar/google_calendar.json
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "field:calendar_name",
  "creation": "2019-07-06 17:54:09.450100",
  "doctype": "DocType",
@@ -108,10 +109,12 @@
    "label": "Push to Google Calendar"
   }
  ],
- "modified": "2019-08-08 15:44:15.798362",
+ "links": [],
+ "modified": "2023-08-28 22:21:44.238862",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Calendar",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -135,12 +138,13 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1,
    "write": 1
   }
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/integrations/doctype/google_contacts/google_contacts.json
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.json
@@ -99,7 +99,7 @@
   }
  ],
  "links": [],
- "modified": "2023-03-30 11:25:48.832384",
+ "modified": "2023-08-28 20:22:58.267442",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Contacts",
@@ -121,7 +121,7 @@
    "delete": 1,
    "if_owner": 1,
    "read": 1,
-   "role": "All",
+   "role": "Desk User",
    "write": 1
   }
  ],

--- a/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
+++ b/frappe/integrations/doctype/ldap_settings/test_ldap_settings.py
@@ -370,6 +370,7 @@ class LDAP_TestCase:
 					"default_role",
 					"frappe_default_all",
 					"frappe_default_guest",
+					"frappe_default_desk_user",
 				],
 				"posix.user2": [
 					"Users",
@@ -377,6 +378,7 @@ class LDAP_TestCase:
 					"default_role",
 					"frappe_default_all",
 					"frappe_default_guest",
+					"frappe_default_desk_user",
 				],
 			}
 
@@ -388,6 +390,7 @@ class LDAP_TestCase:
 					"default_role",
 					"frappe_default_all",
 					"frappe_default_guest",
+					"frappe_default_desk_user",
 				],
 				"posix.user2": [
 					"Domain Users",
@@ -395,6 +398,7 @@ class LDAP_TestCase:
 					"default_role",
 					"frappe_default_all",
 					"frappe_default_guest",
+					"frappe_default_desk_user",
 				],
 			}
 
@@ -405,6 +409,7 @@ class LDAP_TestCase:
 			"Newsletter Manager": "default_role",
 			"All": "frappe_default_all",
 			"Guest": "frappe_default_guest",
+			"Desk User": "frappe_default_desk_user",
 		}
 
 		# re-create user1 to ensure clean

--- a/frappe/printing/doctype/letter_head/letter_head.json
+++ b/frappe/printing/doctype/letter_head/letter_head.json
@@ -168,7 +168,7 @@
  "idx": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2022-06-16 23:10:46.852116",
+ "modified": "2023-08-28 22:19:23.720332",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Letter Head",
@@ -188,7 +188,7 @@
   },
   {
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "sort_field": "modified",

--- a/frappe/printing/doctype/network_printer_settings/network_printer_settings.json
+++ b/frappe/printing/doctype/network_printer_settings/network_printer_settings.json
@@ -41,7 +41,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-10-07 11:23:13.799402",
+ "modified": "2023-08-28 22:25:22.236295",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Network Printer Settings",
@@ -66,11 +66,12 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "All",
+   "role": "Desk User",
    "share": 1
   }
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -259,7 +259,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2023-05-31 15:40:52.919029",
+ "modified": "2023-08-28 20:25:09.660073",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",
@@ -278,7 +278,7 @@
    "write": 1
   },
   {
-   "role": "All",
+   "role": "Desk User",
    "select": 1
   }
  ],

--- a/frappe/social/doctype/energy_point_log/energy_point_log.json
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.json
@@ -110,7 +110,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-09-13 16:10:37.747013",
+ "modified": "2023-08-28 22:33:08.420000",
  "modified_by": "Administrator",
  "module": "Social",
  "name": "Energy Point Log",
@@ -124,7 +124,7 @@
   {
    "read": 1,
    "report": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "sort_field": "modified",

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -322,8 +322,9 @@ class TestEnergyPointLog(FrappeTestCase):
 		# do not update energy points for disabled user
 		self.assertEqual(points_after_closing_todo, energy_point_of_user)
 
-		user.enabled = 1
-		user.save()
+		with self.set_user("Administrator"):
+			user.enabled = 1
+			user.save()
 
 		created_todo.save()
 		points_after_re_saving_todo = get_points("test@example.com")

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe import _
+from frappe.permissions import AUTOMATIC_ROLES
 from frappe.utils import add_to_date, now
 
 UI_TEST_USER = "frappe@example.com"
@@ -444,10 +445,9 @@ def create_test_user(username=None):
 
 	user.reload()
 
-	blocked_roles = {"Administrator", "Guest", "All"}
 	all_roles = set(frappe.get_all("Role", pluck="name"))
 
-	for role in all_roles - blocked_roles:
+	for role in all_roles - set(AUTOMATIC_ROLES):
 		user.append("roles", {"role": role})
 
 	user.save()

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -129,6 +129,13 @@ class FrappeTestCase(unittest.TestCase):
 			)
 		)
 
+	@contextmanager
+	def set_user(user: str):
+		old_user = frappe.session.user
+		frappe.set_user(user)
+		yield
+		frappe.set_user(old_user)
+
 
 class MockedRequestTestCase(FrappeTestCase):
 	def setUp(self):

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -130,7 +130,7 @@ class FrappeTestCase(unittest.TestCase):
 		)
 
 	@contextmanager
-	def set_user(user: str):
+	def set_user(self, user: str):
 		old_user = frappe.session.user
 		frappe.set_user(user)
 		yield

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -9,6 +9,7 @@ import pyotp
 import frappe
 import frappe.defaults
 from frappe import _
+from frappe.permissions import ALL_USER_ROLE
 from frappe.utils import cint, get_datetime, get_url, time_diff_in_seconds
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.password import decrypt, encrypt
@@ -116,8 +117,7 @@ def two_factor_is_enabled_for_(user):
 
 	if isinstance(user, str):
 		user = frappe.get_doc("User", user)
-
-	roles = [d.role for d in user.roles or []] + ["All"]
+	roles = [d.role for d in user.roles or []] + [ALL_USER_ROLE]
 
 	role_doctype = frappe.qb.DocType("Role")
 	no_of_users = frappe.db.count(

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -9,7 +9,7 @@ import frappe.share
 from frappe import _dict
 from frappe.boot import get_allowed_reports
 from frappe.core.doctype.domain_settings.domain_settings import get_active_modules
-from frappe.permissions import get_roles, get_valid_perms
+from frappe.permissions import AUTOMATIC_ROLES, get_roles, get_valid_perms
 from frappe.query_builder import DocType, Order
 from frappe.query_builder.functions import Concat_ws
 
@@ -347,7 +347,7 @@ def add_system_manager(
 	roles = frappe.get_all(
 		"Role",
 		fields=["name"],
-		filters={"name": ["not in", ("Administrator", "Guest", "All")]},
+		filters={"name": ["not in", AUTOMATIC_ROLES]},
 	)
 	roles = [role.name for role in roles]
 	user.add_roles(*roles)
@@ -376,6 +376,8 @@ def is_website_user(username: str | None = None) -> str | None:
 
 
 def is_system_user(username: str | None = None) -> str | None:
+	# TODO: Depracate this. Inefficient, incorrect. This function is meant to be used in emails only.
+	# Problem: Filters on email instead of PK, implicitly filters out disabled users.
 	return frappe.db.get_value(
 		"User",
 		{
@@ -383,6 +385,7 @@ def is_system_user(username: str | None = None) -> str | None:
 			"enabled": 1,
 			"user_type": "System User",
 		},
+		cache=True,
 	)
 
 

--- a/frappe/website/doctype/marketing_campaign/marketing_campaign.json
+++ b/frappe/website/doctype/marketing_campaign/marketing_campaign.json
@@ -21,7 +21,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-20 22:47:25.768582",
+ "modified": "2023-08-28 22:26:04.298759",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Marketing Campaign",
@@ -53,7 +53,7 @@
    "write": 1
   },
   {
-   "role": "All",
+   "role": "Desk User",
    "select": 1
   }
  ],

--- a/frappe/workflow/doctype/workflow_action/workflow_action.json
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.json
@@ -79,7 +79,7 @@
   }
  ],
  "links": [],
- "modified": "2022-02-23 21:06:45.122258",
+ "modified": "2023-08-28 22:32:58.947849",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow Action",
@@ -88,7 +88,7 @@
   {
    "delete": 1,
    "read": 1,
-   "role": "All"
+   "role": "Desk User"
   }
  ],
  "sort_field": "modified",

--- a/frappe/workflow/doctype/workflow_state/workflow_state.json
+++ b/frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -40,7 +40,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2023-03-13 22:33:58.504532",
+ "modified": "2023-08-28 22:19:35.232574",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow State",
@@ -58,7 +58,7 @@
    "write": 1
   },
   {
-   "role": "All",
+   "role": "Desk User",
    "select": 1
   }
  ],


### PR DESCRIPTION
- [x] add new role
- [x] migrate existing doctypes
    - [x] Frappe
    - [x] ERPNext
- [x] Migration guide
- [x] pass CI _mostly_
- [x] Tests


`All` -> `Desk User` for

- reminder
- report
- submission_queue
- user_group
- doctype_layout
- calendar_view
- custom_html_block
- dashboard
- dashboard_chart
- dashboard_settings
- form_tour
- kanban_board
- list_filter
- module_onboarding
- note
- number_card
- onboarding_step
- document_follow
- email_template
- google_calendar
- google_contacts
- letter_head
- network_printer_settings
- print_format
- energy_point_log
- marketing_campaign
- workflow_action
- workflow_state

Other permission changes:
- activity_log (Only system managers now)
- notification_settings (changed to only if owner)


docs: https://frappeframework.com/docs/user/en/basics/users-and-permissions