### PR TITLE
fix(search): Fix URL encoding for search result

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/search.js
+++ b/frappe/public/js/frappe/ui/toolbar/search.js
@@ -317,7 +317,7 @@ frappe.search.SearchDialog = class {
 	get_link(result) {
 		let link = "";
 		if (result.route) {
-			link = `href="/app/${result.route.join("/")}"`;
+			link = `href="${frappe.router.make_url(result.route)}"`;
 		} else if (result.data_path) {
 			link = `data-path=${result.data_path}"`;
 		}


### PR DESCRIPTION
When documents have slashes (/) in their names, they were not properly encoded in the search results.