### PR TITLE
fix(UX): Restrict grid upload to CSV files

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1082,6 +1082,9 @@ export default class Grid {
 					new frappe.ui.FileUploader({
 						as_dataurl: true,
 						allow_multiple: false,
+						restrictions: {
+							allowed_file_types: [".csv"],
+						},
 						on_success(file) {
 							var data = frappe.utils.csv_to_array(
 								frappe.utils.get_decoded_string(file.dataurl)


### PR DESCRIPTION
Users end up uploading wrong files and wonder why it's not working.

Only CSV filetype is supported here.

Internal refernce: 5377
