### PR TITLE
fix(mobile-ui): tabs should scroll instead of stack

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -424,6 +424,7 @@
 		align-items: center;
 
 		.nav-item {
+			white-space: nowrap;
 			@include get_textstyle("base", "regular");
 			.nav-link {
 				color: var(--text-muted);

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -419,6 +419,10 @@
 	border-radius: var(--border-radius-md) var(--border-radius-md) 0 0;
 
 	.form-tabs {
+		flex-wrap: nowrap;
+		overflow: overlay;
+		align-items: center;
+
 		.nav-item {
 			@include get_textstyle("base", "regular");
 			.nav-link {


### PR DESCRIPTION
- fix: improve mobile design
- fix: don't wrap text in tab labels

fix extracted from https://github.com/frappe/frappe/pull/24252 originally authored by @safwansamsudeen 


| Before | After |
| ---    | ---   |
| <img src="https://github.com/frappe/frappe/assets/9079960/c2e74b76-6ec7-4b0d-9463-c16fb207e4cb"> | <img src="https://github.com/frappe/frappe/assets/9079960/6ef0fb64-b2cb-43ac-a30f-d250a2a1e14c"> |

