### PR TITLE
fix!: Remove misleading "raise_exception"

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1015,7 +1015,7 @@ def has_permission(
 		ptype,
 		doc=doc,
 		user=user,
-		raise_exception=throw,
+		print_logs=throw,
 		parent_doctype=parent_doctype,
 		debug=debug,
 	)

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -237,7 +237,7 @@ def get_user_pages_or_reports(parent, cache=False):
 				has_role[p.name] = {"modified": p.modified, "title": p.title}
 
 	elif parent == "Report":
-		if not has_permission("Report", raise_exception=False):
+		if not has_permission("Report", print_logs=False):
 			return {}
 
 		reports = frappe.get_list(

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -4,6 +4,7 @@ from types import NoneType
 from typing import TYPE_CHECKING
 
 import frappe
+import frappe.permissions
 from frappe import _, bold
 from frappe.model.document import Document
 from frappe.model.dynamic_links import get_dynamic_link_map
@@ -379,7 +380,7 @@ def validate_rename(
 		frappe.throw(_("Another {0} with name {1} exists, select another name").format(doctype, new))
 
 	if not (
-		ignore_permissions or frappe.permissions.has_permission(doctype, "write", raise_exception=False)
+		ignore_permissions or frappe.permissions.has_permission(doctype, "write", print_logs=False)
 	):
 		frappe.throw(_("You need write permission to rename"))
 

--- a/frappe/share.py
+++ b/frappe/share.py
@@ -136,7 +136,7 @@ def get_users(doctype: str, name: str) -> list:
 def _get_users(doc: "Document") -> list:
 	from frappe.permissions import has_permission
 
-	if not has_permission(doc.doctype, "read", doc, raise_exception=False):
+	if not has_permission(doc.doctype, "read", doc, print_logs=False):
 		return []
 
 	return frappe.get_all(

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -470,7 +470,7 @@ def filter_allowed_users(users, doc, transition):
 		user
 		for user in users
 		if has_approval_access(user, doc, transition)
-		and has_permission(doctype=doc, user=user, raise_exception=False)
+		and has_permission(doctype=doc, user=user, print_logs=False)
 	]
 
 


### PR DESCRIPTION
frappe.permission.has_permission won't accept raise_exception anymore,
it was extremely misleading argument and actual purpose of the argument
was to print perm check logs.
