### PR TITLE
refactor: Deprecate bolden_match_part and turn it into a wrapper.

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -600,40 +600,11 @@ frappe.search.utils = {
 		return { score, marked_string };
 	},
 
+	/**
+	 * @deprecated Use frappe.search.utils.fuzzy_search(subseq, str, true).marked_string instead.
+	 */
 	bolden_match_part: function (str, subseq) {
-		if (fuzzy_match(subseq, str)[0] === false) {
-			return str;
-		}
-		if (str.indexOf(subseq) == 0) {
-			var tail = str.split(subseq)[1];
-			return "<mark>" + subseq + "</mark>" + tail;
-		}
-		var rendered = "";
-		var str_orig = str;
-		var str_len = str.length;
-		str = str.toLowerCase();
-		subseq = subseq.toLowerCase();
-
-		outer: for (var i = 0, j = 0; i < subseq.length; i++) {
-			var sub_ch = subseq.charCodeAt(i);
-			while (j < str_len) {
-				if (str.charCodeAt(j) === sub_ch) {
-					var str_char = str_orig.charAt(j);
-					if (str_char === str_char.toLowerCase()) {
-						rendered += "<mark>" + subseq.charAt(i) + "</mark>";
-					} else {
-						rendered += "<mark>" + subseq.charAt(i).toUpperCase() + "</mark>";
-					}
-					j++;
-					continue outer;
-				}
-				rendered += str_orig.charAt(j);
-				j++;
-			}
-			return str_orig;
-		}
-		rendered += str_orig.slice(j);
-		return rendered;
+		return this.fuzzy_search(subseq, str, true).marked_string;
 	},
 
 	get_executables(keywords) {

--- a/frappe/public/js/frappe/ui/toolbar/tag_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/tag_utils.js
@@ -13,15 +13,14 @@ frappe.tags.utils = {
 			return [];
 		}
 
-		for (let i in frappe.tags.tags) {
-			let tag = frappe.tags.tags[i];
-			let level = frappe.search.utils.fuzzy_search(txt, tag);
-			if (level) {
+		frappe.tags.tags.forEach((tag) => {
+			const search_result = frappe.search.utils.fuzzy_search(txt, tag, true);
+			if (search_result.score) {
 				out.push({
 					type: "Tag",
-					label: __("#{0}", [frappe.search.utils.bolden_match_part(__(tag), txt)]),
+					label: __("#{0}", [search_result.marked_string]),
 					value: __("#{0}", [__(tag)]),
-					index: 1 + level,
+					index: 1 + search_result.score,
 					match: tag,
 					onclick() {
 						// Use Global Search Dialog for tag search too.
@@ -29,8 +28,7 @@ frappe.tags.utils = {
 					},
 				});
 			}
-		}
-
+		});
 		return out;
 	},
 


### PR DESCRIPTION
Followup to #22801.

Convert the last remaining use in `frappe.tags.utils.get_tags()` to the now enhanced `fuzzy_search()` and turn `bolden_match_part()` into a mere wrapper.

It is deprecated, as using it will _always_ be less performant than using `fuzzy_search()` with the `return_marked_string` flag enabled in the first place. Also, it‘s a misnomer, as we‘re not actually boldening matched parts and probably won‘t be in the future either.

Manually tested.