### PR TITLE
fix(I18n): Use normalize to make fuzzy_match recognize diacritics, umlauts etc.

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
+++ b/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
@@ -82,17 +82,16 @@ function fuzzy_match_recursive(
 	let first_match = true;
 	while (pattern_cur_index < pattern.length && str_curr_index < str.length) {
 		// Normalize and compare individual characters
-		const normalizedPatternChar = pattern[pattern_cur_index]
+		const normalized_pattern_char = pattern[pattern_cur_index]
 			.normalize("NFD")
 			.replace(/[\u0300-\u036f]/g, "")
 			.toLowerCase();
-		const normalizedStrChar = str[str_curr_index]
+		const normalized_str_char = str[str_curr_index]
 			.normalize("NFD")
 			.replace(/[\u0300-\u036f]/g, "")
 			.toLowerCase();
-
 		// Match found.
-		if (normalizedPatternChar === normalizedStrChar) {
+		if (normalized_pattern_char === normalized_str_char) {
 			if (next_match >= max_matches) {
 				return [false, out_score, matches];
 			}

--- a/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
+++ b/frappe/public/js/frappe/ui/toolbar/fuzzy_match.js
@@ -81,8 +81,18 @@ function fuzzy_match_recursive(
 	// Loop through pattern and str looking for a match.
 	let first_match = true;
 	while (pattern_cur_index < pattern.length && str_curr_index < str.length) {
+		// Normalize and compare individual characters
+		const normalizedPatternChar = pattern[pattern_cur_index]
+			.normalize("NFD")
+			.replace(/[\u0300-\u036f]/g, "")
+			.toLowerCase();
+		const normalizedStrChar = str[str_curr_index]
+			.normalize("NFD")
+			.replace(/[\u0300-\u036f]/g, "")
+			.toLowerCase();
+
 		// Match found.
-		if (pattern[pattern_cur_index].toLowerCase() === str[str_curr_index].toLowerCase()) {
+		if (normalizedPatternChar === normalizedStrChar) {
 			if (next_match >= max_matches) {
 				return [false, out_score, matches];
 			}


### PR DESCRIPTION
> Hello bosue, taking advantage of the occasion of this change, is it possible for the search to be performed using accented letters? Example: "Página", currently if you search for "pagina" the search does not return the accented word:
> 
> ![image](https://github.com/frappe/frappe/assets/1592496/cb69de13-3174-42ef-8c59-b39c9a05809e)
> 
> _Originally posted by @ernestoruiz89 in https://github.com/frappe/frappe/issues/22801#issuecomment-1768536147_

Sure. This may not be the end-all-be-all, as quite some diacritics, umlauts etc. 
will need special handling on a per-language base. But implementing the JS string.normalize method will help in 70 % of all usecases, including these:

![8BB25AA4-0E3F-4C62-A162-05B8FD379C48](https://github.com/frappe/frappe/assets/46800703/7e81e3e6-3e63-463d-be32-5072b6ad0b46)
![64366EF1-A667-4B75-B61C-028A82AC5582](https://github.com/frappe/frappe/assets/46800703/d8a8f71e-ea20-410c-bb4a-12e3036039bb)

![6587A483-6E95-4530-9F7C-228D7D8A53F3](https://github.com/frappe/frappe/assets/46800703/87233701-002a-400d-9c13-2e85a7d55270)