### PR TITLE
fix: Fix typo in meta_block.html

### DIFF
--- a/frappe/templates/includes/meta_block.html
+++ b/frappe/templates/includes/meta_block.html
@@ -2,7 +2,7 @@
 {%- for name in metatags %}
 {%- set content = metatags.get(name, '') -%}
 {%- if content -%}
-<meta {% if name.startswith('og:') %}property="{{ name }}" {% else %}name="{{ name }}"{% endif %} content="{{ content | striptags | escape }}">
+<meta {% if name.startswith('og:') %}property="{{ name }}"{% else %}name="{{ name }}"{% endif %} content="{{ content | striptags | escape }}">
 {%- endif -%}
 {%- endfor -%}
 {%- endif -%}


### PR DESCRIPTION
This broke the following unit test: test_webform_html_meta_is_added

> no-docs