### PR TITLE
fix(Virtual DocType): don't call db get_value in link field validation

### DIFF
--- a/frappe/client.py
+++ b/frappe/client.py
@@ -10,6 +10,7 @@ import frappe.utils
 from frappe import _
 from frappe.desk.reportview import validate_args
 from frappe.model.db_query import check_parent_permission
+from frappe.model.utils import is_virtual_doctype
 from frappe.utils import get_safe_filters
 from frappe.utils.deprecations import deprecated
 
@@ -430,17 +431,19 @@ def validate_link(doctype: str, docname: str, fields=None):
 			frappe.PermissionError,
 		)
 
-	if frappe.get_meta(doctype).is_virtual:
+	values = frappe._dict()
+
+	if is_virtual_doctype(doctype):
 		try:
 			frappe.get_doc(doctype, docname)
-			return frappe._dict({"name": docname})
+			values.name = docname
 		except frappe.DoesNotExistError:
 			frappe.clear_last_message()
 			frappe.msgprint(
 				_("Document {0} {1} does not exist").format(frappe.bold(doctype), frappe.bold(docname)),
 			)
+		return values
 
-	values = frappe._dict()
 	values.name = frappe.db.get_value(doctype, docname, cache=True)
 
 	fields = frappe.parse_json(fields)

--- a/frappe/client.py
+++ b/frappe/client.py
@@ -430,6 +430,16 @@ def validate_link(doctype: str, docname: str, fields=None):
 			frappe.PermissionError,
 		)
 
+	if frappe.get_meta(doctype).is_virtual:
+		try:
+			frappe.get_doc(doctype, docname)
+			return frappe._dict({"name": docname})
+		except frappe.DoesNotExistError:
+			frappe.clear_last_message()
+			frappe.msgprint(
+				_("Document {0} {1} does not exist").format(frappe.bold(doctype), frappe.bold(docname)),
+			)
+
 	values = frappe._dict()
 	values.name = frappe.db.get_value(doctype, docname, cache=True)
 


### PR DESCRIPTION
Link fields to virtual doctypes don't work right now.

Any better suggestions are welcome.