### PR TITLE
fix: review points when added more then once.

### DIFF
--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -296,17 +296,13 @@ def review(doc, points, to_user, reason, review_type="Appreciation"):
 		frappe.msgprint(_("You do not have enough review points"))
 		return
 
-	points = abs(points)
-	if review_type != "Appreciation":
-		points = -points
-
 	review_doc = create_energy_points_log(
 		doc.doctype,
 		doc.name,
 		{
 			"type": review_type,
 			"reason": reason,
-			"points": points,
+			"points": points if review_type == "Appreciation" else -points,
 			"user": to_user,
 		},
 	)

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -187,11 +187,9 @@ def get_alert_dict(doc):
 	return alert_dict
 
 
-def create_energy_points_log(
-	ref_doctype, ref_name, doc, is_energy_point_rule=False, apply_only_once=False
-):
+def create_energy_points_log(ref_doctype, ref_name, doc, apply_only_once=False):
 	doc = frappe._dict(doc)
-	if is_energy_point_rule:
+	if doc.rule:
 		log_exists = check_if_log_exists(
 			ref_doctype, ref_name, doc.rule, None if apply_only_once else doc.user
 		)

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -187,15 +187,16 @@ def get_alert_dict(doc):
 	return alert_dict
 
 
-def create_energy_points_log(ref_doctype, ref_name, doc, apply_only_once=False):
+def create_energy_points_log(
+	ref_doctype, ref_name, doc, is_energy_point_rule=False, apply_only_once=False
+):
 	doc = frappe._dict(doc)
-
-	log_exists = check_if_log_exists(
-		ref_doctype, ref_name, doc.rule, None if apply_only_once else doc.user
-	)
-
-	if log_exists:
-		return frappe.get_doc("Energy Point Log", log_exists)
+	if is_energy_point_rule:
+		log_exists = check_if_log_exists(
+			ref_doctype, ref_name, doc.rule, None if apply_only_once else doc.user
+		)
+		if log_exists:
+			return frappe.get_doc("Energy Point Log", log_exists)
 
 	new_log = frappe.new_doc("Energy Point Log")
 	new_log.reference_doctype = ref_doctype
@@ -297,13 +298,17 @@ def review(doc, points, to_user, reason, review_type="Appreciation"):
 		frappe.msgprint(_("You do not have enough review points"))
 		return
 
+	points = abs(points)
+	if review_type != "Appreciation":
+		points = -points
+
 	review_doc = create_energy_points_log(
 		doc.doctype,
 		doc.name,
 		{
 			"type": review_type,
 			"reason": reason,
-			"points": points if review_type == "Appreciation" else -points,
+			"points": points,
 			"user": to_user,
 		},
 	)

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -44,6 +44,7 @@ class EnergyPointRule(Document):
 	def apply(self, doc):
 		if self.rule_condition_satisfied(doc):
 			multiplier = 1
+			is_energy_point_rule = True
 
 			points = self.points
 			if self.multiplier_field:
@@ -74,6 +75,7 @@ class EnergyPointRule(Document):
 						reference_doctype,
 						reference_name,
 						{"points": points, "user": user, "rule": rule},
+						is_energy_point_rule,
 						self.apply_only_once,
 					)
 			except Exception as e:

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -44,7 +44,6 @@ class EnergyPointRule(Document):
 	def apply(self, doc):
 		if self.rule_condition_satisfied(doc):
 			multiplier = 1
-			is_energy_point_rule = True
 
 			points = self.points
 			if self.multiplier_field:
@@ -75,7 +74,6 @@ class EnergyPointRule(Document):
 						reference_doctype,
 						reference_name,
 						{"points": points, "user": user, "rule": rule},
-						is_energy_point_rule,
 						self.apply_only_once,
 					)
 			except Exception as e:


### PR DESCRIPTION
previously when user added review more then once it didn't work properly because of apply_only_once check which is only meant for rule based points changed that behaviour to only check when called from energy_point_rule.

Also changed points logic to explictly have positive value then if not Appreciation it is converted to negative value.
