### PR TITLE
perf(GlobalSearch): bulk insert queued items

### DIFF
--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -419,7 +419,7 @@ def sync_values(values):
 		if frappe.db.db_type == "mariadb":
 			query = query.on_duplicate_key_update(GlobalSearch[field], Values(field))
 		elif frappe.db.db_type == "postgres":
-			query = query.do_update(GlobalSearch[field], Values(field))
+			query = query.do_update(GlobalSearch[field])
 		else:
 			raise NotImplementedError
 

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -377,8 +377,8 @@ def sync_global_search():
 	from itertools import islice
 
 	def get_search_queue_item_generator():
-		while frappe.cache.llen("global_search_queue") > 0:
-			yield frappe.cache.rpop("global_search_queue")
+		while value := frappe.cache.rpop("global_search_queue"):
+			yield value
 
 	item_generator = get_search_queue_item_generator()
 	while search_items := tuple(islice(item_generator, 10_000)):

--- a/frappe/utils/global_search.py
+++ b/frappe/utils/global_search.py
@@ -11,6 +11,7 @@ import frappe
 from frappe.model.base_document import get_controller
 from frappe.utils import cint, strip_html_tags
 from frappe.utils.data import cstr
+from frappe.utils.deprecations import deprecated
 from frappe.utils.html_utils import unescape_html
 
 HTML_TAGS_PATTERN = re.compile(r"(?s)<[\s]*(script|style).*?</\1>")
@@ -381,11 +382,11 @@ def sync_global_search():
 
 	item_generator = get_search_queue_item_generator()
 	while search_items := tuple(islice(item_generator, 10_000)):
-		values = get_deduped_search_item_values(search_items)
+		values = _get_deduped_search_item_values(search_items)
 		sync_values(values)
 
 
-def get_deduped_search_item_values(items):
+def _get_deduped_search_item_values(items):
 	from collections import OrderedDict
 
 	values_dict = OrderedDict()
@@ -393,16 +394,12 @@ def get_deduped_search_item_values(items):
 		item_json = item.decode("utf-8")
 		item_dict = json.loads(item_json)
 		key = (item_dict["doctype"], item_dict["name"])
-
-		if key in values_dict:
-			del values_dict[key]
-
 		values_dict[key] = tuple(item_dict.values())
 
 	return values_dict.values()
 
 
-def sync_values(values):
+def sync_values(values: list):
 	from pypika.terms import Values
 
 	GlobalSearch = frappe.qb.Table("__global_search")
@@ -432,10 +429,11 @@ def sync_value_in_queue(value):
 		frappe.cache.lpush("global_search_queue", json.dumps(value))
 	except redis.exceptions.ConnectionError:
 		# not connected, sync directly
-		sync_value(value)
+		sync_values((value,))
 
 
-def sync_value(value):
+@deprecated
+def sync_value(value: dict):
 	"""
 	Sync a given document to global search
 	:param value: dict of { doctype, name, content, published, title, route }

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -154,11 +154,11 @@ class RedisWrapper(redis.Redis):
 	def rpush(self, key, value):
 		super().rpush(self.make_key(key), value)
 
-	def lpop(self, key):
-		return super().lpop(self.make_key(key))
+	def lpop(self, key, count = None):
+		return super().lpop(self.make_key(key), count)
 
-	def rpop(self, key):
-		return super().rpop(self.make_key(key))
+	def rpop(self, key, count = None):
+		return super().rpop(self.make_key(key), count)
 
 	def llen(self, key):
 		return super().llen(self.make_key(key))

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -154,11 +154,11 @@ class RedisWrapper(redis.Redis):
 	def rpush(self, key, value):
 		super().rpush(self.make_key(key), value)
 
-	def lpop(self, key, count = None):
-		return super().lpop(self.make_key(key), count)
+	def lpop(self, key):
+		return super().lpop(self.make_key(key))
 
-	def rpop(self, key, count = None):
-		return super().rpop(self.make_key(key), count)
+	def rpop(self, key):
+		return super().rpop(self.make_key(key))
 
 	def llen(self, key):
 		return super().llen(self.make_key(key))


### PR DESCRIPTION
Fixes #14660

Global search queue items are popped and inserted into the `__global_search`
table. This used to happen individually.

This PR bulk inserts them in chunks of 10,000.