### PR TITLE
fix: prevent DB lock on tools based on Single Doctypes

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1093,13 +1093,21 @@ class Document(BaseDocument):
 	def load_doc_before_save(self, *, raise_exception: bool = False):
 		"""load existing document from db before saving"""
 
+		for_update = True
+		if (
+			getattr(self.meta, "issingle", True)
+			and self.flags.get("for_update") != None
+			and not self.flags.for_update
+		):
+			for_update = False
+
 		self._doc_before_save = None
 
 		if self.is_new():
 			return
 
 		try:
-			self._doc_before_save = frappe.get_doc(self.doctype, self.name, for_update=True)
+			self._doc_before_save = frappe.get_doc(self.doctype, self.name, for_update=for_update)
 		except frappe.DoesNotExistError:
 			if raise_exception:
 				raise


### PR DESCRIPTION
Concurrent usage of Payment Reconciliation tool can result in 'Lock Wait Timeout' when working on large datasets. Adding provision to set `for_update` for single doctypes.
```
request.js:457 Traceback (most recent call last):
  File "apps/frappe/frappe/database/database.py", line 220, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 158, in execute
    result = self._query(query)
             ^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 325, in _query
    conn.query(q)
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 549, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 779, in _read_query_result
    result.read()
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 1164, in read
    self._read_result_packet(first_packet)
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 1240, in _read_result_packet
    self._read_rowdata_packet()
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 1274, in _read_rowdata_packet
    packet = self.connection._read_packet()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 729, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.11/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.11/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1205, 'Lock wait timeout exceeded; try restarting transaction')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
               ^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1622, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 299, in run_doc_method
    doc.check_if_latest()
  File "apps/frappe/frappe/model/document.py", line 761, in check_if_latest
    self.load_doc_before_save(raise_exception=True)
  File "apps/frappe/frappe/model/document.py", line 1076, in load_doc_before_save
    self._doc_before_save = frappe.get_doc(self.doctype, self.name, for_update=True)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1199, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 75, in get_doc
    return controller(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py", line 27, in __init__
    super(PaymentReconciliation, self).__init__(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 107, in __init__
    self.load_from_db()
  File "apps/frappe/frappe/model/document.py", line 135, in load_from_db
    single_doc = frappe.db.get_singles_dict(self.doctype, for_update=self.flags.for_update)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 714, in get_singles_dict
    ).run(debug=debug)
      ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/query_builder/utils.py", line 87, in execute_query
    result = frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 229, in sql
    raise frappe.QueryTimeoutError(e) from e
frappe.exceptions.QueryTimeoutError: (1205, 'Lock wait timeout exceeded; try restarting transaction')
```