### PR TITLE
chore: cleanup frappe connect (I/II)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -274,13 +274,25 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 		local.conf.db_user = local.conf.db_name
 
 
-def connect(db_name: str | None = None, set_admin_as_user: bool = True) -> None:
+def connect(
+	site: str | None = None, db_name: str | None = None, set_admin_as_user: bool = True
+) -> None:
 	"""Connect to site database instance.
 
+	:param site: (Deprecated) If site is given, calls `frappe.init`.
 	:param db_name: Optional. Will use from `site_config.json`.
 	:param set_admin_as_user: Set Administrator as current user.
 	"""
 	from frappe.database import get_db
+
+	if site:
+		from frappe.utils.deprecations import deprecation_warning
+
+		deprecation_warning(
+			"Calling frappe.connect with the site argument is deprecated and will be removed in next major version. "
+			"Instead, explicitly invoke frappe.init(site) prior to calling frappe.connect(), if initializing the site is necessary."
+		)
+		init(site)
 
 	local.db = get_db(
 		host=local.conf.db_host,

--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -274,19 +274,13 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 		local.conf.db_user = local.conf.db_name
 
 
-def connect(
-	site: str | None = None, db_name: str | None = None, set_admin_as_user: bool = True
-) -> None:
+def connect(db_name: str | None = None, set_admin_as_user: bool = True) -> None:
 	"""Connect to site database instance.
 
-	:param site: If site is given, calls `frappe.init`.
 	:param db_name: Optional. Will use from `site_config.json`.
 	:param set_admin_as_user: Set Administrator as current user.
 	"""
 	from frappe.database import get_db
-
-	if site:
-		init(site)
 
 	local.db = get_db(
 		host=local.conf.db_host,

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -342,7 +342,7 @@ def partial_restore(context, sql_file_path, verbose, encryption_key=None):
 	site = get_site(context)
 	verbose = context.verbose or verbose
 	frappe.init(site=site)
-	frappe.connect(site=site)
+	frappe.connect()
 	err, out = frappe.utils.execute_in_shell(f"file {sql_file_path}", check_exit_code=True)
 	if err:
 		click.secho("Failed to detect type of backup file", fg="red")
@@ -538,7 +538,8 @@ def add_db_index(context, doctype, column):
 
 	columns = column  # correct naming
 	for site in context.sites:
-		frappe.connect(site=site)
+		frappe.init(site=site)
+		frappe.connect()
 		try:
 			frappe.db.add_index(doctype, columns)
 			if len(columns) == 1:
@@ -580,7 +581,8 @@ def describe_database_table(context, doctype, column):
 	import json
 
 	for site in context.sites:
-		frappe.connect(site=site)
+		frappe.init(site=site)
+		frappe.connect()
 		try:
 			data = _extract_table_stats(doctype, column)
 			# NOTE: Do not print anything else in this to avoid clobbering the output.
@@ -666,7 +668,8 @@ def add_system_manager(context, email, first_name, last_name, send_welcome_email
 	import frappe.utils.user
 
 	for site in context.sites:
-		frappe.connect(site=site)
+		frappe.init(site=site)
+		frappe.connect()
 		try:
 			frappe.utils.user.add_system_manager(email, first_name, last_name, send_welcome_email, password)
 			frappe.db.commit()
@@ -692,7 +695,8 @@ def add_user_for_sites(
 	import frappe.utils.user
 
 	for site in context.sites:
-		frappe.connect(site=site)
+		frappe.init(site=site)
+		frappe.connect()
 		try:
 			add_new_user(email, first_name, last_name, user_type, send_welcome_email, password, add_role)
 			frappe.db.commit()

--- a/frappe/commands/translate.py
+++ b/frappe/commands/translate.py
@@ -34,7 +34,8 @@ def new_language(context, lang_code, app):
 		raise Exception("--site is required")
 
 	# init site
-	frappe.connect(site=context["sites"][0])
+	frappe.init(site=context["sites"][0])
+	frappe.connect()
 	frappe.translate.write_translations_file(app, lang_code)
 
 	print(

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -108,7 +108,8 @@ def clear_cache(context):
 
 	for site in context.sites:
 		try:
-			frappe.connect(site)
+			frappe.init(site=site)
+			frappe.connect()
 			frappe.clear_cache()
 			clear_website_cache()
 		finally:

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -188,7 +188,8 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 	retval = None
 
 	if is_async:
-		frappe.connect(site)
+		frappe.init(site=site)
+		frappe.connect()
 		if os.environ.get("CI"):
 			frappe.flags.in_test = True
 


### PR DESCRIPTION
# Context

[This change](https://github.com/frappe/frappe/pull/23329/files#diff-0c820faa40e5ac07693b83f29d8505e63b5e46c8fa6019a5239da3b89144f531L290-R294) introduced a regression in which test failed because `local.conf.db_user` wasn't properly initialized with `local.conf.db_name`.

This can occur when `frappe.connect` is called without `site` argument, but also no circumstantial prior call to `frappe.init` had been made.

It was reasonable to assume that otherwise the argument `db_name` to the `frappe.connect` function would have properly provided the missing value.

However,the `db_name` argument is a single purpose argument only used by both `setup_db.py`.

This is an extremely confusing code path that leads to this kind of hidden regressions, even at the current level of test coverage.

# Proposed Solution

- [x] simplify

cc @akhilnarang 