### PR TITLE
fix: Footer should show up once at end if not repeating header/footer

### DIFF
--- a/frappe/templates/print_formats/standard.html
+++ b/frappe/templates/print_formats/standard.html
@@ -6,19 +6,6 @@
 		{{ add_header(loop.index, layout|len, doc, letter_head, no_letterhead, footer, print_settings, print_heading_template) }}
 	</div>
 
-	{% if print_settings.repeat_header_footer %}
-	<div id="footer-html" class="visible-pdf">
-		{% if not no_letterhead and footer %}
-		<div class="letter-head-footer">
-			{{ footer }}
-		</div>
-		{% endif %}
-		<p class="text-center small page-number visible-pdf">
-			{{ _("Page {0} of {1}").format('<span class="page"></span>', '<span class="topage"></span>') }}
-		</p>
-	</div>
-	{% endif %}
-
 	{% for section in page %}
 	<div class="row section-break" data-label="{{ section.label or '' | e }}">
 		{%- if doc.print_line_breaks and loop.index != 1 -%}<hr>{%- endif -%}
@@ -35,5 +22,16 @@
 		{% endfor %}
 	</div>
 	{% endfor %}
+
+	<div {% if print_settings.repeat_header_footer %} id="footer-html" class="visible-pdf" {% endif %}>
+		{% if not no_letterhead and footer %}
+		<div class="letter-head-footer">
+			{{ footer }}
+		</div>
+		{% endif %}
+		<p class="text-center small page-number visible-pdf">
+			{{ _("Page {0} of {1}").format('<span class="page"></span>', '<span class="topage"></span>') }}
+		</p>
+	</div>
 </div>
 {% endfor %}

--- a/frappe/templates/print_formats/standard.html
+++ b/frappe/templates/print_formats/standard.html
@@ -29,9 +29,11 @@
 			{{ footer }}
 		</div>
 		{% endif %}
-		<p class="text-center small page-number visible-pdf">
-			{{ _("Page {0} of {1}").format('<span class="page"></span>', '<span class="topage"></span>') }}
-		</p>
+		{% if print_settings.repeat_header_footer %}
+			<p class="text-center small page-number visible-pdf">
+				{{ _("Page {0} of {1}").format('<span class="page"></span>', '<span class="topage"></span>') }}
+			</p>
+		{% endif %}
 	</div>
 </div>
 {% endfor %}


### PR DESCRIPTION
- Create letter head with header and footer
- Go to print settings and disable "repeat header and footer"
- print document with letterhead -> only header shows up. 

Expected design after this:

|     | repeat=off | repeat=on | 
|--- |--- |--- |
| Header | very first element in document | first element on every page | 
| Footer | last element just after end of content | always at bottom |