### PR TITLE
fix: delete existing children first to avoid `UniqueValidationError`

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -420,36 +420,35 @@ class Document(BaseDocument):
 
 	def update_child_table(self, fieldname: str, df: Optional["DocField"] = None):
 		"""sync child table for given fieldname"""
-		rows = []
 		df: "DocField" = df or self.meta.get_field(fieldname)
-
-		for d in self.get(df.fieldname):
-			d: Document
-			d.db_update()
-			rows.append(d.name)
-
-		if (
-			df.options in (self.flags.ignore_children_type or [])
-			or frappe.get_meta(df.options).is_virtual == 1
-		):
-			# do not delete rows for this because of flags
-			# hack for docperm :(
-			return
+		all_rows = self.get(df.fieldname)
 
 		# delete rows that do not match the ones in the document
-		tbl = frappe.qb.DocType(df.options)
-		qry = (
-			frappe.qb.from_(tbl)
-			.where(tbl.parent == self.name)
-			.where(tbl.parenttype == self.doctype)
-			.where(tbl.parentfield == fieldname)
-			.delete()
-		)
+		# if the doctype isn't in ignore_children_type flag and isn't virtual
+		if not (
+			df.options in (self.flags.ignore_children_type or ())
+			or frappe.get_meta(df.options).is_virtual == 1
+		):
+			existing_row_names = [row.name for row in all_rows if row.name and not row.is_new()]
 
-		if rows:
-			qry = qry.where(tbl.name.notin(rows))
+			tbl = frappe.qb.DocType(df.options)
+			qry = (
+				frappe.qb.from_(tbl)
+				.where(tbl.parent == self.name)
+				.where(tbl.parenttype == self.doctype)
+				.where(tbl.parentfield == fieldname)
+				.delete()
+			)
 
-		qry.run()
+			if existing_row_names:
+				qry = qry.where(tbl.name.notin(existing_row_names))
+
+			qry.run()
+
+		# update / insert
+		for d in all_rows:
+			d: Document
+			d.db_update()
 
 	def get_doc_before_save(self) -> "Document":
 		return getattr(self, "_doc_before_save", None)


### PR DESCRIPTION
#### steps to replicate

\> Create child table with a unique column
\> Add values 1,2 to the unique column
\> Try clearing all rows, and then adding values 2,3,4 to the unique column
\> causes **UniqueValidationError** like so:

```
 File "apps/frappe/frappe/model/document.py", line 312, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 365, in _save
    self.update_children()
  File "apps/frappe/frappe/model/document.py", line 397, in update_children
    self.update_child_table(df.fieldname, df)
  File "apps/frappe/frappe/model/document.py", line 406, in update_child_table
    d.db_update()
  File "apps/frappe/frappe/model/base_document.py", line 449, in db_update
    self.db_insert()
  File "apps/frappe/frappe/model/base_document.py", line 440, in db_insert
    self.show_unique_validation_message(e)
  File "apps/frappe/frappe/model/base_document.py", line 500, in show_unique_validation_message
    raise frappe.UniqueValidationError(self.doctype, self.name, e)
frappe.exceptions.UniqueValidationError: ('ABC VAT Code', '10c591d57e', IntegrityError(1062, "Duplicate entry '2' for key 'abc_id'"))
```

#### solution

delete existing rows first.