### PR TITLE
fix(minor): check if markdown_preview exists

### DIFF
--- a/frappe/public/js/frappe/form/controls/markdown_editor.js
+++ b/frappe/public/js/frappe/form/controls/markdown_editor.js
@@ -46,6 +46,7 @@ frappe.ui.form.ControlMarkdownEditor = class ControlMarkdownEditor extends (
 	}
 
 	update_preview() {
+		if (!this.markdown_preview) return;
 		const value = this.get_value() || "";
 		this.markdown_preview.html(frappe.markdown(value));
 	}


### PR DESCRIPTION
return if markdown_preview doesn't exist in update_preview.
because it's not necessary to try updating html if markdown_preview doesn't exist.