### PR TITLE
refactor: remove dead handling for "fnargs"

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1694,17 +1694,14 @@ def get_newargs(fn: Callable, kwargs: dict[str, Any]) -> dict[str, Any]:
 	# Ref: https://docs.python.org/3/library/inspect.html#inspect.Parameter.kind
 	varkw_exist = False
 
-	if hasattr(fn, "fnargs"):
-		fnargs = fn.fnargs
-	else:
-		signature = inspect.signature(fn)
-		fnargs = list(signature.parameters)
+	signature = inspect.signature(fn)
+	fnargs = list(signature.parameters)
 
-		for param_name, parameter in signature.parameters.items():
-			if parameter.kind == inspect.Parameter.VAR_KEYWORD:
-				varkw_exist = True
-				fnargs.remove(param_name)
-				break
+	for param_name, parameter in signature.parameters.items():
+		if parameter.kind == inspect.Parameter.VAR_KEYWORD:
+			varkw_exist = True
+			fnargs.remove(param_name)
+			break
 
 	newargs = {}
 	for a in kwargs:


### PR DESCRIPTION
This was added for some function here: https://github.com/frappe/frappe/commit/2dd28afcb7e89cf6968886717f413d6620602d87#diff-4a7c68f7105f3a52a7504ce52ab85bd106df91e69ab07a9f12fe23dc258870a6R266

It's not used anywhere. https://sourcegraph.com/search?q=context:global+fnargs+repo:%5Egithub%5C.com/frappe/.*&patternType=standard&sm=0&groupBy=repo
