### PR TITLE
fix: add `after_mapping` doc method to run custom mapping functions

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -163,6 +163,7 @@ def get_mapped_doc(
 	if postprocess:
 		postprocess(source_doc, target_doc)
 
+	ret_doc.run_method("after_mapping", source_doc)
 	ret_doc.set_onload("load_after_mapping", True)
 
 	if (


### PR DESCRIPTION
## Use case

Ability to add custom mapping.

## Alternatives Considered

Override whitelisted method: Here, only `source_name` is received as input parameter instead of `source_doc`

Required for: https://github.com/resilient-tech/india-compliance/pull/1321
Note: Test Case added in India Compliance App