### PR TITLE
feat: let social login keys control signups

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -53,6 +53,7 @@
   {
    "allow_in_quick_entry": 1,
    "depends_on": "eval:doc.frequency==='Cron'",
+   "description": "<pre>*  *  *  *  *\n\u252c  \u252c  \u252c  \u252c  \u252c\n\u2502  \u2502  \u2502  \u2502  \u2502\n\u2502  \u2502  \u2502  \u2502  \u2514 day of week (0 - 6) (0 is Sunday)\n\u2502  \u2502  \u2502  \u2514\u2500\u2500\u2500\u2500\u2500 month (1 - 12)\n\u2502  \u2502  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 day of month (1 - 31)\n\u2502  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 hour (0 - 23)\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 minute (0 - 59)\n\n---\n\n* - Any value\n/ - Step values\n</pre>\n",
    "fieldname": "cron_format",
    "fieldtype": "Data",
    "label": "Cron Format",
@@ -100,7 +101,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2022-06-28 02:55:12.470915",
+ "modified": "2023-10-14 11:26:05.005930",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -136,6 +136,7 @@
   },
   {
    "depends_on": "eval:doc.event_frequency==='Cron'",
+   "description": "<pre>*  *  *  *  *\n\u252c  \u252c  \u252c  \u252c  \u252c\n\u2502  \u2502  \u2502  \u2502  \u2502\n\u2502  \u2502  \u2502  \u2502  \u2514 day of week (0 - 6) (0 is Sunday)\n\u2502  \u2502  \u2502  \u2514\u2500\u2500\u2500\u2500\u2500 month (1 - 12)\n\u2502  \u2502  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 day of month (1 - 31)\n\u2502  \u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 hour (0 - 23)\n\u2514\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500 minute (0 - 59)\n\n---\n\n* - Any value\n/ - Step values\n</pre>\n",
    "fieldname": "cron_format",
    "fieldtype": "Data",
    "label": "Cron Format"
@@ -148,7 +149,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2023-05-27 16:33:16.595424",
+ "modified": "2023-10-14 11:24:46.478533",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/integrations/doctype/social_login_key/social_login_key.json
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.json
@@ -18,6 +18,8 @@
   "icon",
   "column_break_1",
   "base_url",
+  "configuration_section",
+  "sign_ups",
   "client_urls",
   "authorize_url",
   "access_token_url",
@@ -157,11 +159,24 @@
    "fieldname": "user_id_property",
    "fieldtype": "Data",
    "label": "User ID Property"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "configuration_section",
+   "fieldtype": "Section Break",
+   "label": "Configuration"
+  },
+  {
+   "description": "Controls whether new users can sign up using this Social Login Key. If unset, Website Settings is respected. ",
+   "fieldname": "sign_ups",
+   "fieldtype": "Select",
+   "label": "Sign ups",
+   "options": "\nAllow\nDeny"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-09-30 14:37:13.616002",
+ "modified": "2023-10-14 12:22:23.601130",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Social Login Key",
@@ -182,6 +197,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "provider_name",
  "track_changes": 1
 }

--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -54,6 +54,7 @@ class SocialLoginKey(Document):
 		icon: DF.Data | None
 		provider_name: DF.Data
 		redirect_url: DF.Data | None
+		sign_ups: DF.Literal["", "Allow", "Deny"]
 		social_login_provider: DF.Literal[
 			"Custom", "Facebook", "Frappe", "GitHub", "Google", "Office 365", "Salesforce", "fairlogin"
 		]
@@ -214,3 +215,13 @@ class SocialLoginKey(Document):
 			return
 
 		return providers.get(provider) if provider else providers
+
+
+def provider_allows_signup(provider: str) -> bool:
+	from frappe.website.utils import is_signup_disabled
+
+	sign_up_config = frappe.db.get_value("Social Login Key", provider, "sign_ups")
+
+	if not (sign_up_config and provider):  # fallback to global settings
+		return is_signup_disabled()
+	return sign_up_config == "Allow"

--- a/frappe/integrations/doctype/social_login_key/test_social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/test_social_login_key.py
@@ -7,13 +7,22 @@ from rauth import OAuth2Service
 import frappe
 from frappe.auth import CookieManager, LoginManager
 from frappe.integrations.doctype.social_login_key.social_login_key import BaseUrlNotSetError
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import set_request
 from frappe.utils.oauth import login_via_oauth2
 
+TEST_GITHUB_USER = "githublogin@example.com"
+
 
 class TestSocialLoginKey(FrappeTestCase):
+	def setUp(self) -> None:
+		frappe.set_user("Administrator")
+		frappe.delete_doc("User", TEST_GITHUB_USER, force=True)
+		super().setUp()
+		frappe.set_user("Guest")
+
 	def test_adding_frappe_social_login_provider(self):
+		frappe.set_user("Administrator")
 		provider_name = "Frappe"
 		social_login_key = make_social_login_key(social_login_provider=provider_name)
 		social_login_key.get_social_login_provider(provider_name, initialize=True)
@@ -40,17 +49,43 @@ class TestSocialLoginKey(FrappeTestCase):
 	def test_normal_signup_and_github_login(self):
 		github_social_login_setup()
 
