### PR TITLE
feat: Queue selection for webhooks

### DIFF
--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -8,7 +8,7 @@ def get_all_webhooks():
 	# query webhooks
 	webhooks_list = frappe.get_all(
 		"Webhook",
-		fields=["name", "condition", "webhook_docevent", "webhook_doctype", "webhook_queue"],
+		fields=["name", "condition", "webhook_docevent", "webhook_doctype", "background_jobs_queue"],
 		filters={"enabled": True},
 	)
 
@@ -104,5 +104,5 @@ def flush_webhook_execution_queue():
 			doc=instance.doc,
 			webhook=instance.webhook,
 			now=frappe.flags.in_test,
-			queue=instance.webhook.webhook_queue or "default",
+			queue=instance.webhook.background_jobs_queue or "default",
 		)

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -104,5 +104,5 @@ def flush_webhook_execution_queue():
 			doc=instance.doc,
 			webhook=instance.webhook,
 			now=frappe.flags.in_test,
-			queue=instance.webhook.get("webhook_queue") or "default",
+			queue=instance.webhook.webhook_queue or "default",
 		)

--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -8,7 +8,7 @@ def get_all_webhooks():
 	# query webhooks
 	webhooks_list = frappe.get_all(
 		"Webhook",
-		fields=["name", "condition", "webhook_docevent", "webhook_doctype"],
+		fields=["name", "condition", "webhook_docevent", "webhook_doctype", "webhook_queue"],
 		filters={"enabled": True},
 	)
 
@@ -104,4 +104,5 @@ def flush_webhook_execution_queue():
 			doc=instance.doc,
 			webhook=instance.webhook,
 			now=frappe.flags.in_test,
+			queue=instance.webhook.get("webhook_queue") or "default",
 		)

--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -76,27 +76,15 @@ frappe.webhook = {
 			}
 		}
 	},
