### PR TITLE
fix: Validate invalid links in fetch_from dependency fields

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -782,8 +782,11 @@ class BaseDocument:
 					else:
 						values_to_fetch = ["name"] + [_df.fetch_from.split(".")[-1] for _df in fields_to_fetch]
 
+						# fallback to dict with field_to_fetch=None if link field value is not found
+						# (for compatibility, `values` must have same data type)
+						empty_values = _dict({value: None for value in values_to_fetch})
 						# don't cache if fetching other values too
-						values = frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True)
+						values = frappe.db.get_value(doctype, docname, values_to_fetch, as_dict=True) or empty_values
 
 				if getattr(frappe.get_meta(doctype), "issingle", 0):
 					values.name = doctype


### PR DESCRIPTION
**Before:**
- Consider a link field **A**, that is used to fetch values into field **B** (`fetch_from: A.name`)
- If **A** had an invalid value, no error was thrown
- Here, Serial no is a link field that is used to fetch information into a data field. We try setting a non-existent value in the link field.
  ![2023-10-30 13 26 14](https://github.com/frappe/frappe/assets/25857446/e2511589-3066-4c38-973d-de5975a36e2f)

- Issue: values was `None` in the case that there were fields to fetch and the link field value is non-existent. Since there is no handling for `if not values`, no error was thrown

**After:**
- Make sure `values` is always a dict, even if the field is non-existent
![2023-10-30 13 24 43](https://github.com/frappe/frappe/assets/25857446/645ddda8-2bd6-427d-a071-36d08b69e6e3)
