### PR TITLE
fix: validate newsletter recipients

### DIFF
--- a/frappe/email/doctype/email_group/email_group.py
+++ b/frappe/email/doctype/email_group/email_group.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import contextlib
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -41,7 +43,7 @@ class EmailGroup(Document):
 		added = 0
 
 		for user in frappe.get_all(doctype, [email_field, unsubscribed_field or "name"]):
-			try:
+			with contextlib.suppress(frappe.UniqueValidationError, frappe.InvalidEmailAddressError):
 				email = parse_addr(user.get(email_field))[1] if user.get(email_field) else None
 				if email:
 					frappe.get_doc(
@@ -52,10 +54,7 @@ class EmailGroup(Document):
 							"unsubscribed": user.get(unsubscribed_field) if unsubscribed_field else 0,
 						}
 					).insert(ignore_permissions=True)
-
 					added += 1
-			except frappe.UniqueValidationError:
-				pass
 
 		frappe.msgprint(_("{0} subscribers added").format(added))
 

--- a/frappe/email/doctype/email_group_member/email_group_member.json
+++ b/frappe/email/doctype/email_group_member/email_group_member.json
@@ -28,6 +28,7 @@
    "in_global_search": 1,
    "in_list_view": 1,
    "label": "Email",
+   "options": "Email",
    "reqd": 1
   },
   {
@@ -40,7 +41,7 @@
   }
  ],
  "links": [],
- "modified": "2022-07-11 16:38:34.165271",
+ "modified": "2023-11-25 16:54:59.828669",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Group Member",

--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -50,10 +50,10 @@ class Newsletter(WebsiteGenerator):
 		total_recipients: DF.Int
 		total_views: DF.Int
 	# end: auto-generated types
+
 	def validate(self):
 		self.route = f"newsletters/{self.name}"
 		self.validate_sender_address()
-		self.validate_recipient_address()
 		self.validate_publishing()
 		self.validate_scheduling_date()
 
@@ -135,7 +135,6 @@ class Newsletter(WebsiteGenerator):
 	def validate_newsletter_recipients(self):
 		if not self.newsletter_recipients:
 			frappe.throw(_("Newsletter should have atleast one recipient"), exc=NoRecipientFoundError)
-		self.validate_recipient_address()
 
 	def validate_sender_address(self):
 		"""Validate self.send_from is a valid email address or not."""
@@ -144,11 +143,6 @@ class Newsletter(WebsiteGenerator):
 			self.send_from = (
 				f"{self.sender_name} <{self.sender_email}>" if self.sender_name else self.sender_email
 			)
-
-	def validate_recipient_address(self):
-		"""Validate if self.newsletter_recipients are all valid email addresses or not."""
-		for recipient in self.newsletter_recipients:
-			frappe.utils.validate_email_address(recipient, throw=True)
 
 	def validate_publishing(self):
 		if self.send_webview_link and not self.published:

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -231,3 +231,4 @@ execute:frappe.db.set_single_value("Document Naming Settings", "default_amend_na
 frappe.patches.v15_0.move_event_cancelled_to_status
 frappe.patches.v15_0.set_file_type
 frappe.core.doctype.data_import.patches.remove_stale_docfields_from_legacy_version
+frappe.patches.v15_0.validate_newsletter_recipients

--- a/frappe/patches/v15_0/validate_newsletter_recipients.py
+++ b/frappe/patches/v15_0/validate_newsletter_recipients.py
@@ -6,3 +6,4 @@ def execute():
 	for name, email in frappe.get_all("Email Group Member", fields=["name", "email"], as_list=True):
 		if not validate_email_address(email, throw=False):
 			frappe.db.set_value("Email Group Member", name, "unsubscribed", 1)
+			frappe.db.commit()

--- a/frappe/patches/v15_0/validate_newsletter_recipients.py
+++ b/frappe/patches/v15_0/validate_newsletter_recipients.py
@@ -1,0 +1,8 @@
+import frappe
+from frappe.utils import validate_email_address
+
+
+def execute():
+	for name, email in frappe.get_all("Email Group Member", fields=["name", "email"], as_list=True):
+		if not validate_email_address(email, throw=False):
+			frappe.db.set_value("Email Group Member", name, "unsubscribed", 1)


### PR DESCRIPTION
Before:

- We can add arbitrary stings as _Email_ in **Email Group Member**
- Email addresses get verified when trying to send a **Newsletter**.

After:

- We can only add valid email addresses as _Email_ in **Email Group Member**
- Existing **Email Group Member**s with an invalid _Email_ get unsubscribed. (This way, the Newsletter Manager can still fix any typos.)
- **Newsletter** can trust that all recipients are valid
