### PR TITLE
fix: remove quotes from IMAP Folder Name

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -220,6 +220,9 @@ class EmailServer:
 			).where(Communication.email_account == self.settings.email_account).run()
 
 			if self.settings.use_imap:
+				# Remove {"} quotes that are added to handle spaces in IMAP Folder names
+				if folder[0] == folder[-1] == '"':
+					folder = folder[1:-2]
 				# new update for the IMAP Folder DocType
 				IMAPFolder = frappe.qb.DocType("IMAP Folder")
 				frappe.qb.update(IMAPFolder).set(IMAPFolder.uidvalidity, current_uid_validity).set(


### PR DESCRIPTION
Quotes were added around folder name as spaces would cause issue with IMAP.

These extra quotes are also passed to query which sets the uidnext and uidvalidity. where condition is never met

These values are used on subsequent pulls and without these values, it is considered first pull and all UNSEEN mails are synced.

So even If user selected All in sync option it will still always work as the UNSEEN option.

When UNSEEN is used it will mark all emails as seen on IMAP server when pulled.
