### PR TITLE
fix: `flt` with trailing zeros

### DIFF
--- a/cypress/integration/control_currency.js
+++ b/cypress/integration/control_currency.js
@@ -48,6 +48,17 @@ context("Control Currency", () => {
 				blur_expected: "10",
 			},
 			{
+				input: "10.000",
+				number_format: "#.###,##",
+				df_options: { precision: 0 },
+				blur_expected: "10.000",
+			},
+			{
+				input: "10.000",
+				number_format: "#.###,##",
+				blur_expected: "10.000,00",
+			},
+			{
 				input: "10.101",
 				df_options: { precision: "" },
 				blur_expected: "10.1",
@@ -61,6 +72,7 @@ context("Control Currency", () => {
 				.then((frappe) => {
 					frappe.boot.sysdefaults.currency = test_case.currency;
 					frappe.boot.sysdefaults.currency_precision = test_case.default_precision ?? 2;
+					frappe.boot.sysdefaults.number_format = test_case.number_format ?? "#,###.##";
 				});
 
 			get_dialog_with_currency(test_case.df_options).as("dialog");

--- a/cypress/integration/control_float.js
+++ b/cypress/integration/control_float.js
@@ -89,13 +89,13 @@ context("Control Float", () => {
 				values: [
 					{
 						input: "12.345",
-						blur_expected: "12.345",
+						blur_expected: "12.345,000",
 						focus_expected: "12345",
 					},
 					{
 						// parseFloat would reduce 12,340 to 12,34 if this string was ever to be parsed
 						input: "12.340",
-						blur_expected: "12.340",
+						blur_expected: "12.340,000",
 						focus_expected: "12340",
 					},
 				],

--- a/cypress/integration/control_float.js
+++ b/cypress/integration/control_float.js
@@ -83,6 +83,23 @@ context("Control Float", () => {
 					},
 				],
 			},
+			{
+				// '.' is the parseFloat's decimal separator
+				number_format: "#.###,##",
+				values: [
+					{
+						input: "12.345",
+						blur_expected: "12.345",
+						focus_expected: "12345",
+					},
+					{
+						// parseFloat would reduce 12,340 to 12,34 if this string was ever to be parsed
+						input: "12.340",
+						blur_expected: "12.340",
+						focus_expected: "12340",
+					},
+				],
+			},
 		];
 	}
 });

--- a/cypress/integration/rounding.js
+++ b/cypress/integration/rounding.js
@@ -49,7 +49,7 @@ context("Rounding behaviour", () => {
 				let rounding_method = "Banker's Rounding";
 
 				expect(flt("0.5", 0, null, rounding_method)).eq(0);
-				expect(flt("0.3", null, rounding_method)).eq(0.3);
+				expect(flt("0.3", null, null, rounding_method)).eq(0.3);
 
 				expect(flt("1.5", 0, null, rounding_method)).eq(2);
 

--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -8,12 +8,7 @@ if (!window.frappe) window.frappe = {};
 function flt(v, decimals, number_format, rounding_method) {
 	if (v == null || v == "") return 0;
 
-	if (!(typeof v === "number" || String(parseFloat(v)) == v)) {
-		// cases in which this block should not run
-		// 1. 'v' is already a number
-		// 2. v is already parsed but in string form
-		// if (typeof v !== "number") {
-
+	if (typeof v !== "number") {
 		v = v + "";
 
 		// strip currency symbol if exists
@@ -29,7 +24,6 @@ function flt(v, decimals, number_format, rounding_method) {
 		if (isNaN(v)) v = 0;
 	}
 
-	v = parseFloat(v);
 	if (decimals != null) return _round(v, decimals, rounding_method);
 	return v;
 }


### PR DESCRIPTION
closes: https://github.com/frappe/frappe/issues/22438

# Context


https://github.com/frappe/frappe/commit/f4d0b0d35efa64a1692e075b71ae70c4969b81cda introduced the following regression:


```js
// parseFloat happens **not** to faithfully conserve the string value
parseFloat("12.030")
12.03
String(parseFloat(v)) == v)) == false

// parseFloat happens to faithfully conserve the string value
parseFloat("12.035")
12.035
String(parseFloat(v)) == v)) == true
```

If the string value is faithfully conserved, the parsing block is skipped.

In our case, that's the bad thing:

1. With the change of https://github.com/frappe/frappe/commit/f4d0b0d35efa64a1692e075b71ae70c4969b81cda, `parseFloat` may thus be invoked on the the raw string (in our example `"12.035"`) effectively returning 1/100th of that value (here `12,035`, a number!)
2. `_round` is then invoked on 1/100th of the actual value (`12.035`, a number!)
3. `_round`'s logic thus applies to 1/100th of the actual value
   - with a decimal precision of `0`, that will result in `12`.
   - that is awesomely wrong. QED.

# Proposed Solution

- [x] add test case and proof it fails ([link](https://cloud.cypress.io/projects/92odwv/runs/4f50994b-90a5-48e6-9f32-139e01c1fb77/test-results/c0dfa4ee-7ef6-4dc1-bb09-a8f51358814b/screenshots) showing a different symptom without having decimal precision set to `0` and thus is still proving point no 2 above)
- [x] revert the commit
- [ ] proof relevant test cases still work; findings:
    - The first commit's test resulted after the revert in:
      `Timed out retrying after 20000ms: expected '<input.input-with-feedback.form-control>' to have value '12.345', but the value was '12.345,000'` -> adapted the test in the 3rd commit together with more test coverage
    - after additional tests `control_float` [link](https://cloud.cypress.io/projects/92odwv/runs/35405/test-results?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%7B%22label%22%3A%22control_float.js%22%2C%22value%22%3A%22%5B%5C%225631a033-449f-499f-8eac-624606f6e76e%5C%22%5D%22%7D%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D)
    - after additional tests `control_currency` [link](https://cloud.cypress.io/projects/92odwv/runs/35405/test-results?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%7B%22label%22%3A%22control_currency.js%22%2C%22value%22%3A%22%5B%5C%220452d0a1-743d-4b9c-800d-e290d5488da4%5C%22%5D%22%7D%5D&statuses=%5B%5D&testingTypesEnum=%5B%5D)
    - While this PR solves the original issue, the CI errors on [banker's rounding integration tests](https://cloud.cypress.io/projects/92odwv/runs/35405/test-results/b8230168-9cb7-4c56-9f0a-078053ba8553) even though I wasn't able to reproduce the failure locally (in my own environment) and even with these changes, banker's rounding continues to work as expected. (@ankush I might need some help with this, could be flaky or it is above my experience)


## Root Contributing Factors

I analyze that the root contributing factors to this happening are:
- Excessive functional impurity
- Lack of typing

<sub>If these patterns sound familiar, feel free to have a look at https://github.com/frappe/frappe/pull/21781, https://github.com/frappe/frappe/pull/21780 and https://github.com/frappe/frappe/pull/21779 which try to address _excessive functional impurity_ for the db backend.</sub>