### PR TITLE
fix: roles editor

### DIFF
--- a/frappe/public/js/frappe/roles_editor.js
+++ b/frappe/public/js/frappe/roles_editor.js
@@ -3,7 +3,7 @@ frappe.RoleEditor = class {
 		this.frm = frm;
 		this.wrapper = wrapper;
 		this.disable = disable;
-		let user_roles = this.frm.doc.roles.map((a) => a.role);
+		let user_roles = this.frm.doc.roles ? this.frm.doc.roles.map((a) => a.role) : [];
 		this.multicheck = frappe.ui.form.make_control({
 			parent: wrapper,
 			df: {


### PR DESCRIPTION
## Issue

When trying to create a new Role Profile, an error appears in the console that prevents the Roles Editor from being displayed.

<img width="1425" alt="Screenshot 2023-12-27 at 3 52 08 PM" src="https://github.com/frappe/frappe/assets/31363128/244e35a1-6916-4452-b2ce-5996713e38ff">
