### PR TITLE
fix: Make as_iterator work when there are no child queries

### DIFF
--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -89,7 +89,7 @@ def patch_query_execute():
 		return result
 
 	def execute_child_queries(queries, result):
-		if not result or not isinstance(result[0], dict) or not result[0].name:
+		if not queries or not result or not isinstance(result[0], dict) or not result[0].name:
 			return
 		parent_names = [d.name for d in result]
 		for child_query in queries:


### PR DESCRIPTION
backport https://github.com/frappe/frappe/commit/a69b779715f1dfa2a4aa2748f1252c837e7eabf3