### PR TITLE
feat(Communication): Schedule Send

### DIFF
--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -31,6 +31,7 @@
   "additional_info",
   "communication_date",
   "read_receipt",
+  "send_after",
   "column_break_14",
   "sender_full_name",
   "read_by_recipient",
@@ -390,12 +391,17 @@
    "hidden": 1,
    "label": "IMAP Folder",
    "read_only": 1
+  },
+  {
+   "fieldname": "send_after",
+   "fieldtype": "Datetime",
+   "label": "Send After"
   }
  ],
  "icon": "fa fa-comment",
  "idx": 1,
  "links": [],
- "modified": "2023-08-29 17:20:52.541483",
+ "modified": "2023-11-24 16:20:34.035984",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Communication",

--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -126,7 +126,7 @@
    "fieldtype": "Select",
    "hidden": 1,
    "label": "Delivery Status",
-   "options": "\nSent\nBounced\nOpened\nMarked As Spam\nRejected\nDelayed\nSoft-Bounced\nClicked\nRecipient Unsubscribed\nError\nExpired\nSending\nRead"
+   "options": "\nSent\nBounced\nOpened\nMarked As Spam\nRejected\nDelayed\nSoft-Bounced\nClicked\nRecipient Unsubscribed\nError\nExpired\nSending\nRead\nScheduled"
   },
   {
    "fieldname": "section_break_8",
@@ -401,7 +401,7 @@
  "icon": "fa fa-comment",
  "idx": 1,
  "links": [],
- "modified": "2023-11-24 16:20:34.035984",
+ "modified": "2023-11-27 20:38:27.467076",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Communication",

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -106,6 +106,7 @@ class Communication(Document, CommunicationEmailMixin):
 		reference_name: DF.DynamicLink | None
 		reference_owner: DF.ReadOnly | None
 		seen: DF.Check
+		send_after: DF.Datetime | None
 		sender: DF.Data | None
 		sender_full_name: DF.Data | None
 		sent_or_received: DF.Literal["Sent", "Received"]

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -87,6 +87,7 @@ class Communication(Document, CommunicationEmailMixin):
 			"Expired",
 			"Sending",
 			"Read",
+			"Scheduled",
 		]
 		email_account: DF.Link | None
 		email_status: DF.Literal["Open", "Spam", "Trash"]
@@ -162,6 +163,9 @@ class Communication(Document, CommunicationEmailMixin):
 		if not self.sent_or_received:
 			self.seen = 1
 			self.sent_or_received = "Sent"
+
+		if not self.send_after:  # Handle empty string, always set NULL
+			self.send_after = None
 
 		validate_email(self)
 
@@ -342,6 +346,9 @@ class Communication(Document, CommunicationEmailMixin):
 			self.status = "Open"
 		else:
 			self.status = "Closed"
+
+		if self.send_after and self.is_new():
+			self.delivery_status = "Scheduled"
 
 	def mark_email_as_spam(self):
 		if (

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -65,6 +65,7 @@ def make(
 	:param attachments: List of File names or dicts with keys "fname" and "fcontent"
 	:param send_me_a_copy: Send a copy to the sender (default **False**).
 	:param email_template: Template which is used to compose mail .
+	:param send_after: Send after the given datetime.
 	"""
 	if kwargs:
 		from frappe.utils.commands import warn

--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -46,6 +46,7 @@ def make(
 	print_letterhead=True,
 	email_template=None,
 	communication_type=None,
+	send_after=None,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -99,6 +100,7 @@ def make(
 		email_template=email_template,
 		communication_type=communication_type,
 		add_signature=False,
+		send_after=send_after,
 	)
 
 
@@ -124,6 +126,7 @@ def _make(
 	email_template=None,
 	communication_type=None,
 	add_signature=True,
+	send_after=None,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -151,6 +154,7 @@ def _make(
 			"read_receipt": read_receipt,
 			"has_attachment": 1 if attachments else 0,
 			"communication_type": communication_type,
+			"send_after": send_after,
 		}
 	)
 	comm.flags.skip_add_signature = not add_signature

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -290,6 +290,7 @@ class CommunicationEmailMixin:
 			"read_receipt": self.read_receipt,
 			"is_notification": (self.sent_or_received == "Received"),
 			"print_letterhead": print_letterhead,
+			"send_after": self.send_after,
 		}
 
 	def send_email(

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -297,7 +297,7 @@ class FormTimeline extends BaseTimeline {
 		let indicator_color = "red";
 		if (in_list(["Sent", "Clicked"], doc.delivery_status)) {
 			indicator_color = "green";
-		} else if (doc.delivery_status === "Sending") {
+		} else if (["Sending", "Scheduled"].includes(doc.delivery_status)) {
 			indicator_color = "orange";
 		} else if (in_list(["Opened", "Read"], doc.delivery_status)) {
 			indicator_color = "blue";

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -78,6 +78,11 @@ frappe.views.CommunicationComposer = class {
 				fieldname: "bcc",
 			},
 			{
+				label: __("Send After"),
+				fieldtype: "Datetime",
+				fieldname: "send_after",
+			},
+			{
 				fieldtype: "Section Break",
 				fieldname: "email_template_section_break",
 				hidden: 1,
@@ -676,6 +681,7 @@ frappe.views.CommunicationComposer = class {
 				attachments: selected_attachments,
 				read_receipt: form_values.send_read_receipt,
 				print_letterhead: me.is_print_letterhead_checked(),
+				send_after: form_values.send_after ? form_values.send_after : null,
 			},
 			btn,
 			callback(r) {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -78,7 +78,7 @@ frappe.views.CommunicationComposer = class {
 				fieldname: "bcc",
 			},
 			{
-				label: __("Send After"),
+				label: __("Schedule Send At"),
 				fieldtype: "Datetime",
 				fieldname: "send_after",
 			},


### PR DESCRIPTION
## What's changed:
1.  Allow Communication mail to be sent after set time in `send_after` field.


ref : https://github.com/frappe/frappe/issues/23283