### PR TITLE
fix: hide `sidebar-image-actions` if the user doesn't have write permission

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -16,6 +16,7 @@ frappe.ui.form.Sidebar = class {
 		var sidebar_content = frappe.render_template("form_sidebar", {
 			doctype: this.frm.doctype,
 			frm: this.frm,
+			can_write: frappe.model.can_write(this.frm.doctype, this.frm.docname),
 		});
 
 		this.sidebar = $('<div class="form-sidebar overlay-sidebar hidden-xs hidden-sm"></div>')

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -5,6 +5,7 @@
 		<div class="sidebar-standard-image">
 			<div class="standard-image"></div>
 		</div>
+		{% if can_write %}
 		<div class="sidebar-image-actions">
 			<div class="dropdown">
 				<a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ __("Change") }}</a>
@@ -14,6 +15,7 @@
 				</div>
 			</div>
 		</div>
+		{% endif %}
 	</li>
 </ul>
 {% if frm.meta.beta %}


### PR DESCRIPTION
Previously, even if the user didn't have write permissions, the option to upload / remove a profile picture was shown.
This would lead to the file getting uploaded to the server, but the actual change of profile picture failing due to a lack of permissions. So we can simply hide the dropdown if the user doesn't have write permissions in the first place.

This resolves #14915 

![image](https://github.com/frappe/frappe/assets/10119037/8e8675f7-681a-4d6c-8931-762eead56cf0)
![image](https://github.com/frappe/frappe/assets/10119037/195f51ef-8b58-4537-9bd1-b8d64aac11ca)
