### PR TITLE
test: Add unittest for translation import & export.

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -71,13 +71,11 @@ class TestTranslate(FrappeTestCase):
 		try:
 			frappe.local.lang = "pt-BR"
 			self.assertEqual(_("Mobile No"), "Telefone Celular")
+			frappe.local.lang = "pt"
+			self.assertEqual(_("Mobile No"), "Nr. de Telemóvel")
 		finally:
-			try:
-				frappe.local.lang = "pt"
-				self.assertEqual(_("Mobile No"), "Nr. de Telemóvel")
-			finally:
-				frappe.local.lang = "en"
-				self.assertEqual(_("Mobile No"), "Mobile No")
+			frappe.local.lang = "en"
+			self.assertEqual(_("Mobile No"), "Mobile No")
 
 	def test_write_language_variant(self):
 		def import_export_translation(lang, updates):

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -79,7 +79,7 @@ class TestTranslate(FrappeTestCase):
 
 	def test_write_language_variant(self):
 		def import_export_translation(lang, updates):
-			path = frappe.get_app_path("frappe", "translations", lang + ".csv")
+			path = os.path.join(frappe.get_app_path("frappe", "translations"), lang + ".csv")
 			translations = get_translation_dict_from_file(path, lang, "frappe")
 			translations.update(updates)
 			write_translations_file("frappe", lang, translations)

--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -79,6 +79,29 @@ class TestTranslate(FrappeTestCase):
 				frappe.local.lang = "en"
 				self.assertEqual(_("Mobile No"), "Mobile No")
 
+	def test_write_language_variant(self):
+		def import_export_translation(lang, updates):
+			path = frappe.get_app_path("frappe", "translations", lang + ".csv")
+			translations = get_translation_dict_from_file(path, lang, "frappe")
+			translations.update(updates)
+			write_translations_file("frappe", lang, translations)
+			clear_cache()
+
+		frappe.local.lang = "pt-BR"
+		self.assertEqual(_("Mobile No"), "Telefone Celular")
+		try:
+			updates = {"Mobile No": "Nr. de Telemóvel"}
+			import_export_translation("pt-BR", updates)
+			self.assertEqual(_("Mobile No"), "Nr. de Telemóvel")
+		finally:
+			try:
+				restore = {"Mobile No": "Telefone Celular"}
+				import_export_translation("pt-BR", restore)
+				self.assertEqual(_("Mobile No"), "Telefone Celular")
+			finally:
+				frappe.local.lang = "en"
+				self.assertEqual(_("Mobile No"), "Mobile No")
+
 	def test_translation_with_context(self):
 		try:
 			frappe.local.lang = "fr"


### PR DESCRIPTION
When folding unittests from #23235 into #23320, the just as relevant second test case `test_write_language_variant` got lost.

It is testing the only indirectly covered [get_translation_dict_from_file()](https://github.com/frappe/frappe/blob/develop/frappe/translate.py#L214) in combination with the currently completely uncovered [write_translations_file()](https://github.com/frappe/frappe/blob/develop/frappe/translate.py#L1064) and I think it merits being evaluated and considered as well, even if it may add a few lines of testing code.

At this occasion I‘m simplifying the more basic test `test_read_language_variant` a bit. In this case we only have to make sure we‘re resetting to “en“ in the end, so one level of `try… finally` should suffice.