### PR TITLE
fix: parse error messages in data import

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -450,11 +450,23 @@ frappe.ui.form.on("Data Import", {
 						} else {
 							let messages = JSON.parse(log.messages || "[]")
 								.map((m) => {
+									// If message is json string try to parse it
+									if (typeof m === "string") {
+										try {
+											m = JSON.parse(m);
+										} catch {
+											console.error(
+												"Message isn't valid json string",
+												message
+											);
+										}
+									}
 									let title = m.title ? `<strong>${m.title}</strong>` : "";
 									let message = m.message ? `<div>${m.message}</div>` : "";
 									return title + message;
 								})
 								.join("");
+
 							let id = frappe.dom.get_unique_id();
 							html = `${messages}
 								<button class="btn btn-default btn-xs" type="button" data-toggle="collapse" data-target="#${id}" aria-expanded="false" aria-controls="${id}" style="margin-top: 15px;">


### PR DESCRIPTION
When error is thrown during data import, the error message is saved in data import log as json string. Even though we are parsing log.messages as json. we are not parsing individual error messages which are also saved as json string.

added a check if individual error message is string then try to parse it.


### Before
<img width="603" alt="Screenshot 2024-01-11 at 11 41 49 AM" src="https://github.com/frappe/frappe/assets/39730881/83e956c0-fcd5-4182-b12a-3e96a61f8ba9">

### After
<img width="889" alt="Screenshot 2024-01-11 at 11 41 32 AM" src="https://github.com/frappe/frappe/assets/39730881/bb0a3abc-8677-42bc-950d-ffe513ac11b6">

