### PR TITLE
fix: don't update docstatus

### DIFF
--- a/frappe/workflow/doctype/workflow/test_workflow.py
+++ b/frappe/workflow/doctype/workflow/test_workflow.py
@@ -150,32 +150,6 @@ class TestWorkflow(FrappeTestCase):
 		self.assertEqual(workflow_actions[0].status, "Completed")
 		frappe.set_user("Administrator")
 
-	def test_update_docstatus(self):
-		todo = create_new_todo()
-		apply_workflow(todo, "Approve")
-
-		self.workflow._update_state_docstatus = True
-		self.workflow.states[1].doc_status = 0
-		self.workflow.save()
-		todo.reload()
-		self.assertEqual(todo.docstatus, 0)
-		self.workflow.states[1].doc_status = 1
-		self.workflow.save()
-		todo.reload()
-		self.assertEqual(todo.docstatus, 1)
-
-		self.workflow.states[1].doc_status = 0
-		self.workflow.save()
-
-		self.workflow._update_state_docstatus = False
-		self.workflow.states[1].doc_status = 1
-		self.workflow.save()
-		todo.reload()
-		self.assertEqual(todo.docstatus, 0)
-
-		self.workflow.states[1].doc_status = 0
-		self.workflow.save()
-
 	def test_if_workflow_set_on_action(self):
 		self.workflow._update_state_docstatus = True
 		self.workflow.states[1].doc_status = 1

--- a/frappe/workflow/doctype/workflow/workflow.py
+++ b/frappe/workflow/doctype/workflow/workflow.py
@@ -38,7 +38,6 @@ class Workflow(Document):
 		self.validate_docstatus()
 
 	def on_update(self):
-		self.update_doc_status()
 		frappe.clear_cache(doctype=self.document_type)
 
 	def create_custom_field_for_workflow_state(self):
@@ -84,34 +83,6 @@ class Workflow(Document):
 				)
 
 				docstatus_map[d.doc_status] = d.state
-
-	def update_doc_status(self):
-		"""
-		Checks if the docstatus of a state was updated.
-		If yes then the docstatus of the document with same state will be updated
-		"""
-
-		if not self.get("_update_state_docstatus"):
-			return
-
-		doc_before_save = self.get_doc_before_save()
-		before_save_states, new_states = {}, {}
-		if doc_before_save:
-			for d in doc_before_save.states:
-				before_save_states[d.state] = d
-			for d in self.states:
-				new_states[d.state] = d
-
-			for key in new_states:
-				if key in before_save_states:
-					if new_states[key].doc_status != before_save_states[key].doc_status:
-						frappe.db.set_value(
-							self.document_type,
-							{self.workflow_state_field: before_save_states[key].state},
-							"docstatus",
-							new_states[key].doc_status,
-							update_modified=False,
-						)
 
 	def validate_docstatus(self):
 		def get_state(state):


### PR DESCRIPTION
This doesn't make sense.

Updating docstatus without resaving document is a bad idea.

Co-Authored-By: rohitwaghchaure <rohitw1991@gmail.com>
