### PR TITLE
fix: workspace don't strip filter info on save.

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1605,6 +1605,20 @@ Object.assign(frappe.utils, {
 				return string;
 		}
 	},
+	// deprecated!
+	get_filter_as_json(filters) {
+		console.warn("frappe.utils.get_filter_as_json is deprecated.");
+		// convert filter array to json
+		let filter = null;
+		if (filters.length) {
+			filter = {};
+			filters.forEach((arr) => {
+				filter[arr[1]] = [arr[2], arr[3]];
+			});
+			filter = JSON.stringify(filter);
+		}
+		return filter;
+	},
 
 	process_filter_expression(filter) {
 		return new Function(`return ${filter}`)();

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1605,9 +1605,8 @@ Object.assign(frappe.utils, {
 				return string;
 		}
 	},
-	// deprecated!
+
 	get_filter_as_json(filters) {
-		console.warn("frappe.utils.get_filter_as_json is deprecated.");
 		// convert filter array to json
 		let filter = null;
 		if (filters.length) {

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1606,19 +1606,8 @@ Object.assign(frappe.utils, {
 		}
 	},
 
-	get_filter_as_json(filters) {
-		// convert filter array to json
-		let filter = null;
-
-		if (filters.length) {
-			filter = {};
-			filters.forEach((arr) => {
-				filter[arr[1]] = [arr[2], arr[3]];
-			});
-			filter = JSON.stringify(filter);
-		}
-
-		return filter;
+	process_filter_expression(filter) {
+		return new Function(`return ${filter}`)();
 	},
 
 	get_filter_from_json(filter_json, doctype) {
@@ -1628,12 +1617,22 @@ Object.assign(frappe.utils, {
 				return [];
 			}
 
-			const filters_json = new Function(`return ${filter_json}`)();
+			const filters_json = this.process_filter_expression(filter_json);
 			if (!doctype) {
 				// e.g. return {
 				//    priority: (2) ['=', 'Medium'],
 				//    status: (2) ['=', 'Open']
 				// }
+
+				// don't remove unless patch is created to convert all existing filters from object to array
+				// backward compatibility
+				if (Array.isArray(filters_json)) {
+					let filter = {};
+					filters_json.forEach((arr) => {
+						filter[arr[1]] = [arr[2], arr[3]];
+					});
+					return filter || [];
+				}
 				return filters_json || [];
 			}
 
@@ -1641,6 +1640,11 @@ Object.assign(frappe.utils, {
 			//    ['ToDo', 'status', '=', 'Open', false],
 			//    ['ToDo', 'priority', '=', 'Medium', false]
 			// ]
+			if (Array.isArray(filters_json)) {
+				return filters_json;
+			}
+			// don't remove unless patch is created to convert all existing filters from object to array
+			// backward compatibility
 			return Object.keys(filters_json).map((filter) => {
 				let val = filters_json[filter];
 				return [doctype, filter, val[0], val[1], false];

--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -76,7 +76,7 @@ export default class QuickListWidget extends Widget {
 			delete this.filter_group;
 		}
 
-		this.filters = frappe.utils.get_filter_from_json(this.quick_list_filter, doctype);
+		this.filters = frappe.utils.process_filter_expression(this.quick_list_filter);
 
 		this.filter_group = new frappe.ui.FilterGroup({
 			parent: this.dialog.get_field("filter_area").$wrapper,
@@ -104,7 +104,7 @@ export default class QuickListWidget extends Widget {
 			primary_action: function () {
 				let old_filter = me.quick_list_filter;
 				let filters = me.filter_group.get_filters();
-				me.quick_list_filter = frappe.utils.get_filter_as_json(filters);
+				me.quick_list_filter = JSON.parse(filters);
 
 				this.hide();
 
@@ -193,7 +193,7 @@ export default class QuickListWidget extends Widget {
 
 			fields.push("modified");
 
-			let quick_list_filter = frappe.utils.get_filter_from_json(this.quick_list_filter);
+			let quick_list_filter = frappe.utils.process_filter_expression(this.quick_list_filter);
 
 			let args = {
 				method: "frappe.desk.reportview.get",

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -71,7 +71,7 @@ export default class ShortcutWidget extends Widget {
 
 		this.widget.addClass("shortcut-widget-box");
 
-		let filters = frappe.utils.get_filter_from_json(this.stats_filter);
+		let filters = frappe.utils.process_filter_expression(this.stats_filter);
 		if (this.type == "DocType" && filters) {
 			frappe.db
 				.count(this.link_to, {

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -182,7 +182,7 @@ class QuickListDialog extends WidgetDialog {
 	process_data(data) {
 		if (this.filter_group) {
 			let filters = this.filter_group.get_filters();
-			data.quick_list_filter = frappe.utils.get_filter_as_json(filters);
+			data.quick_list_filter = JSON.stringify(filters);
 		}
 
 		data.label = data.label ? data.label : data.document_type;
@@ -540,7 +540,7 @@ class ShortcutDialog extends WidgetDialog {
 	process_data(data) {
 		if (this.dialog.get_value("type") == "DocType" && this.filter_group) {
 			let filters = this.filter_group.get_filters();
-			data.stats_filter = frappe.utils.get_filter_as_json(filters);
+			data.stats_filter = JSON.stringify(filters);
 		}
 
 		data.label = data.label ? data.label : frappe.model.unscrub(data.link_to);


### PR DESCRIPTION
currently on save of filter ( get_filter_as_json ) is used to convert it to object with following structure:

```
{
   priority: (2) ['=', 'Medium'],
   status: (2) ['=', 'Open']
}
```

Doing this we lose information of parent doctype.
Missing parent doctype causes field not permitted error.
### Before Fix

https://github.com/frappe/frappe/assets/39730881/8b004bdd-09c1-4a88-b08e-79e62ee79f6f



To fix this, I saved filter as it is and converted to object when required.
### After Fix
https://github.com/frappe/frappe/assets/39730881/2bc9bbbb-267e-4187-803a-1ad6080e7ef7

