### PR TITLE
fix: ToDo assignment

### DIFF
--- a/frappe/public/js/frappe/views/interaction.js
+++ b/frappe/public/js/frappe/views/interaction.js
@@ -356,7 +356,7 @@ function get_doc_mappings() {
 				due_date: "date",
 				reference_doctype: "reference_type",
 				reference_document: "reference_name",
-				assigned_to: "owner",
+				assigned_to: "allocated_to",
 			},
 			reqd_fields: ["description"],
 			hidden_fields: ["public", "category"],


### PR DESCRIPTION
**Before:**
- Tasks from CRM activities does not carry assigned_to into allocated_to

**Fix:** 
- Map assigned_to to allocated_to

