### PR TITLE
fix: allow internal routing using workspace shortcut url option

### DIFF
--- a/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
+++ b/frappe/desk/doctype/workspace_shortcut/workspace_shortcut.json
@@ -102,8 +102,7 @@
    "fieldname": "url",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "URL",
-   "options": "URL"
+   "label": "URL"
   },
   {
    "depends_on": "eval:doc.doc_view == \"Kanban\"",
@@ -116,7 +115,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-07-18 16:12:53.546430",
+ "modified": "2023-11-27 14:13:38.489737",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Shortcut",

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -419,7 +419,6 @@ class ShortcutDialog extends WidgetDialog {
 				fieldtype: "Data",
 				fieldname: "url",
 				label: "URL",
-				options: "URL",
 				default: "",
 				depends_on: (s) => s.type == "URL",
 				mandatory_depends_on: (s) => s.type == "URL",
@@ -547,7 +546,11 @@ class ShortcutDialog extends WidgetDialog {
 		data.label = data.label ? data.label : frappe.model.unscrub(data.link_to);
 
 		if (data.url) {
-			!validate_url(data.url) &&
+			let _url = data.url;
+			if (data.url.startsWith("/")) {
+				_url = frappe.urllib.get_base_url() + data.url;
+			}
+			!validate_url(_url) &&
 				frappe.throw({
 					message: __("<b>{0}</b> is not a valid URL", [data.url]),
 					title: __("Invalid URL"),


### PR DESCRIPTION
Allow routing to internal pages. Just start the URL as /
E.g if I want to route to the CRM Portal page set the URL as `/crm` 