### PR TITLE
fix: don't create new record for address quick entry

### DIFF
--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -61,8 +61,8 @@ $.extend(frappe.contacts, {
 
 function new_record(doctype, link_doctype, link_name) {
 	return frappe.new_doc(doctype).then(() => {
-		if (cur_frm.doc.links) {
-			// avoid adding the same link twice
+		if (!cur_frm.get_field("links") || cur_frm.doc.links) {
+			// avoid adding the same link twice (only if the link field exists)
 			return;
 		}
 

--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -61,8 +61,11 @@ $.extend(frappe.contacts, {
 
 function new_record(doctype, link_doctype, link_name) {
 	return frappe.new_doc(doctype).then(() => {
-		if (!cur_frm.get_field("links") || cur_frm.doc.links) {
-			// avoid adding the same link twice (only if the link field exists)
+		// usecase: address quick entry form
+		if (!cur_frm.get_field("links")) return;
+
+		if (cur_frm.doc.links) {
+			// avoid adding the same link twice
 			return;
 		}
 


### PR DESCRIPTION
Closes: https://github.com/resilient-tech/india-compliance/issues/1014
Created from: https://github.com/frappe/frappe/pull/20865

## Screenshot

![image](https://github.com/frappe/frappe/assets/10496564/7853d696-36ee-47d6-9343-c39f528d1590)

## Error
For Address quick entry forms from Party Doctype, it tries to add_child for links and raises an error.
