### PR TITLE
feat(database): Support One-Way TLS when using MariaDB

### DIFF
--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -134,4 +134,20 @@ def get_command(
 		if extra:
 			command.extend(extra)
 
+		if frappe.conf.db_ssl_ca:
+			command.extend(
+				[
+					f"--ssl-ca={frappe.conf.db_ssl_ca}",
+				]
+			)
+			# Check if Two-Way TLS is enabled
+			# https://mariadb.com/kb/en/securing-connections-for-client-and-server/#enabling-two-way-tls-for-mariadb-clients
+			if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+				command.extend(
+					[
+						f"--ssl-cert={frappe.conf.db_ssl_cert}",
+						f"--ssl-key={frappe.conf.db_ssl_key}"
+					]
+				)
+
 	return bin, command, bin_name

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -132,12 +132,14 @@ class MariaDBConnectionUtil:
 		if frappe.conf.local_infile:
 			conn_settings["local_infile"] = frappe.conf.local_infile
 
-		if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
-			conn_settings["ssl"] = {
-				"ca": frappe.conf.db_ssl_ca,
-				"cert": frappe.conf.db_ssl_cert,
-				"key": frappe.conf.db_ssl_key,
-			}
+		if frappe.conf.db_ssl_ca:
+			ssl = {"ca": frappe.conf.db_ssl_ca}
+			# Check if Two-Way TLS is enabled
+			# https://mariadb.com/kb/en/securing-connections-for-client-and-server/#enabling-two-way-tls-for-mariadb-clients
+			if frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+				ssl.update({"cert": frappe.conf.db_ssl_cert, "key": frappe.conf.db_ssl_key})
+			conn_settings["ssl"] = ssl
+
 		return conn_settings
 
 


### PR DESCRIPTION
Make `db_ssl_cert` and `db_ssl_key` optional to support One-Way TLS when using MariaDB.

closes #23929

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
