### PR TITLE
fix: lower default retention periods

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -532,15 +532,15 @@ standard_help_items = [
 
 # log doctype cleanups to automatically add in log settings
 default_log_clearing_doctypes = {
-	"Error Log": 30,
-	"Activity Log": 90,
+	"Error Log": 14,
 	"Email Queue": 30,
-	"Scheduled Job Log": 90,
-	"Route History": 90,
-	"Submission Queue": 30,
-	"Prepared Report": 30,
+	"Scheduled Job Log": 7,
+	"Submission Queue": 7,
+	"Prepared Report": 14,
 	"Webhook Request Log": 30,
-	"Integration Request": 90,
 	"Unhandled Email": 30,
 	"Reminder": 30,
+	"Integration Request": 90,
+	"Activity Log": 90,
+	"Route History": 90,
 }


### PR DESCRIPTION
These can still be configured to different number. We are just changing
defaults. Why?

- Scheduled job log - errors get logged in error log anyway. Success log
  isn't that useful of 90 days?
- Prepared report - most reports are expired in a day or max a week.
  Rarely last month's report makes any sense today.
