### PR TITLE
fix(minor): use inline-flex in page-actions btn

### DIFF
--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -61,7 +61,7 @@
 		line-height: 1;
 		padding: 4px 8px;
 		&, & .hidden-xs {
-			display: flex;
+			display: inline-flex;
 			align-items: center;
 			gap: 6px;
 		}


### PR DESCRIPTION
Some times text and icons are in separate span and applying flex takes up the whole row. instead use inline-flex to avoid this.

https://github.com/frappe/frappe/issues/22845#issuecomment-1773071578

### Before
<img width="1335" alt="page action btn before" src="https://github.com/frappe/frappe/assets/39730881/12f43463-ef8c-4c9a-9cfe-853f6418f3e4">

### After
<img width="1335" alt="page action btn after" src="https://github.com/frappe/frappe/assets/39730881/be285003-574f-4c19-bc18-4718701e352f">
