### PR TITLE
fix(UX): Improve Quick Entry modal animation, feedback and code.

### DIFF
--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -161,9 +161,12 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 
 			if (data) {
 				me.dialog.working = true;
-				me.dialog.set_message(__("Saving..."));
 				me.insert().then(() => {
-					me.dialog.clear_message();
+					let messagetxt = __("Created new {0} {1}", [
+						__(me.doctype),
+						this.doc.name.bold(),
+					]);
+					frappe.show_alert({ message: messagetxt, indicator: "green" }, 3);
 				});
 			}
 		});

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -167,6 +167,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 						this.doc.name.bold(),
 					]);
 					frappe.show_alert({ message: messagetxt, indicator: "green" }, 3);
+					me.dialog.hide();
 				});
 			}
 		});
@@ -192,19 +193,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 							},
 						]);
 					} else {
-						me.dialog.hide();
-						// delete the old doc
-						frappe.model.clear_doc(me.dialog.doc.doctype, me.dialog.doc.name);
-						me.dialog.doc = r.message;
-						if (frappe._from_link) {
-							frappe.ui.form.update_calling_link(me.dialog.doc);
-						} else {
-							if (me.after_insert) {
-								me.after_insert(me.dialog.doc);
-							} else {
-								me.open_form_if_not_list();
-							}
-						}
+						me.process_after_insert(r);
 					}
 				},
 				error: function () {
@@ -229,23 +218,23 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 				doc: doc,
 			},
 			callback: function (r) {
-				me.dialog.hide();
-				// delete the old doc
-				frappe.model.clear_doc(me.dialog.doc.doctype, me.dialog.doc.name);
-				me.dialog.doc = r.message;
-				if (frappe._from_link) {
-					frappe.ui.form.update_calling_link(me.dialog.doc);
-				} else {
-					if (me.after_insert) {
-						me.after_insert(me.dialog.doc);
-					} else {
-						me.open_form_if_not_list();
-					}
-				}
-
+				me.process_after_insert(r);
 				cur_frm && cur_frm.reload_doc();
 			},
 		});
+	}
+
+	process_after_insert(r) {
+		// delete the old doc
+		frappe.model.clear_doc(this.dialog.doc.doctype, this.dialog.doc.name);
+		this.dialog.doc = r.message;
+		if (frappe._from_link) {
+			frappe.ui.form.update_calling_link(this.dialog.doc);
+		} else if (this.after_insert) {
+			this.after_insert(this.dialog.doc);
+		} else {
+			this.open_form_if_not_list();
+		}
 	}
 
 	open_form_if_not_list() {

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -166,8 +166,11 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 						__(me.doctype),
 						this.doc.name.bold(),
 					]);
-					frappe.show_alert({ message: messagetxt, indicator: "green" }, 3);
+					me.dialog.animation_speed = "slow";
 					me.dialog.hide();
+					setTimeout(function () {
+						frappe.show_alert({ message: messagetxt, indicator: "green" }, 3);
+					}, 500);
 				});
 			}
 		});
@@ -205,7 +208,6 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 					me.dialog.working = false;
 					resolve(me.dialog.doc);
 				},
-				freeze: true,
 			});
 		});
 	}

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -252,6 +252,10 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 	}
 
 	hide() {
+		if (this.animate && this.animation_speed === "slow") {
+			this.$wrapper.addClass("slow");
+			$(".modal-backdrop").addClass("slow");
+		}
 		this.$wrapper.modal("hide");
 		this.is_visible = false;
 	}

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -154,6 +154,24 @@ body.modal-open[style^="padding-right"] {
 	opacity: 0.8;
 }
 
+.fade.slow {
+	transition: opacity 0.4s linear;
+}
+
+.modal.fade .modal-dialog {
+	transition: transform 0.2s ease;
+	transform: translateY(-15%);
+}
+
+.modal.fade.slow .modal-dialog {
+	transition: transform 0.4s ease;
+	transform: translateY(-25%);
+}
+
+.modal.show .modal-dialog {
+	transform: none;
+}
+
 .modal-minimize {
 	position: initial;
 	height: 0;


### PR DESCRIPTION
1. Removes intermittent ‘Saving…’ dialog that doesn’t improve UX but adds visual friction, see #22598.

2. Same with the similarly redundant freeze effect which interferes with the dialog‘s backdrop.

3. Instead adds a (green) confirmation message:
> Created new [Doctype] ‘[Name]’.

4. Reloading the document list after a new one was added, takes quite some time, and the contrast between a fast animation and the long waiting period is awkward. Whenever the Quick Entry Form‘s input is saved, I‘m therefore slowing the animation a bit down (to 0.4s). In the other cases, particularly when aborting the Quick Entry Form, the animation may run a bit faster (0.2s). Before, the animation always ran 0.3s.

5. Some refactoring.

This is how it used to look like:

https://github.com/frappe/frappe/assets/46800703/ec83bc44-4e2b-4766-94e8-cc73571271cc

And this is how it looks like now – way smoother, way less friction, way less obvious waiting for the reload:


https://github.com/frappe/frappe/assets/46800703/c24899c4-5bbc-418e-86b1-024308ae2faf



Fixes #22599.
Checks the first two or three todos on #22598.