### PR TITLE
feat: 'Save as draft' button for new, submittable documents.

### DIFF
--- a/cypress/integration/submittable_doctype.js
+++ b/cypress/integration/submittable_doctype.js
@@ -1,0 +1,51 @@
+import custom_submittable_doctype from "../fixtures/custom_submittable_doctype";
+
+context("Submittable doctype", () => {
+	before(() => {
+		cy.visit("/login");
+		cy.login();
+
+		// Create custom submittable doctype
+		cy.visit("/app/doctype");
+		cy.insert_doc("DocType", custom_submittable_doctype, true);
+	});
+
+	it("Submittable doc can be created via Quick Entry form", () => {
+		cy.visit("/app/custom-submittable-doctype");
+		cy.click_listview_primary_button("Add Custom Submittable DocType");
+
+		// Add a new entry via Quick Entry Form.
+		cy.fill_field("title", "Test");
+		cy.click_modal_primary_button("Save");
+		cy.click_modal_primary_button("Submit");
+
+		// Find the new document and cancel it.
+		cy.visit("/app/custom-submittable-doctype");
+		cy.click_listview_row_item(0);
+		cy.get('[id="page-Custom Submittable DocType"] .page-actions')
+			.findByRole("button", { name: "Cancel" })
+			.click();
+		cy.get_open_dialog().findByRole("button", { name: "Yes" }).click();
+
+		// Now delete the document.
+		cy.visit("/app/custom-submittable-doctype");
+		cy.select_listview_row_checkbox(0);
+		cy.get(".page-actions").findByRole("button", { name: "Actions" }).click();
+		cy.get('.page-actions .actions-btn-group [data-label="Delete"]').click();
+		cy.click_modal_primary_button("Yes");
+	});
+
+	it("Submittable doc can be created via full form", () => {
+		cy.visit("/app/custom-submittable-doctype");
+		cy.click_listview_primary_button("Add Custom Submittable DocType");
+
+		// Dismiss Quick Entry and create a new document via full form.
+		cy.click_modal_custom_button("Edit Full Form");
+		cy.fill_field("title", "Test");
+		cy.click_doc_primary_button("Save");
+		cy.click_doc_primary_button("Submit");
+
+		cy.visit("/app/custom-submittable-doctype");
+		cy.click_listview_row_item(0);
+	});
+});

