### PR TITLE
fix: only update primary action if it is new action is provided

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -180,11 +180,9 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		this.footer.removeClass("hide");
 		this.has_primary_action = true;
 		var me = this;
-		return this.get_primary_btn()
-			.removeClass("hide")
-			.html(label)
-			.off("click")
-			.on("click", function () {
+		const primary_btn = this.get_primary_btn().removeClass("hide").html(label);
+		if (typeof click == "function") {
+			primary_btn.off("click").on("click", function () {
 				me.primary_action_fulfilled = true;
 				// get values and send it
 				// as first parameter to click callback
@@ -193,6 +191,8 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 				if (!values) return;
 				click && click.apply(me, [values]);
 			});
+		}
+		return primary_btn;
 	}
 
 	set_secondary_action(click) {


### PR DESCRIPTION
Currently, the primary action is updated even if the new action is None. This breaks some old code that relies on the primary action being None when no action is provided. (used to update primary action label)

I changed the code to only update the primary action if the new action function is provided