### PR TITLE
feat: Letterhead Scripts & fix disappearing header in pdf

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2050,10 +2050,7 @@ def get_print(
 	if not html:
 		html = get_response_content("printview")
 
-	if as_pdf:
-		return get_pdf(html, options=pdf_options, output=output, letterhead=letterhead)
-	else:
-		return html
+	return get_pdf(html, options=pdf_options, output=output) if as_pdf else html
 
 
 def attach_print(
@@ -2093,7 +2090,7 @@ def attach_print(
 			ext = ".pdf"
 			kwargs["as_pdf"] = True
 			content = (
-				get_pdf(html, options={"password": password} if password else None, letterhead=letterhead)
+				get_pdf(html, options={"password": password} if password else None)
 				if html
 				else get_print(doctype, name, **kwargs)
 			)

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2051,7 +2051,7 @@ def get_print(
 		html = get_response_content("printview")
 
 	if as_pdf:
-		return get_pdf(html, options=pdf_options, output=output)
+		return get_pdf(html, options=pdf_options, output=output, letterhead=letterhead)
 	else:
 		return html
 
@@ -2093,7 +2093,7 @@ def attach_print(
 			ext = ".pdf"
 			kwargs["as_pdf"] = True
 			content = (
-				get_pdf(html, options={"password": password} if password else None)
+				get_pdf(html, options={"password": password} if password else None, letterhead=letterhead)
 				if html
 				else get_print(doctype, name, **kwargs)
 			)

--- a/frappe/printing/doctype/letter_head/letter_head.js
+++ b/frappe/printing/doctype/letter_head/letter_head.js
@@ -2,6 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Letter Head", {
+	setup(frm) {
+		frm.get_field("instructions").html(INSTRUCTIONS);
+	},
 	refresh: function (frm) {
 		frm.flag_public_attachments = true;
 	},
@@ -22,3 +25,38 @@ frappe.ui.form.on("Letter Head", {
 		});
 	},
 });
+
+const INSTRUCTIONS = `<h4>Letter Head Scripts</h4>
+<p>Header/Footer scripts can be used to add dynamic behaviours.</p>
+
+<pre>
+<code>
+// The following Header Script will add the current date to an element in 'Header HTML' with class "header-content"
+var el = document.getElementsByClassName("header-content");
+if (el.length > 0) {
+	el[0].textContent += " " + new Date().toGMTString();
+}
+</code>
+</pre>
+
+<p>You can also access wkhtmltopdf variables (valid only in PDF print):</p>
+
+<pre>
+<code>
+// Get Header and Footer wkhtmltopdf variables
+// Snippet and more variables: https://wkhtmltopdf.org/usage/wkhtmltopdf.txt
+var vars = {};
+var query_strings_from_url = document.location.search.substring(1).split('&');
+for (var query_string in query_strings_from_url) {
+	if (query_strings_from_url.hasOwnProperty(query_string)) {
+		var temp_var = query_strings_from_url[query_string].split('=', 2);
+		vars[temp_var[0]] = decodeURI(temp_var[1]);
+	}
+}
+
+var el = document.getElementsByClassName("header-content");
+if (el.length > 0 && vars["page"] == 1) {
+	el[0].textContent += " : " + vars["date"];
+}
+</code>
+</pre>`;

--- a/frappe/printing/doctype/letter_head/letter_head.js
+++ b/frappe/printing/doctype/letter_head/letter_head.js
@@ -5,4 +5,20 @@ frappe.ui.form.on("Letter Head", {
 	refresh: function (frm) {
 		frm.flag_public_attachments = true;
 	},
+
+	validate: (frm) => {
+		["header_script", "footer_script"].forEach((field) => {
+			if (!frm.doc[field]) return;
+
+			try {
+				eval(frm.doc[field]);
+			} catch (e) {
+				frappe.throw({
+					title: __("Error in Header/Footer Script"),
+					indicator: "orange",
+					message: '<pre class="small"><code>' + e.stack + "</code></pre>",
+				});
+			}
+		});
+	},
 });

--- a/frappe/printing/doctype/letter_head/letter_head.js
+++ b/frappe/printing/doctype/letter_head/letter_head.js
@@ -26,12 +26,14 @@ frappe.ui.form.on("Letter Head", {
 	},
 });
 
-const INSTRUCTIONS = `<h4>Letter Head Scripts</h4>
-<p>Header/Footer scripts can be used to add dynamic behaviours.</p>
+const INSTRUCTIONS = `<h4>${__("Letter Head Scripts")}</h4>
+<p>${__("Header/Footer scripts can be used to add dynamic behaviours.")}</p>
 
 <pre>
 <code>
-// The following Header Script will add the current date to an element in 'Header HTML' with class "header-content"
+// ${__(
+	"The following Header Script will add the current date to an element in 'Header HTML' with class 'header-content'"
+)}
 var el = document.getElementsByClassName("header-content");
 if (el.length > 0) {
 	el[0].textContent += " " + new Date().toGMTString();
@@ -39,12 +41,12 @@ if (el.length > 0) {
 </code>
 </pre>
 
-<p>You can also access wkhtmltopdf variables (valid only in PDF print):</p>
+<p>${__("You can also access wkhtmltopdf variables (valid only in PDF print):")}</p>
 
 <pre>
 <code>
-// Get Header and Footer wkhtmltopdf variables
-// Snippet and more variables: https://wkhtmltopdf.org/usage/wkhtmltopdf.txt
+// ${__("Get Header and Footer wkhtmltopdf variables")}
+// ${__("Snippet and more variables:  {0}", ["https://wkhtmltopdf.org/usage/wkhtmltopdf.txt"])}
 var vars = {};
 var query_strings_from_url = document.location.search.substring(1).split('&');
 for (var query_string in query_strings_from_url) {

--- a/frappe/printing/doctype/letter_head/letter_head.json
+++ b/frappe/printing/doctype/letter_head/letter_head.json
@@ -20,15 +20,17 @@
   "align",
   "header_section",
   "content",
-  "header_script",
   "footer_section",
   "footer",
-  "footer_script",
   "footer_image_section",
   "footer_image",
   "footer_image_height",
   "footer_image_width",
-  "footer_align"
+  "footer_align",
+  "scripts_section",
+  "header_script",
+  "footer_script",
+  "instructions"
  ],
  "fields": [
   {
@@ -111,7 +113,7 @@
    "description": "Footer will display correctly only in PDF",
    "fieldname": "footer",
    "fieldtype": "HTML Editor",
-   "label": "Footer HTML"
+   "label": "Footer HTML (visible only in PDF)"
   },
   {
    "default": "Left",
@@ -166,23 +168,38 @@
    "options": "Image\nHTML"
   },
   {
+   "depends_on": "eval:!doc.__islocal && doc.source==='HTML'",
    "fieldname": "header_script",
    "fieldtype": "Code",
    "label": "Header Script",
    "options": "Javascript"
   },
   {
+   "depends_on": "eval:!doc.__islocal && doc.footer_source==='HTML'",
    "fieldname": "footer_script",
    "fieldtype": "Code",
    "label": "Footer Script",
    "options": "Javascript"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.header_script || doc.footer_script",
+   "fieldname": "scripts_section",
+   "fieldtype": "Section Break",
+   "label": "Scripts"
+  },
+  {
+   "fieldname": "instructions",
+   "fieldtype": "HTML",
+   "label": "Instructions",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-font",
  "idx": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2023-11-17 15:56:24.547700",
+ "modified": "2023-11-20 22:28:00.602973",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Letter Head",

--- a/frappe/printing/doctype/letter_head/letter_head.json
+++ b/frappe/printing/doctype/letter_head/letter_head.json
@@ -20,8 +20,10 @@
   "align",
   "header_section",
   "content",
+  "header_script",
   "footer_section",
   "footer",
+  "footer_script",
   "footer_image_section",
   "footer_image",
   "footer_image_height",
@@ -162,13 +164,25 @@
    "fieldtype": "Select",
    "label": "Footer Based On",
    "options": "Image\nHTML"
+  },
+  {
+   "fieldname": "header_script",
+   "fieldtype": "Code",
+   "label": "Header Script",
+   "options": "Javascript"
+  },
+  {
+   "fieldname": "footer_script",
+   "fieldtype": "Code",
+   "label": "Footer Script",
+   "options": "Javascript"
   }
  ],
  "icon": "fa fa-font",
  "idx": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2022-06-16 23:10:46.852116",
+ "modified": "2023-11-17 15:56:24.547700",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Letter Head",

--- a/frappe/templates/print_formats/pdf_header_footer.html
+++ b/frappe/templates/print_formats/pdf_header_footer.html
@@ -56,28 +56,14 @@
 					}
 				}
 			}
