### PR TITLE
fix: revert to setting `frappe.dynamic_link` instead of using `cur_frm`

### DIFF
--- a/frappe/public/js/frappe/utils/address_and_contact.js
+++ b/frappe/public/js/frappe/utils/address_and_contact.js
@@ -12,7 +12,7 @@ $.extend(frappe.contacts, {
 			$(frm.fields_dict["address_html"].wrapper)
 				.html(frappe.render_template("address_list", frm.doc.__onload))
 				.find(".btn-address")
-				.on("click", () => new_record("Address", frm.doctype, frm.doc.name));
+				.on("click", () => new_record("Address", frm.doc));
 		}
 
 		// render contact
@@ -20,7 +20,7 @@ $.extend(frappe.contacts, {
 			$(frm.fields_dict["contact_html"].wrapper)
 				.html(frappe.render_template("contact_list", frm.doc.__onload))
 				.find(".btn-contact")
-				.on("click", () => new_record("Contact", frm.doctype, frm.doc.name));
+				.on("click", () => new_record("Contact", frm.doc));
 		}
 	},
 	get_last_doc: function (frm) {
@@ -59,14 +59,12 @@ $.extend(frappe.contacts, {
 	},
 });
 
-function new_record(doctype, link_doctype, link_name) {
-	return frappe.new_doc(doctype).then(() => {
-		if (cur_frm.doc.links) {
-			// avoid adding the same link twice
-			return;
-		}
+function new_record(doctype, source_doc) {
+	frappe.dynamic_link = {
+		doctype: source_doc.doctype,
+		doc: source_doc,
+		fieldname: "name",
+	};
 
-		cur_frm.add_child("links", { link_doctype: link_doctype, link_name: link_name });
-		cur_frm.refresh_field("links");
-	});
+	return frappe.new_doc(doctype);
 }


### PR DESCRIPTION
usage of `cur_frm` was introduced in https://github.com/frappe/frappe/pull/20865, and that bit is being reverted in this PR.

### Rationale

the expectation of `cur_frm` does not get fulfilled when creating a new address and contact if quick entry is enabled in Address/Contact either as a regional default ([as in India Compliance](https://github.com/resilient-tech/india-compliance/issues/1014)) or using customize form.

setting `frappe.dynamic_link` works for the normal use-case (`cur_frm` is available) and may also be extended for usage with quick entry in any regional / custom app - [as in India Compliance](https://github.com/resilient-tech/india-compliance/blob/cd8f2902b964773d3dffa2f2b7ac539c43588c0b/india_compliance/public/js/quick_entry.js#L294).

Earlier attempt: https://github.com/frappe/frappe/pull/22690
Note: backport not required for v14.