### PR TITLE
fix: revert unintentional quick entry default for Address

### DIFF
--- a/frappe/contacts/doctype/address/address.json
+++ b/frappe/contacts/doctype/address/address.json
@@ -148,7 +148,7 @@
  "icon": "fa fa-map-marker",
  "idx": 5,
  "links": [],
- "modified": "2023-10-11 11:48:26.954934",
+ "modified": "2023-10-30 05:50:23.912366",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Address",
@@ -217,7 +217,6 @@
    "write": 1
   }
  ],
- "quick_entry": 1,
  "search_fields": "country, state",
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
refer: https://github.com/frappe/frappe/pull/22604#issuecomment-1746598854

this is causing `links` table to not get set, based on the code defined in [this PR](https://github.com/frappe/frappe/pull/20865)

that's because `cur_frm` isn't available for quick entry.