### PR TITLE
fix(integration): preserver data json formatting on update

### DIFF
--- a/frappe/integrations/doctype/integration_request/integration_request.py
+++ b/frappe/integrations/doctype/integration_request/integration_request.py
@@ -4,7 +4,7 @@
 import json
 
 import frappe
-from frappe.integrations.utils import json_handler
+from frappe.integrations.utils import get_json, json_handler
 from frappe.model.document import Document
 
 
@@ -45,7 +45,7 @@ class IntegrationRequest(Document):
 		data = json.loads(self.data)
 		data.update(params)
 
-		self.data = json.dumps(data)
+		self.data = get_json(data)
 		self.status = status
 		self.save(ignore_permissions=True)
 		frappe.db.commit()


### PR DESCRIPTION
# Motivation

A (power) user who needs to analyze gateway integration failures, for example in the role of a customer agent, will greatly benefit from a pretty formatted `data` json if already she needs to get into technical details to find the cause of a e.g. payment gateway failure while having an angry customer on the phone.
