### PR TITLE
fix(sentry): set scope for background jobs

### DIFF
--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -107,13 +107,13 @@ def capture_exception(message: str | None = None) -> None:
 		return
 	try:
 		hub = Hub.current
-		if frappe.request:
-			with hub.configure_scope() as scope:
-				if (
-					os.getenv("ENABLE_SENTRY_DB_MONITORING") is None
-					or os.getenv("SENTRY_TRACING_SAMPLE_RATE") is None
-				):
-					set_scope(scope)
+		with hub.configure_scope() as scope:
+			if (
+				os.getenv("ENABLE_SENTRY_DB_MONITORING") is None
+				or os.getenv("SENTRY_TRACING_SAMPLE_RATE") is None
+			):
+				set_scope(scope)
+			if frappe.request:
 				evt_processor = _make_wsgi_event_processor(frappe.request.environ, False)
 				scope.add_event_processor(evt_processor)
 				if frappe.request.is_json:


### PR DESCRIPTION
We need to always set scope, very little of this is dependent on an HTTP request
