### PR TITLE
fix: prevent edit of readonly popup fields

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -902,6 +902,14 @@ export default class GridRow {
 			}, 600);
 		}
 
+		function trigger_focus(input_field, col_df) {
+			if (["Date", "Datetime"].includes(col_df.fieldtype) && col_df?.read_only) {
+				return;
+			}
+
+			input_field.trigger("focus");
+		}
+
 		var $col = $(
 			'<div class="col grid-static-col col-xs-' + colsize + " " + add_class + '"></div>'
 		)
@@ -978,7 +986,7 @@ export default class GridRow {
 						}
 					});
 
-				!input_in_focus && first_input_field.trigger("focus");
+				!input_in_focus && trigger_focus(first_input_field, $(col).data("df"));
 
 				if (event.pointerType == "touch") {
 					first_input_field.length && on_input_focus(first_input_field);


### PR DESCRIPTION

https://github.com/frappe/frappe/assets/29507195/bd448304-ed28-4d5b-a87e-7af4f769f780

Clicking on table row causes focus on on `read_only` Date, Datetime fields causes date[time] picker popup allowing edit and save of readonly fields.