### PR TITLE
fix: strip html instead of escaping when creating/updating workspace

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -11,6 +11,7 @@ from frappe.desk.utils import validate_route_conflict
 from frappe.model.document import Document
 from frappe.model.rename_doc import rename_doc
 from frappe.modules.export_file import delete_folder, export_to_files
+from frappe.utils import strip_html
 
 
 class Workspace(Document):
@@ -65,6 +66,8 @@ class Workspace(Document):
 		title: DF.Data
 	# end: auto-generated types
 	def validate(self):
+		self.title = strip_html(self.title)
+
 		if self.public and not is_workspace_manager() and not disable_saving_as_public():
 			frappe.throw(_("You need to be Workspace Manager to edit this document"))
 		if self.has_value_changed("title"):
@@ -275,6 +278,8 @@ def save_page(title, public, new_widgets, blocks):
 	pages = frappe.get_all("Workspace", filters=filters)
 	if pages:
 		doc = frappe.get_doc("Workspace", pages[0])
+	else:
+		frappe.throw(_("Workspace not found"), frappe.DoesNotExistError)
 
 	doc.content = blocks
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -232,3 +232,4 @@ frappe.patches.v15_0.move_event_cancelled_to_status
 frappe.patches.v15_0.set_file_type
 frappe.core.doctype.data_import.patches.remove_stale_docfields_from_legacy_version
 frappe.patches.v15_0.validate_newsletter_recipients
+frappe.patches.v15_0.sanitize_workspace_titles

--- a/frappe/patches/v15_0/sanitize_workspace_titles.py
+++ b/frappe/patches/v15_0/sanitize_workspace_titles.py
@@ -1,0 +1,25 @@
+import frappe
+from frappe.desk.doctype.workspace.workspace import update_page
+from frappe.utils import strip_html
+from frappe.utils.html_utils import unescape_html
+
+
+def execute():
+	workspaces_to_update = frappe.get_all(
+		"Workspace",
+		filters={"module": ("is", "not set")},
+		fields=["name", "title", "icon", "indicator_color", "parent_page as parent", "public"],
+	)
+	for workspace in workspaces_to_update:
+		new_title = strip_html(unescape_html(workspace.title))
+
+		if new_title == workspace.title:
+			continue
+
+		workspace.title = new_title
+		try:
+			update_page(**workspace)
+			frappe.db.commit()
+
+		except Exception:
+			frappe.db.rollback()

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -646,7 +646,7 @@ frappe.views.Workspace = class Workspace {
 			],
 			primary_action_label: __("Update"),
 			primary_action: (values) => {
-				values.title = frappe.utils.escape_html(values.title);
+				values.title = strip_html(values.title);
 				let is_title_changed = values.title != old_item.title;
 				let is_section_changed = Boolean(values.is_public) != Boolean(old_item.public);
 				if (
@@ -1216,7 +1216,7 @@ frappe.views.Workspace = class Workspace {
 			],
 			primary_action_label: __("Create"),
 			primary_action: (values) => {
-				values.title = frappe.utils.escape_html(values.title);
+				values.title = strip_html(values.title);
 				if (!this.validate_page(values)) return;
 				d.hide();
 				this.initialize_editorjs_undo();


### PR DESCRIPTION
Closes #23555
Closes #23556

---

- Strip HTML instead of escaping
- Strip in backend for completeness
- Patch for existing workspaces with issue