### PR TITLE
feat: tooltip descriptions for Workspace Cards

### DIFF
--- a/frappe/core/workspace/build/build.json
+++ b/frappe/core/workspace/build/build.json
@@ -155,101 +155,6 @@
    "type": "Link"
   },
   {
-   "description": "Create new forms and views with doctypes. Set up multi-level workflows for approval",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Models",
-   "link_count": 2,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "DocType",
-   "link_count": 0,
-   "link_to": "DocType",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Workflow",
-   "link_count": 0,
-   "link_to": "Workflow",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "description": "Build your own reports, print formats, and dashboards. Create personalized workspaces for easier navigation",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Views",
-   "link_count": 5,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Report",
-   "link_count": 0,
-   "link_to": "Report",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Print Format",
-   "link_count": 0,
-   "link_to": "Print Format",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Workspace",
-   "link_count": 0,
-   "link_to": "Workspace",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Dashboard",
-   "link_count": 0,
-   "link_to": "Dashboard",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Dashboard Chart",
-   "link_count": 0,
-   "link_to": "Dashboard Chart",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
    "description": "Packages are lightweight apps (collection of Module Defs) that can be created, imported, or released right from the UI",
    "hidden": 0,
    "is_query_report": 0,
@@ -321,9 +226,104 @@
    "onboard": 0,
    "only_for": "",
    "type": "Link"
+  },
+  {
+   "description": "Build your own reports, print formats, and dashboards. Create personalized workspaces for easier navigation",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Views",
+   "link_count": 5,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Report",
+   "link_count": 0,
+   "link_to": "Report",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Print Format",
+   "link_count": 0,
+   "link_to": "Print Format",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Workspace",
+   "link_count": 0,
+   "link_to": "Workspace",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Dashboard",
+   "link_count": 0,
+   "link_to": "Dashboard",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Dashboard Chart",
+   "link_count": 0,
+   "link_to": "Dashboard Chart",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "description": "Create new forms and views with doctypes. Set up multi-level workflows for approval",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Models",
+   "link_count": 2,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "DocType",
+   "link_count": 0,
+   "link_to": "DocType",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Workflow",
+   "link_count": 0,
+   "link_to": "Workflow",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
   }
  ],
- "modified": "2024-01-16 15:45:02.341142",
+ "modified": "2024-01-23 17:27:44.769958",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Build",

--- a/frappe/core/workspace/build/build.json
+++ b/frappe/core/workspace/build/build.json
@@ -13,113 +13,12 @@
  "label": "Build",
  "links": [
   {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Models",
-   "link_count": 0,
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "DocType",
-   "link_count": 0,
-   "link_to": "DocType",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Workflow",
-   "link_count": 0,
-   "link_to": "Workflow",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Scripting",
-   "link_count": 0,
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Server Script",
-   "link_count": 0,
-   "link_to": "Server Script",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Client Script",
-   "link_count": 0,
-   "link_to": "Client Script",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Scheduled Job Type",
-   "link_count": 0,
-   "link_to": "Scheduled Job Type",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Packages",
-   "link_count": 2,
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Package",
-   "link_count": 0,
-   "link_to": "Package",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Package Import",
-   "link_count": 0,
-   "link_to": "Package Import",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
+   "description": "Configure reports and print formats for your doctypes and build insightful dashboards. Group your doctypes under workspaces for easier navigation.",
    "hidden": 0,
    "is_query_report": 0,
    "label": "Views",
    "link_count": 5,
+   "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
   },
@@ -177,10 +76,12 @@
    "type": "Link"
   },
   {
+   "description": "Customize properties, naming, fields and more for standard doctypes",
    "hidden": 0,
    "is_query_report": 0,
    "label": "Customization",
    "link_count": 4,
+   "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
   },
