### PR TITLE
fix: Check the truthy value of the returned array by adding the length property

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -301,7 +301,7 @@ frappe.ui.form.on("User", {
 				email: frm.doc.email,
 			},
 			callback: function (r) {
-				if (!Array.isArray(r.message)) {
+				if (!Array.isArray(r.message) || !r.message.length) {
 					frappe.route_options = {
 						email_id: frm.doc.email,
 						awaiting_password: 1,


### PR DESCRIPTION
Solves this

" TypeError: Cannot read properties of undefined (reading 'name')
    at Object.callback (user__js:324:60)
    at Object.t [as success_callback] (request.js:85:16)
    at 200 (request.js:128:34)
    at Object.<anonymous> (request.js:294:6)
    at I (jquery.js:3213:31)
    at Object.fireWith [as resolveWith] (jquery.js:3343:7)
    at en (jquery.js:9617:14)
    at XMLHttpRequest.<anonymous> (jquery.js:9878:9) "
