### PR TITLE
fix: don't add fallback for child table perms

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -163,9 +163,6 @@ def get_doc_permissions(doc, user=None, ptype=None):
 	if not user:
 		user = frappe.session.user
 
-	if frappe.is_table(doc.doctype):
-		return {"read": 1, "write": 1}
-
 	meta = frappe.get_meta(doc.doctype)
 
 	def is_user_owner():


### PR DESCRIPTION
This doesn't make sense anymore as we have different logic for child table <> parent permissions
