### PR TITLE
chore(deps): bump cairocffi version to from 1.5.1 to 1.6.1 to make v5 install possible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "beautifulsoup4~=4.12.2",
     "bleach-allowlist~=1.0.3",
     "bleach[css]~=6.0.0",
-    "cairocffi==1.5.1",
+    "cairocffi==1.6.1",
     "chardet~=5.1.0",
     "croniter~=2.0.1",
     "cryptography~=41.0.3",


### PR DESCRIPTION
I tried to initialize a new bench in my Ubuntu 22.04 WSL2 Enviroment. I installed all the neccessary versions (node, Python, etc) for 
the installation. When I run `bench init` the process eventually crashed while installing. The error message is given below

The same problem occurs when I install version 1.5.1 or 1.5.0 `cairocffi` package manually via pip. However the newer versions do not have this problem. 

When the cairocffi version is bumped a working package should be installed and the installation should continue properly.

This problem only occurs in version 15. I can install version 14 without any problems.

Additionally I looked into the code base and did not find any usage of cairocffi. Is this package even needed? If not it should be removed from the depenencies


### Error Message

```
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "/home/frappe/v15/env/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/frappe/v15/env/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/frappe/v15/env/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 112, in get_requires_for_build_wheel
          backend = _build_backend()
        File "/home/frappe/v15/env/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 77, in _build_backend
          obj = import_module(mod_path)
        File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
          return _bootstrap._gcd_import(name[level:], package, level)
        File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
        File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
        File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
        File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
        File "<frozen importlib._bootstrap_external>", line 883, in exec_module
        File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
        File "/tmp/pip-install-maecl87r/cairocffi_c697609eb45c4ac1b70729602d839221/utils/build.py", line 7, in <module>
          from setuptools.build_meta import *  # noqa
      AttributeError: module 'setuptools.build_meta' has no attribute 'get_requires_for_build_editable'. Did you mean: 'get_requires_for_build_sdist'?
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
```
