### PR TITLE
fix(minor): hide side section on new doc.

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -67,7 +67,9 @@ frappe.ui.form.Sidebar = class {
 	refresh() {
 		if (this.frm.doc.__islocal) {
 			this.sidebar.toggle(false);
+			this.page.sidebar.addClass("hide-sidebar");
 		} else {
+			this.page.sidebar.removeClass("hide-sidebar");
 			this.sidebar.toggle(true);
 			this.frm.assign_to.refresh();
 			this.frm.attachments.refresh();

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -169,6 +169,10 @@ body[data-route^="Module"] .main-menu {
 	@include get_textstyle("base", "regular");
 	padding-right: 30px;
 
+	&.hide-sidebar {
+		display: none;
+	}
+
 	> .divider {
 		display: none !important;
 	}


### PR DESCRIPTION
* on new doc, hide sidebar is hidden. however, layout-side-section is still visible.
* added hide-sidebar class to layout-side-section when doc is new.