### PR TITLE
fix(UX): Switch 'Duplicate' and 'Move' buttons on Form Builder.

### DIFF
--- a/frappe/public/js/form_builder/components/Field.vue
+++ b/frappe/public/js/form_builder/components/Field.vue
@@ -115,6 +115,13 @@ onMounted(() => selected.value && label_input.value.focus_on_label());
 						<div v-html="frappe.utils.icon('add', 'sm')" />
 					</AddFieldButton>
 					<button
+						class="btn btn-xs btn-icon"
+						:title="__('Duplicate field')"
+						@click.stop="duplicate_field"
+					>
+						<div v-html="frappe.utils.icon('duplicate', 'sm')"></div>
+					</button>
+					<button
 						v-if="column.fields.indexOf(field)"
 						class="btn btn-xs btn-icon"
 						:title="
@@ -123,13 +130,6 @@ onMounted(() => selected.value && label_input.value.focus_on_label());
 						@click="move_fields_to_column"
 					>
 						<div v-html="frappe.utils.icon('move', 'sm')"></div>
-					</button>
-					<button
-						class="btn btn-xs btn-icon"
-						:title="__('Duplicate field')"
-						@click.stop="duplicate_field"
-					>
-						<div v-html="frappe.utils.icon('duplicate', 'sm')"></div>
 					</button>
 					<button
 						class="btn btn-xs btn-icon"


### PR DESCRIPTION
Before:
![IMG_1999](https://github.com/frappe/frappe/assets/46800703/26c74556-6e3e-4b2b-9bed-efe151b12203)

After:
![IMG_2001](https://github.com/frappe/frappe/assets/46800703/cbbaece7-4f4b-4509-81e9-fe96d97fd94e)

“Add new” and “Duplicate” are similar, so let these two come first.

Also, “Move to new column” should be on the right-hand side as the new column is created to the right. Only the “Close” button needs to be where it always is.

@shariquerik