### PR TITLE
feat: sort multicheck by label

### DIFF
--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -76,7 +76,7 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 		this.$load_state.hide();
 		this.$checkbox_area.empty();
 		this.options
-			.sort((a, b) => a.label.localeCompare(b.label))
+			.sort((a, b) => cstr(a.label).localeCompare(cstr(b.label)))
 			.forEach((option) => {
 				let checkbox = this.get_checkbox_element(option).appendTo(this.$checkbox_area);
 				if (option.danger) {

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -75,13 +75,15 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	make_checkboxes() {
 		this.$load_state.hide();
 		this.$checkbox_area.empty();
-		this.options.forEach((option) => {
-			let checkbox = this.get_checkbox_element(option).appendTo(this.$checkbox_area);
-			if (option.danger) {
-				checkbox.find(".label-area").addClass("text-danger");
-			}
-			option.$checkbox = checkbox;
-		});
+		this.options
+			.sort((a, b) => a.label.localeCompare(b.label))
+			.forEach((option) => {
+				let checkbox = this.get_checkbox_element(option).appendTo(this.$checkbox_area);
+				if (option.danger) {
+					checkbox.find(".label-area").addClass("text-danger");
+				}
+				option.$checkbox = checkbox;
+			});
 		if (this.df.select_all) {
 			this.setup_select_all();
 		}

--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -154,7 +154,7 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 			<div class="checkbox unit-checkbox">
 				<label title="${option.description || ""}">
 					<input type="checkbox" data-unit="${option.value}"></input>
-					<span class="label-area" data-unit="${option.value}">${__(option.label)}</span>
+					<span class="label-area" data-unit="${option.value}">${option.label}</span>
 				</label>
 			</div>
 		`);


### PR DESCRIPTION
### Before

![Bildschirmfoto 2023-12-27 um 18 39 52](https://github.com/frappe/frappe/assets/14891507/bb372efa-71bf-4c0e-ad72-eb7993d70745)

Module Profile, lang: de, order appears random (ordered by untranslated values)

### After

![Bildschirmfoto 2023-12-27 um 18 39 32](https://github.com/frappe/frappe/assets/14891507/016c1380-1de7-44d0-a575-bf3192c4157b)

Module Profile, lang: de, alphabetical order

Labels already get translated in the `get_data` method, we don't need to do it again (translating closer to the data source is better, IMO).

https://github.com/frappe/frappe/blob/0162d3bda03132861c8d247edc2edf5a31402163/frappe/public/js/frappe/roles_editor.js#L20

https://github.com/frappe/frappe/blob/0162d3bda03132861c8d247edc2edf5a31402163/frappe/public/js/frappe/module_editor.js#L16