### PR TITLE
feat: view committed queries in console log

### DIFF
--- a/frappe/desk/doctype/console_log/console_log.json
+++ b/frappe/desk/doctype/console_log/console_log.json
@@ -7,7 +7,8 @@
  "engine": "InnoDB",
  "field_order": [
   "script",
-  "type"
+  "type",
+  "committed"
  ],
  "fields": [
   {
@@ -23,11 +24,18 @@
    "hidden": 1,
    "label": "Type",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "committed",
+   "fieldtype": "Check",
+   "label": "Committed",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-27 22:52:37.239039",
+ "modified": "2023-09-19 13:02:56.332137",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Console Log",

--- a/frappe/desk/doctype/console_log/console_log.py
+++ b/frappe/desk/doctype/console_log/console_log.py
@@ -14,6 +14,7 @@ class ConsoleLog(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		committed: DF.Check
 		script: DF.Code | None
 		type: DF.Data | None
 	# end: auto-generated types

--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -40,7 +40,9 @@ class SystemConsole(Document):
 			frappe.db.commit()
 		else:
 			frappe.db.rollback()
-		frappe.get_doc(dict(doctype="Console Log", script=self.console, type=self.type, commited=self.commit)).insert()
+		frappe.get_doc(
+			dict(doctype="Console Log", script=self.console, type=self.type, committed=self.commit)
+		).insert()
 		frappe.db.commit()
 
 

--- a/frappe/desk/doctype/system_console/system_console.py
+++ b/frappe/desk/doctype/system_console/system_console.py
@@ -40,7 +40,7 @@ class SystemConsole(Document):
 			frappe.db.commit()
 		else:
 			frappe.db.rollback()
-		frappe.get_doc(dict(doctype="Console Log", script=self.console, type=self.type)).insert()
+		frappe.get_doc(dict(doctype="Console Log", script=self.console, type=self.type, commited=self.commit)).insert()
 		frappe.db.commit()
 
 


### PR DESCRIPTION
### Changes:
* Committed queries can now be identified from the console log

<img width="918" alt="Screenshot 2023-09-19 at 1 13 38 PM" src="https://github.com/frappe/frappe/assets/30501401/3c17f98f-e7a1-44f1-9a8b-5af32857f95d">
