### PR TITLE
fix(UX): Preserve filters between list and report views

### DIFF
--- a/frappe/public/js/frappe/list/list_view_select.js
+++ b/frappe/public/js/frappe/list/list_view_select.js
@@ -40,6 +40,11 @@ frappe.views.ListViewSelect = class ListViewSelect {
 	set_route(view, calendar_name) {
 		const route = [this.slug(), "view", view];
 		if (calendar_name) route.push(calendar_name);
+
+		let search_params = cur_list?.get_search_params();
+		if (search_params) {
+			frappe.route_options = Object.fromEntries(search_params);
+		}
 		frappe.set_route(route);
 	}
 

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -427,7 +427,7 @@ frappe.ui.GroupBy = class {
 	}
 
 	get_group_by_field_label() {
-		let field = this.group_by_fields[this.group_by_doctype].find(
+		let field = this.group_by_fields[this.group_by_doctype]?.find(
 			(field) => field.fieldname == this.group_by_field
 		);
 		return field?.label || field?.fieldname;


### PR DESCRIPTION
This is a common complaint that filters are not preserved between list and report views.

So before switching views, now we set route option as whatever filters were applied on current view.


![Peek 2023-10-17 11-32](https://github.com/frappe/frappe/assets/9079960/0044fb2c-35d3-45e5-9bc7-fe53772943be)


