### PR TITLE
fix: workspace loading issue

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -346,7 +346,7 @@ frappe.views.Workspace = class Workspace {
 		) {
 			default_page = {
 				name: localStorage.current_page,
-				public: localStorage.is_current_page_public == "true",
+				public: localStorage.is_current_page_public != "false",
 			};
 		} else if (Object.keys(this.all_pages).length !== 0) {
 			default_page = { name: this.all_pages[0].title, public: this.all_pages[0].public };
@@ -370,8 +370,9 @@ frappe.views.Workspace = class Workspace {
 		if (this.all_pages.length) {
 			this.create_page_skeleton();
 
-			let pages =
-				page.public && this.public_pages.length ? this.public_pages : this.private_pages;
+			let pages = (
+				page.public && this.public_pages.length ? this.public_pages : this.private_pages
+			);
 			let current_page = pages.filter((p) => p.title == page.name)[0];
 			this.content = current_page && JSON.parse(current_page.content);
 

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -370,9 +370,8 @@ frappe.views.Workspace = class Workspace {
 		if (this.all_pages.length) {
 			this.create_page_skeleton();
 
-			let pages = (
-				page.public && this.public_pages.length ? this.public_pages : this.private_pages
-			);
+			let pages =
+				page.public && this.public_pages.length ? this.public_pages : this.private_pages;
 			let current_page = pages.filter((p) => p.title == page.name)[0];
 			this.content = current_page && JSON.parse(current_page.content);
 


### PR DESCRIPTION

https://github.com/frappe/frappe/assets/52111700/2c58ae7e-7e41-43f7-adc7-087dd044926d

`localStorage.is_current_page_public` sometimes gets the value `1`, which fails when asserted against `true`.
I have changed the logic to rather negate against `false` to determine if the page is public or not.