### PR TITLE
fix(email.receive): ensure is_exist_in_system checks Email Account associated with Inbound Mail

### DIFF
--- a/frappe/email/doctype/email_account/test_records.json
+++ b/frappe/email/doctype/email_account/test_records.json
@@ -22,6 +22,29 @@
 		"imap_folder": [{"folder_name": "INBOX", "append_to": "ToDo"}, {"folder_name": "Test Folder", "append_to": "Communication"}],
 		"track_email_status": 1
 	},
+    {
+		"is_default": 1,
+		"is_global": 1,
+		"doctype": "Email Account",
+		"domain":"example.com",
+		"email_account_name": "_Test Email Account 2",
+		"enable_outgoing": 1,
+		"smtp_server": "test.example.com",
+		"email_id": "test2@example.com",
+		"password": "password",
+		"add_signature": 1,
+		"signature": "\nBest Wishes\nTest Signature",
+		"enable_auto_reply": 1,
+		"auto_reply_message": "",
+		"enable_incoming": 1,
+		"notify_if_unreplied": 1,
+		"unreplied_for_mins": 20,
+		"send_notification_to": "test_unreplied@example.com",
+		"pop3_server": "pop.test.example.com",
+		"append_to": "ToDo",
+		"imap_folder": [{"folder_name": "INBOX", "append_to": "ToDo"}, {"folder_name": "Test Folder", "append_to": "Communication"}],
+		"track_email_status": 1
+	},
 	{
 		"doctype": "ToDo",
 		"description":"test doctype"

--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -687,7 +687,9 @@ class InboundMail(Email):
 		if not self.message_id:
 			return
 
-		return Communication.find_one_by_filters(message_id=self.message_id, order_by="creation DESC")
+		return Communication.find_one_by_filters(
+			message_id=self.message_id, email_account=self.email_account, order_by="creation DESC"
+		)
 
 	def is_sender_same_as_receiver(self):
 		return self.from_email == self.email_account.email_id


### PR DESCRIPTION
🐛 fix(receive.py): fix find_one_by_filters method to filter by email account as well

🐛 fix(test_email_account.py): modify test case to check if communication record is created when associated with a different email account

📝 chore(test_records.json): add test email account 2 for test_email_account.py

The test_mail_exist_validation test case was not correctly checking if a communication record is created. The fix ensures that the communication record is created only if the mail is not already downloaded into that specific Email Account.

A new test case was added to test_mail_exist_validation to check if a communication record is created when the mail is associated with a different email account.

The test_records.json file was updated to include a new test email account, "Email Account 2", for the test_email_account.py test cases.

The find_one_by_filters method in receive.py was fixed to correctly filter by both the message_id and email_account, ensuring that the correct communication record is found.

Closes #19370, #23189

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Right now if you have email forwarding enabled in your email server when the ERP syncs the forwarded email it will only sync the email to the first Email Account that the sync routine encounters the email in.

This is because some email servers instead of creating a new email when forwarding to different inboxes they just share the same email and so the `message_id` is the same in all the Email Accounts where this email exists.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This changes the behavior of checking if an email already exists by making sure it checks if it exists associated to the current Email Account thus allowing for the same email with the same `message_id` to exist associated to different Email Accounts.

This leads to identical Communication docs being created with the only difference being the associated Email Account (and uid of course). The alternative would be to modify the Communication document to allow multiple Email Accounts to be associated with instead of just one.

> Screenshots/GIFs

No visual changes.
