### PR TITLE
fix: permission check for the child table in search link

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -207,6 +207,7 @@ def search_widget(
 					and has_permission(
 						doctype,
 						ptype="select" if frappe.only_has_select_perm(doctype) else "read",
+						parent_doctype=reference_doctype,
 					)
 				)
 			)


### PR DESCRIPTION
- Using the parent doctype by passing the reference doctype

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

This PR contains the update for the check permissions for the search link for the child table using the reference doctype as the parent doctype.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

When we add a field to a doctype that is linked to a child table doctype, then we will face a permissions error because the child table has no permissions rules, so we should use or pass the p[arent doctype to the `has_permission` util so we can validate the user permissions for the child table based on the parent doctype.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

![image](https://github.com/frappe/frappe/assets/30384731/41741cbd-9f2b-452f-b323-3b3d75e24d8a)
The user has permissions on the parent doctype but listing for the child table gives this permissions error.

![image](https://github.com/frappe/frappe/assets/30384731/d15647a4-c84d-4961-a78e-95ec23d90344)
Payload for the request.

![image](https://github.com/frappe/frappe/assets/30384731/494dc0c7-1066-4a95-8341-2e6f3fe2d5c9)
Request and response after updating the `has_permission` with the parent doctype.

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
