### PR TITLE
feat: enable `tabSelect` for awesomplete

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -184,6 +184,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		this.$input.cache = {};
 
 		this.awesomplete = new Awesomplete(me.input, {
+			tabSelect: true,
 			minChars: 0,
 			maxItems: 99,
 			autoFirst: true,


### PR DESCRIPTION
Resolves #14669

Was implemented in https://github.com/LeaVerou/awesomplete/pull/17145 but left disabled by default - so we just had to enable it.

> no-docs