### PR TITLE
feat: `add-database-index` command to add and persist custom indexes

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -524,6 +524,40 @@ def list_apps(context, format):
 		click.echo(frappe.as_json(summary_dict))
 
 
+@click.command("add-database-index")
+@click.option("--doctype", help="DocType on which index needs to be added")
+@click.option(
+	"--column",
+	multiple=True,
+	help="Column to index. Multiple columns will create multi-column index in given order. To create a multiple, single column index, execute the command multiple times.",
+)
+@pass_context
+def add_db_index(context, doctype, column):
+	"Adds a new DB index and creates a property setter to persist it."
+	from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+
+	columns = column  # correct naming
+	for site in context.sites:
+		frappe.connect(site=site)
+		try:
+			frappe.db.add_index(doctype, columns)
+			if len(columns) == 1:
+				make_property_setter(
+					doctype,
+					columns[0],
+					property="search_index",
+					value="1",
+					property_type="Check",
+					for_doctype=False,  # Applied on docfield
+				)
+			frappe.db.commit()
+		finally:
+			frappe.destroy()
+
+	if not context.sites:
+		raise SiteNotSpecifiedError
+
+
 @click.command("add-system-manager")
 @click.argument("email")
 @click.option("--first-name")
@@ -1436,6 +1470,7 @@ def add_new_user(
 commands = [
 	add_system_manager,
 	add_user_for_sites,
+	add_db_index,
 	backup,
 	drop_site,
 	install_app,

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -788,6 +788,17 @@ class TestBenchBuild(BaseTestCommands):
 		)
 
 
+class TestDBUtils(BaseTestCommands):
+	def test_db_add_index(self):
+		field = "reset_password_key"
+		self.execute("bench --site {site} add-database-index --doctype User --column " + field, {})
+		frappe.db.rollback()
+		index_name = frappe.db.get_index_name((field,))
+		self.assertTrue(frappe.db.has_index("tabUser", index_name))
+		meta = frappe.get_meta("User", cached=False)
+		self.assertTrue(meta.get_field(field).search_index)
+
+
 class TestSchedulerUtils(BaseTestCommands):
 	# Retry just in case there are stuck queued jobs
 	@retry(


### PR DESCRIPTION
Usage:
```bash
bench --site sitename add-database-index --doctype="Sales Order" --column="order_id"
```

for https://github.com/frappe/press/issues/1265
