### PR TITLE
fix: ignore duplicate perm check on assign hooks

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1713,6 +1713,7 @@ def get_newargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
 		if (a in fnargs) or varkw_exist:
 			newargs[a] = kwargs.get(a)
 
+	# WARNING: This behaviour is now  part of business logic in places, never remove.
 	newargs.pop("ignore_permissions", None)
 	newargs.pop("flags", None)
 

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -92,7 +92,8 @@ class AssignmentRule(Document):
 					assignment_rule=self.name,
 					notify=True,
 					date=doc.get(self.due_date_based_on) if self.due_date_based_on else None,
-				)
+				),
+				ignore_permissions=doc.flags.ignore_permissions,
 			)
 
 			# set for reference in round robin

--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -78,7 +78,7 @@ class AssignmentRule(Document):
 
 	def do_assignment(self, doc):
 		# clear existing assignment, to reassign
-		assign_to.clear(doc.get("doctype"), doc.get("name"))
+		assign_to.clear(doc.get("doctype"), doc.get("name"), ignore_permissions=True)
 
 		user = self.get_user(doc)
 
@@ -93,7 +93,7 @@ class AssignmentRule(Document):
 					notify=True,
 					date=doc.get(self.due_date_based_on) if self.due_date_based_on else None,
 				),
-				ignore_permissions=doc.flags.ignore_permissions,
+				ignore_permissions=True,
 			)
 
 			# set for reference in round robin
@@ -105,12 +105,14 @@ class AssignmentRule(Document):
 	def clear_assignment(self, doc):
 		"""Clear assignments"""
 		if self.safe_eval("unassign_condition", doc):
-			return assign_to.clear(doc.get("doctype"), doc.get("name"))
+			return assign_to.clear(doc.get("doctype"), doc.get("name"), ignore_permissions=True)
 
 	def close_assignments(self, doc):
 		"""Close assignments"""
 		if self.safe_eval("close_condition", doc):
-			return assign_to.close_all_assignments(doc.get("doctype"), doc.get("name"))
+			return assign_to.close_all_assignments(
+				doc.get("doctype"), doc.get("name"), ignore_permissions=True
+			)
 
 	def get_user(self, doc):
 		"""

--- a/frappe/desk/form/assign_to.py
+++ b/frappe/desk/form/assign_to.py
@@ -39,7 +39,7 @@ def get(args=None):
 
 
 @frappe.whitelist()
-def add(args=None):
+def add(args=None, *, ignore_permissions=False):
 	"""add in someone's to do list
 	args = {
 	        "assign_to": [],
@@ -63,8 +63,9 @@ def add(args=None):
 			"status": "Open",
 			"allocated_to": assign_to,
 		}
-		parent_doc = frappe.get_doc(args["doctype"], args["name"])
-		parent_doc.check_permission()
+		if not ignore_permissions:
+			parent_doc = frappe.get_doc(args["doctype"], args["name"])
+			parent_doc.check_permission()
 
 		if frappe.get_all("ToDo", filters=filters):
 			users_with_duplicate_todo.append(assign_to)

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -140,22 +140,26 @@ class FrappeTestCase(unittest.TestCase):
 
 	@contextmanager
 	def set_user(self, user: str):
-		old_user = frappe.session.user
-		frappe.set_user(user)
-		yield
-		frappe.set_user(old_user)
+		try:
+			old_user = frappe.session.user
+			frappe.set_user(user)
+			yield
+		finally:
+			frappe.set_user(old_user)
 
 	@contextmanager
 	def switch_site(self, site: str):
 		"""Switch connection to different site.
 		Note: Drops current site connection completely."""
 
-		old_site = frappe.local.site
-		frappe.init(site, force=True)
-		frappe.connect()
-		yield
-		frappe.init(old_site, force=True)
-		frappe.connect()
+		try:
+			old_site = frappe.local.site
+			frappe.init(site, force=True)
+			frappe.connect()
+			yield
+		finally:
+			frappe.init(old_site, force=True)
+			frappe.connect()
 
 	@contextmanager
 	def freeze_time(self, time_to_freeze, *args, **kwargs):


### PR DESCRIPTION
When assingment is triggered via document hooks we can assume that permission checks are:
- Already completed before doc events triggered
- Are not applicable (e.g. `doc.save(ignore_permissions=True)`)