### PR TITLE
fix: show fieldname if field label is not set

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -147,10 +147,13 @@ frappe.ui.GroupBy = class {
 					doctype_fields.forEach((field) => {
 						// pick numeric fields for sum / avg
 						if (frappe.model.is_numeric_field(field.fieldtype)) {
+							let field_label = field.label
+								? field.label
+								: frappe.model.unscrub(field.fieldname);
 							let option_text =
 								doctype == this.doctype
-									? field.label
-									: `${field.label} (${__(doctype)})`;
+									? field_label
+									: `${field_label} (${__(doctype)})`;
 							this.aggregate_on_html += `<option data-doctype="${doctype}"
 								value="${field.fieldname}">${__(option_text)}</option>`;
 						}

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -153,7 +153,7 @@ frappe.ui.GroupBy = class {
 							let option_text =
 								doctype == this.doctype
 									? field_label
-									: `${field_label} (${__(doctype)})`;
+									: `${__(field_label)} (${__(doctype)})`;
 							this.aggregate_on_html += `<option data-doctype="${doctype}"
 								value="${field.fieldname}">${__(option_text)}</option>`;
 						}


### PR DESCRIPTION
### Issue
In Report view, while applying sum or average aggregate functions if field label is not set `undefined` is shown.

### Solution
Show fieldname if field label is not set

### Before
![Screenshot from 2023-11-23 12-40-15](https://github.com/frappe/frappe/assets/30501401/d3ccb0e6-8903-4833-9df1-e0e6de080c16)

### After
![image](https://github.com/frappe/frappe/assets/30501401/addd0ef7-ea2f-4f0b-bc54-c5b656400c05)
