### PR TITLE
fix: use system font for printing

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -582,7 +582,7 @@ def get_print_style(
 def get_font(
 	print_settings: "PrintSettings", print_format: Optional["PrintFormat"] = None, for_legacy=False
 ) -> str:
-	default = 'Inter, "Helvetica Neue", Helvetica, Arial, "Open Sans", sans-serif'
+	default = "var(--font-stack)"
 	if for_legacy:
 		return default
 


### PR DESCRIPTION
Before, most text in print was set to `font-family: Inter, "Helvetica Neue", Helvetica, Arial, "Open Sans", sans-serif` while content from Text Editor fields was set to `font-family: var(--font-stack)`, resulting in inconsistent styling.

With this PR, the print format will use the same font-family as content from Text Editor fields (and the rest of the system).

No backport, since this changes the look of existing print formats.