### PR TITLE
style: new app boilerplate

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -303,9 +303,7 @@ class PatchCreator:
 		init_py.touch()
 
 
-init_template = """
-__version__ = '0.0.1'
-
+init_template = """__version__ = "0.0.1"
 """
 
 pyproject_template = """[project]

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -378,7 +378,7 @@ app_license = "{app_license}"
 
 # website user home page (by Role)
 # role_home_page = {{
-#	"Role": "home_page"
+# 	"Role": "home_page"
 # }}
 
 # Generators
@@ -392,8 +392,8 @@ app_license = "{app_license}"
 
 # add methods and filters to jinja environment
 # jinja = {{
-#	"methods": "{app_name}.utils.jinja_methods",
-#	"filters": "{app_name}.utils.jinja_filters"
+# 	"methods": "{app_name}.utils.jinja_methods",
+# 	"filters": "{app_name}.utils.jinja_filters"
 # }}
 
 # Installation
@@ -435,11 +435,11 @@ app_license = "{app_license}"
 # Permissions evaluated in scripted ways
 
 # permission_query_conditions = {{
-#	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
+# 	"Event": "frappe.desk.doctype.event.event.get_permission_query_conditions",
 # }}
 #
 # has_permission = {{
-#	"Event": "frappe.desk.doctype.event.event.has_permission",
+# 	"Event": "frappe.desk.doctype.event.event.has_permission",
 # }}
 
 # DocType Class
@@ -447,7 +447,7 @@ app_license = "{app_license}"
 # Override standard doctype classes
 
 # override_doctype_class = {{
-#	"ToDo": "custom_app.overrides.CustomToDo"
+# 	"ToDo": "custom_app.overrides.CustomToDo"
 # }}
 
 # Document Events
@@ -455,32 +455,32 @@ app_license = "{app_license}"
 # Hook on document methods and events
 
 # doc_events = {{
-#	"*": {{
-#		"on_update": "method",
-#		"on_cancel": "method",
-#		"on_trash": "method"
-#	}}
+# 	"*": {{
+# 		"on_update": "method",
+# 		"on_cancel": "method",
+# 		"on_trash": "method"
+# 	}}
 # }}
 
 # Scheduled Tasks
 # ---------------
 
 # scheduler_events = {{
-#	"all": [
-#		"{app_name}.tasks.all"
-#	],
-#	"daily": [
-#		"{app_name}.tasks.daily"
-#	],
-#	"hourly": [
-#		"{app_name}.tasks.hourly"
-#	],
-#	"weekly": [
-#		"{app_name}.tasks.weekly"
-#	],
-#	"monthly": [
-#		"{app_name}.tasks.monthly"
-#	],
+# 	"all": [
+# 		"{app_name}.tasks.all"
+# 	],
+# 	"daily": [
+# 		"{app_name}.tasks.daily"
+# 	],
+# 	"hourly": [
+# 		"{app_name}.tasks.hourly"
+# 	],
+# 	"weekly": [
+# 		"{app_name}.tasks.weekly"
+# 	],
+# 	"monthly": [
+# 		"{app_name}.tasks.monthly"
+# 	],
 # }}
 
 # Testing
@@ -492,14 +492,14 @@ app_license = "{app_license}"
 # ------------------------------
 #
 # override_whitelisted_methods = {{
-#	"frappe.desk.doctype.event.event.get_events": "{app_name}.event.get_events"
+# 	"frappe.desk.doctype.event.event.get_events": "{app_name}.event.get_events"
 # }}
 #
 # each overriding function accepts a `data` argument;
 # generated from the base implementation of the doctype dashboard,
 # along with any modifications made in other Frappe apps
 # override_doctype_dashboards = {{
-#	"Task": "{app_name}.task.get_dashboard_data"
+# 	"Task": "{app_name}.task.get_dashboard_data"
 # }}
 
 # exempt linked doctypes from being automatically cancelled
@@ -525,38 +525,38 @@ app_license = "{app_license}"
 # --------------------
 
 # user_data_fields = [
-#	{{
-#		"doctype": "{{doctype_1}}",
-#		"filter_by": "{{filter_by}}",
-#		"redact_fields": ["{{field_1}}", "{{field_2}}"],
-#		"partial": 1,
-#	}},
-#	{{
-#		"doctype": "{{doctype_2}}",
-#		"filter_by": "{{filter_by}}",
-#		"partial": 1,
-#	}},
-#	{{
-#		"doctype": "{{doctype_3}}",
-#		"strict": False,
-#	}},
-#	{{
-#		"doctype": "{{doctype_4}}"
-#	}}
+# 	{{
+# 		"doctype": "{{doctype_1}}",
+# 		"filter_by": "{{filter_by}}",
+# 		"redact_fields": ["{{field_1}}", "{{field_2}}"],
+# 		"partial": 1,
+# 	}},
+# 	{{
+# 		"doctype": "{{doctype_2}}",
+# 		"filter_by": "{{filter_by}}",
+# 		"partial": 1,
+# 	}},
+# 	{{
+# 		"doctype": "{{doctype_3}}",
+# 		"strict": False,
+# 	}},
+# 	{{
+# 		"doctype": "{{doctype_4}}"
+# 	}}
 # ]
 
 # Authentication and authorization
 # --------------------------------
 
 # auth_hooks = [
-#	"{app_name}.auth.validate"
+# 	"{app_name}.auth.validate"
 # ]
 
 # Automatically update python controller files with type annotations for this app.
 # export_python_type_annotations = True
 
 # default_log_clearing_doctypes = {{
-#	"Logging DocType Name": 30  # days to retain logs
+# 	"Logging DocType Name": 30  # days to retain logs
 # }}
 
 """


### PR DESCRIPTION
- Add spaces to `hooks_template`
    Black wants comments to start with a space. Adding them here means less formatting later.
- `init_template`
    Put version on the first line and use double quotes.

