### PR TITLE
fix(MultiCheck): Use df.sort_options to enable/disable sort

### DIFF
--- a/frappe/public/js/frappe/form/controls/multicheck.js
+++ b/frappe/public/js/frappe/form/controls/multicheck.js
@@ -75,15 +75,17 @@ frappe.ui.form.ControlMultiCheck = class ControlMultiCheck extends frappe.ui.for
 	make_checkboxes() {
 		this.$load_state.hide();
 		this.$checkbox_area.empty();
-		this.options
-			.sort((a, b) => cstr(a.label).localeCompare(cstr(b.label)))
-			.forEach((option) => {
-				let checkbox = this.get_checkbox_element(option).appendTo(this.$checkbox_area);
-				if (option.danger) {
-					checkbox.find(".label-area").addClass("text-danger");
-				}
-				option.$checkbox = checkbox;
-			});
+		if (this.df.sort_options != false) {
+			// Sort if sort_options is undefined, null or truthy.
+			this.options.sort((a, b) => cstr(a.label).localeCompare(cstr(b.label)));
+		}
+		this.options.forEach((option) => {
+			let checkbox = this.get_checkbox_element(option).appendTo(this.$checkbox_area);
+			if (option.danger) {
+				checkbox.find(".label-area").addClass("text-danger");
+			}
+			option.$checkbox = checkbox;
+		});
 		if (this.df.select_all) {
 			this.setup_select_all();
 		}


### PR DESCRIPTION
Allow disabling sorting of MultiCheck options.

I had a MultiCheck field with Monday, Tuesday, … and it was sorted lexicographically (bad) since #23985

When df.sort_options is null/undefined/truthy, then sort options. When df.sort_options is explicitely falsy, then do NOT sort options.
