### PR TITLE
feat(minor): include filter values in exported report excel

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -328,7 +328,8 @@ def export_query():
 		report_name, form_params.filters, custom_columns=custom_columns, are_default_filters=False
 	)
 	data = frappe._dict(data)
-	data.filters = form_params.filters
+	data.filters = form_params.applied_filters
+
 	if not data.columns:
 		frappe.respond_as_web_page(
 			_("No data to export"),
@@ -396,7 +397,7 @@ def build_xlsx_data(
 			if filter_value in ["", None, []]:
 				continue
 			filter_value = ", ".join(filter_value) if isinstance(filter_value, list) else cstr(filter_value)
-			filter_data.append([cstr(filter_name) + ": ", filter_value])
+			filter_data.append([cstr(filter_name), filter_value])
 		filter_data.append([])
 		result += filter_data
 

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -397,7 +397,7 @@ def build_xlsx_data(
 			if not filter_value:
 				continue
 			filter_value = (
-				", ".join(map(lambda x: cstr(x), filter_value))
+				", ".join([cstr(x) for x in filter_value])
 				if isinstance(filter_value, list)
 				else cstr(filter_value)
 			)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -394,7 +394,7 @@ def build_xlsx_data(
 		filter_data = []
 		filters = data.filters
 		for filter_name, filter_value in filters.items():
-			if filter_value in ["", None, []]:
+			if not filter_value:
 				continue
 			filter_value = (
 				", ".join(map(lambda x: cstr(x), filter_value))

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -318,6 +318,7 @@ def export_query():
 	file_format_type = form_params.file_format_type
 	custom_columns = frappe.parse_json(form_params.custom_columns or "[]")
 	include_indentation = form_params.include_indentation
+	include_filters = form_params.include_filters
 	visible_idx = form_params.visible_idx
 
 	if isinstance(visible_idx, str):
@@ -327,6 +328,7 @@ def export_query():
 		report_name, form_params.filters, custom_columns=custom_columns, are_default_filters=False
 	)
 	data = frappe._dict(data)
+	data.filters = form_params.filters
 	if not data.columns:
 		frappe.respond_as_web_page(
 			_("No data to export"),
@@ -335,7 +337,9 @@ def export_query():
 		return
 
 	format_duration_fields(data)
-	xlsx_data, column_widths = build_xlsx_data(data, visible_idx, include_indentation)
+	xlsx_data, column_widths = build_xlsx_data(
+		data, visible_idx, include_indentation, include_filters=include_filters
+	)
 
 	if file_format_type == "CSV":
 		content = get_csv_bytes(xlsx_data, csv_params)
@@ -360,7 +364,9 @@ def format_duration_fields(data: frappe._dict) -> None:
 				row[index] = format_duration(row[index])
 
 
-def build_xlsx_data(data, visible_idx, include_indentation, ignore_visible_idx=False):
+def build_xlsx_data(
+	data, visible_idx, include_indentation, include_filters=False, ignore_visible_idx=False
+):
 	EXCEL_TYPES = (
 		str,
 		bool,
@@ -380,17 +386,30 @@ def build_xlsx_data(data, visible_idx, include_indentation, ignore_visible_idx=F
 		# Note: converted for faster lookups
 		visible_idx = set(visible_idx)
 
-	result = [[]]
+	result = []
 	column_widths = []
 
+	if cint(include_filters):
+		filter_data = []
+		filters = data.filters
+		for filter_name, filter_value in filters.items():
+			if filter_value in ["", None, []]:
+				continue
+			filter_value = ", ".join(filter_value) if isinstance(filter_value, list) else cstr(filter_value)
+			filter_data.append([cstr(filter_name) + ": ", filter_value])
+		filter_data.append([])
+		result += filter_data
+
+	column_data = []
 	for column in data.columns:
 		if column.get("hidden"):
 			continue
-		result[0].append(_(column.get("label")))
+		column_data.append(_(column.get("label")))
 		column_width = cint(column.get("width", 0))
 		# to convert into scale accepted by openpyxl
 		column_width /= 10
 		column_widths.append(column_width)
+	result.append(column_data)
 
 	# build table from result
 	for row_idx, row in enumerate(data.result):

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -396,7 +396,11 @@ def build_xlsx_data(
 		for filter_name, filter_value in filters.items():
 			if filter_value in ["", None, []]:
 				continue
-			filter_value = ", ".join(filter_value) if isinstance(filter_value, list) else cstr(filter_value)
+			filter_value = (
+				", ".join(map(lambda x: cstr(x), filter_value))
+				if isinstance(filter_value, list)
+				else cstr(filter_value)
+			)
 			filter_data.append([cstr(filter_name), filter_value])
 		filter_data.append([])
 		result += filter_data

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -217,6 +217,8 @@ def clean_params(data):
 def parse_json(data):
 	if (filters := data.get("filters")) and isinstance(filters, str):
 		data["filters"] = json.loads(filters)
+	if (applied_filters := data.get("applied_filters")) and isinstance(applied_filters, str):
+		data["applied_filters"] = json.loads(applied_filters)
 	if (or_filters := data.get("or_filters")) and isinstance(or_filters, str):
 		data["or_filters"] = json.loads(or_filters)
 	if (fields := data.get("fields")) and isinstance(fields, str):

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1512,6 +1512,12 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						filters
 					);
 				}
+				let applied_filters = Object.fromEntries(
+					Object.entries(filters).map(([key, value]) => [
+						frappe.query_report.get_filter(key).df.label,
+						value,
+					])
+				);
 
 				const visible_idx = this.datatable.bodyRenderer.visibleRowIndices;
 				if (visible_idx.length + 1 === this.data.length) {
@@ -1524,6 +1530,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					custom_columns: this.custom_columns.length ? this.custom_columns : [],
 					file_format_type: file_format,
 					filters: filters,
+					applied_filters: applied_filters,
 					visible_idx,
 					csv_delimiter,
 					csv_quoting,

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1512,10 +1512,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 						filters
 					);
 				}
+				let boolean_labels = { 1: __("Yes"), 0: __("No") };
 				let applied_filters = Object.fromEntries(
 					Object.entries(filters).map(([key, value]) => [
 						frappe.query_report.get_filter(key).df.label,
-						value,
+						frappe.query_report.get_filter(key).df.fieldtype == "Check"
+							? boolean_labels[value]
+							: value,
 					])
 				);
 

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1475,21 +1475,34 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			return;
 		}
 
-		let extra_fields = null;
+		let extra_fields = [];
+
 		if (this.tree_report) {
-			extra_fields = [
-				{
-					label: __("Include indentation"),
-					fieldname: "include_indentation",
-					fieldtype: "Check",
-				},
-			];
+			extra_fields.push({
+				label: __("Include indentation"),
+				fieldname: "include_indentation",
+				fieldtype: "Check",
+			});
+		}
+
+		if (this.filters.length > 0) {
+			extra_fields.push({
+				label: __("Include filters"),
+				fieldname: "include_filters",
+				fieldtype: "Check",
+			});
 		}
 
 		this.export_dialog = frappe.report_utils.get_export_dialog(
 			__(this.report_name),
 			extra_fields,
-			({ file_format, include_indentation, csv_delimiter, csv_quoting }) => {
+			({
+				file_format,
+				include_indentation,
+				include_filters,
+				csv_delimiter,
+				csv_quoting,
+			}) => {
 				this.make_access_log("Export", file_format);
 
 				let filters = this.get_filter_values(true);
@@ -1515,6 +1528,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					csv_delimiter,
 					csv_quoting,
 					include_indentation,
+					include_filters,
 				};
 
 				open_url_post(frappe.request.url, args);


### PR DESCRIPTION
**Description**
Introduces the option to export applied filters along with the report data when a report is exported to Excel or other formats.

**Screenshot**

<br>

<img width="559" alt="Screenshot 2023-12-15 at 5 53 30 PM" src="https://github.com/frappe/frappe/assets/40693548/36c1bfc6-379d-4572-a0dc-6c13912e5be0">




<br>
<br>

Resolves #23511


`no-docs`