### PR TITLE
fix: + btn not appearing for connections with both internal and external links

### DIFF
--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -270,7 +270,9 @@ def get_open_count(doctype, name, items=None):
 	}
 
 	for d in items:
-		internal_link_for_doctype = links.get("internal_links", {}).get(d)
+		internal_link_for_doctype = links.get("internal_links", {}).get(d) or links.get(
+			"internal_and_external_links", {}
+		).get(d)
 		if internal_link_for_doctype:
 			internal_links_data_for_d = get_internal_links(doc, internal_link_for_doctype, d)
 			if internal_links_data_for_d["count"]:

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -249,6 +249,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		this.data = this.frm.meta.__dashboard || {};
 		if (!this.data.transactions) this.data.transactions = [];
 		if (!this.data.internal_links) this.data.internal_links = {};
+		if (!this.data.internal_and_external_links) this.data.internal_and_external_links = {};
 		this.filter_permissions();
 	}
 

--- a/frappe/tests/test_dashboard_connections.py
+++ b/frappe/tests/test_dashboard_connections.py
@@ -252,7 +252,7 @@ def get_dashboard_for_test_doctype_a_with_test_child_table_with_link_to_doctype_
 
 	data = {
 		"fieldname": "test_doctype_a_with_test_child_table_with_link_to_doctype_b",
-		"internal_links": {
+		"internal_and_external_links": {
 			"Test Doctype B With Child Table With Link To Doctype A": [
 				"child_table",
 				"test_doctype_b_with_test_child_table_with_link_to_doctype_a",
@@ -264,7 +264,7 @@ def get_dashboard_for_test_doctype_a_with_test_child_table_with_link_to_doctype_
 	}
 
 	dashboard.fieldname = data["fieldname"]
-	dashboard.internal_links = data["internal_links"]
+	dashboard.internal_and_external_links = data["internal_and_external_links"]
 	dashboard.transactions = data["transactions"]
 
 	return dashboard


### PR DESCRIPTION
For better clarity for devs, I'm allowing a new `internal_and_external_links` in `<doctype>_dashboard.py` for connections with both internal and external links. That also fixes the problem of the + btn not appearing for connections with both internal and external links ([example](https://github.com/frappe/erpnext/pull/36980)) because of [this](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/templates/form_links.html#L20) condition.

Docs: https://frappeframework.com/docs/user/en/basics/doctypes/actions-and-links#via-script