### PR TITLE
fix: rename doc old_doc bug and validate for rename field

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -201,8 +201,9 @@ def rename_doc(
 	# call after_rename
 	new_doc = frappe.get_doc(doctype, new)
 
-	# copy any flags if required
-	new_doc._local = getattr(old_doc, "_local", None)
+	if validate:
+		# copy any flags if required
+		new_doc._local = getattr(old_doc, "_local", None)
 
 	new_doc.run_method("after_rename", old, new, merge)
 

--- a/frappe/model/utils/rename_field.py
+++ b/frappe/model/utils/rename_field.py
@@ -8,19 +8,21 @@ from frappe.model.utils.user_settings import sync_user_settings, update_user_set
 from frappe.utils.password import rename_password_field
 
 
-def rename_field(doctype, old_fieldname, new_fieldname):
+def rename_field(doctype, old_fieldname, new_fieldname, validate=True):
 	"""This functions assumes that doctype is already synced"""
 
 	meta = frappe.get_meta(doctype, cached=False)
 	new_field = meta.get_field(new_fieldname)
-	if not new_field:
-		print("rename_field: " + (new_fieldname) + " not found in " + doctype)
-		return
 
-	if not meta.issingle and not frappe.db.has_column(doctype, old_fieldname):
-		print("rename_field: " + (old_fieldname) + " not found in table for: " + doctype)
-		# never had the field?
-		return
+	if validate:
+		if not new_field:
+			print("rename_field: " + (new_fieldname) + " not found in " + doctype)
+			return
+
+		if not meta.issingle and not frappe.db.has_column(doctype, old_fieldname):
+			print("rename_field: " + (old_fieldname) + " not found in table for: " + doctype)
+			# never had the field?
+			return
 
 	if new_field.fieldtype in table_fields:
 		# change parentfield of table mentioned in options


### PR DESCRIPTION
- Added a new `validate` arg for `rename_field()` since I had a use case where I didn't want the validation to be made. For example: in v14 erpnext, there's a doctype with a fieldname "A". In v15, that doctype was moved to a separate lending app after which the fieldname was renamed to "B". Now on v14->v15 migration, on installation of the lending app, I'm running a [patch](https://github.com/frappe/lending/blob/e6b853410fc29a563045d1f5cb2a8c3694f175a5/lending/patches/v15_0/add_loan_product_code_and_rename_loan_name.py#L10) to rename fieldname "A" to "B", but in `rename_field()`, `frappe.db.has_column(doctype, old_fieldname)` would fail since the doctype won't have the old fieldname "A".
- If `rename_doc()` is called with `validate`=False, an `old_doc` is not defined error is thrown since `old_doc` is initialised only if `validate`=True. So now that one line using `old_doc` is only executed if `validate`=True.