### PR TITLE
fix: show progress in doc, if given

### DIFF
--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -13,7 +13,7 @@ def publish_progress(percent, title=None, doctype=None, docname=None, descriptio
 	publish_realtime(
 		"progress",
 		{"percent": percent, "title": title, "description": description},
-		user=frappe.session.user,
+		user=None if doctype and docname else frappe.session.user,
 		doctype=doctype,
 		docname=docname,
 	)


### PR DESCRIPTION
If doc is given, show progress in doc only. Else, show progress to the current user (in all tabs).

Alternative to https://github.com/frappe/frappe/pull/22234 (have a look there for the problem statement)

This PR is maybe less disruptive than the above, because it doesn't change the logic of the more general `publish_realtime`.