### PR TITLE
fix(rq_job): resolve deprecation warning

### DIFF
--- a/frappe/core/doctype/rq_job/rq_job.py
+++ b/frappe/core/doctype/rq_job/rq_job.py
@@ -152,6 +152,12 @@ def serialize_job(job: Job) -> frappe._dict:
 	if matches := re.match(r"<function (?P<func_name>.*) at 0x.*>", job_name):
 		job_name = matches.group("func_name")
 
+	exc_info = None
+
+	# Get exc_string from the job result if it exists
+	if job_result := job.latest_result():
+		exc_info = job_result.exc_string
+
 	return frappe._dict(
 		name=job.id,
 		job_id=job.id,
@@ -161,7 +167,7 @@ def serialize_job(job: Job) -> frappe._dict:
 		started_at=convert_utc_to_system_timezone(job.started_at) if job.started_at else "",
 		ended_at=convert_utc_to_system_timezone(job.ended_at) if job.ended_at else "",
 		time_taken=(job.ended_at - job.started_at).total_seconds() if job.ended_at else "",
-		exc_info=job.exc_info,
+		exc_info=exc_info,
 		arguments=frappe.as_json(job.kwargs),
 		timeout=job.timeout,
 		creation=convert_utc_to_system_timezone(job.created_at),


### PR DESCRIPTION
env/lib/python3.11/site-packages/rq/job.py:796: DeprecationWarning: job.exc_info is deprecated, use job.latest_result() instead.
warnings.warn("job.exc_info is deprecated, use job.latest_result() instead.", DeprecationWarning)
