### PR TITLE
fix: Ensure Google Calendar `scopes` is a list

### DIFF
--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -214,7 +214,7 @@ def get_google_calendar_object(g_calendar):
 		"token_uri": GoogleOAuth.OAUTH_URL,
 		"client_id": google_settings.client_id,
 		"client_secret": google_settings.get_password(fieldname="client_secret", raise_exception=False),
-		"scopes": "https://www.googleapis.com/auth/calendar/v3",
+		"scopes": ["https://www.googleapis.com/auth/calendar/v3"],
 	}
 
 	credentials = google.oauth2.credentials.Credentials(**credentials_dict)


### PR DESCRIPTION
As per the documentation/source code of `google.oauth2.credentials.Credentials`:
```
            scopes (Sequence[str]): The scopes used to obtain authorization.
                This parameter is used by :meth:`has_scopes`. OAuth 2.0
                credentials can not request additional scopes after
                authorization. The scopes must be derivable from the refresh
                token if refresh information is provided (e.g. The refresh
                token scopes are a superset of this or contain a wild card
                scope like 'https://www.googleapis.com/auth/any-api').
```

> **[google/oauth2/credentials.py:103](https://github.com/googleapis/google-auth-library-python/blob/8b8fce6a1e1ca6e0199cb5f15a90af477bf1c853/google/oauth2/credentials.py#L103-L109)**

### Error returned by the google apiAPI
```json
{
	"exception": "google.auth.exceptions.RefreshError: ('invalid_scope: Some requested scopes were invalid. {invalid=[a, c, d, e, g, h, i, l, m, ., n, /, o, p, r, s, 3, t, u, v, w, :]}', {'error': 'invalid_scope', 'error_description': 'Some requested scopes were invalid. {invalid=[a, c, d, e, g, h, i, l, m, ., n, /, o, p, r, s, 3, t, u, v, w, :]}', 'error_uri': '[https://developers.google.com/identity/protocols/oauth2'}](https://developers.google.com/identity/protocols/oauth2'%7D))"
}
```

> no-docs