### PR TITLE
fix: Return empty result if no perm level access

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -217,6 +217,10 @@ class DatabaseQuery:
 		args = self.prepare_args()
 		args.limit = self.add_limit()
 
+		if not args.fields:
+			# apply_fieldlevel_read_permissions has likely removed ALL the fields that user asked for
+			return []
+
 		if args.conditions:
 			args.conditions = "where " + args.conditions
 

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1255,6 +1255,9 @@ class TestReportView(FrappeTestCase):
 			response = execute_cmd("frappe.desk.reportview.get")
 			self.assertNotIn("published", response["keys"])
 
+			# If none of the fields are accessible then result should be empty
+			self.assertEqual(frappe.get_list("Blog Post", "published"), [])
+
 	def test_reportview_get_admin(self):
 		# Admin should be able to see access all fields
 		with setup_patched_blog_post():


### PR DESCRIPTION
Decision:

1. Throw error that nothing can be selected
2. Silently don't return anything as not permitted. 


IMO 2 is more consistent with rest of the code but 1 is more user friendly. We can go either way. 



related to https://github.com/frappe/frappe/pull/19533