### PR TITLE
fix: plus icon missing in workspace

### DIFF
--- a/frappe/public/icons/timeless/icons.svg
+++ b/frappe/public/icons/timeless/icons.svg
@@ -921,7 +921,7 @@
 	</symbol>
 
 	<symbol viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" stroke="none" id="icon-add-round">
-		<rect width="24" height="24" rx="12" fill="url(#paint0_linear_76:14)"/>
+		<rect width="24" height="24" rx="12" fill="var(--primary)"/>
 		<path d="M12 7V17" stroke="white" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 		<path d="M7 12H17" stroke="white" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
 		<defs>


### PR DESCRIPTION
Before:
<img width="1387" alt="image" src="https://github.com/frappe/frappe/assets/30859809/d8803e4e-72f3-46c5-95bc-b7471ded9838">

After:
<img width="1336" alt="image" src="https://github.com/frappe/frappe/assets/30859809/35e0b171-79ff-4c32-8a8a-86f62f004bfe">
