### PR TITLE
fix(minor): mobile menu & sidebar attachment text

### DIFF
--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -407,15 +407,17 @@ body[data-route^="Module"] .main-menu {
 	margin-bottom: 3px;
 	max-width: 100%;
 	.data-pill {
+		@include get_textstyle("sm", "regular");
 		justify-content: space-between;
 		box-shadow: none;
+		line-height: 1;
 	}
 }
 .attachment-row {
 	.data-pill {
 		background-color: unset;
 		box-shadow: none;
-		padding:0 var(--padding-xs) 0 var(--padding-md);
+		padding: 0 var(--padding-xs) 0 var(--padding-md) !important;
 	}
 }
 

--- a/frappe/public/scss/website/navbar.scss
+++ b/frappe/public/scss/website/navbar.scss
@@ -22,6 +22,17 @@
 @media (max-width: map-get($grid-breakpoints, "lg")) {
 	.navbar {
 		padding: 0 1rem;
+
+		.navbar-search {
+			width: 75vw;
+		}
+	}
+}
+@media (max-width: map-get($grid-breakpoints, "sm")) {
+	.navbar-collapse.collapse.show {
+		.navbar-nav {
+			align-items: flex-start;
+		}
 	}
 }
 


### PR DESCRIPTION
- Added Mobile Menu to be  left Aligned until SM Breakpoint.
- Attachment Text in Sidebar is now smaller to match the rest of the text
- fixed close icon aligned in form tags that broken by .btn padding

### Navbar on different breakpoints
https://github.com/frappe/frappe/assets/39730881/f629c5d1-386a-47ff-b2d2-1442b1a0a6e4




### Sidebar Text and form tags
![Screenshot 2023-10-31 at 1 37 37 PM](https://github.com/frappe/frappe/assets/39730881/0c8bda43-03e8-4620-9a38-a4c6389ef161)
