### PR TITLE
fix: undefined variable name fixed in dark.scss fixed

### DIFF
--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -21,7 +21,7 @@
 	--icon-stroke: var(--gray-300);
 
 	// Error colors
-	--error-bg: var(--red-70);
+	--error-bg: var(--red-700);
 	--error-border: var(--red-400);
 
 	// Layout Colors


### PR DESCRIPTION
The style class `error-bg` resp. `field.df.invalid` or `field.set_invalid()` has now an effect when using the dark theme.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

The previously used variable is not defined in dark-mode, after this PR it is.

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR fixes the problem:

When e.g. editing a doctype with field validation and you made an invalid input you get a red-ish colored background to highlight the location of the invalid input (via style class `error-bg`). This works fine in the light-mode (Frappe Light), but not in the dark mode (Timeless Night).

This PR fixes this in the dark mode.


> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

## before fix

Invalid field in light-mode: ![2023-12-05_15h26_37](https://github.com/frappe/frappe/assets/3751412/c455d15a-ac6e-4545-8439-05dc09b1203f)

Invalid field in dark-mode: ![2023-12-05_15h29_38](https://github.com/frappe/frappe/assets/3751412/1854459e-dde5-4a11-9335-f87dedbd431d)

## after fix

Invalid field in dark-mode:  ![2023-12-06_16h10_34](https://github.com/frappe/frappe/assets/3751412/adc52b18-445b-4f38-9e1c-c5d7722cd674)




