### PR TITLE
perf: lazy load SVG icons

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -36,8 +36,8 @@ app_include_css = [
 	"report.bundle.css",
 ]
 app_include_icons = [
-	"frappe/public/icons/timeless/icons.svg",
-	"frappe/public/icons/espresso/icons.svg",
+	"frappe/icons/timeless/icons.svg",
+	"frappe/icons/espresso/icons.svg",
 ]
 
 doctype_js = {

--- a/frappe/tests/test_website.py
+++ b/frappe/tests/test_website.py
@@ -391,27 +391,6 @@ class TestWebsite(FrappeTestCase):
 			delattr(frappe.local, "request")
 			frappe.set_user("Guest")
 
-	def test_include_icons(self):
-		from frappe import get_hooks
-
-		TEST_ICONS_PATH = "frappe/public/icons/timeless/test.svg"
-
-		def patched_get_hooks(*args, **kwargs):
-			return_value = get_hooks(*args, **kwargs)
-			if isinstance(return_value, dict) and "app_include_icons" in return_value:
-				return_value.app_include_icons.append(TEST_ICONS_PATH)
-			return return_value
-
-		with patch.object(frappe, "get_hooks", patched_get_hooks):
-			frappe.set_user("Administrator")
-
-			set_request(method="GET", path="/app")
-			content = get_response_content("/app")
-			# icon is available in a symbol tag
-			self.assertIn('id="icon-TEST-ONLY"', content)
-			delattr(frappe.local, "request")
-			frappe.set_user("Guest")
-
 
 def patched_get_hooks(hook, value):
 	def wrapper(*args, **kwargs):

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -563,10 +563,18 @@ def set_content_type(response, data, path):
 
 def add_preload_for_bundled_assets(response):
 	links = [f"<{css}>; rel=preload; as=style" for css in frappe.local.preload_assets["style"]]
-
 	links.extend(f"<{js}>; rel=preload; as=script" for js in frappe.local.preload_assets["script"])
+	links.extend(_preload_svg_headers())
+
 	if links:
 		response.headers["Link"] = ",".join(links)
+
+
+def _preload_svg_headers():
+	include_icons = frappe.get_hooks().get("app_include_icons", [])
+
+	version = frappe.cache.get_value("metadata_version")
+	return [f"</assets/{svg}?v={version}>; rel=preload; as=fetch" for svg in include_icons]
 
 
 @lru_cache

--- a/frappe/www/app.html
+++ b/frappe/www/app.html
@@ -20,16 +20,12 @@
 			href="{{ favicon or "/assets/frappe/images/frappe-favicon.svg" }}" type="image/x-icon">
 		<link rel="icon"
 			href="{{ favicon or "/assets/frappe/images/frappe-favicon.svg" }}" type="image/x-icon">
+		<div id="all-symbols" style="display:none"></div>
 		{% for include in include_css -%}
 		{{ include_style(include) }}
 		{%- endfor -%}
 	</head>
 	<body>
-		<div id="all-symbols" style="display:none!important;">
-			{%- for path in include_icons -%}
-				<!-- {{ path }} -->{%- include path ignore missing -%}
-			{%- endfor -%}
-		</div>
 		{% include "templates/includes/splash_screen.html" %}
 		<div class="main-section">
 			<header></header>
@@ -49,6 +45,16 @@
 			frappe.boot = JSON.parse({{ boot }});
 			frappe._messages = frappe.boot["__messages"];
 			frappe.csrf_token = "{{ csrf_token }}";
+
+
+			{%- for path in include_icons -%}
+			fetch(`/assets/{{ path }}?v=${window._version_number}`, { credentials: "same-origin" })
+				.then((r) => r.text())
+				.then((svg) => {
+					let svg_container = document.getElementById("all-symbols");
+					svg_container.insertAdjacentHTML("beforeend", svg);
+				});
+			{%- endfor -%}
 		</script>
 
 	{% for include in include_js %}


### PR DESCRIPTION
| Metric                             | Before | After | Change    |
| ---                                | ---    | ---   | ---       |
| app.html first response size       | 421kb  | 106kb | -75% (!)  |
| First response duration            | 60ms   | 40ms  | -33%      |

huge thanks to @cogk for doing most of the work for this PR on this issue: https://github.com/frappe/frappe/issues/17449#issuecomment-1728328726
