### PR TITLE
fix(query_doctypes): Allow search in translated name

### DIFF
--- a/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
+++ b/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.py
@@ -59,6 +59,6 @@ def query_doctypes(doctype, txt, searchfield, start, page_len, filters):
 	return [
 		[dt]
 		for dt in can_read
-		if txt.lower().replace("%", "") in dt.lower()
+		if txt.lower().replace("%", "") in frappe._(dt).lower()
 		and (include_single_doctypes or dt not in single_doctypes)
 	]

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -94,6 +94,33 @@ class TestSearch(FrappeTestCase):
 		finally:
 			frappe.local.lang = "en"
 
+	def test_doctype_search_in_foreign_language(self):
+		def do_search(txt: str):
+			search_link(
+				doctype="DocType",
+				txt=txt,
+				query="frappe.core.report.permitted_documents_for_user.permitted_documents_for_user.query_doctypes",
+				filters={"user": "Administrator"},
+				page_length=20,
+				searchfield=None,
+			)
+			return frappe.response["results"]
+
+		try:
+			frappe.local.lang = "en"
+			results = do_search("user")
+			self.assertIn("User", [x["value"] for x in results])
+
+			frappe.local.lang = "fr"
+			results = do_search("utilisateur")
+			self.assertIn("User", [x["value"] for x in results])
+
+			frappe.local.lang = "de"
+			results = do_search("nutzer")
+			self.assertIn("User", [x["value"] for x in results])
+		finally:
+			frappe.local.lang = "en"
+
 	def test_validate_and_sanitize_search_inputs(self):
 
 		# should raise error if searchfield is injectable


### PR DESCRIPTION
When searching for a DocType while adding a Shortcut block in a workspace, I'm using my language (i.e. French), but the search only works in English.

```js
await frappe.call("frappe.desk.search.search_link", {
  txt: "Article",  // 'Article' means Item in French
  filters: { "user": "french@example.com" },
  query: "frappe.core.report.permitted_documents_for_user.permitted_documents_for_user.query_doctypes",
  doctype: "DocType",
  reference_doctype: "",
});
// results -> empty
```

---

Used in two locations:

https://github.com/frappe/frappe/blob/a0783fa8cc4d98618227db981c168bb900fb24b2/frappe/core/report/permitted_documents_for_user/permitted_documents_for_user.js#L21

https://github.com/frappe/frappe/blob/a0783fa8cc4d98618227db981c168bb900fb24b2/frappe/public/js/frappe/widgets/widget_dialog.js#L358

> no-docs