### PR TITLE
feat(form): Add link to list in mobile sidebar

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -1,3 +1,12 @@
+{% if frm.doctype %}
+<div class="sidebar-menu d-lg-none">
+	<h4>
+		<a href="{{ frappe.utils.generate_route({ type: "doctype", name: frm.doctype }) }}">
+			{{ __(frm.doctype) }}
+		</a>
+	</h4>
+</div>
+{% endif %}
 <ul class="list-unstyled sidebar-menu user-actions hidden"></ul>
 <ul class="list-unstyled sidebar-menu sidebar-image-section hide">
 	<li class="sidebar-image-wrapper">

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -169,10 +169,13 @@ frappe.ui.Page = class Page {
 		if (this.disable_sidebar_toggle || !sidebar_wrapper.length) {
 			sidebar_toggle.remove();
 		} else {
-			sidebar_toggle.attr("title", __("Toggle Sidebar")).tooltip({
-				delay: { show: 600, hide: 100 },
-				trigger: "hover",
-			});
+			sidebar_toggle.attr("title", __("Toggle Sidebar"));
+			if (!frappe.is_mobile()) {
+				sidebar_toggle.tooltip({
+					delay: { show: 600, hide: 100 },
+					trigger: "hover",
+				});
+			}
 			sidebar_toggle.click(() => {
 				if (frappe.utils.is_xs() || frappe.utils.is_sm()) {
 					this.setup_overlay_sidebar();


### PR DESCRIPTION
Add a link to the list view of the form's doctype in mobile sidebar because breadcrumbs are truncated on mobile, making it sometimes difficult to go back to the list after navigating to another document.

Also hide form sidebar tooltip on mobile because it gets stuck on click and becomes annoying.

![image](https://github.com/frappe/frappe/assets/10946971/6d7e255b-1189-4897-a592-715a8ad4c091)

---

Does the link to list view look too bad?

![image](https://github.com/frappe/frappe/assets/10946971/8cff59da-fa02-4916-8fc5-9a9c709ec84e)


> no-docs