### PR TITLE
fix: keyerror on reports with subtotal

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -573,7 +573,9 @@ def get_filtered_data(ref_doctype, columns, data, user):
 	if match_filters_per_doctype:
 		for row in data:
 			# Why linked_doctypes.get(ref_doctype)? because if column is empty, linked_doctypes[ref_doctype] is removed
-			if linked_doctypes.get(ref_doctype) and shared and row[linked_doctypes[ref_doctype]] in shared:
+			if (
+				linked_doctypes.get(ref_doctype) and shared and row.get(linked_doctypes[ref_doctype]) in shared
+			):
 				result.append(row)
 
 			elif has_match(


### PR DESCRIPTION
Sub Totals rows on reports doesn't necessarily have all the columns populated. On such reports, the permission based filteration logic throws Key Error, as the column to filter on doesn't exist. Use `get` for key access on rows.


<img width="1440" alt="Screenshot 2023-10-08 at 5 22 50 PM" src="https://github.com/frappe/frappe/assets/3272205/2cd8daeb-33fa-4f80-acfe-dc1b65cff1df">
<img width="1440" alt="Screenshot 2023-10-08 at 5 23 22 PM" src="https://github.com/frappe/frappe/assets/3272205/05112326-a6a4-4749-aedc-8528482114b5">

