### PR TITLE
fix: use correct parent field in rebuild_tree()

### DIFF
--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -235,7 +235,9 @@ frappe.views.TreeView = class TreeView {
 			method: "frappe.utils.nestedset.rebuild_tree",
 			args: {
 				doctype: me.doctype,
-				parent_field: "parent_" + me.doctype.toLowerCase().replace(/ /g, "_"),
+				parent_field:
+					frappe.get_meta(me.doctype)?.nsm_parent_field ||
+					"parent_" + me.doctype.toLowerCase().replace(/ /g, "_"),
 			},
 			callback: function (r) {
 				if (!r.exc) {

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -235,9 +235,6 @@ frappe.views.TreeView = class TreeView {
 			method: "frappe.utils.nestedset.rebuild_tree",
 			args: {
 				doctype: me.doctype,
-				parent_field:
-					frappe.get_meta(me.doctype)?.nsm_parent_field ||
-					"parent_" + me.doctype.toLowerCase().replace(/ /g, "_"),
 			},
 			callback: function (r) {
 				if (!r.exc) {

--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -168,9 +168,10 @@ def update_move_node(doc: Document, parent_field: str):
 
 
 @frappe.whitelist()
-def rebuild_tree(doctype, parent_field):
-	"""
-	call rebuild_node for all root nodes
+def rebuild_tree(doctype, parent_field=None):
+	"""Call rebuild_node for all root nodes.
+
+	The `parent_field` parameter is ignored and will be removed in v16+ (kept for backward compatibility).
 	"""
 
 	# Check for perm if called from client-side
@@ -183,6 +184,8 @@ def rebuild_tree(doctype, parent_field):
 			_("Rebuilding of tree is not supported for {}").format(frappe.bold(doctype)),
 			title=_("Invalid Action"),
 		)
+
+	parent_field = meta.nsm_parent_field or f"parent_{frappe.scrub(doctype)}"
 
 	# get all roots
 	right = 1


### PR DESCRIPTION
The `parent_field` parameter to `rebuild_tree()` was hardcoded to `"parent_{doctype}"`. This is only correct accidentally, for some doctypes. For example, in ERPNext's Employee DocType, the correct parent field would be `"reports_to"`.

With this PR, we use the `nsm_parent_field` from the DocType's meta data and keep `"parent_{doctype}"` as a fallback.