### PR TITLE
fix(money_in_words)!: Don't translate the result of num2words

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1518,18 +1518,12 @@ def money_in_words(
 		out = _(main_currency, context="Currency") + " " + _("Zero")
 	# 0.XX
 	elif main == "0":
-		out = _(in_words(fraction, in_million).title()) + " " + fraction_currency
+		out = in_words(fraction, in_million).title() + " " + fraction_currency
 	else:
-		out = _(main_currency, context="Currency") + " " + _(in_words(main, in_million).title())
+		out = _(main_currency, context="Currency") + " " + in_words(main, in_million).title()
 		if cint(fraction):
 			out = (
-				out
-				+ " "
-				+ _("and")
-				+ " "
-				+ _(in_words(fraction, in_million).title())
-				+ " "
-				+ fraction_currency
+				out + " " + _("and") + " " + in_words(fraction, in_million).title() + " " + fraction_currency
 			)
 
 	return _("{0} only.", context="Money in words").format(out)


### PR DESCRIPTION
It's unlikely that a translation for the results of num2words exists, because it should return a string that is already translated in the target language. If there are some numbers that have a specific translation, then it should already be handled in the num2words library. A domain-specific library is surely better at this hypothetical task than Frappe's generic translation system.

In French, 100 is called Cent. But in English, Cent is 1/100th of a dollar, which is called Centime in French.  
Expected: num2words(200).title() == "Cent"  
Actual: _(num2words(200).title()) == _("Cent") == "Centime"

closes #24547 ⋅ /cc @barredterra (Thanks!)