### PR TITLE
perf: Primary key is never nullable

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -739,7 +739,7 @@ class DatabaseQuery:
 		df = meta.get("fields", {"fieldname": f.fieldname})
 		df = df[0] if df else None
 
-		can_be_null = True
+		can_be_null = f.fieldname != "name"  # primary key is never nullable
 
 		value = None
 
@@ -794,7 +794,7 @@ class DatabaseQuery:
 			# if values contain '' or falsy values then only coalesce column
 			# for `in` query this is only required if values contain '' or values are empty.
 			# for `not in` queries we can't be sure as column values might contain null.
-			can_be_null = not getattr(df, "not_nullable", False)
+			can_be_null &= not getattr(df, "not_nullable", False)
 			if f.operator.lower() == "in":
 				can_be_null &= not f.value or any(v is None or v == "" for v in f.value)
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1017,13 +1017,17 @@ class TestDBQuery(FrappeTestCase):
 			self.assertEqual(call_args["order_by"], DefaultOrderBy)
 
 	def test_coalesce_with_in_ops(self):
-		self.assertNotIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", "b"])}, run=0))
-		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", None])}, run=0))
-		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", ""])}, run=0))
-		self.assertIn("ifnull", frappe.get_all("User", {"name": ("in", [])}, run=0))
-		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", ["a"])}, run=0))
-		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", [])}, run=0))
-		self.assertIn("ifnull", frappe.get_all("User", {"name": ("not in", [""])}, run=0))
+		self.assertNotIn("ifnull", frappe.get_all("User", {"first_name": ("in", ["a", "b"])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"first_name": ("in", ["a", None])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"first_name": ("in", ["a", ""])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"first_name": ("in", [])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"first_name": ("not in", ["a"])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"first_name": ("not in", [])}, run=0))
+		self.assertIn("ifnull", frappe.get_all("User", {"first_name": ("not in", [""])}, run=0))
+
+		# primary key is never nullable
+		self.assertNotIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", None])}, run=0))
+		self.assertNotIn("ifnull", frappe.get_all("User", {"name": ("in", ["a", ""])}, run=0))
 
 	def test_ambiguous_linked_tables(self):
 		from frappe.desk.reportview import get


### PR DESCRIPTION
People ususally write queries like these...

```
frappe.get_all(doctype, {"name": ("in", list_of_docs))
```

Ocassionally, the `list_of_docs` is empty because it's dynamically
generated and in this case we end up doing full table scan to find... nothing!

As you can see, insane amount of time spent doing essentially nothing:
![image](https://github.com/frappe/frappe/assets/9079960/547a19fb-6410-4fcb-982d-05ebae3bd337)
 