### PR TITLE
fix(UX): remove unnecessary delay from numeric inputs

### DIFF
--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -2,21 +2,13 @@ frappe.ui.form.ControlInt = class ControlInt extends frappe.ui.form.ControlData 
 	static trigger_change_on_input_event = false;
 	make() {
 		super.make();
-		// $(this.label_area).addClass('pull-right');
-		// $(this.disp_area).addClass('text-right');
 	}
 	make_input() {
-		var me = this;
 		super.make_input();
-		this.$input
-			// .addClass("text-right")
-			.on("focus", function () {
-				setTimeout(function () {
-					if (!document.activeElement) return;
-					document.activeElement.select();
-				}, 100);
-				return false;
-			});
+		this.$input.on("focus", () => {
+			document.activeElement?.select?.();
+			return false;
+		});
 	}
 	validate(value) {
 		return this.parse(value);


### PR DESCRIPTION
I am not REALLY sure why this is required.

These create bad UX when you're typing fast enough. Like your input
getting mixed up with what was there before.

This also causes an issue when user has moved to a field which is not
"select-able" anymore.


Notice how sometimes my keystrokes are replacing the input and sometimes they are adding to it. 

![number_format](https://github.com/frappe/frappe/assets/9079960/78445c08-b5d1-4a8b-bb52-9a5dc1c31aa5)





```
TypeError: document.activeElement.select is not a function
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/form/controls/int.js:17:29)
  at r(../../../../../apps/frappe/node_modules/src/helpers.ts:98:1)
```

Sentry: FRAPPE-11
