### PR TITLE
fix: attribute error on old custom reports

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -484,21 +484,19 @@ def get_data_for_custom_report(columns, result):
 	doc_field_value_map = {}
 
 	for column in columns:
-		# backwards compatibile `link_field`
-		# old custom reports which use `str` should not break
-		link_field = column.get("link_field")
-		if isinstance(link_field, str):
-			link_field = frappe._dict({"fieldname": link_field, "names": []})
+		if link_field := column.get("link_field"):
+			# backwards compatibile `link_field`
+			# old custom reports which use `str` should not break
+			if isinstance(link_field, str):
+				link_field = frappe._dict({"fieldname": link_field, "names": []})
 
-		fieldname = column.get("fieldname")
-		doctype = column.get("doctype")
+			fieldname = column.get("fieldname")
+			doctype = column.get("doctype")
 
-		names = None
-		if link_field:
 			row_key = link_field.get("fieldname")
 			names = list({row[row_key] for row in result}) or None
 
-		doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(doctype, fieldname, names)
+			doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(doctype, fieldname, names)
 
 	return doc_field_value_map
 


### PR DESCRIPTION
Assuming `link_field`\'s availability causes downstream fetch logic for custom column data to throw error in old custom reports. Modified the fetch logic to only try iff `link_field` is set. This is the same approach as pre-[performance fix](https://github.com/frappe/frappe/pull/22231/files) . 

<img width="731" alt="Screenshot 2023-09-02 at 9 20 03 AM" src="https://github.com/frappe/frappe/assets/3272205/85b79c4c-d5ba-45fb-a32a-211eeab8fb93">


regression: https://github.com/frappe/frappe/pull/22231