-
-			function custom_load() {
-				if (window.custom_header_footer_script) {
-					window.custom_header_footer_script();
-				}
-			}
 		</script>
-
-		{% if custom_header_footer_script -%}
-			<script>
-				window.custom_header_footer_script = function() {
-					{{ custom_header_footer_script }}
-				}
-			</script>
-		{%- endif %}
 
 		{% for tag in styles -%}
 			{{ tag | string }}
 		{%- endfor %}
 
 	</head>
-	<body onload="subst(); custom_load();">
+	<body onload="subst()">
 		<div class="print-format">
 			<div class="wrapper">
 				{% for tag in content -%}

--- a/frappe/templates/print_formats/pdf_header_footer.html
+++ b/frappe/templates/print_formats/pdf_header_footer.html
@@ -56,14 +56,28 @@
 					}
 				}
 			}
+
+			function custom_load() {
+				if (window.custom_header_footer_script) {
+					window.custom_header_footer_script();
+				}
+			}
 		</script>
+
+		{% if custom_header_footer_script -%}
+			<script>
+				window.custom_header_footer_script = function() {
+					{{ custom_header_footer_script }}
+				}
+			</script>
+		{%- endif %}
 
 		{% for tag in styles -%}
 			{{ tag | string }}
 		{%- endfor %}
 
 	</head>
