### PR TITLE
feat: set sender name in documents created from email

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -68,6 +68,7 @@
   "column_break_51",
   "email_append_to",
   "sender_field",
+  "sender_name_field",
   "subject_field",
   "sb2",
   "permissions",
@@ -520,7 +521,7 @@
    "depends_on": "email_append_to",
    "fieldname": "sender_field",
    "fieldtype": "Data",
-   "label": "Sender Field",
+   "label": "Sender Email Field",
    "mandatory_depends_on": "email_append_to"
   },
   {
@@ -661,6 +662,12 @@
    "fieldtype": "Tab Break",
    "label": "Connections",
    "show_dashboard": 1
+  },
+  {
+   "depends_on": "email_append_to",
+   "fieldname": "sender_name_field",
+   "fieldtype": "Data",
+   "label": "Sender Name Field"
   }
  ],
  "icon": "fa fa-bolt",
@@ -743,7 +750,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2023-11-01 16:45:14.960949",
+ "modified": "2023-12-01 18:37:16.799471",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -162,6 +162,7 @@ class DocType(Document):
 		route: DF.Data | None
 		search_fields: DF.Data | None
 		sender_field: DF.Data | None
+		sender_name_field: DF.Data | None
 		show_name_in_global_search: DF.Check
 		show_preview_popup: DF.Check
 		show_title_field_in_link: DF.Check
@@ -177,6 +178,7 @@ class DocType(Document):
 		translated_doctype: DF.Check
 		website_search_field: DF.Data | None
 	# end: auto-generated types
+
 	def validate(self):
 		"""Validate DocType before saving.
 

--- a/frappe/custom/doctype/customize_form/customize_form.json
+++ b/frappe/custom/doctype/customize_form/customize_form.json
@@ -46,6 +46,7 @@
   "column_break_26",
   "email_append_to",
   "sender_field",
+  "sender_name_field",
   "subject_field",
   "section_break_8",
   "sort_field",
@@ -219,7 +220,7 @@
    "depends_on": "email_append_to",
    "fieldname": "sender_field",
    "fieldtype": "Data",
-   "label": "Sender Field",
+   "label": "Sender Email Field",
    "mandatory_depends_on": "email_append_to"
   },
   {
@@ -392,6 +393,12 @@
    "fieldname": "details_tab",
    "fieldtype": "Tab Break",
    "label": "Details"
+  },
+  {
+   "depends_on": "email_append_to",
+   "fieldname": "sender_name_field",
+   "fieldtype": "Data",
+   "label": "Sender Name Field"
   }
  ],
  "hide_toolbar": 1,
@@ -400,7 +407,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-16 11:23:06.427432",
+ "modified": "2023-12-01 18:18:23.086134",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form",

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -72,6 +72,7 @@ class CustomizeForm(Document):
 		quick_entry: DF.Check
 		search_fields: DF.Data | None
 		sender_field: DF.Data | None
+		sender_name_field: DF.Data | None
 		show_preview_popup: DF.Check
 		show_title_field_in_link: DF.Check
 		sort_field: DF.Literal
@@ -83,6 +84,7 @@ class CustomizeForm(Document):
 		track_views: DF.Check
 		translated_doctype: DF.Check
 	# end: auto-generated types
+
 	def on_update(self):
 		frappe.db.delete("Singles", {"doctype": "Customize Form"})
 		frappe.db.delete("Customize Form Field")

--- a/frappe/email/doctype/email_account/test_email_account.py
+++ b/frappe/email/doctype/email_account/test_email_account.py
@@ -626,7 +626,6 @@ class TestInboundMail(FrappeTestCase):
 		email_account = frappe.get_doc("Email Account", "_Test Email Account 1")
 		inbound_mail = InboundMail(mail_content, email_account, 12345, 1)
 		communication = inbound_mail.process()
-		self.assertTrue(communication.is_first)
 		self.assertTrue(communication._attachments)
 
 

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -821,6 +821,9 @@ class InboundMail(Email):
 		if email_fields.sender_field:
 			parent.set(email_fields.sender_field, frappe.as_unicode(self.from_email))
 
+		if email_fields.sender_name_field:
+			parent.set(email_fields.sender_name_field, frappe.as_unicode(self.from_real_name))
+
 		parent.flags.ignore_mandatory = True
 
 		try:
@@ -864,7 +867,7 @@ class InboundMail(Email):
 		"""Returns Email related fields of a doctype."""
 		fields = frappe._dict()
 
-		email_fields = ["subject_field", "sender_field"]
+		email_fields = ["subject_field", "sender_field", "sender_name_field"]
 		meta = frappe.get_meta(doctype)
 
 		for field in email_fields:

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -815,13 +815,13 @@ class InboundMail(Email):
 	def _create_reference_document(self, doctype):
 		"""Create reference document if it does not exist in the system."""
 		parent = frappe.new_doc(doctype)
-		email_fileds = self.get_email_fields(doctype)
+		email_fields = self.get_email_fields(doctype)
 
-		if email_fileds.subject_field:
-			parent.set(email_fileds.subject_field, frappe.as_unicode(self.subject)[:140])
+		if email_fields.subject_field:
+			parent.set(email_fields.subject_field, frappe.as_unicode(self.subject)[:140])
 
-		if email_fileds.sender_field:
-			parent.set(email_fileds.sender_field, frappe.as_unicode(self.from_email))
+		if email_fields.sender_field:
+			parent.set(email_fields.sender_field, frappe.as_unicode(self.from_email))
 
 		parent.flags.ignore_mandatory = True
 
@@ -830,7 +830,7 @@ class InboundMail(Email):
 		except frappe.DuplicateEntryError:
 			# try and find matching parent
 			parent_name = frappe.db.get_value(
-				self.email_account.append_to, {email_fileds.sender_field: self.from_email}
+				self.email_account.append_to, {email_fields.sender_field: self.from_email}
 			)
 			if parent_name:
 				parent.name = parent_name


### PR DESCRIPTION
Add a new field `sender_name_field` to **DocType** and **Customize Form** ...

![doctype](https://github.com/frappe/frappe/assets/14891507/ad18e7bb-0261-45be-b709-95cf9afd3a9c)

... and use this field to set the full name of the email sender in documents created from incoming emails:

![lead](https://github.com/frappe/frappe/assets/14891507/d75d1968-0504-453e-94bf-f74052d0fbd5)

Other small changes:

- Fix typo in variable name
- `_create_reference_document` returns only docname instead of entire doc
- Remove unused property `Communication.is_first`
- Fix fallback on DuplicateEntryError