### PR TITLE
fix: font loading on custom website theme

### DIFF
--- a/frappe/public/css/fonts/inter/inter.scss
+++ b/frappe/public/css/fonts/inter/inter.scss
@@ -1,5 +1,5 @@
-/* This file is depricated use Inter.scss instead. */
-/* Backward compatibility */
+// TODO instead of making copy of inter.css find a way to import it.
+// workaround for css import as it fails for custom website_theme_template
 @font-face {
 	font-family: 'Inter V';
 	font-weight: 100 900;

--- a/frappe/public/scss/website/css_variables.scss
+++ b/frappe/public/scss/website/css_variables.scss
@@ -1,9 +1,4 @@
 @import '../common/css_variables.scss';
-@import "../espresso/colors";
-@import "../espresso/spacing";
-@import "../espresso/typography";
-@import "../espresso/shadows";
-@import "../espresso/borders";
 
 // Deprecated but remove after all use is removed as well.
 :root {

--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -1,5 +1,5 @@
 @import 'variables';
-@import "frappe/public/css/fonts/inter/inter.css";
+@import "../../css/fonts/inter/inter.scss";
 @import '../common/quill';
 @import '~bootstrap/scss/bootstrap';
 @import '~cropperjs/dist/cropper.min';

--- a/frappe/website/doctype/website_theme/website_theme_template.scss
+++ b/frappe/website/doctype/website_theme/website_theme_template.scss
@@ -1,8 +1,16 @@
 {% if google_font %}
 @import url("https://fonts.googleapis.com/css2?family={{ google_font.replace(' ', '+') }}:{{ font_properties }}&display=swap");
-$font-family-sans-serif: "{{ google_font }}", -apple-system, BlinkMacSystemFont,
+// backward compatibility. deprecated in v15
+$font-family-sans-serif: "{{ google_font }}", "Inter V", "Inter", -apple-system, BlinkMacSystemFont,
 	"Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
 	"Droid Sans", "Helvetica Neue", sans-serif;
+
+// override font stack if custom font is set in website theme
+:root {
+	--font-stack: "{{ google_font }}", "Inter V", "Inter", -apple-system, BlinkMacSystemFont,
+	"Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+	"Droid Sans", "Helvetica Neue", sans-serif !important;
+}
 {% endif -%}
 
 {% if primary_color %}$primary: {{ frappe.db.get_value('Color', primary_color, 'color') }};{% endif -%}


### PR DESCRIPTION
- added inter.scss as css import is failing in custom website theme
- changed css to inter.scss for website/index.scss
- inter.css is deprecated and should be removed in future
- update --font-stack if custom fonts are used in website theme.
- removed espresso variables from css_variables.scss as they are already imported in variables.scss