-	<body onload="subst()">
+	<body onload="subst(); custom_load();">
 		<div class="print-format">
 			<div class="wrapper">
 				{% for tag in content -%}

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -23,9 +23,9 @@ PDF_CONTENT_ERRORS = [
 ]
 
 
-def get_pdf(html, options=None, output: PdfWriter | None = None, letterhead: str | None = None):
+def get_pdf(html, options=None, output: PdfWriter | None = None):
 	html = scrub_urls(html)
-	html, options = prepare_options(html, options, letterhead=letterhead)
+	html, options = prepare_options(html, options)
 
 	options.update({"disable-javascript": "", "disable-local-file-access": ""})
 
@@ -84,7 +84,7 @@ def get_file_data_from_writer(writer_obj):
 	return stream.read()
 
 
-def prepare_options(html, options, letterhead: str | None = None):
+def prepare_options(html, options):
 	if not options:
 		options = {}
 
@@ -106,7 +106,7 @@ def prepare_options(html, options, letterhead: str | None = None):
 	if not options.get("margin-left"):
 		options["margin-left"] = "15mm"
 
-	html, html_options = read_options_from_html(html, letterhead=letterhead)
+	html, html_options = read_options_from_html(html)
 	options.update(html_options or {})
 
 	# cookies
@@ -147,11 +147,11 @@ def get_cookie_options():
 	return options
 
 
-def read_options_from_html(html, letterhead: str | None = None):
+def read_options_from_html(html):
 	options = {}
 	soup = BeautifulSoup(html, "html5lib")
 
-	options.update(prepare_header_footer(soup, letterhead=letterhead))
+	options.update(prepare_header_footer(soup))
 
 	toggle_visible_pdf(soup)
 
@@ -178,7 +178,7 @@ def read_options_from_html(html, letterhead: str | None = None):
 	return str(soup), options
 
 
-def prepare_header_footer(soup: BeautifulSoup, letterhead: str | None = None):
+def prepare_header_footer(soup: BeautifulSoup):
 	options = {}
 
 	head = soup.find("head").contents
@@ -189,13 +189,7 @@ def prepare_header_footer(soup: BeautifulSoup, letterhead: str | None = None):
 
 	# extract header and footer
 	for html_id in ("header-html", "footer-html"):
