### PR TITLE
fix: set correct recipient when reply to own email

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -230,6 +230,10 @@ frappe.views.CommunicationComposer = class {
 
 		if (!this.forward && !this.recipients && this.last_email) {
 			this.recipients = this.last_email.sender;
+			// If Same user is replies to his own email, set recipients to last email recipients
+			if (this.last_email.sender == this.sender) {
+				this.recipients = this.last_email.recipients;
+			}
 			this.cc = this.last_email.cc;
 			this.bcc = this.last_email.bcc;
 		}

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -230,7 +230,7 @@ frappe.views.CommunicationComposer = class {
 
 		if (!this.forward && !this.recipients && this.last_email) {
 			this.recipients = this.last_email.sender;
-			// If Same user is replies to his own email, set recipients to last email recipients
+			// If same user replies to their own email, set recipients to last email recipients
 			if (this.last_email.sender == this.sender) {
 				this.recipients = this.last_email.recipients;
 			}


### PR DESCRIPTION
When Sender clicks on reply to own email, the recipient is set to the Sender's email address instead of the original ( last_email ) recipient. 

Added a check if sender is composing a reply to own email and set the recipient to the original ( last_email ) recipient.
