### PR TITLE
fix: improve translatable string description

### DIFF
--- a/frappe/gettext/extractors/doctype.py
+++ b/frappe/gettext/extractors/doctype.py
@@ -22,12 +22,18 @@ def extract(fileobj, *args, **kwargs):
 
 	for field in fields:
 		fieldtype = field.get("fieldtype")
+		label = field.get("label")
 
-		if label := field.get("label"):
+		if label:
 			messages.append((label, f"Label of a {fieldtype} field in DocType '{doctype}'"))
+			_label = label
+		else:
+			_label = field.get("fieldname")
 
 		if description := field.get("description"):
-			messages.append((description, f"Description of a {fieldtype} field in DocType '{doctype}'"))
+			messages.append(
+				(description, f"Description of the '{_label}' ({fieldtype}) field in DocType '{doctype}'")
+			)
 
 		if message := field.get("options"):
 			if fieldtype == "Select":
@@ -37,10 +43,16 @@ def extract(fileobj, *args, **kwargs):
 					continue
 
 				messages.extend(
-					(option, f"Option for a Select field in DocType '{doctype}'") for option in select_options
+					(
+						option,
+						f"Option for the '{_label}' ({fieldtype}) field in DocType '{doctype}'",
+					)
+					for option in select_options
 				)
 			elif fieldtype == "HTML":
-				messages.append((message, f"Content of an HTML field in DocType '{doctype}'"))
+				messages.append(
+					(message, f"Content of the '{_label}' ({fieldtype}) field in DocType '{doctype}'")
+				)
 
 	for link in links:
 		if group := link.get("group"):

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -133,7 +133,7 @@ def generate_pot(target_app: str | None = None):
 
 	for app in apps:
 		app_path = frappe.get_pymodule_path(app)
-		catalog = get_catalog(app)
+		catalog = new_catalog(app)
 
 		# Each file will only be processed by the first method that matches,
 		# so more specific methods should come first.

--- a/frappe/locale/main.pot
+++ b/frappe/locale/main.pot
@@ -1,15 +1,14 @@
 # Translations template for Frappe Framework.
 # Copyright (C) 2024 Frappe Technologies
-# This file is distributed under the same license as the Frappe Framework
-# project.
+# This file is distributed under the same license as the Frappe Framework project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Frappe Framework VERSION\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
-"POT-Creation-Date: 2024-01-10 16:34+0553\n"
-"PO-Revision-Date: 2024-01-10 16:34+0553\n"
+"POT-Creation-Date: 2024-01-12 01:53+0053\n"
+"PO-Revision-Date: 2024-01-12 01:53+0053\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: developers@frappe.io\n"
 "MIME-Version: 1.0\n"
@@ -21,13 +20,15 @@ msgstr ""
 msgid " to your browser"
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Rule Condition'
+#. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
+#. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgctxt "Document Naming Rule Condition"
 msgid "!="
 msgstr ""
 
-#. Description of a Data field in DocType 'About Us Settings'
+#. Description of the 'Org History Heading' (Data) field in DocType 'About Us
+#. Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
 msgctxt "About Us Settings"
 msgid "\"Company History\""
@@ -37,7 +38,8 @@ msgstr ""
 msgid "\"Parent\" signifies the parent table in which this row must be added"
 msgstr ""
 
-#. Description of a Data field in DocType 'About Us Settings'
+#. Description of the 'Team Members Heading' (Data) field in DocType 'About Us
+#. Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
 msgctxt "About Us Settings"
 msgid "\"Team Members\" or \"Management\""
@@ -51,121 +53,121 @@ msgstr ""
 msgid "\"{0}\" is not a valid Google Sheets URL"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "# ###,##"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "# ###,##"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "# ###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "# ###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#'###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#'###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#, ###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#, ###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#,###"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#,###"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#,###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#,###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#,###.###"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#,###.###"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#,##,###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#,##,###.##"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#.###"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#.###"
 msgstr ""
 
-#. Option for a Select field in DocType 'Currency'
+#. Option for the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "#.###,##"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Number Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "#.###,##"
@@ -210,17 +212,18 @@ msgstr ""
 msgid "'{0}' not allowed for type {1} in row {2}"
 msgstr ""
 
-#: model/rename_doc.py:688
+#: model/rename_doc.py:689
 msgid "** Failed: {0} to {1}: {2}"
 msgstr ""
 
-#. Description of a Select field in DocType 'Workflow Document State'
+#. Description of the 'Doc Status' (Select) field in DocType 'Workflow Document
+#. State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
 msgctxt "Workflow Document State"
 msgid "0 - Draft; 1 - Submitted; 2 - Cancelled"
 msgstr ""
 
-#. Description of a Int field in DocType 'Web Page'
+#. Description of the 'Priority' (Int) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "0 is highest"
@@ -230,7 +233,7 @@ msgstr ""
 msgid "1 = True & 0 = False"
 msgstr ""
 
-#. Description of a Int field in DocType 'Currency'
+#. Description of the 'Fraction Units' (Int) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid ""
@@ -326,13 +329,15 @@ msgstr ""
 msgid "; not allowed in condition"
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Rule Condition'
+#. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
+#. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgctxt "Document Naming Rule Condition"
 msgid "<"
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Rule Condition'
+#. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
+#. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgctxt "Document Naming Rule Condition"
 msgid "<="
@@ -342,15 +347,14 @@ msgstr ""
 msgid "<b>{0}</b> is not a valid URL"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Property Setter'
+#. Content of the 'Help' (HTML) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
-msgid ""
-"<div class=\"alert\">Please don't update it as it can mess up your form. "
-"Use the Customize Form View and Custom Fields to set properties!</div>"
+msgid "<div class=\"alert\">Please don't update it as it can mess up your form. Use the Customize Form View and Custom Fields to set properties!</div>"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Document Naming Settings'
+#. Content of the 'Help HTML' (HTML) field in DocType 'Document Naming
+#. Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid ""
@@ -360,15 +364,12 @@ msgid ""
 "        <li>Each Series Prefix on a new line.</li>\n"
 "        <li>Allowed special characters are \"/\" and \"-\"</li>\n"
 "        <li>\n"
-"            Optionally, set the number of digits in the series using dot "
-"(.)\n"
-"            followed by hashes (#). For example, \".####\" means that the"
-" series\n"
+"            Optionally, set the number of digits in the series using dot (.)\n"
+"            followed by hashes (#). For example, \".####\" means that the series\n"
 "            will have four digits. Default is five digits.\n"
 "        </li>\n"
 "        <li>\n"
-"            You can also use variables in the series name by putting them"
-"\n"
+"            You can also use variables in the series name by putting them\n"
 "            between (.) dots\n"
 "            <br>\n"
 "            Supported Variables:\n"
@@ -380,8 +381,7 @@ msgid ""
 "                <li><code>.WW.</code> - Week of the year</li>\n"
 "                <li><code>.FY.</code> - Fiscal Year</li>\n"
 "                <li>\n"
-"                    <code>.{fieldname}.</code> - fieldname on the "
-"document e.g.\n"
+"                    <code>.{fieldname}.</code> - fieldname on the document e.g.\n"
 "                    <code>branch</code>\n"
 "                </li>\n"
 "            </ul>\n"
@@ -398,7 +398,7 @@ msgid ""
 "<br>\n"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Print Format'
+#. Content of the 'Custom HTML Help' (HTML) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid ""
@@ -407,8 +407,7 @@ msgid ""
 "<p>Notes:</p>\n"
 "\n"
 "<ol>\n"
-"<li>All field groups (label + value) are set attributes <code>data-"
-"fieldtype</code> and <code>data-fieldname</code></li>\n"
+"<li>All field groups (label + value) are set attributes <code>data-fieldtype</code> and <code>data-fieldname</code></li>\n"
 "<li>All values are given class <code>value</code></li>\n"
 "<li>All Section Breaks are given class <code>section-break</code></li>\n"
 "<li>All Column Breaks are given class <code>column-break</code></li>\n"
@@ -418,18 +417,15 @@ msgid ""
 "\n"
 "<p>1. Left align integers</p>\n"
 "\n"
-"<pre><code>[data-fieldtype=\"Int\"] .value { text-align: left; "
-"}</code></pre>\n"
+"<pre><code>[data-fieldtype=\"Int\"] .value { text-align: left; }</code></pre>\n"
 "\n"
 "<p>1. Add border to sections except the last section</p>\n"
 "\n"
-"<pre><code>.section-break { padding: 30px 0px; border-bottom: 1px solid "
-"#eee; }\n"
-".section-break:last-child { padding-bottom: 0px; border-bottom: 0px;  "
-"}</code></pre>\n"
+"<pre><code>.section-break { padding: 30px 0px; border-bottom: 1px solid #eee; }\n"
+".section-break:last-child { padding-bottom: 0px; border-bottom: 0px;  }</code></pre>\n"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Print Format'
+#. Content of the 'Print Format Help' (HTML) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 #, python-format
 msgctxt "Print Format"
@@ -437,33 +433,24 @@ msgid ""
 "<h3>Print Format Help</h3>\n"
 "<hr>\n"
 "<h4>Introduction</h4>\n"
-"<p>Print Formats are rendered on the server side using the Jinja "
-"Templating Language. All forms have access to the <code>doc</code> object"
-" which contains information about the document that is being formatted. "
-"You can also access common utilities via the <code>frappe</code> "
-"module.</p>\n"
-"<p>For styling, the Boostrap CSS framework is provided and you can enjoy "
-"the full range of classes.</p>\n"
+"<p>Print Formats are rendered on the server side using the Jinja Templating Language. All forms have access to the <code>doc</code> object which contains information about the document that is being formatted. You can also access common utilities via the <code>frappe</code> module.</p>\n"
+"<p>For styling, the Boostrap CSS framework is provided and you can enjoy the full range of classes.</p>\n"
 "<hr>\n"
 "<h4>References</h4>\n"
 "<ol>\n"
-"\t<li><a href=\"http://jinja.pocoo.org/docs/templates/\" "
-"target=\"_blank\">Jinja Templating Language</a></li>\n"
-"\t<li><a href=\"http://getbootstrap.com\" target=\"_blank\">Bootstrap CSS"
-" Framework</a></li>\n"
+"\t<li><a href=\"http://jinja.pocoo.org/docs/templates/\" target=\"_blank\">Jinja Templating Language</a></li>\n"
+"\t<li><a href=\"http://getbootstrap.com\" target=\"_blank\">Bootstrap CSS Framework</a></li>\n"
 "</ol>\n"
 "<hr>\n"
 "<h4>Example</h4>\n"
-"<pre><code>&lt;h3&gt;{{ doc.select_print_heading or \"Invoice\" "
-"}}&lt;/h3&gt;\n"
+"<pre><code>&lt;h3&gt;{{ doc.select_print_heading or \"Invoice\" }}&lt;/h3&gt;\n"
 "&lt;div class=\"row\"&gt;\n"
 "\t&lt;div class=\"col-md-3 text-right\"&gt;Customer Name&lt;/div&gt;\n"
 "\t&lt;div class=\"col-md-9\"&gt;{{ doc.customer_name }}&lt;/div&gt;\n"
 "&lt;/div&gt;\n"
 "&lt;div class=\"row\"&gt;\n"
 "\t&lt;div class=\"col-md-3 text-right\"&gt;Date&lt;/div&gt;\n"
-"\t&lt;div class=\"col-md-9\"&gt;{{ doc.get_formatted(\"invoice_date\") "
-"}}&lt;/div&gt;\n"
+"\t&lt;div class=\"col-md-9\"&gt;{{ doc.get_formatted(\"invoice_date\") }}&lt;/div&gt;\n"
 "&lt;/div&gt;\n"
 "&lt;table class=\"table table-bordered\"&gt;\n"
 "\t&lt;tbody&gt;\n"
@@ -485,10 +472,8 @@ msgid ""
 "\t\t\t\t{%- endif %}\n"
 "\t\t\t&lt;/td&gt;\n"
 "\t\t\t&lt;td style=\"width: 37%;\"&gt;\n"
-"\t\t\t\t&lt;div style=\"border: 0px;\"&gt;{{ row.description "
-"}}&lt;/div&gt;&lt;/td&gt;\n"
-"\t\t\t&lt;td style=\"width: 10%; text-align: right;\"&gt;{{ row.qty }} {{"
-" row.uom or row.stock_uom }}&lt;/td&gt;\n"
+"\t\t\t\t&lt;div style=\"border: 0px;\"&gt;{{ row.description }}&lt;/div&gt;&lt;/td&gt;\n"
+"\t\t\t&lt;td style=\"width: 10%; text-align: right;\"&gt;{{ row.qty }} {{ row.uom or row.stock_uom }}&lt;/td&gt;\n"
 "\t\t\t&lt;td style=\"width: 15%; text-align: right;\"&gt;{{\n"
 "\t\t\t\trow.get_formatted(\"rate\", doc) }}&lt;/td&gt;\n"
 "\t\t\t&lt;td style=\"width: 15%; text-align: right;\"&gt;{{\n"
@@ -502,29 +487,24 @@ msgid ""
 "<table class=\"table table-bordered\">\n"
 "\t<tbody>\n"
 "\t\t<tr>\n"
-"\t\t\t<td style=\"width: 30%;\"><code>doc.get_formatted(\"[fieldname]\", "
-"[parent_doc])</code></td>\n"
-"\t\t\t<td>Get document value formatted as Date, Currency, etc. Pass "
-"parent <code>doc</code> for currency type fields.</td>\n"
+"\t\t\t<td style=\"width: 30%;\"><code>doc.get_formatted(\"[fieldname]\", [parent_doc])</code></td>\n"
+"\t\t\t<td>Get document value formatted as Date, Currency, etc. Pass parent <code>doc</code> for currency type fields.</td>\n"
 "\t\t</tr>\n"
 "\t\t<tr>\n"
-"\t\t\t<td style=\"width: 30%;\"><code>frappe.db.get_value(\"[doctype]\", "
-"\"[name]\", \"fieldname\")</code></td>\n"
+"\t\t\t<td style=\"width: 30%;\"><code>frappe.db.get_value(\"[doctype]\", \"[name]\", \"fieldname\")</code></td>\n"
 "\t\t\t<td>Get value from another document.</td>\n"
 "\t\t</tr>\n"
 "\t</tbody>\n"
 "</table>\n"
 msgstr ""
 
-#. Description of a Code field in DocType 'Address Template'
+#. Description of the 'Template' (Code) field in DocType 'Address Template'
 #: contacts/doctype/address_template/address_template.json
 #, python-format
 msgctxt "Address Template"
 msgid ""
 "<h4>Default Template</h4>\n"
-"<p>Uses <a href=\"http://jinja.pocoo.org/docs/templates/\">Jinja "
-"Templating</a> and all the fields of Address (including Custom Fields if "
-"any) will be available</p>\n"
+"<p>Uses <a href=\"http://jinja.pocoo.org/docs/templates/\">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>\n"
 "<pre><code>{{ address_line1 }}&lt;br&gt;\n"
 "{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}\n"
 "{{ city }}&lt;br&gt;\n"
@@ -537,7 +517,7 @@ msgid ""
 "</code></pre>"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Email Template'
+#. Content of the 'Email Reply Help' (HTML) field in DocType 'Email Template'
 #: email/doctype/email_template/email_template.json
 msgctxt "Email Template"
 msgid ""
@@ -545,8 +525,7 @@ msgid ""
 "\n"
 "<pre>Order Overdue\n"
 "\n"
-"Transaction {{ name }} has exceeded Due Date. Please take necessary "
-"action.\n"
+"Transaction {{ name }} has exceeded Due Date. Please take necessary action.\n"
 "\n"
 "Details\n"
 "\n"
@@ -556,26 +535,20 @@ msgid ""
 "\n"
 "<h4>How to get fieldnames</h4>\n"
 "\n"
-"<p>The fieldnames you can use in your email template are the fields in "
-"the document from which you are sending the email. You can find out the "
-"fields of any documents via Setup &gt; Customize Form View and selecting "
-"the document type (e.g. Sales Invoice)</p>\n"
+"<p>The fieldnames you can use in your email template are the fields in the document from which you are sending the email. You can find out the fields of any documents via Setup &gt; Customize Form View and selecting the document type (e.g. Sales Invoice)</p>\n"
 "\n"
 "<h4>Templating</h4>\n"
 "\n"
-"<p>Templates are compiled using the Jinja Templating Language. To learn "
-"more about Jinja, <a class=\"strong\" "
-"href=\"http://jinja.pocoo.org/docs/dev/templates/\">read this "
-"documentation.</a></p>\n"
+"<p>Templates are compiled using the Jinja Templating Language. To learn more about Jinja, <a class=\"strong\" href=\"http://jinja.pocoo.org/docs/dev/templates/\">read this documentation.</a></p>\n"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Data Import'
+#. Content of the 'html_5' (HTML) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "<h5 class=\"text-muted uppercase\">Or</h5>"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Notification'
+#. Content of the 'Message Examples' (HTML) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 #, python-format
 msgctxt "Notification"
@@ -584,8 +557,7 @@ msgid ""
 "\n"
 "<pre>&lt;h3&gt;Order Overdue&lt;/h3&gt;\n"
 "\n"
-"&lt;p&gt;Transaction {{ doc.name }} has exceeded Due Date. Please take "
-"necessary action.&lt;/p&gt;\n"
+"&lt;p&gt;Transaction {{ doc.name }} has exceeded Due Date. Please take necessary action.&lt;/p&gt;\n"
 "\n"
 "&lt;!-- show last comment --&gt;\n"
 "{% if comments %}\n"
@@ -601,39 +573,34 @@ msgid ""
 "</pre>"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Webhook'
+#. Content of the 'html_condition' (HTML) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid ""
 "<p><strong>Condition Examples:</strong></p>\n"
-"<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; "
-"40000\n"
+"<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; 40000\n"
 "</pre>"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Notification'
+#. Content of the 'html_7' (HTML) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid ""
 "<p><strong>Condition Examples:</strong></p>\n"
-"<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; "
-"40000\n"
+"<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; 40000\n"
 "</pre>\n"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Web Form'
+#. Content of the 'Condition Description' (HTML) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
 msgctxt "Web Form"
 msgid ""
-"<p>Multiple webforms can be created for a single doctype. Add filters "
-"specific to this webform to display correct record after "
-"submission.</p><p>For Example:</p>\n"
-"<p>If you create a separate webform every year to capture feedback from "
-"employees add a \n"
+"<p>Multiple webforms can be created for a single doctype. Add filters specific to this webform to display correct record after submission.</p><p>For Example:</p>\n"
+"<p>If you create a separate webform every year to capture feedback from employees add a \n"
 " field named year in doctype and add a filter <b>year = 2023</b></p>\n"
 msgstr ""
 
-#. Description of a Code field in DocType 'Web Page'
+#. Description of the 'Context Script' (Code) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid ""
@@ -643,27 +610,22 @@ msgid ""
 "</code></pre></div>"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Custom HTML Block'
+#. Content of the 'JS Message' (HTML) field in DocType 'Custom HTML Block'
 #: desk/doctype/custom_html_block/custom_html_block.json
 msgctxt "Custom HTML Block"
 msgid ""
-"<p>To interact with above HTML you will have to use `root_element` as a "
-"parent selector.</p><p>For example:</p><pre class=\"p-3 bg-gray-100 "
-"border-radius rounded-sm mb-0\" style=\"width: fit-content;\"><code>// "
-"here root_element is provided by default\n"
+"<p>To interact with above HTML you will have to use `root_element` as a parent selector.</p><p>For example:</p><pre class=\"p-3 bg-gray-100 border-radius rounded-sm mb-0\" style=\"width: fit-content;\"><code>// here root_element is provided by default\n"
 "let some_class_element = root_element.querySelector('.some-class');\n"
 "some_class_element.textContent = \"New content\";\n"
 "</code></pre>"
 msgstr ""
 
 #: twofactor.py:469
-msgid ""
-"<p>Your OTP secret on {0} has been reset. If you did not perform this "
-"reset and did not request it, please contact your System Administrator "
-"immediately.</p>"
+msgid "<p>Your OTP secret on {0} has been reset. If you did not perform this reset and did not request it, please contact your System Administrator immediately.</p>"
 msgstr ""
 
-#. Description of a Data field in DocType 'Scheduled Job Type'
+#. Description of the 'Cron Format' (Data) field in DocType 'Scheduled Job
+#. Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid ""
@@ -683,7 +645,7 @@ msgid ""
 "</pre>\n"
 msgstr ""
 
-#. Description of a Data field in DocType 'Server Script'
+#. Description of the 'Cron Format' (Data) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid ""
@@ -703,14 +665,13 @@ msgid ""
 "</pre>\n"
 msgstr ""
 
-#. Content of an HTML field in DocType 'Workflow Transition'
+#. Content of the 'Example' (HTML) field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
 msgctxt "Workflow Transition"
 msgid ""
 "<pre><code>doc.grand_total &gt; 0</code></pre>\n"
 "\n"
-"<p>Conditions should be written in simple Python. Please use properties "
-"available in the form only.</p>\n"
+"<p>Conditions should be written in simple Python. Please use properties available in the form only.</p>\n"
 "<p>Allowed functions:\n"
 "</p><ul>\n"
 "<li>frappe.db.get_value</li>\n"
@@ -721,30 +682,29 @@ msgid ""
 "<li>frappe.utils.add_to_date</li>\n"
 "<li>frappe.utils.now</li>\n"
 "</ul>\n"
-"<p>Example: </p><pre><code>doc.creation &gt; "
-"frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-5, "
-"as_string=True, as_datetime=True) </code></pre><p></p>"
+"<p>Example: </p><pre><code>doc.creation &gt; frappe.utils.add_to_date(frappe.utils.now_datetime(), days=-5, as_string=True, as_datetime=True) </code></pre><p></p>"
 msgstr ""
 
 #: custom/doctype/custom_field/custom_field.js:39
-msgid ""
-"<strong>Warning:</strong> This field is system generated and may be "
-"overwritten by a future update. Modify it using {0} instead."
+msgid "<strong>Warning:</strong> This field is system generated and may be overwritten by a future update. Modify it using {0} instead."
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Rule Condition'
+#. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
+#. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgctxt "Document Naming Rule Condition"
 msgid "="
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Rule Condition'
+#. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
+#. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgctxt "Document Naming Rule Condition"
 msgid ">"
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Rule Condition'
+#. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
+#. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 msgctxt "Document Naming Rule Condition"
 msgid ">="
@@ -752,17 +712,11 @@ msgstr ""
 
 #. Description of the Onboarding Step 'Custom Document Types'
 #: custom/onboarding_step/custom_doctype/custom_doctype.json
-msgid ""
-"A DocType (Document Type) is used to insert forms in ERPNext. Forms such "
-"as Customer, Orders, and Invoices are Doctypes in the backend. You can "
-"also create new DocTypes to create new forms in ERPNext as per your "
-"business needs."
+msgid "A DocType (Document Type) is used to insert forms in ERPNext. Forms such as Customer, Orders, and Invoices are Doctypes in the backend. You can also create new DocTypes to create new forms in ERPNext as per your business needs."
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:1015
-msgid ""
-"A DocType's name should start with a letter and can only consist of "
-"letters, numbers, spaces, underscores and hyphens"
+msgid "A DocType's name should start with a letter and can only consist of letters, numbers, spaces, underscores and hyphens"
 msgstr ""
 
 #: website/doctype/blog_post/blog_post.py:93
@@ -777,12 +731,10 @@ msgstr ""
 msgid "A file with same name {} already exists"
 msgstr ""
 
-#. Description of a Text field in DocType 'OAuth Client'
+#. Description of the 'Scopes' (Text) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
 msgctxt "OAuth Client"
-msgid ""
-"A list of resources which the Client App will have access to after the "
-"user allows it.<br> e.g. project"
+msgid "A list of resources which the Client App will have access to after the user allows it.<br> e.g. project"
 msgstr ""
 
 #: templates/emails/new_user.html:5
@@ -793,7 +745,7 @@ msgstr ""
 msgid "A recurring {0} {1} has been created for you via Auto Repeat {2}."
 msgstr ""
 
-#. Description of a Data field in DocType 'Currency'
+#. Description of the 'Symbol' (Data) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "A symbol for this currency. For e.g. $"
@@ -807,73 +759,73 @@ msgstr ""
 msgid "A word by itself is easy to guess."
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A0"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A1"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A2"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A3"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A4"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A5"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A6"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A7"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A8"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "A9"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Email Sync Option' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "ALL"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "API"
@@ -916,7 +868,7 @@ msgctxt "User"
 msgid "API Key"
 msgstr ""
 
-#. Description of a Data field in DocType 'User'
+#. Description of the 'API Key' (Data) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "API Key cannot be regenerated"
@@ -934,13 +886,13 @@ msgctxt "User"
 msgid "API Secret"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Sort Order' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "ASC"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Default Sort Order' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "ASC"
@@ -1081,7 +1033,7 @@ msgctxt "Email Flag Queue"
 msgid "Action"
 msgstr ""
 
-#. Option for a Select field in DocType 'Navbar Item'
+#. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
 #. Label of a Data field in DocType 'Navbar Item'
 #: core/doctype/navbar_item/navbar_item.json
 msgctxt "Navbar Item"
@@ -1185,25 +1137,25 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Status' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Active"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Status' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Active"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Bearer Token'
+#. Option for the 'Status' (Select) field in DocType 'OAuth Bearer Token'
 #: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 msgctxt "OAuth Bearer Token"
 msgid "Active"
 msgstr ""
 
-#. Option for a Select field in DocType 'LDAP Settings'
+#. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Active Directory"
@@ -1403,7 +1355,7 @@ msgctxt "Button in list view actions menu"
 msgid "Add Tags"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:316
+#: public/js/frappe/views/communication.js:320
 msgid "Add Template"
 msgstr ""
 
@@ -1479,12 +1431,11 @@ msgstr ""
 msgid "Add to this activity by mailing to {0}"
 msgstr ""
 
-#. Description of a Code field in DocType 'Website Settings'
+#. Description of the '&lt;head&gt; HTML' (Code) field in DocType 'Website
+#. Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
-msgid ""
-"Added HTML in the &lt;head&gt; section of the web page, primarily used "
-"for website verification and SEO"
+msgid "Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO"
 msgstr ""
 
 #: core/doctype/log_settings/log_settings.py:82
@@ -1501,9 +1452,7 @@ msgid "Added {0} ({1})"
 msgstr ""
 
 #: core/doctype/user/user.py:271
-msgid ""
-"Adding System Manager to this User as there must be atleast one System "
-"Manager"
+msgid "Adding System Manager to this User as there must be atleast one System Manager"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Custom DocPerm'
@@ -1592,7 +1541,8 @@ msgctxt "Address"
 msgid "Address Type"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Website Settings'
+#. Description of the 'Address' (Small Text) field in DocType 'Website
+#. Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "Address and other legal information you may want to put in the footer."
@@ -1628,11 +1578,11 @@ msgstr ""
 msgid "Administrator"
 msgstr ""
 
-#: core/doctype/user/user.py:1179
+#: core/doctype/user/user.py:1180
 msgid "Administrator Logged In"
 msgstr ""
 
-#: core/doctype/user/user.py:1173
+#: core/doctype/user/user.py:1174
 msgid "Administrator accessed {0} on {1} via IP Address {2}."
 msgstr ""
 
@@ -1665,31 +1615,31 @@ msgctxt "OAuth Client"
 msgid "Advanced Settings"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "After Cancel"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "After Delete"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "After Insert"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "After Save"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "After Save (Submitted Document)"
@@ -1701,7 +1651,7 @@ msgctxt "Web Form"
 msgid "After Submission"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "After Submit"
@@ -1727,7 +1677,7 @@ msgstr ""
 msgid "Aggregate Function field is required to create a dashboard chart"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification Log'
+#. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
 msgctxt "Notification Log"
 msgid "Alert"
@@ -1779,13 +1729,13 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "All"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "All"
@@ -1823,12 +1773,10 @@ msgstr ""
 msgid "All fields are necessary to submit the comment."
 msgstr ""
 
-#. Description of a Table field in DocType 'Workflow'
+#. Description of the 'Document States' (Table) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid ""
-"All possible Workflow States and roles of the workflow. Docstatus "
-"Options: 0 is \"Saved\", 1 is \"Submitted\" and 2 is \"Cancelled\""
+msgid "All possible Workflow States and roles of the workflow. Docstatus Options: 0 is \"Saved\", 1 is \"Submitted\" and 2 is \"Cancelled\""
 msgstr ""
 
 #: utils/password_strength.py:187
@@ -1851,7 +1799,7 @@ msgstr ""
 msgid "Allow"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Sign ups' (Select) field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Allow"
@@ -2071,7 +2019,8 @@ msgctxt "System Settings"
 msgid "Allow Sending Usage Data for Improving Applications"
 msgstr ""
 
-#. Description of a Check field in DocType 'Workflow Transition'
+#. Description of the 'Allow Self Approval' (Check) field in DocType 'Workflow
+#. Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
 msgctxt "Workflow Transition"
 msgid "Allow approval for creator of the document"
@@ -2147,7 +2096,8 @@ msgstr ""
 msgid "Allow recording my first session to improve user experience"
 msgstr ""
 
-#. Description of a Check field in DocType 'Web Form'
+#. Description of the 'Allow Incomplete Forms' (Check) field in DocType 'Web
+#. Form'
 #: website/doctype/web_form/web_form.json
 msgctxt "Web Form"
 msgid "Allow saving if mandatory fields are not filled"
@@ -2157,24 +2107,23 @@ msgstr ""
 msgid "Allow sending usage data for improving applications"
 msgstr ""
 
-#. Description of a Int field in DocType 'User'
+#. Description of the 'Login After' (Int) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Allow user to login only after this hour (0-24)"
 msgstr ""
 
-#. Description of a Int field in DocType 'User'
+#. Description of the 'Login Before' (Int) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Allow user to login only before this hour (0-24)"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Login with email link' (Check) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"Allow users to log in without a password, using a login link sent to "
-"their email"
+msgid "Allow users to log in without a password, using a login link sent to their email"
 msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Transition'
@@ -2263,13 +2212,15 @@ msgctxt "User Document Type"
 msgid "Amend"
 msgstr ""
 
-#. Option for a Select field in DocType 'Amended Document Naming Settings'
+#. Option for the 'Action' (Select) field in DocType 'Amended Document Naming
+#. Settings'
 #: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
 msgctxt "Amended Document Naming Settings"
 msgid "Amend Counter"
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Settings'
+#. Option for the 'Default Amendment Naming' (Select) field in DocType
+#. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid "Amend Counter"
@@ -2317,12 +2268,10 @@ msgstr ""
 msgid "An error occurred while setting Session Defaults"
 msgstr ""
 
-#. Description of a Attach field in DocType 'Website Settings'
+#. Description of the 'FavIcon' (Attach) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
-msgid ""
-"An icon file with .ico extension. Should be 16 x 16 px. Generated using a"
-" favicon generator. [favicon-generator.org]"
+msgid "An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org]"
 msgstr ""
 
 #: templates/includes/oauth_confirmation.html:35
@@ -2339,7 +2288,7 @@ msgstr ""
 msgid "Ancestors Of"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Annual"
@@ -2358,25 +2307,17 @@ msgid "Anonymous"
 msgstr ""
 
 #: public/js/frappe/request.js:186
-msgid ""
-"Another transaction is blocking this one. Please try again in a few "
-"seconds."
+msgid "Another transaction is blocking this one. Please try again in a few seconds."
 msgstr ""
 
-#: model/rename_doc.py:379
+#: model/rename_doc.py:380
 msgid "Another {0} with name {1} exists, select another name"
 msgstr ""
 
-#. Description of a Code field in DocType 'Print Format'
+#. Description of the 'Raw Commands' (Code) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
-msgid ""
-"Any string-based printer languages can be used. Writing raw commands "
-"requires knowledge of the printer's native language provided by the "
-"printer manufacturer. Please refer to the developer manual provided by "
-"the printer manufacturer on how to write their native commands. These "
-"commands are rendered on the server side using the Jinja Templating "
-"Language."
+msgid "Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language."
 msgstr ""
 
 #. Label of a Data field in DocType 'Desktop Icon'
@@ -2457,7 +2398,7 @@ msgstr ""
 msgid "App not found for module: {0}"
 msgstr ""
 
-#: __init__.py:1660
+#: __init__.py:1677
 msgid "App {0} is not installed"
 msgstr ""
 
@@ -2489,13 +2430,10 @@ msgstr ""
 msgid "Append To can be one of {0}"
 msgstr ""
 
-#. Description of a Link field in DocType 'Email Account'
+#. Description of the 'Append To' (Link) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
-msgid ""
-"Append as communication against this DocType (must have fields: "
-"\"Sender\" and \"Subject\"). These fields can be defined in the email "
-"settings section of the appended doctype."
+msgid "Append as communication against this DocType (must have fields: \"Sender\" and \"Subject\"). These fields can be defined in the email settings section of the appended doctype."
 msgstr ""
 
 #: core/doctype/user_permission/user_permission_list.js:105
@@ -2584,19 +2522,21 @@ msgctxt "User Type"
 msgid "Apply User Permission On"
 msgstr ""
 
-#. Description of a Check field in DocType 'Custom DocPerm'
+#. Description of the 'If user is the owner' (Check) field in DocType 'Custom
+#. DocPerm'
 #: core/doctype/custom_docperm/custom_docperm.json
 msgctxt "Custom DocPerm"
 msgid "Apply this rule if the User is the Owner"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocPerm'
+#. Description of the 'If user is the owner' (Check) field in DocType 'DocPerm'
 #: core/doctype/docperm/docperm.json
 msgctxt "DocPerm"
 msgid "Apply this rule if the User is the Owner"
 msgstr ""
 
