### PR TITLE
fix(capture): Add input to DOM before emitting click on it

### DIFF
--- a/frappe/public/js/frappe/ui/capture.js
+++ b/frappe/public/js/frappe/ui/capture.js
@@ -31,6 +31,10 @@ function get_file_input() {
 	input.setAttribute("accept", "image/*");
 	input.setAttribute("multiple", "");
 
+	// Make sure that the input exists in the DOM
+	input.classList.add("visually-hidden");
+	document.body.appendChild(input);
+
 	return input;
 }
 
@@ -125,6 +129,10 @@ frappe.ui.Capture = class {
 				let f = await read(file);
 				me.images.push(f);
 			}
+
+			// Remove the input from the DOM
+			me.input.remove();
+			me.input = null;
 
 			me.render_preview();
 			me.dialog.show();


### PR DESCRIPTION
I think there are some issues when trying to take a picture in the file upload dialog on iOS. I don't have an iOS device to check, but this bit of code seemed suspicious.