### PR TITLE
fix: backward compatible get_site_path

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1449,9 +1449,9 @@ def get_site_path(*joins):
 	"""Return path of current site.
 
 	:param *joins: Join additional path elements using `os.path.join`."""
-	from os.path import join, normpath
+	from os.path import join
 
-	return normpath(join(local.site_path, *joins))
+	return join(local.site_path, *joins)
 
 
 def get_pymodule_path(modulename, *joins):

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -142,6 +142,18 @@ class FrappeTestCase(unittest.TestCase):
 		yield
 		frappe.set_user(old_user)
 
+	@contextmanager
+	def switch_site(self, site: str):
+		"""Switch connection to different site.
+		Note: Drops current site connection completely."""
+
+		old_site = frappe.local.site
+		frappe.init(site, force=True)
+		frappe.connect()
+		yield
+		frappe.init(old_site, force=True)
+		frappe.connect()
+
 
 class MockedRequestTestCase(FrappeTestCase):
 	def setUp(self):


### PR DESCRIPTION
Before: `./sitename`
After:  `sitename`

This used to return `.` before, even though these are paths identical
they aren't REALLY. Tar command strips 2 subpaths so this ended up
breaking file restores.


https://github.com/frappe/frappe/blob/c0a39a69f1e941f03c4867d175c948c89b1b33f7/frappe/installer.py#L759


caused by https://github.com/frappe/frappe/pull/22142, attempted fix here doesn't work too: https://github.com/frappe/frappe/pull/22509