-#. Description of a Check field in DocType 'Energy Point Rule'
+#. Description of the 'Apply Only Once' (Check) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "Apply this rule only once per document"
@@ -2614,7 +2554,7 @@ msgstr ""
 msgid "Appreciate"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Log'
+#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
 msgctxt "Energy Point Log"
 msgid "Appreciation"
@@ -2629,7 +2569,7 @@ msgctxt "Number system"
 msgid "Ar"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Status' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Archived"
@@ -2698,22 +2638,18 @@ msgctxt "RQ Job"
 msgid "Arguments"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Arial"
 msgstr ""
 
 #: desk/form/assign_to.py:102
-msgid ""
-"As document sharing is disabled, please give them the required "
-"permissions before assigning."
+msgid "As document sharing is disabled, please give them the required permissions before assigning."
 msgstr ""
 
 #: templates/emails/account_deletion_notification.html:3
-msgid ""
-"As per your request, your account and data on {0} associated with email "
-"{1} has been permanently deleted"
+msgid "As per your request, your account and data on {0} associated with email {1} has been permanently deleted"
 msgstr ""
 
 #. Label of a Code field in DocType 'Assignment Rule'
@@ -2757,13 +2693,13 @@ msgstr ""
 msgid "Assign to the user set in this field"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Assigned"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Assigned"
@@ -2789,7 +2725,7 @@ msgstr ""
 msgid "Assigned By Me"
 msgstr ""
 
-#: model/__init__.py:151 model/meta.py:54
+#: model/__init__.py:151 model/meta.py:55
 #: public/js/frappe/list/list_sidebar_group_by.js:71
 #: public/js/frappe/model/meta.js:207 public/js/frappe/model/model.js:126
 #: public/js/frappe/views/interaction.js:82
@@ -2804,19 +2740,19 @@ msgstr ""
 msgid "Assigning..."
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification Log'
+#. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
 msgctxt "Notification Log"
 msgid "Assignment"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Assignment Completed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Assignment Completed"
@@ -2915,25 +2851,25 @@ msgstr ""
 msgid "Attach"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Attach"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Attach"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Attach"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Attach"
@@ -2943,31 +2879,31 @@ msgstr ""
 msgid "Attach Document Print"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Attach Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Attach Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Attach Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Attach Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Attach Image"
@@ -3017,13 +2953,13 @@ msgstr ""
 msgid "Attached To Name must be a string or an integer"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Attachment"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Attachment"
@@ -3058,13 +2994,13 @@ msgctxt "Notification Log"
 msgid "Attachment Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Attachment Removed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Attachment Removed"
@@ -3167,7 +3103,7 @@ msgctxt "OAuth Authorization Code"
 msgid "Authorization Code"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Client'
+#. Option for the 'Grant Type' (Select) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
 msgctxt "OAuth Client"
 msgid "Authorization Code"
@@ -3219,19 +3155,20 @@ msgctxt "Social Login Key"
 msgid "Authorize URL"
 msgstr ""
 
-#. Option for a Select field in DocType 'Integration Request'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
 msgctxt "Integration Request"
 msgid "Authorized"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Log'
+#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
 msgctxt "Energy Point Log"
 msgid "Auto"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Provider Settings'
+#. Option for the 'Skip Authorization' (Select) field in DocType 'OAuth
+#. Provider Settings'
 #: integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
 msgctxt "OAuth Provider Settings"
 msgid "Auto"
@@ -3349,31 +3286,32 @@ msgctxt "User"
 msgid "Auto follow documents that you create"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Autocomplete"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Autocomplete"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Autocomplete"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Autoincrement"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Communication Type' (Select) field in DocType
+#. 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Automated Message"
@@ -3383,7 +3321,7 @@ msgstr ""
 msgid "Automatic"
 msgstr ""
 
-#. Option for a Select field in DocType 'User'
+#. Option for the 'Desk Theme' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Automatic"
@@ -3419,13 +3357,14 @@ msgstr ""
 msgid "Average"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Group By Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Average"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Average"
@@ -3476,67 +3415,67 @@ msgctxt "Number system"
 msgid "B"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B0"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B1"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B10"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B2"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B3"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B4"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B5"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B6"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B7"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B8"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "B9"
@@ -3654,12 +3593,11 @@ msgid "Backup Frequency"
 msgstr ""
 
 #: desk/page/backups/backups.py:99
-msgid ""
-"Backup job is already queued. You will receive an email with the download"
-" link"
+msgid "Backup job is already queued. You will receive an email with the download link"
 msgstr ""
 
-#. Description of a Check field in DocType 'S3 Backup Settings'
+#. Description of the 'Backup Files' (Check) field in DocType 'S3 Backup
+#. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgctxt "S3 Backup Settings"
 msgid "Backup public and private files along with the database."
@@ -3671,13 +3609,13 @@ msgctxt "System Settings"
 msgid "Backups"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Rounding Method' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Banker's Rounding"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Rounding Method' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Banker's Rounding (legacy)"
@@ -3707,31 +3645,31 @@ msgctxt "Web Form"
 msgid "Banner Image"
 msgstr ""
 
-#. Description of a Code field in DocType 'Website Settings'
+#. Description of the 'Banner HTML' (Code) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "Banner is above the Top Menu Bar."
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Bar"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Barcode"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Barcode"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Barcode"
@@ -3759,7 +3697,7 @@ msgctxt "Language"
 msgid "Based On"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule'
+#. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Based on Field"
@@ -3771,7 +3709,7 @@ msgctxt "Auto Email Report"
 msgid "Based on Permissions For User"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Method' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Basic"
@@ -3783,49 +3721,49 @@ msgctxt "User"
 msgid "Basic Info"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Before Cancel"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Before Delete"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Before Insert"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Before Save"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Before Save (Submitted Document)"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Before Submit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Before Validate"
 msgstr ""
 
-#. Option for a Select field in DocType 'Help Article'
+#. Option for the 'Level' (Select) field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
 msgctxt "Help Article"
 msgid "Beginner"
@@ -3849,7 +3787,7 @@ msgstr ""
 msgid "Between"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Billing"
@@ -4012,13 +3950,13 @@ msgstr ""
 msgid "Blogs, Website View Tracking, and more."
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Blue"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Blue"
@@ -4042,7 +3980,7 @@ msgctxt "DocField"
 msgid "Bold"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Bot"
@@ -4052,43 +3990,43 @@ msgstr ""
 msgid "Both DocType and Name required"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Bottom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Bottom Center"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Bottom Center"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Bottom Left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Bottom Right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Bottom Right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Bounced"
@@ -4118,14 +4056,12 @@ msgctxt "Email Account"
 msgid "Brand Logo"
 msgstr ""
 
-#. Description of a Code field in DocType 'Website Settings'
+#. Description of the 'Brand HTML' (Code) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid ""
-"Brand is what appears on the top-left of the toolbar. If it is an image, "
-"make sure it\n"
-"has a transparent background and use the &lt;img /&gt; tag. Keep size as "
-"200px x 30px"
+"Brand is what appears on the top-left of the toolbar. If it is an image, make sure it\n"
+"has a transparent background and use the &lt;img /&gt; tag. Keep size as 200px x 30px"
 msgstr ""
 
 #. Label of a Code field in DocType 'Web Form'
@@ -4241,19 +4177,19 @@ msgstr ""
 msgid "Bulk {0} is enqueued in background."
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Button"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Button"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Button"
@@ -4277,13 +4213,13 @@ msgctxt "Website Theme"
 msgid "Button Shadows"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "By \"Naming Series\" field"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "By \"Naming Series\" field"
@@ -4291,36 +4227,35 @@ msgstr ""
 
 #: website/doctype/web_page/web_page.js:111
 #: website/doctype/web_page/web_page.js:118
-msgid ""
-"By default the title is used as meta title, adding a value here will "
-"override it."
+msgid "By default the title is used as meta title, adding a value here will override it."
 msgstr ""
 
-#. Description of a Check field in DocType 'S3 Backup Settings'
+#. Description of the 'Send Email for Successful Backup' (Check) field in
+#. DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgctxt "S3 Backup Settings"
 msgid "By default, emails are only sent for failed backups."
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "By fieldname"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "By fieldname"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "By script"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "By script"
@@ -4344,7 +4279,7 @@ msgctxt "System Settings"
 msgid "Bypass restricted IP Address check If Two Factor Auth Enabled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "C5E"
@@ -4400,19 +4335,20 @@ msgctxt "Web Page Block"
 msgid "CSS Class"
 msgstr ""
 
-#. Description of a Data field in DocType 'Form Tour Step'
+#. Description of the 'Element Selector' (Data) field in DocType 'Form Tour
+#. Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "CSS selector for the element you want to highlight."
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "CSV"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Export'
+#. Option for the 'File Type' (Select) field in DocType 'Data Export'
 #: core/doctype/data_export/data_export.json
 msgctxt "Data Export"
 msgid "CSV"
@@ -4444,13 +4380,13 @@ msgctxt "Event"
 msgid "Calendar"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Calendar"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Calendar"
@@ -4477,7 +4413,7 @@ msgstr ""
 msgid "Call"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Event Category' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Call"
@@ -4545,20 +4481,17 @@ msgid "Can not rename as column {0} is already present on DocType."
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:1114
-msgid ""
-"Can only change to/from Autoincrement naming rule when there is no data "
-"in the doctype"
+msgid "Can only change to/from Autoincrement naming rule when there is no data in the doctype"
 msgstr ""
 
-#. Description of a Link field in DocType 'User Type'
+#. Description of the 'Apply User Permission On' (Link) field in DocType 'User
+#. Type'
 #: core/doctype/user_type/user_type.json
 msgctxt "User Type"
-msgid ""
-"Can only list down the document types which has been linked to the User "
-"document type."
+msgid "Can only list down the document types which has been linked to the User document type."
 msgstr ""
 
-#: model/rename_doc.py:366
+#: model/rename_doc.py:367
 msgid "Can't rename {0} to {1} because {0} doesn't exist."
 msgstr ""
 
@@ -4584,13 +4517,14 @@ msgctxt "DocPerm"
 msgid "Cancel"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Rule'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "Cancel"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Cancel"
@@ -4629,31 +4563,31 @@ msgstr ""
 msgid "Cancelled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Cancelled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Cancelled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Status' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Cancelled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Integration Request'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
 msgctxt "Integration Request"
 msgid "Cancelled"
 msgstr ""
 
-#. Option for a Select field in DocType 'ToDo'
+#. Option for the 'Status' (Select) field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
 msgctxt "ToDo"
 msgid "Cancelled"
@@ -4697,9 +4631,7 @@ msgid "Cannot access file path {0}"
 msgstr ""
 
 #: public/js/workflow_builder/utils.js:183
-msgid ""
-"Cannot cancel before submitting while transitioning from <b>{0} State</b>"
-" to <b>{1} State</b>"
+msgid "Cannot cancel before submitting while transitioning from <b>{0} State</b> to <b>{1} State</b>"
 msgstr ""
 
 #: workflow/doctype/workflow/workflow.py:112
@@ -4763,9 +4695,7 @@ msgid "Cannot delete standard document state."
 msgstr ""
 
 #: custom/doctype/customize_form/customize_form.js:276
-msgid ""
-"Cannot delete standard field <strong>{0}</strong>. You can hide it "
-"instead."
+msgid "Cannot delete standard field <strong>{0}</strong>. You can hide it instead."
 msgstr ""
 
 #: custom/doctype/customize_form/customize_form.js:298
@@ -4773,9 +4703,7 @@ msgid "Cannot delete standard link. You can hide it if you want"
 msgstr ""
 
 #: custom/doctype/customize_form/customize_form.js:268
-msgid ""
-"Cannot delete system generated field <strong>{0}</strong>. You can hide "
-"it instead."
+msgid "Cannot delete system generated field <strong>{0}</strong>. You can hide it instead."
 msgstr ""
 
 #: public/js/frappe/list/bulk_operations.js:171
@@ -4791,9 +4719,7 @@ msgid "Cannot edit Standard Dashboards"
 msgstr ""
 
 #: email/doctype/notification/notification.py:120
-msgid ""
-"Cannot edit Standard Notification. To edit, please disable this and "
-"duplicate it"
+msgid "Cannot edit Standard Notification. To edit, please disable this and duplicate it"
 msgstr ""
 
 #: desk/doctype/dashboard_chart/dashboard_chart.py:388
@@ -4857,9 +4783,7 @@ msgid "Cannot set Notification on Document Type {0}"
 msgstr ""
 
 #: core/doctype/docshare/docshare.py:69
-msgid ""
-"Cannot share {0} with submit permission as the doctype {1} is not "
-"submittable"
+msgid "Cannot share {0} with submit permission as the doctype {1} is not submittable"
 msgstr ""
 
 #: public/js/frappe/list/bulk_operations.js:226
@@ -4875,11 +4799,11 @@ msgstr ""
 msgid "Cannot update {0}"
 msgstr ""
 
-#: model/db_query.py:1126
+#: model/db_query.py:1125
 msgid "Cannot use sub-query in order by"
 msgstr ""
 
-#: model/db_query.py:1144
+#: model/db_query.py:1143
 msgid "Cannot use {0} in order/group by"
 msgstr ""
 
@@ -4901,7 +4825,7 @@ msgctxt "Number Card Link"
 msgid "Card"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Link'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
 msgctxt "Workspace Link"
 msgid "Card Break"
@@ -4953,13 +4877,13 @@ msgstr ""
 msgid "Cent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Letter Head'
+#. Option for the 'Align' (Select) field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
 msgctxt "Letter Head"
 msgid "Center"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Text Align' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Center"
@@ -4975,11 +4899,11 @@ msgctxt "Transaction Log"
 msgid "Chaining Hash"
 msgstr ""
 
-#: tests/test_translate.py:119
+#: tests/test_translate.py:98
 msgid "Change"
 msgstr ""
 
-#: tests/test_translate.py:120
+#: tests/test_translate.py:99
 msgctxt "Coins"
 msgid "Change"
 msgstr ""
@@ -5005,27 +4929,22 @@ msgstr ""
 msgid "Change User"
 msgstr ""
 
-#. Description of a Section Break field in DocType 'Document Naming Settings'
+#. Description of the 'Update Series Counter' (Section Break) field in DocType
+#. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid ""
-"Change the starting / current sequence number of an existing series. <br>"
+"Change the starting / current sequence number of an existing series. <br>\n"
 "\n"
-"\n"
-"Warning: Incorrectly updating counters can prevent documents from getting"
-" created. "
+"Warning: Incorrectly updating counters can prevent documents from getting created. "
 msgstr ""
 
 #: email/doctype/email_domain/email_domain.js:5
-msgid ""
-"Changing any setting will reflect on all the email accounts associated "
-"with this domain."
+msgid "Changing any setting will reflect on all the email accounts associated with this domain."
 msgstr ""
 
 #: core/doctype/system_settings/system_settings.js:62
-msgid ""
-"Changing rounding method on site with data can result in unexpected "
-"behaviour."
+msgid "Changing rounding method on site with data can result in unexpected behaviour."
 msgstr ""
 
 #. Label of a Select field in DocType 'Notification'
@@ -5098,49 +5017,51 @@ msgctxt "Workspace"
 msgid "Charts"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
+#. Option for the 'Communication Type' (Select) field in DocType
+#. 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Chat"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Check"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Check"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Check"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Check"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Check"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Check"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Check"
@@ -5159,17 +5080,14 @@ msgid "Check the Error Log for more information: {0}"
 msgstr ""
 
 #: website/doctype/website_settings/website_settings.js:147
-msgid ""
-"Check this if you don't want users to sign up for an account on your "
-"site. Users won't get desk access unless you explicitly provide it."
+msgid "Check this if you don't want users to sign up for an account on your site. Users won't get desk access unless you explicitly provide it."
 msgstr ""
 
-#. Description of a Check field in DocType 'Document Naming Settings'
+#. Description of the 'User must always select' (Check) field in DocType
+#. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
-msgid ""
-"Check this if you want to force the user to select a series before "
-"saving. There will be no default if you check this."
+msgid "Check this if you want to force the user to select a series before saving. There will be no default if you check this."
 msgstr ""
 
 #: email/doctype/newsletter/newsletter.js:20
@@ -5184,22 +5102,19 @@ msgstr ""
 msgid "Checking this will enable tracking page views for blogs, web pages, etc."
 msgstr ""
 
-#. Description of a Check field in DocType 'Workspace'
+#. Description of the 'Hide Custom DocTypes and Reports' (Check) field in
+#. DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "Checking this will hide custom doctypes and reports cards in Links section"
 msgstr ""
 
 #: website/doctype/web_page/web_page.js:78
-msgid ""
-"Checking this will publish the page on your website and it'll be visible "
-"to everyone."
+msgid "Checking this will publish the page on your website and it'll be visible to everyone."
 msgstr ""
 
 #: website/doctype/web_page/web_page.js:104
-msgid ""
-"Checking this will show a text area where you can write custom javascript"
-" that will run on this page."
+msgid "Checking this will show a text area where you can write custom javascript that will run on this page."
 msgstr ""
 
 #. Label of a Data field in DocType 'Transaction Log'
@@ -5226,7 +5141,7 @@ msgstr ""
 msgid "Child Tables are shown as a Grid in other DocTypes"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Is Child Table' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Child Tables are shown as a Grid in other DocTypes"
@@ -5248,7 +5163,8 @@ msgstr ""
 msgid "Choose an icon"
 msgstr ""
 
-#. Description of a Select field in DocType 'System Settings'
+#. Description of the 'Two Factor Authentication method' (Select) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Choose authentication method to be used by all users"
@@ -5270,7 +5186,7 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:321
+#: public/js/frappe/views/communication.js:325
 msgid "Clear & Add Template"
 msgstr ""
 
@@ -5296,7 +5212,7 @@ msgstr ""
 msgid "Clear User Permissions"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:322
+#: public/js/frappe/views/communication.js:326
 msgid "Clear the email message and add the template"
 msgstr ""
 
@@ -5313,9 +5229,7 @@ msgid "Click here to verify"
 msgstr ""
 
 #: integrations/doctype/google_drive/google_drive.js:46
-msgid ""
-"Click on <b>Authorize Google Drive Access</b> to authorize Google Drive "
-"Access."
+msgid "Click on <b>Authorize Google Drive Access</b> to authorize Google Drive Access."
 msgstr ""
 
 #: templates/emails/login_with_email_link.html:19
@@ -5327,9 +5241,7 @@ msgid "Click on the link below to approve the request"
 msgstr ""
 
 #: templates/emails/new_user.html:7
-msgid ""
-"Click on the link below to complete your registration and set a new "
-"password"
+msgid "Click on the link below to complete your registration and set a new password"
 msgstr ""
 
 #: templates/emails/download_data.html:3
@@ -5351,7 +5263,7 @@ msgstr ""
 msgid "Click table to edit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Clicked"
@@ -5483,25 +5395,25 @@ msgctxt "Assignment Rule"
 msgid "Close Condition"
 msgstr ""
 
-#. Option for a Select field in DocType 'Activity Log'
+#. Option for the 'Status' (Select) field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
 msgctxt "Activity Log"
 msgid "Closed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Closed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Status' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Closed"
 msgstr ""
 
-#. Option for a Select field in DocType 'ToDo'
+#. Option for the 'Status' (Select) field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
 msgctxt "ToDo"
 msgid "Closed"
@@ -5517,25 +5429,25 @@ msgctxt "Country"
 msgid "Code"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Code"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Code"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Code"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Client'
+#. Option for the 'Response Type' (Select) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
 msgctxt "OAuth Client"
 msgid "Code"
@@ -5617,13 +5529,13 @@ msgctxt "Color"
 msgid "Color"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Color"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Color"
@@ -5647,7 +5559,7 @@ msgctxt "Desktop Icon"
 msgid "Color"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Color"
@@ -5689,7 +5601,7 @@ msgctxt "ToDo"
 msgid "Color"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Color"
@@ -5705,31 +5617,31 @@ msgstr ""
 msgid "Column <b>{0}</b> already exist."
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Column Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Column Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Column Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Column Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Column Break"
@@ -5799,12 +5711,10 @@ msgid "Columns based on"
 msgstr ""
 
 #: integrations/doctype/oauth_client/oauth_client.py:43
-msgid ""
-"Combination of Grant Type (<code>{0}</code>) and Response Type "
-"(<code>{1}</code>) not allowed"
+msgid "Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Comm10E"
@@ -5817,13 +5727,15 @@ msgstr ""
 msgid "Comment"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Comment"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Communication Type' (Select) field in DocType
+#. 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Comment"
@@ -5863,19 +5775,19 @@ msgctxt "Blog Settings"
 msgid "Comment limit"
 msgstr ""
 
-#. Description of a Int field in DocType 'Blog Settings'
+#. Description of the 'Comment limit' (Int) field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
 msgctxt "Blog Settings"
 msgid "Comment limit per hour"
 msgstr ""
 
-#: model/__init__.py:150 model/meta.py:53 public/js/frappe/model/meta.js:206
+#: model/__init__.py:150 model/meta.py:54 public/js/frappe/model/meta.js:206
 #: public/js/frappe/model/model.js:125
 #: website/doctype/web_form/templates/web_form.html:119
 msgid "Comments"
 msgstr ""
 
-#. Description of a Data field in DocType 'DocType'
+#. Description of the 'Timeline Field' (Data) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Comments and Communications will be associated with this linked document"
@@ -5885,7 +5797,7 @@ msgstr ""
 msgid "Comments cannot have links or email addresses"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Rounding Method' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Commercial Rounding"
@@ -5908,11 +5820,13 @@ msgid "Common names and surnames are easy to guess."
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/communication/communication.json
+#: core/doctype/communication/communication.json tests/test_translate.py:35
+#: tests/test_translate.py:103
 msgid "Communication"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Communication Type' (Select) field in DocType
+#. 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Communication"
@@ -5992,7 +5906,7 @@ msgstr ""
 msgid "Complete"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Log'
+#. Option for the 'Status' (Select) field in DocType 'Scheduled Job Log'
 #: core/doctype/scheduled_job_log/scheduled_job_log.json
 msgctxt "Scheduled Job Log"
 msgid "Complete"
@@ -6010,31 +5924,31 @@ msgstr ""
 msgid "Completed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Status' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Completed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Status' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Completed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Integration Request'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
 msgctxt "Integration Request"
 msgid "Completed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Prepared Report'
+#. Option for the 'Status' (Select) field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
 msgctxt "Prepared Report"
 msgid "Completed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow Action'
+#. Option for the 'Status' (Select) field in DocType 'Workflow Action'
 #: workflow/doctype/workflow_action/workflow_action.json
 msgctxt "Workflow Action"
 msgid "Completed"
@@ -6052,7 +5966,7 @@ msgctxt "Workflow Action"
 msgid "Completed By User"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template'
+#. Option for the 'Type' (Select) field in DocType 'Web Template'
 #: website/doctype/web_template/web_template.json
 msgctxt "Web Template"
 msgid "Component"
@@ -6142,17 +6056,16 @@ msgstr ""
 msgid "Configure Columns"
 msgstr ""
 
-#. Description of a Section Break field in DocType 'Document Naming Settings'
+#. Description of the 'Amended Documents' (Section Break) field in DocType
+#. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid ""
 "Configure how amended documents will be named.<br>\n"
 "\n"
-"Default behaviour is to follow an amend counter which adds a number to "
-"the end of the original name indicating the amended version. <br>\n"
+"Default behaviour is to follow an amend counter which adds a number to the end of the original name indicating the amended version. <br>\n"
 "\n"
-"Default Naming will make the amended document to behave same as new "
-"documents."
+"Default Naming will make the amended document to behave same as new documents."
 msgstr ""
 
 #: www/update-password.html:30
@@ -6198,10 +6111,7 @@ msgid "Confirmed"
 msgstr ""
 
 #: public/js/frappe/widgets/onboarding_widget.js:530
-msgid ""
-"Congratulations on completing the module setup. If you want to learn more"
-" you can refer to the documentation <a target=\"_blank\" "
-"href=\"{0}\">here</a>."
+msgid "Congratulations on completing the module setup. If you want to learn more you can refer to the documentation <a target=\"_blank\" href=\"{0}\">here</a>."
 msgstr ""
 
 #: integrations/doctype/connected_app/connected_app.js:25
@@ -6336,12 +6246,11 @@ msgctxt "Contact Us Settings"
 msgid "Contact Us Settings"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Contact Us Settings'
+#. Description of the 'Query Options' (Small Text) field in DocType 'Contact Us
+#. Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
 msgctxt "Contact Us Settings"
-msgid ""
-"Contact options, like \"Sales Query, Support Query\" etc each on a new "
-"line or separated by commas."
+msgid "Contact options, like \"Sales Query, Support Query\" etc each on a new line or separated by commas."
 msgstr ""
 
 #. Label of a Text Editor field in DocType 'Blog Post'
@@ -6477,12 +6386,10 @@ msgctxt "Translation"
 msgid "Contribution Status"
 msgstr ""
 
-#. Description of a Select field in DocType 'Social Login Key'
+#. Description of the 'Sign ups' (Select) field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
-msgid ""
-"Controls whether new users can sign up using this Social Login Key. If "
-"unset, Website Settings is respected. "
+msgid "Controls whether new users can sign up using this Social Login Key. If unset, Website Settings is respected. "
 msgstr ""
 
 #: public/js/frappe/utils/utils.js:1030
@@ -6532,13 +6439,14 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Group By Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Count"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Count"
@@ -6680,7 +6588,7 @@ msgstr ""
 msgid "Create Duplicate"
 msgstr ""
 
-#. Option for a Select field in DocType 'Onboarding Step'
+#. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "Create Entry"
@@ -6753,13 +6661,13 @@ msgstr ""
 msgid "Create your workflow visually using the Workflow Builder."
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Created"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Created"
@@ -6771,7 +6679,7 @@ msgctxt "Submission Queue"
 msgid "Created At"
 msgstr ""
 
-#: model/__init__.py:138 model/meta.py:50
+#: model/__init__.py:138 model/meta.py:51
 #: public/js/frappe/list/list_sidebar_group_by.js:73
 #: public/js/frappe/model/meta.js:203 public/js/frappe/model/model.js:113
 msgid "Created By"
@@ -6782,7 +6690,7 @@ msgid "Created Custom Field {0} in {1}"
 msgstr ""
 
 #: desk/doctype/dashboard_chart/dashboard_chart.js:241 model/__init__.py:140
-#: model/meta.py:45 public/js/frappe/model/meta.js:198
+#: model/meta.py:46 public/js/frappe/model/meta.js:198
 #: public/js/frappe/model/model.js:115
 #: public/js/frappe/views/dashboard/dashboard_view.js:478
 msgid "Created On"
@@ -6792,7 +6700,7 @@ msgstr ""
 msgid "Creating {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Log'
+#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
 msgctxt "Energy Point Log"
 msgid "Criticism"
@@ -6802,13 +6710,13 @@ msgstr ""
 msgid "Criticize"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Cron"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Cron"
@@ -6836,37 +6744,37 @@ msgstr ""
 msgid "Currency"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Currency"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Currency"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Currency"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Currency"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Currency"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Currency"
@@ -6884,7 +6792,7 @@ msgctxt "System Settings"
 msgid "Currency Precision"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Current"
@@ -6915,7 +6823,7 @@ msgstr ""
 msgid "Custom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Custom"
@@ -6945,13 +6853,14 @@ msgctxt "DocType State"
 msgid "Custom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Rule'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "Custom"
 msgstr ""
 
-#. Option for a Select field in DocType 'LDAP Settings'
+#. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Custom"
@@ -6963,25 +6872,26 @@ msgctxt "Module Def"
 msgid "Custom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Custom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Type' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Custom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Custom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Custom"
@@ -7044,7 +6954,7 @@ msgstr ""
 msgid "Custom Document Types Limit Exceeded"
 msgstr ""
 
-#: desk/desktop.py:480
+#: desk/desktop.py:483
 msgid "Custom Documents"
 msgstr ""
 
@@ -7072,16 +6982,12 @@ msgid "Custom Field"
 msgstr ""
 
 #: custom/doctype/custom_field/custom_field.py:216
-msgid ""
-"Custom Field {0} is created by the Administrator and can only be deleted "
-"through the Administrator account."
+msgid "Custom Field {0} is created by the Administrator and can only be deleted through the Administrator account."
 msgstr ""
 
 #. Subtitle of the Module Onboarding 'Customization'
 #: custom/module_onboarding/customization/customization.json
-msgid ""
-"Custom Field, Custom Doctype, Naming Series, Role Permission, Workflow, "
-"Print Formats, Reports"
+msgid "Custom Field, Custom Doctype, Naming Series, Role Permission, Workflow, Print Formats, Reports"
 msgstr ""
 
 #: custom/doctype/custom_field/custom_field.py:260
@@ -7111,9 +7017,7 @@ msgid "Custom Group Search"
 msgstr ""
 
 #: integrations/doctype/ldap_settings/ldap_settings.py:119
-msgid ""
-"Custom Group Search if filled needs to contain the user placeholder {0}, "
-"eg uid={0},ou=users,dc=example,dc=com"
+msgid "Custom Group Search if filled needs to contain the user placeholder {0}, eg uid={0},ou=users,dc=example,dc=com"
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:190
@@ -7133,9 +7037,7 @@ msgid "Custom HTML Help"
 msgstr ""
 
 #: integrations/doctype/ldap_settings/ldap_settings.py:111
-msgid ""
-"Custom LDAP Directoy Selected, please ensure 'LDAP Group Member "
-"attribute' and 'Group Object Class' are entered"
+msgid "Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute' and 'Group Object Class' are entered"
 msgstr ""
 
 #. Label of a Data field in DocType 'Web Form Field'
@@ -7168,13 +7070,13 @@ msgctxt "Website Theme"
 msgid "Custom Overrides"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report'
+#. Option for the 'Report Type' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "Custom Report"
 msgstr ""
 
-#: desk/desktop.py:481
+#: desk/desktop.py:484
 msgid "Custom Reports"
 msgstr ""
 
@@ -7307,43 +7209,43 @@ msgstr ""
 msgid "Cut"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Cyan"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Cyan"
 msgstr ""
 
-#. Option for a Select field in DocType 'Recorder'
+#. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "DELETE"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Request Method' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "DELETE"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Sort Order' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "DESC"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Default Sort Order' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "DESC"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "DLE"
@@ -7358,73 +7260,77 @@ msgstr ""
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dropbox Settings'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'Dropbox
+#. Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
 msgctxt "Dropbox Settings"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Settings'
+#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
+#. 'Energy Point Settings'
 #: social/doctype/energy_point_settings/energy_point_settings.json
 msgctxt "Energy Point Settings"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Google Drive'
+#. Option for the 'Frequency' (Select) field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
 msgctxt "Google Drive"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'S3 Backup Settings'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
+#. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgctxt "S3 Backup Settings"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Daily"
 msgstr ""
 
-#. Option for a Select field in DocType 'User'
+#. Option for the 'Frequency' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Daily"
@@ -7438,25 +7344,25 @@ msgstr ""
 msgid "Daily Events should finish on the Same Day."
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Daily Long"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Daily Long"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "Danger"
 msgstr ""
 
-#. Option for a Select field in DocType 'User'
+#. Option for the 'Desk Theme' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Dark"
@@ -7485,7 +7391,7 @@ msgctxt "Dashboard"
 msgid "Dashboard"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Dashboard"
@@ -7497,7 +7403,8 @@ msgctxt "Role"
 msgid "Dashboard"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Dashboard"
@@ -7559,13 +7466,13 @@ msgstr ""
 msgid "Data"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Data"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Data"
@@ -7577,19 +7484,19 @@ msgctxt "Deleted Document"
 msgid "Data"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Data"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Data"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Data"
@@ -7607,13 +7514,13 @@ msgctxt "Version"
 msgid "Data"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Data"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Data"
@@ -7694,9 +7601,7 @@ msgid "Database Table Row Size Limit"
 msgstr ""
 
 #: public/js/frappe/doctype/index.js:40
-msgid ""
-"Database Table Row Size Utilization: {0}%, this limits number of fields "
-"you can add."
+msgid "Database Table Row Size Utilization: {0}%, this limits number of fields you can add."
 msgstr ""
 
 #: desk/report/todo/todo.py:38 email/doctype/newsletter/newsletter.js:109
@@ -7716,37 +7621,37 @@ msgctxt "Communication"
 msgid "Date"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Date"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Date"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Date"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Date"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Date"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Date"
@@ -7788,37 +7693,37 @@ msgstr ""
 msgid "Dates are often easy to guess."
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Datetime"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Datetime"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Datetime"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Datetime"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Datetime"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Datetime"
@@ -7846,13 +7751,13 @@ msgctxt "Auto Email Report"
 msgid "Day of Week"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Days After"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Days Before"
@@ -7903,7 +7808,7 @@ msgctxt "DocField"
 msgid "Default"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Default"
@@ -7969,13 +7874,15 @@ msgctxt "Letter Head"
 msgid "Default Letter Head"
 msgstr ""
 
-#. Option for a Select field in DocType 'Amended Document Naming Settings'
+#. Option for the 'Action' (Select) field in DocType 'Amended Document Naming
+#. Settings'
 #: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
 msgctxt "Amended Document Naming Settings"
 msgid "Default Naming"
 msgstr ""
 
-#. Option for a Select field in DocType 'Document Naming Settings'
+#. Option for the 'Default Amendment Naming' (Select) field in DocType
+#. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid "Default Naming"
@@ -8105,7 +8012,7 @@ msgstr ""
 msgid "Default {0}"
 msgstr ""
 
-#. Description of a Data field in DocType 'Contact Us Settings'
+#. Description of the 'Heading' (Data) field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
 msgctxt "Contact Us Settings"
 msgid "Default: \"Contact Us\""
@@ -8132,7 +8039,7 @@ msgstr ""
 msgid "Defaults Updated"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Delayed"
