### PR TITLE
fix!: revert UI behavior of `fetch_if_empty`

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -244,9 +244,10 @@
   },
   {
    "default": "0",
+   "description": "If unchecked, the value will always be re-fetched on save.",
    "fieldname": "fetch_if_empty",
    "fieldtype": "Check",
-   "label": "Fetch only if value is not set"
+   "label": "Fetch on Save if Empty"
   },
   {
    "fieldname": "permissions",
@@ -565,7 +566,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-06-08 19:05:10.778371",
+ "modified": "2023-10-25 06:53:45.194081",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -153,10 +153,10 @@
   },
   {
    "default": "0",
-   "description": "If checked, this field will be not overwritten based on Fetch From if a value already exists.",
+   "description": "If unchecked, the value will always be re-fetched on save.",
    "fieldname": "fetch_if_empty",
    "fieldtype": "Check",
-   "label": "Fetch If Empty"
+   "label": "Fetch on Save if Empty"
   },
   {
    "fieldname": "options_help",
@@ -450,7 +450,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-06-08 19:05:51.737234",
+ "modified": "2023-10-25 06:55:10.713382",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -193,10 +193,10 @@
   },
   {
    "default": "0",
-   "description": "If checked, this field will be not overwritten based on Fetch From if a value already exists.",
+   "description": "If unchecked, the value will always be re-fetched on save.",
    "fieldname": "fetch_if_empty",
    "fieldtype": "Check",
-   "label": "Fetch If Empty"
+   "label": "Fetch on Save if Empty"
   },
   {
    "fieldname": "permissions",
@@ -477,7 +477,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-06-08 19:05:37.767838",
+ "modified": "2023-10-25 06:55:50.718441",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -592,19 +592,13 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			let field_value = "";
 			for (const [target_field, source_field] of Object.entries(fetch_map)) {
 				if (value) field_value = response[source_field];
-				let target_df = frappe.meta.get_docfield(df.parent, target_field);
-				let target_value = frappe.model.get_value(df.parent, docname, target_field);
-				if (target_df?.fetch_if_empty && target_value) {
-					continue;
-				} else {
-					frappe.model.set_value(
-						df.parent,
-						docname,
-						target_field,
-						field_value,
-						df.fieldtype
-					);
-				}
+				frappe.model.set_value(
+					df.parent,
+					docname,
+					target_field,
+					field_value,
+					df.fieldtype
+				);
 			}
 		}
 


### PR DESCRIPTION
### Rationale

As per the [original design](https://github.com/frappe/frappe/pull/6991), Fetch if Empty was supposed to have it's effect only when saving the document. The same was also documented in the field's [original description](https://user-images.githubusercontent.com/16315650/53428304-8b273100-3a10-11e9-8039-c8ec3026624a.png). Most usage in ERPNext (54 instances) and other development relies on this behavior. Instead of adding fixes like [this one](https://github.com/resilient-tech/india-compliance/pull/1165) in all such places, we have decided to revert the UI behavior introduced in [#19586](https://github.com/frappe/frappe/pull/19586).

### Discarded Alternatives

Keeping existing behavior and updating older usage was considered. This was discarded because it impacts all related development/customization done before Aug 2023 in ERPNext, custom apps and using Customize Form.

### Notes

Updated label and description of the field based on discussion with @bosue and @ruchamahabal:


![Screenshot-2023-10-26-150012](https://github.com/frappe/frappe/assets/16315650/7399c74d-1aac-4a49-8d42-280ce4095fce)



I don't think we need the current "Fetch Only if Not Set" behavior out-of-the-box as of now.