### PR TITLE
refactor: Remove unused 'data1' parameter from 'format' function

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1259,13 +1259,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				width: parseInt(column.width) || null,
 				editable: false,
 				compareValue: compareFn,
-				format: (value, row, column, data, filter, data1) => {
+				format: (value, row, column, data, filter) => {
 					if (this.report_settings.formatter) {
 						return this.report_settings.formatter(
 							value,
 							row,
 							column,
-							data1,
+							data,
 							format_cell,
 							filter
 						);


### PR DESCRIPTION
**Version:**

Frappe Framework: v15.7.0 (version-15)
ERPNext: v15.8.3 (version-15)

**And Also faced an issue in Version-14**
___

Removed the `data1` parameter from the `format` function signature. because `data1` parameter was being passed to the `format` function, but it was not utilized within the function body. After a careful review, it was determined that `data1` is not needed for the internal logic of the `format` function.

This change only affects the `format` function and does not impact any existing functionality. The `format` function continues to receive the same set of parameters, excluding `data1`.

From report side:

**Before:**
- When you view the Stock Ledger or Stock Balance report, you might notice that the color formatting isn't displaying correctly. Additionally, if you use a Dynamic Link in the report, it doesn't function as expected. We've included a video demonstrating the issue with the Stock Ledger report, where the Voucher ID hyperlink and color formatting are not being displayed correctly.


https://github.com/frappe/frappe/assets/141945075/b9263b2e-7bea-42ff-a9ce-dc83f1b28c33

<br>

**After:**
- We've made some updates to ensure that the Stock Balance and Stock Ledger reports now display correctly with the right colors, and the hyperlinks work as intended. so please check it.


https://github.com/frappe/frappe/assets/141945075/811f8bc4-5b3c-42b9-96a6-ea6bbae54161

Thank You!