### PR TITLE
fix: ignore workspace links on delete

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -418,6 +418,7 @@ ignore_links_on_delete = [
 	"Integration Request",
 	"Unhandled Email",
 	"Webhook Request Log",
+	"Workspace",
 ]
 
 # Request Hooks


### PR DESCRIPTION
These can be manually modified later. It's not important to completely block and prevent deletion.

related https://github.com/frappe/erpnext/pull/37668