### PR TITLE
Fix: sign up stuck on open dialog

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -1,5 +1,6 @@
 import "./field_group";
 import "../dom";
+import "../form/grid";
 
 frappe.provide("frappe.ui");
 
@@ -91,10 +92,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				me.is_minimized = false;
 				me.hide_scrollbar(false);
 				// hide any grid row form if open
-				if (typeof frappe.ui.form.get_open_grid_form === "function") {
-					// If the function is defined, call it
-					frappe.ui.form.get_open_grid_form()?.hide_form();
-				}
+				frappe.ui.form.get_open_grid_form()?.hide_form();
 
 				if (frappe.ui.open_dialogs[frappe.ui.open_dialogs.length - 1] === me) {
 					frappe.ui.open_dialogs.pop();

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -91,7 +91,10 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				me.is_minimized = false;
 				me.hide_scrollbar(false);
 				// hide any grid row form if open
-				frappe.ui.form.get_open_grid_form()?.hide_form();
+				if (typeof frappe.ui.form.get_open_grid_form === "function") {
+					// If the function is defined, call it
+					frappe.ui.form.get_open_grid_form()?.hide_form();
+				}
 
 				if (frappe.ui.open_dialogs[frappe.ui.open_dialogs.length - 1] === me) {
 					frappe.ui.open_dialogs.pop();


### PR DESCRIPTION
The dialog at the end of the sign-up journey can't be closed due to an uncaught type error. (see screenshot)

imo, it can be solved in 2 ways:
 * import form/grid.js in ui/dialog.js
 * only use get_open_grid_form when defined

Opted for the first option. 

### Screenshot
![image](https://github.com/frappe/frappe/assets/26723011/18486c9d-9fc4-4f72-b0a6-b13a7dc1b64c)

