### PR TITLE
perf: Improve link checks during cancellation

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -870,6 +870,7 @@ class DocType(Document):
 						"read_only": 1,
 						"print_hide": 1,
 						"no_copy": 1,
+						"search_index": 1,
 					},
 				)
 

--- a/frappe/core/doctype/recorder/recorder.js
+++ b/frappe/core/doctype/recorder/recorder.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Recorder", {
+	onload: function (frm) {
+		frm.fields_dict.sql_queries.grid.only_sortable();
+	},
 	refresh: function (frm) {
 		frm.disable_save();
 		frm._sort_order = {};

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -71,7 +71,7 @@ class SubmittableDocumentTree:
 
 	def get_all_children(self):
 		"""Get all nodes of a tree except the root node (all the nested submitted
-		documents those are present in referencing tables (dependent tables).
+		documents those are present in referencing tables dependent tables).
 		"""
 		while self.to_be_visited_documents:
 			next_level_children = defaultdict(list)
@@ -101,6 +101,10 @@ class SubmittableDocumentTree:
 
 		child_docs = defaultdict(list)
 		for field in referencing_fields:
+			if field["fieldname"] == "amended_from":
+				# perf: amended_from links are always linked to cancelled documents.
+				continue
+
 			links = (
 				get_referencing_documents(
 					parent_dt,

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -245,11 +245,16 @@ def check_if_doc_is_linked(doc, method="Delete"):
 	from frappe.model.rename_doc import get_link_fields
 
 	link_fields = get_link_fields(doc.doctype)
-	ignore_linked_doctypes = doc.get("ignore_linked_doctypes") or []
+	ignored_doctypes = set()
+
+	if method == "Cancel" and (doc_ignore_flags := doc.get("ignore_linked_doctypes")):
+		ignored_doctypes.update(doc_ignore_flags)
+	if method == "Delete":
+		ignored_doctypes.update(frappe.get_hooks("ignore_links_on_delete"))
 
 	for lf in link_fields:
 		link_dt, link_field, issingle = lf["parent"], lf["fieldname"], lf["issingle"]
-		if link_field == "amended_from":
+		if link_dt in ignored_doctypes or link_field == "amended_from":
 			continue
 
 		try:
@@ -272,12 +277,9 @@ def check_if_doc_is_linked(doc, method="Delete"):
 		for item in frappe.db.get_values(link_dt, {link_field: doc.name}, fields, as_dict=True):
 			# available only in child table cases
 			item_parent = getattr(item, "parent", None)
-			linked_doctype = item.parenttype if item_parent else link_dt
+			linked_parent_doctype = item.parenttype if item_parent else link_dt
 
-			if linked_doctype in frappe.get_hooks("ignore_links_on_delete") or (
-				linked_doctype in ignore_linked_doctypes and method == "Cancel"
-			):
-				# don't check for communication and todo!
+			if linked_parent_doctype in ignored_doctypes:
 				continue
 
 			if method != "Delete" and (method != "Cancel" or not DocStatus(item.docstatus).is_submitted()):
@@ -290,7 +292,7 @@ def check_if_doc_is_linked(doc, method="Delete"):
 				continue
 			else:
 				reference_docname = item_parent or item.name
-				raise_link_exists_exception(doc, linked_doctype, reference_docname)
+				raise_link_exists_exception(doc, linked_parent_doctype, reference_docname)
 
 
 def check_if_doc_is_dynamically_linked(doc, method="Delete"):

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -249,6 +249,8 @@ def check_if_doc_is_linked(doc, method="Delete"):
 
 	for lf in link_fields:
 		link_dt, link_field, issingle = lf["parent"], lf["fieldname"], lf["issingle"]
+		if link_field == "amended_from":
+			continue
 
 		try:
 			meta = frappe.get_meta(link_dt)
@@ -258,7 +260,7 @@ def check_if_doc_is_linked(doc, method="Delete"):
 			continue
 
 		if issingle:
-			if frappe.db.get_value(link_dt, None, link_field) == doc.name:
+			if frappe.db.get_single_value(link_dt, link_field) == doc.name:
 				raise_link_exists_exception(doc, link_dt, link_dt)
 			continue
 


### PR DESCRIPTION
- perf: Ignore `amended_from` link fields in link field checks
- perf: Make `amended_from` indexed by default
- perf: dont query ignored link doctypes

Unrelated:
- fix(recorder): Always enable sortable

