### PR TITLE
fix: broken `dynamic_link` to `link` formatting in query report

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1259,13 +1259,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				width: parseInt(column.width) || null,
 				editable: false,
 				compareValue: compareFn,
-				format: (value, row, column, data, filter, data1) => {
+				format: (value, row, column, data, filter) => {
 					if (this.report_settings.formatter) {
 						return this.report_settings.formatter(
 							value,
 							row,
 							column,
-							data1,
+							data,
 							format_cell,
 							filter
 						);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "fast-deep-equal": "^2.0.1",
     "fast-glob": "^3.2.5",
     "frappe-charts": "2.0.0-rc22",
-    "frappe-datatable": "^1.17.9",
+    "frappe-datatable": "1.17.10",
     "frappe-gantt": "^0.6.0",
     "highlight.js": "^10.4.1",
     "html5-qrcode": "^2.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,10 +1497,10 @@ frappe-charts@2.0.0-rc22:
   resolved "https://registry.yarnpkg.com/frappe-charts/-/frappe-charts-2.0.0-rc22.tgz#9a5a747febdc381a1d4d7af96e89cf519dfba8c0"
   integrity sha512-N7f/8979wJCKjusOinaUYfMxB80YnfuVLrSkjpj4LtyqS0BGS6SuJxUnb7Jl4RWUFEIs7zEhideIKnyLeFZF4Q==
 
-frappe-datatable@^1.17.9:
-  version "1.17.9"
-  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.9.tgz#5ef4e5d335079ab5bf2abfecc916e31ecf17a5cb"
-  integrity sha512-C1U5YKk7kP32eiHVnv1AdY5LafKKoGrcDpbErqM95PYrhanaq2Uvkvdsjo6yioLpPfnvFD8Vihm4JoGc8FjDcw==
+frappe-datatable@1.17.10:
+  version "1.17.10"
+  resolved "https://registry.yarnpkg.com/frappe-datatable/-/frappe-datatable-1.17.10.tgz#8526e0e360b493a72114afd2a4dc4c155b4a14dd"
+  integrity sha512-D537Kfs9F/P8kw7tk/yvdNc/mexRShOlCJc4dL1yPXk6wXIXthFiniq+R8P8jh61aHLqLQr0LmPahAI40+9v+w==
   dependencies:
     hyperlist "^1.0.0-beta"
     lodash "^4.17.5"


### PR DESCRIPTION
![CleanShot 2024-01-01 at 11 57 25@2x](https://github.com/frappe/frappe/assets/25369014/f2709f01-3392-4359-a220-69005c695f0e)


depends on: https://github.com/frappe/datatable/pull/187