### PR TITLE
fix: remove roles for Website User in UI

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -341,6 +341,13 @@ frappe.ui.form.on("User", {
 			frappe.ui.toolbar.clear_cache();
 		}
 	},
+	user_type: function(frm) {
+		if(frm.doc.user_type == "Website User"){
+			frm.set_value("role_profile_name", "");
+			frm.set_value("roles", []);
+			frm.roles_editor.reset();
+		}
+	},
 });
 
 frappe.ui.form.on("User Email", {


### PR DESCRIPTION
Remove roles for Website User in UI.

Before
[before.webm](https://github.com/frappe/frappe/assets/101092028/ce4f6fd0-2a9d-4d28-8bad-fb66f0cc6a77)

After
[after.webm](https://github.com/frappe/frappe/assets/101092028/304783c7-a529-4ef5-82db-42c73fcedaba)
