### PR TITLE
feat: file extension validate

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -88,6 +88,7 @@ class File(Document):
 		self.set_file_name()
 		self.validate_attachment_limit()
 		self.set_file_type()
+		self.validate_file_extension()
 
 		if self.is_folder:
 			return
@@ -342,6 +343,20 @@ class File(Document):
 
 		file_extension = mimetypes.guess_extension(file_type)
 		self.file_type = file_extension.lstrip(".").upper() if file_extension else None
+
+	def validate_file_extension(self):
+		if self.is_folder or not self.file_type:
+			return
+
+		if extension := frappe.db.sql_list(
+			"select UPPER(extension) as extension from `tabFile Extension`"
+		):
+			if self.file_type not in extension:
+				frappe.throw(
+					"Only following extensions are allowed : {}".format(
+						", ".join(frappe.bold(ext) for ext in extension)
+					)
+				)
 
 	def validate_file_on_disk(self):
 		"""Validates existence file"""

--- a/frappe/core/doctype/file_extension/file_extension.js
+++ b/frappe/core/doctype/file_extension/file_extension.js
@@ -1,0 +1,5 @@
+frappe.ui.form.on("File Extension", {
+    refresh: function (frm) {
+        //
+    }
+})

--- a/frappe/core/doctype/file_extension/file_extension.json
+++ b/frappe/core/doctype/file_extension/file_extension.json
@@ -1,0 +1,46 @@
+{
+    "actions": [],
+    "allow_rename": 1,
+    "autoname": "field:extension",
+    "creation": "2023-09-25 09:48:47.95",
+    "default_view": "List",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+      "extension"
+    ],
+    "fields": [
+      {
+        "fieldname": "extension",
+        "fieldtype": "Data",
+        "label": "Extension",
+        "unique": 1
+      }
+    ],
+    "index_web_pages_for_search": 1,
+    "links": [],
+    "modified": "2023-09-25 09:48:47.95",
+    "modified_by": "Administrator",
+    "module": "Core",
+    "name": "File Extension",
+    "naming_rule": "By fieldname",
+    "owner": "Administrator",
+    "permissions": [
+      {
+        "create": 1,
+        "delete": 1,
+        "email": 1,
+        "export": 1,
+        "print": 1,
+        "read": 1,
+        "report": 1,
+        "role": "System Manager",
+        "share": 1,
+        "write": 1
+      }
+    ],
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
+  }

--- a/frappe/core/doctype/file_extension/file_extension.py
+++ b/frappe/core/doctype/file_extension/file_extension.py
@@ -1,0 +1,5 @@
+import frappe
+from frappe.model.document import Document
+
+class FileExtension(Document):
+	pass


### PR DESCRIPTION
Validate File Extension, if records exist in File Extension Doctype then at the time of inserting new files it will allow only that type of extension that exists in File Extension.
