### PR TITLE
chore: use env variables in esbuilds

### DIFF
--- a/esbuild/utils.js
+++ b/esbuild/utils.js
@@ -1,11 +1,16 @@
 const path = require("path");
 const fs = require("fs");
 const chalk = require("chalk");
+let bench_path;
+if (process.env.FRAPPE_BENCH_ROOT) {
+	bench_path = process.env.FRAPPE_BENCH_ROOT;
+} else {
+	const frappe_path = path.resolve(__dirname, "..");
+	bench_path = path.resolve(frappe_path, "..", "..");
+}
 
-const frappe_path = path.resolve(__dirname, "..");
-const bench_path = path.resolve(frappe_path, "..", "..");
-const sites_path = path.resolve(bench_path, "sites");
 const apps_path = path.resolve(bench_path, "apps");
+const sites_path = path.resolve(bench_path, "sites");
 const assets_path = path.resolve(sites_path, "assets");
 const app_list = get_apps_list();
 

--- a/node_utils.js
+++ b/node_utils.js
@@ -1,7 +1,12 @@
 const fs = require("fs");
 const path = require("path");
 const redis = require("@redis/client");
-const bench_path = path.resolve(__dirname, "..", "..");
+let bench_path;
+if (process.env.FRAPPE_BENCH_ROOT) {
+	bench_path = process.env.FRAPPE_BENCH_ROOT;
+} else {
+	bench_path = path.resolve(__dirname, "..", "..");
+}
 
 const dns = require("dns");
 


### PR DESCRIPTION
# Context

Nixos-based deployments have globally unique paths (`/nix/store/<hash>-...`) for sources and build artifacts.

That means that the node environment needed to dynamically build custom website theme assets may be at something like: 
```
/nix/store/<hash>-frappe-apps-frontend-assets/share/<app>/node_modules
```

# Proposed Solutions
- [x] use the same environment variables as in python in order to be able to configure the script and point it to the right artifacts

# More Context

- Required for `blaggacao/frappix` to work with website themes
- Used in `frappix` together with: https://github.com/frappe/frappe/pull/24317