@@ -225,10 +126,117 @@
    "type": "Link"
   },
   {
+   "description": "Automate processes and add extra functionality to doctypes using scripts and background jobs.",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Scripting",
+   "link_count": 3,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Server Script",
+   "link_count": 0,
+   "link_to": "Server Script",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Client Script",
+   "link_count": 0,
+   "link_to": "Client Script",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Scheduled Job Type",
+   "link_count": 0,
+   "link_to": "Scheduled Job Type",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "description": "Group your custom doctypes under modules",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Modules",
+   "link_count": 2,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Module Def",
+   "link_count": 0,
+   "link_to": "Module Def",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Module Onboarding",
+   "link_count": 0,
+   "link_to": "Module Onboarding",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "description": "Packages are lightweight apps (collection of Module Defs) that can be created, imported, or released right from the UI.",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Packages",
+   "link_count": 2,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Package",
+   "link_count": 0,
+   "link_to": "Package",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Package Import",
+   "link_count": 0,
+   "link_to": "Package Import",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "description": "Monitor issues, communications, and access control in your system with out of the box logging",
    "hidden": 0,
    "is_query_report": 0,
    "label": "System Logs",
    "link_count": 5,
+   "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
   },
@@ -283,9 +291,10 @@
    "type": "Link"
   },
   {
+   "description": "Create new forms and describe the model and view of your data with doctypes. You can also set up multi-level workflows for approval",
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Modules",
+   "label": "Models",
    "link_count": 2,
    "link_type": "DocType",
    "onboard": 0,
@@ -294,9 +303,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Module Def",
+   "label": "DocType",
    "link_count": 0,
-   "link_to": "Module Def",
+   "link_to": "DocType",
    "link_type": "DocType",
    "onboard": 0,
    "only_for": "",
@@ -305,16 +314,16 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Module Onboarding",
+   "label": "Workflow",
    "link_count": 0,
-   "link_to": "Module Onboarding",
+   "link_to": "Workflow",
    "link_type": "DocType",
    "onboard": 0,
    "only_for": "",
    "type": "Link"
   }
  ],
- "modified": "2024-01-02 15:38:42.806824",
+ "modified": "2024-01-16 12:53:07.278671",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Build",
@@ -325,7 +334,7 @@
  "quick_lists": [],
  "restrict_to_domain": "",
  "roles": [],
