### PR TITLE
refactor: store reference to leaflet draw control

### DIFF
--- a/frappe/public/js/frappe/form/controls/geolocation.js
+++ b/frappe/public/js/frappe/form/controls/geolocation.js
@@ -166,7 +166,8 @@ frappe.ui.form.ControlGeolocation = class ControlGeolocation extends frappe.ui.f
 			return;
 		}
 
-		this.map.addControl(this.get_leaflet_controls());
+		this.draw_control = this.get_leaflet_controls();
+		this.map.addControl(this.draw_control);
 	}
 
 	get_leaflet_controls() {


### PR DESCRIPTION
Store a reference to the leaflet draw control.

This enables easier customization of draw controls in Geolocation fields.

With this change, we can do something like the following in our client script:

```javascript
// define a custom icon
const CustomIcon = L.Icon.extend({
	options: {
		iconSize: new L.Point(24, 24),
		iconUrl:`/path/to/my_custom_icon.png`,
	}
});

// use the custom icon when placing a new marker
frm.fields_dict.my_map.draw_control.setDrawingOptions(
	{
		marker: {
			icon: new CustomIcon();
		}
	}
);
```

> Note: above example is incomplete. You'll need additional code for storing and retrieving the custom icon (to/from GeoJSON).