### PR TITLE
fix(text_editor): Fix bubble's link tooltip clipping

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -208,7 +208,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 			},
 			theme: this.df.theme || "snow",
 			readOnly: this.disabled,
-			bounds: this.quill_container[0],
+			bounds: document.body,
 			placeholder: this.df.placeholder || "",
 		};
 	}

--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -12,6 +12,7 @@
 	font-family: var(--font-stack);
 	color: var(--text-color);
 	line-height: 1.6;
+	overflow: visible;
 	h1,
 	h2,
 	h3,


### PR DESCRIPTION
Closes #23903 using info from https://github.com/quilljs/quill/issues/360#issuecomment-542095246 and https://github.com/quilljs/quill/issues/360#issuecomment-584789063
