### PR TITLE
refactor(treewide): code cleanup

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -17,7 +17,6 @@ import inspect
 import json
 import os
 import re
-import unicodedata
 import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, overload
@@ -43,7 +42,6 @@ from .utils.jinja import (
 	get_template,
 	render_template,
 )
-from .utils.lazy_loader import lazy_import
 
 __version__ = "15.0.0-dev"
 __title__ = "Frappe Framework"
@@ -418,7 +416,7 @@ def errprint(msg: str) -> None:
 
 	:param msg: Message."""
 	msg = as_unicode(msg)
-	if not request or (not "cmd" in local.form_dict) or conf.developer_mode:
+	if not request or ("cmd" not in local.form_dict) or conf.developer_mode:
 		print(msg)
 
 	error_log.append({"exc": msg})
@@ -433,7 +431,7 @@ def log(msg: str) -> None:
 
 	:param msg: Message."""
 	if not request:
-		if conf.get("logging") or False:
+		if conf.get("logging"):
 			print(repr(msg))
 
 	debug_log.append(as_unicode(msg))
@@ -1959,7 +1957,7 @@ def get_all(doctype, *args, **kwargs):
 	        frappe.get_all("ToDo", fields=["*"], filters = [["modified", ">", "2014-01-01"]])
 	"""
 	kwargs["ignore_permissions"] = True
-	if not "limit_page_length" in kwargs:
+	if "limit_page_length" not in kwargs:
 		kwargs["limit_page_length"] = 0
 	return get_list(doctype, *args, **kwargs)
 
@@ -2008,7 +2006,7 @@ def as_json(obj: dict | list, indent=1, separators=None, ensure_ascii=True) -> s
 
 
 def are_emails_muted():
-	return flags.mute_emails or cint(conf.get("mute_emails") or 0) or False
+	return flags.mute_emails or cint(conf.get("mute_emails"))
 
 
 def get_test_records(doctype):

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -96,7 +96,6 @@ class HTTPRequest:
 
 
 class LoginManager:
-
 	__slots__ = ("user", "info", "full_name", "user_type", "resume")
 
 	def __init__(self):
@@ -305,8 +304,8 @@ class LoginManager:
 
 	def validate_hour(self):
 		"""check if user is logging in during restricted hours"""
-		login_before = int(frappe.db.get_value("User", self.user, "login_before", ignore=True) or 0)
-		login_after = int(frappe.db.get_value("User", self.user, "login_after", ignore=True) or 0)
+		login_before = cint(frappe.db.get_value("User", self.user, "login_before", ignore=True))
+		login_after = cint(frappe.db.get_value("User", self.user, "login_after", ignore=True))
 
 		if not (login_before or login_after):
 			return

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -950,7 +950,7 @@ def move(dest_dir, site):
 	site_dump_exists = True
 	count = 0
 	while site_dump_exists:
-		final_new_path = new_path + str(count)
+		final_new_path = new_path + str(count or "")
 		site_dump_exists = os.path.exists(final_new_path)
 		count += 1
 

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -413,7 +413,6 @@ def _reinstall(
 	verbose=False,
 ):
 	from frappe.installer import _new_site
-	from frappe.utils.synchronization import filelock
 
 	if not yes:
 		click.confirm("This will wipe your database. Are you sure you want to reinstall?", abort=True)
@@ -951,9 +950,9 @@ def move(dest_dir, site):
 	site_dump_exists = True
 	count = 0
 	while site_dump_exists:
-		final_new_path = new_path + (count and str(count) or "")
+		final_new_path = new_path + str(count)
 		site_dump_exists = os.path.exists(final_new_path)
-		count = int(count or 0) + 1
+		count += 1
 
 	shutil.move(old_path, final_new_path)
 	frappe.destroy()

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -288,7 +288,7 @@ class CommunicationEmailMixin:
 			"delayed": True,
 			"communication": self.name,
 			"read_receipt": self.read_receipt,
-			"is_notification": (self.sent_or_received == "Received" and True) or False,
+			"is_notification": (self.sent_or_received == "Received"),
 			"print_letterhead": print_letterhead,
 		}
 

--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -144,8 +144,7 @@ class Exporter:
 				value = doc.get(df.fieldname, None)
 
 				if df.fieldtype == "Duration":
-					value = flt(value or 0)
-					value = format_duration(value, df.hide_days)
+					value = format_duration(flt(value), df.hide_days)
 
 				row[i] = value
 		return rows

--- a/frappe/core/doctype/domain/domain.py
+++ b/frappe/core/doctype/domain/domain.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.model.document import Document
+from frappe.utils import cint
 
 
 class Domain(Document):
@@ -28,7 +29,7 @@ class Domain(Document):
 		self.setup_properties()
 		self.set_values()
 
-		if not int(frappe.defaults.get_defaults().setup_complete or 0):
+		if not cint(frappe.defaults.get_defaults().setup_complete):
 			# if setup not complete, setup desktop etc.
 			self.setup_sidebar_items()
 			self.set_default_portal_role()

--- a/frappe/core/doctype/recorder/recorder.py
+++ b/frappe/core/doctype/recorder/recorder.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.model.document import Document
 from frappe.recorder import get as get_recorder_data
-from frappe.utils import cint, evaluate_filters, make_filter_dict
+from frappe.utils import cint, evaluate_filters
 
 
 class Recorder(Document):
@@ -27,6 +27,7 @@ class Recorder(Document):
 		sql_queries: DF.Table[RecorderQuery]
 		time: DF.Datetime | None
 		time_in_queries: DF.Float
+
 	# end: auto-generated types
 
 	def load_from_db(self):
@@ -38,7 +39,7 @@ class Recorder(Document):
 
 	@staticmethod
 	def get_list(args):
-		start = cint(args.get("start")) or 0
+		start = cint(args.get("start"))
 		page_length = cint(args.get("page_length")) or 20
 		requests = Recorder.get_filtered_requests(args)[start : start + page_length]
 

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -45,6 +45,7 @@ class Report(Document):
 		report_script: DF.Code | None
 		report_type: DF.Literal["Report Builder", "Query Report", "Script Report", "Custom Report"]
 		roles: DF.Table[HasRole]
+
 	# end: auto-generated types
 	def validate(self):
 		"""only administrator can save standard report"""
@@ -129,7 +130,7 @@ class Report(Document):
 		if frappe.flags.in_import:
 			return
 
-		if self.is_standard == "Yes" and (frappe.local.conf.get("developer_mode") or 0) == 1:
+		if self.is_standard == "Yes" and (frappe.local.conf.get("developer_mode", 0) == 1):
 			export_to_files(
 				record_list=[["Report", self.name]], record_module=self.module, create_init=True
 			)
@@ -155,7 +156,6 @@ class Report(Document):
 	def execute_script_report(self, filters):
 		# save the timestamp to automatically set to prepared
 		threshold = 15
-		res = []
 
 		start_time = datetime.datetime.now()
 
@@ -382,7 +382,7 @@ class Report(Document):
 
 
 def is_prepared_report_enabled(report):
-	return cint(frappe.db.get_value("Report", report, "prepared_report")) or 0
+	return cint(frappe.db.get_value("Report", report, "prepared_report"))
 
 
 def get_report_module_dotted_path(module, report_name):

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -130,7 +130,7 @@ class Report(Document):
 		if frappe.flags.in_import:
 			return
 
-		if self.is_standard == "Yes" and (frappe.local.conf.get("developer_mode", 0) == 1):
+		if self.is_standard == "Yes" and frappe.conf.developer_mode:
 			export_to_files(
 				record_list=[["Report", self.name]], record_module=self.module, create_init=True
 			)

--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -59,6 +59,7 @@ class RQJob(Document):
 		]
 		time_taken: DF.Duration | None
 		timeout: DF.Duration | None
+
 	# end: auto-generated types
 	def load_from_db(self):
 		try:
@@ -79,7 +80,7 @@ class RQJob(Document):
 	@staticmethod
 	def get_list(args):
 
-		start = cint(args.get("start")) or 0
+		start = cint(args.get("start"))
 		page_length = cint(args.get("page_length")) or 20
 
 		order_desc = "desc" in args.get("order_by", "")

--- a/frappe/core/doctype/rq_worker/rq_worker.py
+++ b/frappe/core/doctype/rq_worker/rq_worker.py
@@ -34,6 +34,7 @@ class RQWorker(Document):
 		total_working_time: DF.Duration | None
 		utilization_percent: DF.Percent
 		worker_name: DF.Data | None
+
 	# end: auto-generated types
 	def load_from_db(self):
 
@@ -47,7 +48,7 @@ class RQWorker(Document):
 
 	@staticmethod
 	def get_list(args):
-		start = cint(args.get("start")) or 0
+		start = cint(args.get("start"))
 		page_length = cint(args.get("page_length")) or 20
 
 		workers = get_workers()

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -93,12 +93,13 @@ class SystemSettings(Document):
 		time_zone: DF.Literal
 		two_factor_method: DF.Literal["OTP App", "SMS", "Email"]
 		welcome_email_template: DF.Link | None
+
 	# end: auto-generated types
 	def validate(self):
 		from frappe.twofactor import toggle_two_factor_auth
 
-		enable_password_policy = cint(self.enable_password_policy) and True or False
-		minimum_password_score = cint(getattr(self, "minimum_password_score", 0)) or 0
+		enable_password_policy = cint(self.enable_password_policy)
+		minimum_password_score = cint(getattr(self, "minimum_password_score", 0))
 		if enable_password_policy and minimum_password_score <= 0:
 			frappe.throw(_("Please select Minimum Password Score"))
 		elif not enable_password_policy:
@@ -195,7 +196,7 @@ def update_last_reset_password_date():
 def load():
 	from frappe.utils.momentjs import get_all_timezones
 
-	if not "System Manager" in frappe.get_roles():
+	if "System Manager" not in frappe.get_roles():
 		frappe.throw(_("Not permitted"), frappe.PermissionError)
 
 	all_defaults = frappe.db.get_defaults()

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -872,7 +872,7 @@ def test_password_strength(
 			"Arguments `key` and `old_password` are deprecated in function `test_password_strength`."
 		)
 
-	enable_password_policy = frappe.get_system_settings("enable_password_policy") or 0
+	enable_password_policy = frappe.get_system_settings("enable_password_policy")
 
 	if not enable_password_policy:
 		return {}
@@ -885,7 +885,7 @@ def test_password_strength(
 	if new_password:
 		result = _test_password_strength(new_password, user_inputs=user_data)
 		password_policy_validation_passed = False
-		minimum_password_score = cint(frappe.get_system_settings("minimum_password_score")) or 0
+		minimum_password_score = cint(frappe.get_system_settings("minimum_password_score"))
 
 		# score should be greater than 0 and minimum_password_score
 		if result.get("score") and result.get("score") >= minimum_password_score:

--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -31,6 +31,7 @@ class UserType(Document):
 		user_doctypes: DF.Table[UserDocumentType]
 		user_id_field: DF.Literal
 		user_type_modules: DF.Table[UserTypeModule]
+
 	# end: auto-generated types
 	def validate(self):
 		self.set_modules()
@@ -140,7 +141,7 @@ class UserType(Document):
 		for row in self.user_doctypes:
 			docperm = add_role_permissions(row.document_type, self.role)
 
-			values = {perm: row.get(perm) or 0 for perm in perms}
+			values = {perm: row.get(perm, default=0) for perm in perms}
 			for perm in ["print", "email", "share"]:
 				values[perm] = 1
 

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -24,7 +24,7 @@ class MariaDBTable(DBTable):
 			additional_definitions += index_defs
 
 		# child table columns
-		if self.meta.get("istable") or 0:
+		if self.meta.get("istable", default=0):
 			additional_definitions += [
 				f"parent varchar({varchar_len})",
 				f"parentfield varchar({varchar_len})",

--- a/frappe/database/postgres/schema.py
+++ b/frappe/database/postgres/schema.py
@@ -17,7 +17,7 @@ class PostgresTable(DBTable):
 			additional_definitions += ",\n".join(column_defs)
 
 		# child table columns
-		if self.meta.get("istable") or 0:
+		if self.meta.get("istable", default=0):
 			if column_defs:
 				additional_definitions += ",\n"
 

--- a/frappe/database/schema.py
+++ b/frappe/database/schema.py
@@ -213,11 +213,11 @@ class DbColumn:
 		unique = False
 
 		if self.fieldtype in ("Check", "Int"):
-			default = cint(self.default) or 0
+			default = cint(self.default)
 			null = False
 
 		elif self.fieldtype in ("Currency", "Float", "Percent"):
-			default = flt(self.default) or 0
+			default = flt(self.default)
 			null = False
 
 		elif (
@@ -292,7 +292,7 @@ class DbColumn:
 		if (current_def["index"] and not self.set_index) and column_type not in ("text", "longtext"):
 			self.table.drop_index.append(self)
 
-		elif (not current_def["index"] and self.set_index) and not (column_type in ("text", "longtext")):
+		elif (not current_def["index"] and self.set_index) and column_type not in ("text", "longtext"):
 			self.table.add_index.append(self)
 
 	def default_changed(self, current_def):

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -37,6 +37,7 @@ class DesktopIcon(Document):
 		reverse: DF.Check
 		standard: DF.Check
 		type: DF.Literal["module", "list", "link", "page", "query-report"]
+
 	# end: auto-generated types
 	def validate(self):
 		if not self.label:
@@ -225,7 +226,7 @@ def add_user_icon(_doctype, _report=None, label=None, link=None, type="link", st
 
 			icon_name = new_icon.name
 
-		except frappe.UniqueValidationError as e:
+		except frappe.UniqueValidationError:
 			frappe.throw(_("Desktop Icon already exists"))
 		except Exception as e:
 			raise e
@@ -262,7 +263,7 @@ def set_desktop_icons(visible_list, ignore_duplicate=True):
 	an icon for the doctype"""
 
 	# clear all custom only if setup is not complete
