### PR TITLE
fix: Fix email subject decoding

### DIFF
--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -606,6 +606,20 @@ class TestInboundMail(FrappeTestCase):
 		reference_doc = inbound_mail.reference_document()
 		self.assertEqual(todo.name, reference_doc.name)
 
+	def test_reference_document_by_subject_match_with_accents(self):
+		subject = "Nouvelle tâche à faire 😃"
+		todo = self.new_todo(sender="test_sender@example.com", description=subject)
+
+		mail_content = (
+			self.get_test_mail(fname="incoming-subject-placeholder.raw")
+			.replace("{{ subject }}", f"RE: {subject}")
+			.encode("utf-8")
+		)  # note: encode to bytes because that's what triggered the error
+		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
+		inbound_mail = InboundMail(mail_content, email_account, 12345, 1)
+		reference_doc = inbound_mail.reference_document()
+		self.assertEqual(todo.name, reference_doc.name)
+
 	def test_create_communication_from_mail(self):
 		# Create email queue record
 		mail_content = self.get_test_mail(fname="incoming-2.raw")

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -412,6 +412,9 @@ class Email:
 			# assume that the encoding is utf-8
 			self.subject = safe_decode(self.subject)[:140]
 
+		if isinstance(self.subject, bytes):
+			self.subject = self.subject.decode("utf8", "replace")  # last resort
+
 		if not self.subject:
 			self.subject = "No Subject"
 


### PR DESCRIPTION
I noticed that I sometimes had _Unhandled Emails_ when receiving support emails sent directly from the desk. I quickly understood that to be the fault of accented characters present in the subject email.

For some reason it's not encoded (sent as UTF-8 bytes?), and decode_headers thinks that the Subject header is encoded with `unknown-8bit` encoding. This means that the safe_decode("...", "unknown-8bit") silently fails, which means that self.subject remains a `bytes` object, causing the following error:

```python
TypeError: a bytes-like object is required, not 'str'

# frappe/email/doctype/email_account/email_account.py in receive
    communication = mail.process()
# frappe/email/receive.py in process
    return self._build_communication_doc()
# frappe/email/receive.py in _build_communication_doc
    if self.reference_document():
# frappe/email/receive.py in reference_document
    reference_document = self.match_record_by_subject_and_sender(self.email_account.append_to)
# frappe/email/receive.py in match_record_by_subject_and_sender
    name = self.get_reference_name_from_subject()
# frappe/email/receive.py in get_reference_name_from_subject
    return self.subject.rsplit("#", 1)[-1].strip(" ()")
#               ^~~~~~~ self.subject is a bytes object, so rsplit expects a bytes object too
#                     > but self.subject should have been a str in the first place
```

> no-docs