### PR TITLE
fix: dont rename link fields of Virtual doctypes

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -464,11 +464,12 @@ def get_link_fields(doctype: str) -> list[dict]:
 		cf = frappe.qb.DocType("Custom Field")
 		ps = frappe.qb.DocType("Property Setter")
 
-		st_issingle = frappe.qb.from_(dt).select(dt.issingle).where(dt.name == df.parent).as_("issingle")
 		standard_fields = (
 			frappe.qb.from_(df)
-			.select(df.parent, df.fieldname, st_issingle)
-			.where((df.options == doctype) & (df.fieldtype == "Link"))
+			.inner_join(dt)
+			.on(df.parent == dt.name)
+			.select(df.parent, df.fieldname, dt.issingle.as_("issingle"))
+			.where((df.options == doctype) & (df.fieldtype == "Link") & (dt.is_virtual == 0))
 			.run(as_dict=True)
 		)
 


### PR DESCRIPTION
1. Create a Virutal Doctype 'dummy1' with a Link field to Existing non-virtual doctype 'Account'. 
2. Open a record of the non-virtual doctype and rename it.

Framework tries to rename the values in Virtual doctype.

Ex: https://github.com/frappe/erpnext/actions/runs/6911668601/job/18806479322?pr=38148#step:13:1186

### App Versions
```
{
	"erpnext": "15.0.0-dev",
	"frappe": "15.0.0-dev",
	"hrms": "16.0.0-dev",
	"india_compliance": "16.0.0-dev",
	"payments": "0.0.1"
}
```
### Route
```
Form/Account/1211-11-4 - 6 - - Debtors 1 - Test - - _TC
```
### Traceback
```
Error in query:
('UPDATE `tabdummy1` SET `account`=%(param1)s WHERE `account`=%(param2)s', {'param1': '1211-11-4 - 7 - Debtors 1 - Test1 - _TC', 'param2': '1211-11-4 - 6 - - Debtors 1 - Test - - _TC'})
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 110, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1673, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "apps/erpnext/erpnext/accounts/doctype/account/account.py", line 462, in update_account_number
    frappe.rename_doc("Account", name, new_name, force=1)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1385, in rename_doc
    return rename_doc(
  File "apps/frappe/frappe/model/rename_doc.py", line 184, in rename_doc
    update_link_field_values(link_fields, old, new, doctype)
  File "apps/frappe/frappe/model/rename_doc.py", line 449, in update_link_field_values
    frappe.db.set_value(parent, {docfield: old}, docfield, new, update_modified=False)
  File "apps/frappe/frappe/database/database.py", line 919, in set_value
    query.run(debug=debug)
  File "apps/frappe/frappe/query_builder/utils.py", line 87, in execute_query
    result = frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
  File "apps/frappe/frappe/database/database.py", line 217, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 558, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 822, in _read_query_result
    result.read()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 1200, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 772, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1146, "Table '_ec3fc8286df941c1.tabdummy1' doesn't exist")

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"account_number": "1211-11-4 - 7",
		"account_name": "Debtors 1 - Test1",
		"name": "1211-11-4 - 6 - - Debtors 1 - Test - - _TC"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/erpnext.accounts.doctype.account.account.update_account_number",
	"request_id": null
}
```
### Response Data
```
{
	"exception": "pymysql.err.ProgrammingError: (1146, \"Table '_ec3fc8286df941c1.tabdummy1' doesn't exist\")",
	"exc_type": "ProgrammingError"
}
```