### PR TITLE
feat: allow setting fields as not nullable

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -19,6 +19,7 @@
   "reqd",
   "is_virtual",
   "search_index",
+  "not_nullable",
   "column_break_18",
   "options",
   "sort_options",
@@ -566,13 +567,20 @@
    "fieldname": "link_filters",
    "fieldtype": "JSON",
    "label": "Link Filters"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!in_list([\"Check\", \"Currency\", \"Float\", \"Int\", \"Percent\", \"Rating\", \"Select\", \"Table\", \"Table MultiSelect\"], doc.fieldtype)",
+   "fieldname": "not_nullable",
+   "fieldtype": "Check",
+   "label": "Not Nullable"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-13 11:48:51.502812",
+ "modified": "2023-11-16 11:26:56.364594",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.py
+++ b/frappe/core/doctype/docfield/docfield.py
@@ -92,6 +92,7 @@ class DocField(Document):
 		max_height: DF.Data | None
 		no_copy: DF.Check
 		non_negative: DF.Check
+		not_nullable: DF.Check
 		oldfieldname: DF.Data | None
 		oldfieldtype: DF.Data | None
 		options: DF.SmallText | None

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -365,16 +365,23 @@ class DocType(Document):
 							SET `{fieldname}` = source.`{source_fieldname}`
 							FROM `tab{link_doctype}` as source
 							WHERE `{link_fieldname}` = source.name
-							AND ifnull(`{fieldname}`, '')=''
 						"""
+						if df.not_nullable:
+							update_query += "AND `{fieldname}`=''"
+						else:
+							update_query += "AND ifnull(`{fieldname}`, '')=''"
+
 					else:
 						update_query = """
 							UPDATE `tab{doctype}` as target
 							INNER JOIN `tab{link_doctype}` as source
 							ON `target`.`{link_fieldname}` = `source`.`name`
 							SET `target`.`{fieldname}` = `source`.`{source_fieldname}`
-							WHERE ifnull(`target`.`{fieldname}`, '')=""
 						"""
+						if df.not_nullable:
+							update_query += "WHERE `target`.`{fieldname}`=''"
+						else:
+							update_query += "WHERE ifnull(`target`.`{fieldname}`, '')=" ""
 
 					self.flags.update_fields_to_fetch_queries.append(
 						update_query.format(

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -381,7 +381,7 @@ class DocType(Document):
 						if df.not_nullable:
 							update_query += "WHERE `target`.`{fieldname}`=''"
 						else:
-							update_query += "WHERE ifnull(`target`.`{fieldname}`, '')=" ""
+							update_query += "WHERE ifnull(`target`.`{fieldname}`, '')=''"
 
 					self.flags.update_fields_to_fetch_queries.append(
 						update_query.format(

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -375,10 +375,11 @@ class Database:
 		"""Raises exception if more than 200,000 `INSERT`, `UPDATE` queries are
 		executed in one transaction. This is to ensure that writes are always flushed otherwise this
 		could cause the system to hang."""
-		self.check_implicit_commit(query, ignore_implicit_commit)
 
-		if query and is_query_type(query, ("commit", "rollback")):
+		if query and is_query_type(query, ("start", "begin", "commit", "rollback")):
 			self.transaction_writes = 0
+
+		self.check_implicit_commit(query, ignore_implicit_commit)
 
 		if query[:6].lower() in ("update", "insert", "delete"):
 			self.transaction_writes += 1

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -375,11 +375,10 @@ class Database:
 		"""Raises exception if more than 200,000 `INSERT`, `UPDATE` queries are
 		executed in one transaction. This is to ensure that writes are always flushed otherwise this
 		could cause the system to hang."""
+		self.check_implicit_commit(query)
 
 		if query and is_query_type(query, ("commit", "rollback")):
 			self.transaction_writes = 0
-
-		self.check_implicit_commit(query)
 
 		if query[:6].lower() in ("update", "insert", "delete"):
 			self.transaction_writes += 1

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -310,7 +310,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		)
 
 	@staticmethod
-	def get_on_duplicate_update(key=None):
+	def get_on_duplicate_update():
 		return "ON DUPLICATE key UPDATE "
 
 	def get_table_columns_description(self, table_name):
@@ -329,7 +329,8 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 					and Seq_in_index = 1
 					limit 1
 			), 0) as 'index',
-			column_key = 'UNI' as 'unique'
+			column_key = 'UNI' as 'unique',
+			(is_nullable = 'NO') AS 'not_nullable'
 			from information_schema.columns as columns
 			where table_name = '{table_name}' """.format(
 				table_name=table_name

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -438,7 +438,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			db_table = MariaDBTable(doctype, meta)
 			db_table.validate()
 
-			self.commit(new_transaction=False)
+			self.commit()
 			db_table.sync()
 			self.begin()
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -438,7 +438,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 			db_table = MariaDBTable(doctype, meta)
 			db_table.validate()
 
-			self.commit()
+			self.commit(new_transaction=False)
 			db_table.sync()
 			self.begin()
 

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -120,6 +120,7 @@ class MariaDBTable(DBTable):
 				if query_parts:
 					query_body = ", ".join(query_parts)
 					query = f"ALTER TABLE `{self.table_name}` {query_body}"
+					# nosemgrep
 					frappe.db.sql(query, ignore_implicit_commit=True)
 
 		except Exception as e:

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -110,9 +110,9 @@ class MariaDBTable(DBTable):
 				try:
 					table = frappe.qb.DocType(self.doctype)
 					frappe.qb.update(table).set(col.fieldname, default_value).where(
-						getattr(table, col.fieldname).isnull()
+						table[col.fieldname].isnull()
 					).run()
-				except Exception as e:
+				except Exception:
 					print(f"Failed to update data in {self.table_name} for {col.fieldname}")
 					raise
 		try:

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -121,7 +121,7 @@ class MariaDBTable(DBTable):
 					query_body = ", ".join(query_parts)
 					query = f"ALTER TABLE `{self.table_name}` {query_body}"
 					# nosemgrep
-					frappe.db.sql(query, ignore_implicit_commit=True)
+					frappe.db.sql(query)
 
 		except Exception as e:
 			if query := locals().get("query"):  # this weirdness is to avoid potentially unbounded vars

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -3,6 +3,7 @@ from pymysql.constants.ER import DUP_ENTRY
 import frappe
 from frappe import _
 from frappe.database.schema import DBTable
+from frappe.utils.defaults import get_not_null_defaults
 
 
 class MariaDBTable(DBTable):
@@ -106,9 +107,9 @@ class MariaDBTable(DBTable):
 			if col.not_nullable:
 				try:
 					table = frappe.qb.DocType(self.doctype)
-					frappe.qb.update(table).set(col.fieldname, col.default).where(
-						table[col.fieldname].isnull()
-					).run()
+					frappe.qb.update(table).set(
+						col.fieldname, col.default or get_not_null_defaults(col.fieldtype)
+					).where(table[col.fieldname].isnull()).run()
 				except Exception:
 					print(f"Failed to update data in {self.table_name} for {col.fieldname}")
 					raise

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -3,7 +3,6 @@ from pymysql.constants.ER import DUP_ENTRY
 import frappe
 from frappe import _
 from frappe.database.schema import DBTable
-from frappe.utils.defaults import get_not_null_defaults
 
 
 class MariaDBTable(DBTable):
@@ -104,12 +103,10 @@ class MariaDBTable(DBTable):
 					drop_index_query.append(f"DROP INDEX `{index_record.Key_name}`")
 
 		for col in self.change_nullability:
-			current_column = self.current_columns.get(col.fieldname.lower())
 			if col.not_nullable:
-				default_value = get_not_null_defaults(col.fieldtype)
 				try:
 					table = frappe.qb.DocType(self.doctype)
-					frappe.qb.update(table).set(col.fieldname, default_value).where(
+					frappe.qb.update(table).set(col.fieldname, col.default).where(
 						table[col.fieldname].isnull()
 					).run()
 				except Exception:

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -121,7 +121,7 @@ class MariaDBTable(DBTable):
 					query_body = ", ".join(query_parts)
 					query = f"ALTER TABLE `{self.table_name}` {query_body}"
 					# nosemgrep
-					frappe.db.sql(query)
+					frappe.db.sql_ddl(query)
 
 		except Exception as e:
 			if query := locals().get("query"):  # this weirdness is to avoid potentially unbounded vars

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -337,7 +337,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			key = '", "'.join(key)
 		return f'ON CONFLICT ("{key}") DO UPDATE SET '
 
-	def check_implicit_commit(self, query):
+	def check_implicit_commit(self, query, ignore_implicit_commit=False):
 		pass  # postgres can run DDL in transactions without implicit commits
 
 	def has_index(self, table_name, index_name):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -392,7 +392,8 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			END AS type,
 			BOOL_OR(b.index) AS index,
 			SPLIT_PART(COALESCE(a.column_default, NULL), '::', 1) AS default,
-			BOOL_OR(b.unique) AS unique
+			BOOL_OR(b.unique) AS unique,
+			COALESCE(a.is_nullable = 'NO', false) AS not_nullable
 			FROM information_schema.columns a
 			LEFT JOIN
 				(SELECT indexdef, tablename,
@@ -402,7 +403,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 					WHERE tablename='{table_name}') b
 				ON SUBSTRING(b.indexdef, '(.*)') LIKE CONCAT('%', a.column_name, '%')
 			WHERE a.table_name = '{table_name}'
-			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length;
+			GROUP BY a.column_name, a.data_type, a.column_default, a.character_maximum_length, a.is_nullable;
 		""".format(
 				table_name=table_name
 			),

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -337,7 +337,7 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 			key = '", "'.join(key)
 		return f'ON CONFLICT ("{key}") DO UPDATE SET '
 
-	def check_implicit_commit(self, query, ignore_implicit_commit=False):
+	def check_implicit_commit(self, query):
 		pass  # postgres can run DDL in transactions without implicit commits
 
 	def has_index(self, table_name, index_name):

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -143,12 +143,13 @@ class PostgresTable(DBTable):
 
 		change_nullability = []
 		for col in self.change_nullability:
+			default = col.default or get_not_null_defaults(col.fieldtype)
+			if isinstance(default, str):
+				default = frappe.db.escape(default)
 			change_nullability.append(
 				f"ALTER COLUMN \"{col.fieldname}\" {'SET' if col.not_nullable else 'DROP'} NOT NULL"
 			)
-			change_nullability.append(
-				f'ALTER COLUMN "{col.fieldname}" SET DEFAULT {col.default or frappe.db.escape(col.default)}'
-			)
+			change_nullability.append(f'ALTER COLUMN "{col.fieldname}" SET DEFAULT {default}')
 
 			if col.not_nullable:
 				try:

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -209,7 +209,7 @@ class DbColumn:
 			return column_def
 
 		null = True
-		default = ""
+		default = None
 		unique = False
 
 		if self.fieldtype in ("Check", "Int"):
@@ -240,7 +240,7 @@ class DbColumn:
 		if not null:
 			column_def += " NOT NULL"
 
-		if default:
+		if default is not None:
 			column_def += f" DEFAULT {default}"
 
 		if unique:

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -91,16 +91,16 @@ class DBTable:
 				continue
 
 			self.columns[field.get("fieldname")] = DbColumn(
-				self,
-				field.get("fieldname"),
-				field.get("fieldtype"),
-				field.get("length"),
-				field.get("default"),
-				field.get("search_index"),
-				field.get("options"),
-				field.get("unique"),
-				field.get("precision"),
-				field.get("not_nullable"),
+				table=self,
+				fieldname=field.get("fieldname"),
+				fieldtype=field.get("fieldtype"),
+				length=field.get("length"),
+				default=field.get("default"),
+				set_index=field.get("search_index"),
+				options=field.get("options"),
+				unique=field.get("unique"),
+				precision=field.get("precision"),
+				not_nullable=field.get("not_nullable"),
 			)
 
 	def validate(self):
@@ -179,6 +179,7 @@ class DBTable:
 class DbColumn:
 	def __init__(
 		self,
+		*,
 		table,
 		fieldname,
 		fieldtype,

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -25,6 +25,7 @@ class DBTable:
 		self.add_column: list[DbColumn] = []
 		self.change_type: list[DbColumn] = []
 		self.change_name: list[DbColumn] = []
+		self.change_nullability: list[DbColumn] = []
 		self.add_unique: list[DbColumn] = []
 		self.add_index: list[DbColumn] = []
 		self.drop_unique: list[DbColumn] = []
@@ -268,6 +269,10 @@ class DbColumn:
 			and not cstr(self.default).startswith(":")
 		):
 			self.table.set_default.append(self)
+
+		# nullability
+		if self.not_nullable is not None and (self.not_nullable != current_def["not_nullable"]):
+			self.table.change_nullability.append(self)
 
 		# index should be applied or dropped irrespective of type change
 		if (current_def["index"] and not self.set_index) and column_type not in ("text", "longtext"):

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -227,8 +227,8 @@ class DbColumn:
 		):
 			default = frappe.db.escape(self.default)
 
-		if self.not_nullable and null == "":
-			if default == "":
+		if self.not_nullable and null:
+			if default is None:
 				default = get_not_null_defaults(self.fieldtype)
 				if isinstance(default, str):
 					default = frappe.db.escape(default)

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -1,16 +1,12 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-import typing
 from functools import cached_property
 from types import NoneType
 
 import frappe
 from frappe.query_builder.builder import MariaDB, Postgres
 from frappe.query_builder.functions import Function
-
-if typing.TYPE_CHECKING:
-	from frappe.query_builder import DocType
 
 Query = str | MariaDB | Postgres
 QueryValues = tuple | list | dict | NoneType
@@ -27,7 +23,7 @@ NestedSetHierarchy = (
 )
 
 
-def is_query_type(query: str, query_type: str | tuple[str]) -> bool:
+def is_query_type(query: str, query_type: str | tuple[str, ...]) -> bool:
 	return query.lstrip().split(maxsplit=1)[0].lower().startswith(query_type)
 
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -31,6 +31,7 @@ from frappe.utils import (
 	sanitize_html,
 	strip_html,
 )
+from frappe.utils.defaults import get_not_null_defaults
 from frappe.utils.html_utils import unescape_html
 
 if TYPE_CHECKING:
@@ -383,6 +384,10 @@ class BaseDocument:
 
 			if ignore_nulls and not is_virtual_field and value is None:
 				continue
+
+			# If the docfield is not nullable - set a default non-null value
+			if value is None and getattr(df, "not_nullable", False):
+				value = get_not_null_defaults(df.fieldtype)
 
 			d[fieldname] = value
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -387,7 +387,10 @@ class BaseDocument:
 
 			# If the docfield is not nullable - set a default non-null value
 			if value is None and getattr(df, "not_nullable", False):
-				value = get_not_null_defaults(df.fieldtype)
+				if df.default:
+					value = df.default
+				else:
+					value = get_not_null_defaults(df.fieldtype)
 
 			d[fieldname] = value
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -807,7 +807,10 @@ class DatabaseQuery:
 			df = meta.get("fields", {"fieldname": f.fieldname})
 			df = df[0] if df else None
 
-			if df and df.fieldtype in ("Check", "Float", "Int", "Currency", "Percent"):
+			if df and (
+				df.fieldtype in ("Check", "Float", "Int", "Currency", "Percent")
+				or getattr(df, "not_nullable", False)
+			):
 				can_be_null = False
 
 			if f.operator.lower() in ("previous", "next", "timespan"):

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -109,7 +109,6 @@ class DatabaseQuery:
 		save_user_settings=False,
 		save_user_settings_fields=False,
 		update=None,
-		add_total_row=None,
 		user_settings=None,
 		reference_doctype=None,
 		run=True,
@@ -981,7 +980,6 @@ class DatabaseQuery:
 		)
 
 	def add_user_permissions(self, user_permissions):
-		doctype_link_fields = []
 		doctype_link_fields = self.doctype_meta.get_link_fields()
 
 		# append current doctype with fieldname as 'name' as first link field

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -343,7 +343,7 @@ class Document(BaseDocument):
 		:param ignore_permissions: Do not check permissions if True.
 		:param ignore_version: Do not save version if True."""
 		if self.flags.in_print:
-			return
+			return self
 
 		self.flags.notifications_executed = []
 

--- a/frappe/tests/test_non_nullable_docfield.py
+++ b/frappe/tests/test_non_nullable_docfield.py
@@ -1,0 +1,62 @@
+import frappe
+from frappe.core.doctype.doctype.test_doctype import new_doctype
+from frappe.database.schema import DBTable
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestNonNullableDocfield(FrappeTestCase):
+	def setUp(self):
+		doc = new_doctype(
+			fields=[
+				{
+					"fieldname": "test_field",
+					"fieldtype": "Data",
+					"label": "test_field",
+					"not_nullable": 1,
+				},
+			],
+		)
+		doc.insert()
+		self.doctype_name = doc.name
+
+		nullable_doc = new_doctype(
+			fields=[
+				{
+					"fieldname": "test_field",
+					"fieldtype": "Data",
+					"label": "test_field",
+				}
+			]
+		)
+		nullable_doc.insert()
+		self.nullable_doctype_name = nullable_doc.name
+
+	def test_non_nullable_field(self):
+		doc = frappe.new_doc(doctype=self.doctype_name)
+		doc.insert()
+		inserted_doc = frappe.db.get(self.doctype_name, {"name": doc.name})
+		self.assertEqual(inserted_doc.test_field, "")
+
+	def test_edit_field_nullable_status(self):
+		doc = frappe.new_doc(doctype=self.nullable_doctype_name)
+		doc.insert()
+		inserted_doc = frappe.db.get(self.nullable_doctype_name, {"name": doc.name})
+		self.assertEqual(inserted_doc.test_field, None)
+		table = DBTable(self.nullable_doctype_name)
+		column_data = frappe.db.get_table_columns_description(table.table_name)
+		for column in column_data:
+			if column.name == "test_field":
+				self.assertEqual(column.default, "NULL")
+				self.assertFalse(column.not_nullable)
+
+		doctype_doc = frappe.get_doc("DocType", self.nullable_doctype_name)
+		doctype_doc.fields[0].not_nullable = 1
+		doctype_doc.save()
+		column_data = frappe.db.get_table_columns_description(table.table_name)
+		for column in column_data:
+			if column.name == "test_field":
+				self.assertEqual(column.default, "''")
+				self.assertIsNotNone(column.default)
+				self.assertTrue(column.not_nullable)
+		inserted_doc = frappe.db.get(self.nullable_doctype_name, {"name": doc.name})
+		self.assertEqual(inserted_doc.test_field, "")

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -162,6 +162,9 @@ class TypeExporter:
 		if field.fieldtype in non_nullable_types:
 			return False
 
+		if field.not_nullable:
+			return False
+
 		return not bool(field.reqd)
 
 	def _generic_parameters(self, field) -> str | None:

--- a/frappe/utils/defaults.py
+++ b/frappe/utils/defaults.py
@@ -1,0 +1,50 @@
+from typing import Literal
+
+
+def get_not_null_defaults(column_type: str) -> Literal["", 0] | None:
+	"""
+	Method to return a default value for a column type that is not NoneType
+	:param column_type: The type of column
+	:return: The value to be set
+	"""
+	column_type_map = {
+		"Data": str,
+		"Text": str,
+		"Autocomplete": str,
+		"Attach": str,
+		"AttachImage": str,
+		"Barcode": str,
+		"Check": int,
+		"Code": str,
+		"Color": str,
+		"Currency": float,
+		"Date": str,
+		"Datetime": str,
+		"Duration": int,
+		"DynamicLink": str,
+		"Float": float,
+		"HTMLEditor": str,
+		"Int": int,
+		"JSON": str,
+		"Link": str,
+		"LongText": str,
+		"MarkdownEditor": str,
+		"Password": str,
+		"Percent": float,
+		"Phone": str,
+		"ReadOnly": str,
+		"Rating": float,
+		"Select": str,
+		"SmallText": str,
+		"TextEditor": str,
+		"Time": str,
+		"Table": list,
+		"Table MultiSelect": list,
+	}
+	data_type = column_type_map.get(column_type.replace(" ", ""), str)
+	# data_type = eval(f"frappe.types.DF.{column_type.replace(' ', '')}")
+	if data_type == str:
+		return ""
+	if data_type in (int, float):
+		return 0
+	return None


### PR DESCRIPTION
Resolves #21824

This adds in a `not nullable` checkbox for docfields
If selected - this will ensure that a sane default value (0 / "") will get set instead of `NULL`
