### PR TITLE
fix: update count after realtime refresh

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1470,11 +1470,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			const data = frappe.utils.dict(message.keys, message.values);
 
 			if (!(data && data.length)) {
-				// this doc was changed and should not be visible
-				// in the listview according to filters applied
-				// let's remove it manually
+				// No docs returned => they are deleted or don't meet applied filters.
 				this.data = this.data.filter((d) => names.indexOf(d.name) === -1);
 				this.render_list();
+				this.render_count();
 				return;
 			}
 


### PR DESCRIPTION
List update implies -> docs got updated or deleted. In both cases
filtered count number will not be valid anymore and need to validated by
server side call.

This PR just refreshes count in case of all updated documents don't
match the filter.

TODO:
- [ ] implement get_count for partial changes too. i.e. some docs
  removed from filtered view but some stayed/added.



closes https://github.com/frappe/frappe/issues/22965
