### PR TITLE
fix(UX): Responsive, column-major design for multicheck elements

### DIFF
--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -14,10 +14,13 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 		this.$select_buttons = this.get_select_buttons().appendTo(this.wrapper);
 		this.$load_state.appendTo(this.wrapper);
 
-		const row = this.get_column_size() === 12 ? "" : "row";
-		this.$checkbox_area = $(`<div class="checkbox-options ${row}"></div>`).appendTo(
-			this.wrapper
-		);
+		// In your implementation, you may use the 'columns' property to specify either of:
+		// - minimum column width, e.g. `"15rem"`
+		// - fixed number of columns, e.g. `3`
+		// - both minimum column width and maximum number of columns, e.g. `"15rem 5"`
+		const columns = this.df.columns;
+		this.$checkbox_area = $('<div class="checkbox-options"></div>').appendTo(this.wrapper);
+		this.$checkbox_area.get(0).style.setProperty("--checkbox-options-columns", columns);
 	}
 
 	refresh() {
@@ -145,9 +148,8 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	}
 
 	get_checkbox_element(option) {
-		const column_size = this.get_column_size();
 		return $(`
-			<div class="checkbox unit-checkbox col-sm-${column_size}">
+			<div class="checkbox unit-checkbox">
 				<label title="${option.description || ""}">
 					<input type="checkbox" data-unit="${option.value}"></input>
 					<span class="label-area" data-unit="${option.value}">${__(option.label)}</span>
@@ -167,9 +169,5 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 			</button>
 		</div>
 		`);
-	}
-
-	get_column_size() {
-		return 12 / (+this.df.columns || 1);
 	}
 };

--- a/frappe/public/js/frappe/module_editor.js
+++ b/frappe/public/js/frappe/module_editor.js
@@ -9,7 +9,7 @@ frappe.ModuleEditor = class ModuleEditor {
 				fieldname: "block_modules",
 				fieldtype: "MultiCheck",
 				select_all: true,
-				columns: 3,
+				columns: "15rem",
 				get_data: () => {
 					return this.frm.doc.__onload.all_modules.map((module) => {
 						return {

--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -10,7 +10,7 @@ frappe.RoleEditor = class {
 				fieldname: "roles",
 				fieldtype: "MultiCheck",
 				select_all: true,
-				columns: 3,
+				columns: "15rem",
 				get_data: () => {
 					return frappe
 						.xcall("frappe.core.doctype.user.user.get_all_roles")

--- a/frappe/templates/styles/standard.css
+++ b/frappe/templates/styles/standard.css
@@ -78,6 +78,10 @@
 	margin: 20px 0px;
 }
 
+.checkbox-options {
+	columns: var(--checkbox-options-columns);
+}
+
 .square-image {
 	width: 100%;
 	height: 0;


### PR DESCRIPTION
Before (multicheck item order jumping columns):
![IMG_1396](https://github.com/frappe/frappe/assets/46800703/c33da0e6-d0d2-4b13-ba36-27d80787a12d)

After (multicheck items following column):
![IMG_1395](https://github.com/frappe/frappe/assets/46800703/0abf0bb2-a60e-46ef-993d-fe42accb289c)

Fixes frappe/frappe#22360