--- a/cypress/integration/submittable_doctype.js
+++ b/cypress/integration/submittable_doctype.js
@@ -16,7 +16,7 @@ context("Submittable doctype", () => {
 
 		// Add a new entry via Quick Entry Form.
 		cy.fill_field("title", "Test");
-		cy.click_modal_primary_button("Save");
+		cy.click_modal_primary_button("Save as draft");
 		cy.click_modal_primary_button("Submit");
 
 		// Find the new document and cancel it.
@@ -42,7 +42,7 @@ context("Submittable doctype", () => {
 		// Dismiss Quick Entry and create a new document via full form.
 		cy.click_modal_custom_button("Edit Full Form");
 		cy.fill_field("title", "Test");
-		cy.click_doc_primary_button("Save");
+		cy.click_doc_primary_button("Save as draft");
 		cy.click_doc_primary_button("Submit");
 
 		cy.visit("/app/custom-submittable-doctype");

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -479,6 +479,13 @@ Cypress.Commands.add("click_modal_primary_button", (btn_name) => {
 		.click({ force: true });
 });
 
+Cypress.Commands.add("click_modal_custom_button", (btn_name) => {
+	cy.wait(400);
+	cy.get(".modal-footer > .custom-actions > .btn-secondary")
+		.contains(btn_name)
+		.click({ force: true });
+});
+
 Cypress.Commands.add("click_sidebar_button", (btn_name) => {
 	cy.get(".list-group-by-fields .list-link > a").contains(btn_name).click({ force: true });
 });

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -153,7 +153,10 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 
 	register_primary_action() {
 		var me = this;
-		this.dialog.set_primary_action(__("Save"), function () {
+		const button_label = frappe.model.is_submittable(me.doctype)
+			? __("Save as draft")
+			: __("Save");
+		this.dialog.set_primary_action(button_label, function () {
 			if (me.dialog.working) {
 				return;
 			}

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -304,14 +304,13 @@ frappe.ui.form.Toolbar = class Toolbar {
 		const me = this;
 		const p = this.frm.perm[0];
 		const docstatus = cint(this.frm.doc.docstatus);
-		const is_submittable = frappe.model.is_submittable(this.frm.doc.doctype);
 
 		const print_settings = frappe.model.get_doc(":Print Settings", "Print Settings");
 		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
 		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
 
 		if (
-			!is_submittable ||
+			!this.is_submittable() ||
 			docstatus == 1 ||
 			(allow_print_for_cancelled && docstatus == 2) ||
 			(allow_print_for_draft && docstatus == 0)
@@ -559,6 +558,14 @@ frappe.ui.form.Toolbar = class Toolbar {
 	can_save() {
 		return this.get_docstatus() === 0;
 	}
+	can_save_as_draft() {
+		return (
+			this.is_submittable() &&
+			this.get_docstatus() === 0 &&
+			this.frm.doc.__islocal &&
+			this.frm.doc.__unsaved
+		);
+	}
 	can_submit() {
 		return (
 			this.get_docstatus() === 0 &&
@@ -591,6 +598,9 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 	get_docstatus() {
 		return cint(this.frm.doc.docstatus);
+	}
+	is_submittable() {
+		return frappe.model.is_submittable(this.frm.doc.doctype);
 	}
 	show_linked_with() {
 		if (!this.frm.linked_with) {
@@ -638,6 +648,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 		var status = null;
 		if (this.frm.page.current_view_name === "print" || this.frm.hidden) {
 			status = "Edit";
+		} else if (this.can_save_as_draft()) {
+			status = "Save as draft";
 		} else if (this.can_submit()) {
 			status = "Submit";
 		} else if (this.can_save()) {
@@ -661,7 +673,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 		this.page.clear_actions();
 
 		if (status !== "Edit") {
-			var perm_to_check = this.frm.action_perm_type_map[status];
+			var perm_to_check =
+				this.frm.action_perm_type_map[status === "Save as draft" ? "Save" : status];
 			if (!this.frm.perm[0][perm_to_check]) {
 				return;
 			}
@@ -695,22 +708,15 @@ frappe.ui.form.Toolbar = class Toolbar {
 				add_cancel_button();
 			}
 		} else {
-			var click = {
-				Save: function () {
-					return me.frm.save("Save", null, this);
-				},
-				Submit: function () {
-					return me.frm.savesubmit(this);
-				},
-				Update: function () {
-					return me.frm.save("Update", null, this);
-				},
-				Amend: function () {
-					return me.frm.amend_doc();
-				},
+			const click = {
+				Save: () => me.frm.save("Save", null, this),
+				"Save as draft": () => me.frm.save("Save", null, this),
+				Submit: () => me.frm.savesubmit(this),
+				Update: () => me.frm.save("Update", null, this),
+				Amend: () => me.frm.amend_doc(),
 			}[status];
 
-			var icon = {
+			const icon = {
 				Update: "edit",
 			}[status];
 


### PR DESCRIPTION
Turns the primary action button on new, submittable documents into “Save as draft“ to clearly communicate their preliminary status.

This is how new, submittable documents look like now:
![After](https://github.com/frappe/frappe/assets/46800703/dc602692-6b17-473f-9704-5bb405145e89)

Included some minor code refactoring where convenient.

~As is, this PR is going to fail quite some tests as particularly UI tests will be expecting a “Save” button. Tests need to be adapted then accordingly.~ Previously no coverage, so added UI tests.

Fixes #22435.

`no-docs`