### PR TITLE
fix: unpack error due to wrong splitting the field

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -650,7 +650,7 @@ class DatabaseQuery:
 			else:
 				# field: 'count(`tabPhoto`.name) as total_count'
 				# column: 'tabPhoto.name'
-				column = field.split("(")[-1].split(")", 1)[0]
+				column = field.split("(", 3)[-1][::-1].split(")", 1)[-1][::-1]
 				column = strip_alias(column).replace("`", "")
 
 			if column == "*" and not in_function("*", field):


### PR DESCRIPTION
closes #23794 

Before:
```field = "(1 / nullif(locate('Test (Demo)', `tabCompany`.`name`), 0)) as `_relevance`"```
```field.split("(")[-1].split(")", 1)[0]```
After split it will be `Demo`
Before it takes the innermost value within parentheses. If the value has these parentheses, then the split has gone wrong.

Now
```field.split("(", 3)[-1][::-1].split(")", 1)[-1][::-1]```
After split it will be ```'Test (Demo)', `tabCompany`.`name`), 0)```