### PR TITLE
refactor: set pipefail in shell before running piped backup/restore commands

### DIFF
--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -57,7 +57,7 @@ class DbManager:
 		from frappe.database import get_command
 		from frappe.utils import execute_in_shell
 
-		command = []
+		command = ["set -o pipefail;"]
 
 		if source.endswith(".gz"):
 			if gzip := which("gzip"):

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -5,6 +5,7 @@ import functools
 import hashlib
 import io
 import os
+import shutil
 import sys
 import traceback
 from collections import deque
@@ -452,7 +453,12 @@ def execute_in_shell(cmd, verbose=False, low_priority=False, check_exit_code=Fal
 		cmd = shlex.join(cmd)
 
 	with (tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr):
-		kwargs = {"shell": True, "stdout": stdout, "stderr": stderr}
+		kwargs = {
+			"shell": True,
+			"stdout": stdout,
+			"stderr": stderr,
+			"executable": shutil.which("bash") or "/bin/bash",
+		}
 
 		if low_priority:
 			kwargs["preexec_fn"] = lambda: os.nice(10)


### PR DESCRIPTION
Drop the complicated logic behind storing pid and killing process if first stage of pipe fails

This check was missing from restore completely - would've caused issues if gzip failed
