### PR TITLE
refactor: force ipv4 localhost

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -408,7 +408,7 @@ def serve(
 		application = application_with_statics()
 
 	application.debug = True
-	application.config = {"SERVER_NAME": "localhost:8000"}
+	application.config = {"SERVER_NAME": "127.0.0.1:8000"}
 
 	log = logging.getLogger("werkzeug")
 	log.propagate = False

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1169,7 +1169,7 @@ def start_ngrok(context, bind_tls, use_default_authtoken):
 	port = frappe.conf.http_port or frappe.conf.webserver_port
 	tunnel = ngrok.connect(addr=str(port), host_header=site, bind_tls=bind_tls)
 	print(f"Public URL: {tunnel.public_url}")
-	print("Inspect logs at http://localhost:4040")
+	print("Inspect logs at http://127.0.0.1:4040")
 
 	ngrok_process = ngrok.get_ngrok_process()
 	try:

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -152,7 +152,7 @@ class EmailAccount(Document):
 			self.password = None
 
 		if not frappe.local.flags.in_install and not self.awaiting_password:
-			if validate_oauth or self.password or self.smtp_server in ("127.0.0.1", "localhost"):
+			if validate_oauth or self.password or self.smtp_server in ("127.0.0.1", "127.0.0.1"):
 				if self.enable_incoming:
 					self.get_incoming_server()
 					self.no_failed = 0

--- a/frappe/email/test_smtp.py
+++ b/frappe/email/test_smtp.py
@@ -73,7 +73,7 @@ def create_email_account(email_id, password, enable_outgoing, default_outgoing=0
 		"enable_incoming": 1,
 		"append_to": append_to,
 		"is_dummy_password": 1,
-		"smtp_server": "localhost",
+		"smtp_server": "127.0.0.1",
 		"use_imap": 0,
 	}
 

--- a/frappe/printing/doctype/network_printer_settings/network_printer_settings.py
+++ b/frappe/printing/doctype/network_printer_settings/network_printer_settings.py
@@ -20,7 +20,7 @@ class NetworkPrinterSettings(Document):
 		server_ip: DF.Data
 	# end: auto-generated types
 	@frappe.whitelist()
-	def get_printers_list(self, ip="localhost", port=631):
+	def get_printers_list(self, ip="127.0.0.1", port=631):
 		printer_list = []
 		try:
 			import cups

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -936,7 +936,7 @@ class TestTransactionManagement(FrappeTestCase):
 # Treat same DB as replica for tests, a separate connection will be opened
 class TestReplicaConnections(FrappeTestCase):
 	def test_switching_to_replica(self):
-		with patch.dict(frappe.local.conf, {"read_from_replica": 1, "replica_host": "localhost"}):
+		with patch.dict(frappe.local.conf, {"read_from_replica": 1, "replica_host": "127.0.0.1"}):
 
 			def db_id():
 				return id(frappe.local.db)

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -61,7 +61,7 @@ class TestOAuth20(FrappeRequestTestCase):
 
 		cls.form_header = {"content-type": "application/x-www-form-urlencoded"}
 		cls.scope = "all openid"
-		cls.redirect_uri = "http://localhost"
+		cls.redirect_uri = "http://127.0.0.1"
 
 		# Set Frappe server URL reqired for id_token generation
 		frappe_login_key: "SocialLoginKey" = frappe.new_doc("Social Login Key")
@@ -78,12 +78,12 @@ class TestOAuth20(FrappeRequestTestCase):
 			{
 				"app_name": "_Test OAuth Client",
 				"client_secret": "test_client_secret",
-				"default_redirect_uri": "http://localhost",
+				"default_redirect_uri": "http://127.0.0.1",
 				"docstatus": 0,
 				"doctype": "OAuth Client",
 				"grant_type": "Authorization Code",
 				"name": "test_client_id",
-				"redirect_uris": "http://localhost",
+				"redirect_uris": "http://127.0.0.1",
 				"response_type": "Code",
 				"scopes": "all openid",
 				"skip_authorization": 1,

--- a/frappe/tests/test_oauth20.py
+++ b/frappe/tests/test_oauth20.py
@@ -61,7 +61,7 @@ class TestOAuth20(FrappeRequestTestCase):
 
 		cls.form_header = {"content-type": "application/x-www-form-urlencoded"}
 		cls.scope = "all openid"
-		cls.redirect_uri = "http://127.0.0.1"
+		cls.redirect_uri = "http://localhost"
 
 		# Set Frappe server URL reqired for id_token generation
 		frappe_login_key: "SocialLoginKey" = frappe.new_doc("Social Login Key")
@@ -78,12 +78,12 @@ class TestOAuth20(FrappeRequestTestCase):
 			{
 				"app_name": "_Test OAuth Client",
 				"client_secret": "test_client_secret",
-				"default_redirect_uri": "http://127.0.0.1",
+				"default_redirect_uri": "http://localhost",
 				"docstatus": 0,
 				"doctype": "OAuth Client",
 				"grant_type": "Authorization Code",
 				"name": "test_client_id",
-				"redirect_uris": "http://127.0.0.1",
+				"redirect_uris": "http://localhost",
 				"response_type": "Code",
 				"scopes": "all openid",
 				"skip_authorization": 1,

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -31,7 +31,7 @@ class BackupGenerator:
 	"""
 	This class contains methods to perform On Demand Backup
 
-	To initialize, specify (db_name, user, password, db_file_name=None, db_host="localhost")
+	To initialize, specify (db_name, user, password, db_file_name=None, db_host="127.0.0.1")
 	If specifying db_file_name, also append ".sql.gz"
 	"""
 

--- a/frappe/utils/connections.py
+++ b/frappe/utils/connections.py
@@ -28,7 +28,7 @@ def is_open(scheme, hostname, port, timeout=10):
 def check_database():
 	config = get_conf()
 	db_type = config.get("db_type", "mariadb")
-	db_host = config.get("db_host", "localhost")
+	db_host = config.get("db_host", "127.0.0.1")
 	db_port = config.get("db_port", 3306 if db_type == "mariadb" else 5432)
 	return {db_type: is_open(db_type, db_host, db_port)}
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1592,7 +1592,7 @@ def get_url(uri: str | None = None, full_address: bool = False) -> str:
 			host_name = frappe.db.get_single_value("Website Settings", "subdomain")
 
 			if not host_name:
-				host_name = "http://localhost"
+				host_name = "http://127.0.0.1"
 
 	if host_name and not (host_name.startswith("http://") or host_name.startswith("https://")):
 		host_name = "http://" + host_name


### PR DESCRIPTION
Replacing `localhost` with `127.0.0.1` in the codebase; sometimes the name localhost force-resolves to ipv6
