### PR TITLE
fix: Fix breakpoints CSS variables using map-get

### DIFF
--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -3,12 +3,12 @@
 :root,
 [data-theme="light"] {
 	// breakpoints
-	--xxl-width: map-get($grid-breakpoints, '2xl');
-	--xl-width: map-get($grid-breakpoints, 'xl');
-	--lg-width: map-get($grid-breakpoints, 'lg');
-	--md-width: map-get($grid-breakpoints, 'md');
-	--sm-width: map-get($grid-breakpoints, 'sm');
-	--xs-width: map-get($grid-breakpoints, 'xs');
+	--xxl-width: #{map-get($grid-breakpoints, '2xl')};
+	--xl-width: #{map-get($grid-breakpoints, 'xl')};
+	--lg-width: #{map-get($grid-breakpoints, 'lg')};
+	--md-width: #{map-get($grid-breakpoints, 'md')};
+	--sm-width: #{map-get($grid-breakpoints, 'sm')};
+	--xs-width: #{map-get($grid-breakpoints, 'xs')};
 
 	--navbar-height: 48px;
 


### PR DESCRIPTION
## I fixed them but maybe we should just remove these CSS variables ? Because they obviously did not work for quite some time.

**CSS custom properties**
Sass parses custom property declarations differently than other property declarations.
All tokens are passed through to CSS as-is.
— https://sass-lang.com/documentation/style-rules/declarations/#custom-properties

![image](https://github.com/frappe/frappe/assets/10946971/7b20e7ed-8742-4ecb-a64b-d9e076973722)



> no-docs