### PR TITLE
fix: show progress in doc only

### DIFF
--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -60,11 +60,11 @@ def publish_realtime(
 			if "task_id" not in message:
 				message["task_id"] = task_id
 			room = get_task_progress_room(task_id)
+		elif doctype and docname:
+			room = get_doc_room(doctype, docname)
 		elif user:
 			# transmit to specific user: System, Website or Guest
 			room = get_user_room(user)
-		elif doctype and docname:
-			room = get_doc_room(doctype, docname)
 		else:
 			# This will be broadcasted to all Desk users
 			room = get_site_room()


### PR DESCRIPTION
### Problem

```python
from frappe.realtime import publish_progress

publish_progress(percent=50, title="Progress", doctype="User", docname="Administrator")
```

With above code, you'd assume that the progress bar would only be shown on the `/app/user/Administrator` document. However, it is getting displayed on all open tabs of the user.

### Cause

`publish_progress` always passes the current user to `publish_realtime`. If a user is set, we always use the user's room. So the `doctype` and `docname` parameters have no effect.

### Possible solutions

a) Swap the conditions, so that we preferentially publish to the document room, if available, and fall back to user room, if not. (this PR)
b) Pass user parameter only if `doctype and docname` is false (https://github.com/frappe/frappe/pull/22256)

### Workaround

Implement your own version of `publish_progress`, calling `publish_realtime` without the user parameter (https://github.com/alyf-de/erpnext_pdf-on-submit/commit/9932ea87f3f2209989d57eb251db7e6c1db792ed)