### PR TITLE
fix: clash in fieldnames in report when adding new column

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -84,8 +84,8 @@ def generate_report_result(
 	columns, result, message, chart, report_summary, skip_total_row = ljust_list(res, 6)
 	columns = [get_column_as_dict(col) for col in (columns or [])]
 	report_column_names = [col["fieldname"] for col in columns]
-
 	# convert to list of dicts
+
 	result = normalize_result(result, columns)
 
 	if report.custom_columns:
@@ -101,6 +101,13 @@ def generate_report_result(
 	report_custom_columns = [
 		column for column in columns if column["fieldname"] not in report_column_names
 	]
+	# for column in report_custom_columns:
+	# 	column["fieldname"] = column["fieldname"].split("-")[0]
+
+	# for column in columns:
+	# 	if (len(column.get("fieldname").split("-")) > 1):
+	# 		print(column.get("fieldname"))
+	# 		column["fieldname"] = column["fieldname"].split("-")[0]
 
 	if report_custom_columns:
 		result = add_custom_column_data(report_custom_columns, result)
@@ -111,6 +118,7 @@ def generate_report_result(
 	if cint(report.add_total_row) and result and not skip_total_row:
 		result = add_total_row(result, columns, is_tree=is_tree, parent_field=parent_field)
 
+	# breakpoint()
 	return {
 		"result": result,
 		"columns": columns,
@@ -223,6 +231,9 @@ def run(
 
 
 def add_custom_column_data(custom_columns, result):
+	for column in custom_columns:
+		column["fieldname"] = column["fieldname"].split("-")[0]
+
 	custom_column_data = get_data_for_custom_report(custom_columns, result)
 
 	for column in custom_columns:
@@ -240,6 +251,9 @@ def add_custom_column_data(custom_columns, result):
 				# possible if the row is empty
 				if not row_reference:
 					continue
+
+				if custom_column_data.get(key).get(row_reference) is None:
+					column["fieldname"] = column.get("fieldname") + "-" + frappe.unscrub(key[0])
 				row[column.get("fieldname")] = custom_column_data.get(key).get(row_reference)
 
 	return result
@@ -501,7 +515,6 @@ def get_data_for_custom_report(columns, result):
 			names = list(set(names))
 
 			doc_field_value_map[(doctype, fieldname)] = get_data_for_custom_field(doctype, fieldname, names)
-
 	return doc_field_value_map
 
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -101,13 +101,6 @@ def generate_report_result(
 	report_custom_columns = [
 		column for column in columns if column["fieldname"] not in report_column_names
 	]
-	# for column in report_custom_columns:
-	# 	column["fieldname"] = column["fieldname"].split("-")[0]
-
-	# for column in columns:
-	# 	if (len(column.get("fieldname").split("-")) > 1):
-	# 		print(column.get("fieldname"))
-	# 		column["fieldname"] = column["fieldname"].split("-")[0]
 
 	if report_custom_columns:
 		result = add_custom_column_data(report_custom_columns, result)
@@ -118,7 +111,6 @@ def generate_report_result(
 	if cint(report.add_total_row) and result and not skip_total_row:
 		result = add_total_row(result, columns, is_tree=is_tree, parent_field=parent_field)
 
-	# breakpoint()
 	return {
 		"result": result,
 		"columns": columns,
@@ -231,7 +223,11 @@ def run(
 
 
 def add_custom_column_data(custom_columns, result):
+	doctype_name_from_custom_field = []
 	for column in custom_columns:
+		doctype_name_from_custom_field.append(frappe.unscrub(column["fieldname"].split("-")[1])) if len(
+			column["fieldname"].split("-")
+		) > 1 else None
 		column["fieldname"] = column["fieldname"].split("-")[0]
 
 	custom_column_data = get_data_for_custom_report(custom_columns, result)
@@ -251,8 +247,10 @@ def add_custom_column_data(custom_columns, result):
 				# possible if the row is empty
 				if not row_reference:
 					continue
-
-				if custom_column_data.get(key).get(row_reference) is None:
+				if (
+					custom_column_data.get(key).get(row_reference) is None
+					and key[0] in doctype_name_from_custom_field
+				):
 					column["fieldname"] = column.get("fieldname") + "-" + frappe.unscrub(key[0])
 				row[column.get("fieldname")] = custom_column_data.get(key).get(row_reference)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -223,11 +223,12 @@ def run(
 
 
 def add_custom_column_data(custom_columns, result):
-	doctype_name_from_custom_field = []
+	doctype_names_from_custom_field = []
 	for column in custom_columns:
-		doctype_name_from_custom_field.append(frappe.unscrub(column["fieldname"].split("-")[1])) if len(
-			column["fieldname"].split("-")
-		) > 1 else None
+		if len(column["fieldname"].split("-")) > 1:
+			# length greater than 1, means that the column is a custom field with confilicting fieldname
+			doctype_name = frappe.unscrub(column["fieldname"].split("-")[1])
+			doctype_names_from_custom_field.append(doctype_name)
 		column["fieldname"] = column["fieldname"].split("-")[0]
 
 	custom_column_data = get_data_for_custom_report(custom_columns, result)
@@ -247,7 +248,7 @@ def add_custom_column_data(custom_columns, result):
 				# possible if the row is empty
 				if not row_reference:
 					continue
-				if key[0] in doctype_name_from_custom_field:
+				if key[0] in doctype_names_from_custom_field:
 					column["fieldname"] = column.get("id")
 				row[column.get("fieldname")] = custom_column_data.get(key).get(row_reference)
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -247,11 +247,8 @@ def add_custom_column_data(custom_columns, result):
 				# possible if the row is empty
 				if not row_reference:
 					continue
-				if (
-					custom_column_data.get(key).get(row_reference) is None
-					and key[0] in doctype_name_from_custom_field
-				):
-					column["fieldname"] = column.get("fieldname") + "-" + frappe.unscrub(key[0])
+				if key[0] in doctype_name_from_custom_field:
+					column["fieldname"] = column.get("id")
 				row[column.get("fieldname")] = custom_column_data.get(key).get(row_reference)
 
 	return result

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -933,10 +933,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	render_datatable() {
 		let data = this.data;
-		console.log(this.data);
 		let columns = this.columns.filter((col) => !col.hidden);
-		// columns = this.
-		// debugger
 
 		if (this.raw_data.add_total_row && !this.report_settings.tree) {
 			data = data.slice();
@@ -1683,8 +1680,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							const insert_after_index = this.columns.findIndex(
 								(column) => column.label === values.insert_after
 							);
+
 							custom_columns.push({
-								fieldname: df.fieldname + "-" + frappe.scrub(values.doctype),
+								fieldname: this.columns
+									.map((column) => column.fieldname)
+									.includes(df.fieldname)
+									? df.fieldname + "-" + frappe.scrub(values.doctype)
+									: df.fieldname,
 								fieldtype: df.fieldtype,
 								label: df.label,
 								insert_after_index: insert_after_index,
@@ -1706,10 +1708,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								},
 								callback: (r) => {
 									const custom_data = r.message;
-									console.log(r.message);
 									const link_field =
 										this.doctype_field_map[values.doctype].fieldname;
-									console.log(link_field, values.field);
 									this.add_custom_column(
 										custom_columns,
 										custom_data,
@@ -1802,15 +1802,18 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		new_column_data,
 		insert_after_index
 	) {
-		console.log(custom_column);
 		const column = this.prepare_columns(custom_column);
 		const column_field = new_column_data.field;
 
 		this.columns.splice(insert_after_index + 1, 0, column[0]);
+
 		this.data.forEach((row) => {
-			console.log(row);
-			row[column_field + "-" + frappe.scrub(new_column_data.doctype)] =
-				custom_data[row[link_field]];
+			if (column[0].fieldname.includes("-")) {
+				row[column_field + "-" + frappe.scrub(new_column_data.doctype)] =
+					custom_data[row[link_field]];
+			} else {
+				row[column_field] = custom_data[row[link_field]];
+			}
 		});
 
 		this.render_datatable();

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -933,7 +933,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	render_datatable() {
 		let data = this.data;
+		console.log(this.data);
 		let columns = this.columns.filter((col) => !col.hidden);
+		// columns = this.
+		// debugger
 
 		if (this.raw_data.add_total_row && !this.report_settings.tree) {
 			data = data.slice();
@@ -1681,7 +1684,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								(column) => column.label === values.insert_after
 							);
 							custom_columns.push({
-								fieldname: df.fieldname,
+								fieldname: df.fieldname + "-" + frappe.scrub(values.doctype),
 								fieldtype: df.fieldtype,
 								label: df.label,
 								insert_after_index: insert_after_index,
@@ -1703,14 +1706,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 								},
 								callback: (r) => {
 									const custom_data = r.message;
+									console.log(r.message);
 									const link_field =
 										this.doctype_field_map[values.doctype].fieldname;
-
+									console.log(link_field, values.field);
 									this.add_custom_column(
 										custom_columns,
 										custom_data,
 										link_field,
-										values.field,
+										values,
 										insert_after_index
 									);
 									d.hide();
@@ -1791,13 +1795,22 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		}
 	}
 
-	add_custom_column(custom_column, custom_data, link_field, column_field, insert_after_index) {
+	add_custom_column(
+		custom_column,
+		custom_data,
+		link_field,
+		new_column_data,
+		insert_after_index
+	) {
+		console.log(custom_column);
 		const column = this.prepare_columns(custom_column);
+		const column_field = new_column_data.field;
 
 		this.columns.splice(insert_after_index + 1, 0, column[0]);
-
 		this.data.forEach((row) => {
-			row[column_field] = custom_data[row[link_field]];
+			console.log(row);
+			row[column_field + "-" + frappe.scrub(new_column_data.doctype)] =
+				custom_data[row[link_field]];
 		});
 
 		this.render_datatable();

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -7,14 +7,7 @@ import os
 import frappe
 import frappe.utils
 from frappe.core.doctype.doctype.test_doctype import new_doctype
-from frappe.desk.query_report import (
-	build_xlsx_data,
-	export_query,
-	generate_report_result,
-	get_data_for_custom_field,
-	get_data_for_custom_report,
-	run,
-)
+from frappe.desk.query_report import build_xlsx_data, export_query, run
 from frappe.tests.ui_test_helpers import create_doctype
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.xlsxutils import make_xlsx

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -10,6 +10,11 @@ from frappe.utils.xlsxutils import make_xlsx
 
 
 class TestQueryReport(FrappeTestCase):
+	@classmethod
+	def setUpClass(cls) -> None:
+		cls.enable_safe_exec()
+		return super().setUpClass()
+
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -1,14 +1,10 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import json
-import os
-
 import frappe
 import frappe.utils
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.query_report import build_xlsx_data, export_query, run
-from frappe.tests.ui_test_helpers import create_doctype
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.xlsxutils import make_xlsx
 

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -190,7 +190,6 @@ columns = [{
 data = columns, result
 				"""
 			report.save()
-			data = report.get_data()
 
 			custom_columns = [
 				{

--- a/frappe/tests/test_query_report.py
+++ b/frappe/tests/test_query_report.py
@@ -1,14 +1,29 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import json
+import os
+
 import frappe
 import frappe.utils
-from frappe.desk.query_report import build_xlsx_data, export_query
+from frappe.core.doctype.doctype.test_doctype import new_doctype
+from frappe.desk.query_report import (
+	build_xlsx_data,
+	export_query,
+	generate_report_result,
+	get_data_for_custom_field,
+	get_data_for_custom_report,
+	run,
+)
+from frappe.tests.ui_test_helpers import create_doctype
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils.xlsxutils import make_xlsx
 
 
 class TestQueryReport(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
 	def test_xlsx_data_with_multiple_datatypes(self):
 		"""Test exporting report using rows with multiple datatypes (list, dict)"""
 
@@ -110,3 +125,121 @@ class TestQueryReport(FrappeTestCase):
 						self.assertIn(column, row)
 
 		frappe.delete_doc("Report", REPORT_NAME, delete_permanently=True)
+
+	def test_report_for_duplicate_column_names(self):
+		"""Test report with duplicate column names"""
+
+		try:
+			fields = [
+				{"label": "First Name", "fieldname": "first_name", "fieldtype": "Data"},
+				{"label": "Last Name", "fieldname": "last_name", "fieldtype": "Data"},
+			]
+			docA = frappe.get_doc(
+				{
+					"doctype": "DocType",
+					"name": "Doc A",
+					"module": "Core",
+					"custom": 1,
+					"autoname": "field:first_name",
+					"fields": fields,
+					"permissions": [{"role": "System Manager"}],
+				}
+			).insert(ignore_if_duplicate=True)
+
+			docB = frappe.get_doc(
+				{
+					"doctype": "DocType",
+					"name": "Doc B",
+					"module": "Core",
+					"custom": 1,
+					"autoname": "field:last_name",
+					"fields": fields,
+					"permissions": [{"role": "System Manager"}],
+				}
+			).insert(ignore_if_duplicate=True)
+
+			for i in range(1, 3):
+				frappe.get_doc({"doctype": "Doc A", "first_name": f"John{i}", "last_name": "Doe"}).insert()
+				frappe.get_doc({"doctype": "Doc B", "last_name": f"Doe{i}", "first_name": "John"}).insert()
+
+			if not frappe.db.exists("Report", "Doc A Report"):
+				report = frappe.get_doc(
+					{
+						"doctype": "Report",
+						"ref_doctype": "Doc A",
+						"report_name": "Doc A Report",
+						"report_type": "Script Report",
+						"is_standard": "No",
+					}
+				).insert(ignore_permissions=True)
+			else:
+				report = frappe.get_doc("Report", "Doc A Report")
+
+			report.report_script = """
+result = [["Ritvik","Sardana", "Doe1"],["Shariq","Ansari", "Doe2"]]
+columns = [{
+			"label": "First Name",
+			"fieldname": "first_name",
+			"fieldtype": "Data",
+			"width": 180,
+		},
+		{
+			"label": "Last Name",
+			"fieldname": "last_name",
+			"fieldtype": "Data",
+			"width": 180,
+		},
+		{
+			"label": "Linked Field",
+			"fieldname": "linked_field",
+			"fieldtype": "Link",
+			"options": "Doc B",
+			"width": 180,
+		},
+	]
+
+data = columns, result
+				"""
+			report.save()
+			data = report.get_data()
+
+			custom_columns = [
+				{
+					"fieldname": "first_name-Doc_B",
+					"fieldtype": "Data",
+					"label": "First Name",
+					"insert_after_index": 1,
+					"link_field": {"fieldname": "linked_field", "names": {}},
+					"doctype": "Doc B",
+					"width": 100,
+					"id": "first_name-Doc_B",
+					"name": "First Name",
+					"editable": False,
+					"compareValue": None,
+				},
+			]
+
+			response = run(
+				"Doc A Report",
+				filters={"user": "Administrator", "doctype": "Doc A"},
+				custom_columns=custom_columns,
+			)
+
+			self.assertListEqual(
+				["first_name", "last_name", "first_name-Doc_B", "linked_field"],
+				[d["fieldname"] for d in response["columns"]],
+			)
+
+			self.assertDictEqual(
+				{
+					"first_name": "Ritvik",
+					"last_name": "Sardana",
+					"linked_field": "Doe1",
+					"first_name-Doc_B": "John",
+				},
+				response["result"][0],
+			)
+
+		except Exception as e:
+			raise e
+			frappe.db.rollback()


### PR DESCRIPTION
**Issue:**
when we add a column in General Ledger Report, if the fieldname of the new column already exists in the table, then no data is shown.
<img width="1395" alt="image" src="https://github.com/frappe/frappe/assets/65544983/bfedec7b-8a1b-44ad-9e34-e96ab0220d1b">

here when we add a new field which is "Entry Type", the fieldname of "Entry Type" is "voucher_type" which clashes with already existing field "Voucher Type"

### **Explanation:**
From frontend, if the the column fieldname clashes with the existing data, then we store that column as ‘fieldname-doctype_name’.

when we save the report and see the report, a backend call is there, where : 

In the variable “doctype_name_from_custom_field” we store the clashed fieldname’s doctype by splitting it with (”-”) , so the second element in the array is the doctype which is stored.

now here key[0] gets the current doctype of the custom field that we added. 

so if key[0] is in “doctype_name_from_custom_field” then we save the column’s

fieldname as column’s id as id is what we stored from the frontend i.e. ( ‘fieldname-doctype_name’. )

Result:

![image](https://github.com/frappe/frappe/assets/65544983/a68c854c-c471-41c6-b5b2-87a37f81186b)


above :

“Entry Type” is clashing with “Voucher Type”

and

“Company” is clashing with “Company”
but we are still getting the data correctly

API response for this particular column

![image](https://github.com/frappe/frappe/assets/65544983/8cc4a4f0-b7a6-4eaa-a437-567631b4ca2a)

![image](https://github.com/frappe/frappe/assets/65544983/835e2c31-b3fa-4d72-b33d-6fc498781dcc)
