### PR TITLE
fix!: Set default child table fields on save

### DIFF
--- a/frappe/core/doctype/doctype/test_doctype.py
+++ b/frappe/core/doctype/doctype/test_doctype.py
@@ -786,6 +786,7 @@ def new_doctype(
 	depends_on: str = "",
 	fields: list[dict] | None = None,
 	custom: bool = True,
+	default: str | None = None,
 	**kwargs,
 ):
 	if not name:
@@ -803,6 +804,7 @@ def new_doctype(
 					"fieldname": "some_fieldname",
 					"fieldtype": "Data",
 					"unique": unique,
+					"default": default,
 					"depends_on": depends_on,
 				}
 			],

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -356,6 +356,7 @@ class Document(BaseDocument):
 			return self.insert()
 
 		self.check_if_locked()
+		self._set_defaults()
 		self.check_permission("write", "save")
 
 		self.set_user_and_timestamp()
@@ -771,8 +772,9 @@ class Document(BaseDocument):
 		if frappe.flags.in_import:
 			return
 
-		new_doc = frappe.new_doc(self.doctype, as_dict=True)
-		self.update_if_missing(new_doc)
+		if self.is_new():
+			new_doc = frappe.new_doc(self.doctype, as_dict=True)
+			self.update_if_missing(new_doc)
 
 		# children
 		for df in self.meta.get_table_fields():
@@ -780,7 +782,8 @@ class Document(BaseDocument):
 			value = self.get(df.fieldname)
 			if isinstance(value, list):
 				for d in value:
-					d.update_if_missing(new_doc)
+					if d.is_new():
+						d.update_if_missing(new_doc)
 
 	def check_if_latest(self):
 		"""Checks if `modified` timestamp provided by document being updated is same as the

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 import frappe
 from frappe.app import make_form_dict
+from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.doctype.note.note import Note
 from frappe.model.naming import make_autoname, parse_naming_series, revert_series_if_last
 from frappe.tests.utils import FrappeTestCase
@@ -62,6 +63,20 @@ class TestDocument(FrappeTestCase):
 		# test if default values are added
 		self.assertEqual(d.send_reminder, 1)
 		return d
+
+	def test_website_route_default(self):
+		default = frappe.generate_hash()
+		child_table = new_doctype(default=default, istable=1).insert().name
+		parent = (
+			new_doctype(fields=[{"fieldtype": "Table", "options": child_table, "fieldname": "child_table"}])
+			.insert()
+			.name
+		)
+
+		doc = frappe.get_doc({"doctype": parent, "child_table": [{"some_fieldname": "xasd"}]}).insert()
+		doc.append("child_table", {})
+		doc.save()
+		self.assertEqual(doc.child_table[-1].some_fieldname, default)
 
 	def test_insert_with_child(self):
 		d = frappe.get_doc(


### PR DESCRIPTION
We set defaults on creation of new doc but when you append a new child
doc on existing document it doesn't seem to set the defaults.

This seems like a bug and not a deliberate choice.
