### PR TITLE
fix: Handle empty value of datetime control

### DIFF
--- a/frappe/public/js/frappe/form/controls/datetime.js
+++ b/frappe/public/js/frappe/form/controls/datetime.js
@@ -16,7 +16,7 @@ frappe.ui.form.ControlDatetime = class ControlDatetime extends frappe.ui.form.Co
 	}
 
 	get_start_date() {
-		this.value = this.value == null ? undefined : this.value;
+		this.value = this.value == null || this.value == "" ? undefined : this.value;
 		let value = frappe.datetime.convert_to_user_tz(this.value);
 		return frappe.datetime.str_to_obj(value);
 	}


### PR DESCRIPTION
fixes https://github.com/frappe/frappe/issues/23193

**Before:**
<img width="610" alt="Screenshot 2024-01-08 at 5 20 51 PM" src="https://github.com/frappe/frappe/assets/13928957/db923fd7-6c78-4f79-b8e3-68e16ef35ab3">

**After:**
<img width="608" alt="Screenshot 2024-01-08 at 5 21 10 PM" src="https://github.com/frappe/frappe/assets/13928957/4b30adc3-c390-4b93-9bfe-7b4aff5d7b5b">
