### PR TITLE
fix: Duplicate columns while configuring columns in New Print Format Builder

### DIFF
--- a/frappe/public/js/print_format_builder/ConfigureColumns.vue
+++ b/frappe/public/js/print_format_builder/ConfigureColumns.vue
@@ -18,8 +18,8 @@
 			:group="df.fieldname"
 			handle=".icon-drag"
 		>
-			<template #item="{ element }">
-				<div class="mt-2 row align-center column-row" v-for="column in df.table_columns">
+			<template #item="{ element: column }">
+				<div class="mt-2 row align-center column-row">
 					<div class="col-8">
 						<div class="column-label d-flex align-center">
 							<div class="px-2 icon-drag ml-n2">


### PR DESCRIPTION
## Changes Made

Removed additional loop over table columns as draggable component already does this here:
https://github.com/frappe/frappe/blob/b21fdaf8c455baf6a6695cf7725ba14e5976db9e/frappe/public/js/print_format_builder/ConfigureColumns.vue#L16

## **Screenshots**
### Before


https://github.com/frappe/frappe/assets/108476017/6076cffe-56e1-411d-8316-40e7ec9f304b



### After

https://github.com/frappe/frappe/assets/108476017/aedf250b-089a-43a0-8aab-e7a096daf986


