### PR TITLE
fix: webform banner_image name replacing navbar banner_image

### DIFF
--- a/frappe/website/doctype/web_form/templates/web_form.html
+++ b/frappe/website/doctype/web_form/templates/web_form.html
@@ -7,9 +7,9 @@
 {% block breadcrumbs %}{% endblock %}
 
 {% block header %}
-	{% if banner_image %}
+	{% if webform_banner_image %}
 		<!-- banner image -->
-		<img class="web-form-banner-image" src="{{ banner_image }}" alt="Banner Image">
+		<img class="web-form-banner-image" src="{{ webform_banner_image }}" alt="Banner Image">
 	{% endif %}
 {% endblock %}
 
@@ -51,7 +51,7 @@
 	<!-- web form container -->
 	<div class="web-form-container">
 		<!-- breadcrumb -->
-		{% if not banner_image and has_header and login_required and show_list %}
+		{% if not webform_banner_image and has_header and login_required and show_list %}
 			{% include "templates/includes/breadcrumbs.html" %}
 			{% else %}
 				<div style="height: 3rem"></div>
@@ -59,7 +59,7 @@
 
 		<!-- header -->
 		<div class="web-form-header">
-			{% if banner_image and has_header and login_required and show_list %}
+			{% if webform_banner_image and has_header and login_required and show_list %}
 				{% include "templates/includes/breadcrumbs.html" %}
 			{% endif %}
 			<div class="web-form-head">

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -245,6 +245,9 @@ def get_context(context):
 		context.boot = get_boot_data()
 		context.boot["link_title_doctypes"] = frappe.boot.get_link_title_doctypes()
 
+		context.webform_banner_image = self.banner_image
+		context.pop("banner_image", None)
+
 	def add_metatags(self, context):
 		description = self.meta_description
 


### PR DESCRIPTION
Before:

<img width="1440" alt="image" src="https://github.com/frappe/frappe/assets/30859809/a0c24985-5b12-46dd-bd62-b4b7da5fa6f6">

After:

<img width="1440" alt="image" src="https://github.com/frappe/frappe/assets/30859809/86808fea-c22e-42ca-a0d2-bb4582d05100">
