### PR TITLE
fix(UI): Action button design

### DIFF
--- a/frappe/public/js/frappe/ui/page.html
+++ b/frappe/public/js/frappe/ui/page.html
@@ -52,7 +52,7 @@
 					<button class="btn btn-secondary btn-default btn-sm hide"></button>
 					<div class="actions-btn-group hide">
 						<button type="button" class="btn btn-primary btn-sm" data-toggle="dropdown" aria-expanded="false">
-							<span>
+							<span class="flex align-center">
 								<span class="hidden-xs actions-btn-group-label">{%= __("Actions") %}</span>
 								<svg class="icon icon-xs">
 									<use href="#icon-select">


### PR DESCRIPTION
In latest v15 `Action` button design is not arranged properly.

<img width="347" alt="Screenshot 2023-10-23 at 5 48 50 PM" src="https://github.com/frappe/frappe/assets/28840468/ffd28e11-a544-4626-8206-64ea873d8057">

### What's Changed
- Added CSS classes to `Actions` span tag.

<img width="347" alt="Screenshot 2023-10-23 at 5 50 16 PM" src="https://github.com/frappe/frappe/assets/28840468/57f0289f-06dd-4185-952c-f9abe9a067f5">

