### PR TITLE
fix: Color indicator style

### DIFF
--- a/frappe/public/scss/common/color_picker.scss
+++ b/frappe/public/scss/common/color_picker.scss
@@ -96,19 +96,19 @@
 
 .frappe-control[data-fieldtype="Color"] {
 	input {
-		padding-left: 38px;
+		padding-left: 32px;
 	}
 	.control-input {
 		position: relative;
 	}
 	.selected-color {
 		cursor: pointer;
-		width: 22px;
-		height: 22px;
+		width: 16px;
+		height: 16px;
 		border-radius: 5px;
 		background-color: red;
 		position: absolute;
-		top: 5px;
+		top: 6px;
 		left: 8px;
 		content: " ";
 		&.no-value {


### PR DESCRIPTION
**Before:**
<img width="552" alt="Screenshot 2023-12-08 at 10 55 11 AM" src="https://github.com/frappe/frappe/assets/13928957/e72f8350-43c3-4918-b445-6d95621f904f">

**After:**
<img width="233" alt="Screenshot 2023-12-08 at 11 03 42 AM" src="https://github.com/frappe/frappe/assets/13928957/a0391f7d-6a94-46ca-8778-cbdf5f810031">
