### PR TITLE
perf(migrate): Only re-evaluate users which are potentially changed

### DIFF
--- a/frappe/core/doctype/role/role.py
+++ b/frappe/core/doctype/role/role.py
@@ -80,12 +80,23 @@ class Role(Document):
 		if frappe.flags.in_install:
 			return
 		if self.has_value_changed("desk_access"):
-			for user_name in get_users(self.name):
-				user = frappe.get_doc("User", user_name)
-				user_type = user.user_type
-				user.set_system_user()
-				if user_type != user.user_type:
-					user.save()
+			self.update_user_type_on_change()
+
+	def update_user_type_on_change(self):
+		"""When desk access changes, all the users that have this role need to be re-evaluated"""
+
+		users_with_role = get_users(self.name)
+
+		# perf: Do not re-evaluate users who already have same desk access that this role permits.
+		role_user_type = "System User" if self.desk_access else "Website User"
+		users_with_same_user_type = frappe.get_all("User", {"user_type": role_user_type}, pluck="name")
+
+		for user_name in set(users_with_role) - set(users_with_same_user_type):
+			user = frappe.get_doc("User", user_name)
+			user_type = user.user_type
+			user.set_system_user()
+			if user_type != user.user_type:
+				user.save()
 
 
 def get_info_based_on_role(role, field="email", ignore_permissions=False):


### PR DESCRIPTION
When roles are added in fixture `desk_access` always appears to be
"changed" because of how fixtures work.

This causes all users with the said role to be re-evaluated. This is
unnecessary computation because desk_access rarely changes in most apps.

Fix: See if role's desk access is same as user's desk access and don't
re-evalute them.

E.g. If role fixture without desk access is being migrated then it will
skip all users who are already website users. Likewise role with desk
access will skip all users who are already system users.
