### PR TITLE
fix: Only allow user with role set in Dashboard chart

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.json
@@ -280,6 +280,7 @@
    "options": "DocType"
   },
   {
+   "description": "If set, only user with these roles can access this chart. If not set, DocType or Report permissions will be used.",
    "fieldname": "roles",
    "fieldtype": "Table",
    "label": "Roles",
@@ -287,7 +288,7 @@
   }
  ],
  "links": [],
- "modified": "2023-08-28 20:20:54.186299",
+ "modified": "2023-09-18 13:41:05.263676",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Dashboard Chart",

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -79,17 +79,16 @@ def has_permission(doc, ptype, user):
 	if "System Manager" in roles:
 		return True
 
-	if doc.chart_type == "Report":
+	if doc.roles:
+		allowed = [d.role for d in doc.roles]
+		if has_common(roles, allowed):
+			return True
+	elif doc.chart_type == "Report":
 		if doc.report_name in get_allowed_report_names():
 			return True
 	else:
 		allowed_doctypes = frappe.permissions.get_doctypes_with_read()
 		if doc.document_type in allowed_doctypes:
-			return True
-
-	if doc.roles:
-		allowed = [d.role for d in doc.roles]
-		if has_common(roles, allowed):
 			return True
 
 	return False


### PR DESCRIPTION
If roles are set is Dashboard Chart, only user with those roles should be able to access the chart.
If not set, DocType or Report permissions can be used.

Previously: Roles table just used to extend permission. It was quite confusing for users since user thought only users with the role set in the Dashboard chart will get the access to that chart.
![Screenshot 2023-09-18 at 1 47 04 PM](https://github.com/frappe/frappe/assets/13928957/bd99f348-3279-4ebd-ae80-d58d53d71dae)

Proposal is to strictly follow roles (if set) in the Dashboard Chart.
![Screenshot 2023-09-18 at 1 48 19 PM](https://github.com/frappe/frappe/assets/13928957/6e0b199c-3761-4b63-807f-1af3166b0930)


Continuation of: https://github.com/frappe/frappe/pull/17634

