### PR TITLE
fix: set `sidebar_items` only if not present

### DIFF
--- a/frappe/website/page_renderers/template_page.py
+++ b/frappe/website/page_renderers/template_page.py
@@ -109,7 +109,8 @@ class TemplatePage(BaseTemplatePage):
 		super().post_process_context()
 
 	def add_sidebar_and_breadcrumbs(self):
-		self.context.sidebar_items = get_sidebar_items(self.context.website_sidebar, self.basepath)
+		if not self.context.sidebar_items:
+			self.context.sidebar_items = get_sidebar_items(self.context.website_sidebar, self.basepath)
 
 		if self.context.add_breadcrumbs and not self.context.parents:
 			parent_path = os.path.dirname(self.path)


### PR DESCRIPTION
The `get_context` of some templates set their own sidebar if this is done, no need to override.

Example from **Help Articles** which are served on `/kb` by default. Their `get_context` sets `sidebar_items`.

**Before:**

![Screenshot 2023-11-29 at 12 06 25](https://github.com/frappe/frappe/assets/29507195/96fd809c-23af-49e4-8483-1e36b0864d41)

**After:**

![Screenshot 2023-11-29 at 12 06 38](https://github.com/frappe/frappe/assets/29507195/8fbcf277-b622-450c-9123-4f14fe78c4df)
