### PR TITLE
feat: generalize notifications

### DIFF
--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -54,10 +54,7 @@
   "uid",
   "imap_folder",
   "email_status",
-  "has_attachment",
-  "feedback_section",
-  "rating",
-  "feedback_request"
+  "has_attachment"
  ],
  "fields": [
   {
@@ -74,9 +71,10 @@
    "label": "To and CC"
   },
   {
-   "depends_on": "eval:doc.communication_type===\"Communication\"",
    "fieldname": "communication_medium",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Type",
    "options": "\nEmail\nChat\nPhone\nSMS\nEvent\nMeeting\nVisit\nOther"
   },
@@ -153,8 +151,10 @@
    "default": "Communication",
    "fieldname": "communication_type",
    "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Communication Type",
-   "options": "Communication\nFeedback\nAutomated Message",
+   "options": "Communication\nAutomated Message",
    "read_only": 1,
    "reqd": 1
   },
@@ -336,25 +336,6 @@
    "label": "Has  Attachment"
   },
   {
-   "collapsible": 1,
-   "depends_on": "eval: doc.rating > 0",
-   "fieldname": "feedback_section",
-   "fieldtype": "Section Break",
-   "label": "Feedback"
-  },
-  {
-   "fieldname": "rating",
-   "fieldtype": "Int",
-   "label": "Rating",
-   "read_only": 1
-  },
-  {
-   "fieldname": "feedback_request",
-   "fieldtype": "Data",
-   "label": "Feedback Request",
-   "read_only": 1
-  },
-  {
    "fieldname": "email_template",
    "fieldtype": "Link",
    "label": "Email Template",
@@ -390,7 +371,7 @@
  "icon": "fa fa-comment",
  "idx": 1,
  "links": [],
- "modified": "2023-11-27 20:38:27.467076",
+ "modified": "2023-12-23 21:46:05.422430",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Communication",

--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -24,7 +24,6 @@
   "status_section",
   "text_content",
   "communication_type",
-  "comment_type",
   "column_break_5",
   "status",
   "sent_or_received",
@@ -155,19 +154,9 @@
    "fieldname": "communication_type",
    "fieldtype": "Select",
    "label": "Communication Type",
-   "options": "Communication\nComment\nChat\nNotification\nFeedback\nAutomated Message",
+   "options": "Communication\nFeedback\nAutomated Message",
    "read_only": 1,
    "reqd": 1
-  },
-  {
-   "fieldname": "comment_type",
-   "fieldtype": "Select",
-   "hidden": 1,
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Comment Type",
-   "options": "\nComment\nLike\nInfo\nLabel\nWorkflow\nCreated\nSubmitted\nCancelled\nUpdated\nDeleted\nAssigned\nAssignment Completed\nAttachment\nAttachment Removed\nShared\nUnshared\nRelinked",
-   "read_only": 1
   },
   {
    "fieldname": "column_break_5",

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -48,9 +48,7 @@ class Communication(Document, CommunicationEmailMixin):
 		communication_medium: DF.Literal[
 			"", "Email", "Chat", "Phone", "SMS", "Event", "Meeting", "Visit", "Other"
 		]
-		communication_type: DF.Literal[
-			"Communication", "Feedback", "Automated Message"
-		]
+		communication_type: DF.Literal["Communication", "Automated Message"]
 		content: DF.TextEditor | None
 		delivery_status: DF.Literal[
 			"",
@@ -72,13 +70,11 @@ class Communication(Document, CommunicationEmailMixin):
 		email_account: DF.Link | None
 		email_status: DF.Literal["Open", "Spam", "Trash"]
 		email_template: DF.Link | None
-		feedback_request: DF.Data | None
 		has_attachment: DF.Check
 		imap_folder: DF.Data | None
 		in_reply_to: DF.Link | None
 		message_id: DF.SmallText | None
 		phone_no: DF.Data | None
-		rating: DF.Int
 		read_by_recipient: DF.Check
 		read_by_recipient_on: DF.Datetime | None
 		read_receipt: DF.Check
@@ -99,6 +95,7 @@ class Communication(Document, CommunicationEmailMixin):
 		unread_notification_sent: DF.Check
 		user: DF.Link | None
 	# end: auto-generated types
+
 	"""Communication represents an external communication like Email."""
 
 	no_feed_on_delete = True

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -524,17 +524,6 @@ class User(Document):
 
 		# delete shares
 		frappe.db.delete("DocShare", {"user": self.name})
-		# delete messages
-		table = DocType("Communication")
-		frappe.db.delete(
-			table,
-			filters=(
-				(table.communication_type.isin(["Chat", "Notification"]))
-				& (table.reference_doctype == "User")
-				& ((table.reference_name == self.name) | table.owner == self.name)
-			),
-			run=False,
-		)
 		# unlink contact
 		table = DocType("Contact")
 		frappe.qb.update(table).where(table.user == self.name).set(table.user, None).run()

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -303,7 +303,7 @@ def get_communication_data(
 	part1 = """
 		SELECT {fields}
 		FROM `tabCommunication` as C
-		WHERE C.communication_type IN ('Communication', 'Feedback', 'Automated Message')
+		WHERE C.communication_type IN ('Communication', 'Automated Message')
 		AND (C.reference_doctype = %(doctype)s AND C.reference_name = %(name)s)
 		{conditions}
 	""".format(
@@ -315,7 +315,7 @@ def get_communication_data(
 		SELECT {fields}
 		FROM `tabCommunication` as C
 		INNER JOIN `tabCommunication Link` ON C.name=`tabCommunication Link`.parent
-		WHERE C.communication_type IN ('Communication', 'Feedback', 'Automated Message')
+		WHERE C.communication_type IN ('Communication', 'Automated Message')
 		AND `tabCommunication Link`.link_doctype = %(doctype)s AND `tabCommunication Link`.link_name = %(name)s
 		{conditions}
 	""".format(

--- a/frappe/email/doctype/notification/README.md
+++ b/frappe/email/doctype/notification/README.md
@@ -1,0 +1,39 @@
+# Notifications
+
+The "Notification" DocType and its associated methods provide a comprehensive framework for managing and sending notifications within the Frappe application.
+
+## Channels
+
+The "channels" refer to the various means through which notifications can be sent.
+Frappe has built-in support for the following channels for sending notifications:
+
+- Email: Notifications can be sent via email to the specified recipients.
+- Slack: Messages can be sent to Slack channels or users using the configured Slack webhook URL.
+- System Notification: Notifications can be sent within the system as alerts or messages.
+- SMS: Notifications can be sent as text messages to the specified mobile phone numbers.
+
+## Handlers
+ 
+Each channel is associated with a specific handler method for sending the notifications.
+These are specified in the `hook.py` file and can be extended by downstream applications.
+Refer to frappe's own `hook.py` for examples which implement the built in channels.
+
+## Notification vs Communication
+
+The _Communication_ DocType is responsible for logging and representing external communications such as emails, SMS, phone, chat, etc.
+Although not limited to emails, with appropriate filters, it serves as Frappe's Inbox-like functionality.
+
+One of its core functionalities is to log any such communication to external parties in the respective documents.
+This allows the user can have a unified view about the state of an external conversation.
+
+Therfore, a _Notification_ may also be a _Communication_ if it is intended to reach an external recipient.
+Such a _Notification_ is generally classified as `communication_type = "Automated Message"` with the appropriate `communication_medium` (Email, Chat, SMS, ...).
+
+## Notification vs System Notification
+
+System Notifications are shown to the user via the desk's bell icon. The _Notification Log_ doctype serves as the centralized table for recording these system notifications and their state, such as if they already have been shown or acknowledge by the user.
+
+"System Notification" can be configured as a channel in a _Notification_ in order to notify a user via the bell icon.
+
+As such, it is **never** considered an external _Communication_.
+

--- a/frappe/email/doctype/notification/email.py
+++ b/frappe/email/doctype/notification/email.py
@@ -1,0 +1,119 @@
+import frappe
+from frappe.core.doctype.communication.email import _make as make_communication
+from frappe.core.doctype.role.role import get_info_based_on_role
+from frappe.utils import validate_email_address
+from frappe.utils.jinja import validate_template
+
+
+def validate(self):
+	validate_template(self.subject)
+	validate_template(self.message)
+
+
+def get_assignees(doc):
+	assignees = []
+	assignees = frappe.get_all(
+		"ToDo",
+		filters={"status": "Open", "reference_name": doc.name, "reference_type": doc.doctype},
+		fields=["allocated_to"],
+	)
+
+	return [d.allocated_to for d in assignees]
+
+
+def get_emails_from_template(template, context):
+	if not template:
+		return ()
+
+	emails = frappe.render_template(template, context) if "{" in template else template
+	return filter(None, emails.replace(",", "\n").split("\n"))
+
+
+def get_list_of_recipients(self, doc, context):
+	recipients = []
+	cc = []
+	bcc = []
+	for recipient in self.recipients:
+		if not recipient.should_receive(context):
+			continue
+		if recipient.receiver_by_document_field:
+			fields = recipient.receiver_by_document_field.split(",")
+			# fields from child table
+			if len(fields) > 1:
+				for d in doc.get(fields[1]):
+					email_id = d.get(fields[0])
+					if validate_email_address(email_id):
+						recipients.append(email_id)
+			# field from parent doc
+			else:
+				email_ids_value = doc.get(fields[0])
+				if validate_email_address(email_ids_value):
+					email_ids = email_ids_value.replace(",", "\n")
+					recipients = recipients + email_ids.split("\n")
+
+		cc.extend(get_emails_from_template(recipient.cc, context))
+		bcc.extend(get_emails_from_template(recipient.bcc, context))
+
+		# For sending emails to specified role
+		if recipient.receiver_by_role:
+			emails = get_info_based_on_role(recipient.receiver_by_role, "email", ignore_permissions=True)
+
+			for email in emails:
+				recipients = recipients + email.split("\n")
+
+	if self.send_to_all_assignees:
+		recipients = recipients + get_assignees(doc)
+
+	return list(set(recipients)), list(set(cc)), list(set(bcc))
+
+
+def send(self, doc, context):
+	from email.utils import formataddr
+
+	subject = self.subject
+	if "{" in subject:
+		subject = frappe.render_template(self.subject, context)
+
+	attachments = self.get_attachment(doc)
+	recipients, cc, bcc = get_list_of_recipients(self, doc, context)
+	if not (recipients or cc or bcc):
+		return
+
+	sender = None
+	message = frappe.render_template(self.message, context)
+	if self.sender and self.sender_email:
+		sender = formataddr((self.sender, self.sender_email))
+
+	communication = None
+	# Add mail notification to communication list
+	# No need to add if it is already a communication.
+	if doc.doctype != "Communication":
+		communication = make_communication(
+			doctype=doc.doctype,
+			name=doc.name,
+			content=message,
+			subject=subject,
+			sender=sender,
+			recipients=recipients,
+			communication_medium="Email",
+			send_email=False,
+			attachments=attachments,
+			cc=cc,
+			bcc=bcc,
+			communication_type="Automated Message",
+		).get("name")
+
+	frappe.sendmail(
+		recipients=recipients,
+		subject=subject,
+		sender=sender,
+		cc=cc,
+		bcc=bcc,
+		message=message,
+		reference_doctype=doc.doctype,
+		reference_name=doc.name,
+		attachments=attachments,
+		expose_recipients="header",
+		print_letterhead=((attachments and attachments[0].get("print_letterhead")) or False),
+		communication=communication,
+	)

--- a/frappe/email/doctype/notification/slack.py
+++ b/frappe/email/doctype/notification/slack.py
@@ -1,0 +1,17 @@
+import frappe
+from frappe.integrations.doctype.slack_webhook_url.slack_webhook_url import send_slack_message
+from frappe.utils.jinja import validate_template
+
+
+def validate(self):
+	validate_template(self.subject)
+	validate_template(self.message)
+
+
+def send(self, doc, context):
+	send_slack_message(
+		webhook_url=self.slack_webhook_url,
+		message=frappe.render_template(self.message, context),
+		reference_doctype=doc.doctype,
+		reference_name=doc.name,
+	)

--- a/frappe/email/doctype/notification/sms.py
+++ b/frappe/email/doctype/notification/sms.py
@@ -1,0 +1,36 @@
+import frappe
+from frappe.core.doctype.role.role import get_info_based_on_role, get_user_info
+from frappe.core.doctype.sms_settings.sms_settings import send_sms
+from frappe.utils.jinja import validate_template
+
+
+def validate(self):
+	validate_template(self.message)
+
+
+def get_receiver_list(self, doc, context):
+	"""return receiver list based on the doc field and role specified"""
+	receiver_list = []
+	for recipient in self.recipients:
+		if not recipient.should_receive(context):
+			continue
+
+		# For sending messages to the owner's mobile phone number
+		if recipient.receiver_by_document_field == "owner":
+			receiver_list += get_user_info([dict(user_name=doc.get("owner"))], "mobile_no")
+		# For sending messages to the number specified in the receiver field
+		elif recipient.receiver_by_document_field:
+			receiver_list.append(doc.get(recipient.receiver_by_document_field))
+
+		# For sending messages to specified role
+		if recipient.receiver_by_role:
+			receiver_list += get_info_based_on_role(recipient.receiver_by_role, "mobile_no")
+
+	return receiver_list
+
+
+def send(self, doc, context):
+	send_sms(
+		receiver_list=get_receiver_list(self, doc, context),
+		msg=frappe.utils.strip_html_tags(frappe.render_template(self.message, context)),
+	)

--- a/frappe/email/doctype/notification/system_notification.py
+++ b/frappe/email/doctype/notification/system_notification.py
@@ -1,0 +1,38 @@
+import json
+
+import frappe
+from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
+from frappe.utils.jinja import validate_template
+
+from .email import get_list_of_recipients
+
+
+def validate(self):
+	validate_template(self.subject)
+	validate_template(self.message)
+
+
+def send(self, doc, context):
+	subject = self.subject
+	if "{" in subject:
+		subject = frappe.render_template(self.subject, context)
+
+	attachments = self.get_attachment(doc)
+
+	recipients, cc, bcc = get_list_of_recipients(self, doc, context)
+
+	users = recipients + cc + bcc
+
+	if not users:
+		return
+
+	notification_doc = {
+		"type": "Alert",
+		"document_type": doc.doctype,
+		"document_name": doc.name,
+		"subject": subject,
+		"from_user": doc.modified_by or doc.owner,
+		"email_content": frappe.render_template(self.message, context),
+		"attached_file": attachments and json.dumps(attachments[0]),
+	}
+	enqueue_create_notification(users, notification_doc)

--- a/frappe/email/doctype/notification/test_notification.py
+++ b/frappe/email/doctype/notification/test_notification.py
@@ -55,7 +55,7 @@ class TestNotification(FrappeTestCase):
 	def test_new_and_save(self):
 		"""Check creating a new communication triggers a notification."""
 		communication = frappe.new_doc("Communication")
-		communication.communication_type = "Comment"
+		communication.communication_type = "Communication"
 		communication.subject = "test"
 		communication.content = "test"
 		communication.insert(ignore_permissions=True)

--- a/frappe/email/doctype/notification/test_records.json
+++ b/frappe/email/doctype/notification/test_records.json
@@ -6,7 +6,7 @@
 		"event": "New",
 		"attach_print": 0,
 		"message": "New comment {{ doc.content }} created",
-		"condition": "doc.communication_type=='Comment'",
+		"condition": "doc.communication_type=='Communication'",
 		"recipients": [
 			{ "receiver_by_document_field": "owner" }
 		]
@@ -18,7 +18,7 @@
 		"event": "Save",
 		"attach_print": 0,
 		"message": "New comment {{ doc.content }} saved",
-		"condition": "doc.communication_type=='Comment'",
+		"condition": "doc.communication_type=='Communication'",
 		"recipients": [
 			{ "receiver_by_document_field": "owner" }
 		],

--- a/frappe/email/doctype/notification_recipient/notification_recipient.py
+++ b/frappe/email/doctype/notification_recipient/notification_recipient.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2018, Frappe Technologies and contributors
 # License: MIT. See LICENSE
-
+import frappe
 from frappe.model.document import Document
 
 
@@ -23,3 +23,8 @@ class NotificationRecipient(Document):
 		receiver_by_role: DF.Link | None
 	# end: auto-generated types
 	pass
+
+	def should_receive(self, context):
+		if self.condition:
+			return frappe.safe_eval(self.condition, None, context)
+		return True

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -417,6 +417,25 @@ ignore_links_on_delete = [
 	"Workspace",
 ]
 
+notification_channels = {
+	"Email": {
+		"validate": "frappe.email.doctype.notification.email.validate",
+		"send": "frappe.email.doctype.notification.email.send",
+	},
+	"Slack": {
+		"validate": "frappe.email.doctype.notification.slack.validate",
+		"send": "frappe.email.doctype.notification.slack.send",
+	},
+	"System Notification": {
+		"validate": "frappe.email.doctype.notification.system_notification.validate",
+		"send": "frappe.email.doctype.notification.system_notification.send",
+	},
+	"SMS": {
+		"validate": "frappe.email.doctype.notification.sms.validate",
+		"send": "frappe.email.doctype.notification.sms.send",
+	},
+}
+
 # Request Hooks
 before_request = [
 	"frappe.recorder.record",


### PR DESCRIPTION
closes: #23700

Contains overdue collateral clean up to facilitate the implementation of the core functionality and make the newly added readme not only accurate, but the code comply and concise.

It therefore also encourages to log notifications into the timeline and starts doing so for SMS notifications.
