### PR TITLE
fix: set default to private for InteractionComposer

### DIFF
--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -75,7 +75,7 @@ frappe.views.InteractionComposer = class InteractionComposer {
 				options: "",
 				hidden: 1,
 			},
-			{ label: __("Public"), fieldtype: "Check", fieldname: "public", default: "1" },
+			{ label: __("Public"), fieldtype: "Check", fieldname: "public", default: "0" },
 			{ fieldtype: "Column Break" },
 			{ label: __("Date"), fieldtype: "Datetime", fieldname: "due_date" },
 			{


### PR DESCRIPTION
Most common use case for event/task is private so that should be default value for this. 

Public events are visible to everyone so it's not a good default IMO. 