### PR TITLE
fix: incorrect duplicate filter check

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -265,10 +265,7 @@ frappe.ui.FilterGroup = class {
 				let value = filter_value[3];
 				let equal = frappe.utils.arrays_equal;
 
-				if (
-					equal(f_value.slice(0, 4), filter_value.slice(0, 4)) ||
-					(Array.isArray(value) && equal(value, f_value[3]))
-				) {
+				if (equal(f_value.slice(0, 4), filter_value.slice(0, 4))) {
 					exists = true;
 				}
 			});

--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -252,24 +252,15 @@ frappe.ui.FilterGroup = class {
 
 	filter_exists(filter_value) {
 		// filter_value of form: [doctype, fieldname, condition, value]
-		let exists = false;
-		this.filters
+		return this.filters
 			.filter((f) => f.field)
-			.map((f) => {
+			.some((f) => {
 				let f_value = f.get_value();
 				if (filter_value.length === 2) {
-					exists = filter_value[0] === f_value[0] && filter_value[1] === f_value[1];
-					return;
+					return filter_value[0] === f_value[0] && filter_value[1] === f_value[1];
 				}
-
-				let value = filter_value[3];
-				let equal = frappe.utils.arrays_equal;
-
-				if (equal(f_value.slice(0, 4), filter_value.slice(0, 4))) {
-					exists = true;
-				}
+				return frappe.utils.arrays_equal(f_value.slice(0, 4), filter_value.slice(0, 4));
 			});
-		return exists;
 	}
 
 	get_filters() {
@@ -278,7 +269,6 @@ frappe.ui.FilterGroup = class {
 			.map((f) => {
 				return f.get_value();
 			});
-		// {}: this.list.update_standard_filters(values);
 	}
 
 	update_filters() {


### PR DESCRIPTION
The duplicate filter check was returing true if ANY of the field match the filters. It should be only returning true for specific filters. 

> If the page you open is:
> `/app/doctype?description=["in",["a","b"]]&name=["in",["a","b"]]`
> You will find that the name is not filtered in the filter.
> And the page path will be changed by the page to `/app/doctype?description=["in",["a","b"]]`
> 
> But if you open the page is:
> `/app/doctype?description=["in",["a","b"]]&name=["in",["a","b","c"]]`
> Contains a filter for name.
> 
> Because in the first page, the values in the filter are all `["a", "b" ]`, which is judged to be the same filtering information.
> 


- fix: Solve the problem that the filter conditions are regarded as the same when the filter values are equivalent arrays in the filter
- refactor: simplify duplicate filter checking code



alternate to https://github.com/frappe/frappe/pull/23951 