### PR TITLE
fix: use translated single doctype as label in get_link_to_form

### DIFF
--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -59,6 +59,7 @@ from frappe.utils.data import (
 	get_time,
 	get_timedelta,
 	get_timespan_date_range,
+	get_url_to_form,
 	get_year_ending,
 	getdate,
 	now_datetime,
@@ -981,6 +982,10 @@ class TestMiscUtils(FrappeTestCase):
 		installed_apps = [app["app_name"] for app in info["installed_apps"]]
 		self.assertIn("frappe", installed_apps)
 		self.assertGreaterEqual(len(info["users"]), 1)
+
+	def test_get_url_to_form(self):
+		self.assertTrue(get_url_to_form("System Settings").endswith("/app/system-settings"))
+		self.assertTrue(get_url_to_form("User", "Test User").endswith("/app/user/Test%20User"))
 
 	def test_safe_json_load(self):
 		self.assertEqual(safe_json_loads("{}"), {})

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1836,13 +1836,16 @@ def get_host_name() -> str:
 	return get_url().rsplit("//", 1)[-1]
 
 
-def get_link_to_form(doctype: str, name: str, label: str | None = None) -> str:
+def get_link_to_form(doctype: str, name: str | None = None, label: str | None = None) -> str:
 	"""Return the HTML link to the given document's form view.
 
 	e.g. get_link_to_form("Sales Invoice", "INV-0001", "Link Label") returns:
 	    '<a href="https://frappe.io/app/sales-invoice/INV-0001">Link Label</a>'.
 	"""
 	from frappe import _
+
+	if not name:
+		name = doctype
 
 	if not label:
 		label = _(doctype) if doctype == name else name

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1844,11 +1844,8 @@ def get_link_to_form(doctype: str, name: str | None = None, label: str | None = 
 	"""
 	from frappe import _
 
-	if not name:
-		name = doctype
-
 	if not label:
-		label = _(doctype) if doctype == name else name
+		label = name or _(doctype)
 
 	return f"""<a href="{get_url_to_form(doctype, name)}">{label}</a>"""
 
@@ -1895,13 +1892,18 @@ def get_absolute_url(doctype: str, name: str) -> str:
 	return f"/app/{quoted(slug(doctype))}/{quoted(name)}"
 
 
-def get_url_to_form(doctype: str, name: str) -> str:
+def get_url_to_form(doctype: str, name: str | None = None) -> str:
 	"""Return the absolute URL for the form view of the given document in the desk.
 
 	e.g. when doctype="Sales Invoice" and your site URL is "https://frappe.io",
 	         returns 'https://frappe.io/app/sales-invoice/INV-00001'
 	"""
-	return get_url(uri=f"/app/{quoted(slug(doctype))}/{quoted(name)}")
+	if not name:
+		uri = f"/app/{quoted(slug(doctype))}"
+	else:
+		uri = f"/app/{quoted(slug(doctype))}/{quoted(name)}"
+
+	return get_url(uri=uri)
 
 
 def get_url_to_list(doctype: str) -> str:

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1842,8 +1842,10 @@ def get_link_to_form(doctype: str, name: str, label: str | None = None) -> str:
 	e.g. get_link_to_form("Sales Invoice", "INV-0001", "Link Label") returns:
 	    '<a href="https://frappe.io/app/sales-invoice/INV-0001">Link Label</a>'.
 	"""
+	from frappe import _
+
 	if not label:
-		label = name
+		label = _(doctype) if doctype == name else name
 
 	return f"""<a href="{get_url_to_form(doctype, name)}">{label}</a>"""
 


### PR DESCRIPTION
- Use translated single doctype as label in `get_link_to_form`
- Allow name to be missing (for single doctypes)

Before:

```python
frappe.local.lang = "de"
get_link_to_form("System Settings", "System Settings")
# <a href="/app/system-settings/System%20Settings">System Settings</a>
```

After:

```python
frappe.local.lang = "de"
get_link_to_form("System Settings")
# <a href="/app/system-settings">Systemverwaltung</a>
```