### PR TITLE
fix(setup_wizard): don't suppress original exception

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -196,7 +196,7 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 					this.abort_setup(r.message.fail);
 				}
 			},
-			error: () => this.abort_setup("Error in setup"),
+			error: () => this.abort_setup(),
 		});
 	}
 
@@ -213,7 +213,11 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 
 	abort_setup(fail_msg) {
 		this.$working_state.find(".state-icon-container").html("");
-		fail_msg = fail_msg ? fail_msg : __("Failed to complete setup");
+		fail_msg = fail_msg
+			? fail_msg
+			: frappe.last_response.setup_wizard_failure_message
+			? frappe.last_response.setup_wizard_failure_message
+			: __("Failed to complete setup");
 
 		this.update_setup_message("Could not start up: " + fail_msg);
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -83,6 +83,7 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 				task.get("fn")(task.get("args"))
 	except Exception:
 		handle_setup_exception(user_input)
+		frappe.log_error(title=f"Setup failed: {current_task.get('fail_msg')}")
 		if not is_background_task:
 			raise
 		frappe.publish_realtime(

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -83,12 +83,14 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 				task.get("fn")(task.get("args"))
 	except Exception:
 		handle_setup_exception(user_input)
-		frappe.log_error(title=f"Setup failed: {current_task.get('fail_msg')}")
+		message = current_task.get("fail_msg") if current_task else "Failed to complete setup"
+		frappe.log_error(title=f"Setup failed: {message}")
 		if not is_background_task:
+			frappe.response["setup_wizard_failure_message"] = message
 			raise
 		frappe.publish_realtime(
 			"setup_task",
-			{"status": "fail", "fail_msg": current_task.get("fail_msg")},
+			{"status": "fail", "fail_msg": message},
 			user=frappe.session.user,
 		)
 	else:

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -84,7 +84,7 @@ def process_setup_stages(stages, user_input, is_background_task=False):
 	except Exception:
 		handle_setup_exception(user_input)
 		if not is_background_task:
-			return {"status": "fail", "fail": current_task.get("fail_msg")}
+			raise
 		frappe.publish_realtime(
 			"setup_task",
 			{"status": "fail", "fail_msg": current_task.get("fail_msg")},


### PR DESCRIPTION
Raise the exception instead of returning a generic response so that the user can know what went wrong

Resolves #23406
