### PR TITLE
refactor: Use fuzzy_match‘s positional indices for marking matches in Awesomebar

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
+++ b/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
@@ -25,15 +25,14 @@ const UNMATCHED_LETTER_PENALTY = -1;
 
 /**
  * Does a fuzzy search to find pattern inside a string.
- * @param {*} pattern string				pattern to search for
- * @param {*} str string    				string which is being searched
- * @returns [boolean, number]   			a boolean which tells if pattern was
- *											found or not and a search score
+ * @param {*} pattern string				Pattern to search for
+ * @param {*} str string    				String being searched
+ * @returns [boolean, number, Array<number>]		A boolean whether the pattern was found or not, a search score,
+ * 							and an array with the positional match indices.
  */
 export function fuzzy_match(pattern, str) {
 	const recursion_count = 0;
 	const recursion_limit = 10;
-	const matches = [];
 	const max_matches = 256;
 
 	return fuzzy_match_recursive(
@@ -42,7 +41,7 @@ export function fuzzy_match(pattern, str) {
 		0 /* pattern_cur_index */,
 		0 /* str_curr_index */,
 		null /* src_matches */,
-		matches,
+		[] /* matches */,
 		max_matches,
 		0 /* next_match */,
 		recursion_count,
@@ -66,12 +65,12 @@ function fuzzy_match_recursive(
 
 	// Return if recursion limit is reached.
 	if (++recursion_count >= recursion_limit) {
-		return [false, out_score];
+		return [false, out_score, matches];
 	}
 
 	// Return if we reached ends of strings.
 	if (pattern_cur_index === pattern.length || str_curr_index === str.length) {
-		return [false, out_score];
+		return [false, out_score, matches];
 	}
 
 	// Recursion params
@@ -85,7 +84,7 @@ function fuzzy_match_recursive(
 		// Match found.
 		if (pattern[pattern_cur_index].toLowerCase() === str[str_curr_index].toLowerCase()) {
 			if (next_match >= max_matches) {
-				return [false, out_score];
+				return [false, out_score, matches];
 			}
 
 			if (first_match && src_matches) {
@@ -93,14 +92,13 @@ function fuzzy_match_recursive(
 				first_match = false;
 			}
 
-			const recursive_matches = [];
-			const [matched, recursive_score] = fuzzy_match_recursive(
+			const [matched, recursive_score, recursive_matches] = fuzzy_match_recursive(
 				pattern,
 				str,
 				pattern_cur_index,
 				str_curr_index + 1,
 				matches,
-				recursive_matches,
+				[] /* recursive_matches */,
 				max_matches,
 				next_match,
 				recursion_count,
@@ -170,13 +168,13 @@ function fuzzy_match_recursive(
 			// Recursive score is better than "this"
 			matches = [...best_recursive_matches];
 			out_score = best_recursive_score;
-			return [true, out_score];
+			return [true, out_score, matches];
 		} else if (matched) {
 			// "this" score is better than recursive
-			return [true, out_score];
+			return [true, out_score, matches];
 		} else {
-			return [false, out_score];
+			return [false, out_score, matches];
 		}
 	}
-	return [false, out_score];
+	return [false, out_score, matches];
 }


### PR DESCRIPTION
`bolden_match_part()` currently tries marking matches without even knowing which chars were actually matched in `fuzzy_match()`.

Still it runs `fuzzy_match()` a second time, only to see whether there have been any matches at all. Next it reengineers a simplified matching algorithm that may in many cases come close to the original, but certainly won‘t figure out the proper match in situations with more than one possible matching, where `fuzzy_match()` recursively finds out the best match, while `bolden_match_part()` doesn‘t, because it can‘t.

This makes our Fuzzy Match algorithm look way less clever than it actually is. It also makes it hard to even see why `fuzzy_match()` in some cases may fail expectations, so might need another tweak or two for optimal results.

This PR is therefore enabling `fuzzy_match()` to return the positional match indices, and then goes on replacing `bolden_match_part()` by some postprocessing code rolled into `fuzzy_search()` to mark actually matched parts.

This ensures the marks exactly represent the actual matches resulting from `fuzzy_match()` which in many cases may already be optimal, in other cases may need some initialization tweak:

![7F0630E3-04EF-4072-A65C-A365C741669C](https://github.com/frappe/frappe/assets/46800703/1afe3b35-1b0a-45ab-8bee-11505535708f)
![C5498290-BBD1-43A1-B0F1-9BE141A46710](https://github.com/frappe/frappe/assets/46800703/527e7fea-4fb7-43b7-b285-35aceff63d85)
![F4D5215B-3A49-4BF5-8AA1-589538AF6791](https://github.com/frappe/frappe/assets/46800703/12a8d4de-3139-402d-8d31-c5815f8e6fed)
![AD12C30B-5CD3-4B11-923C-AB86994BF294](https://github.com/frappe/frappe/assets/46800703/f6710429-ddfc-4a48-a10f-93ab1791628d)

This may seem like negligible subtleties, but the few wrongly marked ones suffice in making users think the matching algorithm was kind of random. Which isn‘t the case.

Further advantages / improvements:
- Performance improvement as `fuzzy_match()` is only run once, not twice, for each match.
- Resulting HTML is `<mark>Item</mark> List` now, while before it was `<mark>I</mark><mark>t</mark><mark>e</mark><mark>m</mark> List`

Note that for now I‘m not removing `bolden_match_part()` in order to remain BC compatible. Atm, `frappe.tags.utils.get_tags()` continues using it, which for now may serve as a BC test. Should be turned into a wrapper though and deprecated later.

Manually tested in both English and translated environments.

Closes #22707.