### PR TITLE
fix: Make editor editable in grid

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -349,6 +349,13 @@
 			display: none;
 		}
 	}
+
+	.editable-row {
+		.markdown-container {
+			position: relative;
+			z-index: 1;
+		}
+	}
 }
 
 @mixin base-grid() {


### PR DESCRIPTION
**Before:** 
<img width="599" alt="Screenshot 2023-11-03 at 2 28 48 PM" src="https://github.com/frappe/frappe/assets/13928957/766fdcac-9c9b-44d1-b4f4-7538945de69c">

**After:**
<img width="597" alt="Screenshot 2023-11-03 at 2 26 48 PM" src="https://github.com/frappe/frappe/assets/13928957/861aad05-bc9e-48b3-a85d-cf4820f10f58">
