### PR TITLE
fix: sync doctype layout on update standard field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -16,6 +16,7 @@ from frappe import _
 from frappe.cache_manager import clear_controller_cache, clear_user_cache
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.database import savepoint
 from frappe.database.schema import validate_column_length, validate_column_name
 from frappe.desk.notifications import delete_notification_count_for, get_filters_for
 from frappe.desk.utils import validate_route_conflict
@@ -522,24 +523,8 @@ class DocType(Document):
 			if self.flags.in_insert:
 				self.run_module_method("after_doctype_insert")
 
+		self.sync_doctype_layouts()
 		delete_notification_count_for(doctype=self.name)
-
-		"""Sync Doctype Layout"""
-		doctype_layouts = frappe.get_all(
-			"DocType Layout", filters={"document_type": self.name}, pluck="name"
-		)
-
-		for layout in doctype_layouts:
-			layout_doc = frappe.get_doc("DocType Layout", layout)
-			savepoint = "sync_fields_" + layout_doc.name
-			try:
-				frappe.db.savepoint(savepoint)
-				layout_doc.sync_fields()
-				layout_doc.save()
-
-			except Exception as e:
-				frappe.clear_last_message()
-				frappe.db.rollback(save_point=savepoint)
 
 		frappe.clear_cache(doctype=self.name)
 
@@ -550,6 +535,17 @@ class DocType(Document):
 			self.sync_global_search()
 
 		clear_linked_doctype_cache()
+
+	@savepoint(catch=Exception)
+	def sync_doctype_layouts(self):
+		"""Sync Doctype Layout"""
+		doctype_layouts = frappe.get_all(
+			"DocType Layout", filters={"document_type": self.name}, pluck="name", ignore_ddl=True
+		)
+		for layout in doctype_layouts:
+			layout_doc = frappe.get_doc("DocType Layout", layout)
+			layout_doc.sync_fields()
+			layout_doc.save()
 
 	def setup_autoincrement_and_sequence(self):
 		"""Changes name type and makes sequence on change (if required)"""

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -523,6 +523,24 @@ class DocType(Document):
 				self.run_module_method("after_doctype_insert")
 
 		delete_notification_count_for(doctype=self.name)
+
+		"""Sync Doctype Layout"""
+		doctype_layouts = frappe.get_all(
+			"DocType Layout", filters={"document_type": self.name}, pluck="name"
+		)
+
+		for layout in doctype_layouts:
+			layout_doc = frappe.get_doc("DocType Layout", layout)
+			savepoint = "sync_fields_" + layout_doc.name
+			try:
+				frappe.db.savepoint(savepoint)
+				layout_doc.sync_fields()
+				layout_doc.save()
+
+			except Exception as e:
+				frappe.clear_last_message()
+				frappe.db.rollback(save_point=savepoint)
+
 		frappe.clear_cache(doctype=self.name)
 
 		# clear user cache so that on the next reload this doctype is included in boot

--- a/frappe/custom/doctype/doctype_layout/doctype_layout.py
+++ b/frappe/custom/doctype/doctype_layout/doctype_layout.py
@@ -32,7 +32,7 @@ class DocTypeLayout(Document):
 
 	@frappe.whitelist()
 	def sync_fields(self):
-		doctype_fields = frappe.get_meta(self.document_type).fields
+		doctype_fields = frappe.get_meta(self.document_type, cached=False).fields
 
 		if self.is_new():
 			added_fields = [field.fieldname for field in doctype_fields]


### PR DESCRIPTION
When standard field is deleted & it is not updated in the doctype layout, Error occurs as it will try to render fields that doesn't exist and layout won't render.

To fix this, sync doctype layout on update standard field
