### PR TITLE
feat: show warning headline in public files

### DIFF
--- a/frappe/core/doctype/file/file.js
+++ b/frappe/core/doctype/file/file.js
@@ -5,6 +5,13 @@ frappe.ui.form.on("File", {
 			frm.add_custom_button(__("Download"), () => frm.trigger("download"), "fa fa-download");
 		}
 
+		if (!frm.doc.is_private) {
+			frm.dashboard.set_headline(
+				__("This file is public. It can be accessed without authentication."),
+				"orange"
+			);
+		}
+
 		frm.toggle_display("preview", false);
 
 		// preview different file types


### PR DESCRIPTION
It's quite easy to accidentally create lots of public files, which can become a security / confidentiality risk. This PR introduces a warning banner to make it absolutely clear to the user when a file is public and exposed to anyone on the network.

https://github.com/frappe/frappe/assets/14891507/d6f63ac6-e0a9-4f04-beb7-39ba6cf7b5c7

