### PR TITLE
fix: not able to edit private workspace

### DIFF
--- a/cypress/integration/web_form.js
+++ b/cypress/integration/web_form.js
@@ -156,6 +156,7 @@ context("Web Form", () => {
 
 		cy.findByRole("tab", { name: "Customization" }).click();
 		cy.fill_field("breadcrumbs", '[{"label": _("Notes"), "route":"note"}]', "Code");
+		cy.wait(2000);
 		cy.get(".form-tabs .nav-item .nav-link").contains("Customization").click();
 		cy.save();
 

--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -20,7 +20,6 @@ context("Workspace 2.0", () => {
 		cy.get(".codex-editor__redactor .ce-block");
 		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
 		cy.fill_field("title", "Test Private Page", "Data");
-		cy.fill_field("icon", "edit", "Icon");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
 
@@ -52,7 +51,6 @@ context("Workspace 2.0", () => {
 		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
 		cy.fill_field("title", "Test Child Page", "Data");
 		cy.fill_field("parent", "Test Private Page", "Select");
-		cy.fill_field("icon", "edit", "Icon");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
 

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -20,7 +20,6 @@ context("Workspace Blocks", () => {
 		cy.get(".codex-editor__redactor .ce-block");
 		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
 		cy.fill_field("title", "Test Block Page", "Data");
-		cy.fill_field("icon", "edit", "Icon");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
 

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -616,6 +616,8 @@ frappe.views.Workspace = class Workspace {
 							"options",
 							this.get_value() ? me.public_parent_pages : me.private_parent_pages
 						);
+						d.set_df_property("icon", "hidden", this.get_value() ? 0 : 1);
+						d.set_df_property("indicator_color", "hidden", this.get_value() ? 1 : 0);
 					},
 				},
 				{
@@ -625,24 +627,23 @@ frappe.views.Workspace = class Workspace {
 					label: __("Icon"),
 					fieldtype: "Icon",
 					fieldname: "icon",
-					default: item.icon,
-					change: function () {
-						d.set_df_property("indicator_color", "hidden", this.get_value() ? 1 : 0);
-					},
+					default: item.public && item.icon,
+					hidden: !item.public,
 				},
 				{
 					label: __("Indicator color"),
 					fieldtype: "Select",
 					fieldname: "indicator_color",
 					options: this.indicator_colors,
-					default: item.indicator_color,
+					default: !item.public && item.indicator_color,
+					hidden: item.public,
 				},
 			],
 			primary_action_label: __("Update"),
 			primary_action: (values) => {
 				values.title = frappe.utils.escape_html(values.title);
 				let is_title_changed = values.title != old_item.title;
-				let is_section_changed = values.is_public != old_item.public;
+				let is_section_changed = Boolean(values.is_public) != Boolean(old_item.public);
 				if (
 					(is_title_changed || is_section_changed) &&
 					!this.validate_page(values, old_item)
@@ -943,6 +944,8 @@ frappe.views.Workspace = class Workspace {
 							"options",
 							this.get_value() ? me.public_parent_pages : me.private_parent_pages
 						);
+						d.set_df_property("icon", "hidden", this.get_value() ? 0 : 1);
+						d.set_df_property("indicator_color", "hidden", this.get_value() ? 1 : 0);
 					},
 				},
 				{
@@ -952,17 +955,16 @@ frappe.views.Workspace = class Workspace {
 					label: __("Icon"),
 					fieldtype: "Icon",
 					fieldname: "icon",
-					default: new_page.icon,
-					change: function () {
-						d.set_df_property("indicator_color", "hidden", this.get_value() ? 1 : 0);
-					},
+					default: new_page.public && new_page.icon,
+					hidden: !new_page.public,
 				},
 				{
 					label: __("Indicator color"),
 					fieldtype: "Select",
 					fieldname: "indicator_color",
 					options: this.indicator_colors,
-					default: new_page.indicator_color,
+					hidden: new_page.public,
+					default: !new_page.public && new_page.indicator_color,
 				},
 			],
 			primary_action_label: __("Duplicate"),
@@ -1187,6 +1189,8 @@ frappe.views.Workspace = class Workspace {
 							"options",
 							this.get_value() ? me.public_parent_pages : me.private_parent_pages
 						);
+						d.set_df_property("icon", "hidden", this.get_value() ? 0 : 1);
+						d.set_df_property("indicator_color", "hidden", this.get_value() ? 1 : 0);
 					},
 				},
 				{
@@ -1196,9 +1200,7 @@ frappe.views.Workspace = class Workspace {
 					label: __("Icon"),
 					fieldtype: "Icon",
 					fieldname: "icon",
-					change: function () {
-						d.set_df_property("indicator_color", "hidden", this.get_value() ? 1 : 0);
-					},
+					hidden: 1,
 				},
 				{
 					label: __("Indicator color"),


### PR DESCRIPTION
Fixes: https://github.com/frappe/frappe/issues/23214

1. Was not able to edit private workspace icon
2. Only show the icon field for the public workspace and the indicator color field for the private workspace
3. Fixed Webform UI test
