### PR TITLE
fix: Fix typo in form_tour

### DIFF
--- a/frappe/desk/doctype/form_tour/form_tour.js
+++ b/frappe/desk/doctype/form_tour/form_tour.js
@@ -108,8 +108,8 @@ let add_custom_button = (frm) => {
 							tour_name: frm.doc.name,
 						},
 					});
-				},
-				delete frappe.boot.user.onboarding_status[frm.doc.name]
+					delete frappe.boot.user.onboarding_status[frm.doc.name];
+				}
 			);
 		});
 	} else {


### PR DESCRIPTION
Should've been a function instead of an expression

> no-docs