@@ -8204,25 +8111,27 @@ msgctxt "Title of confirmation dialog"
 msgid "Delete {0} items permanently?"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Deleted"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Deleted"
 msgstr ""
 
-#. Option for a Select field in DocType 'Personal Data Deletion Request'
+#. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
+#. Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 msgctxt "Personal Data Deletion Request"
 msgid "Deleted"
 msgstr ""
 
-#. Option for a Select field in DocType 'Personal Data Deletion Step'
+#. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
+#. Step'
 #: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 msgctxt "Personal Data Deletion Step"
 msgid "Deleted"
@@ -8287,7 +8196,7 @@ msgstr ""
 msgid "Deny"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Sign ups' (Select) field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Deny"
@@ -8426,20 +8335,17 @@ msgctxt "Website Slideshow Item"
 msgid "Description"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Blog Post'
+#. Description of the 'Blog Intro' (Small Text) field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
-msgid ""
-"Description for listing page, in plain text, only a couple of lines. (max"
-" 200 characters)"
+msgid "Description for listing page, in plain text, only a couple of lines. (max 200 characters)"
 msgstr ""
 
-#. Description of a Section Break field in DocType 'Onboarding Step'
+#. Description of the 'Description' (Section Break) field in DocType
+#. 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
-msgid ""
-"Description to inform the user about any action that is going to be "
-"performed"
+msgid "Description to inform the user about any action that is going to be performed"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
@@ -8540,12 +8446,10 @@ msgstr ""
 msgid "Diff"
 msgstr ""
 
-#. Description of a Section Break field in DocType 'Workflow'
+#. Description of the 'States' (Section Break) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid ""
-"Different \"States\" this document can exist in. Like \"Open\", \"Pending"
-" Approval\" etc."
+msgid "Different \"States\" this document can exist in. Like \"Open\", \"Pending Approval\" etc."
 msgstr ""
 
 #. Label of a Int field in DocType 'Document Naming Rule'
@@ -8664,7 +8568,7 @@ msgid "Disabled"
 msgstr ""
 
 #. Label of a Check field in DocType 'Auto Repeat'
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Status' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Disabled"
@@ -8784,7 +8688,8 @@ msgctxt "LDAP Settings"
 msgid "Do Not Create New User "
 msgstr ""
 
-#. Description of a Check field in DocType 'LDAP Settings'
+#. Description of the 'Do Not Create New User ' (Check) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Do not create new user if user with email does not exist in the system"
@@ -8829,7 +8734,7 @@ msgstr ""
 msgid "DocField"
 msgstr ""
 
-#. Option for a Select field in DocType 'Property Setter'
+#. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
 msgid "DocField"
@@ -8847,12 +8752,9 @@ msgstr ""
 
 #: workflow/doctype/workflow/workflow.js:264
 msgid ""
-"DocStatus of the following states have "
-"changed:<br><strong>{0}</strong><br>\n"
-"\t\t\t\tDo you want to update the docstatus of existing documents in "
-"those states?<br>\n"
-"\t\t\t\tThis does not undo any effect bought in by the document's "
-"existing docstatus.\n"
+"DocStatus of the following states have changed:<br><strong>{0}</strong><br>\n"
+"\t\t\t\tDo you want to update the docstatus of existing documents in those states?<br>\n"
+"\t\t\t\tThis does not undo any effect bought in by the document's existing docstatus.\n"
 "\t\t\t\t"
 msgstr ""
 
@@ -8901,9 +8803,9 @@ msgctxt "Module Def"
 msgid "DocType"
 msgstr ""
 
-#. Label of a Link field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Label of a Link field in DocType 'Permission Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "DocType"
 msgstr ""
 
@@ -8913,7 +8815,7 @@ msgctxt "Print Format"
 msgid "DocType"
 msgstr ""
 
-#. Option for a Select field in DocType 'Property Setter'
+#. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
 #. Label of a Link field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
@@ -8932,7 +8834,7 @@ msgctxt "Webhook"
 msgid "DocType"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Link'
+#. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
 msgctxt "Workspace Link"
 msgid "DocType"
@@ -8944,16 +8846,14 @@ msgctxt "Workspace Quick List"
 msgid "DocType"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "DocType"
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:1528
-msgid ""
-"DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast "
-"one Link field"
+msgid "DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field"
 msgstr ""
 
 #. Name of a DocType
@@ -8961,13 +8861,13 @@ msgstr ""
 msgid "DocType Action"
 msgstr ""
 
-#. Option for a Select field in DocType 'Property Setter'
+#. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
 msgid "DocType Action"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #. Label of a Select field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
@@ -8989,7 +8889,7 @@ msgstr ""
 msgid "DocType Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Property Setter'
+#. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
 msgid "DocType Link"
@@ -9004,7 +8904,7 @@ msgstr ""
 msgid "DocType State"
 msgstr ""
 
-#. Option for a Select field in DocType 'Property Setter'
+#. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
 msgid "DocType State"
@@ -9040,7 +8940,7 @@ msgstr ""
 msgid "DocType not supported by Log Settings."
 msgstr ""
 
-#. Description of a Link field in DocType 'Workflow'
+#. Description of the 'Document Type' (Link) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
 msgid "DocType on which this Workflow is applicable."
@@ -9094,7 +8994,7 @@ msgctxt "Audit Trail"
 msgid "Document"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Document"
@@ -9112,9 +9012,9 @@ msgctxt "Notification Subscribed Document"
 msgid "Document"
 msgstr ""
 
-#. Label of a Dynamic Link field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Label of a Dynamic Link field in DocType 'Permission Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "Document"
 msgstr ""
 
@@ -9295,7 +9195,7 @@ msgctxt "Workflow"
 msgid "Document States"
 msgstr ""
 
-#: model/__init__.py:152 model/meta.py:46 public/js/frappe/model/meta.js:199
+#: model/__init__.py:152 model/meta.py:47 public/js/frappe/model/meta.js:199
 #: public/js/frappe/model/model.js:127
 msgid "Document Status"
 msgstr ""
@@ -9386,7 +9286,7 @@ msgid "Document Type"
 msgstr ""
 
 #. Label of a Link field in DocType 'Number Card'
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Type' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Document Type"
@@ -9444,11 +9344,11 @@ msgstr ""
 msgid "Document Type and Function are required to create a number card"
 msgstr ""
 
-#: permissions.py:146
+#: permissions.py:149
 msgid "Document Type is not importable"
 msgstr ""
 
-#: permissions.py:142
+#: permissions.py:145
 msgid "Document Type is not submittable"
 msgstr ""
 
@@ -9500,7 +9400,7 @@ msgstr ""
 msgid "Document not Relinked"
 msgstr ""
 
-#: model/rename_doc.py:229 public/js/frappe/form/toolbar.js:145
+#: model/rename_doc.py:230 public/js/frappe/form/toolbar.js:145
 msgid "Document renamed from {0} to {1}"
 msgstr ""
 
@@ -9594,12 +9494,11 @@ msgctxt "Domain Settings"
 msgid "Domains HTML"
 msgstr ""
 
-#. Description of a Check field in DocType 'Custom Field'
+#. Description of the 'Ignore XSS Filter' (Check) field in DocType 'Custom
+#. Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
-msgid ""
-"Don't HTML Encode HTML tags like &lt;script&gt; or just characters like "
-"&lt; or &gt;, as they could be intentionally used in this field"
+msgid "Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field"
 msgstr ""
 
 #: public/js/frappe/data_import/import_preview.js:268
@@ -9624,20 +9523,17 @@ msgctxt "Data Import"
 msgid "Don't Send Emails"
 msgstr ""
 
-#. Description of a Check field in DocType 'Customize Form Field'
+#. Description of the 'Ignore XSS Filter' (Check) field in DocType 'Customize
+#. Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
-msgid ""
-"Don't encode HTML tags like &lt;script&gt; or just characters like &lt; "
-"or &gt;, as they could be intentionally used in this field"
+msgid "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocField'
+#. Description of the 'Ignore XSS Filter' (Check) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
-msgid ""
-"Don't encode HTML tags like &lt;script&gt; or just characters like &lt; "
-"or &gt;, as they could be intentionally used in this field"
+msgid "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field"
 msgstr ""
 
 #: www/login.html:119 www/login.html:135 www/update-password.html:34
@@ -9649,7 +9545,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Donut"
@@ -9770,7 +9666,7 @@ msgstr ""
 msgid "Duplicate Filter Name"
 msgstr ""
 
-#: model/base_document.py:563 model/rename_doc.py:112
+#: model/base_document.py:563 model/rename_doc.py:113
 msgid "Duplicate Name"
 msgstr ""
 
@@ -9787,19 +9683,19 @@ msgstr ""
 msgid "Duplicate of {0} named as {1} is created successfully"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Duration"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Duration"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Duration"
@@ -9817,13 +9713,13 @@ msgctxt "Recorder Query"
 msgid "Duration"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Duration"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Duration"
@@ -9858,31 +9754,31 @@ msgstr ""
 msgid "Dynamic Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Dynamic Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Dynamic Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Dynamic Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Dynamic Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Dynamic Link"
@@ -9908,11 +9804,7 @@ msgstr ""
 
 #. Description of the Onboarding Step 'Setup Naming Series'
 #: custom/onboarding_step/naming_series/naming_series.json
-msgid ""
-"Each document created in ERPNext can have a unique ID generated for it, "
-"using a prefix defined for it. Though each document has some prefix pre-"
-"configured, you can further customize it using tools like Naming Series "
-"Tool and Document Naming Rule.\n"
+msgid "Each document created in ERPNext can have a unique ID generated for it, using a prefix defined for it. Though each document has some prefix pre-configured, you can further customize it using tools like Naming Series Tool and Document Naming Rule.\n"
 msgstr ""
 
 #: core/page/dashboard_view/dashboard_view.js:169
@@ -9939,7 +9831,7 @@ msgctxt "Button in list view actions menu"
 msgid "Edit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Edit"
@@ -10052,7 +9944,8 @@ msgstr ""
 msgid "Editing {0}"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'SMS Settings'
+#. Description of the 'SMS Gateway URL' (Small Text) field in DocType 'SMS
+#. Settings'
 #: core/doctype/sms_settings/sms_settings.json
 msgctxt "SMS Settings"
 msgid "Eg. smsgateway.com/api/send_sms.cgi"
@@ -10079,7 +9972,7 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Email"
@@ -10115,7 +10008,7 @@ msgctxt "Event Participants"
 msgid "Email"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Channel' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Email"
@@ -10127,7 +10020,8 @@ msgctxt "Personal Data Deletion Request"
 msgid "Email"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Two Factor Authentication method' (Select) field in DocType
+#. 'System Settings'
 #. Label of a Tab Break field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
@@ -10204,9 +10098,7 @@ msgid "Email Account added multiple times"
 msgstr ""
 
 #: email/smtp.py:42
-msgid ""
-"Email Account not setup. Please create a new Email Account from Settings "
-"> Email Account"
+msgid "Email Account not setup. Please create a new Email Account from Settings > Email Account"
 msgstr ""
 
 #: desk/page/setup_wizard/setup_wizard.js:470 www/complete_signup.html:11
@@ -10238,7 +10130,7 @@ msgctxt "Google Contacts"
 msgid "Email Address"
 msgstr ""
 
-#. Description of a Data field in DocType 'Google Contacts'
+#. Description of the 'Email Address' (Data) field in DocType 'Google Contacts'
 #: integrations/doctype/google_contacts/google_contacts.json
 msgctxt "Google Contacts"
 msgid "Email Address whose Google Contacts are to be synced."
@@ -10248,7 +10140,8 @@ msgstr ""
 msgid "Email Addresses"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Email Account'
+#. Description of the 'Send Notification to' (Small Text) field in DocType
+#. 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Email Addresses"
@@ -10480,7 +10373,7 @@ msgstr ""
 msgid "Email has been moved to trash"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:703
+#: public/js/frappe/views/communication.js:707
 msgid "Email not sent to {0} (unsubscribed / disabled)"
 msgstr ""
 
@@ -10492,7 +10385,7 @@ msgstr ""
 msgid "Emails are muted"
 msgstr ""
 
-#. Description of a Check field in DocType 'Workflow'
+#. Description of the 'Send Email Alert' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
 msgid "Emails will be sent with next possible workflow actions"
@@ -10695,15 +10588,14 @@ msgstr ""
 msgid "Enable developer mode to create a standard Web Template"
 msgstr ""
 
-#. Description of a Check field in DocType 'Blog Post'
+#. Description of the 'Enable Email Notification' (Check) field in DocType
+#. 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
-msgid ""
-"Enable email notification for any comment or likes received on your Blog "
-"Post."
+msgid "Enable email notification for any comment or likes received on your Blog Post."
 msgstr ""
 
-#. Description of a Check field in DocType 'Form Tour Step'
+#. Description of the 'Modal Trigger' (Check) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid ""
@@ -10812,31 +10704,33 @@ msgstr ""
 msgid "Enabled scheduled execution for script {0}"
 msgstr ""
 
-#. Description of a Check field in DocType 'Customize Form'
+#. Description of the 'Is Calendar and Gantt' (Check) field in DocType
+#. 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Enables Calendar and Gantt views."
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Is Calendar and Gantt' (Check) field in DocType
+#. 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Enables Calendar and Gantt views."
 msgstr ""
 
 #: email/doctype/email_account/email_account.js:232
-msgid ""
-"Enabling auto reply on an incoming email account will send automated "
-"replies to all the synchronized emails. Do you wish to continue?"
+msgid "Enabling auto reply on an incoming email account will send automated replies to all the synchronized emails. Do you wish to continue?"
 msgstr ""
 
-#. Description of a Check field in DocType 'Customize Form'
+#. Description of the 'Queue in Background (BETA)' (Check) field in DocType
+#. 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Enabling this will submit documents in background"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Queue in Background (BETA)' (Check) field in DocType
+#. 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Enabling this will submit documents in background"
@@ -10918,7 +10812,7 @@ msgctxt "Event"
 msgid "Ends on"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification Log'
+#. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
 msgctxt "Notification Log"
 msgid "Energy Point"
@@ -10979,7 +10873,7 @@ msgstr ""
 msgid "Enter Client Id and Client Secret in Google Settings."
 msgstr ""
 
-#: public/js/frappe/views/communication.js:659
+#: public/js/frappe/views/communication.js:663
 msgid "Enter Email Recipient(s)"
 msgstr ""
 
@@ -10998,35 +10892,32 @@ msgstr ""
 msgid "Enter a name for this {0}"
 msgstr ""
 
-#. Description of a Table field in DocType 'User'
+#. Description of the 'User Defaults' (Table) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
-msgid ""
-"Enter default value fields (keys) and values. If you add multiple values "
-"for a field, the first one will be picked. These defaults are also used "
-"to set \"match\" permission rules. To see list of fields, go to "
-"\"Customize Form\"."
+msgid "Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set \"match\" permission rules. To see list of fields, go to \"Customize Form\"."
 msgstr ""
 
 #: public/js/frappe/views/file/file_view.js:111
 msgid "Enter folder name"
 msgstr ""
 
-#. Description of a Table field in DocType 'SMS Settings'
+#. Description of the 'Static Parameters' (Table) field in DocType 'SMS
+#. Settings'
 #: core/doctype/sms_settings/sms_settings.json
 msgctxt "SMS Settings"
-msgid ""
-"Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, "
-"password=1234 etc.)"
+msgid "Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, password=1234 etc.)"
 msgstr ""
 
-#. Description of a Data field in DocType 'SMS Settings'
+#. Description of the 'Message Parameter' (Data) field in DocType 'SMS
+#. Settings'
 #: core/doctype/sms_settings/sms_settings.json
 msgctxt "SMS Settings"
 msgid "Enter url parameter for message"
 msgstr ""
 
-#. Description of a Data field in DocType 'SMS Settings'
+#. Description of the 'Receiver Parameter' (Data) field in DocType 'SMS
+#. Settings'
 #: core/doctype/sms_settings/sms_settings.json
 msgctxt "SMS Settings"
 msgid "Enter url parameter for receiver nos"
@@ -11053,19 +10944,19 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Error"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Import'
+#. Option for the 'Status' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Error"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Queue'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue'
 #. Label of a Code field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
 msgctxt "Email Queue"
@@ -11090,7 +10981,7 @@ msgctxt "Integration Request"
 msgid "Error"
 msgstr ""
 
-#. Option for a Select field in DocType 'Prepared Report'
+#. Option for the 'Status' (Select) field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
 msgctxt "Prepared Report"
 msgid "Error"
@@ -11129,14 +11020,7 @@ msgid "Error Message"
 msgstr ""
 
 #: public/js/frappe/form/print_utils.js:126
-msgid ""
-"Error connecting to QZ Tray Application...<br><br> You need to have QZ "
-"Tray application installed and running, to use the Raw Print "
-"feature.<br><br><a target=\"_blank\" "
-"href=\"https://qz.io/download/\">Click here to Download and install QZ "
-"Tray</a>.<br> <a target=\"_blank\" "
-"href=\"https://erpnext.com/docs/user/manual/en/setting-up/print/raw-"
-"printing\">Click here to learn more about Raw Printing</a>."
+msgid "Error connecting to QZ Tray Application...<br><br> You need to have QZ Tray application installed and running, to use the Raw Print feature.<br><br><a target=\"_blank\" href=\"https://qz.io/download/\">Click here to Download and install QZ Tray</a>.<br> <a target=\"_blank\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/print/raw-printing\">Click here to learn more about Raw Printing</a>."
 msgstr ""
 
 #: email/doctype/email_domain/email_domain.py:32
@@ -11190,13 +11074,13 @@ msgstr ""
 msgid "Event"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Event"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Event Category' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Event"
@@ -11255,12 +11139,9 @@ msgstr ""
 #. Description of the Onboarding Step 'Create Custom Fields'
 #: custom/onboarding_step/custom_field/custom_field.json
 msgid ""
-"Every form in ERPNext has a standard set of fields. If you need to "
-"capture some information, but there is no standard Field available for "
-"it, you can insert Custom Field for it.\n"
+"Every form in ERPNext has a standard set of fields. If you need to capture some information, but there is no standard Field available for it, you can insert Custom Field for it.\n"
 "\n"
-"Once custom fields are added, you can use them for reports and analytics "
-"charts as well.\n"
+"Once custom fields are added, you can use them for reports and analytics charts as well.\n"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocShare'
@@ -11269,7 +11150,8 @@ msgctxt "DocShare"
 msgid "Everyone"
 msgstr ""
 
-#. Description of a Code field in DocType 'Dashboard Chart'
+#. Description of the 'Custom Options' (Code) field in DocType 'Dashboard
+#. Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"]"
@@ -11287,39 +11169,40 @@ msgctxt "Workflow Transition"
 msgid "Example"
 msgstr ""
 
-#. Description of a Data field in DocType 'Portal Settings'
+#. Description of the 'Default Portal Home' (Data) field in DocType 'Portal
+#. Settings'
 #: website/doctype/portal_settings/portal_settings.json
 msgctxt "Portal Settings"
 msgid "Example: \"/desk\""
 msgstr ""
 
-#. Description of a Data field in DocType 'Onboarding Step'
+#. Description of the 'Path' (Data) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "Example: #Tree/Account"
 msgstr ""
 
-#. Description of a Int field in DocType 'Document Naming Rule'
+#. Description of the 'Digits' (Int) field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
 msgctxt "Document Naming Rule"
 msgid "Example: 00001"
 msgstr ""
 
-#. Description of a Data field in DocType 'System Settings'
+#. Description of the 'Session Expiry (idle timeout)' (Data) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"Example: Setting this to 24:00 will log out a user if they are not active"
-" for 24:00 hours."
+msgid "Example: Setting this to 24:00 will log out a user if they are not active for 24:00 hours."
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Assignment Rule'
+#. Description of the 'Description' (Small Text) field in DocType 'Assignment
+#. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Example: {{ subject }}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Export'
+#. Option for the 'File Type' (Select) field in DocType 'Data Export'
 #: core/doctype/data_export/data_export.json
 msgctxt "Data Export"
 msgid "Excel"
@@ -11370,7 +11253,7 @@ msgstr ""
 msgid "Execution Time: {0} sec"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Executive"
@@ -11389,7 +11272,7 @@ msgstr ""
 msgid "Expand All"
 msgstr ""
 
-#. Option for a Select field in DocType 'Help Article'
+#. Option for the 'Level' (Select) field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
 msgctxt "Help Article"
 msgid "Expert"
@@ -11413,7 +11296,7 @@ msgctxt "Note"
 msgid "Expire Notification On"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Expired"
@@ -11526,7 +11409,8 @@ msgstr ""
 msgid "Export not allowed. You need {0} role to export."
 msgstr ""
 
-#. Description of a Check field in DocType 'Data Export'
+#. Description of the 'Export without main header' (Check) field in DocType
+#. 'Data Export'
 #: core/doctype/data_export/data_export.json
 msgctxt "Data Export"
 msgid "Export the data without any header notes and column descriptions"
@@ -11548,31 +11432,32 @@ msgctxt "Email Queue"
 msgid "Expose Recipients"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Expression"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Expression"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Expression (old style)"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Expression (old style)"
 msgstr ""
 
-#. Description of a Data field in DocType 'Notification Recipient'
+#. Description of the 'Condition' (Data) field in DocType 'Notification
+#. Recipient'
 #: email/doctype/notification_recipient/notification_recipient.json
 msgctxt "Notification Recipient"
 msgid "Expression, Optional"
@@ -11584,31 +11469,32 @@ msgctxt "Connected App"
 msgid "Extra Parameters"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Facebook"
 msgstr ""
 
-#. Option for a Select field in DocType 'Activity Log'
+#. Option for the 'Status' (Select) field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
 msgctxt "Activity Log"
 msgid "Failed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Integration Request'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
 msgctxt "Integration Request"
 msgid "Failed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Log'
+#. Option for the 'Status' (Select) field in DocType 'Scheduled Job Log'
 #: core/doctype/scheduled_job_log/scheduled_job_log.json
 msgctxt "Scheduled Job Log"
 msgid "Failed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Submission Queue'
+#. Option for the 'Status' (Select) field in DocType 'Submission Queue'
 #: core/doctype/submission_queue/submission_queue.json
 msgctxt "Submission Queue"
 msgid "Failed"
@@ -11685,11 +11571,11 @@ msgstr ""
 msgid "Failed to optimize image: {0}"
 msgstr ""
 
-#: email/doctype/email_queue/email_queue.py:276
+#: email/doctype/email_queue/email_queue.py:278
 msgid "Failed to send email with subject:"
 msgstr ""
 
-#: desk/doctype/notification_log/notification_log.py:40
+#: desk/doctype/notification_log/notification_log.py:41
 msgid "Failed to send notification email"
 msgstr ""
 
@@ -11723,7 +11609,8 @@ msgctxt "Blog Post"
 msgid "Featured"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Communication Type' (Select) field in DocType
+#. 'Communication'
 #. Label of a Section Break field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
@@ -11883,12 +11770,10 @@ msgstr ""
 msgid "Field not permitted in query"
 msgstr ""
 
-#. Description of a Data field in DocType 'Workflow'
+#. Description of the 'Workflow State Field' (Data) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid ""
-"Field that represents the Workflow State of the transaction (if field is "
-"not present, a new hidden Custom Field will be created)"
+msgid "Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)"
 msgstr ""
 
 #. Label of a Select field in DocType 'Milestone Tracker'
@@ -11909,7 +11794,7 @@ msgstr ""
 msgid "Field {0} is referring to non-existing doctype {1}."
 msgstr ""
 
-#: public/js/frappe/form/form.js:1708
+#: public/js/frappe/form/form.js:1727
 msgid "Field {0} not found."
 msgstr ""
 
@@ -12050,12 +11935,10 @@ msgstr ""
 msgid "Fields `file_name` or `file_url` must be set for File"
 msgstr ""
 
-#. Description of a Data field in DocType 'Customize Form'
+#. Description of the 'Search Fields' (Data) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
-msgid ""
-"Fields separated by comma (,) will be included in the \"Search By\" list "
-"of Search dialog box"
+msgid "Fields separated by comma (,) will be included in the \"Search By\" list of Search dialog box"
 msgstr ""
 
 #. Label of a Data field in DocType 'Form Tour Step'
@@ -12113,7 +11996,7 @@ msgctxt "File"
 msgid "File"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "File"
@@ -12380,13 +12263,10 @@ msgstr ""
 msgid "Filters saved"
 msgstr ""
 
-#. Description of a Code field in DocType 'Report'
+#. Description of the 'Script' (Code) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
-msgid ""
-"Filters will be accessible via <code>filters</code>. <br><br>Send output "
-"as <code>result = [result]</code>, or for old style <code>data = "
-"[columns], [result]</code>"
+msgid "Filters will be accessible via <code>filters</code>. <br><br>Send output as <code>result = [result]</code>, or for old style <code>data = [columns], [result]</code>"
 msgstr ""
 
 #: public/js/frappe/ui/toolbar/search_utils.js:556
@@ -12400,7 +12280,7 @@ msgstr ""
 msgid "Find {0} in {1}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Submission Queue'
+#. Option for the 'Status' (Select) field in DocType 'Submission Queue'
 #: core/doctype/submission_queue/submission_queue.json
 msgctxt "Submission Queue"
 msgid "Finished"
@@ -12458,37 +12338,37 @@ msgctxt "Language"
 msgid "Flag"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Float"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Float"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Float"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Float"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Float"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Float"
@@ -12500,31 +12380,31 @@ msgctxt "System Settings"
 msgid "Float Precision"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Fold"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Fold"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Fold"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Fold"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Fold"
@@ -12558,7 +12438,7 @@ msgstr ""
 msgid "Folder {0} is not empty"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Folio"
@@ -12646,7 +12526,7 @@ msgctxt "Letter Head"
 msgid "Footer"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template'
+#. Option for the 'Type' (Select) field in DocType 'Web Template'
 #: website/doctype/web_template/web_template.json
 msgctxt "Web Template"
 msgid "Footer"
@@ -12727,13 +12607,14 @@ msgstr ""
 msgid "Footer might not be visible as {0} option is disabled</div>"
 msgstr ""
 
-#. Description of a HTML Editor field in DocType 'Letter Head'
+#. Description of the 'Footer HTML' (HTML Editor) field in DocType 'Letter
+#. Head'
 #: printing/doctype/letter_head/letter_head.json
 msgctxt "Letter Head"
 msgid "Footer will display correctly only in PDF"
 msgstr ""
 
-#. Description of a Data field in DocType 'Property Setter'
+#. Description of the 'Row Name' (Data) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
 msgid "For DocType Link / DocType Action"
@@ -12753,7 +12634,8 @@ msgstr ""
 msgid "For Example: {} Open"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Customize Form Field'
+#. Description of the 'Options' (Small Text) field in DocType 'Customize Form
+#. Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid ""
@@ -12761,7 +12643,7 @@ msgid ""
 "For Select, enter list of Options, each on a new line."
 msgstr ""
 
-#. Description of a Small Text field in DocType 'DocField'
+#. Description of the 'Options' (Small Text) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid ""
@@ -12800,49 +12682,41 @@ msgstr ""
 
 #: public/js/frappe/views/reports/query_report.js:1958
 #: public/js/frappe/views/reports/report_view.js:96
-msgid ""
-"For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values "
-"between 5 & 10)."
+msgid "For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 & 10)."
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:744
 msgid "For example: If you want to include the document ID, use {0}"
 msgstr ""
 
-#. Description of a Data field in DocType 'Workspace Shortcut'
+#. Description of the 'Format' (Data) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "For example: {} Open"
 msgstr ""
 
-#. Description of a Code field in DocType 'Web Form'
+#. Description of the 'Client Script' (Code) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
 msgctxt "Web Form"
-msgid ""
-"For help see <a href=\"https://frappeframework.com/docs/user/en/guides"
-"/portal-development/web-forms\" target=\"_blank\">Client Script API and "
-"Examples</a>"
+msgid "For help see <a href=\"https://frappeframework.com/docs/user/en/guides/portal-development/web-forms\" target=\"_blank\">Client Script API and Examples</a>"
 msgstr ""
 
-#. Description of a Check field in DocType 'Email Account'
+#. Description of the 'Enable Automatic Linking in Documents' (Check) field in
+#. DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
-msgid ""
-"For more information, <a class=\"text-muted\" "
-"href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-"
-"emails-to-document\">click here</a>."
+msgid "For more information, <a class=\"text-muted\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document\">click here</a>."
 msgstr ""
 
 #: integrations/doctype/google_settings/google_settings.js:7
 msgid "For more information, {0}."
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Auto Email Report'
+#. Description of the 'Email To' (Small Text) field in DocType 'Auto Email
+#. Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
-msgid ""
-"For multiple addresses, enter the address on different line. e.g. "
-"test@test.com ⏎ test1@test.com"
+msgid "For multiple addresses, enter the address on different line. e.g. test@test.com ⏎ test1@test.com"
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:199
@@ -12853,7 +12727,8 @@ msgstr ""
 msgid "For {0} at level {1} in {2} in row {3}"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Provider Settings'
+#. Option for the 'Skip Authorization' (Select) field in DocType 'OAuth
+#. Provider Settings'
 #: integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
 msgctxt "OAuth Provider Settings"
 msgid "Force"
@@ -12907,7 +12782,7 @@ msgstr ""
 msgid "Form"
 msgstr ""
 
-#. Option for a Select field in DocType 'Client Script'
+#. Option for the 'Apply To' (Select) field in DocType 'Client Script'
 #: custom/doctype/client_script/client_script.json
 msgctxt "Client Script"
 msgid "Form"
@@ -12925,7 +12800,7 @@ msgctxt "DocType"
 msgid "Form"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Form"
@@ -12989,7 +12864,7 @@ msgstr ""
 msgid "Form Tour Step"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Request Structure' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "Form URL-Encoded"
@@ -13043,7 +12918,8 @@ msgstr ""
 msgid "Frappe"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Frappe"
@@ -13097,19 +12973,19 @@ msgctxt "User"
 msgid "Frequency"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule Day'
+#. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
 #: automation/doctype/assignment_rule_day/assignment_rule_day.json
 msgctxt "Assignment Rule Day"
 msgid "Friday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Friday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat Day'
+#. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
 msgctxt "Auto Repeat Day"
 msgid "Friday"
@@ -13121,7 +12997,8 @@ msgctxt "Event"
 msgid "Friday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'First Day of the Week' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Friday"
@@ -13180,7 +13057,7 @@ msgstr ""
 msgid "From version"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart Link'
+#. Option for the 'Width' (Select) field in DocType 'Dashboard Chart Link'
 #: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
 msgctxt "Dashboard Chart Link"
 msgid "Full"
@@ -13245,7 +13122,7 @@ msgstr ""
 msgid "Function Based On"
 msgstr ""
 
-#: __init__.py:818
+#: __init__.py:835
 msgid "Function {0} is not whitelisted."
 msgstr ""
 
@@ -13257,25 +13134,25 @@ msgstr ""
 msgid "Fw: {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Recorder'
+#. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "GET"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "GMail"
 msgstr ""
 
-#. Option for a Select field in DocType 'Package'
+#. Option for the 'License Type' (Select) field in DocType 'Package'
 #: core/doctype/package/package.json
 msgctxt "Package"
 msgid "GNU Affero General Public License"
 msgstr ""
 
-#. Option for a Select field in DocType 'Package'
+#. Option for the 'License Type' (Select) field in DocType 'Package'
 #: core/doctype/package/package.json
 msgctxt "Package"
 msgid "GNU General Public License"
@@ -13285,7 +13162,7 @@ msgstr ""
 msgid "Gantt"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Gantt"
@@ -13338,19 +13215,19 @@ msgstr ""
 msgid "Generate Tracking URL"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Geolocation"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Geolocation"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Geolocation"
@@ -13386,21 +13263,21 @@ msgstr ""
 msgid "Get PDF"
 msgstr ""
 
-#. Description of a Data field in DocType 'Document Naming Settings'
+#. Description of the 'Try a Naming Series' (Data) field in DocType 'Document
+#. Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid "Get a preview of generated names with a series."
 msgstr ""
 
-#. Description of a Check field in DocType 'Notification Settings'
+#. Description of the 'Email Threads on Assigned Document' (Check) field in
+#. DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
 msgctxt "Notification Settings"
-msgid ""
-"Get notified when an email is received on any of the documents assigned "
-"to you."
+msgid "Get notified when an email is received on any of the documents assigned to you."
 msgstr ""
 
-#. Description of a Attach Image field in DocType 'User'
+#. Description of the 'User Image' (Attach Image) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Get your globally recognized avatar from Gravatar.com"
@@ -13412,7 +13289,8 @@ msgctxt "Installed Application"
 msgid "Git Branch"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "GitHub"
@@ -13461,7 +13339,7 @@ msgstr ""
 msgid "Go to Notification Settings List"
 msgstr ""
 
-#. Option for a Select field in DocType 'Onboarding Step'
+#. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "Go to Page"
@@ -13487,7 +13365,7 @@ msgstr ""
 msgid "Go to the document"
 msgstr ""
 
-#. Description of a Data field in DocType 'Web Form'
+#. Description of the 'Success URL' (Data) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
 msgctxt "Web Form"
 msgid "Go to this URL after completing the form"
@@ -13514,7 +13392,8 @@ msgstr ""
 msgid "Goal"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Google"
