### PR TITLE
fix: skip invalid numbers on SMS `receiver_list`

### DIFF
--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -30,7 +30,7 @@ def validate_receiver_nos(receiver_list):
 	validated_receiver_list = []
 	for d in receiver_list:
 		if not d:
-			break
+			continue
 
 		# remove invalid character
 		for x in [" ", "-", "(", ")"]:


### PR DESCRIPTION
This PR switches the loop in the `validate_receiver_nos` function in the SMS Settings Doctype from `break` to `continue`.

The prior functionality would throw an error if any recipients on the receiver_list were invalid, which created an issue with SMS notifications that send to a user role, since any user without a valid mobile phone number would prevent the notification sending to any users (even those with valid mobile numbers).

By switching the loop from `break` to `continue`, the function still eliminates invalid entries and enforces the existence of at least one valid phone number, but doesn't break sending based on a single absent or invalid recipient entry.