### PR TITLE
fix: set href in awesome bar

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -29,16 +29,18 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				};
 			},
 			item: function (item, term) {
-				var d = this.get_item(item.value);
-				var name = __(d.label || d.value);
-				var html = "<span>" + name + "</span>";
+				const d = this.get_item(item.value);
+				const target = d.route ? frappe.router.make_url(d.route) : "#";
+				let html = `<span>${__(d.label || d.value)}</span>`;
+
 				if (d.description && d.value !== d.description) {
 					html +=
 						'<br><span class="text-muted ellipsis">' + __(d.description) + "</span>";
 				}
+
 				return $("<li></li>")
 					.data("item.autocomplete", d)
-					.html(`<a style="font-weight:normal">${html}</a>`)
+					.html(`<a style="font-weight:normal" href="${target}">${html}</a>`)
 					.get(0);
 			},
 			sort: function (a, b) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -30,7 +30,16 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			},
 			item: function (item, term) {
 				const d = this.get_item(item.value);
-				const target = d.route ? frappe.router.make_url(d.route) : "#";
+				let target = "#";
+				if (d.route) {
+					target = frappe.router.make_url(
+						frappe.router.convert_from_standard_route(
+							frappe.router.get_route_from_arguments(
+								typeof d.route === "string" ? [d.route] : d.route
+							)
+						)
+					);
+				}
 				let html = `<span>${__(d.label || d.value)}</span>`;
 
 				if (d.description && d.value !== d.description) {


### PR DESCRIPTION
- Browser shows link target
- Supports "middle click" to open in new tab
- Less magic/doubts as to what and how happens on click

I didn't change or remove any of the existing click handling, but I guess the `href` just takes precedence in above cases.