@@ -13553,9 +13432,7 @@ msgid "Google Calendar"
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.py:781
-msgid ""
-"Google Calendar - Contact / email not found. Did not add attendee for "
-"-<br>{0}"
+msgid "Google Calendar - Contact / email not found. Did not add attendee for -<br>{0}"
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.py:251
@@ -13563,33 +13440,23 @@ msgid "Google Calendar - Could not create Calendar for {0}, error code {1}."
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.py:575
-msgid ""
-"Google Calendar - Could not delete Event {0} from Google Calendar, error "
-"code {1}."
+msgid "Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}."
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.py:288
-msgid ""
-"Google Calendar - Could not fetch event from Google Calendar, error code "
-"{0}."
+msgid "Google Calendar - Could not fetch event from Google Calendar, error code {0}."
 msgstr ""
 
 #: integrations/doctype/google_contacts/google_contacts.py:229
-msgid ""
-"Google Calendar - Could not insert contact in Google Contacts {0}, error "
-"code {1}."
+msgid "Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}."
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.py:458
-msgid ""
-"Google Calendar - Could not insert event in Google Calendar {0}, error "
-"code {1}."
+msgid "Google Calendar - Could not insert event in Google Calendar {0}, error code {1}."
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.py:542
-msgid ""
-"Google Calendar - Could not update Event {0} in Google Calendar, error "
-"code {1}."
+msgid "Google Calendar - Could not update Event {0} in Google Calendar, error code {1}."
 msgstr ""
 
 #. Label of a Data field in DocType 'Event'
@@ -13635,15 +13502,11 @@ msgid "Google Contacts"
 msgstr ""
 
 #: integrations/doctype/google_contacts/google_contacts.py:136
-msgid ""
-"Google Contacts - Could not sync contacts from Google Contacts {0}, error"
-" code {1}."
+msgid "Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}."
 msgstr ""
 
 #: integrations/doctype/google_contacts/google_contacts.py:291
-msgid ""
-"Google Contacts - Could not update contact in Google Contacts {0}, error "
-"code {1}."
+msgid "Google Contacts - Could not update contact in Google Contacts {0}, error code {1}."
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
@@ -13732,9 +13595,7 @@ msgid "Google Sheets URL is invalid or not publicly accessible."
 msgstr ""
 
 #: utils/csvutils.py:204
-msgid ""
-"Google Sheets URL must end with \"gid={number}\". Copy and paste the URL "
-"from the browser address bar and try again."
+msgid "Google Sheets URL must end with \"gid={number}\". Copy and paste the URL from the browser address bar and try again."
 msgstr ""
 
 #. Label of a HTML field in DocType 'Blog Post'
@@ -13753,25 +13614,25 @@ msgstr ""
 msgid "Graph"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Gray"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Gray"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Green"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Green"
@@ -13803,7 +13664,7 @@ msgstr ""
 msgid "Group By"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Group By"
@@ -13839,19 +13700,19 @@ msgstr ""
 msgid "Grouped by <span style='font-weight:600;'>{0}</b>"
 msgstr ""
 
-#. Option for a Select field in DocType 'Recorder'
+#. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "HEAD"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Time Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "HH:mm"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Time Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "HH:mm:ss"
@@ -13861,19 +13722,19 @@ msgstr ""
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Blog Post'
+#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "HTML"
@@ -13885,31 +13746,33 @@ msgctxt "Custom HTML Block"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Letter Head'
+#. Option for the 'Letter Head Based On' (Select) field in DocType 'Letter
+#. Head'
+#. Option for the 'Footer Based On' (Select) field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
 msgctxt "Letter Head"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Newsletter'
+#. Option for the 'Content Type' (Select) field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
 msgctxt "Newsletter"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Message Type' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "HTML"
@@ -13921,31 +13784,31 @@ msgctxt "Print Format"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Content Type' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "HTML Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "HTML Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "HTML Editor"
@@ -13957,19 +13820,19 @@ msgctxt "Access Log"
 msgid "HTML Page"
 msgstr ""
 
-#. Description of a HTML Editor field in DocType 'Web Page'
+#. Description of the 'Header' (HTML Editor) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "HTML for header section. Optional"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart Link'
+#. Option for the 'Width' (Select) field in DocType 'Dashboard Chart Link'
 #: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
 msgctxt "Dashboard Chart Link"
 msgid "Half"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Half Yearly"
@@ -13979,7 +13842,7 @@ msgstr ""
 msgid "Half-yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Half-yearly"
@@ -14085,19 +13948,19 @@ msgctxt "Contact Us Settings"
 msgid "Heading"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Heading"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Heading"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Heading"
@@ -14109,7 +13972,7 @@ msgctxt "Website Slideshow Item"
 msgid "Heading"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Heatmap"
@@ -14179,12 +14042,10 @@ msgstr ""
 msgid "Help on Search"
 msgstr ""
 
-#. Description of a Text Editor field in DocType 'Note'
+#. Description of the 'Content' (Text Editor) field in DocType 'Note'
 #: desk/doctype/note/note.json
 msgctxt "Note"
-msgid ""
-"Help: To link to another record in the system, use \"/app/note/[Note "
-"Name]\" as the Link URL. (don't use \"http://\")"
+msgid "Help: To link to another record in the system, use \"/app/note/[Note Name]\" as the Link URL. (don't use \"http://\")"
 msgstr ""
 
 #. Label of a Int field in DocType 'Help Article'
@@ -14193,13 +14054,13 @@ msgctxt "Help Article"
 msgid "Helpful"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Helvetica"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Helvetica Neue"
@@ -14279,7 +14140,7 @@ msgstr ""
 msgid "Hide"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Hide"
@@ -14382,7 +14243,7 @@ msgstr ""
 msgid "Hide Preview"
 msgstr ""
 
-#. Description of a Check field in DocType 'Form Tour Step'
+#. Description of the 'Hide Buttons' (Check) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Hide Previous, Next and Close button on highlight dialog."
@@ -14434,7 +14295,8 @@ msgstr ""
 msgid "Hide Workspace"
 msgstr ""
 
-#. Description of a Check field in DocType 'User Permission'
+#. Description of the 'Hide Descendants' (Check) field in DocType 'User
+#. Permission'
 #: core/doctype/user_permission/user_permission.json
 msgctxt "User Permission"
 msgid "Hide descendant records of <b>For Value</b>."
@@ -14460,13 +14322,13 @@ msgstr ""
 msgid "High"
 msgstr ""
 
-#. Option for a Select field in DocType 'ToDo'
+#. Option for the 'Priority' (Select) field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
 msgctxt "ToDo"
 msgid "High"
 msgstr ""
 
-#. Description of a Int field in DocType 'Assignment Rule'
+#. Description of the 'Priority' (Int) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Higher priority rule will be applied first"
@@ -14531,55 +14393,54 @@ msgstr ""
 msgid "Home/Test Folder 2"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Hourly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Hourly"
 msgstr ""
 
-#. Option for a Select field in DocType 'User'
+#. Option for the 'Frequency' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Hourly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Hourly Long"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Hourly Long"
 msgstr ""
 
-#. Description of a Int field in DocType 'System Settings'
+#. Description of the 'Password Reset Link Generation Limit' (Int) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Hourly rate limit for generating password reset links"
 msgstr ""
 
-#. Description of a Select field in DocType 'Currency'
+#. Description of the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
-msgid ""
-"How should this currency be formatted? If not set, will use system "
-"defaults"
+msgid "How should this currency be formatted? If not set, will use system defaults"
 msgstr ""
 
 #: core/doctype/data_import/importer.py:1120
 #: core/doctype/data_import/importer.py:1126
 #: core/doctype/data_import/importer.py:1192
 #: core/doctype/data_import/importer.py:1195 desk/report/todo/todo.py:36
-#: model/__init__.py:137 model/meta.py:44
+#: model/__init__.py:137 model/meta.py:45
 #: public/js/frappe/data_import/data_exporter.js:326
 #: public/js/frappe/data_import/data_exporter.js:341
 #: public/js/frappe/list/list_view.js:355
@@ -14593,18 +14454,16 @@ msgctxt "Label of name column in report"
 msgid "ID"
 msgstr ""
 
-#. Description of a Data field in DocType 'Property Setter'
+#. Description of the 'Field Name' (Data) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
 msgid "ID (name) of the entity whose property is to be set"
 msgstr ""
 
-#. Description of a Data field in DocType 'Web Page Block'
+#. Description of the 'Section ID' (Data) field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
 msgctxt "Web Page Block"
-msgid ""
-"IDs must contain only alphanumeric characters, not contain spaces, and "
-"should be unique."
+msgid "IDs must contain only alphanumeric characters, not contain spaces, and should be unique."
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Account'
@@ -14648,13 +14507,13 @@ msgstr ""
 msgid "Icon"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Icon"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Icon"
@@ -14666,7 +14525,7 @@ msgctxt "Desktop Icon"
 msgid "Icon"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Icon"
@@ -14708,7 +14567,7 @@ msgctxt "Workspace Shortcut"
 msgid "Icon"
 msgstr ""
 
-#. Description of a Select field in DocType 'Workflow State'
+#. Description of the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "Icon will appear on the button"
@@ -14726,22 +14585,22 @@ msgctxt "Desktop Icon"
 msgid "Idx"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Apply Strict User Permissions' (Check) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"If Apply Strict User Permission is checked and User Permission is defined"
-" for a DocType for a User, then all the documents where value of the link"
-" is blank, will not be shown to that User"
+msgid "If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User"
 msgstr ""
 
-#. Description of a Check field in DocType 'Workflow'
+#. Description of the 'Don't Override Status' (Check) field in DocType
+#. 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
 msgid "If Checked workflow status will not override status in list view"
 msgstr ""
 
-#. Description of a Check field in DocType 'Workflow Document State'
+#. Description of the 'Don't Override Status' (Check) field in DocType
+#. 'Workflow Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
 msgctxt "Workflow Document State"
 msgid "If Checked workflow status will not override status in list view"
@@ -14751,166 +14610,157 @@ msgstr ""
 msgid "If Owner"
 msgstr ""
 
-#. Description of a Check field in DocType 'Workflow'
+#. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
 msgid "If checked, all other workflows become inactive."
 msgstr ""
 
-#. Description of a Check field in DocType 'Print Format'
+#. Description of the 'Show Absolute Values' (Check) field in DocType 'Print
+#. Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
-msgid ""
-"If checked, negative numeric values of Currency, Quantity or Count would "
-"be shown as positive"
+msgid "If checked, negative numeric values of Currency, Quantity or Count would be shown as positive"
 msgstr ""
 
-#. Description of a Check field in DocType 'OAuth Client'
+#. Description of the 'Skip Authorization' (Check) field in DocType 'OAuth
+#. Client'
 #: integrations/doctype/oauth_client/oauth_client.json
 msgctxt "OAuth Client"
 msgid "If checked, users will not see the Confirm Access dialog."
 msgstr ""
 
-#. Description of a Check field in DocType 'Role'
+#. Description of the 'Disabled' (Check) field in DocType 'Role'
 #: core/doctype/role/role.json
 msgctxt "Role"
 msgid "If disabled, this role will be removed from all users."
 msgstr ""
 
-#. Description of a Check field in DocType 'User'
+#. Description of the 'Bypass Restricted IP Address Check If Two Factor Auth
+#. Enabled' (Check) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
-msgid ""
-"If enabled,  user can login from any IP Address using Two Factor Auth, "
-"this can also be set for all users in System Settings"
+msgid "If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Bypass restricted IP Address check If Two Factor Auth
+#. Enabled' (Check) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"If enabled, all users can login from any IP Address using Two Factor "
-"Auth. This can also be set only for specific user(s) in User Page"
+msgid "If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Track Changes' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "If enabled, changes to the document are tracked and shown in timeline"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Track Views' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "If enabled, document views are tracked, this can happen multiple times"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Track Seen' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "If enabled, the document is marked as seen, the first time a user opens it"
 msgstr ""
 
-#. Description of a Check field in DocType 'Notification'
+#. Description of the 'Send System Notification' (Check) field in DocType
+#. 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
-msgid ""
-"If enabled, the notification will show up in the notifications dropdown "
-"on the top right corner of the navigation bar."
+msgid "If enabled, the notification will show up in the notifications dropdown on the top right corner of the navigation bar."
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Enable Password Policy' (Check) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"If enabled, the password strength will be enforced based on the Minimum "
-"Password Score value. A value of 2 being medium strong and 4 being very "
-"strong."
+msgid "If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong."
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Bypass Two Factor Auth for users who login from
+#. restricted IP Address' (Check) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"If enabled, users who login from Restricted IP Address, won't be prompted"
-" for Two Factor Auth"
+msgid "If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth"
 msgstr ""
 
-#. Description of a Check field in DocType 'Note'
+#. Description of the 'Notify Users On Every Login' (Check) field in DocType
+#. 'Note'
 #: desk/doctype/note/note.json
 msgctxt "Note"
-msgid ""
-"If enabled, users will be notified every time they login. If not enabled,"
-" users will only be notified once."
+msgid "If enabled, users will be notified every time they login. If not enabled, users will only be notified once."
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Domain'
+#. Description of the 'Port' (Data) field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
 msgctxt "Email Domain"
 msgid "If non standard port (e.g. 587)"
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Account'
+#. Description of the 'Port' (Data) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "If non standard port (e.g. 587). If on Google Cloud, try port 2525."
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Account'
+#. Description of the 'Port' (Data) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)"
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Domain'
+#. Description of the 'Port' (Data) field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
 msgctxt "Email Domain"
 msgid "If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)"
 msgstr ""
 
-#. Description of a Select field in DocType 'System Settings'
+#. Description of the 'Currency Precision' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "If not set, the currency precision will depend on number format"
 msgstr ""
 
-#. Description of a Table field in DocType 'Dashboard Chart'
+#. Description of the 'Roles' (Table) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
-msgid ""
-"If set, only user with these roles can access this chart. If not set, "
-"DocType or Report permissions will be used."
+msgid "If set, only user with these roles can access this chart. If not set, DocType or Report permissions will be used."
 msgstr ""
 
-#. Description of a Code field in DocType 'Energy Point Rule'
+#. Description of the 'Condition' (Code) field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
-msgid ""
-"If the condition is satisfied user will be rewarded with the points. eg. "
-"doc.status == 'Closed'\n"
+msgid "If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'\n"
 msgstr ""
 
-#. Description of a Link field in DocType 'User'
+#. Description of the 'User Type' (Link) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
-msgid ""
-"If the user has any role checked, then the user becomes a \"System "
-"User\". \"System User\" has access to the desktop"
+msgid "If the user has any role checked, then the user becomes a \"System User\". \"System User\" has access to the desktop"
 msgstr ""
 
-#. Description of a Check field in DocType 'Custom Field'
+#. Description of the 'Fetch on Save if Empty' (Check) field in DocType 'Custom
+#. Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "If unchecked, the value will always be re-fetched on save."
 msgstr ""
 
-#. Description of a Check field in DocType 'Customize Form Field'
+#. Description of the 'Fetch on Save if Empty' (Check) field in DocType
+#. 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "If unchecked, the value will always be re-fetched on save."
 msgstr ""
 
-#. Description of a Check field in DocType 'DocField'
+#. Description of the 'Fetch on Save if Empty' (Check) field in DocType
+#. 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "If unchecked, the value will always be re-fetched on save."
@@ -14929,15 +14779,11 @@ msgid "If user is the owner"
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:206
-msgid ""
-"If you are updating, please select \"Overwrite\" else existing rows will "
-"not be deleted."
+msgid "If you are updating, please select \"Overwrite\" else existing rows will not be deleted."
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:190
-msgid ""
-"If you are uploading new records, \"Naming Series\" becomes mandatory, if"
-" present."
+msgid "If you are uploading new records, \"Naming Series\" becomes mandatory, if present."
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:187
@@ -14945,35 +14791,27 @@ msgid "If you are uploading new records, leave the \"name\" (ID) column blank."
 msgstr ""
 
 #: utils/password.py:200
-msgid ""
-"If you have recently restored the site you may need to copy the site "
-"config contaning original Encryption Key."
+msgid "If you have recently restored the site you may need to copy the site config contaning original Encryption Key."
 msgstr ""
 
 #: core/doctype/doctype/doctype.js:80
 msgid "If you just want to customize for your site, use {0} instead."
 msgstr ""
 
-#. Description of a Select field in DocType 'Top Bar Item'
+#. Description of the 'Parent Label' (Select) field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
 msgctxt "Top Bar Item"
-msgid ""
-"If you set this, this Item will come in a drop-down under the selected "
-"parent."
+msgid "If you set this, this Item will come in a drop-down under the selected parent."
 msgstr ""
 
 #: templates/emails/administrator_logged_in.html:3
-msgid ""
-"If you think this is unauthorized, please change the Administrator "
-"password."
+msgid "If you think this is unauthorized, please change the Administrator password."
 msgstr ""
 
-#. Description of a Code field in DocType 'Translation'
+#. Description of the 'Source Text' (Code) field in DocType 'Translation'
 #: core/doctype/translation/translation.json
 msgctxt "Translation"
-msgid ""
-"If your data is in HTML, please copy paste the exact HTML code with the "
-"tags."
+msgid "If your data is in HTML, please copy paste the exact HTML code with the tags."
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom Field'
@@ -15012,13 +14850,15 @@ msgctxt "DocField"
 msgid "Ignore XSS Filter"
 msgstr ""
 
-#. Description of a Int field in DocType 'Email Account'
+#. Description of the 'Attachment Limit (MB)' (Int) field in DocType 'Email
+#. Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Ignore attachments over this size"
 msgstr ""
 
-#. Description of a Int field in DocType 'Email Domain'
+#. Description of the 'Attachment Limit (MB)' (Int) field in DocType 'Email
+#. Domain'
 #: email/doctype/email_domain/email_domain.json
 msgctxt "Email Domain"
 msgid "Ignore attachments over this size"
@@ -15038,7 +14878,7 @@ msgstr ""
 msgid "Illegal Document Status for {0}"
 msgstr ""
 
-#: model/db_query.py:451 model/db_query.py:454 model/db_query.py:1129
+#: model/db_query.py:451 model/db_query.py:454 model/db_query.py:1128
 msgid "Illegal SQL Query"
 msgstr ""
 
@@ -15052,32 +14892,34 @@ msgctxt "Contact"
 msgid "Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Letter Head'
+#. Option for the 'Letter Head Based On' (Select) field in DocType 'Letter
+#. Head'
 #. Label of a Attach Image field in DocType 'Letter Head'
+#. Option for the 'Footer Based On' (Select) field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
 msgctxt "Letter Head"
 msgid "Image"
@@ -15095,7 +14937,7 @@ msgctxt "Website Slideshow Item"
 msgid "Image"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Image"
@@ -15155,7 +14997,7 @@ msgstr ""
 msgid "Implement `clear_old_logs` method to enable auto error clearing."
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Client'
+#. Option for the 'Grant Type' (Select) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
 msgctxt "OAuth Client"
 msgid "Implicit"
@@ -15283,7 +15125,8 @@ msgstr ""
 msgid "In"
 msgstr ""
 
-#. Description of a Int field in DocType 'System Settings'
+#. Description of the 'Force User to Reset Password' (Int) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "In Days"
@@ -15291,11 +15134,7 @@ msgstr ""
 
 #. Description of the Onboarding Step 'Setup Limited Access for a User'
 #: custom/onboarding_step/role_permissions/role_permissions.json
-msgid ""
-"In ERPNext, you can add your Employees as Users, and give them restricted"
-" access. Tools like Role Permission and User Permission allow you to "
-"define rules which give restricted access to the user to masters and "
-"transactions."
+msgid "In ERPNext, you can add your Employees as Users, and give them restricted access. Tools like Role Permission and User Permission allow you to define rules which give restricted access to the user to masters and transactions."
 msgstr ""
 
 #. Label of a Check field in DocType 'Customize Form Field'
@@ -15406,21 +15245,17 @@ msgstr ""
 
 #. Description of the Onboarding Step 'Generate Custom Reports'
 #: custom/onboarding_step/report_builder/report_builder.json
-msgid ""
-"In each module, you will find a host of single-click reports, ranging "
-"from financial statements to sales and purchase analytics and stock "
-"tracking reports. If a required new report is not available out-of-the-"
-"box, you can create custom reports in ERPNext by pulling values from the "
-"same multiple ERPNext tables.\n"
+msgid "In each module, you will find a host of single-click reports, ranging from financial statements to sales and purchase analytics and stock tracking reports. If a required new report is not available out-of-the-box, you can create custom reports in ERPNext by pulling values from the same multiple ERPNext tables.\n"
 msgstr ""
 
-#. Description of a Float field in DocType 'Print Settings'
+#. Description of the 'Font Size' (Float) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "In points. Default is 9."
 msgstr ""
 
-#. Description of a Int field in DocType 'System Settings'
+#. Description of the 'Allow Login After Fail' (Int) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "In seconds"
@@ -15438,7 +15273,7 @@ msgstr ""
 msgid "Inbox"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Inbox"
@@ -15544,7 +15379,7 @@ msgstr ""
 msgid "Incorrect value: {0} must be {1} {2}"
 msgstr ""
 
-#: model/__init__.py:139 model/meta.py:47 public/js/frappe/model/meta.js:200
+#: model/__init__.py:139 model/meta.py:48 public/js/frappe/model/meta.js:200
 #: public/js/frappe/model/model.js:114
 #: public/js/frappe/views/reports/report_view.js:941
 msgid "Index"
@@ -15604,19 +15439,19 @@ msgstr ""
 msgid "Indicator color"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Info"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Info"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "Info"
@@ -15632,7 +15467,7 @@ msgctxt "Email Account"
 msgid "Initial Sync Count"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Database Engine' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "InnoDB"
@@ -15657,9 +15492,7 @@ msgid "Insert After cannot be set as {0}"
 msgstr ""
 
 #: custom/doctype/custom_field/custom_field.py:242
-msgid ""
-"Insert After field '{0}' mentioned in Custom Field '{1}', with label "
-"'{2}', does not exist"
+msgid "Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist"
 msgstr ""
 
 #: public/js/frappe/views/reports/report_view.js:364
@@ -15670,7 +15503,7 @@ msgstr ""
 msgid "Insert Image in Markdown"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Import'
+#. Option for the 'Import Type' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Insert New Records"
@@ -15707,12 +15540,11 @@ msgstr ""
 msgid "Installed Apps"
 msgstr ""
 
-#: permissions.py:824
+#: permissions.py:826
 msgid "Insufficient Permission Level for {0}"
 msgstr ""
 
-#: database/query.py:371 desk/form/load.py:40 model/db_query.py:530
-#: model/document.py:234
+#: database/query.py:371 desk/form/load.py:40 model/document.py:234
 msgid "Insufficient Permission for {0}"
 msgstr ""
 
@@ -15728,43 +15560,43 @@ msgstr ""
 msgid "Insufficient attachment limit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Int"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Int"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Int"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Int"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Int"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Int"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Int"
@@ -15792,13 +15624,14 @@ msgctxt "Website Settings"
 msgid "Integrations"
 msgstr ""
 
-#. Description of a Select field in DocType 'Communication'
+#. Description of the 'Delivery Status' (Select) field in DocType
+#. 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Integrations can use this field to set email delivery status"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Inter"
@@ -15810,7 +15643,7 @@ msgctxt "User"
 msgid "Interests"
 msgstr ""
 
-#. Option for a Select field in DocType 'Help Article'
+#. Option for the 'Level' (Select) field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
 msgctxt "Help Article"
 msgid "Intermediate"
@@ -15826,7 +15659,8 @@ msgctxt "Onboarding Step"
 msgid "Intro Video URL"
 msgstr ""
 
-#. Description of a Text Editor field in DocType 'About Us Settings'
+#. Description of the 'Company Introduction' (Text Editor) field in DocType
+#. 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
 msgctxt "About Us Settings"
 msgid "Introduce your company to the website visitor."
@@ -15850,7 +15684,8 @@ msgstr ""
 msgid "Introduction to Website"
 msgstr ""
 
-#. Description of a Text Editor field in DocType 'Contact Us Settings'
+#. Description of the 'Introduction' (Text Editor) field in DocType 'Contact Us
+#. Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
 msgctxt "Contact Us Settings"
 msgid "Introductory information for the Contact Us Page"
@@ -15862,7 +15697,8 @@ msgctxt "Connected App"
 msgid "Introspection URI"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Authorization Code'
+#. Option for the 'Validity' (Select) field in DocType 'OAuth Authorization
+#. Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 msgctxt "OAuth Authorization Code"
 msgid "Invalid"
@@ -15918,9 +15754,7 @@ msgid "Invalid File URL"
 msgstr ""
 
 #: public/js/form_builder/store.js:216
-msgid ""
-"Invalid Filter Format for field {0} of type {1}. Try using filter icon on"
-" the field to set it correctly"
+msgid "Invalid Filter Format for field {0} of type {1}. Try using filter icon on the field to set it correctly"
 msgstr ""
 
 #: utils/dashboard.py:61
@@ -15967,7 +15801,7 @@ msgstr ""
 msgid "Invalid Parameters."
 msgstr ""
 
-#: core/doctype/user/user.py:1194 www/update-password.html:121
+#: core/doctype/user/user.py:1195 www/update-password.html:121
 #: www/update-password.html:142 www/update-password.html:144
 #: www/update-password.html:246
 msgid "Invalid Password"
@@ -16093,7 +15927,7 @@ msgstr ""
 msgid "Invalid {0} condition"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "Inverse"
@@ -16481,7 +16315,7 @@ msgstr ""
 msgid "Item cannot be added to its own descendants"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Print Format Type' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "JS"
@@ -16493,13 +16327,13 @@ msgctxt "Custom HTML Block"
 msgid "JS Message"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "JSON"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "JSON"
@@ -16511,7 +16345,7 @@ msgctxt "Report"
 msgid "JSON"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Request Structure' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "JSON"
@@ -16533,7 +16367,7 @@ msgctxt "Website Theme"
 msgid "JavaScript"
 msgstr ""
 
-#. Description of a Code field in DocType 'Report'
+#. Description of the 'Javascript' (Code) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "JavaScript Format: frappe.query_reports['REPORTNAME'] = {}"
@@ -16567,7 +16401,7 @@ msgstr ""
 msgid "Javascript is disabled on your browser"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Print Format Type' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Jinja"
@@ -16632,13 +16466,13 @@ msgctxt "Number system"
 msgid "K"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Kanban"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Kanban"
@@ -16839,9 +16673,7 @@ msgid "LDAP Search String"
 msgstr ""
 
 #: integrations/doctype/ldap_settings/ldap_settings.py:127
-msgid ""
-"LDAP Search String must be enclosed in '()' and needs to contian the user"
-" placeholder {0}, eg sAMAccountName={0}"
+msgid "LDAP Search String must be enclosed in '()' and needs to contian the user placeholder {0}, eg sAMAccountName={0}"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'LDAP Settings'
@@ -16918,13 +16750,13 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Label"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Label"
@@ -17146,7 +16978,7 @@ msgstr ""
 msgid "Last Modified On"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Last Month"
@@ -17180,7 +17012,7 @@ msgctxt "Energy Point Settings"
 msgid "Last Point Allocation Date"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Last Quarter"
@@ -17204,12 +17036,12 @@ msgctxt "Dashboard Chart"
 msgid "Last Synced On"
 msgstr ""
 
-#: model/__init__.py:145 model/meta.py:49 public/js/frappe/model/meta.js:202
+#: model/__init__.py:145 model/meta.py:50 public/js/frappe/model/meta.js:202
 #: public/js/frappe/model/model.js:120
 msgid "Last Updated By"
 msgstr ""
 
-#: model/__init__.py:141 model/meta.py:48 public/js/frappe/model/meta.js:201
+#: model/__init__.py:141 model/meta.py:49 public/js/frappe/model/meta.js:201
 #: public/js/frappe/model/model.js:116
 msgid "Last Updated On"
 msgstr ""
@@ -17220,13 +17052,13 @@ msgctxt "Assignment Rule"
 msgid "Last User"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Last Week"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Last Year"
@@ -17277,7 +17109,7 @@ msgstr ""
 msgid "Learn more about creating new DocTypes"
 msgstr ""
 
-#. Description of a Date field in DocType 'Event'
+#. Description of the 'Repeat Till' (Date) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Leave blank to repeat always"
@@ -17288,25 +17120,25 @@ msgstr ""
 msgid "Leave this conversation"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Ledger"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Letter Head'
+#. Option for the 'Align' (Select) field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
 msgctxt "Letter Head"
 msgid "Left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Text Align' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Left"
@@ -17317,13 +17149,13 @@ msgctxt "alignment"
 msgid "Left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Left Bottom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Left Center"
@@ -17333,7 +17165,7 @@ msgstr ""
 msgid "Left this conversation"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Legal"
@@ -17358,9 +17190,7 @@ msgid "Length"
 msgstr ""
 
 #: public/js/frappe/ui/chart.js:11
-msgid ""
-"Length of passed data array is greater than value of maximum allowed "
-"label points!"
+msgid "Length of passed data array is greater than value of maximum allowed label points!"
 msgstr ""
 
 #: database/schema.py:133
@@ -17396,7 +17226,7 @@ msgstr ""
 msgid "Let's take you back to onboarding"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Letter"
@@ -17437,7 +17267,8 @@ msgstr ""
 msgid "Letter Head cannot be both disabled and default"
 msgstr ""
 
-#. Description of a HTML Editor field in DocType 'Letter Head'
+#. Description of the 'Header HTML' (HTML Editor) field in DocType 'Letter
+#. Head'
 #: printing/doctype/letter_head/letter_head.json
 msgctxt "Letter Head"
 msgid "Letter Head in HTML"
@@ -17466,9 +17297,7 @@ msgid "Level"
 msgstr ""
 
 #: core/page/permission_manager/permission_manager.js:450
-msgid ""
-"Level 0 is for document level permissions, higher levels for field level "
-"permissions."
+msgid "Level 0 is for document level permissions, higher levels for field level permissions."
 msgstr ""
 
 #. Label of a Data field in DocType 'Review Level'
@@ -17489,19 +17318,19 @@ msgctxt "Package"
 msgid "License Type"
 msgstr ""
 
-#. Option for a Select field in DocType 'User'
+#. Option for the 'Desk Theme' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Light"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Light Blue"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Light Blue"
@@ -17521,13 +17350,13 @@ msgstr ""
 msgid "Like"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Like"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Like"
@@ -17539,7 +17368,7 @@ msgctxt "Blog Settings"
 msgid "Like limit"
 msgstr ""
 
-#. Description of a Int field in DocType 'Blog Settings'
+#. Description of the 'Like limit' (Int) field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
 msgctxt "Blog Settings"
 msgid "Like limit per hour"
@@ -17553,7 +17382,7 @@ msgstr ""
 msgid "Liked"
 msgstr ""
 
-#: model/__init__.py:149 model/meta.py:52 public/js/frappe/model/meta.js:205
+#: model/__init__.py:149 model/meta.py:53 public/js/frappe/model/meta.js:205
 #: public/js/frappe/model/model.js:124
 msgid "Liked By"
 msgstr ""
@@ -17576,19 +17405,19 @@ msgctxt "Dropbox Settings"
 msgid "Limit Number of DB Backups"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Line"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Link"
@@ -17600,7 +17429,7 @@ msgctxt "Desktop Icon"
 msgid "Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Link"
@@ -17612,31 +17441,31 @@ msgctxt "Notification Log"
 msgid "Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Link'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
 msgctxt "Workspace Link"
 msgid "Link"
@@ -17771,29 +17600,25 @@ msgstr ""
 msgid "Link for About Us Page is \"/about\"."
 msgstr ""
 
-#. Description of a Data field in DocType 'Website Settings'
+#. Description of the 'Home Page' (Data) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
-msgid ""
-"Link that is the website home page. Standard Links (home, login, "
-"products, blog, about, contact)"
+msgid "Link that is the website home page. Standard Links (home, login, products, blog, about, contact)"
 msgstr ""
 
-#. Description of a Data field in DocType 'Top Bar Item'
+#. Description of the 'URL' (Data) field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
 msgctxt "Top Bar Item"
-msgid ""
-"Link to the page you want to open. Leave blank if you want to make it a "
-"group parent."
+msgid "Link to the page you want to open. Leave blank if you want to make it a group parent."
 msgstr ""
 
-#. Option for a Select field in DocType 'Activity Log'
+#. Option for the 'Status' (Select) field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
 msgctxt "Activity Log"
 msgid "Linked"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Linked"
@@ -17844,19 +17669,20 @@ msgctxt "Workspace"
 msgid "Links"
 msgstr ""
 
-#. Option for a Select field in DocType 'Client Script'
+#. Option for the 'Apply To' (Select) field in DocType 'Client Script'
 #: custom/doctype/client_script/client_script.json
 msgctxt "Client Script"
 msgid "List"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'View' (Select) field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "List"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "List"
@@ -17917,13 +17743,13 @@ msgstr ""
 msgid "List a document type"
 msgstr ""
 
-#. Description of a Code field in DocType 'Web Form'
+#. Description of the 'Breadcrumbs' (Code) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
 msgctxt "Web Form"
 msgid "List as [{\"label\": _(\"Jobs\"), \"route\":\"jobs\"}]"
 msgstr ""
 
-#. Description of a Code field in DocType 'Web Page'
+#. Description of the 'Breadcrumbs' (Code) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "List as [{\"label\": _(\"Jobs\"), \"route\":\"jobs\"}]"
@@ -17933,7 +17759,7 @@ msgstr ""
 msgid "Lists"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule'
+#. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Load Balancing"
@@ -18032,7 +17858,7 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#. Option for a Select field in DocType 'Activity Log'
+#. Option for the 'Operation' (Select) field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
 msgctxt "Activity Log"
 msgid "Login"
@@ -18099,9 +17925,7 @@ msgid "Login and view in Browser"
 msgstr ""
 
 #: website/doctype/web_form/web_form.js:358
-msgid ""
-"Login is required to see web form list view. Enable {0} to see list "
-"settings"
+msgid "Login is required to see web form list view. Enable {0} to see list settings"
 msgstr ""
 
 #: auth.py:322 auth.py:325
