### PR TITLE
fix: button "Add Chart to Dashboard" visible before saving

### DIFF
--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -30,19 +30,21 @@ frappe.ui.form.on("Dashboard Chart", {
 			frm.disable_form();
 		}
 
-		frm.add_custom_button("Add Chart to Dashboard", () => {
-			const dialog = frappe.dashboard_utils.get_add_to_dashboard_dialog(
-				frm.doc.name,
-				"Dashboard Chart",
-				"frappe.desk.doctype.dashboard_chart.dashboard_chart.add_chart_to_dashboard"
-			);
+		if (!frm.is_new()){
+			frm.add_custom_button("Add Chart to Dashboard", () => {
+				const dialog = frappe.dashboard_utils.get_add_to_dashboard_dialog(
+					frm.doc.name,
+					"Dashboard Chart",
+					"frappe.desk.doctype.dashboard_chart.dashboard_chart.add_chart_to_dashboard"
+				);
 
-			if (!frm.doc.chart_name) {
-				frappe.msgprint(__("Please create chart first"));
-			} else {
-				dialog.show();
-			}
-		});
+				if (!frm.doc.chart_name) {
+					frappe.msgprint(__("Please create chart first"));
+				} else {
+					dialog.show();
+				}
+			});
+		}
 
 		frm.set_df_property("filters_section", "hidden", 1);
 		frm.set_df_property("dynamic_filters_section", "hidden", 1);

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.js
@@ -30,7 +30,7 @@ frappe.ui.form.on("Dashboard Chart", {
 			frm.disable_form();
 		}
 
-		if (!frm.is_new()){
+		if (!frm.is_new()) {
 			frm.add_custom_button("Add Chart to Dashboard", () => {
 				const dialog = frappe.dashboard_utils.get_add_to_dashboard_dialog(
 					frm.doc.name,


### PR DESCRIPTION
The 'Add Chart to Dashboard' button in the Doctype Dashboard Chart is now consistently visible even before saving the document. This issue was resolved by incorporating the '!frm.is_new()' function..

![Screenshot (253)](https://github.com/frappe/frappe/assets/91895505/b1995dc2-766a-4520-b492-ccef4d23e158)
