### PR TITLE
feat: pass doctype as context when translating label

### DIFF
--- a/frappe/core/doctype/data_export/data_export.js
+++ b/frappe/core/doctype/data_export/data_export.js
@@ -153,7 +153,7 @@ const add_doctype_field_multicheck_control = (doctype, parent_wrapper) => {
 
 	const options = fields.map((df) => {
 		return {
-			label: __(df.label),
+			label: __(df.label, null, df.parent),
 			value: df.fieldname,
 			danger: df.reqd,
 			checked: 1,

--- a/frappe/core/doctype/data_export/exporter.py
+++ b/frappe/core/doctype/data_export/exporter.py
@@ -306,7 +306,7 @@ class DataExporter:
 
 		self.tablerow.append("")
 		self.fieldrow.append(docfield.fieldname)
-		self.labelrow.append(_(docfield.label))
+		self.labelrow.append(_(docfield.label, context=docfield.parent))
 		self.mandatoryrow.append(docfield.reqd and "Yes" or "No")
 		self.typerow.append(docfield.fieldtype)
 		self.inforow.append(self.getinforow(docfield))

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -313,7 +313,7 @@ class DocType(Document):
 
 				frappe.msgprint(
 					_("{0} should be indexed because it's referred in dashboard connections").format(
-						_(d.label)
+						_(d.label, context=d.parent)
 					),
 					alert=True,
 					indicator="orange",
@@ -1548,7 +1548,7 @@ def validate_fields(meta):
 
 		if docfield.fieldtype == "Data" and not (docfield.oldfieldtype and docfield.oldfieldtype != "Data"):
 			if docfield.options and (docfield.options not in data_field_options):
-				df_str = frappe.bold(_(docfield.label))
+				df_str = frappe.bold(_(docfield.label, context=docfield.parent))
 				text_str = (
 					_("{0} is an invalid Data field.").format(df_str)
 					+ "<br>" * 2

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -259,7 +259,7 @@ def get_fields_label(doctype=None):
 		return frappe.msgprint(_("Custom Fields can only be added to a standard DocType."))
 
 	return [
-		{"value": df.fieldname or "", "label": _(df.label) if df.label else ""}
+		{"value": df.fieldname or "", "label": _(df.label, context=df.parent) if df.label else ""}
 		for df in frappe.get_meta(doctype).get("fields")
 	]
 

--- a/frappe/desk/doctype/desktop_icon/desktop_icon.py
+++ b/frappe/desk/doctype/desktop_icon/desktop_icon.py
@@ -143,7 +143,7 @@ def get_desktop_icons(user=None):
 		# translate
 		for d in user_icons:
 			if d.label:
-				d.label = _(d.label)
+				d.label = _(d.label, context=d.parent)
 
 		frappe.cache.hset("desktop_icons", user, user_icons)
 

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.js
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.js
@@ -75,7 +75,7 @@ function setup_fields(frm) {
 				})
 				.map((df) => {
 					return {
-						label: `${__(df.label)} (${df.fieldname})`,
+						label: `${__(df.label, null, df.parent)} (${df.fieldname})`,
 						value: df.fieldname,
 					};
 				});

--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -15,7 +15,7 @@ frappe.notification = {
 
 				return {
 					value: select_value,
-					label: df.fieldname + " (" + __(df.label) + ")",
+					label: df.fieldname + " (" + __(df.label, null, df.parent) + ")",
 				};
 			};
 

--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -14,11 +14,9 @@ frappe.webhook = {
 							!frappe.model.table_fields.includes(d.fieldtype)
 						) {
 							return null;
-						} else if (d.fieldtype === "Currency" || d.fieldtype === "Float") {
-							return { label: d.label, value: d.fieldname };
 						} else {
 							return {
-								label: `${__(d.label)} (${d.fieldtype})`,
+								label: `${__(d.label, null, d.parent)} (${__(d.fieldtype)})`,
 								value: d.fieldname,
 							};
 						}
@@ -28,10 +26,12 @@ frappe.webhook = {
 				// add meta fields
 				for (let field of frappe.model.std_fields) {
 					if (field.fieldname == "name") {
-						fields.unshift({ label: "Name (Doc Name)", value: "name" });
+						fields.unshift({ label: __("Name (Doc Name)"), value: "name" });
 					} else {
 						fields.push({
-							label: `${__(field.label)} (${field.fieldtype})`,
+							label: `${__(field.label, null, field.parent)} (${__(
+								field.fieldtype
+							)})`,
 							value: field.fieldname,
 						});
 					}

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -376,7 +376,7 @@ class BaseDocument:
 						)
 
 				if isinstance(value, list) and df.fieldtype not in table_fields:
-					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label)))
+					frappe.throw(_("Value for {0} cannot be a list").format(_(df.label, context=df.parent)))
 
 				if df.fieldtype == "Check":
 					value = 1 if cint(value) else 0
@@ -719,7 +719,9 @@ class BaseDocument:
 
 		def get_msg(df):
 			if df.fieldtype in table_fields:
-				return "{}: {}: {}".format(_("Error"), _("Data missing in table"), _(df.label))
+				return "{}: {}: {}".format(
+					_("Error"), _("Data missing in table"), _(df.label, context=df.parent)
+				)
 
 			# check if parentfield exists (only applicable for child table doctype)
 			elif self.get("parentfield"):
@@ -729,10 +731,10 @@ class BaseDocument:
 					_("Row"),
 					self.idx,
 					_("Value missing for"),
-					_(df.label),
+					_(df.label, context=df.parent),
 				)
 
-			return _("Error: Value missing for {0}: {1}").format(_(df.parent), _(df.label))
+			return _("Error: Value missing for {0}: {1}").format(_(df.parent), _(df.label, context=df.parent))
 
 		def has_content(df):
 			value = cstr(self.get(df.fieldname))
@@ -767,9 +769,9 @@ class BaseDocument:
 		def get_msg(df, docname):
 			# check if parentfield exists (only applicable for child table doctype)
 			if self.get("parentfield"):
-				return "{} #{}: {}: {}".format(_("Row"), self.idx, _(df.label), docname)
+				return "{} #{}: {}: {}".format(_("Row"), self.idx, _(df.label, context=df.parent), docname)
 
-			return f"{_(df.label)}: {docname}"
+			return f"{_(df.label, context=df.parent)}: {docname}"
 
 		invalid_links = []
 		cancelled_links = []
@@ -1014,7 +1016,7 @@ class BaseDocument:
 
 		frappe.throw(
 			_("{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}").format(
-				reference, _(df.label), max_length, value
+				reference, _(df.label, context=df.parent), max_length, value
 			),
 			frappe.CharacterLengthExceededError,
 			title=_("Value too big"),
@@ -1049,7 +1051,7 @@ class BaseDocument:
 					frappe.throw(
 						_("{0} Not allowed to change {1} after submission from {2} to {3}").format(
 							f"Row #{self.idx}:" if self.get("parent") else "",
-							frappe.bold(_(df.label)),
+							frappe.bold(_(df.label, context=df.parent)),
 							frappe.bold(db_value),
 							frappe.bold(self_value),
 						),

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -591,11 +591,11 @@ class Document(BaseDocument):
 					_("Row"),
 					self.idx,
 					_("Value cannot be negative for"),
-					frappe.bold(_(df.label)),
+					frappe.bold(_(df.label, context=df.parent)),
 				)
 			else:
 				return _("Value cannot be negative for {0}: {1}").format(
-					_(df.parent), frappe.bold(_(df.label))
+					_(df.parent), frappe.bold(_(df.label, context=df.parent))
 				)
 
 		for df in self.meta.get(

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -406,7 +406,7 @@ def has_user_permission(doc, user=None, debug=False):
 						_(field.options),
 						d.get(field.fieldname) or _("empty"),
 						d.idx,
-						_(field.label) if field.label else field.fieldname,
+						_(field.label, context=field.parent) if field.label else field.fieldname,
 					)
 				else:
 					# "You are not allowed to access Company 'Restricted Company' in field Reference Type"
@@ -416,7 +416,7 @@ def has_user_permission(doc, user=None, debug=False):
 						_(meta.doctype),
 						_(field.options),
 						d.get(field.fieldname) or _("empty"),
-						_(field.label) if field.label else field.fieldname,
+						_(field.label, context=field.parent) if field.label else field.fieldname,
 					)
 
 				push_perm_check_log(msg, debug=debug)

--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -2,7 +2,7 @@
 	{% if(field.print_hide) { %}style="background-color: #F7FAFC; color: #8D99A6;"
 		title="{{ __("Hidden") }}"{% } %}
 	data-fieldname="{%= field.fieldname %}"
-	data-label="{{ __(field.label) }}"
+	data-label="{{ __(field.label, context=field.parent) }}"
 
 	{% if field.align %}data-align="{{ field.align }}"{% endif %}
 	data-fieldtype="{%= field.fieldtype %}"
@@ -34,13 +34,13 @@
 			<span class="drag-handle">
 				<svg class="icon icon-xs"><use href="#icon-drag"></use></svg>
 			</span>
-			<span class="field-label">{{ __(field.label) || __(field.fieldname) }}
+			<span class="field-label">{{ __(field.label, context=field.parent) || __(field.fieldname) }}
 				<span> ({%= __("Table") %})</span>
 			</span>
 			<a class="pull-right select-columns btn btn-default btn-xs">
 				{%= __("Select Columns") %}</a>
 		{% } else { %}
-			<span class="field-label">{{ __(field.label) }}</span>
+			<span class="field-label">{{ __(field.label, context=field.parent) }}</span>
 		{% } %}
 	{% } %}
 </div>

