### PR TITLE
fix: Treat Document Links entries as all non-std fields

### DIFF
--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -240,8 +240,9 @@ class TestCustomizeForm(FrappeTestCase):
 		# Using Notification Log doctype as it doesn't have any other custom fields
 		d = self.get_customize_form("Notification Log")
 
+		new_document_length = 255
 		document_name = d.get("fields", {"fieldname": "document_name"})[0]
-		document_name.length = 255
+		document_name.length = new_document_length
 		d.run_method("save_customization")
 
 		self.assertEqual(
@@ -250,10 +251,8 @@ class TestCustomizeForm(FrappeTestCase):
 				{"doc_type": "Notification Log", "property": "length", "field_name": "document_name"},
 				"value",
 			),
-			"255",
+			str(new_document_length),
 		)
-
-		self.assertTrue(d.flags.update_db)
 
 		length = frappe.db.sql(
 			"""SELECT character_maximum_length
@@ -262,7 +261,7 @@ class TestCustomizeForm(FrappeTestCase):
 			AND column_name = 'document_name'"""
 		)[0][0]
 
-		self.assertEqual(length, 255)
+		self.assertEqual(length, new_document_length)
 
 	def test_custom_link(self):
 		try:

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -677,15 +677,12 @@ class Meta(Document):
 					dict(label=link.group, items=[link.parent_doctype or link.link_doctype])
 				)
 
+			if not data.fieldname and link.link_fieldname:
+				data.fieldname = link.link_fieldname
+
 			if not link.is_child_table:
-				if link.link_fieldname != data.fieldname:
-					if data.fieldname:
-						data.non_standard_fieldnames[link.link_doctype] = link.link_fieldname
-					else:
-						data.fieldname = link.link_fieldname
+				data.non_standard_fieldnames[link.link_doctype] = link.link_fieldname
 			elif link.is_child_table:
-				if not data.fieldname:
-					data.fieldname = link.link_fieldname
 				data.internal_links[link.parent_doctype] = [link.table_fieldname, link.link_fieldname]
 
 	def get_row_template(self):

--- a/frappe/tests/test_dashboard_connections.py
+++ b/frappe/tests/test_dashboard_connections.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 import frappe
 import frappe.utils
 from frappe.core.doctype.doctype.test_doctype import new_doctype
+from frappe.custom.doctype.customize_form.test_customize_form import TestCustomizeForm
 from frappe.desk.notifications import get_open_count
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase, patch_hooks
 
 
 class TestDashboardConnections(FrappeTestCase):
@@ -122,11 +123,42 @@ class TestDashboardConnections(FrappeTestCase):
 			)
 
 
+	def test_external_doctype_link_with_dashboard_override(self):
+		# add a custom links
+		todo = TestCustomizeForm().get_customize_form("ToDo")
+		todo.append("links", dict(link_doctype="Test Doctype D", link_fieldname="doclink", group="Test"))
+		todo.append("links", dict(link_doctype="Test Doctype E", link_fieldname="todo", group="Test"))
+		todo.run_method("save_customization")
+
+		# create a test doc
+		todo_doc = frappe.get_doc(dict(doctype="ToDo", description="test")).insert()
+		frappe.get_doc(dict(doctype="Test Doctype D", title="d-001", doclink=todo_doc.name)).insert()
+		frappe.get_doc(dict(doctype="Test Doctype E", title="e-001", todo=todo_doc.name)).insert()
+
+		connections = get_open_count("ToDo", todo_doc.name)["count"]
+		self.assertEqual(len(connections["external_links_found"]), 2)
+
+		# Change standard fieldname, see if all custom links still work
+		with patch_hooks(
+			{"override_doctype_dashboards": {
+				"ToDo": ["frappe.tests.test_dashboard_connections.get_dashboard_for_todo"]
+			}
+		}):
+			connections = get_open_count("ToDo", todo_doc.name)["count"]
+			self.assertEqual(len(connections["external_links_found"]), 2)
+
+		# remove the custom links
+		todo = TestCustomizeForm().get_customize_form("ToDo")
+		todo.links = todo.links[:-2]
+		todo.run_method("save_customization")
+
+
 def create_test_data():
 	create_test_child_table_with_link_to_doctype_a()
 	create_test_child_table_with_link_to_doctype_b()
 	create_test_doctype_a_with_test_child_table_with_link_to_doctype_b()
 	create_test_doctype_b_with_test_child_table_with_link_to_doctype_a()
+	create_linked_doctypes()
 	add_links_in_child_tables()
 
 
