### PR TITLE
fix: show right permission for user cannot create doctypes

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -251,7 +251,7 @@ frappe.PermissionEngine = class PermissionEngine {
 
 			this.rights.forEach((r) => {
 				if (!d.is_submittable && ["submit", "cancel", "amend"].includes(r)) return;
-				if (d.in_create && ["create", "write", "delete"].includes(r)) return;
+				if (d.in_create && ["create", "delete"].includes(r)) return;
 				this.add_check(perm_container, d, r);
 			});
 


### PR DESCRIPTION
## Issue
1. For DocTypes that have **User Cannot Create** checked, we don't show **Create** and **Write** rights in the Role Permission Manager.

![image](https://github.com/frappe/frappe/assets/31363128/d98c1194-746d-4726-810f-6d6fb85b2c79)

2. This restricts the users wanting to have custom roles around such doctypes.

## Fix

1. Write permission should be allowed for such doctypes.

<img width="1254" alt="Screenshot 2023-12-29 at 11 48 22 AM" src="https://github.com/frappe/frappe/assets/31363128/4e0c2713-bc4d-4015-bd71-0e0153bcd4ab">
