### PR TITLE
fix(UX): updated `error.html` message

### DIFF
--- a/frappe/www/error.html
+++ b/frappe/www/error.html
@@ -39,7 +39,6 @@
 		please </br> <b>copy the error below </b> and attach it for a quicker resolution.
 	</p>
 	<button class="btn btn-xs btn-secondary text-muted small view-error" >{{ _("Show Error") if not dev_server else _("Hide Error") }}</a>
-	
 </div>
 
 <div class="error-content {{ 'hidden' if not dev_server else '' }}">

--- a/frappe/www/error.html
+++ b/frappe/www/error.html
@@ -34,7 +34,12 @@
 	{{ _("Error Code: {0}").format(http_status_code) }}
 </p>
 <div class="text-center mt-3">
-	<button class="btn btn-xs btn-link text-muted small view-error" >{{ _("Show Traceback") if not dev_server else _("Hide Traceback") }}</a>
+	<p class="text-muted text-center small">
+		If you don't know what just happened, and wish to file a ticket
+		please </br> <b>copy the error below </b> and attach it for a quicker resolution.
+	</p>
+	<button class="btn btn-xs btn-secondary text-muted small view-error" >{{ _("Show Error") if not dev_server else _("Hide Error") }}</a>
+	
 </div>
 
 <div class="error-content {{ 'hidden' if not dev_server else '' }}">
@@ -49,10 +54,10 @@
 
 	toggle_button.on('click', () => {
 		if (error_log.hasClass("hidden")) {
-			toggle_button.html(`{{ _("Hide Traceback") }}`);
+			toggle_button.html(`{{ _("Hide Error") }}`);
 			error_log.removeClass("hidden");
 		} else {
-			toggle_button.html(`{{ _("Show Traceback") }}`);
+			toggle_button.html(`{{ _("Show Error") }}`);
 			error_log.addClass("hidden");
 		}
 	})

--- a/frappe/www/error.html
+++ b/frappe/www/error.html
@@ -36,7 +36,7 @@
 <div class="text-center mt-3">
 	<p class="text-muted text-center small">
 		If you don't know what just happened, and wish to file a ticket
-		please </br> <b>copy the error below </b> and attach it for a quicker resolution.
+		please </br> <b>copy the error below </b> and share it.
 	</p>
 	<button class="btn btn-xs btn-secondary text-muted small view-error" >{{ _("Show Error") if not dev_server else _("Hide Error") }}</a>
 </div>


### PR DESCRIPTION
Minor change to help direct an end user to copy and attach a traceback for support portal.