### PR TITLE
fix: Form Builder fixes for v15

### DIFF
--- a/cypress/integration/form_builder.js
+++ b/cypress/integration/form_builder.js
@@ -77,7 +77,8 @@ context("Form Builder", () => {
 			.as("input");
 		cy.get("@input").clear({ force: true }).type("Web Form Field", { delay: 200 });
 		cy.wait("@search_link");
-		cy.get("@input").type("{enter}").blur();
+
+		cy.get(first_field).click({ force: true });
 
 		cy.get(first_field)
 			.find(".table-controls .table-column")

--- a/frappe/public/js/form_builder/components/FieldProperties.vue
+++ b/frappe/public/js/form_builder/components/FieldProperties.vue
@@ -10,11 +10,14 @@ let search_text = ref("");
 let args = ref({});
 
 let docfield_df = computed(() => {
-	let fields = store.get_docfields.filter(df => {
+	let fields = store.get_docfields.filter((df) => {
 		if (in_list(frappe.model.layout_fields, df.fieldtype) || df.hidden) {
 			return false;
 		}
-		if (df.depends_on && !evaluate_depends_on_value(df.depends_on, store.form.selected_field)) {
+		if (
+			df.depends_on &&
+			!evaluate_depends_on_value(df.depends_on, store.form.selected_field)
+		) {
 			return false;
 		}
 

--- a/frappe/public/js/form_builder/components/controls/CodeControl.vue
+++ b/frappe/public/js/form_builder/components/controls/CodeControl.vue
@@ -7,43 +7,47 @@ let emit = defineEmits(["update:modelValue"]);
 let slots = useSlots();
 
 let code = ref(null);
-let code_control = ref(null);
 let update_control = ref(true);
+
+let code_control = computed(() => {
+	if (!code.value) return;
+	code.value.innerHTML = "";
+
+	return frappe.ui.form.make_control({
+		parent: code.value,
+		df: {
+			...props.df,
+			fieldtype: "Code",
+			hidden: 0,
+			read_only: props.read_only,
+			change: () => {
+				if (update_control.value) {
+					content.value = code_control.value.get_value();
+				}
+				update_control.value = true;
+			},
+		},
+		value: content.value,
+		disabled: Boolean(slots.label) || props.read_only,
+		render_input: true,
+		only_input: Boolean(slots.label),
+	});
+});
 
 let content = computed({
 	get: () => props.modelValue,
-	set: (value) => emit('update:modelValue', value)
+	set: (value) => emit("update:modelValue", value),
 });
 
 onMounted(() => {
-	if (code.value) {
-		code_control.value = frappe.ui.form.make_control({
-			parent: code.value,
-			df: {
-				...props.df,
-				fieldtype: "Code",
-				hidden: 0,
-				read_only: props.read_only,
-				change: () => {
-					if (update_control.value) {
-						content.value = code_control.value.get_value();
-					}
-					update_control.value = true;
-				}
-			},
-			value: content.value,
-			disabled: Boolean(slots.label) || props.read_only,
-			render_input: true,
-			only_input: Boolean(slots.label),
-		});
-	}
+	if (code.value) code_control.value;
 });
 
 watch(
 	() => content.value,
 	(value) => {
 		update_control.value = false;
-		code_control.value.set_value(value);
+		code_control.value?.set_value(value);
 	}
 );
 
@@ -53,7 +57,7 @@ watch(
 		if (code_control.value) {
 			code_control.value.ace_editor_target.css("max-height", value);
 		}
-	},
+	}
 );
 </script>
 

--- a/frappe/public/js/form_builder/components/controls/DataControl.vue
+++ b/frappe/public/js/form_builder/components/controls/DataControl.vue
@@ -48,7 +48,7 @@ if (props.df.fieldtype === "Icon") {
 			class="form-control"
 			type="text"
 			:value="value"
-			:disabled="read_only"
+			:disabled="read_only || df.read_only"
 			@input="event => $emit('update:modelValue', event.target.value)"
 		/>
 		<input

--- a/frappe/public/js/form_builder/components/controls/FetchFromControl.vue
+++ b/frappe/public/js/form_builder/components/controls/FetchFromControl.vue
@@ -77,13 +77,20 @@ watch([() => doctype.value, () => fieldname.value], ([doctype_value, fieldname_v
 </script>
 
 <template>
-	<SelectControl :df="doctype_df" :value="doctype" :read_only="read_only" v-model="doctype" />
-	<SelectControl
-		v-if="doctype"
-		:df="field_df"
-		:read_only="read_only"
-		:value="fieldname"
-		v-model="fieldname"
-		:no_label="true"
-	/>
+	<div>
+		<SelectControl
+			:df="doctype_df"
+			:value="doctype"
+			:read_only="read_only"
+			v-model="doctype"
+		/>
+		<SelectControl
+			v-if="doctype"
+			:df="field_df"
+			:read_only="read_only"
+			:value="fieldname"
+			v-model="fieldname"
+			:no_label="true"
+		/>
+	</div>
 </template>

--- a/frappe/public/js/form_builder/components/controls/GeolocationControl.vue
+++ b/frappe/public/js/form_builder/components/controls/GeolocationControl.vue
@@ -1,21 +1,24 @@
 <script setup>
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 const props = defineProps(["df"]);
 
 let map = ref(null);
-let map_control = ref(null);
+let map_control = computed(() => {
+	if (!map.value) return;
+	map.value.innerHTML = "";
+
+	return frappe.ui.form.make_control({
+		parent: map.value,
+		df: { ...props.df, hidden: 0 },
+		frm: true,
+		disabled: true,
+		render_input: true,
+	});
+});
 
 onMounted(() => {
-	if (map.value) {
-		map_control.value = frappe.ui.form.make_control({
-			parent: map.value,
-			df: { ...props.df, hidden: 0 },
-			frm: true,
-			disabled: true,
-			render_input: true,
-		});
-	}
+	if (map.value) map_control.value;
 });
 </script>
 

--- a/frappe/public/js/form_builder/components/controls/LinkControl.vue
+++ b/frappe/public/js/form_builder/components/controls/LinkControl.vue
@@ -7,12 +7,34 @@ let emit = defineEmits(["update:modelValue"]);
 let slots = useSlots();
 
 let link = ref(null);
-let link_control = ref(null);
 let update_control = ref(true);
+
+let link_control = computed(() => {
+	if (!link.value) return;
+	link.value.innerHTML = "";
+
+	return frappe.ui.form.make_control({
+		parent: link.value,
+		df: {
+			...props.df,
+			hidden: 0,
+			read_only: Boolean(slots.label) || props.read_only,
+			change: () => {
+				if (update_control.value) {
+					content.value = link_control.value.get_value();
+				}
+				update_control.value = true;
+			},
+		},
+		value: content.value,
+		render_input: true,
+		only_input: Boolean(slots.label),
+	});
+});
 
 let content = computed({
 	get: () => props.modelValue,
-	set: value => emit("update:modelValue", value)
+	set: (value) => emit("update:modelValue", value),
 });
 
 onMounted(() => {
@@ -27,36 +49,20 @@ onMounted(() => {
 			}
 		} else {
 			// reset filters
-			if (props.df.filters && 'istable' in props.df.filters) {
+			if (props.df.filters && "istable" in props.df.filters) {
 				delete props.df.filters.istable;
 			}
 		}
 
-		link_control.value = frappe.ui.form.make_control({
-			parent: link.value,
-			df: {
-				...props.df,
-				hidden: 0,
-				read_only: Boolean(slots.label) || props.read_only,
-				change: () => {
-					if (update_control.value) {
-						content.value = link_control.value.get_value();
-					}
-					update_control.value = true;
-				}
-			},
-			value: content.value,
-			render_input: true,
-			only_input: Boolean(slots.label)
-		});
+		link_control.value;
 	}
 });
 
 watch(
 	() => content.value,
-	value => {
+	(value) => {
 		update_control.value = false;
-		link_control.value.set_value(value);
+		link_control.value?.set_value(value);
 	}
 );
 </script>

--- a/frappe/public/js/form_builder/components/controls/RatingControl.vue
+++ b/frappe/public/js/form_builder/components/controls/RatingControl.vue
@@ -1,21 +1,24 @@
 <script setup>
-import { onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 const props = defineProps(["df"]);
 
 let rating = ref(null);
-let rating_control = ref(null);
+let rating_control = computed(() => {
+	if (!rating.value) return;
+	rating.value.innerHTML = "";
+
+	return frappe.ui.form.make_control({
+		parent: rating.value,
+		df: { ...props.df, hidden: 0 },
+		disabled: true,
+		render_input: true,
+		only_input: true,
+	});
+});
 
 onMounted(() => {
-	if (rating.value) {
-		rating_control.value = frappe.ui.form.make_control({
-			parent: rating.value,
-			df: { ...props.df, hidden: 0 },
-			disabled: true,
-			render_input: true,
-			only_input: true,
-		});
-	}
+	if (rating.value) rating_control.value;
 });
 
 watch(
@@ -23,9 +26,9 @@ watch(
 	(value) => {
 		if (rating_control.value) {
 			rating_control.value.df.options = value;
-			rating_control.value.make_input();
+			rating_control.value?.make_input();
 		}
-	},
+	}
 );
 </script>
 
@@ -44,5 +47,4 @@ watch(
 :deep(.rating) {
 	--star-fill: var(--yellow-300) !important;
 }
-
 </style>

--- a/frappe/public/js/form_builder/components/controls/TextEditorControl.vue
+++ b/frappe/public/js/form_builder/components/controls/TextEditorControl.vue
@@ -1,21 +1,24 @@
 <script setup>
-import { onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 const props = defineProps(["df"]);
 
 let quill = ref(null);
-let quill_control = ref(null);
+let quill_control = computed(() => {
+	if (!quill.value) return;
+	quill.value.innerHTML = "";
+
+	return frappe.ui.form.make_control({
+		parent: quill.value,
+		df: { ...props.df, hidden: 0 },
+		disabled: true,
+		render_input: true,
+		only_input: true,
+	});
+});
 
 onMounted(() => {
-	if (quill.value) {
-		quill_control.value = frappe.ui.form.make_control({
-			parent: quill.value,
-			df: { ...props.df, hidden: 0 },
-			disabled: true,
-			render_input: true,
-			only_input: true,
-		});
-	}
+	if (quill.value) quill_control.value;
 });
 </script>
 

--- a/frappe/public/js/frappe/form/controls/select.js
+++ b/frappe/public/js/frappe/form/controls/select.js
@@ -161,7 +161,7 @@ function parse_option(v) {
 		is_disabled = Boolean(v.disabled);
 		is_selected = Boolean(v.selected);
 
-		if (is_value_null && is_label_null) {
+		if (is_value_null && is_label_null && typeof v === "string") {
 			value = v;
 			label = __(v);
 		} else {


### PR DESCRIPTION
- [x]  Precision select options have [object object] as the first value - https://github.com/frappe/frappe/issues/22749
- [x] form builder (customize) shouldn't allow setting fieldnames - https://github.com/frappe/frappe/issues/22717
- [x] while selecting same type of fields depends_on value seems to show in both fields even thought only one field has it
- [ ] Form buidler sometimes silently fails to save - https://github.com/frappe/frappe/issues/22723

Cannot reproduce last one will fix after getting enough information

