### PR TITLE
fix: quicklist

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -104,7 +104,7 @@ export default class QuickListWidget extends Widget {
 			primary_action: function () {
 				let old_filter = me.quick_list_filter;
 				let filters = me.filter_group.get_filters();
-				me.quick_list_filter = JSON.parse(filters);
+				me.quick_list_filter = JSON.stringify(filters);
 
 				this.hide();
 

--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -114,7 +114,7 @@ export default class QuickListWidget extends Widget {
 					me.set_body();
 				}
 			},
-			primary_action_label: __("Set"),
+			primary_action_label: __("Save"),
 		});
 
 		this.dialog.show();


### PR DESCRIPTION
- Stringify object instead of trying to parse it

    What we were trying to `parse` here is an array. We want to compare it to a string, so we should `stringify` the array instead.

- More appropriate label for saving filters

    "Set" is already occupied in filters as ["is", "Set"], referring to a state, while here it is an action. This makes it easier to translate.
