### PR TITLE
perf(desk)!: Don't send translations in frappe.boot

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -63,7 +63,7 @@ def get_bootinfo():
 	]
 	add_home_page(bootinfo, doclist)
 	bootinfo.page_info = get_allowed_pages()
-	load_translations(bootinfo)
+	load_translations(bootinfo, only_hash=True)
 	add_timezone_info(bootinfo)
 	load_conf_settings(bootinfo)
 	load_print(bootinfo, doclist)
@@ -258,10 +258,15 @@ def get_user_pages_or_reports(parent, cache=False):
 	return has_role
 
 
-def load_translations(bootinfo):
-	from frappe.translate import get_messages_for_boot
+def load_translations(bootinfo, only_hash=False):
+	from frappe.translate import get_messages_for_boot, get_translations_hash
 
 	bootinfo["lang"] = frappe.lang
+
+	if only_hash:
+		bootinfo["translations_hash"] = get_translations_hash(lang=frappe.local.lang)
+		return
+
 	bootinfo["__messages"] = get_messages_for_boot()
 
 

--- a/frappe/public/js/frappe/desk.js
+++ b/frappe/public/js/frappe/desk.js
@@ -30,7 +30,9 @@ frappe.Application = class Application {
 		this.startup();
 	}
 
-	startup() {
+	async startup() {
+		await new TranslationsLoader().initSafe();
+
 		frappe.realtime.init();
 		frappe.model.init();
 
@@ -582,3 +584,48 @@ frappe.get_module = function (m, default_module) {
 
 	return module;
 };
+
+class TranslationsLoader {
+	async initSafe() {
+		try {
+			return await this.init();
+		} catch (e) {
+			console.error(e);
+		}
+	}
+
+	async init() {
+		this.setTranslations({});
+		const res = await this.download();
+		this.setTranslations(res);
+		return res;
+	}
+
+	/** @returns {Promise<Record<string, string>>} */
+	async download() {
+		const res = await fetch(this.url);
+		if (res.ok) {
+			return await res.json();
+		} else {
+			return [];
+		}
+	}
+
+	get url() {
+		const url = new URL(
+			"/api/method/frappe.translate.load_all_translations",
+			window.location.origin
+		);
+		url.searchParams.append("lang", frappe.boot.lang);
+		url.searchParams.append("hash", frappe.boot.translations_hash || window._version_number); // for cache busting
+		return url;
+	}
+
+	/** @param translations {Record<string, string>} */
+	setTranslations(translations) {
+		delete translations["translations_hash__"];
+		frappe._messages ??= {};
+		Object.assign(frappe._messages, translations);
+		frappe.boot.__messages = frappe._messages;
+	}
+}

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -133,6 +133,30 @@ def get_messages_for_boot():
 	return get_all_translations(frappe.local.lang)
 
 
+@frappe.whitelist(allow_guest=True, methods=["GET"])
+def load_all_translations(lang: str, hash: str | None = None):
+	from werkzeug.wrappers import Response
+
+	response = Response()
+	response.data = json.dumps(
+		get_all_translations(lang or frappe.local.lang),
+		ensure_ascii=False,
+		separators=(",", ":"),
+	)
+	response.status_code = 200
+	response.headers["Content-Type"] = "application/json"
+
+	# Cache (private: browser only, public: proxy caching)
+	response.headers["Cache-Control"] = "private, max-age=31536000"
+
+	return response
+
+
+def get_translations_hash(lang: str) -> str:
+	"""Return hash of all translations for a language"""
+	return get_all_translations(lang).get("translations_hash__") or ""
+
+
 def get_all_translations(lang: str) -> dict[str, str]:
 	"""Load and return the entire translations dictionary for a language from apps + user translations.
 
@@ -148,6 +172,15 @@ def get_all_translations(lang: str) -> dict[str, str]:
 		with suppress(Exception):
 			all_translations.update(get_user_translations(lang))
 			all_translations.update(get_translated_countries())
+
+		if "translations_hash__" not in all_translations:
+			import hashlib
+			import json
+
+			# Compute stable hash
+			t_hash = json.dumps(all_translations, sort_keys=True)
+			t_hash = hashlib.md5(t_hash.encode(), usedforsecurity=False).hexdigest()
+			all_translations["translations_hash__"] = t_hash
 
 		return all_translations
 

--- a/frappe/www/app.html
+++ b/frappe/www/app.html
@@ -52,7 +52,7 @@
 			if (!window.frappe) window.frappe = {};
 
 			frappe.boot = JSON.parse({{ boot }});
-			frappe._messages = frappe.boot["__messages"];
+			frappe._messages = {};
 			frappe.csrf_token = "{{ csrf_token }}";
 
 


### PR DESCRIPTION
Only for desk, partially addresses the issue #24423.

Translations are loaded using `fetch` pseudo-synchronously. Cache-Control header is used to store in browser cache.