### PR TITLE
fix(router): handle exceptions when trying to JSONify a circular reference

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -368,11 +368,17 @@ frappe.router = {
 				window.open(sub_path, "_blank");
 				frappe.open_in_new_tab = false;
 			} else {
-				const route_options = frappe.route_options || {};
-				const query_params = Object.entries(route_options)
-					.map(([key, value]) => `${key}=` + encodeURIComponent(JSON.stringify(value)))
-					.join("&");
-				this.push_state(sub_path, query_params ? `?${query_params}` : "");
+				try {
+					const route_options = frappe.route_options || {};
+					const query_params = Object.entries(route_options)
+						.map(
+							([key, value]) => `${key}=` + encodeURIComponent(JSON.stringify(value))
+						)
+						.join("&");
+					this.push_state(sub_path, query_params ? `?${query_params}` : "");
+				} catch (e) {
+					this.push_state(sub_path);
+				}
 			}
 			setTimeout(() => {
 				frappe.after_ajax &&


### PR DESCRIPTION
This issue seems to have occurred after #23025

To reproduce the crash, try to print a document like `Email Account`

```js
router.js:373 Uncaught (in promise) TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'frappe.ui.form.Form'
    |     property 'grids' -> object with constructor 'Array'
    |     index 0 -> object with constructor 'frappe.ui.form.ControlTable'
    --- property 'frm' closes the circle
    at JSON.stringify (<anonymous>)
    at router.js:373:65
    at Array.map (<anonymous>)
    at Promise.finally.frappe.route_flags (router.js:373:7)
    at new Promise (<anonymous>)
    at Object.set_route (router.js:360:10)
    at frappe.set_route (router.js:567:33)
    at frappe.ui.form.Form.print_doc (form.js:1276:10)
    at HTMLButtonElement.<anonymous> (toolbar.js:330:14)
    at HTMLButtonElement.dispatch (jquery.js:5135:27)
    at Rt.handle (jquery.js:4939:28)
    at HTMLButtonElement.i (helpers.ts:95:1)
```