### PR TITLE
fix: error - permission denied for schema public from Postgres >= 15 (closes #23798)

### DIFF
--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -13,6 +13,9 @@ def setup_database():
 	root_conn.sql(f"CREATE DATABASE `{frappe.conf.db_name}`")
 	root_conn.sql(f"CREATE user {frappe.conf.db_name} password '{frappe.conf.db_password}'")
 	root_conn.sql("GRANT ALL PRIVILEGES ON DATABASE `{0}` TO {0}".format(frappe.conf.db_name))
+	psql_version = root_conn.sql(f"SELECT VERSION()", as_dict=True)
+	if psql_version and psql_version[0].get("version", "PostgreSQL 14").split()[1] >= "15":
+		root_conn.sql("ALTER DATABASE `{0}` OWNER TO {0}".format(frappe.conf.db_name))
 	root_conn.close()
 
 


### PR DESCRIPTION
# fix: error - permission denied for schema public from Postgres >= 15

### Error from Postgres:
ERROR:  permission denied for schema public at character 14

### Error from Frappe:
psql:/home/frappe/frappe-bench/apps/frappe/frappe/database/postgres/framework_postgres.sql:72: ERROR:  permission denied for schema public

## Error Causer:
Starting Postgres version >= 15, all users will have the `CREATE` permission revoked by default.

## Fix:
Grant relevant privileges to the database in question for the user. In this case, DB owner privilege using the below command:
```sql
ALTER DATABASE `erpnext` OWNER TO erpnext
```

### Note: the below two permission attempts were unsuccessful and still caused the same public schema permission error
```sql
GRANT USAGE, CREATE ON SCHEMA public TO {frappe.conf.db_name};
GRANT ALL ON SCHEMA public TO {frappe.conf.db_name}
```

### References:
https://stackoverflow.com/questions/74110708/postgres-15-permission-denied-for-schema-public https://stackoverflow.com/questions/67276391/why-am-i-getting-a-permission-denied-error-for-schema-public-on-pgadmin-4

closes #23798 

