### PR TITLE
refactor: use mariadb connector

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -148,7 +148,7 @@ runs:
 
       sudo apt -qq update
       sudo apt -qq remove mysql-server mysql-client
-      sudo apt -qq install libcups2-dev redis-server mariadb-client-10.6
+      sudo apt -qq install libcups2-dev redis-server mariadb-client-10.6 libmariadb-dev
 
       if [ "$(lsb_release -rs)" = "22.04" ]; then
           wget -q -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -86,7 +86,6 @@ local = Local()
 bench = Bench()
 cache: Optional["RedisWrapper"] = None
 STANDARD_USERS = ("Guest", "Administrator")
-DISABLE_DATABASE_CONNECTION_POOLING = None
 
 _qb_patched: dict[str, bool] = {}
 _dev_server = int(sbool(os.environ.get("DEV_SERVER", False)))

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -86,6 +86,7 @@ local = Local()
 bench = Bench()
 cache: Optional["RedisWrapper"] = None
 STANDARD_USERS = ("Guest", "Administrator")
+DISABLE_DATABASE_CONNECTION_POOLING = None
 
 _qb_patched: dict[str, bool] = {}
 _dev_server = int(sbool(os.environ.get("DEV_SERVER", False)))

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -89,7 +89,6 @@ def new_site(
 	"Create a new site"
 	from frappe.installer import _new_site
 
-	frappe.DISABLE_DATABASE_CONNECTION_POOLING = True
 	frappe.init(site=site, new_site=True)
 
 	if no_mariadb_socket:

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -89,7 +89,8 @@ def new_site(
 	"Create a new site"
 	from frappe.installer import _new_site
 
-	frappe.init(site, new_site=True)
+	frappe.DISABLE_DATABASE_CONNECTION_POOLING = True
+	frappe.init(site=site, new_site=True)
 
 	if no_mariadb_socket:
 		click.secho(

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -369,7 +369,7 @@ class Database:
 		# TODO: Use mogrify until MariaDB Connector/C 1.1 is released and we can fetch something
 		# like cursor._transformed_statement from the cursor object. We can also avoid setting
 		# mogrified_query if we don't need to log it.
-		mogrified_query = self.lazy_mogrify(query, values)
+		mogrified_query = self.mogrify(query, values)
 		self._log_query(mogrified_query, debug, explain, unmogrified_query=query)
 		return mogrified_query
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -15,32 +15,8 @@ from frappe.database.database import Database, QueryValues
 from frappe.database.mariadb.schema import MariaDBTable
 from frappe.utils import UnicodeWithAttrs, get_datetime, get_table_name
 
-if TYPE_CHECKING:
-	from mariadb import ConnectionPool
-
 _FIND_ITER_PATTERN = re.compile("%s")
 _PARAM_COMP = re.compile(r"%\([\w]*\)s")
-_SITE_POOLS = defaultdict(frappe._dict)
-_MAX_POOL_SIZE = 64
-_POOL_SIZE = 1
-
-
-# _POOL_SIZE is selected "arbitrarily" to avoid overloading the server and being mindful of multitenancy
-# init size of connection pool will be _POOL_SIZE for each site. Replica setups will have separate pool.
-# This means each site with a replica setup can have 2 active pools of size _POOL_SIZE each. Each pool may
-# expand up to _MAX_POOL_SIZE as per requirement. This cannot be a function of @@global.max_connections,
-# no. of sites since there may be multiple processes holding connections; and this defines the size for each
-# of those processes/workers. Check MariaDBConnectionUtil for connection & pool management.
-
-
-def is_connection_pooling_enabled() -> bool:
-	"""Set `frappe.DISABLE_CONNECTION_POOLING` to enable/disable connection pooling for all on current
-	process. This will override config key `disable_database_connection_pooling`. Set key
-	`disable_database_connection_pooling` in site config for persistent settings across workers."""
-
-	if frappe.DISABLE_DATABASE_CONNECTION_POOLING is not None:
-		return not frappe.DISABLE_DATABASE_CONNECTION_POOLING
-	return not frappe.local.conf.disable_database_connection_pooling
 
 
 class MariaDBExceptionUtil:
@@ -142,79 +118,7 @@ class MariaDBConnectionUtil:
 		return conn
 
 	def _get_connection(self) -> "mariadb.Connection":
-		"""Return MariaDB connection object.
-
-		If frappe.conf.disable_database_connection_pooling is set, return a new connection
-		object and close existing pool if exists. Else, return a connection from the pool.
-		"""
-		global _SITE_POOLS
-
-		# don't pool root connections
-		if self.user == "root":
-			return self.create_connection()
-
-		if not is_connection_pooling_enabled():
-			self.close_connection_pools()
-			return self.create_connection()
-
-		if frappe.local.site not in _SITE_POOLS:
-			site_pool = self.create_connection_pool()
-		else:
-			site_pool = self.get_connection_pool()
-
-		try:
-			conn = site_pool.get_connection()
-		except mariadb.PoolError:
-			# PoolError is raised when the pool is exhausted
-			conn = self.create_connection()
-			try:
-				site_pool.add_connection(conn)
-			# log this via frappe.logger & continue - site needs bigger pool...over _POOL_SIZE
-			except mariadb.PoolError:
-				# PoolError is raised when size limit is reached
-				# log this via frappe.logger & continue - site needs a much bigger pool...over _MAX_POOL_SIZE
-				pass
-
-		return conn
-
-	def close_connection_pools(self):
-		if frappe.local.site in _SITE_POOLS:
-			pools = _SITE_POOLS[frappe.local.site]
-			for pool in pools.values():
-				try:
-					pool.close()
-				except Exception:
-					pass
-			_SITE_POOLS.pop(frappe.local.site, None)
-
-	def get_pool_name(self) -> str:
-		pool_type = "read-only" if self.read_only else "default"
-		return f"{frappe.local.site}-{pool_type}"
-
-	def get_connection_pool(self) -> "ConnectionPool":
-		"""Return MariaDB connection pool object.
-
-		If `read_only` is True, return a read only pool.
-		"""
-		return _SITE_POOLS[frappe.local.site]["read_only" if self.read_only else "default"]
-
-	def create_connection_pool(self):
-		pool = mariadb.ConnectionPool(
-			pool_name=self.get_pool_name(),
-			pool_size=_MAX_POOL_SIZE,
-			pool_reset_connection=False,
-		)
-		pool.set_config(**self.get_connection_settings())
-
-		if self.read_only:
-			_SITE_POOLS[frappe.local.site].read_only = pool
-		else:
-			_SITE_POOLS[frappe.local.site].default = pool
-
-		for _ in range(_POOL_SIZE):
-			pool.add_connection()
-
-		return pool
+		return self.create_connection()
 
 	def create_connection(self):
 		return mariadb.connect(**self.get_connection_settings())

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -1,14 +1,12 @@
 import re
-from collections import defaultdict
 from contextlib import contextmanager
 from decimal import Decimal
-from typing import TYPE_CHECKING
 
 import mariadb
 import pymysql
 from mariadb.constants import ERR, FIELD_TYPE
 from pymysql.constants import ER
-from pymysql.converters import conversions, escape_sequence, escape_string
+from pymysql.converters import escape_sequence, escape_string
 
 import frappe
 from frappe.database.database import Database, QueryValues
@@ -206,9 +204,7 @@ class MariaDBCursorPatchUtil:
 		return _result
 
 
-class MariaDBDatabase(
-	MariaDBCursorPatchUtil, MariaDBConnectionUtil, MariaDBExceptionUtil, Database
-):
+class MariaDBDatabase(MariaDBCursorPatchUtil, MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 	REGEX_CHARACTER = "regexp"
 	# NOTE: using a very small cache - as during backup, if the sequence was used in anyform,
 	# it drops the cache and uses the next non cached value in setval query and
@@ -220,7 +216,7 @@ class MariaDBDatabase(
 	SEQUENCE_CACHE = 50
 	CONVERSION_MAP = {
 		FIELD_TYPE.NEWDECIMAL: float,
-		FIELD_TYPE.DATETIME: get_datetime,
+		# FIELD_TYPE.DATETIME: get_datetime,
 		UnicodeWithAttrs: escape_string,
 	}
 	default_port = "3306"

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -218,7 +218,7 @@ class MariaDBDatabase(
 	# using the system after a restore.
 	# issue link: https://jira.mariadb.org/browse/MDEV-21786
 	SEQUENCE_CACHE = 50
-	CONVERSION_MAP = conversions | {
+	CONVERSION_MAP = {
 		FIELD_TYPE.NEWDECIMAL: float,
 		FIELD_TYPE.DATETIME: get_datetime,
 		UnicodeWithAttrs: escape_string,

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -24,6 +24,7 @@ _SITE_POOLS = defaultdict(frappe._dict)
 _MAX_POOL_SIZE = 64
 _POOL_SIZE = 1
 
+
 # _POOL_SIZE is selected "arbitrarily" to avoid overloading the server and being mindful of multitenancy
 # init size of connection pool will be _POOL_SIZE for each site. Replica setups will have separate pool.
 # This means each site with a replica setup can have 2 active pools of size _POOL_SIZE each. Each pool may
@@ -168,7 +169,7 @@ class MariaDBConnectionUtil:
 			conn = self.create_connection()
 			try:
 				site_pool.add_connection(conn)
-				# log this via frappe.logger & continue - site needs bigger pool...over _POOL_SIZE
+			# log this via frappe.logger & continue - site needs bigger pool...over _POOL_SIZE
 			except mariadb.PoolError:
 				# PoolError is raised when size limit is reached
 				# log this via frappe.logger & continue - site needs a much bigger pool...over _MAX_POOL_SIZE
@@ -373,12 +374,6 @@ class MariaDBDatabase(
 		)
 
 		return db_size[0].get("database_size")
-
-	def log_query(self, query, values, debug, explain):
-		# TODO: check correctness
-		self.last_query = self._cursor._executed
-		self._log_query(self.last_query, debug, explain, query)
-		return self.last_query
 
 	def _clean_up(self):
 		# PERF: Erase internal references of pymysql to trigger GC as soon as

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -1,100 +1,132 @@
 import re
+from collections import defaultdict
 from contextlib import contextmanager
+from decimal import Decimal
+from typing import TYPE_CHECKING
 
+import mariadb
 import pymysql
-from pymysql.constants import ER, FIELD_TYPE
-from pymysql.converters import conversions, escape_string
+from mariadb.constants import ERR, FIELD_TYPE
+from pymysql.constants import ER
+from pymysql.converters import conversions, escape_sequence, escape_string
 
 import frappe
-from frappe.database.database import Database
+from frappe.database.database import Database, QueryValues
 from frappe.database.mariadb.schema import MariaDBTable
-from frappe.utils import UnicodeWithAttrs, cstr, get_datetime, get_table_name
+from frappe.utils import UnicodeWithAttrs, get_datetime, get_table_name
 
+if TYPE_CHECKING:
+	from mariadb import ConnectionPool
+
+_FIND_ITER_PATTERN = re.compile("%s")
 _PARAM_COMP = re.compile(r"%\([\w]*\)s")
+_SITE_POOLS = defaultdict(frappe._dict)
+_MAX_POOL_SIZE = 64
+_POOL_SIZE = 1
+
+# _POOL_SIZE is selected "arbitrarily" to avoid overloading the server and being mindful of multitenancy
+# init size of connection pool will be _POOL_SIZE for each site. Replica setups will have separate pool.
+# This means each site with a replica setup can have 2 active pools of size _POOL_SIZE each. Each pool may
+# expand up to _MAX_POOL_SIZE as per requirement. This cannot be a function of @@global.max_connections,
+# no. of sites since there may be multiple processes holding connections; and this defines the size for each
+# of those processes/workers. Check MariaDBConnectionUtil for connection & pool management.
+
+
+def is_connection_pooling_enabled() -> bool:
+	"""Set `frappe.DISABLE_CONNECTION_POOLING` to enable/disable connection pooling for all on current
+	process. This will override config key `disable_database_connection_pooling`. Set key
+	`disable_database_connection_pooling` in site config for persistent settings across workers."""
+
+	if frappe.DISABLE_DATABASE_CONNECTION_POOLING is not None:
+		return not frappe.DISABLE_DATABASE_CONNECTION_POOLING
+	return not frappe.local.conf.disable_database_connection_pooling
 
 
 class MariaDBExceptionUtil:
-	ProgrammingError = pymysql.ProgrammingError
-	TableMissingError = pymysql.ProgrammingError
-	OperationalError = pymysql.OperationalError
-	InternalError = pymysql.InternalError
-	SQLError = pymysql.ProgrammingError
-	DataError = pymysql.DataError
+	ProgrammingError = mariadb.ProgrammingError
+	TableMissingError = mariadb.ProgrammingError
+	OperationalError = mariadb.OperationalError
+	InternalError = mariadb.InternalError
+	SQLError = mariadb.ProgrammingError
+	DataError = mariadb.DataError
 
 	# match ER_SEQUENCE_RUN_OUT - https://mariadb.com/kb/en/mariadb-error-codes/
-	SequenceGeneratorLimitExceeded = pymysql.OperationalError
+	SequenceGeneratorLimitExceeded = mariadb.OperationalError
 	SequenceGeneratorLimitExceeded.errno = 4084
 
 	@staticmethod
-	def is_deadlocked(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.LOCK_DEADLOCK
+	def is_deadlocked(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_LOCK_DEADLOCK
 
 	@staticmethod
-	def is_timedout(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.LOCK_WAIT_TIMEOUT
+	def is_timedout(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_LOCK_WAIT_TIMEOUT
 
 	@staticmethod
 	def is_read_only_mode_error(e: pymysql.Error) -> bool:
+		# TODO: replace this error
 		return e.args[0] == 1792
 
 	@staticmethod
-	def is_table_missing(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.NO_SUCH_TABLE
+	def is_table_missing(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_NO_SUCH_TABLE
 
 	@staticmethod
-	def is_missing_table(e: pymysql.Error) -> bool:
+	def is_missing_table(e: mariadb.Error) -> bool:
 		return MariaDBDatabase.is_table_missing(e)
 
 	@staticmethod
-	def is_missing_column(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.BAD_FIELD_ERROR
+	def is_missing_column(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_BAD_FIELD_ERROR
 
 	@staticmethod
-	def is_duplicate_fieldname(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.DUP_FIELDNAME
+	def is_duplicate_fieldname(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_DUP_FIELDNAME
 
 	@staticmethod
-	def is_duplicate_entry(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.DUP_ENTRY
+	def is_duplicate_entry(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_DUP_ENTRY
 
 	@staticmethod
-	def is_access_denied(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.ACCESS_DENIED_ERROR
+	def is_access_denied(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_ACCESS_DENIED_ERROR
 
 	@staticmethod
-	def cant_drop_field_or_key(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.CANT_DROP_FIELD_OR_KEY
+	def cant_drop_field_or_key(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_CANT_DROP_FIELD_OR_KEY
 
 	@staticmethod
-	def is_syntax_error(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.PARSE_ERROR
+	def is_syntax_error(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_PARSE_ERROR
 
 	@staticmethod
 	def is_statement_timeout(e: pymysql.Error) -> bool:
+		# TODO: replace
 		return e.args[0] == 1969
 
 	@staticmethod
-	def is_data_too_long(e: pymysql.Error) -> bool:
-		return e.args[0] == ER.DATA_TOO_LONG
-
-	@staticmethod
 	def is_db_table_size_limit(e: pymysql.Error) -> bool:
+		# TODO: replace
 		return e.args[0] == ER.TOO_BIG_ROWSIZE
 
 	@staticmethod
-	def is_primary_key_violation(e: pymysql.Error) -> bool:
+	def is_data_too_long(e: mariadb.Error) -> bool:
+		return getattr(e, "errno", None) == ERR.ER_DATA_TOO_LONG
+
+	@staticmethod
+	def is_primary_key_violation(e: mariadb.Error) -> bool:
 		return (
 			MariaDBDatabase.is_duplicate_entry(e)
-			and "PRIMARY" in cstr(e.args[1])
-			and isinstance(e, pymysql.IntegrityError)
+			and "PRIMARY" in e.errmsg
+			and isinstance(e, mariadb.IntegrityError)
 		)
 
 	@staticmethod
-	def is_unique_key_violation(e: pymysql.Error) -> bool:
+	def is_unique_key_violation(e: mariadb.Error) -> bool:
 		return (
 			MariaDBDatabase.is_duplicate_entry(e)
-			and "Duplicate" in cstr(e.args[1])
-			and isinstance(e, pymysql.IntegrityError)
+			and "Duplicate" in e.errmsg
+			and isinstance(e, mariadb.IntegrityError)
 		)
 
 	@staticmethod
@@ -108,12 +140,83 @@ class MariaDBConnectionUtil:
 		conn.auto_reconnect = True
 		return conn
 
-	def _get_connection(self):
-		"""Return MariaDB connection object."""
-		return self.create_connection()
+	def _get_connection(self) -> "mariadb.Connection":
+		"""Return MariaDB connection object.
+
+		If frappe.conf.disable_database_connection_pooling is set, return a new connection
+		object and close existing pool if exists. Else, return a connection from the pool.
+		"""
+		global _SITE_POOLS
+
+		# don't pool root connections
+		if self.user == "root":
+			return self.create_connection()
+
+		if not is_connection_pooling_enabled():
+			self.close_connection_pools()
+			return self.create_connection()
+
+		if frappe.local.site not in _SITE_POOLS:
+			site_pool = self.create_connection_pool()
+		else:
+			site_pool = self.get_connection_pool()
+
+		try:
+			conn = site_pool.get_connection()
+		except mariadb.PoolError:
+			# PoolError is raised when the pool is exhausted
+			conn = self.create_connection()
+			try:
+				site_pool.add_connection(conn)
+				# log this via frappe.logger & continue - site needs bigger pool...over _POOL_SIZE
+			except mariadb.PoolError:
+				# PoolError is raised when size limit is reached
+				# log this via frappe.logger & continue - site needs a much bigger pool...over _MAX_POOL_SIZE
+				pass
+
+		return conn
+
+	def close_connection_pools(self):
+		if frappe.local.site in _SITE_POOLS:
+			pools = _SITE_POOLS[frappe.local.site]
+			for pool in pools.values():
+				try:
+					pool.close()
+				except Exception:
+					pass
+			_SITE_POOLS.pop(frappe.local.site, None)
+
+	def get_pool_name(self) -> str:
+		pool_type = "read-only" if self.read_only else "default"
+		return f"{frappe.local.site}-{pool_type}"
+
+	def get_connection_pool(self) -> "ConnectionPool":
+		"""Return MariaDB connection pool object.
+
+		If `read_only` is True, return a read only pool.
+		"""
+		return _SITE_POOLS[frappe.local.site]["read_only" if self.read_only else "default"]
+
+	def create_connection_pool(self):
+		pool = mariadb.ConnectionPool(
+			pool_name=self.get_pool_name(),
+			pool_size=_MAX_POOL_SIZE,
+			pool_reset_connection=False,
+		)
+		pool.set_config(**self.get_connection_settings())
+
+		if self.read_only:
+			_SITE_POOLS[frappe.local.site].read_only = pool
+		else:
+			_SITE_POOLS[frappe.local.site].default = pool
+
+		for _ in range(_POOL_SIZE):
+			pool.add_connection()
+
+		return pool
 
 	def create_connection(self):
-		return pymysql.connect(**self.get_connection_settings())
+		return mariadb.connect(**self.get_connection_settings())
 
 	def set_execution_timeout(self, seconds: int):
 		self.sql("set session max_statement_time = %s", int(seconds))
@@ -143,16 +246,73 @@ class MariaDBConnectionUtil:
 			conn_settings["local_infile"] = frappe.conf.local_infile
 
 		if frappe.conf.db_ssl_ca and frappe.conf.db_ssl_cert and frappe.conf.db_ssl_key:
+			# TODO: check correctness
 			conn_settings["ssl"] = {
 				"ca": frappe.conf.db_ssl_ca,
 				"cert": frappe.conf.db_ssl_cert,
 				"key": frappe.conf.db_ssl_key,
+				"ssl": True,
 			}
 		return conn_settings
 
 
-class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
+class MariaDBCursorPatchUtil:
+	"""Patch mariadb.cursor.Cursor to handle things not supported by pinned version of MariaDB client."""
+
+	def _transform_query(self, query: str, values: QueryValues) -> tuple:
+		"""Transform the query to handle things not supported by pinned version of MariaDB client.
+
+		Transformations:
+		        - Escape sequences in values
+		"""
+		_values = []
+
+		if isinstance(values, tuple | list):
+			for val in values:
+				if isinstance(val, tuple | list):
+					_values.append(escape_sequence(val, charset=self._conn.character_set))
+				else:
+					_values.append(val)
+			values = _values
+		else:
+			for token in _PARAM_COMP.findall(query):
+				key = token[2:-2]
+				try:
+					val = values[key]
+				except KeyError:
+					raise self.ProgrammingError(f"Missing value for key '{key}'")
+				if isinstance(val, tuple | list):
+					values[key] = escape_sequence(val, charset=self._conn.character_set)
+
+		return query, values or []
+
+	def _transform_result(self, result: list[tuple]) -> list[tuple]:
+		# ref: https://jira.mariadb.org/projects/CONPY/issues/CONPY-213
+		_result = []
+		for row in result:
+			_row = []
+			for el in row:
+				if isinstance(el, Decimal):
+					el = float(el)
+				elif isinstance(el, UnicodeWithAttrs):
+					el = escape_string(el)
+				_row.append(el)
+			_result.append(tuple(_row))
+		return _result
+
+
+class MariaDBDatabase(
+	MariaDBCursorPatchUtil, MariaDBConnectionUtil, MariaDBExceptionUtil, Database
+):
 	REGEX_CHARACTER = "regexp"
+	# NOTE: using a very small cache - as during backup, if the sequence was used in anyform,
+	# it drops the cache and uses the next non cached value in setval query and
+	# puts that in the backup file, which will start the counter
+	# from that value when inserting any new record in the doctype.
+	# By default the cache is 1000 which will mess up the sequence when
+	# using the system after a restore.
+	# issue link: https://jira.mariadb.org/browse/MDEV-21786
+	SEQUENCE_CACHE = 50
 	CONVERSION_MAP = conversions | {
 		FIELD_TYPE.NEWDECIMAL: float,
 		FIELD_TYPE.DATETIME: get_datetime,
@@ -215,6 +375,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		return db_size[0].get("database_size")
 
 	def log_query(self, query, values, debug, explain):
+		# TODO: check correctness
 		self.last_query = self._cursor._executed
 		self._log_query(self.last_query, debug, explain, query)
 		return self.last_query
@@ -249,11 +410,11 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 	# column type
 	@staticmethod
 	def is_type_number(code):
-		return code == pymysql.NUMBER
+		return code == mariadb.NUMBER
 
 	@staticmethod
 	def is_type_datetime(code):
-		return code == pymysql.DATETIME
+		return code == mariadb.DATETIME
 
 	def rename_table(self, old_name: str, new_name: str) -> list | tuple:
 		old_name = get_table_name(old_name)

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -202,7 +202,4 @@ def get_apps():
 if __name__ == "__main__":
 	if not frappe._dev_server:
 		warnings.simplefilter("ignore")
-
-	frappe.DISABLE_DATABASE_CONNECTION_POOLING = not int(os.environ.get("DATABASE_POOLING", "0"))
-
 	main()

--- a/frappe/utils/bench_helper.py
+++ b/frappe/utils/bench_helper.py
@@ -203,4 +203,6 @@ if __name__ == "__main__":
 	if not frappe._dev_server:
 		warnings.simplefilter("ignore")
 
+	frappe.DISABLE_DATABASE_CONNECTION_POOLING = not int(os.environ.get("DATABASE_POOLING", "0"))
+
 	main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "PyMySQL==1.1.1",
     "pypdf~=3.17.0",
     "PyPika==0.48.9",
-    "mariadb~=1.1.9",
+    "mariadb~=1.1.10",
     "PyQRCode~=1.2.1",
     "PyYAML~=6.0.1",
     "RestrictedPython~=7.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "frappe"
 authors = [
-    { name = "Frappe Technologies Pvt Ltd", email = "developers@frappe.io"}
+    { name = "Frappe Technologies Pvt Ltd", email = "developers@frappe.io" }
 ]
 description = "Metadata driven, full-stack low code web framework"
 requires-python = ">=3.10,<3.14"
@@ -22,6 +22,7 @@ dependencies = [
     "PyMySQL==1.1.1",
     "pypdf~=3.17.0",
     "PyPika==0.48.9",
+    "mariadb~=1.1.9",
     "PyQRCode~=1.2.1",
     "PyYAML~=6.0.1",
     "RestrictedPython~=7.4",
@@ -79,7 +80,6 @@ dependencies = [
     "xlrd~=2.0.1",
     "zxcvbn~=4.4.28",
     "markdownify~=0.11.6",
-
     # integration dependencies
     "boto3~=1.34.143",
     "dropbox~=11.36.2",


### PR DESCRIPTION
- Revert "refactor: Use pymysql over mariadb client"
- build: add mariadb client
- chore: remove separate log_query
- revert: connection pooling
- fix: disable pymysql convertors
- ci: install libmariadb-dev
- DEBUG: mogrify non-lazily
