### PR TITLE
feat: add defaults to db superuser prompt

### DIFF
--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -162,19 +162,17 @@ def check_compatible_versions():
 
 def get_root_connection():
 	if not frappe.local.flags.root_connection:
-		if not frappe.flags.root_login:
-			frappe.flags.root_login = frappe.conf.get("root_login") or None
+		from getpass import getpass
 
 		if not frappe.flags.root_login:
-			frappe.flags.root_login = input("Enter mysql super user [root]: ") or "root"
+			frappe.flags.root_login = (
+				frappe.conf.get("root_login") or input("Enter mysql super user [root]: ") or "root"
+			)
 
 		if not frappe.flags.root_password:
-			frappe.flags.root_password = frappe.conf.get("root_password") or None
-
-		if not frappe.flags.root_password:
-			import getpass
-
-			frappe.flags.root_password = getpass.getpass("MySQL root password: ")
+			frappe.flags.root_password = frappe.conf.get("root_password") or getpass(
+				"MySQL root password: "
+			)
 
 		frappe.local.flags.root_connection = frappe.database.get_db(
 			host=frappe.conf.db_host,

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -163,7 +163,10 @@ def check_compatible_versions():
 def get_root_connection():
 	if not frappe.local.flags.root_connection:
 		if not frappe.flags.root_login:
-			frappe.flags.root_login = "root"
+			frappe.flags.root_login = frappe.conf.get("root_login") or None
+
+		if not frappe.flags.root_login:
+			frappe.flags.root_login = input("Enter mysql super user [root]: ") or "root"
 
 		if not frappe.flags.root_password:
 			frappe.flags.root_password = frappe.conf.get("root_password") or None

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -67,7 +67,7 @@ def get_root_connection():
 			frappe.flags.root_login = frappe.conf.get("root_login") or None
 
 		if not frappe.flags.root_login:
-			frappe.flags.root_login = input("Enter postgres super user: ")
+			frappe.flags.root_login = input("Enter postgres super user [postgres]: ") or "postgres"
 
 		if not frappe.flags.root_password:
 			frappe.flags.root_password = frappe.conf.get("root_password") or None

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -63,19 +63,17 @@ def import_db_from_sql(source_sql=None, verbose=False):
 
 def get_root_connection():
 	if not frappe.local.flags.root_connection:
-		if not frappe.flags.root_login:
-			frappe.flags.root_login = frappe.conf.get("root_login") or None
+		from getpass import getpass
 
 		if not frappe.flags.root_login:
-			frappe.flags.root_login = input("Enter postgres super user [postgres]: ") or "postgres"
+			frappe.flags.root_login = (
+				frappe.conf.get("root_login") or input("Enter postgres super user [postgres]: ") or "postgres"
+			)
 
 		if not frappe.flags.root_password:
-			frappe.flags.root_password = frappe.conf.get("root_password") or None
-
-		if not frappe.flags.root_password:
-			from getpass import getpass
-
-			frappe.flags.root_password = getpass("Postgres super user password: ")
+			frappe.flags.root_password = frappe.conf.get("root_password") or getpass(
+				"Postgres super user password: "
+			)
 
 		frappe.local.flags.root_connection = frappe.database.get_db(
 			host=frappe.conf.db_host,

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -461,12 +461,17 @@ class TestCommands(BaseTestCommands):
 		self.execute(
 			f"bench new-site {site} --force --verbose "
 			f"--admin-password {frappe.conf.admin_password} "
-			f"--mariadb-root-password {frappe.conf.root_password} "
+			f"--db-root-username {frappe.conf.root_login} "
+			f"--db-root-password {frappe.conf.root_password} "
 			f"--db-type {frappe.conf.db_type} "
 		)
 		self.assertEqual(self.returncode, 0)
 
-		self.execute(f"bench drop-site {site} --force --root-password {frappe.conf.root_password}")
+		self.execute(
+			f"bench drop-site {site} --force "
+			f"--db-root-username {frappe.conf.root_login} "
+			f"--db-root-password {frappe.conf.root_password} "
+		)
 		self.assertEqual(self.returncode, 0)
 
 		bench_path = get_bench_path()
@@ -486,7 +491,8 @@ class TestCommands(BaseTestCommands):
 			self.execute(
 				f"bench new-site {TEST_SITE} --verbose "
 				f"--admin-password {frappe.conf.admin_password} "
-				f"--mariadb-root-password {frappe.conf.root_password} "
+				f"--db-root-username {frappe.conf.root_login} "
+				f"--db-root-password {frappe.conf.root_password} "
 				f"--db-type {frappe.conf.db_type} "
 			)
 
@@ -520,16 +526,17 @@ class TestCommands(BaseTestCommands):
 		kwargs = {
 			"new_site": site,
 			"admin_password": frappe.conf.admin_password,
-			"root_password": frappe.conf.root_password or "",
 			"db_type": frappe.conf.db_type,
 			"db_user": user,
 			"db_password": password,
 			"db_root_username": frappe.conf.root_login,
+			"db_root_password": frappe.conf.root_password or "",
 		}
 		self.execute(
 			"bench new-site {new_site} --force --verbose "
 			"--admin-password {admin_password} "
-			"--db-root-password {root_password} "
+			"--db-root-username {db_root_username} "
+			"--db-root-password {db_root_password} "
 			"--db-type {db_type} "
 			"--db-user {db_user} "
 			"--db-password {db_password}",
@@ -542,7 +549,9 @@ class TestCommands(BaseTestCommands):
 		self.assertEqual(config[site]["db_user"], user)
 		self.assertEqual(config[site]["db_password"], password)
 		self.execute(
-			"bench drop-site {new_site} --force --db-root-username {db_root_username} --db-root-password {root_password}",
+			"bench drop-site {new_site} --force "
+			"--db-root-username {db_root_username} "
+			"--db-root-password {db_root_password} ",
 			kwargs,
 		)
 		self.assertEqual(self.returncode, 0)
@@ -564,19 +573,20 @@ class TestCommands(BaseTestCommands):
 		kwargs = {
 			"new_site": site,
 			"admin_password": frappe.conf.admin_password,
-			"root_password": frappe.conf.root_password,
 			"db_type": frappe.conf.db_type,
 			"db_user": user,
 			"db_password": password,
 			"db_root_username": frappe.conf.root_login,
+			"db_root_password": frappe.conf.root_password,
 		}
 		self.execute(
 			"bench new-site {new_site} --force --verbose "
 			"--admin-password {admin_password} "
-			"--db-root-password {root_password} "
 			"--db-type {db_type} "
 			"--db-user {db_user} "
-			"--db-password {db_password}",
+			"--db-password {db_password} "
+			"--db-root-username {db_root_username} "
+			"--db-root-password {db_root_password} ",
 			kwargs,
 		)
 		self.assertEqual(self.returncode, 0)
@@ -586,7 +596,9 @@ class TestCommands(BaseTestCommands):
 		self.assertEqual(config[site]["db_user"], user)
 		self.assertEqual(config[site]["db_password"], password)
 		self.execute(
-			"bench drop-site {new_site} --force --db-root-username {db_root_username} --db-root-password {root_password}",
+			"bench drop-site {new_site} --force "
+			"--db-root-username {db_root_username} "
+			"--db-root-password {db_root_password} ",
 			kwargs,
 		)
 		self.assertEqual(self.returncode, 0)


### PR DESCRIPTION
# Context

- Usually postgres superuser is `postgres` on most default installations
- _Usually_ (but not always) mysql superuser is `root` on most default installations
  - For example, in some installations, the current logged in linux user is a superuser, too, that in addition also doesn't need to enter a password when connecting via unix socket

However, the root connection logic prompts only for postgres (not giving a chance to the mysql user to select a different user, such as the current user).

Forthermore, the defaults aren't taken into account, so that the user is _forced_ to enter a value, even if the defaults would be fine.

# Proposed Solution

- [x] allow mysql users to choose a different user via prompt, using `root` by default
- [x] suggest postgres users to use `postgres` by default

This also better functionally aligns the two database implementations.

cc @akhilnarang 
