### PR TITLE
refactor: execute last instance of webhook trigger on documents

### DIFF
--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -33,9 +33,6 @@ def run_webhooks(doc, method):
 	):
 		return
 
-	if frappe_flags.webhooks_executed is None:
-		frappe_flags.webhooks_executed = {}
-
 	# load all webhooks from cache / DB
 	webhooks = frappe.cache.get_value("webhooks", get_all_webhooks)
 
@@ -45,20 +42,6 @@ def run_webhooks(doc, method):
 	if not webhooks_for_doc:
 		# no webhooks, quit
 		return
-
-	def _webhook_request(webhook):
-		if webhook.name not in frappe_flags.webhooks_executed.get(doc.name, []):
-			frappe.enqueue(
-				"frappe.integrations.doctype.webhook.webhook.enqueue_webhook",
-				enqueue_after_commit=True,
-				doc=doc,
-				webhook=webhook,
-			)
-
-			# keep list of webhooks executed for this doc in this request
-			# so that we don't run the same webhook for the same document multiple times
-			# in one request
-			frappe_flags.webhooks_executed.setdefault(doc.name, []).append(webhook.name)
 
 	event_list = ["on_update", "after_insert", "on_submit", "on_cancel", "on_trash"]
 
@@ -78,4 +61,52 @@ def run_webhooks(doc, method):
 			trigger_webhook = True
 
 		if trigger_webhook and event and webhook.webhook_docevent == event:
-			_webhook_request(webhook)
+			_add_webhook_to_queue(webhook, doc)
+
+
+def _add_webhook_to_queue(webhook, doc):
+	# Maintain a queue and flush on commit
+	if not getattr(frappe.local, "_webhook_queue", None):
+		frappe.local._webhook_queue = []
+		frappe.db.after_commit.add(flush_webhook_execution_queue)
+
+	frappe.local._webhook_queue.append(frappe._dict(doc=doc, webhook=webhook))
+
+
+def flush_webhook_execution_queue():
+	"""Enqueue all pending webhook executions.
+
+	Each webhook can trigger multiple times on same document or even different instance of same
+	document. We assume that last enqueued version of document is the final document for this DB
+	transaction.
+	"""
+	if not getattr(frappe.local, "_webhook_queue", None):
+		return
+
+	uniq_hooks = set()
+	unique_last_instances = []
+
+	# reverse
+	frappe.local._webhook_queue.reverse()
+
+	# deduplicate on (doc.name, webhook.name)
+	# 'doc' holds the last instance values
+	for execution in frappe.local._webhook_queue:
+		key = (execution.webhook.get("name"), execution.doc.get("name"))
+		if key not in uniq_hooks:
+			uniq_hooks.add(key)
+			unique_last_instances.append(execution)
+
+	# Clear original queue so next enqueue computation happens correctly.
+	del frappe.local._webhook_queue
+
+	# reverse again, to get back the original order on which to execute webhooks
+	unique_last_instances.reverse()
+
+	for instance in unique_last_instances:
+		frappe.enqueue(
+			"frappe.integrations.doctype.webhook.webhook.enqueue_webhook",
+			doc=instance.doc,
+			webhook=instance.webhook,
+			now=frappe.flags.in_test,
+		)

--- a/frappe/integrations/doctype/webhook/test_webhook.py
+++ b/frappe/integrations/doctype/webhook/test_webhook.py
@@ -7,6 +7,7 @@ import responses
 from responses.matchers import json_params_matcher
 
 import frappe
+from frappe.integrations.doctype.webhook import flush_webhook_execution_queue
 from frappe.integrations.doctype.webhook.webhook import (
 	enqueue_webhook,
 	get_webhook_data,
@@ -96,6 +97,7 @@ class TestWebhook(FrappeTestCase):
 		self.test_user = frappe.new_doc("User")
 		self.test_user.email = "user1@integration.webhooks.test.com"
 		self.test_user.first_name = "user1"
+		self.test_user.send_welcome_email = False
 
 		self.responses = responses.RequestsMock()
 		self.responses.start()
@@ -118,12 +120,13 @@ class TestWebhook(FrappeTestCase):
 
 		webhooks = frappe.cache.get_value("webhooks")
 		self.assertTrue("User" in webhooks)
-		# only 1 hook (enabled) must be queued
 		self.assertEqual(len(webhooks.get("User")), 1)
-		self.assertTrue(self.test_user.email in frappe.flags.webhooks_executed)
-		self.assertEqual(
-			frappe.flags.webhooks_executed.get(self.test_user.email)[0], self.sample_webhooks[0].name
-		)
+
+		# only 1 hook (enabled) must be queued
+		self.assertEqual(len(frappe.local._webhook_queue), 1)
+		execution = frappe.local._webhook_queue[0]
+		self.assertEqual(execution.webhook.name, self.sample_webhooks[0].name)
+		self.assertEqual(execution.doc.name, self.test_user.name)
 
 	def test_validate_doc_events(self):
 		"Test creating a submit-related webhook for a non-submittable DocType"
@@ -206,7 +209,7 @@ class TestWebhook(FrappeTestCase):
 		wh_config = {
 			"doctype": "Webhook",
 			"webhook_doctype": "Note",
-			"webhook_docevent": "after_insert",
+			"webhook_docevent": "on_change",
 			"enabled": 1,
 			"request_url": "https://httpbin.org/post",
 			"request_method": "POST",
@@ -223,8 +226,9 @@ class TestWebhook(FrappeTestCase):
 
 		doc = frappe.new_doc("Note")
 		doc.title = "Test Webhook Note"
+		final_title = frappe.generate_hash()
 
-		expected_req = [{"title": doc.title} for _ in range(3)]
+		expected_req = [{"title": final_title} for _ in range(3)]
 		self.responses.add(
 			responses.POST,
 			"https://httpbin.org/post",
@@ -233,8 +237,15 @@ class TestWebhook(FrappeTestCase):
 			match=[json_params_matcher(expected_req)],
 		)
 
-		with get_test_webhook(wh_config) as wh:
-			enqueue_webhook(doc, wh)
+		with get_test_webhook(wh_config):
+			# It should only execute once in a transaction
+			doc.insert()
+			doc.reload()
+			doc.save()
+			doc = frappe.get_doc(doc.doctype, doc.name)
+			doc.title = final_title
+			doc.save()
+			flush_webhook_execution_queue()
 			log = frappe.get_last_doc("Webhook Request Log")
 			self.assertEqual(len(json.loads(log.response)), 3)
 

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -201,7 +201,7 @@ def _commit_watcher():
 	import traceback
 
 	print("Warning:, transaction committed during tests.")
-	traceback.print_stack(limit=5)
+	traceback.print_stack(limit=10)
 
 
 def _rollback_db():


### PR DESCRIPTION
## Scenario
Consider a webhook setup on the `on_change` event of a doctype. Now, when a document undergoes multiple changes in one DB transaction(web request), webhook is triggered only on the first instance, and the [rest are suppressed](https://github.com/frappe/frappe/blob/d67a6d168eb8f10b50d93fc567555f3f016643d4/frappe/integrations/doctype/webhook/__init__.py#L47-L59).

## Drawbacks
There are scenarios, where the later changes are lost - no webhook triggered; due to this design, as the ['doc'](https://github.com/frappe/frappe/blob/d67a6d168eb8f10b50d93fc567555f3f016643d4/frappe/integrations/doctype/webhook/__init__.py#L52C9-L52C9) variable holds the value from the instance on which the trigger was made.

## Fix
Capture all webhook triggers in a list and at the end of the transaction, execute only the last instance of the webhooks.
