### PR TITLE
feat: Jinja syntax highlighting

### DIFF
--- a/frappe/email/doctype/email_template/email_template.json
+++ b/frappe/email/doctype/email_template/email_template.json
@@ -52,12 +52,12 @@
    "fieldname": "response_html",
    "fieldtype": "Code",
    "label": "Response ",
-   "options": "HTML"
+   "options": "Jinja"
   }
  ],
  "icon": "fa fa-comment",
  "links": [],
- "modified": "2023-08-28 22:29:04.457992",
+ "modified": "2023-12-12 20:01:07.080625",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Template",

--- a/frappe/email/doctype/email_template/email_template.py
+++ b/frappe/email/doctype/email_template/email_template.py
@@ -22,6 +22,7 @@ class EmailTemplate(Document):
 		subject: DF.Data
 		use_html: DF.Check
 	# end: auto-generated types
+
 	@property
 	def response_(self):
 		return self.response_html if self.use_html else self.response

--- a/frappe/printing/doctype/print_format/print_format.json
+++ b/frappe/printing/doctype/print_format/print_format.json
@@ -112,14 +112,15 @@
    "label": "HTML",
    "oldfieldname": "html",
    "oldfieldtype": "Text Editor",
-   "options": "HTML"
+   "options": "Jinja"
   },
   {
    "depends_on": "raw_printing",
    "description": "Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language.",
    "fieldname": "raw_commands",
    "fieldtype": "Code",
-   "label": "Raw Commands"
+   "label": "Raw Commands",
+   "options": "Jinja"
   },
   {
    "depends_on": "eval:!doc.custom_format",
@@ -259,7 +260,7 @@
  "icon": "fa fa-print",
  "idx": 1,
  "links": [],
- "modified": "2023-08-28 20:25:09.660073",
+ "modified": "2023-12-12 19:59:37.133301",
  "modified_by": "Administrator",
  "module": "Printing",
  "name": "Print Format",

--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -48,6 +48,7 @@ class PrintFormat(Document):
 		show_section_headings: DF.Check
 		standard: DF.Literal["No", "Yes"]
 	# end: auto-generated types
+
 	def onload(self):
 		templates = frappe.get_all(
 			"Print Format Field Template",

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -160,6 +160,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 			JSON: "ace/mode/json",
 			Golang: "ace/mode/golang",
 			Go: "ace/mode/golang",
+			Jinja: "ace/mode/django",
 		};
 		const language = this.df.options;
 

--- a/frappe/website/doctype/web_template/web_template.json
+++ b/frappe/website/doctype/web_template/web_template.json
@@ -19,7 +19,7 @@
    "fieldname": "template",
    "fieldtype": "Code",
    "label": "Template",
-   "options": "HTML"
+   "options": "Jinja"
   },
   {
    "fieldname": "fields",
@@ -54,7 +54,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-09-04 12:38:27.656042",
+ "modified": "2023-12-12 20:01:21.524022",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Template",
@@ -76,5 +76,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -27,6 +27,7 @@ class WebTemplate(Document):
 		template: DF.Code | None
 		type: DF.Literal["Component", "Section", "Navbar", "Footer"]
 	# end: auto-generated types
+
 	def validate(self):
 		if self.standard and not frappe.conf.developer_mode and not frappe.flags.in_patch:
 			frappe.throw(_("Enable developer mode to create a standard Web Template"))


### PR DESCRIPTION
- Add Jinja syntax highlighting to ACE editor

    ACE doesn't explicitly support Jinja, but "Django" which has a very similar syntax.

- Switch from pure HTML to Jinja highlighting in the following DocTypes:
	- **Email Template**
	- **Print Format**
	- **Web Template**

### Preview

![Bildschirmfoto 2023-12-12 um 20 11 56](https://github.com/frappe/frappe/assets/14891507/a8983498-a7e1-44ca-b3a0-132dc639677f)
> no-docs
