### PR TITLE
fix: allow enabling telemetry for either posthog/sentry

### DIFF
--- a/frappe/public/js/telemetry/index.js
+++ b/frappe/public/js/telemetry/index.js
@@ -43,7 +43,12 @@ class TelemetryManager {
 	}
 
 	can_enable() {
-		return Boolean(this.telemetry_host && this.project_id && !cint(navigator.doNotTrack));
+		if (cint(navigator.doNotTrack)) {
+			return false;
+		}
+		let posthog_available = Boolean(this.telemetry_host && this.project_id);
+		let sentry_available = Boolean(frappe.boot.sentry_dsn);
+		return posthog_available || sentry_available;
 	}
 
 	send_heartbeat() {


### PR DESCRIPTION
posthog is not required to be present everwhere and is more of a
solution for onboarding problems. Sentry on other hand should be
available everywhere.
