### PR TITLE
fix: Avoid enqueueing during install

### DIFF
--- a/frappe/core/doctype/role_profile/role_profile.py
+++ b/frappe/core/doctype/role_profile/role_profile.py
@@ -25,7 +25,11 @@ class RoleProfile(Document):
 		self.name = self.role_profile
 
 	def on_update(self):
-		self.queue_action("update_all_users", now=frappe.flags.in_test, enqueue_after_commit=True)
+		self.queue_action(
+			"update_all_users",
+			now=frappe.flags.in_test or frappe.flags.in_install,
+			enqueue_after_commit=True,
+		)
 
 	def update_all_users(self):
 		"""Changes in role_profile reflected across all its user"""


### PR DESCRIPTION
This isn't strictly required but if bench isn't running this can break installation.
