### PR TITLE
feat: date filters in audit trail

### DIFF
--- a/frappe/core/doctype/audit_trail/audit_trail.js
+++ b/frappe/core/doctype/audit_trail/audit_trail.js
@@ -2,6 +2,17 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Audit Trail", {
+	onload(frm) {
+		let prev_route = frappe.get_prev_route();
+		if (prev_route.length > 2 && prev_route[0] == "Form" && prev_route[1] != "Audit Trail") {
+			frm.doc.doctype_name = prev_route[1];
+			frm.doc.document = prev_route[2];
+			frm.doc.start_date = "";
+			frm.doc.end_date = "";
+		}
+		frm.events.get_audit_trail_for_document(frm);
+	},
+
 	refresh(frm) {
 		frm.page.clear_indicator();
 
@@ -30,16 +41,7 @@ frappe.ui.form.on("Audit Trail", {
 		});
 
 		frm.page.set_primary_action("Compare", () => {
-			frm.call({
-				doc: frm.doc,
-				method: "compare_document",
-				callback: function (r) {
-					let document_names = r.message[0];
-					let changed_fields = r.message[1];
-					frm.events.render_changed_fields(frm, document_names, changed_fields);
-					frm.events.render_rows_added_or_removed(frm, changed_fields);
-				},
-			});
+			frm.events.get_audit_trail_for_document(frm);
 		});
 	},
 
@@ -68,6 +70,19 @@ frappe.ui.form.on("Audit Trail", {
 					frm.refresh_fields();
 				}
 			});
