### PR TITLE
fix(event/sync_communication): add `distinct` while querying communication links

### DIFF
--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -121,9 +121,7 @@ class Event(Document):
 					["Communication Link", "link_doctype", "=", participant.reference_doctype],
 					["Communication Link", "link_name", "=", participant.reference_docname],
 				]
-				comms = frappe.get_all("Communication", filters=filters, fields=["name"])
-
-				if comms:
+				if comms := frappe.get_all("Communication", filters=filters, fields=["name"], distinct=True):
 					for comm in comms:
 						communication = frappe.get_doc("Communication", comm.name)
 						self.update_communication(participant, communication)


### PR DESCRIPTION
There's cases where these are duplicated - have noticed it happening in power of 2.
The duplication needs to be investigated separately - it seems like deduplication is only being called for Email communication
https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/communication/communication.py#L167-L170

Internal Reference: 5969
