### PR TITLE
fix(minor): show footer on login via Website Settings, fixes #24153

### DIFF
--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -4,8 +4,10 @@ body {
 	@include media-breakpoint-up(sm) {
 		background-color: var(--bg-light-gray);
 	}
+	.page-content-wrapper {
+		min-height: calc(100vh - 220px);
+	}
 	.web-footer {
-		margin-top: 3rem;
 		display: none;
 	}
 }

--- a/frappe/public/scss/login.bundle.scss
+++ b/frappe/public/scss/login.bundle.scss
@@ -5,6 +5,7 @@ body {
 		background-color: var(--bg-light-gray);
 	}
 	.web-footer {
+		margin-top: 3rem;
 		display: none;
 	}
 }

--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -2,6 +2,7 @@
 // don't remove this line (used in test)
 
 window.disable_signup = {{ disable_signup and "true" or "false" }};
+window.show_footer_on_login = {{ show_footer_on_login and "true" or "false" }};
 
 window.login = {};
 
@@ -303,6 +304,10 @@ frappe.ready(function () {
 		window.location.hash = "#login";
 	} else {
 		$(window).trigger("hashchange");
+	}
+
+	if (window.show_footer_on_login) {
+		$("body .web-footer").show();
 	}
 
 	$(".form-signup, .form-forgot, .form-login-with-email-link").removeClass("hide");

--- a/frappe/website/doctype/top_bar_item/top_bar_item.json
+++ b/frappe/website/doctype/top_bar_item/top_bar_item.json
@@ -11,8 +11,7 @@
   "open_in_new_tab",
   "right",
   "column_break_5",
-  "parent_label",
-  "icon"
+  "parent_label"
  ],
  "fields": [
   {
@@ -51,12 +50,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "If Icon is set, it will be shown instead of Label",
-   "fieldname": "icon",
-   "fieldtype": "Attach Image",
-   "label": "Icon"
-  },
-  {
    "default": "0",
    "depends_on": "eval:doc.url",
    "fieldname": "open_in_new_tab",
@@ -68,12 +61,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-26 20:59:42.142208",
+ "modified": "2024-01-08 12:05:25.782635",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Top Bar Item",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "ASC"
+ "sort_order": "ASC",
+ "states": []
 }

--- a/frappe/website/doctype/top_bar_item/top_bar_item.py
+++ b/frappe/website/doctype/top_bar_item/top_bar_item.py
@@ -14,7 +14,6 @@ class TopBarItem(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		icon: DF.AttachImage | None
 		label: DF.Data
 		open_in_new_tab: DF.Check
 		parent: DF.Data
@@ -24,4 +23,5 @@ class TopBarItem(Document):
 		right: DF.Check
 		url: DF.Data | None
 	# end: auto-generated types
+
 	pass

--- a/frappe/website/doctype/website_settings/website_settings.json
+++ b/frappe/website/doctype/website_settings/website_settings.json
@@ -19,6 +19,7 @@
   "misc_section",
   "app_name",
   "disable_signup",
+  "show_footer_on_login",
   "column_break_9",
   "app_logo",
   "section_break_6",
@@ -49,9 +50,9 @@
   "footer",
   "footer_items",
   "footer_details_section",
-  "hide_footer_signup",
   "copyright",
   "footer_logo",
+  "hide_footer_signup",
   "column_break_37",
   "address",
   "footer_powered",
@@ -126,7 +127,7 @@
    "fieldname": "website_theme_image_link",
    "fieldtype": "Code",
    "hidden": 1,
-   "label": "Website Theme Image Link"
+   "label": "Website Theme image link"
   },
   {
    "collapsible": 1,
@@ -211,7 +212,7 @@
    "default": "0",
    "fieldname": "hide_footer_signup",
    "fieldtype": "Check",
-   "label": "Hide Footer Signup"
+   "label": "Hide footer signup"
   },
   {
    "collapsible": 1,
@@ -248,10 +249,10 @@
   },
   {
    "default": "1",
-   "description": "Disable Signups on site. New users will have to be manually registered by system managers.",
+   "description": "New users will have to be manually registered by system managers.",
    "fieldname": "disable_signup",
    "fieldtype": "Check",
-   "label": "Disable Signup"
+   "label": "Disable signups"
   },
   {
    "collapsible": 1,
@@ -282,20 +283,20 @@
    "description": "To use Google Indexing, enable <a href=\"/app/google-settings\">Google Settings</a>.",
    "fieldname": "enable_google_indexing",
    "fieldtype": "Check",
-   "label": "Enable Google Indexing"
+   "label": "Enable Google indexing"
   },
   {
    "fieldname": "indexing_refresh_token",
    "fieldtype": "Data",
    "hidden": 1,
-   "label": "Indexing Refresh Token",
+   "label": "Indexing refresh token",
    "read_only": 1
   },
   {
    "fieldname": "indexing_authorization_code",
    "fieldtype": "Data",
    "hidden": 1,
-   "label": "Indexing Authorization Code",
+   "label": "Indexing authorization code",
    "read_only": 1
   },
   {
@@ -308,7 +309,7 @@
    "default": "0",
    "fieldname": "enable_view_tracking",
    "fieldtype": "Check",
-   "label": "Enable In App Website Tracking"
+   "label": "Enable in-app website tracking"
   },
   {
    "fieldname": "footer_logo",
@@ -373,7 +374,7 @@
    "default": "1",
    "fieldname": "google_analytics_anonymize_ip",
    "fieldtype": "Check",
-   "label": "Google Analytics Anonymize IP"
+   "label": "Google Analytics anonymise IP"
   },
   {
    "default": "0",
@@ -408,13 +409,13 @@
    "default": "0",
    "fieldname": "show_account_deletion_link",
    "fieldtype": "Check",
-   "label": "Show Account Deletion Link in My Account Page"
+   "label": "Show account deletion link in My Account page"
   },
   {
    "default": "72",
    "fieldname": "auto_account_deletion",
    "fieldtype": "Int",
-   "label": "Auto Account Deletion within (Hours)"
+   "label": "Automatically delete account within (hours)"
   },
   {
    "fieldname": "footer_powered",
@@ -469,6 +470,12 @@
    "fieldname": "analytics_section",
    "fieldtype": "Section Break",
    "label": "Analytics"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_footer_on_login",
+   "fieldtype": "Check",
+   "label": "Show footer on login"
   }
  ],
  "icon": "fa fa-cog",
