### PR TITLE
chore: compose postgres conn settings in the same way as with mariadb

### DIFF
--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -160,11 +160,16 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 		return LazyDecode(self._cursor.query)
 
 	def get_connection(self):
-		conn = psycopg2.connect(
-			"host='{}' dbname='{}' user='{}' password='{}' port={}".format(
-				self.host, self.user, self.user, self.password, self.port
-			)
-		)
+		conn_settings = {
+			"user": self.user,
+			"dbname": self.user,
+			"host": self.host,
+			"password": self.password,
+		}
+		if self.port:
+			conn_settings["port"] = self.port
+
+		conn = psycopg2.connect(**conn_settings)
 		conn.set_isolation_level(ISOLATION_LEVEL_REPEATABLE_READ)
 
 		return conn


### PR DESCRIPTION
# Motivation

- Align postgres and mariadb implementation as much as possible
- Reduce diff of #22548 cc @akhilnarang 
- It's a very low-risk no-brainer
- It's now easier to implement optional settings (such as the port) see: [Higlighted Docs](https://www.psycopg.org/docs/module.html#psycopg2.connect:~:text=connection%20port%20number%20(defaults%20to%205432%20if%20not%20provided))
