### PR TITLE
fix(mobile-view): correct sidebar closing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ typings/
 
 # Optional npm cache directory
 .npm
+.yarn
 
 # Optional eslint cache
 .eslintcache

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -185,6 +185,11 @@ frappe.views.Workspace = class Workspace {
 			sidebar_section.addClass("hidden");
 		}
 
+		$(".item-anchor").on("click", () => {
+			$(".list-sidebar.hidden-xs.hidden-sm").removeClass("opened");
+			$(".close-sidebar").css("display", "none");
+		});
+
 		if (
 			sidebar_section.find(".sidebar-item-container").length &&
 			sidebar_section.find("> [item-is-hidden='0']").length == 0


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

I tried and failed to find a function to cleanly close the sidebar with a transition. My code does it rather abruptly. There is almost no visible difference, though.

I've also added `.yarn` to gitignore, was causing troubles for me.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Currently, the side bar doesn't close in mobile after clicking on a link, as said in #18921.
