### PR TITLE
fix: sudan country info

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2545,7 +2545,7 @@
   "currency_fraction": "Piastre",
   "currency_fraction_units": 100,
   "currency_name": "Sudanese Pound",
-  "currency_symbol": "\u20a6 or \u062c.\u0633.",
+  "currency_symbol": "\u062c.\u0633.",
   "number_format": "#,###.##",
   "timezones": [
     "Africa/Khartoum"

--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2541,15 +2541,17 @@
  },
  "Sudan": {
   "code": "sd",
+  "currency": "SDG",
   "currency_fraction": "Piastre",
   "currency_fraction_units": 100,
-  "currency_symbol": "\u00a3",
+  "currency_name": "Sudanese Pound",
+  "currency_symbol": "\u20a6 or \u062c.\u0633.",
   "number_format": "#,###.##",
   "timezones": [
-   "Africa/Khartoum"
+    "Africa/Khartoum"
   ],
   "isd": "+249"
- },
+},
  "Suriname": {
   "code": "sr",
   "currency": "SRD",


### PR DESCRIPTION
### Summary

Updated currency information for Sudan.

### Changes Made

- Added Sudanese Pounds to the list of currencies.
- Updated currency details including code, currency symbol, and other relevant information.

### Reason for the Changes

The existing currency information for Sudan was incomplete or outdated. This pull request updates the information to reflect accurate and up-to-date details for the Sudanese Pounds.

### Checklist

- [x] All tests pass locally (UI and Unit tests)
- [ ] Business logic and validations are on the server-side


### Related Issue
No Related Issue

### Additional Information

No additional information.

