### PR TITLE
fix: base class replace on `has_web_view` update

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -593,7 +593,7 @@ class DocType(Document):
 		if not self.has_value_changed("has_web_view"):
 			return
 
-		despaced_name = self.name.replace(" ", "_")
+		despaced_name = self.name.replace(" ", "")
 		scrubbed_name = frappe.scrub(self.name)
 		scrubbed_module = frappe.scrub(self.module)
 		controller_path = frappe.get_module_path(


### PR DESCRIPTION
## The Problem

`Document` not getting automatically replaced with `WebsiteGenerator` class when web view is enabled, and vice-versa. This happened only for DocType's with name having more than 1 word.

## The Fix

The actual fix is just 1 line:

```diff
- despaced_name = self.name.replace(" ", "_")
+ despaced_name = self.name.replace(" ", "")
```

--- 

*[Optional Read]*

## Back Story

I have been teaching Web Views for half a dozen Frappe Framework batches now. The example doctype I use for demonstration is named **Vehicle** and I enable web view for it. I go back to VSCode and walk the student through the changes it makes to the controller file: imports the class `WebsiteGenerator` and uses this instead of `Document` as the base class of the doctype controller. Everything goes smooth, the _students go home_.

I has an assignment in place that requires the student to create a web view for a doctype named **Airplane Flight**. Every batch, a few students come to me and show me 404 errors on why the web view isn't working. At first it was not apparent, but when I inspected, I found out why it wasn't working (the error message was not that clear though): the `Document` class was not replaced with `WebsiteGenerator` class.

**I have been delaying to check it because it always worked for me, so, I assumed it might be a edge case for 2-3 students, probably because they changed the files.** Guilty.

So, today I decided (the trigger being yet another case arising yesterday) to finally look into it. I started by trying to write a unit test that will replicate this issue. Luckily, I named my test doctype with 2 words instead of 1 and the test failed in the first attempt. Ahha: "The automatic replacement only fails for doctype names with 2 words or more!". The actual debugging was easy: breakpoint.

## Epilog

* Write *more* tests (this change was made in #14564)
* Act faster on student feedback (for me)