### PR TITLE
fix(restore): check backup directory and bench directory if we can't find the file

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -260,7 +260,27 @@ def restore_backup(
 	admin_password,
 	force,
 ):
+	from pathlib import Path
+
 	from frappe.installer import _new_site, is_downgrade, is_partial, validate_database_sql
+
+	# Check for the backup file in the backup directory, as well as the main bench directory
+	dirs = (f"{site}/private/backups", "..")
+
+	# Try to resolve path to the file if we can't find it directly
+	if not Path(sql_file_path).exists():
+		click.secho(
+			f"File {sql_file_path} not found. Trying to check in alternative directories.", fg="yellow"
+		)
+		for dir in dirs:
+			potential_path = Path(dir) / Path(sql_file_path)
+			if potential_path.exists():
+				sql_file_path = str(potential_path.resolve())
+				click.secho(f"File {sql_file_path} found.", fg="green")
+				break
+		else:
+			click.secho(f"File {sql_file_path} not found.", fg="red")
+			sys.exit(1)
 
 	if is_partial(sql_file_path):
 		click.secho(

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -757,8 +757,8 @@ def is_downgrade(sql_file_path, verbose=False):
 	if backup_version is None:
 		# This is likely an older backup, so try to extract another way
 		header = get_db_dump_header(sql_file_path).split("\n")
-		if "Version" in header[0]:
-			backup_version = header[0].split(":")[-1].strip()
+		if match := re.search(r"Frappe (\d+\.\d+\.\d+)", header[0]):
+			backup_version = match.group(1)
 
 	# Assume it's not a downgrade if we can't determine backup version
 	if backup_version is None:


### PR DESCRIPTION
#22915 dropped usage of `get_bench_relative_path()` leading to only absolute paths (or relative paths from `{bench_dir}/sites` working)

This allows someone to pass in just a backup file name from the backup directory or the bench directory