### PR TITLE
fix: Rating control read only mode

### DIFF
--- a/frappe/public/js/frappe/form/controls/rating.js
+++ b/frappe/public/js/frappe/form/controls/rating.js
@@ -1,4 +1,4 @@
-frappe.ui.form.ControlRating = class ControlRating extends frappe.ui.form.ControlInt {
+frappe.ui.form.ControlRating = class ControlRating extends frappe.ui.form.ControlFloat {
 	make_input() {
 		super.make_input();
 		let stars = "";


### PR DESCRIPTION
- It should inherit ControlFloat as underlying value is float.

closes https://github.com/frappe/frappe/issues/24053
