### PR TITLE
fix(Link, Autocomplete): Open awesomplete on focus

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -104,20 +104,19 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 
 		this.init_option_cache();
 
-		this.$input.on(
-			"input",
-			frappe.utils.debounce((e) => {
-				const cached_options =
-					this.$input.cache[this.doctype][this.df.fieldname][e.target.value];
-				if (cached_options && cached_options.length) {
-					this.set_data(cached_options);
-				} else if (this.get_query || this.df.get_query) {
-					this.execute_query_if_exists(e.target.value);
-				} else {
-					this.awesomplete.list = this.get_data();
-				}
-			}, 500)
-		);
+		const refresh_options = (e) => {
+			const cached_options =
+				this.$input.cache[this.doctype][this.df.fieldname][e.target.value];
+			if (cached_options && cached_options.length) {
+				this.set_data(cached_options);
+			} else if (this.get_query || this.df.get_query) {
+				this.execute_query_if_exists(e.target.value);
+			} else {
+				this.awesomplete.list = this.get_data();
+			}
+		};
+
+		this.$input.on("input", frappe.utils.debounce(refresh_options, 500));
 
 		this.$input.on("focus", () => {
 			if (!this.$input.val()) {

--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -118,10 +118,11 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 
 		this.$input.on("input", frappe.utils.debounce(refresh_options, 500));
 
-		this.$input.on("focus", () => {
+		this.$input.on("focus", (e) => {
 			if (!this.$input.val()) {
 				this.$input.val("");
-				this.$input.trigger("input");
+				// this.$input.trigger("input"); // flickering
+				refresh_options(e);
 			}
 		});
 

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -245,6 +245,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 				// immediately show from cache
 				me.awesomplete.list = me.$input.cache[doctype][term];
 			}
+
 			var args = {
 				txt: term,
 				doctype: doctype,
@@ -327,6 +328,13 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 
 		const debounced_update_list = frappe.utils.debounce(query_and_update_list, 500);
 		this.$input.on("input", debounced_update_list);
+
+		this.$input.on("focus", (e) => {
+			if (!e.target.value) {
+				// Show results as soon as possible on focus
+				query_and_update_list(e);
+			}
+		});
 
 		this.$input.on("blur", function () {
 			if (me.selected) {


### PR DESCRIPTION
Every time someone clicks on a Link/Autocomplete/Multiselect control, there is a 500ms delay before showing the list because the input is debounced (which is good). With this PR, the `focus` event will immediately trigger the fetching/rendering, instead of waiting for the debounced `input` event that is triggered by it.

### After (immediate)
https://github.com/frappe/frappe/assets/10946971/10b12181-2dfb-4a2a-9381-2f82ea5a2c04

### Before (delayed)
https://github.com/frappe/frappe/assets/10946971/b16547fc-7422-49e8-8b2e-159875dadbc1

> no-docs

## How to review?

Use the following settings on GitHub:

![image](https://github.com/frappe/frappe/assets/10946971/cabc68ec-8f56-4a23-b29b-afe9cae1e763)