### PR TITLE
fix: Skip fulltext indexes during sync

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -383,6 +383,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 				WHERE Column_name = "{fieldname}"
 					AND Seq_in_index = 1
 					AND Non_unique={int(not unique)}
+					AND Index_type != 'FULLTEXT'
 				""",
 			as_dict=True,
 		)


### PR DESCRIPTION
These are not managed by framework's migration system so we shouldn't delete them.
