### PR TITLE
feat: Permissions for frappe.qb.get_query 

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -818,8 +818,7 @@ class Database:
 			for_update=for_update,
 			fields=fields,
 			distinct=distinct,
-			limit=limit,
-			validate_filters=True,
+			limit=limit
 		)
 		if isinstance(fields, str) and fields == "*":
 			as_dict = True
@@ -847,8 +846,7 @@ class Database:
 				filters=names,
 				order_by=order_by,
 				distinct=distinct,
-				limit=limit,
-				validate_filters=True,
+				limit=limit
 			).run(debug=debug, run=run, as_dict=as_dict, pluck=pluck)
 		return {}
 
@@ -903,8 +901,7 @@ class Database:
 		query = frappe.qb.get_query(
 			table=dt,
 			filters=dn,
-			update=True,
-			validate_filters=True,
+			update=True
 		)
 
 		if isinstance(dn, str):
@@ -1065,7 +1062,6 @@ class Database:
 			filters=filters,
 			fields=Count("*"),
 			distinct=distinct,
-			validate_filters=True,
 		).run(debug=debug)[0][0]
 		if not filters and cache:
 			frappe.cache.set_value(f"doctype:count:{dt}", count, expires_in_sec=86400)
@@ -1190,7 +1186,6 @@ class Database:
 			table=doctype,
 			filters=filters,
 			delete=True,
-			validate_filters=True,
 		)
 		if "debug" not in kwargs:
 			kwargs["debug"] = debug

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -770,7 +770,7 @@ class Database:
 			return self.value_cache[doctype][fieldname]
 
 		val = frappe.qb.get_query(
-			table="Singles",
+			"Singles",
 			filters={"doctype": doctype, "field": fieldname},
 			fields="value",
 		).run()
@@ -812,7 +812,7 @@ class Database:
 		limit=None,
 	):
 		query = frappe.qb.get_query(
-			table=doctype,
+			doctype=doctype,
 			filters=filters,
 			order_by=order_by,
 			for_update=for_update,
@@ -899,7 +899,7 @@ class Database:
 		)
 
 		query = frappe.qb.get_query(
-			table=dt,
+			doctype=dt,
 			filters=dn,
 			update=True
 		)
@@ -1058,7 +1058,7 @@ class Database:
 			if cache_count is not None:
 				return cache_count
 		count = frappe.qb.get_query(
-			table=dt,
+			doctype=dt,
 			filters=filters,
 			fields=Count("*"),
 			distinct=distinct,
@@ -1183,7 +1183,7 @@ class Database:
 		"""
 		filters = filters or kwargs.get("conditions")
 		query = frappe.qb.get_query(
-			table=doctype,
+			doctype=doctype,
 			filters=filters,
 			delete=True,
 		)

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -34,7 +34,7 @@ TABLE_NAME_PATTERN = re.compile(r"^[\w -]*$", flags=re.ASCII)
 class Engine:
 	def get_query(
 		self,
-		table: str | Table,
+		doctype: str | Table,
 		fields: list | tuple | None = None,
 		filters: dict[str, str | int] | str | int | list[list | str | int] | None = None,
 		order_by: str | None = None,
@@ -50,13 +50,13 @@ class Engine:
 		self.is_mariadb = frappe.db.db_type == "mariadb"
 		self.is_postgres = frappe.db.db_type == "postgres"
 
-		if isinstance(table, Table):
-			self.table = table
-			self.doctype = get_doctype_name(table.get_sql())
+		if isinstance(doctype, Table):
+			self.table = doctype
+			self.doctype = get_doctype_name(doctype.get_sql())
 		else:
-			self.doctype = table
+			self.doctype = doctype
 			self.validate_doctype()
-			self.table = frappe.qb.DocType(table)
+			self.table = frappe.qb.DocType(doctype)
 
 		if update:
 			self.query = frappe.qb.update(self.table)

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -231,8 +231,7 @@ def get_cards_for_user(doctype, txt, searchfield, start, page_len, filters):
 
 	condition_query = frappe.qb.get_query(
 		doctype,
-		filters=filters,
-		validate_filters=True,
+		filters=filters
 	)
 
 	return (

--- a/frappe/desk/listview.py
+++ b/frappe/desk/listview.py
@@ -41,7 +41,6 @@ def get_group_by_count(doctype: str, current_filters: str, field: str) -> list[d
 			doctype,
 			filters=current_filters,
 			fields=["name"],
-			validate_filters=True,
 		)
 
 		return (

--- a/frappe/tests/test_nestedset.py
+++ b/frappe/tests/test_nestedset.py
@@ -294,5 +294,5 @@ class TestNestedSet(FrappeTestCase):
 		self.assertNotIn(record, str(frappe.qb.get_query(TEST_DOCTYPE, filters=exclusive_filter)))
 		self.assertIn(record, str(frappe.qb.get_query(TEST_DOCTYPE, filters=inclusive_filter)))
 
-		self.assertNotIn(record, str(frappe.qb.get_query(table=linked_doctype, filters=exclusive_link)))
-		self.assertIn(record, str(frappe.qb.get_query(table=linked_doctype, filters=inclusive_link)))
+		self.assertNotIn(record, str(frappe.qb.get_query(linked_doctype, filters=exclusive_link)))
+		self.assertIn(record, str(frappe.qb.get_query(linked_doctype, filters=inclusive_link)))

--- a/frappe/tests/test_query.py
+++ b/frappe/tests/test_query.py
@@ -253,12 +253,21 @@ class TestQuery(FrappeTestCase):
 
 		self.assertRaisesRegex(
 			frappe.ValidationError,
-			"Invalid filter",
+			"Invalid fieldname",
 			lambda: frappe.qb.get_query(
 				"DocType",
 				fields=["name"],
-				filters={"permissions.role": "System Manager"},
-				validate_filters=True,
+				filters={"asdf.test": "System Manager"},
+			),
+		)
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			"Invalid fieldname",
+			lambda: frappe.qb.get_query(
+				"DocType",
+				fields=["name"],
+				filters={"user #": "System Manager"},
 			),
 		)
 

--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -30,8 +30,7 @@ def get_monthly_results(
 				DateFormat(Table[date_col], date_format).as_("month_year"),
 				Function(aggregation, goal_field),
 			],
-			filters=filters,
-			validate_filters=True,
+			filters=filters
 		)
 		.groupby("month_year")
 		.run()

--- a/frappe/utils/goal.py
+++ b/frappe/utils/goal.py
@@ -25,7 +25,7 @@ def get_monthly_results(
 
 	return dict(
 		frappe.qb.get_query(
-			table=goal_doctype,
+			goal_doctype,
 			fields=[
 				DateFormat(Table[date_col], date_format).as_("month_year"),
 				Function(aggregation, goal_field),


### PR DESCRIPTION
```py
In: frappe.qb.get_query('Note', fields=['name', 'title'], filters={'title': 'asdf'}, apply_permissions=True)
Out: "SELECT `name`,`title` FROM `tabNote` WHERE `title`='asdf' AND ((`name` IN ('437c2bcf21','',NULL) AND (`tabNote`.owner = 'user2@example.com' or `tabNote`.public = 1)) OR `name` IN ('437c2bcf21'))"
```

- [ ] Replace internal implementation of db.get_all to use qb.get_query and make tests pass