### PR TITLE
fix: document image invisible on mobile 

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -25,8 +25,8 @@ frappe.ui.form.Sidebar = class {
 
 		this.comments = this.sidebar.find(".form-sidebar-stats .comments");
 		this.user_actions = this.sidebar.find(".user-actions");
-		this.image_section = this.sidebar.find(".sidebar-image-section");
-		this.image_wrapper = this.image_section.find(".sidebar-image-wrapper");
+		this.image_section = this.sidebar.find(".display-image-section");
+		this.image_wrapper = this.image_section.find(".display-image-wrapper");
 		this.make_assignments();
 		this.make_attachments();
 		this.make_review();
@@ -57,6 +57,18 @@ frappe.ui.form.Sidebar = class {
 				me.refresh_like();
 			});
 		});
+
+		$(window).resize(this.move_image_based_on_screen_width);
+		$(document).ready(this.move_image_based_on_screen_width);
+	}
+
+	move_image_based_on_screen_width() {
+		const $imageSection = $(".display-image-section:visible");
+		if (window.innerWidth < 995 && !$imageSection.parent().hasClass("form-section")) {
+			$imageSection.prependTo($(".row.form-section.visible-section:visible").first());
+		} else if (window.innerWidth >= 995 && !$imageSection.parent().hasClass("form-sidebar")) {
+			$imageSection.prependTo(".form-sidebar:visible").first();
+		}
 	}
 
 	setup_keyboard_shortcuts() {

--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -42,6 +42,11 @@ frappe.ui.form.Sidebar = class {
 		frappe.ui.form.setup_user_image_event(this.frm);
 
 		this.refresh();
+		$(document).ready(() => {
+			const mobileImage = $(".display-image-section:visible").clone().addClass("hidden-lg");
+			mobileImage.find("img").removeClass("hidden-sm").addClass("hidden-lg");
+			mobileImage.prependTo($(".row.form-section.visible-section:visible").first());
+		});
 	}
 
 	bind_events() {
@@ -57,18 +62,6 @@ frappe.ui.form.Sidebar = class {
 				me.refresh_like();
 			});
 		});
