### PR TITLE
fix: simultenous sessions causing invalid expiry

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -462,7 +462,7 @@
    "read_only": 1
   },
   {
-   "default": "1",
+   "default": "2",
    "fieldname": "simultaneous_sessions",
    "fieldtype": "Int",
    "label": "Simultaneous Sessions"

--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -784,7 +784,7 @@ class Database:
 		Example:
 
 		        # Update the `deny_multiple_sessions` field in System Settings DocType.
-		        company = frappe.db.set_single_value("System Settings", "deny_multiple_sessions", True)
+		        frappe.db.set_single_value("System Settings", "deny_multiple_sessions", True)
 		"""
 
 		to_update = self._get_update_dict(

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -59,11 +59,12 @@ def get_sessions_to_clear(user=None, keep_current=False):
 	offset = 0
 	if user == frappe.session.user:
 		simultaneous_sessions = frappe.db.get_value("User", user, "simultaneous_sessions") or 1
-		offset = simultaneous_sessions - 1
+		offset = simultaneous_sessions
 
 	session = frappe.qb.DocType("Sessions")
 	session_id = frappe.qb.from_(session).where(session.user == user)
 	if keep_current:
+		offset = max(0, offset - 1)
 		session_id = session_id.where(session.sid != frappe.session.sid)
 
 	query = (

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -22,6 +22,7 @@ def add_user(email, password, username=None, mobile_no=None):
 		dict(doctype="User", email=email, first_name=first_name, username=username, mobile_no=mobile_no)
 	).insert()
 	user.new_password = password
+	user.simultaneous_sessions = 1
 	user.add_roles("System Manager")
 	frappe.db.commit()
 

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -212,12 +212,12 @@ class TestSessionExpirty(FrappeAPITestCase):
 			seconds_elapsed = expiry_in * step / 100
 
 			time_now = add_to_date(session_created, seconds=seconds_elapsed, as_string=True)
-			with patch("frappe.utils.now", return_value=time_now):
+			with self.freeze_time(time_now):
 				data = s.get_session_data_from_db()
 				self.assertEqual(data.user, "Administrator")
 
 		# 1% higher should immediately expire
-		time_now = add_to_date(session_created, seconds=expiry_in * 1.01, as_string=True)
-		with patch("frappe.utils.now", return_value=time_now):
+		time_of_expiry = add_to_date(session_created, seconds=expiry_in * 1.01, as_string=True)
+		with self.freeze_time(time_of_expiry):
 			self.assertIn(sid, get_expired_sessions())
 			self.assertFalse(s.get_session_data_from_db())


### PR DESCRIPTION
- fix: set 2 as simultaneous_sessions by default
- fix: Correct offset for simultaneous_sessions
