### PR TITLE
fix: Enqueue deletion of dynamic link after comitting

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -133,6 +133,7 @@ def delete_doc(
 					doctype=doc.doctype,
 					name=doc.name,
 					now=frappe.flags.in_test,
+					enqueue_after_commit=True,
 				)
 
 		# clear cache for Document


### PR DESCRIPTION
most likely closes https://github.com/frappe/frappe/issues/15607 


Version is likely being modified from both transaction at same time leading to deadlock. 