### PR TITLE
feat: show doctype description in list views

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -465,7 +465,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			? __("No {0} found with matching filters. Clear filters to see all {0}.", [
 					__(this.doctype),
 			  ])
+			: this.meta.description
+			? __(this.meta.description)
 			: __("You haven't created a {0} yet", [__(this.doctype)]);
+
 		let new_button_label = has_filters_set
 			? __("Create a new {0}", [__(this.doctype)], "Create a new document from list view")
 			: __(


### PR DESCRIPTION
Show doctype description from meta in empty list views

`no-docs`

<img width="1334" alt="list-1" src="https://github.com/frappe/frappe/assets/24353136/636a99ea-be09-4840-890a-be306a687bee">

<img width="1334" alt="list-2" src="https://github.com/frappe/frappe/assets/24353136/1e40085f-6985-43f5-96df-ea5a33d02052">

Default if the description is not set:

<img width="1334" alt="list-default" src="https://github.com/frappe/frappe/assets/24353136/a3d5e66b-a4f3-4fdb-bf75-ae48aa1156c1">
