### PR TITLE
fix: the secondary button always visible

### DIFF
--- a/frappe/public/js/frappe/ui/messages.js
+++ b/frappe/public/js/frappe/ui/messages.js
@@ -243,6 +243,9 @@ frappe.msgprint = function (msg, title, is_minimizable) {
 	if (data.secondary_action) {
 		frappe.msg_dialog.set_secondary_action(data.secondary_action.action);
 		frappe.msg_dialog.set_secondary_action_label(__(data.secondary_action.label || "Close"));
+	} else {
+		let btn = frappe.msg_dialog.get_secondary_btn();
+		if (btn) btn.addClass("hide");
 	}
 
 	if (data.message == null) {


### PR DESCRIPTION
The secondary button is visible for new messages after being created in a message

Function: msgprint

Simulate:
```
frappe.msgprint({
    message: "Msg", 
    title: "Test 1",
    primary_action: {
        label: __("Primary"),
        action: function() {
            console.log("primary");
        }
    },
    secondary_action: {
        label: __("Secondary"),
        action: function() {
            console.log("secondary");
        }
    }
});

frappe.msgprint({
    message: "Show unsolicited secondary button!!!!", 
    title: "Test 2",
    primary_action: {
        label: __("Primary"),
        action: function() {
            console.log("primary");
        }
    }
});
```