### PR TITLE
refactor(treewide): use `mariadb` commands directly instead of `mysql`

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -504,9 +504,9 @@ def postgres(context, extra_args):
 
 
 def _mariadb(extra_args=None):
-	mysql = which("mysql")
+	mariadb = which("mariadb")
 	command = [
-		mysql,
+		mariadb,
 		"--port",
 		str(frappe.conf.db_port),
 		"-u",
@@ -521,7 +521,7 @@ def _mariadb(extra_args=None):
 	]
 	if extra_args:
 		command += list(extra_args)
-	os.execv(mysql, command)
+	os.execv(mariadb, command)
 
 
 def _psql(extra_args=None):

--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -68,7 +68,7 @@ class DbManager:
 		if pipe:
 			print("Restoring Database file...")
 
-		command = "{pipe} mysql -u {user} -p{password} -h{host} -P{port} {target} {source}"
+		command = "{pipe} mariadb -u {user} -p{password} -h{host} -P{port} {target} {source}"
 		command = command.format(
 			pipe=pipe,
 			user=esc(user),

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -726,8 +726,8 @@ def _guess_mariadb_version() -> tuple[int] | None:
 	# in non-interactive mode.
 	# Use db.sql("select version()") instead if connection is available.
 	with suppress(Exception):
-		mysql = which("mysql")
-		version_output = subprocess.getoutput(f"{mysql} --version")
+		mariadb = which("mariadb")
+		version_output = subprocess.getoutput(f"{mariadb} --version")
 		version_regex = r"(?P<version>\d+\.\d+\.\d+)-MariaDB"
 
 		version = re.search(version_regex, version_output).group("version")

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -367,7 +367,7 @@ class BackupGenerator:
 		from frappe.utils.change_log import get_app_branch
 
 		db_exc = {
-			"mariadb": ("mysqldump", which("mysqldump")),
+			"mariadb": ("mariadb-dump", which("mariadb-dump")),
 			"postgres": ("pg_dump", which("pg_dump")),
 		}[self.db_type]
 		gzip_exc = which("gzip")

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -596,7 +596,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
       - name: Clone
@@ -638,8 +638,8 @@ jobs:
         run: |
           pip install frappe-bench
           bench init --skip-redis-config-generation --skip-assets --python "$(which python)" ~/frappe-bench
-          mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
-          mysql --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
+          mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
       - name: Install
         working-directory: /home/runner/frappe-bench


### PR DESCRIPTION
refactor: use `mariadb` instead of `mysql`

This resolves https://github.com/frappe/bench/issues/1472

This has been done because the mysql command issues a deprecation warning now
mysql: Deprecated program name. It will be removed in a future release, use '/usr/bin/mariadb' instead