@@ -18154,7 +17978,7 @@ msgctxt "Navbar Settings"
 msgid "Logo Width"
 msgstr ""
 
-#. Option for a Select field in DocType 'Activity Log'
+#. Option for the 'Operation' (Select) field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
 msgctxt "Activity Log"
 msgid "Logout"
@@ -18198,19 +18022,19 @@ msgctxt "Log Settings"
 msgid "Logs to Clear"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Long Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Long Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Long Text"
@@ -18228,7 +18052,7 @@ msgstr ""
 msgid "Low"
 msgstr ""
 
-#. Option for a Select field in DocType 'ToDo'
+#. Option for the 'Priority' (Select) field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
 msgctxt "ToDo"
 msgid "Low"
@@ -18239,7 +18063,7 @@ msgctxt "Number system"
 msgid "M"
 msgstr ""
 
-#. Option for a Select field in DocType 'Package'
+#. Option for the 'License Type' (Select) field in DocType 'Package'
 #: core/doctype/package/package.json
 msgctxt "Package"
 msgid "MIT License"
@@ -18297,12 +18121,11 @@ msgctxt "DocType"
 msgid "Make Attachments Public by Default"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Disable Username/Password Login' (Check) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"Make sure to configure a Social Login Key before disabling to prevent "
-"lockout"
+msgid "Make sure to configure a Social Login Key before disabling to prevent lockout"
 msgstr ""
 
 #: utils/password_strength.py:94
@@ -18408,7 +18231,7 @@ msgstr ""
 msgid "Mandatory:"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Map"
@@ -18419,12 +18242,10 @@ msgstr ""
 msgid "Map Columns"
 msgstr ""
 
-#. Description of a Check field in DocType 'Web Page'
+#. Description of the 'Dynamic Route' (Check) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
-msgid ""
-"Map route parameters into form variables. Example "
-"<code>/project/&lt;name&gt;</code>"
+msgid "Map route parameters into form variables. Example <code>/project/&lt;name&gt;</code>"
 msgstr ""
 
 #: core/doctype/data_import/importer.py:877
@@ -18473,55 +18294,55 @@ msgstr ""
 msgid "Mark as Unread"
 msgstr ""
 
-#. Option for a Select field in DocType 'Blog Post'
+#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
 msgid "Markdown"
 msgstr ""
 
-#. Option for a Select field in DocType 'Newsletter'
+#. Option for the 'Content Type' (Select) field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
 msgctxt "Newsletter"
 msgid "Markdown"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Message Type' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Markdown"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Content Type' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Markdown"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Markdown Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Markdown Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Markdown Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Markdown Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Marked As Spam"
@@ -18532,7 +18353,7 @@ msgstr ""
 msgid "Marketing Campaign"
 msgstr ""
 
-#. Description of a Int field in DocType 'Bulk Update'
+#. Description of the 'Limit' (Int) field in DocType 'Bulk Update'
 #: desk/doctype/bulk_update/bulk_update.json
 msgctxt "Bulk Update"
 msgid "Max 500 records at a time"
@@ -18590,7 +18411,7 @@ msgstr ""
 msgid "Max width for type Currency is 100px in row {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Maximum"
@@ -18616,16 +18437,16 @@ msgstr ""
 msgid "Maximum attachment limit of {0} has been reached."
 msgstr ""
 
-#. Description of a Int field in DocType 'Energy Point Rule'
+#. Description of the 'Maximum Points' (Int) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid ""
-"Maximum points allowed after multiplying points with the multiplier value"
-"\n"
+"Maximum points allowed after multiplying points with the multiplier value\n"
 "(Note: For no limit leave this field empty or set 0)"
 msgstr ""
 
-#: model/rename_doc.py:674
+#: model/rename_doc.py:675
 msgid "Maximum {0} rows allowed"
 msgstr ""
 
@@ -18639,7 +18460,7 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#. Option for a Select field in DocType 'ToDo'
+#. Option for the 'Priority' (Select) field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
 msgctxt "ToDo"
 msgid "Medium"
@@ -18651,13 +18472,13 @@ msgctxt "Web Page View"
 msgid "Medium"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Meeting"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Event Category' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Meeting"
@@ -18675,7 +18496,7 @@ msgctxt "Email Group"
 msgid "Members"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification Log'
+#. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
 msgctxt "Notification Log"
 msgid "Mention"
@@ -18730,7 +18551,7 @@ msgctxt "Communication"
 msgid "Message"
 msgstr ""
 
-#: __init__.py:510 public/js/frappe/ui/messages.js:267
+#: __init__.py:527 public/js/frappe/ui/messages.js:267
 msgctxt "Default title of the message dialog"
 msgid "Message"
 msgstr ""
@@ -18820,7 +18641,7 @@ msgctxt "Notification"
 msgid "Message Type"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:837
+#: public/js/frappe/views/communication.js:841
 msgid "Message clipped"
 msgstr ""
 
@@ -18832,7 +18653,7 @@ msgstr ""
 msgid "Message not setup"
 msgstr ""
 
-#. Description of a Text field in DocType 'Web Form'
+#. Description of the 'Success Message' (Text) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
 msgctxt "Web Form"
 msgid "Message to be displayed on successful completion"
@@ -18938,7 +18759,7 @@ msgctxt "Email Account"
 msgid "Method"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Method"
@@ -18966,7 +18787,7 @@ msgstr ""
 msgid "Method is required to create a number card"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Mid Center"
@@ -19006,7 +18827,7 @@ msgctxt "Milestone"
 msgid "Milestone Tracker"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Minimum"
@@ -19067,10 +18888,8 @@ msgstr ""
 msgid "Mobile"
 msgstr ""
 
-#: tests/test_translate.py:83 tests/test_translate.py:86
-#: tests/test_translate.py:88 tests/test_translate.py:91
-#: tests/test_translate.py:102 tests/test_translate.py:106
-#: tests/test_translate.py:111 tests/test_translate.py:114
+#: tests/test_translate.py:86 tests/test_translate.py:89
+#: tests/test_translate.py:91 tests/test_translate.py:94
 msgid "Mobile No"
 msgstr ""
 
@@ -19342,19 +19161,19 @@ msgctxt "User"
 msgid "Modules HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule Day'
+#. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
 #: automation/doctype/assignment_rule_day/assignment_rule_day.json
 msgctxt "Assignment Rule Day"
 msgid "Monday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Monday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat Day'
+#. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
 msgctxt "Auto Repeat Day"
 msgid "Monday"
@@ -19366,13 +19185,14 @@ msgctxt "Event"
 msgid "Monday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'First Day of the Week' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Monday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Monospace"
@@ -19387,67 +19207,70 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Settings'
+#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
+#. 'Energy Point Settings'
 #: social/doctype/energy_point_settings/energy_point_settings.json
 msgctxt "Energy Point Settings"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'S3 Backup Settings'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
+#. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgctxt "S3 Backup Settings"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Monthly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Monthly Long"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Monthly Long"
@@ -19490,7 +19313,8 @@ msgstr ""
 msgid "More articles on {0}"
 msgstr ""
 
-#. Description of a Text Editor field in DocType 'About Us Settings'
+#. Description of the 'Footer' (Text Editor) field in DocType 'About Us
+#. Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
 msgctxt "About Us Settings"
 msgid "More content for the bottom of the page."
@@ -19538,18 +19362,17 @@ msgstr ""
 msgid "Move to Row Number"
 msgstr ""
 
-#. Description of a Check field in DocType 'Form Tour Step'
+#. Description of the 'Next on Click' (Check) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Move to next step when clicked inside highlighted area."
 msgstr ""
 
-#. Description of a Data field in DocType 'Form Tour Step'
+#. Description of the 'Parent Element Selector' (Data) field in DocType 'Form
+#. Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
-msgid ""
-"Mozilla doesn't support :has() so you can pass parent selector here as "
-"workaround"
+msgid "Mozilla doesn't support :has() so you can pass parent selector here as workaround"
 msgstr ""
 
 #: utils/nestedset.py:334
@@ -19562,27 +19385,27 @@ msgctxt "Energy Point Rule"
 msgid "Multiplier Field"
 msgstr ""
 
-#. Description of a Data field in DocType 'Data Import'
+#. Description of the 'Import from Google Sheets' (Data) field in DocType 'Data
+#. Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Must be a publicly accessible Google Sheets URL"
 msgstr ""
 
-#. Description of a Data field in DocType 'LDAP Settings'
+#. Description of the 'LDAP Search String' (Data) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
-msgid ""
-"Must be enclosed in '()' and include '{0}', which is a placeholder for "
-"the user/login name. i.e. (&(objectclass=user)(uid={0}))"
+msgid "Must be enclosed in '()' and include '{0}', which is a placeholder for the user/login name. i.e. (&(objectclass=user)(uid={0}))"
 msgstr ""
 
-#. Description of a Data field in DocType 'Customize Form'
+#. Description of the 'Image Field' (Data) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Must be of type \"Attach Image\""
 msgstr ""
 
-#. Description of a Data field in DocType 'DocType'
+#. Description of the 'Image Field' (Data) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Must be of type \"Attach Image\""
@@ -19621,25 +19444,21 @@ msgstr ""
 msgid "My Settings"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Database Engine' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "MyISAM"
 msgstr ""
 
 #: workflow/doctype/workflow/workflow.js:19
-msgid ""
-"NOTE: If you add states or transitions in the table, it will be reflected"
-" in the Workflow Builder but you will have to position them manually. "
-"Also Workflow Builder is currently in <b>BETA</b>."
+msgid "NOTE: If you add states or transitions in the table, it will be reflected in the Workflow Builder but you will have to position them manually. Also Workflow Builder is currently in <b>BETA</b>."
 msgstr ""
 
-#. Description of a Data field in DocType 'LDAP Settings'
+#. Description of the 'LDAP Group Field' (Data) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
-msgid ""
-"NOTE: This box is due for depreciation. Please re-setup LDAP to work with"
-" the newer settings"
+msgid "NOTE: This box is due for depreciation. Please re-setup LDAP to work with the newer settings"
 msgstr ""
 
 #: public/js/frappe/form/layout.js:75
@@ -19683,9 +19502,7 @@ msgid "Name cannot contain special characters like {0}"
 msgstr ""
 
 #: custom/doctype/custom_field/custom_field.js:91
-msgid ""
-"Name of the Document Type (DocType) you want this field to be linked to. "
-"e.g. Customer"
+msgid "Name of the Document Type (DocType) you want this field to be linked to. e.g. Customer"
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:117
@@ -19718,35 +19535,22 @@ msgctxt "Document Naming Rule"
 msgid "Naming"
 msgstr ""
 
-#. Description of a Data field in DocType 'DocType'
+#. Description of the 'Auto Name' (Data) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid ""
 "Naming Options:\n"
-"<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>autoincrement</b> "
-"- Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - "
-"By Naming Series (field called naming_series must be "
-"present)</li><li><b>Prompt</b> - Prompt user for a "
-"name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for"
-" example PRE.#####</li>\n"
-"<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> "
-"- Replace all braced words (fieldnames, date words (DD, MM, YY), series) "
-"with their value. Outside braces, any characters can be used.</li></ol>"
+"<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>autoincrement</b> - Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n"
+"<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>"
 msgstr ""
 
-#. Description of a Data field in DocType 'Customize Form'
+#. Description of the 'Auto Name' (Data) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid ""
 "Naming Options:\n"
-"<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b>"
-" - By Naming Series (field called naming_series must be "
-"present)</li><li><b>Prompt</b> - Prompt user for a "
-"name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for"
-" example PRE.#####</li>\n"
-"<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> "
-"- Replace all braced words (fieldnames, date words (DD, MM, YY), series) "
-"with their value. Outside braces, any characters can be used.</li></ol>"
+"<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n"
+"<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>"
 msgstr ""
 
 #. Label of a Select field in DocType 'Customize Form'
@@ -19771,7 +19575,7 @@ msgstr ""
 msgid "Naming Series mandatory"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template'
+#. Option for the 'Type' (Select) field in DocType 'Web Template'
 #: website/doctype/web_template/web_template.json
 msgctxt "Web Template"
 msgid "Navbar"
@@ -19866,19 +19670,20 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Rule'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "New"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "New"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "New"
@@ -19983,13 +19788,15 @@ msgstr ""
 msgid "New updates are available"
 msgstr ""
 
-#. Description of a Check field in DocType 'Website Settings'
+#. Description of the 'Disable signups' (Check) field in DocType 'Website
+#. Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "New users will have to be manually registered by system managers."
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Property Setter'
+#. Description of the 'Set Value' (Small Text) field in DocType 'Property
+#. Setter'
 #: custom/doctype/property_setter/property_setter.json
 msgctxt "Property Setter"
 msgid "New value to be set"
@@ -20170,25 +19977,26 @@ msgctxt "Dismiss confirmation dialog"
 msgid "No"
 msgstr ""
 
-#. Option for a Select field in DocType 'LDAP Settings'
+#. Option for the 'Require Trusted Certificate' (Select) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "No"
 msgstr ""
 
-#. Option for a Select field in DocType 'Page'
+#. Option for the 'Standard' (Select) field in DocType 'Page'
 #: core/doctype/page/page.json
 msgctxt "Page"
 msgid "No"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Standard' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "No"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report'
+#. Option for the 'Is Standard' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "No"
@@ -20318,7 +20126,7 @@ msgstr ""
 msgid "No changes in document"
 msgstr ""
 
-#: model/rename_doc.py:369
+#: model/rename_doc.py:370
 msgid "No changes made because old and new name are the same."
 msgstr ""
 
@@ -20351,9 +20159,7 @@ msgid "No data to export"
 msgstr ""
 
 #: contacts/doctype/address/address.py:251
-msgid ""
-"No default Address Template found. Please create a new one from Setup > "
-"Printing and Branding > Address Template."
+msgid "No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template."
 msgstr ""
 
 #: public/js/frappe/ui/toolbar/search.js:71
@@ -20361,9 +20167,7 @@ msgid "No documents found tagged with {0}"
 msgstr ""
 
 #: public/js/frappe/views/inbox/inbox_view.js:21
-msgid ""
-"No email account associated with the User. Please add an account under "
-"User > Email Inbox."
+msgid "No email account associated with the User. Please add an account under User > Email Inbox."
 msgstr ""
 
 #: utils/file_manager.py:143
@@ -20412,7 +20216,7 @@ msgctxt "SMS Log"
 msgid "No of Sent SMS"
 msgstr ""
 
-#: __init__.py:1010 client.py:109 client.py:151
+#: __init__.py:1027 client.py:109 client.py:151
 msgid "No permission for {0}"
 msgstr ""
 
@@ -20421,7 +20225,7 @@ msgctxt "{0} = verb, {1} = object"
 msgid "No permission to '{0}' {1}"
 msgstr ""
 
-#: model/db_query.py:944
+#: model/db_query.py:943
 msgid "No permission to read {0}"
 msgstr ""
 
@@ -20479,7 +20283,8 @@ msgctxt "DocField"
 msgid "Non Negative"
 msgstr ""
 
-#. Option for a Select field in DocType 'S3 Backup Settings'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
+#. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgctxt "S3 Backup Settings"
 msgid "None"
@@ -20545,7 +20350,7 @@ msgctxt "DocField"
 msgid "Not Nullable"
 msgstr ""
 
-#: __init__.py:904 app.py:354 desk/calendar.py:26 geo/utils.py:97
+#: __init__.py:921 app.py:354 desk/calendar.py:26 geo/utils.py:97
 #: public/js/frappe/web_form/webform_script.js:15
 #: website/doctype/web_form/web_form.py:603
 #: website/page_renderers/not_permitted_page.py:20 www/login.py:177
@@ -20580,13 +20385,13 @@ msgstr ""
 msgid "Not Sent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Queue'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
 msgctxt "Email Queue"
 msgid "Not Sent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Queue Recipient'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue Recipient'
 #: email/doctype/email_queue_recipient/email_queue_recipient.json
 msgctxt "Email Queue Recipient"
 msgid "Not Sent"
@@ -20617,14 +20422,12 @@ msgstr ""
 msgid "Not active"
 msgstr ""
 
-#: permissions.py:364
+#: permissions.py:367
 msgid "Not allowed for {0}: {1}"
 msgstr ""
 
 #: email/doctype/notification/notification.py:388
-msgid ""
-"Not allowed to attach {0} document, please enable Allow Print For {0} in "
-"Print Settings"
+msgid "Not allowed to attach {0} document, please enable Allow Print For {0} in Print Settings"
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:338
@@ -20639,7 +20442,7 @@ msgstr ""
 msgid "Not allowed to print draft documents"
 msgstr ""
 
-#: permissions.py:210
+#: permissions.py:213
 msgid "Not allowed via controller permission check"
 msgstr ""
 
@@ -20689,13 +20492,15 @@ msgstr ""
 msgid "Note:"
 msgstr ""
 
-#. Description of a Check field in DocType 'Dropbox Settings'
+#. Description of the 'Send Email for Successful Backup' (Check) field in
+#. DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
 msgctxt "Dropbox Settings"
 msgid "Note: By default emails for failed backups are sent."
 msgstr ""
 
-#. Description of a Check field in DocType 'Google Drive'
+#. Description of the 'Send Email for Successful backup' (Check) field in
+#. DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
 msgctxt "Google Drive"
 msgid "Note: By default emails for failed backups are sent."
@@ -20709,24 +20514,22 @@ msgstr ""
 msgid "Note: Etc timezones have their signs reversed."
 msgstr ""
 
-#. Description of a Section Break field in DocType 'Website Slideshow'
+#. Description of the 'sb0' (Section Break) field in DocType 'Website
+#. Slideshow'
 #: website/doctype/website_slideshow/website_slideshow.json
 msgctxt "Website Slideshow"
-msgid ""
-"Note: For best results,  images must be of the same size and width must "
-"be greater than height."
+msgid "Note: For best results,  images must be of the same size and width must be greater than height."
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Allow only one session per user' (Check) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Note: Multiple sessions will be allowed in case of mobile device"
 msgstr ""
 
 #: website/web_form/request_to_delete_data/request_to_delete_data.js:8
-msgid ""
-"Note: Your request for account deletion will be fulfilled within {0} "
-"hours."
+msgid "Note: Your request for account deletion will be fulfilled within {0} hours."
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:183
@@ -20762,7 +20565,8 @@ msgctxt "Auto Repeat"
 msgid "Notification"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Communication Type' (Select) field in DocType
+#. 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Notification"
@@ -20830,7 +20634,8 @@ msgctxt "Role"
 msgid "Notifications"
 msgstr ""
 
-#. Description of a Check field in DocType 'Email Account'
+#. Description of the 'Default Outgoing' (Check) field in DocType 'Email
+#. Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Notifications and bulk mails will be sent from this outgoing server."
@@ -20959,39 +20764,32 @@ msgstr ""
 msgid "Number of backups must be greater than zero."
 msgstr ""
 
-#. Description of a Int field in DocType 'Customize Form Field'
+#. Description of the 'Columns' (Int) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
-msgid ""
-"Number of columns for a field in a Grid (Total Columns in a grid should "
-"be less than 11)"
+msgid "Number of columns for a field in a Grid (Total Columns in a grid should be less than 11)"
 msgstr ""
 
-#. Description of a Int field in DocType 'Custom Field'
+#. Description of the 'Columns' (Int) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
-msgid ""
-"Number of columns for a field in a List View or a Grid (Total Columns "
-"should be less than 11)"
+msgid "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)"
 msgstr ""
 
-#. Description of a Int field in DocType 'DocField'
+#. Description of the 'Columns' (Int) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
-msgid ""
-"Number of columns for a field in a List View or a Grid (Total Columns "
-"should be less than 11)"
+msgid "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)"
 msgstr ""
 
-#. Description of a Int field in DocType 'System Settings'
+#. Description of the 'Document Share Key Expiry (in Days)' (Int) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"Number of days after which the document Web View link shared on email "
-"will be expired"
+msgid "Number of days after which the document Web View link shared on email will be expired"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Method' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "OAuth"
@@ -21045,22 +20843,21 @@ msgid "OAuth Scope"
 msgstr ""
 
 #: email/doctype/email_account/email_account.js:187
-msgid ""
-"OAuth has been enabled but not authorised. Please use \"Authorise API "
-"Access\" button to do the same."
+msgid "OAuth has been enabled but not authorised. Please use \"Authorise API Access\" button to do the same."
 msgstr ""
 
 #: templates/includes/oauth_confirmation.html:39
 msgid "OK"
 msgstr ""
 
-#. Option for a Select field in DocType 'Recorder'
+#. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "OPTIONS"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Two Factor Authentication method' (Select) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "OTP App"
@@ -21080,19 +20877,20 @@ msgstr ""
 msgid "OTP Secret has been reset. Re-registration will be required on next login."
 msgstr ""
 
-#. Option for a Select field in DocType 'LDAP Settings'
+#. Option for the 'SSL/TLS Mode' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Off"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Office"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Office 365"
@@ -21118,25 +20916,27 @@ msgstr ""
 msgid "Old and new fieldnames are same."
 msgstr ""
 
-#. Description of a Int field in DocType 'System Settings'
+#. Description of the 'Number of Backups' (Int) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Older backups will be automatically deleted"
 msgstr ""
 
-#. Option for a Select field in DocType 'Personal Data Deletion Request'
+#. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
+#. Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 msgctxt "Personal Data Deletion Request"
 msgid "On Hold"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "On Payment Authorization"
 msgstr ""
 
-#. Description of a Check field in DocType 'Webhook'
+#. Description of the 'Is Dynamic URL?' (Check) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "On checking this option, URL will be treated like a jinja template string"
@@ -21180,17 +20980,13 @@ msgid "Onboarding complete"
 msgstr ""
 
 #: core/doctype/doctype/doctype_list.js:28
-msgid ""
-"Once submitted, submittable documents cannot be changed. They can only be"
-" Cancelled and Amended."
+msgid "Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended."
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Is Submittable' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
-msgid ""
-"Once submitted, submittable documents cannot be changed. They can only be"
-" Cancelled and Amended."
+msgid "Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended."
 msgstr ""
 
 #: www/complete_signup.html:7
@@ -21206,9 +21002,7 @@ msgid "One of"
 msgstr ""
 
 #: public/js/frappe/views/workspace/workspace.js:1312
-msgid ""
-"One of the child page with name {0} already exist in {1} Section. Please "
-"update the name of the child page first before moving"
+msgid "One of the child page with name {0} already exist in {1} Section. Please update the name of the child page first before moving"
 msgstr ""
 
 #: client.py:213
@@ -21259,12 +21053,11 @@ msgstr ""
 msgid "Only allowed to export customizations in developer mode"
 msgstr ""
 
-#. Description of a Data field in DocType 'S3 Backup Settings'
+#. Description of the 'Endpoint URL' (Data) field in DocType 'S3 Backup
+#. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgctxt "S3 Backup Settings"
-msgid ""
-"Only change this if you want to use other S3 compatible object storage "
-"backends."
+msgid "Only change this if you want to use other S3 compatible object storage backends."
 msgstr ""
 
 #. Label of a Link field in DocType 'Workspace Link'
@@ -21274,9 +21067,7 @@ msgid "Only for"
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:194
-msgid ""
-"Only mandatory fields are necessary for new records. You can delete non-"
-"mandatory columns if you wish."
+msgid "Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish."
 msgstr ""
 
 #: contacts/doctype/contact/contact.py:129
@@ -21317,31 +21108,32 @@ msgctxt "Access"
 msgid "Open"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'Communication'
+#. Option for the 'Email Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Open"
 msgstr ""
 
-#. Option for a Select field in DocType 'Contact'
+#. Option for the 'Status' (Select) field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
 msgctxt "Contact"
 msgid "Open"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Status' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Open"
 msgstr ""
 
-#. Option for a Select field in DocType 'ToDo'
+#. Option for the 'Status' (Select) field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
 msgctxt "ToDo"
 msgid "Open"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow Action'
+#. Option for the 'Status' (Select) field in DocType 'Workflow Action'
 #: workflow/doctype/workflow_action/workflow_action.json
 msgctxt "Workflow Action"
 msgid "Open"
@@ -21381,7 +21173,7 @@ msgctxt "Top Bar Item"
 msgid "Open URL in a New Tab"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Quick Entry' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Open a dialog with mandatory fields to create a new record quickly"
@@ -21418,13 +21210,13 @@ msgctxt "Connected App"
 msgid "OpenID Configuration"
 msgstr ""
 
-#. Option for a Select field in DocType 'LDAP Settings'
+#. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "OpenLDAP"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Opened"
@@ -21464,13 +21256,13 @@ msgstr ""
 msgid "Option {0} for field {1} is not a child table"
 msgstr ""
 
-#. Description of a Code field in DocType 'Notification Recipient'
+#. Description of the 'CC' (Code) field in DocType 'Notification Recipient'
 #: email/doctype/notification_recipient/notification_recipient.json
 msgctxt "Notification Recipient"
 msgid "Optional: Always send to these ids. Each Email Address on a new row"
 msgstr ""
 
-#. Description of a Code field in DocType 'Notification'
+#. Description of the 'Condition' (Code) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Optional: The alert will be sent if this expression is true"
@@ -21519,9 +21311,7 @@ msgid "Options"
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:1317
-msgid ""
-"Options 'Dynamic Link' type of field must point to another Link Field "
-"with options as 'DocType'"
+msgid "Options 'Dynamic Link' type of field must point to another Link Field with options as 'DocType'"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Custom Field'
@@ -21550,13 +21340,13 @@ msgstr ""
 msgid "Options not set for link field {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Orange"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Orange"
@@ -21585,25 +21375,25 @@ msgstr ""
 msgid "Orientation"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Other"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Other"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Other"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Event Category' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Other"
@@ -21637,7 +21427,7 @@ msgstr ""
 msgid "Outgoing email account not correct"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Outlook.com"
@@ -21649,9 +21439,9 @@ msgctxt "Integration Request"
 msgid "Output"
 msgstr ""
 
-#. Label of a Code field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Label of a Code field in DocType 'Permission Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "Output"
 msgstr ""
 
@@ -21666,7 +21456,7 @@ msgstr ""
 msgid "Owner"
 msgstr ""
 
-#. Option for a Select field in DocType 'Recorder'
+#. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "PATCH"
@@ -21719,25 +21509,25 @@ msgctxt "RQ Worker"
 msgid "PID"
 msgstr ""
 
-#. Option for a Select field in DocType 'Recorder'
+#. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "POST"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Request Method' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "POST"
 msgstr ""
 
-#. Option for a Select field in DocType 'Recorder'
+#. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "PUT"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Request Method' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "PUT"
@@ -21810,38 +21600,39 @@ msgctxt "Custom Role"
 msgid "Page"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Page"
 msgstr ""
 
-#. Option for a Select field in DocType 'Role Permission for Page and Report'
+#. Option for the 'Set Role For' (Select) field in DocType 'Role Permission for
+#. Page and Report'
 #. Label of a Link field in DocType 'Role Permission for Page and Report'
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
 msgctxt "Role Permission for Page and Report"
 msgid "Page"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Link'
+#. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
 msgctxt "Workspace Link"
 msgid "Page"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Page"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Page Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Content Type' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Page Builder"
@@ -22020,7 +21811,7 @@ msgstr ""
 msgid "Parent is the name of the document to which the data will get added to."
 msgstr ""
 
-#: permissions.py:804
+#: permissions.py:806
 msgid "Parentfield not specified in {0}: {1}"
 msgstr ""
 
@@ -22034,13 +21825,13 @@ msgctxt "Personal Data Deletion Step"
 msgid "Partial"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Import'
+#. Option for the 'Status' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Partial Success"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Queue'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
 msgctxt "Email Queue"
 msgid "Partially Sent"
@@ -22056,7 +21847,7 @@ msgctxt "Event"
 msgid "Participants"
 msgstr ""
 
-#. Option for a Select field in DocType 'Contact'
+#. Option for the 'Status' (Select) field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
 msgctxt "Contact"
 msgid "Passive"
@@ -22068,19 +21859,19 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Password"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Password"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Password"
@@ -22099,7 +21890,7 @@ msgctxt "System Settings"
 msgid "Password"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Password"
@@ -22250,55 +22041,58 @@ msgctxt "Data Import"
 msgid "Payload Count"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Import'
+#. Option for the 'Status' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Pending"
 msgstr ""
 
-#. Option for a Select field in DocType 'Personal Data Deletion Step'
+#. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
+#. Step'
 #: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 msgctxt "Personal Data Deletion Step"
 msgid "Pending"
 msgstr ""
 
-#. Option for a Select field in DocType 'Translation'
+#. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
 #: core/doctype/translation/translation.json
 msgctxt "Translation"
 msgid "Pending"
 msgstr ""
 
-#. Option for a Select field in DocType 'Personal Data Deletion Request'
+#. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
+#. Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 msgctxt "Personal Data Deletion Request"
 msgid "Pending Approval"
 msgstr ""
 
-#. Option for a Select field in DocType 'Personal Data Deletion Request'
+#. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
+#. Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 msgctxt "Personal Data Deletion Request"
 msgid "Pending Verification"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Percent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Percent"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Percent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Percentage"
@@ -22322,7 +22116,7 @@ msgctxt "DocField"
 msgid "Perm Level"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Permanent"
@@ -22340,13 +22134,13 @@ msgstr ""
 msgid "Permanently delete {0}?"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/permission_debugger/permission_debugger.json
-msgid "Permission Debugger"
-msgstr ""
-
 #: core/doctype/user_type/user_type.py:83
 msgid "Permission Error"
+msgstr ""
+
+#. Name of a DocType
+#: core/doctype/permission_inspector/permission_inspector.json
+msgid "Permission Inspector"
 msgstr ""
 
 #: core/page/permission_manager/permission_manager.js:446
@@ -22364,7 +22158,7 @@ msgstr ""
 msgid "Permission Manager"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Permission Query"
@@ -22382,9 +22176,9 @@ msgctxt "DocType"
 msgid "Permission Rules"
 msgstr ""
 
-#. Label of a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Label of a Select field in DocType 'Permission Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "Permission Type"
 msgstr ""
 
@@ -22448,7 +22242,7 @@ msgctxt "Workflow Action"
 msgid "Permitted Roles"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Personal"
@@ -22475,7 +22269,7 @@ msgctxt "Address"
 msgid "Phone"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Phone"
@@ -22493,19 +22287,19 @@ msgctxt "Contact Us Settings"
 msgid "Phone"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Phone"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Phone"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Phone"
@@ -22517,7 +22311,7 @@ msgctxt "User"
 msgid "Phone"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Phone"
@@ -22539,7 +22333,7 @@ msgstr ""
 msgid "Pick Columns"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Pie"
@@ -22551,25 +22345,25 @@ msgctxt "Contact Us Settings"
 msgid "Pincode"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Pink"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Pink"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Message Type' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Plain Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Plant"
@@ -22607,7 +22401,7 @@ msgstr ""
 msgid "Please ask your administrator to verify your sign-up"
 msgstr ""
 
-#: public/js/frappe/form/controls/select.js:95
+#: public/js/frappe/form/controls/select.js:96
 msgid "Please attach a file first."
 msgstr ""
 
@@ -22644,15 +22438,11 @@ msgid "Please check your email login credentials."
 msgstr ""
 
 #: twofactor.py:246
-msgid ""
-"Please check your registered email address for instructions on how to "
-"proceed. Do not close this window as you will have to return to it."
+msgid "Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it."
 msgstr ""
 
 #: twofactor.py:291
-msgid ""
-"Please click on the following link and follow the instructions on the "
-"page. {0}"
+msgid "Please click on the following link and follow the instructions on the page. {0}"
 msgstr ""
 
 #: templates/emails/password_reset.html:2
@@ -22692,9 +22482,7 @@ msgid "Please duplicate this to make changes"
 msgstr ""
 
 #: core/doctype/system_settings/system_settings.py:145
-msgid ""
-"Please enable atleast one Social Login Key or LDAP or Login With Email "
-"Link before disabling username/password based login."
+msgid "Please enable atleast one Social Login Key or LDAP or Login With Email Link before disabling username/password based login."
 msgstr ""
 
 #: desk/doctype/notification_log/notification_log.js:45
@@ -22783,9 +22571,7 @@ msgid "Please login to post a comment."
 msgstr ""
 
 #: core/doctype/communication/communication.py:210
-msgid ""
-"Please make sure the Reference Communication Docs are not circularly "
-"linked."
+msgid "Please make sure the Reference Communication Docs are not circularly linked."
 msgstr ""
 
 #: model/document.py:810
@@ -22844,7 +22630,7 @@ msgstr ""
 msgid "Please select a file or url"
 msgstr ""
 
-#: model/rename_doc.py:669
+#: model/rename_doc.py:670
 msgid "Please select a valid csv file with data"
 msgstr ""
 
@@ -22856,7 +22642,7 @@ msgstr ""
 msgid "Please select applicable Doctypes"
 msgstr ""
 
-#: model/db_query.py:1141
+#: model/db_query.py:1140
 msgid "Please select atleast 1 column from {0} to sort/group"
 msgstr ""
 
@@ -22868,7 +22654,8 @@ msgstr ""
 msgid "Please select the Document Type."
 msgstr ""
 
-#. Description of a Select field in DocType 'LDAP Settings'
+#. Description of the 'Directory Server' (Select) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Please select the LDAP Directory being used"
@@ -22911,9 +22698,7 @@ msgid "Please set the series to be used."
 msgstr ""
 
 #: core/doctype/system_settings/system_settings.py:116
-msgid ""
-"Please setup SMS before setting it as an authentication method, via SMS "
-"Settings"
+msgid "Please setup SMS before setting it as an authentication method, via SMS Settings"
 msgstr ""
 
 #: automation/doctype/auto_repeat/auto_repeat.js:102
@@ -22932,7 +22717,7 @@ msgstr ""
 msgid "Please specify"
 msgstr ""
 
