### PR TITLE
fix: ignore and gracefully handle img optimization failure

### DIFF
--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -5,6 +5,8 @@ import os
 
 from PIL import Image
 
+import frappe
+
 
 def resize_images(path, maxdim=700):
 	size = (maxdim, maxdim)
@@ -51,22 +53,25 @@ def optimize_image(
 	if content_type == "image/svg+xml":
 		return content
 
-	image = Image.open(io.BytesIO(content))
-	width, height = image.size
-	max_height = max(min(max_height, height * 0.8), 200)
-	max_width = max(min(max_width, width * 0.8), 200)
-	image_format = content_type.split("/")[1]
-	size = max_width, max_height
-	image.thumbnail(size, Image.Resampling.LANCZOS)
+	try:
+		image = Image.open(io.BytesIO(content))
+		width, height = image.size
+		max_height = max(min(max_height, height * 0.8), 200)
+		max_width = max(min(max_width, width * 0.8), 200)
+		image_format = content_type.split("/")[1]
+		size = max_width, max_height
+		image.thumbnail(size, Image.Resampling.LANCZOS)
 
-	output = io.BytesIO()
-	image.save(
-		output,
-		format=image_format,
-		optimize=optimize,
-		quality=quality,
-		save_all=True if image_format == "gif" else None,
-	)
-
-	optimized_content = output.getvalue()
-	return optimized_content if len(optimized_content) < len(content) else content
+		output = io.BytesIO()
+		image.save(
+			output,
+			format=image_format,
+			optimize=optimize,
+			quality=quality,
+			save_all=True if image_format == "gif" else None,
+		)
+		optimized_content = output.getvalue()
+		return optimized_content if len(optimized_content) < len(content) else content
+	except Exception as e:
+		frappe.msgprint(frappe._("Failed to optimize image: {0}").format(str(e)))
+		return content


### PR DESCRIPTION
PIL doesn't handle ALL image types. E.g. HEIC fails with bad error.

