### PR TITLE
fix: check if autoname is promt before setting __newname

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -464,11 +464,10 @@ class Document(BaseDocument):
 		if self.flags.name_set and not force:
 			return
 
-		meta = self.meta or frappe.get_meta(self.doctype)
-		autoname = meta.autoname or ""
+		autoname = self.meta.autoname or ""
 
 		# If autoname has set as Prompt (name)
-		if self.get("__newname") and autoname == "Prompt":
+		if self.get("__newname") and autoname.lower() == "prompt":
 			self.name = validate_name(self.doctype, self.get("__newname"))
 			self.flags.name_set = True
 			return

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -464,8 +464,11 @@ class Document(BaseDocument):
 		if self.flags.name_set and not force:
 			return
 
+		meta = self.meta or frappe.get_meta(self.doctype)
+		autoname = meta.autoname or ""
+
 		# If autoname has set as Prompt (name)
-		if self.get("__newname"):
+		if self.get("__newname") and autoname == "Prompt":
 			self.name = validate_name(self.doctype, self.get("__newname"))
 			self.flags.name_set = True
 			return

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -104,6 +104,7 @@ class TestDBQuery(FrappeTestCase):
 				"doctype": "DocType",
 				"name": "Parent DocType 1",
 				"module": "Custom",
+				"autoname": "Prompt",
 				"custom": 1,
 				"fields": [
 					{"label": "Title", "fieldname": "title", "fieldtype": "Data"},
@@ -122,6 +123,7 @@ class TestDBQuery(FrappeTestCase):
 			{
 				"doctype": "DocType",
 				"name": "Parent DocType 2",
+				"autoname": "Prompt",
 				"module": "Custom",
 				"custom": 1,
 				"fields": [


### PR DESCRIPTION
Issue: If you `Copy to Clipboard` Purchase Order document then try to save it. It doesn't allow saving with the error "the document already exists"