### PR TITLE
fix: Reload whenever the effective language or timezone has changed.

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.js
+++ b/frappe/core/doctype/system_settings/system_settings.js
@@ -45,6 +45,7 @@ frappe.ui.form.on("System Settings", {
 
 		const attr_tuples = [
 			[frm.doc.language, frappe.boot.sysdefaults.language, frappe.boot.user.language],
+			[frm.doc.rounding_method, frappe.boot.sysdefaults.rounding_method], // no user override.
 		];
 
 		if (attr_tuples.some(has_effectively_changed)) {

--- a/frappe/core/doctype/system_settings/system_settings.js
+++ b/frappe/core/doctype/system_settings/system_settings.js
@@ -32,10 +32,24 @@ frappe.ui.form.on("System Settings", {
 			frm.set_value("bypass_restrict_ip_check_if_2fa_enabled", 0);
 		}
 	},
-	on_update: function (frm) {
-		if (frappe.boot.time_zone && frappe.boot.time_zone.system !== frm.doc.time_zone) {
-			// Clear cache after saving to refresh the values of boot.
-			frappe.ui.toolbar.clear_cache();
+	after_save: function (frm) {
+		/**
+		 * Checks whether the effective value has changed.
+		 *
+		 * @param {Array.<string>} - Tuple with new fallback, previous fallback and
+		 *   optionally an override value.
+		 * @returns {boolean} - Whether the resulting value has effectively changed
+		 */
+		const has_effectively_changed = ([new_fallback, prev_fallback, override = undefined]) =>
+			!override && prev_fallback !== new_fallback;
+
+		const attr_tuples = [
+			[frm.doc.language, frappe.boot.sysdefaults.language, frappe.boot.user.language],
+		];
+
+		if (attr_tuples.some(has_effectively_changed)) {
+			frappe.msgprint(__("Refreshing..."));
+			window.location.reload();
 		}
 	},
 	first_day_of_the_week(frm) {

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -114,22 +114,6 @@ frappe.ui.form.on("User", {
 			return;
 		}
 
-		const hasChanged = (doc_attr, boot_attr) => {
-			return doc_attr && boot_attr && doc_attr !== boot_attr;
-		};
-
-		if (
-			doc.name === frappe.session.user &&
-			!doc.__unsaved &&
-			frappe.all_timezones &&
-			(hasChanged(doc.language, frappe.boot.user.language) ||
-				hasChanged(doc.time_zone, frappe.boot.time_zone.user) ||
-				hasChanged(doc.desk_theme, frappe.boot.user.desk_theme))
-		) {
-			frappe.msgprint(__("Refreshing..."));
-			window.location.reload();
-		}
-
 		frm.toggle_display(["sb1", "sb3", "modules_access"], false);
 
 		if (!frm.is_new()) {
@@ -335,10 +319,31 @@ frappe.ui.form.on("User", {
 			},
 		});
 	},
-	on_update: function (frm) {
-		if (frappe.boot.time_zone && frappe.boot.time_zone.user !== frm.doc.time_zone) {
-			// Clear cache after saving to refresh the values of boot.
-			frappe.ui.toolbar.clear_cache();
+	after_save: function (frm) {
+		/**
+		 * Checks whether the effective value has changed.
+		 *
+		 * @param {Array.<string>} - Tuple with new override, previous override,
+		 *   and optionally fallback.
+		 * @returns {boolean} - Whether the resulting value has effectively changed
+		 */
+		const has_effectively_changed = ([new_override, prev_override, fallback = undefined]) => {
+			const prev_effective = prev_override || fallback;
+			const new_effective = new_override || fallback;
+			return new_override !== undefined && prev_effective !== new_effective;
+		};
+
+		const doc = frm.doc;
+		const boot = frappe.boot;
+		const attr_tuples = [
+			[doc.language, boot.user.language, boot.sysdefaults.language],
+			[doc.time_zone, boot.time_zone.user, boot.time_zone.system],
+			[doc.desk_theme, boot.user.desk_theme], // No system default.
+		];
+
+		if (doc.name === frappe.session.user && attr_tuples.some(has_effectively_changed)) {
+			frappe.msgprint(__("Refreshing..."));
+			window.location.reload();
 		}
 	},
 });


### PR DESCRIPTION
This should finally fix our “reload upon language or timezone change“ logic:

- To determine whether a reload is needed, we need to take both the system fallback and the current user’s override into account:
   - Changing the current user’s override from “en” to “” or the other way around will not cause any effective change if the system fallback is already “en”, but it will if the system fallback is “fr.”
   - Changing the system fallback from “en” to “fr” will only cause an effective change to the current user if no user override is in place.

- An `on_update` event is never triggered because it doesn‘t exist. So move everything back to where it was before 576efed and consolidate with the code later added to the `refresh` event.

- On System Settings, the time zone has been read-only for years now, so may be left out. But changing the system language may require a reload, so added this one instead.

Two or three more things a reviewer might want to consider:

- On the user level, we‘ve been automatically replacing an empty time zone override by the system time zone. We don‘t have to. A user might want to go with whatever the system time zone is.

- I‘m still unsure if upon changing the user time zone, we really need a reload or if properly setting `boot.time_zone` might do. Given this is such a minor annoyance in a rare case, we may not care though.

- ~While slightly over the top for comparing just a single attribute in System Setting, I left a generic (arrow) function in place, so more attribute checks may be easily added at a later point. We may further condense it, but I think it‘s alright as it is.~ Added a second one and slightly refactored it, so it’s just fine now and easy to add more tuples whenever needed.

Fixes #22644. Fixes #22944. Fixes frappe/erpnext#25650.