### PR TITLE
fix: call onchange with GridRow object as its scope

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1105,7 +1105,7 @@ export default class GridRow {
 		if (!field.df.onchange_modified) {
 			var field_on_change_function = field.df.onchange;
 			field.df.onchange = (e) => {
-				field_on_change_function && field_on_change_function(e);
+				field_on_change_function && field_on_change_function.apply(me, [e]);
 				this.refresh_field(field.df.fieldname);
 			};
 


### PR DESCRIPTION
**Before PR**
Window object was the callers scope.
![image](https://github.com/frappe/frappe/assets/29856401/fd5df9f3-fa7e-43bf-a362-64cadb34cd62)


**After PR**
GridRow object is the callers scope.
![image](https://github.com/frappe/frappe/assets/29856401/5fd2935a-e1e4-4430-92a2-95df13d72ee0)
