### PR TITLE
fix: changed quick list filter JSON.parse to stringify

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -104,7 +104,7 @@ export default class QuickListWidget extends Widget {
 			primary_action: function () {
 				let old_filter = me.quick_list_filter;
 				let filters = me.filter_group.get_filters();
-				me.quick_list_filter = JSON.parse(filters);
+				me.quick_list_filter = JSON.stringify(filters);
 
 				this.hide();
 


### PR DESCRIPTION
The code context seems to suggest stringify instead of parse.

closes #23250

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

The code seems to be comparing old json filter string against new json filter string but instead of stringifying the filter array, it's attempting to parse. Changed to stringify and the filtering seems to be working.

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
