### PR TITLE
feat: Allow plural DocType forms in Awesomebar

### DIFF
--- a/cypress/integration/awesome_bar.js
+++ b/cypress/integration/awesome_bar.js
@@ -21,9 +21,18 @@ context("Awesome Bar", () => {
 	});
 
 	it("navigates to doctype list", () => {
+		// Entering singular to see if 'List' option comes first and 'New' option is present.
 		cy.get("@awesome_bar").type("todo");
 		cy.wait(100); // Wait a bit before hitting enter.
 		cy.get(".awesomplete").findByRole("listbox").should("be.visible");
+		cy.get('ul[id="awesomplete_list_1"] li').first().contains("ToDo List");
+		cy.get('ul[id="awesomplete_list_1"] li').contains("New ToDo");
+		// Add plural "s" to see if 'List' still comes first, while 'New' is gone.
+		cy.get("@awesome_bar").type("s");
+		cy.wait(100);
+		cy.get('ul[id="awesomplete_list_1"] li').first().contains("ToDos List");
+		cy.get('ul[id="awesomplete_list_1"] li').contains("New ToDo").should("not.exist");
+		// Now hit enter to open the ToDo List and see if it's there.
 		cy.get("@awesome_bar").type("{enter}");
 		cy.get(".title-text").should("contain", "To Do");
 		cy.location("pathname").should("eq", "/app/todo");

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -560,6 +560,18 @@ frappe.search.utils = {
 		];
 	},
 
+	match_doctype_singular_plural: function (key, doctype) {
+		const singular_match = this.fuzzy_search(key, doctype, true);
+		const plural_doctype = doctype.plural();
+		const plural_match = this.fuzzy_search(key, plural_doctype, true);
+
+		if (plural_match.score > singular_match.score) {
+			return { key, item: plural_doctype, ...plural_match };
+		} else {
+			return { key, item: doctype, ...singular_match };
+		}
+	},
+
 	fuzzy_search: function (keywords = "", _item = "", return_marked_string = false) {
 		const item = __(_item);
 

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -113,22 +113,22 @@ frappe.search.utils = {
 	get_search_in_list: function (keywords) {
 		var me = this;
 		var out = [];
-		if (in_list(keywords.split(" "), "in") && keywords.slice(-2) !== "in") {
-			var parts = keywords.split(" in ");
-			frappe.boot.user.can_read.forEach(function (item) {
-				if (frappe.boot.user.can_search.includes(item)) {
-					const search_result = me.fuzzy_search(parts[1], item, true);
-					if (search_result.score) {
+		if (keywords.includes(" in ") && !keywords.trim().endsWith(" in")) {
+			const [key_val, key_dt] = keywords.split(" in ");
+			frappe.boot.user.can_read.forEach(function (doctype) {
+				if (frappe.boot.user.can_search.includes(doctype)) {
+					const match_result = me.match_doctype_singular_plural(key_dt, doctype);
+					if (match_result.score) {
 						out.push({
 							type: "In List",
 							label: __("Find {0} in {1}", [
-								__(parts[0]),
-								search_result.marked_string,
+								__(key_val),
+								match_result.marked_string,
 							]),
-							value: __("Find {0} in {1}", [__(parts[0]), __(item)]),
-							route_options: { name: ["like", "%" + parts[0] + "%"] },
-							index: 1 + search_result.score,
-							route: ["List", item],
+							value: __("Find {0} in {1}", [__(key_val), __(doctype)]),
+							route_options: { name: ["like", "%" + key_val + "%"] },
+							index: 1 + match_result.score,
+							route: ["List", doctype],
 						});
 					}
 				}


### PR DESCRIPTION
Fixes #22216.

1. Previous behaviour when entering the doctype in singular remains unchanged for English as well as for translated languages.

2. Standard case plural “customers” => 1st item is “Customer List”
![IMG_2208](https://github.com/frappe/frappe/assets/46800703/ae0e9ec2-a756-4d17-9d22-999d56faf0ab)

3. Various irregular plural forms (w/ custom doctypes “Child”, “Invoice Child”, “Fisherman”, and “Index”):
![IMG_2209](https://github.com/frappe/frappe/assets/46800703/c5f46f73-c98d-4768-9b1e-755aaffbe68b)
![IMG_2210](https://github.com/frappe/frappe/assets/46800703/c7b58039-235e-478a-8aae-9e33f40dc4ca)
![IMG_2211](https://github.com/frappe/frappe/assets/46800703/cc7751a3-1981-4c63-83c3-e98eb552f787)

=> Works fine in English.

Also works fine in translated languages:

4. German (w/ added translation: “Customers”: “Kunden”):
![IMG_2212](https://github.com/frappe/frappe/assets/46800703/6e31bbb8-68af-4d69-aac6-00e319c464eb)

5. Spanish (w/ added translation: “Customers”: “Clientes”):
![IMG_2213](https://github.com/frappe/frappe/assets/46800703/fd8c2e64-afa3-4267-8def-298d7066ac86)

`no-docs`