### PR TITLE
fix: outgoing email account handlng

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -158,6 +158,7 @@ class EmailQueue(Document):
 			return
 
 		with SendMailContext(self, smtp_server_instance) as ctx:
+			ctx.fetch_smtp_server()
 			message = None
 			for recipient in self.recipients:
 				if recipient.is_mail_sent():
@@ -233,13 +234,15 @@ class SendMailContext:
 		smtp_server_instance: SMTPServer = None,
 	):
 		self.queue_doc: EmailQueue = queue_doc
-		self.email_account_doc = queue_doc.get_email_account(raise_error=True)
-
-		self.smtp_server: SMTPServer = smtp_server_instance or self.email_account_doc.get_smtp_server()
-
+		self.smtp_server: SMTPServer = smtp_server_instance
 		self.sent_to_atleast_one_recipient = any(
 			rec.recipient for rec in self.queue_doc.recipients if rec.is_mail_sent()
 		)
+
+	def fetch_smtp_server(self):
+		self.email_account_doc = self.queue_doc.get_email_account(raise_error=True)
+		if not self.smtp_server:
+			self.smtp_server = self.email_account_doc.get_smtp_server()
 
 	def __enter__(self):
 		self.queue_doc.update_status(status="Sending", commit=True)


### PR DESCRIPTION
1. Currently we give this weird error instead of just saying no outgoing email account is configured.

```
AttributeError: 'NoneType' object has no attribute 'get_smtp_server'
  File "frappe/email/queue.py", line 154, in flush
    email_queue.send()
  File "frappe/email/doctype/email_queue/email_queue.py", line 160, in send
    with SendMailContext(self, smtp_server_instance) as ctx:
  File "frappe/email/doctype/email_queue/email_queue.py", line 236, in __init__
    self.smtp_server: SMTPServer = smtp_server_instance or self.email_account_doc.get_smtp_server()
```

2. These failures don't trigger email queue's retry code because this attempt doesn't get logged. Moved all code that can possibly fail from `__init__` or `__enter__` to context. 

closes https://github.com/frappe/frappe/issues/24480 