### PR TITLE
fix(socketio): send correct url for auth

### DIFF
--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -1,8 +1,19 @@
+const { get_conf } = require("../node_utils");
+const conf = get_conf();
+
 function get_url(socket, path) {
 	if (!path) {
 		path = "";
 	}
-	return socket.request.headers.origin + path;
+	let url = socket.request.headers.origin;
+	if (conf.developer_mode) {
+		let [protocal, host, port] = url.split(':');
+		if (port != conf.webserver_port) {
+			port = conf.webserver_port;
+		}
+		url = `${protocal}:${host}:${port}`;
+	}
+	return url + path;
 }
 
 module.exports = {


### PR DESCRIPTION
Scenario:

An app uses a different frontend stack (Vue) which runs on a separate dev server (Vite) on a different port (8080), when socketio tries to authenticate via `frappe.realtime.get_user_info`, the request fails because the current implementation uses request.host (site:8080) which can be different from the actual frappe server (site:8000).

This change is only required during development.

no-docs: Because this is an internal change, only affects developer environment.

