### PR TITLE
feat(ui): Add LinkCatalog class

### DIFF
--- a/frappe/public/js/frappe/ui/catalog/FrappeFilters.vue
+++ b/frappe/public/js/frappe/ui/catalog/FrappeFilters.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { onMounted, ref, watch } from "vue";
+
+const props = defineProps({
+	doctype: String,
+	parent_doctype: String,
+	modelValue: Array, // Reactive
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const div = ref(null);
+const filter_group = ref(null);
+
+onMounted(() => {
+	filter_group.value = new frappe.ui.FilterGroup({
+		parent: $(div.value),
+		doctype: props.doctype,
+		parent_doctype: props.parent_doctype,
+		on_change: () => {
+			emit("update:modelValue", filter_group.value.get_filters());
+		},
+	});
+
+	// Listen to changes of the filters prop
+	watch(
+		() => props.modelValue,
+		(filters) => {
+			filter_group.value.clear_filters();
+			if (filters?.length) {
+				filter_group.value.add_filters_to_filter_group(filters);
+			}
+		},
+		{ immediate: true }
+	);
+});
+</script>
+
+<template>
+	<div ref="div" />
+</template>

--- a/frappe/public/js/frappe/ui/catalog/LinkCatalog.vue
+++ b/frappe/public/js/frappe/ui/catalog/LinkCatalog.vue
@@ -1,0 +1,179 @@
+<script setup>
+// @ts-check
+import { watch, shallowRef, ref, inject, onMounted, markRaw } from "vue";
+import { with_doctype } from "./link_catalog_common";
+import LinkCatalogItem from "./LinkCatalogItem.vue";
+import VueSmartElement from "./VueSmartElement.vue";
+import FrappeFilters from "./FrappeFilters.vue";
+
+const options = inject("options");
+const bus = inject("bus");
+const layoutAdapter = inject("layoutAdapter");
+
+const results = shallowRef([]);
+
+/** @type {import('vue').Ref<Array>} */
+const filters = ref([]);
+
+/** @type {import('vue').Ref<Array>} */
+const or_filters = ref([]);
+
+const search = ref("");
+const page_index = ref(0);
+const page_length = ref(50);
+
+/** @type {import('vue').Ref<HTMLInputElement | null>} */
+const searchInput = ref(null);
+
+// Watchers
+watch(
+	[filters, or_filters, page_index, page_length],
+	async () => {
+		results.value = await doSearch();
+	},
+	{ immediate: true }
+);
+
+watch(search, (value) => {
+	// Remove old search filters
+	const searchFilters = [];
+	if (value) {
+		for (const fieldname of options.search_fields || ["name"]) {
+			searchFilters.push([options.link_doctype, fieldname, "like", `%${value}%`]);
+		}
+	}
+	or_filters.value = searchFilters;
+});
+
+onMounted(() => {
+	searchInput.value?.focus();
+
+	bus.on("selectItem", async ({ selected, quantity, callback }) => {
+		await setQuantity(selected, quantity);
+		if (typeof callback === "function") {
+			callback();
+		}
+	});
+
+	bus.on("setFilters", (newFilters) => {
+		filters.value = newFilters;
+	});
+});
+
+// Functions
+async function doSearch() {
+	const limit_page_length = page_length.value;
+	const limit_start = page_index.value * page_length.value;
+
+	const args = {
+		filters: filters.value,
+		or_filters: or_filters.value,
+		limit_page_length,
+		limit_start,
+	};
+
+	if (typeof options.search_function === "function") {
+		return await options.search_function({ search, ...args });
+	}
+
+	await with_doctype(options.link_doctype);
+	const meta = frappe.get_meta(options.link_doctype);
+	const fields = new Set(["name", meta.title_field || "name", meta.image_field || null]);
+	const res = await frappe.db.get_list(options.link_doctype, { fields: [...fields], ...args });
+	for (const doc of res) {
+		doc.doctype = options.link_doctype;
+	}
+	return res;
+}
+
+async function setQuantity(selected, newQuantity = 1) {
+	if (newQuantity > 0) {
+		const values = {};
+		if (options.link_fieldname) {
+			values[options.link_fieldname] = selected.name;
+		}
+		if (options.quantity_fieldname) {
+			values[options.quantity_fieldname] = newQuantity;
+		}
+		await layoutAdapter.upsert(selected, values);
+	} else {
+		await layoutAdapter.remove(selected);
+	}
+}
+</script>
+
+<template>
+	<section class="LinkCatalog">
+		<nav role="navigation" aria-label="Sidebar">
+			<VueSmartElement
+				v-if="options.title && typeof options.title == 'object'"
+				:element="markRaw(options.title)"
+			/>
+			<h2 v-else-if="options.title">{{ options.title }}</h2>
+
+			<form role="search">
+				<label for="LinkCatalog__search-input" class="LinkCatalog__search-input">
+					<input
+						id="LinkCatalog__search-input"
+						class="form-control"
+						type="search"
+						autocomplete="off"
+						v-model="search"
+						ref="searchInput"
+						:placeholder="__('Search...')"
+						:aria-label="__('Type something in the search box to search')"
+					/>
+					<span v-html="frappe.utils.icon('es-line-search')" />
+				</label>
+				<button type="submit" class="sr-only">{{ __("Search") }}</button>
+			</form>
+
+			<VueSmartElement :element="markRaw(options.sidebar_contents || [])" />
+
+			<FrappeFilters class="mt-4" v-model="filters" :doctype="options.link_doctype" />
+		</nav>
+
+		<main>
+			<LinkCatalogItem :doc="doc" v-for="doc in results" :key="doc.name" />
+		</main>
+	</section>
+</template>
+
+<style>
+.LinkCatalog {
+	display: flex;
+	flex-direction: row;
+	align-items: flex-start;
+	gap: 1.4em;
+}
+
+.LinkCatalog > nav {
+	flex: 0 0 250px;
+}
+
+.LinkCatalog > main {
+	flex: 1 0 0;
+
+	/* Fallback */
+	display: flex;
+	flex-direction: column;
+
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+	grid-template-rows: 1fr;
+	align-items: stretch;
+	justify-items: stretch;
+	gap: 1.4em;
+}
+
+.LinkCatalog__search-input {
+	position: relative;
+}
+.LinkCatalog__search-input > span {
+	position: absolute;
+	inset-inline-end: 8px;
+	inset-block: 0;
+	display: flex;
+	align-items: center;
+}
+</style>

--- a/frappe/public/js/frappe/ui/catalog/LinkCatalogAdapter.js
+++ b/frappe/public/js/frappe/ui/catalog/LinkCatalogAdapter.js
@@ -1,0 +1,225 @@
+/**
+ * @param {frappe.ui.form.Layout} layout
+ * @param {import('./link_catalog_common').CatalogOptions} options
+ */
+export function getLayoutAdapter(layout, options) {
+	if (options.table_fieldname) {
+		return new LayoutAdapterTable(layout, options);
+	} else {
+		return new LayoutAdapterField(layout, options);
+	}
+}
+
+export class BaseLayoutAdapter {
+	/**
+	 * @param {frappe.ui.form.Layout} layout
+	 * @param {import('./link_catalog_common').CatalogOptions} options
+	 */
+	constructor(layout, options) {
+		this.layout = layout;
+		this.options = options;
+	}
+
+	get parent_doc() {
+		return this.layout.doc;
+	}
+
+	get link_fieldname() {
+		return this.options.link_fieldname;
+	}
+
+	get quantity_fieldname() {
+		return this.options.quantity_fieldname;
+	}
+
+	// Methods to be implemented by subclasses
+	upsert(selected, values) {
+		throw new Error("Not implemented");
+	}
+
+	remove(selected) {
+		throw new Error("Not implemented");
+	}
+
+	grab_quantity(selected) {
+		throw new Error("Not implemented");
+	}
+}
+
+export class LayoutAdapterField extends BaseLayoutAdapter {
+	set_values(values) {
+		if (this.layout.set_values) {
+			this.layout.set_values(values);
+		} else {
+			this.layout.set_value(values);
+		}
+	}
+
+	upsert(selected, values) {
+		// selected is ignored because we are not in a table
+		this.set_values(values); // Assuming that values is a dict
+	}
+
+	remove(selected) {
+		const values = {
+			[this.link_fieldname]: null,
+			[this.quantity_fieldname]: null,
+		};
+		this.set_values(values);
+	}
+
+	grab_quantity(selected) {
+		if (!this.quantity_fieldname) {
+			return this._get_value(this.link_fieldname) ? 1 : 0;
+		}
+		return this._get_value(this.quantity_fieldname) ?? 0;
+	}
+
+	_get_value(fieldname) {
+		if (this.layout.get_value) {
+			return this.layout.get_value(this.quantity_fieldname);
+		} else {
+			return this.parent_doc?.[this.quantity_fieldname];
+		}
+	}
+}
+
+export class LayoutAdapterTable extends BaseLayoutAdapter {
+	get child_doctype() {
+		return frappe.meta.get_docfield(this.parent_doc.doctype, this.options.table_fieldname)
+			.options;
+	}
+
+	get_initial_values() {
+		return {};
+	}
+
+	get_grid() {
+		return this.layout.get_field(this.options.table_fieldname).grid;
+	}
+
+	async upsert(selected, values) {
+		const rows = Array.from(this.find_rows(selected));
+
+		if (rows.length === 0) {
+			Object.assign(values, this.get_initial_values());
+			const row = this.get_grid().add_new_row();
+			await frappe.model.set_value(row.doctype, row.name, values);
+		} else {
+			const expected_qty = this.quantity_fieldname ? values[this.quantity_fieldname] : 1;
+			const qtys = this._generate_quantities(selected, expected_qty, rows);
+			for (const [row, qty] of qtys) {
+				if (qty === 0) {
+					this._remove_row(row);
+				} else {
+					delete row.__removed;
+					await frappe.model.set_value(
+						row.doctype,
+						row.name,
+						this.quantity_fieldname,
+						qty
+					);
+				}
+			}
+		}
+	}
+
+	_remove_row(row) {
+		if (!this.quantity_fieldname) {
+			row.__removed = true;
+		}
+		const grid = this.get_grid();
+		const row_form = grid.get_row(row.name);
+		if (row_form) {
+			row_form.remove();
+		} else {
+			// Row form is not available when the row is not visible.
+			const table = grid.get_data();
+			const oldIndex = table.findIndex((r) => r.name == row.name);
+			if (oldIndex !== -1) {
+				table.splice(oldIndex, 1);
+			}
+
+			// renum idx
+			for (let i = 0; i < table.length; i++) {
+				table[i].idx = i + 1;
+			}
+
+			grid.refresh();
+			this.layout.dirty?.();
+			this.layout.script_manager?.trigger?.(
+				this.options.table_fieldname + "_delete",
+				this.child_doctype
+			);
+		}
+	}
+
+	*_generate_quantities(selected, total_quantity, _rows = null) {
+		const rows = _rows || Array.from(this.find_rows(selected));
+		let running_total_qty = 0;
+		for (let i = 0; i < rows.length; i++) {
+			const row = rows[i];
+			const current_qty = this.quantity_fieldname ? row[this.quantity_fieldname] : 1;
+			const next_running_total_qty = running_total_qty + current_qty;
+			const too_little = next_running_total_qty < total_quantity;
+
+			// If the last row doesn't have enough quantity, we need to increase its quantity.
+			// The last row is the only row that can have its quantity increased.
+			if (i === rows.length - 1 && too_little) {
+				yield [row, total_quantity - running_total_qty];
+				break;
+			}
+
+			// If a non-last row has not enough quantity, we can skip it.
+			// We don't need to increase its quantity because we will increase the last row's quantity.
+			if (too_little) {
+				running_total_qty = next_running_total_qty;
+				continue;
+			}
+
+			// If any row will make the total quantity too much, we need to decrease its quantity.
+			// All subsequent rows will have to be zeroed out.
+			// This is done by setting running_total_qty to total_quantity.
+			if (!too_little) {
+				const delta = total_quantity - running_total_qty;
+				yield [row, delta];
+				running_total_qty = total_quantity;
+			}
+		}
+	}
+
+	remove(selected) {
+		for (const row of this.find_rows(selected)) {
+			this._remove_row(row);
+		}
+	}
+
+	*find_rows(selected) {
+		if (!selected) {
+			return [];
+		}
+		for (const row of this.parent_doc[this.options.table_fieldname]) {
+			if (row?.[this.link_fieldname] === selected.name) {
+				yield row;
+			}
+		}
+	}
+
+	grab_quantity(selected) {
+		if (!this.quantity_fieldname) {
+			return Array.from(this.find_rows(selected)).filter((x) => !x.__removed).length;
+		}
+
+		let total_qty = 0;
+		for (const row of this.find_rows(selected)) {
+			if (row.__removed) {
+				continue;
+			}
+			const qty = row?.[this.quantity_fieldname] ?? 0;
+			if (typeof qty === "number") {
+				total_qty += qty;
+			}
+		}
+		return total_qty;
+	}
+}

--- a/frappe/public/js/frappe/ui/catalog/LinkCatalogItem.vue
+++ b/frappe/public/js/frappe/ui/catalog/LinkCatalogItem.vue
@@ -1,0 +1,326 @@
+<script setup>
+import {
+	computed,
+	provide,
+	inject,
+	ref,
+	shallowRef,
+	markRaw,
+	watch,
+	onMounted,
+	onUnmounted,
+} from "vue";
+import { with_doctype } from "./link_catalog_common";
+import VueSmartElement from "./VueSmartElement.vue";
+
+// Props
+const props = defineProps({
+	doc: {
+		type: Object,
+		required: true,
+	},
+});
+
+// Injected
+
+/** @type {import('./link_catalog_common').CatalogOptions} */
+const options = inject("options");
+
+/** @type {import('./link_catalog_common').Bus} */
+const bus = inject("bus");
+
+/** @type {import('./LinkCatalogAdapter').BaseLayoutAdapter} */
+const layoutAdapter = inject("layoutAdapter");
+
+// Provide
+
+provide("item", props.doc);
+
+// State
+const state = ref("loading");
+const meta = shallowRef(null);
+const spec = shallowRef(null);
+const quantity = ref(0);
+
+const href = computed(() => {
+	return frappe.utils.get_form_link(props.doc.doctype, props.doc.name);
+});
+
+// Listen to the refresh event
+let off = null;
+onMounted(() => {
+	off = bus.on("refresh", refreshQuantity);
+});
+onUnmounted(() => {
+	off?.();
+});
+
+watch(
+	() => props.doc.doctype,
+	async () => {
+		state.value = "loading";
+		await with_doctype(props.doc.doctype);
+		meta.value = frappe.get_meta(props.doc.doctype);
+		spec.value = getSpec();
+		refreshQuantity();
+		state.value = "loaded";
+	},
+	{ immediate: true }
+);
+
+function getSpec() {
+	const image_field = meta.value.image_field || null;
+	const title_field = meta.value.title_field || null;
+
+	return {
+		image_field,
+		title_field,
+	};
+}
+
+// Event handlers
+
+function plus() {
+	setQuantity(quantity.value + 1);
+}
+
+function minus() {
+	setQuantity(quantity.value - 1);
+}
+
+function setQuantity(qty) {
+	qty = Math.max(0, Number(qty));
+	quantity.value = qty;
+	bus.emit("selectItem", {
+		selected: props.doc,
+		quantity: qty,
+		// callback: qty && refreshQuantity,
+	});
+}
+
+function refreshQuantity() {
+	quantity.value = layoutAdapter.grab_quantity(props.doc);
+}
+
+// Utilities
+
+function get_df(fieldname) {
+	const df = frappe.meta.get_docfield(props.doc.doctype, fieldname);
+	if (!df) {
+		throw new Error(`Invalid fieldname: ${fieldname}`);
+	}
+	return df;
+}
+
+function format(field) {
+	if (!frappe.get_meta(props.doc?.doctype)) {
+		return "Ensure component is running in Suspense context";
+	}
+
+	let df = null;
+	if (typeof field === "string") {
+		df = get_df(field);
+	} else if (field?.fieldtype) {
+		df = field;
+	} else {
+		throw new Error("Invalid field");
+	}
+
+	if (!df) {
+		return "";
+	}
+
+	const value = props.doc[df.fieldname];
+	return frappe.format(value, df, null, props.doc);
+}
+</script>
+
+<template>
+	<article class="LinkCatalogItem" :class="{ 'LinkCatalogItem--selected': quantity > 0 }">
+		<template v-if="state === 'loading'">
+			<i class="fa fa-spinner fa-spin"></i>
+		</template>
+		<template v-else>
+			<template v-if="spec.image_field && doc[spec.image_field]">
+				<a class="LinkCatalogItem__image" :href="doc[spec.image_field]" target="_blank">
+					<img :src="doc[spec.image_field]" alt="" />
+				</a>
+			</template>
+
+			<header class="user-select-none">
+				<h3>
+					<a :href="href" target="_blank">
+						{{ spec.title_field ? format(spec.title_field) : doc.name }}
+					</a>
+				</h3>
+			</header>
+
+			<div style="grid-area: body">
+				<VueSmartElement :element="markRaw(options.item_contents || [])" />
+			</div>
+
+			<footer>
+				<VueSmartElement :element="markRaw(options.item_footer || [])" />
+
+				<div class="LinkCatalogItem__buttons">
+					<div class="btn-group" v-if="options.quantity_fieldname">
+						<button
+							class="btn btn-md btn-text-default LinkCatalogItem__decrement"
+							type="button"
+							:aria-label="__('Remove')"
+							@click="minus"
+							v-html="frappe.utils.icon('es-line-dash')"
+						/>
+						<input
+							class="btn-reset input-xs font-weight-bold LinkCatalogItem__quantity"
+							type="number"
+							inputmode="numeric"
+							min="0"
+							:value="quantity"
+							:aria-label="__('Quantity')"
+							@change="($e) => setQuantity($e.target.value)"
+							@focus="($e) => $e.target.select()"
+						/>
+						<button
+							class="btn btn-md btn-text-default LinkCatalogItem__increment"
+							type="button"
+							:aria-label="__('Add')"
+							@click="plus"
+							v-html="frappe.utils.icon('es-line-add')"
+						/>
+					</div>
+					<button
+						v-else-if="quantity > 0"
+						class="btn btn-md btn-text-default"
+						type="button"
+						@click="setQuantity(0)"
+					>
+						Remove
+					</button>
+					<button
+						v-else
+						class="btn btn-md btn-text-default"
+						type="button"
+						@click="setQuantity(1)"
+					>
+						Add
+					</button>
+				</div>
+			</footer>
+		</template>
+	</article>
+</template>
+
+<style lang="scss">
+.LinkCatalogItem {
+	display: grid;
+	grid-template-areas:
+		"image header"
+		"image body"
+		"footer footer";
+	grid-template-columns: 1fr 2fr;
+	grid-template-rows: auto 1fr auto;
+	gap: 0px;
+
+	border-radius: var(--border-radius);
+	word-break: break-word;
+	/* text-wrap: balance; */
+
+	box-shadow: 0 0 0 1px var(--border-color);
+
+	&:not(:hover, :focus-visible, :focus-within, .LinkCatalogItem--selected) {
+		.LinkCatalogItem__buttons {
+			opacity: 0.5;
+		}
+	}
+
+	&:not(:has(.LinkCatalogItem__image)) {
+		grid-template-columns: 0px 1fr;
+	}
+
+	&--selected {
+		box-shadow: 0 0 0 2px var(--text-muted);
+	}
+
+	& > header {
+		grid-area: header;
+		display: flex;
+		align-items: center;
+		padding: 0.5em;
+	}
+
+	& > header > h3 {
+		margin: 0;
+		font-size: var(--text-lg);
+		font-weight: var(--weight-bold);
+	}
+
+	& > &__image {
+		grid-area: image;
+		padding: 0.25em;
+
+		& > img {
+			/* width: 100%;
+			height: 100%; */
+			object-fit: contain;
+			transition: all 0.2s ease;
+			transition-property: transform, box-shadow, background-color;
+			max-height: 64px;
+
+			&:hover {
+				transform: scale(3);
+				z-index: 100;
+				cursor: zoom-in;
+				box-shadow: var(--shadow-2xl);
+				background-color: var(--fg-color);
+			}
+		}
+	}
+
+	& > dl {
+		grid-area: body;
+		padding: 0 0.5em;
+		display: flex;
+		flex-direction: column;
+		gap: 0.125em;
+		font-size: var(--text-sm);
+
+		:is(dt, dd) {
+			display: inline;
+			margin: 0;
+			font-weight: var(--weight-normal);
+		}
+		dd {
+			font-weight: var(--weight-semibold);
+		}
+	}
+
+	& > footer {
+		margin-top: auto;
+		grid-area: footer;
+		display: flex;
+		justify-content: flex-end;
+		// background-color: var(--bg-color);
+
+		.btn {
+			font-size: var(--text-xs);
+		}
+	}
+
+	.LinkCatalogItem__quantity {
+		text-align: center;
+		width: 2.5em;
+
+		// https://www.w3schools.com/howto/howto_css_hide_arrow_number.asp
+		/* Firefox */
+		-moz-appearance: textfield;
+
+		/* Chrome, Safari, Edge, Opera */
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
+	}
+}
+</style>

--- a/frappe/public/js/frappe/ui/catalog/VueSmartElement.vue
+++ b/frappe/public/js/frappe/ui/catalog/VueSmartElement.vue
@@ -1,0 +1,33 @@
+<script setup>
+// @ts-check
+import { markRaw } from "vue";
+
+const props = defineProps({
+	element: {
+		type: [String, Object, Function, Promise],
+		required: true,
+	},
+});
+
+// NOTE: When providing a component, it must be included in the same bundle as the parent LinkCatalog component.
+// Otherwise, this will cause issues with reactivity (because of the multiple Vue library imports).
+</script>
+
+<template>
+	<template v-if="typeof element === 'string'">
+		{{ element }}
+	</template>
+	<template v-if="Array.isArray(element)">
+		<template v-for="item in element">
+			<VueSmartElement :element="markRaw(item)" />
+		</template>
+	</template>
+	<template v-else-if="element?.component">
+		<component :is="element?.component" />
+	</template>
+	<template v-else-if="element?.html">
+		<div v-html="element.html" />
+	</template>
+	<slot v-else-if="!element" name="fallback" />
+	<slot v-else name="error" />
+</template>

--- a/frappe/public/js/frappe/ui/catalog/index.js
+++ b/frappe/public/js/frappe/ui/catalog/index.js
@@ -1,0 +1,49 @@
+import { createApp } from "vue";
+import LinkCatalogVue from "./LinkCatalog.vue";
+import { getLayoutAdapter } from "./LinkCatalogAdapter";
+import { Bus, CatalogOptions } from "./link_catalog_common";
+
+// Use this class with:
+// import { LinkCatalog } from "frappe/public/js/frappe/ui/catalog";
+
+export class LinkCatalog {
+	constructor({ layout = null, frm = null, dialog = null, options = null, wrapper = null }) {
+		if (!options) {
+			throw new Error("Missing argument: options");
+		}
+		this.options = new CatalogOptions();
+		Object.assign(this.options, options);
+
+		this.layout = frm || dialog || layout || window.cur_frm;
+		if (!this.layout) {
+			throw new Error("Missing argument: Must provide one of: layout, frm, dialog");
+		}
+
+		this.wrapper = wrapper;
+		if (!this.wrapper) {
+			throw new Error("Missing argument: wrapper");
+		}
+		if (window.jQuery && this.wrapper instanceof window.jQuery) {
+			this.wrapper = this.wrapper[0];
+		}
+
+		this.bus = new Bus();
+		this.layoutAdapter = getLayoutAdapter(this.layout, this.options);
+
+		this.make();
+	}
+
+	make() {
+		const app = createApp(LinkCatalogVue);
+		SetVueGlobals(app);
+		app.provide("bus", this.bus);
+		app.provide("frm", this.layout);
+		app.provide("layoutAdapter", this.layoutAdapter);
+		app.provide("options", this.options);
+		app.mount(this.wrapper);
+	}
+
+	refresh() {
+		this.bus?.emit("refresh");
+	}
+}

--- a/frappe/public/js/frappe/ui/catalog/link_catalog_common.js
+++ b/frappe/public/js/frappe/ui/catalog/link_catalog_common.js
@@ -1,0 +1,74 @@
+const promises = {};
+
+export async function with_doctype(doctype) {
+	if (typeof doctype !== "string") {
+		throw new TypeError("Expected doctype to be a string");
+	}
+	if (!promises[doctype]) {
+		promises[doctype] = frappe.model.with_doctype(doctype);
+	}
+	return promises[doctype];
+}
+
+export class Bus {
+	constructor() {
+		this._listeners = {};
+	}
+
+	on(event, callback) {
+		if (!this._listeners[event]) {
+			this._listeners[event] = [];
+		}
+		this._listeners[event].push(callback);
+
+		return () => this.off(event, callback);
+	}
+
+	off(event, callback) {
+		if (!this._listeners[event]) {
+			return;
+		}
+		this._listeners[event] = this._listeners[event].filter((cb) => cb !== callback);
+	}
+
+	emit(event, ...args) {
+		if (!this._listeners[event]) {
+			return;
+		}
+		this._listeners[event].forEach((cb) => cb(...args));
+	}
+}
+
+export class CatalogOptions {
+	/** @typedef {{ html: HTMLElement } | { component: import('vue').Component} | function | Promise} SmartElement */
+
+	/** @type {string} */
+	link_doctype = "";
+
+	/** @type {string[]} */
+	search_fields = ["name"];
+
+	/** @type {(search, filters, or_filters, page_index, page_length)} */
+	search_function = null;
+
+	/** @type {string} */
+	link_fieldname = "";
+
+	/** @type {string | null} */
+	quantity_fieldname = null;
+
+	/** @type {string | null} */
+	table_fieldname = null;
+
+	/** @type {SmartElement[]} */
+	sidebar_contents = [];
+
+	/** @type {SmartElement[]} */
+	item_contents = [];
+
+	/** @type {SmartElement[]} */
+	item_footer = [];
+
+	/** @type {SmartElement[]} */
+	title = [];
+}


### PR DESCRIPTION
As explained in https://github.com/frappe/frappe/issues/23859, **I finished working on a Catalog UI to pick items in ERPNext's Quotations, etc.**

I want this to be an improved UI for Links and similar fields. I believe that this type of UI is not limited to ERPNext, but can apply to other types of selections as well:
* `items` Table in the Quotation DocType (ERPNext, instead of the `Add Multiple` button)
* `links` Table in the Contacts table
* Any `Link`
* Even `MultiSelect Table` fields too

That's why I open the issue/PR here (Frappe). **But feel free to tell me that this isn't a good idea and that I should instead move everything to ERPNext.** Please see the sister PR at https://github.com/frappe/erpnext/pull/39222

---

![image](https://github.com/frappe/frappe/assets/10946971/580c458a-0d66-4d4a-a2b3-cabf2ebb673c)

## Features
- Add/Remove/Update rows in Tables (like `items` in ERPNext's Quotations)
- Correctly handle where multiple rows have the same link value (wrt. quantity updates)
- Pick value of solo Link field (with optional `quantity: Int|Float` field)
- Customize sidebar (as seen in screenshot with the Custom Button)
- Event bus to add/remove filters
- Customize item card content (e.g. to display Item price)
- Metadata: use `meta.image` and `meta.title` meta fields

> no-docs