### PR TITLE
fix: developer mode in website theme

### DIFF
--- a/frappe/website/doctype/website_theme/website_theme.js
+++ b/frappe/website/doctype/website_theme/website_theme.js
@@ -8,7 +8,7 @@ frappe.ui.form.on("Website Theme", {
 
 	refresh(frm) {
 		frm.clear_custom_buttons();
-		frm.toggle_display(["module", "custom"], !frappe.boot.developer_mode);
+		frm.toggle_display(["module", "custom"], frappe.boot.developer_mode);
 
 		frm.trigger("set_default_theme_button_and_indicator");
 		frm.trigger("make_app_theme_selector");


### PR DESCRIPTION
When developer_mode is active the fields module and custom are hidden in docType 'Website Theme' and vice versa.

this should also be backported to:
* version-13-hotfix
* version-14-hotfix