### PR TITLE
fix: Respect "Do Not Track" settings

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -404,7 +404,7 @@ frappe.setup.slides_settings = [
 				fieldname: "enable_telemetry",
 				label: __("Allow sending usage data for improving applications"),
 				fieldtype: "Check",
-				default: 1,
+				default: cint(frappe.telemetry.can_enable()),
 				depends_on: "eval:frappe.telemetry.can_enable()",
 			},
 			{

--- a/frappe/public/js/telemetry/index.js
+++ b/frappe/public/js/telemetry/index.js
@@ -43,7 +43,7 @@ class TelemetryManager {
 	}
 
 	can_enable() {
-		return Boolean(this.telemetry_host && this.project_id);
+		return Boolean(this.telemetry_host && this.project_id && !cint(navigator.doNotTrack));
 	}
 
 	send_heartbeat() {


### PR DESCRIPTION
Don't offer telemetry as option if DNT is set in browser.

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack


- Yes, timing is uncanny: https://stackdiary.com/german-court-bans-linkedin-from-ignoring-do-not-track-signals/
- No, we don't just avoid configured settings. This PR just makes the choice for user on the setup wizard page based on their browser settings to remove those fields.