### PR TITLE
[FEAT] new feature on Naming Rules.

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -309,6 +309,10 @@ def parse_naming_series(
 			part = today.strftime("%y")
 		elif e == "MM":
 			part = today.strftime("%m")
+		elif e == "MMM":
+			part = today.strftime("%b")
+		elif e == "MMMM":
+			part = today.strftime("%B")
 		elif e == "DD":
 			part = today.strftime("%d")
 		elif e == "YYYY":


### PR DESCRIPTION
New feature on Naming Rules if you use 'MMMM' in expression the id  generates full months and if you use 'MMM' then id will generate first three letter of months.

---

In "Naming Rule" Expression is Selected and in "Auto Name" we use {MMMM} full months is generated as a Id Formate .
![Screenshot from 2023-10-15 11-38-27](https://github.com/frappe/frappe/assets/90375329/8ffc3e76-3bf4-4ecf-87cd-35a41a03a9f8)

![Screenshot from 2023-10-15 11-37-51](https://github.com/frappe/frappe/assets/90375329/70a6c095-2176-417d-8210-c236fd4bc67c)


### And Again "Naming Rule" Expression is Selected and in "Auto Name" we use {MMM} first three letter of  months is generated as a Id Formate .
![Screenshot from 2023-10-15 11-38-34](https://github.com/frappe/frappe/assets/90375329/4bb5bdb1-83f4-4a46-b031-023f01c8e291)

![Screenshot from 2023-10-15 11-39-06](https://github.com/frappe/frappe/assets/90375329/d67bab05-46e8-4f1d-bf83-9596a9b3ac02)


