### PR TITLE
fix(calendar): Replace route in load_last_view

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -11,6 +11,7 @@ frappe.views.CalendarView = class CalendarView extends frappe.views.ListView {
 			const doctype = route[1];
 			const user_settings = frappe.get_user_settings(doctype)["Calendar"] || {};
 			route.push(user_settings.last_calendar || "default");
+			frappe.route_flags.replace_route = true;
 			frappe.set_route(route);
 			return true;
 		} else {


### PR DESCRIPTION
Use `replaceState` instead of `pushState` to avoid breaking the browser's <kbd>Back</kbd> navigation button. This is done using the `frappe.route_flags.replace_route` flag. When going back, the calendar view did immediately push a new route again, thus preventing going back completely.