### PR TITLE
feat: add frappe push notification client

### DIFF
--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.js
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2024, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Push Notification Settings", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
@@ -5,18 +5,12 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "metadata_section",
-  "enable_push_notification_relay",
   "authentication_credential_section",
+  "enable_push_notification_relay",
   "api_key",
   "api_secret"
  ],
  "fields": [
-  {
-   "fieldname": "metadata_section",
-   "fieldtype": "Section Break",
-   "label": "Metadata"
-  },
   {
    "default": "0",
    "fieldname": "enable_push_notification_relay",
@@ -26,7 +20,7 @@
   {
    "fieldname": "authentication_credential_section",
    "fieldtype": "Section Break",
-   "label": "Authentication Credential"
+   "label": "Authentication"
   },
   {
    "fieldname": "api_key",
@@ -35,14 +29,14 @@
   },
   {
    "fieldname": "api_secret",
-   "fieldtype": "Data",
+   "fieldtype": "Password",
    "label": "API Secret"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-01-04 11:56:25.953147",
+ "modified": "2024-01-04 17:52:41.383109",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Push Notification Settings",

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
@@ -18,7 +18,7 @@
    "label": "Metadata"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "enable_push_notification_relay",
    "fieldtype": "Check",
    "label": "Enable Push Notification Relay"
@@ -42,7 +42,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-01-04 11:37:29.956799",
+ "modified": "2024-01-04 11:56:25.953147",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Push Notification Settings",

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
@@ -1,12 +1,14 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "beta": 1,
  "creation": "2024-01-04 11:36:08.013039",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "authentication_credential_section",
+  "section_break_qgjr",
   "enable_push_notification_relay",
+  "authentication_credential_section",
   "api_key",
   "api_secret"
  ],
@@ -18,6 +20,7 @@
    "label": "Enable Push Notification Relay"
   },
   {
+   "description": "API Key and Secret to interact with the relay server. These will be auto-generated when the first push notification is sent from any of the apps installed on this site.",
    "fieldname": "authentication_credential_section",
    "fieldtype": "Section Break",
    "label": "Authentication"
@@ -25,18 +28,26 @@
   {
    "fieldname": "api_key",
    "fieldtype": "Data",
-   "label": "API Key"
+   "label": "API Key",
+   "read_only": 1
   },
   {
    "fieldname": "api_secret",
    "fieldtype": "Password",
-   "label": "API Secret"
+   "label": "API Secret",
+   "read_only": 1
+  },
+  {
+   "description": "Enabling this will register your site on a central relay server to send push notifications for all installed apps through Firebase Cloud Messaging. This server only stores user tokens and error logs, and no messages are saved. ",
+   "fieldname": "section_break_qgjr",
+   "fieldtype": "Section Break",
+   "label": "Relay Settings"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-01-04 17:52:41.383109",
+ "modified": "2024-02-28 00:37:18.398000",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Push Notification Settings",

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
@@ -1,0 +1,65 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-01-04 11:36:08.013039",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "metadata_section",
+  "enable_push_notification_relay",
+  "authentication_credential_section",
+  "api_key",
+  "api_secret"
+ ],
+ "fields": [
+  {
+   "fieldname": "metadata_section",
+   "fieldtype": "Section Break",
+   "label": "Metadata"
+  },
+  {
+   "default": "1",
+   "fieldname": "enable_push_notification_relay",
+   "fieldtype": "Check",
+   "label": "Enable Push Notification Relay"
+  },
+  {
+   "fieldname": "authentication_credential_section",
+   "fieldtype": "Section Break",
+   "label": "Authentication Credential"
+  },
+  {
+   "fieldname": "api_key",
+   "fieldtype": "Data",
+   "label": "API Key"
+  },
+  {
+   "fieldname": "api_secret",
+   "fieldtype": "Data",
+   "label": "API Secret"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-01-04 11:37:29.956799",
+ "modified_by": "Administrator",
+ "module": "Integrations",
+ "name": "Push Notification Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.json
@@ -3,6 +3,7 @@
  "allow_rename": 1,
  "beta": 1,
  "creation": "2024-01-04 11:36:08.013039",
+ "description": "Enabling this will register your site on a central relay server to send push notifications for all installed apps through Firebase Cloud Messaging. This server only stores user tokens and error logs, and no messages are saved.",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -28,14 +29,12 @@
   {
    "fieldname": "api_key",
    "fieldtype": "Data",
-   "label": "API Key",
-   "read_only": 1
+   "label": "API Key"
   },
   {
    "fieldname": "api_secret",
    "fieldtype": "Password",
-   "label": "API Secret",
-   "read_only": 1
+   "label": "API Secret"
   },
   {
    "description": "Enabling this will register your site on a central relay server to send push notifications for all installed apps through Firebase Cloud Messaging. This server only stores user tokens and error logs, and no messages are saved. ",
@@ -47,7 +46,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-02-28 00:37:18.398000",
+ "modified": "2024-02-28 11:03:30.518196",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Push Notification Settings",

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2024, Frappe Technologies and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -19,4 +20,12 @@ class PushNotificationSettings(Document):
 		enable_push_notification_relay: DF.Check
 	# end: auto-generated types
 
-	pass
+	def validate(self):
+		self.validate_relay_server_setup()
+
+	def validate_relay_server_setup(self):
+		if self.enable_push_notification_relay and not frappe.conf.get("push_relay_server_url"):
+			frappe.throw(
+				_("The Push Relay Server URL key (`push_relay_server_url`) is missing in your site config"),
+				title=_("Relay Server URL missing"),
+			)

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
@@ -15,7 +15,7 @@ class PushNotificationSettings(Document):
 		from frappe.types import DF
 
 		api_key: DF.Data | None
-		api_secret: DF.Data | None
+		api_secret: DF.Password | None
 		enable_push_notification_relay: DF.Check
 	# end: auto-generated types
 

--- a/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
+++ b/frappe/integrations/doctype/push_notification_settings/push_notification_settings.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PushNotificationSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		api_key: DF.Data | None
+		api_secret: DF.Data | None
+		enable_push_notification_relay: DF.Check
+	# end: auto-generated types
+
+	pass

--- a/frappe/integrations/doctype/push_notification_settings/test_push_notification_settings.py
+++ b/frappe/integrations/doctype/push_notification_settings/test_push_notification_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestPushNotificationSettings(FrappeTestCase):
+	pass

--- a/frappe/integrations/workspace/integrations/integrations.json
+++ b/frappe/integrations/workspace/integrations/integrations.json
@@ -1,6 +1,6 @@
 {
  "charts": [],
- "content": "[{\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Reports &amp; Masters</b></span>\",\"col\":12}},{\"type\":\"card\",\"data\":{\"card_name\":\"Backup\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Google Services\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Authentication\",\"col\":4}},{\"type\":\"card\",\"data\":{\"card_name\":\"Settings\",\"col\":4}}]",
+ "content": "[{\"id\":\"NPK_AfSLQ2\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\"><b>Reports &amp; Masters</b></span>\",\"col\":12}},{\"id\":\"lDOo58F7ZI\",\"type\":\"card\",\"data\":{\"card_name\":\"Backup\",\"col\":4}},{\"id\":\"ij1pcK8jst\",\"type\":\"card\",\"data\":{\"card_name\":\"Google Services\",\"col\":4}},{\"id\":\"aTlMujEHpN\",\"type\":\"card\",\"data\":{\"card_name\":\"Authentication\",\"col\":4}},{\"id\":\"gY5NXKtXss\",\"type\":\"card\",\"data\":{\"card_name\":\"Settings\",\"col\":4}},{\"id\":\"n_CI3GGqW-\",\"type\":\"card\",\"data\":{\"card_name\":\"Push Notifications\",\"col\":4}}]",
  "creation": "2020-03-02 15:16:18.714190",
  "custom_blocks": [],
  "docstatus": 0,
@@ -197,9 +197,28 @@
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Push Notifications",
+   "link_count": 1,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Push Notification Settings",
+   "link_count": 0,
+   "link_to": "Push Notification Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
   }
  ],
- "modified": "2023-05-24 14:58:55.910408",
+ "modified": "2024-02-28 10:47:38.188832",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Integrations",

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -184,12 +184,14 @@ class PushNotification:
 		"""
 		notification_settings = frappe.get_doc("Push Notification Settings")
 		if notification_settings.api_key and notification_settings.api_secret:
-			return notification_settings.api_key, notification_settings.get_password('api_secret')
+			return notification_settings.api_key, notification_settings.get_password("api_secret")
 		else:
 			# Generate new credentials
 			token = frappe.generate_hash(length=48)
 			# store the token in the redis cache
-			frappe.cache().set_value(f"{self._site_name}:push_relay_registration_token", token, expires_in_sec=600)
+			frappe.cache().set_value(
+				f"{self._site_name}:push_relay_registration_token", token, expires_in_sec=600
+			)
 			body = {
 				"endpoint": self._site_name,
 				"protocol": self._site_protocol,

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 import frappe
 from frappe.utils.response import Response
+from frappe import sbool
 
 from .frappeclient import FrappeClient
 
@@ -98,34 +99,34 @@ class PushNotification:
 		self,
 		user_id: str,
 		title: str,
-		content: str,
+		body: str,
 		link: str = None,
 		data=None,
-		truncate_content: bool = False,
+		truncate_body: bool = False,
 	) -> bool:
 		"""
 		Send notification to a user.
 
 		:param user_id: (str) The ID of the user. This should be user's unique identifier.
 		:param title: (str) The title of the notification.
-		:param content: (str) The body of the notification. At max 1000 characters.
+		:param body: (str) The body of the notification. At max 1000 characters.
 		:param link: (str) The link to be opened when the notification is clicked.
 		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
-		:param truncate_content: (bool) Whether to truncate the content or not. If True, the content will be truncated to 1000 characters.
+		:param truncate_body: (bool) Whether to truncate the body or not. If True, the body will be truncated to 1000 characters.
 		:return: bool True if the request queued successfully, False otherwise.
 		"""
 		if data is None:
 			data = {}
 		if link is not None and link != "":
 			data["click_action"] = link
-		if len(content) > 1000:
-			if truncate_content:
-				content = content[:1000]
+		if len(body) > 1000:
+			if truncate_body:
+				body = body[:1000]
 			else:
-				raise Exception("Content should be at max 1000 characters")
+				raise Exception("Body should be at max 1000 characters")
 		response_data = self._send_post_request(
 			"notification_relay.api.send_notification.user",
-			{"user_id": user_id, "title": title, "content": content, "data": json.dumps(data)},
+			{"user_id": user_id, "title": title, "body": body, "data": json.dumps(data)},
 		)
 		return response_data["success"]
 
@@ -133,34 +134,34 @@ class PushNotification:
 		self,
 		topic_name: str,
 		title: str,
-		content: str,
+		body: str,
 		link: str = None,
 		data=None,
-		truncate_content: bool = False,
+		truncate_body: bool = False,
 	) -> bool:
 		"""
 		Send notification to a notification topic.
 
 		:param topic_name: (str) The name of the topic. This topic should be already created.
 		:param title: (str) The title of the notification.
-		:param content: (str) The body of the notification. At max 1000 characters.
+		:param body: (str) The body of the notification. At max 1000 characters.
 		:param link: (str) The link to be opened when the notification is clicked.
 		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
-		:param truncate_content: (bool) Whether to truncate the content or not. If True, the content will be truncated to 1000 characters.
+		:param truncate_body: (bool) Whether to truncate the body or not. If True, the body will be truncated to 1000 characters.
 		:return:  bool True if the request queued successfully, False otherwise.
 		"""
 		if data is None:
 			data = {}
 		if link is not None and link != "":
 			data["click_action"] = link
-		if len(content) > 1000:
-			if truncate_content:
-				content = content[:1000]
+		if len(body) > 1000:
+			if truncate_body:
+				body = body[:1000]
 			else:
-				raise Exception("Content should be at max 1000 characters")
+				raise Exception("Body should be at max 1000 characters")
 		response_data = self._send_post_request(
 			"notification_relay.api.send_notification.topic",
-			{"topic_name": topic_name, "title": title, "content": content, "data": json.dumps(data)},
+			{"topic_name": topic_name, "title": title, "body": body, "data": json.dumps(data)},
 		)
 		return response_data["success"]
 
@@ -170,8 +171,7 @@ class PushNotification:
 
 		:return: bool True if enabled, False otherwise.
 		"""
-		notification_settings = frappe.get_doc("Push Notification Settings")
-		return notification_settings.enable_push_notification_relay
+		return sbool(frappe.db.get_single_value("Push Notification Settings", "enable_push_notification_relay"))
 
 	def _get_credential(self) -> tuple[str, str]:
 		"""
@@ -251,8 +251,7 @@ class PushNotification:
 		site_uri = urlparse(frappe.utils.get_url())
 		if site_uri.port is not None:
 			return str(site_uri.port)
-		else:
-			return ""
+		return ""
 
 
 # Webhook which will be called by the central relay server for authentication

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -92,9 +92,9 @@ class PushNotification:
 		user_id: str,
 		title: str,
 		body: str,
-		link: str = None,
-		icon: str = None,
-		data=None,
+		link: str | None = None,
+		icon: str | None = None,
+		data: dict | None = None,
 		truncate_body: bool = True,
 		strip_html: bool = True,
 	) -> bool:
@@ -124,6 +124,7 @@ class PushNotification:
 				raise Exception("Body should be at max 1000 characters")
 		if strip_html:
 			body = frappe.utils.strip_html(body)
+
 		response_data = self._send_post_request(
 			"notification_relay.api.send_notification.user",
 			{"user_id": user_id, "title": title, "body": body, "data": json.dumps(data)},
@@ -135,9 +136,9 @@ class PushNotification:
 		topic_name: str,
 		title: str,
 		body: str,
-		link: str = None,
-		icon: str = None,
-		data=None,
+		link: str | None = None,
+		icon: str | None = None,
+		data: dict | None = None,
 		truncate_body: bool = True,
 		strip_html: bool = True,
 	) -> bool:

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -94,7 +94,8 @@ class PushNotification:
 		body: str,
 		link: str = None,
 		data=None,
-		truncate_body: bool = False,
+		truncate_body: bool = True,
+		strip_html: bool = True
 	) -> bool:
 		"""
 		Send notification to a user.
@@ -105,6 +106,7 @@ class PushNotification:
 		:param link: (str) The link to be opened when the notification is clicked.
 		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
 		:param truncate_body: (bool) Whether to truncate the body or not. If True, the body will be truncated to 1000 characters.
+		:param strip_html: (bool) Whether to strip HTML tags from the body or not.
 		:return: bool True if the request queued successfully, False otherwise.
 		"""
 		if data is None:
@@ -116,6 +118,8 @@ class PushNotification:
 				body = body[:1000]
 			else:
 				raise Exception("Body should be at max 1000 characters")
+		if strip_html:
+			body = frappe.utils.strip_html(body)
 		response_data = self._send_post_request(
 			"notification_relay.api.send_notification.user",
 			{"user_id": user_id, "title": title, "body": body, "data": json.dumps(data)},

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -1,9 +1,11 @@
 import json
+from urllib.parse import urlparse
 
 import frappe
 from frappe.utils.response import Response
-from urllib.parse import urlparse
+
 from .frappeclient import FrappeClient
+
 
 class PushNotification:
 	project_name = ""
@@ -26,10 +28,9 @@ class PushNotification:
 		:param token: (str) The token to be added.
 		:return: tuple[bool, str] First element is the success status, second element is the message.
 		"""
-		data = self._send_post_request("notification_relay.api.token.add", {
-			"user_id": user_id,
-			"fcm_token": token
-		})
+		data = self._send_post_request(
+			"notification_relay.api.token.add", {"user_id": user_id, "fcm_token": token}
+		)
 		return data["success"], data["message"]
 
 	def remove_token(self, user_id: str, token: str) -> tuple[bool, str]:
@@ -40,10 +41,9 @@ class PushNotification:
 		:param token: (str) The token to be removed.
 		:return: tuple[bool, str] First element is the success status, second element is the message.
 		"""
-		data =  self._send_post_request("notification_relay.api.token.remove", {
-			"user_id": user_id,
-			"fcm_token": token
-		})
+		data = self._send_post_request(
+			"notification_relay.api.token.remove", {"user_id": user_id, "fcm_token": token}
+		)
 		return data["success"], data["message"]
 
 	def add_topic(self, topic_name: str) -> bool:
@@ -53,9 +53,7 @@ class PushNotification:
 		:param topic_name: (str) The name of the topic.
 		:return: bool True if successful, False otherwise.
 		"""
-		data =  self._send_post_request("notification_relay.api.topic.add", {
-			"topic_name": topic_name
-		})
+		data = self._send_post_request("notification_relay.api.topic.add", {"topic_name": topic_name})
 		return data["success"]
 
 	# Remove Topic
@@ -66,9 +64,7 @@ class PushNotification:
 		:param topic_name: (str) The name of the topic.
 		:return: bool True if successful, False otherwise.
 		"""
-		data =  self._send_post_request("notification_relay.api.topic.remove", {
-			"topic_name": topic_name
-		})
+		data = self._send_post_request("notification_relay.api.topic.remove", {"topic_name": topic_name})
 		return data["success"]
 
 	def subscribe_topic(self, user_id: str, topic_name: str) -> bool:
@@ -79,10 +75,9 @@ class PushNotification:
 		:param topic_name: (str) The name of the topic. This topic should be already created.
 		:return:
 		"""
-		data =  self._send_post_request("notification_relay.api.topic.subscribe", {
-			"user_id": user_id,
-			"topic_name": topic_name
-		})
+		data = self._send_post_request(
+			"notification_relay.api.topic.subscribe", {"user_id": user_id, "topic_name": topic_name}
+		)
 		return data["success"]
 
 	# Unsubscribe Topic (User)
@@ -94,13 +89,20 @@ class PushNotification:
 		:param topic_name: (str) The name of the topic. This topic should be already created.
 		:return: bool True if successful, False otherwise.
 		"""
-		data =  self._send_post_request("notification_relay.api.topic.unsubscribe", {
-			"user_id": user_id,
-			"topic_name": topic_name
-		})
+		data = self._send_post_request(
+			"notification_relay.api.topic.unsubscribe", {"user_id": user_id, "topic_name": topic_name}
+		)
 		return data["success"]
 
-	def send_notification_to_user(self, user_id: str, title: str, content: str, link:str=None, data=None, truncate_content:bool=False) -> bool:
+	def send_notification_to_user(
+		self,
+		user_id: str,
+		title: str,
+		content: str,
+		link: str = None,
+		data=None,
+		truncate_content: bool = False,
+	) -> bool:
 		"""
 		Send notification to a user.
 
@@ -121,15 +123,21 @@ class PushNotification:
 				content = content[:1000]
 			else:
 				raise Exception("Content should be at max 1000 characters")
-		response_data = self._send_post_request("notification_relay.api.send_notification.user", {
-			"user_id": user_id,
-			"title": title,
-			"content": content,
-			"data": json.dumps(data)
-		})
+		response_data = self._send_post_request(
+			"notification_relay.api.send_notification.user",
+			{"user_id": user_id, "title": title, "content": content, "data": json.dumps(data)},
+		)
 		return response_data["success"]
 
-	def send_notification_to_topic(self, topic_name: str, title: str, content: str, link:str=None, data=None, truncate_content:bool=False) -> bool:
+	def send_notification_to_topic(
+		self,
+		topic_name: str,
+		title: str,
+		content: str,
+		link: str = None,
+		data=None,
+		truncate_content: bool = False,
+	) -> bool:
 		"""
 		Send notification to a notification topic.
 
@@ -150,12 +158,10 @@ class PushNotification:
 				content = content[:1000]
 			else:
 				raise Exception("Content should be at max 1000 characters")
-		response_data = self._send_post_request("notification_relay.api.send_notification.topic", {
-			"topic_name": topic_name,
-			"title": title,
-			"content": content,
-			"data": json.dumps(data)
-		})
+		response_data = self._send_post_request(
+			"notification_relay.api.send_notification.topic",
+			{"topic_name": topic_name, "title": title, "content": content, "data": json.dumps(data)},
+		)
 		return response_data["success"]
 
 	def is_enabled(self) -> bool:
@@ -177,8 +183,12 @@ class PushNotification:
 		:return: tuple[str, str] The API key and secret.
 		"""
 		notification_settings = frappe.get_doc("Push Notification Settings")
-		if notification_settings.api_key != "" and notification_settings.api_secret != ""\
-				and notification_settings.api_key is not None and notification_settings.api_secret is not None:
+		if (
+			notification_settings.api_key != ""
+			and notification_settings.api_secret != ""
+			and notification_settings.api_key is not None
+			and notification_settings.api_secret is not None
+		):
 			return notification_settings.api_key, notification_settings.api_secret
 		else:
 			# Generate new credentials
@@ -190,7 +200,7 @@ class PushNotification:
 				"protocol": self._get_site_protocol,
 				"port": self._get_site_port,
 				"token": token,
-				"webhook_route": "/api/method/frappe.push_notification.auth_webhook"
+				"webhook_route": "/api/method/frappe.push_notification.auth_webhook",
 			}
 			response = self._send_post_request("notification_relay.api.auth.get_credential", body, False)
 			success = response["success"]
@@ -202,7 +212,7 @@ class PushNotification:
 			frappe.db.commit()
 			return notification_settings.api_key, notification_settings.api_secret
 
-	def _send_post_request(self, method: str, params: dict, use_authentication: bool=True):
+	def _send_post_request(self, method: str, params: dict, use_authentication: bool = True):
 		"""
 		Send a POST request to the central relay server.
 
@@ -244,8 +254,9 @@ class PushNotification:
 		else:
 			return ""
 
+
 # Webhook which will be called by the central relay server for authentication
-@frappe.whitelist(allow_guest=True, methods=['GET'])
+@frappe.whitelist(allow_guest=True, methods=["GET"])
 def auth_webhook():
 	token = frappe.cache().get(f"{frappe.local.site}:push_relay_registration_token")
 	response = Response()
@@ -260,19 +271,15 @@ def auth_webhook():
 	response.status_code = 200
 	return response
 
+
 # Subscribe and Unsubscribe API
 @frappe.whitelist(methods=["GET"])
 def subscribe(fcm_token: str):
 	success, message = PushNotification().add_token(frappe.session.user, fcm_token)
-	return {
-		"success": success,
-		"message": message
-	}
+	return {"success": success, "message": message}
+
 
 @frappe.whitelist(methods=["GET"])
 def unsubscribe(fcm_token: str):
 	success, message = PushNotification().remove_token(frappe.session.user, fcm_token)
-	return {
-		"success": success,
-		"message": message
-	}
+	return {"success": success, "message": message}

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -252,7 +252,8 @@ class PushNotification:
 # Webhook which will be called by the central relay server for authentication
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def auth_webhook():
-	token = frappe.cache().get_value(f"{frappe.local.site}:push_relay_registration_token")
+	url = urlparse(frappe.utils.get_url()).hostname
+	token = frappe.cache().get_value(f"{url}:push_relay_registration_token")
 	response = Response()
 	response.mimetype = "text/plain; charset=UTF-8"
 

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -1,0 +1,278 @@
+import json
+
+import frappe
+from frappe.utils.response import Response
+from urllib.parse import urlparse
+from .frappeclient import FrappeClient
+
+class PushNotification:
+	project_name = ""
+
+	@staticmethod
+	def set_project(project_name: str) -> None:
+		"""
+		Set the project name.
+
+		:param project_name:  (str) The name of the project.
+		:return:
+		"""
+		PushNotification.project_name = project_name
+
+	def add_token(self, user_id: str, token: str) -> tuple[bool, str]:
+		"""
+		Add a token for a user.
+
+		:param user_id: (str) The ID of the user. This should be user's unique identifier.
+		:param token: (str) The token to be added.
+		:return: tuple[bool, str] First element is the success status, second element is the message.
+		"""
+		data = self._send_post_request("notification_relay.api.token.add", {
+			"user_id": user_id,
+			"fcm_token": token
+		})
+		return data["success"], data["message"]
+
+	def remove_token(self, user_id: str, token: str) -> tuple[bool, str]:
+		"""
+		Remove a token for a user.
+
+		:param user_id: (str) The ID of the user. This should be user's unique identifier.
+		:param token: (str) The token to be removed.
+		:return: tuple[bool, str] First element is the success status, second element is the message.
+		"""
+		data =  self._send_post_request("notification_relay.api.token.remove", {
+			"user_id": user_id,
+			"fcm_token": token
+		})
+		return data["success"], data["message"]
+
+	def add_topic(self, topic_name: str) -> bool:
+		"""
+		Add a notification topic.
+
+		:param topic_name: (str) The name of the topic.
+		:return: bool True if successful, False otherwise.
+		"""
+		data =  self._send_post_request("notification_relay.api.topic.add", {
+			"topic_name": topic_name
+		})
+		return data["success"]
+
+	# Remove Topic
+	def remove_topic(self, topic_name: str) -> bool:
+		"""
+		Remove a notification topic.
+
+		:param topic_name: (str) The name of the topic.
+		:return: bool True if successful, False otherwise.
+		"""
+		data =  self._send_post_request("notification_relay.api.topic.remove", {
+			"topic_name": topic_name
+		})
+		return data["success"]
+
+	def subscribe_topic(self, user_id: str, topic_name: str) -> bool:
+		"""
+		Subscribe a user to a topic.
+
+		:param user_id: (str) The ID of the user. This should be user's unique identifier.
+		:param topic_name: (str) The name of the topic. This topic should be already created.
+		:return:
+		"""
+		data =  self._send_post_request("notification_relay.api.topic.subscribe", {
+			"user_id": user_id,
+			"topic_name": topic_name
+		})
+		return data["success"]
+
+	# Unsubscribe Topic (User)
+	def unsubscribe_topic(self, user_id: str, topic_name: str) -> bool:
+		"""
+		Unsubscribe a user from a topic.
+
+		:param user_id: (str) The ID of the user. This should be user's unique identifier.
+		:param topic_name: (str) The name of the topic. This topic should be already created.
+		:return: bool True if successful, False otherwise.
+		"""
+		data =  self._send_post_request("notification_relay.api.topic.unsubscribe", {
+			"user_id": user_id,
+			"topic_name": topic_name
+		})
+		return data["success"]
+
+	def send_notification_to_user(self, user_id: str, title: str, content: str, link:str=None, data=None, truncate_content:bool=False) -> bool:
+		"""
+		Send notification to a user.
+
+		:param user_id: (str) The ID of the user. This should be user's unique identifier.
+		:param title: (str) The title of the notification.
+		:param content: (str) The body of the notification. At max 1000 characters.
+		:param link: (str) The link to be opened when the notification is clicked.
+		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
+		:param truncate_content: (bool) Whether to truncate the content or not. If True, the content will be truncated to 1000 characters.
+		:return: bool True if the request queued successfully, False otherwise.
+		"""
+		if data is None:
+			data = {}
+		if link is not None and link != "":
+			data["click_action"] = link
+		if len(content) > 1000:
+			if truncate_content:
+				content = content[:1000]
+			else:
+				raise Exception("Content should be at max 1000 characters")
+		response_data = self._send_post_request("notification_relay.api.send_notification.user", {
+			"user_id": user_id,
+			"title": title,
+			"content": content,
+			"data": json.dumps(data)
+		})
+		return response_data["success"]
+
+	def send_notification_to_topic(self, topic_name: str, title: str, content: str, link:str=None, data=None, truncate_content:bool=False) -> bool:
+		"""
+		Send notification to a notification topic.
+
+		:param topic_name: (str) The name of the topic. This topic should be already created.
+		:param title: (str) The title of the notification.
+		:param content: (str) The body of the notification. At max 1000 characters.
+		:param link: (str) The link to be opened when the notification is clicked.
+		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
+		:param truncate_content: (bool) Whether to truncate the content or not. If True, the content will be truncated to 1000 characters.
+		:return:  bool True if the request queued successfully, False otherwise.
+		"""
+		if data is None:
+			data = {}
+		if link is not None and link != "":
+			data["click_action"] = link
+		if len(content) > 1000:
+			if truncate_content:
+				content = content[:1000]
+			else:
+				raise Exception("Content should be at max 1000 characters")
+		response_data = self._send_post_request("notification_relay.api.send_notification.topic", {
+			"topic_name": topic_name,
+			"title": title,
+			"content": content,
+			"data": json.dumps(data)
+		})
+		return response_data["success"]
+
+	def is_enabled(self) -> bool:
+		"""
+		Check whether the push notification relay is enabled or not.
+
+		:return: bool True if enabled, False otherwise.
+		"""
+		notification_settings = frappe.get_doc("Push Notification Settings")
+		return notification_settings.enable_push_notification_relay
+
+	def _get_credential(self) -> tuple[str, str]:
+		"""
+		Register & Get the API key and secret from the central relay server.
+		Also store the API key and secret in the database for future use.
+
+		NOTE: This method is private and should not be called directly.
+
+		:return: tuple[str, str] The API key and secret.
+		"""
+		notification_settings = frappe.get_doc("Push Notification Settings")
+		if notification_settings.api_key != "" and notification_settings.api_secret != ""\
+				and notification_settings.api_key is not None and notification_settings.api_secret is not None:
+			return notification_settings.api_key, notification_settings.api_secret
+		else:
+			# Generate new credentials
+			token = frappe.generate_hash(length=48)
+			# store the token in the redis cache
+			frappe.cache().set(f"{self._get_site_name}:push_relay_registration_token", token, ex=600)
+			body = {
+				"endpoint": self._get_site_name,
+				"protocol": self._get_site_protocol,
+				"port": self._get_site_port,
+				"token": token,
+				"webhook_route": "/api/method/frappe.push_notification.auth_webhook"
+			}
+			response = self._send_post_request("notification_relay.api.auth.get_credential", body, False)
+			success = response["success"]
+			if not success:
+				raise Exception(response["message"])
+			notification_settings.api_key = response["credentials"]["api_key"]
+			notification_settings.api_secret = response["credentials"]["api_secret"]
+			notification_settings.save(ignore_permissions=True)
+			frappe.db.commit()
+			return notification_settings.api_key, notification_settings.api_secret
+
+	def _send_post_request(self, method: str, params: dict, use_authentication: bool=True):
+		"""
+		Send a POST request to the central relay server.
+
+		NOTE: This method is private and should not be called directly.
+
+		:param method: (str) The method to be called on the central relay server.
+		:param params: (dict) The parameters to be sent with the request.
+		:param use_authentication: (bool) Whether to use authentication or not.
+		:return: tuple[bool, dict] First element is the success status of request, second element is the response data.
+		"""
+
+		if not self.is_enabled():
+			raise Exception("Push Notification Relay is not enabled")
+
+		relay_server_endpoint = frappe.conf.get("push_relay_server_url")
+		if use_authentication:
+			api_key, api_secret = self._get_credential()
+			client = FrappeClient(relay_server_endpoint, api_key=api_key, api_secret=api_secret)
+		else:
+			client = FrappeClient(relay_server_endpoint)
+		params["project_name"] = PushNotification.project_name
+		params["site_name"] = self._get_site_name
+		return client.post_api(method, params)
+
+	# Helper methods to fetch properties
+	@property
+	def _get_site_name(self) -> str:
+		return urlparse(frappe.utils.get_url()).hostname
+
+	@property
+	def _get_site_protocol(self) -> str:
+		return urlparse(frappe.utils.get_url()).scheme
+
+	@property
+	def _get_site_port(self) -> str:
+		site_uri = urlparse(frappe.utils.get_url())
+		if site_uri.port is not None:
+			return str(site_uri.port)
+		else:
+			return ""
+
+# Webhook which will be called by the central relay server for authentication
+@frappe.whitelist(allow_guest=True, methods=['GET'])
+def auth_webhook():
+	token = frappe.cache().get(f"{frappe.local.site}:push_relay_registration_token")
+	response = Response()
+	response.mimetype = "text/plain; charset=UTF-8"
+
+	if token is None or token == "":
+		response.data = ""
+		response.status_code = 401
+		return response
+
+	response.data = token
+	response.status_code = 200
+	return response
+
+# Subscribe and Unsubscribe API
+@frappe.whitelist(methods=["GET"])
+def subscribe(fcm_token: str):
+	success, message = PushNotification().add_token(frappe.session.user, fcm_token)
+	return {
+		"success": success,
+		"message": message
+	}
+
+@frappe.whitelist(methods=["GET"])
+def unsubscribe(fcm_token: str):
+	success, message = PushNotification().remove_token(frappe.session.user, fcm_token)
+	return {
+		"success": success,
+		"message": message
+	}

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -93,6 +93,7 @@ class PushNotification:
 		title: str,
 		body: str,
 		link: str = None,
+		icon: str = None,
 		data=None,
 		truncate_body: bool = True,
 		strip_html: bool = True,
@@ -104,6 +105,7 @@ class PushNotification:
 		:param title: (str) The title of the notification.
 		:param body: (str) The body of the notification. At max 1000 characters.
 		:param link: (str) The link to be opened when the notification is clicked.
+		:param icon: (str) The icon to be shown in the notification.
 		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
 		:param truncate_body: (bool) Whether to truncate the body or not. If True, the body will be truncated to 1000 characters.
 		:param strip_html: (bool) Whether to strip HTML tags from the body or not.
@@ -111,8 +113,10 @@ class PushNotification:
 		"""
 		if data is None:
 			data = {}
-		if link is not None and link != "":
+		if link:
 			data["click_action"] = link
+		if icon:
+			data["notification_icon"] = icon
 		if len(body) > 1000:
 			if truncate_body:
 				body = body[:1000]
@@ -132,6 +136,7 @@ class PushNotification:
 		title: str,
 		body: str,
 		link: str = None,
+		icon: str = None,
 		data=None,
 		truncate_body: bool = True,
 		strip_html: bool = True,
@@ -143,6 +148,7 @@ class PushNotification:
 		:param title: (str) The title of the notification.
 		:param body: (str) The body of the notification. At max 1000 characters.
 		:param link: (str) The link to be opened when the notification is clicked.
+		:param icon: (str) The icon to be shown in the notification.
 		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
 		:param truncate_body: (bool) Whether to truncate the body or not. If True, the body will be truncated to 1000 characters.
 		:param strip_html: (bool) Whether to strip HTML tags from the body or not.
@@ -152,6 +158,8 @@ class PushNotification:
 			data = {}
 		if link:
 			data["click_action"] = link
+		if icon:
+			data["notification_icon"] = icon
 		if len(body) > 1000:
 			if truncate_body:
 				body = body[:1000]

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -9,17 +9,11 @@ from .frappeclient import FrappeClient
 
 
 class PushNotification:
-	project_name = ""
-
-	@staticmethod
-	def set_project(project_name: str) -> None:
+	def __init__(self, project_name: str):
 		"""
-		Set the project name.
-
-		:param project_name:  (str) The name of the project.
-		:return:
+		:param project_name: (str) The name of the project.
 		"""
-		PushNotification.project_name = project_name
+		self.project_name = project_name
 
 	def add_token(self, user_id: str, token: str) -> tuple[bool, str]:
 		"""
@@ -231,7 +225,7 @@ class PushNotification:
 			client = FrappeClient(relay_server_endpoint, api_key=api_key, api_secret=api_secret)
 		else:
 			client = FrappeClient(relay_server_endpoint)
-		params["project_name"] = PushNotification.project_name
+		params["project_name"] = self.project_name
 		params["site_name"] = self._site_name
 		return client.post_api(method, params)
 
@@ -271,12 +265,12 @@ def auth_webhook():
 
 # Subscribe and Unsubscribe API
 @frappe.whitelist(methods=["GET"])
-def subscribe(fcm_token: str):
-	success, message = PushNotification().add_token(frappe.session.user, fcm_token)
+def subscribe(fcm_token: str, project_name: str):
+	success, message = PushNotification(project_name).add_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}
 
 
 @frappe.whitelist(methods=["GET"])
-def unsubscribe(fcm_token: str):
-	success, message = PushNotification().remove_token(frappe.session.user, fcm_token)
+def unsubscribe(fcm_token: str, project_name: str):
+	success, message = PushNotification(project_name).remove_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -215,7 +215,7 @@ class PushNotification:
 		:param method: (str) The method to be called on the central relay server.
 		:param params: (dict) The parameters to be sent with the request.
 		:param use_authentication: (bool) Whether to use authentication or not.
-		:return: dict Response data of the request.
+		:return: (dict) Response data of the request.
 		"""
 
 		if not self.is_enabled():

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -204,7 +204,8 @@ class PushNotification:
 			notification_settings.api_key = response["credentials"]["api_key"]
 			notification_settings.api_secret = response["credentials"]["api_secret"]
 			notification_settings.save(ignore_permissions=True)
-			frappe.db.commit()
+			# GET request, hence using commit to persist changes
+			frappe.db.commit()  # nosemgrep
 			return notification_settings.api_key, notification_settings.api_secret
 
 	def _send_post_request(self, method: str, params: dict, use_authentication: bool = True):

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -168,6 +168,7 @@ class PushNotification:
 				raise Exception("Body should be at max 1000 characters")
 		if strip_html:
 			body = frappe.utils.strip_html(body)
+
 		response_data = self._send_post_request(
 			"notification_relay.api.send_notification.topic",
 			{"topic_name": topic_name, "title": title, "body": body, "data": json.dumps(data)},
@@ -282,12 +283,12 @@ def auth_webhook():
 
 # Subscribe and Unsubscribe API
 @frappe.whitelist(methods=["GET"])
-def subscribe(fcm_token: str, project_name: str):
+def subscribe(fcm_token: str, project_name: str) -> dict:
 	success, message = PushNotification(project_name).add_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}
 
 
 @frappe.whitelist(methods=["GET"])
-def unsubscribe(fcm_token: str, project_name: str):
+def unsubscribe(fcm_token: str, project_name: str) -> dict:
 	success, message = PushNotification(project_name).remove_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -194,7 +194,7 @@ class PushNotification:
 			# Generate new credentials
 			token = frappe.generate_hash(length=48)
 			# store the token in the redis cache
-			frappe.cache().set(f"{self._get_site_name}:push_relay_registration_token", token, ex=600)
+			frappe.cache().set_value(f"{self._get_site_name}:push_relay_registration_token", token, ex=600)
 			body = {
 				"endpoint": self._get_site_name,
 				"protocol": self._get_site_protocol,
@@ -258,7 +258,7 @@ class PushNotification:
 # Webhook which will be called by the central relay server for authentication
 @frappe.whitelist(allow_guest=True, methods=["GET"])
 def auth_webhook():
-	token = frappe.cache().get(f"{frappe.local.site}:push_relay_registration_token")
+	token = frappe.cache().get_value(f"{frappe.local.site}:push_relay_registration_token")
 	response = Response()
 	response.mimetype = "text/plain; charset=UTF-8"
 

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -184,7 +184,7 @@ class PushNotification:
 		"""
 		notification_settings = frappe.get_doc("Push Notification Settings")
 		if notification_settings.api_key and notification_settings.api_secret:
-			return notification_settings.api_key, notification_settings.api_secret
+			return notification_settings.api_key, notification_settings.get_password('api_secret')
 		else:
 			# Generate new credentials
 			token = frappe.generate_hash(length=48)

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -215,7 +215,7 @@ class PushNotification:
 		:param method: (str) The method to be called on the central relay server.
 		:param params: (dict) The parameters to be sent with the request.
 		:param use_authentication: (bool) Whether to use authentication or not.
-		:return: tuple[bool, dict] First element is the success status of request, second element is the response data.
+		:return: dict Response data from the central relay server.
 		"""
 
 		if not self.is_enabled():

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -183,12 +183,7 @@ class PushNotification:
 		:return: tuple[str, str] The API key and secret.
 		"""
 		notification_settings = frappe.get_doc("Push Notification Settings")
-		if (
-			notification_settings.api_key != ""
-			and notification_settings.api_secret != ""
-			and notification_settings.api_key is not None
-			and notification_settings.api_secret is not None
-		):
+		if notification_settings.api_key and notification_settings.api_secret:
 			return notification_settings.api_key, notification_settings.api_secret
 		else:
 			# Generate new credentials

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -206,7 +206,6 @@ class PushNotification:
 			notification_settings.api_key = response["credentials"]["api_key"]
 			notification_settings.api_secret = response["credentials"]["api_secret"]
 			notification_settings.save(ignore_permissions=True)
-			frappe.db.commit()
 			return notification_settings.api_key, notification_settings.api_secret
 
 	def _send_post_request(self, method: str, params: dict, use_authentication: bool = True):
@@ -269,13 +268,13 @@ def auth_webhook():
 
 
 # Subscribe and Unsubscribe API
-@frappe.whitelist(methods=["GET"])
+@frappe.whitelist(methods=["POST"])
 def subscribe(fcm_token: str):
 	success, message = PushNotification().add_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}
 
 
-@frappe.whitelist(methods=["GET"])
+@frappe.whitelist(methods=["POST"])
 def unsubscribe(fcm_token: str):
 	success, message = PushNotification().remove_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -189,7 +189,7 @@ class PushNotification:
 			# Generate new credentials
 			token = frappe.generate_hash(length=48)
 			# store the token in the redis cache
-			frappe.cache().set_value(f"{self._site_name}:push_relay_registration_token", token, ex=600)
+			frappe.cache().set_value(f"{self._site_name}:push_relay_registration_token", token, expires_in_sec=600)
 			body = {
 				"endpoint": self._site_name,
 				"protocol": self._site_protocol,

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -204,6 +204,7 @@ class PushNotification:
 			notification_settings.api_key = response["credentials"]["api_key"]
 			notification_settings.api_secret = response["credentials"]["api_secret"]
 			notification_settings.save(ignore_permissions=True)
+			frappe.db.commit()
 			return notification_settings.api_key, notification_settings.api_secret
 
 	def _send_post_request(self, method: str, params: dict, use_authentication: bool = True):
@@ -265,13 +266,13 @@ def auth_webhook():
 
 
 # Subscribe and Unsubscribe API
-@frappe.whitelist(methods=["POST"])
+@frappe.whitelist(methods=["GET"])
 def subscribe(fcm_token: str):
 	success, message = PushNotification().add_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}
 
 
-@frappe.whitelist(methods=["POST"])
+@frappe.whitelist(methods=["GET"])
 def unsubscribe(fcm_token: str):
 	success, message = PushNotification().remove_token(frappe.session.user, fcm_token)
 	return {"success": success, "message": message}

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -95,7 +95,7 @@ class PushNotification:
 		link: str = None,
 		data=None,
 		truncate_body: bool = True,
-		strip_html: bool = True
+		strip_html: bool = True,
 	) -> bool:
 		"""
 		Send notification to a user.
@@ -134,7 +134,7 @@ class PushNotification:
 		link: str = None,
 		data=None,
 		truncate_body: bool = True,
-		strip_html: bool = True
+		strip_html: bool = True,
 	) -> bool:
 		"""
 		Send notification to a notification topic.

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -215,7 +215,7 @@ class PushNotification:
 		:param method: (str) The method to be called on the central relay server.
 		:param params: (dict) The parameters to be sent with the request.
 		:param use_authentication: (bool) Whether to use authentication or not.
-		:return: dict Response data from the central relay server.
+		:return: dict Response data of the request.
 		"""
 
 		if not self.is_enabled():

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -208,7 +208,7 @@ class PushNotification:
 		notification_settings.save(ignore_permissions=True)
 		# GET request, hence using commit to persist changes
 		frappe.db.commit()  # nosemgrep
-		return notification_settings.api_key, notification_settings.api_secret.get_password("api_secret")
+		return notification_settings.api_key, notification_settings.get_password("api_secret")
 
 	def _send_post_request(self, method: str, params: dict, use_authentication: bool = True):
 		"""

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -57,7 +57,6 @@ class PushNotification:
 		data = self._send_post_request("notification_relay.api.topic.add", {"topic_name": topic_name})
 		return data["success"]
 
-	# Remove Topic
 	def remove_topic(self, topic_name: str) -> bool:
 		"""
 		Remove a notification topic.
@@ -81,7 +80,6 @@ class PushNotification:
 		)
 		return data["success"]
 
-	# Unsubscribe Topic (User)
 	def unsubscribe_topic(self, user_id: str, topic_name: str) -> bool:
 		"""
 		Unsubscribe a user from a topic.
@@ -191,11 +189,11 @@ class PushNotification:
 			# Generate new credentials
 			token = frappe.generate_hash(length=48)
 			# store the token in the redis cache
-			frappe.cache().set_value(f"{self._get_site_name}:push_relay_registration_token", token, ex=600)
+			frappe.cache().set_value(f"{self._site_name}:push_relay_registration_token", token, ex=600)
 			body = {
-				"endpoint": self._get_site_name,
-				"protocol": self._get_site_protocol,
-				"port": self._get_site_port,
+				"endpoint": self._site_name,
+				"protocol": self._site_protocol,
+				"port": self._site_port,
 				"token": token,
 				"webhook_route": "/api/method/frappe.push_notification.auth_webhook",
 			}
@@ -230,20 +228,19 @@ class PushNotification:
 		else:
 			client = FrappeClient(relay_server_endpoint)
 		params["project_name"] = PushNotification.project_name
-		params["site_name"] = self._get_site_name
+		params["site_name"] = self._site_name
 		return client.post_api(method, params)
 
-	# Helper methods to fetch properties
 	@property
-	def _get_site_name(self) -> str:
+	def _site_name(self) -> str:
 		return urlparse(frappe.utils.get_url()).hostname
 
 	@property
-	def _get_site_protocol(self) -> str:
+	def _site_protocol(self) -> str:
 		return urlparse(frappe.utils.get_url()).scheme
 
 	@property
-	def _get_site_port(self) -> str:
+	def _site_port(self) -> str:
 		site_uri = urlparse(frappe.utils.get_url())
 		if site_uri.port is not None:
 			return str(site_uri.port)

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -2,8 +2,8 @@ import json
 from urllib.parse import urlparse
 
 import frappe
-from frappe.utils.response import Response
 from frappe import sbool
+from frappe.utils.response import Response
 
 from .frappeclient import FrappeClient
 
@@ -171,7 +171,9 @@ class PushNotification:
 
 		:return: bool True if enabled, False otherwise.
 		"""
-		return sbool(frappe.db.get_single_value("Push Notification Settings", "enable_push_notification_relay"))
+		return sbool(
+			frappe.db.get_single_value("Push Notification Settings", "enable_push_notification_relay")
+		)
 
 	def _get_credential(self) -> tuple[str, str]:
 		"""

--- a/frappe/push_notification.py
+++ b/frappe/push_notification.py
@@ -129,7 +129,8 @@ class PushNotification:
 		body: str,
 		link: str = None,
 		data=None,
-		truncate_body: bool = False,
+		truncate_body: bool = True,
+		strip_html: bool = True
 	) -> bool:
 		"""
 		Send notification to a notification topic.
@@ -140,6 +141,7 @@ class PushNotification:
 		:param link: (str) The link to be opened when the notification is clicked.
 		:param data: (dict) The data to be sent with the notification. This can be used to provide extra information while dealing with in-app notifications.
 		:param truncate_body: (bool) Whether to truncate the body or not. If True, the body will be truncated to 1000 characters.
+		:param strip_html: (bool) Whether to strip HTML tags from the body or not.
 		:return: bool True if the request queued successfully, False otherwise.
 		"""
 		if data is None:
@@ -151,6 +153,8 @@ class PushNotification:
 				body = body[:1000]
 			else:
 				raise Exception("Body should be at max 1000 characters")
+		if strip_html:
+			body = frappe.utils.strip_html(body)
 		response_data = self._send_post_request(
 			"notification_relay.api.send_notification.topic",
 			{"topic_name": topic_name, "title": title, "body": body, "data": json.dumps(data)},


### PR DESCRIPTION
This PR is to add **Frappe Push Notification Client** in Frappe Framework.

**Push Notification Client** is a library to communicate with [**Frappe Push Notification Relay Server**](https://github.com/frappe/notification_relay) to manage users, topics and send notifications.

### Changes -
- Added **Push Notification Client**  in the Framework.
- Added **Push Notification Settings** doctype to hold some notification settings. The doctype has these parameters
  - `api_key` & `api_secret` to send authorized request to **Frappe Push Notification Relay Server**
  - `enable push notification relay` checkbox  to disable/enable push notification accross the site

### Documentation -

**Configure Push Notification Relay Server**
User can configure relay server endpoint by adding `push_relay_server_url` in `site config`

**Enable Push Notification System**
User can visit `Push Notification Settings` from desk to enable/disable push notification across the site.

**Features -**
- Add/Remove Notification (FCM) Token of end-user
- Create/Delete Notification Topic
- Subscribe/Unsubscribe a end-user to/from a notification topic
- Send notification to end-user
- Send notification to a notification topic

**Available Methods -**
- `constructor(project_name)`: To use PushNotification, create an object and provide the project_name during its creation to set it for the current instance.
   ```python
  from frappe.push_notification import PushNotification
  
  push_notification = PushNotification("hrms")
   ```
- `is_enabled() -> bool`: This function checks whether the push notification relay is enabled or not for curent site.
- `add_token(user_id, token)`: This function register the FCM notification token for a particular user of current site in relay server
- `remove_token(user_id, token)`: This function removes a specific token of a user from relay server.
- `add_topic(topic_name)`: This function helps to add a new notification topic.
- `remove_topic(topic_name)`: This function removes a notification topic from relay server.
- `subscribe_topic(user_id, topic_name)`: This function subscribes a user to a particular notification topic.
- `unsubscribe_topic(user_id, topic_name)`: This function unsubscribes a user from a particular notification topic.
- `send_notification_to_user(user_id, title, content, link, body, truncate_content)`: This function sends a notification to a user.
  - title : Notification title
  - content: Notication content
  - link: Action link, If provided, on tapping the notification that particular url will be opened
  - truncate_body: Notification content has a limitation of 1000 characters, If `truncate_body` enabled, it will auto truncate content if exceeds 1000 characters.
- `send_notification_to_topic(topic_name: str, title: str, content: str, link: str = None, body=None, truncate_body: bool = False) -> bool`: This function sends a notification to a topic and returns a boolean indicating the success status.

**API Endpoints -**
- `/api/method/frappe.push_notification.auth_webhook` : This endpoint is for webhook call which will be invoked by the push notification relay server for registration confirmation and authentication purpose.
- `/api/method/frappe.push_notification.subscribe?fcm_token=<fcm_token_retrieved_from_js_client>`: This API provide support to register end-user device token / FCM token to notification relay server.
  For example - This endpoint can be called from web app, when the end-user subscribe for push notification
- `/api/method/frappe.push_notification.unsubscribe?fcm_token=<fcm_token_retrieved_from_js_client>`: This API provide support to de-register end-user device token / FCM token to notification relay server.
  For example - This endpoint can be called from web app, when the end-user logout from the application.

`no-docs` (temp)