### PR TITLE
fix(mobile): scroll issue after workspace change

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -188,6 +188,7 @@ frappe.views.Workspace = class Workspace {
 		$(".item-anchor").on("click", () => {
 			$(".list-sidebar.hidden-xs.hidden-sm").removeClass("opened");
 			$(".close-sidebar").css("display", "none");
+			$("body").css("overflow", "auto");
 		});
 
 		if (


### PR DESCRIPTION
Scrollbar was missing after changing workspace in mobile view.
Introduced via https://github.com/frappe/frappe/pull/24312