### PR TITLE
fix(UX): show status indicator in moblie view

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -934,7 +934,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				</span>
 			</div>
 			<div class="level-item visible-xs text-right">
-				${this.get_indicator_dot(doc)}
+				${this.get_indicator_html(doc)}
 			</div>
 		`;
 


### PR DESCRIPTION
Status pill isn't THAT useful on mobile view.

- Firstly the colours aren't that different for few states
- You might not even know what those colours mean if you haven't used it
  before.



| Before | After |
| ---    | ---   |
| <img src="https://github.com/frappe/frappe/assets/9079960/28cb499b-6436-4d63-b91a-8c753588b86c"> | <img src="https://github.com/frappe/frappe/assets/9079960/1e3ee563-6b8b-486b-b41e-1c1e4fbffc9d"> |
