### PR TITLE
fix: `typeerror` on custom reports

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -229,7 +229,7 @@ def add_custom_column_data(custom_columns, result):
 		key = (column.get("doctype"), column.get("fieldname"))
 		if key in custom_column_data:
 			for row in result:
-				row_reference = row.get(column.get("link_field"))
+				row_reference = row.get(column.get("link_field").get("fieldname"))
 				# possible if the row is empty
 				if not row_reference:
 					continue

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -223,13 +223,20 @@ def run(
 
 
 def add_custom_column_data(custom_columns, result):
-	custom_column_data = get_data_for_custom_report(custom_columns)
+	custom_column_data = get_data_for_custom_report(custom_columns, result)
 
 	for column in custom_columns:
 		key = (column.get("doctype"), column.get("fieldname"))
 		if key in custom_column_data:
 			for row in result:
-				row_reference = row.get(column.get("link_field").get("fieldname"))
+				link_field = column.get("link_field")
+
+				# backwards compatibile `link_field`
+				# old custom reports which use `str` should not break.
+				if type(link_field) == str:
+					link_field = frappe._dict({"fieldname": link_field, "names": []})
+
+				row_reference = row.get(link_field.get("fieldname"))
 				# possible if the row is empty
 				if not row_reference:
 					continue
@@ -466,19 +473,30 @@ def get_data_for_custom_field(doctype, field, names=None):
 
 	filters = {}
 	if names:
-		filters.update({"name": ["in", json.loads(names)]})
+		if type(names) in [str, bytearray]:
+			names = frappe.json.loads(names)
+		filters.update({"name": ["in", names]})
 
 	return frappe._dict(frappe.get_list(doctype, filters=filters, fields=["name", field], as_list=1))
 
 
-def get_data_for_custom_report(columns):
+def get_data_for_custom_report(columns, result):
 	doc_field_value_map = {}
 
 	for column in columns:
-		if column.get("link_field"):
-			fieldname = column.get("fieldname")
-			doctype = column.get("doctype")
-			doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(doctype, fieldname)
+		# backwards compatibile `link_field`
+		# old custom reports which use `str` should not break
+		link_field = column.get("link_field")
+		if type(link_field) == str:
+			link_field = frappe._dict({"fieldname": link_field, "names": []})
+
+		fieldname = column.get("fieldname")
+		doctype = column.get("doctype")
+
+		row_key = link_field.get("fieldname")
+		names = list({row[row_key] for row in result}) or None
+
+		doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(doctype, fieldname, names)
 
 	return doc_field_value_map
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -233,7 +233,7 @@ def add_custom_column_data(custom_columns, result):
 
 				# backwards compatibile `link_field`
 				# old custom reports which use `str` should not break.
-				if type(link_field) == str:
+				if isinstance(link_field, str):
 					link_field = frappe._dict({"fieldname": link_field, "names": []})
 
 				row_reference = row.get(link_field.get("fieldname"))
@@ -473,7 +473,7 @@ def get_data_for_custom_field(doctype, field, names=None):
 
 	filters = {}
 	if names:
-		if type(names) in [str, bytearray]:
+		if isinstance(names, (str, bytearray)):
 			names = frappe.json.loads(names)
 		filters.update({"name": ["in", names]})
 
@@ -487,7 +487,7 @@ def get_data_for_custom_report(columns, result):
 		# backwards compatibile `link_field`
 		# old custom reports which use `str` should not break
 		link_field = column.get("link_field")
-		if type(link_field) == str:
+		if isinstance(link_field, str):
 			link_field = frappe._dict({"fieldname": link_field, "names": []})
 
 		fieldname = column.get("fieldname")


### PR DESCRIPTION
regression: https://github.com/frappe/frappe/pull/22133

TypeError: <img width="1411" alt="Screenshot 2023-08-29 at 4 48 51 PM" src="https://github.com/frappe/frappe/assets/3272205/f4bf13bf-4cd7-496a-9ae1-7a42ff357152">

Additionally, the `name` based filter was only working while a new column is added. It wasn't being used on already saved custom reports. Addressed that as well.