### PR TITLE
fix: minor desk style inconsistencies

### DIFF
--- a/frappe/public/js/frappe/widgets/onboarding_widget.js
+++ b/frappe/public/js/frappe/widgets/onboarding_widget.js
@@ -124,12 +124,12 @@ export default class OnboardingWidget extends Widget {
 			set_description();
 
 			if (step.intro_video_url) {
-				$(`<button class="btn btn-primary btn-sm">${__("Watch Tutorial")}</button>`)
+				$(`<button class="btn btn-default btn-sm">${__("Watch Tutorial")}</button>`)
 					.appendTo(this.step_footer)
 					.on("click", toggle_video);
 			} else {
 				$(
-					`<button class="btn btn-primary btn-sm">${__(
+					`<button class="btn btn-default btn-sm">${__(
 						step.action_label || step.action
 					)}</button>`
 				)

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -194,7 +194,7 @@ $check-icon-dark: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xm
 		}
 	}
 	.comment-input-wrapper .ql-editor.ql-blank::before {
-		color: var(--text-muted);
+		color: var(--text-color);
 	}
 	// --appreciation-color: var(--dark-green-100);
 	// --appreciation-bg: var(--dark-green-600);

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -551,9 +551,9 @@ body {
 		cursor: pointer;
 
 		&:hover {
-			--icon-stroke: var(--gray-600);
+			--icon-stroke: var(--invert-neutral);
 			.widget-title {
-				color: var(--gray-600) !important;
+				color: var(--invert-neutral) !important;
 			}
 		}
 
@@ -600,7 +600,7 @@ body {
 			.link-content {
 				flex: 1;
 				&:hover {
-					color: var(--gray-600);
+					color: var(--invert-neutral);
 				}
 			}
 

--- a/frappe/public/scss/desk/navbar.scss
+++ b/frappe/public/scss/desk/navbar.scss
@@ -1,7 +1,6 @@
 .navbar {
 	height: $navbar-height;
 	background: var(--navbar-bg);
-	box-shadow: var(--shadow-sm);
 	border-bottom: 1px solid var(--border-color);
 	padding: 0;
 	.navbar-brand {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -58,9 +58,13 @@
 		height: var(--btn-height);
 		margin-left: var(--margin-sm, 8px);
 		border-radius: var(--border-radius);
-		display: flex;
-		align-items: center;
-		gap: 8px;
+		line-height: 1;
+		padding: 4px 8px;
+		&, & .hidden-xs {
+			display: flex;
+			align-items: center;
+			gap: 6px;
+		}
 	}
 	.btn:not(.icon-btn) {
 		padding: 4px 8px;

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -183,7 +183,7 @@ body[data-route^="Module"] .main-menu {
 }
 
 .layout-side-section {
-	@include get_textstyle("base", "regular");
+	@include get_textstyle("sm", "regular");
 	padding-right: 30px;
 
 	&.hide-sidebar {
@@ -415,8 +415,7 @@ body[data-route^="Module"] .main-menu {
 	.data-pill {
 		background-color: unset;
 		box-shadow: none;
-		padding: 0;
-		padding-left: var(--padding-md);
+		padding:0 var(--padding-xs) 0 var(--padding-md);
 	}
 }
 
@@ -467,6 +466,11 @@ body[data-route^="Module"] .main-menu {
 	width: unset;
 	height: unset;
 	margin-right: 0;
+	padding: var(--padding-xs) !important;
+	border-radius: var(--border-radius-full);
+	&:hover {
+		background-color: var(--subtle-fg);
+	}
 	&:focus {
 		box-shadow: none;
 	}

--- a/frappe/public/scss/desk/slides.scss
+++ b/frappe/public/scss/desk/slides.scss
@@ -72,11 +72,10 @@
 }
 
 .slides-wrapper {
-	width: 520px;
 	max-width: 520px;
 	background: var(--card-bg);
 	padding: var(--padding-xl);
-	border: 1px solid var(--gray-400);
+	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius-md);
 
 	.slide-wrapper:focus {

--- a/frappe/public/scss/desk/tree.scss
+++ b/frappe/public/scss/desk/tree.scss
@@ -1,5 +1,19 @@
 .tree {
 	padding: var(--padding-sm);
+	.btn-group {
+		.btn {
+			box-shadow: none;
+			outline: 1px solid var(--btn-group-border-color);
+
+			&:not(:first-child) {
+				margin-left: 1px;
+			}
+
+			&:focus {
+				outline: 2px solid var(--dark-border-color);
+			}
+		}
+	}
 }
 
 .tree li {


### PR DESCRIPTION
- made onboarding widget button default from primary as it takes too much attention
- removed desk navbar drop-shadow
- made sidebar text smaller and added padding to plus icon and hover effect
- as we need border in tree view btn-group added those styles in tree.scss
- made hover black on workspace links
- dark mode misc
- added flex for page-action buttons to center them and removed extra line-height.

- minor slides style : removed width (responsive)  and changed border color  to --border-color

https://github.com/frappe/frappe/assets/39730881/4eb209fd-18f3-484e-9de3-7be38d049b0f

