### PR TITLE
fix: honour max file size in upload file

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -184,7 +184,7 @@ def init_request(request):
 
 		request.max_content_length = get_max_file_size()
 	else:
-		request.max_content_length = cint(frappe.local.conf.get("max_file_size")) or 10 * 1024 * 1024
+		request.max_content_length = cint(frappe.local.conf.get("max_file_size")) or 25 * 1024 * 1024
 	make_form_dict(request)
 
 	if request.method != "OPTIONS":

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -179,9 +179,12 @@ def init_request(request):
 			raise frappe.SessionStopped("Session Stopped")
 	else:
 		frappe.connect(set_admin_as_user=False)
+	if request.path.startswith("/api/method/upload_file"):
+		from frappe.core.api.file import get_max_file_size
 
-	request.max_content_length = cint(frappe.local.conf.get("max_file_size")) or 10 * 1024 * 1024
-
+		request.max_content_length = get_max_file_size()
+	else:
+		request.max_content_length = cint(frappe.local.conf.get("max_file_size")) or 10 * 1024 * 1024
 	make_form_dict(request)
 
 	if request.method != "OPTIONS":

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -122,12 +122,12 @@ def get_letter_heads():
 
 
 def load_conf_settings(bootinfo):
-	from frappe import conf
+	from frappe.core.api.file import get_max_file_size
 
-	bootinfo.max_file_size = conf.get("max_file_size") or 10485760
+	bootinfo.max_file_size = get_max_file_size()
 	for key in ("developer_mode", "socketio_port", "file_watcher_port"):
-		if key in conf:
-			bootinfo[key] = conf.get(key)
+		if key in frappe.conf:
+			bootinfo[key] = frappe.conf.get(key)
 
 
 def load_desktop_data(bootinfo):


### PR DESCRIPTION
In case path is /api/method/upload_file, we should honour the max file size set in system settings and set request max_content_length to that value.