### PR TITLE
fix: Show list similar to how it looks in text editor

### DIFF
--- a/frappe/public/scss/email.bundle.scss
+++ b/frappe/public/scss/email.bundle.scss
@@ -346,3 +346,85 @@ blockquote {
 		margin: 5px 0;
 	}
 }
+
+.ql-editor li {
+	list-style-type: none;
+	padding-left: 1.5em;
+	position: relative;
+}
+.ql-editor li > .ql-ui:before {
+	display: inline-block;
+	margin-left: -1.5em;
+	margin-right: 0.3em;
+	text-align: right;
+	white-space: nowrap;
+	width: 1.2em;
+}
+.ql-editor li[data-list="checked"] > .ql-ui,
+.ql-editor li[data-list="unchecked"] > .ql-ui {
+	color: #777;
+}
+.ql-editor li[data-list="bullet"] > .ql-ui:before {
+	content: "\2022";
+}
+.ql-editor li[data-list="checked"] > .ql-ui:before {
+	content: "\2611";
+}
+.ql-editor li[data-list="unchecked"] > .ql-ui:before {
+	content: "\2610";
+}
+.ql-editor li[data-list="ordered"] {
+	counter-reset: list-1 list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+	counter-increment: list-0;
+}
+.ql-editor li[data-list="ordered"] > .ql-ui:before {
+	content: counter(list-0, decimal) ". ";
+}
+.ql-editor li[data-list="ordered"].ql-indent-1 {
+	counter-increment: list-1;
+}
+.ql-editor li[data-list="ordered"].ql-indent-1 > .ql-ui:before {
+	content: counter(list-1, lower-alpha) ". ";
+}
+.ql-editor li[data-list="ordered"].ql-indent-1 {
+	counter-reset: list-2 list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+}
+.ql-editor li[data-list="ordered"].ql-indent-2 {
+	counter-increment: list-2;
+}
+.ql-editor li[data-list="ordered"].ql-indent-2 > .ql-ui:before {
+	content: counter(list-2, lower-roman) ". ";
+}
+.ql-editor li[data-list="ordered"].ql-indent-2 {
+	counter-reset: list-3 list-4 list-5 list-6 list-7 list-8 list-9;
+}
+.ql-editor li[data-list="ordered"].ql-indent-3 {
+	counter-increment: list-3;
+}
+.ql-editor li[data-list="ordered"].ql-indent-3 > .ql-ui:before {
+	content: counter(list-3, decimal) ". ";
+}
+.ql-editor li[data-list="ordered"].ql-indent-3 {
+	counter-reset: list-4 list-5 list-6 list-7 list-8 list-9;
+}
+.ql-editor .ql-indent-1:not(.ql-direction-rtl) {
+	padding-left: 3em;
+}
+
+.ql-editor li.ql-indent-1:not(.ql-direction-rtl) {
+	padding-left: 4.5em;
+}
+
+.ql-editor .ql-indent-2:not(.ql-direction-rtl) {
+	padding-left: 6em;
+}
+.ql-editor li.ql-indent-2:not(.ql-direction-rtl) {
+	padding-left: 7.5em;
+}
+
+.ql-editor .ql-indent-3:not(.ql-direction-rtl) {
+	padding-left: 9em;
+}
+.ql-editor li.ql-indent-3:not(.ql-direction-rtl) {
+	padding-left: 10.5em;
+}


### PR DESCRIPTION
Un-ordered list used to look different in email client compared to desk.

**Email in desk**
<img width="249" alt="Screenshot 2023-11-22 at 5 06 22 PM" src="https://github.com/frappe/frappe/assets/13928957/0a786934-2dfa-4e50-874b-bee45aa73ef6">

**Before (email in client):**
<img width="298" alt="Screenshot 2023-11-22 at 5 05 32 PM" src="https://github.com/frappe/frappe/assets/13928957/db1c4006-35a6-49bf-8c5f-be2e22ffe1b6">

**After (email in client)**
<img width="296" alt="Screenshot 2023-11-22 at 5 05 59 PM" src="https://github.com/frappe/frappe/assets/13928957/bbb2f13c-82fe-4626-84b3-e16fc0e97708">


> Note: Just picked few styles of quill editor instead of loading complete quill css to keep it lite and avoid unexpected style changes 