### PR TITLE
fix: ignore if controller doesn't have `get_list` attr

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -179,6 +179,9 @@ class DatabaseQuery:
 			from frappe.model.base_document import get_controller
 
 			controller = get_controller(self.doctype)
+			if not hasattr(controller, "get_list"):
+				return []
+
 			self.parse_args()
 			kwargs = {
 				"as_list": as_list,


### PR DESCRIPTION
Frappe Internal Reference: https://support.frappe.io/app/hd-ticket/7100
Only process links in virtual doctypes which has `get_list` attribute

