### PR TITLE
fix(boilerplate): Fix WebsiteGenerator HTML templates

### DIFF
--- a/frappe/core/doctype/doctype/boilerplate/templates/controller.html
+++ b/frappe/core/doctype/doctype/boilerplate/templates/controller.html
@@ -1,7 +1,7 @@
 {{% extends "templates/web.html" %}}
 
 {{% block page_content %}}
-<h1>{{{{ title }}}}</h1>
+<h1>{{{{ title |e }}}}</h1>
 {{% endblock %}}
 
 <!-- this is a sample default web page template -->

--- a/frappe/core/doctype/doctype/boilerplate/templates/controller_row.html
+++ b/frappe/core/doctype/doctype/boilerplate/templates/controller_row.html
@@ -1,4 +1,4 @@
 <div>
-	<a href="{{{{ doc.route }}}}">{{{{ doc.title or doc.name }}}}</a>
+	<a href="/{{{{ doc.route |e }}}}">{{{{ (doc.title or doc.name) |e }}}}</a>
 </div>
 <!-- this is a sample default list template -->


### PR DESCRIPTION
closes #24477

* Prefixed `doc.route` in `href` with a slash (all `route` values are absolute, but no slash is stored in the field right?)
* Used the `|e` filter for page title / row title
* ~~Used the `.get_title()` controller method~~