### PR TITLE
fix: convert status field data to String before guessing the style

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -214,7 +214,6 @@ class DocType(Document):
 		self.validate_website()
 		self.validate_virtual_doctype_methods()
 		self.ensure_minimum_max_attachment_limit()
-		self.check_status_field_fieldtype()
 		validate_links_table_fieldnames(self)
 
 		if not self.is_new():
@@ -446,17 +445,6 @@ class DocType(Document):
 				title=_("Insufficient attachment limit"),
 				alert=True,
 			)
-
-	def check_status_field_fieldtype(self):
-		allowed_fieldtypes = ["Select", "Data", "Check"]
-		for d in self.fields:
-			if d.fieldname == "status":
-				if d.fieldtype not in allowed_fieldtypes:
-					frappe.throw(
-						_("{0} is a reserved keyword. <br> Fieldtype of {0} field must be one of {1}").format(
-							frappe.bold("status"), allowed_fieldtypes
-						)
-					)
 
 	def change_modified_of_parent(self):
 		"""Change the timestamp of parent DocType if the current one is a child to clear caches."""

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -204,7 +204,7 @@ class DocType(Document):
 		self.validate_document_type()
 		validate_fields(self)
 		self.check_indexing_for_dashboard_links()
-
+		self.check_status_field_fieldtype()
 		if not self.istable:
 			validate_permissions(self)
 
@@ -226,6 +226,17 @@ class DocType(Document):
 
 		if self.default_print_format and not self.custom:
 			frappe.throw(_("Standard DocType cannot have default print format, use Customize Form"))
+
+	def check_status_field_fieldtype(self):
+		allowed_fieldtypes = ["Select", "Data", "Check"]
+		for d in self.fields:
+			if d.fieldname == "status":
+				if d.fieldtype not in allowed_fieldtypes:
+					frappe.throw(
+						_("{0} is a reserved keyword. <br> Fieldtype of {0} field must be one of {1}").format(
+							frappe.bold("status"), allowed_fieldtypes
+						)
+					)
 
 	def validate_field_name_conflicts(self):
 		"""Check if field names dont conflict with controller properties and methods"""

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -204,7 +204,6 @@ class DocType(Document):
 		self.validate_document_type()
 		validate_fields(self)
 		self.check_indexing_for_dashboard_links()
-		self.check_status_field_fieldtype()
 		if not self.istable:
 			validate_permissions(self)
 
@@ -215,6 +214,7 @@ class DocType(Document):
 		self.validate_website()
 		self.validate_virtual_doctype_methods()
 		self.ensure_minimum_max_attachment_limit()
+		self.check_status_field_fieldtype()
 		validate_links_table_fieldnames(self)
 
 		if not self.is_new():
@@ -226,17 +226,6 @@ class DocType(Document):
 
 		if self.default_print_format and not self.custom:
 			frappe.throw(_("Standard DocType cannot have default print format, use Customize Form"))
-
-	def check_status_field_fieldtype(self):
-		allowed_fieldtypes = ["Select", "Data", "Check"]
-		for d in self.fields:
-			if d.fieldname == "status":
-				if d.fieldtype not in allowed_fieldtypes:
-					frappe.throw(
-						_("{0} is a reserved keyword. <br> Fieldtype of {0} field must be one of {1}").format(
-							frappe.bold("status"), allowed_fieldtypes
-						)
-					)
 
 	def validate_field_name_conflicts(self):
 		"""Check if field names dont conflict with controller properties and methods"""
@@ -457,6 +446,17 @@ class DocType(Document):
 				title=_("Insufficient attachment limit"),
 				alert=True,
 			)
+
+	def check_status_field_fieldtype(self):
+		allowed_fieldtypes = ["Select", "Data", "Check"]
+		for d in self.fields:
+			if d.fieldname == "status":
+				if d.fieldtype not in allowed_fieldtypes:
+					frappe.throw(
+						_("{0} is a reserved keyword. <br> Fieldtype of {0} field must be one of {1}").format(
+							frappe.bold("status"), allowed_fieldtypes
+						)
+					)
 
 	def change_modified_of_parent(self):
 		"""Change the timestamp of parent DocType if the current one is a child to clear caches."""

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -480,7 +480,7 @@ Object.assign(frappe.utils, {
 		var style = default_style || "default";
 		var colour = "gray";
 		if (text) {
-			text = String(text);
+			text = cstr(text);
 			if (has_words(["Pending", "Review", "Medium", "Not Approved"], text)) {
 				style = "warning";
 				colour = "orange";

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -480,6 +480,7 @@ Object.assign(frappe.utils, {
 		var style = default_style || "default";
 		var colour = "gray";
 		if (text) {
+			text = String(text);
 			if (has_words(["Pending", "Review", "Medium", "Not Approved"], text)) {
 				style = "warning";
 				colour = "orange";


### PR DESCRIPTION
When status field is created and saved as "Int"/ "Check" type the "doctype" breaks as shown below.

**Before Fix:**
<img width="1300" alt="Screenshot 2024-01-10 at 12 18 39 PM" src="https://github.com/frappe/frappe/assets/65544983/63e1fca3-c3be-4a41-b6ee-fdfde1ebd393">


**After Fix:**

1. When Status field is of type Int.


<img width="1293" alt="Screenshot 2024-01-10 at 12 20 31 PM" src="https://github.com/frappe/frappe/assets/65544983/9a8df28f-a426-4b1c-8414-1c7d91211ee5">

2.When Status Field is of type "Check".

<img width="1311" alt="Screenshot 2024-01-10 at 12 23 33 PM" src="https://github.com/frappe/frappe/assets/65544983/d0c6a1dc-5847-4d55-a150-0c1dd3f7db80">



Closes:https://github.com/frappe/frappe/issues/12367