### PR TITLE
chore: bump dropbox

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -95,5 +95,4 @@ jobs:
         run: |
           pip install pip-audit
           cd ${GITHUB_WORKSPACE}
-          sed -i '/dropbox/d' pyproject.toml   # Remove dropbox temporarily https://github.com/dropbox/dropbox-sdk-python/pull/456
           pip-audit --desc on --ignore-vuln GHSA-4xqq-73wg-5mjp .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dependencies = [
 
     # integration dependencies
     "boto3~=1.28.10",
-    "dropbox~=11.36.0",
+    "dropbox~=11.36.2",
     "google-api-python-client~=2.2.0",
     "google-auth-oauthlib~=0.4.4",
     "google-auth~=1.29.0",


### PR DESCRIPTION
https://github.com/dropbox/dropbox-sdk-python/pull/456#issuecomment-1589248410

Fix is published, we shouldn't have to ignore dropbox in the vulnerability check anymore.