--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -73,8 +73,11 @@ frappe.data_import.DataExporter = class DataExporter {
 					let child_fieldname = df.fieldname;
 					let label = df.reqd
 						? // prettier-ignore
-						  __('{0} ({1}) (1 row mandatory)', [__(df.label || df.fieldname), __(doctype)])
-						: __("{0} ({1})", [__(df.label || df.fieldname), __(doctype)]);
+						  __('{0} ({1}) (1 row mandatory)', [__(df.label || df.fieldname, null, df.parent), __(doctype)])
+						: __("{0} ({1})", [
+								__(df.label || df.fieldname, null, df.parent),
+								__(doctype),
+						  ]);
 					return {
 						label,
 						fieldname: child_fieldname,
@@ -291,7 +294,7 @@ frappe.data_import.DataExporter = class DataExporter {
 			})
 			.map((df) => {
 				return {
-					label: __(df.label),
+					label: __(df.label, null, df.parent),
 					value: df.fieldname,
 					danger: is_field_mandatory(df),
 					checked: false,

--- a/frappe/public/js/frappe/data_import/import_preview.js
+++ b/frappe/public/js/frappe/data_import/import_preview.js
@@ -334,11 +334,11 @@ function get_fields_as_options(doctype, column_map) {
 	return [].concat(
 		...keys.map((key) => {
 			return column_map[key].map((df) => {
-				let label = __(df.label);
+				let label = __(df.label, null, df.parent);
 				let value = df.fieldname;
 				if (doctype !== key) {
 					let table_field = frappe.meta.get_docfield(doctype, key);
-					label = `${__(df.label)} (${__(table_field.label)})`;
+					label = `${__(df.label, null, df.parent)} (${__(table_field.label)})`;
 					value = `${table_field.fieldname}.${df.fieldname}`;
 				}
 				return {

--- a/frappe/public/js/frappe/form/column.js
+++ b/frappe/public/js/frappe/form/column.js
@@ -30,7 +30,7 @@ export default class Column {
 		if (this.df.label) {
 			$(`
 				<label class="column-label">
-					${__(this.df.label)}
+					${__(this.df.label, null, this.df.parent)}
 				</label>
 			`).prependTo(this.wrapper);
 		}

--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -67,7 +67,7 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 					d.label = d.value;
 				}
 
-				var _label = me.translate_values ? __(d.label) : d.label;
+				var _label = me.translate_values ? __(d.label, null, d.parent) : d.label;
 				var html = "<strong>" + _label + "</strong>";
 				if (d.description) {
 					html += '<br><span class="small">' + __(d.description) + "</span>";

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -160,7 +160,8 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 
 		var icon = "";
 		this.label_span.innerHTML =
-			(icon ? '<i class="' + icon + '"></i> ' : "") + __(this.df.label) || "&nbsp;";
+			(icon ? '<i class="' + icon + '"></i> ' : "") +
+				__(this.df.label, null, this.df.parent) || "&nbsp;";
 		this._label = this.df.label;
 	}
 

--- a/frappe/public/js/frappe/form/controls/button.js
+++ b/frappe/public/js/frappe/form/controls/button.js
@@ -60,7 +60,9 @@ frappe.ui.form.ControlButton = class ControlButton extends frappe.ui.form.Contro
 		if (label) {
 			this.df.label = label;
 		}
-		label = (this.df.icon ? frappe.utils.icon(this.df.icon) : "") + __(this.df.label);
+		label =
+			(this.df.icon ? frappe.utils.icon(this.df.icon) : "") +
+			__(this.df.label, null, this.df.parent);
 		$(this.label_span).html("&nbsp;");
 		this.$input && this.$input.html(label);
 	}

--- a/frappe/public/js/frappe/form/controls/heading.js
+++ b/frappe/public/js/frappe/form/controls/heading.js
@@ -1,5 +1,5 @@
 frappe.ui.form.ControlHeading = class ControlHeading extends frappe.ui.form.ControlHTML {
 	get_content() {
-		return "<h4>" + __(this.df.label) + "</h4>";
+		return "<h4>" + __(this.df.label, null, this.df.parent) + "</h4>";
 	}
 };

--- a/frappe/public/js/frappe/form/controls/signature.js
+++ b/frappe/public/js/frappe/form/controls/signature.js
@@ -6,7 +6,7 @@ frappe.ui.form.ControlSignature = class ControlSignature extends frappe.ui.form.
 		super.make();
 
 		if (this.df.label) {
-			$(this.wrapper).find("label").text(__(this.df.label));
+			$(this.wrapper).find("label").text(__(this.df.label, null, this.df.parent));
 		}
 		this.set_doc_url();
 

--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -110,7 +110,7 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 				return (
 					field.fieldname.toLowerCase() === field_name ||
 					(field.label || "").toLowerCase() === field_name ||
-					(__(field.label) || "").toLowerCase() === field_name
+					(__(field.label, null, field.parent) || "").toLowerCase() === field_name
 				);
 			};
 

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -92,7 +92,7 @@ function get_version_timeline_content(version_doc, frm) {
 					if (field_display_status === "Read" || field_display_status === "Write") {
 						parts.push(
 							__("{0} from {1} to {2}", [
-								__(df.label),
+								__(df.label, null, df.parent),
 								format_content_for_timeline(p[1]),
 								format_content_for_timeline(p[2]),
 							])

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1530,7 +1530,10 @@ frappe.ui.form.Form = class FrappeForm {
 		$.each(fields_list, function (i, fname) {
 			var docfield = frappe.meta.docfield_map[doctype][fname];
 			if (docfield) {
-				var label = __(docfield.label || "").replace(/\([^\)]*\)/g, ""); // eslint-disable-line
+				var label = __(docfield.label || "", null, docfield.parent).replace(
+					/\([^\)]*\)/g,
+					""
+				); // eslint-disable-line
 				if (parentfield) {
 					grid_field_label_map[doctype + "-" + fname] =
 						label.trim() + " (" + __(currency) + ")";

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -546,7 +546,7 @@ export default class GridRow {
 								<a style='cursor: grabbing;'>${frappe.utils.icon("drag", "xs")}</a>
 							</div>
 							<div class='col-6 col-md-8' style='padding-right:0px; padding-top: 5px;'>
-								${__(docfield.label)}
+								${__(docfield.label, null, docfield.parent)}
 							</div>
 							<div class='col-3 col-md-2' style='padding-left:0px; padding-top: 2px; margin-top:-2px;' title='${__(
 								"Columns"
@@ -694,7 +694,7 @@ export default class GridRow {
 
 			let txt = this.doc
 				? frappe.format(this.doc[df.fieldname], df, null, this.doc)
-				: __(df.label);
+				: __(df.label, null, df.parent);
 
 			if (this.doc && df.fieldtype === "Select") {
 				txt = __(txt);
@@ -1077,7 +1077,7 @@ export default class GridRow {
 
 					let txt = this.doc
 						? frappe.format(this.doc[df.fieldname], df, null, this.doc)
-						: __(df.label);
+						: __(df.label, null, df.parent);
 
 					this.refresh_field(df.fieldname, txt);
 				}

--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -47,7 +47,7 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 				columns: 2,
 				select_all: true,
 				options: pick_columns.map((df) => ({
-					label: __(df.label),
+					label: __(df.label, null, df.parent),
 					value: df.fieldname,
 				})),
 			}

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -135,7 +135,7 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 						!frappe.model.has_value(doc.doctype, doc.name, df.fieldname)
 					) {
 						has_errors = true;
-						error_fields[error_fields.length] = __(df.label);
+						error_fields[error_fields.length] = __(df.label, null, df.parent);
 						// scroll to field
 						if (!frm.scroll_set) {
 							scroll_to(doc.parentfield || df.fieldname);

--- a/frappe/public/js/frappe/form/section.js
+++ b/frappe/public/js/frappe/form/section.js
@@ -63,7 +63,7 @@ export default class Section {
 	make_head() {
 		this.head = $(`
 			<div class="section-head">
-				${__(this.df.label)}
+				${__(this.df.label, null, this.df.parent)}
 				<span class="ml-2 collapse-indicator mb-1"></span>
 			</div>
 		`);

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -808,7 +808,7 @@ class FilterArea {
 
 					return {
 						fieldtype: fieldtype,
-						label: __(df.label),
+						label: __(df.label, null, df.parent),
 						options: options,
 						fieldname: df.fieldname,
 						condition: condition,

--- a/frappe/public/js/frappe/list/list_sidebar_group_by.js
+++ b/frappe/public/js/frappe/list/list_sidebar_group_by.js
@@ -152,7 +152,7 @@ frappe.views.ListGroupBy = class ListGroupBy {
 			fieldtype: "MultiCheck",
 			columns: 2,
 			options: fields.map((df) => ({
-				label: __(df.label),
+				label: __(df.label, null, df.parent),
 				value: df.fieldname,
 				checked: this.group_by_fields.includes(df.fieldname),
 			})),

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -653,13 +653,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					html = subject_html;
 				} else {
 					const fieldname = col.df?.fieldname;
-					const attrs = fieldname
-						? ` data-sort-by="${fieldname}"
-							title="${__("Click to sort by {0}", [col.df?.label])}"`
-						: "";
-					html = `<span ${attrs}>
-						${__(col.df?.label || col.type)}
-					</span>`;
+					const label = __(col.df?.label || col.type, null, col.df?.parent);
+					const title = __("Click to sort by {0}", [label]);
+					const attrs = fieldname ? `data-sort-by="${fieldname}" title="${title}"` : "";
+					html = `<span ${attrs}>${label}</span>`;
 				}
 
 				return `<div class="${classes}">${html}</div>

--- a/frappe/public/js/frappe/ui/filters/field_select.js
+++ b/frappe/public/js/frappe/ui/filters/field_select.js
@@ -166,10 +166,10 @@ frappe.ui.FieldSelect = class FieldSelect {
 		let table = null;
 
 		if (me.doctype && df.parent == me.doctype) {
-			label = __(df.label);
+			label = __(df.label, null, df.parent);
 			table = me.doctype;
 		} else {
-			label = __(df.label) + " (" + __(df.parent) + ")";
+			label = __(df.label, null, df.parent) + " (" + __(df.parent) + ")";
 			table = df.parent;
 		}
 

--- a/frappe/public/js/frappe/ui/group_by/group_by.html
+++ b/frappe/public/js/frappe/ui/group_by/group_by.html
@@ -9,12 +9,12 @@
 			<select class="group-by form-control input-xs">
 				<option value="" disabled selected>{{ __("Select Group By...") }}</option>
 				{% for (var parent_doctype in group_by_conditions) { %}
-					{% for (var val in group_by_conditions[parent_doctype]) { %}
+					{% for (var val of group_by_conditions[parent_doctype]) { %}
 						<option
 							data-doctype="{{parent_doctype}}"
-							value="{{group_by_conditions[parent_doctype][val].fieldname}}"
+							value="{{val.fieldname}}"
 						>
-							{{ __(group_by_conditions[parent_doctype][val].label || group_by_conditions[parent_doctype][val].fieldname) }}
+							{{ __(val.label || val.fieldname, null, val.parent ) }}
 						</option>
 					{% } %}
 				{% } %}

--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -147,15 +147,13 @@ frappe.ui.GroupBy = class {
 					doctype_fields.forEach((field) => {
 						// pick numeric fields for sum / avg
 						if (frappe.model.is_numeric_field(field.fieldtype)) {
-							let field_label = field.label
-								? field.label
-								: frappe.model.unscrub(field.fieldname);
+							let field_label = field.label || frappe.model.unscrub(field.fieldname);
 							let option_text =
 								doctype == this.doctype
-									? field_label
-									: `${__(field_label)} (${__(doctype)})`;
+									? __(field_label, null, field.parent)
+									: `${__(field_label, null, field.parent)} (${__(doctype)})`;
 							this.aggregate_on_html += `<option data-doctype="${doctype}"
-								value="${field.fieldname}">${__(option_text)}</option>`;
+								value="${field.fieldname}">${option_text}</option>`;
 						}
 					});
 				}
@@ -327,9 +325,9 @@ frappe.ui.GroupBy = class {
 			);
 
 			if (this.aggregate_function === "sum") {
-				docfield.label = __("Sum of {0}", [__(docfield.label)]);
+				docfield.label = __("Sum of {0}", [__(docfield.label, null, docfield.parent)]);
 			} else {
-				docfield.label = __("Average of {0}", [__(docfield.label)]);
+				docfield.label = __("Average of {0}", [__(docfield.label, null, docfield.parent)]);
 			}
 		}
 
@@ -433,6 +431,6 @@ frappe.ui.GroupBy = class {
 		let field = this.group_by_fields[this.group_by_doctype]?.find(
 			(field) => field.fieldname == this.group_by_field
 		);
-		return field?.label || field?.fieldname;
+		return field?.label ? __(field.label, null, field.parent) : field?.fieldname;
 	}
 };

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -891,7 +891,7 @@ frappe.ui.Page = class Page {
 		f.refresh();
 		$(f.wrapper)
 			.addClass("col-md-2")
-			.attr("title", __(df.label))
+			.attr("title", __(df.label, null, df.parent))
 			.tooltip({
 				delay: { show: 600, hide: 100 },
 				trigger: "hover",
@@ -905,7 +905,7 @@ frappe.ui.Page = class Page {
 		// hidden fields dont have $input
 		if (!f.$input) f.make_input();
 
-		f.$input.attr("placeholder", __(df.label));
+		f.$input.attr("placeholder", __(df.label, null, df.parent));
 
 		if (df.fieldtype === "Check") {
 			$(f.wrapper).find(":first-child").removeClass("col-md-offset-4 col-md-8");

--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -736,7 +736,9 @@ frappe.provide("frappe.views");
 				let field =
 					frappe.meta.docfield_map[card.doctype]?.[field_name] ||
 					frappe.model.get_std_field(field_name);
-				let label = cur_list.board.show_labels ? `<span>${__(field.label)}: </span>` : "";
+				let label = cur_list.board.show_labels
+					? `<span>${__(field.label, null, field.parent)}: </span>`
+					: "";
 				let value = frappe.format(card.doc[field_name], field);
 				fields.push(`
 					<div class="text-muted text-truncate">

--- a/frappe/public/js/frappe/views/kanban/kanban_settings.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_settings.js
@@ -97,7 +97,7 @@ export default class KanbanSettings {
 							${frappe.utils.icon("drag", "xs", "", "", "sortable-handle")}
 						</div>
 						<div class="col-md-10" style="padding-left:0px;">
-							${__(field.label)}
+							${__(field.label, null, field.parent)}
 						</div>
 						<div class="col-md-1">
 							<a class="text-muted remove-field" data-fieldname="${field.fieldname}">
@@ -238,7 +238,7 @@ export default class KanbanSettings {
 			)
 			.map((field) => {
 				return {
-					label: __(field.label),
+					label: __(field.label, null, field.parent),
 					value: field.fieldname,
 					checked: this.fields.includes(field.fieldname),
 				};

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1461,7 +1461,10 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			.map((fieldname) => {
 				const docfield = frappe.query_report.get_filter(fieldname).df;
 				const value = applied_filters[fieldname];
-				return `<h6>${__(docfield.label)}: ${frappe.format(value, docfield)}</h6>`;
+				return `<h6>${__(docfield.label, null, docfield.parent)}: ${frappe.format(
+					value,
+					docfield
+				)}</h6>`;
 			})
 			.join("");
 	}

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -334,7 +334,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						columns_in_picker = columns[this.doctype]
 							.filter((df) => !this.is_column_added(df))
 							.map((df) => ({
-								label: __(df.label),
+								label: __(df.label, null, df.parent),
 								value: df.fieldname,
 							}));
 
@@ -344,7 +344,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							columns[cdt]
 								.filter((df) => !this.is_column_added(df))
 								.map((df) => ({
-									label: __(df.label) + ` (${cdt})`,
+									label: __(df.label, null, df.parent) + ` (${cdt})`,
 									value: df.fieldname + "," + cdt,
 								}))
 								.forEach((df) => columns_in_picker.push(df));
@@ -961,7 +961,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					return !df.hidden && df.fieldname !== "name";
 				})
 				.map((df) => ({
-					label: __(df.label),
+					label: __(df.label, null, df.parent),
 					value: df.fieldname,
 					checked: this.fields.find(
 						(f) => f[0] === df.fieldname && f[1] === this.doctype
@@ -977,7 +977,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			const cdt = df.options;
 
 			dialog_fields.push({
-				label: __(df.label) + ` (${__(cdt)})`,
+				label: __(df.label, null, df.parent) + ` (${__(cdt)})`,
 				fieldname: df.options,
 				fieldtype: "MultiCheck",
 				columns: 2,
@@ -986,7 +986,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 						return !df.hidden;
 					})
 					.map((df) => ({
-						label: __(df.label),
+						label: __(df.label, null, df.parent),
 						value: df.fieldname,
 						checked: this.fields.find((f) => f[0] === df.fieldname && f[1] === cdt),
 					})),
@@ -1075,7 +1075,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		}
 		if (!docfield || docfield.report_hide) return;
 
-		let title = __(docfield.label);
+		let title = __(docfield.label, null, docfield.parent);
 		if (doctype !== this.doctype) {
 			title += ` (${__(doctype)})`;
 		}

--- a/frappe/public/js/frappe/web_form/web_form_list.js
+++ b/frappe/public/js/frappe/web_form/web_form_list.js
@@ -57,7 +57,7 @@ export default class WebFormList {
 							options: field.options,
 							input_class: "input-xs",
 							only_select: true,
-							label: __(field.label),
+							label: __(field.label, null, field.parent),
 							onchange: (event) => {
 								this.add_filter(field.fieldname, input.value, field.fieldtype);
 								this.refresh();
@@ -70,13 +70,13 @@ export default class WebFormList {
 
 					$(input.wrapper)
 						.addClass("col-md-2")
-						.attr("title", __(field.label))
+						.attr("title", __(field.label, null, field.parent))
 						.tooltip({
 							delay: { show: 600, hide: 100 },
 							trigger: "hover",
 						});
 
-					input.$input.attr("placeholder", __(field.label));
+					input.$input.attr("placeholder", __(field.label, null, field.parent));
 					this.filter_input.push(input);
 				});
 				this.refresh();

--- a/frappe/public/js/print_format_builder/PrintFormatControls.vue
+++ b/frappe/public/js/print_format_builder/PrintFormatControls.vue
@@ -230,7 +230,7 @@ let print_templates = computed(() => {
 			};
 		}
 		out.push({
-			label: `${__(df.label)} (${__("Field Template")})`,
+			label: `${__(df.label, null, df.parent)} (${__("Field Template")})`,
 			fieldname: df.fieldname + "_template",
 			fieldtype: "Field Template",
 			field_template: template.name,

--- a/frappe/public/js/print_format_builder/utils.js
+++ b/frappe/public/js/print_format_builder/utils.js
@@ -66,7 +66,7 @@ export function create_default_layout(meta, print_format) {
 
 				let field_template = get_field_template(print_format, df.fieldname);
 				if (field_template) {
-					field.label = `${__(df.label)} (${__("Field Template")})`;
+					field.label = `${__(df.label, null, df.parent)} (${__("Field Template")})`;
 					field.fieldtype = "Field Template";
 					field.field_template = field_template.name;
 					field.fieldname = df.fieldname = "_template";

--- a/frappe/templates/print_formats/standard_macros.html
+++ b/frappe/templates/print_formats/standard_macros.html
@@ -93,7 +93,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 				<div class="{{label_col_class}}
 					{%- if doc.align_labels_right %} text-right{%- endif -%}">
 					{% if df.fieldtype not in ("Image", "HTML") %}
-					<label>{{ _(df.label) }}: </label>
+					<label>{{ _(df.label, context=df.parent) }}: </label>
 					{% endif %}
 				</div>
 				<div class="{{value_col_class}}
@@ -107,7 +107,7 @@ data-fieldname="{{ df.fieldname }}" data-fieldtype="{{ df.fieldtype }}"
 {%- macro render_text_field(df, doc) -%}
 {%- if doc.get(df.fieldname) != None -%}
 <div style="padding: 10px 0px" {{ fieldmeta(df) }}>
-	{%- if df.fieldtype in ("Text", "Code", "Long Text") %}<label>{{ _(df.label) }}</label>{%- endif %}
+	{%- if df.fieldtype in ("Text", "Code", "Long Text") %}<label>{{ _(df.label, context=df.parent) }}</label>{%- endif %}
 	{%- if df.fieldtype=="Code" %}
 		<pre class="value">{{ doc.get(df.fieldname)|e }}</pre>
 	{% else -%}

--- a/frappe/utils/csvutils.py
+++ b/frappe/utils/csvutils.py
@@ -134,7 +134,7 @@ def check_record(d):
 				if val not in docfield.options.split("\n"):
 					frappe.throw(
 						_("{0} must be one of {1}").format(
-							_(docfield.label), comma_or(docfield.options.split("\n"))
+							_(docfield.label, context=docfield.parent), comma_or(docfield.options.split("\n"))
 						)
 					)
 


### PR DESCRIPTION
Whenever a field label is translated, pass the parent doctype as context. This way, the same label can be translated differently for different doctypes. (The doctype is already passed as context when generating translation files.)

> no-docs