### PR TITLE
fix: ```link_filters``` DocField property shown only for Link fieldtype 

### DIFF
--- a/frappe/public/js/form_builder/components/Field.vue
+++ b/frappe/public/js/form_builder/components/Field.vue
@@ -174,8 +174,13 @@ function edit_filters() {
 }
 
 function is_filter_applied() {
-	if (props.field.df.link_filters && JSON.parse(props.field.df.link_filters).length > 0) {
-		return "btn-filter-applied";
+	if (props.field.df.link_filters) {
+		try {
+			JSON.parse(props.field.df.link_filters).length > 0;
+			return "btn-filter-applied";
+		} catch (error) {
+			return "";
+		}
 	}
 }
 

--- a/frappe/public/js/form_builder/components/Field.vue
+++ b/frappe/public/js/form_builder/components/Field.vue
@@ -176,8 +176,9 @@ function edit_filters() {
 function is_filter_applied() {
 	if (props.field.df.link_filters) {
 		try {
-			JSON.parse(props.field.df.link_filters).length > 0;
-			return "btn-filter-applied";
+			if (JSON.parse(props.field.df.link_filters).length > 0) {
+				return "btn-filter-applied";
+			}
 		} catch (error) {
 			return "";
 		}

--- a/frappe/public/js/form_builder/components/FieldProperties.vue
+++ b/frappe/public/js/form_builder/components/FieldProperties.vue
@@ -51,6 +51,11 @@ let docfield_df = computed(() => {
 			}
 		}
 
+		// show link_filters docfield only when link field is selected
+		if (df.fieldname === "link_filters" && store.form.selected_field.fieldtype !== "Link") {
+			return false;
+		}
+
 		if (search_text.value) {
 			if (
 				df.label.toLowerCase().includes(search_text.value.toLowerCase()) ||
@@ -62,7 +67,6 @@ let docfield_df = computed(() => {
 		}
 		return true;
 	});
-
 	return [...fields];
 });
 </script>

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -202,14 +202,18 @@ export const useStore = defineStore("form-builder-store", () => {
 				);
 			}
 
-			// check if link_filters format is correct or not
+			if (df.link_filters === "") {
+				delete df.link_filters;
+			}
 
+			// check if link_filters format is correct or not
 			if (df.link_filters) {
 				try {
 					let link_filters = JSON.parse(df.link_filters);
 				} catch (e) {
 					error_message = __(
-						`Invalid Filter Format. Try using filter icon on the field to set it correctly`
+						"Invalid Filter Format for field {0} of type {1}. Try using filter icon on the field to set it correctly",
+						get_field_data(df)
 					);
 				}
 			}


### PR DESCRIPTION
**Issue:**

1.     ```pymysql.err.OperationalError: (4025, 'CONSTRAINT tabDocField.link_filters failed for _1234567891234567.tabDocField')```
    The above error is thrown when we try to save link_filters without any value.

2.  link_filters property is shown for each fieldtype

**Solution:**

1) when link_filters is set to empty from the sidebar we delete the property from that particular field.

2) Display link_filters only when fieldtype is "Link" .

closes
#23311 

