### PR TITLE
fix(basedoc): add immutability on validation

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -51,16 +51,14 @@ class Role(Document):
 		frappe.cache.hdel("roles", "Administrator")
 
 	def validate(self):
+		if self.disabled and self.name in STANDARD_ROLES:
+			frappe.throw(frappe._("Standard roles cannot be disabled"))
+
+	def after_validate(self):
 		if self.disabled:
-			self.disable_role()
+			self.remove_roles()
 		else:
 			self.set_desk_properties()
-
-	def disable_role(self):
-		if self.name in STANDARD_ROLES:
-			frappe.throw(frappe._("Standard roles cannot be disabled"))
-		else:
-			self.remove_roles()
 
 	def set_desk_properties(self):
 		# set if desk_access is not allowed, unset all desk properties

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -96,6 +96,18 @@ class DataError(ValidationError):
 	pass
 
 
+class ProgrammingError(ValidationError):
+	def __init__(self, message):
+		self.message = message
+		super().__init__(self.message)
+
+class ReadOnlyDocument(ProgrammingError):
+	def __init__(self, repr, key):
+		super().__init__(
+			f"{repr} has been temporarily set to read-only. (raised while mutating attribute: {key})"
+		)
+
+
 class UnknownDomainError(Exception):
 	pass
 

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -183,7 +183,11 @@ class BaseDocument:
 		More info: https://docs.python.org/3/library/pickle.html#handling-stateful-objects
 		"""
 
-		_dict, _slots = object.__getstate__(self)
+		_dict, _slots = self.__dict__.copy(), dict()
+		for slot in self.__slots__:
+			if hasattr(self, slot) and slot != "__dict__":
+				_slots[slot] = getattr(self, slot)
+
 		self.remove_unpicklable_values(_dict)
 
 		return _dict, _slots

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1291,15 +1291,15 @@ class Document(BaseDocument):
 
 		def add_to_return_value(self, new_return_value):
 			if new_return_value is None:
-				self._return_value = self.get("_return_value")
+				self.flags._return_value = self.flags.get("_return_value")
 				return
 
 			if isinstance(new_return_value, dict):
-				if not self.get("_return_value"):
-					self._return_value = {}
-				self._return_value.update(new_return_value)
+				if not self.flags.get("_return_value"):
+					self.flags._return_value = {}
+				self.flags._return_value.update(new_return_value)
 			else:
-				self._return_value = new_return_value
+				self.flags._return_value = new_return_value
 
 		def compose(fn, *hooks):
 			def runner(self, method, *args, **kwargs):
@@ -1307,7 +1307,7 @@ class Document(BaseDocument):
 				for f in hooks:
 					add_to_return_value(self, f(self, method, *args, **kwargs))
 
-				return self.__dict__.pop("_return_value", None)
+				return self.flags.pop("_return_value", None)
 
 			return runner
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1088,11 +1088,15 @@ class Document(BaseDocument):
 			except Exception:
 				raise frappe.exceptions.ProgrammingError("after_validate may not throw / raise")
 
-		# Other validations and mutations on cancel and update_after_submit
-		elif self._action == "cancel":
-			self.run_method("before_cancel")
-		elif self._action == "update_after_submit":
-			self.run_method("before_update_after_submit")
+		# Other validations on cancel and update_after_submit
+		elif self._action == "cancel" and not self.flags.ignore_validate:
+			self.immutable()
+			self.run_method("validate_before_cancel")
+			self.mutable()
+		elif self._action == "update_after_submit" and not self.flags.ignore_validate:
+			self.immutable()
+			self.run_method("validate_before_update_after_submit")
+			self.mutable()
 
 		self.set_title_field()
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1070,6 +1070,7 @@ class Document(BaseDocument):
 
 		self.reset_seen()
 
+		# Full Validation Sequence on save and submit
 		if self._action in ("save", "submit"):
 			# prepares the doc for validation
 			try:
@@ -1087,10 +1088,7 @@ class Document(BaseDocument):
 			except Exception:
 				raise frappe.exceptions.ProgrammingError("after_validate may not throw / raise")
 
-		if self._action == "save":
-			self.run_method("before_save")
-		elif self._action == "submit":
-			self.run_method("before_submit")
+		# Other validations and mutations on cancel and update_after_submit
 		elif self._action == "cancel":
 			self.run_method("before_cancel")
 		elif self._action == "update_after_submit":


### PR DESCRIPTION
# Motivation

Validations on immutable documents eliminate an entire bug class from the frappe and downstream codebases.

The bug class stems from intermixing arbitrary sequences of mutation and validation in such ways that a later validation is not guaranteed to be independent of prior mutations.

The deeper the callstack, the bigger the problem.

Ultimately, this is the mediated root cause for failures like https://github.com/frappe/erpnext/issues/37587 and its 
regressionful fix in https://github.com/frappe/erpnext/pull/37597.

This change requires a fair amount of refactoring of controllers and validation methods, but the benefit is profound and long lasting.

With this change, the doc life-cycle becomes unambiguous:

1. Complete the document state in `before_validate` (_must not throw_)
2. Validate in `validate` (_must not anything but throw_)
3. Finalize the document state or remote documents in `after_validate` (_must not throw_)
4. The document state is **finalized**, use `before_{save,submit}` exclusively for remote state (such as file system, remote db, webhooks, etc), but not for further mutating the docstate meaningfully

`self.flags.ignore_validate` unambiguously gives you a completed/healed document but would not throw on eventual remaining validations. This makes a lot of mapper flows trivial with only very occasional requirements of post processing to set missing values (motivated by not reaching the validation target via `ignore_validate` flag for example in bulk updates, etc).

The overall consistency of any sort of pre-validation-throw target is ensured.

[Example Refactoring](https://github.com/frappe/frappe/pull/23201/commits/6cf2bbcadc7034712b1bd146877a8995b044e8e9)

cc @ankush - first PoC (without migrations/refactorings)
