### PR TITLE
fix: Do not change global search label to lower case

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search_utils.js
+++ b/frappe/public/js/frappe/ui/toolbar/search_utils.js
@@ -613,7 +613,7 @@ frappe.search.utils = {
 			const target = item.label.toLowerCase();
 			const txt = keywords.toLowerCase();
 			if (txt === target || target.indexOf(txt) === 0) {
-				const search_result = this.fuzzy_search(txt, target, true);
+				const search_result = this.fuzzy_search(txt, item.label, true);
 				results.push({
 					type: "Executable",
 					value: search_result.marked_string,


### PR DESCRIPTION
Issue: All searchable functions were converted to lowercase in the result

Issue introduced via https://github.com/frappe/frappe/commit/7c24377239455bc5b3d9a5e402529b928d9a6661
