### PR TITLE
fix: error when configuring child table columns in New Print Format Builder

### DIFF
--- a/frappe/public/js/print_format_builder/Field.vue
+++ b/frappe/public/js/print_format_builder/Field.vue
@@ -126,9 +126,9 @@ function configure_columns() {
 			},
 		],
 		on_page_show: () => {
-			createApp(ConfigureColumnsVue, { df: props.df }).mount(
-				dialog.get_field("columns_area").$wrapper.get(0)
-			);
+			const app = createApp(ConfigureColumnsVue, { df: props.df });
+			SetVueGlobals(app);
+			app.mount(dialog.get_field("columns_area").$wrapper.get(0));
 		},
 		on_hide: () => {
 			props.df["table_columns"] = props.df.table_columns.filter((col) => !col.invalid_width);


### PR DESCRIPTION
## Changes Made

- Added missing call to `SetVueGlobals` required from Vue 3 to access globals like `frappe` and `__`.


## Screenshots


### Before

<img width="701" alt="Screenshot 2024-01-24 at 5 04 20 PM" src="https://github.com/frappe/frappe/assets/108476017/03f52954-f680-46f7-8c5c-4bd6745907d5">

### After

<img width="651" alt="Screenshot 2024-01-24 at 5 04 45 PM" src="https://github.com/frappe/frappe/assets/108476017/84399b72-2ba2-4020-94b6-eff8ae16fca7">


Closes #23817 