### PR TITLE
feat: renamed Reload to Hard Reload

### DIFF
--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -217,7 +217,7 @@ def add_standard_navbar_items():
 			"is_standard": 1,
 		},
 		{
-			"item_label": "Reload",
+			"item_label": "Hard Reload",
 			"item_type": "Action",
 			"action": "frappe.ui.toolbar.clear_cache()",
 			"is_standard": 1,


### PR DESCRIPTION
I have changed Reload to Hard Reload, as this clears the cache when clicked i believe it will be appropriate for Hard Reload and not just Reload

![image](https://github.com/frappe/frappe/assets/85731451/5dc0b94e-3fbc-4c2b-8567-15d75afeac46)
