### PR TITLE
fix: remove data import legacy leftover fields

### DIFF
--- a/frappe/core/doctype/data_import/patches/remove_stale_docfields_from_legacy_version.py
+++ b/frappe/core/doctype/data_import/patches/remove_stale_docfields_from_legacy_version.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+	"""Remove stale docfields from legacy version"""
+	frappe.db.delete("DocField", {"options": "Data Import", "parent": "Data Import Legacy"})

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -260,6 +260,7 @@ def check_if_doc_is_linked(doc, method="Delete"):
 		try:
 			meta = frappe.get_meta(link_dt)
 		except frappe.DoesNotExistError:
+			frappe.clear_last_message()
 			# This mostly happens when app do not remove their customizations, we shouldn't
 			# prevent link checks from failing in those cases
 			continue

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -230,3 +230,4 @@ execute:frappe.delete_doc_if_exists("Workspace", "Customization")
 execute:frappe.db.set_single_value("Document Naming Settings", "default_amend_naming", "Amend Counter")
 frappe.patches.v15_0.move_event_cancelled_to_status
 frappe.patches.v15_0.set_file_type
+frappe.core.doctype.data_import.patches.remove_stale_docfields_from_legacy_version

--- a/frappe/patches/v14_0/drop_data_import_legacy.py
+++ b/frappe/patches/v14_0/drop_data_import_legacy.py
@@ -8,7 +8,7 @@ def execute():
 	table = frappe.utils.get_table_name(doctype)
 
 	# delete the doctype record to avoid broken links
-	frappe.db.delete("DocType", {"name": doctype})
+	frappe.delete_doc("DocType", doctype, force=True)
 
 	# leaving table in database for manual cleanup
 	click.secho(


### PR DESCRIPTION
- fix: clear last message if ignoring DNE
- fix: attempt to delete data import legacy leftover fields



Doctype rename left the old name in link fields: https://github.com/frappe/frappe/commit/6f80a0b462510b9b63a282c8e1628611da4ccce2 