### PR TITLE
test: remove invalid assertion

### DIFF
--- a/frappe/core/doctype/page/test_page.py
+++ b/frappe/core/doctype/page/test_page.py
@@ -16,10 +16,6 @@ class TestPage(FrappeTestCase):
 			frappe.NameError,
 			frappe.get_doc(dict(doctype="Page", page_name="DocType", module="Core")).insert,
 		)
-		self.assertRaises(
-			frappe.NameError,
-			frappe.get_doc(dict(doctype="Page", page_name="Settings", module="Core")).insert,
-		)
 
 	@unittest.skipUnless(
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"


### PR DESCRIPTION
This workspace no longer exists so test fails.

https://github.com/frappe/frappe/pull/24077 