-		content = soup.find(id=html_id)
-		if content:
-			script = None
-			if letterhead:
-				field = "header_script" if html_id == "header-html" else "footer_script"
-				script = frappe.db.get_value("Letter Head", letterhead, field)
-
+		if content := soup.find(id=html_id):
 			toggle_visible_pdf(content)
 			html = frappe.render_template(
 				"templates/print_formats/pdf_header_footer.html",
@@ -207,7 +201,6 @@ def prepare_header_footer(soup: BeautifulSoup, letterhead: str | None = None):
 					"css": css,
 					"lang": frappe.local.lang,
 					"layout_direction": "rtl" if is_rtl() else "ltr",
-					"custom_header_footer_script": script,
 				},
 			)
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -189,7 +189,13 @@ def prepare_header_footer(soup: BeautifulSoup):
 
 	# extract header and footer
 	for html_id in ("header-html", "footer-html"):
-		if content := soup.find(id=html_id):
+		if content := soup.find(id=html_id).extract():
+			# `header/footer-html` are extracted, rendered as html
+			# and passed in wkhtmltopdf options (as '--header/footer-html')
+			# Remove instances of them from main content for render_template
+			for tag in soup.find_all(id=html_id):
+				tag.extract()
+
 			toggle_visible_pdf(content)
 			html = frappe.render_template(
 				"templates/print_formats/pdf_header_footer.html",
@@ -203,12 +209,6 @@ def prepare_header_footer(soup: BeautifulSoup):
 					"layout_direction": "rtl" if is_rtl() else "ltr",
 				},
 			)
-
-			# `header/footer-html` are extracted, rendered as html
-			# and passed in wkhtmltopdf options (as '--header/footer-html')
-			# Remove instances of them from main content after render_template
-			for tag in soup.find_all(id=html_id):
-				tag.extract()
 
 			# create temp file
 			fname = os.path.join("/tmp", f"frappe-pdf-{frappe.generate_hash()}.html")

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -189,7 +189,8 @@ def prepare_header_footer(soup: BeautifulSoup):
 
 	# extract header and footer
 	for html_id in ("header-html", "footer-html"):
-		if content := soup.find(id=html_id).extract():
+		if content := soup.find(id=html_id):
+			content = content.extract()
 			# `header/footer-html` are extracted, rendered as html
 			# and passed in wkhtmltopdf options (as '--header/footer-html')
 			# Remove instances of them from main content for render_template

--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -31,14 +31,17 @@
 		document.addEventListener('DOMContentLoaded', () => {
 			const page_div = document.querySelector('.page-break');
 
-			page_div.style.display = 'flex';
-			page_div.style.flexDirection = 'column';
+			if (page_div) {
+				page_div.style.display = 'flex';
+				page_div.style.flexDirection = 'column';
+			}
 
-			const footer_html = document.getElementById('footer-html');
-			footer_html.classList.add('hidden-pdf');
-			footer_html.classList.remove('visible-pdf');
-			footer_html.style.order = 1;
-			footer_html.style.marginTop = '20px';
+			if (footer_html)  {
+				footer_html.classList.add('hidden-pdf');
+				footer_html.classList.remove('visible-pdf');
+				footer_html.style.order = 1;
+				footer_html.style.marginTop = '20px';
+			}
 		});
 	</script>
 </body>

--- a/frappe/www/printview.html
+++ b/frappe/www/printview.html
@@ -36,6 +36,7 @@
 				page_div.style.flexDirection = 'column';
 			}
 
