### PR TITLE
fix: handle poorly encoded from emails

### DIFF
--- a/frappe/core/doctype/log_settings/log_settings.py
+++ b/frappe/core/doctype/log_settings/log_settings.py
@@ -20,6 +20,7 @@ DEFAULT_LOGTYPES_RETENTION = {
 	"Prepared Report": 30,
 	"Webhook Request Log": 30,
 	"Integration Request": 90,
+	"Unhandled Email": 30,
 	"Reminder": 30,
 }
 

--- a/frappe/email/doctype/unhandled_email/unhandled_email.py
+++ b/frappe/email/doctype/unhandled_email/unhandled_email.py
@@ -20,10 +20,12 @@ class UnhandledEmail(Document):
 		reason: DF.LongText | None
 		uid: DF.Data | None
 	# end: auto-generated types
-	pass
 
-
-def remove_old_unhandled_emails():
-	frappe.db.delete(
-		"Unhandled Email", {"creation": ("<", frappe.utils.add_days(frappe.utils.nowdate(), -30))}
-	)
+	@staticmethod
+	def clear_old_logs(days=30):
+		frappe.db.delete(
+			"Unhandled Email",
+			{
+				"modified": ("<", frappe.utils.add_days(frappe.utils.nowdate(), -1 * days)),
+			},
+		)

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -435,7 +435,8 @@ class Email:
 
 		self.from_real_name = parse_addr(_from_email)[0] if "@" in _from_email else _from_email
 
-	def decode_email(self, email):
+	@staticmethod
+	def decode_email(email):
 		if not email:
 			return
 		decoded = ""
@@ -443,7 +444,7 @@ class Email:
 			frappe.as_unicode(email).replace('"', " ").replace("'", " ")
 		):
 			if encoding:
-				decoded += part.decode(encoding)
+				decoded += part.decode(encoding, "replace")
 			else:
 				decoded += safe_decode(part)
 		return decoded

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -197,6 +197,12 @@ Reply-To: test2_@erpnext.com
 		mail = Email(content_bytes)
 		self.assertEqual(mail.text_content, text_content)
 
+	def test_poorly_encoded_messages(self):
+		mail = Email.decode_email(
+			"=?iso-2022-jp?B?VEFLQVlBTUEgS2FvcnUgWxskQnxiOzMbKEIgGyRCNzAbKEJd?=\n\t<user@example.com>"
+		)
+		self.assertIn("user@example.com", mail)
+
 
 def fixed_column_width(string, chunk_size):
 	parts = [string[0 + i : chunk_size + i] for i in range(0, len(string), chunk_size)]

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -237,7 +237,6 @@ scheduler_events = {
 		"frappe.integrations.doctype.google_contacts.google_contacts.sync",
 		"frappe.automation.doctype.auto_repeat.auto_repeat.make_auto_repeat_entry",
 		"frappe.automation.doctype.auto_repeat.auto_repeat.set_auto_repeat_as_completed",
-		"frappe.email.doctype.unhandled_email.unhandled_email.remove_old_unhandled_emails",
 	],
 	"daily_long": [
 		"frappe.integrations.doctype.dropbox_settings.dropbox_settings.take_backups_daily",


### PR DESCRIPTION
- refactor: move unhandled email to log settings
- fix: ignore poorly encoded email parts
