### PR TITLE
fix!: consider only source_doc's no_copy

### DIFF
--- a/frappe/model/mapper.py
+++ b/frappe/model/mapper.py
@@ -197,11 +197,7 @@ def map_fields(source_doc, target_doc, table_map, source_parent):
 			for d in source_doc.meta.get("fields")
 			if (d.no_copy == 1 or d.fieldtype in table_fields)
 		]
-		+ [
-			d.fieldname
-			for d in target_doc.meta.get("fields")
-			if (d.no_copy == 1 or d.fieldtype in table_fields)
-		]
+		+ [d.fieldname for d in target_doc.meta.get("fields") if (d.fieldtype in table_fields)]
 		+ list(default_fields)
 		+ list(child_table_fields)
 		+ list(table_map.get("field_no_map", []))


### PR DESCRIPTION
### Problem

Considering the _No Copy_ attribute of both source and target document makes flows like this one impossible:

```
Quotation -(copy)-> Sales Order -(no copy)-> Sales Invoice -(copy)-> Delivery Note
```

- Cannot mark a Sales Order field as _No Copy_ because it would block the copy from Quotation
- Cannot mark a Sales Invoice field as _No Copy_ because it would block the copy to Delivery Note

### Proposed Solution

The common sense assumption seems to be that the _No Copy_ attribute applies only to the source document, not to the target document.