### PR TITLE
fix: Don't mutate `df` object in frappe.format

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -394,7 +394,7 @@ frappe.form.get_formatter = function (fieldtype) {
 
 frappe.format = function (value, df, options, doc) {
 	if (!df) df = { fieldtype: "Data" };
-	if (df.fieldname == "_user_tags") df.fieldtype = "Tag";
+	if (df.fieldname == "_user_tags") df = { ...df, fieldtype: "Tag" };
 	var fieldtype = df.fieldtype || "Data";
 
 	// format Dynamic Link as a Link


### PR DESCRIPTION
When customizing the **Communication** DocType by setting the property `in_list_view` for the field `_user_tags` to `1`, the *fieldtype* of the `_user_tags` docfield can be mutated to `"Tag"` by the `frappe.format` function called during the list view rendering. Then, when opening a Communication form view, the layout tries to render the `_user_tags` field which has the invalid fieldtype `"Tag"`, which crashes the rendering of the form.

https://github.com/frappe/frappe/blob/497807cbbc99d1c9d164a29d4ea3ea98ae7be249/frappe/core/doctype/communication/communication.json#L49

https://github.com/frappe/frappe/blob/497807cbbc99d1c9d164a29d4ea3ea98ae7be249/frappe/core/doctype/communication/communication.json#L304-L311


```json
{
  "doctype": "Property Setter",
  "doctype_or_field": "DocField",
  "doc_type": "Communication",
  "field_name": "_user_tags",
  "property": "in_list_view",
  "property_type": "Check",
  "value": "1"
}
```