### PR TITLE
fix(Email Inline Embed): Unescape embed path

### DIFF
--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -509,9 +509,10 @@ def replace_filename_with_cid(message):
 
 		# found match
 		img_path = groups[0]
-		filename = img_path.rsplit("/")[-1]
+		img_path_escaped = frappe.utils.html_utils.unescape_html(img_path)
+		filename = img_path_escaped.rsplit("/")[-1]
 
-		filecontent = get_filecontent_from_path(img_path)
+		filecontent = get_filecontent_from_path(img_path_escaped)
 		if not filecontent:
 			message = re.sub(f"""embed=['"]{re.escape(img_path)}['"]""", "", message)
 			continue


### PR DESCRIPTION
- Email is HTML escaped by `Premailer`
- Image paths are escaped like embed="test-&amp;-test.jpg"
- System is unable to load the invalid escaped file path

Solution: unescape the file path