### PR TITLE
fix: Ignore perm while updating module onboarding

### DIFF
--- a/frappe/desk/doctype/module_onboarding/module_onboarding.py
+++ b/frappe/desk/doctype/module_onboarding/module_onboarding.py
@@ -52,7 +52,7 @@ class ModuleOnboarding(Document):
 		is_complete = [bool(step.is_complete or step.is_skipped) for step in steps]
 		if all(is_complete):
 			self.is_complete = True
-			self.save()
+			self.save(ignore_permissions=True)
 			return True
 
 		return False

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -216,7 +216,7 @@ class Document(BaseDocument):
 	def check_permission(self, permtype="read", permlevel=None):
 		"""Raise `frappe.PermissionError` if not permitted"""
 		if not self.has_permission(permtype):
-			self.raise_no_permission_to(permlevel or permtype)
+			self.raise_no_permission_to(permtype)
 
 	def has_permission(self, permtype="read") -> bool:
 		"""


### PR DESCRIPTION

When module onboarding is completed by a user but not saved it causes this error when user without system manager role logs in. 

![image](https://github.com/frappe/frappe/assets/9079960/394267fb-8bd2-41d8-a3dd-db93b80d7c20)

