### PR TITLE
revert: added back quick list status indicator

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -133,6 +133,8 @@ export default class QuickListWidget extends Widget {
 	}
 
 	setup_quick_list_item(doc) {
+		const indicator = frappe.get_indicator(doc, this.document_type);
+
 		let $quick_list_item = $(`
 			<div class="quick-list-item">
 				<div class="ellipsis left">
@@ -146,6 +148,14 @@ export default class QuickListWidget extends Widget {
 				</div>
 			</div>
 		`);
+
+		if (indicator) {
+			$(`
+				<div class="status indicator-pill ${indicator[1]} ellipsis">
+					${__(indicator[0])}
+				</div>
+			`).appendTo($quick_list_item);
+		}
 
 		$(`<div class="right-arrow">${frappe.utils.icon("right", "xs")}</div>`).appendTo(
 			$quick_list_item


### PR DESCRIPTION
Caused By: https://github.com/frappe/frappe/pull/22626

Reverting only Status Indicator Part