@@ -136,6 +168,8 @@ def delete_test_data():
 		"Test Child Table With Link To Doctype B",
 		"Test Doctype A With Child Table With Link To Doctype B",
 		"Test Doctype B With Child Table With Link To Doctype A",
+		"Test Doctype D",
+		"Test Doctype E",
 	]
 	for doctype in doctypes:
 		if frappe.db.table_exists(doctype):
@@ -268,3 +302,48 @@ def get_dashboard_for_test_doctype_a_with_test_child_table_with_link_to_doctype_
 	dashboard.transactions = data["transactions"]
 
 	return dashboard
+
+
+def create_linked_doctypes():
+	"""
+	Test Doctype D and Test Doctype E linked to "ToDo"
+	"""
+	new_doctype(
+		"Test Doctype D",
+		fields=[
+			{"fieldname": "title", "fieldtype": "Data", "label": "Title", "unique": 1},
+			{
+				"fieldname": "doclink",
+				"fieldtype": "Link",
+				"label": "DocLink",
+				"options": "ToDo",
+			},
+		],
+		custom=False,
+		autoname="field:title",
+		naming_rule="By fieldname",
+	).insert(ignore_if_duplicate=True)
+
+	new_doctype(
+		"Test Doctype E",
+		fields=[
+			{"fieldname": "title", "fieldtype": "Data", "label": "Title", "unique": 1},
+			{
+				"fieldname": "todo",
+				"fieldtype": "Link",
+				"label": "Linked ToDo",
+				"options": "ToDo",
+			},
+		],
+		custom=False,
+		autoname="field:title",
+		naming_rule="By fieldname",
+	).insert(ignore_if_duplicate=True)
+
+
+def get_dashboard_for_todo(data: dict):
+	return data | {
+		"heatmap": True,
+		"heatmap_message": "This is a heatmap message",
+		"fieldname": "todo",
+	}

--- a/frappe/tests/test_dashboard_connections.py
+++ b/frappe/tests/test_dashboard_connections.py
@@ -122,7 +122,6 @@ class TestDashboardConnections(FrappeTestCase):
 				expected_open_count,
 			)
 
-
 	def test_external_doctype_link_with_dashboard_override(self):
 		# add a custom links
 		todo = TestCustomizeForm().get_customize_form("ToDo")
@@ -140,10 +139,12 @@ class TestDashboardConnections(FrappeTestCase):
 
 		# Change standard fieldname, see if all custom links still work
 		with patch_hooks(
-			{"override_doctype_dashboards": {
-				"ToDo": ["frappe.tests.test_dashboard_connections.get_dashboard_for_todo"]
+			{
+				"override_doctype_dashboards": {
+					"ToDo": ["frappe.tests.test_dashboard_connections.get_dashboard_for_todo"]
+				}
 			}
-		}):
+		):
 			connections = get_open_count("ToDo", todo_doc.name)["count"]
 			self.assertEqual(len(connections["external_links_found"]), 2)
 


### PR DESCRIPTION
## Issue
- Add a document link via Customize Form with a non standard fieldname. [Here I added the following to **Employee**]
  <img width="900" alt="Screenshot 2023-11-24 at 5 13 28 PM" src="https://github.com/frappe/frappe/assets/25857446/0cab1ce1-c8ed-4a04-a220-36e9c531de35">
- The doctype has a custom dashboard override via the hooks
-  The dashboard uses the wrong fieldname to get the custom link data
   <img width="900" alt="Screenshot 2023-11-24 at 5 16 01 PM" src="https://github.com/frappe/frappe/assets/25857446/d7160d05-1a3a-4174-a928-80f1bd790b21">

## Why it breaks
- The doctype links are fetched and then the hooks overrides are added
- `meta.py` tries to "guess" the standard fieldname from the document links. In this case it assumes **party** is the standard fieldname (because it is the first entry). Thus **it is never added to non standard fieldnames**
- Then, the custom dashboard, in this case, via hooks overrides the standard fieldname to `employee`
- Since **Bank Transaction** has no non standard fieldname, standard fieldname  `employee` is used against it > hence the error

## What fixes it:
- Since the field name is specified/mandatory in the Document Links table > use it as a non standard field because it is hard to determine which field is standard. And we honestly don't need the guess work afaik
   <img width="800" alt="Screenshot 2023-11-24 at 5 22 28 PM" src="https://github.com/frappe/frappe/assets/25857446/2ccee20b-9a8e-4b6c-afd8-4be67cc6c79e">
