### PR TITLE
refactor: allow setting a db user name different from the database name

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -291,7 +291,7 @@ def connect(
 	local.db = get_db(
 		host=local.conf.db_host,
 		port=local.conf.db_port,
-		user=local.conf.db_user,
+		user=local.conf.db_user or db_name,
 		password=None,
 	)
 	if set_admin_as_user:

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -304,12 +304,12 @@ def connect_replica() -> bool:
 	if local and hasattr(local, "replica_db") and hasattr(local, "primary_db"):
 		return False
 
-	user = local.conf.db_name
+	user = local.conf.db_user
 	password = local.conf.db_password
 	port = local.conf.replica_db_port
 
 	if local.conf.different_credentials_for_replica:
-		user = local.conf.replica_db_name
+		user = local.conf.replica_db_user or local.conf.replica_db_name
 		password = local.conf.replica_db_password
 
 	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -269,6 +269,10 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 
 	local.initialised = True
 
+	# Set the user as database name if not set in config
+	if local.conf and local.conf.db_name is not None and local.conf.db_user is None:
+		local.conf.db_user = local.conf.db_name
+
 
 def connect(
 	site: str | None = None, db_name: str | None = None, set_admin_as_user: bool = True
@@ -287,7 +291,7 @@ def connect(
 	local.db = get_db(
 		host=local.conf.db_host,
 		port=local.conf.db_port,
-		user=db_name or local.conf.db_name,
+		user=local.conf.db_user,
 		password=None,
 	)
 	if set_admin_as_user:

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -68,6 +68,7 @@ def new_site(
 	db_type=None,
 	db_host=None,
 	db_port=None,
+	db_user=None,
 	set_default=False,
 	setup_db=True,
 ):
@@ -91,6 +92,7 @@ def new_site(
 		db_type=db_type,
 		db_host=db_host,
 		db_port=db_port,
+		db_user=db_user,
 		setup_db=setup_db,
 	)
 
@@ -1058,7 +1060,9 @@ def _drop_site(
 			sys.exit(1)
 
 	click.secho("Dropping site database and user", fg="green")
-	drop_user_and_database(frappe.conf.db_name, db_root_username, db_root_password)
+	drop_user_and_database(
+		frappe.conf.db_name, frappe.conf.db_user, db_root_username, db_root_password
+	)
 
 	archived_sites_path = archived_sites_path or os.path.join(
 		frappe.utils.get_bench_path(), "archived", "sites"

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -53,6 +53,7 @@ from frappe.exceptions import SiteNotSpecifiedError
 	default=True,
 	help="Create user and database in mariadb/postgres; only bootstrap if false",
 )
+@click.option("--db-user", help="Database user if you already have one")
 def new_site(
 	site,
 	db_root_username=None,

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1061,9 +1061,11 @@ def _drop_site(
 			sys.exit(1)
 
 	click.secho("Dropping site database and user", fg="green")
-	drop_user_and_database(
-		frappe.conf.db_name, frappe.conf.db_user, db_root_username, db_root_password
-	)
+
+	frappe.flags.root_login = db_root_username
+	frappe.flags.root_password = db_root_password
+
+	drop_user_and_database(frappe.conf.db_name, frappe.conf.db_user)
 
 	archived_sites_path = archived_sites_path or os.path.join(
 		frappe.utils.get_bench_path(), "archived", "sites"
@@ -1341,7 +1343,6 @@ def build_search_index(context):
 @click.option("--no-backup", is_flag=True, default=False, help="Do not backup the table")
 @pass_context
 def clear_log_table(context, doctype, days, no_backup):
-
 	"""If any logtype table grows too large then clearing it with DELETE query
 	is not feasible in reasonable time. This command copies recent data to new
 	table and replaces current table with new smaller table.

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -36,21 +36,17 @@ def bootstrap_database(db_name, verbose=None, source_sql=None):
 		return frappe.database.mariadb.setup_db.bootstrap_database(db_name, verbose, source_sql)
 
 
-def drop_user_and_database(db_name, db_user, root_login=None, root_password=None):
+def drop_user_and_database(db_name, db_user):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.setup_db
 
-		return frappe.database.postgres.setup_db.drop_user_and_database(
-			db_name, db_user, root_login, root_password
-		)
+		return frappe.database.postgres.setup_db.drop_user_and_database(db_name, db_user)
 	else:
 		import frappe.database.mariadb.setup_db
 
-		return frappe.database.mariadb.setup_db.drop_user_and_database(
-			db_name, db_user, root_login, root_password
-		)
+		return frappe.database.mariadb.setup_db.drop_user_and_database(db_name, db_user)
 
 
 def get_db(host=None, user=None, password=None, port=None):

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -36,20 +36,20 @@ def bootstrap_database(db_name, verbose=None, source_sql=None):
 		return frappe.database.mariadb.setup_db.bootstrap_database(db_name, verbose, source_sql)
 
 
-def drop_user_and_database(db_name, root_login=None, root_password=None):
+def drop_user_and_database(db_name, db_user, root_login=None, root_password=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.setup_db
 
 		return frappe.database.postgres.setup_db.drop_user_and_database(
-			db_name, root_login, root_password
+			db_name, db_user, root_login, root_password
 		)
 	else:
 		import frappe.database.mariadb.setup_db
 
 		return frappe.database.mariadb.setup_db.drop_user_and_database(
-			db_name, root_login, root_password
+			db_name, db_user, root_login, root_password
 		)
 
 

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -80,7 +80,7 @@ class Database:
 		self.setup_type_map()
 		self.host = host or frappe.conf.db_host
 		self.port = port or frappe.conf.db_port
-		self.user = user or frappe.conf.db_user
+		self.user = user or frappe.conf.db_user or frappe.conf.db_name
 		self.cur_db_name = frappe.conf.db_name
 		self._conn = None
 
@@ -583,7 +583,7 @@ class Database:
 		"""
 		out = None
 		if cache and isinstance(filters, str) and (
-		doctype, filters, fieldname) in self.value_cache:
+			doctype, filters, fieldname) in self.value_cache:
 			return self.value_cache[(doctype, filters, fieldname)]
 
 		if distinct:

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -263,8 +263,7 @@ class Database:
 
 			if not (
 				ignore_ddl
-				and (self.is_missing_column(e) or self.is_table_missing(
-				e) or self.cant_drop_field_or_key(e))
+				and (self.is_missing_column(e) or self.is_table_missing(e) or self.cant_drop_field_or_key(e))
 			):
 				raise
 
@@ -377,11 +376,9 @@ class Database:
 			return self._cursor.mogrify(query, values)
 		except AttributeError:
 			if isinstance(values, dict):
-				return query % {k: frappe.db.escape(v) if isinstance(v, str) else v for k, v in
-								values.items()}
+				return query % {k: frappe.db.escape(v) if isinstance(v, str) else v for k, v in values.items()}
 			elif isinstance(values, (list, tuple)):
-				return query % tuple(
-					frappe.db.escape(v) if isinstance(v, str) else v for v in values)
+				return query % tuple(frappe.db.escape(v) if isinstance(v, str) else v for v in values)
 			return query, values
 
 	def lazy_mogrify(self, query: Query, values: QueryValues) -> LazyMogrify:
@@ -582,8 +579,7 @@ class Database:
 		        user = frappe.db.get_values("User", "test@example.com", "*")[0]
 		"""
 		out = None
-		if cache and isinstance(filters, str) and (
-			doctype, filters, fieldname) in self.value_cache:
+		if cache and isinstance(filters, str) and (doctype, filters, fieldname) in self.value_cache:
 			return self.value_cache[(doctype, filters, fieldname)]
 
 		if distinct:
@@ -631,23 +627,20 @@ class Database:
 						skip_locked=skip_locked,
 					)
 				except Exception as e:
-					if ignore and (
-						frappe.db.is_missing_column(e) or frappe.db.is_table_missing(e)):
+					if ignore and (frappe.db.is_missing_column(e) or frappe.db.is_table_missing(e)):
 						# table or column not found, return None
 						out = None
 					elif (not ignore) and frappe.db.is_table_missing(e):
 						# table not found, look in singles
 						out = self.get_values_from_single(
-							fields, filters, doctype, as_dict, debug, update, run=run,
-							distinct=distinct
+							fields, filters, doctype, as_dict, debug, update, run=run, distinct=distinct
 						)
 
 					else:
 						raise
 			else:
 				out = self.get_values_from_single(
-					fields, filters, doctype, as_dict, debug, update, run=run, pluck=pluck,
-					distinct=distinct
+					fields, filters, doctype, as_dict, debug, update, run=run, pluck=pluck, distinct=distinct
 				)
 
 		if cache and isinstance(filters, str):
@@ -758,8 +751,7 @@ class Database:
 
 	@staticmethod
 	def _get_update_dict(
-		fieldname: str | dict, value: Any, *, modified: str, modified_by: str,
-		update_modified: bool
+		fieldname: str | dict, value: Any, *, modified: str, modified_by: str, update_modified: bool
 	) -> dict[str, Any]:
 		"""Create update dict that represents column-values to be updated."""
 		update_dict = fieldname if isinstance(fieldname, dict) else {fieldname: value}
@@ -795,8 +787,7 @@ class Database:
 		"""
 
 		to_update = self._get_update_dict(
-			fieldname, value, modified=modified, modified_by=modified_by,
-			update_modified=update_modified
+			fieldname, value, modified=modified, modified_by=modified_by, update_modified=update_modified
 		)
 
 		frappe.db.delete(

--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -18,6 +18,20 @@ class DbManager:
 		password_predicate = f" IDENTIFIED BY '{password}'" if password else ""
 		self.db.sql(f"CREATE USER '{user}'@'{host}'{password_predicate}")
 
+	def does_user_exist(self, username: str, host: str | None = None) -> bool:
+		return (
+			self.db.sql(
+				f"SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = '{username}' and "
+				f"host = '{host or self.get_current_host()}')"
+			)[0][0]
+			== 1
+		)
+
+	def set_user_password(self, username: str, password: str, host: str | None = None) -> None:
+		self.db.sql(
+			f"SET PASSWORD FOR '{username}'@'{host or self.get_current_host()}' = PASSWORD('{password}')"
+		)
+
 	def delete_user(self, target, host=None):
 		host = host or self.get_current_host()
 		self.db.sql(f"DROP USER IF EXISTS '{target}'@'{host}'")

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -34,15 +34,20 @@ def setup_database(force, verbose, no_mariadb_socket=False):
 	if no_mariadb_socket:
 		dbman_kwargs["host"] = "%"
 
+	if dbman.does_user_exist(db_user):
+		print("User exists", db_user)
+		dbman.set_user_password(db_user, frappe.conf.db_password, **dbman_kwargs)
+		if verbose:
+			print("Re-used existing user %s" % db_user)
+	else:
+		dbman.create_user(db_user, frappe.conf.db_password, **dbman_kwargs)
+		if verbose:
+			print("Created user %s" % db_user)
+
 	if force or (db_name not in dbman.get_database_list()):
-		dbman.delete_user(db_user, **dbman_kwargs)
 		dbman.drop_database(db_name)
 	else:
 		raise Exception(f"Database {db_name} already exists")
-
-	dbman.create_user(db_user, frappe.conf.db_password, **dbman_kwargs)
-	if verbose:
-		print("Created user %s" % db_user)
 
 	dbman.create_database(db_name)
 	if verbose:

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -28,7 +28,7 @@ def setup_database(force, verbose, no_mariadb_socket=False):
 
 	db_user = frappe.conf.db_user
 	db_name = frappe.local.conf.db_name
-	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
+	root_conn = get_root_connection()
 	dbman = DbManager(root_conn)
 	dbman_kwargs = {}
 	if no_mariadb_socket:
@@ -62,8 +62,11 @@ def setup_database(force, verbose, no_mariadb_socket=False):
 	root_conn.close()
 
 
-def drop_user_and_database(db_name, db_user, root_login, root_password):
-	frappe.local.db = get_root_connection(root_login, root_password)
+def drop_user_and_database(
+	db_name,
+	db_user,
+):
+	frappe.local.db = get_root_connection()
 	dbman = DbManager(frappe.local.db)
 	dbman.drop_database(db_name)
 	dbman.delete_user(db_user, host="%")
@@ -109,7 +112,6 @@ def import_db_from_sql(source_sql=None, verbose=False):
 
 
 def check_database_settings():
-
 	check_compatible_versions()
 
 	# Check each expected value vs. actuals:
@@ -158,24 +160,24 @@ def check_compatible_versions():
 		)
 
 
-def get_root_connection(root_login, root_password):
-	import getpass
-
+def get_root_connection():
 	if not frappe.local.flags.root_connection:
-		if not root_login:
-			root_login = "root"
+		if not frappe.flags.root_login:
+			frappe.flags.root_login = "root"
 
-		if not root_password:
-			root_password = frappe.conf.get("root_password") or None
+		if not frappe.flags.root_password:
+			frappe.flags.root_password = frappe.conf.get("root_password") or None
 
-		if not root_password:
-			root_password = getpass.getpass("MySQL root password: ")
+		if not frappe.flags.root_password:
+			import getpass
+
+			frappe.flags.root_password = getpass.getpass("MySQL root password: ")
 
 		frappe.local.flags.root_connection = frappe.database.get_db(
 			host=frappe.conf.db_host,
 			port=frappe.conf.db_port,
-			user=root_login,
-			password=root_password,
+			user=frappe.flags.root_login,
+			password=frappe.flags.root_password,
 		)
 
 	return frappe.local.flags.root_connection

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -102,7 +102,7 @@ def import_db_from_sql(source_sql=None, verbose=False):
 	if not source_sql:
 		source_sql = os.path.join(os.path.dirname(__file__), "framework_mariadb.sql")
 	DbManager(frappe.local.db).restore_database(
-		verbose, db_name, source_sql, db_name, frappe.conf.db_password
+		verbose, db_name, source_sql, frappe.conf.db_user, frappe.conf.db_password
 	)
 	if verbose:
 		print("Imported from database %s" % source_sql)

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -55,7 +55,7 @@ def import_db_from_sql(source_sql=None, verbose=False):
 	if not source_sql:
 		source_sql = os.path.join(os.path.dirname(__file__), "framework_postgres.sql")
 	DbManager(frappe.local.db).restore_database(
-		verbose, db_name, source_sql, db_name, frappe.conf.db_password
+		verbose, db_name, source_sql, frappe.conf.db_user, frappe.conf.db_password
 	)
 	if verbose:
 		print("Imported from database %s" % source_sql)

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -11,15 +11,21 @@ def setup_database():
 	root_conn.commit()
 	root_conn.sql("end")
 	root_conn.sql(f"DROP DATABASE IF EXISTS `{frappe.conf.db_name}`")
-	root_conn.sql(f"DROP USER IF EXISTS {frappe.conf.db_name}")
+
+	# If user exists, just update password
+	if root_conn.sql(f"SELECT 1 FROM pg_roles WHERE rolname='{frappe.conf.db_user}'"):
+		root_conn.sql(f"ALTER USER {frappe.conf.db_user} WITH PASSWORD '{frappe.conf.db_password}'")
+	else:
+		root_conn.sql(f"CREATE USER {frappe.conf.db_user} WITH PASSWORD '{frappe.conf.db_password}'")
 	root_conn.sql(f"CREATE DATABASE `{frappe.conf.db_name}`")
-	root_conn.sql(f"CREATE user {frappe.conf.db_name} password '{frappe.conf.db_password}'")
-	root_conn.sql("GRANT ALL PRIVILEGES ON DATABASE `{0}` TO {0}".format(frappe.conf.db_name))
+	root_conn.sql(
+		f"GRANT ALL PRIVILEGES ON DATABASE `{frappe.conf.db_name}` TO {frappe.conf.db_user}"
+	)
 	if psql_version := root_conn.sql("SELECT VERSION()", as_dict=True):
 		version_string = psql_version[0].get("version") or "PostgreSQL 14"
 		major_version = cint(re.split(r"[\w\.]", version_string)[1])
 		if major_version > 15:
-			root_conn.sql("ALTER DATABASE `{0}` OWNER TO {0}".format(frappe.conf.db_name))
+			root_conn.sql(f"ALTER DATABASE `{frappe.conf.db_name}` OWNER TO {frappe.conf.db_user}")
 	root_conn.close()
 
 

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -81,7 +81,7 @@ def get_root_connection(root_login=None, root_password=None):
 	return frappe.local.flags.root_connection
 
 
-def drop_user_and_database(db_name, root_login, root_password):
+def drop_user_and_database(db_name, db_user, root_login, root_password):
 	root_conn = get_root_connection(
 		frappe.flags.root_login or root_login, frappe.flags.root_password or root_password
 	)
@@ -92,4 +92,4 @@ def drop_user_and_database(db_name, root_login, root_password):
 	)
 	root_conn.sql("end")
 	root_conn.sql(f"DROP DATABASE IF EXISTS {db_name}")
-	root_conn.sql(f"DROP USER IF EXISTS {db_name}")
+	root_conn.sql(f"DROP USER IF EXISTS {db_user}")

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -10,22 +10,22 @@ def setup_database():
 	root_conn = get_root_connection()
 	root_conn.commit()
 	root_conn.sql("end")
-	root_conn.sql(f"DROP DATABASE IF EXISTS `{frappe.conf.db_name}`")
+	root_conn.sql(f'DROP DATABASE IF EXISTS "{frappe.conf.db_name}"')
 
 	# If user exists, just update password
 	if root_conn.sql(f"SELECT 1 FROM pg_roles WHERE rolname='{frappe.conf.db_user}'"):
-		root_conn.sql(f"ALTER USER {frappe.conf.db_user} WITH PASSWORD '{frappe.conf.db_password}'")
+		root_conn.sql(f"ALTER USER \"{frappe.conf.db_user}\" WITH PASSWORD '{frappe.conf.db_password}'")
 	else:
-		root_conn.sql(f"CREATE USER {frappe.conf.db_user} WITH PASSWORD '{frappe.conf.db_password}'")
-	root_conn.sql(f"CREATE DATABASE `{frappe.conf.db_name}`")
+		root_conn.sql(f"CREATE USER \"{frappe.conf.db_user}\" WITH PASSWORD '{frappe.conf.db_password}'")
+	root_conn.sql(f'CREATE DATABASE "{frappe.conf.db_name}"')
 	root_conn.sql(
-		f"GRANT ALL PRIVILEGES ON DATABASE `{frappe.conf.db_name}` TO {frappe.conf.db_user}"
+		f'GRANT ALL PRIVILEGES ON DATABASE "{frappe.conf.db_name}" TO "{frappe.conf.db_user}"'
 	)
 	if psql_version := root_conn.sql("SELECT VERSION()", as_dict=True):
 		version_string = psql_version[0].get("version") or "PostgreSQL 14"
 		major_version = cint(re.split(r"[\w\.]", version_string)[1])
 		if major_version > 15:
-			root_conn.sql(f"ALTER DATABASE `{frappe.conf.db_name}` OWNER TO {frappe.conf.db_user}")
+			root_conn.sql(f'ALTER DATABASE "{frappe.conf.db_name}" OWNER TO "{frappe.conf.db_user}"')
 	root_conn.close()
 
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -585,8 +585,7 @@ def make_site_config(
 			if db_port:
 				site_config["db_port"] = db_port
 
-			if db_user:
-				site_config["db_user"] = db_user
+			site_config["db_user"] = db_user or db_name
 
 		with open(site_file, "w") as f:
 			f.write(json.dumps(site_config, indent=1, sort_keys=True))

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -49,6 +49,7 @@ def _new_site(
 	db_type=None,
 	db_host=None,
 	db_port=None,
+	db_user=None,
 	setup_db=True,
 ):
 	"""Install a new Frappe site"""
@@ -97,6 +98,7 @@ def _new_site(
 			db_type=db_type,
 			db_host=db_host,
 			db_port=db_port,
+			db_user=db_user,
 			no_mariadb_socket=no_mariadb_socket,
 			setup=setup_db,
 		)
@@ -135,6 +137,7 @@ def install_db(
 	db_type=None,
 	db_host=None,
 	db_port=None,
+	db_user=None,
 	no_mariadb_socket=False,
 	setup=True,
 ):
@@ -156,6 +159,7 @@ def install_db(
 		db_type=db_type,
 		db_host=db_host,
 		db_port=db_port,
+		db_user=db_user,
 	)
 	frappe.flags.in_install_db = True
 
@@ -533,11 +537,23 @@ def init_singles():
 
 
 def make_conf(
-	db_name=None, db_password=None, site_config=None, db_type=None, db_host=None, db_port=None
+	db_name=None,
+	db_password=None,
+	site_config=None,
+	db_type=None,
+	db_host=None,
+	db_port=None,
+	db_user=None,
 ):
 	site = frappe.local.site
 	make_site_config(
-		db_name, db_password, site_config, db_type=db_type, db_host=db_host, db_port=db_port
+		db_name,
+		db_password,
+		site_config,
+		db_type=db_type,
+		db_host=db_host,
+		db_port=db_port,
+		db_user=db_user,
 	)
 	sites_path = frappe.local.sites_path
 	frappe.destroy()
@@ -545,7 +561,13 @@ def make_conf(
 
 
 def make_site_config(
-	db_name=None, db_password=None, site_config=None, db_type=None, db_host=None, db_port=None
+	db_name=None,
+	db_password=None,
+	site_config=None,
+	db_type=None,
+	db_host=None,
+	db_port=None,
+	db_user=None,
 ):
 	frappe.create_folder(os.path.join(frappe.local.site_path))
 	site_file = get_site_config_path()
@@ -562,6 +584,9 @@ def make_site_config(
 
 			if db_port:
 				site_config["db_port"] = db_port
+
+			if db_user:
+				site_config["db_user"] = db_user
 
 		with open(site_file, "w") as f:
 			f.write(json.dumps(site_config, indent=1, sort_keys=True))

--- a/frappe/integrations/offsite_backup_utils.py
+++ b/frappe/integrations/offsite_backup_utils.py
@@ -52,7 +52,7 @@ def get_latest_backup_file(with_files=False):
 
 	odb = BackupGenerator(
 		frappe.conf.db_name,
-		frappe.conf.db_name,
+		frappe.conf.db_user,
 		frappe.conf.db_password,
 		db_host=frappe.conf.db_host,
 		db_port=frappe.conf.db_port,
@@ -110,7 +110,7 @@ def generate_files_backup():
 
 	backup = BackupGenerator(
 		frappe.conf.db_name,
-		frappe.conf.db_name,
+		frappe.conf.db_user,
 		frappe.conf.db_password,
 		db_host=frappe.conf.db_host,
 		db_port=frappe.conf.db_port,

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -524,6 +524,7 @@ class TestCommands(BaseTestCommands):
 			"db_type": frappe.conf.db_type,
 			"db_user": user,
 			"db_password": password,
+			"db_root_username": frappe.conf.root_login,
 		}
 		self.execute(
 			"bench new-site {new_site} --force --verbose "
@@ -540,7 +541,10 @@ class TestCommands(BaseTestCommands):
 		config = json.loads(self.stdout)
 		self.assertEqual(config[site]["db_user"], user)
 		self.assertEqual(config[site]["db_password"], password)
-		self.execute("bench drop-site {new_site} --force --db-root-password {root_password}", kwargs)
+		self.execute(
+			"bench drop-site {new_site} --force --db-root-username {db_root_username} --db-root-password {root_password}",
+			kwargs,
+		)
 		self.assertEqual(self.returncode, 0)
 
 	def test_existing_db_username(self):
@@ -550,12 +554,12 @@ class TestCommands(BaseTestCommands):
 			if frappe.conf.db_type == "mariadb":
 				from frappe.database.mariadb.setup_db import get_root_connection
 
-				root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
+				root_conn = get_root_connection()
 				root_conn.sql(f"CREATE USER '{user}'@'localhost'")
 			else:
 				from frappe.database.postgres.setup_db import get_root_connection
 
-				root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
+				root_conn = get_root_connection()
 				root_conn.sql(f"CREATE USER {user}")
 		password = frappe.conf.db_password or frappe.generate_hash()
 		kwargs = {
@@ -565,6 +569,7 @@ class TestCommands(BaseTestCommands):
 			"db_type": frappe.conf.db_type,
 			"db_user": user,
 			"db_password": password,
+			"db_root_username": frappe.conf.root_login,
 		}
 		self.execute(
 			"bench new-site {new_site} --force --verbose "
@@ -581,7 +586,10 @@ class TestCommands(BaseTestCommands):
 		config = json.loads(self.stdout)
 		self.assertEqual(config[site]["db_user"], user)
 		self.assertEqual(config[site]["db_password"], password)
-		self.execute("bench drop-site {new_site} --force --db-root-password {root_password}", kwargs)
+		self.execute(
+			"bench drop-site {new_site} --force --db-root-username {db_root_username} --db-root-password {root_password}",
+			kwargs,
+		)
 		self.assertEqual(self.returncode, 0)
 
 

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -520,7 +520,7 @@ class TestCommands(BaseTestCommands):
 		kwargs = {
 			"new_site": site,
 			"admin_password": frappe.conf.admin_password,
-			"root_password": frappe.conf.root_password,
+			"root_password": frappe.conf.root_password or "",
 			"db_type": frappe.conf.db_type,
 			"db_user": user,
 			"db_password": password,
@@ -549,19 +549,18 @@ class TestCommands(BaseTestCommands):
 
 	def test_existing_db_username(self):
 		site = frappe.generate_hash()
-		if (user := frappe.conf.db_user) is None:
-			user = "".join(secrets.choice(string.ascii_letters) for _ in range(8))
-			if frappe.conf.db_type == "mariadb":
-				from frappe.database.mariadb.setup_db import get_root_connection
+		user = "".join(secrets.choice(string.ascii_letters) for _ in range(8))
+		if frappe.conf.db_type == "mariadb":
+			from frappe.database.mariadb.setup_db import get_root_connection
 
-				root_conn = get_root_connection()
-				root_conn.sql(f"CREATE USER '{user}'@'localhost'")
-			else:
-				from frappe.database.postgres.setup_db import get_root_connection
+			root_conn = get_root_connection()
+			root_conn.sql(f"CREATE USER '{user}'@'localhost'")
+		else:
+			from frappe.database.postgres.setup_db import get_root_connection
 
-				root_conn = get_root_connection()
-				root_conn.sql(f"CREATE USER {user}")
-		password = frappe.conf.db_password or frappe.generate_hash()
+			root_conn = get_root_connection()
+			root_conn.sql(f"CREATE USER {user}")
+		password = frappe.generate_hash()
 		kwargs = {
 			"new_site": site,
 			"admin_password": frappe.conf.admin_password,

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -496,7 +496,7 @@ def fetch_latest_backups(partial=False) -> dict:
 	frappe.only_for("System Manager")
 	odb = BackupGenerator(
 		frappe.conf.db_name,
-		frappe.conf.db_name,
+		frappe.conf.db_user,
 		frappe.conf.db_password,
 		db_host=frappe.conf.db_host,
 		db_port=frappe.conf.db_port,
@@ -563,7 +563,7 @@ def new_backup(
 	delete_temp_backups()
 	odb = BackupGenerator(
 		frappe.conf.db_name,
-		frappe.conf.db_name,
+		frappe.conf.db_user or frappe.conf.db_name,
 		frappe.conf.db_password,
 		db_host=frappe.conf.db_host,
 		db_port=frappe.conf.db_port,

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -563,7 +563,7 @@ def new_backup(
 	delete_temp_backups()
 	odb = BackupGenerator(
 		frappe.conf.db_name,
-		frappe.conf.db_user or frappe.conf.db_name,
+		frappe.conf.db_user,
 		frappe.conf.db_password,
 		db_host=frappe.conf.db_host,
 		db_port=frappe.conf.db_port,


### PR DESCRIPTION
This will allow us to use a separate database user, and not only one matching the database name

Resolves #23323
