### PR TITLE
fix: key error on link_field 

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -494,7 +494,11 @@ def get_data_for_custom_report(columns, result):
 			doctype = column.get("doctype")
 
 			row_key = link_field.get("fieldname")
-			names = list({row[row_key] for row in result}) or None
+			names = []
+			for row in result:
+				if row.get(row_key):
+					names.append(row.get(row_key))
+			names = list(set(names))
 
 			doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(doctype, fieldname, names)
 


### PR DESCRIPTION
```
 File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1622, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 802, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 232, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 802, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 114, in generate_report_result
    result = add_custom_column_data(report_custom_columns, result)
  File "apps/frappe/frappe/desk/query_report.py", line 244, in add_custom_column_data
    custom_column_data = get_data_for_custom_report(custom_columns, result)
  File "apps/frappe/frappe/desk/query_report.py", line 514, in get_data_for_custom_report
    names = list({row[row_key] for row in result}) or None
  File "apps/frappe/frappe/desk/query_report.py", line 514, in <setcomp>
    names = list({row[row_key] for row in result}) or None
KeyError: 'supplier'
```