### PR TITLE
fix: print perm check logs from DB query

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -526,6 +526,7 @@ class DatabaseQuery:
 			ptype=ptype,
 			parent_doctype=parent_doctype or self.doctype,
 			throw=True,
+			user=self.user,
 		)
 		self.permission_map[doctype] = ptype
 

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -521,14 +521,12 @@ class DatabaseQuery:
 
 	def _set_permission_map(self, doctype: str, parent_doctype: str | None = None):
 		ptype = "select" if frappe.only_has_select_perm(doctype) else "read"
-		val = frappe.has_permission(
+		frappe.has_permission(
 			doctype,
 			ptype=ptype,
 			parent_doctype=parent_doctype or self.doctype,
+			throw=True,
 		)
-		if not val:
-			frappe.flags.error_message = _("Insufficient Permission for {0}").format(frappe.bold(doctype))
-			raise frappe.PermissionError(doctype)
 		self.permission_map[doctype] = ptype
 
 	def set_field_tables(self):

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -62,7 +62,7 @@ def report_error(status_code):
 
 def _link_error_with_message_log(error_log, exception, message_logs):
 	for message in message_logs:
-		if message.get("__frappe_exc_id") == exception.__frappe_exc_id:
+		if message.get("__frappe_exc_id") == getattr(exception, "__frappe_exc_id", None):
 			error_log.update(message)
 			message_logs.remove(message)
 			error_log.pop("raise_exception", None)


### PR DESCRIPTION
Doing has_permission and then manually raising exception erases the perm check messages.

This causes insane amounts of confusion when perm error says X not
permitted while user is trying to check Y.
