### PR TITLE
feat: disable assigned thread notification

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -84,7 +84,6 @@ class CommunicationEmailMixin:
 			assignees = set(self.get_assignees())
 			# Check and remove If user disabled notifications for incoming emails on assigned document.
 			for assignee in assignees.copy():
-
 				if not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document"):
 					assignees.remove(assignee)
 			cc.update(assignees)

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -1,6 +1,9 @@
 import frappe
 from frappe import _
 from frappe.core.utils import get_parent_doc
+from frappe.desk.doctype.notification_settings.notification_settings import (
+	is_email_notifications_enabled_for_type,
+)
 from frappe.desk.doctype.todo.todo import ToDo
 from frappe.email.doctype.email_account.email_account import EmailAccount
 from frappe.utils import get_formatted_email, get_url, parse_addr
@@ -78,7 +81,13 @@ class CommunicationEmailMixin:
 			if doc_owner := self.get_owner():
 				cc.append(doc_owner)
 			cc = set(cc) - {self.sender_mailid}
-			cc.update(self.get_assignees())
+			assignees = set(self.get_assignees())
+			# Check and remove If user disabled notifications for incoming emails on assigned document.
+			for assignee in assignees.copy():
+
+				if not is_email_notifications_enabled_for_type(assignee, "threads_on_assigned_document"):
+					assignees.remove(assignee)
+			cc.update(assignees)
 
 		cc = set(cc) - set(self.filter_thread_notification_disbled_users(cc))
 		cc = cc - set(self.mail_recipients(is_inbound_mail_communcation=is_inbound_mail_communcation))

--- a/frappe/desk/doctype/notification_settings/notification_settings.json
+++ b/frappe/desk/doctype/notification_settings/notification_settings.json
@@ -12,6 +12,7 @@
   "enable_email_notifications",
   "enable_email_mention",
   "enable_email_assignment",
+  "enable_email_threads_on_assigned_document",
   "enable_email_energy_point",
   "enable_email_share",
   "enable_email_event_reminders",
@@ -105,12 +106,20 @@
    "fieldname": "enable_email_event_reminders",
    "fieldtype": "Check",
    "label": "Event Reminders"
+  },
+  {
+   "default": "1",
+   "depends_on": "enable_email_notifications",
+   "description": "Get notified when an email is received on any of the documents assigned to you.",
+   "fieldname": "enable_email_threads_on_assigned_document",
+   "fieldtype": "Check",
+   "label": "Email Threads on Assigned Document"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-11-24 14:45:31.931154",
+ "modified": "2023-12-01 12:46:15.490640",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Settings",
@@ -132,5 +141,6 @@
  "read_only": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -23,6 +23,7 @@ class NotificationSettings(Document):
 		enable_email_mention: DF.Check
 		enable_email_notifications: DF.Check
 		enable_email_share: DF.Check
+		enable_email_threads_on_assigned_document: DF.Check
 		enabled: DF.Check
 		energy_points_system_notifications: DF.Check
 		seen: DF.Check


### PR DESCRIPTION
-   currently, an email notification is sent to the assigned users of any doc
    when a new email is received.
-   This is not desirable in some cases, so this commit adds a new
    configuration option to disable this notification from notification settings.
-   By default, this option is enabled to ensure backward compatibility.

`no-docs`

<img width="1316" alt="Screenshot 2023-12-01 at 1 34 27 PM" src="https://github.com/frappe/frappe/assets/39730881/5e547479-4bbe-4707-ba66-7a0f8bf06678">
