### PR TITLE
fix: ignore rtlcss for cropperjs

### DIFF
--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -39,7 +39,7 @@ def make_post_request(url, **kwargs):
 
 def make_put_request(url, **kwargs):
 	return make_request("PUT", url, **kwargs)
-	
+
 
 def make_patch_request(url, **kwargs):
 	return make_request("PATCH", url, **kwargs)

--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -118,7 +118,6 @@ export default {
 </script>
 
 <style scoped>
-@import "cropperjs/dist/cropper.min.css";
 img {
 	display: block;
 	max-width: 100%;

--- a/frappe/public/js/frappe/form/sidebar/user_image.js
+++ b/frappe/public/js/frappe/form/sidebar/user_image.js
@@ -74,7 +74,7 @@ frappe.ui.form.setup_user_image_event = function (frm) {
 				}
 				field.$input.trigger("attach_doc_image");
 				// close sidebar
-				frm.page.close_sidebar();
+				frm.page.close_sidebar && frm.page.close_sidebar();
 			} else {
 				/// on remove event for a sidebar image wrapper remove attach file.
 				frm.attachments.remove_attachment_by_filename(

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -1,4 +1,7 @@
 @import "../common/form.scss";
+/*rtl:begin:ignore*/
+@import "~cropperjs/dist/cropper.min";
+/*rtl:end:ignore*/
 
 .std-form-layout > .form-layout > .form-page {
 	border-radius: var(--border-radius-md);


### PR DESCRIPTION
Caused By: https://github.com/frappe/frappe/pull/23492

In v14, CSS import doesn't work in Vue 2's style causing issue. 