### PR TITLE
fix: select label `null` breaks form rendering

### DIFF
--- a/frappe/public/js/frappe/form/controls/select.js
+++ b/frappe/public/js/frappe/form/controls/select.js
@@ -111,7 +111,7 @@ frappe.ui.form.add_options = function (input, options_list, sort) {
 
 	let options = options_list.map((raw_option) => parse_option(raw_option));
 	if (sort) {
-		options = options.sort((a, b) => a.label.localeCompare(b.label));
+		options = options.sort((a, b) => cstr(a.label).localeCompare(cstr(b.label)));
 	}
 
 	options


### PR DESCRIPTION
This only breaks on firefox for some reason :shrug: Chrome doesn't care about types? :sun_with_face:  