-#: permissions.py:780
+#: permissions.py:782
 msgid "Please specify a valid parent DocType for {0}"
 msgstr ""
 
@@ -23063,7 +22848,7 @@ msgstr ""
 msgid "Post it here, our mentors will help you out."
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Postal"
@@ -23169,7 +22954,7 @@ msgstr ""
 msgid "Preparing Report"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:317
+#: public/js/frappe/views/communication.js:321
 msgid "Prepend the template to the email message"
 msgstr ""
 
@@ -23264,11 +23049,11 @@ msgctxt "Transaction Log"
 msgid "Previous Hash"
 msgstr ""
 
-#: public/js/frappe/form/form.js:2143
+#: public/js/frappe/form/form.js:2162
 msgid "Previous Submission"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "Primary"
@@ -23407,10 +23192,7 @@ msgstr ""
 
 #. Description of the Onboarding Step 'Customize Print Formats'
 #: custom/onboarding_step/print_format/print_format.json
-msgid ""
-"Print Formats allow you can define looks for documents when printed or "
-"converted to PDF. You can also create a custom Print Format using drag-"
-"and-drop tools."
+msgid "Print Formats allow you can define looks for documents when printed or converted to PDF. You can also create a custom Print Format using drag-and-drop tools."
 msgstr ""
 
 #. Name of a DocType
@@ -23533,7 +23315,8 @@ msgctxt "DocField"
 msgid "Print Width"
 msgstr ""
 
-#. Description of a Data field in DocType 'Customize Form Field'
+#. Description of the 'Print Width' (Data) field in DocType 'Customize Form
+#. Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Print Width of the field, if the field is a column in a table"
@@ -23624,7 +23407,7 @@ msgctxt "Custom HTML Block"
 msgid "Private"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Event Type' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Private"
@@ -23636,12 +23419,11 @@ msgctxt "Kanban Board"
 msgid "Private"
 msgstr ""
 
-#. Description of a Text Editor field in DocType 'Email Account'
+#. Description of the 'Auto Reply Message' (Text Editor) field in DocType
+#. 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
-msgid ""
-"ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name "
-"}}</code> to send document reference"
+msgid "ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> to send document reference"
 msgstr ""
 
 #: core/doctype/document_naming_rule/document_naming_rule.js:22
@@ -23656,7 +23438,7 @@ msgstr ""
 msgid "Processing"
 msgstr ""
 
-#: email/doctype/email_queue/email_queue.py:404
+#: email/doctype/email_queue/email_queue.py:407
 msgid "Processing..."
 msgstr ""
 
@@ -23709,13 +23491,11 @@ msgctxt "Property Setter"
 msgid "Property Type"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'System Settings'
+#. Description of the 'Allowed File Extensions' (Small Text) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"Provide a list of allowed file extensions for file uploads. Each line "
-"should contain one allowed file type. If unset, all file extensions are "
-"allowed. Example: <br>CSV<br>JPG<br>PNG"
+msgid "Provide a list of allowed file extensions for file uploads. Each line should contain one allowed file type. If unset, all file extensions are allowed. Example: <br>CSV<br>JPG<br>PNG"
 msgstr ""
 
 #. Label of a Data field in DocType 'User Social Login'
@@ -23749,7 +23529,7 @@ msgstr ""
 msgid "Public"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Event Type' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Public"
@@ -23898,13 +23678,13 @@ msgstr ""
 msgid "Purchase User"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Purple"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Purple"
@@ -23926,7 +23706,7 @@ msgstr ""
 msgid "Put on Hold"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Console'
+#. Option for the 'Type' (Select) field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
 msgctxt "System Console"
 msgid "Python"
@@ -23948,19 +23728,19 @@ msgstr ""
 msgid "Quarterly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Quarterly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Quarterly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Quarterly"
@@ -24005,7 +23785,7 @@ msgstr ""
 msgid "Query Report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report'
+#. Option for the 'Report Type' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "Query Report"
@@ -24053,19 +23833,19 @@ msgstr ""
 msgid "Queued"
 msgstr ""
 
-#. Option for a Select field in DocType 'Integration Request'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
 msgctxt "Integration Request"
 msgid "Queued"
 msgstr ""
 
-#. Option for a Select field in DocType 'Prepared Report'
+#. Option for the 'Status' (Select) field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
 msgctxt "Prepared Report"
 msgid "Queued"
 msgstr ""
 
-#. Option for a Select field in DocType 'Submission Queue'
+#. Option for the 'Status' (Select) field in DocType 'Submission Queue'
 #: core/doctype/submission_queue/submission_queue.json
 msgctxt "Submission Queue"
 msgid "Queued"
@@ -24154,13 +23934,13 @@ msgstr ""
 msgid "RQ Worker"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Random"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Random"
@@ -24188,25 +23968,25 @@ msgctxt "Communication"
 msgid "Rating"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Rating"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Rating"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Rating"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Rating"
@@ -24254,7 +24034,7 @@ msgstr ""
 
 #: core/doctype/communication/communication.js:268
 #: public/js/frappe/form/footer/form_timeline.js:564
-#: public/js/frappe/views/communication.js:253
+#: public/js/frappe/views/communication.js:257
 msgid "Re: {0}"
 msgstr ""
 
@@ -24262,7 +24042,7 @@ msgstr ""
 msgid "Read"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Read"
@@ -24286,7 +24066,7 @@ msgctxt "DocShare"
 msgid "Read"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Flag Queue'
+#. Option for the 'Action' (Select) field in DocType 'Email Flag Queue'
 #: email/doctype/email_flag_queue/email_flag_queue.json
 msgctxt "Email Flag Queue"
 msgid "Read"
@@ -24308,21 +24088,21 @@ msgstr ""
 msgid "Read Only"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #. Label of a Check field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Read Only"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Label of a Check field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Read Only"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
@@ -24424,13 +24204,13 @@ msgstr ""
 msgid "Rebuilding of tree is not supported for {}"
 msgstr ""
 
-#. Description of a Check field in DocType 'Web Form'
+#. Description of the 'Anonymous' (Check) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
 msgctxt "Web Form"
 msgid "Receive anonymous response"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Sent or Received' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Received"
@@ -24478,7 +24258,7 @@ msgctxt "Email Queue Recipient"
 msgid "Recipient"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Recipient Unsubscribed"
@@ -24507,13 +24287,13 @@ msgstr ""
 msgid "Recorder Query"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Red"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Red"
@@ -24555,7 +24335,7 @@ msgctxt "User"
 msgid "Redirect URL"
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Group'
+#. Description of the 'Welcome URL' (Data) field in DocType 'Email Group'
 #: email/doctype/email_group/email_group.json
 msgctxt "Email Group"
 msgid "Redirect to this URL after successful confirmation."
@@ -24568,9 +24348,7 @@ msgid "Redirects"
 msgstr ""
 
 #: sessions.py:148
-msgid ""
-"Redis cache server not running. Please contact Administrator / Tech "
-"support"
+msgid "Redis cache server not running. Please contact Administrator / Tech support"
 msgstr ""
 
 #: public/js/frappe/form/toolbar.js:462
@@ -25046,13 +24824,13 @@ msgstr ""
 msgid "Registered but disabled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Rejected"
 msgstr ""
 
-#. Option for a Select field in DocType 'Translation'
+#. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
 #: core/doctype/translation/translation.json
 msgctxt "Translation"
 msgid "Rejected"
@@ -25079,13 +24857,13 @@ msgstr ""
 msgid "Relink Communication"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Relinked"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Relinked"
@@ -25255,13 +25033,13 @@ msgstr ""
 msgid "Repeats {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Replied"
 msgstr ""
 
-#. Option for a Select field in DocType 'Contact'
+#. Option for the 'Status' (Select) field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
 msgctxt "Contact"
 msgid "Replied"
@@ -25305,7 +25083,7 @@ msgctxt "Custom Role"
 msgid "Report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Report"
@@ -25323,13 +25101,13 @@ msgctxt "DocType"
 msgid "Report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Type' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Report"
@@ -25342,20 +25120,21 @@ msgctxt "Report"
 msgid "Report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Role Permission for Page and Report'
+#. Option for the 'Set Role For' (Select) field in DocType 'Role Permission for
+#. Page and Report'
 #. Label of a Link field in DocType 'Role Permission for Page and Report'
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
 msgctxt "Role Permission for Page and Report"
 msgid "Report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Link'
+#. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
 msgctxt "Workspace Link"
 msgid "Report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Report"
@@ -25365,13 +25144,13 @@ msgstr ""
 msgid "Report Builder"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report'
+#. Option for the 'Report Type' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "Report Builder"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Report Builder"
@@ -25468,9 +25247,7 @@ msgid "Report Name"
 msgstr ""
 
 #: desk/doctype/number_card/number_card.py:65
-msgid ""
-"Report Name, Report Field and Fucntion are required to create a number "
-"card"
+msgid "Report Name, Report Field and Fucntion are required to create a number card"
 msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
@@ -25664,13 +25441,15 @@ msgctxt "LDAP Settings"
 msgid "Require Trusted Certificate"
 msgstr ""
 
-#. Description of a Data field in DocType 'LDAP Settings'
+#. Description of the 'LDAP search path for Groups' (Data) field in DocType
+#. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Requires any valid fdn path. i.e. ou=groups,dc=example,dc=com"
 msgstr ""
 
-#. Description of a Data field in DocType 'LDAP Settings'
+#. Description of the 'LDAP search path for Users' (Data) field in DocType
+#. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Requires any valid fdn path. i.e. ou=users,dc=example,dc=com"
@@ -25866,13 +25645,10 @@ msgctxt "Workspace Shortcut"
 msgid "Restrict to Domain"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'User'
+#. Description of the 'Restrict IP' (Small Text) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
-msgid ""
-"Restrict user from this IP address only. Multiple IP addresses can be "
-"added by separating with commas. Also accepts partial IP addresses like "
-"(111.111.111)"
+msgid "Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111)"
 msgstr ""
 
 #: public/js/frappe/list/list_view.js:172
@@ -25904,9 +25680,7 @@ msgid "Retry Sending"
 msgstr ""
 
 #: www/qrcode.html:15
-msgid ""
-"Return to the Verification screen and enter the code displayed by your "
-"authentication app"
+msgid "Return to the Verification screen and enter the code displayed by your authentication app"
 msgstr ""
 
 #. Label of a Check field in DocType 'Desktop Icon'
@@ -25920,7 +25694,7 @@ msgstr ""
 msgid "Revert"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Log'
+#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
 msgctxt "Energy Point Log"
 msgid "Revert"
@@ -25939,12 +25713,10 @@ msgid "Reverted"
 msgstr ""
 
 #: database/schema.py:162
-msgid ""
-"Reverting length to {0} for '{1}' in '{2}'. Setting the length as {3} "
-"will cause truncation of data."
+msgid "Reverting length to {0} for '{1}' in '{2}'. Setting the length as {3} will cause truncation of data."
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Log'
+#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
 msgctxt "Energy Point Log"
 msgid "Review"
@@ -25977,43 +25749,43 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Bearer Token'
+#. Option for the 'Status' (Select) field in DocType 'OAuth Bearer Token'
 #: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 msgctxt "OAuth Bearer Token"
 msgid "Revoked"
 msgstr ""
 
-#. Option for a Select field in DocType 'Blog Post'
+#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
 msgid "Rich Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Newsletter'
+#. Option for the 'Content Type' (Select) field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
 msgctxt "Newsletter"
 msgid "Rich Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Content Type' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Rich Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Letter Head'
+#. Option for the 'Align' (Select) field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
 msgctxt "Letter Head"
 msgid "Right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Text Align' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Right"
@@ -26024,13 +25796,13 @@ msgctxt "alignment"
 msgid "Right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Right Bottom"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Right Center"
@@ -26289,7 +26061,7 @@ msgstr ""
 msgid "Root {0} cannot be deleted"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule'
+#. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Round Robin"
@@ -26319,7 +26091,7 @@ msgctxt "DocType"
 msgid "Route"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType Action'
+#. Option for the 'Action Type' (Select) field in DocType 'DocType Action'
 #: core/doctype/doctype_action/doctype_action.json
 msgctxt "DocType Action"
 msgid "Route"
@@ -26343,7 +26115,7 @@ msgctxt "Help Category"
 msgid "Route"
 msgstr ""
 
-#. Option for a Select field in DocType 'Navbar Item'
+#. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
 #. Label of a Data field in DocType 'Navbar Item'
 #: core/doctype/navbar_item/navbar_item.json
 msgctxt "Navbar Item"
@@ -26403,7 +26175,7 @@ msgctxt "Website Settings"
 msgid "Route Redirects"
 msgstr ""
 
-#. Description of a Data field in DocType 'Role'
+#. Description of the 'Home Page' (Data) field in DocType 'Role'
 #: core/doctype/role/role.json
 msgctxt "Role"
 msgid "Route: Example \"/desk\""
@@ -26414,9 +26186,7 @@ msgid "Row"
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:1772 core/doctype/doctype/doctype.py:1782
-msgid ""
-"Row # {0}: Non administrator user can not set the role {1} to the custom "
-"doctype"
+msgid "Row # {0}: Non administrator user can not set the role {1} to the custom doctype"
 msgstr ""
 
 #: model/base_document.py:868
@@ -26489,10 +26259,8 @@ msgctxt "Energy Point Rule"
 msgid "Rule Name"
 msgstr ""
 
-#: permissions.py:660
-msgid ""
-"Rule for this doctype, role, permlevel and if-owner combination already "
-"exists."
+#: permissions.py:662
+msgid "Rule for this doctype, role, permlevel and if-owner combination already exists."
 msgstr ""
 
 #. Group in DocType's connections
@@ -26501,21 +26269,20 @@ msgctxt "DocType"
 msgid "Rules"
 msgstr ""
 
-#. Description of a Table field in DocType 'Workflow'
+#. Description of the 'Transitions' (Table) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
 msgid "Rules defining transition of state in the workflow."
 msgstr ""
 
-#. Description of a Section Break field in DocType 'Workflow'
+#. Description of the 'Transition Rules' (Section Break) field in DocType
+#. 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid ""
-"Rules for how states are transitions, like next state and which role is "
-"allowed to change state etc."
+msgid "Rules for how states are transitions, like next state and which role is allowed to change state etc."
 msgstr ""
 
-#. Description of a Int field in DocType 'Document Naming Rule'
+#. Description of the 'Priority' (Int) field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
 msgctxt "Document Naming Rule"
 msgid "Rules with higher priority number will be applied first."
@@ -26527,7 +26294,8 @@ msgctxt "System Settings"
 msgid "Run Jobs only Daily if Inactive For (Days)"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Enable Scheduled Jobs' (Check) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Run scheduled jobs only if checked"
@@ -26554,19 +26322,20 @@ msgctxt "S3 Backup Settings"
 msgid "S3 Bucket Details"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "SMS"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Channel' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "SMS"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Two Factor Authentication method' (Select) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "SMS"
@@ -26607,19 +26376,20 @@ msgstr ""
 msgid "SMTP Server is required"
 msgstr ""
 
-#. Description of a Check field in DocType 'Email Account'
+#. Description of the 'Enable Outgoing' (Check) field in DocType 'Email
+#. Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "SMTP Settings for outgoing emails"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Console'
+#. Option for the 'Type' (Select) field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
 msgctxt "System Console"
 msgid "SQL"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Bulk Update'
+#. Description of the 'Condition' (Small Text) field in DocType 'Bulk Update'
 #: desk/doctype/bulk_update/bulk_update.json
 msgctxt "Bulk Update"
 msgid "SQL Conditions. Example: status=\"Open\""
@@ -26669,7 +26439,8 @@ msgstr ""
 msgid "Sales User"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "Salesforce"
@@ -26702,19 +26473,19 @@ msgctxt "Client Script"
 msgid "Sample"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule Day'
+#. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
 #: automation/doctype/assignment_rule_day/assignment_rule_day.json
 msgctxt "Assignment Rule Day"
 msgid "Saturday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Saturday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat Day'
+#. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
 msgctxt "Auto Repeat Day"
 msgid "Saturday"
@@ -26726,7 +26497,8 @@ msgctxt "Event"
 msgid "Saturday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'First Day of the Week' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Saturday"
@@ -26756,7 +26528,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Save"
@@ -26797,7 +26569,7 @@ msgstr ""
 msgid "Save the document."
 msgstr ""
 
-#: desk/form/save.py:46 model/rename_doc.py:107
+#: desk/form/save.py:46 model/rename_doc.py:108
 #: printing/page/print_format_builder/print_format_builder.js:845
 #: public/js/frappe/form/toolbar.js:260
 #: public/js/frappe/views/kanban/kanban_board.bundle.js:910
@@ -26820,9 +26592,7 @@ msgid "Saving Customization..."
 msgstr ""
 
 #: desk/doctype/module_onboarding/module_onboarding.js:8
-msgid ""
-"Saving this will export this document as well as the steps linked here as"
-" json."
+msgid "Saving this will export this document as well as the steps linked here as json."
 msgstr ""
 
 #: public/js/form_builder/store.js:228
@@ -26865,13 +26635,13 @@ msgstr ""
 msgid "Scheduled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Scheduled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Log'
+#. Option for the 'Status' (Select) field in DocType 'Scheduled Job Log'
 #: core/doctype/scheduled_job_log/scheduled_job_log.json
 msgctxt "Scheduled Job Log"
 msgid "Scheduled"
@@ -26937,7 +26707,7 @@ msgstr ""
 msgid "Scheduled to send"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Scheduler Event"
@@ -27041,7 +26811,7 @@ msgstr ""
 msgid "Script Manager"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report'
+#. Option for the 'Report Type' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "Script Report"
@@ -27140,37 +26910,37 @@ msgstr ""
 msgid "Searching ..."
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template'
+#. Option for the 'Type' (Select) field in DocType 'Web Template'
 #: website/doctype/web_template/web_template.json
 msgctxt "Web Template"
 msgid "Section"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Section Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Section Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Section Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Section Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Section Break"
@@ -27265,19 +27035,19 @@ msgctxt "Custom DocPerm"
 msgid "Select"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Select"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Select"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Select"
@@ -27289,25 +27059,25 @@ msgctxt "DocPerm"
 msgid "Select"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Select"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Select"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Select"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Select"
@@ -27350,7 +27120,7 @@ msgctxt "Form Tour"
 msgid "Select Dashboard"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Select Date Range"
@@ -27520,12 +27290,11 @@ msgstr ""
 msgid "Select an Image"
 msgstr ""
 
-#. Description of a Attach Image field in DocType 'Website Settings'
+#. Description of the 'Brand Image' (Attach Image) field in DocType 'Website
+#. Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
-msgid ""
-"Select an image of approx width 150px with a transparent background for "
-"best results."
+msgid "Select an image of approx width 150px with a transparent background for best results."
 msgstr ""
 
 #: public/js/frappe/list/bulk_operations.js:34
@@ -27555,7 +27324,7 @@ msgstr ""
 msgid "Select records for assignment"
 msgstr ""
 
-#. Description of a Select field in DocType 'Custom Field'
+#. Description of the 'Insert After' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Select the label after which you want to insert new field."
@@ -27613,7 +27382,8 @@ msgctxt "Newsletter"
 msgid "Send Email At"
 msgstr ""
 
-#. Description of a Check field in DocType 'Print Settings'
+#. Description of the 'Send Print as PDF' (Check) field in DocType 'Print
+#. Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Send Email Print Attachments as PDF (Recommended)"
@@ -27739,13 +27509,13 @@ msgstr ""
 msgid "Send again"
 msgstr ""
 
-#. Description of a Select field in DocType 'Notification'
+#. Description of the 'Reference Date' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Send alert if date matches this field's value"
 msgstr ""
 
-#. Description of a Select field in DocType 'Notification'
+#. Description of the 'Value Changed' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Send alert if this field's value changes"
@@ -27757,13 +27527,15 @@ msgctxt "Event"
 msgid "Send an email reminder in the morning"
 msgstr ""
 
-#. Description of a Int field in DocType 'Notification'
+#. Description of the 'Days Before or After' (Int) field in DocType
+#. 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Send days before or after the reference date"
 msgstr ""
 
-#. Description of a Data field in DocType 'Contact Us Settings'
+#. Description of the 'Forward To Email Address' (Data) field in DocType
+#. 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
 msgctxt "Contact Us Settings"
 msgid "Send enquiries to this email address"
@@ -27881,7 +27653,7 @@ msgctxt "DocType"
 msgid "Sender Name Field"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Sendgrid"
@@ -27891,13 +27663,13 @@ msgstr ""
 msgid "Sending"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Sending"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Queue'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
 msgctxt "Email Queue"
 msgid "Sending"
@@ -27916,19 +27688,20 @@ msgstr ""
 msgid "Sent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
+#. Option for the 'Sent or Received' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Sent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Queue'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
 msgctxt "Email Queue"
 msgid "Sent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Queue Recipient'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue Recipient'
 #: email/doctype/email_queue_recipient/email_queue_recipient.json
 msgctxt "Email Queue Recipient"
 msgid "Sent"
@@ -27958,13 +27731,13 @@ msgctxt "Communication"
 msgid "Sent or Received"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Event Category' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Sent/Received Email"
 msgstr ""
 
-#. Option for a Select field in DocType 'Navbar Item'
+#. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
 #: core/doctype/navbar_item/navbar_item.json
 msgctxt "Navbar Item"
 msgid "Separator"
@@ -27995,7 +27768,7 @@ msgstr ""
 msgid "Series {0} already used in {1}"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType Action'
+#. Option for the 'Action Type' (Select) field in DocType 'DocType Action'
 #: core/doctype/doctype_action/doctype_action.json
 msgctxt "DocType Action"
 msgid "Server Action"
@@ -28042,9 +27815,7 @@ msgid "Server Script"
 msgstr ""
 
 #: utils/safe_exec.py:90
-msgid ""
-"Server Scripts are disabled. Please enable server scripts from bench "
-"configuration."
+msgid "Server Scripts are disabled. Please enable server scripts from bench configuration."
 msgstr ""
 
 #: core/doctype/server_script/server_script.js:32
@@ -28122,12 +27893,10 @@ msgstr ""
 msgid "Set Chart"
 msgstr ""
 
-#. Description of a Code field in DocType 'Dashboard'
+#. Description of the 'Chart Options' (Code) field in DocType 'Dashboard'
 #: desk/doctype/dashboard/dashboard.json
 msgctxt "Dashboard"
-msgid ""
-"Set Default Options for all charts on this Dashboard (Ex: \"colors\": "
-"[\"#d1d8dd\", \"#ff5858\"])"
+msgid "Set Default Options for all charts on this Dashboard (Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"])"
 msgstr ""
 
 #: desk/doctype/dashboard_chart/dashboard_chart.js:467
@@ -28150,7 +27919,8 @@ msgstr ""
 msgid "Set Limit"
 msgstr ""
 
-#. Description of a Section Break field in DocType 'Document Naming Settings'
+#. Description of the 'Setup Series for transactions' (Section Break) field in
+#. DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid "Set Naming Series options on your transactions."
@@ -28224,37 +27994,38 @@ msgstr ""
 msgid "Set as Default Theme"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Set by user"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Set by user"
 msgstr ""
 
-#. Description of a Select field in DocType 'Custom Field'
+#. Description of the 'Precision' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Set non-standard precision for a Float or Currency field"
 msgstr ""
 
-#. Description of a Select field in DocType 'Customize Form Field'
+#. Description of the 'Precision' (Select) field in DocType 'Customize Form
+#. Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Set non-standard precision for a Float or Currency field"
 msgstr ""
 
-#. Description of a Select field in DocType 'DocField'
+#. Description of the 'Precision' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Set non-standard precision for a Float or Currency field"
 msgstr ""
 
-#. Description of a Select field in DocType 'Web Form Field'
+#. Description of the 'Precision' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Set non-standard precision for a Float or Currency field"
@@ -28266,7 +28037,8 @@ msgctxt "DocField"
 msgid "Set only once"
 msgstr ""
 
-#. Description of a Code field in DocType 'Number Card'
+#. Description of the 'Filters Configuration' (Code) field in DocType 'Number
+#. Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid ""
@@ -28290,12 +28062,11 @@ msgid ""
 "</code></pre>"
 msgstr ""
 
-#. Description of a Data field in DocType 'Number Card'
+#. Description of the 'Method' (Data) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid ""
-"Set the path to a whitelisted function that will return the data for the "
-"number card in the format:\n"
+"Set the path to a whitelisted function that will return the data for the number card in the format:\n"
 "\n"
 "<pre class=\"small text-muted\"><code>\n"
 "{\n"
@@ -28362,7 +28133,7 @@ msgstr ""
 msgid "Setup"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Setup"
@@ -28422,7 +28193,7 @@ msgctxt "DocShare"
 msgid "Share"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification Log'
+#. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
 msgctxt "Notification Log"
 msgid "Share"
@@ -28436,13 +28207,13 @@ msgstr ""
 msgid "Share {0} with"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Shared"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Shared"
@@ -28452,13 +28223,13 @@ msgstr ""
 msgid "Shared with the following Users with Read access:{0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Shipping"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Shop"
@@ -28556,7 +28327,7 @@ msgctxt "Form Tour"
 msgid "Show First Document Tour"
 msgstr ""
 
-#. Option for a Select field in DocType 'Onboarding Step'
+#. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #. Label of a Check field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
@@ -28743,7 +28514,8 @@ msgctxt "Website Settings"
 msgid "Show footer on login"
 msgstr ""
 
-#. Description of a Check field in DocType 'Onboarding Step'
+#. Description of the 'Show Full Form?' (Check) field in DocType 'Onboarding
+#. Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "Show full form instead of a quick entry modal"
@@ -28771,13 +28543,14 @@ msgstr ""
 msgid "Show more details"
 msgstr ""
 
-#. Description of a Select field in DocType 'Number Card'
+#. Description of the 'Stats Time Interval' (Select) field in DocType 'Number
+#. Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Show percentage difference according to this time interval"
 msgstr ""
 
-#. Description of a Data field in DocType 'Website Settings'
+#. Description of the 'Title Prefix' (Data) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "Show title in browser window as \"Prefix - title\""
@@ -28832,19 +28605,19 @@ msgctxt "Social Login Key"
 msgid "Sign ups"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Signature"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Signature"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Signature"
@@ -28857,7 +28630,7 @@ msgctxt "Email Account"
 msgid "Signature"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Signature"
@@ -28871,19 +28644,22 @@ msgstr ""
 msgid "Signups have been disabled for this website."
 msgstr ""
 
-#. Description of a Code field in DocType 'Assignment Rule'
+#. Description of the 'Unassign Condition' (Code) field in DocType 'Assignment
+#. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Simple Python Expression, Example: Status in (\"Closed\", \"Cancelled\")"
 msgstr ""
 
-#. Description of a Code field in DocType 'Assignment Rule'
+#. Description of the 'Close Condition' (Code) field in DocType 'Assignment
+#. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Simple Python Expression, Example: Status in (\"Invalid\")"
 msgstr ""
 
-#. Description of a Code field in DocType 'Assignment Rule'
+#. Description of the 'Assign Condition' (Code) field in DocType 'Assignment
+#. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Simple Python Expression, Example: status == 'Open' and type == 'Bug'"
@@ -28900,23 +28676,17 @@ msgid "Single DocTypes cannot be customized."
 msgstr ""
 
 #: core/doctype/doctype/doctype_list.js:51
-msgid ""
-"Single Types have only one record no tables associated. Values are stored"
-" in tabSingles"
+msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Is Single' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
-msgid ""
-"Single Types have only one record no tables associated. Values are stored"
-" in tabSingles"
+msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
 msgstr ""
 
 #: database/database.py:230
-msgid ""
-"Site is running in read only mode for maintenance or site update, this "
-"action can not be performed right now. Please try again later."
+msgid "Site is running in read only mode for maintenance or site update, this action can not be performed right now. Please try again later."
 msgstr ""
 
 #: public/js/onboarding_tours/onboarding_tours.js:18
@@ -28971,7 +28741,7 @@ msgctxt "Contact Us Settings"
 msgid "Skype"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Channel' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Slack"
@@ -28999,7 +28769,7 @@ msgid "Slack Webhook URL"
 msgstr ""
 
 #. Label of a Link field in DocType 'Web Page'
-#. Option for a Select field in DocType 'Web Page'
+#. Option for the 'Content Type' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Slideshow"
@@ -29017,31 +28787,31 @@ msgctxt "Website Slideshow"
 msgid "Slideshow Name"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Small Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Small Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Small Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Small Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Small Text"
@@ -29053,12 +28823,11 @@ msgctxt "Currency"
 msgid "Smallest Currency Fraction Value"
 msgstr ""
 
-#. Description of a Currency field in DocType 'Currency'
+#. Description of the 'Smallest Currency Fraction Value' (Currency) field in
+#. DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
-msgid ""
-"Smallest circulating fraction unit (coin). For e.g. 1 cent for USD and it"
-" should be entered as 0.01"
+msgid "Smallest circulating fraction unit (coin). For e.g. 1 cent for USD and it should be entered as 0.01"
 msgstr ""
 
 #. Name of a DocType
@@ -29095,16 +28864,14 @@ msgctxt "User"
 msgid "Social Logins"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Soft-Bounced"
 msgstr ""
 
 #: public/js/frappe/desk.js:20
-msgid ""
-"Some of the features might not work in your browser. Please update your "
-"browser to the latest version."
+msgid "Some of the features might not work in your browser. Please update your browser to the latest version."
 msgstr ""
 
 #: public/js/frappe/views/translation_manager.js:101
@@ -29112,9 +28879,7 @@ msgid "Something went wrong"
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.py:116
-msgid ""
-"Something went wrong during the token generation. Click on {0} to "
-"generate a new one."
+msgid "Something went wrong during the token generation. Click on {0} to generate a new one."
 msgstr ""
 
 #: public/js/frappe/views/pageview.js:110
@@ -29200,13 +28965,13 @@ msgctxt "Translation"
 msgid "Source Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Email Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Spam"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "SparkPost"
@@ -29217,9 +28982,7 @@ msgid "Special Characters are not allowed"
 msgstr ""
 
 #: model/naming.py:58
-msgid ""
-"Special Characters except '-', '#', '.', '/', '{{' and '}}' not allowed "
-"in naming series {0}"
+msgid "Special Characters except '-', '#', '.', '/', '{{' and '}}' not allowed in naming series {0}"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Website Settings'
@@ -29387,13 +29150,13 @@ msgstr ""
 msgid "Start new Format"
 msgstr ""
 
-#. Option for a Select field in DocType 'LDAP Settings'
+#. Option for the 'SSL/TLS Mode' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "StartTLS"
 msgstr ""
 
-#. Option for a Select field in DocType 'Prepared Report'
+#. Option for the 'Status' (Select) field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
 msgctxt "Prepared Report"
 msgid "Started"
@@ -29682,15 +29445,14 @@ msgctxt "Scheduled Job Type"
 msgid "Stopped"
 msgstr ""
 
-#. Description of a Text field in DocType 'User'
+#. Description of the 'Last Known Versions' (Text) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
-msgid ""
-"Stores the JSON of last known versions of various installed apps. It is "
-"used to show release notes."
+msgid "Stores the JSON of last known versions of various installed apps. It is used to show release notes."
 msgstr ""
 
-#. Description of a Datetime field in DocType 'User'
+#. Description of the 'Last Reset Password Key Generated On' (Datetime) field
+#. in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Stores the datetime when the last reset password key was generated."
@@ -29728,12 +29490,10 @@ msgctxt "Print Format"
 msgid "Style Settings"
 msgstr ""
 
-#. Description of a Select field in DocType 'Workflow State'
+#. Description of the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
-msgid ""
-"Style represents the button color: Success - Green, Danger - Red, Inverse"
-" - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange"
+msgid "Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Website Theme'
@@ -29742,13 +29502,14 @@ msgctxt "Website Theme"
 msgid "Stylesheet"
 msgstr ""
 
-#. Description of a Data field in DocType 'Currency'
+#. Description of the 'Fraction' (Data) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
 msgctxt "Currency"
 msgid "Sub-currency. For e.g. \"Cent\""
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Website Settings'
+#. Description of the 'Subdomain' (Small Text) field in DocType 'Website
+#. Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "Sub-domain provided by erpnext.com"
@@ -29839,9 +29600,7 @@ msgid "Subject Field"
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:1878
-msgid ""
-"Subject Field type should be Data, Text, Long Text, Small Text, Text "
-"Editor"
+msgid "Subject Field type should be Data, Text, Long Text, Small Text, Text Editor"
 msgstr ""
 
 #. Name of a DocType
@@ -29882,13 +29641,14 @@ msgctxt "DocShare"
 msgid "Submit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Rule'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "Submit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Submit"
@@ -29956,13 +29716,13 @@ msgstr ""
 msgid "Submitted"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Submitted"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Submitted"
@@ -29973,9 +29733,7 @@ msgid "Submitted Document cannot be converted back to draft. Transition row {0}"
 msgstr ""
 
 #: public/js/workflow_builder/utils.js:176
-msgid ""
-"Submitted document cannot be converted back to draft while transitioning "
-"from <b>{0} State</b> to <b>{1} State</b>"
+msgid "Submitted document cannot be converted back to draft while transitioning from <b>{0} State</b> to <b>{1} State</b>"
 msgstr ""
 
 #: public/js/frappe/form/save.js:10
@@ -29987,7 +29745,7 @@ msgstr ""
 msgid "Submitting {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Subsidiary"
@@ -30015,13 +29773,13 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#. Option for a Select field in DocType 'Activity Log'
+#. Option for the 'Status' (Select) field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
 msgctxt "Activity Log"
 msgid "Success"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Import'
+#. Option for the 'Status' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Success"
@@ -30033,7 +29791,7 @@ msgctxt "Data Import Log"
 msgid "Success"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "Success"
