### PR TITLE
fix: default Email Group in system language

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -308,11 +308,11 @@ def confirmed_unsubscribe(email, group):
 
 @frappe.whitelist(allow_guest=True)
 @rate_limit(limit=10, seconds=60 * 60)
-def subscribe(email, email_group=None):  # noqa
+def subscribe(email, email_group=None):
 	"""API endpoint to subscribe an email to a particular email group. Triggers a confirmation email."""
 
 	if email_group is None:
-		email_group = _("Website")
+		email_group = get_default_email_group()
 
 	# build subscription confirmation URL
 	api_endpoint = frappe.utils.get_url(
@@ -355,12 +355,15 @@ def subscribe(email, email_group=None):  # noqa
 
 
 @frappe.whitelist(allow_guest=True)
-def confirm_subscription(email, email_group=_("Website")):  # noqa
+def confirm_subscription(email, email_group=None):
 	"""API endpoint to confirm email subscription.
 	This endpoint is called when user clicks on the link sent to their mail.
 	"""
 	if not verify_request():
 		return
+
+	if email_group is None:
+		email_group = get_default_email_group()
 
 	if not frappe.db.exists("Email Group", email_group):
 		frappe.get_doc({"doctype": "Email Group", "title": email_group}).insert(ignore_permissions=True)
@@ -438,3 +441,7 @@ def newsletter_email_read(recipient_email=None, reference_doctype=None, referenc
 
 	finally:
 		frappe.response.update(frappe.utils.get_imaginary_pixel_response())
+
+
+def get_default_email_group():
+	return _("Website", lang=frappe.db.get_default("language"))


### PR DESCRIPTION
The default **Email Group** should be in the default _Language_ as per **System Settings**. Otherwise, we'll get **Email Groups** in all languages, over time.