### PR TITLE
Fix: Remove Open Filter On Communication Doctype

### DIFF
--- a/frappe/core/doctype/communication/communication_list.js
+++ b/frappe/core/doctype/communication/communication_list.js
@@ -13,8 +13,6 @@ frappe.listview_settings["Communication"] = {
 		"communication_date",
 	],
 
-	filters: [["status", "=", "Open"]],
-
 	onload: function (list_view) {
 		let method = "frappe.email.inbox.create_email_flag_queue";
 


### PR DESCRIPTION
#24799 Removed filter Open on Communication list doctype to be default set on load. It can be set by the user if they want, this will allow the user not to miss any email.