### PR TITLE
fix: validate permission on `tag` creation

### DIFF
--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -34,6 +34,7 @@ def check_user_tags(dt):
 @frappe.whitelist()
 def add_tag(tag, dt, dn, color=None):
 	"adds a new tag to a record, and creates the Tag master"
+	frappe.has_permission(dt, "write", dn, throw=True)
 	DocTags(dt).add(dn, tag)
 
 	return tag
@@ -44,11 +45,13 @@ def add_tags(tags, dt, docs, color=None):
 	"adds a new tag to a record, and creates the Tag master"
 	tags = frappe.parse_json(tags)
 	docs = frappe.parse_json(docs)
+
+	for doc in docs:
+		frappe.has_permission(dt, "write", doc, throw=True)
+
 	for doc in docs:
 		for tag in tags:
 			DocTags(dt).add(doc, tag)
-
-	# return tag
 
 
 @frappe.whitelist()

--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -34,7 +34,6 @@ def check_user_tags(dt):
 @frappe.whitelist()
 def add_tag(tag, dt, dn, color=None):
 	"adds a new tag to a record, and creates the Tag master"
-	frappe.has_permission(dt, "write", dn, throw=True)
 	DocTags(dt).add(dn, tag)
 
 	return tag
@@ -45,10 +44,6 @@ def add_tags(tags, dt, docs, color=None):
 	"adds a new tag to a record, and creates the Tag master"
 	tags = frappe.parse_json(tags)
 	docs = frappe.parse_json(docs)
-
-	for doc in docs:
-		frappe.has_permission(dt, "write", doc, throw=True)
-
 	for doc in docs:
 		for tag in tags:
 			DocTags(dt).add(doc, tag)
@@ -156,6 +151,7 @@ def update_tags(doc, tags):
 
 	:param doc: Document to be added to global tags
 	"""
+	doc.check_permission("write")
 	new_tags = {tag.strip() for tag in tags.split(",") if tag}
 	existing_tags = [
 		tag.tag


### PR DESCRIPTION
Prevent users from adding tags to doctype they lack access to.