### PR TITLE
fix!: remove grid row `field_on_change_function`

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1102,16 +1102,6 @@ export default class GridRow {
 		// sync get_query
 		field.get_query = this.grid.get_field(df.fieldname).get_query;
 
-		if (!field.df.onchange_modified) {
-			var field_on_change_function = field.df.onchange;
-			field.df.onchange = (e) => {
-				field_on_change_function && field_on_change_function(e);
-				this.refresh_field(field.df.fieldname);
-			};
-
-			field.df.onchange_modified = true;
-		}
-
 		field.refresh();
 		if (field.$input) {
 			field.$input


### PR DESCRIPTION
### Before PR
On change would be called with window as it's current scope.

![image](https://github.com/frappe/frappe/assets/29856401/fd5df9f3-fa7e-43bf-a362-64cadb34cd62)

### After PR
On change is called with it's field object as it's current scope.
![image](https://github.com/frappe/frappe/assets/29856401/19f1f46b-15b6-4550-817e-393441b2341f)
