### PR TITLE
fix: handle invalid passwords better

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -25,6 +25,7 @@ from frappe.website.utils import get_home_page
 
 SAFE_HTTP_METHODS = frozenset(("GET", "HEAD", "OPTIONS"))
 UNSAFE_HTTP_METHODS = frozenset(("POST", "PUT", "DELETE", "PATCH"))
+MAX_PASSWORD_SIZE = 512
 
 
 class HTTPRequest:
@@ -234,6 +235,9 @@ class LoginManager:
 			user, pwd = frappe.form_dict.get("usr"), frappe.form_dict.get("pwd")
 		if not (user and pwd):
 			self.fail(_("Incomplete login details"), user=user)
+
+		if len(pwd) > MAX_PASSWORD_SIZE:
+			self.fail(_("Password size exceeded the maximum allowed size"), user=user)
 
 		_raw_user_name = user
 		user = User.find_by_credentials(user, pwd)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -9,6 +9,7 @@ import frappe.defaults
 import frappe.permissions
 import frappe.share
 from frappe import STANDARD_USERS, _, msgprint, throw
+from frappe.auth import MAX_PASSWORD_SIZE
 from frappe.core.doctype.user_type.user_type import user_linked_with_permission_on_doctype
 from frappe.desk.doctype.notification_settings.notification_settings import (
 	create_notification_settings,
@@ -822,6 +823,9 @@ def update_password(
 	        key (str, optional): Password reset key. Defaults to None.
 	        old_password (str, optional): Old password. Defaults to None.
 	"""
+
+	if len(new_password) > MAX_PASSWORD_SIZE:
+		frappe.throw(_("Password size exceeded the maximum allowed size."))
 
 	result = test_password_strength(new_password)
 	feedback = result.get("feedback", None)

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -287,8 +287,9 @@ login.login_handlers = (function () {
 			}
 		},
 		401: get_error_handler('{{ _("Invalid Login. Try again.") }}'),
-		417: get_error_handler('{{ _("Oops! Something went wrong") }}'),
-		404: get_error_handler('{{ _("User does not exist.")}}')
+		417: get_error_handler('{{ _("Oops! Something went wrong.") }}'),
+		404: get_error_handler('{{ _("User does not exist.")}}'),
+		500: get_error_handler('{{ _("Something went wrong.") }}')
 	};
 
 	return login_handlers;


### PR DESCRIPTION
passlib raises an exception if you send in something > 4096 characters
This isn't handled on our end, leads to a 500 response with no clear message for a user

This PR adds in some checks so that we raise an error whenever someone tries to submit a password > 512 characters
That seems more than suitable for any normal usecase


- chore(login): show a message for response code 500 as well
- refactor: reject passwords > 512 characters
