### PR TITLE
fix: respect `null` when formatting number values

### DIFF
--- a/frappe/public/js/frappe/form/formatters.js
+++ b/frappe/public/js/frappe/form/formatters.js
@@ -49,6 +49,10 @@ frappe.form.formatters = {
 		return __(frappe.form.formatters["Data"](value, df));
 	},
 	Float: function (value, docfield, options, doc) {
+		if (value === null) {
+			return "";
+		}
+
 		// don't allow 0 precision for Floats, hence or'ing with null
 		var precision =
 			docfield.precision ||
@@ -73,12 +77,20 @@ frappe.form.formatters = {
 		}
 	},
 	Int: function (value, docfield, options) {
+		if (value === null) {
+			return "";
+		}
+
 		if (cstr(docfield.options).trim() === "File Size") {
 			return frappe.form.formatters.FileSize(value);
 		}
 		return frappe.form.formatters._right(value == null ? "" : cint(value), options);
 	},
 	Percent: function (value, docfield, options) {
+		if (value === null) {
+			return "";
+		}
+
 		const precision =
 			docfield.precision ||
 			cint(frappe.boot.sysdefaults && frappe.boot.sysdefaults.float_precision) ||
@@ -105,6 +117,10 @@ frappe.form.formatters = {
 		</div>`;
 	},
 	Currency: function (value, docfield, options, doc) {
+		if (value === null) {
+			return "";
+		}
+
 		var currency = frappe.meta.get_field_currency(docfield, doc);
 
 		let precision;


### PR DESCRIPTION
Null is the intentional absence of a value. It represents a variable that has been explicitly set to have no value.

Until now, we used to show `0` / `0.00` / `€ 0.00` / `0 %` if the value was actually `null`. This was incorrect. "No value" is different from 0 and we should respect that.

Before:

![Bildschirmfoto 2024-02-04 um 18 28 40](https://github.com/frappe/frappe/assets/14891507/dfaf3735-9c33-4884-83b2-7e03f849b2a6)

After:

![Bildschirmfoto 2024-02-04 um 18 28 02](https://github.com/frappe/frappe/assets/14891507/d8243d56-45c5-47da-a04a-2fc41c758d30)

The latter is much easier to understand because we're not distracted by countless of `€ 0.00` where there should be no value.