### PR TITLE
feat: get_doc optimisation

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -132,7 +132,7 @@ class LoginManager:
 		user, pwd = get_cached_user_pass()
 		self.authenticate(user=user, pwd=pwd)
 		if self.force_user_to_reset_password():
-			doc = frappe.get_doc("User", self.user)
+			doc = frappe.get_doc("User", self.user, load_from_db=False)
 			frappe.local.response["redirect_to"] = doc.reset_password(
 				send_email=False, password_expired=True
 			)

--- a/frappe/automation/doctype/auto_repeat/auto_repeat.py
+++ b/frappe/automation/doctype/auto_repeat/auto_repeat.py
@@ -92,11 +92,11 @@ class AutoRepeat(Document):
 				self.start_date = today_date
 
 	def after_save(self):
-		frappe.get_doc(self.reference_doctype, self.reference_document).notify_update()
+		frappe.get_doc(self.reference_doctype, self.reference_document, children=False).notify_update()
 
 	def on_trash(self):
 		frappe.db.set_value(self.reference_doctype, self.reference_document, "auto_repeat", "")
-		frappe.get_doc(self.reference_doctype, self.reference_document).notify_update()
+		frappe.get_doc(self.reference_doctype, self.reference_document, children=False).notify_update()
 
 	def set_dates(self):
 		if self.disabled:

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -194,7 +194,7 @@ def get_default_contact(doctype, name):
 
 @frappe.whitelist()
 def invite_user(contact):
-	contact = frappe.get_doc("Contact", contact)
+	contact = frappe.db.get_value("Contact", contact, fieldname=["email_id", "first_name", "last_name"], as_dict=True)
 
 	if not contact.email_id:
 		frappe.throw(_("Please set Email Address"))
@@ -415,7 +415,9 @@ def get_contact_display_list(doctype: str, name: str) -> list[dict]:
 		)
 
 		if contact.address and frappe.has_permission("Address", "read"):
-			address = frappe.get_doc("Address", contact.address)
+			address = frappe.db.get_value("Address", contact.address,
+				fieldname=["address_title", "address_line1", "address_line2", "city", "county", "state", "country"],
+				as_dict=True)
 			contact["address"] = get_condensed_address(address)
 
 	return contact_list

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -194,7 +194,9 @@ def get_default_contact(doctype, name):
 
 @frappe.whitelist()
 def invite_user(contact):
-	contact = frappe.db.get_value("Contact", contact, fieldname=["email_id", "first_name", "last_name"], as_dict=True)
+	contact = frappe.db.get_value(
+		"Contact", contact, fieldname=["email_id", "first_name", "last_name"], as_dict=True
+	)
 
 	if not contact.email_id:
 		frappe.throw(_("Please set Email Address"))
@@ -415,9 +417,20 @@ def get_contact_display_list(doctype: str, name: str) -> list[dict]:
 		)
 
 		if contact.address and frappe.has_permission("Address", "read"):
-			address = frappe.db.get_value("Address", contact.address,
-				fieldname=["address_title", "address_line1", "address_line2", "city", "county", "state", "country"],
-				as_dict=True)
+			address = frappe.db.get_value(
+				"Address",
+				contact.address,
+				fieldname=[
+					"address_title",
+					"address_line1",
+					"address_line2",
+					"city",
+					"county",
+					"state",
+					"country",
+				],
+				as_dict=True,
+			)
 			contact["address"] = get_condensed_address(address)
 
 	return contact_list

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -723,7 +723,7 @@ class File(Document):
 	def add_comment_in_reference_doc(self, comment_type, text):
 		if self.attached_to_doctype and self.attached_to_name:
 			try:
-				doc = frappe.get_doc(self.attached_to_doctype, self.attached_to_name, load_from_db=False)
+				doc = frappe.get_doc(self.attached_to_doctype, self.attached_to_name, children=False)
 				doc.add_comment(comment_type, text)
 			except frappe.DoesNotExistError:
 				frappe.clear_messages()

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -723,7 +723,7 @@ class File(Document):
 	def add_comment_in_reference_doc(self, comment_type, text):
 		if self.attached_to_doctype and self.attached_to_name:
 			try:
-				doc = frappe.get_doc(self.attached_to_doctype, self.attached_to_name)
+				doc = frappe.get_doc(self.attached_to_doctype, self.attached_to_name, load_from_db=False)
 				doc.add_comment(comment_type, text)
 			except frappe.DoesNotExistError:
 				frappe.clear_messages()

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -67,7 +67,12 @@ class TestDocument(FrappeTestCase):
 		self.assertTrue(filter(lambda d: d.fieldname == "email", d.fields))
 
 	def test_load_some_children_some_fields(self):
-		d = frappe.get_doc("DocType", "User", children={"fields": True, "permissions": True}, fields=["name", "allow_rename"])
+		d = frappe.get_doc(
+			"DocType",
+			"User",
+			children={"fields": True, "permissions": True},
+			fields=["name", "allow_rename"],
+		)
 		self.assertEqual(d.doctype, "DocType")
 		self.assertEqual(d.name, "User")
 		self.assertEqual(d.allow_rename, 1)

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -40,8 +40,49 @@ class TestDocument(FrappeTestCase):
 		self.assertTrue(isinstance(d.permissions, list))
 		self.assertTrue(filter(lambda d: d.fieldname == "email", d.fields))
 
