### PR TITLE
fix: Passed format options as their own argument

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1029,8 +1029,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				formatTooltipY: (d) =>
 					frappe.format(d, {
 						fieldtype: options.fieldtype,
-						options: options.options,
-					}),
+					}, 
+						options.options),
 			};
 		}
 		options.axisOptions = {


### PR DESCRIPTION
`frappe.format` takes and uses an options parameter, but instead `options.options` is passed into the `df` parameter, where the options are never used (as far as I could tell). This makes it impossible to pass formatting options in some situations, such as chart labels (i.e. when attempting to use currency formatting for labels). 

I'm guessing this was a typo?