### PR TITLE
fix: Include Middle Name in creating FULL NAME in User Doctype

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -233,7 +233,7 @@ class User(Document):
 		return self.name == frappe.session.user
 
 	def set_full_name(self):
-		self.full_name = " ".join(filter(None, [self.first_name, self.last_name]))
+		self.full_name = " ".join(filter(None, [self.first_name, self.middle_name, self.last_name]))
 
 	def check_enable_disable(self):
 		# do not allow disabling administrator/guest


### PR DESCRIPTION
**Before**
![image](https://github.com/frappe/frappe/assets/78477962/c35267e6-0053-400f-87ba-9f8b556e56af)

**After**
<img width="1295" alt="image" src="https://github.com/frappe/frappe/assets/78477962/f11cfb2d-d337-44b3-bdd6-b5b66ab3a27f">


After creating a user, full name is creating by concatenating first name and last name. It ignores middle name.

This pull request ensure the FULL NAME is created by joining FIRST NAME, MIDDLE NAME and LAST NAME.