### PR TITLE
fix: permissions table getting empty after updating any field of doctype

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -135,33 +135,6 @@ frappe.ui.form.on("DocField", {
 	},
 });
 
-function render_form_builder_message(frm) {
-	$(frm.fields_dict["try_form_builder_html"].wrapper).empty();
-	if (!frm.is_new() && frm.fields_dict["try_form_builder_html"]) {
-		let title = __("Use Form Builder to visually edit your form layout");
-		let msg = __(
-			"You can drag and drop fields to create your form layout, add tabs, sections and columns to organize your form and update field properties all from one screen."
-		);
-
-		let message = `
-		<div class="flex form-message blue p-3">
-			<div class="mr-3"><img style="border-radius: var(--border-radius-md)" width="360" src="/assets/frappe/images/form-builder.gif"></div>
-			<div>
-				<p style="font-size: var(--text-lg)">${title}</p>
-				<p>${msg}</p>
-				<div>
-					<a class="btn btn-primary btn-sm" href="/app/form-builder/${frm.doc.name}">
-						${__("Form Builder")} ${frappe.utils.icon("right", "xs")}
-					</a>
-				</div>
-			</div>
-		</div>
-		`;
-
-		$(frm.fields_dict["try_form_builder_html"].wrapper).html(message);
-	}
-}
-
 function render_form_builder(frm) {
 	if (frappe.form_builder && frappe.form_builder.doctype === frm.doc.name) {
 		frappe.form_builder.setup_page_actions();

--- a/frappe/public/js/form_builder/components/controls/FetchFromControl.vue
+++ b/frappe/public/js/form_builder/components/controls/FetchFromControl.vue
@@ -1,6 +1,7 @@
 <!-- Used as Fetch From Control -->
 <script setup>
 import { useStore } from "../../store";
+import { load_doctype_model } from "../../utils";
 import { ref, computed, watch } from "vue";
 import { computedAsync } from "@vueuse/core";
 
@@ -39,7 +40,7 @@ let field_df = computedAsync(async () => {
 		fieldname.value = "";
 	}
 
-	await frappe.model.with_doctype(doctype_name);
+	await load_doctype_model(doctype_name);
 
 	let fields = frappe.meta
 		.get_docfields(doctype_name, null, {

--- a/frappe/public/js/form_builder/components/controls/TableControl.vue
+++ b/frappe/public/js/form_builder/components/controls/TableControl.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { get_table_columns } from "../../utils";
+import { get_table_columns, load_doctype_model } from "../../utils";
 import { computedAsync } from "@vueuse/core";
 
 const props = defineProps(["df"]);
@@ -7,7 +7,9 @@ const props = defineProps(["df"]);
 let table_columns = computedAsync(async () => {
 	let doctype = props.df.options;
 	if (!doctype) return [];
-	await frappe.model.with_doctype(doctype);
+	if (!frappe.get_meta(doctype)) {
+		await load_doctype_model(doctype);
+	}
 	let child_doctype = frappe.get_meta(doctype);
 	return get_table_columns(props.df, child_doctype);
 }, []);

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { create_layout, scrub_field_names } from "./utils";
+import { create_layout, scrub_field_names, load_doctype_model } from "./utils";
 import { computed, nextTick, ref } from "vue";
 import { useDebouncedRefHistory, onKeyDown } from "@vueuse/core";
 
@@ -77,7 +77,9 @@ export const useStore = defineStore("form-builder-store", () => {
 
 		if (!get_docfields.value.length) {
 			let docfield = is_customize_form.value ? "Customize Form Field" : "DocField";
-			await frappe.model.with_doctype(docfield);
+			if (!frappe.get_meta(docfield)) {
+				await load_doctype_model(docfield);
+			}
 			let df = frappe.get_meta(docfield).fields;
 			if (is_customize_form.value) {
 				custom_docfields.value = df;

--- a/frappe/public/js/form_builder/utils.js
+++ b/frappe/public/js/form_builder/utils.js
@@ -96,11 +96,15 @@ export function create_layout(fields) {
 	return layout;
 }
 
+export async function load_doctype_model(doctype) {
+	await frappe.call("frappe.desk.form.load.getdoctype", { doctype });
+}
+
 export async function get_table_columns(df, child_doctype) {
 	let table_columns = [];
 
 	if (!frappe.get_meta(df.options)) {
-		await frappe.model.with_doctype(df.options);
+		await load_doctype_model(df.options);
 	}
 	if (!child_doctype) {
 		child_doctype = frappe.get_meta(df.options);


### PR DESCRIPTION
Fixes: https://github.com/frappe/frappe/issues/22192

**Cause:**
`frappe.model.with_doctype` is loading the doctype and also its parent. In the case of the Sales Invoice doctype when we are trying to load the Sales Invoice Item doctype Sales Invoice is also getting loaded which is causing changes in meta which is causing the issue. 