### PR TITLE
fix!: Update the shortcut for "Customize"

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1673,7 +1673,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					}
 				},
 				standard: true,
-				shortcut: "Ctrl+J",
+				shortcut: "Ctrl+Y",
 			});
 		}
 


### PR DESCRIPTION
`Ctrl-J` is for `jump to field`, define another key for customize