### PR TITLE
fix: don't notify links if not public

### DIFF
--- a/frappe/desk/doctype/note/note.py
+++ b/frappe/desk/doctype/note/note.py
@@ -28,6 +28,9 @@ class Note(Document):
 			# expire this notification in a week (default)
 			self.expire_notification_on = frappe.utils.add_days(self.creation, 7)
 
+		if not self.public and self.notify_on_login:
+			self.notify_on_login = 0
+
 		if not self.content:
 			self.content = "<span></span>"
 


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/15059
