### PR TITLE
feat: add pagination in Kanban Board

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -376,7 +376,7 @@ frappe.views.BaseList = class BaseList {
 					</button>
 				</div>
 			</div>`
-		).hide();
+		);
 		this.$frappe_list.append(this.$paging_area);
 
 		// set default paging btn active

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -64,7 +64,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 			this.board_name = frappe.get_route()[3] || get_board_name() || null;
 			this.page_title = __(this.board_name);
 			this.card_meta = this.get_card_meta();
-			this.page_length = 0;
+			this.page_length = 20;
 
 			return frappe.run_serially([
 				() => this.set_board_perms_and_push_menu_items(),
@@ -114,7 +114,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	setup_paging_area() {
-		// pass
+		super.setup_paging_area();
 	}
 
 	toggle_result_area() {

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -343,6 +343,10 @@ body[data-route*="Kanban"] {
 			color: var(--text-color) !important;
 		}
 	}
+    .list-paging-area {
+        margin-left: 1rem;
+        padding: 1rem 0;
+    }
 }
 
 .edit-card-title {


### PR DESCRIPTION
Fix issue: #22451 

Added basic pagination in Kanban view/board.

**Output**
<img width="1448" alt="Screenshot 2023-09-19 at 11 50 11 PM" src="https://github.com/frappe/frappe/assets/69882648/3560f719-841c-42c4-b56a-804510ece09b">

<img width="1393" alt="Screenshot 2023-09-19 at 11 50 29 PM" src="https://github.com/frappe/frappe/assets/69882648/0919f2f2-f566-4883-b7e0-c8835c986f7a">

