### PR TITLE
fix: possible typeeerror in script_manager.js

### DIFF
--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -103,7 +103,7 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 			let _promise = null;
 			if (is_old_style) {
 				// old style arguments (doc, cdt, cdn)
-				_promise = me.frm.cscript[_function](me.frm.doc, doctype, name);
+				_promise = me.frm.cscript[_function]?.(me.frm.doc, doctype, name);
 			} else {
 				// new style (frm, doctype, name)
 				_promise = _function(me.frm, doctype, name);


### PR DESCRIPTION
```
TypeError: cur_frm.cscript.set_root_readonly is not a function
```

Internal Reference: [7160](https://support.frappe.io/helpdesk/tickets/7160)