### PR TITLE
fix: number card shorten number is not formatted correctly if number format is not default

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -45,6 +45,31 @@ function strip_number_groups(v, number_format) {
 	return v;
 }
 
+function convert_old_to_new_number_format(v, old_number_format, new_number_format) {
+	if (!new_number_format) new_number_format = get_number_format();
+	let new_info = get_number_format_info(new_number_format);
+
+	if (!old_number_format) old_number_format = "#,###.##";
+	let old_info = get_number_format_info(old_number_format);
+
+	if (old_number_format === new_number_format) return v;
+
+	if (new_info.decimal_str == "") {
+		return strip_number_groups(v);
+	}
+
+	let v_parts = v.split(old_info.decimal_str);
+	let v_before_decimal = v_parts[0];
+	let v_after_decimal = v_parts[1] || "";
+
+	// replace old group separator with new group separator in v_before_decimal
+	let old_group_regex = new RegExp(old_info.group_sep === "." ? "\\." : old_info.group_sep, "g");
+	v_before_decimal = v_before_decimal.replace(old_group_regex, new_info.group_sep);
+
+	v = v_before_decimal + new_info.decimal_str + v_after_decimal;
+	return v;
+}
+
 frappe.number_format_info = {
 	"#,###.##": { decimal_str: ".", group_sep: "," },
 	"#.###,##": { decimal_str: ",", group_sep: "." },
@@ -284,6 +309,7 @@ Object.assign(window, {
 	flt,
 	cint,
 	strip_number_groups,
+	convert_old_to_new_number_format,
 	format_currency,
 	fmt_money,
 	get_currency_symbol,

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -222,6 +222,7 @@ export default class NumberCardWidget extends Widget {
 		let number_parts = shortened_number.split(" ");
 
 		const symbol = number_parts[1] || "";
+		number_parts[0] = window.convert_old_to_new_number_format(number_parts[0]);
 		const formatted_number = $(frappe.format(number_parts[0], df)).text();
 
 		this.formatted_number = formatted_number + " " + __(symbol);


### PR DESCRIPTION
number_format: '#.###,##'
report total
<img width="1056" alt="image" src="https://github.com/frappe/frappe/assets/30859809/5e888975-28c5-4964-a28a-13840e64e971">

Before: 
<img width="355" alt="image" src="https://github.com/frappe/frappe/assets/30859809/0287f0b8-e550-4134-9524-9c715b65ade5">

After:
<img width="352" alt="image" src="https://github.com/frappe/frappe/assets/30859809/1fb8a8b4-80b1-4ec1-9dd0-4a0eba74b614">
