### PR TITLE
fix: Update notification_settings.js

### DIFF
--- a/frappe/desk/doctype/notification_settings/notification_settings.js
+++ b/frappe/desk/doctype/notification_settings/notification_settings.js
@@ -3,11 +3,6 @@
 
 frappe.ui.form.on("Notification Settings", {
 	onload: (frm) => {
-		frappe.breadcrumbs.add({
-			label: __("Settings"),
-			route: "#modules/Settings",
-			type: "Custom",
-		});
 		frm.set_query("subscribed_documents", () => {
 			return {
 				filters: {


### PR DESCRIPTION
Remove redundant frappe.breadcrumbs.add from notifications_settings. 

The existing codes leads to a Not Found error since the hyperlink is incorrect:

![image](https://github.com/frappe/frappe/assets/75872475/0d10c9db-b719-4c44-b4ff-9478400629e8)
![image](https://github.com/frappe/frappe/assets/75872475/ea03e72c-b7b0-43f0-8bb0-ebb7df8628f7)



closes #23649

