### PR TITLE
fix: Set sort_order to DESC if sort_field is modified

### DIFF
--- a/frappe/automation/doctype/milestone/milestone.json
+++ b/frappe/automation/doctype/milestone/milestone.json
@@ -53,7 +53,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2022-08-03 12:20:55.076769",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Milestone",
@@ -74,7 +74,7 @@
  ],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "title_field": "reference_type",
  "track_changes": 1

--- a/frappe/automation/doctype/milestone_tracker/milestone_tracker.json
+++ b/frappe/automation/doctype/milestone_tracker/milestone_tracker.json
@@ -35,7 +35,7 @@
   }
  ],
  "links": [],
- "modified": "2022-08-03 12:20:54.955953",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Milestone Tracker",
@@ -55,7 +55,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/contacts/doctype/contact/contact.json
+++ b/frappe/contacts/doctype/contact/contact.json
@@ -257,7 +257,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-02 12:00:27.299156",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Contacts",
  "name": "Contact",
@@ -392,7 +392,7 @@
  ],
  "show_title_field_in_link": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "title_field": "full_name"
 }

--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -70,7 +70,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2023-08-23 14:20:15.343339",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Error Log",
@@ -89,7 +89,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "title_field": "method"
 }

--- a/frappe/core/doctype/file/file.json
+++ b/frappe/core/doctype/file/file.json
@@ -189,7 +189,7 @@
  "icon": "fa fa-file",
  "idx": 1,
  "links": [],
- "modified": "2023-08-02 09:43:51.178012",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "File",
@@ -217,7 +217,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "title_field": "file_name",
  "track_changes": 1

--- a/frappe/core/doctype/module_def/module_def.json
+++ b/frappe/core/doctype/module_def/module_def.json
@@ -123,7 +123,7 @@
    "link_fieldname": "module"
   }
  ],
- "modified": "2022-01-03 13:56:52.817954",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Module Def",
@@ -160,7 +160,7 @@
  ],
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/core/doctype/page/page.json
+++ b/frappe/core/doctype/page/page.json
@@ -102,7 +102,7 @@
  "icon": "fa fa-file",
  "idx": 1,
  "links": [],
- "modified": "2023-10-22 22:41:25.568952",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Page",
@@ -129,7 +129,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/core/doctype/role/role.json
+++ b/frappe/core/doctype/role/role.json
@@ -148,7 +148,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-08-05 18:33:27.694065",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Role",
@@ -169,7 +169,7 @@
  ],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1,
  "translated_doctype": 1

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -639,7 +639,7 @@
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2023-11-27 14:08:01.927794",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",
@@ -655,7 +655,7 @@
  ],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/core/doctype/version/version.json
+++ b/frappe/core/doctype/version/version.json
@@ -54,7 +54,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2022-08-03 12:20:53.929691",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Version",
@@ -74,7 +74,7 @@
  ],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "title_field": "docname",
  "track_changes": 1

--- a/frappe/custom/doctype/client_script/client_script.json
+++ b/frappe/custom/doctype/client_script/client_script.json
@@ -77,7 +77,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-04-12 12:48:15.717985",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Client Script",
@@ -108,7 +108,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/custom/doctype/custom_field/custom_field.json
+++ b/frappe/custom/doctype/custom_field/custom_field.json
@@ -457,7 +457,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-10-25 06:55:10.713382",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Custom Field",
@@ -488,7 +488,7 @@
  ],
  "search_fields": "dt,label,fieldtype,options",
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/custom/doctype/customize_form_field/customize_form_field.json
+++ b/frappe/custom/doctype/customize_form_field/customize_form_field.json
@@ -483,7 +483,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-07 13:17:21.373626",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Custom",
  "name": "Customize Form Field",
@@ -491,6 +491,6 @@
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": []
 }

--- a/frappe/desk/doctype/note/note.json
+++ b/frappe/desk/doctype/note/note.json
@@ -86,7 +86,7 @@
  "icon": "fa fa-file-text",
  "idx": 1,
  "links": [],
- "modified": "2023-08-28 20:23:59.424943",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Note",
@@ -141,7 +141,7 @@
  ],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "title_field": "title",
  "track_changes": 1

--- a/frappe/integrations/doctype/google_contacts/google_contacts.json
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.json
@@ -99,7 +99,7 @@
   }
  ],
  "links": [],
- "modified": "2023-08-28 20:22:58.267442",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Contacts",
@@ -126,7 +126,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/integrations/doctype/google_drive/google_drive.json
+++ b/frappe/integrations/doctype/google_drive/google_drive.json
@@ -102,7 +102,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2022-12-04 15:53:58.702389",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Drive",
@@ -120,7 +120,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/printing/doctype/letter_head/letter_head.json
+++ b/frappe/printing/doctype/letter_head/letter_head.json
@@ -168,7 +168,7 @@
  "idx": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2023-08-28 22:19:23.720332",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Letter Head",
@@ -192,7 +192,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/social/doctype/review_level/review_level.json
+++ b/frappe/social/doctype/review_level/review_level.json
@@ -37,7 +37,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-08-03 12:20:51.571158",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Social",
  "name": "Review Level",
@@ -45,7 +45,7 @@
  "permissions": [],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/website/doctype/web_page/web_page.json
+++ b/frappe/website/doctype/web_page/web_page.json
@@ -338,7 +338,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2022-03-09 01:45:28.548671",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Page",
@@ -357,7 +357,7 @@
  "search_fields": "title",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "title_field": "title",
  "track_changes": 1

--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -476,7 +476,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-14 11:38:47.383840",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",
@@ -498,7 +498,7 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/workflow/doctype/workflow/workflow.json
+++ b/frappe/workflow/doctype/workflow/workflow.json
@@ -104,7 +104,7 @@
  "icon": "fa fa-random",
  "idx": 1,
  "links": [],
- "modified": "2023-05-02 16:56:28.704844",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow",
@@ -123,7 +123,7 @@
  ],
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1
 }

--- a/frappe/workflow/doctype/workflow_state/workflow_state.json
+++ b/frappe/workflow/doctype/workflow_state/workflow_state.json
@@ -40,7 +40,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2023-08-28 22:19:35.232574",
+ "modified": "2023-12-08 15:52:37.525003",
  "modified_by": "Administrator",
  "module": "Workflow",
  "name": "Workflow State",
@@ -65,7 +65,7 @@
  "quick_entry": 1,
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "ASC",
+ "sort_order": "DESC",
  "states": [],
  "track_changes": 1,
  "translated_doctype": 1


### PR DESCRIPTION
Global search and replace operation, including single doctypes even if it does not really matter.

Is there any doctype where `modified ASC` ([oldest first](https://stackoverflow.com/a/5021318)) would make sense?