### PR TITLE
perf: save one network call while creating new form

### DIFF
--- a/frappe/public/js/frappe/views/formview.js
+++ b/frappe/public/js/frappe/views/formview.js
@@ -77,15 +77,16 @@ frappe.views.FormFactory = class FormFactory extends frappe.views.Factory {
 	}
 
 	fetch_and_render(doctype, name, doctype_layout) {
+		if (name && name === "new") {
+			this.render_new_doc(doctype, name, doctype_layout);
+			return;
+		}
+
 		frappe.model.with_doc(doctype, name, (name, r) => {
 			if (r && r["403"]) return; // not permitted
 
 			if (!(locals[doctype] && locals[doctype][name])) {
-				if (name && name.substr(0, 3) === "new") {
-					this.render_new_doc(doctype, name, doctype_layout);
-				} else {
-					frappe.show_not_found();
-				}
+				frappe.show_not_found();
 				return;
 			}
 			this.render(doctype_layout, name);


### PR DESCRIPTION
Save one network call while creating new form.

`frappe.model.with_doc` used to make a network request returning an empty message for new docs. With this PR, we handle new docs first, saving that one request.
