### PR TITLE
feat: add upstream json argument to integrations make_request

### DIFF
--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -10,14 +10,14 @@ from frappe import _
 from frappe.utils import get_request_session
 
 
-def make_request(method, url, auth=None, headers=None, data=None):
+def make_request(method, url, auth=None, headers=None, data=None, json=None):
 	auth = auth or ""
 	data = data or {}
 	headers = headers or {}
 
 	try:
 		s = get_request_session()
-		frappe.flags.integration_request = s.request(method, url, data=data, auth=auth, headers=headers)
+		frappe.flags.integration_request = s.request(method, url, data=data, auth=auth, headers=headers, json=json)
 		frappe.flags.integration_request.raise_for_status()
 
 		if frappe.flags.integration_request.headers.get("content-type") == "text/plain; charset=utf-8":

--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -17,7 +17,9 @@ def make_request(method, url, auth=None, headers=None, data=None, json=None):
 
 	try:
 		s = get_request_session()
-		frappe.flags.integration_request = s.request(method, url, data=data, auth=auth, headers=headers, json=json)
+		frappe.flags.integration_request = s.request(
+			method, url, data=data, auth=auth, headers=headers, json=json
+		)
 		frappe.flags.integration_request.raise_for_status()
 
 		if frappe.flags.integration_request.headers.get("content-type") == "text/plain; charset=utf-8":


### PR DESCRIPTION
# Context

- requests <a href="https://requests.readthedocs.io/en/latest/user/quickstart/#:~:text=If%20you%20need%20that%20header%20set%20and%20you%20don%E2%80%99t%20want%20to%20encode%20the%20dict%20yourself%2C%20you%20can%20also%20pass%20it%20directly%20using%20the%20json%20parameter%20(added%20in%20version%202.4.2)%20and%20it%20will%20be%20encoded%20automatically%3A">added a json quality-of-life parameter in version 2.4.2</a>.
- More than a few api integrations use `application/json` and json-encoded payload (actually probably the vast majority)
- whe passing as `json=`, the user can:
  - omit to set content headers
  - omit manual json encoding

# Proposed Change

Transparently expose that quality-of-life feature for better DevX and slightly cleaner code at the site of the buisness logic.
