### PR TITLE
feat: add more payment lifecycle events to server scripts

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -56,7 +56,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nOn Payment Authorization"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -149,7 +149,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2023-10-14 11:24:46.478533",
+ "modified": "2024-02-06 07:09:45.478533",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -45,6 +45,8 @@ class ServerScript(Document):
 			"Before Save (Submitted Document)",
 			"After Save (Submitted Document)",
 			"On Payment Authorization",
+			"On Payment Paid",
+			"On Payment Failed",
 		]
 		enable_rate_limit: DF.Check
 		event_frequency: DF.Literal[

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -17,6 +17,8 @@ EVENT_MAP = {
 	"after_delete": "After Delete",
 	"before_update_after_submit": "Before Save (Submitted Document)",
 	"on_update_after_submit": "After Save (Submitted Document)",
+	"on_payment_paid": "On Payment Paid",
+	"on_payment_failed": "On Payment Failed",
 	"on_payment_authorized": "On Payment Authorization",
 }
 


### PR DESCRIPTION
# Context

https://github.com/frappe/erpnext/pull/39468 implemented the possibility to work with `on_payment_failed` hooks to expose gateway specific payment error messages more suitably to the operator.

However, these and other foundational payment lifecycle events could not be addressed by Server Scripts and thus maintained by middle management in the Accounts department.

# Proposal

- Add more lifecycle events into which payment gateways can choose to hook into
- Make these available for Server Scripts and give trained middle managers the capability to customize their workflows around payment

# Risk / Reward Profile

- This is a purely a gain in function and has no consequence onto existing deployments, at all.

### Downstream Compatibility Considerations

- It will be the choice of `frappe/payments` maintainers whether they want to leverage this new gain in function for their user base. But this consideration is, imo, out of scope for `frappe/frappe`. If I can secure a downstream review, I can potentially give it a shot myself.