### PR TITLE
chore: Switch to `pydantic.ConfigDict` in `typing_validations.py`

### DIFF
--- a/frappe/utils/typing_validations.py
+++ b/frappe/utils/typing_validations.py
@@ -4,6 +4,8 @@ from inspect import _empty, isclass, signature
 from types import EllipsisType
 from typing import ForwardRef, TypeVar, Union
 
+from pydantic import ConfigDict
+
 from frappe.exceptions import FrappeTypeError
 
 SLACK_DICT = {
@@ -12,8 +14,7 @@ SLACK_DICT = {
 T = TypeVar("T")
 
 
-class FrappePydanticConfig:
-	arbitrary_types_allowed = True
+FrappePydanticConfig = ConfigDict(arbitrary_types_allowed=True)
 
 
 def validate_argument_types(func: Callable, apply_condition: Callable = lambda: True):


### PR DESCRIPTION
Fixes the following deprecation notice:

> **PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.0/migration/**


<sub>no-docs</sub>