### PR TITLE
feat(upload): Add tags when uploading file

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -181,7 +181,12 @@ def upload_file():
 	docname = frappe.form_dict.docname
 	fieldname = frappe.form_dict.fieldname
 	file_url = frappe.form_dict.file_url
-	folder = frappe.form_dict.folder or "Home"
+
+	if frappe.form_dict.folder and frappe.db.get_value("File", frappe.form_dict.folder):
+		folder = frappe.form_dict.folder
+	else:
+		folder = frappe.db.get_value("File", {"is_home_folder": 1})
+
 	method = frappe.form_dict.method
 	filename = frappe.form_dict.file_name
 	optimize = frappe.form_dict.optimize

--- a/frappe/public/js/frappe/file_uploader/FilePreview.vue
+++ b/frappe/public/js/frappe/file_uploader/FilePreview.vue
@@ -34,6 +34,7 @@
 					/>{{ __("Private") }}</label
 				>
 			</div>
+			<FileTagsInput v-model="file.tags" :placeholder="__('Add Tags')" />
 			<div>
 				<span v-if="file.error_message" class="file-error text-danger">
 					{{ file.error_message }}
@@ -72,6 +73,7 @@
 <script setup>
 import { ref, onMounted, computed } from "vue";
 import ProgressRing from "./ProgressRing.vue";
+import FileTagsInput from "./FileTagsInput.vue";
 
 // emits
 let emit = defineEmits(["toggle_optimize", "toggle_private", "toggle_image_cropper", "remove"]);

--- a/frappe/public/js/frappe/file_uploader/FileTagsInput.vue
+++ b/frappe/public/js/frappe/file_uploader/FileTagsInput.vue
@@ -1,0 +1,100 @@
+<script setup>
+import { ref, onMounted } from "vue";
+
+const div = ref(null);
+
+const props = defineProps({
+	modelValue: Array,
+	placeholder: String,
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+onMounted(() => {
+	if (!frappe?.ui?.Tags || !window.Awesomplete || !frappe?.app) {
+		return; // Not in desk
+	}
+
+	const editor = new frappe.ui.Tags({
+		parent: $(div.value),
+		placeholder: props.placeholder,
+		onTagAdd() {
+			emit("update:modelValue", editor.tagsList);
+			refresh("");
+		},
+		onTagRemove() {
+			emit("update:modelValue", editor.tagsList);
+			refresh("");
+		},
+	});
+
+	/** @type {HTMLInputElement} */
+	const input = editor.$input.get(0);
+
+	const awesomplete = new Awesomplete(input, {
+		minChars: 0,
+		maxItems: 99,
+		list: [],
+		item(item) {
+			const el = $("<li></li>").data("item.autocomplete", item).get(0);
+			el.append(item.label);
+			if (editor.tagsList.includes(item.value)) {
+				el.innerHTML += " " + frappe.utils.icon("tick");
+			}
+			return el;
+		},
+	});
+	const refresh = (txt) => {
+		frappe.call({
+			method: "frappe.desk.doctype.tag.tag.get_tags",
+			args: {
+				doctype: "File",
+				txt: txt.toLowerCase(),
+			},
+			callback(r) {
+				awesomplete.list = r.message;
+			},
+		});
+	};
+	input.addEventListener("awesomplete-selectcomplete", (e) => {
+		console.log([...editor.tagsList], editor.tagsList.includes(e.text.value));
+		if (editor.tagsList.includes(e.text.value)) {
+			editor.removeTag(e.text.value);
+			const formTagRows = editor.$ul[0].querySelectorAll(".form-tag-row");
+			console.log(formTagRows);
+			formTagRows.forEach((el) => {
+				if (el.textContent.trim() === e.text.label.trim()) {
+					el.remove();
+				}
+			});
+		} else {
+			editor.addTag(e.text.value);
+		}
+		input.value = "";
+		awesomplete.evaluate();
+	});
+	input.addEventListener("input", (e) => {
+		refresh(e.target.value);
+	});
+	input.addEventListener("focus", () => {
+		refresh(input.value);
+	});
+
+	const btn = editor.$placeholder.get(0);
+	btn.id = "";
+	btn.classList.remove("btn-reset");
+	btn.classList.add("btn", "btn-default", "btn-xs");
+});
+</script>
+
+<template>
+	<ul ref="div" class="list-unstyled">
+		<div class="form-sidebar-items"></div>
+	</ul>
+</template>
+
+<style scoped>
+.form-sidebar-items {
+	margin-bottom: 4px;
+}
+</style>

--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -644,6 +644,10 @@ function upload_file(file, i) {
 			form_data.append("optimize", true);
 		}
 
+		if (Array.isArray(file.tags)) {
+			form_data.append("tags", JSON.stringify(file.tags));
+		}
+
 		if (props.attach_doc_image) {
 			form_data.append("max_width", 200);
 			form_data.append("max_height", 200);


### PR DESCRIPTION
Show a <kbd>Add tags</kbd> button in the upload dialog on desk. On website, it is not shown. Checks are done in back-end to ensure that User is a Desk User before adding tags to uploaded File document.

![image](https://github.com/frappe/frappe/assets/10946971/30c0e8f4-1e53-4f8b-8cff-5fecf935906d)

> no-docs