### PR TITLE
chore: Fix Linter issue with validate_silent_authorization().

### DIFF
--- a/frappe/oauth.py
+++ b/frappe/oauth.py
@@ -395,9 +395,9 @@ class OAuthWebRequestValidator(RequestValidator):
 		- OpenIDConnectHybrid
 		"""
 		if request.prompt == "login":
-			False
+			return False
 		else:
-			True
+			return True
 
 	def validate_silent_login(self, request):
 		"""Ensure session user has authorized silent OpenID login.


### PR DESCRIPTION
Yet another Linter complaint.

I can’t really see why it comes up now and not during the last years.
Also, the validation obviously isn’t tested anywhere. Otherwise we would have a test failure, not just a Linter issue.

Nevertheless it should be fixed.