### PR TITLE
fix: load languages that have capital letters

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -10,12 +10,14 @@ import frappe.translate
 from frappe import _
 from frappe.tests.utils import FrappeTestCase
 from frappe.translate import (
+	clear_cache,
 	extract_javascript,
 	extract_messages_from_javascript_code,
 	extract_messages_from_python_code,
 	get_language,
 	get_parent_language,
 	get_translation_dict_from_file,
+	write_translations_file,
 )
 from frappe.utils import get_bench_path, set_request
 
@@ -62,6 +64,20 @@ class TestTranslate(FrappeTestCase):
 			self.assertEqual(ext_message, exp_message)
 			self.assertEqual(ext_context, exp_context)
 			self.assertEqual(ext_line, exp_line)
+
+	def test_read_language_variant(self):
+		frappe.local.lang = "en"
+		self.assertEqual(_("Mobile No"), "Mobile No")
+		try:
+			frappe.local.lang = "pt-BR"
+			self.assertEqual(_("Mobile No"), "Telefone Celular")
+		finally:
+			try:
+				frappe.local.lang = "pt"
+				self.assertEqual(_("Mobile No"), "Nr. de Telemóvel")
+			finally:
+				frappe.local.lang = "en"
+				self.assertEqual(_("Mobile No"), "Mobile No")
 
 	def test_translation_with_context(self):
 		try:

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -200,7 +200,7 @@ def get_translations_from_apps(lang, apps=None):
 
 	translations = {}
 	for app in apps or frappe.get_installed_apps(_ensure_on_bench=True):
-		path = frappe.get_app_path(app, "translations", lang + ".csv")
+		path = os.path.join(frappe.get_app_path(app, "translations"), lang + ".csv")
 		translations.update(get_translation_dict_from_file(path, lang, app) or {})
 	if "-" in lang:
 		parent = lang.split("-", 1)[0]


### PR DESCRIPTION
for languages where case sensitive is used, frappe.get_app_path returns everything in lowercase.

**Example for lang pt-BR:**
frappe.get_app_path(app, "translations", lang + ".csv")

**Return:**
/workspace/development/frappe-bench/apps/tracker/tracker/translations/pt_br.csv

**pt-br.csv** in lowercase, then the system does not find the file because the file is **pt-BR.csv**
which caused the translation to pt-BR not to load.

**With this new change, the file name will be preserved correctly.**

