### PR TITLE
fix: Workflow doc states not existing on new forms

### DIFF
--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -49,13 +49,13 @@ frappe.ui.form.on("Workflow", {
 		frm.events.update_field_options(frm);
 		frm.ignore_warning = frm.is_new() ? true : false;
 		frm.state_status_mapping = {};
-		frm.doc.states.forEach((row) => {
-			frm.state_status_mapping[row.state] = row.doc_status;
-		});
 
 		if (frm.is_new()) {
 			return;
 		}
+		frm.doc.states.forEach((row) => {
+			frm.state_status_mapping[row.state] = row.doc_status;
+		});
 
 		frm.states = null;
 		frm.trigger("make_state_table");


### PR DESCRIPTION
sentry: FRAPPE-2Y

```
TypeError: Cannot read properties of undefined (reading 'forEach')
  at refresh(workflow__js:58:18)
  at _function(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:30:12)
  at runner(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:109:16)
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:127:22)
```