### PR TITLE
fix: Set default for search result limit if empty

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -132,6 +132,9 @@ class SystemSettings(Document):
 		self.validate_backup_limit()
 		self.validate_file_extensions()
 
+		if not self.link_field_results_limit:
+			self.link_field_results_limit = 10
+
 		if self.link_field_results_limit > 50:
 			self.link_field_results_limit = 50
 			label = _(self.meta.get_label("link_field_results_limit"))


### PR DESCRIPTION
This isn't really required but edge case like this can happen:
- Site created but setup not completed
- Site is now updated
- Now default is not set for new field, so `None` gets propagated. 


```
  File "apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 63, in setup_complete
    return process_setup_stages(stages, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 83, in process_setup_stages
    task.get("fn")(task.get("args"))
  File "apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 112, in update_global_settings
    update_system_settings(args)
  File "apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 191, in update_system_settings
    system_settings.save()
  File "apps/frappe/frappe/model/document.py", line 334, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 370, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1085, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 954, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1320, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1302, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 951, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/system_settings/system_settings.py", line 135, in validate
    if self.link_field_results_limit > 50:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'int'
```