### PR TITLE
fix!: Bind development server only to localhost

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -393,7 +393,13 @@ def sync_database(rollback: bool) -> bool:
 
 
 def serve(
-	port=8000, profile=False, no_reload=False, no_threading=False, site=None, sites_path="."
+	host=None,
+	port=8000,
+	profile=False,
+	no_reload=False,
+	no_threading=False,
+	site=None,
+	sites_path=".",
 ):
 	global application, _site, _sites_path
 	_site = site
@@ -418,7 +424,7 @@ def serve(
 		log.setLevel(logging.ERROR)
 
 	run_simple(
-		"0.0.0.0",
+		host,
 		int(port),
 		application,
 		exclude_patterns=["test_*"],

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -922,6 +922,7 @@ def run_ui_tests(
 
 
 @click.command("serve")
+@click.option("--host", default="127.0.0.1")
 @click.option("--port", default=8000)
 @click.option("--profile", is_flag=True, default=False)
 @click.option("--noreload", "no_reload", is_flag=True, default=False)
@@ -930,6 +931,7 @@ def run_ui_tests(
 @pass_context
 def serve(
 	context,
+	host="127.0.0.1",
 	port=None,
 	profile=False,
 	no_reload=False,
@@ -951,6 +953,7 @@ def serve(
 			no_threading = True
 			no_reload = True
 		frappe.app.serve(
+			host=host,
 			port=port,
 			profile=profile,
 			no_reload=no_reload,


### PR DESCRIPTION
Bind only to localhost, werkzeug server has debugger on and isn't secure enough to serve to public yet people keep running this in prod :facepalm:  

Change procfile like this to allow listening public IPs. 

```
web: bench serve --host=0.0.0.0
```