### PR TITLE
fix(UX): Highlight tabbed element

### DIFF
--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -568,6 +568,12 @@ body {
 			font-weight: 500;
 			@extend .ellipsis;
 		}
+
+		&:focus-visible {
+			text-decoration: underline;
+			background-color: var(--highlight-color);
+			outline: 0;
+		}
 	}
 
 	&.links-widget-box {
@@ -616,6 +622,12 @@ body {
 				&.top > .arrow {
 					left: 20%;
 				}
+			}
+
+			&:focus-visible {
+				text-decoration: underline;
+				background-color: var(--highlight-color);
+				outline: 0;
 			}
 		}
 


### PR DESCRIPTION
continues #23319


![image](https://github.com/frappe/frappe/assets/9079960/6a771c46-ff4a-4a4e-861b-be95edcce24c)

