### PR TITLE
fix: Only allow standard print format modification in migrate

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -66,7 +66,7 @@ class PrintFormat(Document):
 		if (
 			self.standard == "Yes"
 			and not frappe.local.conf.get("developer_mode")
-			and not (frappe.flags.in_migrte or frappe.flags.in_test)
+			and not (frappe.flags.in_migrate or frappe.flags.in_test)
 		):
 
 			frappe.throw(frappe._("Standard Print Format cannot be updated"))

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -66,7 +66,7 @@ class PrintFormat(Document):
 		if (
 			self.standard == "Yes"
 			and not frappe.local.conf.get("developer_mode")
-			and not (frappe.flags.in_import or frappe.flags.in_test)
+			and not (frappe.flags.in_migrte or frappe.flags.in_test)
 		):
 
 			frappe.throw(frappe._("Standard Print Format cannot be updated"))


### PR DESCRIPTION
AFAIK only valid use case is fixtures and there too it should avoid
"standard".
