### PR TITLE
feat: socketio using authorization headers

### DIFF
--- a/realtime/handlers/frappe_handlers.js
+++ b/realtime/handlers/frappe_handlers.js
@@ -1,5 +1,4 @@
-const request = require("superagent");
-const { get_url } = require("../utils");
+const { frappe_request } = require("../utils");
 const log = console.log;
 
 const WEBSITE_ROOM = "website";
@@ -114,11 +113,9 @@ function notify_disconnected_documents(socket) {
 function can_subscribe_doctype(args) {
 	if (!args) return;
 	if (!args.doctype) return;
-	request
-		.get(get_url(args.socket, "/api/method/frappe.realtime.can_subscribe_doctype"))
+	frappe_request("/api/method/frappe.realtime.can_subscribe_doctype", args.socket)
 		.type("form")
 		.query({
-			sid: args.socket.sid,
 			doctype: args.doctype,
 		})
 		.end(function (err, res) {
@@ -166,11 +163,9 @@ function notify_subscribed_doc_users(args) {
 function can_subscribe_doc(args) {
 	if (!args) return;
 	if (!args.doctype || !args.docname) return;
-	request
-		.get(get_url(args.socket, "/api/method/frappe.realtime.can_subscribe_doc"))
+	frappe_request("/api/method/frappe.realtime.can_subscribe_doc", args.socket)
 		.type("form")
 		.query({
-			sid: args.socket.sid,
 			doctype: args.doctype,
 			docname: args.docname,
 		})

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -23,7 +23,7 @@ function authenticate_with_frappe(socket, next) {
 		return;
 	}
 
-	let cookies = cookie.parse(socket.request.headers.cookie);
+	let cookies = cookie.parse(socket.request.headers.cookie || "");
 	let authorization_header = socket.request.headers.authorization;
 
 	if (!cookies.sid && !authorization_header) {

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -1,5 +1,6 @@
 const { get_conf } = require("../node_utils");
 const conf = get_conf();
+const request = require("superagent");
 
 function get_url(socket, path) {
 	if (!path) {
@@ -16,6 +17,17 @@ function get_url(socket, path) {
 	return url + path;
 }
 
+// Authenticates a partial request created using superagent
+function frappe_request(path, socket) {
+	const partial_req = request.get(get_url(socket, path));
+	if (socket.sid) {
+		return partial_req.query({ sid: socket.sid });
+	} else if (socket.authorization_header) {
+		return partial_req.set("Authorization", socket.authorization_header);
+	}
+}
+
 module.exports = {
 	get_url,
+	frappe_request,
 };


### PR DESCRIPTION
Earlier socketio only worked in browser where browser would send cookie
(cause same domain) and hence socketio server used it to auth
connection.

This however is limited and doesn't allow simply creating socket
connection from apps.

Authorization headers on other hand are simple to implement.


closes https://github.com/frappe/frappe/issues/24530