### PR TITLE
fix: use relative path in file backup

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1438,9 +1438,9 @@ def get_site_path(*joins):
 	"""Return path of current site.
 
 	:param *joins: Join additional path elements using `os.path.join`."""
-	from os.path import abspath, join
+	from os.path import join, normpath
 
-	return abspath(join(local.site_path, *joins))
+	return normpath(join(local.site_path, *joins))
 
 
 def get_pymodule_path(modulename, *joins):

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -238,6 +238,7 @@ class TestCommands(BaseTestCommands):
 		self.assertEqual(self.returncode, 0)
 		self.assertEqual(self.stdout[1:-1], frappe.bold(text="DocType"))
 
+	@run_only_if(db_type_is.MARIADB)
 	def test_restore(self):
 		# step 0: create a site to run the test on
 		global_config = {

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -238,7 +238,6 @@ class TestCommands(BaseTestCommands):
 		self.assertEqual(self.returncode, 0)
 		self.assertEqual(self.stdout[1:-1], frappe.bold(text="DocType"))
 
-	@unittest.skip
 	def test_restore(self):
 		# step 0: create a site to run the test on
 		global_config = {


### PR DESCRIPTION
Because of #22142, get_site_path returns an absolute path. It broke file restores on sites.

<img width="878" alt="image" src="https://github.com/frappe/frappe/assets/9355208/0fb6acce-ba65-45b7-bfe9-59ce99ca18bd">
