### PR TITLE
fix: add blank line after auto-generated types

### DIFF
--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -77,12 +77,14 @@ class TypeExporter:
 			existing_block_start = code.find(first_line)
 			existing_block_end = code.find(last_line) + len(last_line)
 
-			code = code[:existing_block_start] + new_code + code[existing_block_end:]
+			code = code[:existing_block_start] + new_code + "\n\n" + code[existing_block_end:].lstrip("\n")
 		elif class_definition in code:  # Add just after class definition
 			# Regex by default will only match till line ends, span end is when we need to stop
 			if class_def := re.search(rf"class {despaced_name}\(.*", code):  # )
 				class_definition_end = class_def.span()[1] + 1
-				code = code[:class_definition_end] + new_code + "\n" + code[class_definition_end:]
+				code = (
+					code[:class_definition_end] + new_code + "\n\n" + code[class_definition_end:].lstrip("\n")
+				)
 
 		if self._validate_code(code):
 			self.controller_path.write_text(code)


### PR DESCRIPTION
### Before

![Bildschirmfoto 2023-11-24 um 16 41 15](https://github.com/frappe/frappe/assets/14891507/fa2aa37b-d53d-47dd-ae80-b47843a96a5c)

### After

![Bildschirmfoto 2023-11-24 um 16 41 29](https://github.com/frappe/frappe/assets/14891507/196f119a-4c41-4049-b99f-c7438252d269)
