### PR TITLE
fix(run-ui-tests): Allow setting browser option

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -850,6 +850,7 @@ def run_parallel_tests(
 @click.option("--headless", is_flag=True, help="Run UI Test in headless mode")
 @click.option("--parallel", is_flag=True, help="Run UI Test in parallel mode")
 @click.option("--with-coverage", is_flag=True, help="Generate coverage report")
+@click.option("--browser", default="electron", help="Browser to run tests in")
 @click.option("--ci-build-id")
 @pass_context
 def run_ui_tests(
@@ -858,6 +859,7 @@ def run_ui_tests(
 	headless=False,
 	parallel=True,
 	with_coverage=False,
+	browser="electron",
 	ci_build_id=None,
 	cypressargs=None,
 ):
@@ -905,8 +907,11 @@ def run_ui_tests(
 		frappe.commands.popen(f"(cd ../frappe && yarn add {packages} --no-lockfile)")
 
 	# run for headless mode
-	run_or_open = "run --browser chrome --record" if headless else "open"
+	run_or_open = f"run --browser {browser}" if headless else "open"
 	formatted_command = f"{site_env} {password_env} {coverage_env} {cypress_path} {run_or_open}"
+
+	if os.environ.get("CYPRESS_RECORD_KEY"):
+		formatted_command += " --record"
 
 	if parallel:
 		formatted_command += " --parallel"

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -850,7 +850,7 @@ def run_parallel_tests(
 @click.option("--headless", is_flag=True, help="Run UI Test in headless mode")
 @click.option("--parallel", is_flag=True, help="Run UI Test in parallel mode")
 @click.option("--with-coverage", is_flag=True, help="Generate coverage report")
-@click.option("--browser", default="electron", help="Browser to run tests in")
+@click.option("--browser", default="chrome", help="Browser to run tests in")
 @click.option("--ci-build-id")
 @pass_context
 def run_ui_tests(
@@ -859,7 +859,7 @@ def run_ui_tests(
 	headless=False,
 	parallel=True,
 	with_coverage=False,
-	browser="electron",
+	browser="chrome",
 	ci_build_id=None,
 	cypressargs=None,
 ):


### PR DESCRIPTION
### Changes

* Pass browser option to Cypress via CLI, maintain `chrome` default
* Pass record option to Cypress if `CYPRESS_RECORD_KEY` envvar is set