### PR TITLE
perf: Cache private files on client side

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -759,7 +759,10 @@ class File(Document):
 		from urllib.parse import urlencode
 
 		if self.is_private:
-			return self.file_url + "?" + urlencode({"fid": self.name})
+			params = {"fid": self.name}  # quickly idenify exact file by filename
+			if self.content_hash:
+				params["hash"] = self.content_hash  # for cache-eviction
+			return self.file_url + "?" + urlencode(params)
 		else:
 			return self.file_url
 

--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -282,7 +282,12 @@ def download_private_file(path: str) -> Response:
 		raise Forbidden(_("You don't have permission to access this file"))
 
 	make_access_log(doctype="File", document=file.name, file_type=os.path.splitext(path)[-1][1:])
-	return send_private_file(path.split("/private", 1)[1])
+	response = send_private_file(path.split("/private", 1)[1])
+
+	if frappe.form_dict.hash:
+		response.cache_control.max_age = 31536000
+
+	return response
 
 
 def send_private_file(path: str) -> Response:


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/24839


1. Invalidations
2. Shorter duration?
3. tests
4. Fix all the places where file_url is used (yuge)