### PR TITLE
fix: Use correct Home and Attachments folder names (when translated)

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -68,6 +68,7 @@ def get_bootinfo():
 	load_print(bootinfo, doclist)
 	doclist.extend(get_meta_bundle("Page"))
 	bootinfo.home_folder = frappe.db.get_value("File", {"is_home_folder": 1})
+	bootinfo.attachments_folder = frappe.db.get_value("File", {"is_attachments_folder": 1})
 	bootinfo.navbar_settings = get_navbar_settings()
 	bootinfo.notification_settings = get_notification_settings()
 	bootinfo.onboarding_tours = get_onboarding_ui_tours()

--- a/frappe/core/api/file.py
+++ b/frappe/core/api/file.py
@@ -41,9 +41,9 @@ def get_attached_images(doctype: str, names: list[str] | str) -> frappe._dict:
 
 @frappe.whitelist()
 def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> dict:
-	attachment_folder = frappe.db.get_value(
+	attachments_folder = frappe.db.get_value(
 		"File",
-		"Home/Attachments",
+		{"is_attachments_folder": 1},
 		["name", "file_name", "file_url", "is_folder", "modified"],
 		as_dict=1,
 	)
@@ -56,8 +56,8 @@ def get_files_in_folder(folder: str, start: int = 0, page_length: int = 20) -> d
 		page_length=page_length + 1,
 	)
 
-	if folder == "Home" and attachment_folder not in files:
-		files.insert(0, attachment_folder)
+	if folder == "Home" and attachments_folder not in files:
+		files.insert(0, attachments_folder)
 
 	return {"files": files[:page_length], "has_more": len(files) > page_length}
 

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -252,7 +252,7 @@ def add_attachments(name: str, attachments: Iterable[str | dict]) -> None:
 			{
 				"attached_to_doctype": "Communication",
 				"attached_to_name": name,
-				"folder": "Home/Attachments",
+				"folder": frappe.db.get_value("File", {"is_attachments_folder": 1}),
 			}
 		)
 

--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -101,7 +101,7 @@ frappe.router = {
 		dashboard: "Dashboard",
 		image: "Image",
 		inbox: "Inbox",
-		file: "Home",
+		file: frappe.boot.home_folder,
 		map: "Map",
 	},
 	layout_mapped: {},

--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -65,7 +65,7 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 		frappe.breadcrumbs.add({
 			type: "Custom",
 			label: __("Home"),
-			route: "/app/List/File/Home",
+			route: `/app/file/view/${frappe.boot.home_folder}`,
 		});
 	}
 


### PR DESCRIPTION
The folders (_File_) named `Home` and `Home/Attachments` might not exist because they are translated during setup, use [`frappe.boot.home_folder`](https://github.com/frappe/frappe/blob/49beb0c48e5d678875f409faa021174bc967247a/frappe/boot.py#L70) instead.