### PR TITLE
feat(dashboard): Open linked document instead of list when count is 1

### DIFF
--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -31,21 +31,28 @@ context("Dashboard links", () => {
 
 		//To check if initially the dashboard contains only the "Contact" link and there is no counter
 		cy.select_form_tab("Connections");
-		cy.get('[data-doctype="Contact"]').should("contain", "Contact");
+		cy.get('.document-link-badge[data-doctype="Contact"]').should("contain", "Contact");
+		cy.get('.document-link-badge[data-doctype="Contact"] > .count').should("contain", "1");
+
+		//To check if a dashboard link with count = 1 contains a link to the document directly
+		cy.get('.document-link-badge[data-doctype="Contact"] > .badge-link')
+			.should("have.attr", "href")
+			.and("include", "/app/contact/");
 
 		//Adding a new contact
-		cy.get('.document-link-badge[data-doctype="Contact"]').click();
+		cy.get('.document-link[data-doctype="Contact"] .btn-new').click();
 		cy.wait(300);
-		cy.findByRole("button", { name: "Add Contact" }).should("be.visible");
-		cy.findByRole("button", { name: "Add Contact" }).click();
 		cy.get('[data-doctype="Contact"][data-fieldname="first_name"]').type("Admin");
 		cy.findByRole("button", { name: "Save" }).click();
-		cy.visit(`/app/user/${cy.config("testUser")}`);
 
 		//To check if the counter for contact doc is "2" after adding additional contact
+		cy.visit(`/app/user/${cy.config("testUser")}`);
 		cy.select_form_tab("Connections");
-		cy.get('[data-doctype="Contact"] > .count').should("contain", "2");
-		cy.get('[data-doctype="Contact"]').contains("Contact").click();
+		cy.get('.document-link-badge[data-doctype="Contact"] > .count').should("contain", "2");
+
+		//To check that the dashboard link with count > 1 links to a list view
+		cy.get('.document-link-badge[data-doctype="Contact"]').contains("Contact").click();
+		cy.url().should("include", "/app/contact");
 
 		//Deleting the newly created contact
 		cy.visit("/app/contact");
@@ -53,12 +60,13 @@ context("Dashboard links", () => {
 		cy.findByRole("button", { name: "Actions" }).click();
 		cy.get('.actions-btn-group [data-label="Delete"]').click();
 		cy.findByRole("button", { name: "Yes" }).click({ delay: 700 });
-
-		//To check if the counter from the "Contact" doc link is removed
 		cy.wait(700);
-		cy.visit("/app/user");
-		cy.get(".list-row-col > .level-item > .ellipsis").eq(0).click({ force: true });
-		cy.get('[data-doctype="Contact"]').should("contain", "Contact");
+
+		//To check if the counter from the "Contact" doc link is decreased
+		cy.visit(`/app/user/${cy.config("testUser")}`);
+		cy.select_form_tab("Connections");
+		cy.get('.document-link-badge[data-doctype="Contact"]').should("contain", "Contact");
+		cy.get('.document-link-badge[data-doctype="Contact"] > .count').should("contain", "1");
 	});
 
 	it("Report link in dashboard", () => {

--- a/cypress/integration/dashboard_links.js
+++ b/cypress/integration/dashboard_links.js
@@ -56,7 +56,7 @@ context("Dashboard links", () => {
 
 		//Deleting the newly created contact
 		cy.visit("/app/contact");
-		cy.get(".list-subject > .select-like > .list-row-checkbox").eq(0).click({ force: true });
+		cy.get('.list-subject > .select-like > .list-row-checkbox[data-name="Admin"]').eq(0).click({ force: true });
 		cy.findByRole("button", { name: "Actions" }).click();
 		cy.get('.actions-btn-group [data-label="Delete"]').click();
 		cy.findByRole("button", { name: "Yes" }).click({ delay: 700 });

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -341,12 +341,14 @@ def get_external_links(doctype, name, links):
 	else:
 		data["open_count"] = 0
 
-	total = len(
-		frappe.get_all(
-			doctype, fields="name", filters={fieldname: name}, limit=100, distinct=True, ignore_ifnull=True
-		)
+	all_docs = frappe.get_all(
+		doctype, fields="name", filters={fieldname: name}, limit=100, distinct=True, ignore_ifnull=True
 	)
+	total = len(all_docs)
 	data["count"] = total
+
+	if total == 1:
+		data["docname"] = all_docs[0].name
 
 	return data
 

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -365,6 +365,11 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	}
 
 	open_document_list($link, show_open) {
+		// don't use set_route if href is set
+		if ($link.find("a").attr("href")) {
+			return;
+		}
+
 		// show document list with filters
 		let doctype = $link.attr("data-doctype"),
 			names = $link.attr("data-names") || [];
@@ -467,17 +472,26 @@ frappe.ui.form.Dashboard = class FormDashboard {
 			me.frm.dashboard.set_badge_count_for_external_link(
 				d.doctype,
 				cint(d.open_count),
-				cint(d.count)
+				cint(d.count),
+				d.docname
 			);
 		});
 	}
 
-	set_badge_count_for_external_link(doctype, open_count, count) {
+	set_badge_count_for_external_link(doctype, open_count, count, docname) {
 		let $link = $(this.transactions_area).find(
 			'.document-link[data-doctype="' + doctype + '"]'
 		);
 
 		this.set_badge_count_common(open_count, count, $link);
+
+		if (docname) {
+			$link.find("a").attr({
+				href: frappe.utils.get_form_link(doctype, docname),
+				"data-name": docname,
+				"data-doctype": doctype,
+			});
+		}
 	}
 
 	set_badge_count_for_internal_link(doctype, open_count, count, names) {

--- a/frappe/tests/test_dashboard_connections.py
+++ b/frappe/tests/test_dashboard_connections.py
@@ -105,6 +105,7 @@ class TestDashboardConnections(FrappeTestCase):
 						"doctype": "Test Doctype B With Child Table With Link To Doctype A",
 						"open_count": 0,
 						"count": 1,
+						"docname": "Pluto",
 					}
 				],
 				"internal_links_found": [],


### PR DESCRIPTION
## Description

When a dashboard link has only one document, open the document instead of the list when clicking on the link.

This is done by adding the `href` attribute to the link, and skipping any `frappe.set_route` calls.
Additional attributes `data-doctype` and `data-name` are added to enable the link preview popover, as shown in the picture below.

![image](https://github.com/frappe/frappe/assets/10946971/87791be8-7d6f-4ff2-aa6f-e7b58db345c6)

---

I tried to be forward compatible, in case document-links stop using `set_route` to instead all have `href`s (to allow ctrl/cmd-click to open in a new tab, etc.).

> no-docs