### PR TITLE
fix(minor): increase rate limit for web form

### DIFF
--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -444,7 +444,7 @@ def get_web_form_module(doc):
 
 
 @frappe.whitelist(allow_guest=True)
-@rate_limit(limit=5, seconds=60)
+@rate_limit(key="web_form", limit=10, seconds=60)
 def accept(web_form, data):
 	"""Save the web form"""
 	data = frappe._dict(json.loads(data))


### PR DESCRIPTION
increased rate limit for web form to 10 requests per minute.

few users are hitting limit of 5 submits per minute per user so increased it to 10