### PR TITLE
fix: DocType Number Card

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -4,8 +4,11 @@
 frappe.ui.form.on("Number Card", {
 	refresh: function (frm) {
 		if (!frappe.boot.developer_mode && frm.doc.is_standard) {
-			frm.disable_form();
+			frm.disable_save();
+		} else {
+			frm.enable_save();
 		}
+
 		frm.set_df_property("filters_section", "hidden", 1);
 		frm.set_df_property("dynamic_filters_section", "hidden", 1);
 		frm.trigger("set_options");
@@ -19,9 +22,6 @@ frappe.ui.form.on("Number Card", {
 		}
 
 		if (frm.doc.type == "Custom") {
-			if (!frappe.boot.developer_mode) {
-				frm.disable_form();
-			}
 			frm.filters = eval(frm.doc.filters_config);
 			frm.trigger("render_filters_table");
 		}

--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -23,8 +23,6 @@ frappe.ui.form.on("Number Card", {
 				frm.disable_form();
 			}
 			frm.filters = eval(frm.doc.filters_config);
-			frm.trigger("set_filters_description");
-			frm.trigger("set_method_description");
 			frm.trigger("render_filters_table");
 		}
 		frm.trigger("set_parent_document_type");
@@ -68,49 +66,7 @@ frappe.ui.form.on("Number Card", {
 		frm.set_df_property("dynamic_filters_section", "hidden", 1);
 	},
 
-	set_filters_description: function (frm) {
-		if (frm.doc.type == "Custom") {
-			frm.fields_dict.filters_config.set_description(`
-		Set the filters here. For example:
-<pre class="small text-muted">
-<code>
-[{
-	fieldname: "company",
-	label: __("Company"),
-	fieldtype: "Link",
-	options: "Company",
-	default: frappe.defaults.get_user_default("Company"),
-	reqd: 1
-},
-{
-	fieldname: "account",
-	label: __("Account"),
-	fieldtype: "Link",
-	options: "Account",
-	reqd: 1
-}]
-</code></pre>`);
-		}
-	},
-
-	set_method_description: function (frm) {
-		if (frm.doc.type == "Custom") {
-			frm.fields_dict.method.set_description(`
-		Set the path to a whitelisted function that will return the data for the number card in the format:
-<pre class="small text-muted">
-<code>
-{
-	"value": value,
-	"fieldtype": "Currency",
-	"route_options": {"from_date": "2023-05-23"},
-	"route": ["query-report", "Permitted Documents For User"]
-}
-</code></pre>`);
-		}
-	},
-
 	type: function (frm) {
-		frm.trigger("set_filters_description");
 		if (frm.doc.type == "Report") {
 			frm.set_query("report_name", () => {
 				return {

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -117,6 +117,7 @@
    "fieldname": "is_standard",
    "fieldtype": "Check",
    "label": "Is Standard",
+   "no_copy": 1,
    "read_only_depends_on": "eval: !frappe.boot.developer_mode"
   },
   {
@@ -202,7 +203,7 @@
   }
  ],
  "links": [],
- "modified": "2023-11-09 13:25:51.394005",
+ "modified": "2023-11-09 13:44:00.280846",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -165,6 +165,7 @@
   },
   {
    "depends_on": "eval: doc.type == 'Custom'",
+   "description": "Set the path to a whitelisted function that will return the data for the number card in the format:\n\n<pre class=\"small text-muted\"><code>\n{\n\t\"value\": value,\n\t\"fieldtype\": \"Currency\",\n\t\"route_options\": {\"from_date\": \"2023-05-23\"},\n\t\"route\": [\"query-report\", \"Permitted Documents For User\"]\n}</code></pre>",
    "fieldname": "method",
    "fieldtype": "Data",
    "label": "Method",
@@ -177,6 +178,7 @@
    "label": "Custom Configuration"
   },
   {
+   "description": "Set the filters here. For example:\n<pre class=\"small text-muted\"><code>\n[{\n\tfieldname: \"company\",\n\tlabel: __(\"Company\"),\n\tfieldtype: \"Link\",\n\toptions: \"Company\",\n\tdefault: frappe.defaults.get_user_default(\"Company\"),\n\treqd: 1\n},\n{\n\tfieldname: \"account\",\n\tlabel: __(\"Account\"),\n\tfieldtype: \"Link\",\n\toptions: \"Account\",\n\treqd: 1\n}]\n</code></pre>",
    "fieldname": "filters_config",
    "fieldtype": "Code",
    "label": "Filters Configuration",
@@ -200,7 +202,7 @@
   }
  ],
  "links": [],
- "modified": "2023-08-28 22:23:56.286804",
+ "modified": "2023-11-09 13:25:51.394005",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Number Card",


### PR DESCRIPTION
### Problem

- We have a whitelisted method that returns values for a Number Card and a standard number card of type "Custom" that makes use of it
- On the production system, a System Manager wants to create other number cards that use the same whitelisted method, but with different filters

This was not possible, because standard Number Cards, especially ones of type "Custom", could not be duplicated and saved. 
 
### Solution

- Don't copy value of "Is Standard" checkbox

    The field becomes read only in production, so after "Menu" > "Duplicate", it wasn't possible to disable "Is Standard " for the copy.

- Disable/enable only the save button, not the entire form

    Disable form is a one way street and cannot adapt to changed conditions, e.g. changing value of "Is Standard" during duplication.

- Move field descriptions to the doctype definition

    Unrelated refactor