### PR TITLE
fix: burger menu disappearing

### DIFF
--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -187,7 +187,7 @@ frappe.ui.Page = class Page {
 		let sidebar_toggle = $(".page-head").find(".sidebar-toggle-btn");
 		let sidebar_wrapper = this.wrapper.find(".layout-side-section");
 		if (this.disable_sidebar_toggle || !sidebar_wrapper.length) {
-			sidebar_toggle.remove();
+			sidebar_toggle.last().remove();
 		} else {
 			if (!frappe.is_mobile()) {
 				sidebar_toggle.attr("title", __("Toggle Sidebar"));


### PR DESCRIPTION
Closes #22904.

> Please provide enough information so that others can review your pull request:

Frappe doesn't clear the DOM upon shifting to another page, and in a page where a sidebar shouldn't exist, _all_ the sidebar icons (burger menu), including the ones at previous pages, get removed. This PR fixes that.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This is a general (not mobile) issue where the burger menu icon disappeared upon going to a page that didn't need a sidebar and returning.
