### PR TITLE
fix(weblist): Fix "More" button not working

### DIFF
--- a/frappe/templates/includes/list/list.js
+++ b/frappe/templates/includes/list/list.js
@@ -6,7 +6,7 @@ frappe.ready(function() {
 		var btn = $(this);
 		var data = $.extend(frappe.utils.get_query_params(), {
 			doctype: "{{ doctype }}",
-			txt: "{{ txt|e or '' }}",
+			txt: "{{ (txt or '')|e }}",
 			limit_start: next_start,
 			pathname: location.pathname,
 		});


### PR DESCRIPTION
When `txt` is `None`, then it was sent in the template-compiled list.js as the value `"None"`, which obviously cannot be found in the documents, thus breaking the More button shown on web list pages.