### PR TITLE
fix(Report View): clear checked items

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1254,6 +1254,10 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		return items;
 	}
 
+	clear_checked_items() {
+		this.datatable.rowmanager.checkAll(false);
+	}
+
 	save_report(save_type) {
 		const _save_report = (name) => {
 			// callback


### PR DESCRIPTION
`ListView` unchecks all selected rows after a bulk action has been executed, by calling `this.clear_checked_items()`.

https://github.com/frappe/frappe/blob/b23ee471c3eadaa791b0029fa00d107479041f76/frappe/public/js/frappe/list/list_view.js#L1930
https://github.com/frappe/frappe/blob/b23ee471c3eadaa791b0029fa00d107479041f76/frappe/public/js/frappe/list/list_view.js#L1580-L1583

`ReportView` inherits from `ListView`. Bulk actions are available, but the unchecking works differently in reports. Hence, this feature is broken.

This PR adds a working implementation of `this.clear_checked_items()` for `ReportView`:

```js
this.datatable.rowmanager.checkAll(false);
```