### PR TITLE
fix: Use `TEXT` type for Webhook URLs to support large URLs

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -91,7 +91,7 @@
   },
   {
    "fieldname": "request_url",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "in_list_view": 1,
    "label": "Request URL",
    "reqd": 1
@@ -221,7 +221,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2023-06-16 10:21:00.971833",
+ "modified": "2024-02-05 17:49:50.203001",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -39,7 +39,7 @@ class Webhook(Document):
 		preview_request_body: DF.Code | None
 		request_method: DF.Literal["POST", "PUT", "DELETE"]
 		request_structure: DF.Literal["", "Form URL-Encoded", "JSON"]
-		request_url: DF.Data
+		request_url: DF.SmallText
 		timeout: DF.Int
 		webhook_data: DF.Table[WebhookData]
 		webhook_docevent: DF.Literal[
@@ -56,6 +56,7 @@ class Webhook(Document):
 		webhook_json: DF.Code | None
 		webhook_secret: DF.Password | None
 	# end: auto-generated types
+
 	def validate(self):
 		self.validate_docevent()
 		self.validate_condition()


### PR DESCRIPTION

closes https://github.com/frappe/frappe/issues/24527
