### PR TITLE
refactor!: remove redundant sending of translations

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -132,16 +132,6 @@ def as_unicode(text: str, encoding: str = "utf-8") -> str:
 		return str(text)
 
 
-def get_lang_dict(fortype: str, name: str | None = None) -> dict[str, str]:
-	"""Returns the translated language dict for the given type and name.
-
-	:param fortype: must be one of `doctype`, `page`, `report`, `include`, `jsfile`, `boot`
-	:param name: name of the document for which assets are to be returned."""
-	from frappe.translate import get_dict
-
-	return get_dict(fortype, name)
-
-
 def set_user_lang(user: str, user_language: str | None = None) -> None:
 	"""Guess and set user language for the session. `frappe.local.lang`"""
 	from frappe.translate import get_user_lang

--- a/frappe/core/doctype/page/page.py
+++ b/frappe/core/doctype/page/page.py
@@ -173,11 +173,6 @@ class Page(Document):
 					# flag for not caching this page
 					self._dynamic_page = True
 
-		if frappe.lang != "en":
-			from frappe.translate import get_lang_js
-
-			self.script += get_lang_js("page", self.name)
-
 		for path in get_code_files_via_hooks("page_js", self.name):
 			js = get_js(path)
 			if js:

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
-import io
 import os
 
 import frappe
@@ -44,9 +43,6 @@ def get_meta(doctype, cached=True) -> "FormMeta":
 			frappe.cache.hset("doctype_form_meta", doctype, meta)
 	else:
 		meta = FormMeta(doctype)
-
-	if frappe.local.lang != "en":
-		meta.set_translations(frappe.local.lang)
 
 	return meta
 
@@ -255,18 +251,6 @@ class FormMeta(Meta):
 					templates[key] = get_html_format(frappe.get_app_path(app, path))
 
 				self.set("__form_grid_templates", templates)
-
-	def set_translations(self, lang):
-		from frappe.translate import extract_messages_from_code, make_dict_from_messages
-
-		self.set("__messages", frappe.get_lang_dict("doctype", self.name))
-
-		# set translations for grid templates
-		if self.get("__form_grid_templates"):
-			for content in self.get("__form_grid_templates").values():
-				messages = extract_messages_from_code(content)
-				messages = make_dict_from_messages(messages)
-				self.get("__messages").update(messages)
 
 	def load_dashboard(self):
 		self.set("__dashboard", self.get_dashboard_data())

--- a/frappe/geo/country_info.py
+++ b/frappe/geo/country_info.py
@@ -8,6 +8,7 @@ import os
 from functools import lru_cache
 
 import frappe
+from frappe.utils.deprecations import deprecated
 from frappe.utils.momentjs import get_all_timezones
 
 
@@ -38,7 +39,12 @@ def _get_country_timezone_info():
 	return {"country_info": get_all(), "all_timezones": get_all_timezones()}
 
 
+@deprecated
 def get_translated_dict():
+	return get_translated_countries()
+
+
+def get_translated_countries():
 	from babel.dates import Locale
 
 	translated_dict = {}

--- a/frappe/geo/country_info.py
+++ b/frappe/geo/country_info.py
@@ -39,27 +39,16 @@ def _get_country_timezone_info():
 
 
 def get_translated_dict():
-	from babel.dates import Locale, get_timezone, get_timezone_name
+	from babel.dates import Locale
 
 	translated_dict = {}
 	locale = Locale.parse(frappe.local.lang, sep="-")
-
-	# timezones
-	for tz in get_all_timezones():
-		timezone_name = get_timezone_name(get_timezone(tz), locale=locale, width="short")
-		if timezone_name:
-			translated_dict[tz] = timezone_name + " - " + tz
 
 	# country names && currencies
 	for country, info in get_all().items():
 		country_name = locale.territories.get((info.get("code") or "").upper())
 		if country_name:
 			translated_dict[country] = country_name
-
-		currency = info.get("currency")
-		currency_name = locale.currencies.get(currency)
-		if currency_name:
-			translated_dict[currency] = currency_name
 
 	return translated_dict
 

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -269,11 +269,6 @@ scheduler_events = {
 	],
 }
 
