### PR TITLE
fix: Include draft transactions only in open_count, not in count.

### DIFF
--- a/cypress/fixtures/doctype_with_links.js
+++ b/cypress/fixtures/doctype_with_links.js
@@ -1,0 +1,45 @@
+export default {
+	name: "Doctype with Links",
+	actions: [],
+	custom: 1,
+	naming_rule: "By fieldname",
+	autoname: "field:title",
+	creation: "2023-10-11 20:17:25.261172",
+	doctype: "DocType",
+	editable_grid: 1,
+	engine: "InnoDB",
+	fields: [
+		{
+			fieldname: "title",
+			fieldtype: "Data",
+			label: "Title",
+			unique: 1,
+		},
+	],
+	links: [
+		{
+			group: "Transactions",
+			link_doctype: "Custom Submittable DocType",
+			link_fieldname: "title",
+		},
+	],
+	modified: "2023-10-11 20:17:25.261172",
+	modified_by: "Administrator",
+	module: "Custom",
+	owner: "Administrator",
+	permissions: [
+		{
+			create: 1,
+			delete: 1,
+			email: 1,
+			print: 1,
+			read: 1,
+			role: "System Manager",
+			share: 1,
+			write: 1,
+		},
+	],
+	sort_field: "modified",
+	sort_order: "ASC",
+	track_changes: 1,
+};

--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -495,18 +495,14 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	}
 
 	set_badge_count_common(open_count, count, $link) {
+		const formatCount = (count) => (count > 99 ? "99+" : count);
 		if (open_count) {
-			$link
-				.find(".open-notification")
-				.removeClass("hidden")
-				.html(open_count > 99 ? "99+" : open_count);
+			$link.find(".open-notification").removeClass("hidden").html(formatCount(open_count));
 		}
 
-		if (count) {
-			$link
-				.find(".count")
-				.removeClass("hidden")
-				.text(count > 99 ? "99+" : count);
+		const net_count = count - open_count;
+		if (net_count) {
+			$link.find(".count").removeClass("hidden").text(formatCount(net_count));
 		}
 	}
 


### PR DESCRIPTION
Before: one and the same draft transaction is counted in both `open_count` and in `count`:
![IMG_1819](https://github.com/frappe/frappe/assets/46800703/0eb36257-70e9-4907-9a38-f9d4a4ffddc9)

After: Draft transactions are shown in `open_count`, but no longer included in `count`:
![IMG_1818](https://github.com/frappe/frappe/assets/46800703/ce84ead0-f5d9-40ff-bef4-a40cc478d66a)

Fixes #22553.