### PR TITLE
fix: temporarily increase recursion depth for safe_eval

### DIFF
--- a/frappe/tests/test_safe_exec.py
+++ b/frappe/tests/test_safe_exec.py
@@ -121,6 +121,10 @@ class TestSafeExec(FrappeTestCase):
 		# dont Allow modifying _dict class
 		self.assertRaises(Exception, safe_exec, "_dict.x = 1")
 
+	def test_long_expression_evaluation(self):
+		long_expression = "0 if False else " + " 0 if False else " * 2000 + "1"
+		self.assertEqual(frappe.safe_eval(long_expression), 1)
+
 
 class TestNoSafeExec(FrappeTestCase):
 	def test_safe_exec_disabled_by_default(self):


### PR DESCRIPTION
This is required because people write long af expression for taxes and
the node transformer roughly visits each node 4ish times. So if you have
a nested if cond that's ~1000 conditions long then it will hit python's
recursion depth limit.

This is a temporary workaround, I'll figure out an alternate fix for it.
