### PR TITLE
chore: Provision to ignore child mapping using get mapped doc

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -152,6 +152,9 @@ def get_mapped_doc(
 							True if target_doc.get(target_parentfield) else False
 						)
 
+					if table_map.get("ignore"):
+						continue
+
 					if table_map.get("add_if_empty") and row_exists_for_parentfield.get(target_parentfield):
 						continue
 


### PR DESCRIPTION
This allows ignoring specific child table mapping using get_mapped_doc