### PR TITLE
fix: run-tests --module-def as not all doctypes are guaranteed to have test_*.py files

### DIFF
--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -89,9 +89,22 @@ def main(
 				doctype, verbose, tests, force, profile, failfast=failfast, junit_xml_output=junit_xml_output
 			)
 		elif module_def:
-			doctypes = frappe.db.get_list(
-				"DocType", filters={"module": module_def, "istable": 0}, pluck="name"
+			doctypes = []
+			doctypes_ = frappe.get_list(
+				"DocType",
+				filters={"module": module_def, "istable": 0},
+				fields=["name", "module"],
+				as_list=True,
 			)
+			for doctype, module in doctypes_:
+				test_module = get_module_name(doctype, module, "test_", app=app)
+				try:
+					importlib.import_module(test_module)
+				except Exception:
+					pass
+				else:
+					doctypes.append(doctype)
+
 			ret = run_tests_for_doctype(
 				doctypes, verbose, tests, force, profile, failfast=failfast, junit_xml_output=junit_xml_output
 			)


### PR DESCRIPTION
# Context

`bench run-tests --module-def Core` fails because not all modules are guaranteed to have a `test_<DocName>.py` file.

Two suche examples are:

- `core/doctype/data_export`
- `core/doctype/data_import`

While they have other test files, they don't have a particular `test_data_{import,export}.py` file.


While not verified, it is imaginable that someone would have eliminated the test file in the absence of tests.

# Proposed Solution

- [x] Make the discovery mechanism sensitive to a test file existence
- [x] if doctype is explicitly specified and no such file exists, it still fails
