### PR TITLE
feat: support background jobs in recorder

### DIFF
--- a/frappe/core/doctype/recorder/recorder.json
+++ b/frappe/core/doctype/recorder/recorder.json
@@ -14,6 +14,7 @@
   "cmd",
   "time",
   "duration",
+  "event_type",
   "section_break_1skt",
   "request_headers",
   "section_break_sgro",
@@ -30,6 +31,7 @@
    "label": "Path"
   },
   {
+   "depends_on": "eval:doc.event_type==\"HTTP Request\"",
    "fieldname": "cmd",
    "fieldtype": "Data",
    "in_standard_filter": 1,
@@ -67,6 +69,7 @@
    "fieldtype": "Section Break"
   },
   {
+   "depends_on": "eval:doc.event_type==\"HTTP Request\"",
    "fieldname": "request_headers",
    "fieldtype": "Code",
    "label": "Request Headers"
@@ -76,11 +79,13 @@
    "fieldtype": "Section Break"
   },
   {
+   "depends_on": "eval:doc.event_type==\"HTTP Request\"",
    "fieldname": "form_dict",
    "fieldtype": "Code",
    "label": "Form Dict"
   },
   {
+   "depends_on": "eval:doc.event_type==\"HTTP Request\"",
    "fieldname": "method",
    "fieldtype": "Select",
    "in_standard_filter": 1,
@@ -96,6 +101,12 @@
   {
    "fieldname": "section_break_9jhm",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "event_type",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Event Type"
   }
  ],
  "hide_toolbar": 1,
@@ -103,7 +114,7 @@
  "index_web_pages_for_search": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2023-08-10 12:01:03.456643",
+ "modified": "2024-01-03 16:45:47.110048",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Recorder",

--- a/frappe/core/doctype/recorder/recorder.py
+++ b/frappe/core/doctype/recorder/recorder.py
@@ -19,6 +19,7 @@ class Recorder(Document):
 
 		cmd: DF.Data | None
 		duration: DF.Float
+		event_type: DF.Data | None
 		form_dict: DF.Code | None
 		method: DF.Literal["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
 		number_of_queries: DF.Int
@@ -27,7 +28,6 @@ class Recorder(Document):
 		sql_queries: DF.Table[RecorderQuery]
 		time: DF.Datetime | None
 		time_in_queries: DF.Float
-
 	# end: auto-generated types
 
 	def load_from_db(self):

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -428,6 +428,7 @@ before_request = [
 
 # Background Job Hooks
 before_job = [
+	"frappe.recorder.record",
 	"frappe.monitor.start",
 ]
 
@@ -438,6 +439,7 @@ if os.getenv("FRAPPE_SENTRY_DSN") and (
 	before_job.append("frappe.utils.sentry.set_sentry_context")
 
 after_job = [
+	"frappe.recorder.dump",
 	"frappe.monitor.stop",
 	"frappe.utils.file_lock.release_document_locks",
 	"frappe.utils.telemetry.flush",

--- a/frappe/recorder.py
+++ b/frappe/recorder.py
@@ -151,7 +151,16 @@ class Recorder:
 			self.method = frappe.request.method
 			self.headers = dict(frappe.local.request.headers)
 			self.form_dict = frappe.local.form_dict
+			self.event_type = "HTTP Request"
+		elif frappe.job:
+			self.event_type = "Background Job"
+			self.path = frappe.job.method
+			self.cmd = None
+			self.method = None
+			self.headers = None
+			self.form_dict = None
 		else:
+			self.event_type = None
 			self.path = None
 			self.cmd = None
 			self.method = None
@@ -173,6 +182,7 @@ class Recorder:
 			"time_queries": float("{:0.3f}".format(sum(call["duration"] for call in self.calls))),
 			"duration": float(f"{(datetime.datetime.now() - self.time).total_seconds() * 1000:0.3f}"),
 			"method": self.method,
+			"event_type": self.event_type,
 		}
 		frappe.cache.hset(RECORDER_REQUEST_SPARSE_HASH, self.uuid, request_data)
 		frappe.publish_realtime(

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -199,7 +199,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 		method_name = method
 		method = frappe.get_attr(method)
 	else:
-		method_name = cstr(method.__name__)
+		method_name = f"{method.__module__}.{method.__qualname__}"
 
 	actual_func_name = kwargs.get("job_type") if "run_scheduled_job" in method_name else method_name
 	setproctitle.setproctitle(f"rq: Started running {actual_func_name} at {time.time()}")


### PR DESCRIPTION
Earlier only HTTP calls were recorded. After this PR, whenever recorder is enabled, background jobs will be recorded as well.

Resolves #24071

<hr>

Example of what it looks like:

![image](https://github.com/frappe/frappe/assets/10119037/cceb249a-3043-4e29-acb3-6a0eca83c4b5)

<hr>

Docs: https://frappeframework.com/docs/user/en/profiling
