### PR TITLE
perf: Unbuffered cursors for large result sets

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -46,6 +46,8 @@ INDEX_PATTERN = re.compile(r"\s*\([^)]+\)\s*")
 SINGLE_WORD_PATTERN = re.compile(r'([`"]?)(tab([A-Z]\w+))\1')
 MULTI_WORD_PATTERN = re.compile(r'([`"])(tab([A-Z]\w+)( [A-Z]\w+)+)\1')
 
+SQL_ITERATOR_BATCH_SIZE = 100
+
 
 class Database:
 	"""
@@ -175,6 +177,8 @@ class Database:
 		:param pluck: Get the plucked field only.
 		:param explain: Print `EXPLAIN` in error log.
 		:param as_iterator: Returns iterator over results instead of fetching all results at once.
+		        This should be used with unbuffered cursor as default cursors used by pymysql and postgres
+		        buffer the results internally. See `Database.unbuffered_cursor`.
 		Examples:
 
 		        # return customer names as dicts
@@ -276,12 +280,10 @@ class Database:
 		if not self._cursor.description:
 			return ()
 
-		last_result = self._transform_result(self._cursor.fetchall())
 		if as_iterator:
-			return self._return_as_iterator(
-				last_result, pluck=pluck, as_dict=as_dict, as_list=as_list, update=update
-			)
+			return self._return_as_iterator(pluck=pluck, as_dict=as_dict, as_list=as_list, update=update)
 
+		last_result = self._transform_result(self._cursor.fetchall())
 		if pluck:
 			last_result = [r[0] for r in last_result]
 			self._clean_up()
@@ -300,24 +302,25 @@ class Database:
 		self._clean_up()
 		return last_result
 
-	def _return_as_iterator(self, result, *, pluck, as_dict, as_list, update):
-		if pluck:
-			for row in result:
-				yield row[0]
+	def _return_as_iterator(self, *, pluck, as_dict, as_list, update):
+		while result := self._transform_result(self._cursor.fetchmany(SQL_ITERATOR_BATCH_SIZE)):
+			if pluck:
+				for row in result:
+					yield row[0]
 
-		elif as_dict:
-			keys = [column[0] for column in self._cursor.description]
-			for row in result:
-				row = frappe._dict(zip(keys, row))
-				if update:
-					row.update(update)
-				yield row
+			elif as_dict:
+				keys = [column[0] for column in self._cursor.description]
+				for row in result:
+					row = frappe._dict(zip(keys, row))
+					if update:
+						row.update(update)
+					yield row
 
-		elif as_list:
-			for row in result:
-				yield list(row)
-		else:
-			frappe.throw(_("`as_iterator` only works with `as_list=True` or `as_dict=True`"))
+			elif as_list:
+				for row in result:
+					yield list(row)
+			else:
+				frappe.throw(_("`as_iterator` only works with `as_list=True` or `as_dict=True`"))
 
 		self._clean_up()
 
@@ -1342,6 +1345,22 @@ class Database:
 		raise NotImplementedError
 
 	def rename_column(self, doctype: str, old_column_name: str, new_column_name: str):
+		raise NotImplementedError
+
+	@contextmanager
+	def unbuffered_cursor(self):
+		"""Context manager to temporarily use unbuffered cursor.
+
+		Using this with `as_iterator=True` provides O(1) memory usage while reading large result sets.
+
+		NOTE: You MUST do entire result set processing in the context, otherwise underlying cursor
+		will be switched and you'll not get complete results.
+
+		Usage:
+		        with frappe.db.unbuffered_cursor():
+		                for row in frappe.db.sql("query with huge result", as_iterator=True):
+		                        continue # Do some processing.
+		"""
 		raise NotImplementedError
 
 

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -1,4 +1,5 @@
 import re
+from contextlib import contextmanager
 
 import pymysql
 from pymysql.constants import ER, FIELD_TYPE
@@ -525,3 +526,15 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 
 		if est_row_size:
 			return int(est_row_size[0][0])
+
+	@contextmanager
+	def unbuffered_cursor(self):
+		from pymysql.cursors import SSCursor
+
+		try:
+			original_cursor = self._cursor
+			new_cursor = self._cursor = self._conn.cursor(SSCursor)
+			yield
+		finally:
+			self._cursor = original_cursor
+			new_cursor.close()

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -11,7 +11,7 @@ import frappe
 from frappe.core.utils import find
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe.database import savepoint
-from frappe.database.database import Database, get_query_execution_timeout
+from frappe.database.database import get_query_execution_timeout
 from frappe.database.utils import FallBackDateTimeStr
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Concat_ws
@@ -1007,3 +1007,8 @@ class TestSqlIterator(FrappeTestCase):
 				list(frappe.db.sql(query, as_list=True, as_iterator=True)),
 				msg=f"{query=} results not same as iterator",
 			)
+
+	@run_only_if(db_type_is.MARIADB)
+	def test_unbuffered_cursor(self):
+		with frappe.db.unbuffered_cursor():
+			self.test_db_sql_iterator()


### PR DESCRIPTION
If you're reading 1000s of rows from MySQL, the default behaviour is to
read all of them in memory at once.

One of the use case for reading large rows is reporting where a lot of
data is read and then processed in Python. The read row is hoever not
used again but still consumes memory until entire function exits.

SSCursor (Server Side Cursor) allows fetching one row at a time.

Note: This is slower than fetching everything at once AND has risk of
connection loss. So, don't use this as a crutch. If possible rewrite
code so processing is done in SQL.


```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
  1008    104.5 MiB    104.5 MiB           1    @profile
  1009                                          def test_run_memory_profile(self):
  1010    104.5 MiB      0.0 MiB           1            frappe.db.sql("select * from `tabGL Entry` limit 1")  # warmup
  1011    195.5 MiB      91 MiB       50001            for gl in frappe.db.sql("select * from `tabGL Entry` order by modified limit 50000", as_dict=True, as_iterator=True):
  1012    195.5 MiB      0.0 MiB       50000                    continue  # consume iterator
  1013
  1014    109.0 MiB    -86.5 MiB           1            pass # notice drop due to gc trigger
```

After:

```
Line #    Mem usage    Increment  Occurrences   Line Contents
=============================================================
  1013    104.5 MiB    104.5 MiB           1    @profile
  1014                                          def test_reads(self):
  1015    105.0 MiB      0.0 MiB           2            with frappe.db.unbuffered_cursor():
  1016    104.5 MiB      0.0 MiB           1                    frappe.db.sql("select * from `tabGL Entry` limit 1")  # warmup
  1017    105.0 MiB      0.5 MiB       50002                    for gl in frappe.db.sql(
  1018    104.5 MiB      0.0 MiB           1                            "select * from `tabGL Entry` order by modified limit 50000", as_dict=True, as_iterator=True
  1019                                                          ):
  1020    105.0 MiB      0.0 MiB       50000                            continue  # just consume the iterator
  1021    105.0 MiB      0.0 MiB           1                    pass

```

Extends https://github.com/frappe/frappe/pull/19810 
Closes https://github.com/frappe/frappe/issues/18826 