### PR TITLE
fix: lazy translate circular imports

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -130,9 +130,45 @@ def _lt(msg: str, lang: str | None = None, context: str | None = None):
 
 	Note: Result is not guaranteed to equivalent to pure strings for all operations.
 	"""
-	from frappe.translate import LazyTranslate
+	return _LazyTranslate(msg, lang, context)
 
-	return LazyTranslate(msg, lang, context)
+
+@functools.total_ordering
+class _LazyTranslate:
+	__slots__ = ("msg", "lang", "context")
+
+	def __init__(self, msg: str, lang: str | None = None, context: str | None = None) -> None:
+		self.msg = msg
+		self.lang = lang
+		self.context = context
+
+	@property
+	def value(self) -> str:
+		return _(str(self.msg), self.lang, self.context)
+
+	def __str__(self):
+		return self.value
+
+	def __add__(self, other):
+		if isinstance(other, (str, _LazyTranslate)):
+			return self.value + str(other)
+		raise NotImplementedError
+
+	def __radd__(self, other):
+		if isinstance(other, (str, _LazyTranslate)):
+			return str(other) + self.value
+		return NotImplementedError
+
+	def __repr__(self) -> str:
+		return f"'{self.value}'"
+
+	# NOTE: it's required to override these methods and raise error as default behaviour will
+	# return `False` in all cases.
+	def __eq__(self, other):
+		raise NotImplementedError
+
+	def __lt__(self, other):
+		raise NotImplementedError
 
 
 def as_unicode(text, encoding: str = "utf-8") -> str:

--- a/frappe/gettext/extractors/utils.py
+++ b/frappe/gettext/extractors/utils.py
@@ -1,7 +1,6 @@
 import re
 
 import frappe
-from frappe.model.utils import InvalidIncludePath, render_include
 
 TRANSLATE_PATTERN = re.compile(
 	r"_\(\s*"  # starts with literal `_(`, ignore following whitespace/newlines
@@ -35,6 +34,8 @@ def extract_messages_from_code(code):
 	:param code: code from which translatable files are to be extracted
 	"""
 	from jinja2 import TemplateError
+
+	from frappe.model.utils import InvalidIncludePath, render_include
 
 	try:
 		code = frappe.as_unicode(render_include(code))

--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -1029,44 +1029,6 @@ def print_language(language: str):
 	frappe.local.jenv = _jenv
 
 
-@functools.total_ordering
-class LazyTranslate:
-	__slots__ = ("msg", "lang", "context")
-
-	def __init__(self, msg: str, lang: str | None = None, context: str | None = None) -> None:
-		self.msg = msg
-		self.lang = lang
-		self.context = context
-
-	@property
-	def value(self) -> str:
-		return frappe._(str(self.msg), self.lang, self.context)
-
-	def __str__(self):
-		return self.value
-
-	def __add__(self, other):
-		if isinstance(other, (str, LazyTranslate)):
-			return self.value + str(other)
-		raise NotImplementedError
-
-	def __radd__(self, other):
-		if isinstance(other, (str, LazyTranslate)):
-			return str(other) + self.value
-		return NotImplementedError
-
-	def __repr__(self) -> str:
-		return f"'{self.value}'"
-
-	# NOTE: it's required to override these methods and raise error as default behaviour will
-	# return `False` in all cases.
-	def __eq__(self, other):
-		raise NotImplementedError
-
-	def __lt__(self, other):
-		raise NotImplementedError
-
-
 # Backward compatibility
 get_full_dict = get_all_translations
 load_lang = get_translations_from_apps


### PR DESCRIPTION
- Revert "fix: remove _lt from frappe.model.std_fields (#24662)"
- fix: circular import

closes https://github.com/frappe/frappe/issues/24661
