### PR TITLE
fix: add dedicated add field button at each column (Form Builder)

### DIFF
--- a/cypress/integration/form_builder.js
+++ b/cypress/integration/form_builder.js
@@ -58,16 +58,15 @@ context("Form Builder", () => {
 
 		let first_column = ".tab-content.active .section-columns-container:first .column:first";
 
-		let first_field = first_column + " .field:first";
 		let last_field = first_column + " .field:last";
 
-		let add_new_field_btn = first_field + " .field-actions .add-field-btn";
+		let add_new_field_btn = first_column + " .add-new-field-btn button";
 
 		// add new field
 		cy.get(add_new_field_btn).click();
 
 		// type table and press enter
-		cy.get(".combo-box-options:first .search-box > input").type("table{enter}");
+		cy.get(".combo-box-options:visible .search-box > input").type("table{enter}");
 
 		// save
 		cy.click_doc_primary_button("Save");
@@ -236,16 +235,15 @@ context("Form Builder", () => {
 
 		let first_column = ".tab-content.active .section-columns-container:first .column:first";
 
-		let first_field = first_column + " .field:first";
 		let last_field = first_column + " .field:last";
 
-		let add_new_field_btn = first_field + " .field-actions .add-field-btn";
+		let add_new_field_btn = first_column + " .add-new-field-btn button";
 
 		// add new field
 		cy.get(add_new_field_btn).click();
 
 		// type data and press enter
-		cy.get(".combo-box-options:first .search-box > input").type("data{enter}");
+		cy.get(".combo-box-options:visible .search-box > input").type("data{enter}");
 
 		cy.get(last_field).click();
 

--- a/frappe/public/js/form_builder/FormBuilder.vue
+++ b/frappe/public/js/form_builder/FormBuilder.vue
@@ -244,6 +244,10 @@ onMounted(() => store.fetch());
 								margin-bottom: 5px;
 							}
 						}
+
+						.add-new-field-btn {
+							display: none;
+						}
 					}
 				}
 			}

--- a/frappe/public/js/form_builder/components/AddFieldButton.vue
+++ b/frappe/public/js/form_builder/components/AddFieldButton.vue
@@ -2,11 +2,11 @@
 	<button
 		ref="add_field_btn_ref"
 		class="add-field-btn btn btn-xs btn-icon"
-		:title="__('Add field')"
+		:title="tooltip"
 		@click.stop="toggle_fieldtype_options"
 	>
 		<slot>
-			{{ __("Add a field") }}
+			{{ __("Add field") }}
 		</slot>
 		<Teleport to="#autocomplete-area">
 			<div class="autocomplete" ref="autocomplete_ref">
@@ -42,6 +42,10 @@ const props = defineProps({
 	field: {
 		type: Object,
 		default: null,
+	},
+	tooltip: {
+		type: String,
+		default: __("Add field"),
 	},
 });
 

--- a/frappe/public/js/form_builder/components/Column.vue
+++ b/frappe/public/js/form_builder/components/Column.vue
@@ -176,6 +176,9 @@ function move_columns_to_section() {
 		>
 			<AddFieldButton :column="column" />
 		</div>
+		<div v-if="column.fields.length" class="add-new-field-btn">
+			<AddFieldButton :field="column.fields[column.fields.length - 1]" :column="column" />
+		</div>
 	</div>
 </template>
 
@@ -207,7 +210,7 @@ function move_columns_to_section() {
 			display: flex;
 		}
 
-		.column-container {
+		.column-container:empty {
 			height: 80%;
 		}
 	}
@@ -263,12 +266,12 @@ function move_columns_to_section() {
 	}
 
 	.column-container {
-		flex: 1;
 		min-height: 2rem;
 		border-radius: var(--border-radius);
 		z-index: 1;
 
 		&:empty {
+			flex: 1;
 			& + .empty-column {
 				display: flex;
 				justify-content: center;
@@ -294,6 +297,18 @@ function move_columns_to_section() {
 
 		& + .empty-column {
 			display: none;
+		}
+	}
+
+	.add-new-field-btn {
+		padding: 10px 6px 5px;
+
+		button {
+			background-color: var(--white);
+
+			&:hover {
+				background-color: var(--btn-default-hover-bg);
+			}
 		}
 	}
 }

--- a/frappe/public/js/form_builder/components/Field.vue
+++ b/frappe/public/js/form_builder/components/Field.vue
@@ -111,7 +111,13 @@ onMounted(() => selected.value && label_input.value.focus_on_label());
 			</template>
 			<template #actions>
 				<div class="field-actions" :hidden="store.read_only">
-					<AddFieldButton ref="add_field_ref" :column="column" :field="field">
+					<AddFieldButton
+						v-if="column.fields.indexOf(field) != column.fields.length - 1"
+						ref="add_field_ref"
+						:field="field"
+						:column="column"
+						:tooltip="__('Add field below')"
+					>
 						<div v-html="frappe.utils.icon('add', 'sm')" />
 					</AddFieldButton>
 					<button


### PR DESCRIPTION
Always show the "Add field" button on each column since it was unclear how to add a field.

<img width="1041" alt="image" src="https://github.com/frappe/frappe/assets/30859809/49355dc8-4f2d-4a11-a2bc-0b0c36dcaf3f">
