### PR TITLE
fix: conditional webform with list view enabled

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -36,7 +36,7 @@ frappe.ui.FilterGroup = class {
 	}
 
 	hide_popover() {
-		this.filter_button.popover("hide");
+		this.filter_button?.popover("hide");
 	}
 
 	init_filter_popover() {

--- a/frappe/public/js/frappe/web_form/web_form_list.js
+++ b/frappe/public/js/frappe/web_form/web_form_list.js
@@ -109,6 +109,12 @@ export default class WebFormList {
 	}
 
 	fetch_data() {
+		if (this.condition_json && JSON.parse(this.condition_json)) {
+			let filter = frappe.utils.get_filter_from_json(this.condition_json);
+			filter = frappe.utils.get_filter_as_json(filter);
+			this.filters = Object.assign(this.filters, JSON.parse(filter));
+		}
+
 		let args = {
 			method: "frappe.www.list.get_list_data",
 			args: {

--- a/frappe/public/js/frappe/web_form/webform_script.js
+++ b/frappe/public/js/frappe/web_form/webform_script.js
@@ -27,6 +27,7 @@ frappe.ready(function () {
 			doctype: web_form_doc.doc_type,
 			web_form_name: web_form_doc.name,
 			list_columns: web_form_doc.list_columns,
+			condition_json: web_form_doc.condition_json,
 			settings: {
 				allow_delete: web_form_doc.allow_delete,
 			},

--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -183,60 +183,69 @@ frappe.ui.form.on("Web Form", {
 	},
 
 	render_condition_table: function (frm) {
-		// frm.set_df_property("filters_section", "hidden", 0);
-		let is_document_type = true;
-
 		let wrapper = $(frm.get_field("condition_json").wrapper).empty();
-		let table = $(`<table class="table table-bordered" style="cursor:pointer; margin:0px;">
+		let table = $(`
+			<style>
+			.table-bordered th, .table-bordered td {
+				border: none;
+				border-right: 1px solid var(--border-color);
+			}
+			.table-bordered td {
+				border-top: 1px solid var(--border-color);
+			}
+			.table thead th {
+				border-bottom: none;
+				font-weight: var(--weight-regular);
+			}
+			tr th:last-child, tr td:last-child{
+				border-right: none;
+			}
+			thead {
+				font-size: var(--text-sm);
+				color: var(--gray-600);
+				background-color: var(--subtle-fg);
+			}
+			thead th:first-child {
+				border-top-left-radius: 9px;
+			}
+			thead th:last-child {
+				border-top-right-radius: 9px;
+			}
+			</style>
+
+			<table class="table table-bordered" style="cursor:pointer; margin:0px; border-radius: 10px; border-spacing: 0; border-collapse: separate;">
 			<thead>
 				<tr>
-					<th style="width: 20%">${__("Filter")}</th>
+					<th>${__("Filter")}</th>
 					<th style="width: 20%">${__("Condition")}</th>
 					<th>${__("Value")}</th>
 				</tr>
 			</thead>
 			<tbody></tbody>
 		</table>`).appendTo(wrapper);
-		$(`<p class="text-muted small">${__("Click table to edit")}</p>`).appendTo(wrapper);
+		$(`<p class="text-muted small mt-2">${__("Click table to edit")}</p>`).appendTo(wrapper);
 
 		let filters = JSON.parse(frm.doc.condition_json || "[]");
 		let filters_set = false;
 
-		let fields = [];
-		if (is_document_type) {
-			fields = [
-				{
-					fieldtype: "HTML",
-					fieldname: "filter_area",
-				},
-			];
+		let fields = [
+			{
+				fieldtype: "HTML",
+				fieldname: "filter_area",
+			},
+		];
 
-			if (filters?.length) {
-				filters.forEach((filter) => {
-					const filter_row = $(`<tr>
+		if (filters?.length) {
+			filters.forEach((filter) => {
+				const filter_row = $(`<tr>
 							<td>${filter[1]}</td>
 							<td>${filter[2] || ""}</td>
 							<td>${filter[3]}</td>
 						</tr>`);
 
-					table.find("tbody").append(filter_row);
-				});
-				filters_set = true;
-			}
-		} else if (frm.filters.length) {
-			fields = frm.filters.filter((f) => f.fieldname);
-			fields.map((f) => {
-				if (filters[f.fieldname]) {
-					let condition = "=";
-					const filter_row = $(`<tr>
-							<td>${f.label}</td>
-							<td>${condition}</td>
-							<td>${filters[f.fieldname] || ""}</td>
-						</tr>`);
-					table.find("tbody").append(filter_row);
-					if (!filters_set) filters_set = true;
-				}
+				table.find("tbody").append(filter_row);
 			});
+			filters_set = true;
 		}
 
 		if (!filters_set) {
@@ -253,26 +262,20 @@ frappe.ui.form.on("Web Form", {
 					let values = this.get_values();
 					if (values) {
 						this.hide();
-						if (is_document_type) {
-							let filters = frm.filter_group.get_filters();
-							frm.set_value("condition_json", JSON.stringify(filters));
-						} else {
-							frm.set_value("condition_json", JSON.stringify(values));
-						}
+						let filters = frm.filter_group.get_filters();
+						frm.set_value("condition_json", JSON.stringify(filters));
 						frm.trigger("render_condition_table");
 					}
 				},
 				primary_action_label: "Set",
 			});
 
-			if (is_document_type) {
-				frm.filter_group = new frappe.ui.FilterGroup({
-					parent: dialog.get_field("filter_area").$wrapper,
-					doctype: frm.doc.doc_type,
-					on_change: () => {},
-				});
-				filters && frm.filter_group.add_filters_to_filter_group(filters);
-			}
+			frm.filter_group = new frappe.ui.FilterGroup({
+				parent: dialog.get_field("filter_area").$wrapper,
+				doctype: frm.doc.doc_type,
+				on_change: () => {},
+			});
+			filters && frm.filter_group.add_filters_to_filter_group(filters);
 
 			dialog.show();
 

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -31,9 +31,8 @@
   "allow_incomplete",
   "section_break_2",
   "max_attachment_size",
-  "section_break_xzqr",
-  "condition",
-  "column_break_tjgl",
+  "condition_section",
+  "condition_json",
   "condition_description",
   "section_break_3",
   "list_setting_message",
@@ -375,31 +374,26 @@
    "label": "Anonymous"
   },
   {
-   "fieldname": "condition",
-   "fieldtype": "Code",
-   "label": "Condition",
-   "max_height": "150px"
-  },
-  {
-   "fieldname": "section_break_xzqr",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_tjgl",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "condition_description",
    "fieldtype": "HTML",
    "label": "Condition Description",
    "options": "<p>Multiple webforms can be created for a single doctype. Write a condition specific to this webform to display correct record after submission.</p><p>For Example:</p>\n<p>If you create a separate webform every year to capture feedback from employees add a \n field named year in doctype and add a condition <b>doc.year==\"2023\"</b></p>\n"
+  },
+  {
+   "fieldname": "condition_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "condition_json",
+   "fieldtype": "JSON",
+   "label": "Condition JSON"
   }
  ],
  "has_web_view": 1,
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2023-06-03 19:18:56.760479",
+ "modified": "2023-10-10 11:31:56.609386",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -32,8 +32,8 @@
   "section_break_2",
   "max_attachment_size",
   "condition_section",
-  "condition_json",
   "condition_description",
+  "condition_json",
   "section_break_3",
   "list_setting_message",
   "show_list",
@@ -377,7 +377,7 @@
    "fieldname": "condition_description",
    "fieldtype": "HTML",
    "label": "Condition Description",
-   "options": "<p>Multiple webforms can be created for a single doctype. Write a condition specific to this webform to display correct record after submission.</p><p>For Example:</p>\n<p>If you create a separate webform every year to capture feedback from employees add a \n field named year in doctype and add a condition <b>doc.year==\"2023\"</b></p>\n"
+   "options": "<p>Multiple webforms can be created for a single doctype. Add filters specific to this webform to display correct record after submission.</p><p>For Example:</p>\n<p>If you create a separate webform every year to capture feedback from employees add a \n field named year in doctype and add a filter <b>year = 2023</b></p>\n"
   },
   {
    "fieldname": "condition_section",
@@ -393,7 +393,7 @@
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2023-10-10 11:31:56.609386",
+ "modified": "2023-10-10 12:51:18.341792",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -200,16 +200,12 @@ def get_context(context):
 			and not frappe.form_dict.name
 			and not frappe.form_dict.is_list
 		):
-			names = frappe.db.get_values(self.doc_type, {"owner": frappe.session.user}, pluck="name")
-			for name in names:
-				if self.condition:
-					doc = frappe.get_doc(self.doc_type, name)
-					if frappe.safe_eval(self.condition, None, {"doc": doc.as_dict()}):
-						context.in_view_mode = True
-						frappe.redirect(f"/{self.route}/{name}")
-				else:
-					context.in_view_mode = True
-					frappe.redirect(f"/{self.route}/{name}")
+			condition_json = json.loads(self.condition_json) if self.condition_json else []
+			condition_json.append(["owner", "=", frappe.session.user])
+			names = frappe.get_all(self.doc_type, filters=condition_json, pluck="name")
+			if names:
+				context.in_view_mode = True
+				frappe.redirect(f"/{self.route}/{names[0]}")
 
 		# Show new form when
 		# - User is Guest


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/21220 
Extending and refactoring the above PR

The above PR only works for webform if the list view is not enabled. This PR handles that. Also in the above PR, we had to write the conditions which are now replaced with a filter table.

<img width="1426" alt="image" src="https://github.com/frappe/frappe/assets/30859809/808f47bd-42ba-4624-856b-24b74e9fa4c9">

**List View only shows records with the filter applied above**
<img width="1426" alt="image" src="https://github.com/frappe/frappe/assets/30859809/42cf666e-2d70-43da-a6fb-a8c1aad61b12">
