### PR TITLE
refactor: Writing multi-pdf

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -1,4 +1,5 @@
 import os
+from io import BytesIO
 
 from pypdf import PdfWriter
 
@@ -61,7 +62,7 @@ def download_multi_pdf(
 
 	import json
 
-	output = PdfWriter()
+	pdf_writer = PdfWriter()
 
 	if isinstance(options, str):
 		options = json.loads(options)
@@ -71,12 +72,12 @@ def download_multi_pdf(
 
 		# Concatenating pdf files
 		for i, ss in enumerate(result):
-			output = frappe.get_print(
+			pdf_writer = frappe.get_print(
 				doctype,
 				ss,
 				format,
 				as_pdf=True,
-				output=output,
+				output=pdf_writer,
 				no_letterhead=no_letterhead,
 				letterhead=letterhead,
 				pdf_options=options,
@@ -88,12 +89,12 @@ def download_multi_pdf(
 		for doctype_name in doctype:
 			for doc_name in doctype[doctype_name]:
 				try:
-					output = frappe.get_print(
+					pdf_writer = frappe.get_print(
 						doctype_name,
 						doc_name,
 						format,
 						as_pdf=True,
-						output=output,
+						output=pdf_writer,
 						no_letterhead=no_letterhead,
 						letterhead=letterhead,
 						pdf_options=options,
@@ -107,19 +108,11 @@ def download_multi_pdf(
 					)
 		frappe.local.response.filename = f"{name}.pdf"
 
-	frappe.local.response.filecontent = read_multi_pdf(output)
+	with BytesIO() as merged_pdf:
+		pdf_writer.write(merged_pdf)
+		frappe.local.response.filecontent = merged_pdf.getvalue()
+
 	frappe.local.response.type = "pdf"
-
-
-def read_multi_pdf(output):
-	# Get the content of the merged pdf files
-	fname = os.path.join("/tmp", f"frappe-pdf-{frappe.generate_hash()}.pdf")
-	output.write(open(fname, "wb"))
-
-	with open(fname, "rb") as fileobj:
-		filedata = fileobj.read()
-
-	return filedata
 
 
 @frappe.whitelist(allow_guest=True)


### PR DESCRIPTION
- rename variables, output -> pdf_writer
- write to in memory stream instead of disk
