### PR TITLE
fix: permission manager if-owner behaviour

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -370,6 +370,7 @@ frappe.PermissionEngine = class PermissionEngine {
 						doctype: d.parent,
 						role: d.role,
 						permlevel: d.permlevel,
+						if_owner: d.if_owner,
 					},
 					callback: (r) => {
 						if (r.exc) {

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -291,6 +291,7 @@ frappe.PermissionEngine = class PermissionEngine {
 			.attr("data-ptype", fieldname)
 			.attr("data-role", d.role)
 			.attr("data-permlevel", d.permlevel)
+			.attr("data-if_owner", d.if_owner)
 			.attr("data-doctype", d.parent);
 
 		checkbox.find("label").css("text-transform", "capitalize");
@@ -399,6 +400,7 @@ frappe.PermissionEngine = class PermissionEngine {
 				doctype: chk.attr("data-doctype"),
 				ptype: chk.attr("data-ptype"),
 				value: chk.prop("checked") ? 1 : 0,
+				if_owner: chk.attr("data-if_owner"),
 			};
 			return frappe.call({
 				module: "frappe.core",

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -135,11 +135,14 @@ def update(doctype, role, permlevel, ptype, value=None):
 
 
 @frappe.whitelist()
-def remove(doctype, role, permlevel):
+def remove(doctype, role, permlevel, if_owner):
 	frappe.only_for("System Manager")
 	setup_custom_perms(doctype)
 
-	frappe.db.delete("Custom DocPerm", {"parent": doctype, "role": role, "permlevel": permlevel})
+	frappe.db.delete(
+		"Custom DocPerm",
+		{"parent": doctype, "role": role, "permlevel": permlevel, "if_owner": if_owner},
+	)
 
 	if not frappe.get_all("Custom DocPerm", {"parent": doctype}):
 		frappe.throw(_("There must be atleast one permission rule."), title=_("Cannot Remove"))

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -109,7 +109,7 @@ def add(parent, role, permlevel):
 
 
 @frappe.whitelist()
-def update(doctype, role, permlevel, ptype, value=None):
+def update(doctype, role, permlevel, ptype, value=None, if_owner=0):
 	"""Update role permission params
 
 	Args:
@@ -127,7 +127,7 @@ def update(doctype, role, permlevel, ptype, value=None):
 		frappe.clear_cache(doctype=doctype)
 
 	frappe.only_for("System Manager")
-	out = update_permission_property(doctype, role, permlevel, ptype, value)
+	out = update_permission_property(doctype, role, permlevel, ptype, value, if_owner=if_owner)
 
 	frappe.db.after_commit.add(clear_cache)
 
@@ -135,7 +135,7 @@ def update(doctype, role, permlevel, ptype, value=None):
 
 
 @frappe.whitelist()
-def remove(doctype, role, permlevel, if_owner):
+def remove(doctype, role, permlevel, if_owner=0):
 	frappe.only_for("System Manager")
 	setup_custom_perms(doctype)
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -579,6 +579,12 @@ def add_permission(doctype, role, permlevel=0, ptype=None):
 	if frappe.db.get_value(
 		"Custom DocPerm", dict(parent=doctype, role=role, permlevel=permlevel, if_owner=0)
 	):
+		frappe.msgprint(
+			_("Rule for this doctype, role, permlevel and if-owner combination already exists.").format(
+				doctype,
+			),
+			alert=True,
+		)
 		return
 
 	if not ptype:

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -546,13 +546,23 @@ def can_export(doctype, raise_exception=False):
 		return has_access
 
 
-def update_permission_property(doctype, role, permlevel, ptype, value=None, validate=True):
+def update_permission_property(
+	doctype,
+	role,
+	permlevel,
+	ptype,
+	value=None,
+	validate=True,
+	if_owner=0,
+):
 	"""Update a property in Custom Perm"""
 	from frappe.core.doctype.doctype.doctype import validate_permissions_for_doctype
 
 	out = setup_custom_perms(doctype)
 
-	name = frappe.db.get_value("Custom DocPerm", dict(parent=doctype, role=role, permlevel=permlevel))
+	name = frappe.db.get_value(
+		"Custom DocPerm", dict(parent=doctype, role=role, permlevel=permlevel, if_owner=if_owner)
+	)
 	table = DocType("Custom DocPerm")
 	frappe.qb.update(table).set(ptype, value).where(table.name == name).run()
 

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -477,9 +477,9 @@ class TestPermissions(FrappeTestCase):
 		# check if user is not granted access if the user is not the owner of the doc
 		# Blogger has only read access on the blog post unless he is the owner of the blog
 		update("Blog Post", "Blogger", 0, "if_owner", 1)
-		update("Blog Post", "Blogger", 0, "read", 1)
-		update("Blog Post", "Blogger", 0, "write", 1)
-		update("Blog Post", "Blogger", 0, "delete", 1)
+		update("Blog Post", "Blogger", 0, "read", 1, 1)
+		update("Blog Post", "Blogger", 0, "write", 1, 1)
+		update("Blog Post", "Blogger", 0, "delete", 1, 1)
 
 		# currently test2 user has not created any document
 		# still he should be able to do get_list query which should
@@ -588,9 +588,9 @@ class TestPermissions(FrappeTestCase):
 
 	def test_if_owner_permission_on_delete(self):
 		update("Blog Post", "Blogger", 0, "if_owner", 1)
-		update("Blog Post", "Blogger", 0, "read", 1)
-		update("Blog Post", "Blogger", 0, "write", 1)
-		update("Blog Post", "Blogger", 0, "delete", 1)
+		update("Blog Post", "Blogger", 0, "read", 1, 1)
+		update("Blog Post", "Blogger", 0, "write", 1, 1)
+		update("Blog Post", "Blogger", 0, "delete", 1, 1)
 
 		# Remove delete perm
 		update("Blog Post", "Website Manager", 0, "delete", 0)
@@ -627,7 +627,7 @@ class TestPermissions(FrappeTestCase):
 
 		frappe.set_user("test2@example.com")
 		frappe.delete_doc("Blog Post", "-test-blog-post-title-new-1")
-		update("Blog Post", "Website Manager", 0, "delete", 1)
+		update("Blog Post", "Website Manager", 0, "delete", 1, 1)
 
 	def test_clear_user_permissions(self):
 		current_user = frappe.session.user


### PR DESCRIPTION
Misc correctness/UX problems:


1. You can't add multiple rules for same role and no message is shown. Added alert to show that new rule can't be added for same combination. 
2. When deleting single rule other rule that match same params are deleted. `if_owner` is ignored in code. 
3. RPM always updates last inserted rule regardless of `if_owner`. 
