### PR TITLE
feat: max_file_size configurable from system settings

### DIFF
--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -84,7 +84,11 @@ def get_files_by_search_text(text: str) -> list[dict]:
 
 @frappe.whitelist(allow_guest=True)
 def get_max_file_size() -> int:
-	return cint(frappe.conf.get("max_file_size")) or 10485760
+	return (
+		cint(frappe.get_system_settings("max_file_size")) * 1024 * 1024
+		or cint(frappe.conf.get("max_file_size"))
+		or 25 * 1024 * 1024
+	)
 
 
 @frappe.whitelist()

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -659,10 +659,10 @@ class File(Document):
 		file_size = len(self._content or b"")
 
 		if file_size > max_file_size:
-			frappe.throw(
-				_("File size exceeded the maximum allowed size of {0} MB").format(max_file_size / 1048576),
-				exc=MaxFileSizeReachedError,
-			)
+			msg = _("File size exceeded the maximum allowed size of {0} MB").format(max_file_size / 1048576)
+			if frappe.has_permission("System Settings", "write"):
+				msg += ".<br>" + _("You can increase the limit from System Settings.")
+			frappe.throw(msg, exc=MaxFileSizeReachedError)
 
 		return file_size
 

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -81,7 +81,10 @@
   "disable_system_update_notification",
   "disable_change_log_notification",
   "telemetry_section",
-  "enable_telemetry"
+  "enable_telemetry",
+  "files_section",
+  "max_file_size",
+  "column_break_uqma"
  ],
  "fields": [
   {
@@ -571,12 +574,28 @@
    "fieldname": "force_web_capture_mode_for_uploads",
    "fieldtype": "Check",
    "label": "Force Web Capture Mode for Uploads"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "files_section",
+   "fieldtype": "Section Break",
+   "label": "Files"
+  },
+  {
+   "fieldname": "max_file_size",
+   "fieldtype": "Int",
+   "label": "Max File Size (MB)",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "column_break_uqma",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2023-08-31 20:19:07.181041",
+ "modified": "2023-09-13 12:49:32.309521",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -64,6 +64,7 @@ class SystemSettings(Document):
 		login_with_email_link_expiry: DF.Int
 		logout_on_password_reset: DF.Check
 		max_auto_email_report_per_user: DF.Int
+		max_file_size: DF.Int
 		minimum_password_score: DF.Literal["2", "3", "4"]
 		number_format: DF.Literal[
 			"#,###.##",


### PR DESCRIPTION


This was only configurable from site config which is hard to find for a lot of users.

Over time we can drop site config and only use system settings for this. 

Other changes:
- increase default max_file_size from 10MB to 25MB
- In validation message explain that it can be configured from system settings (if user can do it)