### PR TITLE
fix: don't allow setting an invalid rating

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -553,6 +553,7 @@ class Document(BaseDocument):
 		self._validate_selects()
 		self._validate_non_negative()
 		self._validate_length()
+		self._fix_rating_value()
 		self._validate_code_fields()
 		self._sync_autoname_field()
 		self._extract_images_from_text_editor()
@@ -599,6 +600,15 @@ class Document(BaseDocument):
 			if flt(self.get(df.fieldname)) < 0:
 				msg = get_msg(df)
 				frappe.throw(msg, frappe.NonNegativeError, title=_("Negative Value"))
+
+	def _fix_rating_value(self):
+		for field in self.meta.get("fields", {"fieldtype": "Rating"}):
+			value = self.get(field.fieldname)
+			if not isinstance(value, float):
+				value = flt(value)
+
+			# Make sure rating is between 0 and 1
+			self.set(field.fieldname, max(0, min(value, 1)))
 
 	def validate_workflow(self):
 		"""Validate if the workflow transition is valid"""

--- a/frappe/tests/test_rating.py
+++ b/frappe/tests/test_rating.py
@@ -1,0 +1,29 @@
+import frappe
+from frappe.core.doctype.doctype.test_doctype import new_doctype
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestRating(FrappeTestCase):
+	def setUp(self):
+		doc = new_doctype(
+			fields=[
+				{
+					"fieldname": "rating",
+					"fieldtype": "Rating",
+					"label": "rating",
+					"reqd": 1,  # mandatory
+				},
+			],
+		)
+		doc.insert()
+		self.doctype_name = doc.name
+
+	def test_negative_rating(self):
+		doc = frappe.new_doc(doctype=self.doctype_name, rating=-1)
+		doc.insert()
+		self.assertEqual(doc.rating, 0)
+
+	def test_positive_rating(self):
+		doc = frappe.new_doc(doctype=self.doctype_name, rating=5)
+		doc.insert()
+		self.assertEqual(doc.rating, 1)


### PR DESCRIPTION
Convert anything <0 to 0, and anything >1 to 1

Resolves #16245 

Before this patch:

```bash
❯ curl -sH "Authorization: token $token" http://localhost:8000/api/resource/Item/SKU00001 -X PUT --json '{"rating": 3.14}' | jq -r '.data.rating'
3.14
```

After this patch:

```bash
❯ curl -sH "Authorization: token $token" http://localhost:8000/api/resource/Item/SKU00001 -X PUT --json '{"rating": 3.14}' | jq -r '.data.rating'
1
```

