### PR TITLE
fix: Don't run query if dn is None

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -879,7 +879,9 @@ class Database:
 		"""
 		from frappe.model.utils import is_single_doctype
 
-		if (dn is None or dt == dn) and is_single_doctype(dt):
+		if dn is None or dt == dn:
+			if not is_single_doctype(dt):
+				return
 			deprecation_warning(
 				"Calling db.set_value on single doctype is deprecated. This behaviour will be removed in future. Use db.set_single_value instead."
 			)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -693,6 +693,12 @@ class TestDBSetValue(FrappeTestCase):
 		current_value = frappe.db.get_single_value("System Settings", "deny_multiple_sessions")
 		self.assertEqual(current_value, changed_value)
 
+	def test_none_no_set_value(self):
+		frappe.db.set_value("User", None, "middle_name", "test")
+		with self.assertQueryCount(0):
+			frappe.db.set_value("User", None, "middle_name", "test")
+			frappe.db.set_value("User", "User", "middle_name", "test")
+
 	def test_update_single_row_single_column(self):
 		frappe.db.set_value("ToDo", self.todo1.name, "description", "test_set_value change 1")
 		updated_value = frappe.db.get_value("ToDo", self.todo1.name, "description")


### PR DESCRIPTION
Earlier if `None` was passed as Dn it used to put value in tabSingles but now we check if it's a single doctype or not. 

This however causes a problem where the update query runs without any filters. 

Fix: don't do anything, similar to previous behaviour. 