### PR TITLE
fix(grid_row): sort options based on selected data first, so as to maintain order

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -461,6 +461,7 @@ export default class GridRow {
 					fieldname: "fields",
 					options: docfields,
 					columns: 2,
+					sort_options: false,
 				},
 			],
 		});
@@ -495,12 +496,31 @@ export default class GridRow {
 
 		const show_field = (f) => always_allow.includes(f) || !blocked_fields.includes(f);
 
+		// First, add selected fields
+		selected_fields.forEach((selectedField) => {
+			const selectedColumn = this.docfields.find(
+				(column) => column.fieldname === selectedField
+			);
+			if (selectedColumn && !selectedColumn.hidden && show_field(selectedColumn.fieldtype)) {
+				fields.push({
+					label: selectedColumn.label,
+					value: selectedColumn.fieldname,
+					checked: true,
+				});
+			}
+		});
+
+		// Then, add the rest of the fields
 		this.docfields.forEach((column) => {
-			if (!column.hidden && show_field(column.fieldtype)) {
+			if (
+				!selected_fields.includes(column.fieldname) &&
+				!column.hidden &&
+				show_field(column.fieldtype)
+			) {
 				fields.push({
 					label: column.label,
 					value: column.fieldname,
-					checked: selected_fields ? selected_fields.includes(column.fieldname) : false,
+					checked: false,
 				});
 			}
 		});


### PR DESCRIPTION
After #23985 and #24202, multicheck options are sorted by default

This breaks user sorted options (reference: ticket 8459)

Add the user selected options at the beginning to preserve the order and don't sort the rest

<hr>

Previous:
![image](https://github.com/frappe/frappe/assets/10119037/6d0677d0-1adc-488e-a3a4-f1041a3ab60d)
![image](https://github.com/frappe/frappe/assets/10119037/43036b98-cbad-413c-9f38-897702e43879)
![image](https://github.com/frappe/frappe/assets/10119037/fe7cd7ec-39b9-478f-831e-10f8fd385622)


New:
![image](https://github.com/frappe/frappe/assets/10119037/0c6763ae-9a9f-4b18-859a-bd68e0b96de8)
![image](https://github.com/frappe/frappe/assets/10119037/14adec10-58a3-482a-8bfa-b33d42c97c5f)


