### PR TITLE
fix(translations): Add context to Image Cropper text

### DIFF
--- a/frappe/public/js/frappe/file_uploader/ImageCropper.vue
+++ b/frappe/public/js/frappe/file_uploader/ImageCropper.vue
@@ -97,19 +97,19 @@ onMounted(() => {
 let aspect_ratio_buttons = computed(() => {
 	return [
 		{
-			label: __("1:1"),
+			label: __("1:1", null, "Image Cropper"),
 			value: 1,
 		},
 		{
-			label: __("4:3"),
+			label: __("4:3", null, "Image Cropper"),
 			value: 4 / 3,
 		},
 		{
-			label: __("16:9"),
+			label: __("16:9", null, "Image Cropper"),
 			value: 16 / 9,
 		},
 		{
-			label: __("Free"),
+			label: __("Free", null, "Image Cropper"),
 			value: NaN,
 		},
 	];


### PR DESCRIPTION
Image cropper aspect ratio “Free” had a curious translation in non-English languages.

> You should think of "free" as in "free aspect ratio," not as in ["free beer"](https://en.wikipedia.org/wiki/Gratis_versus_libre#%22Free_beer%22_and_%22freedom_of_speech%22_distinction) :stuck_out_tongue_winking_eye:  