### PR TITLE
fix(WebForm): Replace `get_cached_value` with `get_value`

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -684,7 +684,7 @@ def get_link_options(web_form_name, doctype, allow_read_on_all_link_options=Fals
 			frappe.get_cached_value("DocType", doctype, "show_title_field_in_link") == 1
 		)
 		if not show_title_field_in_link:
-			value = frappe.get_cached_value(
+			value = frappe.db.get_value(
 				"Property Setter",
 				fieldname="value",
 				filters={"property": "show_title_field_in_link", "doc_type": doctype},


### PR DESCRIPTION
I believe that `frappe.get_cached_value` (values cached in Redis) **does not support filters**, so revert back to `get_value` (queries the DB, optional in-memory/request cache).

https://github.com/frappe/frappe/blob/d715b0ad31147707592357ad1db22ffc78ebabfc/frappe/__init__.py#L1183-L1185


This might mean that unit tests are not covering this case (DocType without show_title_field_in_link).

> https://github.com/frappe/frappe/pull/23270 ⋅ no-docs