### PR TITLE
fix(print-preview): Fix stale reference to iframe's document

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -384,13 +384,13 @@ frappe.ui.form.PrintView = class {
 		this.print_wrapper.find(".preview-beta-wrapper").hide();
 		this.print_wrapper.find(".print-preview-wrapper").show();
 
-		const $print_format = this.print_wrapper.find("iframe");
-		this.$print_format_body = $print_format.contents();
 		this.get_print_html((out) => {
 			if (!out.html) {
 				out.html = this.get_no_preview_html();
 			}
 
+			const $print_format = this.print_wrapper.find("iframe");
+			this.$print_format_body = $print_format.contents();
 			this.setup_print_format_dom(out, $print_format);
 
 			const print_height = $print_format.get(0).offsetHeight;


### PR DESCRIPTION
On Firefox, the <iframe> behavior is different than on other browsers, so the print preview appears blank.

Reproduction:
* go on any document form page
* reload the page
* switch to the print preview
* observe blank preview

```js
const $print_format = this.print_wrapper.find("iframe"); // <iframe>
this.$print_format_body = $print_format.contents(); // #document inside <iframe>
// asynchronous this.get_print_html((out) => {
  this.$print_format_body.doThing(…)  // here the reference to the #document is stale, so changing it does nothing
```