### PR TITLE
fix: stop media stream on hide

### DIFF
--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -98,7 +98,9 @@ frappe.ui.Capture = class {
 					fieldname: "total_count",
 				},
 			],
-			on_hide: this.stop_media_stream(),
+			on_hide: () => {
+				this.stop_media_stream();
+			},
 		});
 
 		me.$template = $(frappe.ui.Capture.TEMPLATE);


### PR DESCRIPTION
When the image capture dialog is hidden, stop the media stream.
Didn't work because the function was executed during setup.
