### PR TITLE
fix: improve email reply

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -550,11 +550,34 @@ class FormTimeline extends BaseTimeline {
 			title: communication_doc ? __("Reply") : null,
 			last_email: communication_doc,
 			subject: communication_doc && communication_doc.subject,
+			reply_all: reply_all,
 		};
 
-		if (communication_doc && reply_all) {
-			args.cc = communication_doc.cc;
-			args.bcc = communication_doc.bcc;
+		const email_accounts = frappe.boot.email_accounts
+			.filter((account) => {
+				return (
+					!["All Accounts", "Sent", "Spam", "Trash"].includes(account.email_account) &&
+					account.enable_outgoing
+				);
+			})
+			.map((e) => e.email_id);
+
+		if (communication_doc && args.is_a_reply) {
+			args.cc = "";
+			if (
+				email_accounts.includes(frappe.session.user_email) &&
+				communication_doc.sender != frappe.session.user_email
+			) {
+				// add recipients to cc if replying sender is different from last email
+				const recipients = communication_doc.recipients.split(",").map((r) => r.trim());
+				args.cc =
+					recipients.filter((r) => r != frappe.session.user_email).join(", ") + ", ";
+			}
+			if (reply_all) {
+				// if reply_all then add cc and bcc as well.
+				args.cc += communication_doc.cc;
+				args.bcc = communication_doc.bcc;
+			}
 		}
 
 		if (this.frm.doctype === "Communication") {

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -172,10 +172,15 @@ frappe.views.CommunicationComposer = class {
 				reqd: 1,
 				fieldname: "sender",
 				options: this.user_email_accounts,
+				onchange: () => {
+					this.setup_recipients_if_reply();
+				},
 			});
 			//Preselect email senders if there is only one
 			if (this.user_email_accounts.length == 1) {
 				this["sender"] = this.user_email_accounts;
+			} else if (this.user_email_accounts.includes(frappe.session.user_email)) {
+				this["sender"] = frappe.session.user_email;
 			}
 		}
 
@@ -223,6 +228,43 @@ frappe.views.CommunicationComposer = class {
 				});
 			};
 		});
+	}
+
+	setup_recipients_if_reply() {
+		if (!this.is_a_reply || !this.last_email) return;
+		let sender = this.dialog.get_value("sender");
+		if (!sender) return;
+		const fields = {
+			recipients: this.dialog.fields_dict.recipients,
+			cc: this.dialog.fields_dict.cc,
+			bcc: this.dialog.fields_dict.bcc,
+		};
+		// If same user replies to their own email, set recipients to last email recipients
+		if (this.last_email.sender == sender) {
+			fields.recipients.set_value(this.last_email.recipients);
+			if (this.reply_all) {
+				fields.cc.set_value(this.last_email.cc);
+				fields.bcc.set_value(this.last_email.bcc);
+			}
+		} else {
+			fields.recipients.set_value(this.last_email.sender);
+			if (this.reply_all) {
+				// if sending reply add ( last email's recipients - sender's email_id ) to cc.
+				const recipients = this.last_email.recipients.split(",").map((r) => r.trim());
+				if (!this.cc) {
+					this.cc = "";
+				}
+				const cc_array = this.cc.split(",").map((r) => r.trim());
+				if (this.cc && !this.cc.endsWith(", ")) {
+					this.cc += ", ";
+				}
+				this.cc += recipients
+					.filter((r) => !cc_array.includes(r) && r != sender)
+					.join(", ");
+				this.cc = this.cc.replace(sender + ", ", "");
+				fields.cc.set_value(this.cc);
+			}
+		}
 	}
 
 	setup_subject_and_recipients() {


### PR DESCRIPTION
form_timeline.js
- check if frappe.session.user_email is available in email_account for the user
- if reply_all and sender is not same as last email sender, set (last email recipient - current sender) to cc

communication.js
- if frappe.session.user_email is available in email_account for the user, set sender by default to frappe.session.user_email
- added on_change on sender to re-evaluate recipients.

- check if sender is same as last email sender
    - if yes, set recipient to last email recipient
    - if no, set recipient to last email sender
    - add all other recipients to cc

### Before
https://github.com/frappe/frappe/assets/39730881/26233c27-7b35-41ea-96d9-5e8d2126ceb0


### After
https://github.com/frappe/frappe/assets/39730881/e738df04-59a0-4afb-ba77-1f752a6e991a

