### PR TITLE
fix(minor): mobile menu class

### DIFF
--- a/frappe/public/scss/website/navbar.scss
+++ b/frappe/public/scss/website/navbar.scss
@@ -29,7 +29,7 @@
 	}
 }
 @media (max-width: map-get($grid-breakpoints, "sm")) {
-	.navbar-collapse.collapse.show {
+	.navbar-collapse {
 		.navbar-nav {
 			align-items: flex-start;
 		}


### PR DESCRIPTION
removed `.collapse.show` class as it is removed during opening animation of menu.

### Before
https://github.com/frappe/frappe/assets/39730881/e4fdd604-9500-41d4-9bce-3088dd345aa7

### After
https://github.com/frappe/frappe/assets/39730881/4c653ddd-c1e6-4288-a3c3-cfcb4e9e6599

