### PR TITLE
fix: prevent title overriden by buttons in small screen

### DIFF
--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -1,7 +1,7 @@
 <div class="page-head flex">
 	<div class="container">
 		<div class="row flex align-center page-head-content justify-between">
-			<div class="col-md-4 col-sm-6 col-xs-8 page-title">
+			<div class="col-md-4 col-sm-6 col-xs-6 page-title">
 				<!-- <div class="title-image hide hidden-md hidden-lg"></div> -->
 				<!-- title -->
 				<span class="sidebar-toggle-btn">

--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -1,7 +1,7 @@
 <div class="page-head flex">
 	<div class="container">
 		<div class="row flex align-center page-head-content justify-between">
-			<div class="col-md-4 col-sm-6 col-xs-6 page-title">
+			<div class="col-md-4 col-sm-6 col-xs-7 page-title">
 				<!-- <div class="title-image hide hidden-md hidden-lg"></div> -->
 				<!-- title -->
 				<span class="sidebar-toggle-btn">

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -12,7 +12,7 @@ body {
 @media (max-width: 1024px) {
 	body[data-route^="Form"] {
 		.page-title .title-text {
-			max-width: 350px;
+			max-width: 35vw;
 		}
 	}
 }
@@ -167,7 +167,7 @@ body {
 		.page-title {
 			.title-text {
 				@include get_textstyle("lg", "regular");
-				max-width: 300px;
+				max-width: 35vw;
 			}
 
 			.indicator {
@@ -385,14 +385,6 @@ body {
 		}
 		.asset-details {
 			line-height: 24px; /*Height of avtar image -36px to align text center vertically*/
-		}
-	}
-}
-
-@media (max-width: 480px) {
-	body[data-route^="Form"] {
-		.page-title .title-text {
-			max-width: 150px;
 		}
 	}
 }

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -9,6 +9,15 @@ body {
 // 	overflow-x: hidden;  //Prevent scroll on narrow devices
 // }
 
+@media (max-width: 1080px) {
+	body[data-route^="Form"] {
+		.page-title .title-text {
+			@include get_textstyle("lg", "regular");
+			max-width: 350px;
+		}
+	}
+}
+
 @media(max-width: 991px) {
 	.intro-area,
 	.footnote-area {

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -9,10 +9,9 @@ body {
 // 	overflow-x: hidden;  //Prevent scroll on narrow devices
 // }
 
-@media (max-width: 1080px) {
+@media (max-width: 1024px) {
 	body[data-route^="Form"] {
 		.page-title .title-text {
-			@include get_textstyle("lg", "regular");
 			max-width: 350px;
 		}
 	}
@@ -386,6 +385,14 @@ body {
 		}
 		.asset-details {
 			line-height: 24px; /*Height of avtar image -36px to align text center vertically*/
+		}
+	}
+}
+
+@media (max-width: 480px) {
+	body[data-route^="Form"] {
+		.page-title .title-text {
+			max-width: 150px;
 		}
 	}
 }

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -165,6 +165,10 @@ body {
 
 	body[data-route^="Form"]{
 		.page-title {
+			.title-text {
+				@include get_textstyle("lg", "regular");
+			}
+
 			.indicator {
 				margin: 0;
 			}

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -387,3 +387,11 @@ body {
 		}
 	}
 }
+
+@media (max-width: 412px) {
+	body[data-route^="Form"] {
+		.page-title .title-text {
+			max-width: 28vw;
+		}
+	}
+}

--- a/frappe/public/scss/desk/mobile.scss
+++ b/frappe/public/scss/desk/mobile.scss
@@ -165,11 +165,6 @@ body {
 
 	body[data-route^="Form"]{
 		.page-title {
-			.title-text {
-				@include get_textstyle("lg", "regular");
-				max-width: 35vw;
-			}
-
 			.indicator {
 				margin: 0;
 			}

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -31,7 +31,7 @@
 			cursor: pointer;
 			margin-bottom: 0px;
 			margin-right: var(--margin-sm);
-			max-width: 500px;
+			max-width: 48vw;
 		}
 		.indicator-pill {
 			margin-top: 2px;


### PR DESCRIPTION
Screen - max-width 480 px

**Before**
![image](https://github.com/frappe/frappe/assets/54097382/424d6fd2-da50-4d88-9e3e-f060fa20ddc9)

**After**
![image](https://github.com/frappe/frappe/assets/54097382/d7706ba2-dc1c-4a8d-9056-09c6260f0b51)

Screen - max-width 1024px

**Before**
![image](https://github.com/frappe/frappe/assets/54097382/88c2bae0-2d34-43b7-bb2b-341eb1c6b9a4)

**After**
![image](https://github.com/frappe/frappe/assets/54097382/2a6c2cab-f9b6-483a-ae04-807991aedc7d)


Closes: #22564
