### PR TITLE
feat: Explicit User Permissions

### DIFF
--- a/frappe/core/doctype/custom_docperm/custom_docperm.json
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.json
@@ -11,6 +11,7 @@
   "role_and_level",
   "role",
   "if_owner",
+  "user_permission_reqd",
   "column_break_2",
   "permlevel",
   "section_break_4",
@@ -212,13 +213,20 @@
    "fieldname": "select",
    "fieldtype": "Check",
    "label": "Select"
+  },
+  {
+   "default": "0",
+   "fieldname": "user_permission_reqd",
+   "fieldtype": "Check",
+   "label": "Require Explicit User Permissions"
   }
  ],
  "links": [],
- "modified": "2023-02-20 13:19:04.889081",
+ "modified": "2024-01-10 23:29:45.136675",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Custom DocPerm",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {
@@ -237,5 +245,6 @@
  "read_only": 1,
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "title_field": "parent"
 }

--- a/frappe/core/doctype/custom_docperm/custom_docperm.py
+++ b/frappe/core/doctype/custom_docperm/custom_docperm.py
@@ -30,7 +30,9 @@ class CustomDocPerm(Document):
 		select: DF.Check
 		share: DF.Check
 		submit: DF.Check
+		user_permission_reqd: DF.Check
 		write: DF.Check
 	# end: auto-generated types
+
 	def on_update(self):
 		frappe.clear_cache(doctype=self.parent)

--- a/frappe/core/doctype/docperm/docperm.json
+++ b/frappe/core/doctype/docperm/docperm.json
@@ -10,6 +10,7 @@
   "role_and_level",
   "role",
   "if_owner",
+  "user_permission_reqd",
   "column_break_2",
   "permlevel",
   "section_break_4",
@@ -205,17 +206,26 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Select"
+  },
+  {
+   "default": "0",
+   "description": "Users will not be able to access any document unless they have explicit user permissions",
+   "fieldname": "user_permission_reqd",
+   "fieldtype": "Check",
+   "label": "Require Explicit User Permissions"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-02-20 13:21:45.071310",
+ "modified": "2024-01-10 23:26:32.919718",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocPerm",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "ASC"
+ "sort_order": "ASC",
+ "states": []
 }

--- a/frappe/core/doctype/docperm/docperm.py
+++ b/frappe/core/doctype/docperm/docperm.py
@@ -31,6 +31,8 @@ class DocPerm(Document):
 		select: DF.Check
 		share: DF.Check
 		submit: DF.Check
+		user_permission_reqd: DF.Check
 		write: DF.Check
 	# end: auto-generated types
+
 	pass

--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -236,9 +236,10 @@ frappe.PermissionEngine = class PermissionEngine {
 			this.set_show_users(role_cell, d.role);
 
 			if (d.permlevel === 0) {
-				// this.setup_user_permissions(d, role_cell);
 				this.setup_if_owner(d, role_cell);
 			}
+
+			this.setup_explicit_user_permissions(d, role_cell);
 
 			let cell = this.add_cell(row, d, "permlevel");
 
@@ -301,6 +302,12 @@ frappe.PermissionEngine = class PermissionEngine {
 
 	setup_if_owner(d, role_cell) {
 		this.add_check(role_cell, d, "if_owner", "Only if Creator")
+			.removeClass("col-md-4")
+			.css({ "margin-top": "15px" });
+	}
+
+	setup_explicit_user_permissions(d, role_cell) {
+		this.add_check(role_cell, d, "user_permission_reqd", "Require Explicit User Permissions")
 			.removeClass("col-md-4")
 			.css({ "margin-top": "15px" });
 	}


### PR DESCRIPTION
Refer: https://discuss.frappe.io/t/the-design-of-user-permissions-is-dangerous/109103 

User permission (UP) design is kind of dangerous because:
1. If user has UP on 1 document then they can only access that document 
2. If that 1 UP is removed, suddenly now users can access everything :woozy_face: 

This PR introduced "Require Explicit User Permission" check. 

Change:
- If explicit UP is checked then user wont be able to access anything in doctype or any document that links to that doctype. 
- If user has some other role where explicit UP is not checked then user will be able to freely access the documents. E.g. Employee role has explicit UP, so Employee user won't be able to access anything unless UP is set for them. HR managers however will be able to bypass it.  

Closes https://github.com/frappe/frappe/issues/18941 


TODO:
- [x] Explicit perms on doc
- [ ] Explicit perm on list
- [ ] Review
- [ ] Tests