### PR TITLE
fix: Use same filter in report view and list view

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -76,6 +76,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		this.setup_charts_area();
 		this.$datatable_wrapper = $('<div class="datatable-wrapper">');
 		this.$result.append(this.$datatable_wrapper);
+		this.settings.onload && this.settings.onload(this);
 	}
 
 	setup_charts_area() {


### PR DESCRIPTION
**Before:** get_query was not getting applied to report view filters.

https://github.com/frappe/frappe/assets/13928957/c6de8760-6f2a-486f-896f-41bc7c03244a


**After:**

https://github.com/frappe/frappe/assets/13928957/1a5d8c4d-312e-40f1-ac50-6de2596503b7

