### PR TITLE
fix: getting workspace roles from doc instead from Has Role doctype

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -72,9 +72,7 @@ class Workspace:
 		"""Returns true if Has Role is not set or the user is allowed."""
 		from frappe.utils import has_common
 
-		allowed = [
-			d.role for d in frappe.get_all("Has Role", fields=["role"], filters={"parent": self.doc.name})
-		]
+		allowed = [d.role for d in self.doc.roles]
 
 		custom_roles = get_custom_allowed_roles("page", self.doc.name)
 		allowed.extend(custom_roles)


### PR DESCRIPTION
Workspace Roles were fetched from `Has Role` Doctype by using a filter `{ parent: doc_name }`, but a duplicate of it can exist which was causing this issue.