### PR TITLE
fix(document): Pass parent_doc and parentfield for child in _set_defaults

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -778,7 +778,7 @@ class Document(BaseDocument):
 
 		# children
 		for df in self.meta.get_table_fields():
-			new_doc = frappe.new_doc(df.options, as_dict=True)
+			new_doc = frappe.new_doc(df.options, parent_doc=self, parentfield=df.fieldname, as_dict=True)
 			value = self.get(df.fieldname)
 			if isinstance(value, list):
 				for d in value:


### PR DESCRIPTION
This bit of code looked weird even though it has not changed in 8 years.  
I'm assuming it's not required when using `doc.append(…)` but it's not always what's used to add children.

---

In ERPNext, the Cost Center for Item rows was not retrieved from the parent document, but from the Company's defaults. This is because the `parent` of the rows was not specified on validate. This PR fixes that. 

---

<details>

Possibly related:
<blockquote>

After insert() new doc is created, but log(doc.child_table) becomes empty.
https://discuss.frappe.io/t/frappe-get-doc-error-on-submit-not-able-to-insert-childtable/114961/4

```py
doc = frappe.get_doc({
    "doctype": "Sales Order",
    "customer": "Frappe Ash",
    "delivery_date": "2023-12-30",
    "items": [{  # insertion of child doc without `doc.append` -> bug?
        "item_name": "123456",
        "qty": 5,
        "rate": 456
    }]
})
```

</blockquote>

</details>