### PR TITLE
fix: Handle bad URL

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -254,7 +254,7 @@ frappe.router = {
 			standard_route = ["Tree", doctype_route.doctype];
 		} else {
 			let new_route = this.list_views_route[_route.toLowerCase()];
-			let re_route = route[2].toLowerCase() !== new_route.toLowerCase();
+			let re_route = route[2].toLowerCase() !== new_route?.toLowerCase();
 
 			if (re_route) {
 				/**


### PR DESCRIPTION
Raises following error if user manually tried to load a page and it does not match our standard list view routes. It used to present a blank page. Now after handling this issue, user will be redirected to standard list view as a fallback.
<img width="1432" alt="Screenshot 2024-01-19 at 2 57 41 PM" src="https://github.com/frappe/frappe/assets/13928957/8caf97ac-4824-4bd6-8950-45e3c5849ab8">
