### PR TITLE
fix: console import progress off-by-one

### DIFF
--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -149,7 +149,7 @@ class Importer:
 
 					if self.console:
 						update_progress_bar(
-							f"Importing ({self.import_type.split()[0]}) for doctype {self.doctype}: {total_payload_count} records",
+							f"Importing {self.doctype}: {total_payload_count} records",
 							current_index - 1,
 							total_payload_count,
 						)

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -150,7 +150,7 @@ class Importer:
 					if self.console:
 						update_progress_bar(
 							f"Importing {total_payload_count} records",
-							current_index,
+							current_index - 1,
 							total_payload_count,
 						)
 					elif total_payload_count > 5:

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -149,7 +149,7 @@ class Importer:
 
 					if self.console:
 						update_progress_bar(
-							f"Importing {total_payload_count} records",
+							f"Importing ({self.import_type.split()[0]}) for doctype {self.doctype}: {total_payload_count} records",
 							current_index - 1,
 							total_payload_count,
 						)


### PR DESCRIPTION
Existing behavior

```
Importing 4 records                 : [==================================================] 125%
```

New behavior
```
Importing (Insert) for doctype Note: 4 records: [========================================] 100%
```
Fixes off-by-one error and adds DocType and import type indicators to message.

closes #24776 