### PR TITLE
fix: kanban hide "add column" for std fields

### DIFF
--- a/frappe/public/js/frappe/build_events/build_events.bundle.js
+++ b/frappe/public/js/frappe/build_events/build_events.bundle.js
@@ -17,7 +17,7 @@ frappe.realtime.on("build_event", (data) => {
 					if (parts.length === 2) {
 						let filename = parts[0].split("/").slice(-1)[0];
 
-						frappe.assets.executed_ = frappe.assets.executed_.filter(
+						frappe.assets._executed = frappe.assets._executed.filter(
 							(asset) => !asset.includes(`${filename}.bundle`)
 						);
 					}

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -377,8 +377,13 @@ frappe.provide("frappe.views");
 		}
 
 		function bind_add_column() {
-			if (!self.board_perms.write) {
+			let doctype = self.cur_list.doctype;
+			let fieldname = self.cur_list.board.field_name;
+			const is_custom_field = frappe.meta.get_docfield(doctype, fieldname)?.is_custom_field;
+
+			if (!self.board_perms.write || !is_custom_field) {
 				// If no write access to board, editing board (by adding column) should be blocked
+				// If standard field then users can't add options
 				self.$kanban_board.find(".add-new-column").remove();
 				return;
 			}


### PR DESCRIPTION
- fix: build events
- fix(kanban): Don't show custom column option on standard fields
