### PR TITLE
poc: indexing

### DIFF
--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -94,7 +94,7 @@ class DBTable:
 				field.get("fieldtype"),
 				field.get("length"),
 				field.get("default"),
-				field.get("search_index"),
+				field.get("search_index") or field.get("fieldtype") in ("Link", "Dynamic Link"),
 				field.get("options"),
 				field.get("unique"),
 				field.get("precision"),


### PR DESCRIPTION
Just index all link/dynamic link fields... What can possibly go wrong?


Why?
- I've not yet seen such large insert volume where updating an index becomes bottleneck at db level
- storage is extremely cheap, developer time optimising slow queries is not.


Gotchas:
- mariadb limits can be hit when adding indexes willy nilly like this implementation. A more robust implementation will stop automatically when we are hitting limits and let developer do it instead.
- many more, this is like half a line of change to see if there are any obviously bad downsides/failures.