### PR TITLE
fix!: initialize child tables correctly

### DIFF
--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -75,7 +75,7 @@ frappe.ui.form.on("User", {
 		if (
 			frm.can_edit_roles &&
 			!frm.is_new() &&
-			in_list(["System User", "Website User"], frm.doc.user_type)
+			["System User", "Website User"].includes(frm.doc.user_type)
 		) {
 			if (!frm.roles_editor) {
 				const role_area = $('<div class="role-editor">').appendTo(
@@ -105,7 +105,7 @@ frappe.ui.form.on("User", {
 		}
 
 		if (
-			in_list(["System User", "Website User"], frm.doc.user_type) &&
+			["System User", "Website User"].includes(frm.doc.user_type) &&
 			!frm.is_new() &&
 			!frm.roles_editor &&
 			frm.can_edit_roles

--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -67,7 +67,7 @@ frappe.ui.form.on("Custom Field", {
 							return v.value;
 						});
 
-						if (insert_after == null || !in_list(fieldnames, insert_after)) {
+						if (insert_after == null || !fieldnames.includes(insert_after)) {
 							insert_after = fieldnames[-1];
 						}
 

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -81,7 +81,7 @@ frappe.ui.form.on("Customize Form", {
 
 	add_customize_child_table_button: function (frm) {
 		frm.doc.fields.forEach(function (f) {
-			if (!in_list(["Table", "Table MultiSelect"], f.fieldtype)) return;
+			if (!["Table", "Table MultiSelect"].includes(f.fieldtype)) return;
 
 			frm.add_custom_button(
 				__(f.options),

--- a/frappe/custom/doctype/property_setter/property_setter.js
+++ b/frappe/custom/doctype/property_setter/property_setter.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Property Setter", {
 	validate: function (frm) {
-		if (frm.doc.property_type == "Check" && !in_list(["0", "1"], frm.doc.value)) {
+		if (frm.doc.property_type == "Check" && !["0", "1"].includes(frm.doc.value)) {
 			frappe.throw(__("Value for a check field can be either 0 or 1"));
 		}
 	},

--- a/frappe/email/doctype/newsletter/newsletter.js
+++ b/frappe/email/doctype/newsletter/newsletter.js
@@ -4,7 +4,7 @@
 frappe.ui.form.on("Newsletter", {
 	refresh(frm) {
 		let doc = frm.doc;
-		let can_write = in_list(frappe.boot.user.can_write, doc.doctype);
+		let can_write = frappe.boot.user.can_write.includes(doc.doctype);
 		if (!frm.is_new() && !frm.is_dirty() && !doc.email_sent && can_write) {
 			frm.add_custom_button(
 				__("Send a test email"),

--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -34,7 +34,7 @@ frappe.notification = {
 
 			let fields = frappe.get_doc("DocType", frm.doc.document_type).fields;
 			let options = $.map(fields, function (d) {
-				return in_list(frappe.model.no_value_type, d.fieldtype)
+				return frappe.model.no_value_type.includes(d.fieldtype)
 					? null
 					: get_select_options(d);
 			});
@@ -66,7 +66,7 @@ frappe.notification = {
 							: null;
 					}
 				});
-			} else if (in_list(["WhatsApp", "SMS"], frm.doc.channel)) {
+			} else if (["WhatsApp", "SMS"].includes(frm.doc.channel)) {
 				receiver_fields = $.map(fields, function (d) {
 					return d.options == "Phone" ? get_select_options(d) : null;
 				});
@@ -102,7 +102,7 @@ Last comment: {{ comments[-1].comment }} by {{ comments[-1].by }}
 &lt;/ul&gt;
 </pre>
 			`;
-		} else if (in_list(["Slack", "System Notification", "SMS"], frm.doc.channel)) {
+		} else if (["Slack", "System Notification", "SMS"].includes(frm.doc.channel)) {
 			template = `<h5>Message Example</h5>
 
 <pre>*Order Overdue*
@@ -166,7 +166,7 @@ frappe.ui.form.on("Notification", {
 		frappe.set_route("Form", "Customize Form");
 	},
 	event: function (frm) {
-		if (in_list(["Days Before", "Days After"], frm.doc.event)) {
+		if (["Days Before", "Days After"].includes(frm.doc.event)) {
 			frm.add_custom_button(__("Get Alerts for Today"), function () {
 				frappe.call({
 					method: "frappe.email.doctype.notification.notification.get_documents_for_today",

--- a/frappe/printing/doctype/print_format/print_format.js
+++ b/frappe/printing/doctype/print_format/print_format.js
@@ -79,7 +79,7 @@ frappe.ui.form.on("Print Format", {
 			frappe.model.with_doctype(doctype, () => {
 				const meta = frappe.get_meta(doctype);
 				const has_int_float_currency_field = meta.fields.filter((df) =>
-					in_list(["Int", "Float", "Currency"], df.fieldtype)
+					["Int", "Float", "Currency"].includes(df.fieldtype)
 				);
 				frm.toggle_display("absolute_value", has_int_float_currency_field.length);
 			});

--- a/frappe/printing/page/print_format_builder/print_format_builder.js
+++ b/frappe/printing/page/print_format_builder/print_format_builder.js
@@ -280,7 +280,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 				set_section(f.label);
 			} else if (f.fieldtype === "Column Break") {
 				set_column();
-			} else if (!in_list(frappe.model.layout_fields, f.fieldtype)) {
+			} else if (!frappe.model.layout_fields.includes(f.fieldtype)) {
 				if (!column) set_column();
 
 				if (f.fieldtype === "Table") {
@@ -317,7 +317,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 		f.visible_columns = [];
 		$.each(frappe.get_meta(f.options).fields, function (i, _f) {
 			if (
-				!in_list(["Section Break", "Column Break", "Tab Break"], _f.fieldtype) &&
+				!["Section Break", "Column Break", "Tab Break"].includes(_f.fieldtype) &&
 				!_f.print_hide &&
 				f.label
 			) {
@@ -636,7 +636,7 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 			// add field which are in column_names first to preserve order
 			var fields = [];
 			$.each(column_names, function (i, v) {
-				if (in_list(Object.keys(docfields_by_name), v)) {
+				if (Object.keys(docfields_by_name).includes(v)) {
 					fields.push(docfields_by_name[v]);
 				}
 			});
@@ -644,8 +644,8 @@ frappe.PrintFormatBuilder = class PrintFormatBuilder {
 			$.each(doc_fields, function (j, f) {
 				if (
 					f &&
-					!in_list(column_names, f.fieldname) &&
-					!in_list(["Section Break", "Column Break", "Tab Break"], f.fieldtype) &&
+					!column_names.includes(f.fieldname) &&
+					!["Section Break", "Column Break", "Tab Break"].includes(f.fieldtype) &&
 					f.label
 				) {
 					fields.push(f);

--- a/frappe/public/js/form_builder/store.js
+++ b/frappe/public/js/form_builder/store.js
@@ -171,7 +171,7 @@ export const useStore = defineStore("form-builder-store", () => {
 			}
 
 			// Link & Table fields should always have options set
-			if (in_list(["Link", ...frappe.model.table_fields], df.fieldtype) && !df.options) {
+			if (["Link", ...frappe.model.table_fields].includes(df.fieldtype) && !df.options) {
 				error_message = __(
 					"Options is required for field {0} of type {1}",
 					get_field_data(df)
@@ -187,7 +187,7 @@ export const useStore = defineStore("form-builder-store", () => {
 			}
 
 			// In List View is not allowed for some fieldtypes
-			if (df.in_list_view && in_list(not_allowed_in_list_view, df.fieldtype)) {
+			if (df.in_list_view && not_allowed_in_list_view.includes(df.fieldtype)) {
 				error_message = __(
 					"'In List View' is not allowed for field {0} of type {1}",
 					get_field_data(df)
@@ -195,7 +195,7 @@ export const useStore = defineStore("form-builder-store", () => {
 			}
 
 			// In Global Search is not allowed for no_value_type fields
-			if (df.in_global_search && in_list(frappe.model.no_value_type, df.fieldtype)) {
+			if (df.in_global_search && frappe.model.no_value_type.includes(df.fieldtype)) {
 				error_message = __(
 					"'In Global Search' is not allowed for field {0} of type {1}",
 					get_field_data(df)

--- a/frappe/public/js/form_builder/utils.js
+++ b/frappe/public/js/form_builder/utils.js
@@ -119,7 +119,7 @@ export async function get_table_columns(df, child_doctype) {
 		1,
 	]);
 	for (let tf of table_fields) {
-		if (!in_list(frappe.model.layout_fields, tf.fieldtype) && tf.in_list_view && tf.label) {
+		if (!frappe.model.layout_fields.includes(tf.fieldtype) && tf.in_list_view && tf.label) {
 			let colsize;
 
 			if (tf.columns) {
@@ -281,7 +281,7 @@ export function scrub_field_names(fields) {
 					if (d.fieldname.endsWith("?")) {
 						d.fieldname = d.fieldname.slice(0, -1);
 					}
-					if (in_list(frappe.model.restricted_fields, d.fieldname)) {
+					if (frappe.model.restricted_fields.includes(d.fieldname)) {
 						d.fieldname = d.fieldname + "1";
 					}
 					if (d.fieldtype == "Section Break") {
@@ -298,7 +298,7 @@ export function scrub_field_names(fields) {
 						frappe.utils.get_random(4);
 				}
 			} else {
-				if (in_list(frappe.model.restricted_fields, d.fieldname)) {
+				if (frappe.model.restricted_fields.includes(d.fieldname)) {
 					frappe.throw(__("Fieldname {0} is restricted", [d.fieldname]));
 				}
 			}

--- a/frappe/public/js/frappe/form/controls/base_control.js
+++ b/frappe/public/js/frappe/form/controls/base_control.js
@@ -87,7 +87,7 @@ frappe.ui.form.Control = class BaseControl {
 			if (
 				status === "Read" &&
 				is_null(value) &&
-				!in_list(["HTML", "Image", "Button"], this.df.fieldtype)
+				!["HTML", "Image", "Button"].includes(this.df.fieldtype)
 			)
 				status = "Read";
 
@@ -115,7 +115,7 @@ frappe.ui.form.Control = class BaseControl {
 
 		let value = frappe.model.get_value(this.doctype, this.docname, this.df.fieldname);
 
-		if (in_list(["Date", "Datetime"], this.df.fieldtype) && value) {
+		if (["Date", "Datetime"].includes(this.df.fieldtype) && value) {
 			value = frappe.datetime.str_to_user(value);
 		}
 
@@ -127,7 +127,7 @@ frappe.ui.form.Control = class BaseControl {
 			status === "Read" &&
 			!this.only_input &&
 			is_null(value) &&
-			!in_list(["HTML", "Image", "Button", "Geolocation"], this.df.fieldtype)
+			!["HTML", "Image", "Button", "Geolocation"].includes(this.df.fieldtype)
 		) {
 			if (explain) console.log("By Hide Read-only, null fields: None");
 			status = "None";

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -138,7 +138,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 
 	set_disp_area(value) {
 		if (
-			in_list(["Currency", "Int", "Float"], this.df.fieldtype) &&
+			["Currency", "Int", "Float"].includes(this.df.fieldtype) &&
 			(this.value === 0 || value === 0)
 		) {
 			// to set the 0 value in readonly for currency, int, float field
@@ -172,7 +172,7 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 		if (
 			!this.df.label ||
 			!this.df?.documentation_url ||
-			in_list(unsupported_fieldtypes, this.df.fieldtype)
+			unsupported_fieldtypes.includes(this.df.fieldtype)
 		)
 			return;
 

--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -215,8 +215,7 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 	}
 	set_input_attributes() {
 		if (
-			in_list(
-				["Data", "Link", "Dynamic Link", "Password", "Select", "Read Only"],
+			["Data", "Link", "Dynamic Link", "Password", "Select", "Read Only"].includes(
 				this.df.fieldtype
 			)
 		) {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -87,10 +87,10 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		return this.is_translatable() ? __(value) : value;
 	}
 	is_translatable() {
-		return in_list(frappe.boot?.translated_doctypes || [], this.get_options());
+		return frappe.boot?.translated_doctypes || [].includes(this.get_options());
 	}
 	is_title_link() {
-		return in_list(frappe.boot?.link_title_doctypes || [], this.get_options());
+		return frappe.boot?.link_title_doctypes || [].includes(this.get_options());
 	}
 	async set_link_title(value) {
 		const doctype = this.get_options();

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -166,7 +166,7 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 		let me = this;
 
 		awesomplete.filter = function (item) {
-			if (in_list(me._rows_list, item.value)) {
+			if (me._rows_list.includes(item.value)) {
 				return false;
 			}
 

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -295,11 +295,11 @@ class FormTimeline extends BaseTimeline {
 
 	set_communication_doc_status(doc) {
 		let indicator_color = "red";
-		if (in_list(["Sent", "Clicked"], doc.delivery_status)) {
+		if (["Sent", "Clicked"].includes(doc.delivery_status)) {
 			indicator_color = "green";
 		} else if (["Sending", "Scheduled"].includes(doc.delivery_status)) {
 			indicator_color = "orange";
-		} else if (in_list(["Opened", "Read"], doc.delivery_status)) {
+		} else if (["Opened", "Read"].includes(doc.delivery_status)) {
 			indicator_color = "blue";
 		} else if (doc.delivery_status == "Error") {
 			indicator_color = "red";

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1412,7 +1412,7 @@ frappe.ui.form.Form = class FrappeForm {
 
 	is_form_builder() {
 		return (
-			in_list(["DocType", "Customize Form"], this.doctype) &&
+			["DocType", "Customize Form"].includes(this.doctype) &&
 			this.get_active_tab().label == "Form"
 		);
 	}

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -158,7 +158,7 @@ export default class Grid {
 		if (
 			!this.df.label ||
 			!this.df?.documentation_url ||
-			in_list(unsupported_fieldtypes, this.df.fieldtype)
+			unsupported_fieldtypes.includes(this.df.fieldtype)
 		)
 			return;
 
@@ -685,7 +685,7 @@ export default class Grid {
 	get_modal_data() {
 		return this.df.get_data
 			? this.df.get_data().filter((data) => {
-					if (!this.deleted_docs || !in_list(this.deleted_docs, data.name)) {
+					if (!this.deleted_docs || !this.deleted_docs.includes(data.name)) {
 						return data;
 					}
 			  })
@@ -940,7 +940,7 @@ export default class Grid {
 				!df.hidden &&
 				(this.editable_fields || df.in_list_view) &&
 				((this.frm && this.frm.get_perm(df.permlevel, "read")) || !this.frm) &&
-				!in_list(frappe.model.layout_fields, df.fieldtype)
+				!frappe.model.layout_fields.includes(df.fieldtype)
 			) {
 				if (df.columns) {
 					df.colsize = df.columns;

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -500,7 +500,7 @@ export default class GridRow {
 				fields.push({
 					label: column.label,
 					value: column.fieldname,
-					checked: selected_fields ? in_list(selected_fields, column.fieldname) : false,
+					checked: selected_fields ? selected_fields.includes(column.fieldname) : false,
 				});
 			}
 		});
@@ -1136,7 +1136,7 @@ export default class GridRow {
 		if (field.$input) {
 			field.$input.on("keydown", function (e) {
 				var { TAB, UP: UP_ARROW, DOWN: DOWN_ARROW } = frappe.ui.keyCode;
-				if (!in_list([TAB, UP_ARROW, DOWN_ARROW], e.which)) {
+				if (![TAB, UP_ARROW, DOWN_ARROW].includes(e.which)) {
 					return;
 				}
 
@@ -1145,7 +1145,7 @@ export default class GridRow {
 				var fieldtype = $(this).attr("data-fieldtype");
 
 				let ctrl_key = e.metaKey || e.ctrlKey;
-				if (!in_list(ignore_fieldtypes, fieldtype) && ctrl_key && e.which !== TAB) {
+				if (!ignore_fieldtypes.includes(fieldtype) && ctrl_key && e.which !== TAB) {
 					me.add_new_row_using_keys(e);
 					return;
 				}
@@ -1156,7 +1156,7 @@ export default class GridRow {
 				}
 
 				var move_up_down = function (base) {
-					if (in_list(ignore_fieldtypes, fieldtype) && !e.altKey) {
+					if (ignore_fieldtypes.includes(fieldtype) && !e.altKey) {
 						return false;
 					}
 					if (field.autocomplete_open) {
@@ -1441,8 +1441,8 @@ export default class GridRow {
 				!df.hidden &&
 				df.in_list_view &&
 				me.grid.frm.get_perm(df.permlevel, "read") &&
-				!in_list(frappe.model.layout_fields, df.fieldtype) &&
-				!in_list(blacklist, df.fieldname);
+				!frappe.model.layout_fields.includes(df.fieldtype) &&
+				!blacklist.includes(df.fieldname);
 
 			return visible ? df : null;
 		});

--- a/frappe/public/js/frappe/form/grid_row_form.js
+++ b/frappe/public/js/frappe/form/grid_row_form.js
@@ -134,7 +134,7 @@ export default class GridRowForm {
 				var first = me.form_area.find("input:first");
 				if (
 					first.length &&
-					!in_list(["Date", "Datetime", "Time"], first.attr("data-fieldtype"))
+					!["Date", "Datetime", "Time"].includes(first.attr("data-fieldtype"))
 				) {
 					try {
 						first.get(0).focus();

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -621,7 +621,7 @@ frappe.ui.form.Layout = class Layout {
 					// show grid row (if exists)
 					field.grid.grid_rows[0].show_form();
 					return true;
-				} else if (!in_list(frappe.model.no_value_type, field.df.fieldtype)) {
+				} else if (!frappe.model.no_value_type.includes(field.df.fieldtype)) {
 					this.set_focus(field);
 					return true;
 				}

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -372,7 +372,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		}
 
 		// duplicate
-		if (in_list(frappe.boot.user.can_create, me.frm.doctype) && !me.frm.meta.allow_copy) {
+		if (frappe.boot.user.can_create.includes(me.frm.doctype) && !me.frm.meta.allow_copy) {
 			this.page.add_menu_item(
 				__("Duplicate"),
 				function () {

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -316,7 +316,7 @@ export default class ListSettings {
 		meta.fields.forEach((field) => {
 			if (
 				field.in_list_view &&
-				!in_list(frappe.model.no_value_type, field.fieldtype) &&
+				!frappe.model.no_value_type.includes(field.fieldtype) &&
 				me.subject_field.fieldname != field.fieldname
 			) {
 				me.fields.push({
@@ -363,11 +363,11 @@ export default class ListSettings {
 		let multiselect_fields = [];
 
 		meta.fields.forEach((field) => {
-			if (!in_list(frappe.model.no_value_type, field.fieldtype)) {
+			if (!frappe.model.no_value_type.includes(field.fieldtype)) {
 				multiselect_fields.push({
 					label: field.label,
 					value: field.fieldname,
-					checked: in_list(fields, field.fieldname),
+					checked: fields.includes(field.fieldname),
 				});
 			}
 		});
@@ -384,7 +384,7 @@ export default class ListSettings {
 		}
 
 		existing_fields.forEach((column) => {
-			if (!in_list(new_fields, column)) {
+			if (!new_fields.includes(column)) {
 				removed_fields.push(column);
 			}
 		});

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -755,7 +755,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			: value;
 
 		let translated_doctypes = frappe.boot?.translated_doctypes || [];
-		if (in_list(translated_doctypes, df.options)) {
+		if (translated_doctypes.includes(df.options)) {
 			value_display = __(value_display);
 		}
 

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -84,30 +84,39 @@ $.extend(frappe.model, {
 	},
 
 	set_default_values: function (doc, parent_doc) {
-		var doctype = doc.doctype;
-		var docfields = frappe.meta.get_docfields(doctype);
-		var updated = [];
-		for (var fid = 0; fid < docfields.length; fid++) {
-			var f = docfields[fid];
-			if (!frappe.model.no_value_type.includes(f.fieldtype) && doc[f.fieldname] == null) {
-				if (f.no_default) continue;
-				var v = frappe.model.get_default_value(f, doc, parent_doc);
-				if (v) {
-					if (["Int", "Check"].includes(f.fieldtype)) v = cint(v);
-					else if (["Currency", "Float"].includes(f.fieldtype)) v = flt(v);
+		let doctype = doc.doctype;
+		let docfields = frappe.meta.get_docfields(doctype);
+		let updated = [];
 
-					doc[f.fieldname] = v;
-					updated.push(f.fieldname);
-				} else if (
-					f.fieldtype == "Select" &&
-					f.options &&
-					typeof f.options === "string" &&
-					!["[Select]", "Loading..."].includes(f.options)
-				) {
-					doc[f.fieldname] = f.options.split("\n")[0];
-				}
+		// Table types should be initialized
+		let fieldtypes_without_default = frappe.model.no_value_type.filter(
+			(fieldtype) => !frappe.model.table_fields.includes(fieldtype)
+		);
+		docfields.forEach((f) => {
+			if (
+				fieldtypes_without_default.includes(f.fieldtype) ||
+				doc[f.fieldname] != null ||
+				f.no_default
+			) {
+				return;
 			}
-		}
+
+			let v = frappe.model.get_default_value(f, doc, parent_doc);
+			if (v) {
+				if (["Int", "Check"].includes(f.fieldtype)) v = cint(v);
+				else if (["Currency", "Float"].includes(f.fieldtype)) v = flt(v);
+
+				doc[f.fieldname] = v;
+				updated.push(f.fieldname);
+			} else if (
+				f.fieldtype == "Select" &&
+				f.options &&
+				typeof f.options === "string" &&
+				!["[Select]", "Loading..."].includes(f.options)
+			) {
+				doc[f.fieldname] = f.options.split("\n")[0];
+			}
+		});
 		return updated;
 	},
 
@@ -141,6 +150,10 @@ $.extend(frappe.model, {
 			!$.isEmptyObject(user_permissions) &&
 			df.ignore_user_permissions != 1 &&
 			allowed_records.length;
+
+		if (frappe.model.table_fields.includes(df.fieldtype)) {
+			value = [];
+		}
 
 		// don't set defaults for "User" link field using User Permissions!
 		if (df.fieldtype === "Link" && df.options !== "User") {

--- a/frappe/public/js/frappe/model/create_new.js
+++ b/frappe/public/js/frappe/model/create_new.js
@@ -62,7 +62,7 @@ $.extend(frappe.model, {
 				var df = frappe.meta.has_field(doctype, fieldname);
 				if (
 					df &&
-					in_list(["Link", "Data", "Select", "Dynamic Link"], df.fieldtype) &&
+					["Link", "Data", "Select", "Dynamic Link"].includes(df.fieldtype) &&
 					!df.no_copy
 				) {
 					doc[fieldname] = value;
@@ -89,12 +89,12 @@ $.extend(frappe.model, {
 		var updated = [];
 		for (var fid = 0; fid < docfields.length; fid++) {
 			var f = docfields[fid];
-			if (!in_list(frappe.model.no_value_type, f.fieldtype) && doc[f.fieldname] == null) {
+			if (!frappe.model.no_value_type.includes(f.fieldtype) && doc[f.fieldname] == null) {
 				if (f.no_default) continue;
 				var v = frappe.model.get_default_value(f, doc, parent_doc);
 				if (v) {
-					if (in_list(["Int", "Check"], f.fieldtype)) v = cint(v);
-					else if (in_list(["Currency", "Float"], f.fieldtype)) v = flt(v);
+					if (["Int", "Check"].includes(f.fieldtype)) v = cint(v);
+					else if (["Currency", "Float"].includes(f.fieldtype)) v = flt(v);
 
 					doc[f.fieldname] = v;
 					updated.push(f.fieldname);
@@ -102,7 +102,7 @@ $.extend(frappe.model, {
 					f.fieldtype == "Select" &&
 					f.options &&
 					typeof f.options === "string" &&
-					!in_list(["[Select]", "Loading..."], f.options)
+					!["[Select]", "Loading..."].includes(f.options)
 				) {
 					doc[f.fieldname] = f.options.split("\n")[0];
 				}
@@ -280,7 +280,7 @@ $.extend(frappe.model, {
 			if (
 				df &&
 				key.substr(0, 2) != "__" &&
-				!in_list(no_copy_list, key) &&
+				!no_copy_list.includes(key) &&
 				!(df && !from_amend && cint(df.no_copy) == 1)
 			) {
 				var value = doc[key] || [];

--- a/frappe/public/js/frappe/model/meta.js
+++ b/frappe/public/js/frappe/model/meta.js
@@ -154,7 +154,7 @@ $.extend(frappe.meta, {
 
 	get_doctype_for_field: function (doctype, key) {
 		var out = null;
-		if (in_list(frappe.model.std_fields_list, key)) {
+		if (frappe.model.std_fields_list.includes(key)) {
 			// standard
 			out = doctype;
 		} else if (frappe.meta.has_field(doctype, key)) {
@@ -164,7 +164,7 @@ $.extend(frappe.meta, {
 			frappe.meta.get_table_fields(doctype).every(function (d) {
 				if (
 					frappe.meta.has_field(d.options, key) ||
-					in_list(frappe.model.child_table_field_list, key)
+					frappe.model.child_table_field_list.includes(key)
 				) {
 					out = d.options;
 					return false;
@@ -264,7 +264,7 @@ $.extend(frappe.meta, {
 			});
 		$.each(print_formats, function (i, d) {
 			if (
-				!in_list(print_format_list, d.name) &&
+				!print_format_list.includes(d.name) &&
 				d.print_format_type !== "JS" &&
 				(cint(enable_raw_printing) || !d.raw_printing)
 			) {

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -550,7 +550,7 @@ $.extend(frappe.model, {
 				tasks.push(() => frappe.model.trigger(key, value, doc, skip_dirty_trigger));
 			} else {
 				// execute link triggers (want to reselect to execute triggers)
-				if (in_list(["Link", "Dynamic Link"], fieldtype) && doc) {
+				if (["Link", "Dynamic Link"].includes(fieldtype) && doc) {
 					tasks.push(() => frappe.model.trigger(key, value, doc, skip_dirty_trigger));
 				}
 			}

--- a/frappe/public/js/frappe/model/perm.js
+++ b/frappe/public/js/frappe/model/perm.js
@@ -240,7 +240,7 @@ $.extend(frappe.perm, {
 			// fields updated by workflow must be read-only
 			if (
 				cint(cur_frm.read_only) ||
-				in_list(cur_frm.states.update_fields, df.fieldname) ||
+				cur_frm.states.update_fields.includes(df.fieldname) ||
 				df.fieldname == cur_frm.state_fieldname
 			) {
 				status = "Read";

--- a/frappe/public/js/frappe/ui/field_group.js
+++ b/frappe/public/js/frappe/ui/field_group.js
@@ -55,7 +55,7 @@ frappe.ui.FieldGroup = class FieldGroup extends frappe.ui.form.Layout {
 	focus_on_first_input() {
 		if (this.no_focus) return;
 		$.each(this.fields_list, function (i, f) {
-			if (!in_list(["Date", "Datetime", "Time", "Check"], f.df.fieldtype) && f.set_focus) {
+			if (!["Date", "Datetime", "Time", "Check"].includes(f.df.fieldtype) && f.set_focus) {
 				f.set_focus();
 				return false;
 			}

--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -454,7 +454,7 @@ frappe.ui.filter_utils = {
 	},
 
 	get_selected_label(field) {
-		if (in_list(["Link", "Dynamic Link"], field.df.fieldtype)) {
+		if (["Link", "Dynamic Link"].includes(field.df.fieldtype)) {
 			return field.get_label_value();
 		}
 	},

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -391,7 +391,7 @@ frappe.ui.GroupBy = class {
 		this.all_fields[this.doctype] = this.report_view.meta.fields;
 
 		const standard_fields_filter = (df) =>
-			!in_list(frappe.model.no_value_type, df.fieldtype) && !df.report_hide;
+			!frappe.model.no_value_type.includes(df.fieldtype) && !df.report_hide;
 
 		const table_fields = frappe.meta.get_table_fields(this.doctype).filter((df) => !df.hidden);
 

--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -113,7 +113,7 @@ frappe.search.utils = {
 	get_search_in_list: function (keywords) {
 		var me = this;
 		var out = [];
-		if (in_list(keywords.split(" "), "in") && keywords.slice(-2) !== "in") {
+		if (keywords.split(" ").includes("in") && keywords.slice(-2) !== "in") {
 			var parts = keywords.split(" in ");
 			frappe.boot.user.can_read.forEach(function (item) {
 				if (frappe.boot.user.can_search.includes(item)) {
@@ -190,11 +190,11 @@ frappe.search.utils = {
 			({ score, marked_string } = search_result);
 			if (score) {
 				target = item;
-				if (in_list(frappe.boot.single_types, item)) {
+				if (frappe.boot.single_types.includes(item)) {
 					out.push(option("", ["Form", item, item], 0.05));
 				} else if (frappe.boot.user.can_search.includes(item)) {
 					// include 'making new' option
-					if (in_list(frappe.boot.user.can_create, item)) {
+					if (frappe.boot.user.can_create.includes(item)) {
 						var match = item;
 						out.push({
 							type: "New",

--- a/frappe/public/js/frappe/ui/toolbar/toolbar.js
+++ b/frappe/public/js/frappe/ui/toolbar/toolbar.js
@@ -247,7 +247,7 @@ frappe.ui.toolbar.setup_session_defaults = function () {
 			fields = JSON.parse(data.message);
 			let perms = frappe.perm.get_perm("Session Default Settings");
 			//add settings button only if user is a System Manager or has permission on 'Session Default Settings'
-			if (in_list(frappe.user_roles, "System Manager") || perms[0].read == 1) {
+			if (frappe.user_roles.includes("System Manager") || perms[0].read == 1) {
 				fields[fields.length] = {
 					fieldname: "settings",
 					fieldtype: "Button",

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -219,7 +219,7 @@ window.lstrip = function lstrip(s, chars) {
 	if (!chars) chars = ["\n", "\t", " "];
 	// strip left
 	let first_char = s.substr(0, 1);
-	while (in_list(chars, first_char)) {
+	while (chars.includes(first_char)) {
 		s = s.substr(1);
 		first_char = s.substr(0, 1);
 	}
@@ -229,7 +229,7 @@ window.lstrip = function lstrip(s, chars) {
 window.rstrip = function (s, chars) {
 	if (!chars) chars = ["\n", "\t", " "];
 	let last_char = s.substr(s.length - 1);
-	while (in_list(chars, last_char)) {
+	while (chars.includes(last_char)) {
 		s = s.substr(0, s.length - 1);
 		last_char = s.substr(s.length - 1);
 	}

--- a/frappe/public/js/frappe/utils/datatype.js
+++ b/frappe/public/js/frappe/utils/datatype.js
@@ -75,7 +75,7 @@ window.has_words = function (list, item) {
 window.has_common = function (list1, list2) {
 	if (!list1 || !list2) return false;
 	for (var i = 0, j = list1.length; i < j; i++) {
-		if (in_list(list2, list1[i])) return true;
+		if (list2.includes(list1[i])) return true;
 	}
 	return false;
 };

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -156,7 +156,7 @@ frappe.views.CommunicationComposer = class {
 		// add from if user has access to multiple email accounts
 		const email_accounts = frappe.boot.email_accounts.filter((account) => {
 			return (
-				!in_list(["All Accounts", "Sent", "Spam", "Trash"], account.email_account) &&
+				!["All Accounts", "Sent", "Spam", "Trash"].includes(account.email_account) &&
 				account.enable_outgoing
 			);
 		});

--- a/frappe/public/js/frappe/views/inbox/inbox_view.js
+++ b/frappe/public/js/frappe/views/inbox/inbox_view.js
@@ -141,7 +141,7 @@ frappe.views.InboxView = class InboxView extends frappe.views.ListView {
 				["Communication", "sent_or_received", "=", "Sent", true],
 				["Communication", "email_status", "not in", "Spam,Trash", true],
 			]);
-		} else if (in_list(["Spam", "Trash"], email_account)) {
+		} else if (["Spam", "Trash"].includes(email_account)) {
 			filters = default_filters.concat([
 				["Communication", "email_status", "=", email_account, true],
 				["Communication", "email_account", "in", frappe.boot.all_accounts, true],
@@ -167,7 +167,7 @@ frappe.views.InboxView = class InboxView extends frappe.views.ListView {
 	get_no_result_message() {
 		var email_account = this.email_account;
 		var args;
-		if (in_list(["Spam", "Trash"], email_account)) {
+		if (["Spam", "Trash"].includes(email_account)) {
 			return __("No {0} mail", [email_account]);
 		} else if (!email_account && !frappe.boot.email_accounts.length) {
 			// email account is not configured

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -229,7 +229,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 
 		this.meta.fields.forEach((df) => {
 			const is_valid_field =
-				in_list(["Data", "Text", "Small Text", "Text Editor"], df.fieldtype) && !df.hidden;
+				["Data", "Text", "Small Text", "Text Editor"].includes(df.fieldtype) && !df.hidden;
 
 			if (is_valid_field && !title_field) {
 				// can be mapped to textarea

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1226,7 +1226,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					if (column.colIndex === index && !value) {
 						value = "Total";
 						column = { fieldtype: "Data" }; // avoid type issues for value if Date column
-					} else if (in_list(["Currency", "Float"], column.fieldtype)) {
+					} else if (["Currency", "Float"].includes(column.fieldtype)) {
 						// proxy for currency and float
 						data = this.data[0];
 					}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -890,7 +890,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 	get_columns_for_picker() {
 		let out = {};
 
-		const standard_fields_filter = (df) => !in_list(frappe.model.no_value_type, df.fieldtype);
+		const standard_fields_filter = (df) => !frappe.model.no_value_type.includes(df.fieldtype);
 
 		let doctype_fields = frappe.meta
 			.get_docfields(this.doctype)

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -94,7 +94,7 @@ export function get_table_columns(df) {
 	let total_width = 0;
 	for (let tf of table_fields) {
 		if (
-			!in_list(["Section Break", "Column Break"], tf.fieldtype) &&
+			!["Section Break", "Column Break"].includes(tf.fieldtype) &&
 			!tf.print_hide &&
 			df.label &&
 			total_width < 100


### PR DESCRIPTION
Steps:
- Go to any doctype with child table
- create new doc in desk
- the field will be set to `undefined` instead of `[]`

Why?

Most code expects child table to be an array, `undefined` requires special handling.

Breaking Change:

This will break code like `if (!doc.table) return` because empty arrays in JavaScript are truthy :clown_face: 


Long term fix for https://github.com/frappe/frappe/pull/23976

closes https://github.com/frappe/frappe/issues/23977

port with https://github.com/frappe/frappe/pull/24000