### PR TITLE
fix: no of rows displayed based on report type

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.json
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.json
@@ -88,6 +88,7 @@
   },
   {
    "default": "100",
+   "depends_on": "eval:doc.report_type=='Report Builder'",
    "fieldname": "no_of_rows",
    "fieldtype": "Int",
    "label": "No of Rows (Max 500)"
@@ -211,15 +212,15 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.dynamic_date_period != 'Daily'",
    "description": "To begin the date range at the start of the chosen period. For example, if 'Year' is selected as the period, the report will start from January 1st of the current year.",
    "fieldname": "use_first_day_of_period",
    "fieldtype": "Check",
-   "depends_on": "eval: doc.dynamic_date_period != 'Daily'",
    "label": "Use First Day of Period"
   }
  ],
  "links": [],
- "modified": "2024-01-29 11:42:27.433958",
+ "modified": "2024-02-04 13:31:08.624648",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Auto Email Report",

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -72,7 +72,8 @@ export default class ShortcutWidget extends Widget {
 		this.widget.addClass("shortcut-widget-box");
 
 		let filters = frappe.utils.process_filter_expression(this.stats_filter);
-		if (this.type == "DocType" && filters) {
+
+		if (this.type == "DocType" && this.doc_view != "New" && filters) {
 			frappe.db
 				.count(this.link_to, {
 					filters: filters,


### PR DESCRIPTION
Closes https://github.com/frappe/frappe/issues/24720

Closes https://github.com/frappe/frappe/issues/24723

Before(https://github.com/frappe/frappe/issues/24723):
![before_numcard](https://github.com/frappe/frappe/assets/34086262/874e8631-a10e-4b39-86d4-5a36cd4b1cf0)

After(https://github.com/frappe/frappe/issues/24723):
![after_numbercard](https://github.com/frappe/frappe/assets/34086262/d8c8875a-4a92-4b71-a6c0-6506bd7ac266)

