### PR TITLE
feat(minor): Hook to add custom path resolver

### DIFF
--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -38,7 +38,11 @@ class PathResolver:
 		except frappe.Redirect:
 			return frappe.flags.redirect_location, RedirectPage(self.path)
 
-		endpoint = resolve_path(self.path)
+		if frappe.get_hooks("website_path_resolver"):
+			for handler in frappe.get_hooks("website_path_resolver"):
+				endpoint = frappe.get_attr(handler)(self.path)
+		else:
+			endpoint = resolve_path(self.path)
 
 		# WARN: Hardcoded for better performance
 		if endpoint == "app":


### PR DESCRIPTION
Apps can have a requirement of resolving routes differently. "website_path_resolver" can be used do that.

Docs: https://frappeframework.com/docs/user/en/python-api/hooks#website-path-resolver

<no-docs>