- "sequence_id": 16.0,
+ "sequence_id": 27.0,
  "shortcuts": [
   {
    "color": "Grey",

--- a/frappe/core/workspace/build/build.json
+++ b/frappe/core/workspace/build/build.json
@@ -13,7 +13,181 @@
  "label": "Build",
  "links": [
   {
-   "description": "Configure reports and print formats for your doctypes and build insightful dashboards. Group your doctypes under workspaces for easier navigation.",
+   "description": "Customize properties, naming, fields and more for standard doctypes",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Customization",
+   "link_count": 4,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Customize Form",
+   "link_count": 0,
+   "link_to": "Customize Form",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Custom Field",
+   "link_count": 0,
+   "link_to": "Custom Field",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Custom Translation",
+   "link_count": 0,
+   "link_to": "Translation",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Navbar Settings",
+   "link_count": 0,
+   "link_to": "Navbar Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "description": "Group your custom doctypes under modules",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Modules",
+   "link_count": 2,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Module Def",
+   "link_count": 0,
+   "link_to": "Module Def",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Module Onboarding",
+   "link_count": 0,
+   "link_to": "Module Onboarding",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "description": "Monitor logs for errors, background jobs, communications, and user activity",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "System Logs",
+   "link_count": 5,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Background Jobs",
+   "link_count": 0,
+   "link_to": "RQ Job",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Scheduled Jobs Logs",
+   "link_count": 0,
+   "link_to": "Scheduled Job Log",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Error Logs",
+   "link_count": 0,
+   "link_to": "Error Log",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Communication Logs",
+   "link_count": 0,
+   "link_to": "Communication",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Activity Log",
+   "link_count": 0,
+   "link_to": "Activity Log",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "description": "Create new forms and views with doctypes. Set up multi-level workflows for approval",
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Models",
+   "link_count": 2,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "DocType",
+   "link_count": 0,
+   "link_to": "DocType",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Workflow",
+   "link_count": 0,
+   "link_to": "Workflow",
+   "link_type": "DocType",
+   "onboard": 0,
+   "only_for": "",
+   "type": "Link"
+  },
+  {
+   "description": "Build your own reports, print formats, and dashboards. Create personalized workspaces for easier navigation",
    "hidden": 0,
    "is_query_report": 0,
    "label": "Views",
@@ -76,11 +250,11 @@
    "type": "Link"
   },
   {
-   "description": "Customize properties, naming, fields and more for standard doctypes",
+   "description": "Packages are lightweight apps (collection of Module Defs) that can be created, imported, or released right from the UI",
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Customization",
-   "link_count": 4,
+   "label": "Packages",
+   "link_count": 2,
    "link_type": "DocType",
    "onboard": 0,
    "type": "Card Break"
@@ -88,9 +262,9 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Customize Form",
+   "label": "Package",
    "link_count": 0,
-   "link_to": "Customize Form",
+   "link_to": "Package",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
@@ -98,35 +272,15 @@
   {
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Custom Field",
+   "label": "Package Import",
    "link_count": 0,
-   "link_to": "Custom Field",
+   "link_to": "Package Import",
    "link_type": "DocType",
    "onboard": 0,
    "type": "Link"
   },
   {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Custom Translation",
-   "link_count": 0,
-   "link_to": "Translation",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Navbar Settings",
-   "link_count": 0,
-   "link_to": "Navbar Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "description": "Automate processes and add extra functionality to doctypes using scripts and background jobs.",
+   "description": "Automate processes and extend standard functionality using scripts and background jobs",
    "hidden": 0,
    "is_query_report": 0,
    "label": "Scripting",
@@ -167,163 +321,9 @@
    "onboard": 0,
    "only_for": "",
    "type": "Link"
-  },
-  {
-   "description": "Group your custom doctypes under modules",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Modules",
-   "link_count": 2,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Module Def",
-   "link_count": 0,
-   "link_to": "Module Def",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Module Onboarding",
-   "link_count": 0,
-   "link_to": "Module Onboarding",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "description": "Packages are lightweight apps (collection of Module Defs) that can be created, imported, or released right from the UI.",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Packages",
-   "link_count": 2,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Package",
-   "link_count": 0,
-   "link_to": "Package",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Package Import",
-   "link_count": 0,
-   "link_to": "Package Import",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "description": "Monitor issues, communications, and access control in your system with out of the box logging",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "System Logs",
-   "link_count": 5,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Background Jobs",
-   "link_count": 0,
-   "link_to": "RQ Job",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Scheduled Jobs Logs",
-   "link_count": 0,
-   "link_to": "Scheduled Job Log",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Error Logs",
-   "link_count": 0,
-   "link_to": "Error Log",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Communication Logs",
-   "link_count": 0,
-   "link_to": "Communication",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Activity Log",
-   "link_count": 0,
-   "link_to": "Activity Log",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "description": "Create new forms and describe the model and view of your data with doctypes. You can also set up multi-level workflows for approval",
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Models",
-   "link_count": 2,
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "DocType",
-   "link_count": 0,
-   "link_to": "DocType",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Workflow",
-   "link_count": 0,
-   "link_to": "Workflow",
-   "link_type": "DocType",
-   "onboard": 0,
-   "only_for": "",
-   "type": "Link"
   }
  ],
- "modified": "2024-01-16 12:53:07.278671",
+ "modified": "2024-01-16 15:45:02.341142",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Build",

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -186,6 +186,7 @@ class Workspace(Document):
 					"label": card.get("label"),
 					"type": "Card Break",
 					"icon": card.get("icon"),
+					"description": card.get("description"),
 					"hidden": card.get("hidden") or False,
 					"link_count": card.get("link_count"),
 					"idx": 1 if not self.links else self.links[-1].idx + 1,

--- a/frappe/desk/doctype/workspace_link/workspace_link.json
+++ b/frappe/desk/doctype/workspace_link/workspace_link.json
@@ -112,14 +112,16 @@
   {
    "depends_on": "eval:doc.type == \"Card Break\"",
    "fieldname": "description",
-   "fieldtype": "Small Text",
-   "label": "Description"
+   "fieldtype": "HTML Editor",
+   "ignore_xss_filter": 1,
+   "label": "Description",
+   "max_height": "7rem"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-01-16 11:04:45.763041",
+ "modified": "2024-01-23 17:39:16.833318",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Link",

--- a/frappe/desk/doctype/workspace_link/workspace_link.json
+++ b/frappe/desk/doctype/workspace_link/workspace_link.json
@@ -8,6 +8,7 @@
   "type",
   "label",
   "icon",
+  "description",
   "hidden",
   "link_details_section",
   "link_type",
@@ -107,12 +108,18 @@
    "fieldtype": "Int",
    "hidden": 1,
    "label": "Link Count"
+  },
+  {
+   "depends_on": "eval:doc.type == \"Card Break\"",
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-06-01 11:23:28.990593",
+ "modified": "2024-01-16 11:04:45.763041",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Link",
@@ -121,5 +128,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/desk/doctype/workspace_link/workspace_link.py
+++ b/frappe/desk/doctype/workspace_link/workspace_link.py
@@ -15,6 +15,7 @@ class WorkspaceLink(Document):
 		from frappe.types import DF
 
 		dependencies: DF.Data | None
+		description: DF.SmallText | None
 		hidden: DF.Check
 		icon: DF.Data | None
 		is_query_report: DF.Check
@@ -29,4 +30,5 @@ class WorkspaceLink(Document):
 		parenttype: DF.Data
 		type: DF.Literal["Link", "Card Break"]
 	# end: auto-generated types
+
 	pass

--- a/frappe/desk/doctype/workspace_link/workspace_link.py
+++ b/frappe/desk/doctype/workspace_link/workspace_link.py
@@ -15,7 +15,7 @@ class WorkspaceLink(Document):
 		from frappe.types import DF
 
 		dependencies: DF.Data | None
-		description: DF.SmallText | None
+		description: DF.HTMLEditor | None
 		hidden: DF.Check
 		icon: DF.Data | None
 		is_query_report: DF.Check

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -36,7 +36,7 @@ export default class LinksWidget extends Widget {
 			description.popover({
 				trigger: "hover",
 				placement: "top",
-				content: () => `<div class="card-description small">${this.description}</div>`,
+				content: () => `<div class="card-description small">${__(this.description)}</div>`,
 				html: true,
 			});
 		}

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -15,6 +15,7 @@ export default class LinksWidget extends Widget {
 			link_count: this.links.length,
 			label: this.label,
 			hidden: this.hidden,
+			description: this.description,
 		};
 	}
 
@@ -24,6 +25,22 @@ export default class LinksWidget extends Widget {
 			this.options.links = this.links;
 		}
 		this.widget.addClass("links-widget-box");
+
+		if (this.description) {
+			const description = $(`
+				<button class="btn-reset card-description-btn ml-2">
+					${frappe.utils.icon("help", "sm")}
+				</button>
+			`).appendTo(this.widget.find(".widget-title"));
+
+			description.popover({
+				trigger: "hover",
+				placement: "top",
+				content: () => `<div class="card-description small">${this.description}</div>`,
+				html: true,
+			});
+		}
+
 		const is_link_disabled = (item) => {
 			return item.dependencies && item.incomplete_dependencies;
 		};

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -222,9 +222,10 @@ class CardDialog extends WidgetDialog {
 				label: __("Label"),
 			},
 			{
-				fieldtype: "Small Text",
+				fieldtype: "HTML Editor",
 				fieldname: "description",
 				label: __("Description"),
+				max_height: "7rem",
 			},
 			{
 				fieldname: "links",

--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -219,7 +219,12 @@ class CardDialog extends WidgetDialog {
 			{
 				fieldtype: "Data",
 				fieldname: "label",
-				label: "Label",
+				label: __("Label"),
+			},
+			{
+				fieldtype: "Small Text",
+				fieldname: "description",
+				label: __("Description"),
 			},
 			{
 				fieldname: "links",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "filetype~=1.2.0",
     "GitPython~=3.1.34",
     "Jinja2~=3.1.2",
-    "Pillow~=10.0.1",
+    "Pillow~=10.2.0",
     "PyJWT~=2.8.0",
     # We depend on internal attributes,
     # do NOT add loose requirements on PyMySQL versions.


### PR DESCRIPTION
When a user lands on the workspace, they might not know what the links grouped under a card are meant for. They have to search the docs/google for understanding. Eg: I did not know what Dunning meant.

<img width="340" alt="image" src="https://github.com/frappe/frappe/assets/24353136/7b23cb06-b161-4883-b701-32e92fbd228a">

Add the ability to optionally set workspace card descriptions for context. 

Updated the Build workspace for an example copy. Will work on making the descriptions more precise:

https://github.com/frappe/frappe/assets/24353136/2503ba17-47dc-4db7-9547-3b7a033eaf58

PS: Also tried subtitles for cards but it looks very wordy and cluttered. Also once someone gets familiarized with the system, these persistent subtitles would turn into noise.

`no-docs` (temp)