### PR TITLE
fix: render new doctype dialog box if doctype is not copied

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("DocType", {
 	onload: function (frm) {
-		if (frm.is_new()) {
+		if (frm.is_new() && !frm.doc?.fields) {
 			frappe.listview_settings["DocType"].new_doctype_dialog();
 		}
 	},


### PR DESCRIPTION
**Issue**

Duplicating doctype using `Copy to Clipboard` was rendering a **New Doctype** dialog box which was confusing and fields and data was not get copied in a new doctype.

**Before**


https://github.com/frappe/frappe/assets/54097382/d3eeae36-404e-49cb-b997-abececaf3ae6

**After**


https://github.com/frappe/frappe/assets/54097382/93b1cb95-3be4-4805-9ab4-69526ef64e1b



Closes: #23802