### PR TITLE
fix: strip html and show text

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1029,8 +1029,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		link.dataset.doctype = this.doctype;
 		link.dataset.name = doc.name;
 		link.href = this.get_form_link(doc);
-		link.title = value.toString();
-		link.textContent = value.toString();
+		// "Text Editor" and some other fieldtypes can have html tags in them so strip and show text.
+		// If no text is found show "No Text Found in {Field Label}"
+		let textValue = frappe.utils.html2text(value) || "No Text Found in " + subject_field.label;
+		link.title = textValue;
+		link.textContent = textValue;
 
 		return div.innerHTML;
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1031,7 +1031,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		link.href = this.get_form_link(doc);
 		// "Text Editor" and some other fieldtypes can have html tags in them so strip and show text.
 		// If no text is found show "No Text Found in {Field Label}"
-		let textValue = frappe.utils.html2text(value) || "No Text Found in " + subject_field.label;
+		let textValue = frappe.utils.html2text(value);
 		link.title = textValue;
 		link.textContent = textValue;
 


### PR DESCRIPTION
Quill editor adds html which is useless for user so strip html using  html2text and render Text only. If no text is found it will render No Text Found in + "Field Label" (ex. Description).

### Before

https://github.com/frappe/frappe/assets/39730881/06ae81b6-3f4c-43ce-8d1f-56250dc8df8d

### After

https://github.com/frappe/frappe/assets/39730881/6286ee08-8cb4-43cf-b570-2c89ce167379

