### PR TITLE
fix: Remove invalid and nested filter conditions for mobile browsers.

### DIFF
--- a/frappe/public/js/frappe/ui/filters/edit_filter.html
+++ b/frappe/public/js/frappe/ui/filters/edit_filter.html
@@ -8,9 +8,6 @@
 		<div class="fieldname-select-area col-sm-4 ui-front form-group"></div>
 		<div class="col-sm-3 form-group">
 			<select class="condition form-control input-xs">
-				{% for condition in conditions %}
-				<option value="{{condition[0]}}">{{ condition[1] }}</option>
-				{% endfor %}
 			</select>
 		</div>
 		<div class="col-sm-4 form-group">

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -73,11 +73,7 @@ frappe.ui.Filter = class {
 	make() {
 		this.filter_edit_area = $(
 			frappe.render_template("edit_filter", {
-				conditions: [
-					...this.conditions,
-					...this.nested_set_conditions,
-					...this.conditions_from_config,
-				],
+				conditions: [], // BC
 			})
 		);
 		this.parent && this.filter_edit_area.appendTo(this.parent.find(".filter-edit-area"));


### PR DESCRIPTION
For mobile browsers, at least Safari on iOS, unfortunately we have to completely remove invalid (and for non-nested fieldtypes) nested conditions from the DOM and then rebuild the options from scratch every time another field has been chosen.

Setting the rebuilt selected options once should still allow for slightly better performance than our previous approach toggling the individual filter options one by one.

Fixes #23157.