### PR TITLE
feat(doc): Document.remove_tag

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1576,6 +1576,12 @@ class Document(BaseDocument):
 
 		DocTags(self.doctype).add(self.name, tag)
 
+	def remove_tag(self, tag):
+		"""Remove a Tag to this document"""
+		from frappe.desk.doctype.tag.tag import DocTags
+
+		DocTags(self.doctype).remove(self.name, tag)
+
 	def get_tags(self):
 		"""Return a list of Tags attached to this document"""
 		from frappe.desk.doctype.tag.tag import DocTags


### PR DESCRIPTION
Added remove_tag API for consistency

---

Although, having a specific namespace for each category of APIs like `Document.tags.remove` would seem nicer IMO

<!-- no-docs -->