### PR TITLE
chore(sentry): use site as "user"

### DIFF
--- a/frappe/public/js/sentry.bundle.js
+++ b/frappe/public/js/sentry.bundle.js
@@ -6,8 +6,8 @@ Sentry.init({
 	autoSessionTracking: false,
 	initialScope: {
 		// don't use frappe.session.user, it's set much later and will fail because of async loading
-		user: { id: frappe.boot.user.name ?? "Unidentified" },
-		tags: { site: frappe.boot.sitename },
+		user: { id: frappe.boot.sitename },
+		tags: { frappe_user: frappe.boot.user.name ?? "Unidentified" },
 	},
 	beforeSend(event, hint) {
 		// Check if it was caused by frappe.throw()

--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -73,11 +73,9 @@ def set_scope(scope):
 			source=SOURCE_FOR_STYLE["endpoint"],
 		)
 
-	scope.set_tag("site", frappe.local.site)
+	scope.set_user({"id": frappe.local.site})
 	user = getattr(frappe.session, "user", "Unidentified")
-	if "@" not in user:
-		user = f"{user}@{frappe.local.site}"
-	scope.set_user({"id": user, "email": user})
+	scope.set_tag("frappe_user", user)
 	# Extract `X-Frappe-Request-ID` to store as a separate field if its present
 	if trace_id := frappe.monitor.get_trace_id():
 		scope.set_tag("frappe_trace_id", trace_id)


### PR DESCRIPTION
For us, a user is single site. This is because logic like "issue affects
more than 1 user" only makes sense for site. Same client/server script
can affect multiple user on same site but it's not a useful error for
us.
