### PR TITLE
feat: allow multiple email accounts for Automatic Linking 2 of 2

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -389,7 +389,7 @@ def get_tags(doctype: str, name: str) -> str:
 
 
 def get_document_email(doctype, name):
-	email = get_automatic_email_link()
+	email = get_automatic_email_link(doctype)
 	if not email:
 		return None
 
@@ -397,9 +397,9 @@ def get_document_email(doctype, name):
 	return f"{email[0]}+{quote(doctype)}={quote(cstr(name))}@{email[1]}"
 
 
-def get_automatic_email_link():
+def get_automatic_email_link(doctype):
 	return frappe.db.get_value(
-		"Email Account", {"enable_incoming": 1, "enable_automatic_linking": 1}, "email_id"
+		"Email Account", {"enable_incoming": 1, "enable_automatic_linking": 1, "append_to":doctype}, "email_id"
 	)
 
 


### PR DESCRIPTION
complete description at https://github.com/frappe/frappe/issues/23712

This change ensures that automatic email link is done as per append_to doctype of email account.

The two fixes ensures that different email account can be mapped to different doctypes for automatic linking the communication trail