@@ -30088,7 +29846,7 @@ msgstr ""
 msgid "Successful Transactions"
 msgstr ""
 
-#: model/rename_doc.py:683
+#: model/rename_doc.py:684
 msgid "Successful: {0} to {1}"
 msgstr ""
 
@@ -30122,15 +29880,11 @@ msgid "Successfully {0} 1 record."
 msgstr ""
 
 #: core/doctype/data_import/data_import.js:156
-msgid ""
-"Successfully {0} {1} record out of {2}. Click on Export Errored Rows, fix"
-" the errors and import again."
+msgid "Successfully {0} {1} record out of {2}. Click on Export Errored Rows, fix the errors and import again."
 msgstr ""
 
 #: core/doctype/data_import/data_import.js:161
-msgid ""
-"Successfully {0} {1} records out of {2}. Click on Export Errored Rows, "
-"fix the errors and import again."
+msgid "Successfully {0} {1} records out of {2}. Click on Export Errored Rows, fix the errors and import again."
 msgstr ""
 
 #: core/doctype/data_import/data_import.js:151
@@ -30145,13 +29899,14 @@ msgstr ""
 msgid "Sum"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Group By Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Sum"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Sum"
@@ -30165,19 +29920,19 @@ msgstr ""
 msgid "Summary"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule Day'
+#. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
 #: automation/doctype/assignment_rule_day/assignment_rule_day.json
 msgctxt "Assignment Rule Day"
 msgid "Sunday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Sunday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat Day'
+#. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
 msgctxt "Auto Repeat Day"
 msgid "Sunday"
@@ -30189,7 +29944,8 @@ msgctxt "Event"
 msgid "Sunday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'First Day of the Week' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Sunday"
@@ -30282,7 +30038,7 @@ msgstr ""
 msgid "Syntax Error"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType'
+#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "System"
@@ -30338,7 +30094,7 @@ msgstr ""
 #: core/doctype/package_import/package_import.json
 #: core/doctype/package_release/package_release.json
 #: core/doctype/page/page.json core/doctype/patch_log/patch_log.json
-#: core/doctype/permission_debugger/permission_debugger.json
+#: core/doctype/permission_inspector/permission_inspector.json
 #: core/doctype/prepared_report/prepared_report.json
 #: core/doctype/report/report.json core/doctype/role/role.json
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
@@ -30437,7 +30193,7 @@ msgstr ""
 msgid "System Manager privileges required."
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Channel' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "System Notification"
@@ -30466,7 +30222,8 @@ msgctxt "System Settings"
 msgid "System Settings"
 msgstr ""
 
-#. Description of a Table MultiSelect field in DocType 'Module Onboarding'
+#. Description of the 'Allow Roles' (Table MultiSelect) field in DocType
+#. 'Module Onboarding'
 #: desk/doctype/module_onboarding/module_onboarding.json
 msgctxt "Module Onboarding"
 msgid "System managers are allowed by default"
@@ -30477,19 +30234,19 @@ msgctxt "Number system"
 msgid "T"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Tab Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Tab Break"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Tab Break"
@@ -30499,31 +30256,31 @@ msgstr ""
 msgid "Table"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Table"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Table"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Table"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Table"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Table Break"
@@ -30545,19 +30302,19 @@ msgctxt "Version"
 msgid "Table HTML"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Table MultiSelect"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Table MultiSelect"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Table MultiSelect"
@@ -30571,7 +30328,7 @@ msgstr ""
 msgid "Table {0} cannot be empty"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Tabloid"
@@ -30587,7 +30344,7 @@ msgstr ""
 msgid "Tag Link"
 msgstr ""
 
-#: model/__init__.py:148 model/meta.py:51
+#: model/__init__.py:148 model/meta.py:52
 #: public/js/frappe/list/bulk_operations.js:365
 #: public/js/frappe/list/list_sidebar.js:226 public/js/frappe/model/meta.js:204
 #: public/js/frappe/model/model.js:123
@@ -30716,31 +30473,31 @@ msgstr ""
 msgid "Test_Folder"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Text"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Template Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Text"
@@ -30764,25 +30521,25 @@ msgctxt "Communication"
 msgid "Text Content"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Text Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Text Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Text Editor"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Text Editor"
@@ -30820,12 +30577,11 @@ msgstr ""
 msgid "The CSV format is case sensitive"
 msgstr ""
 
-#. Description of a Data field in DocType 'Google Settings'
+#. Description of the 'Client ID' (Data) field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
 msgctxt "Google Settings"
 msgid ""
-"The Client ID obtained from the Google Cloud Console under <a "
-"href=\"https://console.cloud.google.com/apis/credentials\">\n"
+"The Client ID obtained from the Google Cloud Console under <a href=\"https://console.cloud.google.com/apis/credentials\">\n"
 "\"APIs &amp; Services\" &gt; \"Credentials\"\n"
 "</a>"
 msgstr ""
@@ -30839,18 +30595,15 @@ msgid "The File URL you've entered is incorrect"
 msgstr ""
 
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:364
-msgid ""
-"The User record for this request has been auto-deleted due to inactivity "
-"by system admins."
+msgid "The User record for this request has been auto-deleted due to inactivity by system admins."
 msgstr ""
 
 #: public/js/frappe/desk.js:127
-msgid ""
-"The application has been updated to a new version, please refresh this "
-"page"
+msgid "The application has been updated to a new version, please refresh this page"
 msgstr ""
 
-#. Description of a Data field in DocType 'System Settings'
+#. Description of the 'Application Name' (Data) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "The application name will be used in the Login page."
@@ -30860,12 +30613,11 @@ msgstr ""
 msgid "The attachments could not be correctly linked to the new document"
 msgstr ""
 
-#. Description of a Data field in DocType 'Google Settings'
+#. Description of the 'API Key' (Data) field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
 msgctxt "Google Settings"
 msgid ""
-"The browser API key obtained from the Google Cloud Console under <a "
-"href=\"https://console.cloud.google.com/apis/credentials\">\n"
+"The browser API key obtained from the Google Cloud Console under <a href=\"https://console.cloud.google.com/apis/credentials\">\n"
 "\"APIs &amp; Services\" &gt; \"Credentials\"\n"
 "</a>"
 msgstr ""
@@ -30875,10 +30627,7 @@ msgid "The changes have been reverted."
 msgstr ""
 
 #: core/doctype/data_import/importer.py:962
-msgid ""
-"The column {0} has {1} different date formats. Automatically setting {2} "
-"as the default format as it is the most common. Please change other "
-"values in this column to this format."
+msgid "The column {0} has {1} different date formats. Automatically setting {2} as the default format as it is the most common. Please change other values in this column to this format."
 msgstr ""
 
 #: templates/includes/comments/comments.py:34
@@ -30893,20 +30642,18 @@ msgstr ""
 msgid "The document has been assigned to {0}"
 msgstr ""
 
-#. Description of a Link field in DocType 'Dashboard Chart'
+#. Description of the 'Parent Document Type' (Link) field in DocType 'Dashboard
+#. Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
-msgid ""
-"The document type selected is a child table, so the parent document type "
-"is required."
+msgid "The document type selected is a child table, so the parent document type is required."
 msgstr ""
 
-#. Description of a Link field in DocType 'Number Card'
+#. Description of the 'Parent Document Type' (Link) field in DocType 'Number
+#. Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
-msgid ""
-"The document type selected is a child table, so the parent document type "
-"is required."
+msgid "The document type selected is a child table, so the parent document type is required."
 msgstr ""
 
 #: core/doctype/user_type/user_type.py:109
@@ -30938,32 +30685,26 @@ msgid "The link you trying to login is invalid or expired."
 msgstr ""
 
 #: website/doctype/web_page/web_page.js:125
-msgid ""
-"The meta description is an HTML attribute that provides a brief summary "
-"of a web page. Search engines such as Google often display the meta "
-"description in search results, which can influence click-through rates."
+msgid "The meta description is an HTML attribute that provides a brief summary of a web page. Search engines such as Google often display the meta description in search results, which can influence click-through rates."
 msgstr ""
 
 #: website/doctype/web_page/web_page.js:132
-msgid ""
-"The meta image is unique image representing the content of the page. "
-"Images for this Card should be at least 280px in width, and at least "
-"150px in height."
+msgid "The meta image is unique image representing the content of the page. Images for this Card should be at least 280px in width, and at least 150px in height."
 msgstr ""
 
-#. Description of a Data field in DocType 'Google Calendar'
+#. Description of the 'Calendar Name' (Data) field in DocType 'Google Calendar'
 #: integrations/doctype/google_calendar/google_calendar.json
 msgctxt "Google Calendar"
 msgid "The name that will appear in Google Calendar"
 msgstr ""
 
-#. Description of a Check field in DocType 'Form Tour'
+#. Description of the 'Track Steps' (Check) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "The next tour will start from where the user left off."
 msgstr ""
 
-#. Description of a Int field in DocType 'Webhook'
+#. Description of the 'Request Timeout' (Int) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "The number of seconds until the request expires"
@@ -30978,17 +30719,14 @@ msgid "The password of your account has expired."
 msgstr ""
 
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:395
-msgid ""
-"The process for deletion of {0} data associated with {1} has been "
-"initiated."
+msgid "The process for deletion of {0} data associated with {1} has been initiated."
 msgstr ""
 
-#. Description of a Data field in DocType 'Google Settings'
+#. Description of the 'App ID' (Data) field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
 msgctxt "Google Settings"
 msgid ""
-"The project number obtained from Google Cloud Console under <a "
-"href=\"https://console.cloud.google.com/iam-admin/settings\">\n"
+"The project number obtained from Google Cloud Console under <a href=\"https://console.cloud.google.com/iam-admin/settings\">\n"
 "\"IAM &amp; Admin\" &gt; \"Settings\"\n"
 "</a>"
 msgstr ""
@@ -31013,7 +30751,7 @@ msgstr ""
 msgid "The selected document {0} is not a {1}."
 msgstr ""
 
-#: utils/response.py:317
+#: utils/response.py:321
 msgid "The system is being updated. Please refresh again after a few moments."
 msgstr ""
 
@@ -31025,19 +30763,18 @@ msgstr ""
 msgid "The total number of user document types limit has been crossed."
 msgstr ""
 
-#. Description of a Select field in DocType 'Energy Point Rule'
+#. Description of the 'User Field' (Select) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "The user from this field will be rewarded points"
 msgstr ""
 
 #: public/js/frappe/form/controls/data.js:24
-msgid ""
-"The value you pasted was {0} characters long. Max allowed characters is "
-"{1}."
+msgid "The value you pasted was {0} characters long. Max allowed characters is {1}."
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Webhook'
+#. Description of the 'Condition' (Small Text) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "The webhook will be triggered if this expression is true"
@@ -31125,7 +30862,7 @@ msgstr ""
 msgid "There were errors while creating the document. Please try again."
 msgstr ""
 
-#: public/js/frappe/views/communication.js:724
+#: public/js/frappe/views/communication.js:728
 msgid "There were errors while sending email. Please try again."
 msgstr ""
 
@@ -31137,19 +30874,17 @@ msgstr ""
 msgid "There's nothing here"
 msgstr ""
 
-#. Description of a Section Break field in DocType 'LDAP Settings'
+#. Description of the 'LDAP Custom Settings' (Section Break) field in DocType
+#. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "These settings are required if 'Custom' LDAP Directory is used"
 msgstr ""
 
-#. Description of a Section Break field in DocType 'User'
+#. Description of the 'Defaults' (Section Break) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
-msgid ""
-"These values will be automatically updated in transactions and also will "
-"be useful to restrict permissions for this user on transactions "
-"containing these values."
+msgid "These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values."
 msgstr ""
 
 #: www/third_party_apps.html:3 www/third_party_apps.html:13
@@ -31178,7 +30913,7 @@ msgstr ""
 msgid "This Kanban Board will be private"
 msgstr ""
 
-#: __init__.py:900
+#: __init__.py:917
 msgid "This action is only allowed for {}"
 msgstr ""
 
@@ -31186,23 +30921,20 @@ msgstr ""
 msgid "This cannot be undone"
 msgstr ""
 
-#. Description of a Check field in DocType 'Number Card'
+#. Description of the 'Is Public' (Check) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "This card will be available to all Users if this is set"
 msgstr ""
 
-#. Description of a Check field in DocType 'Dashboard Chart'
+#. Description of the 'Is Public' (Check) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "This chart will be available to all Users if this is set"
 msgstr ""
 
 #: desk/doctype/workspace/workspace.js:23
-msgid ""
-"This document allows you to edit limited fields. For all kinds of "
-"workspace customization, use the Edit button located on the workspace "
-"page"
+msgid "This document allows you to edit limited fields. For all kinds of workspace customization, use the Edit button located on the workspace page"
 msgstr ""
 
 #: social/doctype/energy_point_log/energy_point_log.py:90
@@ -31232,16 +30964,15 @@ msgstr ""
 #: printing/doctype/network_printer_settings/network_printer_settings.py:29
 msgid ""
 "This feature can not be used as dependencies are missing.\n"
-"\t\t\t\tPlease contact your system manager to enable this by installing "
-"pycups!"
+"\t\t\t\tPlease contact your system manager to enable this by installing pycups!"
 msgstr ""
 
-#. Description of a Code field in DocType 'Customize Form Field'
+#. Description of the 'Depends On' (Code) field in DocType 'Customize Form
+#. Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid ""
-"This field will appear only if the fieldname defined here has value OR "
-"the rules are true (examples):\n"
+"This field will appear only if the fieldname defined here has value OR the rules are true (examples):\n"
 "myfield\n"
 "eval:doc.myfield=='My Value'\n"
 "eval:doc.age&gt;18"
@@ -31259,22 +30990,21 @@ msgstr ""
 msgid "This form is not editable due to a Workflow."
 msgstr ""
 
-#. Description of a Check field in DocType 'Address Template'
+#. Description of the 'Is Default' (Check) field in DocType 'Address Template'
 #: contacts/doctype/address_template/address_template.json
 msgctxt "Address Template"
 msgid "This format is used if country specific format is not found"
 msgstr ""
 
-#. Description of a HTML Editor field in DocType 'Website Slideshow'
+#. Description of the 'Header' (HTML Editor) field in DocType 'Website
+#. Slideshow'
 #: website/doctype/website_slideshow/website_slideshow.json
 msgctxt "Website Slideshow"
 msgid "This goes above the slideshow."
 msgstr ""
 
 #: public/js/frappe/views/reports/query_report.js:1995
-msgid ""
-"This is a background report. Please set the appropriate filters and then "
-"generate a new one."
+msgid "This is a background report. Please set the appropriate filters and then generate a new one."
 msgstr ""
 
 #: utils/password_strength.py:162
@@ -31297,7 +31027,8 @@ msgstr ""
 msgid "This is an automatically generated reply"
 msgstr ""
 
-#. Description of a HTML field in DocType 'Blog Post'
+#. Description of the 'Google Snippet Preview' (HTML) field in DocType 'Blog
+#. Post'
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
 msgid "This is an example Google SERP Preview."
@@ -31307,7 +31038,8 @@ msgstr ""
 msgid "This is similar to a commonly used password."
 msgstr ""
 
-#. Description of a Int field in DocType 'Document Naming Settings'
+#. Description of the 'Current Value' (Int) field in DocType 'Document Naming
+#. Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid "This is the number of the last created transaction with this prefix"
@@ -31318,9 +31050,7 @@ msgid "This link has already been activated for verification."
 msgstr ""
 
 #: utils/verified_command.py:49
-msgid ""
-"This link is invalid or expired. Please make sure you have pasted "
-"correctly."
+msgid "This link is invalid or expired. Please make sure you have pasted correctly."
 msgstr ""
 
 #: printing/page/print/print.js:403
@@ -31336,9 +31066,7 @@ msgid "This newsletter is scheduled to be sent on {0}"
 msgstr ""
 
 #: email/doctype/newsletter/newsletter.js:50
-msgid ""
-"This newsletter was scheduled to send on a later date. Are you sure you "
-"want to send it now?"
+msgid "This newsletter was scheduled to send on a later date. Are you sure you want to send it now?"
 msgstr ""
 
 #: templates/emails/auto_email_report.html:57
@@ -31358,15 +31086,11 @@ msgid "This site is in read only mode, full functionality will be restored soon.
 msgstr ""
 
 #: core/doctype/doctype/doctype.js:76
-msgid ""
-"This site is running in developer mode. Any change made here will be "
-"updated in code."
+msgid "This site is running in developer mode. Any change made here will be updated in code."
 msgstr ""
 
 #: website/doctype/web_page/web_page.js:71
-msgid ""
-"This title will be used as the title of the webpage as well as in meta "
-"tags"
+msgid "This title will be used as the title of the webpage as well as in meta tags"
 msgstr ""
 
 #: public/js/frappe/form/controls/base_input.js:120
@@ -31374,18 +31098,18 @@ msgid "This value is fetched from {0}'s {1} field"
 msgstr ""
 
 #: website/doctype/web_page/web_page.js:85
-msgid ""
-"This will be automatically generated when you publish the page, you can "
-"also enter a route yourself if you wish"
+msgid "This will be automatically generated when you publish the page, you can also enter a route yourself if you wish"
 msgstr ""
 
-#. Description of a Small Text field in DocType 'Onboarding Step'
+#. Description of the 'Callback Message' (Small Text) field in DocType
+#. 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "This will be shown in a modal after routing"
 msgstr ""
 
-#. Description of a Data field in DocType 'Onboarding Step'
+#. Description of the 'Report Description' (Data) field in DocType 'Onboarding
+#. Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "This will be shown to the user in a dialog after routing to the report"
@@ -31404,12 +31128,10 @@ msgid "This will reset this tour and show it to all users. Are you sure?"
 msgstr ""
 
 #: core/doctype/rq_job/rq_job.js:15
-msgid ""
-"This will terminate the job immediately and might be dangerous, are you "
-"sure? "
+msgid "This will terminate the job immediately and might be dangerous, are you sure? "
 msgstr ""
 
-#: core/doctype/user/user.py:1208
+#: core/doctype/user/user.py:1209
 msgid "Throttled"
 msgstr ""
 
@@ -31419,19 +31141,19 @@ msgctxt "File"
 msgid "Thumbnail URL"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule Day'
+#. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
 #: automation/doctype/assignment_rule_day/assignment_rule_day.json
 msgctxt "Assignment Rule Day"
 msgid "Thursday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Thursday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat Day'
+#. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
 msgctxt "Auto Repeat Day"
 msgid "Thursday"
@@ -31443,7 +31165,8 @@ msgctxt "Event"
 msgid "Thursday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'First Day of the Week' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Thursday"
@@ -31453,19 +31176,19 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#. Option for a Select field in DocType 'Custom Field'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Time"
 msgstr ""
 
-#. Option for a Select field in DocType 'Customize Form Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
 msgid "Time"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocField'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
 msgctxt "DocField"
 msgid "Time"
@@ -31477,19 +31200,19 @@ msgctxt "Recorder"
 msgid "Time"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Time"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report Filter'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Time"
 msgstr ""
 
-#. Option for a Select field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
 msgctxt "Web Form Field"
 msgid "Time"
@@ -31571,12 +31294,11 @@ msgctxt "Recorder"
 msgid "Time in Queries"
 msgstr ""
 
-#. Description of a Int field in DocType 'System Settings'
+#. Description of the 'Expiry time of QR Code Image Page' (Int) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"Time in seconds to retain QR code image on server. "
-"Min:<strong>240</strong>"
+msgid "Time in seconds to retain QR code image on server. Min:<strong>240</strong>"
 msgstr ""
 
 #: desk/doctype/dashboard_chart/dashboard_chart.py:413
@@ -31587,7 +31309,7 @@ msgstr ""
 msgid "Time {0} must be in format: {1}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Import'
+#. Option for the 'Status' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Timed Out"
@@ -31875,7 +31597,7 @@ msgstr ""
 msgid "To User"
 msgstr ""
 
-#. Description of a Data field in DocType 'Auto Repeat'
+#. Description of the 'Subject' (Data) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid ""
@@ -31884,7 +31606,7 @@ msgid ""
 "<div><pre><code>New {{ doc.doctype }} #{{ doc.name }}</code></pre></div>"
 msgstr ""
 
-#. Description of a Data field in DocType 'Notification'
+#. Description of the 'Subject' (Data) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid ""
@@ -31893,7 +31615,7 @@ msgid ""
 "<div><pre><code>{{ doc.name }} Delivered</code></pre></div>"
 msgstr ""
 
-#. Description of a Code field in DocType 'Webhook'
+#. Description of the 'JSON Request Body' (Code) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid ""
@@ -31924,9 +31646,7 @@ msgid "To enable it follow the instructions in the following link: {0}"
 msgstr ""
 
 #: desk/doctype/onboarding_step/onboarding_step.js:18
-msgid ""
-"To export this step as JSON, link it in a Onboarding document and save "
-"the document."
+msgid "To export this step as JSON, link it in a Onboarding document and save the document."
 msgstr ""
 
 #: public/js/frappe/views/reports/query_report.js:783
@@ -31937,16 +31657,14 @@ msgstr ""
 msgid "To manage your authorized third party apps"
 msgstr ""
 
-#. Description of a Code field in DocType 'System Console'
+#. Description of the 'Console' (Code) field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
 msgctxt "System Console"
 msgid "To print output use <code>print(text)</code>"
 msgstr ""
 
 #: core/doctype/user_type/user_type.py:295
-msgid ""
-"To set the role {0} in the user {1}, kindly set the {2} field as {3} in "
-"one of the {4} record."
+msgid "To set the role {0} in the user {1}, kindly set the {2} field as {3} in one of the {4} record."
 msgstr ""
 
 #: integrations/doctype/google_calendar/google_calendar.js:8
@@ -31961,20 +31679,17 @@ msgstr ""
 msgid "To use Google Drive, enable {0}."
 msgstr ""
 
-#. Description of a Check field in DocType 'Website Settings'
+#. Description of the 'Enable Google indexing' (Check) field in DocType
+#. 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
-msgid ""
-"To use Google Indexing, enable <a href=\"/app/google-settings\">Google "
-"Settings</a>."
+msgid "To use Google Indexing, enable <a href=\"/app/google-settings\">Google Settings</a>."
 msgstr ""
 
-#. Description of a Link field in DocType 'Notification'
+#. Description of the 'Slack Channel' (Link) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
-msgid ""
-"To use Slack Channel, add a <a "
-"href=\"#List/Slack%20Webhook%20URL/List\">Slack Webhook URL</a>."
+msgid "To use Slack Channel, add a <a href=\"#List/Slack%20Webhook%20URL/List\">Slack Webhook URL</a>."
 msgstr ""
 
 #: public/js/frappe/utils/diffview.js:43
@@ -32038,7 +31753,7 @@ msgstr ""
 msgid "Toggle Theme"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Client'
+#. Option for the 'Response Type' (Select) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
 msgctxt "OAuth Client"
 msgid "Token"
@@ -32090,9 +31805,7 @@ msgid "Too many changes to database in single action."
 msgstr ""
 
 #: core/doctype/user/user.py:984
-msgid ""
-"Too many users signed up recently, so the registration is disabled. "
-"Please try back in an hour"
+msgid "Too many users signed up recently, so the registration is disabled. Please try back in an hour"
 msgstr ""
 
 #. Name of a Workspace
@@ -32101,7 +31814,7 @@ msgstr ""
 msgid "Tools"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Top"
@@ -32118,19 +31831,19 @@ msgctxt "Website Settings"
 msgid "Top Bar Items"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Top Center"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Top Center"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Top Left"
@@ -32144,13 +31857,13 @@ msgstr ""
 msgid "Top Reviewer"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour Step'
+#. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Top Right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Top Right"
@@ -32200,7 +31913,8 @@ msgctxt "RQ Worker"
 msgid "Total Working Time"
 msgstr ""
 
-#. Description of a Select field in DocType 'Email Account'
+#. Description of the 'Initial Sync Count' (Select) field in DocType 'Email
+#. Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Total number of emails to sync in initial sync process "
@@ -32275,14 +31989,14 @@ msgctxt "DocType"
 msgid "Track Views"
 msgstr ""
 
-#. Description of a Check field in DocType 'Email Account'
+#. Description of the 'Track Email Status' (Check) field in DocType 'Email
+#. Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid ""
 "Track if your email has been opened by the recipient.\n"
 "<br>\n"
-"Note: If you're sending to multiple recipients, even if 1 recipient reads"
-" the email, it'll be considered \"Opened\""
+"Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered \"Opened\""
 msgstr ""
 
 #: public/js/frappe/utils/utils.js:1744
@@ -32366,25 +32080,25 @@ msgstr ""
 msgid "Translations"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Email Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Trash"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Tree"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Tree"
 msgstr ""
 
-#. Description of a Check field in DocType 'DocType'
+#. Description of the 'Is Tree' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Tree structures are implemented using Nested Set"
@@ -32404,16 +32118,14 @@ msgstr ""
 msgid "Trigger Primary Action"
 msgstr ""
 
-#: tests/test_translate.py:51
+#: tests/test_translate.py:55
 msgid "Trigger caching"
 msgstr ""
 
-#. Description of a Data field in DocType 'Notification'
+#. Description of the 'Trigger Method' (Data) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
-msgid ""
-"Trigger on valid methods like \"before_insert\", \"after_update\", etc "
-"(will depend on the DocType selected)"
+msgid "Trigger on valid methods like \"before_insert\", \"after_update\", etc (will depend on the DocType selected)"
 msgstr ""
 
 #: public/js/frappe/widgets/onboarding_widget.js:323
@@ -32434,19 +32146,19 @@ msgstr ""
 msgid "Try to use a longer keyboard pattern with more turns"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule Day'
+#. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
 #: automation/doctype/assignment_rule_day/assignment_rule_day.json
 msgctxt "Assignment Rule Day"
 msgid "Tuesday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Tuesday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat Day'
+#. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
 msgctxt "Auto Repeat Day"
 msgid "Tuesday"
@@ -32458,7 +32170,8 @@ msgctxt "Event"
 msgid "Tuesday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'First Day of the Week' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Tuesday"
@@ -32634,21 +32347,18 @@ msgctxt "IMAP Folder"
 msgid "UIDVALIDITY"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Email Sync Option' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "UNSEEN"
 msgstr ""
 
-#. Description of a Text field in DocType 'OAuth Client'
+#. Description of the 'Redirect URIs' (Text) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
 msgctxt "OAuth Client"
 msgid ""
-"URIs for receiving authorization code once the user allows access, as "
-"well as failure responses. Typically a REST endpoint exposed by the "
-"Client App.\n"
-"<br>e.g. "
-"http://hostname/api/method/frappe.integrations.oauth2_logins.login_via_facebook"
+"URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.\n"
+"<br>e.g. http://hostname/api/method/frappe.integrations.oauth2_logins.login_via_facebook"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Integration Request'
@@ -32675,14 +32385,14 @@ msgctxt "Website Slideshow Item"
 msgid "URL"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace Shortcut'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
 #. Label of a Data field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "URL"
 msgstr ""
 
-#. Description of a Data field in DocType 'DocType'
+#. Description of the 'Documentation Link' (Data) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "URL for documentation or help"
@@ -32696,7 +32406,7 @@ msgstr ""
 msgid "URL of the page"
 msgstr ""
 
-#. Description of a Data field in DocType 'Website Slideshow Item'
+#. Description of the 'URL' (Data) field in DocType 'Website Slideshow Item'
 #: website/doctype/website_slideshow_item/website_slideshow_item.json
 msgctxt "Website Slideshow Item"
 msgid "URL to go to on clicking the slideshow image"
@@ -32723,9 +32433,7 @@ msgid "Unable to read file format for {0}"
 msgstr ""
 
 #: core/doctype/communication/email.py:173
-msgid ""
-"Unable to send mail because of a missing email account. Please setup "
-"default Email Account from Settings > Email Account"
+msgid "Unable to send mail because of a missing email account. Please setup default Email Account from Settings > Email Account"
 msgstr ""
 
 #: public/js/frappe/views/calendar/calendar.js:439
@@ -32814,7 +32522,7 @@ msgstr ""
 msgid "Unpublish"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Flag Queue'
+#. Option for the 'Action' (Select) field in DocType 'Email Flag Queue'
 #: email/doctype/email_flag_queue/email_flag_queue.json
 msgctxt "Email Flag Queue"
 msgid "Unread"
@@ -32830,13 +32538,13 @@ msgstr ""
 msgid "Unsafe SQL query"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Unshared"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Unshared"
@@ -32929,7 +32637,7 @@ msgstr ""
 msgid "Update Details"
 msgstr ""
 
-#. Option for a Select field in DocType 'Data Import'
+#. Option for the 'Import Type' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
 msgctxt "Data Import"
 msgid "Update Existing Records"
@@ -32962,7 +32670,7 @@ msgctxt "Document Naming Settings"
 msgid "Update Series Number"
 msgstr ""
 
-#. Option for a Select field in DocType 'Onboarding Step'
+#. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "Update Settings"
@@ -32993,13 +32701,13 @@ msgstr ""
 msgid "Updated"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Updated"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Updated"
@@ -33023,7 +32731,7 @@ msgctxt "System Settings"
 msgid "Updates"
 msgstr ""
 
-#: utils/response.py:316
+#: utils/response.py:320
 msgid "Updating"
 msgstr ""
 
@@ -33032,10 +32740,8 @@ msgctxt "Freeze message while updating a document"
 msgid "Updating"
 msgstr ""
 
-#: email/doctype/email_queue/email_queue.py:403
-msgid ""
-"Updating Email Queue Statuses. The emails will be picked up in the next "
-"scheduled run."
+#: email/doctype/email_queue/email_queue.py:406
+msgid "Updating Email Queue Statuses. The emails will be picked up in the next scheduled run."
 msgstr ""
 
 #: core/doctype/document_naming_rule/document_naming_rule.js:17
@@ -33079,7 +32785,8 @@ msgctxt "File"
 msgid "Uploaded To Google Drive"
 msgstr ""
 
-#. Description of a Data field in DocType 'Onboarding Step'
+#. Description of the 'Value to Validate' (Data) field in DocType 'Onboarding
+#. Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 #, python-format
 msgctxt "Onboarding Step"
@@ -33180,7 +32887,7 @@ msgstr ""
 msgid "Use the new Print Format Builder"
 msgstr ""
 
-#. Description of a Data field in DocType 'Customize Form'
+#. Description of the 'Title Field' (Data) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
 msgctxt "Customize Form"
 msgid "Use this fieldname to generate title"
@@ -33296,9 +33003,9 @@ msgctxt "OAuth Client"
 msgid "User"
 msgstr ""
 
-#. Label of a Link field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Label of a Link field in DocType 'Permission Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "User"
 msgstr ""
 
@@ -33581,13 +33288,15 @@ msgctxt "User Type"
 msgid "User Type Module"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Allow Login using Mobile Number' (Check) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "User can login using Email id or Mobile number"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Allow Login using User Name' (Check) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "User can login using Email id or User Name"
@@ -33624,9 +33333,7 @@ msgid "User with email address {0} does not exist"
 msgstr ""
 
 #: integrations/doctype/ldap_settings/ldap_settings.py:224
-msgid ""
-"User with email: {0} does not exist in the system. Please ask 'System "
-"Administrator' to create the user for you."
+msgid "User with email: {0} does not exist in the system. Please ask 'System Administrator' to create the user for you."
 msgstr ""
 
 #: core/doctype/user/user.py:504
@@ -33641,11 +33348,11 @@ msgstr ""
 msgid "User {0} cannot be renamed"
 msgstr ""
 
-#: permissions.py:136
+#: permissions.py:139
 msgid "User {0} does not have access to this document"
 msgstr ""
 
-#: permissions.py:159
+#: permissions.py:162
 msgid "User {0} does not have doctype access via role permission for document {1}"
 msgstr ""
 
@@ -33700,7 +33407,8 @@ msgctxt "Assignment Rule"
 msgid "Users"
 msgstr ""
 
-#. Description of a Check field in DocType 'Energy Point Rule'
+#. Description of the 'Allot Points To Assigned Users' (Check) field in DocType
+#. 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "Users assigned to the reference document will get points."
@@ -33715,9 +33423,7 @@ msgid "Uses system's theme to switch between light and dark mode"
 msgstr ""
 
 #: public/js/frappe/desk.js:112
-msgid ""
-"Using this console may allow attackers to impersonate you and steal your "
-"information. Do not enter or paste code that you do not understand."
+msgid "Using this console may allow attackers to impersonate you and steal your information. Do not enter or paste code that you do not understand."
 msgstr ""
 
 #. Label of a Percent field in DocType 'RQ Worker'
@@ -33726,7 +33432,8 @@ msgctxt "RQ Worker"
 msgid "Utilization %"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Authorization Code'
+#. Option for the 'Validity' (Select) field in DocType 'OAuth Authorization
+#. Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 msgctxt "OAuth Authorization Code"
 msgid "Valid"
@@ -33802,13 +33509,14 @@ msgctxt "Dashboard Chart"
 msgid "Value Based On"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Rule'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "Value Change"
 msgstr ""
 
-#. Option for a Select field in DocType 'Notification'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Value Change"
@@ -33843,16 +33551,15 @@ msgid "Value for a check field can be either 0 or 1"
 msgstr ""
 
 #: custom/doctype/customize_form/customize_form.py:611
-msgid ""
-"Value for field {0} is too long in {1}. Length should be lesser than {2} "
-"characters"
+msgid "Value for field {0} is too long in {1}. Length should be lesser than {2} characters"
 msgstr ""
 
 #: model/base_document.py:360
 msgid "Value for {0} cannot be a list"
 msgstr ""
 
-#. Description of a Select field in DocType 'Assignment Rule'
+#. Description of the 'Due Date Based On' (Select) field in DocType 'Assignment
+#. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
 msgctxt "Assignment Rule"
 msgid "Value from this field will be set as the due date in the ToDo"
