### PR TITLE
refactor: use gzip library's compress() and decompress() methods directly

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2018, Frappe Technologies and contributors
 # License: MIT. See LICENSE
-
-
+import gzip
 import json
 from contextlib import suppress
 from typing import Any
@@ -13,7 +12,7 @@ from frappe.desk.form.load import get_attachments
 from frappe.desk.query_report import generate_report_result
 from frappe.model.document import Document
 from frappe.monitor import add_data_to_monitor
-from frappe.utils import add_to_date, gzip_compress, gzip_decompress, now
+from frappe.utils import add_to_date, now
 from frappe.utils.background_jobs import enqueue
 
 # If prepared report runs for longer than this time it's automatically considered as failed
@@ -84,8 +83,8 @@ class PreparedReport(Document):
 			attached_file = frappe.get_doc("File", attachment.name)
 
 			if with_file_name:
-				return (gzip_decompress(attached_file.get_content()), attachment.file_name)
-			return gzip_decompress(attached_file.get_content())
+				return (gzip.decompress(attached_file.get_content()), attachment.file_name)
+			return gzip.decompress(attached_file.get_content())
 
 
 def generate_report(prepared_report):
@@ -222,7 +221,7 @@ def create_json_gz_file(data, dt, dn):
 		frappe.utils.data.format_datetime(frappe.utils.now(), "Y-m-d-H:M")
 	)
 	encoded_content = frappe.safe_encode(frappe.as_json(data))
-	compressed_content = gzip_compress(encoded_content)
+	compressed_content = gzip.compress(encoded_content)
 
 	# Call save() file function to upload and attach the file
 	_file = frappe.get_doc(

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -4,9 +4,7 @@
 import functools
 import hashlib
 import io
-import json
 import os
-import re
 import sys
 import traceback
 from collections import deque
@@ -21,16 +19,13 @@ from collections.abc import (
 )
 from email.header import decode_header, make_header
 from email.utils import formataddr, parseaddr
-from typing import Any, Literal, TypedDict
-from urllib.parse import quote, urlparse
+from typing import TypedDict
 
-from redis.exceptions import ConnectionError
 from werkzeug.test import Client
-
-import frappe
 
 # utility functions like cint, int, flt, etc.
 from frappe.utils.data import *
+from frappe.utils.deprecations import deprecated
 from frappe.utils.html_utils import sanitize_html
 
 EMAIL_NAME_PATTERN = re.compile(r"[^A-Za-z0-9\u00C0-\u024F\/\_\' ]+")
@@ -869,6 +864,9 @@ def call(fn, *args, **kwargs):
 
 # Following methods are aken as-is from Python 3 codebase
 # since gzip.compress and gzip.decompress are not available in Python 2.7
+
+
+@deprecated
 def gzip_compress(data, compresslevel=9):
 	"""Compress data in one shot and return the compressed string.
 	Optional argument is the compression level, in range of 0-9.
@@ -881,6 +879,7 @@ def gzip_compress(data, compresslevel=9):
 	return buf.getvalue()
 
 
+@deprecated
 def gzip_decompress(data):
 	"""Decompress a gzip compressed string in one shot.
 	Return the decompressed string.


### PR DESCRIPTION
The util methods were added for python2.7 compat, so can be removed

This reverts fc48597

