### PR TITLE
fix: reportview where fields dont have label

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.html
+++ b/frappe/public/js/frappe/ui/group_by/group_by.html
@@ -10,22 +10,12 @@
 				<option value="" disabled selected>{{ __("Select Group By...") }}</option>
 				{% for (var parent_doctype in group_by_conditions) { %}
 					{% for (var val in group_by_conditions[parent_doctype]) { %}
-						{% if (parent_doctype !== doctype) { %}
-						<option
-							data-doctype="{{parent_doctype}}"
-							value="{{group_by_conditions[parent_doctype][val].fieldname}}"
-						>
-							{{ __(group_by_conditions[parent_doctype][val].label) }}
-							({{ __(parent_doctype) }})
-						</option>
-						{% } else { %}
 						<option
 							data-doctype="{{parent_doctype}}"
 							value="{{group_by_conditions[parent_doctype][val].fieldname}}"
 						>
 							{{ __(group_by_conditions[parent_doctype][val].label || group_by_conditions[parent_doctype][val].fieldname) }}
 						</option>
-						{% } %}
 					{% } %}
 				{% } %}
 			</select>

--- a/frappe/public/js/frappe/ui/group_by/group_by.html
+++ b/frappe/public/js/frappe/ui/group_by/group_by.html
@@ -23,7 +23,7 @@
 							data-doctype="{{parent_doctype}}"
 							value="{{group_by_conditions[parent_doctype][val].fieldname}}"
 						>
-							{{ __(group_by_conditions[parent_doctype][val].label) }}
+							{{ __(group_by_conditions[parent_doctype][val].label || group_by_conditions[parent_doctype][val].fieldname) }}
 						</option>
 						{% } %}
 					{% } %}

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -369,7 +369,7 @@ frappe.ui.GroupBy = class {
 		const tag_field = { fieldname: "_user_tags", fieldtype: "Data", label: __("Tags") };
 		this.group_by_fields[this.doctype] = fields
 			.concat(tag_field)
-			.sort((a, b) => __(a.label).localeCompare(__(b.label)));
+			.sort((a, b) => __(cstr(a.label)).localeCompare(cstr(__(b.label))));
 		this.all_fields[this.doctype] = this.report_view.meta.fields;
 
 		const standard_fields_filter = (df) =>
@@ -407,8 +407,9 @@ frappe.ui.GroupBy = class {
 	}
 
 	get_group_by_field_label() {
-		return this.group_by_fields[this.group_by_doctype].find(
+		let field = this.group_by_fields[this.group_by_doctype].find(
 			(field) => field.fieldname == this.group_by_field
-		).label;
+		);
+		return field.label || field.fieldname;
 	}
 };


### PR DESCRIPTION
- Fixes an issue where old fields don't have label set (i.e. `None`) This doesn't happen with newly created fields AFAIK. 
- Also handles fields where label is empty by falling back to fieldname.
- the code for handling child table vs parent table was exactly same, so remove the conditional branches. 

![image](https://github.com/frappe/frappe/assets/9079960/7f80101d-bd87-47b1-ba0f-7d507cb0e66e)
