### PR TITLE
fix (REST API): Do not show traceback, if method is executed via `api/method`

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -44,9 +44,13 @@ def handle():
 	cmd = frappe.local.form_dict.cmd
 	data = None
 
+	if not cmd:
+		raise frappe.DoesNotExistError
 	if cmd != "login":
-		data = execute_cmd(cmd)
-
+		try:
+			data = execute_cmd(cmd)
+		except Exception:
+			raise frappe.DoesNotExistError
 	# data can be an empty string or list which are valid responses
 	if data is not None:
 		if isinstance(data, Response):

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -44,13 +44,9 @@ def handle():
 	cmd = frappe.local.form_dict.cmd
 	data = None
 
-	if not cmd:
-		raise frappe.DoesNotExistError
 	if cmd != "login":
-		try:
-			data = execute_cmd(cmd)
-		except Exception:
-			raise frappe.DoesNotExistError
+		data = execute_cmd(cmd)
+
 	# data can be an empty string or list which are valid responses
 	if data is not None:
 		if isinstance(data, Response):
@@ -65,6 +61,8 @@ def handle():
 
 def execute_cmd(cmd, from_async=False):
 	"""execute a request as python module"""
+	if not cmd:
+		raise frappe.DoesNotExistError
 	for hook in reversed(frappe.get_hooks("override_whitelisted_methods", {}).get(cmd, [])):
 		# override using the first hook
 		cmd = hook


### PR DESCRIPTION
Fixes: https://github.com/frappe/erpnext/issues/37474

Initially, executing any method via `api/method`, it displayed error log similar to below screenshot, While any error occured at `api/resource` endpoint it just displays `Not Found`. 
<img width="700" alt="Screenshot 2023-10-12 at 4 40 01 PM" src="https://github.com/frappe/frappe/assets/28840468/88c25c5a-65fb-40d5-b4fc-53a8c2ac52ee">

After fix :
<img width="472" alt="Screenshot 2023-10-12 at 4 40 26 PM" src="https://github.com/frappe/frappe/assets/28840468/960c0e05-6eb2-4fe6-a42c-0fbbc00b741e">
 