@@ -33888,7 +33595,7 @@ msgstr ""
 msgid "Value {0} must in {1} format"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Settings'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
 msgctxt "Print Settings"
 msgid "Verdana"
@@ -33906,7 +33613,7 @@ msgstr ""
 msgid "Verification code has been sent to your registered email address."
 msgstr ""
 
-#. Option for a Select field in DocType 'Translation'
+#. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
 #: core/doctype/translation/translation.json
 msgctxt "Translation"
 msgid "Verified"
@@ -33982,7 +33689,7 @@ msgstr ""
 msgid "View Ref"
 msgstr ""
 
-#. Option for a Select field in DocType 'Onboarding Step'
+#. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "View Report"
@@ -34062,9 +33769,7 @@ msgid "Virtual DocType {} requires a static method called {} found {}"
 msgstr ""
 
 #: model/virtual_doctype.py:91
-msgid ""
-"Virtual DocType {} requires overriding an instance method called {} found"
-" {}"
+msgid "Virtual DocType {} requires overriding an instance method called {} found {}"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'DocField'
@@ -34073,7 +33778,7 @@ msgctxt "DocField"
 msgid "Visibility"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Visit"
@@ -34093,13 +33798,13 @@ msgstr ""
 msgid "Want to discuss?"
 msgstr ""
 
-#. Option for a Select field in DocType 'Address'
+#. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Warehouse"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "Warning"
@@ -34109,29 +33814,24 @@ msgstr ""
 msgid "Warning: Unable to find {0} in any table related to {1}"
 msgstr ""
 
-#. Description of a Int field in DocType 'Document Naming Rule'
+#. Description of the 'Counter' (Int) field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
 msgctxt "Document Naming Rule"
-msgid ""
-"Warning: Updating counter may lead to document name conflicts if not done"
-" properly"
+msgid "Warning: Updating counter may lead to document name conflicts if not done properly"
 msgstr ""
 
 #: website/doctype/help_article/templates/help_article.html:24
 msgid "Was this article helpful?"
 msgstr ""
 
-#. Option for a Select field in DocType 'Onboarding Step'
+#. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
 msgid "Watch Video"
 msgstr ""
 
 #: desk/doctype/workspace/workspace.js:38
-msgid ""
-"We do not allow editing of this document. Simply click the Edit button on"
-" the workspace page to make your workspace editable and customize it as "
-"you wish"
+msgid "We do not allow editing of this document. Simply click the Edit button on the workspace page to make your workspace editable and customize it as you wish"
 msgstr ""
 
 #: templates/emails/delete_data_confirmation.html:2
@@ -34139,9 +33839,7 @@ msgid "We have received a request for deletion of {0} data associated with: {1}"
 msgstr ""
 
 #: templates/emails/download_data.html:2
-msgid ""
-"We have received a request from you to download your {0} data associated "
-"with: {1}"
+msgid "We have received a request from you to download your {0} data associated with: {1}"
 msgstr ""
 
 #: public/js/frappe/form/controls/password.js:88
@@ -34524,19 +34222,19 @@ msgctxt "Website Settings"
 msgid "Website Theme image link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Assignment Rule Day'
+#. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
 #: automation/doctype/assignment_rule_day/assignment_rule_day.json
 msgctxt "Assignment Rule Day"
 msgid "Wednesday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Wednesday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat Day'
+#. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
 msgctxt "Auto Repeat Day"
 msgid "Wednesday"
@@ -34548,7 +34246,8 @@ msgctxt "Event"
 msgid "Wednesday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'First Day of the Week' (Select) field in DocType 'System
+#. Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Wednesday"
@@ -34558,7 +34257,7 @@ msgstr ""
 msgid "Week"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Weekdays"
@@ -34569,85 +34268,89 @@ msgstr ""
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dropbox Settings'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'Dropbox
+#. Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
 msgctxt "Dropbox Settings"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Energy Point Settings'
+#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
+#. 'Energy Point Settings'
 #: social/doctype/energy_point_settings/energy_point_settings.json
 msgctxt "Energy Point Settings"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Google Drive'
+#. Option for the 'Frequency' (Select) field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
 msgctxt "Google Drive"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'S3 Backup Settings'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
+#. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgctxt "S3 Backup Settings"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'User'
+#. Option for the 'Frequency' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
 msgid "Weekly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Weekly Long"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Weekly Long"
@@ -34676,7 +34379,7 @@ msgid "Welcome URL"
 msgstr ""
 
 #. Name of a Workspace
-#: core/workspace/welcome_workspace/welcome_workspace.json desk/desktop.py:465
+#: core/workspace/welcome_workspace/welcome_workspace.json desk/desktop.py:468
 msgid "Welcome Workspace"
 msgstr ""
 
@@ -34688,29 +34391,26 @@ msgstr ""
 msgid "Welcome to {0}"
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Allow Guests to Upload Files' (Check) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"When enabled this will allow guests to upload files to your application, "
-"You can enable this if you wish to collect files from user without having"
-" them to log in, for example in job applications web form."
+msgid "When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form."
 msgstr ""
 
-#. Description of a Check field in DocType 'System Settings'
+#. Description of the 'Force Web Capture Mode for Uploads' (Check) field in
+#. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"When uploading files, force the use of the web-based image capture. If "
-"this is unchecked, the default behavior is to use the mobile native "
-"camera when use from a mobile is detected."
+msgid "When uploading files, force the use of the web-based image capture. If this is unchecked, the default behavior is to use the mobile native camera when use from a mobile is detected."
 msgstr ""
 
 #: public/js/frappe/widgets/widget_dialog.js:440
 msgid "Which view of the associated DocType should this shortcut take you to?"
 msgstr ""
 
-#. Description of a Select field in DocType 'Workspace Shortcut'
+#. Description of the 'DocType View' (Select) field in DocType 'Workspace
+#. Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Which view of the associated DocType should this shortcut take you to?"
@@ -34752,13 +34452,14 @@ msgctxt "Report Filter"
 msgid "Wildcard Filter"
 msgstr ""
 
-#. Description of a Check field in DocType 'Report Filter'
+#. Description of the 'Wildcard Filter' (Check) field in DocType 'Report
+#. Filter'
 #: core/doctype/report_filter/report_filter.json
 msgctxt "Report Filter"
 msgid "Will add \"%\" before and after the query"
 msgstr ""
 
-#. Description of a Data field in DocType 'Blogger'
+#. Description of the 'Short Name' (Data) field in DocType 'Blogger'
 #: website/doctype/blogger/blogger.json
 msgctxt "Blogger"
 msgid "Will be used in url (usually first name)."
@@ -34772,12 +34473,11 @@ msgstr ""
 msgid "Will only be shown if section headings are enabled"
 msgstr ""
 
-#. Description of a Int field in DocType 'System Settings'
+#. Description of the 'Run Jobs only Daily if Inactive For (Days)' (Int) field
+#. in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
-msgid ""
-"Will run scheduled jobs only once a day for inactive sites. Default 4 "
-"days if set to 0."
+msgid "Will run scheduled jobs only once a day for inactive sites. Default 4 days if set to 0."
 msgstr ""
 
 #: public/js/frappe/form/print_utils.js:13
@@ -34805,13 +34505,13 @@ msgstr ""
 msgid "Workflow"
 msgstr ""
 
-#. Option for a Select field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
 msgctxt "Comment"
 msgid "Workflow"
 msgstr ""
 
-#. Option for a Select field in DocType 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
 msgid "Workflow"
@@ -34852,7 +34552,8 @@ msgstr ""
 msgid "Workflow Action Permitted Role"
 msgstr ""
 
-#. Description of a Check field in DocType 'Workflow Document State'
+#. Description of the 'Is Optional State' (Check) field in DocType 'Workflow
+#. Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
 msgctxt "Workflow Document State"
 msgid "Workflow Action is not created for optional states"
@@ -34875,10 +34576,7 @@ msgid "Workflow Builder ID"
 msgstr ""
 
 #: workflow/doctype/workflow/workflow.js:11
-msgid ""
-"Workflow Builder allows you to create workflows visually. You can drag "
-"and drop states and link them to create transitions. Also you can update "
-"thieir properties from the sidebar."
+msgid "Workflow Builder allows you to create workflows visually. You can drag and drop states and link them to create transitions. Also you can update thieir properties from the sidebar."
 msgstr ""
 
 #. Label of a JSON field in DocType 'Workflow'
@@ -34934,10 +34632,7 @@ msgstr ""
 
 #. Description of the Onboarding Step 'Setup Approval Workflows'
 #: custom/onboarding_step/workflows/workflows.json
-msgid ""
-"Workflows allow you to define custom rules for the approval process of a "
-"particular document in ERPNext. You can also set complex Workflow Rules "
-"and set approval conditions."
+msgid "Workflows allow you to define custom rules for the approval process of a particular document in ERPNext. You can also set complex Workflow Rules and set approval conditions."
 msgstr ""
 
 #. Name of a DocType
@@ -35011,7 +34706,7 @@ msgstr ""
 msgid "Workspace {0} Edited Successfully"
 msgstr ""
 
-#. Option for a Select field in DocType 'Form Tour'
+#. Option for the 'View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
 msgctxt "Form Tour"
 msgid "Workspaces"
@@ -35055,7 +34750,7 @@ msgctxt "Dashboard Chart"
 msgid "X Field"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "XLSX"
@@ -35081,13 +34776,13 @@ msgctxt "Dashboard Chart Field"
 msgid "Y Field"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Yahoo Mail"
 msgstr ""
 
-#. Option for a Select field in DocType 'Email Account'
+#. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Yandex.Mail"
@@ -35109,55 +34804,55 @@ msgstr ""
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Email Report'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
 msgctxt "Auto Repeat"
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Dashboard Chart'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
 msgctxt "Dashboard Chart"
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Event'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Number Card'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Scheduled Job Type'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
 msgctxt "Scheduled Job Type"
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'Server Script'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Yearly"
 msgstr ""
 
-#. Option for a Select field in DocType 'DocType State'
+#. Option for the 'Color' (Select) field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
 msgctxt "DocType State"
 msgid "Yellow"
 msgstr ""
 
-#. Option for a Select field in DocType 'Kanban Board Column'
+#. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Yellow"
@@ -35183,25 +34878,26 @@ msgctxt "Checkbox is checked"
 msgid "Yes"
 msgstr ""
 
-#. Option for a Select field in DocType 'LDAP Settings'
+#. Option for the 'Require Trusted Certificate' (Select) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "Yes"
 msgstr ""
 
-#. Option for a Select field in DocType 'Page'
+#. Option for the 'Standard' (Select) field in DocType 'Page'
 #: core/doctype/page/page.json
 msgctxt "Page"
 msgid "Yes"
 msgstr ""
 
-#. Option for a Select field in DocType 'Print Format'
+#. Option for the 'Standard' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Yes"
 msgstr ""
 
-#. Option for a Select field in DocType 'Report'
+#. Option for the 'Is Standard' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "Yes"
@@ -35220,16 +34916,12 @@ msgstr ""
 msgid "You are connected to internet."
 msgstr ""
 
-#: permissions.py:414
-msgid ""
-"You are not allowed to access this {0} record because it is linked to {1}"
-" '{2}' in field {3}"
+#: permissions.py:417
+msgid "You are not allowed to access this {0} record because it is linked to {1} '{2}' in field {3}"
 msgstr ""
 
-#: permissions.py:403
-msgid ""
-"You are not allowed to access this {0} record because it is linked to {1}"
-" '{2}' in row {3}, field {4}"
+#: permissions.py:406
+msgid "You are not allowed to access this {0} record because it is linked to {1} '{2}' in row {3}, field {4}"
 msgstr ""
 
 #: public/js/frappe/views/kanban/kanban_board.bundle.js:69
@@ -35248,7 +34940,7 @@ msgstr ""
 msgid "You are not allowed to edit the report."
 msgstr ""
 
-#: permissions.py:612
+#: permissions.py:614
 msgid "You are not allowed to export {} doctype"
 msgstr ""
 
@@ -35256,7 +34948,7 @@ msgstr ""
 msgid "You are not allowed to print this report"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:669
+#: public/js/frappe/views/communication.js:673
 msgid "You are not allowed to send emails related to this document"
 msgstr ""
 
@@ -35276,14 +34968,12 @@ msgstr ""
 msgid "You are not permitted to access this page."
 msgstr ""
 
-#: __init__.py:817
+#: __init__.py:834
 msgid "You are not permitted to access this resource."
 msgstr ""
 
 #: public/js/frappe/form/sidebar/document_follow.js:131
-msgid ""
-"You are now following this document. You will receive daily updates via "
-"email. You can change this in User Settings."
+msgid "You are now following this document. You will receive daily updates via email. You can change this in User Settings."
 msgstr ""
 
 #: core/doctype/installed_applications/installed_applications.py:59
@@ -35291,10 +34981,7 @@ msgid "You are only allowed to update order, do not remove or add apps."
 msgstr ""
 
 #: email/doctype/email_account/email_account.js:221
-msgid ""
-"You are selecting Sync Option as ALL, It will resync all read as well as "
-"unread message from server. This may also cause the duplication of "
-"Communication (emails)."
+msgid "You are selecting Sync Option as ALL, It will resync all read as well as unread message from server. This may also cause the duplication of Communication (emails)."
 msgstr ""
 
 #: public/js/frappe/form/footer/form_timeline.js:413
@@ -35303,9 +34990,7 @@ msgid "You attached {0}"
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:741
-msgid ""
-"You can add dynamic properties from the document by using Jinja "
-"templating."
+msgid "You can add dynamic properties from the document by using Jinja templating."
 msgstr ""
 
 #: templates/emails/new_user.html:22
@@ -35349,9 +35034,7 @@ msgid "You can only upload JPG, PNG, PDF, TXT or Microsoft documents."
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:201
-msgid ""
-"You can only upload upto 5000 records in one go. (may be less in some "
-"cases)"
+msgid "You can only upload upto 5000 records in one go. (may be less in some cases)"
 msgstr ""
 
 #: desk/query_report.py:336
@@ -35423,9 +35106,7 @@ msgid "You do not have Read or Select Permissions for {}"
 msgstr ""
 
 #: public/js/frappe/request.js:174
-msgid ""
-"You do not have enough permissions to access this resource. Please "
-"contact your manager to get access."
+msgid "You do not have enough permissions to access this resource. Please contact your manager to get access."
 msgstr ""
 
 #: app.py:355
@@ -35456,7 +35137,7 @@ msgstr ""
 msgid "You don't have permission to access the {0} DocType."
 msgstr ""
 
-#: utils/response.py:274
+#: utils/response.py:278
 msgid "You don't have permission to access this file"
 msgstr ""
 
@@ -35513,9 +35194,7 @@ msgid "You haven't created a {0} yet"
 msgstr ""
 
 #: rate_limiter.py:150
-msgid ""
-"You hit the rate limit because of too many requests. Please try after "
-"sometime."
+msgid "You hit the rate limit because of too many requests. Please try after sometime."
 msgstr ""
 
 #: public/js/frappe/form/footer/form_timeline.js:149
@@ -35543,10 +35222,8 @@ msgstr ""
 msgid "You need to be in developer mode to edit a Standard Web Form"
 msgstr ""
 
-#: utils/response.py:255
-msgid ""
-"You need to be logged in and have System Manager Role to be able to "
-"access backups."
+#: utils/response.py:259
+msgid "You need to be logged in and have System Manager Role to be able to access backups."
 msgstr ""
 
 #: www/me.py:13 www/third_party_apps.py:10
@@ -35573,7 +35250,7 @@ msgstr ""
 msgid "You need to set one IMAP folder for {0}"
 msgstr ""
 
-#: model/rename_doc.py:384
+#: model/rename_doc.py:385
 msgid "You need write permission to rename"
 msgstr ""
 
@@ -35637,7 +35314,7 @@ msgstr ""
 msgid "Your account has been locked and will resume after {0} seconds"
 msgstr ""
 
-#: desk/form/assign_to.py:266
+#: desk/form/assign_to.py:268
 msgid "Your assignment on {0} {1} has been removed by {2}"
 msgstr ""
 
@@ -35665,16 +35342,15 @@ msgstr ""
 msgid "Your old password is incorrect."
 msgstr ""
 
-#. Description of a Small Text field in DocType 'System Settings'
+#. Description of the 'Email Footer Address' (Small Text) field in DocType
+#. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Your organization name and address for the email footer."
 msgstr ""
 
 #: templates/emails/auto_reply.html:2
-msgid ""
-"Your query has been received. We will reply back shortly. If you have any"
-" additional information, please reply to this mail."
+msgid "Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail."
 msgstr ""
 
 #: app.py:346
@@ -35694,7 +35370,8 @@ msgstr ""
 msgid "Zero"
 msgstr ""
 
-#. Description of a Int field in DocType 'Auto Email Report'
+#. Description of the 'Only Send Records Updated in Last X Hours' (Int) field
+#. in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
 msgctxt "Auto Email Report"
 msgid "Zero means send records updated at anytime"
@@ -35720,45 +35397,46 @@ msgstr ""
 msgid "added rows for {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "adjust"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "after_insert"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "align-center"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "align-justify"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "align-left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "align-right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "amend"
 msgstr ""
 
@@ -35766,25 +35444,25 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "arrow-down"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "arrow-left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "arrow-right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "arrow-up"
@@ -35794,25 +35472,25 @@ msgstr ""
 msgid "ascending"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "asterisk"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "backward"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "ban-circle"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "barcode"
@@ -35822,43 +35500,43 @@ msgstr ""
 msgid "beginning with"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "bell"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "blue"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "bold"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "book"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "bookmark"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "briefcase"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "bullhorn"
@@ -35868,85 +35546,86 @@ msgstr ""
 msgid "calendar"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "calendar"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "camera"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "cancel"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "canceled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "certificate"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "check"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "chevron-down"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "chevron-left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "chevron-right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "chevron-up"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "circle-arrow-down"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "circle-arrow-left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "circle-arrow-right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "circle-arrow-up"
@@ -35956,25 +35635,26 @@ msgstr ""
 msgid "clear"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "cog"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "comment"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "create"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "cyan"
@@ -35985,7 +35665,7 @@ msgctxt "Days (Field: Duration)"
 msgid "d"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "darkgrey"
@@ -35995,45 +35675,46 @@ msgstr ""
 msgid "dashboard"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "dd-mm-yyyy"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "dd.mm.yyyy"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "dd/mm/yyyy"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Queue' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "default"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Worker'
+#. Option for the 'Queue Type(s)' (Select) field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
 msgctxt "RQ Worker"
 msgid "default"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "deferred"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "delete"
 msgstr ""
 
@@ -36045,19 +35726,20 @@ msgstr ""
 msgid "document type..., e.g. customer"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "download"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "download-alt"
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Account'
+#. Description of the 'Email Account Name' (Data) field in DocType 'Email
+#. Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "e.g. \"Support\", \"Sales\", \"Jerry Yang\""
@@ -36067,31 +35749,32 @@ msgstr ""
 msgid "e.g. (55 + 434) / 4 or =Math.sin(Math.PI/2)..."
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Account'
+#. Description of the 'Incoming Server' (Data) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "e.g. pop.gmail.com / imap.gmail.com"
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Domain'
+#. Description of the 'Incoming Server' (Data) field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
 msgctxt "Email Domain"
 msgid "e.g. pop.gmail.com / imap.gmail.com"
 msgstr ""
 
-#. Description of a Check field in DocType 'Email Account'
+#. Description of the 'Default Incoming' (Check) field in DocType 'Email
+#. Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "e.g. replies@yourcomany.com. All replies will come to this inbox."
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Account'
+#. Description of the 'Outgoing Server' (Data) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "e.g. smtp.gmail.com"
 msgstr ""
 
-#. Description of a Data field in DocType 'Email Domain'
+#. Description of the 'Outgoing Server' (Data) field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
 msgctxt "Email Domain"
 msgid "e.g. smtp.gmail.com"
@@ -36101,25 +35784,27 @@ msgstr ""
 msgid "e.g.:"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "edit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "eject"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "email"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Link Settings'
+#. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
+#. Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
 msgctxt "Social Link Settings"
 msgid "email"
@@ -36129,138 +35814,141 @@ msgstr ""
 msgid "email inbox"
 msgstr ""
 
-#: permissions.py:408 permissions.py:419
+#: permissions.py:411 permissions.py:422
 #: public/js/frappe/form/controls/link.js:479
 msgid "empty"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "envelope"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "exclamation-sign"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "export"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "eye-close"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "eye-open"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Link Settings'
+#. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
+#. Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
 msgctxt "Social Link Settings"
 msgid "facebook"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "facetime-video"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "failed"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Login Key'
+#. Option for the 'Social Login Provider' (Select) field in DocType 'Social
+#. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "fairlogin"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "fast-backward"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "fast-forward"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "file"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "film"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "filter"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "finished"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "fire"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "flag"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "folder-close"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "folder-open"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "font"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "forward"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "fullscreen"
@@ -36270,37 +35958,37 @@ msgstr ""
 msgid "gained by {0} via automatic rule {1}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "gift"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "glass"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "globe"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "gray"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "green"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "grey"
@@ -36315,49 +36003,49 @@ msgctxt "Hours (Field: Duration)"
 msgid "h"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "hand-down"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "hand-left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "hand-right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "hand-up"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "hdd"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "headphones"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "heart"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "home"
@@ -36373,43 +36061,44 @@ msgctxt "Page"
 msgid "icon"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "import"
 msgstr ""
 
-#. Description of a Int field in DocType 'Blog Post'
+#. Description of the 'Read Time' (Int) field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
 msgid "in minutes"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "inbox"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "indent-left"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "indent-right"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "info-sign"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "italic"
@@ -36427,49 +36116,50 @@ msgstr ""
 msgid "label"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "leaf"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "light-blue"
 msgstr ""
 
-#. Option for a Select field in DocType 'Desktop Icon'
+#. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
 msgctxt "Desktop Icon"
 msgid "link"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Link Settings'
+#. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
+#. Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
 msgctxt "Social Link Settings"
 msgid "linkedin"
 msgstr ""
 
-#. Option for a Select field in DocType 'Desktop Icon'
+#. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
 msgctxt "Desktop Icon"
 msgid "list"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "list"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "list-alt"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "lock"
@@ -36479,13 +36169,13 @@ msgstr ""
 msgid "logged in"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Queue' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "long"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Worker'
+#. Option for the 'Queue Type(s)' (Select) field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
 msgctxt "RQ Worker"
 msgid "long"
@@ -36496,19 +36186,19 @@ msgctxt "Minutes (Field: Duration)"
 msgid "m"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "magnet"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "map-marker"
 msgstr ""
 
-#: model/rename_doc.py:213
+#: model/rename_doc.py:214
 msgid "merged {0} into {1}"
 msgstr ""
 
@@ -36517,31 +36207,31 @@ msgstr ""
 msgid "min read"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "minus"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "minus-sign"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "mm-dd-yyyy"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "mm/dd/yyyy"
 msgstr ""
 
-#. Option for a Select field in DocType 'Desktop Icon'
+#. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
 msgctxt "Desktop Icon"
 msgid "module"
@@ -36551,13 +36241,13 @@ msgstr ""
 msgid "module name..."
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "move"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "music"
@@ -36597,25 +36287,25 @@ msgstr ""
 msgid "now"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "off"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "ok"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "ok-circle"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "ok-sign"
@@ -36627,37 +36317,37 @@ msgctxt "File"
 msgid "old_parent"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "on_cancel"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "on_change"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "on_submit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "on_trash"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "on_update"
 msgstr ""
 
-#. Option for a Select field in DocType 'Webhook'
+#. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "on_update_after_submit"
@@ -36675,85 +36365,87 @@ msgstr ""
 msgid "or"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "orange"
 msgstr ""
 
-#. Option for a Select field in DocType 'Desktop Icon'
+#. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
 msgctxt "Desktop Icon"
 msgid "page"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "pause"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "pencil"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "picture"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "pink"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Authorization Code'
+#. Option for the 'Code challenge method' (Select) field in DocType 'OAuth
+#. Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 msgctxt "OAuth Authorization Code"
 msgid "plain"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "plane"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "play"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "play-circle"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "plus"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "plus-sign"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "print"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "print"
@@ -36765,73 +36457,74 @@ msgctxt "System Console"
 msgid "processlist"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "purple"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "qrcode"
 msgstr ""
 
-#. Option for a Select field in DocType 'Desktop Icon'
+#. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
 msgctxt "Desktop Icon"
 msgid "query-report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "question-sign"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "queued"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "random"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "read"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "red"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "refresh"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "remove"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "remove-circle"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "remove-sign"
@@ -36841,41 +36534,42 @@ msgstr ""
 msgid "removed rows for {0}"
 msgstr ""
 
-#: model/rename_doc.py:216
+#: model/rename_doc.py:217
 msgid "renamed from {0} to {1}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "repeat"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "report"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "resize-full"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "resize-horizontal"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "resize-small"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "resize-vertical"
@@ -36891,13 +36585,13 @@ msgstr ""
 msgid "restored {0} as {1}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "retweet"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "road"
@@ -36908,73 +36602,76 @@ msgctxt "Seconds (Field: Duration)"
 msgid "s"
 msgstr ""
 
-#. Option for a Select field in DocType 'OAuth Authorization Code'
+#. Option for the 'Code challenge method' (Select) field in DocType 'OAuth
+#. Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 msgctxt "OAuth Authorization Code"
 msgid "s256"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "scheduled"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "screenshot"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "search"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "select"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "share"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "share"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "share-alt"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "shopping-cart"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Queue' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "short"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Worker'
+#. Option for the 'Queue Type(s)' (Select) field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
 msgctxt "RQ Worker"
 msgid "short"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "signal"
@@ -36996,19 +36693,19 @@ msgstr ""
 msgid "since yesterday"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "star"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "star-empty"
 msgstr ""
 
-#. Option for a Select field in DocType 'RQ Job'
+#. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
 msgid "started"
@@ -37018,49 +36715,53 @@ msgstr ""
 msgid "starting the setup..."
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "step-backward"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "step-forward"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "stop"
 msgstr ""
 
-#. Description of a Data field in DocType 'LDAP Settings'
+#. Description of the 'Group Object Class' (Data) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "string value, i.e. group"
 msgstr ""
 
-#. Description of a Data field in DocType 'LDAP Settings'
+#. Description of the 'LDAP Group Member attribute' (Data) field in DocType
+#. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "string value, i.e. member"
 msgstr ""
 
-#. Description of a Data field in DocType 'LDAP Settings'
+#. Description of the 'Custom Group Search' (Data) field in DocType 'LDAP
+#. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
 msgctxt "LDAP Settings"
 msgid "string value, i.e. {0} or uid={0},ou=users,dc=example,dc=com"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "submit"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "tag"
@@ -37070,13 +36771,13 @@ msgstr ""
 msgid "tag name..., e.g. #tag"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "tags"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "tasks"
@@ -37086,31 +36787,31 @@ msgstr ""
 msgid "text in document type"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "text-height"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "text-width"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "th"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "th-large"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "th-list"
@@ -37120,47 +36821,48 @@ msgstr ""
 msgid "this form"
 msgstr ""
 
-#: tests/test_translate.py:166
+#: tests/test_translate.py:158
 msgid "this shouldn't break"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "thumbs-down"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "thumbs-up"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "time"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "tint"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "trash"
 msgstr ""
 
-#. Option for a Select field in DocType 'Social Link Settings'
+#. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
+#. Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
 msgctxt "Social Link Settings"
 msgid "twitter"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "upload"
@@ -37170,7 +36872,7 @@ msgstr ""
 msgid "use % as wildcard"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "user"
@@ -37195,7 +36897,7 @@ msgstr ""
 msgid "via Data Import"
 msgstr ""
 
-#. Description of a Check field in DocType 'Event'
+#. Description of the 'Add Video Conferencing' (Check) field in DocType 'Event'
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "via Google Meet"
@@ -37213,19 +36915,19 @@ msgstr ""
 msgid "via {0}"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "volume-down"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "volume-off"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "volume-up"
@@ -37235,31 +36937,33 @@ msgstr ""
 msgid "wants to access the following details from your account"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "warning-sign"
 msgstr ""
 
-#. Description of a Check field in DocType 'Form Tour Step'
+#. Description of the 'Popover Element' (Check) field in DocType 'Form Tour
+#. Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "when clicked on element it will focus popover if present."
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "wrench"
 msgstr ""
 
-#. Option for a Select field in DocType 'Permission Debugger'
-#: core/doctype/permission_debugger/permission_debugger.json
-msgctxt "Permission Debugger"
+#. Option for the 'Permission Type' (Select) field in DocType 'Permission
+#. Inspector'
+#: core/doctype/permission_inspector/permission_inspector.json
+msgctxt "Permission Inspector"
 msgid "write"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workspace'
+#. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
 msgctxt "Workspace"
 msgid "yellow"
@@ -37269,19 +36973,19 @@ msgstr ""
 msgid "yesterday"
 msgstr ""
 
-#. Option for a Select field in DocType 'System Settings'
+#. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "yyyy-mm-dd"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "zoom-in"
 msgstr ""
 
-#. Option for a Select field in DocType 'Workflow State'
+#. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "zoom-out"
@@ -37459,7 +37163,7 @@ msgstr ""
 msgid "{0} are required"
 msgstr ""
 
-#: desk/form/assign_to.py:273
+#: desk/form/assign_to.py:275
 msgid "{0} assigned a new task {1} {2} to you"
 msgstr ""
 
@@ -37559,15 +37263,11 @@ msgid "{0} does not exist in row {1}"
 msgstr ""
 
 #: database/mariadb/schema.py:131 database/postgres/schema.py:184
-msgid ""
-"{0} field cannot be set as unique in {1}, as there are non-unique "
-"existing values"
+msgid "{0} field cannot be set as unique in {1}, as there are non-unique existing values"
 msgstr ""
 
 #: core/doctype/data_import/importer.py:1017
-msgid ""
-"{0} format could not be determined from the values in this column. "
-"Defaulting to {1}."
+msgid "{0} format could not be determined from the values in this column. Defaulting to {1}."
 msgstr ""
 
 #: public/js/frappe/form/footer/version_timeline_content_builder.js:97
@@ -37610,7 +37310,7 @@ msgstr ""
 msgid "{0} has left the conversation in {1} {2}"
 msgstr ""
 
-#: __init__.py:2356
+#: __init__.py:2373
 msgid "{0} has no versions tracked."
 msgstr ""
 
@@ -37709,23 +37409,19 @@ msgid "{0} is not a valid Phone Number"
 msgstr ""
 
 #: model/workflow.py:186
-msgid ""
-"{0} is not a valid Workflow State. Please update your Workflow and try "
-"again."
+msgid "{0} is not a valid Workflow State. Please update your Workflow and try again."
 msgstr ""
 
-#: permissions.py:793
+#: permissions.py:795
 msgid "{0} is not a valid parent DocType for {1}"
 msgstr ""
 
-#: permissions.py:813
+#: permissions.py:815
 msgid "{0} is not a valid parentfield for {1}"
 msgstr ""
 
 #: email/doctype/auto_email_report/auto_email_report.py:109
-msgid ""
-"{0} is not a valid report format. Report format should one of the "
-"following {1}"
+msgid "{0} is not a valid report format. Report format should one of the following {1}"
 msgstr ""
 
 #: core/doctype/file/file.py:483
@@ -37828,7 +37524,7 @@ msgstr ""
 msgid "{0} not a valid State"
 msgstr ""
 
-#: model/rename_doc.py:387
+#: model/rename_doc.py:388
 msgid "{0} not allowed to be renamed"
 msgstr ""
 
@@ -37988,7 +37684,7 @@ msgstr ""
 msgid "{0} {1} added to Dashboard {2}"
 msgstr ""
 
-#: model/base_document.py:562 model/rename_doc.py:111
+#: model/base_document.py:562 model/rename_doc.py:112
 msgid "{0} {1} already exists"
 msgstr ""
 
@@ -38000,7 +37696,7 @@ msgstr ""
 msgid "{0} {1} cannot be a leaf node as it has children"
 msgstr ""
 
-#: model/rename_doc.py:376
+#: model/rename_doc.py:377
 msgid "{0} {1} does not exist, select a new target to merge"
 msgstr ""
 
@@ -38008,14 +37704,12 @@ msgstr ""
 msgid "{0} {1} is linked with the following submitted documents: {2}"
 msgstr ""
 
-#: model/document.py:170 permissions.py:564
+#: model/document.py:170 permissions.py:566
 msgid "{0} {1} not found"
 msgstr ""
 
 #: model/delete_doc.py:231
-msgid ""
-"{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it "
-"first."
+msgid "{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it first."
 msgstr ""
 
 #: model/base_document.py:988
@@ -38055,10 +37749,7 @@ msgid "{0}: Cannot set import as {1} is not importable"
 msgstr ""
 
 #: automation/doctype/auto_repeat/auto_repeat.py:393
-msgid ""
-"{0}: Failed to attach new recurring document. To enable attaching "
-"document in the auto repeat notification email, enable {1} in Print "
-"Settings"
+msgid "{0}: Failed to attach new recurring document. To enable attaching document in the auto repeat notification email, enable {1} in Print Settings"
 msgstr ""
 
 #: core/doctype/doctype/doctype.py:1377
@@ -38180,7 +37871,7 @@ msgstr ""
 msgid "{} is not a valid date string."
 msgstr ""
 
-#: commands/utils.py:515
+#: commands/utils.py:519
 msgid "{} not found in PATH! This is required to access the console."
 msgstr ""
 


### PR DESCRIPTION
```diff
- Description of a Data field in DocType 'About Us Settings'
+ Description of the 'Org History Heading' (Data) field in DocType 'About Us Settings'
```

Towards #24250 