### PR TITLE
perf: Simplify dynamic route evaluation to speed up route resolution

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -279,7 +279,7 @@ def get_context(context):
 			if field.fieldtype == "Select" and field.options:
 				messages.extend(field.options.split("\n"))
 
-		messages.extend(col.label for col in self.list_columns)
+		messages.extend(col.get("label") if col else "" for col in self.list_columns)
 
 		context.translated_messages = frappe.as_json(
 			{message: _(message) for message in messages if message}

--- a/frappe/website/page_renderers/document_page.py
+++ b/frappe/website/page_renderers/document_page.py
@@ -44,7 +44,7 @@ class DocumentPage(BaseTemplatePage):
 
 	@cache_html
 	def get_html(self):
-		self.doc = frappe.get_doc(self.doctype, self.docname)
+		self.doc = frappe.get_cached_doc(self.doctype, self.docname)
 		self.init_context()
 		self.update_context()
 		self.post_process_context()


### PR DESCRIPTION
- Simplify dynamic route evaluation to speed up route resolution to validate complete route only if starting of the path matches with the webform route. This avoids the expensive matching from huge route_map (in sites with lots of web forms)

**Before:** On a site with ~60 web forms
<img width="801" alt="Screenshot 2023-12-08 at 9 31 45 PM" src="https://github.com/frappe/frappe/assets/13928957/c38e5728-5a16-4ebb-a45b-f6878809920a">

**After:** Dramatically reduces number of internal function and makes each web page/document page/web form request ~370ms faster.
<img width="802" alt="Screenshot 2023-12-08 at 9 32 04 PM" src="https://github.com/frappe/frappe/assets/13928957/98cf886e-c46a-4527-b568-5e03d5afb05b">


- Use `get_cached_doc` instead of get_doc
	-  Makes document pages with no-cache flag load a bit faster	