### PR TITLE
refactor!: Simplify asset caching

### DIFF
--- a/frappe/public/js/frappe/assets.js
+++ b/frappe/public/js/frappe/assets.js
@@ -19,11 +19,22 @@ frappe.require = function (items, callback) {
 	});
 };
 
-frappe.assets = {
-	check: function () {
+class AssetManager {
+	constructor() {
+		this._executed = [];
+		this._handlers = {
+			js: function (txt) {
+				frappe.dom.eval(txt);
+			},
+			css: function (txt) {
+				frappe.dom.set_style(txt);
+			},
+		};
+	}
+	check() {
 		// if version is different then clear localstorage
 		if (window._version_number != localStorage.getItem("_version_number")) {
-			frappe.assets.clear_local_storage();
+			this.clear_local_storage();
 			console.log("Cleared App Cache.");
 		}
 
@@ -33,160 +44,79 @@ frappe.assets = {
 			// Evict cache if page is reloaded within 10 seconds. Which could be user trying to
 			// refresh if things feel broken.
 			if ((not_updated_since < 5000 && is_reload()) || not_updated_since > 2 * 86400000) {
-				frappe.assets.clear_local_storage();
+				this.clear_local_storage();
 			}
 		} else {
-			frappe.assets.clear_local_storage();
+			this.clear_local_storage();
 		}
 
-		frappe.assets.init_local_storage();
-	},
+		this.init_local_storage();
+	}
 
-	init_local_storage: function () {
+	init_local_storage() {
 		localStorage._last_load = new Date();
 		localStorage._version_number = window._version_number;
 		if (frappe.boot) localStorage.metadata_version = frappe.boot.metadata_version;
-	},
+	}
 
-	clear_local_storage: function () {
-		$.each(
-			["_last_load", "_version_number", "metadata_version", "page_info", "last_visited"],
-			function (i, key) {
-				localStorage.removeItem(key);
-			}
+	clear_local_storage() {
+		["_last_load", "_version_number", "metadata_version", "page_info", "last_visited"].forEach(
+			(key) => localStorage.removeItem(key)
 		);
 
 		// clear assets
-		for (var key in localStorage) {
+		for (let key in localStorage) {
 			if (
-				key.indexOf("desk_assets:") === 0 ||
-				key.indexOf("_page:") === 0 ||
-				key.indexOf("_doctype:") === 0 ||
-				key.indexOf("preferred_breadcrumbs:") === 0
+				key.startsWith("_page:") ||
+				key.startsWith("_doctype:") ||
+				key.startsWith("preferred_breadcrumbs:")
 			) {
 				localStorage.removeItem(key);
 			}
 		}
 		console.log("localStorage cleared");
-	},
+	}
 
-	// keep track of executed assets
-	executed_: [],
+	eval_assets(path, content) {
+		if (!this._executed.includes(path)) {
+			this._handlers[this.extn(path)](content);
+			this._executed.push(path);
+		}
+	}
 
-	// pass on to the handler to set
-	execute: function (items, callback) {
-		var to_fetch = [];
-		for (var i = 0, l = items.length; i < l; i++) {
-			if (!frappe.assets.exists(items[i])) {
-				to_fetch.push(items[i]);
-			}
-		}
-		if (to_fetch.length) {
-			frappe.assets.fetch(to_fetch, function () {
-				frappe.assets.eval_assets(items, callback);
-			});
-		} else {
-			frappe.assets.eval_assets(items, callback);
-		}
-	},
-
-	eval_assets: function (items, callback) {
-		for (var i = 0, l = items.length; i < l; i++) {
-			// execute js/css if not already.
-			var path = items[i];
-			if (frappe.assets.executed_.indexOf(path) === -1) {
-				// execute
-				frappe.assets.handler[frappe.assets.extn(path)](frappe.assets.get(path), path);
-				frappe.assets.executed_.push(path);
-			}
-		}
-		callback && callback();
-	},
-
-	// check if the asset exists in
-	// localstorage
-	exists: function (src) {
-		if (frappe.assets.executed_.indexOf(src) !== -1) {
-			return true;
-		}
-		if (frappe.boot.developer_mode) {
-			return false;
-		}
-		if (frappe.assets.get(src)) {
-			return true;
-		} else {
-			return false;
-		}
-	},
-
-	// load an asset via
-	fetch: function (items, callback) {
+	execute(items, callback) {
 		// this is virtual page load, only get the the source
-		// *without* the template
-
-		if (items.length === 0) {
-			callback();
-			return;
-		}
+		let me = this;
 
 		const version_string =
 			frappe.boot.developer_mode || window.dev_server ? Date.now() : window._version_number;
 
-		async function fetch_item(item) {
+		async function fetch_item(path) {
 			// Add the version to the URL to bust the cache for non-bundled assets
-			let url = new URL(item, window.location.origin);
+			let url = new URL(path, window.location.origin);
 
-			if (!item.includes(".bundle.") && !url.searchParams.get("v")) {
+			if (!path.includes(".bundle.") && !url.searchParams.get("v")) {
 				url.searchParams.append("v", version_string);
 			}
 			const response = await fetch(url.toString());
 			const body = await response.text();
-			frappe.assets.add(item, body);
+			me.eval_assets(path, body);
 		}
 
 		frappe.dom.freeze();
 		const fetch_promises = items.map(fetch_item);
 		Promise.all(fetch_promises).then(() => {
 			frappe.dom.unfreeze();
-			callback();
+			callback?.();
 		});
-	},
+	}
 
-	add: function (src, txt) {
-		if ("localStorage" in window) {
-			try {
-				frappe.assets.set(src, txt);
-			} catch (e) {
-				// if quota is exceeded, clear local storage and set item
-				frappe.assets.clear_local_storage();
-				frappe.assets.set(src, txt);
-			}
-		}
-	},
-
-	get: function (src) {
-		return localStorage.getItem("desk_assets:" + src);
-	},
-
-	set: function (src, txt) {
-		localStorage.setItem("desk_assets:" + src, txt);
-	},
-
-	extn: function (src) {
+	extn(src) {
 		if (src.indexOf("?") != -1) {
 			src = src.split("?").slice(-1)[0];
 		}
 		return src.split(".").slice(-1)[0];
-	},
-
-	handler: {
-		js: function (txt, src) {
-			frappe.dom.eval(txt);
-		},
-		css: function (txt, src) {
-			frappe.dom.set_style(txt);
-		},
-	},
+	}
 
 	bundled_asset(path, is_rtl = null) {
 		if (!path.startsWith("/assets") && path.includes(".bundle.")) {
@@ -197,8 +127,8 @@ frappe.assets = {
 			return path;
 		}
 		return path;
-	},
-};
+	}
+}
 
 function is_reload() {
 	try {
@@ -211,3 +141,5 @@ function is_reload() {
 		return true;
 	}
 }
+
+frappe.assets = new AssetManager();


### PR DESCRIPTION
Few changes:

1. Client side asset caching is needlessly complicated with 2 layer of caching. Browser already caches things, moving them again to localstorage is uselss and counterproductive because of limits on localstorage.
2. `frappe.assets` was an object that should've been a class.
3. lots of old js syntax.
