### PR TITLE
feat: communication: override `on_update`

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -273,6 +273,11 @@ class Communication(Document, CommunicationEmailMixin):
 		# comments count for the list view
 		update_comment_in_doc(self)
 
+		parent = get_parent_doc(self)
+		if hasattr(parent, "on_communication_update"):
+			parent.on_communication_update(self)
+			return
+
 		if self.comment_type != "Updated":
 			update_parent_document_on_communication(self)
 

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -274,7 +274,7 @@ class Communication(Document, CommunicationEmailMixin):
 		update_comment_in_doc(self)
 
 		parent = get_parent_doc(self)
-		if hasattr(parent, "on_communication_update"):
+		if (method := getattr(parent, "on_communication_update", None)) and callable(method):
 			parent.on_communication_update(self)
 			return
 


### PR DESCRIPTION
If reference doc has property, `on_communication_update`, execute it. Otherwise, continue with default/magic actions