### PR TITLE
fix: webform render with link field

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -684,11 +684,8 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 			frappe.get_cached_value("DocType", doctype, "show_title_field_in_link") == 1
 		)
 		if not show_title_field_in_link:
-			value = frappe.get_cached_value(
-				"Property Setter",
-				fieldname="value",
-				filters={"property": "show_title_field_in_link", "doc_type": doctype},
-			)
+			doc = doctype + "-main-show_title_field_in_link"
+			value = frappe.get_cached_value("Property Setter", doc, "value")
 			if value and int(value) == 1:
 				show_title_field_in_link = True
 


### PR DESCRIPTION
`get_cached_doc`  don't handle filters, so here I build right Property Setter docname to get the desired value.
I don't know if this is the best way to fix it 

fix https://github.com/frappe/frappe/issues/23284