### PR TITLE
fix: Improve feedback when bulk editing fails.

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -233,7 +233,7 @@ class Document(BaseDocument):
 		frappe.flags.error_message = (
 			_("Insufficient Permission for {0}").format(self.doctype) + f" ({frappe.bold(_(perm_type))})"
 		)
-		raise frappe.PermissionError
+		frappe.throw(frappe.flags.error_message, frappe.PermissionError, _("Error"))
 
 	def insert(
 		self,

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -286,17 +286,24 @@ export default class BulkOperations {
 					.then((r) => {
 						let failed = r.message || [];
 
-						if (failed.length && !r._server_messages) {
-							dialog.enable_primary_action();
-							frappe.throw(
-								__("Cannot update {0}", [
-									failed.map((f) => (f.bold ? f.bold() : f)).join(", "),
-								])
-							);
+						if (failed.length) {
+							if (!r._server_messages) {
+								dialog.enable_primary_action();
+								frappe.throw(
+									__("Cannot update {0}", [
+										failed.map((f) => (f.bold ? f.bold() : f)).join(", "),
+									])
+								);
+							}
+							if (failed.length < docnames.length) {
+								done();
+								frappe.show_alert(__("Some documents were updated."));
+							}
+						} else {
+							done();
+							frappe.show_alert(__("Updated successfully"));
 						}
-						done();
 						dialog.hide();
-						frappe.show_alert(__("Updated successfully"));
 					});
 			},
 			primary_action_label: __("Update {0} records", [docnames.length]),


### PR DESCRIPTION
Fixes #22964.

Improves the feedback given when:
- some or all bulk edits failed for whatever reason
- editing a document failed for insufficient permission