### PR TITLE
refactor: Remove usage of utcnow

### DIFF
--- a/frappe/core/doctype/rq_worker/rq_worker.py
+++ b/frappe/core/doctype/rq_worker/rq_worker.py
@@ -4,6 +4,7 @@
 import datetime
 from contextlib import suppress
 
+import pytz
 from rq import Worker
 
 import frappe
@@ -105,5 +106,7 @@ def serialize_worker(worker: Worker) -> frappe._dict:
 
 def compute_utilization(worker: Worker) -> float:
 	with suppress(Exception):
-		total_time = (datetime.datetime.utcnow() - worker.birth_date).total_seconds()
+		total_time = (
+			datetime.datetime.now(pytz.UTC) - worker.birth_date.replace(tzinfo=pytz.UTC)
+		).total_seconds()
 		return worker.total_working_time / total_time * 100

--- a/frappe/integrations/doctype/token_cache/token_cache.py
+++ b/frappe/integrations/doctype/token_cache/token_cache.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
-from datetime import datetime, timedelta
+import datetime
 
 import pytz
 
@@ -73,8 +73,8 @@ class TokenCache(Document):
 		system_timezone = pytz.timezone(get_system_timezone())
 		modified = frappe.utils.get_datetime(self.modified)
 		modified = system_timezone.localize(modified)
-		expiry_utc = modified.astimezone(pytz.utc) + timedelta(seconds=self.expires_in)
-		now_utc = datetime.utcnow().replace(tzinfo=pytz.utc)
+		expiry_utc = modified.astimezone(pytz.utc) + datetime.timedelta(seconds=self.expires_in)
+		now_utc = datetime.datetime.now(pytz.utc)
 		return cint((expiry_utc - now_utc).total_seconds())
 
 	def is_expired(self):

--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import datetime
 import json
 import os
 import traceback
 import uuid
-from datetime import datetime
 
+import pytz
 import rq
 
 import frappe
@@ -50,7 +51,7 @@ class Monitor:
 			self.data = frappe._dict(
 				{
 					"site": frappe.local.site,
-					"timestamp": datetime.utcnow(),
+					"timestamp": datetime.datetime.now(pytz.UTC),
 					"transaction_type": transaction_type,
 					"uuid": str(uuid.uuid4()),
 				}
@@ -92,7 +93,7 @@ class Monitor:
 
 	def dump(self, response=None):
 		try:
-			timediff = datetime.utcnow() - self.data.timestamp
+			timediff = datetime.datetime.now(pytz.UTC) - self.data.timestamp
 			# Obtain duration in microseconds
 			self.data.duration = int(timediff.total_seconds() * 1000000)
 

--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -245,7 +245,7 @@ class OAuthWebRequestValidator(RequestValidator):
 		)
 		token_expiration_utc = token_expiration_local.astimezone(pytz.utc)
 		is_token_valid = (
-			frappe.utils.datetime.datetime.utcnow().replace(tzinfo=pytz.utc) < token_expiration_utc
+			datetime.datetime.now(pytz.UTC) < token_expiration_utc
 		) and otoken.status != "Revoked"
 		client_scopes = frappe.db.get_value("OAuth Client", otoken.client, "scopes").split(
 			get_url_delimiter()

--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import datetime
 from collections.abc import Callable
-from datetime import datetime
 from functools import wraps
 
+import pytz
 from werkzeug.wrappers import Response
 
 import frappe
@@ -34,7 +35,7 @@ class RateLimiter:
 		self.limit = int(limit * 1000000)
 		self.window = window
 
-		self.start = datetime.utcnow()
+		self.start = datetime.datetime.now(pytz.UTC)
 		timestamp = int(frappe.utils.now_datetime().timestamp())
 
 		self.window_number, self.spent = divmod(timestamp, self.window)
@@ -79,7 +80,7 @@ class RateLimiter:
 	def record_request_end(self):
 		if self.end is not None:
 			return
-		self.end = datetime.utcnow()
+		self.end = datetime.datetime.now(pytz.UTC)
 		self.duration = int((self.end - self.start).total_seconds() * 1000000)
 
 	def respond(self):

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -1,11 +1,13 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. Check LICENSE
 
+import datetime
 import json
 from collections import defaultdict
 from collections.abc import Callable
-from datetime import datetime, timedelta
 from functools import wraps
+
+import pytz
 
 import frappe
 
@@ -96,7 +98,7 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 
 		if ttl is not None and not callable(ttl):
 			func.ttl = ttl
-			func.expiration = datetime.utcnow() + timedelta(seconds=func.ttl)
+			func.expiration = datetime.datetime.now(pytz.UTC) + datetime.timedelta(seconds=func.ttl)
 
 		if maxsize is not None and not callable(maxsize):
 			func.maxsize = maxsize
@@ -106,9 +108,9 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 			if getattr(frappe.local, "initialised", None):
 				func_call_key = json.dumps((args, kwargs))
 
-				if hasattr(func, "ttl") and datetime.utcnow() >= func.expiration:
+				if hasattr(func, "ttl") and datetime.datetime.now(pytz.UTC) >= func.expiration:
 					func.clear_cache()
-					func.expiration = datetime.utcnow() + timedelta(seconds=func.ttl)
+					func.expiration = datetime.datetime.now(pytz.UTC) + datetime.timedelta(seconds=func.ttl)
 
 				if hasattr(func, "maxsize") and len(_SITE_CACHE[func_key][frappe.local.site]) >= func.maxsize:
 					_SITE_CACHE[func_key][frappe.local.site].pop(

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Any, Literal, Optional, TypeVar, Union
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlunparse
 
+import pytz
 from click import secho
 from dateutil import parser
 from dateutil.parser import ParserError
@@ -295,7 +296,7 @@ def time_diff_in_hours(string_ed_date, string_st_date):
 
 
 def now_datetime():
-	dt = convert_utc_to_system_timezone(datetime.datetime.utcnow())
+	dt = convert_utc_to_system_timezone(datetime.datetime.now(pytz.UTC))
 	return dt.replace(tzinfo=None)
 
 
@@ -322,15 +323,16 @@ def get_system_timezone():
 def convert_utc_to_timezone(utc_timestamp, time_zone):
 	from pytz import UnknownTimeZoneError, timezone
 
-	utcnow = timezone("UTC").localize(utc_timestamp)
+	if utc_timestamp.tzinfo is None:
+		utc_timestamp = timezone("UTC").localize(utc_timestamp)
 	try:
-		return utcnow.astimezone(timezone(time_zone))
+		return utc_timestamp.astimezone(timezone(time_zone))
 	except UnknownTimeZoneError:
-		return utcnow
+		return utc_timestamp
 
 
 def get_datetime_in_timezone(time_zone):
-	utc_timestamp = datetime.datetime.utcnow()
+	utc_timestamp = datetime.datetime.now(pytz.UTC)
 	return convert_utc_to_timezone(utc_timestamp, time_zone)
 
 


### PR DESCRIPTION
TODO:

- [x] datetime.UTC was added in 3.11 so doesn't work in 3.10
