### PR TITLE
fix: don't set default value for fields with fetch_if_empty set

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -195,6 +195,7 @@ class BaseDocument:
 				# dont_update_if_missing is a list of fieldnames
 				# for which you don't want to set default value
 				and key not in self.dont_update_if_missing
+				and (not self.meta.get_field(key) or not self.meta.get_field(key).fetch_if_empty)
 			):
 				self.set(key, value)
 
@@ -773,7 +774,7 @@ class BaseDocument:
 					_df
 					for _df in self.meta.get_fields_to_fetch(df.fieldname)
 					if not _df.get("fetch_if_empty")
-					or (_df.get("fetch_if_empty") and not self.get(_df.fieldname))
+					or (self.get(_df.fieldname) is None and not self.get("__from_client"))
 				]
 				if not frappe.get_meta(doctype).get("is_virtual"):
 					if not fields_to_fetch:

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -20,6 +20,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 
 		$(frm.wrapper).addClass("validated-form");
 		if ((action !== "Save" || frm.is_dirty()) && check_mandatory()) {
+			frm.doc.__from_client = 1;
 			_call({
 				method: "frappe.desk.form.save.savedocs",
 				args: { doc: frm.doc, action: action },


### PR DESCRIPTION
**Example problem**:

I have a `Loan` doctype with a `Repay From Salary` check field. I have a `Loan Repayment` doctype and it has a `Against Loan` link field (linked to a `Loan` doc) and a `Repay From Salary` check field (which fetches from the `Repay From Salary` check field of the `Loan` in `Against Loan` link field). `fetch_if_empty` is set for the `Repay From Salary` check field since I want to let the user edit the checkbox if needed.

Now, consider the `Repay From Salary` check field of a `Loan` is checked. From desk, the user tries to create a `Loan Repayment` corresponding to the `Loan` and unchecks the `Repay From Salary` field, but it gets checked back on save.

Currently if the system finds a unchecked checkbox, it considers the checkbox as unset (even if the user intentionally unchecked it) hence it sets the `fetch_from` value of the checkbox on save. 

**Fix:**

Now the system won't attempt to fetch values on save if the doc is created from desk so the "it gets checked back on save" problem is solved. For server based doc creation, now default value is not set in `update_if_missing()` for fields with `fetch_if_empty` set -- they'll remain `None` until they reach `get_invalid_links()` where they'll get set with their fetched values.