### PR TITLE
fix: Redirect loop on going back from File list

### DIFF
--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -495,6 +495,9 @@ frappe.views.FileView.grid_view =
 function redirect_to_home_if_invalid_route() {
 	const route = frappe.get_route();
 	if (route[2] === "List") {
+		// Remove List/File/List from route history to avoid redirect loop on going back
+		frappe.route_history.pop();
+
 		// if the user somehow redirects to List/File/List
 		// redirect back to Home
 		frappe.set_route("List", "File", "Home");


### PR DESCRIPTION
> Seen on v13 as v14/15 have a different routing design altogether

### Issue:
- 'List/File/List' redirects to 'List/File/Home'
- But when user tries to go back (browser) from 'List/File/Home' it goes to last visited 'List/File/List'
- This again causes a redirect, and therefore a redirect loop
![2023-09-15 14 22 55](https://github.com/frappe/frappe/assets/25857446/2c06f237-284b-493c-9e6f-059c4d5e66ca)

### Fix
- Before redirecting from 'List/File/List' to 'List/File/Home', remove 'List/File/List' from the route history since it was an invalid route anyway
![2023-09-15 14 25 26](https://github.com/frappe/frappe/assets/25857446/5e904fd0-c375-4e7a-bdb4-1d0dd2816db0)
