### PR TITLE
build(python): restricted python goes up to 3.11 only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "developers@frappe.io"}
 ]
 description = "Metadata driven, full-stack low code web framework"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.12"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
Versiovn 6.2 (which we use) has this constraint: https://github.com/zopefoundation/RestrictedPython/blob/a460be4348edb773138d7b3cccab9a2bb67e62f4/setup.py#L71

It's the latest tag: https://github.com/zopefoundation/RestrictedPython/tags

Only the development branch expands up to `<3.14`: https://github.com/zopefoundation/RestrictedPython/blob/b5d8e7f801343818c0bd3e9a7107922ddd9f6407/setup.py#L70
