### PR TITLE
fix: like/comment icons and count

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -136,21 +136,21 @@
 </ul>
 <ul class="list-unstyled sidebar-menu form-sidebar-stats">
 	<li class="flex">
-		<div class="form-stats">
+		<div class="form-stats d-flex">
 			<span class="form-stats-likes">
-				<span class="liked-by like-action">
+				<span class="liked-by like-action d-flex align-items-center">
 					<svg class="es-icon icon-sm">
 						<use href="#es-solid-heart" class="like-icon"></use>
 					</svg>
-					<span class="like-count"></span>
+					<span class="like-count ml-2"></span>
 				</span>
 			</span>
-			<span class="mx-1">·</span>
-			<a class="comments">
+			<span class="mx-2">·</span>
+			<a class="comments d-flex align-items-center">
 				<svg class="es-icon icon-sm">
 					<use href="#es-line-chat-alt" class="comment-icon"></use>
 				</svg>
-				<span class="comments-count"></span>
+				<span class="comments-count ml-2"></span>
 			</a>
 		</div>
 		<a class="form-follow text-sm">

--- a/frappe/public/scss/common/icons.scss
+++ b/frappe/public/scss/common/icons.scss
@@ -22,7 +22,7 @@
 use.like-icon {
 	--icon-stroke: transparent;
 	cursor: pointer;
-	stroke: var(--gray-600);
+	stroke: var(--gray-800);
 }
 
 #icon-file-large {
@@ -44,7 +44,6 @@ use.like-icon {
 .liked {
 	use.like-icon {
 		--icon-stroke: var(--red-500);
-		stroke: var(--icon-stroke);
 		fill: var(--icon-stroke);
 	}
 }


### PR DESCRIPTION
- Change outline of like icon to `gray-800`, for consistency with other icons
- Vertically center icon and count
- Uniform spacing

State | Before | After
------|--------|-------
Unliked | ![before_0](https://github.com/frappe/frappe/assets/14891507/a33efdc6-be06-4ace-a35a-3c2ec9a61e1d) | ![after_0](https://github.com/frappe/frappe/assets/14891507/edb1cac3-a10f-46a3-864b-d0047edf5621)
Liked | ![before_1](https://github.com/frappe/frappe/assets/14891507/5548a8fb-a575-4f1b-b74a-b9fe51f3b91e) | ![after_1](https://github.com/frappe/frappe/assets/14891507/7b43fdcc-2e3c-4faf-a73a-c8bed3d667dd)