-get_translated_dict = {
-	("doctype", "System Settings"): "frappe.geo.country_info.get_translated_dict",
-	("page", "setup-wizard"): "frappe.geo.country_info.get_translated_dict",
-}
-
 sounds = [
 	{"name": "email", "src": "/assets/frappe/sounds/email.mp3", "volume": 0.1},
 	{"name": "submit", "src": "/assets/frappe/sounds/submit.mp3", "volume": 0.1},

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -16,7 +16,7 @@ $.extend(frappe.meta, {
 		$.each(doc.fields, function (i, df) {
 			frappe.meta.add_field(df);
 		});
-		frappe.meta.sync_messages(doc);
+
 		if (doc.__print_formats) frappe.model.sync(doc.__print_formats);
 		if (doc.__workflow_docs) frappe.model.sync(doc.__workflow_docs);
 	},
@@ -279,12 +279,6 @@ $.extend(frappe.meta, {
 		}
 
 		return print_format_list;
-	},
-
-	sync_messages: function (doc) {
-		if (doc.__messages) {
-			$.extend(frappe._messages, doc.__messages);
-		}
 	},
 
 	get_field_currency: function (df, doc) {

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -194,18 +194,18 @@ class TestFilters(FrappeTestCase):
 class TestMoney(FrappeTestCase):
 	def test_money_in_words(self):
 		nums_bhd = [
-			(5000, "BHD Five Thousand only."),
-			(5000.0, "BHD Five Thousand only."),
+			(5000, "Bahraini Dinar Five Thousand only."),
+			(5000.0, "Bahraini Dinar Five Thousand only."),
 			(0.1, "One Hundred Fils only."),
-			(0, "BHD Zero only."),
+			(0, "Bahraini Dinar Zero only."),
 			("Fail", ""),
 		]
 
 		nums_ngn = [
-			(5000, "NGN Five Thousand only."),
-			(5000.0, "NGN Five Thousand only."),
+			(5000, "Nigerian Naira Five Thousand only."),
+			(5000.0, "Nigerian Naira Five Thousand only."),
 			(0.1, "Ten Kobo only."),
-			(0, "NGN Zero only."),
+			(0, "Nigerian Naira Zero only."),
 			("Fail", ""),
 		]
 

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -194,18 +194,18 @@ class TestFilters(FrappeTestCase):
 class TestMoney(FrappeTestCase):
 	def test_money_in_words(self):
 		nums_bhd = [
-			(5000, "Bahraini Dinar Five Thousand only."),
-			(5000.0, "Bahraini Dinar Five Thousand only."),
+			(5000, "BHD Five Thousand only."),
+			(5000.0, "BHD Five Thousand only."),
 			(0.1, "One Hundred Fils only."),
-			(0, "Bahraini Dinar Zero only."),
+			(0, "BHD Zero only."),
 			("Fail", ""),
 		]
 
 		nums_ngn = [
-			(5000, "Nigerian Naira Five Thousand only."),
-			(5000.0, "Nigerian Naira Five Thousand only."),
+			(5000, "NGN Five Thousand only."),
+			(5000.0, "NGN Five Thousand only."),
 			(0.1, "Ten Kobo only."),
-			(0, "Nigerian Naira Zero only."),
+			(0, "NGN Zero only."),
 			("Fail", ""),
 		]
 

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -197,12 +197,12 @@ def get_all_translations(lang: str) -> dict[str, str]:
 		return {}
 
 	def _merge_translations():
-		from frappe.geo.country_info import get_translated_dict
+		from frappe.geo.country_info import get_translated_countries
 
 		all_translations = get_translations_from_apps(lang).copy()
 		with suppress(Exception):
 			all_translations.update(get_user_translations(lang))
-			all_translations.update(get_translated_dict())
+			all_translations.update(get_translated_countries())
 
 		return all_translations
 

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -258,10 +258,29 @@ def get_context(context):
 		}
 
 	def load_translations(self, context):
-		translated_messages = frappe.translate.get_dict("doctype", self.doc_type)
-		# Sr is not added by default, had to be added manually
-		translated_messages["Sr"] = _("Sr")
-		context.translated_messages = frappe.as_json(translated_messages)
+		messages = [
+			"Sr",
+			"Attach",
+			self.title,
+			self.introduction_text,
+			self.success_title,
+			self.success_message,
+			self.list_title,
+			self.button_label,
+			self.meta_title,
+			self.meta_description,
+		]
+
+		for field in self.web_form_fields:
+			messages.extend([field.label, field.description])
+			if field.fieldtype == "Select" and field.options:
+				messages.extend(field.options.split("\n"))
+
+		messages.extend(col.label for col in self.list_columns)
+
+		context.translated_messages = frappe.as_json(
+			{message: _(message) for message in messages if message}
+		)
 
 	def load_list_data(self, context):
 		if not self.list_columns:


### PR DESCRIPTION
This code was used to load the specific translations needed for a particular view. A while ago, we've started sending **all** translations to the frontend, regardless of the view (https://github.com/frappe/frappe/pull/18764). Therefore, this became redundant.

The only exception are web forms, which don't receive all translations. I've added a dedicated mechanism to load the required translations for web form.


- [x] update https://github.com/frappe/frappe/wiki/Migrating-to-nightly-version
	- removed functionality of `get_translated_dict` hook
	- stopped translating currency codes and timezones
		- deprecated `get_translated_dict` method. What's remaining is now called `get_translated_countries`
	- general availability of translations for country names