### PR TITLE
perf(Grid Table): 60% - 75% faster grid refresh

### DIFF
--- a/frappe/public/js/frappe/dom.js
+++ b/frappe/public/js/frappe/dom.js
@@ -39,7 +39,7 @@ frappe.dom = {
 
 		if (!this.unsafe_tags_regex) {
 			const evil_and_unsafe_tags = evil_tags.concat(unsafe_tags);
-			const regex_str = evil_and_unsafe_tags.map(t => `<([\\s]*)${t}`).join("|");
+			const regex_str = evil_and_unsafe_tags.map((t) => `<([\\s]*)${t}`).join("|");
 			this.unsafe_tags_regex = new RegExp(regex_str, "im");
 		}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -310,7 +310,10 @@ export default class Grid {
 		this.remove_all_rows_button.toggleClass("hidden", !show_delete_all_btn);
 	}
 
-	debounced_refresh_remove_rows_button = frappe.utils.debounce(this.refresh_remove_rows_button, 100)
+	debounced_refresh_remove_rows_button = frappe.utils.debounce(
+		this.refresh_remove_rows_button,
+		100
+	);
 
 	get_selected() {
 		return (this.grid_rows || [])

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -310,6 +310,8 @@ export default class Grid {
 		this.remove_all_rows_button.toggleClass("hidden", !show_delete_all_btn);
 	}
 
+	debounced_refresh_remove_rows_button = frappe.utils.debounce(this.refresh_remove_rows_button, 100)
+
 	get_selected() {
 		return (this.grid_rows || [])
 			.map((row) => {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -90,7 +90,7 @@ export default class GridRow {
 		this.wrapper
 			.find(".grid-row-check")
 			.prop("checked", this.doc ? !!this.doc.__checked : false);
-		this.grid.refresh_remove_rows_button();
+		this.grid.debounced_refresh_remove_rows_button();
 	}
 	remove() {
 		var me = this;


### PR DESCRIPTION
### Issue

`frm.refresh_fields()` or `frm.fields_dict.items.grid.refresh()` is incredibly slow when you have a big document with many child table rows.

For example adding a row to DocType = DocType `fields` table (having around 230 rows) would take around 200ms on powerful laptop.
For slower systems it could take upto 1000ms to add a new row to the `Sales Invoice` DocType

The following parts are slow when running a `Grid.refresh()` and have been addressed in the PR

1. **`frappe.format()`** for each in_list_view field for each `GridRow`'s. And for every `frappe.format()` a computationally expensive `frappe.dom.remove_script_and_style()` is run which parses the formatted string using `DomParser`.
2. During `GridRow.refresh()` a `GridRow.refresh_check()` is run which then calls `Grid.refresh_remove_rows_button()` for each row (though it should only be called once) which runs a computationally expensive jQuery selector lookup to determine the grid buttons.

### Solution
1. Regex check for unsafe tags in `frappe.dom.remove_script_and_style()` so that `DomParser` does not need to be called unnecessarily. `frappe.format()` is called hundreds of times for almost every task, so it should speed up other parts of the UI as well.
2. `Grid.refresh_remove_rows_button()` only needs to be called once, however, I did not want to remove any code so I'm using debounce to prevent multiple calls in one refresh

### Regex

Regex = `<([\s]*)script | ...`

Should match all unsafe tags including:

```
<script>
< script>
<  script>
<

script>
<script >
<script  >
< script >
<  script  >
<script type="javascript>
< script type="javascript>
< script type="javascript >
< script   type="javascript >
<       	     script
<scriptxyz (as well)
<stylexyz (as well)
<style
<meta
...
```

### Screenshots
<details>
  <summary><b>Heavy Case:</b> DocType = DocType, name = Sales Invoice, rows = ~230, action = "Add Row" button. Before: 230ms, After: 55ms</summary>

  **Before**
![SI Before](https://github.com/frappe/frappe/assets/328330/fdef79b4-ecab-4a0e-bcdd-5f07552988c7)

  **After**
![SI After](https://github.com/frappe/frappe/assets/328330/1be13e11-f622-4417-acce-83edd6a7deb8)

</details>

<details>
  <summary><b>Medium Case:</b> DocType = Stock Entry, rows = ~35, action = "Add Row" button. Before: 52ms, After: 20ms</summary>

  **Before**
![STE Before](https://github.com/frappe/frappe/assets/328330/00e5f923-3d7d-4007-9007-4674eea5446b)

  **After**
![STE After](https://github.com/frappe/frappe/assets/328330/4157d780-1be1-4668-80f8-c186ae3c46f0)

</details>