### PR TITLE
fix(setup wizard): skip user creation if email is not provided

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -196,6 +196,9 @@ def update_system_settings(args):  # nosemgrep
 
 def create_or_update_user(args):  # nosemgrep
 	email = args.get("email")
+	if not email:
+		return
+
 	first_name, last_name = args.get("full_name", ""), ""
 	if " " in first_name:
 		first_name, last_name = first_name.split(" ", 1)


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/24483

The user slide is not shown when an admin runs the setup wizard in developer mode. Skip user creation on the server side if email is not provided