### PR TITLE
fix(Build): reinit `app_path`, avoid `get_app_path`

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -158,7 +158,7 @@ async function update_assets_json_from_built_assets(apps) {
 }
 
 async function update_assets_obj(app, assets, assets_rtl) {
-	const app_path = get_app_path(app);
+	const app_path = path.join(apps_path, app, app);
 	const dist_path = path.join(app_path, "public, dist");
 	const files = await glob("**/*.bundle.*.{js,css}", { cwd: dist_path });
 	const prefix = path.join("/", "assets", app, "dist");


### PR DESCRIPTION
Since the `app_paths` object is initialized when the file is imported, `get_app_path` returns `undefined` if the app was added after initializing. This is unreliable and stupid.

The fix just figures out `app_path` without relying on `get_app_path`.