### PR TITLE
feat: let people add custom DB index from customize form

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -371,6 +371,7 @@ def rename_fieldname(custom_field: str, fieldname: str):
 
 	frappe.db.commit()
 	frappe.clear_cache()
+	frappe.msgprint(_("Fieldname renamed to {0}").format(new_fieldname), alert=True)
 
 
 def _update_fieldname_references(

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -774,6 +774,7 @@ docfield_properties = {
 	"hide_seconds": "Check",
 	"is_virtual": "Check",
 	"link_filters": "JSON",
+	"search_index": "Check",
 }
 
 doctype_link_properties = {

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -15,6 +15,7 @@
   "non_negative",
   "reqd",
   "unique",
+  "search_index",
   "is_virtual",
   "in_list_view",
   "in_standard_filter",
@@ -477,13 +478,19 @@
    "fieldname": "link_filters",
    "fieldtype": "JSON",
    "label": "Link Filters"
+  },
+  {
+   "default": "0",
+   "fieldname": "search_index",
+   "fieldtype": "Check",
+   "label": "Index"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-07 13:17:21.373626",
+ "modified": "2023-11-20 13:17:21.373626",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.py
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.py
@@ -104,6 +104,7 @@ class CustomizeFormField(Document):
 		remember_last_selected_value: DF.Check
 		report_hide: DF.Check
 		reqd: DF.Check
+		search_index: DF.Check
 		show_dashboard: DF.Check
 		sort_options: DF.Check
 		translatable: DF.Check


### PR DESCRIPTION
This assumes you understand what you're doing. Adding random indexes is
easy way to shoot yourself in foot with slow insert and large DB size.
