### PR TITLE
fix: preferred_language cookie

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -65,7 +65,7 @@ def get_language(lang_list: list = None) -> str:
 		if preferred_language_cookie in lang_set:
 			return preferred_language_cookie
 
-		parent_language = get_parent_language(language)
+		parent_language = get_parent_language(preferred_language_cookie)
 		if parent_language in lang_set:
 			return parent_language
 


### PR DESCRIPTION
This fixes the use of the "preferred_language" cookie to change the language for a unregistered user.

Before the fix, the following error is thrown:

> Traceback (most recent call last):
>   File "apps/frappe/frappe/app.py", line 95, in application
>     init_request(request)
>   File "apps/frappe/frappe/app.py", line 191, in init_request
>     frappe.local.http_request = HTTPRequest()
>                                 ^^^^^^^^^^^^^
>   File "apps/frappe/frappe/auth.py", line 45, in __init__
>     self.set_lang()
>   File "apps/frappe/frappe/auth.py", line 96, in set_lang
>     frappe.local.lang = get_language()
>                         ^^^^^^^^^^^^^^
>   File "apps/frappe/frappe/translate.py", line 68, in get_language
>     parent_language = get_parent_language(language)
>                                           ^^^^^^^^
> UnboundLocalError: cannot access local variable 'language' where it is not associated with a value
> 

After the fix, the language is changed by the cookie as intended.