-
-	set_webhook_queue: (frm) => {
-		frappe.model.with_doctype(frm.doc.webhook_doctype, () => {
-			// get list of queue names
-			frm.call({
-				method: "get_all_queues",
-				freeze: true,
-				callback: (r) => {
-					if (r.message) {
-						frm.fields_dict.webhook_queue.set_data(r.message);
-					}
-				},
-			});
-		});
-	},
 };
 
 frappe.ui.form.on("Webhook", {
 	refresh: (frm) => {
 		frappe.webhook.set_fieldname_select(frm);
-		frappe.webhook.set_webhook_queue(frm);
+		frm.set_query(
+			"background_jobs_queue",
+			"frappe.integrations.doctype.webhook.webhook.get_all_queues"
+		);
 	},
 
 	request_structure: (frm) => {

--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -76,11 +76,27 @@ frappe.webhook = {
 			}
 		}
 	},
+
+	set_webhook_queue: (frm) => {
+		frappe.model.with_doctype(frm.doc.webhook_doctype, () => {
+			// get list of queue names
+			frm.call({
+				method: "get_all_queues",
+				freeze: true,
+				callback: (r) => {
+					if (r.message) {
+						frm.fields_dict.webhook_queue.set_data(r.message);
+					}
+				},
+			});
+		});
+	},
 };
 
 frappe.ui.form.on("Webhook", {
 	refresh: (frm) => {
 		frappe.webhook.set_fieldname_select(frm);
+		frappe.webhook.set_webhook_queue(frm);
 	},
 
 	request_structure: (frm) => {

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -19,7 +19,7 @@
   "request_url",
   "is_dynamic_url",
   "timeout",
-  "webhook_queue",
+  "background_jobs_queue",
   "cb_webhook",
   "request_method",
   "request_structure",
@@ -215,9 +215,9 @@
    "label": "Request Timeout"
   },
   {
-   "fieldname": "webhook_queue",
+   "fieldname": "background_jobs_queue",
    "fieldtype": "Autocomplete",
-   "label": "Webhook Queue"
+   "label": "Background Jobs Queue"
   }
  ],
  "links": [
@@ -226,7 +226,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-02-19 11:39:46.529574",
+ "modified": "2024-02-19 11:40:58.387233",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -8,6 +8,7 @@
  "field_order": [
   "sb_doc_events",
   "webhook_doctype",
+  "webhook_queue",
   "cb_doc_events",
   "webhook_docevent",
   "enabled",
@@ -213,6 +214,11 @@
    "fieldtype": "Int",
    "label": "Request Timeout",
    "reqd": 1
+  },
+  {
+   "fieldname": "webhook_queue",
+   "fieldtype": "Autocomplete",
+   "label": "Webhook Queue"
   }
  ],
  "links": [
@@ -221,7 +227,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-02-05 17:49:50.203001",
+ "modified": "2024-02-12 10:35:21.811887",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -8,7 +8,6 @@
  "field_order": [
   "sb_doc_events",
   "webhook_doctype",
-  "webhook_queue",
   "cb_doc_events",
   "webhook_docevent",
   "enabled",
@@ -18,8 +17,9 @@
   "html_condition",
   "sb_webhook",
   "request_url",
-  "timeout",
   "is_dynamic_url",
+  "timeout",
+  "webhook_queue",
   "cb_webhook",
   "request_method",
   "request_structure",
@@ -212,8 +212,7 @@
    "description": "The number of seconds until the request expires",
    "fieldname": "timeout",
    "fieldtype": "Int",
-   "label": "Request Timeout",
-   "reqd": 1
+   "label": "Request Timeout"
   },
   {
    "fieldname": "webhook_queue",
@@ -227,7 +226,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-02-12 10:35:21.811887",
+ "modified": "2024-02-19 11:39:46.529574",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -31,6 +31,7 @@ class Webhook(Document):
 		from frappe.integrations.doctype.webhook_header.webhook_header import WebhookHeader
 		from frappe.types import DF
 
+		background_jobs_queue: DF.Autocomplete | None
 		condition: DF.SmallText | None
 		enable_security: DF.Check
 		enabled: DF.Check
@@ -55,7 +56,6 @@ class Webhook(Document):
 		webhook_doctype: DF.Link
 		webhook_headers: DF.Table[WebhookHeader]
 		webhook_json: DF.Code | None
-		webhook_queue: DF.Autocomplete | None
 		webhook_secret: DF.Password | None
 	# end: auto-generated types
 

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -259,5 +259,6 @@ def get_webhook_data(doc, webhook):
 @frappe.whitelist()
 def get_all_queues():
 	"""Fetches all workers and returns a list of available queue names."""
+	frappe.only_for("System Manager")
 
 	return get_queues_timeout().keys()

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -13,6 +13,7 @@ import requests
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils.background_jobs import get_queues_timeout
 from frappe.utils.jinja import validate_template
 from frappe.utils.safe_exec import get_safe_globals
 
@@ -54,6 +55,7 @@ class Webhook(Document):
 		webhook_doctype: DF.Link
 		webhook_headers: DF.Table[WebhookHeader]
 		webhook_json: DF.Code | None
+		webhook_queue: DF.Autocomplete | None
 		webhook_secret: DF.Password | None
 	# end: auto-generated types
 
@@ -252,3 +254,10 @@ def get_webhook_data(doc, webhook):
 		data = json.loads(data)
 
 	return data
+
+
+@frappe.whitelist()
+def get_all_queues():
+	"""Fetches all workers and returns a list of available queue names."""
+
+	return get_queues_timeout().keys()


### PR DESCRIPTION
## Context
There should be an ability to select dedicated queues on webhook.  

closes #24875 

## Proposed Solution
- Append a field on webhook for queue selection
- List both default (`short`, `long`, `default`) and custom queues

## Risk / Reward
- Feature is backward compatible
- Does not conflict/block existing flow for webhooks


## Progress
- [X] Code
- [ ] Add integration test
- [x] Update docs 

Draft Doc: https://frappeframework.com/docs/user/en/guides/integration/webhooks?editWiki=1&wikiPagePatch=eed808bc03