### PR TITLE
fix: optimize clear_permissions_cache method

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1668,23 +1668,12 @@ def validate_permissions_for_doctype(doctype, for_remove=False, alert=False):
 
 
 def clear_permissions_cache(doctype):
+	from frappe.cache_manager import clear_user_cache
+
 	frappe.clear_cache(doctype=doctype)
 	delete_notification_count_for(doctype)
 
-	has_role_doctype = frappe.qb.DocType("Has Role")
-	doc_perm_doctype = frappe.qb.DocType("DocPerm")
-	
-	users = (
-		frappe.qb.from_(has_role_doctype)
-		.inner_join(doc_perm_doctype)
-		.on(has_role_doctype.role == doc_perm_doctype.role)
-		.select(has_role_doctype.parent)
-		.where((doc_perm_doctype.parent == doctype)
-		  & (has_role_doctype.parenttype == "User"))
-		.distinct()
-	)
-	for user in frappe.db.sql_list(users):
-		frappe.clear_cache(user=user)
+	clear_user_cache()
 
 
 def validate_permissions(doctype, for_remove=False, alert=False):


### PR DESCRIPTION
Based on the [Issue #23840](https://github.com/frappe/frappe/issues/23840)

the batch wise `frappe.clear_cache` method will improve the performance.
