### PR TITLE
fix: Correctly update fields on doctype form

### DIFF
--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -201,7 +201,7 @@ export const useStore = defineStore("form-builder-store", () => {
 			let fields = get_updated_fields();
 			let has_error = validate_fields(fields, doc.value.istable);
 			if (has_error) return has_error;
-			doc.value.fields = fields;
+			frm.value.set_value("fields", fields);
 			return fields;
 		} catch (e) {
 			console.error(e);


### PR DESCRIPTION
Problem:
frm.save fails with mandatory error because form builder is modifying `df.name` of newly created docfields. DFs are located by `locals.doctype.docname` and if you change the name it's orphaned.  

This was working so far only because we follow this naming: `new-doctype-#` so it would pick up any arbitrary document and move on.

---

Alternate solution: Since form builder was directly updating `doc.fields` changes were not reflected in underlying model. doing `frm.set_value` prevent this out-of-sync model problems.





closes https://github.com/frappe/frappe/issues/22851 
closes https://github.com/frappe/frappe/issues/22723