### PR TITLE
feat: allow multiple email accounts for Automatic Linking 1 of 2

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -670,9 +670,9 @@ class EmailAccount(Document):
 				frappe.throw(_("Automatic Linking can be activated only if Incoming is enabled."))
 
 			if frappe.db.exists(
-				"Email Account", {"enable_automatic_linking": 1, "name": ("!=", self.name)}
+				"Email Account", {"enable_automatic_linking": 1, "name": ("!=", self.name),"append_to": self.append_to}
 			):
-				frappe.throw(_("Automatic Linking can be activated only for one Email Account."))
+				frappe.throw(_("Automatic Linking can be activated only once for {0} doctype.".format(self.append_to)))
 
 	def append_email_to_sent_folder(self, message):
 		if not (self.enable_incoming and self.use_imap):


### PR DESCRIPTION
complete description at https://github.com/frappe/frappe/issues/23712

This change ensures a doctype is append_to  once for any incoming email account for linked communication

The two fixes ensures that different email account can be mapped to different doctypes for automatic linking the communication trail