### PR TITLE
feat!: remove `import-translations` command

### DIFF
--- a/frappe/commands/translate.py
+++ b/frappe/commands/translate.py
@@ -85,23 +85,6 @@ def update_translations(context, lang, untranslated_file, translated_file, app="
 		frappe.destroy()
 
 
-@click.command("import-translations")
-@click.argument("lang")
-@click.argument("path")
-@pass_context
-def import_translations(context, lang, path):
-	"Update translated strings"
-	import frappe.translate
-
-	site = get_site(context)
-	try:
-		frappe.init(site=site)
-		frappe.connect()
-		frappe.translate.import_translations(lang, path)
-	finally:
-		frappe.destroy()
-
-
 @click.command("migrate-translations")
 @click.argument("source-app")
 @click.argument("target-app")
@@ -122,7 +105,6 @@ def migrate_translations(context, source_app, target_app):
 commands = [
 	build_message_files,
 	get_untranslated,
-	import_translations,
 	new_language,
 	update_translations,
 	migrate_translations,

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -1000,16 +1000,6 @@ def update_translations(lang, untranslated_file, translated_file, app="_ALL_APPS
 		write_translations_file(app_name, lang, full_dict)
 
 
-def import_translations(lang, path):
-	"""Import translations from file in standard format"""
-	clear_cache()
-	full_dict = get_all_translations(lang)
-	full_dict.update(get_translation_dict_from_file(path, lang, "import"))
-
-	for app in frappe.get_all_apps(True):
-		write_translations_file(app, lang, full_dict)
-
-
 def migrate_translations(source_app, target_app):
 	"""Migrate target-app-specific translations from source-app to target-app"""
 	clear_cache()


### PR DESCRIPTION
Maybe a remnant from single-app times; does nothing apart from messing up translation files.

I would expect `import-translations` to take translations from my CSV file and add them to the translations for a specific language and app.

What this command did, was completely overwrite the translations from all apps with the combined translations of all other apps (and the provided CSV). More harmful than useful, IMO.

Docs: https://frappeframework.com/docs/user/en/bench/frappe-commands#translation-commands