### PR TITLE
fix(sentry): `name` field is ignored

### DIFF
--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -38,7 +38,8 @@ def capture_exception(message: str | None = None) -> None:
 				evt_processor = _make_wsgi_event_processor(frappe.request.environ, False)
 				scope.add_event_processor(evt_processor)
 				scope.set_tag("site", frappe.local.site)
-				scope.set_user({"name": getattr(frappe.session, "user", "Unidentified")})
+				user = getattr(frappe.session, "user", "Unidentified")
+				scope.set_user({"id": user, "email": user})
 
 				# Extract `X-Frappe-Request-ID` to store as a separate field if its present
 				if trace_id := frappe.monitor.get_trace_id():


### PR DESCRIPTION
Only `id`, `username`, `email`, and `ip_address` are accepted here
