### PR TITLE
fix: dont pass removed parameter `name`

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -333,7 +333,7 @@ def get_rendered_raw_commands(doc: str, name: str | None = None, print_format: s
 
 	return {
 		"raw_commands": get_rendered_template(
-			doc=document, name=name, print_format=print_format, meta=document.meta
+			doc=document, print_format=print_format, meta=document.meta
 		)
 	}
 


### PR DESCRIPTION
Removed in https://github.com/frappe/frappe/commit/d3250f650499272b92e3c4e9a9b38cff68a51543#diff-43b4bf320e7e406d0bd973142a44a7dbd3e40c17fa72e45488d2b4ed9752bd5aL92