### PR TITLE
feat: added  "Dashboard Chart" button

### DIFF
--- a/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.js
+++ b/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.js
@@ -1,4 +1,15 @@
 // Copyright (c) 2019, Frappe Technologies and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on("Dashboard Chart Source", {});
+frappe.ui.form.on("Dashboard Chart Source", {
+	refresh: function (frm) {
+		if (!frm.is_new()){
+			frm.add_custom_button(__('Dashboard Chart'), function () {
+				let dashboard_chart = frappe.model.get_new_doc("Dashboard Chart");
+				dashboard_chart.chart_type = "Custom"
+				dashboard_chart.source = frm.doc.name
+				frappe.set_route('Form', "Dashboard Chart", dashboard_chart.name);
+			}, __("Create"));
+		}
+	}
+});

--- a/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.js
+++ b/frappe/desk/doctype/dashboard_chart_source/dashboard_chart_source.js
@@ -3,13 +3,17 @@
 
 frappe.ui.form.on("Dashboard Chart Source", {
 	refresh: function (frm) {
-		if (!frm.is_new()){
-			frm.add_custom_button(__('Dashboard Chart'), function () {
-				let dashboard_chart = frappe.model.get_new_doc("Dashboard Chart");
-				dashboard_chart.chart_type = "Custom"
-				dashboard_chart.source = frm.doc.name
-				frappe.set_route('Form', "Dashboard Chart", dashboard_chart.name);
-			}, __("Create"));
+		if (!frm.is_new()) {
+			frm.add_custom_button(
+				__("Dashboard Chart"),
+				function () {
+					let dashboard_chart = frappe.model.get_new_doc("Dashboard Chart");
+					dashboard_chart.chart_type = "Custom";
+					dashboard_chart.source = frm.doc.name;
+					frappe.set_route("Form", "Dashboard Chart", dashboard_chart.name);
+				},
+				__("Create")
+			);
 		}
-	}
+	},
 });


### PR DESCRIPTION
This commit adds a new "Dashboard Chart" button to the dashboard chart source  interface. The button is designed to create a dashboard chart directly from the dashboard chart source, simplifying the process of chart creation for our users.

https://github.com/frappe/frappe/assets/105106551/4d023a23-ec91-42f2-9ced-d88c73fd8bf2

no-docs