### PR TITLE
feat(listview): move likes to the right

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -136,21 +136,21 @@
 </ul>
 <ul class="list-unstyled sidebar-menu form-sidebar-stats">
 	<li class="flex">
-		<div class="form-stats">
+		<div class="form-stats d-flex">
 			<span class="form-stats-likes">
-				<span class="liked-by like-action">
+				<span class="liked-by like-action d-flex align-items-center">
 					<svg class="es-icon icon-sm">
 						<use href="#es-solid-heart" class="like-icon"></use>
 					</svg>
-					<span class="like-count"></span>
+					<span class="like-count ml-2"></span>
 				</span>
 			</span>
-			<span class="mx-1">·</span>
-			<a class="comments">
+			<span class="mx-2">·</span>
+			<a class="comments d-flex align-items-center">
 				<svg class="es-icon icon-sm">
 					<use href="#es-line-chat-alt" class="comment-icon"></use>
 				</svg>
-				<span class="comments-count"></span>
+				<span class="comments-count ml-2"></span>
 			</a>
 		</div>
 		<a class="form-follow text-sm">

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -919,7 +919,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		html += `
-			<div class="level-item list-row-activity hidden-xs d-flex align-items-center">
+			<div class="level-item list-row-activity hidden-xs">
 				<div class="hidden-md hidden-xs">
 					${settings_button || assigned_to}
 				</div>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -631,9 +631,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		let subject_html = `
 			<input class="level-item list-check-all" type="checkbox"
 				title="${__("Select All")}">
-			<span class="level-item list-liked-by-me hidden-xs">
-				<span title="${__("Likes")}">${frappe.utils.icon("es-solid-heart", "sm", "like-icon")}</span>
-			</span>
 			<span class="level-item" data-sort-by="${subject_field.fieldname}"
 				title="${__("Click to sort by {0}", [subject_field.label])}">
 				${__(subject_field.label)}
@@ -667,7 +664,16 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			})
 			.join("");
 
-		return this.get_header_html_skeleton($columns, '<span class="list-count"></span>');
+		const right_html = `
+			<span class="list-count"></span>
+			<span class="level-item list-liked-by-me hidden-xs">
+				<span title="${__("Liked by me")}">
+					${frappe.utils.icon("es-solid-heart", "sm", "like-icon")}
+				</span>
+			</span>
+		`;
+
+		return this.get_header_html_skeleton($columns, right_html);
 	}
 
 	get_header_html_skeleton(left = "", right = "") {
@@ -909,19 +915,23 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		let comment_count = null;
 		if (this.list_view_settings && !this.list_view_settings.disable_comment_count) {
-			comment_count = $(`<span class="comment-count"></span>`);
+			comment_count = $(`<span class="comment-count d-flex align-items-center"></span>`);
 			$(comment_count).append(`
 				${frappe.utils.icon("es-line-chat-alt")}
 				${doc._comment_count > 99 ? "99+" : doc._comment_count || 0}`);
 		}
 
 		html += `
-			<div class="level-item list-row-activity hidden-xs">
+			<div class="level-item list-row-activity hidden-xs d-flex align-items-center">
 				<div class="hidden-md hidden-xs">
 					${settings_button || assigned_to}
 				</div>
-				${modified}
+				<span class="modified">${modified}</span>
 				${comment_count ? $(comment_count).prop("outerHTML") : ""}
+				${comment_count ? '<span class="mx-2">·</span>' : ""}
+				<span class="list-row-like hidden-xs style="margin-bottom: 1px;">
+					${this.get_like_html(doc)}
+				</span>
 			</div>
 			<div class="level-item visible-xs text-right">
 				${this.get_indicator_dot(doc)}
@@ -1012,9 +1022,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		div.innerHTML = `
 			<span class="level-item select-like">
 				<input class="list-row-checkbox" type="checkbox">
-				<span class="list-row-like hidden-xs style="margin-bottom: 1px;">
-					${this.get_like_html(doc)}
-				</span>
 			</span>
 			<span class="level-item ${seen} ellipsis">
 				<a class="ellipsis"></a>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -901,14 +901,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		const modified = comment_when(doc.modified, true);
 
-		let assigned_to = `<div class="list-assignments">
-			<span class="avatar avatar-small">
-			<span class="avatar-empty"></span>
-		</div>`;
+		let assigned_to = ``;
 
 		let assigned_users = JSON.parse(doc._assign || "[]");
 		if (assigned_users.length) {
-			assigned_to = `<div class="list-assignments">
+			assigned_to = `<div class="list-assignments d-flex align-items-center">
 					${frappe.avatar_group(assigned_users, 3, { filterable: true })[0].outerHTML}
 				</div>`;
 		}

--- a/frappe/public/scss/common/icons.scss
+++ b/frappe/public/scss/common/icons.scss
@@ -22,7 +22,7 @@
 use.like-icon {
 	--icon-stroke: transparent;
 	cursor: pointer;
-	stroke: var(--gray-600);
+	stroke: var(--gray-800);
 }
 
 #icon-file-large {
@@ -44,7 +44,6 @@ use.like-icon {
 .liked {
 	use.like-icon {
 		--icon-stroke: var(--red-500);
-		stroke: var(--icon-stroke);
 		fill: var(--icon-stroke);
 	}
 }

--- a/frappe/public/scss/desk/avatar.scss
+++ b/frappe/public/scss/desk/avatar.scss
@@ -95,11 +95,6 @@
 	.standard-image {
 		font-size: var(--text-xs);
 	}
-
-	.avatar-empty::after {
-		content: "\002D";
-		line-height: 28px;
-	}
 }
 
 .avatar-medium {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -118,10 +118,10 @@
 
 		&> span {
 			display: inline-block;
+		}
 
-			&:not(:last-child) {
-				margin-right: 15px;
-			}
+		.modified {
+			margin-right: var(--margin-sm);
 		}
 
 		.comment-count {
@@ -131,7 +131,6 @@
 		.frappe-timestamp {
 			font-size: var(--text-xs);
 			white-space: nowrap;
-			min-width: 30px;
 		}
 
 		.list-assignments, .list-actions {
@@ -193,10 +192,6 @@ $level-margin-right: 8px;
 
 	a {
 		color: var(--text-color);
-	}
-
-	.level-item:not(.file-select) {
-		margin-right: $level-margin-right;
 	}
 
 	&.seen {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -94,6 +94,7 @@
 	.level-right {
 		flex: 1;
 		overflow: visible;
+		align-items: center;
 	}
 
 	.tag-col {


### PR DESCRIPTION
Builds on top of https://github.com/frappe/frappe/pull/22650, please merge that one first.

- Move likes to the right
- Assigned to
    - don't show "-" if assignments are empty
    - vertically center avatars in row
    - remove unused avatar-empty class

Default:
![Bildschirmfoto 2023-10-08 um 15 57 21](https://github.com/frappe/frappe/assets/14891507/8ab3df52-6db5-4748-baad-e08f21fe8de8)

With entry count disabled:

![Bildschirmfoto 2023-10-08 um 15 57 42](https://github.com/frappe/frappe/assets/14891507/3f3a2abc-4d93-4c60-9ffb-fdd51960b440)

With comment count disabled:

![Bildschirmfoto 2023-10-08 um 15 57 32](https://github.com/frappe/frappe/assets/14891507/7df6b712-64e2-4599-8d70-89cb3c372f1b)

> Note: in all screenshots, the filter "liked by me" is active. For most entries, the heart has a transparent background color.