### PR TITLE
fix: don't reset checkbox value on save in case of fetch_if_empty

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -784,7 +784,9 @@ class BaseDocument:
 					_df
 					for _df in self.meta.get_fields_to_fetch(df.fieldname)
 					if not _df.get("fetch_if_empty")
-					or (_df.get("fetch_if_empty") and not self.get(_df.fieldname))
+					or (
+						_df.get("fetch_if_empty") and not self.get(_df.fieldname) and _df.get("fieldtype") != "Check"
+					)
 				]
 				if not frappe.get_meta(doctype).get("is_virtual"):
 					if not fields_to_fetch:


### PR DESCRIPTION
Problem:

I have a `Loan` doctype with a `Repay From Salary` check field. I have a `Loan Repayment` doctype and it has a `Against Loan` link field (linked to a `Loan` doc) and a `Repay From Salary` check field (which fetches from the `Repay From Salary` check field of the `Loan` in `Against Loan` link field). `fetch_if_empty` is set for the `Repay From Salary` check field since I want to let the user edit the box if needed.

Now, consider the `Repay From Salary` check field of a `Loan` is checked. The user tries to create a `Loan Repayment` corresponding to the `Loan` and unchecks the field, but it gets checked back on save.

Currently if the system finds a unchecked checkbox, it considers the checkbox as unset hence it sets the `fetch_from` value of the checkbox on save, which is incorrect. 

Solution:

Now, the system won't consider unchecked checkboxes as unset, hence won't set the `fetch_from` value on save.