### PR TITLE
fix: enable syntax highlighting for `PythonExpression` code fields

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -153,6 +153,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 			JS: "ace/mode/javascript",
 			Python: "ace/mode/python",
 			Py: "ace/mode/python",
+			PythonExpression: "ace/mode/python",
 			HTML: "ace/mode/html",
 			CSS: "ace/mode/css",
 			Markdown: "ace/mode/markdown",


### PR DESCRIPTION
## Before

<img width="1337" alt="image" src="https://github.com/frappe/frappe/assets/24353136/2ce810a9-4ec1-41dc-9300-93b30d359e0e">

## After

<img width="1337" alt="image" src="https://github.com/frappe/frappe/assets/24353136/1b81b40c-ffbf-4188-8123-e2352382dbee">
