### PR TITLE
fix!: Stricter requirement for permission hooks

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -504,12 +504,14 @@ def on_doctype_update():
 def has_permission(doc, ptype, user=None, debug=False):
 	if ptype == "read":
 		if doc.reference_doctype == "Communication" and doc.reference_name == doc.name:
-			return
+			return True
 
 		if doc.reference_doctype and doc.reference_name:
 			return frappe.has_permission(
 				doc.reference_doctype, ptype="read", doc=doc.reference_name, user=user, debug=debug
 			)
+
+	return True
 
 
 def get_permission_query_conditions_for_communication(user):

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1157,6 +1157,7 @@ def has_permission(doc, user):
 	if (user != "Administrator") and (doc.name in STANDARD_USERS):
 		# dont allow non Administrator user to view / edit Administrator user
 		return False
+	return True
 
 
 def notify_admin_access_to_system_manager(login_manager=None):

--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -57,4 +57,4 @@ def get_permission_query_conditions(user):
 
 
 def has_permission(doc, user):
-	return doc.public or doc.owner == user
+	return bool(doc.public or doc.owner == user)

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -452,10 +452,9 @@ def has_controller_permissions(doc, ptype, user=None, debug=False) -> bool:
 	for method in reversed(methods):
 		controller_permission = frappe.call(method, doc=doc, ptype=ptype, user=user, debug=debug)
 		debug and _debug_log(f"Controller permission check from {method}: {controller_permission}")
-		if controller_permission is not None:
+		if not controller_permission:
 			return bool(controller_permission)
 
-	# None of the controller hooks returned anything conclusive
 	return True
 
 

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -185,6 +185,7 @@ class TestAPIHooks(FrappeAPITestCase):
 def custom_has_permission(doc, ptype, user):
 	if doc.flags.dont_touch_me:
 		return False
+	return True
 
 
 def custom_auth():


### PR DESCRIPTION
BREAKING CHANGE:

before: `has_permission` hooks need to explicitly return "False" to block a user.

after: `has_permission` hooks need to explicitly return "True" (or truthy) value to allow user. They will be blocked otherwise.

Why? Everything related to permission should be block by default and allow if some checks pass.
