### PR TITLE
fix: Only preload icons for desk

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -237,7 +237,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	local.jloader = None
 	local.cache = {}
 	local.form_dict = _dict()
-	local.preload_assets = {"style": [], "script": []}
+	local.preload_assets = {"style": [], "script": [], "icons": []}
 	local.session = _dict()
 	local.dev_server = _dev_server
 	local.qb = get_query_builder(local.conf.db_type)

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -217,7 +217,7 @@ def _restore_thread_locals(flags):
 	frappe.local.conf = frappe._dict(frappe.get_site_config())
 	frappe.local.cache = {}
 	frappe.local.lang = "en"
-	frappe.local.preload_assets = {"style": [], "script": []}
+	frappe.local.preload_assets = {"style": [], "script": [], "icons": []}
 
 	if hasattr(frappe.local, "request"):
 		delattr(frappe.local, "request")

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -573,19 +573,16 @@ def set_content_type(response, data, path):
 def add_preload_for_bundled_assets(response):
 	links = [f"<{css}>; rel=preload; as=style" for css in frappe.local.preload_assets["style"]]
 	links.extend(f"<{js}>; rel=preload; as=script" for js in frappe.local.preload_assets["script"])
-	links.extend(_preload_svg_headers())
+
+	version = get_build_version()
+	# include_icons = frappe.get_hooks().get("app_include_icons", [])
+	links.extend(
+		f"</assets/{svg}?v={version}>; rel=preload; as=fetch; crossorigin"
+		for svg in frappe.local.preload_assets["icons"]
+	)
 
 	if links:
 		response.headers["Link"] = ",".join(links)
-
-
-def _preload_svg_headers():
-	include_icons = frappe.get_hooks().get("app_include_icons", [])
-
-	version = get_build_version()
-	return [
-		f"</assets/{svg}?v={version}>; rel=preload; as=fetch; crossorigin" for svg in include_icons
-	]
 
 
 @lru_cache

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -45,6 +45,7 @@ def get_context(context):
 	include_js = hooks.get("app_include_js", []) + frappe.conf.get("app_include_js", [])
 	include_css = hooks.get("app_include_css", []) + frappe.conf.get("app_include_css", [])
 	include_icons = hooks.get("app_include_icons", [])
+	frappe.local.preload_assets["icons"].extend(include_icons)
 
 	context.update(
 		{


### PR DESCRIPTION
We always send preload hint, but it's only required for loading `/app/*`