### PR TITLE
fix(base_list): setup_filter_area error handling

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -308,7 +308,9 @@ frappe.views.BaseList = class BaseList {
 		this.filter_area = new FilterArea(this);
 
 		if (this.filters && this.filters.length > 0) {
-			return this.filter_area.set(this.filters);
+			return this.filter_area.set(this.filters).catch(() => {
+				this.filter_area.clear(false);
+			});
 		}
 	}
 


### PR DESCRIPTION
Depends on https://github.com/frappe/frappe/pull/22484

**Problem**

List view initial setup can fail on setting filter values and can become unusable in certain cases.

`__UserSettings` list view filters or URL route option filters may include some filter values that will fail on setting. For example a filter value on a field which the user does not have permission to Select or Read. Or some other error. This leads to list view failing on setup and becoming dysfunctional and unusable.

![image](https://github.com/frappe/frappe/assets/328330/dda61bfc-e8e7-4ce4-a34b-08861a605ee7)


**Solution**
Catch exception on setting up filter area and setting filter values and remove all filters