### PR TITLE
fix: Allow int fields to be unique

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1353,7 +1353,7 @@ def validate_fields(meta):
 			d.search_index = 0
 
 		if getattr(d, "unique", False):
-			if d.fieldtype not in ("Data", "Link", "Read Only"):
+			if d.fieldtype not in ("Data", "Link", "Read Only", "Int"):
 				frappe.throw(
 					_("{0}: Fieldtype {1} for {2} cannot be unique").format(docname, d.fieldtype, d.label),
 					NonUniqueError,


### PR DESCRIPTION
PS: This will automatically make it mandatory because you can't have multiple default values of `0`.

close https://github.com/frappe/frappe/issues/19287
