### PR TITLE
fix: add mariadb-client install step in workflow boilerplate

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -634,6 +634,9 @@ jobs:
           restore-keys: |
             ${{{{ runner.os }}}}-yarn-
 
+      - name: Install MariaDB Client
+        run: sudo apt-get install mariadb-client-10.6
+
       - name: Setup
         run: |
           pip install frappe-bench


### PR DESCRIPTION
MariaDB Client (`mariadb-client-10.6`) package is required now. This PR adds the install step in our GitHub workflow template.

ref: #22620 

`no-docs`