### PR TITLE
chore: print full path to backup

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -336,7 +336,7 @@ class BackupGenerator:
 
 		for _type, info in backup_summary.items():
 			template = f"{{0:{title}}}: {{1:{path}}} {{2}}"
-			print(template.format(_type.title(), info["path"], info["size"]))
+			print(template.format(_type.title(), os.path.abspath(info["path"]), info["size"]))
 
 	def backup_files(self):
 		for folder in ("public", "private"):


### PR DESCRIPTION
The relative path is fine to pass to `bench restore`, but since you can run the command while you may not be in the site directory, having the full path is useful if you want to check the file externally / back it up somewhere, etc.