### PR TITLE
fix(naming_rule): polish list view

### DIFF
--- a/frappe/core/doctype/document_naming_rule/document_naming_rule.json
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule.json
@@ -35,6 +35,7 @@
   {
    "fieldname": "prefix",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Prefix",
    "mandatory_depends_on": "eval:doc.naming_by===\"Numbered\"",
    "reqd": 1
@@ -44,6 +45,7 @@
    "description": "Warning: Updating counter may lead to document name conflicts if not done properly",
    "fieldname": "counter",
    "fieldtype": "Int",
+   "in_list_view": 1,
    "label": "Counter",
    "no_copy": 1
   },
@@ -78,6 +80,7 @@
    "description": "Rules with higher priority number will be applied first.",
    "fieldname": "priority",
    "fieldtype": "Int",
+   "in_standard_filter": 1,
    "label": "Priority"
   },
   {
@@ -87,7 +90,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-04-24 15:14:32.054272",
+ "modified": "2023-11-21 11:58:25.712375",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Document Naming Rule",
@@ -107,7 +110,7 @@
   }
  ],
  "quick_entry": 1,
- "sort_field": "modified",
+ "sort_field": "priority",
  "sort_order": "DESC",
  "states": [],
  "title_field": "document_type",

--- a/frappe/core/doctype/document_naming_rule/document_naming_rule_list.js
+++ b/frappe/core/doctype/document_naming_rule/document_naming_rule_list.js
@@ -1,0 +1,3 @@
+frappe.listview_settings["Document Naming Rule"] = {
+	hide_name_column: true,
+};


### PR DESCRIPTION
# Motivation

- Make the occasional list view more useful (as I notice)
- This time: Document Naming Rule

# Screenshot (after)

![image](https://github.com/frappe/frappe/assets/7548295/62b8cbad-f017-40ea-bea4-ce4dba014263)

After force-push (fixup), also:

![image](https://github.com/frappe/frappe/assets/7548295/d9a23459-ccd0-4c3a-aef9-684c46ce071a)
