### PR TITLE
feat: toggle file privacy from sidebar

### DIFF
--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -118,3 +118,11 @@ def zip_files(files: str):
 	frappe.response["filename"] = "files.zip"
 	frappe.response["filecontent"] = File.zip_files(files)
 	frappe.response["type"] = "download"
+
+
+@frappe.whitelist()
+def toggle_is_private(file_name: str):
+	"""Toggle is_private flag of file"""
+	file = frappe.get_doc("File", file_name)
+	file.is_private = not file.is_private
+	file.save()

--- a/frappe/public/js/frappe/form/sidebar/attachments.js
+++ b/frappe/public/js/frappe/form/sidebar/attachments.js
@@ -161,13 +161,35 @@ frappe.ui.form.Attachments = class Attachments {
 			};
 		}
 
-		const icon = `<a href="/app/file/${fileid}">
+		const icon = `<div class="file-privacy-icon" title="${__("Toggle file privacy")}">
 				${frappe.utils.icon(attachment.is_private ? "lock" : "unlock", "sm ml-0")}
-			</a>`;
+			</div>`;
 
-		$(`<li class="attachment-row">`)
+		const row = $(`<li class="attachment-row">`)
 			.append(frappe.get_data_pill(file_label, fileid, remove_action, icon))
 			.insertAfter(this.add_attachment_wrapper);
+
+		row.find(".file-privacy-icon").on("click", () => {
+			if (this.frm.is_dirty()) {
+				frappe.show_alert({
+					message: __("Please save the document before changing privacy settings."),
+					indicator: "orange",
+				});
+				return;
+			}
+
+			frappe.call({
+				method: "frappe.core.api.file.toggle_is_private",
+				args: {
+					file_name: attachment.name,
+				},
+				callback: (r) => {
+					if (!r.exc) {
+						this.frm.reload_doc();
+					}
+				},
+			});
+		});
 
 		this.parent.find(".explore-btn").toggle(true); // show explore icon button if hidden
 	}


### PR DESCRIPTION
- When you accidentally upload a file with the wrong privacy settings, it's hard to change that afterwards.
- #12864 made the lock icon point to the file document, so you could change the privacy settings there, before returning to the original form. I found this hard to discover (I only noticed it while working on this PR).
- This PR changes this behavior: clicking on the lock icon now toggles the privacy status. The current doc is reloaded, so that the icon and links reflect the change.

https://github.com/frappe/frappe/assets/14891507/45402420-bd70-4695-a818-023a15605264

> no-docs
(will add docs after merge)