@@ -476,7 +483,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-12-08 15:52:37.525003",
+ "modified": "2024-01-08 11:50:34.750809",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Website Settings",

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -56,6 +56,7 @@ class WebsiteSettings(Document):
 		robots_txt: DF.Code | None
 		route_redirects: DF.Table[WebsiteRouteRedirect]
 		show_account_deletion_link: DF.Check
+		show_footer_on_login: DF.Check
 		show_language_picker: DF.Check
 		splash_image: DF.AttachImage | None
 		subdomain: DF.SmallText | None
@@ -63,8 +64,8 @@ class WebsiteSettings(Document):
 		top_bar_items: DF.Table[TopBarItem]
 		website_theme: DF.Link | None
 		website_theme_image_link: DF.Code | None
-
 	# end: auto-generated types
+
 	def validate(self):
 		self.validate_top_bar_items()
 		self.validate_footer_items()

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -37,6 +37,7 @@ def get_context(context):
 	context["hide_login"] = True  # dont show login link on login page again.
 	context["provider_logins"] = []
 	context["disable_signup"] = cint(frappe.get_website_settings("disable_signup"))
+	context["show_footer_on_login"] = cint(frappe.get_website_settings("show_footer_on_login"))
 	context["disable_user_pass_login"] = cint(frappe.get_system_settings("disable_user_pass_login"))
 	context["logo"] = frappe.get_website_settings("app_logo") or frappe.get_hooks("app_logo_url")[-1]
 	context["app_name"] = (


### PR DESCRIPTION
Option to show footer in login added in "Website Settings"

<img width="788" alt="Screenshot 2024-01-08 at 11 57 25 AM" src="https://github.com/frappe/frappe/assets/140076/472ab7e8-1ef9-4bad-86d5-b6085839a9c2">
