### PR TITLE
fix(minor): return if no steps are defined.

### DIFF
--- a/frappe/public/js/frappe/form/form_tour.js
+++ b/frappe/public/js/frappe/form/form_tour.js
@@ -43,6 +43,8 @@ frappe.ui.form.FormTour = class FormTour {
 			}
 		}
 
+		if (!this.tour.steps) return;
+
 		if (on_finish) this.on_finish = on_finish;
 
 		this.init_driver();


### PR DESCRIPTION
if steps are not defined, don't try to run form tour.