### PR TITLE
test: Make control_phone UI test idempotent and a bit more reliable.

### DIFF
--- a/cypress/integration/control_phone.js
+++ b/cypress/integration/control_phone.js
@@ -37,14 +37,14 @@ context("Control Phone", () => {
 
 		let phone_number = "9312672712";
 		cy.get(".selected-phone > img").click().first();
-		cy.get_field("phone").first().click({ multiple: true });
+		cy.get_field("phone").first().click();
 		cy.get(".frappe-control[data-fieldname=phone]")
 			.findByRole("textbox")
 			.first()
-			.type(phone_number, { force: true });
+			.type(phone_number);
 
 		cy.get_field("phone").first().should("have.value", phone_number);
-		cy.get_field("phone").first().blur({ force: true });
+		cy.get_field("phone").first().blur();
 		cy.wait(100);
 		cy.get("@dialog").then((dialog) => {
 			let value = dialog.get_value("phone");

--- a/cypress/integration/control_phone.js
+++ b/cypress/integration/control_phone.js
@@ -20,10 +20,18 @@ context("Control Phone", () => {
 
 	it("should set flag and data", () => {
 		get_dialog_with_phone().as("dialog");
+
 		cy.get(".selected-phone").click();
+		cy.wait(100);
 		cy.get(".phone-picker .phone-wrapper[id='afghanistan']").click();
+		cy.wait(100);
+		cy.get(".selected-phone .country").should("have.text", "+93");
+		cy.get(".selected-phone > img").should("have.attr", "src").and("include", "/af.svg");
+
 		cy.get(".selected-phone").click();
+		cy.wait(100);
 		cy.get(".phone-picker .phone-wrapper[id='india']").click();
+		cy.wait(100);
 		cy.get(".selected-phone .country").should("have.text", "+91");
 		cy.get(".selected-phone > img").should("have.attr", "src").and("include", "/in.svg");
 

--- a/cypress/integration/control_phone.js
+++ b/cypress/integration/control_phone.js
@@ -6,6 +6,10 @@ context("Control Phone", () => {
 		cy.visit("/app/website");
 	});
 
+	afterEach(() => {
+		cy.clear_dialogs();
+	});
+
 	function get_dialog_with_phone() {
 		return cy.dialog({
 			title: "Phone",
@@ -50,9 +54,7 @@ context("Control Phone", () => {
 			let value = dialog.get_value("phone");
 			expect(value).to.equal("+91-" + phone_number);
 		});
-	});
 
-	it("case insensitive search for country and clear search", () => {
 		let search_text = "india";
 		cy.get(".selected-phone").click().first();
 		cy.get(".phone-picker").get(".search-phones").click().type(search_text);


### PR DESCRIPTION
Fixes #23568.

- `force` rarely really improves reliability. It may be useful to type into a disabled field and may sometimes cover flakiness. But in the end it will only make it harder to understand what‘s failing.

- Same with `multiple`. If only one element is expected, why apply the same to several of them and wonder later why something else is failing?

- `cy.wait()` isn‘t the most beautiful approach either, but it works reliably without any side effects.

- Clearing the dialog in `afterEach` means it runs for ~all~ both test cases, not just the one with a dialog. This shouldn‘t hurt and the only way to avoid it seems to be splitting the test file in two.

- Idempotency also means we need to combine the second test case into the first one it relies on. Alternative would be opening and setting the same dialog all over again which I wanted to avoid.

I‘m explaining these changes in detail, because the test really doesn‘t fail often, so the improvement won‘t be seen immediately. The screen captures in #23568 however clearly indicate this test is prone to failing and will then fail the subsequent two times as well.