+			const footer_html = document.getElementById('footer-html');
 			if (footer_html)  {
 				footer_html.classList.add('hidden-pdf');
 				footer_html.classList.remove('visible-pdf');

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -180,11 +180,23 @@ def get_rendered_template(
 		letter_head.content = frappe.utils.jinja.render_template(
 			letter_head.content, {"doc": doc.as_dict()}
 		)
+		if letter_head.header_script:
+			letter_head.content += f"""
+				<script>
+					{ letter_head.header_script }
+				</script>
+			"""
 
 	if letter_head.footer:
 		letter_head.footer = frappe.utils.jinja.render_template(
 			letter_head.footer, {"doc": doc.as_dict()}
 		)
+		if letter_head.footer_script:
+			letter_head.footer += f"""
+				<script>
+					{ letter_head.footer_script }
+				</script>
+			"""
 
 	convert_markdown(doc, meta)
 
@@ -388,13 +400,24 @@ def validate_key(key, doc):
 def get_letter_head(doc, no_letterhead, letterhead=None):
 	if no_letterhead:
 		return {}
-	if letterhead:
-		return frappe.db.get_value("Letter Head", letterhead, ["content", "footer"], as_dict=True)
-	if doc.get("letter_head"):
-		return frappe.db.get_value("Letter Head", doc.letter_head, ["content", "footer"], as_dict=True)
+
+	letterhead_name = letterhead or doc.get("letter_head")
+	if letterhead_name:
+		return frappe.db.get_value(
+			"Letter Head",
+			letterhead_name,
+			["content", "footer", "header_script", "footer_script"],
+			as_dict=True,
+		)
 	else:
 		return (
-			frappe.db.get_value("Letter Head", {"is_default": 1}, ["content", "footer"], as_dict=True) or {}
+			frappe.db.get_value(
+				"Letter Head",
+				{"is_default": 1},
+				["content", "footer", "header_script", "footer_script"],
+				as_dict=True,
+			)
+			or {}
 		)
 
 


### PR DESCRIPTION
`no-docs`

## Feature
- Allow script injection into header/footer.html to allow manipulation of styles using page numbers/args received by wkhtmltopdf (because these args are only received/substituted in header and footer html files generated by wkhtmltopdf)
- Eg: we want the page numbers to be red but only on the first page
- Add the following Letterhead HTML
  ```html
  <div id="header-html">
	    <div class="header-content">
	        Page <span class="page"></span> of <span class="topage"></span>
	    </div>
  </div>
   ```
- Add some valid JS in **Header Script** / **Footer Script**. The idea is to have the header be in red on the first page in a pdf and in blue via print to make sure the script is visibly applied
  ```js
	var vars = {};
	var query_strings_from_url = document.location.search.substring(1).split('&');
	for (var query_string in query_strings_from_url) {
		if (query_strings_from_url.hasOwnProperty(query_string)) {
			var temp_var = query_strings_from_url[query_string].split('=', 2);
			vars[temp_var[0]] = decodeURI(temp_var[1]);
		}
	}
	var el = document.getElementsByClassName("header-content");
	
	if (vars["page"] == "1") {
		// "page" will be available only in pdf via wkhtmltopdf
		el[0].style.color = "red";
	} else {
	    el[0].style.color = "blue";
	}
  ```

**Result (Note the header):**
- PDF
   <img width="600" alt="Screenshot 2023-12-21 at 5 31 41 PM" src="https://github.com/frappe/frappe/assets/25857446/3c9702d7-3f44-4046-9bab-42127ba8e840">
- Print (does not have page numbers substituted in custom header because it is not rendered via wkhtmltopdf, treat this as an example)
  <img width="472" alt="Screenshot 2023-12-21 at 5 32 22 PM" src="https://github.com/frappe/frappe/assets/25857446/bb3bc6f2-f244-4f88-b090-b02566ee6f83">

## Issue:
- Create a **Letterhead** record that attempts to show the Page number (as per the `Footers And Headers` section in https://wkhtmltopdf.org/usage/wkhtmltopdf.txt)
   <img width="607" alt="Screenshot 2023-11-20 at 3 22 05 PM" src="https://github.com/frappe/frappe/assets/25857446/d20eb29e-b90f-4fcd-91de-5e4a83703dcf">
- Letter has `id` as `header-html` (extracted in `pdf.py`) so that it is rendered as a separate `header.html` by wkhtmltopdf and so that it receives the "page", "topage" variables for substitution
- Use this letterhead while printing with any format (Standard format taken in eg.). 
-  **The Letterhead does not show up**
   ![2023-11-20 14 20 09](https://github.com/frappe/frappe/assets/25857446/a0b023ec-f3eb-41a9-83ea-041534ecf0ee)
- **Source:** `header-html` is extracted from the html print document to avoid duplicates, but it is done before wkhtmltopdf gets a chance to render the `header-html` section into a `header.html` file


## Fix:
- Make sure 'header-html' is extracted from document after it is rendered as html and loaded in wkhtmltopdf options, else it goes missing
  ![2023-11-20 14 21 47](https://github.com/frappe/frappe/assets/25857446/7baaa9bb-4b57-4061-ad3e-12d475a766c2)
- Use `if` conditions to secure js script. Errors cause silent breakage and hence the scripts are not effective/not run. There is no feedback


