### PR TITLE
feat: scoped progress bar on bulk submit/cancel

### DIFF
--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.core.doctype.submission_queue.submission_queue import queue_submission
 from frappe.model.document import Document
 from frappe.utils import cint
+from frappe.utils.deprecations import deprecated
 from frappe.utils.scheduler import is_scheduler_inactive
 
 
@@ -112,6 +113,7 @@ def _bulk_action(doctype, docnames, action, data, task_id=None):
 	return failed
 
 
+@deprecated
 def show_progress(docnames, message, i, description):
 	n = len(docnames)
 	frappe.publish_progress(float(i) * 100 / n, title=message, description=description)

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -74,8 +74,8 @@ def _bulk_action(doctype, docnames, action, data):
 
 	failed = []
 
-	for i, d in enumerate(docnames, 1):
-		doc = frappe.get_doc(doctype, d)
+	for idx, docname in enumerate(docnames, 1):
+		doc = frappe.get_doc(doctype, docname)
 		try:
 			message = ""
 			if action == "submit" and doc.docstatus.is_draft():
@@ -93,12 +93,12 @@ def _bulk_action(doctype, docnames, action, data):
 				doc.save()
 				message = _("Updating {0}").format(doctype)
 			else:
-				failed.append(d)
+				failed.append(docname)
 			frappe.db.commit()
-			show_progress(docnames, message, i, d)
+			show_progress(docnames, message, idx, docname)
 
 		except Exception:
-			failed.append(d)
+			failed.append(docname)
 			frappe.db.rollback()
 
 	return failed

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -218,9 +218,9 @@ export default class BulkOperations {
 				docnames: docnames,
 				task_id: task_id,
 			})
-			.then((failed) => {
-				if (failed?.length) {
-					const comma_separated_records = frappe.utils.comma_and(failed);
+			.then((failed_docnames) => {
+				if (failed_docnames?.length) {
+					const comma_separated_records = frappe.utils.comma_and(failed_docnames);
 					switch (action) {
 						case "submit":
 							frappe.throw(__("Cannot submit {0}.", [comma_separated_records]));
@@ -232,7 +232,7 @@ export default class BulkOperations {
 							frappe.throw(__("Cannot {0} {1}.", [action, comma_separated_records]));
 					}
 				}
-				if (failed?.length < docnames.length) {
+				if (failed_docnames?.length < docnames.length) {
 					frappe.utils.play_sound(action);
 					if (done) done();
 				}

--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -220,9 +220,17 @@ export default class BulkOperations {
 			})
 			.then((failed) => {
 				if (failed?.length) {
-					frappe.throw(
-						__("Cannot {0} {1}", [action, failed.map((f) => f.bold()).join(", ")])
-					);
+					const comma_separated_records = frappe.utils.comma_and(failed);
+					switch (action) {
+						case "submit":
+							frappe.throw(__("Cannot submit {0}.", [comma_separated_records]));
+							break;
+						case "cancel":
+							frappe.throw(__("Cannot cancel {0}.", [comma_separated_records]));
+							break;
+						default:
+							frappe.throw(__("Cannot {0} {1}.", [action, comma_separated_records]));
+					}
 				}
 				if (failed?.length < docnames.length) {
 					frappe.utils.play_sound(action);

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -9,13 +9,16 @@ import frappe
 from frappe.utils.data import cstr
 
 
-def publish_progress(percent, title=None, doctype=None, docname=None, description=None):
+def publish_progress(
+	percent, title=None, doctype=None, docname=None, description=None, task_id=None
+):
 	publish_realtime(
 		"progress",
 		{"percent": percent, "title": title, "description": description},
 		user=None if doctype and docname else frappe.session.user,
 		doctype=doctype,
 		docname=docname,
+		task_id=task_id,
 	)
 
 
@@ -41,8 +44,11 @@ def publish_realtime(
 	if message is None:
 		message = {}
 
+	if not task_id and hasattr(frappe.local, "task_id"):
+		task_id = frappe.local.task_id
+
 	if event is None:
-		event = "task_progress" if frappe.local.task_id else "global"
+		event = "task_progress" if task_id else "global"
 	elif event == "msgprint" and not user:
 		user = frappe.session.user
 	elif event == "list_update":
@@ -50,9 +56,6 @@ def publish_realtime(
 		room = get_doctype_room(doctype)
 	elif event == "docinfo_update":
 		room = get_doc_room(doctype, docname)
-
-	if not task_id and hasattr(frappe.local, "task_id"):
-		task_id = frappe.local.task_id
 
 	if not room:
 		if task_id:


### PR DESCRIPTION
### Before

On bulk-submit or bulk-cancel, the progress bar was shown on all open tabs.

### After

The progress bar shows only on the current tab.

Other changes:

- Better variable names
- Improve translatability of error message
- Small refactors