### PR TITLE
fix: align base template to socketio port default 9000

### DIFF
--- a/frappe/templates/base.html
+++ b/frappe/templates/base.html
@@ -41,7 +41,7 @@
 			frappe.ready_events.push(fn);
 		}
 		window.dev_server = {{ dev_server }};
-		window.socketio_port = {{ (frappe.socketio_port or 'null') }};
+		window.socketio_port = {{ (frappe.socketio_port or 9000) }};
 		window.show_language_picker = {{ show_language_picker or 'false' }};
 	</script>
 </head>


### PR DESCRIPTION
follow/fixup up on #22277