-		if not frappe.db.exists("User", "githublogin@example.com"):
-			user = frappe.get_doc(
-				{"doctype": "User", "email": "githublogin@example.com", "first_name": "GitHub Login"}
-			)
-			user.save(ignore_permissions=True)
+		if not frappe.db.exists("User", TEST_GITHUB_USER):
+			user = frappe.new_doc("User", email=TEST_GITHUB_USER, first_name="GitHub Login")
+			user.insert(ignore_permissions=True)
 
 		mock_session = MagicMock()
 		mock_session.get.side_effect = github_response_for_login
 
 		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
 			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})
+		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
+
+	def test_force_disabled_signups(self):
+		key = github_social_login_setup()
+		key.sign_ups = "Deny"
+		key.save(ignore_permissions=True)
+
+		mock_session = MagicMock()
+		mock_session.get.side_effect = github_response_for_login
+
+		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
+			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})
+		self.assertEqual(frappe.session.user, "Guest")
+
+	@change_settings("Website Settings", disable_signup=1)
+	def test_force_enabled_signups(self):
+		"""Social login key can override website settings for disabled signups."""
+		key = github_social_login_setup()
+		key.sign_ups = "Allow"
+		key.save(ignore_permissions=True)
+
+		mock_session = MagicMock()
+		mock_session.get.side_effect = github_response_for_login
+
+		with patch.object(OAuth2Service, "get_auth_session", return_value=mock_session):
+			login_via_oauth2("github", "iwriu", {"token": "ewrwerwer"})
+
+		self.assertEqual(frappe.session.user, TEST_GITHUB_USER)
 
 
 def make_social_login_key(**kwargs):
@@ -83,7 +118,6 @@ def create_github_social_login_key():
 		social_login_key = make_social_login_key(social_login_provider=provider_name)
 		social_login_key.get_social_login_provider(provider_name, initialize=True)
 
-		# Dummy client_id and client_secret
 		social_login_key.client_id = "h6htd6q"
 		social_login_key.client_secret = "keoererk988ekkhf8w9e8ewrjhhkjer9889"
 		social_login_key.insert(ignore_permissions=True)
@@ -125,7 +159,7 @@ def github_response_for_login(url, *args, **kwargs):
 			"first_name": "Github Login",
 		}
 	else:
-		return_value = [{"email": "githublogin@example.com", "primary": True, "verified": True}]
+		return_value = [{"email": TEST_GITHUB_USER, "primary": True, "verified": True}]
 
 	return MagicMock(status_code=200, json=MagicMock(return_value=return_value))
 
@@ -135,4 +169,4 @@ def github_social_login_setup():
 	frappe.local.cookie_manager = CookieManager()
 	frappe.local.login_manager = LoginManager()
 
-	create_github_social_login_key()
+	return create_github_social_login_key()

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -195,7 +195,7 @@ def _restore_thread_locals(flags):
 
 
 @contextmanager
-def change_settings(doctype, settings_dict):
+def change_settings(doctype, settings_dict=None, /, **settings):
 	"""A context manager to ensure that settings are changed before running
 	function and restored after running it regardless of exceptions occured.
 	This is useful in tests where you want to make changes in a function but
@@ -206,7 +206,14 @@ def change_settings(doctype, settings_dict):
 	@change_settings("Print Settings", {"send_print_as_pdf": 1})
 	def test_case(self):
 	        ...
+
+	@change_settings("Print Settings", send_print_as_pdf=1)
+	def test_case(self):
+	        ...
 	"""
+
+	if settings_dict is None:
+		settings_dict = settings
 
 	try:
 		settings = frappe.get_doc(doctype)

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -227,11 +227,13 @@ def login_oauth_user(
 		)
 
 
-def get_user_record(user: str, data: dict) -> "User":
+def get_user_record(user: str, data: dict, provider: str) -> "User":
+	from frappe.integrations.doctype.social_login_key.social_login_key import provider_allows_signup
+
 	try:
 		return frappe.get_doc("User", user)
 	except frappe.DoesNotExistError:
-		if frappe.get_website_settings("disable_signup"):
+		if not provider_allows_signup(provider):
 			raise SignupDisabledError
 
 	user: "User" = frappe.new_doc("User")
@@ -263,7 +265,7 @@ def update_oauth_user(user: str, data: dict, provider: str):
 	if isinstance(data.get("location"), dict):
 		data["location"] = data["location"].get("name")
 
-	user: "User" = get_user_record(user, data)
+	user: "User" = get_user_record(user, data, provider)
 	update_user_record = user.is_new()
 
 	if not user.enabled:

--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -248,7 +248,7 @@
   },
   {
    "default": "1",
-   "description": "Disable Customer Signup link in Login page",
+   "description": "Disable Signups on site. New users will have to be manually registered by system managers.",
    "fieldname": "disable_signup",
    "fieldtype": "Check",
    "label": "Disable Signup"
@@ -476,7 +476,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-12-05 04:17:56.478757",
+ "modified": "2023-10-14 11:38:47.383840",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -182,7 +182,7 @@ def get_boot_data():
 
 
 def is_signup_disabled():
-	return frappe.db.get_single_value("Website Settings", "disable_signup", True)
+	return frappe.get_website_settings("disable_signup")
 
 
 def cleanup_page_name(title: str) -> str:


### PR DESCRIPTION
There are cases where certain social login keys

- Should not allow sign-ups at all and only allow logins. E.g. social media login keys.
- Should allow sign-ups even if global sign ups are disabled. e.g. internal SSO like setups.

Fix:
Social login keys can now specify what to do with signups. 
- Default behaviour is current behaviour. Website settings is respected.
- If configured allow/deny then website settings is overridden and only login key setting is respected. 

`no-docs`
