### PR TITLE
Update mapper.py compatible with "custom_xxx" fields

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -193,7 +193,10 @@ def map_fields(source_doc, target_doc, table_map, source_parent):
 	for df in target_doc.meta.get("fields"):
 		if df.fieldname not in no_copy_fields:
 			# map same fields
-			val = source_doc.get(df.fieldname)
+            if df.fieldname[:7] == "custom_":
+                val = source_doc.get(df.fieldname[7:])
+            else:
+                val = source_doc.get(df.fieldname)
 			if val not in (None, ""):
 				target_doc.set(df.fieldname, val)
 


### PR DESCRIPTION
v14 added `custom_` to custom fields, function `map_fields` not worked for these fields.