### PR TITLE
fix: update all users after commit

### DIFF
--- a/frappe/core/doctype/role_profile/role_profile.py
+++ b/frappe/core/doctype/role_profile/role_profile.py
@@ -25,7 +25,7 @@ class RoleProfile(Document):
 		self.name = self.role_profile
 
 	def on_update(self):
-		self.queue_action("update_all_users", now=frappe.flags.in_test)
+		self.queue_action("update_all_users", now=frappe.flags.in_test, enqueue_after_commit=True)
 
 	def update_all_users(self):
 		"""Changes in role_profile reflected across all its user"""


### PR DESCRIPTION
sentry: FRAPPE-NK

This happens because when a new role profile is inserted and background job gets immediately fired before the transaction is committed. 