### PR TITLE
fix: consider allDay on Calendar View

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -378,7 +378,7 @@ frappe.views.Calendar = class Calendar {
 				d[target] = d[source];
 			});
 			
-			if (typeof(d.allDay) === "undefined") {
+			if (typeof d.allDay === "undefined") {
 				d.allDay = me.field_map.allDay;
 			}
 

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -377,7 +377,7 @@ frappe.views.Calendar = class Calendar {
 			$.each(me.field_map, function (target, source) {
 				d[target] = d[source];
 			});
-			
+
 			if (typeof d.allDay === "undefined") {
 				d.allDay = me.field_map.allDay;
 			}

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -379,7 +379,7 @@ frappe.views.Calendar = class Calendar {
 			});
 			
 			if (typeof(d.allDay) === "undefined") {
-				d.allDay = me.field_map.allDay
+				d.allDay = me.field_map.allDay;
 			}
 
 			if (!me.field_map.convertToUserTz) d.convertToUserTz = 1;

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -377,8 +377,11 @@ frappe.views.Calendar = class Calendar {
 			$.each(me.field_map, function (target, source) {
 				d[target] = d[source];
 			});
+			
+			if (typeof(d.allDay) === "undefined") {
+				d.allDay = me.field_map.allDay
+			}
 
-			if (!me.field_map.allDay) d.allDay = 1;
 			if (!me.field_map.convertToUserTz) d.convertToUserTz = 1;
 
 			// convert to user tz


### PR DESCRIPTION
Calendar views created from "Calendar View" doctype, uses 0 or 1 values instead expected field mapping.
So `allDay` property gets `undefined` and calendar shows wrong data.

Solves https://github.com/frappe/frappe/issues/23830
