### PR TITLE
fix(UX): Improve search relevance for link field

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -188,7 +188,7 @@ def search_widget(
 
 			order_by_based_on_meta = get_order_by(doctype, meta)
 			# 2 is the index of _relevance column
-			order_by = f"{order_by_based_on_meta}, `tab{doctype}`.idx desc"
+			order_by = f"`tab{doctype}`.idx desc, {order_by_based_on_meta}"
 
 			if not meta.translated_doctype:
 				formatted_fields.append(

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -192,12 +192,12 @@ def search_widget(
 
 			if not meta.translated_doctype:
 				formatted_fields.append(
-					"""locate({_txt}, `tab{doctype}`.`name`) as `_relevance`""".format(
+					"""(1 / locate({_txt}, `tab{doctype}`.`name`)) as `_relevance`""".format(
 						_txt=frappe.db.escape((txt or "").replace("%", "").replace("@", "")),
 						doctype=doctype,
 					)
 				)
-				order_by = f"_relevance, {order_by}"
+				order_by = f"ifnull(_relevance, -9999) desc, {order_by}"
 
 			ignore_permissions = (
 				True

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -191,13 +191,15 @@ def search_widget(
 			order_by = f"`tab{doctype}`.idx desc, {order_by_based_on_meta}"
 
 			if not meta.translated_doctype:
-				formatted_fields.append(
-					"""(1 / locate({_txt}, `tab{doctype}`.`name`)) as `_relevance`""".format(
-						_txt=frappe.db.escape((txt or "").replace("%", "").replace("@", "")),
-						doctype=doctype,
-					)
-				)
-				order_by = f"ifnull(_relevance, -9999) desc, {order_by}"
+				_txt = frappe.db.escape((txt or "").replace("%", "").replace("@", ""))
+				_relevance = f"(1 / nullif(locate({_txt}, `tab{doctype}`.`name`), 0))"
+				formatted_fields.append(f"""{_relevance} as `_relevance`""")
+				# Since we are sorting by alias postgres needs to know number of column we are sorting
+				if frappe.db.db_type == "mariadb":
+					order_by = f"ifnull(_relevance, -9999) desc, {order_by}"
+				elif frappe.db.db_type == "postgres":
+					# Since we are sorting by alias postgres needs to know number of column we are sorting
+					order_by = f"{len(formatted_fields)} desc nulls last, {order_by}"
 
 			ignore_permissions = (
 				True

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -161,6 +161,16 @@ class TestSearch(FrappeTestCase):
 		for row in results:
 			self.assertIn("es", row["value"])
 
+		# Assume that "es" is used at least 10 times, it should now be first
+		frappe.db.set_value("Language", "es", "idx", 10)
+		results = search(
+			doctype="Language",
+			txt="es",
+			filters=None,
+			page_length=10,
+		)
+		self.assertEqual("es", results[0]["value"])
+
 
 def search(*args, **kwargs):
 	search_link(*args, **kwargs)

--- a/frappe/tests/test_search.py
+++ b/frappe/tests/test_search.py
@@ -132,7 +132,7 @@ class TestSearch(FrappeTestCase):
 
 	def test_reference_doctype(self):
 		"""search query methods should get reference_doctype if they want"""
-		search_link(
+		results = search(
 			doctype="User",
 			txt="",
 			filters=None,
@@ -140,7 +140,31 @@ class TestSearch(FrappeTestCase):
 			reference_doctype="ToDo",
 			query="frappe.tests.test_search.query_with_reference_doctype",
 		)
-		self.assertListEqual(frappe.response["results"], [])
+		self.assertListEqual(results, [])
+
+	def test_search_relevance(self):
+		results = search(
+			doctype="Language",
+			txt="e",
+			filters=None,
+			page_length=10,
+		)
+		for row in results:
+			self.assertTrue(row["value"].startswith("e"))
+
+		results = search(
+			doctype="Language",
+			txt="es",
+			filters=None,
+			page_length=10,
+		)
+		for row in results:
+			self.assertIn("es", row["value"])
+
+
+def search(*args, **kwargs):
+	search_link(*args, **kwargs)
+	return frappe.response["results"]
 
 
 @frappe.validate_and_sanitize_search_inputs


### PR DESCRIPTION
We use `locate` function to rank matches. It's just SQL analogue of `str.find` but the catch is that it returns 0 when the substring match fails. So the worst matches show up on top. 

Fix: instead of sorting `relevance asc` sort `1/relevance desc`. This is a math hack to convert `0` to `null` and avoid using any complex SQL functionality which isn't allowed in DB query.

Closes https://github.com/frappe/frappe/issues/22725



| Before  | After |
| --- | --- |
|  ![image](https://github.com/frappe/frappe/assets/9079960/58bdbe73-17ae-4d4b-9363-57876991988f) |  ![image](https://github.com/frappe/frappe/assets/9079960/27cc2d0f-7f31-4f43-945e-5a0c8eaefc58)    |
|![image](https://github.com/frappe/frappe/assets/9079960/4d5d490c-0b99-417a-bb58-66fa51920baa) | ![image](https://github.com/frappe/frappe/assets/9079960/49a620f8-e983-4e79-ab31-87f0b015b5ee) |



