### PR TITLE
refactor(minor): email retry

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.js
+++ b/frappe/email/doctype/email_queue/email_queue.js
@@ -19,13 +19,18 @@ frappe.ui.form.on("Email Queue", {
 		} else if (frm.doc.status == "Error") {
 			frm.add_custom_button("Retry Sending", function () {
 				frm.call({
-					method: "retry_sending",
-					doc: frm.doc,
+					method: "frappe.email.doctype.email_queue.email_queue.retry_sending",
 					args: {
-						name: frm.doc.name,
+						queues: [frm.doc.name],
 					},
 					callback: function () {
 						frm.reload_doc();
+						frappe.show_alert({
+							message: __(
+								"Status Updated. The email will be picked up in the next scheduled run."
+							),
+							indicator: "green",
+						});
 					},
 				});
 			});

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -441,7 +441,8 @@ class SendMailContext:
 
 @frappe.whitelist()
 def bulk_retry(queues):
-	frappe.only_for("System Manager")
+	if not frappe.has_permission("Email Queue", throw=True):
+		return
 
 	if isinstance(queues, str):
 		queues = json.loads(queues)
@@ -449,11 +450,8 @@ def bulk_retry(queues):
 	if not queues:
 		return
 
-	frappe.msgprint(
-		_("Updating Email Queue Statuses. The emails will be picked up in the next scheduled run."),
-		_("Processing..."),
-	)
-
+	# NOTE: this will probably work fine with the way current listview works (showing and selecting 20-20 records)
+	# but, ideally this should be enqueued
 	email_queue = frappe.qb.DocType("Email Queue")
 	frappe.qb.update(email_queue).set(email_queue.status, "Not Sent").set(email_queue.modified, now()).set(
 		email_queue.modified_by, frappe.session.user

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -222,12 +222,6 @@ class EmailQueue(Document):
 			.where(email_recipient.creation < (Now() - Interval(days=days)))
 		).run()
 
-	@frappe.whitelist()
-	def retry_sending(self):
-		if self.status == "Error":
-			self.status = "Not Sent"
-			self.save(ignore_permissions=True)
-
 
 @task(queue="short")
 @deprecated
@@ -440,7 +434,7 @@ class SendMailContext:
 
 
 @frappe.whitelist()
-def bulk_retry(queues):
+def retry_sending(queues: str | list[str]):
 	if not frappe.has_permission("Email Queue", throw=True):
 		return
 

--- a/frappe/email/doctype/email_queue/email_queue_list.js
+++ b/frappe/email/doctype/email_queue/email_queue_list.js
@@ -45,6 +45,13 @@ function show_toggle_sending_button(list_view) {
 
 function add_bulk_retry_button_to_actions(list_view) {
 	list_view.page.add_actions_menu_item(__("Retry Sending"), () => {
+		frappe.msgprint(
+			__(
+				"Updating Email Queue Statuses. The emails will be picked up in the next scheduled run."
+			),
+			__("Processing...")
+		);
+
 		frappe.call({
 			method: "frappe.email.doctype.email_queue.email_queue.bulk_retry",
 			args: {

--- a/frappe/email/doctype/email_queue/email_queue_list.js
+++ b/frappe/email/doctype/email_queue/email_queue_list.js
@@ -53,7 +53,7 @@ function add_bulk_retry_button_to_actions(list_view) {
 		);
 
 		frappe.call({
-			method: "frappe.email.doctype.email_queue.email_queue.bulk_retry",
+			method: "frappe.email.doctype.email_queue.email_queue.retry_sending",
 			args: {
 				queues: list_view.get_checked_items(true),
 			},


### PR DESCRIPTION
* move msgprint to frontend so that it can be displayed before the api call (not after it's completed)
* removed sys manager permission in bulk_retry whitelisted function (missed in https://github.com/frappe/frappe/pull/21724) and added a basic read perm check in the same