### PR TITLE
feat: enable `tabSelect` for awesomplete

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -37,6 +37,7 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 	get_awesomplete_settings() {
 		var me = this;
 		return {
+			tabSelect: true,
 			minChars: 0,
 			maxItems: this.df.max_items || 99,
 			autoFirst: true,


### PR DESCRIPTION
Enabled for form autocomplete, haven't enabled in other places because it doesn't seem to make _too_ much sense there - a person may be using tab to get to the next element so in that case we wouldn't want it to select the value that's currently highlighted.

This resolves #22673 

[no-docs]