### PR TITLE
fix(NotPermittedPage): Add redirect-to even if starting with /app

### DIFF
--- a/frappe/website/page_renderers/not_permitted_page.py
+++ b/frappe/website/page_renderers/not_permitted_page.py
@@ -15,7 +15,7 @@ class NotPermittedPage(TemplatePage):
 
 	def render(self):
 		action = f"/login?redirect-to={frappe.request.path}"
-		if frappe.request.path.startswith("/app"):
+		if frappe.request.path.startswith("/app/") or frappe.request.path == "/app":
 			action = "/login"
 		frappe.local.message_title = _("Not Permitted")
 		frappe.local.response["context"] = dict(


### PR DESCRIPTION
A page like `/appointment` would redirect to `/login` **without** the `redirect-to` parameter, just because it starts with `/app`. What is desired is a redirect to `/login?redirect-to=/appointment`.

---
#### Suggestion
Maybe we could just drop the condition altogether and always add the redirect-to param?
In the commit (https://github.com/frappe/frappe/commit/abc5b51e57c5c8b3bc1801c256127eb0cd365b21) that introduced this condition, it's explained that it is necessary, but maybe it's not the case anymore? @shariquerik 

> no-docs