+	def test_load_some_fields(self):
+		d = frappe.get_doc("DocType", "User", fields=["name", "allow_rename"])
+		self.assertEqual(d.doctype, "DocType")
+		self.assertEqual(d.name, "User")
+		self.assertEqual(d.allow_rename, 1)
+		self.assertTrue(isinstance(d.fields, list))
+		self.assertTrue(isinstance(d.permissions, list))
+		self.assertTrue(filter(lambda d: d.fieldname == "email", d.fields))
+
+	def test_load_without_children(self):
+		d = frappe.get_doc("DocType", "User", children=False)
+		self.assertEqual(d.doctype, "DocType")
+		self.assertEqual(d.name, "User")
+		self.assertEqual(d.allow_rename, 1)
+		self.assertFalse(getattr(d, "fields", False))
+		self.assertFalse(getattr(d, "permissions", False))
+
+	def test_load_some_children(self):
+		d = frappe.get_doc("DocType", "User", children={"fields": True, "permissions": True})
+		self.assertEqual(d.doctype, "DocType")
+		self.assertEqual(d.name, "User")
+		self.assertEqual(d.allow_rename, 1)
+		self.assertTrue(isinstance(d.fields, list))
+		self.assertTrue(isinstance(d.permissions, list))
+		self.assertTrue(filter(lambda d: d.fieldname == "email", d.fields))
+
+	def test_load_some_children_some_fields(self):
+		d = frappe.get_doc("DocType", "User", children={"fields": True, "permissions": True}, fields=["name", "allow_rename"])
+		self.assertEqual(d.doctype, "DocType")
+		self.assertEqual(d.name, "User")
+		self.assertEqual(d.allow_rename, 1)
+		self.assertTrue(isinstance(d.fields, list))
+		self.assertTrue(isinstance(d.permissions, list))
+		self.assertTrue(filter(lambda d: d.fieldname == "email", d.fields))
+
 	def test_load_single(self):
 		d = frappe.get_doc("Website Settings", "Website Settings")
+		self.assertEqual(d.name, "Website Settings")
+		self.assertEqual(d.doctype, "Website Settings")
+		self.assertTrue(d.disable_signup in (0, 1))
+
+	def test_load_single_without_children(self):
+		d = frappe.get_doc("Website Settings", "Website Settings", children=False)
 		self.assertEqual(d.name, "Website Settings")
 		self.assertEqual(d.doctype, "Website Settings")
 		self.assertTrue(d.disable_signup in (0, 1))

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -591,7 +591,9 @@ def get_messages_from_page(name):
 
 def get_messages_from_report(name):
 	"""Returns all translatable strings from a :class:`frappe.core.doctype.Report`"""
-	report = frappe.get_doc("Report", name, fields=["name", "ref_doctype", "query"], children={"roles": False})
+	report = frappe.get_doc(
+		"Report", name, fields=["name", "ref_doctype", "query"], children={"roles": False}
+	)
 	messages = _get_messages_from_page_or_report(
 		"Report", name, frappe.db.get_value("DocType", report.ref_doctype, "module")
 	)

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -591,7 +591,7 @@ def get_messages_from_page(name):
 
 def get_messages_from_report(name):
 	"""Returns all translatable strings from a :class:`frappe.core.doctype.Report`"""
-	report = frappe.get_doc("Report", name)
+	report = frappe.get_doc("Report", name, fields=["name", "ref_doctype", "query"], children={"roles": False})
 	messages = _get_messages_from_page_or_report(
 		"Report", name, frappe.db.get_value("DocType", report.ref_doctype, "module")
 	)

--- a/frappe/website/website_components/metatags.py
+++ b/frappe/website/website_components/metatags.py
@@ -65,7 +65,7 @@ class MetaTags:
 		)
 
 		if route_exists:
-			website_route_meta = frappe.get_doc("Website Route Meta", route)
+			website_route_meta = frappe.get_doc("Website Route Meta", route, fields=["name"], children={"meta_tags": True})
 			for meta_tag in website_route_meta.meta_tags:
 				d = meta_tag.get_meta_dict()
 				self.tags.update(d)

--- a/frappe/website/website_components/metatags.py
+++ b/frappe/website/website_components/metatags.py
@@ -65,7 +65,9 @@ class MetaTags:
 		)
 
 		if route_exists:
-			website_route_meta = frappe.get_doc("Website Route Meta", route, fields=["name"], children={"meta_tags": True})
+			website_route_meta = frappe.get_doc(
+				"Website Route Meta", route, fields=["name"], children={"meta_tags": True}
+			)
 			for meta_tag in website_route_meta.meta_tags:
 				d = meta_tag.get_meta_dict()
 				self.tags.update(d)


### PR DESCRIPTION
fixes: #22711

Updating get_doc method to take three additional parameters
1. load_from_db: default: True
2. fields: default: '*'
3. children: default: {},  this is dict rather than list to support both pick and omit