### PR TITLE
fix: kanban remove unnecessary get_docfield

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -729,7 +729,7 @@ frappe.provide("frappe.views");
 			let fields = [];
 			for (let field_name of cur_list.board.fields) {
 				let field =
-					frappe.meta.get_docfield(card.doctype, field_name, card.name) ||
+					frappe.meta.docfield_map[card.doctype]?.[field_name] ||
 					frappe.model.get_std_field(field_name);
 				let label = cur_list.board.show_labels ? `<span>${__(field.label)}: </span>` : "";
 				let value = frappe.format(card.doc[field_name], field);


### PR DESCRIPTION
*  Label will be same for all documents so there is no need to call get_docfield.
*  As it internally calls docfield_copy and makes "deep copy" for each document. which causes massive memory usage as number of document increases.
*  Instead get meta from docfield_map.

get_docfield was added for #16257 . 