### PR TITLE
fix: include workspaces without domain restriction

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -417,8 +417,11 @@ def get_workspace_sidebar_items():
 	blocked_modules = frappe.get_doc("User", frappe.session.user).get_blocked_modules()
 	blocked_modules.append("Dummy Module")
 
+	# adding None to allowed_domains to include pages without domain restriction
+	allowed_domains = [None] + frappe.get_active_domains()
+
 	filters = {
-		"restrict_to_domain": ["in", frappe.get_active_domains()],
+		"restrict_to_domain": ["in", allowed_domains],
 		"module": ["not in", blocked_modules],
 	}
 


### PR DESCRIPTION
### Problem

Brand new system. Allowed **Workspaces** are queried like this:

```python
filters = {
	"restrict_to_domain": ["in", frappe.get_active_domains()],
	# ...
}
```

No special domains were enabled/disabled, so `frappe.get_active_domains()` returns `[""]`.

A newly created **Workspace** has `ws.restrict_to_domain == None`. So the `ws.restrict_to_domain in [""]` condition is never `True`.

The **Workspace** has no restrictions, but users without "Worspace Manager" role cannot see it.

### Solution

Include `None` in allowed values:

```python
allowed_domains = [None] + frappe.get_active_domains()
filters = {
	"restrict_to_domain": ["in", allowed_domains],
	# ...
}
```