### PR TITLE
fix: `get_open_grid_form` function not found

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -91,7 +91,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				me.is_minimized = false;
 				me.hide_scrollbar(false);
 				// hide any grid row form if open
-				frappe.ui.form.get_open_grid_form()?.hide_form();
+				frappe.ui.form.get_open_grid_form?.()?.hide_form();
 
 				if (frappe.ui.open_dialogs[frappe.ui.open_dialogs.length - 1] === me) {
 					frappe.ui.open_dialogs.pop();


### PR DESCRIPTION
Issue: Not able to close modal in Supplier Portal.
Issue occured due to https://github.com/frappe/frappe/pull/22930


On click of close button following error occurs:
```
dialog.js:94 Uncaught TypeError: frappe.ui.form.get_open_grid_form is not a function
    at HTMLDivElement.<anonymous> (dialog.js:94:20)
    at HTMLDivElement.dispatch (jquery.js:5135:27)
    at elemData.handle (jquery.js:4939:28)
    at Object.trigger (jquery.js:8619:12)
    at HTMLDivElement.<anonymous> (jquery.js:8697:17)
    at Function.each (jquery.js:383:19)
    at jQuery3.fn.init.each (jquery.js:205:17)
    at jQuery3.fn.init.trigger (jquery.js:8696:15)
    at Modal3.hide (modal.js:153:22)
    at HTMLButtonElement.<anonymous> (modal.js:128:21)
```
 
