### PR TITLE
fix: use encoded filename for arabic (latin) language while exporting

### DIFF
--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -419,6 +419,19 @@ class TestResponse(FrappeAPITestCase):
 		self.assertIn("text/csv", response.headers["content-type"])
 		self.assertGreater(cint(response.headers["content-length"]), 0)
 
+		from frappe.desk.utils import provide_binary_file
+		from frappe.utils.response import build_response
+
+		filename = "دفتر الأستاذ العام"
+		encoded_filename = filename.encode("utf-8").decode("unicode-escape", "ignore") + ".xlsx"
+		provide_binary_file(filename, "xlsx", "content")
+
+		response = build_response("binary")
+		self.assertEqual(response.status_code, 200)
+		self.assertEqual(response.headers["content-type"], "application/octet-stream")
+		self.assertGreater(cint(response.headers["content-length"]), 0)
+		self.assertEqual(response.headers["content-disposition"], f'filename="{encoded_filename}"')
+
 
 def generate_admin_keys():
 	from frappe.core.doctype.user.user import generate_keys

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -145,7 +145,9 @@ def as_pdf():
 def as_binary():
 	response = Response()
 	response.mimetype = "application/octet-stream"
-	response.headers.add("Content-Disposition", None, filename=frappe.response["filename"])
+	filename = frappe.response["filename"]
+	filename = filename.encode("utf-8").decode("unicode-escape", "ignore")
+	response.headers.add("Content-Disposition", None, filename=filename)
 	response.data = frappe.response["filecontent"]
 	return response
 


### PR DESCRIPTION
While exporting any report, if your language is Arabic, it is not working.

Before:

https://github.com/frappe/frappe/assets/30859809/60b86d58-8f4f-4081-80d5-cb29864e623d


After:

https://github.com/frappe/frappe/assets/30859809/e6005b2b-8ec9-4552-85c8-f5853beb4729

