### PR TITLE
fix: ignore case of filetype

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -337,7 +337,7 @@ function check_restrictions(file) {
 
 			// otherwise this is likely an extension
 			if (type[0] === '.') {
-				return file.name.endsWith(type);
+				return file.name.toLowerCase().endsWith(type.toLowerCase());
 			}
 			return false;
 		});


### PR DESCRIPTION
```javascript
new frappe.ui.FileUploader({
	restrictions: {
		allowed_file_types: [".csv"],
	},
});
```

### Before

- `test.csv` ✅ 
- `test.CSV` 🚫 

### After

- `test.csv` ✅ 
- `test.CSV` ✅ 