### PR TITLE
fix: avoid checkbox field in fetch logic if doc created/updated from client side

### DIFF
--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -13,14 +13,11 @@ from frappe.utils.telemetry import capture_doc
 
 
 @frappe.whitelist()
-def savedocs(doc, action, from_client=False):
+def savedocs(doc, action):
 	"""save / submit / update doclist"""
 	doc = frappe.get_doc(json.loads(doc))
 	capture_doc(doc, action)
 	set_local_name(doc)
-
-	if from_client:
-		doc.__from_client = True
 
 	# action
 	doc.docstatus = {

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -13,11 +13,14 @@ from frappe.utils.telemetry import capture_doc
 
 
 @frappe.whitelist()
-def savedocs(doc, action):
+def savedocs(doc, action, from_client=False):
 	"""save / submit / update doclist"""
 	doc = frappe.get_doc(json.loads(doc))
 	capture_doc(doc, action)
 	set_local_name(doc)
+
+	if from_client:
+		doc.__from_client = True
 
 	# action
 	doc.docstatus = {

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -773,7 +773,10 @@ class BaseDocument:
 					_df
 					for _df in self.meta.get_fields_to_fetch(df.fieldname)
 					if not _df.get("fetch_if_empty")
-					or (_df.get("fetch_if_empty") and not self.get(_df.fieldname))
+					or (
+						not self.get(_df.fieldname)
+						and (not self.get("__from_client") or _df.get("fieldtype") != "Check")
+					)
 				]
 				if not frappe.get_meta(doctype).get("is_virtual"):
 					if not fields_to_fetch:

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -20,9 +20,10 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 
 		$(frm.wrapper).addClass("validated-form");
 		if ((action !== "Save" || frm.is_dirty()) && check_mandatory()) {
+			frm.doc.__from_client = 1;
 			_call({
 				method: "frappe.desk.form.save.savedocs",
-				args: { doc: frm.doc, action: action, from_client: 1 },
+				args: { doc: frm.doc, action: action },
 				callback: function (r) {
 					$(document).trigger("save", [frm.doc]);
 					callback(r);

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -22,7 +22,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 		if ((action !== "Save" || frm.is_dirty()) && check_mandatory()) {
 			_call({
 				method: "frappe.desk.form.save.savedocs",
-				args: { doc: frm.doc, action: action },
+				args: { doc: frm.doc, action: action, from_client: 1 },
 				callback: function (r) {
 					$(document).trigger("save", [frm.doc]);
 					callback(r);


### PR DESCRIPTION
Old fix: https://github.com/frappe/frappe/pull/22306

In the above fix, whenever we create a doc using server script the fetched checkbox value was not fetching so added a flag `__from_client` to determine if doc is created or updated from client side or server side


Loan doc
<img width="1352" alt="image" src="https://github.com/frappe/frappe/assets/30859809/8ddc782f-3e2b-4372-b46c-19dd2b53e20e">

Before:

https://github.com/frappe/frappe/assets/30859809/934f0982-7bfc-481a-a545-fdf083499c7a

After:

https://github.com/frappe/frappe/assets/30859809/6ba50fb1-7fe2-4587-9587-8526ea9187f3

