### PR TITLE
fix(website): Handle virtual DocTypes webview routing

### DIFF
--- a/frappe/website/page_renderers/document_page.py
+++ b/frappe/website/page_renderers/document_page.py
@@ -96,7 +96,13 @@ def _find_matching_document_webview(route: str) -> tuple[str, str] | None:
 			filters[condition_field] = 1
 
 		try:
-			docname = frappe.db.get_value(doctype, filters, "name")
+			docname = None
+			if meta.is_virtual:
+				if doclist := frappe.get_all(doctype, filters=filters, fields=["name"], limit=1):
+					docname = doclist[0].get("name")
+			else:
+				docname = frappe.db.get_value(doctype, filters, "name")
+
 			if docname:
 				return (doctype, docname)
 		except Exception as e:


### PR DESCRIPTION
# Virtual DocType × WebsiteGenerator = :heart:

Let's say that we have a **virtual** DocType _Remote Blog Post_ which fetches data from another website (e.g. Airtable, Google Sheets, Nextcloud), which is also a `WebsiteGenerator`. The _Remote Blog Post_ has a `route` field, and a `published` field.

Because the document does not exist in the database, it's not possible to find it using `frappe.db.get_value`. Instead, we have to use `frappe.get_list` (or something better, I'm open to suggestions).

An alternative is to add a `get_docname_for_route` method to WebsiteGenerator but this feels ugly.