### PR TITLE
feat: adding country Nepal in get_number_system country list

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -1926,7 +1926,7 @@
   "currency_fraction_units": 100,
   "currency_name": "Nepalese Rupee",
   "currency_symbol": "\u20a8",
-  "number_format": "#,###.##",
+  "number_format": "#,##,###.##",
   "timezones": [
    "Asia/Kathmandu"
   ],

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1170,7 +1170,7 @@ Object.assign(frappe.utils, {
 	},
 
 	get_number_system: function (country) {
-		if (["Bangladesh", "India", "Myanmar", "Pakistan","Nepal"].includes(country)) {
+		if (["Bangladesh", "India", "Myanmar", "Nepal", "Pakistan"].includes(country)) {
 			return number_systems.indian;
 		} else {
 			return number_systems.default;

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1170,7 +1170,7 @@ Object.assign(frappe.utils, {
 	},
 
 	get_number_system: function (country) {
-		if (["Bangladesh", "India", "Myanmar", "Pakistan"].includes(country)) {
+		if (["Bangladesh", "India", "Myanmar", "Pakistan","Nepal"].includes(country)) {
 			return number_systems.indian;
 		} else {
 			return number_systems.default;


### PR DESCRIPTION
Nepal has also same numbering system as India ( Crore , Lakh )  

![image](https://github.com/frappe/frappe/assets/64308806/52badf47-341c-4e40-bc74-1c1bf95680b6)

![image](https://github.com/frappe/frappe/assets/64308806/c752b926-d019-48aa-bdc7-5cd5786c33fb)

Changes: 
- Adding country Nepal on list of country to return number_systems.indian

Reference : https://en.wikipedia.org/wiki/Numbers_in_Nepali_language