### PR TITLE
feat: `after_response` callback manager

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import functools
 import gc
 import logging
 import os
@@ -11,6 +12,7 @@ from werkzeug.local import LocalManager
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.shared_data import SharedDataMiddleware
 from werkzeug.wrappers import Request, Response
+from werkzeug.wsgi import ClosingIterator
 
 import frappe
 import frappe.api
@@ -22,7 +24,7 @@ import frappe.utils.response
 from frappe import _
 from frappe.auth import SAFE_HTTP_METHODS, UNSAFE_HTTP_METHODS, HTTPRequest
 from frappe.middlewares import StaticDataMiddleware
-from frappe.utils import cint, get_site_name, sanitize_html
+from frappe.utils import CallbackManager, cint, get_site_name, sanitize_html
 from frappe.utils.data import escape_html
 from frappe.utils.error import log_error_snapshot
 from frappe.website.serve import get_response
@@ -62,7 +64,22 @@ if frappe._tune_gc:
 # end: module pre-loading
 
 
-@local_manager.middleware
+def after_response_wrapper(app):
+	"""Wrap a WSGI application to call after_response hooks after we have responded.
+
+	This is done to reduce response time by deferring expensive tasks."""
+
+	@functools.wraps(app)
+	def application(environ, start_response):
+		return ClosingIterator(
+			app(environ, start_response),
+			[frappe.request.after_response.run, local_manager.cleanup],
+		)
+
+	return application
+
+
+@after_response_wrapper
 @Request.application
 def application(request: Request):
 	response = None
@@ -136,6 +153,8 @@ def run_after_request_hooks(request, response):
 
 def init_request(request):
 	frappe.local.request = request
+	frappe.local.request.after_response = CallbackManager()
+
 	frappe.local.is_ajax = frappe.get_request_header("X-Requested-With") == "XMLHttpRequest"
 
 	site = _site or request.headers.get("X-Frappe-Site-Name") or get_site_name(request.host)

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -137,8 +137,7 @@ def application(request: Request):
 
 		log_request(request, response)
 		process_response(response)
-		if frappe.db:
-			frappe.db.close()
+		frappe.request.after_response(lambda: frappe.db and frappe.db.close())
 
 	return response
 

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -258,15 +258,17 @@ def add_attachments(name: str, attachments: Iterable[str | dict]) -> None:
 
 @frappe.whitelist(allow_guest=True, methods=("GET",))
 def mark_email_as_seen(name: str = None):
+	frappe.request.after_response.add(lambda: _mark_email_as_seen(name))
+	frappe.response.update(frappe.utils.get_imaginary_pixel_response())
+
+
+def _mark_email_as_seen(name):
 	try:
 		update_communication_as_read(name)
-		frappe.db.commit()  # nosemgrep: this will be called in a GET request
-
 	except Exception:
 		frappe.log_error("Unable to mark as seen", None, "Communication", name)
 
-	finally:
-		frappe.response.update(frappe.utils.get_imaginary_pixel_response())
+	frappe.db.commit()  # nosemgrep: after_response requires explicit commit
 
 
 def update_communication_as_read(name):

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -419,12 +419,6 @@ before_request = [
 	"frappe.rate_limiter.apply",
 ]
 
-after_request = [
-	"frappe.rate_limiter.update",
-	"frappe.monitor.stop",
-	"frappe.recorder.dump",
-]
-
 # Background Job Hooks
 before_job = [
 	"frappe.monitor.start",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -418,7 +418,12 @@ before_request = [
 	"frappe.monitor.start",
 	"frappe.rate_limiter.apply",
 ]
-after_request = ["frappe.rate_limiter.update", "frappe.monitor.stop", "frappe.recorder.dump"]
+
+after_request = [
+	"frappe.rate_limiter.update",
+	"frappe.monitor.stop",
+	"frappe.recorder.dump",
+]
 
 # Background Job Hooks
 before_job = [

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -22,7 +22,7 @@ def start(transaction_type="request", method=None, kwargs=None):
 
 def stop(response=None):
 	if hasattr(frappe.local, "monitor"):
-		frappe.request.after_response(lambda: frappe.local.monitor.dump(response))
+		frappe.local.monitor.dump(response)
 
 
 def add_data_to_monitor(**kwargs) -> None:

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -22,7 +22,7 @@ def start(transaction_type="request", method=None, kwargs=None):
 
 def stop(response=None):
 	if hasattr(frappe.local, "monitor"):
-		frappe.local.monitor.dump(response)
+		frappe.request.after_response(lambda: frappe.local.monitor.dump(response))
 
 
 def add_data_to_monitor(**kwargs) -> None:

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -21,7 +21,7 @@ def apply():
 
 def update():
 	if hasattr(frappe.local, "rate_limiter"):
-		frappe.local.rate_limiter.update()
+		frappe.request.after_response(frappe.local.rate_limiter.update)
 
 
 def respond():

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -56,15 +56,14 @@ class RateLimiter:
 		raise frappe.TooManyRequestsError
 
 	def update(self):
+		self.record_request_end()
 		pipeline = frappe.cache.pipeline()
 		pipeline.incrby(self.key, self.duration)
 		pipeline.expire(self.key, self.window)
 		pipeline.execute()
 
 	def headers(self):
-		self.end = datetime.utcnow()
-		self.duration = int((self.end - self.start).total_seconds() * 1000000)
-
+		self.record_request_end()
 		headers = {
 			"X-RateLimit-Reset": self.reset,
 			"X-RateLimit-Limit": self.limit,
@@ -76,6 +75,12 @@ class RateLimiter:
 			headers["X-RateLimit-Used"] = self.duration
 
 		return headers
+
+	def record_request_end(self):
+		if self.end is not None:
+			return
+		self.end = datetime.utcnow()
+		self.duration = int((self.end - self.start).total_seconds() * 1000000)
 
 	def respond(self):
 		if self.rejected:

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -21,7 +21,7 @@ def apply():
 
 def update():
 	if hasattr(frappe.local, "rate_limiter"):
-		frappe.request.after_response(frappe.local.rate_limiter.update)
+		frappe.local.rate_limiter.update()
 
 
 def respond():
@@ -56,15 +56,15 @@ class RateLimiter:
 		raise frappe.TooManyRequestsError
 
 	def update(self):
-		self.end = datetime.utcnow()
-		self.duration = int((self.end - self.start).total_seconds() * 1000000)
-
 		pipeline = frappe.cache.pipeline()
 		pipeline.incrby(self.key, self.duration)
 		pipeline.expire(self.key, self.window)
 		pipeline.execute()
 
 	def headers(self):
+		self.end = datetime.utcnow()
+		self.duration = int((self.end - self.start).total_seconds() * 1000000)
+
 		headers = {
 			"X-RateLimit-Reset": self.reset,
 			"X-RateLimit-Limit": self.limit,


### PR DESCRIPTION
This allows us to defer "expensive" task like rate-limit/monitor after response has been sent.

This keeps the web worker blocked still but you receive response few ms faster.

Credit: @sagarvora for suggestion


Numbers: after_request hooks used to take 0.4ms on request, after this change they take 0.09ms. So this PR roughly defers 0.3ms of overhead if you have monitor and rate limit on (every site on FC):pinching_hand: :rocket: 