### PR TITLE
fix: count correction when a tag is deleted

### DIFF
--- a/frappe/desk/doctype/tag/tag.py
+++ b/frappe/desk/doctype/tag/tag.py
@@ -109,7 +109,7 @@ class DocTags:
 			tags = ""
 		else:
 			tl = unique(filter(lambda x: x, tl))
-			tags = "," + ",".join(tl)
+			tags = ",".join(tl)
 		try:
 			frappe.db.sql(
 				"update `tab{}` set _user_tags={} where name={}".format(self.dt, "%s", "%s"), (tags, dn)


### PR DESCRIPTION
**Issue:**

When we assign a tag to an entry and then delete it, the "No Tags" count does not change.
![frappe_tag_no_tags_counter_issue.gif](https://i.ibb.co/TMLrDVv/frappe-tag-no-tags-counter-issue.gif)

**Reason:**

When a tag is removed after adding it is stored in DB as " , " instead of empty. Hence the "No Tags" count does not change.

<img width="172" alt="Screenshot 2024-01-09 at 12 09 30 AM" src="https://github.com/frappe/frappe/assets/65544983/4b04a90f-3379-4a6a-9909-17bcedbcec4c">




**After Fix:**

If no tags then no entry will be there in the DB.

<img width="166" alt="Screenshot 2024-01-09 at 12 11 48 AM" src="https://github.com/frappe/frappe/assets/65544983/f4b7864b-897a-4f67-b06e-e9a47874da49">


 