### PR TITLE
fix: shell escaping on external commands

### DIFF
--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -75,12 +75,7 @@ def get_command(
 		else:
 			bin, bin_name = which("psql"), "psql"
 
-		host = frappe.utils.esc(host, "$ ")
-		user = frappe.utils.esc(user, "$ ")
-		db_name = frappe.utils.esc(db_name, "$ ")
-
 		if password:
-			password = frappe.utils.esc(password, "$ ")
 			conn_string = f"postgresql://{user}:{password}@{host}:{port}/{db_name}"
 		else:
 			conn_string = f"postgresql://{user}@{host}:{port}/{db_name}"
@@ -96,10 +91,6 @@ def get_command(
 		else:
 			bin, bin_name = which("mariadb") or which("mysql"), "mariadb"
 
-		host = frappe.utils.esc(host, "$ ")
-		user = frappe.utils.esc(user, "$ ")
-		db_name = frappe.utils.esc(db_name, "$ ")
-
 		command = [
 			f"--user={user}",
 			f"--host={host}",
@@ -107,7 +98,6 @@ def get_command(
 		]
 
 		if password:
-			password = frappe.utils.esc(password, "$ ")
 			command.append(f"--password={password}")
 
 		if dump:

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -370,6 +370,8 @@ class BackupGenerator:
 			n.write(c.read())
 
 	def take_dump(self):
+		import shlex
+
 		import frappe.utils
 		from frappe.utils.change_log import get_app_branch
 
@@ -419,15 +421,15 @@ class BackupGenerator:
 		extra = []
 		if self.db_type == "mariadb":
 			if self.backup_includes:
-				extra.extend([f"'{x}'" for x in self.backup_includes])
+				extra.extend(self.backup_includes)
 			elif self.backup_excludes:
-				extra.extend([f"--ignore-table='{self.db_name}.{table}'" for table in self.backup_excludes])
+				extra.extend([f"--ignore-table={self.db_name}.{table}" for table in self.backup_excludes])
 
 		elif self.db_type == "postgres":
 			if self.backup_includes:
-				extra.extend([f"--table='public.\"{table}\"'" for table in self.backup_includes])
+				extra.extend([f'--table=public."{table}"' for table in self.backup_includes])
 			elif self.backup_excludes:
-				extra.extend([f"--exclude-table-data='public.\"{table}\"'" for table in self.backup_excludes])
+				extra.extend([f'--exclude-table-data=public."{table}"' for table in self.backup_excludes])
 
 		from frappe.database import get_command
 
@@ -446,11 +448,11 @@ class BackupGenerator:
 				exc=frappe.ExecutableNotFound,
 			)
 		cmd.append(bin)
-		cmd.extend(args)
+		cmd.append(shlex.join(args))
 
 		command = " ".join(["set -o pipefail;"] + cmd + ["|", gzip_exc, ">>", self.backup_path_db])
 		if self.verbose:
-			print(command.replace(frappe.utils.esc(self.password, "$ "), "*" * 10) + "\n")
+			print(command.replace(shlex.quote(self.password), "*" * 10) + "\n")
 
 		frappe.utils.execute_in_shell(command, low_priority=True, check_exit_code=True)
 


### PR DESCRIPTION
# Context

This cleanup had been overlooked in past iterations.

It separates the concern of command assembly from the concern of executing it within a shell as opposed to via `os.exec`.

## Risk / Reward Profile

1. This actually fixes a latent issue where the shell escaping wasn't suitable for `execve` and thus would have broken at least `bench db-console`. This PR removes undue shell escaping
2. The refactored calling sites moreover make use of the supposedly more reliable `shlex.*` functions instead of a custom ad-hoc escape utility.
3. I've manually verified that the password is still obscured in the standard case &mdash; and thus in the escaped case unless `shelex.*` would be non-determinisitc, which is hardly plausible.
4. This is also a cleanup and results in more maintainable code with clearer boundaries.

`no-docs`

cc @akhilnarang 
