### PR TITLE
fix(minor): hide grid row on modal close

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -90,6 +90,8 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				me.display = false;
 				me.is_minimized = false;
 				me.hide_scrollbar(false);
+				// hide any grid row form if open
+				frappe.ui.form.get_open_grid_form()?.hide_form();
 
 				if (frappe.ui.open_dialogs[frappe.ui.open_dialogs.length - 1] === me) {
 					frappe.ui.open_dialogs.pop();


### PR DESCRIPTION
Sometimes grid row is open in modal and people closes the dialog which closes orphan backdrop and people are unable to access UI.

check if grid row is open and hide it on hide of modal.

https://github.com/frappe/frappe/issues/22845#issuecomment-1773711282