### PR TITLE
fix: prioritize link_title if value != link_title

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -149,6 +149,10 @@ frappe.form.formatters = {
 		var original_value = value;
 		let link_title = frappe.utils.get_link_title(doctype, value);
 
+		if (link_title === value) {
+			link_title = null;
+		}
+
 		if (value && value.match && value.match(/^['"].*['"]$/)) {
 			value.replace(/^.(.*).$/, "$1");
 		}


### PR DESCRIPTION
Issue after this: https://github.com/frappe/frappe/pull/15321

if `title_field` is set for a doctype, then it takes priority in grid row.