### PR TITLE
Update beautifulsoup4 depedency, bug #21585

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "WeasyPrint==52.5",
     "Werkzeug~=2.3.8",
     "Whoosh~=2.7.4",
-    "beautifulsoup4~=4.9.3",
+    "beautifulsoup4~=4.10.0",
     "bleach-allowlist~=1.0.3",
     "bleach~=3.3.0",
     "cairocffi==1.2.0",


### PR DESCRIPTION
BeautifulSoup 4.9.3 doesn't find div class "hidden-pdf" resulting in skipping letter-head in printing in pdf.py. Just update to new version, to test try this code:

```
from bs4 import BeautifulSoup
s = BeautifulSoup('<div class="hidden-pdf" id="header-html">', "html5lib")
s.find_all(attrs={"class": "hidden-pdf"})
```

closes #21585
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
