### PR TITLE
feat: Deletion of Backup in Google Drive

### DIFF
--- a/frappe/integrations/doctype/google_drive/google_drive.js
+++ b/frappe/integrations/doctype/google_drive/google_drive.js
@@ -39,6 +39,7 @@ frappe.ui.form.on("Google Drive", {
 						frappe.msgprint(r.message);
 					});
 			});
+			
 			let dlt_button = frm.add_custom_button(__("Delete Backup"), function () {
 				frappe.show_alert({
 					indicator: "green",

--- a/frappe/integrations/doctype/google_drive/google_drive.js
+++ b/frappe/integrations/doctype/google_drive/google_drive.js
@@ -39,6 +39,21 @@ frappe.ui.form.on("Google Drive", {
 						frappe.msgprint(r.message);
 					});
 			});
+			let dlt_button = frm.add_custom_button(__("Delete Backup"), function () {
+				frappe.show_alert({
+					indicator: "green",
+					message: __("Deleting in Google Drive."),
+				});
+				frappe
+					.call({
+						method: "frappe.integrations.doctype.google_drive.google_drive.delete_system_backup_to_google_drive",
+						btn: dlt_button,
+					})
+					.then((r) => {
+						frappe.msgprint(r.message);
+					});
+			});
+		
 		}
 
 		if (frm.doc.enable && frm.doc.backup_folder_name && !frm.doc.refresh_token) {

--- a/frappe/integrations/doctype/google_drive/google_drive.json
+++ b/frappe/integrations/doctype/google_drive/google_drive.json
@@ -15,6 +15,7 @@
   "column_break_5",
   "backup_folder_id",
   "last_backup_on",
+  "delete_backup_before",
   "refresh_token",
   "authorization_code"
  ],
@@ -98,6 +99,11 @@
    "label": "Send Notification To",
    "options": "Email",
    "reqd": 1
+  },
+  {
+   "fieldname": "delete_backup_before",
+   "fieldtype": "Int",
+   "label": "Delete Backup Before (in Days)"
   }
  ],
  "issingle": 1,


### PR DESCRIPTION
**Google Drive Deleting Backup Option:**

![Untitled design(1)](https://github.com/frappe/frappe/assets/95605193/c7a777a6-58ad-4f35-a1ec-70af9748278d)


When we are uploading Multiple files frequently for Backup, it will consume whole space in Drive, So, we can delete the files in days Basis.. if needed from ERPNext.