### PR TITLE
fix: use communication date in timeline

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -287,7 +287,7 @@ def get_communication_data(
 	if after:
 		# find after a particular date
 		conditions += f"""
-			AND C.creation > {after}
+			AND C.communication_date > {after}
 		"""
 
 	if doctype == "User":
@@ -319,7 +319,7 @@ def get_communication_data(
 		SELECT *
 		FROM (({part1}) UNION ({part2})) AS combined
 		{group_by}
-		ORDER BY creation DESC
+		ORDER BY communication_date DESC
 		LIMIT %(limit)s
 		OFFSET %(start)s
 	""".format(part1=part1, part2=part2, group_by=(group_by or "")),

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -234,7 +234,7 @@ class FormTimeline extends BaseTimeline {
 			communication_timeline_contents.push({
 				icon: icon_set[medium],
 				icon_size: "sm",
-				creation: communication.creation,
+				creation: communication.communication_date,
 				is_card: true,
 				content: this.get_communication_timeline_content(communication),
 				doctype: "Communication",

--- a/frappe/public/js/frappe/form/templates/timeline_message_box.html
+++ b/frappe/public/js/frappe/form/templates/timeline_message_box.html
@@ -23,7 +23,7 @@
 					{% } %}
 
 					<div class="text-muted">
-						{{ comment_when(doc.creation) }}
+						{{ comment_when(doc.communication_date) }}
 					</div>
 				</span>
 			{% } else if (doc.comment_type && doc.comment_type == "Comment") { %}
@@ -33,7 +33,7 @@
 					<span class="text-muted">{{ __("commented") }}</span>
 					<span> . </span>
 					<span class="margin-left text-muted">
-						{{ comment_when(doc.creation) }}
+						{{ comment_when(doc.communication_date) }}
 					</span>
 				</span>
 			{% } else { %}
@@ -44,7 +44,7 @@
 					{{ doc.user_full_name || frappe.user.full_name(doc.owner) }}
 					<span> . </span>
 					<span class="text-muted">
-						{{ comment_when(doc.creation) }}
+						{{ comment_when(doc.communication_date) }}
 					</span>
 					{% if (doc.subject) { %}
 						<div class="text-muted my-1">{{doc.subject}}</div>


### PR DESCRIPTION
Before, we used the database creation date, which may coincidentally corresponds to the real communication date (email sent and synced today) but not always (email sent three years ago, synced to the database today).

As per the few thousand communications in our system, the communication date is always available. Since it's more accurate, we should use it.

### Before

![before](https://github.com/frappe/frappe/assets/14891507/8d064419-b1a6-42fd-8cdc-6be758fcb44f)

(The communication record was apparently created two weeks ago, but the email is three years old. Displaying the creation date is misleading.)

### After

![after](https://github.com/frappe/frappe/assets/14891507/5a9e27a9-10be-4958-979f-3df485d778dc)
