### PR TITLE
fix(base list): add link_field_title to group_by clause in  base list group by to work with postgres

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -417,7 +417,10 @@ frappe.views.BaseList = class BaseList {
 	get_group_by() {
 		let name_field = this.fields && this.fields.find((f) => f[0] == "name");
 		if (name_field) {
-			return frappe.model.get_full_column_name(name_field[0], name_field[1]);
+			return frappe.model.get_full_column_name(name_field[0], name_field[1]).concat(
+				Object.entries(this.link_field_title_fields || {}).map(
+					(entry) => " ," + entry.join("_")
+				));
 		}
 		return null;
 	}

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -417,10 +417,13 @@ frappe.views.BaseList = class BaseList {
 	get_group_by() {
 		let name_field = this.fields && this.fields.find((f) => f[0] == "name");
 		if (name_field) {
-			return frappe.model.get_full_column_name(name_field[0], name_field[1]).concat(
-				Object.entries(this.link_field_title_fields || {}).map(
-					(entry) => " ," + entry.join("_")
-				));
+			return frappe.model
+				.get_full_column_name(name_field[0], name_field[1])
+				.concat(
+					Object.entries(this.link_field_title_fields || {}).map(
+						(entry) => " ," + entry.join("_")
+					)
+				);
 		}
 		return null;
 	}


### PR DESCRIPTION
## Problem:
- When checking Show Title in Link Fields in view setting in a doctype and using this doctype as a link in another doctype.
- When trying to view the list of the doctype with the link to the first doctype it throws an error regarding postgres that it requires the title field selected to either be in aggregate or group by.

## Solution:
- Add the field  which is being selected from the link doctype to the group_by clause in JavaScript file to included in the postgres query and as the name is already being used in the group_by clause there won't be any issues regarding records with the same field value.