### PR TITLE
fix: short circuit private files perm check

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -265,6 +265,9 @@ def download_backup(path):
 def download_private_file(path: str) -> Response:
 	"""Checks permissions and sends back private file"""
 
+	if frappe.session.user == "Guest":
+		raise Forbidden(_("You don't have permission to access this file"))
+
 	files = frappe.get_all("File", filters={"file_url": path}, fields="*")
 	# this file might be attached to multiple documents
 	# if the file is accessible from any one of those documents


### PR DESCRIPTION
For guest users there's no point in checking permissions, they'll eventually fail... instead just fail immediately.