-
-		$(window).resize(this.move_image_based_on_screen_width);
-		$(document).ready(this.move_image_based_on_screen_width);
-	}
-
-	move_image_based_on_screen_width() {
-		const $imageSection = $(".display-image-section:visible");
-		if (window.innerWidth < 995 && !$imageSection.parent().hasClass("form-section")) {
-			$imageSection.prependTo($(".row.form-section.visible-section:visible").first());
-		} else if (window.innerWidth >= 995 && !$imageSection.parent().hasClass("form-sidebar")) {
-			$imageSection.prependTo(".form-sidebar:visible").first();
-		}
 	}
 
 	setup_keyboard_shortcuts() {

--- a/frappe/public/js/frappe/form/sidebar/user_image.js
+++ b/frappe/public/js/frappe/form/sidebar/user_image.js
@@ -3,7 +3,7 @@ frappe.ui.form.set_user_image = function (frm) {
 	var image_field = frm.meta.image_field;
 	var image = frm.doc[image_field];
 	var title_image = frm.page.$title_area.find(".title-image");
-	var image_actions = frm.sidebar.image_wrapper.find(".sidebar-image-actions");
+	var image_actions = frm.sidebar.image_wrapper.find(".display-image-actions");
 
 	image_section.toggleClass("hide", image_field ? false : true);
 	title_image.toggleClass("hide", image_field ? false : true);
@@ -16,28 +16,28 @@ frappe.ui.form.set_user_image = function (frm) {
 	if (image) {
 		image = window.cordova && image.indexOf("http") === -1 ? frappe.base_url + image : image;
 
-		image_section.find(".sidebar-image").attr("src", image).removeClass("hide");
+		image_section.find(".display-image").attr("src", image).removeClass("hide");
 
-		image_section.find(".sidebar-standard-image").addClass("hide");
+		image_section.find(".display-standard-image").addClass("hide");
 
 		title_image.css("background-image", `url("${image}")`).html("");
 
-		image_actions.find(".sidebar-image-change, .sidebar-image-remove").show();
+		image_actions.find(".display-image-change, .display-image-remove").show();
 	} else {
-		image_section.find(".sidebar-image").attr("src", null).addClass("hide");
+		image_section.find(".display-image").attr("src", null).addClass("hide");
 
 		var title = frm.get_title();
 
 		image_section
-			.find(".sidebar-standard-image")
+			.find(".display-standard-image")
 			.removeClass("hide")
 			.find(".standard-image")
 			.html(frappe.get_abbr(title));
 
 		title_image.css("background-image", "").html(frappe.get_abbr(title));
 
-		image_actions.find(".sidebar-image-change").show();
-		image_actions.find(".sidebar-image-remove").hide();
+		image_actions.find(".display-image-change").show();
+		image_actions.find(".display-image-remove").hide();
 	}
 };
 
@@ -50,12 +50,12 @@ frappe.ui.form.setup_user_image_event = function (frm) {
 	}
 
 	if (frm.meta.image_field && !frm.fields_dict[frm.meta.image_field].df.read_only) {
-		frm.sidebar.image_wrapper.on("click", ":not(.sidebar-image-actions)", (e) => {
+		frm.sidebar.image_wrapper.on("click", ":not(.display-image-actions)", (e) => {
 			let $target = $(e.currentTarget);
 			if ($target.is("a.dropdown-toggle, .dropdown")) {
 				return;
 			}
-			let dropdown = frm.sidebar.image_wrapper.find(".sidebar-image-actions .dropdown");
+			let dropdown = frm.sidebar.image_wrapper.find(".display-image-actions .dropdown");
 			dropdown.toggleClass("open");
 			e.stopPropagation();
 		});
@@ -64,11 +64,11 @@ frappe.ui.form.setup_user_image_event = function (frm) {
 	// bind click on image_wrapper
 	frm.sidebar.image_wrapper.on(
 		"click",
-		".sidebar-image-change, .sidebar-image-remove",
+		".display-image-change, .display-image-remove",
 		function (e) {
 			let $target = $(e.currentTarget);
 			var field = frm.get_field(frm.meta.image_field);
-			if ($target.is(".sidebar-image-change")) {
+			if ($target.is(".display-image-change")) {
 				if (!field.$input) {
 					field.make_input();
 				}

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -1,17 +1,17 @@
 <ul class="list-unstyled sidebar-menu user-actions hidden"></ul>
-<ul class="list-unstyled sidebar-menu sidebar-image-section hide">
-	<li class="sidebar-image-wrapper">
-		<img class="sidebar-image">
-		<div class="sidebar-standard-image">
+<ul class="list-unstyled sidebar-menu display-image-section hide">
+	<li class="display-image-wrapper">
+		<img class="display-image">
+		<div class="display-standard-image">
 			<div class="standard-image"></div>
 		</div>
 		{% if can_write %}
-		<div class="sidebar-image-actions">
+		<div class="display-image-actions">
 			<div class="dropdown">
 				<a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ __("Change") }}</a>
 				<div class="dropdown-menu" role="menu">
-					<a class="dropdown-item sidebar-image-change">{{ __("Upload") }}</a>
-					<a class="dropdown-item sidebar-image-remove">{{ __("Remove") }}</a>
+					<a class="dropdown-item display-image-change">{{ __("Upload") }}</a>
+					<a class="dropdown-item display-image-remove">{{ __("Remove") }}</a>
 				</div>
 			</div>
 		</div>

--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -1,7 +1,7 @@
 <ul class="list-unstyled sidebar-menu user-actions hidden"></ul>
 <ul class="list-unstyled sidebar-menu display-image-section hide">
 	<li class="display-image-wrapper">
-		<img class="display-image">
+		<img class="display-image hidden-sm">
 		<div class="display-standard-image">
 			<div class="standard-image"></div>
 		</div>

--- a/frappe/public/scss/desk/image_view.scss
+++ b/frappe/public/scss/desk/image_view.scss
@@ -234,3 +234,60 @@
 		max-height: 100%;
 	}
 }
+
+.display-image-section {
+	margin: 0 auto 15px;
+	width: min(100%, 170px);
+	cursor: pointer;
+	border-radius: var(--border-radius-lg);
+
+	.display-image {
+		height: auto;
+		max-height: 170px;
+		object-fit: cover;
+	}
+
+	.standard-image {
+		font-size: 52px;
+		border-radius: var(--border-radius-lg);
+	}
+
+	.display-image-wrapper {
+		position: relative;
+		text-align: center;
+	}
+
+	.display-image,
+	.display-standard-image {
+		transition: opacity 0.3s;
+		border-radius: var(--border-radius-lg);
+		border: 1px solid var(--border-color);
+	}
+
+	.display-image-wrapper:hover {
+		.display-image,
+		.display-standard-image {
+			opacity: 0.5;
+		}
+		.display-image-actions {
+			display: block;
+		}
+	}
+	.display-image-actions {
+		display: none;
+		position: absolute;
+		top: 50%;
+		right: 0;
+		left: 0;
+		transform: translateY(-50%);
+		text-align: center;
+		z-index: 1;
+	}
+	// TODO: find better fix
+	.display-standard-image {
+		.standard-image {
+			height: 0;
+			padding: 50% 0;
+		}
+	}
+}

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -123,61 +123,6 @@ body[data-route^="Module"] .main-menu {
 			}
 		}
 	}
-
-	.sidebar-image-section {
-		width: min(100%, 170px);
-		cursor: pointer;
-		border-radius: var(--border-radius-lg);
-
-		.sidebar-image {
-			height: auto;
-			max-height: 170px;
-			object-fit: cover;
-		}
-
-		.standard-image {
-			font-size: 52px;
-			border-radius: var(--border-radius-lg);
-		}
-
-		.sidebar-image-wrapper {
-			position: relative;
-		}
-
-		.sidebar-image,
-		.sidebar-standard-image {
-			transition: opacity 0.3s;
-			border-radius: var(--border-radius-lg);
-			border: 1px solid var(--border-color);
-		}
-
-		.sidebar-image-wrapper:hover {
-			.sidebar-image,
-			.sidebar-standard-image {
-				opacity: 0.5;
-			}
-			.sidebar-image-actions {
-				display: block;
-			}
-		}
-		.sidebar-image-actions {
-			display: none;
-			position: absolute;
-			top: 50%;
-			right: 0;
-			left: 0;
-			transform: translateY(-50%);
-			text-align: center;
-			z-index: 1;
-		}
-		// TODO: find better fix
-		.sidebar-standard-image {
-			.standard-image {
-				height: 0;
-				padding: 50% 0;
-			}
-		}
-	}
 }
 
 .layout-side-section {

--- a/frappe/public/scss/desk/user_profile.scss
+++ b/frappe/public/scss/desk/user_profile.scss
@@ -53,7 +53,7 @@
 }
 
 .user-profile-sidebar {
-	.sidebar-image {
+	.display-image {
 		width: 100%;
 		height: 100%;
 		border-radius: var(--border-radius-lg);


### PR DESCRIPTION

Closes #15139.

> Please provide enough information so that others can review your pull request:

I've implemented this in such a way that the image defaults to being in the sidebar, and is moved to the main part if the screen width < 995px. As it is no longer a `sidebar-image-*`, I've renamed all of those to `display-image-*`.

> Explain the **details** for making this change. What existing problem does the pull request solve?

It was previously not possible to directly view an item's image on the mobile.

> Screenshots/GIFs

On desktop:

<img width="780" alt="image" src="https://github.com/frappe/frappe/assets/62411302/e52594a7-090a-4332-972e-4d54516d38c1">

On mobile:
<img width="496" alt="image" src="https://github.com/frappe/frappe/assets/62411302/11ba1d1c-eb58-4ff4-bf46-aa475797f070">

