### PR TITLE
refactor: skip permlevel check if all levels are 0

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -679,8 +679,7 @@ class Document(BaseDocument):
 		return same
 
 	def apply_fieldlevel_read_permissions(self):
-		"""Remove values the user is not allowed to read (called when loading in desk)"""
-
+		"""Remove values the user is not allowed to read."""
 		if frappe.session.user == "Administrator":
 			return
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -687,7 +687,7 @@ class Document(BaseDocument):
 		for table_field in self.meta.get_table_fields():
 			all_fields += frappe.get_meta(table_field.options).fields or []
 
-		if all(df.permlevel <= 0 for df in all_fields):
+		if all(df.permlevel == 0 for df in all_fields):
 			return
 
 		has_access_to = self.get_permlevel_access("read")

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -684,18 +684,11 @@ class Document(BaseDocument):
 		if frappe.session.user == "Administrator":
 			return
 
-		has_higher_permlevel = False
-
 		all_fields = self.meta.fields.copy()
 		for table_field in self.meta.get_table_fields():
 			all_fields += frappe.get_meta(table_field.options).fields or []
 
-		for df in all_fields:
-			if df.permlevel > 0:
-				has_higher_permlevel = True
-				break
-
-		if not has_higher_permlevel:
+		if all(df.permlevel <= 0 for df in all_fields):
 			return
 
 		has_access_to = self.get_permlevel_access("read")


### PR DESCRIPTION
Before:

```python
has_higher_permlevel = False

for df in all_fields:
	if df.permlevel > 0:
		has_higher_permlevel = True
		break

if not has_higher_permlevel:
	return
```

After

```python
if all(df.permlevel <= 0 for df in all_fields):
	return
```

The two should be equivalent.