### PR TITLE
fix: set ignore_permissions on get_receiver_list in notification.py

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -366,7 +366,7 @@ def get_context(context):
 
 			# For sending messages to specified role
 			if recipient.receiver_by_role:
-				receiver_list += get_info_based_on_role(recipient.receiver_by_role, "mobile_no")
+				receiver_list += get_info_based_on_role(recipient.receiver_by_role, "mobile_no", ignore_permissions=True)
 
 		return receiver_list
 


### PR DESCRIPTION
Similar to fetching the email list in `get_list_of_recipients()`, the `get_info_based_on_role` call to fetch `mobile_no` in `get_receiver_list()` should set `ignore_permissions` in order to allow sms notifications to send based on actions of limited and anonymous users (e.g. web form submissions).
