### PR TITLE
fix: list view formatting logic

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -839,15 +839,18 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			frappe.model.is_numeric_field(df) ? "text-right" : "",
 		].join(" ");
 
-		const html_map = {
-			Subject: this.get_subject_html(doc),
-			Field: field_html(),
-		};
-		let column_html = html_map[col.type];
-
-		// listview_setting formatter
-		if (this.settings.formatters && this.settings.formatters[fieldname]) {
+		let column_html;
+		if (
+			this.settings.formatters &&
+			this.settings.formatters[fieldname] &&
+			col.type !== "Subject"
+		) {
 			column_html = this.settings.formatters[fieldname](value, df, doc);
+		} else {
+			column_html = {
+				Subject: this.get_subject_html(doc),
+				Field: field_html(),
+			}[col.type];
 		}
 
 		return `


### PR DESCRIPTION
### Problem

Custom formatters fail for title/subject field in certain cases due to duplicate formatting.

For example, consider this use case:

DocType ToDo has a Description field that may have html content (Text Editor). We want to add a formatter that strips the HTML:

`todo_list.js`
```js
frappe.listview_settings["ToDo"] = {
	formatters: {
		description: function (value) {
			// strip html tags
			return value.replace(/<\/?[^>]+(>|$)/g, "");
		},
	},
	// ...
}
```

This formatter got called once in `get_subject_html`, and then again, on the correctly generated subject HTML, making it into garbage (checkbox, like and link get stripped):

![Bildschirmfoto 2023-10-06 um 16 22 45](https://github.com/frappe/frappe/assets/14891507/6c7c8201-bfed-4c77-94c9-d845302cf05d)


### Solution

Make sure the formatter only runs once for subject (and normal) columns.

![Bildschirmfoto 2023-10-06 um 16 22 30](https://github.com/frappe/frappe/assets/14891507/f7b9d1b7-4891-4cf6-a755-f662dd9e304e)
