### PR TITLE
fix: undue error printing

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -319,7 +319,7 @@ def restore_backup(
 		)
 
 	except Exception as err:
-		print(err.args[1])
+		print(err)
 		sys.exit(1)
 
 


### PR DESCRIPTION
`Exception` interface has no `.args`.
