### PR TITLE
fix: Correct exit code for failed compressed file backup

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -15,6 +15,7 @@ from cryptography.fernet import Fernet
 
 # imports - module imports
 import frappe
+import frappe.utils
 from frappe import conf
 from frappe.utils import cint, get_file_size, get_url, now, now_datetime
 
@@ -343,12 +344,15 @@ class BackupGenerator:
 			backup_path = self.backup_path_files if folder == "public" else self.backup_path_private_files
 
 			if self.compress_files:
-				cmd_string = "tar cf - {1} | gzip > {0}"
+				cmd_string = "self=$$; ( tar cf - {1} || kill $self ) | gzip > {0}"
 			else:
 				cmd_string = "tar -cf {0} {1}"
 
 			frappe.utils.execute_in_shell(
-				cmd_string.format(backup_path, files_path), verbose=self.verbose, low_priority=True
+				cmd_string.format(backup_path, files_path),
+				verbose=self.verbose,
+				low_priority=True,
+				check_exit_code=True,
 			)
 
 	def copy_site_config(self):


### PR DESCRIPTION
This is very rare but it's still a possibility, so before using it in prod it's best to address this. 

Addresses https://github.com/frappe/press/issues/1052
Same as https://github.com/frappe/frappe/pull/18230