### PR TITLE
fix: remove items linked to non-existing doctypes from portal settings

### DIFF
--- a/frappe/website/doctype/portal_settings/portal_settings.py
+++ b/frappe/website/doctype/portal_settings/portal_settings.py
@@ -49,6 +49,7 @@ class PortalSettings(Document):
 				dirty = True
 
 		if dirty:
+			self.remove_deleted_doctype_items()
 			self.save()
 
 	def on_update(self):
@@ -65,3 +66,9 @@ class PortalSettings(Document):
 
 		# clears role based home pages
 		frappe.clear_cache()
+
+	def remove_deleted_doctype_items(self):
+		existing_doctypes = frappe.get_list("DocType", pluck="name")
+		for menu_item in self.get("menu"):
+			if menu_item.reference_doctype not in existing_doctypes:
+				self.remove(menu_item)

--- a/frappe/website/doctype/portal_settings/portal_settings.py
+++ b/frappe/website/doctype/portal_settings/portal_settings.py
@@ -68,7 +68,7 @@ class PortalSettings(Document):
 		frappe.clear_cache()
 
 	def remove_deleted_doctype_items(self):
-		existing_doctypes = frappe.get_list("DocType", pluck="name")
-		for menu_item in self.get("menu"):
+		existing_doctypes = set(frappe.get_list("DocType", pluck="name"))
+		for menu_item in list(self.get("menu")):
 			if menu_item.reference_doctype not in existing_doctypes:
 				self.remove(menu_item)


### PR DESCRIPTION
**Problem**
Patch Test fails while syncing **Portal Settings** due to menu items that link to previously deleted doctypes.

**Screenshot**
<img width="992" alt="Screenshot 2023-09-15 at 1 24 31 PM" src="https://github.com/frappe/frappe/assets/40693548/edc687c0-6f54-4fe4-aa94-43492381a116">


**Fix**
While syncing the Portal Settings, remove menu items that do not point to an existing doctype.

`no-docs`