### PR TITLE
fix(Data Import): show failed import logs

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -449,7 +449,6 @@ frappe.ui.form.on("Data Import", {
 							}
 						} else {
 							let messages = JSON.parse(log.messages || "[]")
-								.map(JSON.parse)
 								.map((m) => {
 									let title = m.title ? `<strong>${m.title}</strong>` : "";
 									let message = m.message ? `<div>${m.message}</div>` : "";

--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -506,7 +506,13 @@ frappe.ui.form.on("Data Import", {
 	},
 
 	show_import_log(frm) {
+		if (!frm.doc.show_failed_logs) {
+			frm.toggle_display("import_log_preview", false);
+			return;
+		}
+
 		frm.toggle_display("import_log_section", false);
+		frm.toggle_display("import_log_preview", true);
 
 		if (frm.import_in_progress) {
 			return;


### PR DESCRIPTION
Fixes: #23781 #23957

While importing the data, if an error occurs, we get it in console instead of page itself.
<img width="1470" alt="Screenshot 2023-12-27 at 3 09 35 PM" src="https://github.com/frappe/frappe/assets/28840468/4f3f2159-1168-4694-885a-3276f9852763">

The error `"[object Object]" is not valid JSON` is happening from JSON.parse function, as it is already an object.