### PR TITLE
fix: grid row default values not using model

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -838,7 +838,7 @@ export default class Grid {
 					acc[d.fieldname] = d.default;
 					return acc;
 				}, {});
-				this.df.data.push({ idx: this.df.data.length + 1, __islocal: true, ...defaults});
+				this.df.data.push({ idx: this.df.data.length + 1, __islocal: true, ...defaults });
 				this.refresh();
 			}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -834,7 +834,13 @@ export default class Grid {
 				if (!this.df.data) {
 					this.df.data = this.get_data() || [];
 				}
-				this.df.data.push({ idx: this.df.data.length + 1, __islocal: true });
+				const defaults = this.docfields.reduce((acc, d) => {
+					acc[d.fieldname] = d.default;
+					return acc;
+				}, {});
+				this.df.data.push(
+					$.extend({ idx: this.df.data.length + 1, __islocal: true }, defaults)
+				);
 				this.refresh();
 			}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -838,9 +838,7 @@ export default class Grid {
 					acc[d.fieldname] = d.default;
 					return acc;
 				}, {});
-				this.df.data.push(
-					$.extend({ idx: this.df.data.length + 1, __islocal: true }, defaults)
-				);
+				this.df.data.push({ idx: this.df.data.length + 1, __islocal: true, ...defaults});
 				this.refresh();
 			}
 


### PR DESCRIPTION
Use case:
ERPNext update child items dialog. **Note the default key**

```js
fields.splice(2, 0, {
			fieldtype: 'Date',
			fieldname: frm.doc.doctype == 'Sales Order' ? "delivery_date" : "schedule_date",
			in_list_view: 1,
			label: frm.doc.doctype == 'Sales Order' ? __("Delivery Date") : __("Reqd by date"),
			default: frm.doc.doctype == 'Sales Order' ? frm.doc.delivery_date : frm.doc.schedule_date,
			reqd: 1
		})
```

Preview:

https://github.com/frappe/frappe/assets/29856401/b8826252-fcda-4a4c-bdad-03ce2db0fea2





