### PR TITLE
fix(minor): web and timeline styles

### DIFF
--- a/frappe/public/js/frappe/form/templates/timeline_message_box.html
+++ b/frappe/public/js/frappe/form/templates/timeline_message_box.html
@@ -1,5 +1,5 @@
 <div class="timeline-message-box" data-communication-type="{{ doc.communication_type }}">
-	<span class="flex justify-between m-1">
+	<span class="flex justify-between m-1 mb-3">
 		<span class="text-color flex">
 			{% if (doc.communication_type && doc.communication_type == "Automated Message") { %}
 				<span>

--- a/frappe/public/scss/desk/timeline.scss
+++ b/frappe/public/scss/desk/timeline.scss
@@ -90,6 +90,7 @@ $threshold: 34;
 			}
 		}
 		.timeline-content {
+			position: relative;
 			max-width: var(--timeline-content-max-width);
 			padding: var(--padding-sm);
 			margin-left: var(--margin-md);
@@ -111,6 +112,7 @@ $threshold: 34;
 						background-color: transparent;
 						border: none;
 						font-weight: var(--weight-semibold);
+						padding: 0;
 					}
 				}
 			}
@@ -130,6 +132,15 @@ $threshold: 34;
 			.content {
 				overflow: auto;
 				max-height: 500px;
+				&::before {
+					content: '';
+					display: block;
+					height: 1px;
+					margin-top: -10px;
+					width: calc(100% - 64px);
+					position: absolute;
+					background-color: var(--border-color);
+				}
 			}
 
 			.actions {
@@ -145,6 +156,9 @@ $threshold: 34;
 				margin-left: var(--margin-sm);
 				background-color: transparent;
 				--icon-stroke: var(--text-muted);
+			}
+			.action-btn, .custom-actions {
+				@include get_textstyle("sm", "regular");
 			}
 
 			.action-btn:hover {

--- a/frappe/public/scss/website/base.scss
+++ b/frappe/public/scss/website/base.scss
@@ -5,7 +5,7 @@ html {
 body {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-	@include get_textstyle("base", "regular");
+	@include get_textstyle("lg", "regular");
 	color: $body-color;
 	display: flex;
 	flex-direction: column;

--- a/frappe/public/scss/website/blog.scss
+++ b/frappe/public/scss/website/blog.scss
@@ -104,7 +104,7 @@
 			margin-bottom: 3rem;
 			margin-top: 5rem;
 		}
-		a {
+		.from-markdown a {
 			text-decoration: underline;
 		}
 	}

--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -168,7 +168,7 @@ a.card {
 	text-decoration: none;
 }
 
-a.card-link {
+a.card-link, a.card-link:hover {
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
### web typography & links
- changed base text size to lg (16px)
- changed link text-decoration underline to only apply to blog content

 
### comment section
- changed actions/button text to sm
- added seprator line between timeline header and body for message box
- removed padding from mention in read-mode of message/comment box

https://github.com/frappe/frappe/assets/39730881/d41dbe4a-0b34-4efd-982e-1e25e9d08460

