### PR TITLE
fix: Strip HTML tags from SMS Notifications

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -305,7 +305,7 @@ def get_context(context):
 	def send_sms(self, doc, context):
 		send_sms(
 			receiver_list=self.get_receiver_list(doc, context),
-			msg=frappe.render_template(self.message, context),
+			msg=frappe.utils.strip_html_tags(frappe.render_template(self.message, context)),
 		)
 
 	def get_list_of_recipients(self, doc, context):


### PR DESCRIPTION
Notification Doctypes use the Text Editor widget, which injects HTML tags in the markup. These are not relevant for SMS messages and should be removed.
