### PR TITLE
fix: Fetch all matches in search_widget and apply page limit after sorting.

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -72,15 +72,18 @@ def search_widget(
 
 	if searchfield:
 		sanitize_searchfield(searchfield)
-
-	if not searchfield:
+	else:
 		searchfield = "name"
 
 	standard_queries = frappe.get_hooks().standard_queries or {}
 
-	if query and query.split(maxsplit=1)[0].lower() != "select":
-		# by method
+	if query:
+		if query.split(maxsplit=1)[0].lower() == "select":
+			# custom query
+			# frappe.response["values"] = frappe.db.sql(scrub_custom_query(query, searchfield, txt))
+			frappe.throw(_("This query style is discontinued"))
 		try:
+			# by method
 			is_whitelisted(frappe.get_attr(query))
 			frappe.response["values"] = frappe.call(
 				query,
@@ -106,7 +109,7 @@ def search_widget(
 			return
 		except Exception as e:
 			raise e
-	elif not query and doctype in standard_queries:
+	elif doctype in standard_queries:
 		# from standard queries
 		search_widget(
 			doctype=doctype,
@@ -122,136 +125,132 @@ def search_widget(
 			ignore_user_permissions=ignore_user_permissions,
 		)
 	else:
-		meta = frappe.get_meta(doctype)
-
-		if query:
-			frappe.throw(_("This query style is discontinued"))
-			# custom query
-			# frappe.response["values"] = frappe.db.sql(scrub_custom_query(query, searchfield, txt))
-		else:
-			if isinstance(filters, dict):
-				filters_items = filters.items()
-				filters = []
-				for f in filters_items:
-					if isinstance(f[1], (list, tuple)):
-						filters.append([doctype, f[0], f[1][0], f[1][1]])
-					else:
-						filters.append([doctype, f[0], "=", f[1]])
-
-			if filters is None:
-				filters = []
-			or_filters = []
-
-			# build from doctype
-			if txt:
-				field_types = [
-					"Data",
-					"Text",
-					"Small Text",
-					"Long Text",
-					"Link",
-					"Select",
-					"Read Only",
-					"Text Editor",
-				]
-				search_fields = ["name"]
-				if meta.title_field:
-					search_fields.append(meta.title_field)
-
-				if meta.search_fields:
-					search_fields.extend(meta.get_search_fields())
-
-				for f in search_fields:
-					fmeta = meta.get_field(f.strip())
-					if not meta.translated_doctype and (
-						f == "name" or (fmeta and fmeta.fieldtype in field_types)
-					):
-						or_filters.append([doctype, f.strip(), "like", f"%{txt}%"])
-
-			if meta.get("fields", {"fieldname": "enabled", "fieldtype": "Check"}):
-				filters.append([doctype, "enabled", "=", 1])
-			if meta.get("fields", {"fieldname": "disabled", "fieldtype": "Check"}):
-				filters.append([doctype, "disabled", "!=", 1])
-
-			# format a list of fields combining search fields and filter fields
-			fields = get_std_fields_list(meta, searchfield or "name")
-			if filter_fields:
-				fields = list(set(fields + json.loads(filter_fields)))
-			formatted_fields = [f"`tab{meta.name}`.`{f.strip()}`" for f in fields]
-
-			# Insert title field query after name
-			if meta.show_title_field_in_link:
-				formatted_fields.insert(1, f"`tab{meta.name}`.{meta.title_field} as `label`")
-
-			# In order_by, `idx` gets second priority, because it stores link count
-			from frappe.model.db_query import get_order_by
-
-			order_by_based_on_meta = get_order_by(doctype, meta)
-			order_by = f"{order_by_based_on_meta}, `tab{doctype}`.idx desc"
-
-			if not meta.translated_doctype:
-				formatted_fields.append(
-					"""locate({_txt}, `tab{doctype}`.`name`) as `_relevance`""".format(
-						_txt=frappe.db.escape((txt or "").replace("%", "").replace("@", "")),
-						doctype=doctype,
-					)
-				)
-				order_by = f"_relevance, {order_by}"
-
-			ignore_permissions = (
-				True
-				if doctype == "DocType"
-				else (
-					cint(ignore_user_permissions)
-					and has_permission(
-						doctype,
-						ptype="select" if frappe.only_has_select_perm(doctype) else "read",
-						parent_doctype=reference_doctype,
-					)
-				)
-			)
-
-			values = frappe.get_list(
-				doctype,
-				filters=filters,
-				fields=formatted_fields,
-				or_filters=or_filters,
-				limit_start=start,
-				limit_page_length=None,
-				order_by=order_by,
-				ignore_permissions=ignore_permissions,
-				reference_doctype=reference_doctype,
-				as_list=not as_dict,
-				strict=False,
-			)
-
-			if meta.translated_doctype:
-				# Filtering the values array so that query is included in very element
-				values = (
-					result
-					for result in values
-					if any(
-						re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
-						for value in (result.values() if as_dict else result)
-					)
-				)
-
-			# Sorting the values array so that relevant results always come first
-			# This will first bring elements on top in which query is a prefix of element
-			# Then it will bring the rest of the elements and sort them in lexicographical order
-			values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
-
-			if not meta.translated_doctype:
-				# Apply page_length
-				values = values[:page_length]
-				# Remove _relevance from results
-				if as_dict:
-					for r in values:
-						r.pop("_relevance")
+		if filters is None:
+			filters = []
+		elif isinstance(filters, dict):
+			filters_items = filters.items()
+			filters = []
+			for f in filters_items:
+				if isinstance(f[1], (list, tuple)):
+					filters.append([doctype, f[0], f[1][0], f[1][1]])
 				else:
-					values = [r[:-1] for r in values]
+					filters.append([doctype, f[0], "=", f[1]])
 
-			frappe.response["values"] = values
+		# build from doctype
+		meta = frappe.get_meta(doctype)
+		or_filters = []
+
+		if txt:
+			field_types = [
+				"Data",
+				"Text",
+				"Small Text",
+				"Long Text",
+				"Link",
+				"Select",
+				"Read Only",
+				"Text Editor",
+			]
+			search_fields = ["name"]
+			if meta.title_field:
+				search_fields.append(meta.title_field)
+
+			if meta.search_fields:
+				search_fields.extend(meta.get_search_fields())
+
+			for f in search_fields:
+				if f == "name":
+					is_valid_field = True
+				else:
+					fmeta = meta.get_field(f.strip())
+					is_valid_field = fmeta and fmeta.fieldtype in field_types
+				if not meta.translated_doctype and is_valid_field:
+					or_filters.append([doctype, f.strip(), "like", f"%{txt}%"])
+
+		if meta.get("fields", {"fieldname": "enabled", "fieldtype": "Check"}):
+			filters.append([doctype, "enabled", "=", 1])
+		if meta.get("fields", {"fieldname": "disabled", "fieldtype": "Check"}):
+			filters.append([doctype, "disabled", "!=", 1])
+
+		# format a list of fields combining search fields and filter fields
+		fields = get_std_fields_list(meta, searchfield or "name")
+		if filter_fields:
+			fields = list(set(fields + json.loads(filter_fields)))
+		formatted_fields = [f"`tab{meta.name}`.`{f.strip()}`" for f in fields]
+
+		# Insert title field query after name
+		if meta.show_title_field_in_link:
+			formatted_fields.insert(1, f"`tab{meta.name}`.{meta.title_field} as `label`")
+
+		# In order_by, `idx` gets second priority, because it stores link count
+		from frappe.model.db_query import get_order_by
+
+		order_by_based_on_meta = get_order_by(doctype, meta)
+		order_by = f"{order_by_based_on_meta}, `tab{doctype}`.idx desc"
+
+		if not meta.translated_doctype:
+			formatted_fields.append(
+				"""locate({_txt}, `tab{doctype}`.`name`) as `_relevance`""".format(
+					_txt=frappe.db.escape((txt or "").replace("%", "").replace("@", "")),
+					doctype=doctype,
+				)
+			)
+			order_by = f"_relevance, {order_by}"
+
+		ignore_permissions = (
+			True
+			if doctype == "DocType"
+			else (
+				cint(ignore_user_permissions)
+				and has_permission(
+					doctype,
+					ptype="select" if frappe.only_has_select_perm(doctype) else "read",
+					parent_doctype=reference_doctype,
+				)
+			)
+		)
+
+		values = frappe.get_list(
+			doctype,
+			filters=filters,
+			fields=formatted_fields,
+			or_filters=or_filters,
+			limit_start=start,
+			limit_page_length=None,
+			order_by=order_by,
+			ignore_permissions=ignore_permissions,
+			reference_doctype=reference_doctype,
+			as_list=not as_dict,
+			strict=False,
+		)
+
+		if meta.translated_doctype:
+			# Filtering the values array so that query is included in very element
+			values = (
+				result
+				for result in values
+				if any(
+					re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
+					for value in (result.values() if as_dict else result)
+				)
+			)
+
+		# Sorting the values array so that relevant results always come first
+		# This will first bring elements on top in which query is a prefix of element
+		# Then it will bring the rest of the elements and sort them in lexicographical order
+		values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
+
+		if not meta.translated_doctype:
+			# Apply page_length
+			values = values[:page_length]
+			# Remove _relevance from results
+			if as_dict:
+				for r in values:
+					r.pop("_relevance")
+			else:
+				values = [r[:-1] for r in values]
+
+		frappe.response["values"] = values
 
 
 def get_std_fields_list(meta, key):

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -187,7 +187,6 @@ def search_widget(
 			from frappe.model.db_query import get_order_by
 
 			order_by_based_on_meta = get_order_by(doctype, meta)
-			# 2 is the index of _relevance column
 			order_by = f"{order_by_based_on_meta}, `tab{doctype}`.idx desc"
 
 			if not meta.translated_doctype:
@@ -218,7 +217,7 @@ def search_widget(
 				fields=formatted_fields,
 				or_filters=or_filters,
 				limit_start=start,
-				limit_page_length=None if meta.translated_doctype else page_length,
+				limit_page_length=None,
 				order_by=order_by,
 				ignore_permissions=ignore_permissions,
 				reference_doctype=reference_doctype,
@@ -242,8 +241,10 @@ def search_widget(
 			# Then it will bring the rest of the elements and sort them in lexicographical order
 			values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
 
-			# remove _relevance from results
 			if not meta.translated_doctype:
+				# Apply page_length
+				values = values[:page_length]
+				# Remove _relevance from results
 				if as_dict:
 					for r in values:
 						r.pop("_relevance")


### PR DESCRIPTION
Fixes: #22725 (and probably more issues).

Before:


https://github.com/frappe/frappe/assets/46800703/db1126a1-59a4-470f-915e-0f7b799e8ab2


After:


https://github.com/frappe/frappe/assets/46800703/0212de7c-4b37-41a8-b0db-49d9b0d89860



I tried several approaches:

1. Simply turning around the basic SQL sort order doesn‘t really cut it.
2. Moving the whole sort logic from Python to the SQL query should in principle be possible using CASE WHEN, but isn‘t supported by `frappe.get_list()`.

So we could:
3. write our own raw SQL query
4. make `frappe.get_list()` support CASE WHEN clauses
5. call `frappe.get_list()` twice, once for those docs matching the start, and again for the rest.

In the end, I settled with simply removing the page_limit, fetching all docs, and only applying the page_limit later, after sorting in python. This is by far the most flexible solution, and still shouldn‘t hopefully impact performance in any relevant way.
In translated environments, we‘ve already been fetching all docs since #17828 and didn‘t notice any degradation.

I may be adding some (more) refactoring in a separate commit.