### PR TITLE
feat(list_view): Add hide_name_filter setting to hide ID filter

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -739,15 +739,17 @@ class FilterArea {
 		this.standard_filters_wrapper = this.list_view.page.page_form.find(
 			".standard-filter-section"
 		);
-		let fields = [
-			{
+		let fields = [];
+
+		if (!this.list_view.settings.hide_name_filter) {
+			fields.push({
 				fieldtype: "Data",
 				label: "ID",
 				condition: "like",
 				fieldname: "name",
 				onchange: () => this.refresh_list_view(),
-			},
-		];
+			});
+		}
 
 		if (this.list_view.custom_filter_configs) {
 			this.list_view.custom_filter_configs.forEach((config) => {


### PR DESCRIPTION
Remove the ID filter for the page filters for list views.

Similar usage to `hide_name_column`:

```js
// my_app/my_app/doctype/my_doctype/my_doctype_list.js
frappe.listview_settings["My DocType"] = {
	hide_name_filter: true,
	hide_name_column: true,
};
```

> no-docs