### PR TITLE
fix: Fix scopes for Google Calendar

### DIFF
--- a/frappe/integrations/doctype/google_calendar/google_calendar.py
+++ b/frappe/integrations/doctype/google_calendar/google_calendar.py
@@ -214,7 +214,7 @@ def get_google_calendar_object(g_calendar):
 		"token_uri": GoogleOAuth.OAUTH_URL,
 		"client_id": google_settings.client_id,
 		"client_secret": google_settings.get_password(fieldname="client_secret", raise_exception=False),
-		"scopes": ["https://www.googleapis.com/auth/calendar/v3"],
+		"scopes": [SCOPES],
 	}
 
 	credentials = google.oauth2.credentials.Credentials(**credentials_dict)


### PR DESCRIPTION
According to <https://developers.google.com/identity/protocols/oauth2/scopes>, the correct scope is `https://www.googleapis.com/auth/calendar`.

---

Going to the web URL of the legacy scope, it shows:
> _<https://www.googleapis.com/auth/calendar/v3>_
>
> You are receiving this error either because your input OAuth2 scope name is invalid or it refers to a newer scope that is outside the domain of this legacy API.
>
> This API was built at a time when the scope name format was not yet standardized. This is no longer the case and all valid scope names (both old and new) are catalogued at https://developers.google.com/identity/protocols/oauth2/scopes. Use that webpage to lookup (manually) the scope name associated with the API you are trying to call and use it to craft your OAuth2 request.

> no-docs