### PR TITLE
fix(Custom Field): Button Rename Fieldname visible before saving

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.js
+++ b/frappe/custom/doctype/custom_field/custom_field.js
@@ -112,28 +112,30 @@ frappe.ui.form.on("Custom Field", {
 		}
 	},
 	add_rename_field(frm) {
-		frm.add_custom_button(__("Rename Fieldname"), () => {
-			frappe.prompt(
-				{
-					fieldtype: "Data",
-					label: __("Fieldname"),
-					fieldname: "fieldname",
-					reqd: 1,
-					default: frm.doc.fieldname,
-				},
-				function (data) {
-					frappe.call({
-						method: "frappe.custom.doctype.custom_field.custom_field.rename_fieldname",
-						args: {
-							custom_field: frm.doc.name,
-							fieldname: data.fieldname,
-						},
-					});
-				},
-				__("Rename Fieldname"),
-				__("Rename")
-			);
-		});
+		if (!frm.is_new()) {
+			frm.add_custom_button(__("Rename Fieldname"), () => {
+				frappe.prompt(
+					{
+						fieldtype: "Data",
+						label: __("Fieldname"),
+						fieldname: "fieldname",
+						reqd: 1,
+						default: frm.doc.fieldname,
+					},
+					function (data) {
+						frappe.call({
+							method: "frappe.custom.doctype.custom_field.custom_field.rename_fieldname",
+							args: {
+								custom_field: frm.doc.name,
+								fieldname: data.fieldname,
+							},
+						});
+					},
+					__("Rename Fieldname"),
+					__("Rename")
+				);
+			});
+		}
 	},
 });
 


### PR DESCRIPTION
'Rename Fieldname' button in the Custom Field is now consistently visible even before saving the document. 

![image](https://github.com/frappe/frappe/assets/91895505/b2c5bb23-a315-4e22-a89c-5d4d6ba70595)

@rohitwaghchaure Please Check