### PR TITLE
fix: Set system timezone for Administrator and Guest users.

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -251,7 +251,7 @@ def update_user_name(args):
 
 def set_timezone(args):
 	if args.get("timezone"):
-		for name in ["Administrator", "Guest"]:
+		for name in frappe.STANDARD_USERS:
 			frappe.db.set_value("User", name, "time_zone", args.get("timezone"))
 
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -108,6 +108,7 @@ def update_global_settings(args):
 
 	update_system_settings(args)
 	update_user_name(args)
+	set_timezone(args)
 
 
 def run_post_setup_complete(args):
@@ -246,6 +247,12 @@ def update_user_name(args):
 
 	if args.get("name"):
 		add_all_roles_to(args.get("name"))
+
+
+def set_timezone(args):
+	if args.get("timezone"):
+		for name in ["Administrator", "Guest"]:
+			frappe.db.set_value("User", name, "time_zone", args.get("timezone"))
 
 
 def parse_args(args):

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -309,7 +309,7 @@ def get_eta(from_time, percent_complete):
 
 
 def _get_system_timezone():
-	return frappe.db.get_system_setting("time_zone") or "Asia/Kolkata"  # Default to India ?!
+	return frappe.get_system_settings("time_zone") or "Asia/Kolkata"  # Default to India ?!
 
 
 def get_system_timezone():


### PR DESCRIPTION
[install.py](https://github.com/frappe/frappe/blob/3239636e7d0a4cd3809fcbbddec4d06cc3cbd353/frappe/utils/install.py#L65) creates the two default users Administrator and Guest before a timezone is chosen in the Wizard. When saved, the timezone will fall back to the pre-setup default which happens to be “Asia/Kolkata”.

Now, after the configured system timezone has been set, I’m updating both default users to adopt the same configured system timezone.

After setup has finished, new users already adopt the same timezone as the current user, so in later stages the problem shouldn‘t arise at all.

This should hopefully fix most if not all issues reported in #20724 and its various comments.

If someone could point me to how I can add a test that runs on a fresh install, I‘d happily write one, so we can avoid any regressions.