### PR TITLE
fix: do not allow to set if_owner & report perm together

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -253,6 +253,10 @@ frappe.PermissionEngine = class PermissionEngine {
 				if (!d.is_submittable && ["submit", "cancel", "amend"].includes(r)) return;
 				if (d.in_create && ["create", "delete"].includes(r)) return;
 				this.add_check(perm_container, d, r);
+
+				if (d.if_owner && r == "report") {
+					perm_container.find("div[data-fieldname='report']").toggle(false);
+				}
 			});
 
 			// buttons
@@ -414,6 +418,13 @@ frappe.PermissionEngine = class PermissionEngine {
 						chk.prop("checked", !chk.prop("checked"));
 					} else {
 						me.get_perm(args.role)[args.ptype] = args.value;
+
+						if (args.ptype == "if_owner") {
+							let report_checkbox = chk
+								.closest("div.row")
+								.find("div[data-fieldname='report']");
+							report_checkbox.toggle(!args.value);
+						}
 					}
 				},
 			});

--- a/frappe/core/page/permission_manager/permission_manager.py
+++ b/frappe/core/page/permission_manager/permission_manager.py
@@ -129,7 +129,14 @@ def update(
 		frappe.clear_cache(doctype=doctype)
 
 	frappe.only_for("System Manager")
+
+	if ptype == "report" and value == "1" and if_owner == "1":
+		frappe.throw(_("Cannot set 'Report' permission if 'Only If Creator' permission is set"))
+
 	out = update_permission_property(doctype, role, permlevel, ptype, value, if_owner=if_owner)
+
+	if ptype == "if_owner" and value == "1":
+		update_permission_property(doctype, role, permlevel, "report", "0", if_owner=value)
 
 	frappe.db.after_commit.add(clear_cache)
 


### PR DESCRIPTION
If `if_owner` is set along with `report` perm and you try to access any script report you will get an error saying you don't have access to the report.


https://github.com/frappe/frappe/assets/30859809/db39647e-ddbd-4f04-aa0d-728252885470



