### PR TITLE
fix: disable strict user perms for single doctypes

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -343,7 +343,10 @@ def has_user_permission(doc, user=None, debug=False):
 		debug and _debug_log("User permission bypassed because user can modify user permissions.")
 		return True
 
-	apply_strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
+	# don't apply strict user permissions for single doctypes since they contain empty link fields
+	apply_strict_user_permissions = (
+		False if doc.meta.issingle else frappe.get_system_settings("apply_strict_user_permissions")
+	)
 	if apply_strict_user_permissions:
 		debug and _debug_log("Strict user permissions will be applied")
 


### PR DESCRIPTION
**Ref**: https://github.com/frappe/erpnext/pull/39446#discussion_r1457026774

**Bug**
Opening a Single DocType throws a permission error if strict user permissions are applied on any of it's link field DocTypes since the link field has an empty value while opening the form.

**Solution**
Don't apply strict user permissions for Single DocTypes.