### PR TITLE
fix(notification): ensure outgoing mail is set on comms

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -282,6 +282,9 @@ def get_context(context):
 				bcc=bcc,
 				communication_type="Automated Message",
 			).get("name")
+			# set the outgoing email account because we did in fact send it via sendmail above
+			comm = frappe.get_doc("Communication", communication)
+			comm.get_outgoing_email_account()
 
 		frappe.sendmail(
 			recipients=recipients,


### PR DESCRIPTION
# Context

When notifications were sent via email, they didn't show up in outgoing emails in the email inbox (with the intended standard filters set).

This is due to the fact that no autgoing email account was ever set on these communcations because `make_communication` only implements this
for emails that are actually sent through it. However, email in the Notification doctype are sent via `frappe.sendmail`.

# Proposed Solution

- don't rearchitecture to find the root cause of this entangled code path
- [x] but just fix it in the local code context
