### PR TITLE
fix: allow site creation to work on FC again

### DIFF
--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -16,21 +16,7 @@ class DbManager:
 	def create_user(self, user, password, host=None):
 		host = host or self.get_current_host()
 		password_predicate = f" IDENTIFIED BY '{password}'" if password else ""
-		self.db.sql(f"CREATE USER '{user}'@'{host}'{password_predicate}")
-
-	def does_user_exist(self, username: str, host: str | None = None) -> bool:
-		return (
-			self.db.sql(
-				f"SELECT EXISTS(SELECT 1 FROM mysql.user WHERE user = '{username}' and "
-				f"host = '{host or self.get_current_host()}')"
-			)[0][0]
-			== 1
-		)
-
-	def set_user_password(self, username: str, password: str, host: str | None = None) -> None:
-		self.db.sql(
-			f"SET PASSWORD FOR '{username}'@'{host or self.get_current_host()}' = PASSWORD('{password}')"
-		)
+		self.db.sql(f"CREATE USER IF NOT EXISTS '{user}'@'{host}'{password_predicate}")
 
 	def delete_user(self, target, host=None):
 		host = host or self.get_current_host()

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -34,15 +34,9 @@ def setup_database(force, verbose, no_mariadb_socket=False):
 	if no_mariadb_socket:
 		dbman_kwargs["host"] = "%"
 
-	if dbman.does_user_exist(db_user):
-		print("User exists", db_user)
-		dbman.set_user_password(db_user, frappe.conf.db_password, **dbman_kwargs)
-		if verbose:
-			print("Re-used existing user %s" % db_user)
-	else:
-		dbman.create_user(db_user, frappe.conf.db_password, **dbman_kwargs)
-		if verbose:
-			print("Created user %s" % db_user)
+	dbman.create_user(db_user, frappe.conf.db_password, **dbman_kwargs)
+	if verbose:
+		print(f"Created or updated user {db_user}")
 
 	if force or (db_name not in dbman.get_database_list()):
 		dbman.drop_database(db_name)


### PR DESCRIPTION
FC creates a temporary non-root user to use as the root user here, which doesn't have `SELECT` permissions on `mysql.user`

Try to work around it by relying on `CREATE USER IF NOT EXISTS`
