### PR TITLE
fix: don't encode `/` in html escaping

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -253,12 +253,11 @@ Object.assign(frappe.utils, {
 			">": "&gt;",
 			'"': "&quot;",
 			"'": "&#39;",
-			"/": "&#x2F;",
 			"`": "&#x60;",
 			"=": "&#x3D;",
 		};
 
-		return String(txt).replace(/[&<>"'`=/]/g, (char) => escape_html_mapping[char] || char);
+		return String(txt).replace(/[&<>"'`=]/g, (char) => escape_html_mapping[char] || char);
 	},
 
 	unescape_html: function (txt) {
@@ -268,13 +267,12 @@ Object.assign(frappe.utils, {
 			"&gt;": ">",
 			"&quot;": '"',
 			"&#39;": "'",
-			"&#x2F;": "/",
 			"&#x60;": "`",
 			"&#x3D;": "=",
 		};
 
 		return String(txt).replace(
-			/&amp;|&lt;|&gt;|&quot;|&#39;|&#x2F;|&#x60;|&#x3D;/g,
+			/&amp;|&lt;|&gt;|&quot;|&#39;|&#x60;|&#x3D;/g,
 			(char) => unescape_html_mapping[char] || char
 		);
 	},


### PR DESCRIPTION
This isn't really required and `/` is used in user facing text.
