### PR TITLE
fix(DX): filter version logs with changes to field

### DIFF
--- a/frappe/public/js/frappe/utils/diffview.js
+++ b/frappe/public/js/frappe/utils/diffview.js
@@ -16,7 +16,11 @@ frappe.ui.DiffView = class DiffView {
 	make_dialog() {
 		const get_query = () => ({
 			query: "frappe.utils.diff.version_query",
-			filters: { docname: this.docname, ref_doctype: this.doctype },
+			filters: {
+				docname: this.docname,
+				ref_doctype: this.doctype,
+				fieldname: this.fieldname,
+			},
 		});
 		const onchange = () => this.compute_diff();
 		return new frappe.ui.Dialog({

--- a/frappe/utils/diff.py
+++ b/frappe/utils/diff.py
@@ -48,10 +48,19 @@ def _get_value_from_version(version_name: int | str, fieldname: str):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def version_query(doctype, txt, searchfield, start, page_len, filters):
+	version_filters = {
+		"docname": filters["docname"],
+		"ref_doctype": filters["ref_doctype"],
+	}
+
+	if fieldname := filters.get("fieldname"):
+		# This helps filter version logs which contain changes to the field.
+		version_filters["data"] = ("LIKE", f'%"{fieldname}"%')
+
 	results = frappe.get_list(
 		"Version",
 		fields=["name", "modified"],
-		filters=filters,
+		filters=version_filters,
 		limit_start=start,
 		limit_page_length=page_len,
 		order_by="modified desc",


### PR DESCRIPTION
Diff view shows all versions. E.g. if you enable/disable a script it
shows up in possible diff targets. This PR filters versions to only show
the ones that have the field changed somehow.
