### PR TITLE
fix: ignore dead columns in user_settings

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1012,15 +1012,17 @@ export default class Grid {
 
 		let user_settings = frappe.get_user_settings(this.frm.doctype, "GridView");
 		if (user_settings && user_settings[this.doctype] && user_settings[this.doctype].length) {
-			this.user_defined_columns = user_settings[this.doctype].map((row) => {
-				let column = frappe.meta.get_docfield(this.doctype, row.fieldname);
+			this.user_defined_columns = user_settings[this.doctype]
+				.map((row) => {
+					let column = frappe.meta.get_docfield(this.doctype, row.fieldname);
 
-				if (column) {
-					column.in_list_view = 1;
-					column.columns = row.columns;
-					return column;
-				}
-			});
+					if (column) {
+						column.in_list_view = 1;
+						column.columns = row.columns;
+						return column;
+					}
+				})
+				.filter(Boolean);
 		}
 	}
 


### PR DESCRIPTION
When a deleted column is still configured in user defined columns for grid it breaks form rendering. 

![image](https://github.com/frappe/frappe/assets/9079960/1a8f976b-2f76-46f2-a9e7-54db63865656)

```
TypeError: o is undefined     
r grid.js:1227
    update_docfield_property grid.js:1227
    set_currency_labels form.js:1487
    each jQuery
    set_currency_labels form.js:1485
    update_item_grid_labels transaction.js:1386
    change_grid_labels transaction.js:1345
    set_dynamic_labels transaction.js:1289
    set_dynamic_labels sales_common.js:263
    refresh transaction.js:375
    refresh sales_common.js:94
    refresh delivery_note__js:137
    o script_manager.js:106
    trigger script_manager.js:136
    promise callback*frappe.run_serially/< dom.js:262
    run_serially dom.js:260
    trigger script_manager.js:141
    render_form form.js:612
    promise callback*frappe.run_serially/< dom.js:262
    run_serially dom.js:260
    render_form form.js:602
    initialize_new_doc form.js:571
    promise callback*initialize_new_doc form.js:568
    trigger_onload form.js:549
    refresh form.js:432
    render formview.js:107
    fetch_and_render formview.js:91
    callback model.js:317
    e request.js:85
    200 request.js:133
    call request.js:305
    jQuery 6
    call request.js:279
    call request.js:109
    with_doc model.js:309
    with_doc model.js:299
    fetch_and_render formview.js:80
    show_doc formview.js:75
    make_and_show formview.js:32
    make formview.js:15
    with_doctype model.js:232
    make formview.js:12
    show factory.js:25
    render_page router.js:323
    render router.js:302
    route router.js:157
    set_route desk.js:161
    startup desk.js:92
    <anonymous> desk.js:30
    start_app desk.js:12
    <anonymous> desk.js:25
    jQuery 13
    Gi libs.bundle.TIV7ZGVY.js:1
    <anonymous> jQuery
    <anonymous>
```