### PR TITLE
fix: allow write perm by default in audit trail

### DIFF
--- a/frappe/core/doctype/audit_trail/audit_trail.json
+++ b/frappe/core/doctype/audit_trail/audit_trail.json
@@ -21,7 +21,7 @@
    "fieldname": "doctype_name",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Doctype",
+   "label": "DocType",
    "options": "DocType",
    "reqd": 1
   },
@@ -74,7 +74,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-08-22 12:12:59.780845",
+ "modified": "2023-10-04 12:45:49.099121",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Audit Trail",
@@ -85,7 +85,8 @@
    "print": 1,
    "read": 1,
    "role": "System Manager",
-   "share": 1
+   "share": 1,
+   "write": 1
   }
  ],
  "sort_field": "modified",


### PR DESCRIPTION
**Bug**
Inability to edit the DocType and Document fields in Audit Trail due to absence of write permission by default to the **System Manager**.

**Fix**
Allow write permission by default to System Manager.
Rename Doctype label to DocType.

`no-docs`