### PR TITLE
fix: revert translation loading failure logging

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -296,7 +296,6 @@ def get_all_translations(lang: str) -> dict[str, str]:
 	except Exception:
 		# People mistakenly call translation function on global variables
 		# where locals are not initalized, translations dont make much sense there
-		frappe.logger().error("Unable to load translations", exc_info=True)
 		return {}
 
 


### PR DESCRIPTION
 This partially reverts bd3f89bf322aa68ef3d85d3bc216ef7e7fd11ba6
    
A few custom app installations are breaking because of them seemingly writing to `$BENCH_DIR/apps/logs/frappe.log` instead of `$BENCH_DIR/logs/frappe.log`
Until we can figure out why that's happening, reverting this change.
