### PR TITLE
fix: convert value column to `longtext` for Singles

### DIFF
--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -267,7 +267,7 @@ DROP TABLE IF EXISTS `tabSingles`;
 CREATE TABLE `tabSingles` (
   `doctype` varchar(255) DEFAULT NULL,
   `field` varchar(255) DEFAULT NULL,
-  `value` text,
+  `value` longtext,
   KEY `singles_doctype_field_index` (`doctype`, `field`)
 ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC CHARACTER SET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -195,6 +195,7 @@ frappe.patches.v15_0.remove_event_streaming
 frappe.patches.v15_0.copy_disable_prepared_report_to_prepared_report
 execute:frappe.reload_doc("desk", "doctype", "Form Tour")
 execute:frappe.delete_doc('Page', 'recorder', ignore_missing=True, force=True)
+frappe.patches.v14_0.modify_value_column_size_for_singles
 
 [post_model_sync]
 execute:frappe.get_doc('Role', 'Guest').save() # remove desk access

--- a/frappe/patches/v14_0/modify_value_column_size_for_singles.py
+++ b/frappe/patches/v14_0/modify_value_column_size_for_singles.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+	if frappe.db.db_type == "mariadb":
+		frappe.db.sql_ddl("alter table `tabSingles` modify column `value` longtext")


### PR DESCRIPTION
Allow usage of fields like JSON, HTML, Long Text, etc. in a single DocType.

Added storage overhead is very minimal (2 bytes per value stored):
https://dev.mysql.com/doc/refman/8.0/en/storage-requirements.html#data-types-storage-reqs-strings
https://stackoverflow.com/a/58226874

`no-docs`