### PR TITLE
fix: Give All role permission to read/create own address and contact

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -74,8 +74,9 @@
   },
   {
    "fieldname": "state",
-   "fieldtype": "Data",
-   "label": "State/Province"
+   "fieldtype": "Autocomplete",
+   "label": "State/Province",
+   "mandatory_depends_on": "eval: doc.country == 'India'"
   },
   {
    "fieldname": "country",
@@ -91,6 +92,7 @@
    "fieldname": "pincode",
    "fieldtype": "Data",
    "label": "Postal Code",
+   "mandatory_depends_on": "eval: doc.country == 'India' &&(gst_settings.enable_e_invoice || gst_settings.enable_e_waybill)",
    "search_index": 1
   },
   {
@@ -148,7 +150,7 @@
  "icon": "fa fa-map-marker",
  "idx": 5,
  "links": [],
- "modified": "2020-10-21 16:14:37.284830",
+ "modified": "2023-10-02 11:58:04.982763",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",
@@ -206,9 +208,24 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "if_owner": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "All",
+   "share": 1,
+   "write": 1
   }
  ],
+ "quick_entry": 1,
  "search_fields": "country, state",
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -75,8 +75,7 @@
   {
    "fieldname": "state",
    "fieldtype": "Autocomplete",
-   "label": "State/Province",
-   "mandatory_depends_on": "eval: doc.country == 'India'"
+   "label": "State/Province"
   },
   {
    "fieldname": "country",
@@ -92,7 +91,6 @@
    "fieldname": "pincode",
    "fieldtype": "Data",
    "label": "Postal Code",
-   "mandatory_depends_on": "eval: doc.country == 'India' &&(gst_settings.enable_e_invoice || gst_settings.enable_e_waybill)",
    "search_index": 1
   },
   {

--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -74,7 +74,7 @@
   },
   {
    "fieldname": "state",
-   "fieldtype": "Autocomplete",
+   "fieldtype": "Data",
    "label": "State/Province"
   },
   {

--- a/frappe/contacts/doctype/contact/contact.json
+++ b/frappe/contacts/doctype/contact/contact.json
@@ -257,7 +257,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-10-27 10:40:50.097481",
+ "modified": "2023-10-02 12:00:27.299156",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Contact",
@@ -381,10 +381,13 @@
    "write": 1
   },
   {
-   "permlevel": 1,
+   "create": 1,
+   "delete": 1,
+   "if_owner": 1,
    "read": 1,
    "report": 1,
-   "role": "All"
+   "role": "All",
+   "write": 1
   }
  ],
  "show_title_field_in_link": 1,

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -33,6 +33,7 @@ class Contact(Document):
 		google_contacts: DF.Link | None
 		google_contacts_id: DF.Data | None
 		image: DF.AttachImage | None
+		is_billing_contact: DF.Check
 		is_primary_contact: DF.Check
 		last_name: DF.Data | None
 		links: DF.Table[DynamicLink]

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -33,7 +33,6 @@ class Contact(Document):
 		google_contacts: DF.Link | None
 		google_contacts_id: DF.Data | None
 		image: DF.AttachImage | None
-		is_billing_contact: DF.Check
 		is_primary_contact: DF.Check
 		last_name: DF.Data | None
 		links: DF.Table[DynamicLink]


### PR DESCRIPTION
Many users like "E-commerce" or Shopping Cart users need permission to create and view their own addresses and contacts.

After the addition of https://github.com/frappe/frappe/pull/22574, such users were unable to do so.