### PR TITLE
fix: currency permission for accounts manager

### DIFF
--- a/frappe/geo/doctype/currency/currency.json
+++ b/frappe/geo/doctype/currency/currency.json
@@ -82,7 +82,7 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-04 09:42:52.425440",
+ "modified": "2024-01-17 15:37:31.605278",
  "modified_by": "Administrator",
  "module": "Geo",
  "name": "Currency",
@@ -101,6 +101,10 @@
    "role": "System Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Accounts Manager"
   },
   {
    "read": 1,


### PR DESCRIPTION
Accounts Manager Role does have read access over Currency DocType so reports using Currency throw an error.