### PR TITLE
build(deps): Bump frappe-datatable to 1.17.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,9 +1404,9 @@ frappe-charts@2.0.0-rc22:
   integrity sha512-N7f/8979wJCKjusOinaUYfMxB80YnfuVLrSkjpj4LtyqS0BGS6SuJxUnb7Jl4RWUFEIs7zEhideIKnyLeFZF4Q==
 
 frappe-datatable@^1.17.2:
-  version "1.17.2"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.2.tgz#8c717bd40541b8ad0db871e129dc02cff4290df0"
-  integrity sha512-Jk8/3860Zya7Si2cZYEjVj0Gfy7CqhPx/rVZCg2fZ1+NlaOvBsey/zFEIe2yWak8PiJ1Fw9VgOevKOoZ/ckmsw==
+  version "1.17.3"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.3.tgz#f486a0de2e977f0fe57aa65b6cc1bc2c05f94172"
+  integrity sha512-HUBwogmsExglXbBFvHnzRssHGnJlsVXv6/7KhVbdh1y3S8JH4YoRQ6q1SOaW8escTuAa2d91OVe5uJ10IbGrlA==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
Fixes: https://github.com/frappe/datatable/pull/176
