### PR TITLE
refactor!: check latest github release

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -96,4 +96,4 @@ jobs:
           pip install pip-audit
           cd ${GITHUB_WORKSPACE}
           sed -i '/dropbox/d' pyproject.toml   # Remove dropbox temporarily https://github.com/dropbox/dropbox-sdk-python/pull/456
-          pip-audit --desc on --ignore-vuln GHSA-4xqq-73wg-5mjp .
+          pip-audit --desc on .

--- a/frappe/utils/change_log.py
+++ b/frappe/utils/change_log.py
@@ -168,13 +168,19 @@ def check_for_update():
 	apps = get_versions()
 
 	for app in apps:
-		app_details = check_release_on_github(app)
-		if not app_details:
+		remote_url = get_remote_url(app)
+		if not remote_url:
 			continue
 
-		github_version, org_name = app_details
-		# Get local instance's current version or the app
+		owner, repo = parse_github_url(remote_url)
+		if not owner or not repo:
+			continue
 
+		github_version, org_name = check_release_on_github(owner, repo)
+		if not github_version or not org_name:
+			continue
+
+		# Get local instance's current version or the app
 		branch_version = (
 			apps[app]["branch_version"].split(" ", 1)[0] if apps[app].get("branch_version", "") else ""
 		)
@@ -217,42 +223,15 @@ def parse_latest_non_beta_release(response: list) -> list | None:
 	return None
 
 
-def check_release_on_github(app: str) -> tuple | None:
-	"""Check the latest release for a given Frappe application hosted on Github.
-
-	Args:
-	    app: The name of the Frappe application.
-
-	Return:
-	        tuple(Version, str): The semantic version object of the latest release and the
-	                organization name, if the application exists, otherwise None.
-	"""
-
+def check_release_on_github(owner: str, repo: str) -> tuple[Version, str] | tuple[None, None]:
+	"""Check the latest release for a repo URL on GitHub."""
 	import requests
-	from giturlparse import parse
-	from giturlparse.parser import ParserError
 
-	try:
-		# Check if repo remote is on github
-		remote_url = subprocess.check_output(f"cd ../apps/{app} && git ls-remote --get-url", shell=True)
-	except subprocess.CalledProcessError:
-		# Passing this since some apps may not have git initialized in them
-		return
+	if not owner:
+		raise ValueError("Owner cannot be empty")
 
-	if isinstance(remote_url, bytes):
-		remote_url = remote_url.decode()
-
-	try:
-		parsed_url = parse(remote_url)
-	except ParserError:
-		# Invalid URL
-		return
-
-	if parsed_url.resource != "github.com":
-		return
-
-	owner = parsed_url.owner
-	repo = parsed_url.name
+	if not repo:
+		raise ValueError("Repo cannot be empty")
 
 	# Get latest version from GitHub
 	r = requests.get(f"https://api.github.com/repos/{owner}/{repo}/releases")
@@ -260,6 +239,43 @@ def check_release_on_github(app: str) -> tuple | None:
 		latest_non_beta_release = parse_latest_non_beta_release(r.json())
 		if latest_non_beta_release:
 			return Version(latest_non_beta_release), owner
+
+	return None, None
+
+
+def parse_github_url(remote_url: str) -> tuple[str, str] | tuple[None, None]:
+	"""Parse the remote URL to get the owner and repo name."""
+	import re
+
+	if not remote_url:
+		raise ValueError("Remote URL cannot be empty")
+
+	pattern = r"github\.com[:/](.+)\/([^\.]+)"
+	match = re.search(pattern, remote_url)
+
+	return (match[1], match[2]) if match else (None, None)
+
+
+def get_remote_url(app: str) -> str | None:
+	"""Get the remote URL of the app."""
+	if not app:
+		raise ValueError("App cannot be empty")
+
+	if app not in frappe.get_installed_apps(_ensure_on_bench=True):
+		raise ValueError("This app is not installed")
+
+	app_path = frappe.get_app_path(app, "..")
+	try:
+		# Check if repo has a remote URL
+		remote_url = subprocess.check_output(f"cd {app_path} && git ls-remote --get-url", shell=True)
+	except subprocess.CalledProcessError:
+		# Some apps may not have git initialized or not hosted somewhere
+		return None
+
+	if isinstance(remote_url, bytes):
+		remote_url = remote_url.decode()
+
+	return remote_url
 
 
 def add_message_to_redis(update_json):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "croniter~=2.0.1",
     "cryptography~=41.0.3",
     "email-reply-parser~=0.5.12",
-    "git-url-parse~=1.2.2",
     "gunicorn~=21.2.0",
     "html5lib~=1.1",
     "ipython~=8.15.0",


### PR DESCRIPTION
The intention of this PR was to get rid of the `giturlparse` dependency, which is not maintained and has a known security vulnerability.

I used the opportunity to refactor the related code (making it testable) and added tests.

Changed the parameters for `check_release_on_github`, hence this is a breaking change (do not backport).