### PR TITLE
fix: title link check

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -90,7 +90,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		return frappe.boot?.translated_doctypes || [].includes(this.get_options());
 	}
 	is_title_link() {
-		return in_list(frappe.boot?.link_title_doctypes || [], this.get_options());
+		return (frappe.boot?.link_title_doctypes || []).includes(this.get_options());
 	}
 	async set_link_title(value) {
 		const doctype = this.get_options();

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -90,7 +90,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		return frappe.boot?.translated_doctypes || [].includes(this.get_options());
 	}
 	is_title_link() {
-		return frappe.boot?.link_title_doctypes || [].includes(this.get_options());
+		return in_list(frappe.boot?.link_title_doctypes || [], this.get_options());
 	}
 	async set_link_title(value) {
 		const doctype = this.get_options();


### PR DESCRIPTION
Version 15 latest

fixes: #24689

___

It used to work in versions before 15.9 and in versions 15.9 and earlier.

Thank You!