### PR TITLE
fix: show successful rows in the import log

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -506,13 +506,7 @@ frappe.ui.form.on("Data Import", {
 	},
 
 	show_import_log(frm) {
-		if (!frm.doc.show_failed_logs) {
-			frm.toggle_display("import_log_preview", false);
-			return;
-		}
-
 		frm.toggle_display("import_log_section", false);
-		frm.toggle_display("import_log_preview", true);
 
 		if (frm.import_in_progress) {
 			return;

--- a/frappe/core/doctype/data_import/data_import.json
+++ b/frappe/core/doctype/data_import/data_import.json
@@ -139,7 +139,7 @@
    "default": "0",
    "fieldname": "show_failed_logs",
    "fieldtype": "Check",
-   "label": "Show Failed Logs"
+   "label": "Show Only Failed Logs"
   },
   {
    "depends_on": "eval:!doc.__islocal && !doc.import_file",
@@ -171,7 +171,7 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2023-12-15 12:45:49.452834",
+ "modified": "2024-01-30 17:08:05.566686",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data Import",

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -38,7 +38,6 @@ class DataImport(Document):
 		submit_after_import: DF.Check
 		template_options: DF.Code | None
 		template_warnings: DF.Code | None
-
 	# end: auto-generated types
 
 	def validate(self):


### PR DESCRIPTION
- Revert "fix(data_import): respect the value of show_failed_logs checkbox"
- chore: reword checkbox

The previous "fix" had somehow worked for me earlier, maybe I had some bad data from random tests leading to some erratic behaviour, but didn't make sense.
Previous code is working as expected, shouldn't have been changed.
