### PR TITLE
fix: Provide connected user for SMTP auth to Exchange shared mailboxes.

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -466,7 +466,9 @@ class EmailAccount(Document):
 			"email_account": self.name,
 			"server": self.smtp_server,
 			"port": cint(self.smtp_port),
-			"login": getattr(self, "login_id", None) or self.email_id,
+			"login": getattr(self, "login_id", None)
+			or getattr(self, "connected_user", None)
+			or self.email_id,
 			"password": self._password,
 			"use_ssl": cint(self.use_ssl_for_outgoing),
 			"use_tls": cint(self.use_tls),


### PR DESCRIPTION
Fixes #23079.

Should probably come with a testcase mocking authentication at an Exchange server, but some basic testcase will be better than nothing.