### PR TITLE
refactor: Reorganize search_widget for clarity, update & improve comments.

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -72,15 +72,19 @@ def search_widget(
 
 	if searchfield:
 		sanitize_searchfield(searchfield)
-
-	if not searchfield:
+	else:
 		searchfield = "name"
 
 	standard_queries = frappe.get_hooks().standard_queries or {}
 
-	if query and query.split(maxsplit=1)[0].lower() != "select":
-		# by method
+	if query:
+		if query.split(maxsplit=1)[0].lower() == "select":
+			# custom query
+			# frappe.response["values"] = frappe.db.sql(scrub_custom_query(query, searchfield, txt))
+			frappe.throw(_("This query style is discontinued"))
+
 		try:
+			# by method
 			is_whitelisted(frappe.get_attr(query))
 			frappe.response["values"] = frappe.call(
 				query,
@@ -106,7 +110,7 @@ def search_widget(
 			return
 		except Exception as e:
 			raise e
-	elif not query and doctype in standard_queries:
+	elif doctype in standard_queries:
 		# from standard queries
 		search_widget(
 			doctype=doctype,
@@ -122,137 +126,135 @@ def search_widget(
 			ignore_user_permissions=ignore_user_permissions,
 		)
 	else:
+		# build from doctype
 		meta = frappe.get_meta(doctype)
 
-		if query:
-			frappe.throw(_("This query style is discontinued"))
-			# custom query
-			# frappe.response["values"] = frappe.db.sql(scrub_custom_query(query, searchfield, txt))
-		else:
-			if isinstance(filters, dict):
-				filters_items = filters.items()
-				filters = []
-				for f in filters_items:
-					if isinstance(f[1], (list, tuple)):
-						filters.append([doctype, f[0], f[1][0], f[1][1]])
-					else:
-						filters.append([doctype, f[0], "=", f[1]])
-
-			if filters is None:
-				filters = []
-			or_filters = []
-
-			# build from doctype
-			if txt:
-				field_types = [
-					"Data",
-					"Text",
-					"Small Text",
-					"Long Text",
-					"Link",
-					"Select",
-					"Read Only",
-					"Text Editor",
-				]
-				search_fields = ["name"]
-				if meta.title_field:
-					search_fields.append(meta.title_field)
-
-				if meta.search_fields:
-					search_fields.extend(meta.get_search_fields())
-
-				for f in search_fields:
-					fmeta = meta.get_field(f.strip())
-					if not meta.translated_doctype and (
-						f == "name" or (fmeta and fmeta.fieldtype in field_types)
-					):
-						or_filters.append([doctype, f.strip(), "like", f"%{txt}%"])
-
-			if meta.get("fields", {"fieldname": "enabled", "fieldtype": "Check"}):
-				filters.append([doctype, "enabled", "=", 1])
-			if meta.get("fields", {"fieldname": "disabled", "fieldtype": "Check"}):
-				filters.append([doctype, "disabled", "!=", 1])
-
-			# format a list of fields combining search fields and filter fields
-			fields = get_std_fields_list(meta, searchfield or "name")
-			if filter_fields:
-				fields = list(set(fields + json.loads(filter_fields)))
-			formatted_fields = [f"`tab{meta.name}`.`{f.strip()}`" for f in fields]
-
-			# Insert title field query after name
-			if meta.show_title_field_in_link:
-				formatted_fields.insert(1, f"`tab{meta.name}`.{meta.title_field} as `label`")
-
-			# In order_by, `idx` gets second priority, because it stores link count
-			from frappe.model.db_query import get_order_by
-
-			order_by_based_on_meta = get_order_by(doctype, meta)
-			# 2 is the index of _relevance column
-			order_by = f"`tab{doctype}`.idx desc, {order_by_based_on_meta}"
-
-			if not meta.translated_doctype:
-				_txt = frappe.db.escape((txt or "").replace("%", "").replace("@", ""))
-				_relevance = f"(1 / nullif(locate({_txt}, `tab{doctype}`.`name`), 0))"
-				formatted_fields.append(f"""{_relevance} as `_relevance`""")
-				# Since we are sorting by alias postgres needs to know number of column we are sorting
-				if frappe.db.db_type == "mariadb":
-					order_by = f"ifnull(_relevance, -9999) desc, {order_by}"
-				elif frappe.db.db_type == "postgres":
-					# Since we are sorting by alias postgres needs to know number of column we are sorting
-					order_by = f"{len(formatted_fields)} desc nulls last, {order_by}"
-
-			ignore_permissions = (
-				True
-				if doctype == "DocType"
-				else (
-					cint(ignore_user_permissions)
-					and has_permission(
-						doctype,
-						ptype="select" if frappe.only_has_select_perm(doctype) else "read",
-						parent_doctype=reference_doctype,
-					)
-				)
-			)
-
-			values = frappe.get_list(
-				doctype,
-				filters=filters,
-				fields=formatted_fields,
-				or_filters=or_filters,
-				limit_start=start,
-				limit_page_length=None if meta.translated_doctype else page_length,
-				order_by=order_by,
-				ignore_permissions=ignore_permissions,
-				reference_doctype=reference_doctype,
-				as_list=not as_dict,
-				strict=False,
-			)
-
-			if meta.translated_doctype:
-				# Filtering the values array so that query is included in very element
-				values = (
-					result
-					for result in values
-					if any(
-						re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
-						for value in (result.values() if as_dict else result)
-					)
-				)
-
-			# Sorting the values array so that relevant results always come first
-			# This will first bring elements on top in which query is a prefix of element
-			# Then it will bring the rest of the elements and sort them in lexicographical order
-			values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
-
-			# remove _relevance from results
-			if not meta.translated_doctype:
-				if as_dict:
-					for r in values:
-						r.pop("_relevance")
+		if filters is None:
+			filters = []
+		elif isinstance(filters, dict):
+			filters_items = filters.items()
+			filters = []
+			for f in filters_items:
+				if isinstance(f[1], (list, tuple)):
+					filters.append([doctype, f[0], f[1][0], f[1][1]])
 				else:
-					values = [r[:-1] for r in values]
+					filters.append([doctype, f[0], "=", f[1]])
 
-			frappe.response["values"] = values
+		or_filters = []
+
+		if txt:
+			field_types = [
+				"Data",
+				"Text",
+				"Small Text",
+				"Long Text",
+				"Link",
+				"Select",
+				"Read Only",
+				"Text Editor",
+			]
+			search_fields = ["name"]
+			if meta.title_field:
+				search_fields.append(meta.title_field)
+
+			if meta.search_fields:
+				search_fields.extend(meta.get_search_fields())
+
+			for f in search_fields:
+				if f == "name":
+					is_valid_field = True
+				else:
+					fmeta = meta.get_field(f.strip())
+					is_valid_field = fmeta and fmeta.fieldtype in field_types
+				if not meta.translated_doctype and is_valid_field:
+					or_filters.append([doctype, f.strip(), "like", f"%{txt}%"])
+
+		if meta.get("fields", {"fieldname": "enabled", "fieldtype": "Check"}):
+			filters.append([doctype, "enabled", "=", 1])
+		if meta.get("fields", {"fieldname": "disabled", "fieldtype": "Check"}):
+			filters.append([doctype, "disabled", "!=", 1])
+
+		# format a list of fields combining search fields and filter fields
+		fields = get_std_fields_list(meta, searchfield or "name")
+		if filter_fields:
+			fields = list(set(fields + json.loads(filter_fields)))
+		formatted_fields = [f"`tab{meta.name}`.`{f.strip()}`" for f in fields]
+
+		# Insert title field query after name
+		if meta.show_title_field_in_link:
+			formatted_fields.insert(1, f"`tab{meta.name}`.{meta.title_field} as `label`")
+
+		from frappe.model.db_query import get_order_by
+
+		order_by_based_on_meta = get_order_by(doctype, meta)
+		# `idx` stores the link count.
+		order_by = f"`tab{doctype}`.idx desc, {order_by_based_on_meta}"
+
+		if not meta.translated_doctype:
+			_txt = frappe.db.escape((txt or "").replace("%", "").replace("@", ""))
+			# Locate is SQL analogue of str.find but returns 0 when the substring match fails, so
+			# the worst matches show up on top. To convert 0 to null, we're therefore using a math
+			# hack, sorting 1/relevance desc instead of relevance asc.
+			_relevance = f"(1 / nullif(locate({_txt}, `tab{doctype}`.`name`), 0))"
+			formatted_fields.append(f"""{_relevance} as `_relevance`""")
+			if frappe.db.db_type == "mariadb":
+				order_by = f"ifnull(_relevance, -9999) desc, {order_by}"
+			elif frappe.db.db_type == "postgres":
+				# Since we are sorting by alias postgres needs to know number of column we are sorting
+				order_by = f"{len(formatted_fields)} desc nulls last, {order_by}"
+
+		ignore_permissions = (
+			True
+			if doctype == "DocType"
+			else (
+				cint(ignore_user_permissions)
+				and has_permission(
+					doctype,
+					ptype="select" if frappe.only_has_select_perm(doctype) else "read",
+					parent_doctype=reference_doctype,
+				)
+			)
+		)
+
+		values = frappe.get_list(
+			doctype,
+			filters=filters,
+			fields=formatted_fields,
+			or_filters=or_filters,
+			limit_start=start,
+			limit_page_length=None if meta.translated_doctype else page_length,
+			order_by=order_by,
+			ignore_permissions=ignore_permissions,
+			reference_doctype=reference_doctype,
+			as_list=not as_dict,
+			strict=False,
+		)
+
+		if meta.translated_doctype:
+			# Filtering the values array so that query is included in very element
+			values = (
+				result
+				for result in values
+				if any(
+					re.search(f"{re.escape(txt)}.*", _(cstr(value)) or "", re.IGNORECASE)
+					for value in (result.values() if as_dict else result)
+				)
+			)
+
+		# Sorting the values array so that relevant results always come first
+		# This will first bring elements on top in which query is a prefix of element
+		# Then it will bring the rest of the elements and sort them in lexicographical order
+		values = sorted(values, key=lambda x: relevance_sorter(x, txt, as_dict))
+
+		# remove _relevance from results
+		if not meta.translated_doctype:
+			if as_dict:
+				for r in values:
+					r.pop("_relevance")
+			else:
+				values = [r[:-1] for r in values]
+
+		frappe.response["values"] = values
 
 
 def get_std_fields_list(meta, key):


### PR DESCRIPTION
Followup to #22729 which solved the actual bug much more performant than my version did. 💁🏻‍♂️

The mere code reorganization/refactoring part however still makes sense. Without any change in logic, it should now be way less convoluted and less indented. So rescuing this from #22726.

Also, added some minor comment updates/improvements as a followup.

May be added to `.git-blame-ignore-revs`, if we don‘t want mere whitespace differences to claim so many lines of the function.