### PR TITLE
feat: Add image view in Workspace shortcut block

### DIFF
--- a/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
+++ b/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
@@ -44,7 +44,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "DocType View",
-   "options": "\nList\nReport Builder\nDashboard\nTree\nNew\nCalendar\nKanban"
+   "options": "\nList\nReport Builder\nDashboard\nTree\nNew\nCalendar\nKanban\nImage"
   },
   {
    "fieldname": "column_break_4",

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1300,6 +1300,9 @@ Object.assign(frappe.utils, {
 								route += `/${item.kanban_board}`;
 							}
 							break;
+						case "Image":
+							route = `${doctype_slug}/view/image`;
+							break;
 						default:
 							route = doctype_slug;
 					}

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -394,8 +394,9 @@ class ShortcutDialog extends WidgetDialog {
 								this.show_filters();
 							}
 
-							const views = ["List", "Report Builder", "Dashboard", "New", "Image"];
+							const views = ["List", "Report Builder", "Dashboard", "New"];
 							if (meta.is_tree === 1) views.push("Tree");
+							if (meta.image_field) views.push("Image");
 							if (frappe.boot.calendars.includes(doctype)) views.push("Calendar");
 
 							const response = await frappe.db.get_value(

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -394,7 +394,7 @@ class ShortcutDialog extends WidgetDialog {
 								this.show_filters();
 							}
 
-							const views = ["List", "Report Builder", "Dashboard", "New"];
+							const views = ["List", "Report Builder", "Dashboard", "New", "Image"];
 							if (meta.is_tree === 1) views.push("Tree");
 							if (frappe.boot.calendars.includes(doctype)) views.push("Calendar");
 
@@ -427,7 +427,7 @@ class ShortcutDialog extends WidgetDialog {
 				fieldtype: "Select",
 				fieldname: "doc_view",
 				label: "DocType View",
-				options: "List\nReport Builder\nDashboard\nTree\nNew\nCalendar\nKanban",
+				options: "List\nReport Builder\nDashboard\nTree\nNew\nCalendar\nKanban\nImage",
 				description: __(
 					"Which view of the associated DocType should this shortcut take you to?"
 				),


### PR DESCRIPTION
Workspace => In Shortcut added Image view option in doctype view.
![Screenshot from 2023-10-31 23-08-30](https://github.com/frappe/frappe/assets/95605794/02116570-bfd7-4fba-855c-622cbd409ed3)
[Screencast from 31-10-23 11:09:38 PM IST.webm](https://github.com/frappe/frappe/assets/95605794/29239347-e544-4e02-9b67-553ff255cb6c)
![image](https://github.com/frappe/frappe/assets/95605794/18136203-f666-4245-a04f-98a54ad45f61)


>no-docs