### PR TITLE
fix: show folders in Google Drive Picker (backport #24386)

### DIFF
--- a/frappe/public/js/integrations/google_drive_picker.js
+++ b/frappe/public/js/integrations/google_drive_picker.js
@@ -42,11 +42,14 @@ export default class GoogleDrivePicker {
 	}
 
 	createPicker(access_token) {
-		this.view = new google.picker.View(google.picker.ViewId.DOCS);
+		const docsView = new google.picker.DocsView();
+		docsView.setParent("root"); // show the root folder by default
+		docsView.setIncludeFolders(true); // also show folders, not just files
+
 		this.picker = new google.picker.PickerBuilder()
 			.setAppId(this.appId)
 			.setOAuthToken(access_token)
-			.addView(this.view)
+			.addView(docsView)
 			.addView(new google.picker.DocsUploadView())
 			.setLocale(frappe.boot.lang)
 			.setCallback(this.pickerCallback)


### PR DESCRIPTION
This feature was accidentally removed in #23096
