### PR TITLE
fix: add a check for `gpg` existing

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -5,6 +5,7 @@ import contextlib
 # imports - standard imports
 import gzip
 import os
+import sys
 from calendar import timegm
 from datetime import datetime
 from glob import glob
@@ -225,6 +226,9 @@ class BackupGenerator:
 		"""
 		Encrypt all the backups created using gpg.
 		"""
+		if which("gpg") is None:
+			click.secho("Please install `gpg` and ensure its available in your PATH", fg="red")
+			sys.exit(1)
 		paths = (self.backup_path_db, self.backup_path_files, self.backup_path_private_files)
 		for path in paths:
 			if os.path.exists(path):
@@ -640,6 +644,9 @@ def get_or_generate_backup_encryption_key():
 
 @contextlib.contextmanager
 def decrypt_backup(file_path: str, passphrase: str):
+	if which("gpg") is None:
+		click.secho("Please install `gpg` and ensure its available in your PATH", fg="red")
+		sys.exit(1)
 	if not os.path.exists(file_path):
 		print("Invalid path: ", file_path)
 		return


### PR DESCRIPTION
Encrypted backup/restores just fail without a clear error message if gpg is missing

This will atleast let the user know what is wrong
