### PR TITLE
fix: Add more usable fieldtypes to group by

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -364,7 +364,16 @@ frappe.ui.GroupBy = class {
 		this.all_fields = {};
 
 		const fields = this.report_view.meta.fields.filter((f) =>
-			["Select", "Link", "Data", "Int", "Check"].includes(f.fieldtype)
+			[
+				"Select",
+				"Link",
+				"Data",
+				"Int",
+				"Check",
+				"Dynamic Link",
+				"Autocomplete",
+				"Date",
+			].includes(f.fieldtype)
 		);
 		const tag_field = { fieldname: "_user_tags", fieldtype: "Data", label: __("Tags") };
 		this.group_by_fields[this.doctype] = fields


### PR DESCRIPTION
- Autocomplete is same as select
- Dynamic link is same as link
- Date is useful too

Possible improvement `group by date(datetime)` (not part of this PR)
