### PR TITLE
fix(minor): avoid use of form object when routing to audit trail

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1276,10 +1276,6 @@ frappe.ui.form.Form = class FrappeForm {
 		frappe.set_route("print", this.doctype, this.doc.name);
 	}
 
-	show_audit_trail() {
-		frappe.set_route("audit-trail");
-	}
-
 	navigate_records(prev) {
 		let filters, sort_field, sort_order;
 		let list_view = frappe.get_list_view(this.doctype);

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -506,7 +506,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 			this.page.add_menu_item(
 				__("View Audit Trail"),
 				function () {
-					me.frm.show_audit_trail();
+					frappe.set_route("audit-trail");
 				},
 				true
 			);


### PR DESCRIPTION
Removed unnecessary code for routing to Audit Trail as highlighted here - https://github.com/frappe/frappe/pull/23513#discussion_r1413960423
