### PR TITLE
perf: Enqueue "removing of index" on web page save

### DIFF
--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -177,4 +177,4 @@ class WebsiteGenerator(Document):
 			frappe.enqueue(update_index_for_path, path=self.route)
 		elif self.route:
 			# If the website is not published
-			remove_document_from_index(self.route)
+			frappe.enqueue(remove_document_from_index, path=self.route)

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -174,7 +174,7 @@ class WebsiteGenerator(Document):
 			return
 
 		if self.is_website_published():
-			frappe.enqueue(update_index_for_path, path=self.route)
+			frappe.enqueue(update_index_for_path, path=self.route, enqueue_after_commit=True)
 		elif self.route:
 			# If the website is not published
 			frappe.enqueue(remove_document_from_index, path=self.route, enqueue_after_commit=True)

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -177,4 +177,4 @@ class WebsiteGenerator(Document):
 			frappe.enqueue(update_index_for_path, path=self.route)
 		elif self.route:
 			# If the website is not published
-			frappe.enqueue(remove_document_from_index, path=self.route)
+			frappe.enqueue(remove_document_from_index, path=self.route, enqueue_after_commit=True)


### PR DESCRIPTION
Saving a unpublished webpage was getting slow because of "remove_document_from_index".

**Before** (for saving a webpage on site with lot of route index):
<img width="1366" alt="Screenshot 2023-09-14 at 2 24 57 PM" src="https://github.com/frappe/frappe/assets/13928957/505e1b97-eca5-4669-80fe-ddf52b79e98b">

**After**:
<img width="1207" alt="Screenshot 2023-09-14 at 2 38 00 PM" src="https://github.com/frappe/frappe/assets/13928957/36c9e2de-dbdc-4ca0-8d09-d0338c90fd29">


**Note:** `remove_document_from_index` with still take time, but it will not slowdown saving of webpages.
