### PR TITLE
fix(run-tests): don't try to access `frappe.flags` before `frappe.init()`

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -772,9 +772,6 @@ def run_tests(
 			click.secho(f"bench --site {site} set-config allow_tests true", fg="green")
 			return
 
-		frappe.flags.skip_before_tests = skip_before_tests
-		frappe.flags.skip_test_records = skip_test_records
-
 		ret = frappe.test_runner.main(
 			site,
 			app,
@@ -789,6 +786,8 @@ def run_tests(
 			doctype_list_path=doctype_list_path,
 			failfast=failfast,
 			case=case,
+			skip_test_records=skip_test_records,
+			skip_before_tests=skip_before_tests,
 		)
 
 		if len(ret.failures) == 0 and len(ret.errors) == 0:

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -51,12 +51,17 @@ def main(
 	doctype_list_path=None,
 	failfast=False,
 	case=None,
+	skip_test_records=False,
+	skip_before_tests=False,
 ):
 	global unittest_runner
 
 	frappe.init(site=site)
 	if not frappe.db:
 		frappe.connect()
+
+	frappe.flags.skip_before_tests = skip_before_tests
+	frappe.flags.skip_test_records = skip_test_records
 
 	if doctype_list_path:
 		app, doctype_list_path = doctype_list_path.split(os.path.sep, 1)


### PR DESCRIPTION
This broke in #24432 where invocations of `frappe.init()` were cleaned up

Moving the flag setting to after init fixes this
