### PR TITLE
fix: skip overriden doctypes during orphan check

### DIFF
--- a/frappe/model/sync.py
+++ b/frappe/model/sync.py
@@ -153,8 +153,11 @@ def remove_orphan_doctypes():
 	orphan_doctypes = []
 
 	clear_controller_cache()
+	class_overrides = frappe.get_hooks("override_doctype_class", {})
 
 	for doctype in doctype_names:
+		if doctype in class_overrides:
+			continue
 		try:
 			get_controller(doctype=doctype)
 		except ImportError:


### PR DESCRIPTION
These are prone to breakage and shouldn't be deleted automatically.

This mostly works fine but there can be cases where it doesn't. So best to leave them untouched.
