### PR TITLE
fix: allow aspect ratio options to crop from sidebar image field

### DIFF
--- a/frappe/public/js/frappe/form/controls/attach.js
+++ b/frappe/public/js/frappe/form/controls/attach.js
@@ -63,7 +63,6 @@ frappe.ui.form.ControlAttach = class ControlAttach extends frappe.ui.form.Contro
 	on_attach_doc_image() {
 		this.set_upload_options();
 		this.upload_options.restrictions.allowed_file_types = ["image/*"];
-		this.upload_options.restrictions.crop_image_aspect_ratio = 1;
 		this.file_uploader = new frappe.ui.FileUploader(this.upload_options);
 	}
 	set_upload_options() {

--- a/frappe/public/js/frappe/form/sidebar/user_image.js
+++ b/frappe/public/js/frappe/form/sidebar/user_image.js
@@ -74,7 +74,7 @@ frappe.ui.form.setup_user_image_event = function (frm) {
 				}
 				field.$input.trigger("attach_doc_image");
 				// close sidebar
-				frm.page.close_sidebar();
+				frm.page.close_sidebar?.();
 			} else {
 				/// on remove event for a sidebar image wrapper remove attach file.
 				frm.attachments.remove_attachment_by_filename(


### PR DESCRIPTION
Image field in sidebar doesn't allow cropping image in different aspect ratio

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td><img width="404" alt="image" src="https://github.com/frappe/frappe/assets/30859809/c1d87f09-6211-471e-b2ea-9e52dd64bb70"></td>
 <td><img width="404" alt="image" src="https://github.com/frappe/frappe/assets/30859809/5c686687-bec3-435b-ab8a-48660cc1a60e"></td>
</table>
