### PR TITLE
fix: add empty space for notification mark read

### DIFF
--- a/frappe/public/scss/desk/notification.scss
+++ b/frappe/public/scss/desk/notification.scss
@@ -139,18 +139,18 @@
 	justify-content: space-between;
 
 	&.unread {
-		&:hover {
-			.mark-as-read {
-				flex-shrink: 0;
-				align-self: center;
-				justify-self: end;
-				width: 8px;
-				height: 8px;
-				border: 2px solid var(--invert-neutral);
-				border-radius: 1000px;
-			}
+		.mark-as-read {
+			flex-shrink: 0;
+			align-self: center;
+			justify-self: end;
+			width: 8px;
+			height: 8px;
 		}
 
+		&:hover .mark-as-read {
+			border: 2px solid var(--invert-neutral);
+			border-radius: 1000px;
+		}
 		.notification-body::before {
 			background: var(--invert-neutral);
 		}


### PR DESCRIPTION
mark-as-read added 8px width on hover which caused layout shift so i added empty space to compensate for it

### Before

https://github.com/frappe/frappe/assets/39730881/02a53acc-036a-4154-bc24-99670d1ef89f



### After
https://github.com/frappe/frappe/assets/39730881/16c3d9b5-22fb-430f-96f8-e40c1561aacd

