### PR TITLE
fix: pass filter to formatter to handle custom logic

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1259,17 +1259,15 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				width: parseInt(column.width) || null,
 				editable: false,
 				compareValue: compareFn,
-				format: (value, row, column, data, for_filter = false) => {
-					if (for_filter && column?.fieldtype === "Link") {
-						return value || "";
-					}
+				format: (value, row, column, data, filter) => {
 					if (this.report_settings.formatter) {
 						return this.report_settings.formatter(
 							value,
 							row,
 							column,
 							data,
-							format_cell
+							format_cell,
+							filter
 						);
 					}
 					return format_cell(value, row, column, data);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fast-deep-equal": "^2.0.1",
     "fast-glob": "^3.2.5",
     "frappe-charts": "2.0.0-rc22",
-    "frappe-datatable": "^1.17.2",
+    "frappe-datatable": "^1.17.5",
     "frappe-gantt": "^0.6.0",
     "highlight.js": "^10.4.1",
     "html5-qrcode": "^2.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,10 +1497,10 @@ frappe-charts@2.0.0-rc22:
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc22.tgz#9a5a747febdc381a1d4d7af96e89cf519dfba8c0"
   integrity sha512-N7f/8979wJCKjusOinaUYfMxB80YnfuVLrSkjpj4LtyqS0BGS6SuJxUnb7Jl4RWUFEIs7zEhideIKnyLeFZF4Q==
 
-frappe-datatable@^1.17.2:
-  version "1.17.4"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.4.tgz#b003a8097f462fa5933f236590865be0cf370b44"
-  integrity sha512-uqtTzgdYITZM8hDvTEnmYnYRmPsoG+AjbTDls/NMxMBCkzRAE0VTVaPs5yag7HWoYJg/9LFW+sHwgZbVpjyBEA==
+frappe-datatable@^1.17.5:
+  version "1.17.5"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.5.tgz#342814d7f9eb502f55639c1b09d44d9eca782f78"
+  integrity sha512-FJdpsj/xACuk553FXMMqvtTQZII9P9TEtAwOiaKN+AwDAjfCO4b5vhSTmdNp2Kgf26bnZU9QVfRvh2gDtpj3OA==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
Datatable fix: https://github.com/frappe/datatable/pull/182

While filtering the column, all the rows for that column are formatted just to match with the searched text.
So passing the `filter` which contains the type of filter & the searched text so that the custom app can use that to not format before sending the value (custom logic) it will reduce the load.

because of this load, the formatted values returned were faulty.