### PR TITLE
fix: render count on image capture

### DIFF
--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -105,6 +105,7 @@ frappe.ui.Capture = class {
 
 		let field = me.dialog.get_field("capture");
 		$(field.wrapper).html(me.$template);
+		me.update_count();
 
 		me.dialog.get_close_btn().on("click", () => {
 			me.hide();


### PR DESCRIPTION
Previously, "total_count" was displayed below the image stream when no image has been taken yet. Now we immediately call `update_count` to display "No Images".

 ![Bildschirmfoto 2023-08-21 um 13 40 36](https://github.com/frappe/frappe/assets/14891507/9a619cca-9b58-424b-951a-46e62af9871d)