### PR TITLE
fix(UX): Add 'Due Date' to Quick Entry Form, default to Today.

### DIFF
--- a/frappe/desk/doctype/todo/todo.json
+++ b/frappe/desk/doctype/todo/todo.json
@@ -62,8 +62,11 @@
    "label": "Color"
   },
   {
+   "allow_in_quick_entry": 1,
+   "default": "Today",
    "fieldname": "date",
    "fieldtype": "Date",
+   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Due Date",
    "oldfieldname": "date",
@@ -158,7 +161,7 @@
  "icon": "fa fa-check",
  "idx": 2,
  "links": [],
- "modified": "2021-09-16 11:36:34.586898",
+ "modified": "2023-10-05 07:44:38.476400",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "ToDo",


### PR DESCRIPTION
Fixes #22634.