-	if not int(frappe.defaults.get_defaults().setup_complete or 0):
+	if not frappe.defaults.get_defaults().get("setup_complete", 0):
 		frappe.db.delete("Desktop Icon", {"standard": 0})
 
 	# set standard as blocked and hidden if setting first active domain

--- a/frappe/email/doctype/email_domain/email_domain.py
+++ b/frappe/email/doctype/email_domain/email_domain.py
@@ -73,6 +73,7 @@ class EmailDomain(Document):
 		use_ssl_for_outgoing: DF.Check
 		use_starttls: DF.Check
 		use_tls: DF.Check
+
 	# end: auto-generated types
 	def validate(self):
 		"""Validate POP3/IMAP and SMTP connections."""
@@ -120,4 +121,4 @@ class EmailDomain(Document):
 		elif self.use_tls:
 			self.smtp_port = self.smtp_port or 587
 
-		conn_method((self.smtp_server or ""), cint(self.smtp_port) or 0).quit()
+		conn_method((self.smtp_server or ""), cint(self.smtp_port)).quit()

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -250,10 +250,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		client_scopes = frappe.db.get_value("OAuth Client", otoken.client, "scopes").split(
 			get_url_delimiter()
 		)
-		are_scopes_valid = True
-		for scp in scopes:
-			are_scopes_valid = are_scopes_valid if scp in client_scopes else False
-
+		are_scopes_valid = all(scope in client_scopes for scope in scopes)
 		return is_token_valid and are_scopes_valid
 
 	# Token refresh request

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -252,7 +252,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		)
 		are_scopes_valid = True
 		for scp in scopes:
