### PR TITLE
fix(UX)!: permission error messages

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1002,19 +1002,11 @@ def has_permission(
 	)
 
 	if throw and not out:
-		# mimics frappe.throw
 		document_label = (
 			f"{_(doctype)} {doc if isinstance(doc, str) else doc.name}" if doc else _(doctype)
 		)
-		msgprint(
-			_("No permission for {0}").format(document_label),
-			raise_exception=ValidationError,
-			title=None,
-			indicator="red",
-			is_minimizable=None,
-			wide=None,
-			as_list=False,
-		)
+		frappe.flags.error_message = _("No permission for {0}").format(document_label)
+		raise frappe.PermissionError
 
 	return out
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 import copy
+import functools
 
 import frappe
 import frappe.share
@@ -37,17 +38,23 @@ AUTOMATIC_ROLES = (GUEST_ROLE, ALL_USER_ROLE, SYSTEM_USER_ROLE, ADMIN_ROLE)
 
 
 def print_has_permission_check_logs(func):
+	@functools.wraps(func)
 	def inner(*args, **kwargs):
-		frappe.flags["has_permission_check_logs"] = []
-		result = func(*args, **kwargs)
-		self_perm_check = True if not kwargs.get("user") else kwargs.get("user") == frappe.session.user
 		raise_exception = kwargs.get("raise_exception", True)
+		self_perm_check = True if not kwargs.get("user") else kwargs.get("user") == frappe.session.user
+
+		if raise_exception:
+			frappe.flags["has_permission_check_logs"] = []
+
+		result = func(*args, **kwargs)
 
 		# print only if access denied
 		# and if user is checking his own permission
 		if not result and self_perm_check and raise_exception:
 			msgprint(("<br>").join(frappe.flags.get("has_permission_check_logs", [])))
-		frappe.flags.pop("has_permission_check_logs", None)
+
+		if raise_exception:
+			frappe.flags.pop("has_permission_check_logs", None)
 		return result
 
 	return inner


### PR DESCRIPTION
1. If frappe.has_permission check results in another call to frappe.has_permission, it ends up erasing all permission check messages and only shows last one.
2. `frappe.has_permission(throw=True)` returns validation error instead of permission error and also erases all perm check logs. 


BREAKING CHANGE: `frappe.has_permission(throw=True)` will now throw `PermissionError` instead of generic `ValidationError`