### PR TITLE
chore: cleanup low level db interface

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -291,8 +291,9 @@ def connect(
 	local.db = get_db(
 		host=local.conf.db_host,
 		port=local.conf.db_port,
-		user=local.conf.db_user or db_name,
-		password=None,
+		user=local.conf.db_user or db_name or local.conf.db_name,
+		password=local.conf.db_password,
+		cur_db_name=db_name or local.conf.db_name,
 	)
 	if set_admin_as_user:
 		set_user("Administrator")
@@ -312,7 +313,13 @@ def connect_replica() -> bool:
 		user = local.conf.replica_db_user or local.conf.replica_db_name
 		password = local.conf.replica_db_password
 
-	local.replica_db = get_db(host=local.conf.replica_host, user=user, password=password, port=port)
+	local.replica_db = get_db(
+		host=local.conf.replica_host,
+		port=port,
+		user=user,
+		password=password,
+		cur_db_name=local.conf.db_name,
+	)
 
 	# swap db connections
 	local.primary_db = local.db

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -49,17 +49,19 @@ def drop_user_and_database(db_name, db_user):
 		return frappe.database.mariadb.setup_db.drop_user_and_database(db_name, db_user)
 
 
-def get_db(host=None, user=None, password=None, port=None):
+def get_db(host=None, port=None, user=None, password=None, cur_db_name=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.database
 
-		return frappe.database.postgres.database.PostgresDatabase(host, user, password, port=port)
+		return frappe.database.postgres.database.PostgresDatabase(
+			host, port, user, password, cur_db_name
+		)
 	else:
 		import frappe.database.mariadb.database
 
-		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port=port)
+		return frappe.database.mariadb.database.MariaDBDatabase(host, port, user, password, cur_db_name)
 
 
 def get_command(

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -56,12 +56,12 @@ def get_db(host=None, port=None, user=None, password=None, cur_db_name=None):
 		import frappe.database.postgres.database
 
 		return frappe.database.postgres.database.PostgresDatabase(
-			host, port, user, password, cur_db_name
+			host, user, password, port, cur_db_name
 		)
 	else:
 		import frappe.database.mariadb.database
 
-		return frappe.database.mariadb.database.MariaDBDatabase(host, port, user, password, cur_db_name)
+		return frappe.database.mariadb.database.MariaDBDatabase(host, user, password, port, cur_db_name)
 
 
 def get_command(

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -49,7 +49,7 @@ def drop_user_and_database(db_name, db_user):
 		return frappe.database.mariadb.setup_db.drop_user_and_database(db_name, db_user)
 
 
-def get_db(host=None, port=None, user=None, password=None, cur_db_name=None):
+def get_db(host=None, user=None, password=None, port=None, cur_db_name=None):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -71,9 +71,9 @@ class Database:
 	def __init__(
 		self,
 		host=None,
-		port=None,
 		user=None,
 		password=None,
+		port=None,
 		cur_db_name=None,
 	):
 		self.setup_type_map()

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -71,29 +71,22 @@ class Database:
 	def __init__(
 		self,
 		host=None,
+		port=None,
 		user=None,
 		password=None,
-		ac_name=None,
-		use_default=0,
-		port=None,
+		cur_db_name=None,
 	):
 		self.setup_type_map()
-		self.host = host or frappe.conf.db_host
-		self.port = port or frappe.conf.db_port
-		self.user = user or frappe.conf.db_user or frappe.conf.db_name
-		self.cur_db_name = frappe.conf.db_name
+		self.host = host
+		self.port = port
+		self.user = user
+		self.password = password
+		self.cur_db_name = cur_db_name
 		self._conn = None
-
-		if ac_name:
-			self.user = ac_name or frappe.conf.db_name
-
-		if use_default:
-			self.user = frappe.conf.db_name
 
 		self.transaction_writes = 0
 		self.auto_commit_on_many_writes = 0
 
-		self.password = password or frappe.conf.db_password
 		self.value_cache = {}
 		self.logger = frappe.logger("database")
 		self.logger.setLevel("WARNING")

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -124,7 +124,7 @@ class MariaDBConnectionUtil:
 			"use_unicode": True,
 		}
 
-		if self.user not in (frappe.flags.root_login, "root"):
+		if self.cur_db_name:
 			conn_settings["database"] = self.cur_db_name
 
 		if self.port:

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -178,6 +178,7 @@ def get_root_connection():
 			port=frappe.conf.db_port,
 			user=frappe.flags.root_login,
 			password=frappe.flags.root_password,
+			cur_db_name=None,
 		)
 
 	return frappe.local.flags.root_connection

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -161,12 +161,11 @@ class PostgresDatabase(PostgresExceptionUtil, Database):
 
 	def get_connection(self):
 		conn_settings = {
+			"dbname": self.cur_db_name,
 			"user": self.user,
 			"host": self.host,
 			"password": self.password,
 		}
-		if self.user not in (frappe.flags.root_login, "root"):
-			conn_settings["dbname"] = self.cur_db_name
 		if self.port:
 			conn_settings["port"] = self.port
 

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -82,6 +82,7 @@ def get_root_connection():
 			port=frappe.conf.db_port,
 			user=frappe.flags.root_login,
 			password=frappe.flags.root_password,
+			cur_db_name=frappe.flags.root_login,
 		)
 
 	return frappe.local.flags.root_connection


### PR DESCRIPTION
- fix: set defaults at the highest level interface

Like #24318, this is an extraction of #22548.

@akhilnarang I hope this helps reduce the diff further.

---

# Context

It is hard to refactor a code base where layers are mixed and no real boundaries exist.

As such, the database handle has been not only database-facing, but also was made responsible for defaulting and config access.

For being mainly an interface towards a completely different software component (database), this level of configuration responsibility is not appropriate.

# Proposed Solution

- [x] move at least the most prominent configuration defaults transparently to the calling site
- [x] thus enable safer refactoring at the calling site
