### PR TITLE
fix: Solve the problem that the event processing added by' addEventLi…

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -33,6 +33,9 @@ window.addEventListener("popstate", (e) => {
 
 // Capture all clicks so that the target is managed with push-state
 $("body").on("click", "a", function (e) {
+	if (e?.originalEvent?.defaultPrevented) {
+		return;
+	}
 	const target_element = e.currentTarget;
 	const href = target_element.getAttribute("href");
 	const is_on_same_host = target_element.hostname === window.location.hostname;


### PR DESCRIPTION
fix: Solve the problem that the event processing added by' addEventListener' and calling' preventDefault' method is not considered in global link processing

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

Add a `<a>` tag with the following code:

```js
const a = document.createElement('a');
a.href = '/app/doctype';
a.innerHTML = 'this is a link';
document.body.appendChild(a);
a.addEventListener('click', e => {
	e.preventDefault();
});
```

In a normal page, clicking the tag added above will not jump, because calling `e.preventDefault ()` in `addEventListener` will set `e.defaultPrevented` to `true` and cancel the default operation of jumping, and the event listener added through `addEventListener` will not add corresponding HTML attributes to the tag.

However, frappe added a global click listening to the `<a>` tag on `<body>`. In this listening, it is considered that there is an `onclick` HTML attribute on the `<a>` tag, but the `addEventListener` is not considered. This patch is used to append the processing of this case, that is, when `defaultPrevented` is `true`, the default processing of `<a>` by frappe will no longer be executed.

Adding event listening in vue is also realized by `addEventListener`, and `@click.prevent` in vue will also call `e.preventDefault()`. Moreover, in the two modes of `WebHistory` and `WebHashHistory` in `vue-router`, `<RouterLink>` also uses the `<a>` tag by default and calls `preventDefault` in the `click` event.


> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
