### PR TITLE
fix: no perm if doc doesn't exist

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -791,7 +791,11 @@ def has_permission(doc, ptype=None, user=None):
 		attached_to_doctype = doc.attached_to_doctype
 		attached_to_name = doc.attached_to_name
 
-		ref_doc = frappe.get_doc(attached_to_doctype, attached_to_name)
+		try:
+			ref_doc = frappe.get_doc(attached_to_doctype, attached_to_name)
+		except frappe.DoesNotExistError:
+			frappe.clear_last_message()
+			return False
 
 		if ptype in ["write", "create", "delete"]:
 			return ref_doc.has_permission("write")


### PR DESCRIPTION
Right now "doc doesn't exist is thrown, instead we can assume that user
doesn't have permission to this file. User might have access to other
file still.
