### PR TITLE
fix: remove Guest permission on Help Article

### DIFF
--- a/frappe/website/doctype/help_article/help_article.json
+++ b/frappe/website/doctype/help_article/help_article.json
@@ -113,7 +113,7 @@
  "index_web_pages_for_search": 1,
  "is_published_field": "published",
  "links": [],
- "modified": "2022-12-15 20:05:11.317400",
+ "modified": "2024-01-02 11:34:43.594309",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Help Article",
@@ -136,10 +136,6 @@
    "read": 1,
    "role": "Knowledge Base Contributor",
    "write": 1
-  },
-  {
-   "read": 1,
-   "role": "Guest"
   }
  ],
  "sort_field": "modified",

--- a/frappe/website/doctype/help_article/help_article.py
+++ b/frappe/website/doctype/help_article/help_article.py
@@ -29,6 +29,7 @@ class HelpArticle(WebsiteGenerator):
 		route: DF.Data | None
 		title: DF.Data
 	# end: auto-generated types
+
 	def validate(self):
 		self.set_route()
 


### PR DESCRIPTION
Guest permission is not needed, published Help Articles get rendered without permission checks.

Screenshot after changes from this PR:

![Bildschirmfoto 2024-01-02 um 11 39 21](https://github.com/frappe/frappe/assets/14891507/b85d305a-6363-4169-a7fc-3332f8f78946)

Before, the top left window would show an API response.