### PR TITLE
fix: when tree doctype is created ignore_user_permissions is set to 1 by default

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -936,6 +936,7 @@ class DocType(Document):
 				"fieldtype": "Link",
 				"options": self.name,
 				"fieldname": parent_field_name,
+				"ignore_user_permissions": 1,
 			},
 		)
 		self.nsm_parent_field = parent_field_name

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -175,6 +175,11 @@ class TestUserPermission(FrappeTestCase):
 		self.assertTrue(has_user_permission(frappe.get_doc("Person", parent_record.name), user.name))
 		self.assertTrue(has_user_permission(frappe.get_doc("Person", child_record.name), user.name))
 
+		frappe.set_user(user.name)
+		visible_names = frappe.get_list(
+			doctype="Person",
+			pluck="person_name",
+		)
 		frappe.db.set_value(
 			"User Permission", {"allow": "Person", "for_value": parent_record.name}, "hide_descendants", 1
 		)
@@ -184,6 +189,14 @@ class TestUserPermission(FrappeTestCase):
 		# hides child records
 		self.assertTrue(has_user_permission(frappe.get_doc("Person", parent_record.name), user.name))
 		self.assertFalse(has_user_permission(frappe.get_doc("Person", child_record.name), user.name))
+
+		visible_names_after_hide_descendants = frappe.get_list(
+			"Person",
+			pluck="person_name",
+		)
+		self.assertEqual(visible_names, ["Child", "Parent"])
+		self.assertEqual(visible_names_after_hide_descendants, ["Parent"])
+		frappe.set_user("Administrator")
 
 	def test_user_perm_on_new_doc_with_field_default(self):
 		"""Test User Perm impact on frappe.new_doc. with *field* default value"""

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -6,7 +6,7 @@ from frappe.core.doctype.user_permission.user_permission import (
 	add_user_permissions,
 	remove_applicable,
 )
-from frappe.permissions import has_user_permission
+from frappe.permissions import add_permission, has_user_permission
 from frappe.tests.utils import FrappeTestCase
 from frappe.website.doctype.blog_post.test_blog_post import make_test_blog
 
@@ -175,6 +175,8 @@ class TestUserPermission(FrappeTestCase):
 		self.assertTrue(has_user_permission(frappe.get_doc("Person", parent_record.name), user.name))
 		self.assertTrue(has_user_permission(frappe.get_doc("Person", child_record.name), user.name))
 
+		#  give access of Parent DocType to Blogger role
+		add_permission("Person", "Blogger")
 		frappe.set_user(user.name)
 		visible_names = frappe.get_list(
 			doctype="Person",

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -146,7 +146,7 @@ class TestUserPermission(FrappeTestCase):
 		"""Test if descendants' visibility is controlled for a nested DocType."""
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
-		user = create_user("nested_doc_user@example.com", "Blogger")
+		user = create_user("nested_doc_user@example.com")
 		if not frappe.db.exists("DocType", "Person"):
 			doc = new_doctype(
 				"Person",

--- a/frappe/core/doctype/user_permission/test_user_permission.py
+++ b/frappe/core/doctype/user_permission/test_user_permission.py
@@ -146,7 +146,7 @@ class TestUserPermission(FrappeTestCase):
 		"""Test if descendants' visibility is controlled for a nested DocType."""
 		from frappe.core.doctype.doctype.test_doctype import new_doctype
 
-		user = create_user("nested_doc_user@example.com")
+		user = create_user("nested_doc_user@example.com", "Blogger")
 		if not frappe.db.exists("DocType", "Person"):
 			doc = new_doctype(
 				"Person",
@@ -180,10 +180,12 @@ class TestUserPermission(FrappeTestCase):
 			doctype="Person",
 			pluck="person_name",
 		)
-		frappe.db.set_value(
-			"User Permission", {"allow": "Person", "for_value": parent_record.name}, "hide_descendants", 1
+
+		user_permission = frappe.get_doc(
+			"User Permission", {"allow": "Person", "for_value": parent_record.name}
 		)
-		frappe.cache.delete_value("user_permissions")
+		user_permission.hide_descendants = 1
+		user_permission.save(ignore_permissions=True)
 
 		# check if adding perm on a group record with hide_descendants enabled,
 		# hides child records


### PR DESCRIPTION
ignore_user_permission flag is checked by default to the parent_doctypename field when a new tree doctype is created.

Linked PR: [#36869](https://github.com/frappe/erpnext/pull/36869)