### PR TITLE
fix(Custom Field): default fieldname in rename fieldname prompt

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -119,6 +119,7 @@ frappe.ui.form.on("Custom Field", {
 					label: __("Fieldname"),
 					fieldname: "fieldname",
 					reqd: 1,
+					default: frm.doc.fieldname,
 				},
 				function (data) {
 					frappe.call({


### PR DESCRIPTION
Added  default field name to the prompt instead of typing the field name each time. 

@rohitwaghchaure  please check