-			are_scopes_valid = are_scopes_valid and True if scp in client_scopes else False
+			are_scopes_valid = are_scopes_valid if scp in client_scopes else False
 
 		return is_token_valid and are_scopes_valid
 

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -140,7 +140,7 @@ def rate_limit(
 
 			cache_key = f"rl:{frappe.form_dict.cmd}:{identity}"
 
-			value = frappe.cache.get(cache_key) or 0
+			value = frappe.cache.get(cache_key)
 			if not value:
 				frappe.cache.setex(cache_key, seconds, 0)
 

--- a/frappe/social/doctype/energy_point_log/test_energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/test_energy_point_log.py
@@ -376,7 +376,7 @@ def create_a_todo(description=None):
 
 
 def get_points(user, point_type="energy_points"):
-	return _get_energy_points(user).get(point_type) or 0
+	return _get_energy_points(user).get(point_type, 0)
 
 
 def assign_users_to_todo(todo_name, users):

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -43,10 +43,10 @@ def toggle_two_factor_auth(state, roles=None):
 
 def two_factor_is_enabled(user=None):
 	"""Returns True if 2FA is enabled."""
-	enabled = int(frappe.db.get_single_value("System Settings", "enable_two_factor_auth") or 0)
+	enabled = cint(frappe.db.get_single_value("System Settings", "enable_two_factor_auth"))
 	if enabled:
-		bypass_two_factor_auth = int(
-			frappe.db.get_single_value("System Settings", "bypass_2fa_for_retricted_ip_users") or 0
+		bypass_two_factor_auth = cint(
+			frappe.db.get_single_value("System Settings", "bypass_2fa_for_retricted_ip_users")
 		)
 		if bypass_two_factor_auth and user:
 			user_doc = frappe.get_doc("User", user)

--- a/frappe/utils/dashboard.py
+++ b/frappe/utils/dashboard.py
@@ -22,7 +22,7 @@ def cache_source(function):
 			return function(chart=chart, no_cache=no_cache)
 		chart_name = frappe.parse_json(chart).name
 		cache_key = f"chart-data:{chart_name}"
-		if int(kwargs.get("refresh") or 0):
+		if cint(kwargs.get("refresh")):
 			results = generate_and_cache_results(kwargs, function, cache_key, chart)
 		else:
 			cached_results = frappe.cache.get_value(cache_key)

--- a/frappe/utils/file_manager.py
+++ b/frappe/utils/file_manager.py
@@ -3,7 +3,6 @@
 
 import base64
 import hashlib
-import io
 import json
 import mimetypes
 import os
@@ -283,9 +282,7 @@ def remove_file(
 	ignore_permissions, comment = False, None
 	if attached_to_doctype and attached_to_name and not from_delete:
 		doc = frappe.get_doc(attached_to_doctype, attached_to_name)
-		ignore_permissions = doc.has_permission("write") or False
-		if frappe.flags.in_web_form:
-			ignore_permissions = True
+		ignore_permissions = frappe.flags.in_web_form or doc.has_permission("write")
 		if not file_name:
 			file_name = frappe.db.get_value("File", fid, "file_name")
 		comment = doc.add_comment("Attachment Removed", file_name)

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -4,6 +4,7 @@ import getpass
 
 import frappe
 from frappe.geo.doctype.country.country import import_country_and_currency
+from frappe.utils import cint
 from frappe.utils.password import update_password
 
 
@@ -166,7 +167,7 @@ def before_tests():
 	frappe.clear_cache()
 
 	# complete setup if missing
-	if not int(frappe.db.get_single_value("System Settings", "setup_complete") or 0):
+	if not cint(frappe.db.get_single_value("System Settings", "setup_complete")):
 		complete_setup_wizard()
 
 	frappe.db.set_single_value("Website Settings", "disable_signup", 0)

--- a/frappe/website/doctype/blog_post/blog_post.py
+++ b/frappe/website/doctype/blog_post/blog_post.py
@@ -53,6 +53,7 @@ class BlogPost(WebsiteGenerator):
 		read_time: DF.Int
 		route: DF.Data | None
 		title: DF.Data
+
 	# end: auto-generated types
 	@frappe.whitelist()
 	def make_route(self):
@@ -211,14 +212,14 @@ class BlogPost(WebsiteGenerator):
 			"reference_name": self.name,
 		}
 
-		context.like_count = frappe.db.count("Comment", filters) or 0
+		context.like_count = frappe.db.count("Comment", filters)
 
 		filters["comment_email"] = user
 
 		if user == "Guest":
 			filters["ip_address"] = frappe.local.request_ip
 
-		context.like = frappe.db.count("Comment", filters) or 0
+		context.like = frappe.db.count("Comment", filters)
 
 	def set_read_time(self):
 		content = self.content or self.content_html or ""
@@ -385,7 +386,7 @@ def get_blog_list(
 
 		if (
 			post.avatar
-			and (not "http:" in post.avatar and not "https:" in post.avatar)
+			and ("http:" not in post.avatar and "https:" not in post.avatar)
 			and not post.avatar.startswith("/")
 		):
 			post.avatar = "/" + post.avatar

--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -29,6 +29,7 @@ class PersonalDataDeletionRequest(Document):
 		deletion_steps: DF.Table[PersonalDataDeletionStep]
 		email: DF.Data
 		status: DF.Literal["Pending Verification", "Pending Approval", "On Hold", "Deleted"]
+
 	# end: auto-generated types
 	def __init__(self, *args, **kwargs):
 		super().__init__(*args, **kwargs)
@@ -154,7 +155,7 @@ class PersonalDataDeletionRequest(Document):
 			row_data = {
 				"status": "Pending",
 				"document_type": step.get("doctype"),
-				"partial": step.get("partial") or False,
+				"partial": step.get("partial", False),
 				"fields": json.dumps(step.get("redact_fields", [])),
 				"filtered_by": step.get("filtered_by") or "",
 			}

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import encode, get_request_site_address
+from frappe.utils import cint, encode, get_request_site_address
 from frappe.website.utils import get_boot_data
 
 
@@ -63,6 +63,7 @@ class WebsiteSettings(Document):
 		top_bar_items: DF.Table[TopBarItem]
 		website_theme: DF.Link | None
 		website_theme_image_link: DF.Code | None
+
 	# end: auto-generated types
 	def validate(self):
 		self.validate_top_bar_items()
@@ -216,7 +217,7 @@ def get_website_settings(context=None):
 		"linked_in_share",
 		"disable_signup",
 	]:
-		context[k] = int(context.get(k) or 0)
+		context[k] = cint(context.get(k))
 
 	if settings.address:
 		context["footer_address"] = settings.address

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -98,8 +98,8 @@ class WebsiteGenerator(Document):
 
 	def is_website_published(self):
 		"""Return true if published in website"""
-		if self.get_condition_field():
-			return self.get(self.get_condition_field()) and True or False
+		if data := self.get_condition_field():
+			return self.get(data) or False
 		else:
 			return True
 
@@ -141,7 +141,6 @@ class WebsiteGenerator(Document):
 			and self.is_website_published()
 			and self.meta.allow_guest_to_view
 		):
-
 			url = frappe.utils.get_url(self.route)
 			frappe.enqueue(
 				"frappe.website.doctype.website_settings.google_indexing.publish_site",

--- a/frappe/website/website_generator.py
+++ b/frappe/website/website_generator.py
@@ -98,8 +98,8 @@ class WebsiteGenerator(Document):
 
 	def is_website_published(self):
 		"""Return true if published in website"""
-		if data := self.get_condition_field():
-			return self.get(data) or False
+		if condition_field := self.get_condition_field():
+			return self.get(condition_field) or False
 		else:
 			return True
 

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -3,8 +3,8 @@
 
 import frappe
 from frappe import _
-from frappe.model import no_value_fields
 from frappe.model.document import Document
+from frappe.utils import cint
 
 
 class Workflow(Document):
@@ -29,6 +29,7 @@ class Workflow(Document):
 		workflow_data: DF.JSON | None
 		workflow_name: DF.Data
 		workflow_state_field: DF.Data
+
 	# end: auto-generated types
 	def validate(self):
 		self.set_active()
@@ -69,7 +70,7 @@ class Workflow(Document):
 		docstatus_map = {}
 		states = self.get("states")
 		for d in states:
-			if not d.doc_status in docstatus_map:
+			if d.doc_status not in docstatus_map:
 				frappe.db.sql(
 					"""
 					UPDATE `tab{doctype}`
@@ -140,7 +141,7 @@ class Workflow(Document):
 				frappe.throw(frappe._("Cannot cancel before submitting. See Transition {0}").format(t.idx))
 
 	def set_active(self):
-		if int(self.is_active or 0):
+		if cint(self.is_active):
 			# clear all other
 			frappe.db.sql(
 				"""UPDATE `tabWorkflow` SET `is_active`=0


### PR DESCRIPTION
Drop redundant bool conversion, use cint() wherever possible