+	},
+
+	get_audit_trail_for_document(frm) {
+		frm.call({
+			doc: frm.doc,
+			method: "compare_document",
+			callback: function (r) {
+				let document_names = r.message[0];
+				let changed_fields = r.message[1];
+				frm.events.render_changed_fields(frm, document_names, changed_fields);
+				frm.events.render_rows_added_or_removed(frm, changed_fields);
+			},
+		});
 	},
 
 	render_changed_fields(frm, document_names, changed_fields) {

--- a/frappe/core/doctype/audit_trail/audit_trail.js
+++ b/frappe/core/doctype/audit_trail/audit_trail.js
@@ -2,18 +2,21 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Audit Trail", {
-	onload(frm) {
-		let prev_route = frappe.get_prev_route();
-		if (prev_route.length > 2 && prev_route[0] == "Form" && prev_route[1] != "Audit Trail") {
-			frm.doc.doctype_name = prev_route[1];
-			frm.doc.document = prev_route[2];
-			frm.doc.start_date = "";
-			frm.doc.end_date = "";
-		}
-		frm.events.get_audit_trail_for_document(frm);
-	},
-
 	refresh(frm) {
+		let prev_route = frappe.get_prev_route();
+		if (
+			prev_route.length > 2 &&
+			prev_route[0] == "Form" &&
+			!prev_route.includes("Audit Trail")
+		) {
+			frm.set_value("doctype_name", prev_route[1]);
+			frm.set_value("document", prev_route[2]);
+			frm.set_value("start_date", "");
+			frm.set_value("end_date", "");
+			if (frm.doc.doctype_name && frm.doc.document)
+				frm.events.get_audit_trail_for_document(frm);
+		}
+
 		frm.page.clear_indicator();
 
 		frm.disable_save();

--- a/frappe/core/doctype/audit_trail/audit_trail.js
+++ b/frappe/core/doctype/audit_trail/audit_trail.js
@@ -20,6 +20,7 @@ frappe.ui.form.on("Audit Trail", {
 			return {
 				filters: {
 					amended_from: ["!=", ""],
+					creation: ["between", [frm.doc.start_date, frm.doc.end_date]],
 				},
 			};
 		});

--- a/frappe/core/doctype/audit_trail/audit_trail.js
+++ b/frappe/core/doctype/audit_trail/audit_trail.js
@@ -16,6 +16,14 @@ frappe.ui.form.on("Audit Trail", {
 			};
 		});
 
+		frm.set_query("document", () => {
+			return {
+				filters: {
+					amended_from: ["!=", ""],
+				},
+			};
+		});
+
 		frm.page.set_primary_action("Compare", () => {
 			frm.call({
 				doc: frm.doc,

--- a/frappe/core/doctype/audit_trail/audit_trail.json
+++ b/frappe/core/doctype/audit_trail/audit_trail.json
@@ -74,19 +74,21 @@
   {
    "fieldname": "start_date",
    "fieldtype": "Date",
-   "label": "Start Date"
+   "label": "Start Date",
+   "reqd": 1
   },
   {
    "fieldname": "end_date",
    "fieldtype": "Date",
-   "label": "End Date"
+   "label": "End Date",
+   "reqd": 1
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-10 12:55:56.556403",
+ "modified": "2023-10-10 15:20:00.558979",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Audit Trail",

--- a/frappe/core/doctype/audit_trail/audit_trail.json
+++ b/frappe/core/doctype/audit_trail/audit_trail.json
@@ -6,11 +6,13 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "start_date",
   "doctype_name",
   "column_break_peck",
-  "end_date",
   "document",
+  "section_break_dfrx",
+  "start_date",
+  "column_break_ytzm",
+  "end_date",
   "section_break_gppi",
   "version_table",
   "rows_added_section",
@@ -74,21 +76,30 @@
   {
    "fieldname": "start_date",
    "fieldtype": "Date",
-   "label": "Start Date",
-   "reqd": 1
+   "label": "Start Date"
   },
   {
    "fieldname": "end_date",
    "fieldtype": "Date",
-   "label": "End Date",
-   "reqd": 1
+   "label": "End Date"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.start_date || doc.end_date",
+   "fieldname": "section_break_dfrx",
+   "fieldtype": "Section Break",
+   "label": "Date Range"
+  },
+  {
+   "fieldname": "column_break_ytzm",
+   "fieldtype": "Column Break"
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-10 15:20:00.558979",
+ "modified": "2023-10-31 13:12:41.749483",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Audit Trail",

--- a/frappe/core/doctype/audit_trail/audit_trail.json
+++ b/frappe/core/doctype/audit_trail/audit_trail.json
@@ -6,8 +6,10 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "start_date",
   "doctype_name",
   "column_break_peck",
+  "end_date",
   "document",
   "section_break_gppi",
   "version_table",
@@ -68,13 +70,23 @@
    "fieldtype": "Section Break",
    "hidden": 1,
    "label": "Rows Removed"
+  },
+  {
+   "fieldname": "start_date",
+   "fieldtype": "Date",
+   "label": "Start Date"
+  },
+  {
+   "fieldname": "end_date",
+   "fieldtype": "Date",
+   "label": "End Date"
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-08-22 12:12:59.780845",
+ "modified": "2023-10-10 12:55:56.556403",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Audit Trail",

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -28,6 +28,7 @@ class AuditTrail(Document):
 
 	def validate(self):
 		self.validate_fields()
+		self.validate_document()
 
 	def validate_fields(self):
 		fields_dict = {
@@ -37,6 +38,14 @@ class AuditTrail(Document):
 		for field in fields_dict:
 			if not fields_dict[field]:
 				frappe.throw(_("{} field cannot be empty.").format(frappe.bold(field)))
+
+	def validate_document(self):
+		if not frappe.db.exists(self.doctype_name, self.document):
+			frappe.throw(
+				_("The selected document {0} is not a {1}.").format(
+					frappe.bold(self.document), frappe.bold(self.doctype_name)
+				)
+			)
 
 	@frappe.whitelist()
 	def compare_document(self):

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 from frappe.core.doctype.version.version import get_diff
 from frappe.model.document import Document
+from frappe.utils import compare
 
 
 class AuditTrail(Document):
@@ -64,9 +65,15 @@ class AuditTrail(Document):
 	def get_amended_documents(self):
 		amended_document_names = []
 		curr_doc = self.document
-		while curr_doc and len(amended_document_names) < 5:
+		creation = frappe.db.get_value(self.doctype_name, self.document, "creation")
+		while (
+			curr_doc
+			and len(amended_document_names) < 5
+			and compare(creation, ">=", self.start_date, "Date")
+		):
 			amended_document_names.append(curr_doc)
 			curr_doc = frappe.db.get_value(self.doctype_name, curr_doc, "amended_from")
+			creation = frappe.db.get_value(self.doctype_name, curr_doc, "creation")
 		amended_document_names = amended_document_names[::-1]
 
 		return amended_document_names

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -21,8 +21,8 @@ class AuditTrail(Document):
 
 		doctype_name: DF.Link
 		document: DF.DynamicLink
-		end_date: DF.Date
-		start_date: DF.Date
+		end_date: DF.Date | None
+		start_date: DF.Date | None
 	# end: auto-generated types
 	pass
 
@@ -33,8 +33,6 @@ class AuditTrail(Document):
 		fields_dict = {
 			"DocType": self.doctype_name,
 			"Document": self.document,
-			"Start Date": self.start_date,
-			"End Date": self.end_date,
 		}
 		for field in fields_dict:
 			if not fields_dict[field]:
@@ -63,13 +61,14 @@ class AuditTrail(Document):
 		}
 
 	def get_amended_documents(self):
+		start_date = self.get("start_date")
 		amended_document_names = []
 		curr_doc = self.document
 		creation = frappe.db.get_value(self.doctype_name, self.document, "creation")
 		while (
 			curr_doc
 			and len(amended_document_names) < 5
-			and compare(creation, ">=", self.start_date, "Date")
+			and (start_date is None or compare(creation, ">=", start_date, "Date"))
 		):
 			amended_document_names.append(curr_doc)
 			curr_doc = frappe.db.get_value(self.doctype_name, curr_doc, "amended_from")

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -20,6 +20,8 @@ class AuditTrail(Document):
 
 		doctype_name: DF.Link
 		document: DF.DynamicLink
+		end_date: DF.Date | None
+		start_date: DF.Date | None
 	# end: auto-generated types
 	pass
 

--- a/frappe/core/doctype/audit_trail/audit_trail.py
+++ b/frappe/core/doctype/audit_trail/audit_trail.py
@@ -20,22 +20,24 @@ class AuditTrail(Document):
 
 		doctype_name: DF.Link
 		document: DF.DynamicLink
-		end_date: DF.Date | None
-		start_date: DF.Date | None
+		end_date: DF.Date
+		start_date: DF.Date
 	# end: auto-generated types
 	pass
 
 	def validate(self):
-		self.validate_doctype_name()
-		self.validate_document()
+		self.validate_fields()
 
-	def validate_doctype_name(self):
-		if not self.doctype_name:
-			frappe.throw(_("{} field cannot be empty.").format(frappe.bold("Doctype")))
-
-	def validate_document(self):
-		if not self.document:
-			frappe.throw(_("{} field cannot be empty.").format(frappe.bold("Document")))
+	def validate_fields(self):
+		fields_dict = {
+			"DocType": self.doctype_name,
+			"Document": self.document,
+			"Start Date": self.start_date,
+			"End Date": self.end_date,
+		}
+		for field in fields_dict:
+			if not fields_dict[field]:
+				frappe.throw(_("{} field cannot be empty.").format(frappe.bold(field)))
 
 	@frappe.whitelist()
 	def compare_document(self):

--- a/frappe/core/doctype/audit_trail/test_audit_trail.py
+++ b/frappe/core/doctype/audit_trail/test_audit_trail.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
 
 
 class TestAuditTrail(FrappeTestCase):
@@ -129,6 +130,11 @@ def amend_document(amend_from, changed_fields, rows_updated, submit=False):
 
 def create_comparator_doc(doctype_name, document):
 	comparator = frappe.new_doc("Audit Trail")
-	comparator.doctype_name = doctype_name
-	comparator.document = document
+	args_dict = {
+		"doctype_name": doctype_name,
+		"document": document,
+		"start_date": today(),
+		"end_date": today(),
+	}
+	comparator.update(args_dict)
 	return comparator

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1240,6 +1240,10 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.set_route("print", this.doctype, this.doc.name);
 	}
 
+	show_audit_trail() {
+		frappe.set_route("audit-trail");
+	}
+
 	navigate_records(prev) {
 		let filters, sort_field, sort_order;
 		let list_view = frappe.get_list_view(this.doctype);

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -504,7 +504,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 			frappe.model.get_value("DocType", this.frm.doc.doctype, "track_changes")
 		) {
 			this.page.add_menu_item(
-				__("Audit Trail"),
+				__("View Audit Trail"),
 				function () {
 					me.frm.show_audit_trail();
 				},

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -498,6 +498,19 @@ frappe.ui.form.Toolbar = class Toolbar {
 				}
 			);
 		}
+
+		if (
+			this.frm.doc.amended_from &&
+			frappe.model.get_value("DocType", this.frm.doc.doctype, "track_changes")
+		) {
+			this.page.add_menu_item(
+				__("Audit Trail"),
+				function () {
+					me.frm.show_audit_trail();
+				},
+				true
+			);
+		}
 	}
 
 	make_customize_buttons() {

--- a/frappe/translations/fr.csv
+++ b/frappe/translations/fr.csv
@@ -4852,4 +4852,4 @@ Published on,Publié le,
 Bottom,Bas,
 Top,Haut,
 List View,Vue en liste,
-Edit,Détail,Edit grid row,
+Edit,Détail,Edit grid row


### PR DESCRIPTION
**Changes**

- Added condition in the Document field to filter out any non-amended docs.
- Added Date Range filters to show the audit trail only within the selected range.

**Screenshot**

<img width="1296" alt="Screenshot 2023-12-03 at 5 32 42 PM" src="https://github.com/frappe/frappe/assets/40693548/8855bcb9-3acd-4e48-bfcf-59ab8a0e47e5">

<br>
<br>

Updated docs: https://frappeframework.com/docs/user/en/audit-trail