### PR TITLE
fix: rss rendering of blog entries

### DIFF
--- a/frappe/www/rss.py
+++ b/frappe/www/rss.py
@@ -17,16 +17,15 @@ def get_context(context):
 
 	blog_list = frappe.get_all(
 		"Blog Post",
-		fields=["name", "published_on", "modified", "title", "content"],
+		fields=["name", "published_on", "modified", "title", "blog_intro", "route"],
 		filters={"published": 1},
 		order_by="published_on desc",
 		limit=20,
 	)
 
 	for blog in blog_list:
-		blog_page = cstr(quote(blog.name.encode("utf-8")))
-		blog.link = urljoin(host, blog_page)
-		blog.content = escape_html(blog.content or "")
+		blog.link = urljoin(host, blog.route)
+		blog.blog_intro = escape_html(blog.blog_intro or "")
 		blog.title = escape_html(blog.title or "")
 
 	if blog_list:

--- a/frappe/www/rss.xml
+++ b/frappe/www/rss.xml
@@ -9,7 +9,7 @@
         <ttl>1800</ttl>
 		{% for i in items %}<item>
 			        <title>{{ i.title }}</title>
-			        <description>{{ i.content }}</description>
+			        <description>{{ i.blog_intro }}</description>
 			        <link>{{ i.link }}</link>
 			        <guid>{{ i.name }}</guid>
 			        <pubDate>{{ i.published_on }}</pubDate>


### PR DESCRIPTION
# Context

RSS feed was:
```xml

<title>The value of value</title>
<description></description>
<link>http://localhost:8000/the-value-of-value</link>
<guid>the-value-of-value</guid>
<pubDate>2023-09-19</pubDate>
```

- Link is wrong
- Description is empty (because context can be `content`, `content_markdown` or `content_html`)


# Solution

- construe the link properly
- fetch description from blog intro

Result:
```xml
<title>The value of value</title>
<description>babibubabibubabi</description>
<link>http://localhost:8000/blog/food/the-value-of-value</link>
<guid>the-value-of-value</guid>
<pubDate>2023-09-19</pubDate>
```

- Link is ok
- Description is present
