### PR TITLE
fix: is_translatable check in link field

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -87,7 +87,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		return this.is_translatable() ? __(value) : value;
 	}
 	is_translatable() {
-		return frappe.boot?.translated_doctypes || [].includes(this.get_options());
+		return (frappe.boot?.translated_doctypes || []).includes(this.get_options());
 	}
 	is_title_link() {
 		return (frappe.boot?.link_title_doctypes || []).includes(this.get_options());


### PR DESCRIPTION
Version 15 latest

Brackets issue.

Just like the problem with #24731
