### PR TITLE
refactor: remove redundant API Key from Google Picker

### DIFF
--- a/frappe/integrations/doctype/google_settings/google_settings.json
+++ b/frappe/integrations/doctype/google_settings/google_settings.json
@@ -39,8 +39,7 @@
    "description": "The browser API key obtained from the Google Cloud Console under <a href=\"https://console.cloud.google.com/apis/credentials\">\n\"APIs &amp; Services\" &gt; \"Credentials\"\n</a>",
    "fieldname": "api_key",
    "fieldtype": "Data",
-   "label": "API Key",
-   "mandatory_depends_on": "google_drive_picker_enabled"
+   "label": "API Key"
   },
   {
    "depends_on": "enable",
@@ -76,7 +75,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-06-29 18:26:07.094851",
+ "modified": "2024-01-16 13:19:22.365362",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Google Settings",
@@ -96,5 +95,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/integrations/doctype/google_settings/google_settings.py
+++ b/frappe/integrations/doctype/google_settings/google_settings.py
@@ -21,6 +21,7 @@ class GoogleSettings(Document):
 		enable: DF.Check
 		google_drive_picker_enabled: DF.Check
 	# end: auto-generated types
+
 	pass
 
 
@@ -34,6 +35,5 @@ def get_file_picker_settings():
 	return {
 		"enabled": True,
 		"appId": google_settings.app_id,
-		"developerKey": google_settings.api_key,
 		"clientId": google_settings.client_id,
 	}

--- a/frappe/integrations/doctype/google_settings/test_google_settings.py
+++ b/frappe/integrations/doctype/google_settings/test_google_settings.py
@@ -40,4 +40,3 @@ class TestGoogleSettings(FrappeTestCase):
 		self.assertEqual(True, settings.get("enabled", False))
 		self.assertEqual("test_client_id", settings.get("clientId", ""))
 		self.assertEqual("test_app_id", settings.get("appId", ""))
-		self.assertEqual("test_api_key", settings.get("developerKey", ""))

--- a/frappe/public/js/integrations/google_drive_picker.js
+++ b/frappe/public/js/integrations/google_drive_picker.js
@@ -1,12 +1,11 @@
 /* global gapi:false, google:false */
 export default class GoogleDrivePicker {
-	constructor({ pickerCallback, enabled, appId, developerKey, clientId } = {}) {
+	constructor({ pickerCallback, enabled, appId, clientId } = {}) {
 		this.scope = "https://www.googleapis.com/auth/drive.file";
 		this.pickerApiLoaded = false;
 		this.enabled = enabled;
 		this.appId = appId;
 		this.pickerCallback = pickerCallback;
-		this.developerKey = developerKey;
 		this.clientId = clientId;
 	}
 
@@ -45,7 +44,6 @@ export default class GoogleDrivePicker {
 	createPicker(access_token) {
 		this.view = new google.picker.View(google.picker.ViewId.DOCS);
 		this.picker = new google.picker.PickerBuilder()
-			.setDeveloperKey(this.developerKey)
 			.setAppId(this.appId)
 			.setOAuthToken(access_token)
 			.addView(this.view)


### PR DESCRIPTION
> This authentication method is used to anonymously access publicly available data, such as Google Workspace files shared using the "Anyone on the Internet with this link" sharing setting. – https://developers.google.com/drive/picker/guides/overview#api-key

We're using an OAuth client anyway, so this is redundant.

Docs: https://docs.erpnext.com/docs/user/manual/en/google_settings#for-google-maps