### PR TITLE
fix: Always evaluate Virtual Fields

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -344,18 +344,17 @@ class BaseDocument:
 					if ignore_virtual or fieldname not in self.permitted_fieldnames:
 						continue
 
-					if value is None:
-						if (prop := getattr(type(self), fieldname, None)) and is_a_property(prop):
-							value = getattr(self, fieldname)
+					if (prop := getattr(type(self), fieldname, None)) and is_a_property(prop):
+						value = getattr(self, fieldname)
 
-						elif options := getattr(df, "options", None):
-							from frappe.utils.safe_exec import get_safe_globals
+					elif options := getattr(df, "options", None):
+						from frappe.utils.safe_exec import get_safe_globals
 
-							value = frappe.safe_eval(
-								code=options,
-								eval_globals=get_safe_globals(),
-								eval_locals={"doc": self},
-							)
+						value = frappe.safe_eval(
+							code=options,
+							eval_globals=get_safe_globals(),
+							eval_locals={"doc": self},
+						)
 
 				if isinstance(value, list) and df.fieldtype not in table_fields:
 					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label)))


### PR DESCRIPTION
Related: https://github.com/frappe/frappe/issues/23475
Likely caused by: https://github.com/frappe/frappe/pull/22110

Because run_doc_method passes doc from client to server side, we end up
setting values for what is a "virtual field", this is why it finds some
value and not re-evaluate it.

IMO there are only mild breaking ways of fixing this:
1. Virtual fields should always be computed.
2. Virtual fields should not be set when init-ing the document. (e.g. from doc.set APIs )
