### PR TITLE
fix: nested custom reports filter not rendering

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -171,14 +171,14 @@ def get_script(report_name):
 		"html_format": html_format,
 		"execution_time": frappe.cache.hget("report_execution_time", report_name) or 0,
 		"filters": report.filters,
-		"custom_report_name": report.name if report.is_custom_report else None,
+		"custom_report_name": report.name if report.get("is_custom_report") else None,
 	}
 
 
 def get_reference_report(report):
-	reference_report = frappe.get_doc("Report", report.reference_report)
 	if report.report_type != "Custom Report":
 		return report
+	reference_report = frappe.get_doc("Report", report.reference_report)
 	return get_reference_report(reference_report)
 
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -25,8 +25,7 @@ def get_report_doc(report_name):
 
 	if doc.report_type == "Custom Report":
 		custom_report_doc = doc
-		reference_report = custom_report_doc.reference_report
-		doc = frappe.get_doc("Report", reference_report)
+		doc = get_reference_report(doc)
 		doc.custom_report = report_name
 		if custom_report_doc.json:
 			data = json.loads(custom_report_doc.json)
@@ -172,7 +171,15 @@ def get_script(report_name):
 		"html_format": html_format,
 		"execution_time": frappe.cache.hget("report_execution_time", report_name) or 0,
 		"filters": report.filters,
+		"custom_report_name": report.name if report.is_custom_report else None,
 	}
+
+
+def get_reference_report(report):
+	reference_report = frappe.get_doc("Report", report.reference_report)
+	if report.report_type != "Custom Report":
+		return report
+	return get_reference_report(reference_report)
 
 
 @frappe.whitelist()

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -414,7 +414,9 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					.then((settings) => {
 						frappe.dom.eval(settings.script || "");
 						frappe.after_ajax(() => {
-							this.report_settings = this.get_local_report_settings();
+							this.report_settings = this.get_local_report_settings(
+								settings.custom_report_name
+							);
 							this.report_settings.html_format = settings.html_format;
 							this.report_settings.execution_time = settings.execution_time || 0;
 							frappe.query_reports[this.report_name] = this.report_settings;
@@ -432,10 +434,12 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		});
 	}
 
-	get_local_report_settings() {
+	get_local_report_settings(custom_report_name) {
 		let report_script_name =
 			this.report_doc.report_type === "Custom Report"
-				? this.report_doc.reference_report
+				? custom_report_name
+					? custom_report_name
+					: this.report_doc.reference_report
 				: this.report_name;
 		return frappe.query_reports[report_script_name] || {};
 	}


### PR DESCRIPTION
Script Report: Item-wise Sales Register -> Filter is rendering ✅
Custom Report: Master Sheet Sept 2023 -> Filter is rendering ✅
Nested Custom Report: Master Sheet Sept 2023 v1 -> Filter is not rendering ❌

If a custom report (Master Sheet Sept 2023) is created using a script report (Item-wise Sales Register) the filter for the custom report gets rendered properly but if you create another custom report (Master Sheet Sept 2023 v1) using the custom report (Master Sheet Sept 2023) created before then the filter was not rendering

Before:
<img width="1309" alt="image" src="https://github.com/frappe/frappe/assets/30859809/5926b388-9580-44cd-a34e-1a9d8085df33">


After:
<img width="1309" alt="image" src="https://github.com/frappe/frappe/assets/30859809/b6ec52c4-c11d-4c82-8a22-8d853c2ee7ec">

