### PR TITLE
Minor refactoring - remove unnecessary params

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -3,7 +3,7 @@ import os
 import frappe
 
 
-def setup_database(force, source_sql=None, verbose=False):
+def setup_database(source_sql=None, verbose=False):
 	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
 	root_conn.commit()
 	root_conn.sql("end")

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -123,7 +123,6 @@ def install_db(
 	verbose=True,
 	force=0,
 	site_config=None,
-	reinstall=False,
 	db_password=None,
 	db_type=None,
 	db_host=None,


### PR DESCRIPTION
Remove unnecessary 'force' parameter from 'setup_database' and eliminate unused 'reinstall' parameters from 'install_db'.