### PR TITLE
fix: Arabic fonts issue in v15

### DIFF
--- a/frappe/public/css/fonts/inter/inter.css
+++ b/frappe/public/css/fonts/inter/inter.css
@@ -1,23 +1,6 @@
 /* This file is depricated use Inter.scss instead. */
 /* Backward compatibility */
-@font-face {
-	font-family: 'Inter V';
-	font-weight: 100 900;
-	font-display: swap;
-	font-style: normal;
-	src: url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2-variations'),
-	  url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2');
-	src: url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2') tech('variations');
-  }
-  @font-face {
-	font-family: 'Inter V';
-	font-weight: 100 900;
-	font-display: swap;
-	font-style: italic;
-	src: url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2-variations'),
-	  url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2');
-	src: url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2') tech('variations');
-  }
+
 @font-face {
 	font-family: 'Inter';
 	font-display: swap;

--- a/frappe/public/css/fonts/inter/inter.scss
+++ b/frappe/public/css/fonts/inter/inter.scss
@@ -1,23 +1,6 @@
 // TODO instead of making copy of inter.css find a way to import it.
 // workaround for css import as it fails for custom website_theme_template
-@font-face {
-	font-family: 'Inter V';
-	font-weight: 100 900;
-	font-display: swap;
-	font-style: normal;
-	src: url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2-variations'),
-	  url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2');
-	src: url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2') tech('variations');
-  }
-  @font-face {
-	font-family: 'Inter V';
-	font-weight: 100 900;
-	font-display: swap;
-	font-style: italic;
-	src: url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2-variations'),
-	  url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2');
-	src: url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2') tech('variations');
-  }
+
 @font-face {
 	font-family: 'Inter';
 	font-display: swap;

--- a/frappe/website/doctype/website_theme/website_theme_template.scss
+++ b/frappe/website/doctype/website_theme/website_theme_template.scss
@@ -1,13 +1,13 @@
 {% if google_font %}
 @import url("https://fonts.googleapis.com/css2?family={{ google_font.replace(' ', '+') }}:{{ font_properties }}&display=swap");
 // backward compatibility. deprecated in v15
-$font-family-sans-serif: "{{ google_font }}", "Inter V", "Inter", -apple-system, BlinkMacSystemFont,
+$font-family-sans-serif: "{{ google_font }}", "Inter", -apple-system, BlinkMacSystemFont,
 	"Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
 	"Droid Sans", "Helvetica Neue", sans-serif;
 
 // override font stack if custom font is set in website theme
 :root {
-	--font-stack: "{{ google_font }}", "Inter V", "Inter", -apple-system, BlinkMacSystemFont,
+	--font-stack: "{{ google_font }}", "Inter", -apple-system, BlinkMacSystemFont,
 	"Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
 	"Droid Sans", "Helvetica Neue", sans-serif !important;
 }


### PR DESCRIPTION
I've noticed that the 'Inter V' font family has been recently introduced into frappe project. I'd like to bring to your attention that this font may not fully support Arabic text, resulting in incorrectly displayed characters that can affect the readability of Arabic content.

Close: https://github.com/frappe/frappe/issues/22927.