### PR TITLE
chore: disable mergify auto merges

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,27 +21,6 @@ pull_request_rules:
             @{{author}}, thanks for the contribution, but we do not accept pull requests on a stable branch. Please raise PR on an appropriate hotfix branch.
             https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist#which-branch
 
-  - name: Automatic merge on CI success and review
-    conditions:
-      - label!=dont-merge
-      - label!=squash
-      - "#approved-reviews-by>=1"
-    actions:
-      merge:
-        method: merge
-  - name: Automatic squash on CI success and review
-    conditions:
-      - label!=dont-merge
-      - label=squash
-      - "#approved-reviews-by>=1"
-    actions:
-      merge:
-        method: squash
-        commit_message_template: |
-            {{ title }} (#{{ number }})
-
-            {{ body }}
-
   - name: backport to develop
     conditions:
       - label="backport develop"


### PR DESCRIPTION
This has only been the cause of surprises in recent history. Github has auto merge now, no need to use 2 diff versions. 