### PR TITLE
fix: show pointer only if section is collapsible

### DIFF
--- a/frappe/public/js/frappe/form/section.js
+++ b/frappe/public/js/frappe/form/section.js
@@ -73,6 +73,7 @@ export default class Section {
 		this.indicator.hide();
 
 		if (this.df.collapsible) {
+			this.head.addClass("collapsible");
 			// show / hide based on status
 			this.collapse_link = this.head.on("click", () => {
 				this.collapse();

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -48,7 +48,7 @@
 		padding: var(--padding-sm) var(--padding-md);
 		margin: 0;
 		margin-bottom: var(--margin-sm);
-		cursor: pointer;
+		cursor: default;
 
 		.collapse-indicator {
 			color: var(--text-muted);
@@ -56,6 +56,10 @@
 			position: relative;
 			padding: 0px;
 		}
+	}
+
+	.section-head.collapsible {
+		cursor: pointer;
 	}
 
 	.section-head.collapsed {


### PR DESCRIPTION
### Before

Hovering on non-collapsible section title shows the "pointer" cursor. This implies that we can click, but in this case the click has no effect.

### After

Hovering on non-collapsible section title shows the "default" cursor. (Same as for other field labels.)


https://github.com/frappe/frappe/assets/14891507/f5508842-435a-41ea-a96c-2ba03f0a042e

