### PR TITLE
fix(form_builder): Use locale-aware sorting and search for fieldtypes

### DIFF
--- a/frappe/public/js/form_builder/components/Autocomplete.vue
+++ b/frappe/public/js/form_builder/components/Autocomplete.vue
@@ -131,6 +131,8 @@ watch(showOptions, (val) => {
 	border-radius: var(--border-radius-sm);
 	padding: 6px 10px;
 	width: 100%;
+	cursor: pointer;
+	user-select: none;
 
 	&:hover,
 	&.active {

--- a/frappe/public/js/form_builder/components/Autocomplete.vue
+++ b/frappe/public/js/form_builder/components/Autocomplete.vue
@@ -19,7 +19,7 @@
 			<div class="combo-box-items">
 				<ComboboxOption
 					as="template"
-					v-for="(field, i) in filteredOptions"
+					v-for="(field, i) in sortedOptions"
 					:key="i"
 					:value="field"
 					v-slot="{ active }"
@@ -85,11 +85,16 @@ const selectedValue = computed({
 });
 
 const filteredOptions = computed(() => {
-	return query.value
-		? props.options.filter((option) => {
-				return option.label.toLowerCase().includes(query.value.toLowerCase());
-		  })
-		: props.options;
+	if (!query.value) return props.options;
+	return props.options.filter((option) => {
+		return option.label.toLocaleLowerCase().includes(query.value.toLocaleLowerCase());
+	});
+});
+
+const sortedOptions = computed(() => {
+	return filteredOptions.value.sort((a, b) => {
+		return a.label.localeCompare(b.label);
+	});
 });
 
 function clear_search() {


### PR DESCRIPTION
This is my best attempt at locale-aware string search and sorting for the DocFields Autocomplete widget in the Form Builder. Basically nothing changed because it's difficult to do well :sweat_smile: 

---

## Previous attempt 1

I tried to use the following, but it will break for some languages (Cyrillic ё or й, Spanish ñ, doesn't handle German ß i guess too).

```js
const DIACRITICS_REGEX = /\p{Diacritic}/gu;

function removeDiacritics(str) {
	return str.normalize("NFD").replace(DIACRITICS_REGEX, "").toLowerCase();
};

const filteredOptions = computed(() => {
	if (!query.value) return props.options;
	const normQuery = removeDiacritics(query.value);
	return props.options.filter(option => removeDiacritics(option.label).includes(normQuery));
});
```
https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript

---

## Previous attempt 2

I tried to use the Intl Web API but it's not fully ready for this use case (~prefix search), and I wanted to avoid an over-engineered solution.

* https://github.com/tc39/ecma402/issues/506
* https://github.com/arty-name/locale-index-of

> [developer.mozilla.org/…/Intl.Collator#usage "search"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#search)
For **filtering a list of strings** by testing each list item for a full-string match against a key. With "search", **the caller should only pay attention to whether compare() returns zero or non-zero** and should not distinguish the non-zero return values from each other. That is, it is inappropriate to use "search" for sorting/ordering.

> [developer.mozilla.org/…/Intl.Collator#sensitivity](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#sensitivity)
Which differences in the strings should lead to non-zero result values. Possible values are: "base", "accent", "case", "variant".
The default is … locale dependent for **usage "search"** per spec, but the core functionality of "search" is **accent-insensitive** and **case-insensitive** filtering, so "base" makes the most sense (and perhaps "case").