### PR TITLE
feat: frappe.model.can_submit (JS)

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -382,6 +382,11 @@ $.extend(frappe.model, {
 		return frappe.boot.user.can_delete.indexOf(doctype) !== -1;
 	},
 
+	can_submit: function (doctype) {
+		if (!doctype) return false;
+		return frappe.boot.user.can_submit.indexOf(doctype) !== -1;
+	},
+
 	can_cancel: function (doctype) {
 		if (!doctype) return false;
 		return frappe.boot.user.can_cancel.indexOf(doctype) !== -1;

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -32,6 +32,7 @@ class UserPermissions:
 		self.can_select = []
 		self.can_read = []
 		self.can_write = []
+		self.can_submit = []
 		self.can_cancel = []
 		self.can_delete = []
 		self.can_search = []
@@ -142,6 +143,9 @@ class UserPermissions:
 					else:
 						self.can_read.append(dt)
 
+			if p.get("submit"):
+				self.can_submit.append(dt)
+
 			if p.get("cancel"):
 				self.can_cancel.append(dt)
 
@@ -238,6 +242,7 @@ class UserPermissions:
 			"can_create",
 			"can_write",
 			"can_read",
+			"can_submit",
 			"can_cancel",
 			"can_delete",
 			"can_get_report",


### PR DESCRIPTION
Implemented the same way as `frappe.model.can_cancel`, etc.
Idk why this didn't exist before 🤷🏼‍♂️ 

> no-docs