### PR TITLE
fix: relink attachments before saving doc  ( backport #22693 )

### DIFF
--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -192,7 +192,7 @@ context("Attach Control with Failed Document Save", () => {
 	});
 	let temp_name = "";
 	let docname = "";
-	it('Checking functionality for "Attach" Where Document is not saved but File is Uploaded', () => {
+	it("Attaching a file on an unsaved document", () => {
 		//Navigating to the new form for the newly created doctype
 		cy.new_form("Test Mandatory Attach Control");
 		cy.get("body").should(($body) => {
@@ -228,7 +228,7 @@ context("Attach Control with Failed Document Save", () => {
 		});
 	});
 
-	it("Check If File was uploaded correctly", () => {
+	it("Check if file was uploaded correctly", () => {
 		cy.go_to_list("File");
 		cy.open_list_filter();
 		cy.get(".fieldname-select-area .form-control")
@@ -241,7 +241,7 @@ context("Attach Control with Failed Document Save", () => {
 		cy.get("header .level-right .list-count").should("contain.text", "1 of 1");
 	});
 
-	it("Check If File exists with temp name", () => {
+	it("Check if file exists with temporary name", () => {
 		cy.open_list_filter();
 		cy.get('input[data-fieldname="attached_to_name"]').click().clear().type(temp_name).blur();
 		cy.get(".filter-popover .apply-filters").click({ force: true });

--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -162,3 +162,89 @@ context("Attach Control", () => {
 		cy.findByRole("button", { name: "Camera" }).should("not.exist");
 	});
 });
+context("Attach Control with Failed Document Save", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app/doctype");
+		return cy
+			.window()
+			.its("frappe")
+			.then((frappe) => {
+				return frappe.xcall("frappe.tests.ui_test_helpers.create_doctype", {
+					name: "Test Mandatory Attach Control",
+					fields: [
+						{
+							label: "Attach File or Image",
+							fieldname: "attach",
+							fieldtype: "Attach",
+							in_list_view: 1,
+						},
+						{
+							label: "Mandatory Text Field",
+							fieldname: "text_field",
+							fieldtype: "Text Editor",
+							in_list_view: 1,
+							reqd: 1,
+						},
+					],
+				});
+			});
+	});
+	let temp_name = "";
+	let docname = "";
+	it('Checking functionality for "Attach" Where Document is not saved but File is Uploaded', () => {
+		//Navigating to the new form for the newly created doctype
+		cy.new_form("Test Mandatory Attach Control");
+		cy.get("body").should(($body) => {
+			temp_name = $body.attr("data-route").split("/")[2];
+		});
+
+		//Clicking on the attach button which is displayed as part of creating a doctype with "Attach" fieldtype
+		cy.findByRole("button", { name: "Attach" }).click();
+
+		//Clicking on "Link" button to attach a file using the "Link" button
+		cy.findByRole("button", { name: "Link" }).click();
+		cy.findByPlaceholderText("Attach a web link").type(
+			"https://wallpaperplay.com/walls/full/8/2/b/72402.jpg",
+			{ force: true }
+		);
+
+		//Clicking on the Upload button to upload the file
+		cy.intercept("POST", "/api/method/upload_file").as("upload_image");
+		cy.get(".modal-footer").findByRole("button", { name: "Upload" }).click({ delay: 500 });
+		cy.wait("@upload_image");
+		cy.get(".msgprint-dialog .modal-title").contains("Missing Fields").should("be.visible");
+		cy.hide_dialog();
+		cy.fill_field("text_field", "Random value", "Text Editor").wait(500);
+		cy.findByRole("button", { name: "Save" }).click().wait(500);
+
+		//Checking if the URL of the attached image is getting displayed in the field of the newly created doctype
+		cy.get(".attached-file > .ellipsis > .attached-file-link")
+			.should("have.attr", "href")
+			.and("equal", "https://wallpaperplay.com/walls/full/8/2/b/72402.jpg");
+
+		cy.get(".title-text").then(($value) => {
+			docname = $value.text();
+		});
+	});
+
+	it("Check If File was uploaded correctly", () => {
+		cy.go_to_list("File");
+		cy.open_list_filter();
+		cy.get(".fieldname-select-area .form-control")
+			.click()
+			.type("Attached To Name{enter}")
+			.blur()
+			.wait(500);
+		cy.get('input[data-fieldname="attached_to_name"]').click().type(docname).blur();
+		cy.get(".filter-popover .apply-filters").click({ force: true });
+		cy.get("header .level-right .list-count").should("contain.text", "1 of 1");
+	});
+
+	it("Check If File exists with temp name", () => {
+		cy.open_list_filter();
+		cy.get('input[data-fieldname="attached_to_name"]').click().clear().type(temp_name).blur();
+		cy.get(".filter-popover .apply-filters").click({ force: true });
+		cy.get(".frappe-list > .no-result").should("be.visible");
+	});
+});

--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -106,7 +106,10 @@ context("Attach Control", () => {
 				};
 			},
 		});
-		cy.get("body").should("have.attr", "data-route", `Form/${doctype}/new-${dt_in_route}-1`);
+		cy.get("body").should(($body) => {
+			const dataRoute = $body.attr("data-route");
+			expect(dataRoute).to.match(new RegExp(`^Form/${doctype}/new-${dt_in_route}-`));
+		});
 		cy.get("body").should("have.attr", "data-ajax-state", "complete");
 
 		//Clicking on the attach button which is displayed as part of creating a doctype with "Attach" fieldtype
@@ -126,7 +129,10 @@ context("Attach Control", () => {
 				delete win.navigator.mediaDevices;
 			},
 		});
-		cy.get("body").should("have.attr", "data-route", `Form/${doctype}/new-${dt_in_route}-1`);
+		cy.get("body").should(($body) => {
+			const dataRoute = $body.attr("data-route");
+			expect(dataRoute).to.match(new RegExp(`^Form/${doctype}/new-${dt_in_route}-`));
+		});
 		cy.get("body").should("have.attr", "data-ajax-state", "complete");
 
 		//Clicking on the attach button which is displayed as part of creating a doctype with "Attach" fieldtype

--- a/cypress/integration/control_attach.js
+++ b/cypress/integration/control_attach.js
@@ -64,6 +64,25 @@ context("Attach Control", () => {
 		//Clicking on the attach button which is displayed as part of creating a doctype with "Attach" fieldtype
 		cy.findByRole("button", { name: "Attach" }).click();
 
+		//Clicking on "Link" button to attach a file using the "Link" button
+		cy.findByRole("button", { name: "Link" }).click();
+		cy.findByPlaceholderText("Attach a web link").type(
+			"https://wallpaperplay.com/walls/full/8/2/b/72402.jpg",
+			{ force: true }
+		);
+
+		//Clicking on the Upload button to upload the file
+		cy.intercept("POST", "/api/method/upload_file").as("upload_image");
+		cy.get(".modal-footer").findByRole("button", { name: "Upload" }).click({ delay: 500 });
+		cy.wait("@upload_image");
+		cy.findByRole("button", { name: "Save" }).click();
+
+		//Navigating to the new form for the newly created doctype to check Library button
+		cy.new_form("Test Attach Control");
+
+		//Clicking on the attach button which is displayed as part of creating a doctype with "Attach" fieldtype
+		cy.findByRole("button", { name: "Attach" }).click();
+
 		//Clicking on "Library" button to attach a file using the "Library" button
 		cy.findByRole("button", { name: "Library" }).click();
 		cy.contains("72402.jpg").click();
@@ -85,9 +104,10 @@ context("Attach Control", () => {
 		//Checking if clicking on the clear button clears the field of the doctype form and again displays the attach button
 		cy.get(".control-input > .btn-sm").should("contain", "Attach");
 
-		//Deleting the doc
+		//Deleting both docs
 		cy.go_to_list("Test Attach Control");
 		cy.get(".list-row-checkbox").eq(0).click();
+		cy.get(".list-row-checkbox").eq(1).click();
 		cy.get(".actions-btn-group > .btn").contains("Actions").click();
 		cy.get('.actions-btn-group > .dropdown-menu [data-label="Delete"]').click();
 		cy.click_modal_primary_button("Yes");

--- a/cypress/integration/control_data.js
+++ b/cypress/integration/control_data.js
@@ -49,7 +49,7 @@ context("Data Control", () => {
 		cy.new_form("Test Data Control");
 
 		//Checking the URL for the new form of the doctype
-		cy.location("pathname").should("eq", "/app/test-data-control/new-test-data-control-1");
+		cy.location("pathname").should("contains", "/app/test-data-control/new-test-data-control");
 		cy.get(".title-text").should("have.text", "New Test Data Control");
 		cy.get('.frappe-control[data-fieldname="name1"]')
 			.find("label")
@@ -128,7 +128,10 @@ context("Data Control", () => {
 		cy.fill_field("phone", "9432380001", "Data");
 		cy.findByRole("button", { name: "Save" }).click({ force: true });
 		//Checking if the fields contains the data which has been filled in
-		cy.location("pathname").should("not.be", "/app/test-data-control/new-test-data-control-1");
+		cy.location("pathname").should(
+			"not.contains",
+			"/app/test-data-control/new-test-data-control"
+		);
 		cy.get_field("name1").should("have.value", "Komal");
 		cy.get_field("email").should("have.value", "komal@test.com");
 		cy.get_field("phone").should("have.value", "9432380001");

--- a/cypress/integration/dashboard_chart.js
+++ b/cypress/integration/dashboard_chart.js
@@ -5,7 +5,7 @@ context("Dashboard Chart", () => {
 	});
 
 	it("Check filter populate for child table doctype", () => {
-		cy.visit("/app/dashboard-chart/new-dashboard-chart");
+		cy.new_form("Dashboard Chart");
 		cy.get('[data-fieldname="parent_document_type"]').should("have.css", "display", "none");
 
 		cy.get_field("document_type", "Link");

--- a/cypress/integration/dashboard_chart.js
+++ b/cypress/integration/dashboard_chart.js
@@ -5,7 +5,7 @@ context("Dashboard Chart", () => {
 	});
 
 	it("Check filter populate for child table doctype", () => {
-		cy.visit("/app/dashboard-chart/new-dashboard-chart-1");
+		cy.visit("/app/dashboard-chart/new-dashboard-chart");
 		cy.get('[data-fieldname="parent_document_type"]').should("have.css", "display", "none");
 
 		cy.get_field("document_type", "Link");

--- a/cypress/integration/grid_keyboard_shortcut.js
+++ b/cypress/integration/grid_keyboard_shortcut.js
@@ -6,7 +6,7 @@ context("Grid Keyboard Shortcut", () => {
 	});
 	beforeEach(() => {
 		cy.reload();
-		cy.visit("/app/contact/new-contact");
+		cy.new_form("Contact");
 		cy.get('.frappe-control[data-fieldname="email_ids"]').find(".grid-add-row").click();
 		// as new names uses hash instead of numbers get row's data-name dynamically.
 		cy.get('.frappe-control[data-fieldname="email_ids"]')

--- a/cypress/integration/grid_keyboard_shortcut.js
+++ b/cypress/integration/grid_keyboard_shortcut.js
@@ -1,18 +1,25 @@
 context("Grid Keyboard Shortcut", () => {
 	let total_count = 0;
+	let contact_email_name = null;
 	before(() => {
 		cy.login();
 	});
 	beforeEach(() => {
 		cy.reload();
-		cy.visit("/app/contact/new-contact-1");
+		cy.visit("/app/contact/new-contact");
 		cy.get('.frappe-control[data-fieldname="email_ids"]').find(".grid-add-row").click();
+		// as new names uses hash instead of numbers get row's data-name dynamically.
+		cy.get('.frappe-control[data-fieldname="email_ids"]')
+			.find(".grid-body .grid-row")
+			.should(($row) => {
+				contact_email_name = $row.attr("data-name");
+			});
 	});
 	it("Insert new row at the end", () => {
 		cy.add_new_row_in_grid(
 			"{ctrl}{shift}{downarrow}",
 			(cy, total_count) => {
-				cy.get('[data-name="new-contact-email-1"]').should(
+				cy.get(`[data-name="${contact_email_name}"]`).should(
 					"have.attr",
 					"data-idx",
 					`${total_count + 1}`
@@ -23,17 +30,17 @@ context("Grid Keyboard Shortcut", () => {
 	});
 	it("Insert new row at the top", () => {
 		cy.add_new_row_in_grid("{ctrl}{shift}{uparrow}", (cy) => {
-			cy.get('[data-name="new-contact-email-1"]').should("have.attr", "data-idx", "2");
+			cy.get(`[data-name="${contact_email_name}"]`).should("have.attr", "data-idx", "2");
 		});
 	});
 	it("Insert new row below", () => {
 		cy.add_new_row_in_grid("{ctrl}{downarrow}", (cy) => {
-			cy.get('[data-name="new-contact-email-1"]').should("have.attr", "data-idx", "1");
+			cy.get(`[data-name^="${contact_email_name}"]`).should("have.attr", "data-idx", "1");
 		});
 	});
 	it("Insert new row above", () => {
 		cy.add_new_row_in_grid("{ctrl}{uparrow}", (cy) => {
-			cy.get('[data-name="new-contact-email-1"]').should("have.attr", "data-idx", "2");
+			cy.get(`[data-name^="${contact_email_name}"]`).should("have.attr", "data-idx", "2");
 		});
 	});
 });

--- a/cypress/integration/number_card.js
+++ b/cypress/integration/number_card.js
@@ -5,7 +5,7 @@ context("Number Card", () => {
 	});
 
 	it("Check filter populate for child table doctype", () => {
-		cy.visit("/app/number-card/new-number-card-1");
+		cy.new_form("Number Card");
 		cy.get('[data-fieldname="parent_document_type"]').should("have.css", "display", "none");
 
 		cy.get_field("document_type", "Link");

--- a/cypress/integration/timeline.js
+++ b/cypress/integration/timeline.js
@@ -8,7 +8,7 @@ context("Timeline", () => {
 
 	it("Adding new ToDo, adding new comment, verifying comment addition & deletion and deleting ToDo", () => {
 		//Adding new ToDo
-		cy.visit("/app/todo/new-todo-1");
+		cy.visit("/app/todo/new-todo");
 		cy.get('[data-fieldname="description"] .ql-editor.ql-blank')
 			.type("Test ToDo", { force: true })
 			.wait(200);

--- a/cypress/integration/timeline.js
+++ b/cypress/integration/timeline.js
@@ -8,7 +8,7 @@ context("Timeline", () => {
 
 	it("Adding new ToDo, adding new comment, verifying comment addition & deletion and deleting ToDo", () => {
 		//Adding new ToDo
-		cy.visit("/app/todo/new-todo");
+		cy.new_form("ToDo");
 		cy.get('[data-fieldname="description"] .ql-editor.ql-blank')
 			.type("Test ToDo", { force: true })
 			.wait(200);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -254,7 +254,10 @@ Cypress.Commands.add("awesomebar", (text) => {
 Cypress.Commands.add("new_form", (doctype) => {
 	let dt_in_route = doctype.toLowerCase().replace(/ /g, "-");
 	cy.visit(`/app/${dt_in_route}/new`);
-	cy.get("body").should("have.attr", "data-route", `Form/${doctype}/new-${dt_in_route}-1`);
+	cy.get("body").should(($body) => {
+		const dataRoute = $body.attr("data-route");
+		expect(dataRoute).to.match(new RegExp(`^Form/${doctype}/new-${dt_in_route}-`));
+	});
 	cy.get("body").should("have.attr", "data-ajax-state", "complete");
 });
 

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -383,8 +383,6 @@ def relink_files(doc, fieldname, temp_doc_name):
 			mislinked_file,
 			field={
 				"attached_to_name": doc.name,
-				"attached_to_doctype": doc.doctype,
-				"attached_to_field": fieldname,
 			},
 		)
 		return

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -397,6 +397,8 @@ def relink_mismatched_files(doc: "Document") -> None:
 	for df in attach_fields:
 		if doc.get(df.fieldname):
 			relink_files(doc, df.fieldname, doc.__temporary_name)
+	# delete temporary name after relinking is done
+	doc.delete_key("__temporary_name")
 
 
 def decode_file_content(content: bytes) -> bytes:

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -337,6 +337,7 @@ def attach_files_to_document(doc: "Document", event) -> None:
 					"attached_to_name": doc.name,
 					"attached_to_doctype": doc.doctype,
 					"attached_to_field": df.fieldname,
+					"is_private": value.startswith("/private"),
 				},
 			)
 			return
@@ -353,6 +354,49 @@ def attach_files_to_document(doc: "Document", event) -> None:
 			file.insert(ignore_permissions=True)
 		except Exception:
 			doc.log_error("Error Attaching File")
+
+
+def relink_files(doc, fieldname, temp_doc_name):
+	from frappe.utils.data import add_to_date, now_datetime
+
+	"""
+	Relink files attached to incorrect document name to the new document name
+	by check if file with temp name exists that was created in last 60 minutes
+	"""
+	mislinked_file = frappe.db.exists(
+		"File",
+		{
+			"file_url": doc.get(fieldname),
+			"attached_to_name": temp_doc_name,
+			"attached_to_doctype": doc.doctype,
+			"attached_to_field": fieldname,
+			"creation": (
+				"between",
+				[now_datetime() - add_to_date(date=now_datetime(), minutes=-60), now_datetime()],
+			),
+		},
+	)
+	"""If file exists, attach it to the new docname"""
+	if mislinked_file:
+		frappe.db.set_value(
+			"File",
+			mislinked_file,
+			field={
+				"attached_to_name": doc.name,
+				"attached_to_doctype": doc.doctype,
+				"attached_to_field": fieldname,
+			},
+		)
+		return
+
+
+def relink_mismatched_files(doc: "Document") -> None:
+	if not doc.get("file_relink_temp_docname", None):
+		return
+	attach_fields = doc.meta.get("fields", {"fieldtype": ["in", ["Attach", "Attach Image"]]})
+	for df in attach_fields:
+		if doc.get(df.fieldname):
+			relink_files(doc, df.fieldname, doc.file_relink_temp_docname)
 
 
 def decode_file_content(content: bytes) -> bytes:

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 import frappe
 from frappe import _, safe_decode
-from frappe.utils import cstr, encode, get_files_path, random_string, strip
+from frappe.utils import cint, cstr, encode, get_files_path, random_string, strip
 from frappe.utils.file_manager import safe_b64decode
 from frappe.utils.image import optimize_image
 
@@ -337,7 +337,7 @@ def attach_files_to_document(doc: "Document", event) -> None:
 					"attached_to_name": doc.name,
 					"attached_to_doctype": doc.doctype,
 					"attached_to_field": df.fieldname,
-					"is_private": value.startswith("/private"),
+					"is_private": cint(value.startswith("/private")),
 				},
 			)
 			return

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -357,6 +357,8 @@ def attach_files_to_document(doc: "Document", event) -> None:
 
 
 def relink_files(doc, fieldname, temp_doc_name):
+	if not temp_doc_name:
+		return
 	from frappe.utils.data import add_to_date, now_datetime
 
 	"""
@@ -389,12 +391,12 @@ def relink_files(doc, fieldname, temp_doc_name):
 
 
 def relink_mismatched_files(doc: "Document") -> None:
-	if not doc.get("file_relink_temp_docname", None):
+	if not doc.get("__temporary_name", None):
 		return
 	attach_fields = doc.meta.get("fields", {"fieldtype": ["in", ["Attach", "Attach Image"]]})
 	for df in attach_fields:
 		if doc.get(df.fieldname):
-			relink_files(doc, df.fieldname, doc.file_relink_temp_docname)
+			relink_files(doc, df.fieldname, doc.__temporary_name)
 
 
 def decode_file_content(content: bytes) -> bytes:

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -18,7 +18,8 @@ def savedocs(doc, action):
 	if doc.doctype not in ["DocType", "File"] and doc.name.startswith(
 		"new-" + doc.doctype.lower().replace(" ", "-")
 	):
-		doc.file_relink_temp_docname = doc.name
+		# required to relink missing attachments if they exist.
+		doc.__temporary_name = doc.name
 	set_local_name(doc)
 
 	# action

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -15,9 +15,7 @@ def savedocs(doc, action):
 	"""save / submit / update doclist"""
 	doc = frappe.get_doc(json.loads(doc))
 	capture_doc(doc, action)
-	if doc.doctype not in ["DocType", "File"] and doc.name.startswith(
-		"new-" + doc.doctype.lower().replace(" ", "-")
-	):
+	if doc.get("__islocal") and doc.name.startswith("new-" + doc.doctype.lower().replace(" ", "-")):
 		# required to relink missing attachments if they exist.
 		doc.__temporary_name = doc.name
 	set_local_name(doc)

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -15,6 +15,10 @@ def savedocs(doc, action):
 	"""save / submit / update doclist"""
 	doc = frappe.get_doc(json.loads(doc))
 	capture_doc(doc, action)
+	if doc.doctype not in ["DocType", "File"] and doc.name.startswith(
+		"new-" + doc.doctype.lower().replace(" ", "-")
+	):
+		doc.file_relink_temp_docname = doc.name
 	set_local_name(doc)
 
 	# action

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -191,6 +191,14 @@ def upload_file():
 	optimize = frappe.form_dict.optimize
 	content = None
 
+	if frappe.form_dict.get("name", False):
+		doc = frappe.get_value(
+			"File", frappe.form_dict.name, ["is_private", "file_url", "file_name"], as_dict=True
+		)
+		is_private = doc.is_private
+		file_url = doc.file_url
+		filename = doc.file_name
+
 	if "file" in files:
 		file = files["file"]
 		content = file.stream.read()

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -191,9 +191,12 @@ def upload_file():
 	optimize = frappe.form_dict.optimize
 	content = None
 
-	if frappe.form_dict.get("name", False):
+	if frappe.form_dict.get("library_file_name", False):
 		doc = frappe.get_value(
-			"File", frappe.form_dict.name, ["is_private", "file_url", "file_name"], as_dict=True
+			"File",
+			frappe.form_dict.library_file_name,
+			["is_private", "file_url", "file_name"],
+			as_dict=True,
 		)
 		is_private = doc.is_private
 		file_url = doc.file_url

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import NotFound
 
 import frappe
 from frappe import _, is_whitelisted, msgprint
+from frappe.core.doctype.file.utils import relink_mismatched_files
 from frappe.core.doctype.server_script.server_script_utils import run_server_script_for_doc_event
 from frappe.desk.form.document_follow import follow_document
 from frappe.integrations.doctype.webhook import run_webhooks
@@ -284,6 +285,7 @@ class Document(BaseDocument):
 		# flag to prevent creation of event update log for create and update both
 		# during document creation
 		self.flags.update_log_for_doc_creation = True
+		relink_mismatched_files(self)
 		self.run_post_save_methods()
 		self.flags.in_insert = False
 

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -414,7 +414,7 @@ export default {
 			}
 			this.close_dialog = true;
 			return this.upload_file({
-				file_url: selected_file.file_url
+				library_file_name: selected_file.value,
 			});
 		},
 		upload_via_web_link() {
@@ -528,6 +528,10 @@ export default {
 
 				if (file.file_name) {
 					form_data.append('file_name', file.file_name);
+				}
+
+				if (file.library_file_name) {
+					form_data.append('library_file_name', file.library_file_name);
 				}
 
 				if (this.doctype && this.docname) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -5,7 +5,6 @@ frappe.provide("frappe.model");
 
 $.extend(frappe.model, {
 	new_names: {},
-	new_name_count: {},
 
 	get_new_doc: function (doctype, parent_doc, parentfield, with_mandatory_children) {
 		frappe.provide("locals." + doctype);
@@ -78,11 +77,8 @@ $.extend(frappe.model, {
 	},
 
 	get_new_name: function (doctype) {
-		var cnt = frappe.model.new_name_count;
-		if (!cnt[doctype]) cnt[doctype] = 0;
-		cnt[doctype]++;
 		// random hash is added to idenity mislinked files when doc is not saved and file is uploaded.
-		return frappe.router.slug(`new-${doctype}-${cnt[doctype]}${frappe.utils.get_random(10)}`);
+		return frappe.router.slug(`new-${doctype}-${frappe.utils.get_random(10)}`);
 	},
 
 	set_default_values: function (doc, parent_doc) {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -81,7 +81,8 @@ $.extend(frappe.model, {
 		var cnt = frappe.model.new_name_count;
 		if (!cnt[doctype]) cnt[doctype] = 0;
 		cnt[doctype]++;
-		return frappe.router.slug(`new-${doctype}-${cnt[doctype]}`);
+		// random hash is added to idenity mislinked files when doc is not saved and file is uploaded.
+		return frappe.router.slug(`new-${doctype}-${cnt[doctype]}${frappe.utils.get_random(10)}`);
 	},
 
 	set_default_values: function (doc, parent_doc) {

--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -200,7 +200,9 @@ function get_number_format_info(format) {
 
 function _round(num, precision, rounding_method) {
 	rounding_method =
-		rounding_method || frappe.boot.sysdefaults?.rounding_method || "Banker's Rounding (legacy)";
+		rounding_method ||
+		frappe.boot.sysdefaults?.rounding_method ||
+		"Banker's Rounding (legacy)";
 
 	let is_negative = num < 0 ? true : false;
 

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -188,15 +188,16 @@ frappe.breadcrumbs = {
 	set_form_breadcrumb(breadcrumbs, view) {
 		const doctype = breadcrumbs.doctype;
 		let docname = frappe.get_route().slice(2).join("/");
+		let docname_title = docname;
 		if (docname.startsWith("new-" + doctype.toLowerCase().replace(/ /g, "-"))) {
 			// using docname instead of doctype to include No like Doctype Name + 1, 2, 3
-			docname = docname
+			docname_title = docname_title
 				.slice(0, -10)
 				.replace(/-/g, " ")
 				.replace(/\b\w/g, (l) => l.toUpperCase());
 		}
-		let form_route = `/app/${frappe.router.slug(doctype)}/${docname}`;
-		this.append_breadcrumb_element(form_route, __(docname));
+		let form_route = `/app/${frappe.router.slug(doctype)}/${docname_title}`;
+		this.append_breadcrumb_element(form_route, __(docname_title));
 
 		if (view === "form") {
 			let last_crumb = this.$breadcrumbs.find("li").last();

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -187,7 +187,14 @@ frappe.breadcrumbs = {
 
 	set_form_breadcrumb(breadcrumbs, view) {
 		const doctype = breadcrumbs.doctype;
-		const docname = frappe.get_route().slice(2).join("/");
+		let docname = frappe.get_route().slice(2).join("/");
+		if (docname.startsWith("new-" + doctype.toLowerCase().replace(/ /g, "-"))) {
+			// using docname instead of doctype to include No like Doctype Name + 1, 2, 3
+			docname = docname
+				.slice(0, -10)
+				.replace(/-/g, " ")
+				.replace(/\b\w/g, (l) => l.toUpperCase());
+		}
 		let form_route = `/app/${frappe.router.slug(doctype)}/${docname}`;
 		this.append_breadcrumb_element(form_route, __(docname));
 


### PR DESCRIPTION
Manual Backport of #22693 

Certain people add attachment, before filling mandatory fields which will raise Missing Fields error.

Or any other kind of errors raised by different validators due to which file is uploaded but doc is not saved.

This will lead to orphaned/mislinked files. ex. new-purchase-receipt-1

This fix changes name of new docs to `new-<doctype>-<10digithash>` after saving the document we can use this new name to find any mislinked files created in past hour and relink them to the new doc on save.