### PR TITLE
fix: permission error on server script

### DIFF
--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -62,7 +62,7 @@ class FrappeTransformer(RestrictingNodeTransformer):
 
 def is_safe_exec_enabled() -> bool:
 	# server scripts can only be enabled via common_site_config.json
-	return bool(frappe.get_common_site_config().get(SAFE_EXEC_CONFIG_KEY))
+	return bool(frappe.get_site_config().get(SAFE_EXEC_CONFIG_KEY))
 
 
 def safe_exec(script, _globals=None, _locals=None, restrict_commit_rollback=False):


### PR DESCRIPTION
### Information about bug
Showing alert to enable server script, even it's already enabled.
![Screenshot from 2023-12-02 16-39-27](https://github.com/frappe/frappe/assets/43608142/1166459b-5e6c-4fa1-b0fa-ee3d7baf23bd)

after fixes 
![image](https://github.com/frappe/frappe/assets/43608142/3fe36bfd-b3d3-4fb6-9fa9-160a20202fad)


### Version
Frappe version - v15.1.0 (version-15-hotfix)
ERPNext version - v15.4.0 (version-15)

### Relevant log output
![site_config](https://github.com/frappe/frappe/assets/43608142/4a0dbd26-3fba-46ff-90aa-3724b671e7b7)
![common_site_config](https://github.com/frappe/frappe/assets/43608142/03895ee6-4342-44b9-b790-fcad3b2b4d8f)


