### PR TITLE
fix: select field should not have debounce

### DIFF
--- a/frappe/public/js/frappe/form/controls/select.js
+++ b/frappe/public/js/frappe/form/controls/select.js
@@ -1,5 +1,6 @@
 frappe.ui.form.ControlSelect = class ControlSelect extends frappe.ui.form.ControlData {
 	static html_element = "select";
+	static trigger_change_on_input_event = false;
 	make_input() {
 		super.make_input();
 


### PR DESCRIPTION
**Reason:**

if `trigger_change_on_input_event` this value is `true` then the select field goes through debounce which results in 
re-rendering (as shown below)

https://github.com/frappe/frappe/assets/65544983/f1a65824-e80e-40ff-834c-f4617e1dba80


Setting `trigger_change_on_input_event` for Select Field to `false` will avoid such behaviour (as shown below)

https://github.com/frappe/frappe/assets/65544983/e5daca94-8e6e-4b1f-9879-d2f6db454980



