### PR TITLE
fix: Font for arabic and not supported languages

### DIFF
--- a/frappe/public/css/fonts/inter/inter.css
+++ b/frappe/public/css/fonts/inter/inter.css
@@ -8,6 +8,7 @@
 	src: url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2-variations'),
 	  url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2');
 	src: url('/assets/frappe/css/fonts/inter/Inter.var.woff2?v=3.19') format('woff2') tech('variations');
+	unicode-range: U+0460-052F,U+1C80-1C88,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;
   }
   @font-face {
 	font-family: 'Inter V';
@@ -17,6 +18,7 @@
 	src: url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2-variations'),
 	  url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2');
 	src: url('/assets/frappe/css/fonts/inter/Inter-Italic.var.woff2?v=3.19') format('woff2') tech('variations');
+	unicode-range: U+0460-052F,U+1C80-1C88,U+20B4,U+2DE0-2DFF,U+A640-A69F,U+FE2E-FE2F;
   }
 @font-face {
 	font-family: 'Inter';


### PR DESCRIPTION
As we added Inter Variable Font for the website,
we noticed that the font is not supported for arabic and other languages. We added a fallback font for arabic and other languages.

Closes #22927 #23188 