### PR TITLE
feat: extract translatable strings from JS template strings

### DIFF
--- a/frappe/gettext/extractors/tests/test_javascript.py
+++ b/frappe/gettext/extractors/tests/test_javascript.py
@@ -1,0 +1,17 @@
+from frappe.gettext.extractors.javascript import extract_javascript
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestJavaScript(FrappeTestCase):
+	def test_extract_javascript(self):
+		code = "let test = `<p>${__('Test')}</p>`;"
+		self.assertEqual(
+			next(extract_javascript(code)),
+			(1, "__", "Test"),
+		)
+
+		code = "let test = `<p>${__('Test', null, 'Context')}</p>`;"
+		self.assertEqual(
+			next(extract_javascript(code)),
+			(1, "__", ("Test", None, "Context")),
+		)

--- a/frappe/locale/main.pot
+++ b/frappe/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Frappe Framework VERSION\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
-"POT-Creation-Date: 2024-01-29 18:10+0053\n"
-"PO-Revision-Date: 2024-01-29 18:10+0053\n"
+"POT-Creation-Date: 2024-02-16 17:24+0053\n"
+"PO-Revision-Date: 2024-02-16 17:24+0053\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: developers@frappe.io\n"
 "MIME-Version: 1.0\n"
@@ -34,7 +34,7 @@ msgctxt "About Us Settings"
 msgid "\"Company History\""
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:204
+#: core/doctype/data_export/exporter.py:202
 msgid "\"Parent\" signifies the parent table in which this row must be added"
 msgstr ""
 
@@ -49,7 +49,7 @@ msgstr ""
 msgid "\"amended_from\" field must be present to do an amendment."
 msgstr ""
 
-#: utils/csvutils.py:219
+#: utils/csvutils.py:221
 msgid "\"{0}\" is not a valid Google Sheets URL"
 msgstr ""
 
@@ -178,13 +178,17 @@ msgstr ""
 msgid "#{0}"
 msgstr ""
 
+#: public/js/frappe/ui/toolbar/about.js:8
+msgid "&copy; Frappe Technologies Pvt. Ltd. and contributors"
+msgstr ""
+
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "&lt;head&gt; HTML"
 msgstr ""
 
-#: public/js/form_builder/store.js:201
+#: public/js/form_builder/store.js:206
 msgid "'In Global Search' is not allowed for field {0} of type {1}"
 msgstr ""
 
@@ -192,15 +196,15 @@ msgstr ""
 msgid "'In Global Search' not allowed for type {0} in row {1}"
 msgstr ""
 
-#: public/js/form_builder/store.js:193
+#: public/js/form_builder/store.js:198
 msgid "'In List View' is not allowed for field {0} of type {1}"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:360
+#: custom/doctype/customize_form/customize_form.py:358
 msgid "'In List View' not allowed for type {0} in row {1}"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:149
+#: automation/doctype/auto_repeat/auto_repeat.py:150
 msgid "'Recipients' not specified"
 msgstr ""
 
@@ -212,8 +216,16 @@ msgstr ""
 msgid "'{0}' not allowed for type {1} in row {2}"
 msgstr ""
 
-#: model/rename_doc.py:689
+#: public/js/frappe/data_import/data_exporter.js:301
+msgid "(Mandatory)"
+msgstr ""
+
+#: model/rename_doc.py:671
 msgid "** Failed: {0} to {1}: {2}"
+msgstr ""
+
+#: public/js/frappe/views/kanban/kanban_settings.js:111
+msgid "+ Add / Remove Fields"
 msgstr ""
 
 #. Description of the 'Doc Status' (Select) field in DocType 'Workflow Document
@@ -245,15 +257,19 @@ msgstr ""
 msgid "1 Day"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:358
+#: integrations/doctype/google_calendar/google_calendar.py:359
 msgid "1 Google Calendar Event synced."
 msgstr ""
 
-#: website/doctype/blog_post/blog_post.py:378
+#: public/js/frappe/views/reports/query_report.js:877
+msgid "1 Report"
+msgstr ""
+
+#: website/doctype/blog_post/blog_post.py:374
 msgid "1 comment"
 msgstr ""
 
-#: tests/test_utils.py:648
+#: tests/test_utils.py:668
 msgid "1 day ago"
 msgstr ""
 
@@ -261,51 +277,51 @@ msgstr ""
 msgid "1 hour"
 msgstr ""
 
-#: public/js/frappe/utils/pretty_date.js:52 tests/test_utils.py:646
+#: public/js/frappe/utils/pretty_date.js:52 tests/test_utils.py:666
 msgid "1 hour ago"
 msgstr ""
 
-#: public/js/frappe/utils/pretty_date.js:48 tests/test_utils.py:644
+#: public/js/frappe/utils/pretty_date.js:48 tests/test_utils.py:664
 msgid "1 minute ago"
 msgstr ""
 
-#: public/js/frappe/utils/pretty_date.js:66 tests/test_utils.py:652
+#: public/js/frappe/utils/pretty_date.js:66 tests/test_utils.py:672
 msgid "1 month ago"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:223
+#: public/js/frappe/data_import/data_exporter.js:226
 msgid "1 record will be exported"
 msgstr ""
 
-#: tests/test_utils.py:643
+#: tests/test_utils.py:663
 msgid "1 second ago"
 msgstr ""
 
-#: public/js/frappe/utils/pretty_date.js:62 tests/test_utils.py:650
+#: public/js/frappe/utils/pretty_date.js:62 tests/test_utils.py:670
 msgid "1 week ago"
 msgstr ""
 
-#: public/js/frappe/utils/pretty_date.js:70 tests/test_utils.py:654
+#: public/js/frappe/utils/pretty_date.js:70 tests/test_utils.py:674
 msgid "1 year ago"
 msgstr ""
 
-#: tests/test_utils.py:647
+#: tests/test_utils.py:667
 msgid "2 hours ago"
 msgstr ""
 
-#: tests/test_utils.py:653
+#: tests/test_utils.py:673
 msgid "2 months ago"
 msgstr ""
 
-#: tests/test_utils.py:651
+#: tests/test_utils.py:671
 msgid "2 weeks ago"
 msgstr ""
 
-#: tests/test_utils.py:655
+#: tests/test_utils.py:675
 msgid "2 years ago"
 msgstr ""
 
-#: tests/test_utils.py:645
+#: tests/test_utils.py:665
 msgid "3 minutes ago"
 msgstr ""
 
@@ -321,8 +337,12 @@ msgstr ""
 msgid "5 Records"
 msgstr ""
 
-#: tests/test_utils.py:649
+#: tests/test_utils.py:669
 msgid "5 days ago"
+msgstr ""
+
+#: public/js/frappe/list/list_view.js:990
+msgid "99"
 msgstr ""
 
 #: desk/doctype/bulk_update/bulk_update.py:37
@@ -343,7 +363,7 @@ msgctxt "Document Naming Rule Condition"
 msgid "<="
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:570
+#: public/js/frappe/widgets/widget_dialog.js:603
 msgid "<b>{0}</b> is not a valid URL"
 msgstr ""
 
@@ -620,7 +640,7 @@ msgid ""
 "</code></pre>"
 msgstr ""
 
-#: twofactor.py:469
+#: twofactor.py:461
 msgid "<p>Your OTP secret on {0} has been reset. If you did not perform this reset and did not request it, please contact your System Administrator immediately.</p>"
 msgstr ""
 
@@ -715,7 +735,7 @@ msgstr ""
 msgid "A DocType (Document Type) is used to insert forms in ERPNext. Forms such as Customer, Orders, and Invoices are Doctypes in the backend. You can also create new DocTypes to create new forms in ERPNext as per your business needs."
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1011
+#: core/doctype/doctype/doctype.py:1013
 msgid "A DocType's name should start with a letter and can only consist of letters, numbers, spaces, underscores and hyphens"
 msgstr ""
 
@@ -723,11 +743,11 @@ msgstr ""
 msgid "A featured post must have a cover image"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:171
+#: custom/doctype/custom_field/custom_field.py:172
 msgid "A field with the name {0} already exists in {1}"
 msgstr ""
 
-#: core/doctype/file/file.py:254
+#: core/doctype/file/file.py:255
 msgid "A file with same name {} already exists"
 msgstr ""
 
@@ -741,7 +761,7 @@ msgstr ""
 msgid "A new account has been created for you at {0}"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:388
+#: automation/doctype/auto_repeat/auto_repeat.py:389
 msgid "A recurring {0} {1} has been created for you via Auto Repeat {2}."
 msgstr ""
 
@@ -751,11 +771,11 @@ msgctxt "Currency"
 msgid "A symbol for this currency. For e.g. $"
 msgstr ""
 
-#: printing/doctype/print_format_field_template/print_format_field_template.py:48
+#: printing/doctype/print_format_field_template/print_format_field_template.py:49
 msgid "A template already exists for field {0} of {1}"
 msgstr ""
 
-#: utils/password_strength.py:173
+#: utils/password_strength.py:169
 msgid "A word by itself is easy to guess."
 msgstr ""
 
@@ -983,7 +1003,7 @@ msgctxt "Social Login Key"
 msgid "Access Token URL"
 msgstr ""
 
-#: auth.py:455
+#: auth.py:445
 msgid "Access not allowed from this IP Address"
 msgstr ""
 
@@ -1063,7 +1083,7 @@ msgstr ""
 msgid "Action Complete"
 msgstr ""
 
-#: model/document.py:1648
+#: model/document.py:1652
 msgid "Action Failed"
 msgstr ""
 
@@ -1085,11 +1105,11 @@ msgctxt "DocType Action"
 msgid "Action Type"
 msgstr ""
 
-#: core/doctype/submission_queue/submission_queue.py:119
+#: core/doctype/submission_queue/submission_queue.py:120
 msgid "Action {0} completed successfully on {1} {2}. View it {3}"
 msgstr ""
 
-#: core/doctype/submission_queue/submission_queue.py:115
+#: core/doctype/submission_queue/submission_queue.py:116
 msgid "Action {0} failed on {1} {2}. View it {3}"
 msgstr ""
 
@@ -1107,6 +1127,7 @@ msgstr ""
 #: custom/doctype/customize_form/customize_form.js:132
 #: custom/doctype/customize_form/customize_form.js:140
 #: custom/doctype/customize_form/customize_form.js:238
+#: public/js/frappe/ui/page.html:56
 #: public/js/frappe/views/reports/query_report.js:190
 #: public/js/frappe/views/reports/query_report.js:203
 #: public/js/frappe/views/reports/query_report.js:213
@@ -1132,7 +1153,7 @@ msgctxt "Package Import"
 msgid "Activate"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:105 core/doctype/user/user_list.js:12
+#: core/doctype/recorder/recorder_list.js:207 core/doctype/user/user_list.js:12
 #: workflow/doctype/workflow/workflow_list.js:5
 msgid "Active"
 msgstr ""
@@ -1173,6 +1194,7 @@ msgid "Active Sessions"
 msgstr ""
 
 #: public/js/frappe/form/dashboard.js:22
+#: public/js/frappe/form/footer/form_timeline.js:58
 msgid "Activity"
 msgstr ""
 
@@ -1200,10 +1222,11 @@ msgctxt "User"
 msgid "Activity Log"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:465
+#: core/page/permission_manager/permission_manager.js:476
 #: email/doctype/email_group/email_group.js:60
 #: public/js/frappe/form/grid_row.js:469
 #: public/js/frappe/form/sidebar/assign_to.js:100
+#: public/js/frappe/form/templates/set_sharing.html:68
 #: public/js/frappe/list/bulk_operations.js:393
 #: public/js/frappe/views/dashboard/dashboard_view.js:440
 #: public/js/frappe/views/reports/query_report.js:265
@@ -1212,14 +1235,24 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
+#: public/js/frappe/list/list_view.js:264
+msgctxt "Primary action in list view"
+msgid "Add"
+msgstr ""
+
+#: public/js/frappe/form/grid_row.js:429
+msgid "Add / Remove Columns"
+msgstr ""
+
 #: core/doctype/user_permission/user_permission_list.js:4
 msgid "Add / Update"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:425
+#: core/page/permission_manager/permission_manager.js:436
 msgid "Add A New Rule"
 msgstr ""
 
+#: public/js/frappe/views/communication.js:529
 #: public/js/frappe/views/interaction.js:159
 msgid "Add Attachment"
 msgstr ""
@@ -1255,8 +1288,9 @@ msgstr ""
 msgid "Add Child"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1664
+#: public/js/frappe/views/kanban/kanban_board.html:4
 #: public/js/frappe/views/reports/query_report.js:1667
+#: public/js/frappe/views/reports/query_report.js:1670
 #: public/js/frappe/views/reports/report_view.js:329
 #: public/js/frappe/views/reports/report_view.js:354
 msgid "Add Column"
@@ -1282,8 +1316,8 @@ msgctxt "Web Page"
 msgid "Add Custom Tags"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:159
-#: public/js/frappe/widgets/widget_dialog.js:689
+#: public/js/frappe/widgets/widget_dialog.js:192
+#: public/js/frappe/widgets/widget_dialog.js:722
 msgid "Add Filters"
 msgstr ""
 
@@ -1293,11 +1327,16 @@ msgctxt "Web Page Block"
 msgid "Add Gray Background"
 msgstr ""
 
-#: public/js/frappe/ui/group_by/group_by.js:417
+#: public/js/frappe/ui/group_by/group_by.js:230
+#: public/js/frappe/ui/group_by/group_by.js:415
 msgid "Add Group"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:428
+#: public/js/frappe/form/grid.js:63
+msgid "Add Multiple"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager.js:439
 msgid "Add New Permission Rule"
 msgstr ""
 
@@ -1315,8 +1354,12 @@ msgstr ""
 msgid "Add Review"
 msgstr ""
 
-#: core/doctype/user/user.py:768
+#: core/doctype/user/user.py:794
 msgid "Add Roles"
+msgstr ""
+
+#: public/js/frappe/form/grid.js:63
+msgid "Add Row"
 msgstr ""
 
 #: public/js/frappe/views/communication.js:117
@@ -1381,6 +1424,14 @@ msgctxt "Event"
 msgid "Add Video Conferencing"
 msgstr ""
 
+#: public/js/frappe/ui/filters/filter_list.js:296
+msgid "Add a Filter"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:9
+msgid "Add a New Role"
+msgstr ""
+
 #: public/js/frappe/form/form_tour.js:205
 msgid "Add a Row"
 msgstr ""
@@ -1388,6 +1439,10 @@ msgstr ""
 #: templates/includes/comments/comments.html:30
 #: templates/includes/comments/comments.html:47
 msgid "Add a comment"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_layout.html:28
+msgid "Add a new section"
 msgstr ""
 
 #: public/js/frappe/form/form.js:192
@@ -1431,6 +1486,10 @@ msgstr ""
 msgid "Add to this activity by mailing to {0}"
 msgstr ""
 
+#: public/js/frappe/views/kanban/kanban_column.html:20
+msgid "Add {0}"
+msgstr ""
+
 #. Description of the '&lt;head&gt; HTML' (Code) field in DocType 'Website
 #. Settings'
 #: website/doctype/website_settings/website_settings.json
@@ -1442,7 +1501,7 @@ msgstr ""
 msgid "Added default log doctypes: {}"
 msgstr ""
 
-#: core/doctype/file/file.py:720
+#: core/doctype/file/file.py:717
 msgid "Added {0}"
 msgstr ""
 
@@ -1451,7 +1510,7 @@ msgstr ""
 msgid "Added {0} ({1})"
 msgstr ""
 
-#: core/doctype/user/user.py:271
+#: core/doctype/user/user.py:300
 msgid "Adding System Manager to this User as there must be atleast one System Manager"
 msgstr ""
 
@@ -1531,7 +1590,7 @@ msgctxt "Contact Us Settings"
 msgid "Address Title"
 msgstr ""
 
-#: contacts/doctype/address/address.py:71
+#: contacts/doctype/address/address.py:72
 msgid "Address Title is mandatory."
 msgstr ""
 
@@ -1548,7 +1607,7 @@ msgctxt "Website Settings"
 msgid "Address and other legal information you may want to put in the footer."
 msgstr ""
 
-#: contacts/doctype/address/address.py:208
+#: contacts/doctype/address/address.py:206
 msgid "Addresses"
 msgstr ""
 
@@ -1578,11 +1637,11 @@ msgstr ""
 msgid "Administrator"
 msgstr ""
 
-#: core/doctype/user/user.py:1180
+#: core/doctype/user/user.py:1198
 msgid "Administrator Logged In"
 msgstr ""
 
-#: core/doctype/user/user.py:1174
+#: core/doctype/user/user.py:1192
 msgid "Administrator accessed {0} on {1} via IP Address {2}."
 msgstr ""
 
@@ -1657,7 +1716,7 @@ msgctxt "Server Script"
 msgid "After Submit"
 msgstr ""
 
-#: desk/doctype/number_card/number_card.py:58
+#: desk/doctype/number_card/number_card.py:59
 msgid "Aggregate Field is required to create a number card"
 msgstr ""
 
@@ -1673,7 +1732,7 @@ msgctxt "Number Card"
 msgid "Aggregate Function Based On"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.py:410
+#: desk/doctype/dashboard_chart/dashboard_chart.py:400
 msgid "Aggregate Function field is required to create a dashboard chart"
 msgstr ""
 
@@ -1757,12 +1816,16 @@ msgctxt "Event"
 msgid "All Day"
 msgstr ""
 
-#: website/doctype/website_slideshow/website_slideshow.py:42
+#: website/doctype/website_slideshow/website_slideshow.py:43
 msgid "All Images attached to Website Slideshow should be public"
 msgstr ""
 
 #: public/js/frappe/data_import/data_exporter.js:29
 msgid "All Records"
+msgstr ""
+
+#: public/js/frappe/form/form.js:2173
+msgid "All Submissions"
 msgstr ""
 
 #: custom/doctype/customize_form/customize_form.js:384
@@ -1779,7 +1842,7 @@ msgctxt "Workflow"
 msgid "All possible Workflow States and roles of the workflow. Docstatus Options: 0 is \"Saved\", 1 is \"Submitted\" and 2 is \"Cancelled\""
 msgstr ""
 
-#: utils/password_strength.py:187
+#: utils/password_strength.py:183
 msgid "All-uppercase is almost as easy to guess as all-lowercase."
 msgstr ""
 
@@ -1869,16 +1932,16 @@ msgctxt "Web Form"
 msgid "Allow Editing After Submit"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:100
-#: integrations/doctype/google_calendar/google_calendar.py:114
+#: integrations/doctype/google_calendar/google_calendar.py:101
+#: integrations/doctype/google_calendar/google_calendar.py:115
 msgid "Allow Google Calendar Access"
 msgstr ""
 
-#: integrations/doctype/google_contacts/google_contacts.py:39
+#: integrations/doctype/google_contacts/google_contacts.py:40
 msgid "Allow Google Contacts Access"
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:51
+#: integrations/doctype/google_drive/google_drive.py:52
 msgid "Allow Google Drive Access"
 msgstr ""
 
@@ -1972,7 +2035,7 @@ msgctxt "Print Settings"
 msgid "Allow Print for Cancelled"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:395
+#: automation/doctype/auto_repeat/auto_repeat.py:396
 msgid "Allow Print for Draft"
 msgstr ""
 
@@ -2154,11 +2217,11 @@ msgstr ""
 msgid "Allowing DocType, DocType. Be careful!"
 msgstr ""
 
-#: core/doctype/user/user.py:977
+#: core/doctype/user/user.py:1001
 msgid "Already Registered"
 msgstr ""
 
-#: desk/form/assign_to.py:132
+#: desk/form/assign_to.py:134
 msgid "Already in the following Users ToDo list:{0}"
 msgstr ""
 
@@ -2260,7 +2323,7 @@ msgctxt "Document Naming Settings"
 msgid "Amendment Naming Override"
 msgstr ""
 
-#: core/doctype/document_naming_settings/document_naming_settings.py:208
+#: core/doctype/document_naming_settings/document_naming_settings.py:207
 msgid "Amendment naming rules updated."
 msgstr ""
 
@@ -2310,7 +2373,7 @@ msgstr ""
 msgid "Another transaction is blocking this one. Please try again in a few seconds."
 msgstr ""
 
-#: model/rename_doc.py:380
+#: model/rename_doc.py:374
 msgid "Another {0} with name {1} exists, select another name"
 msgstr ""
 
@@ -2318,6 +2381,10 @@ msgstr ""
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:36
+msgid "Apart from System Manager, roles with Set User Permissions right can set permissions for other users for that Document Type."
 msgstr ""
 
 #. Label of a Data field in DocType 'Desktop Icon'
@@ -2360,6 +2427,10 @@ msgctxt "Google Settings"
 msgid "App ID"
 msgstr ""
 
+#: public/js/frappe/ui/toolbar/navbar.html:8
+msgid "App Logo"
+msgstr ""
+
 #. Label of a Attach Image field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
@@ -2394,11 +2465,11 @@ msgctxt "Dropbox Settings"
 msgid "App Secret Key"
 msgstr ""
 
-#: modules/utils.py:268
+#: modules/utils.py:262
 msgid "App not found for module: {0}"
 msgstr ""
 
-#: __init__.py:1731
+#: __init__.py:1765
 msgid "App {0} is not installed"
 msgstr ""
 
@@ -2426,7 +2497,7 @@ msgctxt "IMAP Folder"
 msgid "Append To"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:178
+#: email/doctype/email_account/email_account.py:185
 msgid "Append To can be one of {0}"
 msgstr ""
 
@@ -2546,7 +2617,7 @@ msgstr ""
 msgid "Apply to all Documents Types"
 msgstr ""
 
-#: model/workflow.py:265
+#: model/workflow.py:258
 msgid "Applying: {0}"
 msgstr ""
 
@@ -2569,13 +2640,17 @@ msgctxt "Number system"
 msgid "Ar"
 msgstr ""
 
+#: public/js/frappe/views/kanban/kanban_column.html:14
+msgid "Archive"
+msgstr ""
+
 #. Option for the 'Status' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
 msgctxt "Kanban Board Column"
 msgid "Archived"
 msgstr ""
 
-#: public/js/frappe/views/kanban/kanban_board.bundle.js:490
+#: public/js/frappe/views/kanban/kanban_board.bundle.js:495
 msgid "Archived Columns"
 msgstr ""
 
@@ -2597,6 +2672,10 @@ msgstr ""
 
 #: public/js/frappe/web_form/web_form.js:185
 msgid "Are you sure you want to discard the changes?"
+msgstr ""
+
+#: public/js/frappe/views/reports/query_report.js:891
+msgid "Are you sure you want to generate a new report?"
 msgstr ""
 
 #: public/js/frappe/form/toolbar.js:110
@@ -2627,6 +2706,10 @@ msgstr ""
 msgid "Are you sure you want to reset all customizations?"
 msgstr ""
 
+#: workflow/doctype/workflow/workflow.js:125
+msgid "Are you sure you want to save this document?"
+msgstr ""
+
 #: email/doctype/newsletter/newsletter.js:60
 msgid "Are you sure you want to send this newsletter now?"
 msgstr ""
@@ -2648,7 +2731,11 @@ msgctxt "Print Settings"
 msgid "Arial"
 msgstr ""
 
-#: desk/form/assign_to.py:102
+#: core/page/permission_manager/permission_manager_help.html:11
+msgid "As a best practice, do not assign the same set of permission rule to different Roles. Instead, set multiple Roles to the same User."
+msgstr ""
+
+#: desk/form/assign_to.py:104
 msgid "As document sharing is disabled, please give them the required permissions before assigning."
 msgstr ""
 
@@ -2729,7 +2816,7 @@ msgstr ""
 msgid "Assigned By Me"
 msgstr ""
 
-#: model/__init__.py:151 model/meta.py:55
+#: model/meta.py:55 public/js/frappe/form/templates/form_sidebar.html:48
 #: public/js/frappe/list/list_sidebar_group_by.js:71
 #: public/js/frappe/model/meta.js:207 public/js/frappe/model/model.js:126
 #: public/js/frappe/views/interaction.js:82
@@ -2949,7 +3036,7 @@ msgctxt "File"
 msgid "Attached To Name"
 msgstr ""
 
-#: core/doctype/file/file.py:140
+#: core/doctype/file/file.py:141
 msgid "Attached To Name must be a string or an integer"
 msgstr ""
 
@@ -2983,7 +3070,7 @@ msgctxt "Email Domain"
 msgid "Attachment Limit (MB)"
 msgstr ""
 
-#: core/doctype/file/file.py:321
+#: core/doctype/file/file.py:322
 #: public/js/frappe/form/sidebar/attachments.js:36
 msgid "Attachment Limit Reached"
 msgstr ""
@@ -3008,6 +3095,7 @@ msgstr ""
 
 #: core/doctype/file/utils.py:40
 #: email/doctype/newsletter/templates/newsletter.html:47
+#: public/js/frappe/form/templates/form_sidebar.html:65
 #: website/doctype/web_form/templates/web_form.html:103
 msgid "Attachments"
 msgstr ""
@@ -3069,7 +3157,7 @@ msgstr ""
 msgid "Authentication Apps you can use are: "
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:294
+#: email/doctype/email_account/email_account.py:312
 msgid "Authentication failed while receiving emails from Email Account: {0}."
 msgstr ""
 
@@ -3220,11 +3308,11 @@ msgstr ""
 msgid "Auto Repeat Day"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:158
+#: automation/doctype/auto_repeat/auto_repeat.py:159
 msgid "Auto Repeat Day{0} {1} has been repeated."
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:436
+#: automation/doctype/auto_repeat/auto_repeat.py:437
 msgid "Auto Repeat Document Creation Failed"
 msgstr ""
 
@@ -3236,7 +3324,7 @@ msgstr ""
 msgid "Auto Repeat created for this document"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:439
+#: automation/doctype/auto_repeat/auto_repeat.py:440
 msgid "Auto Repeat failed for {0}"
 msgstr ""
 
@@ -3252,7 +3340,7 @@ msgctxt "Email Account"
 msgid "Auto Reply Message"
 msgstr ""
 
-#: automation/doctype/assignment_rule/assignment_rule.py:176
+#: automation/doctype/assignment_rule/assignment_rule.py:175
 msgid "Auto assignment failed: {0}"
 msgstr ""
 
@@ -3327,11 +3415,11 @@ msgctxt "User"
 msgid "Automatic"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:677
+#: email/doctype/email_account/email_account.py:706
 msgid "Automatic Linking can be activated only for one Email Account."
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:672
+#: email/doctype/email_account/email_account.py:700
 msgid "Automatic Linking can be activated only if Incoming is enabled."
 msgstr ""
 
@@ -3370,23 +3458,23 @@ msgctxt "Number Card"
 msgid "Average"
 msgstr ""
 
-#: public/js/frappe/ui/group_by/group_by.js:332
+#: public/js/frappe/ui/group_by/group_by.js:330
 msgid "Average of {0}"
 msgstr ""
 
-#: utils/password_strength.py:132
+#: utils/password_strength.py:130
 msgid "Avoid dates and years that are associated with you."
 msgstr ""
 
-#: utils/password_strength.py:126
+#: utils/password_strength.py:124
 msgid "Avoid recent years."
 msgstr ""
 
-#: utils/password_strength.py:119
+#: utils/password_strength.py:117
 msgid "Avoid sequences like abc or 6543 as they are easy to guess"
 msgstr ""
 
-#: utils/password_strength.py:126
+#: utils/password_strength.py:124
 msgid "Avoid years that are associated with you."
 msgstr ""
 
@@ -3497,6 +3585,10 @@ msgctxt "Notification Recipient"
 msgid "BCC"
 msgstr ""
 
+#: public/js/frappe/widgets/onboarding_widget.js:186
+msgid "Back"
+msgstr ""
+
 #: templates/pages/integrations/gcalendar-success.html:13
 msgid "Back to Desk"
 msgstr ""
@@ -3543,7 +3635,7 @@ msgctxt "System Settings"
 msgid "Background Workers"
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:173
+#: integrations/doctype/google_drive/google_drive.py:170
 msgid "Backing up Data."
 msgstr ""
 
@@ -3596,7 +3688,7 @@ msgctxt "S3 Backup Settings"
 msgid "Backup Frequency"
 msgstr ""
 
-#: desk/page/backups/backups.py:99
+#: desk/page/backups/backups.py:98
 msgid "Backup job is already queued. You will receive an email with the download link"
 msgstr ""
 
@@ -3783,7 +3875,7 @@ msgctxt "DocType"
 msgid "Beta"
 msgstr ""
 
-#: utils/password_strength.py:75
+#: utils/password_strength.py:73
 msgid "Better add a few more letters or another word"
 msgstr ""
 
@@ -3795,6 +3887,10 @@ msgstr ""
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Billing"
+msgstr ""
+
+#: public/js/frappe/form/templates/contact_list.html:21
+msgid "Billing Contact"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'About Us Team Member'
@@ -3994,6 +4090,10 @@ msgstr ""
 msgid "Both DocType and Name required"
 msgstr ""
 
+#: templates/includes/login/login.js:97
+msgid "Both login and password required"
+msgstr ""
+
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
@@ -4123,7 +4223,7 @@ msgctxt "S3 Backup Settings"
 msgid "Bucket Name"
 msgstr ""
 
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.py:66
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.py:67
 msgid "Bucket {0} not found."
 msgstr ""
 
@@ -4150,7 +4250,7 @@ msgstr ""
 msgid "Bulk Edit"
 msgstr ""
 
-#: public/js/frappe/form/grid.js:1153
+#: public/js/frappe/form/grid.js:1157
 msgid "Bulk Edit {0}"
 msgstr ""
 
@@ -4165,7 +4265,7 @@ msgctxt "Bulk Update"
 msgid "Bulk Update"
 msgstr ""
 
-#: model/workflow.py:253
+#: model/workflow.py:246
 msgid "Bulk approval only support up to 500 documents."
 msgstr ""
 
@@ -4173,11 +4273,11 @@ msgstr ""
 msgid "Bulk operation is enqueued in background."
 msgstr ""
 
-#: desk/doctype/bulk_update/bulk_update.py:70
+#: desk/doctype/bulk_update/bulk_update.py:69
 msgid "Bulk operations only support up to 500 documents."
 msgstr ""
 
-#: model/workflow.py:243
+#: model/workflow.py:236
 msgid "Bulk {0} is enqueued in background."
 msgstr ""
 
@@ -4313,6 +4413,10 @@ msgstr ""
 #: core/doctype/recorder/recorder.json
 msgctxt "Recorder"
 msgid "CMD"
+msgstr ""
+
+#: public/js/frappe/color_picker/color_picker.js:20
+msgid "COLOR PICKER"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Custom HTML Block'
@@ -4457,7 +4561,7 @@ msgstr ""
 msgid "Camera"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1712
+#: public/js/frappe/utils/utils.js:1714
 #: website/report/website_analytics/website_analytics.js:39
 msgid "Campaign"
 msgstr ""
@@ -4480,7 +4584,27 @@ msgctxt "Marketing Campaign"
 msgid "Campaign Description (Optional)"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:360
+#: public/js/frappe/form/templates/set_sharing.html:4
+#: public/js/frappe/form/templates/set_sharing.html:50
+msgid "Can Read"
+msgstr ""
+
+#: public/js/frappe/form/templates/set_sharing.html:7
+#: public/js/frappe/form/templates/set_sharing.html:53
+msgid "Can Share"
+msgstr ""
+
+#: public/js/frappe/form/templates/set_sharing.html:6
+#: public/js/frappe/form/templates/set_sharing.html:52
+msgid "Can Submit"
+msgstr ""
+
+#: public/js/frappe/form/templates/set_sharing.html:5
+#: public/js/frappe/form/templates/set_sharing.html:51
+msgid "Can Write"
+msgstr ""
+
+#: custom/doctype/custom_field/custom_field.py:359
 msgid "Can not rename as column {0} is already present on DocType."
 msgstr ""
 
@@ -4495,7 +4619,7 @@ msgctxt "User Type"
 msgid "Can only list down the document types which has been linked to the User document type."
 msgstr ""
 
-#: model/rename_doc.py:367
+#: model/rename_doc.py:361
 msgid "Can't rename {0} to {1} because {0} doesn't exist."
 msgstr ""
 
@@ -4597,7 +4721,7 @@ msgctxt "ToDo"
 msgid "Cancelled"
 msgstr ""
 
-#: core/doctype/deleted_document/deleted_document.py:51
+#: core/doctype/deleted_document/deleted_document.py:52
 msgid "Cancelled Document restored as Draft"
 msgstr ""
 
@@ -4606,15 +4730,15 @@ msgctxt "Freeze message while cancelling a document"
 msgid "Cancelling"
 msgstr ""
 
-#: desk/form/linked_with.py:379
+#: desk/form/linked_with.py:375
 msgid "Cancelling documents"
 msgstr ""
 
-#: desk/doctype/bulk_update/bulk_update.py:94
+#: desk/doctype/bulk_update/bulk_update.py:92
 msgid "Cancelling {0}"
 msgstr ""
 
-#: core/doctype/prepared_report/prepared_report.py:244
+#: core/doctype/prepared_report/prepared_report.py:243
 msgid "Cannot Download Report due to insufficient permissions"
 msgstr ""
 
@@ -4622,15 +4746,15 @@ msgstr ""
 msgid "Cannot Fetch Values"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.py:150
+#: core/page/permission_manager/permission_manager.py:155
 msgid "Cannot Remove"
 msgstr ""
 
-#: model/base_document.py:1053
+#: model/base_document.py:1059
 msgid "Cannot Update After Submit"
 msgstr ""
 
-#: core/doctype/file/file.py:574
+#: core/doctype/file/file.py:573
 msgid "Cannot access file path {0}"
 msgstr ""
 
@@ -4638,7 +4762,7 @@ msgstr ""
 msgid "Cannot cancel before submitting while transitioning from <b>{0} State</b> to <b>{1} State</b>"
 msgstr ""
 
-#: workflow/doctype/workflow/workflow.py:112
+#: workflow/doctype/workflow/workflow.py:110
 msgid "Cannot cancel before submitting. See Transition {0}"
 msgstr ""
 
@@ -4646,11 +4770,11 @@ msgstr ""
 msgid "Cannot cancel {0}."
 msgstr ""
 
-#: model/document.py:838
+#: model/document.py:827
 msgid "Cannot change docstatus from 0 (Draft) to 2 (Cancelled)"
 msgstr ""
 
-#: model/document.py:852
+#: model/document.py:841
 msgid "Cannot change docstatus from 1 (Submitted) to 0 (Draft)"
 msgstr ""
 
@@ -4658,7 +4782,7 @@ msgstr ""
 msgid "Cannot change state of Cancelled Document <b>({0} State)</b>"
 msgstr ""
 
-#: workflow/doctype/workflow/workflow.py:101
+#: workflow/doctype/workflow/workflow.py:99
 msgid "Cannot change state of Cancelled Document. Transition row {0}"
 msgstr ""
 
@@ -4670,23 +4794,23 @@ msgstr ""
 msgid "Cannot create a {0} against a child document: {1}"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:254
+#: desk/doctype/workspace/workspace.py:252
 msgid "Cannot create private workspace of other users"
 msgstr ""
 
-#: core/doctype/file/file.py:151
+#: core/doctype/file/file.py:152
 msgid "Cannot delete Home and Attachments folders"
 msgstr ""
 
-#: model/delete_doc.py:367
+#: model/delete_doc.py:363
 msgid "Cannot delete or cancel because {0} {1} is linked with {2} {3} {4}"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:423
+#: desk/doctype/workspace/workspace.py:411
 msgid "Cannot delete private workspace of other users"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:416
+#: desk/doctype/workspace/workspace.py:404
 msgid "Cannot delete public workspace without Workspace Manager role"
 msgstr ""
 
@@ -4714,27 +4838,27 @@ msgstr ""
 msgid "Cannot delete {0}"
 msgstr ""
 
-#: utils/nestedset.py:302
+#: utils/nestedset.py:296
 msgid "Cannot delete {0} as it has child nodes"
 msgstr ""
 
-#: desk/doctype/dashboard/dashboard.py:49
+#: desk/doctype/dashboard/dashboard.py:48
 msgid "Cannot edit Standard Dashboards"
 msgstr ""
 
-#: email/doctype/notification/notification.py:120
+#: email/doctype/notification/notification.py:121
 msgid "Cannot edit Standard Notification. To edit, please disable this and duplicate it"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.py:388
+#: desk/doctype/dashboard_chart/dashboard_chart.py:378
 msgid "Cannot edit Standard charts"
 msgstr ""
 
-#: core/doctype/report/report.py:68
+#: core/doctype/report/report.py:69
 msgid "Cannot edit a standard report. Please duplicate and create a new report"
 msgstr ""
 
-#: model/document.py:858
+#: model/document.py:847
 msgid "Cannot edit cancelled document"
 msgstr ""
 
@@ -4746,15 +4870,15 @@ msgstr ""
 msgid "Cannot edit standard fields"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:124
+#: automation/doctype/auto_repeat/auto_repeat.py:125
 msgid "Cannot enable {0} for a non-submittable doctype"
 msgstr ""
 
-#: core/doctype/file/file.py:249
+#: core/doctype/file/file.py:250
 msgid "Cannot find file {} on disk"
 msgstr ""
 
-#: core/doctype/file/file.py:520
+#: core/doctype/file/file.py:519
 msgid "Cannot get file contents of a Folder"
 msgstr ""
 
@@ -4762,15 +4886,15 @@ msgstr ""
 msgid "Cannot have multiple printers mapped to a single print format."
 msgstr ""
 
-#: model/document.py:926
+#: model/document.py:915
 msgid "Cannot link cancelled document: {0}"
 msgstr ""
 
-#: model/mapper.py:184
+#: model/mapper.py:181
 msgid "Cannot map because following condition fails:"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:924
+#: core/doctype/data_import/importer.py:921
 msgid "Cannot match column {0} with any field"
 msgstr ""
 
@@ -4782,11 +4906,15 @@ msgstr ""
 msgid "Cannot remove ID field"
 msgstr ""
 
-#: email/doctype/notification/notification.py:136
+#: core/page/permission_manager/permission_manager.py:132
+msgid "Cannot set 'Report' permission if 'Only If Creator' permission is set"
+msgstr ""
+
+#: email/doctype/notification/notification.py:137
 msgid "Cannot set Notification on Document Type {0}"
 msgstr ""
 
-#: core/doctype/docshare/docshare.py:69
+#: core/doctype/docshare/docshare.py:67
 msgid "Cannot share {0} with submit permission as the doctype {1} is not submittable"
 msgstr ""
 
@@ -4794,7 +4922,7 @@ msgstr ""
 msgid "Cannot submit {0}."
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:357
+#: desk/doctype/workspace/workspace.py:345
 msgid "Cannot update private workspace of other users"
 msgstr ""
 
@@ -4803,11 +4931,11 @@ msgstr ""
 msgid "Cannot update {0}"
 msgstr ""
 
-#: model/db_query.py:1125
+#: model/db_query.py:1119
 msgid "Cannot use sub-query in order by"
 msgstr ""
 
-#: model/db_query.py:1143
+#: model/db_query.py:1137
 msgid "Cannot use {0} in order/group by"
 msgstr ""
 
@@ -4815,7 +4943,7 @@ msgstr ""
 msgid "Cannot {0} {1}."
 msgstr ""
 
-#: utils/password_strength.py:185
+#: utils/password_strength.py:181
 msgid "Capitalization doesn't help very much."
 msgstr ""
 
@@ -4839,7 +4967,7 @@ msgstr ""
 msgid "Card Label"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:233
+#: public/js/frappe/widgets/widget_dialog.js:266
 msgid "Card Links"
 msgstr ""
 
@@ -4877,7 +5005,7 @@ msgctxt "Help Category"
 msgid "Category Name"
 msgstr ""
 
-#: utils/data.py:1491
+#: utils/data.py:1466
 msgid "Cent"
 msgstr ""
 
@@ -4893,6 +5021,10 @@ msgctxt "Web Page"
 msgid "Center"
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:16
+msgid "Certain documents, like an Invoice, should not be changed once final. The final state for such documents is called Submitted. You can restrict which roles can Submit."
+msgstr ""
+
 #: core/report/transaction_log_report/transaction_log_report.py:82
 msgid "Chain Integrity"
 msgstr ""
@@ -4903,6 +5035,7 @@ msgctxt "Transaction Log"
 msgid "Chaining Hash"
 msgstr ""
 
+#: public/js/frappe/form/templates/form_sidebar.html:11
 #: tests/test_translate.py:98
 msgid "Change"
 msgstr ""
@@ -5071,7 +5204,7 @@ msgctxt "Web Template Field"
 msgid "Check"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:95
+#: integrations/doctype/webhook/webhook.py:96
 msgid "Check Request URL"
 msgstr ""
 
@@ -5079,7 +5212,11 @@ msgstr ""
 msgid "Check broken links"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:442
+#: printing/page/print_format_builder/print_format_builder_column_selector.html:1
+msgid "Check columns to select, drag to set order."
+msgstr ""
+
+#: automation/doctype/auto_repeat/auto_repeat.py:443
 msgid "Check the Error Log for more information: {0}"
 msgstr ""
 
@@ -5137,7 +5274,7 @@ msgctxt "Form Tour Step"
 msgid "Child Doctype"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1584
+#: core/doctype/doctype/doctype.py:1582
 msgid "Child Table {0} for field {1}"
 msgstr ""
 
@@ -5151,7 +5288,7 @@ msgctxt "DocType"
 msgid "Child Tables are shown as a Grid in other DocTypes"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:620
+#: public/js/frappe/widgets/widget_dialog.js:653
 msgid "Choose Existing Card or create New Card"
 msgstr ""
 
@@ -5187,6 +5324,7 @@ msgid "City/Town"
 msgstr ""
 
 #: core/doctype/recorder/recorder_list.js:12
+#: public/js/frappe/form/controls/attach.js:16
 msgid "Clear"
 msgstr ""
 
@@ -5211,6 +5349,10 @@ msgstr ""
 msgid "Clear Error Logs"
 msgstr ""
 
+#: public/js/frappe/ui/filters/filter_list.js:296
+msgid "Clear Filters"
+msgstr ""
+
 #. Label of a Int field in DocType 'Logs To Clear'
 #: core/doctype/logs_to_clear/logs_to_clear.json
 msgctxt "Logs To Clear"
@@ -5225,12 +5367,20 @@ msgstr ""
 msgid "Clear the email message and add the template"
 msgstr ""
 
-#: website/doctype/web_page/web_page.py:214
+#: website/doctype/web_page/web_page.py:215
 msgid "Clearing end date, as it cannot be in the past for published pages."
+msgstr ""
+
+#: public/js/frappe/views/dashboard/dashboard_view.js:193
+msgid "Click On Customize to add your first widget"
 msgstr ""
 
 #: website/doctype/web_form/templates/web_form.html:144
 msgid "Click here"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_sidebar.html:26
+msgid "Click here to post bugs and suggestions"
 msgstr ""
 
 #: email/doctype/newsletter/newsletter.py:335
@@ -5261,15 +5411,33 @@ msgstr ""
 msgid "Click on the link below to verify your request"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:101
-#: integrations/doctype/google_contacts/google_contacts.py:40
-#: integrations/doctype/google_drive/google_drive.py:52
+#: integrations/doctype/google_calendar/google_calendar.py:102
+#: integrations/doctype/google_contacts/google_contacts.py:41
+#: integrations/doctype/google_drive/google_drive.py:53
 #: website/doctype/website_settings/website_settings.py:161
 msgid "Click on {0} to generate Refresh Token."
 msgstr ""
 
+#: desk/doctype/dashboard_chart/dashboard_chart.js:315
+#: desk/doctype/number_card/number_card.js:215
 #: email/doctype/auto_email_report/auto_email_report.js:96
+#: website/doctype/web_form/web_form.js:227
 msgid "Click table to edit"
+msgstr ""
+
+#: desk/doctype/dashboard_chart/dashboard_chart.js:502
+#: desk/doctype/number_card/number_card.js:396
+msgid "Click to Set Dynamic Filters"
+msgstr ""
+
+#: desk/doctype/dashboard_chart/dashboard_chart.js:372
+#: desk/doctype/number_card/number_card.js:270
+#: website/doctype/web_form/web_form.js:253
+msgid "Click to Set Filters"
+msgstr ""
+
+#: public/js/frappe/list/list_view.js:657
+msgid "Click to sort by {0}"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
@@ -5394,7 +5562,7 @@ msgid "Client URLs"
 msgstr ""
 
 #: core/doctype/communication/communication.js:39 desk/doctype/todo/todo.js:23
-#: public/js/frappe/ui/messages.js:245
+#: public/js/frappe/ui/messages.js:243 website/js/bootstrap-4.js:24
 msgid "Close"
 msgstr ""
 
@@ -5429,6 +5597,8 @@ msgid "Closed"
 msgstr ""
 
 #: templates/discussions/comment_box.html:25
+#: templates/discussions/reply_section.html:53
+#: templates/discussions/topic_modal.html:11
 msgid "Cmd+Enter to add comment"
 msgstr ""
 
@@ -5484,6 +5654,7 @@ msgctxt "Shrink code field."
 msgid "Collapse"
 msgstr ""
 
+#: public/js/frappe/views/reports/query_report.js:1950
 #: public/js/frappe/views/treeview.js:121
 msgid "Collapse All"
 msgstr ""
@@ -5526,8 +5697,8 @@ msgstr ""
 
 #. Name of a DocType
 #: public/js/frappe/views/reports/query_report.js:1140
-#: public/js/frappe/widgets/widget_dialog.js:511
-#: public/js/frappe/widgets/widget_dialog.js:663
+#: public/js/frappe/widgets/widget_dialog.js:544
+#: public/js/frappe/widgets/widget_dialog.js:696
 #: website/doctype/color/color.json
 msgid "Color"
 msgstr ""
@@ -5622,7 +5793,11 @@ msgctxt "Workspace Shortcut"
 msgid "Color"
 msgstr ""
 
-#: desk/doctype/kanban_board/kanban_board.py:85
+#: printing/page/print_format_builder/print_format_builder_column_selector.html:7
+msgid "Column"
+msgstr ""
+
+#: desk/doctype/kanban_board/kanban_board.py:84
 msgid "Column <b>{0}</b> already exist."
 msgstr ""
 
@@ -5670,12 +5845,20 @@ msgctxt "Kanban Board Column"
 msgid "Column Name"
 msgstr ""
 
-#: desk/doctype/kanban_board/kanban_board.py:44
+#: desk/doctype/kanban_board/kanban_board.py:45
 msgid "Column Name cannot be empty"
+msgstr ""
+
+#: public/js/frappe/form/grid_row.js:429
+msgid "Column Width"
 msgstr ""
 
 #: public/js/frappe/form/grid_row.js:613
 msgid "Column width cannot be zero."
+msgstr ""
+
+#: core/doctype/data_import/data_import.js:380
+msgid "Column {0}"
 msgstr ""
 
 #. Label of a Int field in DocType 'Custom Field'
@@ -5719,7 +5902,7 @@ msgstr ""
 msgid "Columns based on"
 msgstr ""
 
-#: integrations/doctype/oauth_client/oauth_client.py:43
+#: integrations/doctype/oauth_client/oauth_client.py:44
 msgid "Combination of Grant Type (<code>{0}</code>) and Response Type (<code>{1}</code>) not allowed"
 msgstr ""
 
@@ -5730,7 +5913,8 @@ msgid "Comm10E"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/comment/comment.json
+#: core/doctype/comment/comment.json core/doctype/version/version_view.html:3
+#: public/js/frappe/form/controls/comment.js:9
 #: public/js/frappe/form/sidebar/assign_to.js:210
 #: templates/includes/comments/comments.html:34
 msgid "Comment"
@@ -5790,8 +5974,8 @@ msgctxt "Blog Settings"
 msgid "Comment limit per hour"
 msgstr ""
 
-#: model/__init__.py:150 model/meta.py:54 public/js/frappe/model/meta.js:206
-#: public/js/frappe/model/model.js:125
+#: model/meta.py:54 public/js/frappe/form/controls/comment.js:9
+#: public/js/frappe/model/meta.js:206 public/js/frappe/model/model.js:125
 #: website/doctype/web_form/templates/web_form.html:119
 msgid "Comments"
 msgstr ""
@@ -5824,7 +6008,7 @@ msgctxt "Console Log"
 msgid "Committed"
 msgstr ""
 
-#: utils/password_strength.py:180
+#: utils/password_strength.py:176
 msgid "Common names and surnames are easy to guess."
 msgstr ""
 
@@ -5899,15 +6083,15 @@ msgstr ""
 
 #: core/doctype/server_script/server_script.js:14
 #: custom/doctype/client_script/client_script.js:54
-#: public/js/frappe/utils/diffview.js:27
+#: public/js/frappe/utils/diffview.js:28
 msgid "Compare Versions"
 msgstr ""
 
-#: core/doctype/server_script/server_script.py:134
+#: core/doctype/server_script/server_script.py:137
 msgid "Compilation warning"
 msgstr ""
 
-#: website/doctype/website_theme/website_theme.py:125
+#: website/doctype/website_theme/website_theme.py:122
 msgid "Compiled Successfully"
 msgstr ""
 
@@ -5925,11 +6109,16 @@ msgstr ""
 msgid "Complete By"
 msgstr ""
 
-#: core/doctype/user/user.py:438 templates/emails/new_user.html:10
+#: core/doctype/user/user.py:467 templates/emails/new_user.html:10
 msgid "Complete Registration"
 msgstr ""
 
-#: utils/goal.py:117
+#: public/js/frappe/ui/slides.js:355
+msgctxt "Finish the setup wizard"
+msgid "Complete Setup"
+msgstr ""
+
+#: core/doctype/doctype/boilerplate/controller_list.html:31 utils/goal.py:117
 msgid "Completed"
 msgstr ""
 
@@ -5983,6 +6172,14 @@ msgstr ""
 
 #: public/js/frappe/views/inbox/inbox_view.js:184
 msgid "Compose Email"
+msgstr ""
+
+#: desk/doctype/dashboard_chart/dashboard_chart.js:305
+#: desk/doctype/dashboard_chart/dashboard_chart.js:439
+#: desk/doctype/number_card/number_card.js:205
+#: desk/doctype/number_card/number_card.js:333
+#: website/doctype/web_form/web_form.js:188
+msgid "Condition"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Bulk Update'
@@ -6065,6 +6262,10 @@ msgstr ""
 msgid "Configure Columns"
 msgstr ""
 
+#: core/doctype/recorder/recorder_list.js:200
+msgid "Configure Recorder"
+msgstr ""
+
 #. Description of the 'Amended Documents' (Section Break) field in DocType
 #. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
@@ -6077,7 +6278,7 @@ msgid ""
 "Default Naming will make the amended document to behave same as new documents."
 msgstr ""
 
-#: www/update-password.html:30
+#: public/js/frappe/dom.js:332 www/update-password.html:30
 msgid "Confirm"
 msgstr ""
 
@@ -6091,7 +6292,7 @@ msgstr ""
 msgid "Confirm Deletion of Account"
 msgstr ""
 
-#: core/doctype/user/user.js:173
+#: core/doctype/user/user.js:166
 msgid "Confirm New Password"
 msgstr ""
 
@@ -6114,8 +6315,8 @@ msgctxt "Email Group"
 msgid "Confirmation Email Template"
 msgstr ""
 
-#: email/doctype/newsletter/newsletter.py:381
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:394
+#: email/doctype/newsletter/newsletter.py:379
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:393
 msgid "Confirmed"
 msgstr ""
 
@@ -6240,7 +6441,7 @@ msgstr ""
 msgid "Contact Phone"
 msgstr ""
 
-#: integrations/doctype/google_contacts/google_contacts.py:288
+#: integrations/doctype/google_contacts/google_contacts.py:291
 msgid "Contact Synced with Google Contacts."
 msgstr ""
 
@@ -6260,6 +6461,11 @@ msgstr ""
 #: website/doctype/contact_us_settings/contact_us_settings.json
 msgctxt "Contact Us Settings"
 msgid "Contact options, like \"Sales Query, Support Query\" etc each on a new line or separated by commas."
+msgstr ""
+
+#: public/js/frappe/utils/utils.js:1729
+#: website/report/website_analytics/website_analytics.js:41
+msgid "Content"
 msgstr ""
 
 #. Label of a Text Editor field in DocType 'Blog Post'
@@ -6296,6 +6502,12 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
+msgid "Content"
+msgstr ""
+
+#. Label of a Data field in DocType 'Web Page View'
+#: website/doctype/web_page_view/web_page_view.json
+msgctxt "Web Page View"
 msgid "Content"
 msgstr ""
 
@@ -6341,7 +6553,7 @@ msgctxt "Web Page"
 msgid "Content Type"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:82
+#: desk/doctype/workspace/workspace.py:83
 msgid "Content data shoud be a list"
 msgstr ""
 
@@ -6374,6 +6586,7 @@ msgstr ""
 #: public/js/frappe/widgets/onboarding_widget.js:366
 #: public/js/frappe/widgets/onboarding_widget.js:388
 #: public/js/frappe/widgets/onboarding_widget.js:428
+#: public/js/frappe/widgets/onboarding_widget.js:536
 msgid "Continue"
 msgstr ""
 
@@ -6405,6 +6618,10 @@ msgstr ""
 msgid "Copied to clipboard."
 msgstr ""
 
+#: public/js/frappe/form/templates/timeline_message_box.html:83
+msgid "Copy Link"
+msgstr ""
+
 #: public/js/frappe/request.js:615
 msgid "Copy error to clipboard"
 msgstr ""
@@ -6423,7 +6640,7 @@ msgstr ""
 msgid "Core DocTypes cannot be customized."
 msgstr ""
 
-#: desk/doctype/global_search_settings/global_search_settings.py:35
+#: desk/doctype/global_search_settings/global_search_settings.py:36
 msgid "Core Modules {0} cannot be searched in Global Search."
 msgstr ""
 
@@ -6431,11 +6648,11 @@ msgstr ""
 msgid "Could not connect to outgoing email server"
 msgstr ""
 
-#: model/document.py:922
+#: model/document.py:911
 msgid "Could not find {0}"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:886
+#: core/doctype/data_import/importer.py:883
 msgid "Could not map column {0} to field {1}"
 msgstr ""
 
@@ -6444,7 +6661,8 @@ msgid "Couldn't save, please check the data you have entered"
 msgstr ""
 
 #: public/js/frappe/ui/group_by/group_by.js:19
-#: public/js/frappe/ui/group_by/group_by.js:318
+#: public/js/frappe/ui/group_by/group_by.js:316
+#: workflow/doctype/workflow/workflow.js:162
 msgid "Count"
 msgstr ""
 
@@ -6461,11 +6679,11 @@ msgctxt "Number Card"
 msgid "Count"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:505
+#: public/js/frappe/widgets/widget_dialog.js:538
 msgid "Count Customizations"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:490
+#: public/js/frappe/widgets/widget_dialog.js:523
 msgid "Count Filter"
 msgstr ""
 
@@ -6615,6 +6833,11 @@ msgstr ""
 msgid "Create New"
 msgstr ""
 
+#: public/js/frappe/list/list_view.js:484
+msgctxt "Create a new document from list view"
+msgid "Create New"
+msgstr ""
+
 #: core/doctype/doctype/doctype_list.js:100
 msgid "Create New DocType"
 msgstr ""
@@ -6623,12 +6846,16 @@ msgstr ""
 msgid "Create New Kanban Board"
 msgstr ""
 
-#: core/doctype/user/user.js:251
+#: core/doctype/user/user.js:245
 msgid "Create User Email"
 msgstr ""
 
 #: public/js/frappe/views/workspace/workspace.js:471
 msgid "Create Workspace"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_start.html:16
+msgid "Create a New Format"
 msgstr ""
 
 #: public/js/frappe/form/reminders.js:9
@@ -6646,7 +6873,8 @@ msgstr ""
 #: public/js/frappe/form/controls/link.js:292
 #: public/js/frappe/form/controls/link.js:294
 #: public/js/frappe/form/link_selector.js:139
-#: public/js/frappe/list/list_view.js:470
+#: public/js/frappe/list/list_view.js:473
+#: public/js/frappe/web_form/web_form_list.js:225
 msgid "Create a new {0}"
 msgstr ""
 
@@ -6662,12 +6890,16 @@ msgstr ""
 msgid "Create or Edit Workflow"
 msgstr ""
 
-#: public/js/frappe/list/list_view.js:473
+#: public/js/frappe/list/list_view.js:476
 msgid "Create your first {0}"
 msgstr ""
 
 #: workflow/doctype/workflow/workflow.js:16
 msgid "Create your workflow visually using the Workflow Builder."
+msgstr ""
+
+#: public/js/frappe/views/file/file_view.js:317
+msgid "Created"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
@@ -6688,8 +6920,7 @@ msgctxt "Submission Queue"
 msgid "Created At"
 msgstr ""
 
-#: model/__init__.py:138 model/meta.py:51
-#: public/js/frappe/list/list_sidebar_group_by.js:73
+#: model/meta.py:51 public/js/frappe/list/list_sidebar_group_by.js:73
 #: public/js/frappe/model/meta.js:203 public/js/frappe/model/model.js:113
 msgid "Created By"
 msgstr ""
@@ -6698,9 +6929,9 @@ msgstr ""
 msgid "Created Custom Field {0} in {1}"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.js:241 model/__init__.py:140
-#: model/meta.py:46 public/js/frappe/model/meta.js:198
-#: public/js/frappe/model/model.js:115
+#: desk/doctype/dashboard_chart/dashboard_chart.js:241
+#: email/doctype/notification/notification.js:30 model/meta.py:46
+#: public/js/frappe/model/meta.js:198 public/js/frappe/model/model.js:115
 #: public/js/frappe/views/dashboard/dashboard_view.js:478
 msgid "Created On"
 msgstr ""
@@ -6741,6 +6972,14 @@ msgstr ""
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
 msgid "Cron Format"
+msgstr ""
+
+#: public/js/frappe/form/grid_row_form.js:42
+msgid "Ctrl + Down"
+msgstr ""
+
+#: public/js/frappe/form/grid_row_form.js:42
+msgid "Ctrl + Up"
 msgstr ""
 
 #: templates/includes/comments/comments.html:32
@@ -6817,6 +7056,10 @@ msgstr ""
 #: core/doctype/document_naming_settings/document_naming_settings.json
 msgctxt "Document Naming Settings"
 msgid "Current Value"
+msgstr ""
+
+#: public/js/frappe/form/workflow.js:45
+msgid "Current status"
 msgstr ""
 
 #: public/js/frappe/form/form_viewers.js:5
@@ -6963,7 +7206,7 @@ msgstr ""
 msgid "Custom Document Types Limit Exceeded"
 msgstr ""
 
-#: desk/desktop.py:483
+#: desk/desktop.py:484
 msgid "Custom Documents"
 msgstr ""
 
@@ -6990,7 +7233,7 @@ msgctxt "Module Def"
 msgid "Custom Field"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:216
+#: custom/doctype/custom_field/custom_field.py:217
 msgid "Custom Field {0} is created by the Administrator and can only be deleted through the Administrator account."
 msgstr ""
 
@@ -6999,11 +7242,11 @@ msgstr ""
 msgid "Custom Field, Custom Doctype, Naming Series, Role Permission, Workflow, Print Formats, Reports"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:260
+#: custom/doctype/custom_field/custom_field.py:259
 msgid "Custom Fields can only be added to a standard DocType."
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:257
+#: custom/doctype/custom_field/custom_field.py:256
 msgid "Custom Fields cannot be added to core DocTypes."
 msgstr ""
 
@@ -7025,7 +7268,7 @@ msgctxt "LDAP Settings"
 msgid "Custom Group Search"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:119
+#: integrations/doctype/ldap_settings/ldap_settings.py:121
 msgid "Custom Group Search if filled needs to contain the user placeholder {0}, eg uid={0},ou=users,dc=example,dc=com"
 msgstr ""
 
@@ -7045,7 +7288,7 @@ msgctxt "Print Format"
 msgid "Custom HTML Help"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:111
+#: integrations/doctype/ldap_settings/ldap_settings.py:113
 msgid "Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute' and 'Group Object Class' are entered"
 msgstr ""
 
@@ -7085,7 +7328,7 @@ msgctxt "Report"
 msgid "Custom Report"
 msgstr ""
 
-#: desk/desktop.py:484
+#: desk/desktop.py:485
 msgid "Custom Reports"
 msgstr ""
 
@@ -7166,11 +7409,14 @@ msgstr ""
 msgid "Customizations Reset"
 msgstr ""
 
-#: modules/utils.py:95
+#: modules/utils.py:91
 msgid "Customizations for <b>{0}</b> exported to:<br>{1}"
 msgstr ""
 
-#: printing/page/print/print.js:171 public/js/frappe/form/toolbar.js:527
+#: printing/page/print/print.js:171
+#: public/js/frappe/form/templates/print_layout.html:39
+#: public/js/frappe/form/toolbar.js:527
+#: public/js/frappe/views/dashboard/dashboard_view.js:196
 msgid "Customize"
 msgstr ""
 
@@ -7188,6 +7434,7 @@ msgid "Customize Dashboard"
 msgstr ""
 
 #. Name of a DocType
+#: automation/doctype/auto_repeat/auto_repeat.js:33
 #: custom/doctype/customize_form/customize_form.json
 #: public/js/frappe/views/kanban/kanban_view.js:340
 msgid "Customize Form"
@@ -7349,7 +7596,7 @@ msgstr ""
 msgid "Daily Event Digest is sent for Calendar Events where reminders are set."
 msgstr ""
 
-#: desk/doctype/event/event.py:94
+#: desk/doctype/event/event.py:93
 msgid "Daily Events should finish on the Same Day."
 msgstr ""
 
@@ -7576,11 +7823,11 @@ msgstr ""
 msgid "Data Import Template"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:614
+#: custom/doctype/customize_form/customize_form.py:610
 msgid "Data Too Long"
 msgstr ""
 
-#: model/base_document.py:722
+#: model/base_document.py:723
 msgid "Data missing in table"
 msgstr ""
 
@@ -7698,7 +7945,7 @@ msgstr ""
 msgid "Date {0} must be in format: {1}"
 msgstr ""
 
-#: utils/password_strength.py:131
+#: utils/password_strength.py:129
 msgid "Dates are often easy to guess."
 msgstr ""
 
@@ -7805,6 +8052,10 @@ msgctxt "Scheduled Job Log"
 msgid "Debug Log"
 msgstr ""
 
+#: templates/form_grid/fields.html:30
+msgid "Default"
+msgstr ""
+
 #. Label of a Small Text field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
 msgctxt "Customize Form Field"
@@ -7841,7 +8092,7 @@ msgctxt "Web Template Field"
 msgid "Default"
 msgstr ""
 
-#: contacts/doctype/address_template/address_template.py:40
+#: contacts/doctype/address_template/address_template.py:41
 msgid "Default Address Template cannot be deleted"
 msgstr ""
 
@@ -7867,7 +8118,7 @@ msgstr ""
 msgid "Default Inbox"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:194
+#: email/doctype/email_account/email_account.py:201
 msgid "Default Incoming"
 msgstr ""
 
@@ -7897,7 +8148,7 @@ msgctxt "Document Naming Settings"
 msgid "Default Naming"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:201
+#: email/doctype/email_account/email_account.py:209
 msgid "Default Outgoing"
 msgstr ""
 
@@ -8017,7 +8268,7 @@ msgstr ""
 msgid "Default value for {0} must be in the list of options."
 msgstr ""
 
-#: core/doctype/session_default_settings/session_default_settings.py:37
+#: core/doctype/session_default_settings/session_default_settings.py:38
 msgid "Default {0}"
 msgstr ""
 
@@ -8044,7 +8295,7 @@ msgctxt "User"
 msgid "Defaults"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:207
+#: email/doctype/email_account/email_account.py:220
 msgid "Defaults Updated"
 msgstr ""
 
@@ -8055,11 +8306,13 @@ msgid "Delayed"
 msgstr ""
 
 #: core/doctype/user_permission/user_permission_list.js:189
-#: public/js/frappe/form/toolbar.js:423
+#: public/js/frappe/form/footer/form_timeline.js:613
+#: public/js/frappe/form/grid.js:63 public/js/frappe/form/toolbar.js:423
 #: public/js/frappe/views/reports/report_view.js:1645
 #: public/js/frappe/views/treeview.js:313
 #: public/js/frappe/views/workspace/workspace.js:829
 #: templates/discussions/reply_card.html:35
+#: templates/discussions/reply_section.html:29
 msgid "Delete"
 msgstr ""
 
@@ -8090,6 +8343,10 @@ msgstr ""
 msgid "Delete Account"
 msgstr ""
 
+#: public/js/frappe/form/grid.js:63
+msgid "Delete All"
+msgstr ""
+
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.js:10
 msgid "Delete Data"
 msgstr ""
@@ -8102,11 +8359,15 @@ msgstr ""
 msgid "Delete Workspace"
 msgstr ""
 
+#: public/js/frappe/views/reports/query_report.js:858
+msgid "Delete and Generate New"
+msgstr ""
+
 #: public/js/frappe/form/footer/form_timeline.js:719
 msgid "Delete comment?"
 msgstr ""
 
-#: email/doctype/email_unsubscribe/email_unsubscribe.py:30
+#: email/doctype/email_unsubscribe/email_unsubscribe.py:29
 msgid "Delete this record to allow sending to this email address"
 msgstr ""
 
@@ -8169,7 +8430,7 @@ msgctxt "Deleted Document"
 msgid "Deleted Name"
 msgstr ""
 
-#: desk/reportview.py:488
+#: desk/reportview.py:487
 msgid "Deleting {0}"
 msgstr ""
 
@@ -8177,7 +8438,7 @@ msgstr ""
 msgid "Deleting {0} records..."
 msgstr ""
 
-#: public/js/frappe/model/model.js:706
+#: public/js/frappe/model/model.js:711
 msgid "Deleting {0}..."
 msgstr ""
 
@@ -8244,7 +8505,7 @@ msgid "Descendants Of (inclusive)"
 msgstr ""
 
 #: desk/report/todo/todo.py:39 public/js/frappe/form/reminders.js:44
-#: public/js/frappe/widgets/widget_dialog.js:227
+#: public/js/frappe/widgets/widget_dialog.js:260
 msgid "Description"
 msgstr ""
 
@@ -8423,11 +8684,12 @@ msgstr ""
 msgid "Desktop Icon"
 msgstr ""
 
-#: desk/doctype/desktop_icon/desktop_icon.py:230
+#: desk/doctype/desktop_icon/desktop_icon.py:225
 msgid "Desktop Icon already exists"
 msgstr ""
 
-#: public/js/form_builder/store.js:254 public/js/form_builder/utils.js:38
+#: desk/page/user_profile/user_profile_sidebar.html:45
+#: public/js/form_builder/store.js:259 public/js/form_builder/utils.js:38
 #: public/js/frappe/form/layout.js:135 public/js/frappe/views/treeview.js:276
 msgid "Details"
 msgstr ""
@@ -8450,15 +8712,15 @@ msgctxt "Scheduled Job Log"
 msgid "Details"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:477
+#: core/page/permission_manager/permission_manager.js:488
 msgid "Did not add"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:378
+#: core/page/permission_manager/permission_manager.js:382
 msgid "Did not remove"
 msgstr ""
 
-#: public/js/frappe/utils/diffview.js:56
+#: public/js/frappe/utils/diffview.js:57
 msgid "Diff"
 msgstr ""
 
@@ -8566,7 +8828,9 @@ msgctxt "Website Settings"
 msgid "Disable signups"
 msgstr ""
 
-#: core/doctype/user/user_list.js:14 public/js/frappe/model/indicator.js:108
+#: core/doctype/user/user_list.js:14
+#: public/js/frappe/form/templates/address_list.html:29
+#: public/js/frappe/model/indicator.js:108
 #: public/js/frappe/model/indicator.js:115
 msgid "Disabled"
 msgstr ""
@@ -8652,7 +8916,11 @@ msgstr ""
 #: public/js/frappe/views/dashboard/dashboard_view.js:70
 #: public/js/frappe/views/workspace/workspace.js:508
 #: public/js/frappe/web_form/web_form.js:187
+msgid "Discard"
+msgstr ""
+
 #: website/doctype/web_form/templates/web_form.html:41
+msgctxt "Button in web form"
 msgid "Discard"
 msgstr ""
 
@@ -8670,7 +8938,14 @@ msgstr ""
 msgid "Discussion Topic"
 msgstr ""
 
+#: public/js/frappe/form/footer/form_timeline.js:623
 #: templates/discussions/reply_card.html:16
+#: templates/discussions/reply_section.html:29
+msgid "Dismiss"
+msgstr ""
+
+#: public/js/frappe/widgets/onboarding_widget.js:577
+msgctxt "Stop showing the onboarding widget."
 msgid "Dismiss"
 msgstr ""
 
@@ -8711,11 +8986,11 @@ msgctxt "LDAP Settings"
 msgid "Do not create new user if user with email does not exist in the system"
 msgstr ""
 
-#: public/js/frappe/form/grid.js:1158
+#: public/js/frappe/form/grid.js:1162
 msgid "Do not edit headers which are preset in the template"
 msgstr ""
 
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.py:64
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.py:65
 msgid "Do not have permission to access bucket {0}."
 msgstr ""
 
@@ -8932,15 +9207,15 @@ msgctxt "Workspace Shortcut"
 msgid "DocType View"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:642
+#: core/doctype/doctype/doctype.py:645
 msgid "DocType can not be merged"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:636
+#: core/doctype/doctype/doctype.py:639
 msgid "DocType can only be renamed by Administrator"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:79
+#: integrations/doctype/webhook/webhook.py:80
 msgid "DocType must be Submittable for the selected Doc Event"
 msgstr ""
 
@@ -8948,11 +9223,11 @@ msgstr ""
 msgid "DocType must be a string"
 msgstr ""
 
-#: public/js/form_builder/store.js:149
+#: public/js/form_builder/store.js:154
 msgid "DocType must have atleast one field"
 msgstr ""
 
-#: core/doctype/log_settings/log_settings.py:57
+#: core/doctype/log_settings/log_settings.py:58
 msgid "DocType not supported by Log Settings."
 msgstr ""
 
@@ -8966,15 +9241,15 @@ msgstr ""
 msgid "DocType required"
 msgstr ""
 
-#: modules/utils.py:161
+#: modules/utils.py:157
 msgid "DocType {0} does not exist."
 msgstr ""
 
-#: modules/utils.py:224
+#: modules/utils.py:220
 msgid "DocType {} not found"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1005
+#: core/doctype/doctype/doctype.py:1007
 msgid "DocType's name should not start or end with whitespace"
 msgstr ""
 
@@ -8982,7 +9257,7 @@ msgstr ""
 msgid "DocTypes can not be modified, please use {0} instead"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:651
+#: public/js/frappe/widgets/widget_dialog.js:684
 msgid "Doctype"
 msgstr ""
 
@@ -8992,7 +9267,7 @@ msgctxt "Document Follow"
 msgid "Doctype"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1000
+#: core/doctype/doctype/doctype.py:1001
 msgid "Doctype name is limited to {0} characters ({1})"
 msgstr ""
 
@@ -9158,7 +9433,7 @@ msgstr ""
 msgid "Document Restoration Summary"
 msgstr ""
 
-#: core/doctype/deleted_document/deleted_document.py:67
+#: core/doctype/deleted_document/deleted_document.py:68
 msgid "Document Restored"
 msgstr ""
 
@@ -9211,7 +9486,7 @@ msgctxt "Workflow"
 msgid "Document States"
 msgstr ""
 
-#: model/__init__.py:152 model/meta.py:47 public/js/frappe/model/meta.js:199
+#: model/meta.py:47 public/js/frappe/model/meta.js:199
 #: public/js/frappe/model/model.js:127
 msgid "Document Status"
 msgstr ""
@@ -9231,7 +9506,8 @@ msgstr ""
 #: core/doctype/user_permission/user_permission_list.js:26
 #: core/page/permission_manager/permission_manager.js:49
 #: core/page/permission_manager/permission_manager.js:211
-#: core/page/permission_manager/permission_manager.js:432
+#: core/page/permission_manager/permission_manager.js:443
+#: public/js/frappe/roles_editor.js:66
 msgid "Document Type"
 msgstr ""
 
@@ -9356,15 +9632,15 @@ msgctxt "Workflow"
 msgid "Document Type"
 msgstr ""
 
-#: desk/doctype/number_card/number_card.py:55
+#: desk/doctype/number_card/number_card.py:56
 msgid "Document Type and Function are required to create a number card"
 msgstr ""
 
-#: permissions.py:149
+#: permissions.py:147
 msgid "Document Type is not importable"
 msgstr ""
 
-#: permissions.py:145
+#: permissions.py:143
 msgid "Document Type is not submittable"
 msgstr ""
 
@@ -9374,7 +9650,7 @@ msgctxt "Milestone Tracker"
 msgid "Document Type to Track"
 msgstr ""
 
-#: desk/doctype/global_search_settings/global_search_settings.py:39
+#: desk/doctype/global_search_settings/global_search_settings.py:40
 msgid "Document Type {0} has been repeated."
 msgstr ""
 
@@ -9396,7 +9672,7 @@ msgctxt "User Type"
 msgid "Document Types and Permissions"
 msgstr ""
 
-#: core/doctype/submission_queue/submission_queue.py:162
+#: core/doctype/submission_queue/submission_queue.py:163 model/document.py:1716
 msgid "Document Unlocked"
 msgstr ""
 
@@ -9412,11 +9688,15 @@ msgstr ""
 msgid "Document is in draft state"
 msgstr ""
 
+#: public/js/frappe/form/workflow.js:45
+msgid "Document is only editable by users with role"
+msgstr ""
+
 #: core/doctype/communication/communication.js:182
 msgid "Document not Relinked"
 msgstr ""
 
-#: model/rename_doc.py:230 public/js/frappe/form/toolbar.js:145
+#: model/rename_doc.py:226 public/js/frappe/form/toolbar.js:145
 msgid "Document renamed from {0} to {1}"
 msgstr ""
 
@@ -9424,15 +9704,15 @@ msgstr ""
 msgid "Document renaming from {0} to {1} has been queued"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.py:397
+#: desk/doctype/dashboard_chart/dashboard_chart.py:387
 msgid "Document type is required to create a dashboard chart"
 msgstr ""
 
-#: core/doctype/deleted_document/deleted_document.py:44
+#: core/doctype/deleted_document/deleted_document.py:45
 msgid "Document {0} Already Restored"
 msgstr ""
 
-#: workflow/doctype/workflow_action/workflow_action.py:203
+#: workflow/doctype/workflow_action/workflow_action.py:198
 msgid "Document {0} has been set to state {1} by {2}"
 msgstr ""
 
@@ -9456,6 +9736,10 @@ msgstr ""
 #: desk/doctype/module_onboarding/module_onboarding.json
 msgctxt "Module Onboarding"
 msgid "Documentation URL"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_dashboard.html:17
+msgid "Documents"
 msgstr ""
 
 #: core/doctype/deleted_document/deleted_document_list.js:25
@@ -9556,7 +9840,7 @@ msgstr ""
 msgid "Don't have an account?"
 msgstr ""
 
-#: public/js/frappe/ui/messages.js:233
+#: public/js/frappe/ui/messages.js:231
 #: public/js/onboarding_tours/onboarding_tours.js:17
 msgid "Done"
 msgstr ""
@@ -9569,6 +9853,7 @@ msgstr ""
 
 #: core/doctype/file/file.js:5
 #: email/doctype/auto_email_report/auto_email_report.js:8
+#: public/js/frappe/form/grid.js:63
 msgid "Download"
 msgstr ""
 
@@ -9604,9 +9889,9 @@ msgctxt "Data Import"
 msgid "Download Template"
 msgstr ""
 
-#: website/doctype/personal_data_download_request/personal_data_download_request.py:60
-#: website/doctype/personal_data_download_request/personal_data_download_request.py:68
-#: website/doctype/personal_data_download_request/test_personal_data_download_request.py:50
+#: website/doctype/personal_data_download_request/personal_data_download_request.py:61
+#: website/doctype/personal_data_download_request/personal_data_download_request.py:69
+#: website/doctype/personal_data_download_request/test_personal_data_download_request.py:48
 msgid "Download Your Data"
 msgstr ""
 
@@ -9621,6 +9906,10 @@ msgstr ""
 #: public/js/frappe/views/workspace/workspace.js:571
 #: public/js/frappe/widgets/base_widget.js:33
 msgid "Drag"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_layout.html:3
+msgid "Drag elements from the sidebar to add. Drag them back to trash."
 msgstr ""
 
 #. Label of a Password field in DocType 'Dropbox Settings'
@@ -9646,7 +9935,7 @@ msgctxt "Dropbox Settings"
 msgid "Dropbox Settings"
 msgstr ""
 
-#: integrations/doctype/dropbox_settings/dropbox_settings.py:348
+#: integrations/doctype/dropbox_settings/dropbox_settings.py:347
 msgid "Dropbox Setup"
 msgstr ""
 
@@ -9668,13 +9957,14 @@ msgctxt "Assignment Rule"
 msgid "Due Date Based On"
 msgstr ""
 
+#: public/js/frappe/form/grid_row_form.js:42
 #: public/js/frappe/form/toolbar.js:377
 #: public/js/frappe/views/workspace/workspace.js:814
 #: public/js/frappe/views/workspace/workspace.js:981
 msgid "Duplicate"
 msgstr ""
 
-#: printing/doctype/print_format_field_template/print_format_field_template.py:52
+#: printing/doctype/print_format_field_template/print_format_field_template.py:53
 msgid "Duplicate Entry"
 msgstr ""
 
@@ -9682,7 +9972,7 @@ msgstr ""
 msgid "Duplicate Filter Name"
 msgstr ""
 
-#: model/base_document.py:582 model/rename_doc.py:113
+#: model/base_document.py:582 model/rename_doc.py:111
 msgid "Duplicate Name"
 msgstr ""
 
@@ -9818,25 +10108,34 @@ msgctxt "Web Page"
 msgid "Dynamic Template"
 msgstr ""
 
+#: public/js/frappe/form/grid_row_form.js:42
+msgid "ESC"
+msgstr ""
+
 #. Description of the Onboarding Step 'Setup Naming Series'
 #: custom/onboarding_step/naming_series/naming_series.json
 msgid "Each document created in ERPNext can have a unique ID generated for it, using a prefix defined for it. Though each document has some prefix pre-configured, you can further customize it using tools like Naming Series Tool and Document Naming Rule.\n"
 msgstr ""
 
 #: core/page/dashboard_view/dashboard_view.js:169
+#: printing/page/print_format_builder/print_format_builder_start.html:8
 #: printing/page/print_format_builder_beta/print_format_builder_beta.js:46
 #: printing/page/print_format_builder_beta/print_format_builder_beta.js:85
 #: public/js/frappe/form/controls/markdown_editor.js:31
+#: public/js/frappe/form/footer/form_timeline.js:652
 #: public/js/frappe/form/footer/form_timeline.js:661
+#: public/js/frappe/form/templates/address_list.html:7
+#: public/js/frappe/form/templates/contact_list.html:7
 #: public/js/frappe/form/toolbar.js:672
 #: public/js/frappe/views/reports/query_report.js:809
-#: public/js/frappe/views/reports/query_report.js:1617
+#: public/js/frappe/views/reports/query_report.js:1620
 #: public/js/frappe/views/workspace/workspace.js:454
 #: public/js/frappe/views/workspace/workspace.js:808
 #: public/js/frappe/widgets/base_widget.js:64
 #: public/js/frappe/widgets/chart_widget.js:298
 #: public/js/frappe/widgets/number_card_widget.js:314
 #: templates/discussions/reply_card.html:29
+#: templates/discussions/reply_section.html:29
 #: workflow/page/workflow_builder/workflow_builder.js:46
 #: workflow/page/workflow_builder/workflow_builder.js:84
 msgid "Edit"
@@ -9853,8 +10152,21 @@ msgctxt "Comment"
 msgid "Edit"
 msgstr ""
 
+#: public/js/frappe/form/grid_row.js:338
+msgctxt "Edit grid row"
+msgid "Edit"
+msgstr ""
+
 #: templates/emails/auto_email_report.html:63
 msgid "Edit Auto Email Report Settings"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:38
+msgid "Edit Chart"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:50
+msgid "Edit Custom Block"
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:719
@@ -9875,6 +10187,10 @@ msgstr ""
 msgid "Edit Existing"
 msgstr ""
 
+#: public/js/frappe/list/list_sidebar_group_by.js:55
+msgid "Edit Filters"
+msgstr ""
+
 #: printing/doctype/print_format/print_format.js:28
 msgid "Edit Format"
 msgstr ""
@@ -9883,15 +10199,33 @@ msgstr ""
 msgid "Edit Full Form"
 msgstr ""
 
+#: printing/page/print_format_builder/print_format_builder_field.html:26
+msgid "Edit HTML"
+msgstr ""
+
 #: printing/page/print_format_builder/print_format_builder.js:602
+#: printing/page/print_format_builder/print_format_builder_layout.html:8
 msgid "Edit Heading"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:42
+msgid "Edit Links"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:44
+msgid "Edit Number Card"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:46
+msgid "Edit Onboarding"
 msgstr ""
 
 #: public/js/print_format_builder/print_format_builder.bundle.js:24
 msgid "Edit Print Format"
 msgstr ""
 
-#: desk/page/user_profile/user_profile_controller.js:273 www/me.html:27
+#: desk/page/user_profile/user_profile_controller.js:273
+#: desk/page/user_profile/user_profile_sidebar.html:51 www/me.html:27
 msgid "Edit Profile"
 msgstr ""
 
@@ -9899,8 +10233,17 @@ msgstr ""
 msgid "Edit Properties"
 msgstr ""
 
+#: public/js/frappe/widgets/widget_dialog.js:48
+msgid "Edit Quick List"
+msgstr ""
+
 #: website/doctype/web_form/templates/web_form.html:20
+msgctxt "Button in web form"
 msgid "Edit Response"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:40
+msgid "Edit Shortcut"
 msgstr ""
 
 #: public/js/frappe/utils/web_template.js:5
@@ -9931,11 +10274,17 @@ msgstr ""
 msgid "Edit to add content"
 msgstr ""
 
+#: public/js/frappe/web_form/web_form.js:442
+msgctxt "Button in web form"
+msgid "Edit your response"
+msgstr ""
+
 #: workflow/doctype/workflow/workflow.js:18
 msgid "Edit your workflow visually using the Workflow Builder."
 msgstr ""
 
 #: public/js/frappe/views/reports/report_view.js:652
+#: public/js/frappe/widgets/widget_dialog.js:52
 msgid "Edit {0}"
 msgstr ""
 
@@ -9953,6 +10302,10 @@ msgstr ""
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Editable Grid"
+msgstr ""
+
+#: public/js/frappe/form/grid_row_form.js:42
+msgid "Editing Row"
 msgstr ""
 
 #: public/js/print_format_builder/print_format_builder.bundle.js:14
@@ -10099,7 +10452,7 @@ msgctxt "User Email"
 msgid "Email Account"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:298
+#: email/doctype/email_account/email_account.py:316
 msgid "Email Account Disabled."
 msgstr ""
 
@@ -10109,7 +10462,7 @@ msgctxt "Email Account"
 msgid "Email Account Name"
 msgstr ""
 
-#: core/doctype/user/user.py:697
+#: core/doctype/user/user.py:727
 msgid "Email Account added multiple times"
 msgstr ""
 
@@ -10265,7 +10618,7 @@ msgstr ""
 msgid "Email Queue Recipient"
 msgstr ""
 
-#: email/queue.py:163
+#: email/queue.py:160
 msgid "Email Queue flushing aborted due to too many failures."
 msgstr ""
 
@@ -10393,11 +10746,11 @@ msgstr ""
 msgid "Email not sent to {0} (unsubscribed / disabled)"
 msgstr ""
 
-#: utils/oauth.py:163
+#: utils/oauth.py:158
 msgid "Email not verified with {0}"
 msgstr ""
 
-#: email/queue.py:141
+#: email/queue.py:137
 msgid "Emails are muted"
 msgstr ""
 
@@ -10431,7 +10784,7 @@ msgctxt "Google Settings"
 msgid "Enable"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:116
+#: automation/doctype/auto_repeat/auto_repeat.py:117
 msgid "Enable Allow Auto Repeat for the doctype {0} in Customize Form"
 msgstr ""
 
@@ -10471,8 +10824,8 @@ msgctxt "Notification Settings"
 msgid "Enable Email Notifications"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:89
-#: integrations/doctype/google_contacts/google_contacts.py:35
+#: integrations/doctype/google_calendar/google_calendar.py:90
+#: integrations/doctype/google_contacts/google_contacts.py:36
 #: website/doctype/website_settings/website_settings.py:129
 msgid "Enable Google API in Google Settings."
 msgstr ""
@@ -10483,7 +10836,7 @@ msgctxt "Website Settings"
 msgid "Enable Google indexing"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:194
+#: email/doctype/email_account/email_account.py:202
 msgid "Enable Incoming"
 msgstr ""
 
@@ -10499,7 +10852,7 @@ msgctxt "System Settings"
 msgid "Enable Onboarding"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:201
+#: email/doctype/email_account/email_account.py:210
 msgid "Enable Outgoing"
 msgstr ""
 
@@ -10581,7 +10934,7 @@ msgstr ""
 msgid "Enable Tracking Page Views"
 msgstr ""
 
-#: twofactor.py:456
+#: twofactor.py:448
 msgid "Enable Two Factor Auth"
 msgstr ""
 
@@ -10596,7 +10949,7 @@ msgstr ""
 msgid "Enable Website Tracking"
 msgstr ""
 
-#: printing/doctype/print_format_field_template/print_format_field_template.py:27
+#: printing/doctype/print_format_field_template/print_format_field_template.py:28
 msgid "Enable developer mode to create a standard Print Template"
 msgstr ""
 
@@ -10712,11 +11065,11 @@ msgstr ""
 msgid "Enabled Scheduler"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:898
+#: email/doctype/email_account/email_account.py:927
 msgid "Enabled email inbox for user {0}"
 msgstr ""
 
-#: core/doctype/server_script/server_script.py:262
+#: core/doctype/server_script/server_script.py:265
 msgid "Enabled scheduled execution for script {0}"
 msgstr ""
 
@@ -10794,7 +11147,7 @@ msgctxt "Calendar View"
 msgid "End Date Field"
 msgstr ""
 
-#: website/doctype/web_page/web_page.py:207
+#: website/doctype/web_page/web_page.py:208
 msgid "End Date cannot be before Start Date!"
 msgstr ""
 
@@ -10865,6 +11218,8 @@ msgstr ""
 msgid "Energy Point Update on {0}"
 msgstr ""
 
+#: desk/page/user_profile/user_profile.html:28
+#: desk/page/user_profile/user_profile_controller.js:402
 #: templates/emails/energy_points_summary.html:39
 msgid "Energy Points"
 msgstr ""
@@ -10881,12 +11236,16 @@ msgctxt "Submission Queue"
 msgid "Enqueued By"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:105
+#: integrations/doctype/ldap_settings/ldap_settings.py:107
 msgid "Ensure the user and group search paths are correct."
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:92
+#: integrations/doctype/google_calendar/google_calendar.py:93
 msgid "Enter Client Id and Client Secret in Google Settings."
+msgstr ""
+
+#: templates/includes/login/login.js:359
+msgid "Enter Code displayed in OTP App."
 msgstr ""
 
 #: public/js/frappe/views/communication.js:705
@@ -10939,7 +11298,7 @@ msgctxt "SMS Settings"
 msgid "Enter url parameter for receiver nos"
 msgstr ""
 
-#: public/js/frappe/ui/messages.js:334
+#: public/js/frappe/ui/messages.js:332
 msgid "Enter your password"
 msgstr ""
 
@@ -10955,8 +11314,8 @@ msgstr ""
 msgid "Equals"
 msgstr ""
 
-#: desk/page/backups/backups.js:35 model/base_document.py:722
-#: model/base_document.py:727 public/js/frappe/ui/messages.js:22
+#: desk/page/backups/backups.js:35 model/base_document.py:723
+#: model/base_document.py:729 public/js/frappe/ui/messages.js:22
 msgid "Error"
 msgstr ""
 
@@ -11047,7 +11406,7 @@ msgstr ""
 msgid "Error connecting via SMTP: {e}"
 msgstr ""
 
-#: email/doctype/email_domain/email_domain.py:98
+#: email/doctype/email_domain/email_domain.py:100
 msgid "Error has occurred in {0}"
 msgstr ""
 
@@ -11057,6 +11416,10 @@ msgstr ""
 
 #: public/js/frappe/form/script_manager.js:241
 msgid "Error in Client Script."
+msgstr ""
+
+#: printing/doctype/letter_head/letter_head.js:21
+msgid "Error in Header/Footer Script"
 msgstr ""
 
 #: email/doctype/notification/notification.py:391
@@ -11069,7 +11432,7 @@ msgstr ""
 msgid "Error in print format on line {0}: {1}"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:588
+#: email/doctype/email_account/email_account.py:614
 msgid "Error while connecting to email account {0}"
 msgstr ""
 
@@ -11077,11 +11440,11 @@ msgstr ""
 msgid "Error while evaluating Notification {0}. Please fix your template."
 msgstr ""
 
-#: model/document.py:808
+#: model/document.py:797
 msgid "Error: Document has been modified after you have opened it"
 msgstr ""
 
-#: model/base_document.py:735
+#: model/base_document.py:737
 msgid "Error: Value missing for {0}: {1}"
 msgstr ""
 
@@ -11131,8 +11494,8 @@ msgctxt "Notification Settings"
 msgid "Event Reminders"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:455
-#: integrations/doctype/google_calendar/google_calendar.py:539
+#: integrations/doctype/google_calendar/google_calendar.py:452
+#: integrations/doctype/google_calendar/google_calendar.py:536
 msgid "Event Synced with Google Calendar."
 msgstr ""
 
@@ -11148,7 +11511,7 @@ msgctxt "Recorder"
 msgid "Event Type"
 msgstr ""
 
-#: desk/doctype/event/event.py:264
+#: desk/doctype/event/event.py:261
 msgid "Events in Today's Calendar"
 msgstr ""
 
@@ -11158,6 +11521,10 @@ msgid ""
 "Every form in ERPNext has a standard set of fields. If you need to capture some information, but there is no standard Field available for it, you can insert Custom Field for it.\n"
 "\n"
 "Once custom fields are added, you can use them for reports and analytics charts as well.\n"
+msgstr ""
+
+#: public/js/frappe/form/templates/set_sharing.html:11
+msgid "Everyone"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocShare'
@@ -11265,7 +11632,7 @@ msgstr ""
 msgid "Executing..."
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1961
+#: public/js/frappe/views/reports/query_report.js:1964
 msgid "Execution Time: {0} sec"
 msgstr ""
 
@@ -11284,8 +11651,13 @@ msgctxt "Enlarge code field."
 msgid "Expand"
 msgstr ""
 
+#: public/js/frappe/views/reports/query_report.js:1950
 #: public/js/frappe/views/treeview.js:125
 msgid "Expand All"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_sidebar.html:23
+msgid "Experimental"
 msgstr ""
 
 #. Option for the 'Level' (Select) field in DocType 'Help Article'
@@ -11342,10 +11714,10 @@ msgctxt "System Settings"
 msgid "Expiry time of QR Code Image Page"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:42
-#: public/js/frappe/data_import/data_exporter.js:88
-#: public/js/frappe/data_import/data_exporter.js:239
-#: public/js/frappe/views/reports/query_report.js:1652
+#: core/doctype/recorder/recorder_list.js:37
+#: public/js/frappe/data_import/data_exporter.js:91
+#: public/js/frappe/data_import/data_exporter.js:242
+#: public/js/frappe/views/reports/query_report.js:1655
 #: public/js/frappe/views/reports/report_view.js:1552
 msgid "Export"
 msgstr ""
@@ -11367,7 +11739,7 @@ msgctxt "DocPerm"
 msgid "Export"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:241
+#: public/js/frappe/data_import/data_exporter.js:244
 msgid "Export 1 record"
 msgstr ""
 
@@ -11404,7 +11776,7 @@ msgctxt "Access Log"
 msgid "Export From"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:535
+#: core/doctype/data_import/data_import.js:524
 msgid "Export Import Log"
 msgstr ""
 
@@ -11438,7 +11810,7 @@ msgctxt "Data Export"
 msgid "Export without main header"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:243
+#: public/js/frappe/data_import/data_exporter.js:246
 msgid "Export {0} records"
 msgstr ""
 
@@ -11522,7 +11894,7 @@ msgctxt "RQ Worker"
 msgid "Failed Job Count"
 msgstr ""
 
-#: model/workflow.py:305
+#: model/workflow.py:298
 msgid "Failed Transactions"
 msgstr ""
 
@@ -11530,7 +11902,7 @@ msgstr ""
 msgid "Failed to aquire lock: {}. Lock may be held by another process."
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:360
+#: integrations/doctype/ldap_settings/ldap_settings.py:358
 msgid "Failed to change password."
 msgstr ""
 
@@ -11538,16 +11910,16 @@ msgstr ""
 msgid "Failed to complete setup"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:148
+#: integrations/doctype/webhook/webhook.py:149
 msgid "Failed to compute request body: {}"
 msgstr ""
 
-#: printing/doctype/network_printer_settings/network_printer_settings.py:45
-#: printing/doctype/network_printer_settings/network_printer_settings.py:47
+#: printing/doctype/network_printer_settings/network_printer_settings.py:46
+#: printing/doctype/network_printer_settings/network_printer_settings.py:48
 msgid "Failed to connect to server"
 msgstr ""
 
-#: auth.py:660
+#: auth.py:648
 msgid "Failed to decode token, please provide a valid base64-encoded token."
 msgstr ""
 
@@ -11555,7 +11927,7 @@ msgstr ""
 msgid "Failed to enable scheduler: {0}"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:136
+#: integrations/doctype/webhook/webhook.py:137
 msgid "Failed to evaluate conditions: {}"
 msgstr ""
 
@@ -11563,7 +11935,7 @@ msgstr ""
 msgid "Failed to export python type hints"
 msgstr ""
 
-#: core/doctype/document_naming_settings/document_naming_settings.py:252
+#: core/doctype/document_naming_settings/document_naming_settings.py:249
 msgid "Failed to generate names from the series"
 msgstr ""
 
@@ -11579,15 +11951,15 @@ msgstr ""
 msgid "Failed to get method {0} with {1}"
 msgstr ""
 
-#: model/virtual_doctype.py:64
+#: model/virtual_doctype.py:63
 msgid "Failed to import virtual doctype {}, is controller file present?"
 msgstr ""
 
-#: utils/image.py:75
+#: utils/image.py:73
 msgid "Failed to optimize image: {0}"
 msgstr ""
 
-#: email/doctype/email_queue/email_queue.py:278
+#: email/doctype/email_queue/email_queue.py:280
 msgid "Failed to send email with subject:"
 msgstr ""
 
@@ -11595,11 +11967,11 @@ msgstr ""
 msgid "Failed to send notification email"
 msgstr ""
 
-#: desk/page/setup_wizard/setup_wizard.py:24
+#: desk/page/setup_wizard/setup_wizard.py:23
 msgid "Failed to update global settings"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:470
+#: core/doctype/data_import/data_import.js:465
 msgid "Failure"
 msgstr ""
 
@@ -11623,6 +11995,10 @@ msgstr ""
 #: website/doctype/blog_post/blog_post.json
 msgctxt "Blog Post"
 msgid "Featured"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_sidebar.html:33
+msgid "Feedback"
 msgstr ""
 
 #. Option for the 'Communication Type' (Select) field in DocType
@@ -11683,14 +12059,15 @@ msgctxt "DocField"
 msgid "Fetch on Save if Empty"
 msgstr ""
 
-#: desk/doctype/global_search_settings/global_search_settings.py:60
+#: desk/doctype/global_search_settings/global_search_settings.py:61
 msgid "Fetching default Global Search documents."
 msgstr ""
 
 #: desk/page/leaderboard/leaderboard.js:131
 #: public/js/frappe/list/bulk_operations.js:283
+#: public/js/frappe/list/list_view_permission_restrictions.html:3
 #: public/js/frappe/views/reports/query_report.js:235
-#: public/js/frappe/views/reports/query_report.js:1706
+#: public/js/frappe/views/reports/query_report.js:1709
 msgid "Field"
 msgstr ""
 
@@ -11736,7 +12113,7 @@ msgctxt "Web Form List Column"
 msgid "Field"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:415
+#: core/doctype/doctype/doctype.py:414
 msgid "Field \"route\" is mandatory for Web Views"
 msgstr ""
 
@@ -11754,7 +12131,7 @@ msgctxt "Custom Field"
 msgid "Field Description"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1036
+#: core/doctype/doctype/doctype.py:1038
 msgid "Field Missing"
 msgstr ""
 
@@ -11770,10 +12147,18 @@ msgctxt "Property Setter"
 msgid "Field Name"
 msgstr ""
 
+#: public/js/print_format_builder/utils.js:69
+msgid "Field Template"
+msgstr ""
+
 #. Label of a Select field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
 msgctxt "Energy Point Rule"
 msgid "Field To Check"
+msgstr ""
+
+#: templates/form_grid/fields.html:40
+msgid "Field Type"
 msgstr ""
 
 #. Label of a Select field in DocType 'Custom Field'
@@ -11798,11 +12183,11 @@ msgctxt "Milestone Tracker"
 msgid "Field to Track"
 msgstr ""
 
-#: custom/doctype/property_setter/property_setter.py:50
+#: custom/doctype/property_setter/property_setter.py:51
 msgid "Field type cannot be changed for {0}"
 msgstr ""
 
-#: database/database.py:828
+#: database/database.py:830
 msgid "Field {0} does not exist on {1}"
 msgstr ""
 
@@ -11810,11 +12195,12 @@ msgstr ""
 msgid "Field {0} is referring to non-existing doctype {1}."
 msgstr ""
 
-#: public/js/frappe/form/form.js:1727
+#: public/js/frappe/form/form.js:1730
 msgid "Field {0} not found."
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.js:119
+#: custom/doctype/custom_field/custom_field.js:120
+#: public/js/frappe/form/grid_row.js:429
 msgid "Fieldname"
 msgstr ""
 
@@ -11860,19 +12246,19 @@ msgctxt "Webhook Data"
 msgid "Fieldname"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:266
+#: core/doctype/doctype/doctype.py:265
 msgid "Fieldname '{0}' conflicting with a {1} of the name {2} in {3}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1035
+#: core/doctype/doctype/doctype.py:1037
 msgid "Fieldname called {0} must exist to enable autonaming"
 msgstr ""
 
-#: database/schema.py:125 database/schema.py:359
+#: database/schema.py:125 database/schema.py:356
 msgid "Fieldname is limited to 64 characters ({0})"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:193
+#: custom/doctype/custom_field/custom_field.py:194
 msgid "Fieldname not set for Custom Field"
 msgstr ""
 
@@ -11880,20 +12266,24 @@ msgstr ""
 msgid "Fieldname which will be the DocType for this link field."
 msgstr ""
 
-#: public/js/form_builder/store.js:170
+#: public/js/form_builder/store.js:175
 msgid "Fieldname {0} appears multiple times"
 msgstr ""
 
-#: database/schema.py:349
+#: database/schema.py:346
 msgid "Fieldname {0} cannot have special characters like {1}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1846
+#: core/doctype/doctype/doctype.py:1842
 msgid "Fieldname {0} conflicting with meta object"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:491 public/js/form_builder/utils.js:302
+#: core/doctype/doctype/doctype.py:493 public/js/form_builder/utils.js:302
 msgid "Fieldname {0} is restricted"
+msgstr ""
+
+#: public/js/frappe/views/kanban/kanban_settings.js:111
+msgid "Fields"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Customize Form'
@@ -11947,7 +12337,7 @@ msgctxt "Data Export"
 msgid "Fields Multicheck"
 msgstr ""
 
-#: core/doctype/file/file.py:406
+#: core/doctype/file/file.py:405
 msgid "Fields `file_name` or `file_url` must be set for File"
 msgstr ""
 
@@ -11993,11 +12383,11 @@ msgctxt "Web Template Field"
 msgid "Fieldtype"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:189
+#: custom/doctype/custom_field/custom_field.py:190
 msgid "Fieldtype cannot be changed from {0} to {1}"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:586
+#: custom/doctype/customize_form/customize_form.py:584
 msgid "Fieldtype cannot be changed from {0} to {1} in row {2}"
 msgstr ""
 
@@ -12084,11 +12474,11 @@ msgctxt "File"
 msgid "File URL"
 msgstr ""
 
-#: desk/page/backups/backups.py:109
+#: desk/page/backups/backups.py:107
 msgid "File backup is ready"
 msgstr ""
 
-#: core/doctype/file/file.py:577
+#: core/doctype/file/file.py:576
 msgid "File name cannot have {0}"
 msgstr ""
 
@@ -12096,7 +12486,7 @@ msgstr ""
 msgid "File not attached"
 msgstr ""
 
-#: core/doctype/file/file.py:682 public/js/frappe/request.js:197
+#: core/doctype/file/file.py:681 public/js/frappe/request.js:197
 #: utils/file_manager.py:221
 msgid "File size exceeded the maximum allowed size of {0} MB"
 msgstr ""
@@ -12109,7 +12499,7 @@ msgstr ""
 msgid "File type of {0} is not allowed"
 msgstr ""
 
-#: core/doctype/file/file.py:360 core/doctype/file/file.py:422
+#: core/doctype/file/file.py:361 core/doctype/file/file.py:421
 msgid "File {0} does not exist"
 msgstr ""
 
@@ -12125,9 +12515,20 @@ msgctxt "System Settings"
 msgid "Files"
 msgstr ""
 
+#: core/doctype/prepared_report/prepared_report.js:8
+#: desk/doctype/dashboard_chart/dashboard_chart.js:305
+#: desk/doctype/dashboard_chart/dashboard_chart.js:439
+#: desk/doctype/number_card/number_card.js:205
+#: desk/doctype/number_card/number_card.js:333
 #: email/doctype/auto_email_report/auto_email_report.js:90
+#: public/js/frappe/list/base_list.js:850
 #: public/js/frappe/ui/filters/filter_list.js:132
+#: website/doctype/web_form/web_form.js:188
 msgid "Filter"
+msgstr ""
+
+#: public/js/frappe/list/list_sidebar.html:35
+msgid "Filter By"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Auto Email Report'
@@ -12164,12 +12565,16 @@ msgctxt "Prepared Report"
 msgid "Filter Values"
 msgstr ""
 
-#: utils/data.py:2015
+#: utils/data.py:1996
 msgid "Filter must be a tuple or list (in a list)"
 msgstr ""
 
-#: utils/data.py:2023
+#: utils/data.py:2004
 msgid "Filter must have 4 values (doctype, fieldname, operator, value): {0}"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_sidebar.html:3
+msgid "Filter..."
 msgstr ""
 
 #. Label of a Data field in DocType 'Personal Data Deletion Step'
@@ -12283,6 +12688,10 @@ msgstr ""
 #: core/doctype/report/report.json
 msgctxt "Report"
 msgid "Filters will be accessible via <code>filters</code>. <br><br>Send output as <code>result = [result]</code>, or for old style <code>data = [columns], [result]</code>"
+msgstr ""
+
+#: public/js/frappe/views/reports/report_view.js:1353
+msgid "Filters:"
 msgstr ""
 
 #: public/js/frappe/ui/toolbar/search_utils.js:572
@@ -12450,7 +12859,7 @@ msgstr ""
 msgid "Folder name should not include '/' (slash)"
 msgstr ""
 
-#: core/doctype/file/file.py:466
+#: core/doctype/file/file.py:465
 msgid "Folder {0} is not empty"
 msgstr ""
 
@@ -12461,14 +12870,19 @@ msgid "Folio"
 msgstr ""
 
 #: public/js/frappe/form/sidebar/form_sidebar.js:232
+#: public/js/frappe/form/templates/form_sidebar.html:129
 msgid "Follow"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:124
+#: public/js/frappe/form/templates/form_sidebar.html:124
+msgid "Followed by"
+msgstr ""
+
+#: email/doctype/auto_email_report/auto_email_report.py:130
 msgid "Following Report Filters have missing values:"
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:107
+#: website/doctype/web_form/web_form.py:108
 msgid "Following fields are missing:"
 msgstr ""
 
@@ -12476,7 +12890,7 @@ msgstr ""
 msgid "Following fields have invalid values:"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:320
+#: public/js/frappe/widgets/widget_dialog.js:353
 msgid "Following fields have missing values"
 msgstr ""
 
@@ -12584,7 +12998,7 @@ msgctxt "Letter Head"
 msgid "Footer HTML"
 msgstr ""
 
-#: printing/doctype/letter_head/letter_head.py:72
+#: printing/doctype/letter_head/letter_head.py:75
 msgid "Footer HTML set from attachment {0}"
 msgstr ""
 
@@ -12605,6 +13019,12 @@ msgstr ""
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "Footer Logo"
+msgstr ""
+
+#. Label of a Code field in DocType 'Letter Head'
+#: printing/doctype/letter_head/letter_head.json
+msgctxt "Letter Head"
+msgid "Footer Script"
 msgstr ""
 
 #. Label of a Link field in DocType 'Website Settings'
@@ -12646,7 +13066,7 @@ msgstr ""
 msgid "For Document Type"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:535
+#: public/js/frappe/widgets/widget_dialog.js:568
 msgid "For Example: {} Open"
 msgstr ""
 
@@ -12696,9 +13116,13 @@ msgctxt "User Permission"
 msgid "For Value"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1958
+#: public/js/frappe/views/reports/query_report.js:1961
 #: public/js/frappe/views/reports/report_view.js:96
 msgid "For comparison, use >5, <10 or =324. For ranges, use 5:10 (for values between 5 & 10)."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:19
+msgid "For example if you cancel and amend INV004 it will become a new document INV004-1. This helps you to keep track of each amendment."
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:744
@@ -12735,11 +13159,11 @@ msgctxt "Auto Email Report"
 msgid "For multiple addresses, enter the address on different line. e.g. test@test.com ⏎ test1@test.com"
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:199
+#: core/doctype/data_export/exporter.py:197
 msgid "For updating, you can update only selective columns."
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1688
+#: core/doctype/doctype/doctype.py:1686
 msgid "For {0} at level {1} in {2} in row {3}"
 msgstr ""
 
@@ -12886,7 +13310,7 @@ msgctxt "Webhook"
 msgid "Form URL-Encoded"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:534
+#: public/js/frappe/widgets/widget_dialog.js:567
 msgid "Format"
 msgstr ""
 
@@ -12930,7 +13354,7 @@ msgctxt "Currency"
 msgid "Fraction Units"
 msgstr ""
 
-#: www/login.html:61 www/login.html:142 www/login.py:44 www/login.py:134
+#: www/login.html:61 www/login.html:142 www/login.py:44 www/login.py:133
 msgid "Frappe"
 msgstr ""
 
@@ -12955,6 +13379,11 @@ msgstr ""
 msgid "Frappe Support"
 msgstr ""
 
+#: website/doctype/web_page/web_page.js:92
+msgid "Frappe page builder using components"
+msgstr ""
+
+#: automation/doctype/auto_repeat/auto_repeat_schedule.html:5
 #: public/js/frappe/utils/common.js:395
 msgid "Frequency"
 msgstr ""
@@ -13053,7 +13482,7 @@ msgctxt "Auto Email Report"
 msgid "From Date Field"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1672
+#: public/js/frappe/views/reports/query_report.js:1675
 msgid "From Document Type"
 msgstr ""
 
@@ -13069,7 +13498,7 @@ msgctxt "Notification Log"
 msgid "From User"
 msgstr ""
 
-#: public/js/frappe/utils/diffview.js:30
+#: public/js/frappe/utils/diffview.js:31
 msgid "From version"
 msgstr ""
 
@@ -13114,6 +13543,7 @@ msgid "Full Name"
 msgstr ""
 
 #: printing/page/print/print.js:67
+#: public/js/frappe/form/templates/print_layout.html:42
 msgid "Full Page"
 msgstr ""
 
@@ -13124,7 +13554,7 @@ msgid "Full Width"
 msgstr ""
 
 #: public/js/frappe/views/reports/query_report.js:245
-#: public/js/frappe/widgets/widget_dialog.js:672
+#: public/js/frappe/widgets/widget_dialog.js:705
 msgid "Function"
 msgstr ""
 
@@ -13134,11 +13564,11 @@ msgctxt "Number Card"
 msgid "Function"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:679
+#: public/js/frappe/widgets/widget_dialog.js:712
 msgid "Function Based On"
 msgstr ""
 
-#: __init__.py:875
+#: __init__.py:928
 msgid "Function {0} is not whitelisted."
 msgstr ""
 
@@ -13227,7 +13657,7 @@ msgid "Generate Random Password"
 msgstr ""
 
 #: public/js/frappe/ui/toolbar/toolbar.js:137
-#: public/js/frappe/utils/utils.js:1751
+#: public/js/frappe/utils/utils.js:1763
 msgid "Generate Tracking URL"
 msgstr ""
 
@@ -13265,6 +13695,10 @@ msgstr ""
 
 #: website/doctype/web_form/web_form.js:84
 msgid "Get Fields"
+msgstr ""
+
+#: printing/doctype/letter_head/letter_head.js:32
+msgid "Get Header and Footer wkhtmltopdf variables"
 msgstr ""
 
 #: public/js/frappe/form/multi_select_dialog.js:85
@@ -13310,6 +13744,10 @@ msgstr ""
 #: integrations/doctype/social_login_key/social_login_key.json
 msgctxt "Social Login Key"
 msgid "GitHub"
+msgstr ""
+
+#: website/doctype/web_page/web_page.js:92
+msgid "Github flavoured markdown syntax"
 msgstr ""
 
 #: social/doctype/energy_point_settings/energy_point_settings.js:7
@@ -13377,7 +13815,7 @@ msgstr ""
 msgid "Go to previous record"
 msgstr ""
 
-#: integrations/doctype/slack_webhook_url/slack_webhook_url.py:52
+#: integrations/doctype/slack_webhook_url/slack_webhook_url.py:53
 msgid "Go to the document"
 msgstr ""
 
@@ -13447,31 +13885,31 @@ msgctxt "Google Calendar"
 msgid "Google Calendar"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:781
+#: integrations/doctype/google_calendar/google_calendar.py:776
 msgid "Google Calendar - Contact / email not found. Did not add attendee for -<br>{0}"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:251
+#: integrations/doctype/google_calendar/google_calendar.py:252
 msgid "Google Calendar - Could not create Calendar for {0}, error code {1}."
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:575
+#: integrations/doctype/google_calendar/google_calendar.py:572
 msgid "Google Calendar - Could not delete Event {0} from Google Calendar, error code {1}."
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:288
+#: integrations/doctype/google_calendar/google_calendar.py:289
 msgid "Google Calendar - Could not fetch event from Google Calendar, error code {0}."
 msgstr ""
 
-#: integrations/doctype/google_contacts/google_contacts.py:229
+#: integrations/doctype/google_contacts/google_contacts.py:232
 msgid "Google Calendar - Could not insert contact in Google Contacts {0}, error code {1}."
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:458
+#: integrations/doctype/google_calendar/google_calendar.py:455
 msgid "Google Calendar - Could not insert event in Google Calendar {0}, error code {1}."
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:542
+#: integrations/doctype/google_calendar/google_calendar.py:539
 msgid "Google Calendar - Could not update Event {0} in Google Calendar, error code {1}."
 msgstr ""
 
@@ -13493,7 +13931,7 @@ msgctxt "Google Calendar"
 msgid "Google Calendar ID"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:166
+#: integrations/doctype/google_calendar/google_calendar.py:167
 msgid "Google Calendar has been configured."
 msgstr ""
 
@@ -13517,11 +13955,11 @@ msgctxt "Google Contacts"
 msgid "Google Contacts"
 msgstr ""
 
-#: integrations/doctype/google_contacts/google_contacts.py:136
+#: integrations/doctype/google_contacts/google_contacts.py:137
 msgid "Google Contacts - Could not sync contacts from Google Contacts {0}, error code {1}."
 msgstr ""
 
-#: integrations/doctype/google_contacts/google_contacts.py:291
+#: integrations/doctype/google_contacts/google_contacts.py:294
 msgid "Google Contacts - Could not update contact in Google Contacts {0}, error code {1}."
 msgstr ""
 
@@ -13544,19 +13982,19 @@ msgctxt "Google Drive"
 msgid "Google Drive"
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:118
+#: integrations/doctype/google_drive/google_drive.py:117
 msgid "Google Drive - Could not create folder in Google Drive - Error Code {0}"
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:134
+#: integrations/doctype/google_drive/google_drive.py:132
 msgid "Google Drive - Could not find folder in Google Drive - Error Code {0}"
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:196
+#: integrations/doctype/google_drive/google_drive.py:193
 msgid "Google Drive - Could not locate - {0}"
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:207
+#: integrations/doctype/google_drive/google_drive.py:204
 msgid "Google Drive Backup Successful."
 msgstr ""
 
@@ -13606,11 +14044,11 @@ msgctxt "Google Settings"
 msgid "Google Settings"
 msgstr ""
 
-#: utils/csvutils.py:199
+#: utils/csvutils.py:201
 msgid "Google Sheets URL is invalid or not publicly accessible."
 msgstr ""
 
-#: utils/csvutils.py:204
+#: utils/csvutils.py:206
 msgid "Google Sheets URL must end with \"gid={number}\". Copy and paste the URL from the browser address bar and try again."
 msgstr ""
 
@@ -13627,6 +14065,7 @@ msgid "Grant Type"
 msgstr ""
 
 #: public/js/frappe/form/dashboard.js:34
+#: public/js/frappe/form/templates/form_dashboard.html:10
 msgid "Graph"
 msgstr ""
 
@@ -13698,7 +14137,7 @@ msgctxt "Dashboard Chart"
 msgid "Group By Type"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.py:408
+#: desk/doctype/dashboard_chart/dashboard_chart.py:398
 msgid "Group By field is required to create a dashboard chart"
 msgstr ""
 
@@ -13712,7 +14151,7 @@ msgctxt "LDAP Settings"
 msgid "Group Object Class"
 msgstr ""
 
-#: public/js/frappe/ui/group_by/group_by.js:415
+#: public/js/frappe/ui/group_by/group_by.js:413
 msgid "Grouped by <span style='font-weight:600;'>{0}</b>"
 msgstr ""
 
@@ -13734,7 +14173,8 @@ msgctxt "System Settings"
 msgid "HH:mm:ss"
 msgstr ""
 
-#: printing/doctype/print_format/print_format.py:93
+#: printing/doctype/print_format/print_format.py:90
+#: website/doctype/web_page/web_page.js:92
 msgid "HTML"
 msgstr ""
 
@@ -13842,6 +14282,10 @@ msgctxt "Web Page"
 msgid "HTML for header section. Optional"
 msgstr ""
 
+#: website/doctype/web_page/web_page.js:92
+msgid "HTML with jinja support"
+msgstr ""
+
 #. Option for the 'Width' (Select) field in DocType 'Dashboard Chart Link'
 #: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
 msgctxt "Dashboard Chart Link"
@@ -13932,8 +14376,14 @@ msgctxt "Letter Head"
 msgid "Header HTML"
 msgstr ""
 
-#: printing/doctype/letter_head/letter_head.py:60
+#: printing/doctype/letter_head/letter_head.py:63
 msgid "Header HTML set from attachment {0}"
+msgstr ""
+
+#. Label of a Code field in DocType 'Letter Head'
+#: printing/doctype/letter_head/letter_head.json
+msgctxt "Letter Head"
+msgid "Header Script"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Page'
@@ -13946,6 +14396,10 @@ msgstr ""
 #: website/doctype/website_settings/website_settings.json
 msgctxt "Website Settings"
 msgid "Header, Robots"
+msgstr ""
+
+#: printing/doctype/letter_head/letter_head.js:30
+msgid "Header/Footer scripts can be used to add dynamic behaviours."
 msgstr ""
 
 #. Label of a Table field in DocType 'Webhook'
@@ -14004,7 +14458,9 @@ msgstr ""
 msgid "Hello"
 msgstr ""
 
-#: public/js/frappe/form/workflow.js:23 public/js/frappe/utils/help.js:27
+#: public/js/frappe/form/templates/form_sidebar.html:40
+#: public/js/frappe/form/workflow.js:23
+#: public/js/frappe/ui/toolbar/navbar.html:81 public/js/frappe/utils/help.js:27
 msgid "Help"
 msgstr ""
 
@@ -14048,6 +14504,10 @@ msgctxt "Help Category"
 msgid "Help Category"
 msgstr ""
 
+#: public/js/frappe/ui/toolbar/navbar.html:78
+msgid "Help Dropdown"
+msgstr ""
+
 #. Label of a Table field in DocType 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
 msgctxt "Navbar Settings"
@@ -14088,12 +14548,16 @@ msgctxt "Print Settings"
 msgid "Helvetica Neue"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1748
+#: public/js/frappe/utils/utils.js:1760
 msgid "Here's your tracking URL"
 msgstr ""
 
 #: www/qrcode.html:9
 msgid "Hi {0}"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_field.html:3
+msgid "Hidden"
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom Field'
@@ -14159,6 +14623,7 @@ msgstr ""
 #: public/js/frappe/views/workspace/workspace.js:820
 #: public/js/frappe/widgets/base_widget.js:46
 #: public/js/frappe/widgets/base_widget.js:176
+#: templates/includes/login/login.js:83
 msgid "Hide"
 msgstr ""
 
@@ -14362,7 +14827,7 @@ msgctxt "Company History"
 msgid "Highlight"
 msgstr ""
 
-#: www/update-password.html:271
+#: www/update-password.html:274
 msgid "Hint: Include symbols, numbers and capital letters in the password"
 msgstr ""
 
@@ -14402,16 +14867,16 @@ msgctxt "User"
 msgid "Home Settings"
 msgstr ""
 
-#: core/doctype/file/test_file.py:299 core/doctype/file/test_file.py:301
-#: core/doctype/file/test_file.py:365
+#: core/doctype/file/test_file.py:297 core/doctype/file/test_file.py:299
+#: core/doctype/file/test_file.py:363
 msgid "Home/Test Folder 1"
 msgstr ""
 
-#: core/doctype/file/test_file.py:354
+#: core/doctype/file/test_file.py:352
 msgid "Home/Test Folder 1/Test Folder 3"
 msgstr ""
 
-#: core/doctype/file/test_file.py:310
+#: core/doctype/file/test_file.py:308
 msgid "Home/Test Folder 2"
 msgstr ""
 
@@ -14458,20 +14923,19 @@ msgctxt "Currency"
 msgid "How should this currency be formatted? If not set, will use system defaults"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:1120
-#: core/doctype/data_import/importer.py:1126
-#: core/doctype/data_import/importer.py:1192
-#: core/doctype/data_import/importer.py:1195 desk/report/todo/todo.py:36
-#: model/__init__.py:137 model/meta.py:45
-#: public/js/frappe/data_import/data_exporter.js:326
-#: public/js/frappe/data_import/data_exporter.js:341
+#: core/doctype/data_import/importer.py:1115
+#: core/doctype/data_import/importer.py:1121
+#: core/doctype/data_import/importer.py:1186
+#: core/doctype/data_import/importer.py:1189 desk/report/todo/todo.py:36
+#: model/meta.py:45 public/js/frappe/data_import/data_exporter.js:329
+#: public/js/frappe/data_import/data_exporter.js:344
 #: public/js/frappe/list/list_view.js:355
 #: public/js/frappe/list/list_view.js:419 public/js/frappe/model/meta.js:197
 #: public/js/frappe/model/model.js:112
 msgid "ID"
 msgstr ""
 
-#: desk/reportview.py:418 public/js/frappe/views/reports/report_view.js:920
+#: desk/reportview.py:416 public/js/frappe/views/reports/report_view.js:920
 msgctxt "Label of name column in report"
 msgid "ID"
 msgstr ""
@@ -14628,8 +15092,12 @@ msgctxt "Workflow Document State"
 msgid "If Checked workflow status will not override status in list view"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1702
+#: core/doctype/doctype/doctype.py:1698
 msgid "If Owner"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:25
+msgid "If a Role does not have access at Level 0, then higher levels are meaningless."
 msgstr ""
 
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
@@ -14767,6 +15235,10 @@ msgctxt "User"
 msgid "If the user has any role checked, then the user becomes a \"System User\". \"System User\" has access to the desktop"
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:38
+msgid "If these instructions where not helpful, please add in your suggestions on GitHub Issues."
+msgstr ""
+
 #. Description of the 'Fetch on Save if Empty' (Check) field in DocType 'Custom
 #. Field'
 #: custom/doctype/custom_field/custom_field.json
@@ -14800,15 +15272,15 @@ msgctxt "DocPerm"
 msgid "If user is the owner"
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:206
+#: core/doctype/data_export/exporter.py:204
 msgid "If you are updating, please select \"Overwrite\" else existing rows will not be deleted."
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:190
+#: core/doctype/data_export/exporter.py:188
 msgid "If you are uploading new records, \"Naming Series\" becomes mandatory, if present."
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:187
+#: core/doctype/data_export/exporter.py:186
 msgid "If you are uploading new records, leave the \"name\" (ID) column blank."
 msgstr ""
 
@@ -14892,15 +15364,15 @@ msgctxt "Website Theme"
 msgid "Ignored Apps"
 msgstr ""
 
-#: integrations/doctype/dropbox_settings/dropbox_settings.py:349
+#: integrations/doctype/dropbox_settings/dropbox_settings.py:348
 msgid "Illegal Access Token. Please try again"
 msgstr ""
 
-#: model/workflow.py:143
+#: model/workflow.py:139
 msgid "Illegal Document Status for {0}"
 msgstr ""
 
-#: model/db_query.py:451 model/db_query.py:454 model/db_query.py:1128
+#: model/db_query.py:441 model/db_query.py:444 model/db_query.py:1122
 msgid "Illegal SQL Query"
 msgstr ""
 
@@ -15015,7 +15487,7 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: core/doctype/log_settings/log_settings.py:56
+#: core/doctype/log_settings/log_settings.py:57
 msgid "Implement `clear_old_logs` method to enable auto error clearing."
 msgstr ""
 
@@ -15025,7 +15497,7 @@ msgctxt "OAuth Client"
 msgid "Implicit"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:21
+#: core/doctype/recorder/recorder_list.js:16
 #: email/doctype/email_group/email_group.js:31
 msgid "Import"
 msgstr ""
@@ -15119,19 +15591,19 @@ msgctxt "Data Import"
 msgid "Import from Google Sheets"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:598
+#: core/doctype/data_import/importer.py:593
 msgid "Import template should be of type .csv, .xlsx or .xls"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:467
+#: core/doctype/data_import/importer.py:463
 msgid "Import template should contain a Header and atleast one row."
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:170
+#: core/doctype/data_import/data_import.js:165
 msgid "Import timed out, please re-try."
 msgstr ""
 
-#: core/doctype/data_import/data_import.py:61
+#: core/doctype/data_import/data_import.py:60
 msgid "Importing {0} is not allowed."
 msgstr ""
 
@@ -15243,7 +15715,7 @@ msgstr ""
 msgid "In Progress"
 msgstr ""
 
-#: database/database.py:241
+#: database/database.py:240
 msgid "In Read Only Mode"
 msgstr ""
 
@@ -15283,7 +15755,7 @@ msgctxt "System Settings"
 msgid "In seconds"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:107
+#: core/doctype/recorder/recorder_list.js:209
 msgid "Inactive"
 msgstr ""
 
@@ -15329,11 +15801,11 @@ msgctxt "System Settings"
 msgid "Include Web View Link in Email"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1488
+#: public/js/frappe/views/reports/query_report.js:1491
 msgid "Include filters"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1480
+#: public/js/frappe/views/reports/query_report.js:1483
 msgid "Include indentation"
 msgstr ""
 
@@ -15369,11 +15841,11 @@ msgstr ""
 msgid "Incoming email account not correct"
 msgstr ""
 
-#: model/virtual_doctype.py:81 model/virtual_doctype.py:94
+#: model/virtual_doctype.py:79 model/virtual_doctype.py:92
 msgid "Incomplete Virtual Doctype Implementation"
 msgstr ""
 
-#: auth.py:238
+#: auth.py:232
 msgid "Incomplete login details"
 msgstr ""
 
@@ -15381,7 +15853,7 @@ msgstr ""
 msgid "Incorrect Configuration"
 msgstr ""
 
-#: utils/csvutils.py:207
+#: utils/csvutils.py:209
 msgid "Incorrect URL"
 msgstr ""
 
@@ -15389,19 +15861,19 @@ msgstr ""
 msgid "Incorrect User or Password"
 msgstr ""
 
-#: twofactor.py:177 twofactor.py:189
+#: twofactor.py:175 twofactor.py:187
 msgid "Incorrect Verification code"
 msgstr ""
 
-#: model/document.py:1352
+#: model/document.py:1335
 msgid "Incorrect value in row {0}: {1} must be {2} {3}"
 msgstr ""
 
-#: model/document.py:1356
+#: model/document.py:1339
 msgid "Incorrect value: {0} must be {1} {2}"
 msgstr ""
 
-#: model/__init__.py:139 model/meta.py:48 public/js/frappe/model/meta.js:200
+#: model/meta.py:48 public/js/frappe/model/meta.js:200
 #: public/js/frappe/model/model.js:114
 #: public/js/frappe/views/reports/report_view.js:941
 msgid "Index"
@@ -15499,7 +15971,11 @@ msgstr ""
 msgid "Insert"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1712
+#: public/js/frappe/form/grid_row_form.js:42
+msgid "Insert Above"
+msgstr ""
+
+#: public/js/frappe/views/reports/query_report.js:1715
 msgid "Insert After"
 msgstr ""
 
@@ -15509,12 +15985,16 @@ msgctxt "Custom Field"
 msgid "Insert After"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:249
+#: custom/doctype/custom_field/custom_field.py:248
 msgid "Insert After cannot be set as {0}"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:242
+#: custom/doctype/custom_field/custom_field.py:241
 msgid "Insert After field '{0}' mentioned in Custom Field '{1}', with label '{2}', does not exist"
+msgstr ""
+
+#: public/js/frappe/form/grid_row_form.js:42
+msgid "Insert Below"
 msgstr ""
 
 #: public/js/frappe/views/reports/report_view.js:364
@@ -15559,26 +16039,37 @@ msgid "Installed Applications"
 msgstr ""
 
 #: core/doctype/installed_applications/installed_applications.js:18
+#: public/js/frappe/ui/toolbar/about.js:8
 msgid "Installed Apps"
 msgstr ""
 
-#: permissions.py:829
+#. Label of a HTML field in DocType 'Letter Head'
+#: printing/doctype/letter_head/letter_head.json
+msgctxt "Letter Head"
+msgid "Instructions"
+msgstr ""
+
+#: templates/includes/login/login.js:262
+msgid "Instructions Emailed"
+msgstr ""
+
+#: permissions.py:822
 msgid "Insufficient Permission Level for {0}"
 msgstr ""
 
-#: database/query.py:372 desk/form/load.py:40 model/document.py:234
+#: database/query.py:374 desk/form/load.py:40 model/document.py:237
 msgid "Insufficient Permission for {0}"
 msgstr ""
 
-#: desk/reportview.py:322
+#: desk/reportview.py:320
 msgid "Insufficient Permissions for deleting Report"
 msgstr ""
 
-#: desk/reportview.py:293
+#: desk/reportview.py:291
 msgid "Insufficient Permissions for editing Report"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:443
+#: core/doctype/doctype/doctype.py:442
 msgid "Insufficient attachment limit"
 msgstr ""
 
@@ -15659,6 +16150,10 @@ msgctxt "Print Settings"
 msgid "Inter"
 msgstr ""
 
+#: desk/page/user_profile/user_profile_sidebar.html:37
+msgid "Interests"
+msgstr ""
+
 #. Label of a Small Text field in DocType 'User'
 #: core/doctype/user/user.json
 msgctxt "User"
@@ -15673,6 +16168,10 @@ msgstr ""
 
 #: public/js/frappe/request.js:232
 msgid "Internal Server Error"
+msgstr ""
+
+#: desk/page/user_profile/user_profile_sidebar.html:22
+msgid "Intro"
 msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
@@ -15739,7 +16238,7 @@ msgstr ""
 msgid "Invalid \"mandatory_depends_on\" expression"
 msgstr ""
 
-#: utils/nestedset.py:181
+#: utils/nestedset.py:177
 msgid "Invalid Action"
 msgstr ""
 
@@ -15747,7 +16246,7 @@ msgstr ""
 msgid "Invalid CSV Format"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:87
+#: integrations/doctype/webhook/webhook.py:88
 msgid "Invalid Condition: {}"
 msgstr ""
 
@@ -15755,7 +16254,7 @@ msgstr ""
 msgid "Invalid Credentials"
 msgstr ""
 
-#: utils/data.py:124 utils/data.py:285
+#: utils/data.py:125 utils/data.py:286
 msgid "Invalid Date"
 msgstr ""
 
@@ -15771,11 +16270,11 @@ msgstr ""
 msgid "Invalid Fieldname"
 msgstr ""
 
-#: core/doctype/file/file.py:206
+#: core/doctype/file/file.py:207
 msgid "Invalid File URL"
 msgstr ""
 
-#: public/js/form_builder/store.js:216
+#: public/js/form_builder/store.js:221
 msgid "Invalid Filter Format for field {0} of type {1}. Try using filter icon on the field to set it correctly"
 msgstr ""
 
@@ -15795,6 +16294,10 @@ msgstr ""
 msgid "Invalid Login Token"
 msgstr ""
 
+#: templates/includes/login/login.js:291
+msgid "Invalid Login. Try again."
+msgstr ""
+
 #: email/receive.py:105 email/receive.py:142
 msgid "Invalid Mail Server. Please rectify and try again."
 msgstr ""
@@ -15803,11 +16306,11 @@ msgstr ""
 msgid "Invalid Naming Series: {}"
 msgstr ""
 
-#: core/doctype/rq_job/rq_job.py:122
+#: core/doctype/rq_job/rq_job.py:117
 msgid "Invalid Operation"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1578 core/doctype/doctype/doctype.py:1587
+#: core/doctype/doctype/doctype.py:1576 core/doctype/doctype/doctype.py:1585
 msgid "Invalid Option"
 msgstr ""
 
@@ -15815,17 +16318,17 @@ msgstr ""
 msgid "Invalid Outgoing Mail Server or Port: {0}"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:182
+#: email/doctype/auto_email_report/auto_email_report.py:188
 msgid "Invalid Output Format"
 msgstr ""
 
-#: integrations/doctype/connected_app/connected_app.py:166
+#: integrations/doctype/connected_app/connected_app.py:167
 msgid "Invalid Parameters."
 msgstr ""
 
-#: core/doctype/user/user.py:1195 www/update-password.html:121
+#: core/doctype/user/user.py:1213 www/update-password.html:121
 #: www/update-password.html:142 www/update-password.html:144
-#: www/update-password.html:246
+#: www/update-password.html:245
 msgid "Invalid Password"
 msgstr ""
 
@@ -15833,7 +16336,7 @@ msgstr ""
 msgid "Invalid Phone Number"
 msgstr ""
 
-#: auth.py:95 utils/oauth.py:184 utils/oauth.py:191 www/login.py:112
+#: auth.py:93 utils/oauth.py:179 utils/oauth.py:186 www/login.py:112
 msgid "Invalid Request"
 msgstr ""
 
@@ -15849,8 +16352,8 @@ msgstr ""
 msgid "Invalid Transition"
 msgstr ""
 
-#: core/doctype/file/file.py:217 public/js/frappe/widgets/widget_dialog.js:571
-#: utils/csvutils.py:199 utils/csvutils.py:220
+#: core/doctype/file/file.py:218 public/js/frappe/widgets/widget_dialog.js:604
+#: utils/csvutils.py:201 utils/csvutils.py:222
 msgid "Invalid URL"
 msgstr ""
 
@@ -15858,7 +16361,7 @@ msgstr ""
 msgid "Invalid User Name or Support Password. Please rectify and try again."
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:116
+#: integrations/doctype/webhook/webhook.py:117
 msgid "Invalid Webhook Secret"
 msgstr ""
 
@@ -15870,7 +16373,7 @@ msgstr ""
 msgid "Invalid column"
 msgstr ""
 
-#: model/document.py:841 model/document.py:855
+#: model/document.py:830 model/document.py:844
 msgid "Invalid docstatus"
 msgstr ""
 
@@ -15882,11 +16385,11 @@ msgstr ""
 msgid "Invalid expression set in filter {0} ({1})"
 msgstr ""
 
-#: utils/data.py:2122
+#: utils/data.py:2102
 msgid "Invalid field name {0}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1044
+#: core/doctype/doctype/doctype.py:1046
 msgid "Invalid fieldname '{0}' in autoname"
 msgstr ""
 
@@ -15894,20 +16397,16 @@ msgstr ""
 msgid "Invalid file path: {0}"
 msgstr ""
 
-#: database/query.py:174 public/js/frappe/ui/filters/filter_list.js:199
+#: database/query.py:172 public/js/frappe/ui/filters/filter_list.js:199
 msgid "Invalid filter: {0}"
 msgstr ""
 
-#: model/utils/__init__.py:69
-msgid "Invalid include path"
-msgstr ""
-
-#: desk/doctype/dashboard/dashboard.py:68
-#: desk/doctype/dashboard_chart/dashboard_chart.py:424
+#: desk/doctype/dashboard/dashboard.py:67
+#: desk/doctype/dashboard_chart/dashboard_chart.py:414
 msgid "Invalid json added in the custom options: {0}"
 msgstr ""
 
-#: model/naming.py:445
+#: model/naming.py:439
 msgid "Invalid name type (integer) for varchar name column"
 msgstr ""
 
@@ -15915,7 +16414,7 @@ msgstr ""
 msgid "Invalid naming series {}: dot (.) missing"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:438
+#: core/doctype/data_import/importer.py:434
 msgid "Invalid or corrupted content for import"
 msgstr ""
 
@@ -15923,19 +16422,19 @@ msgstr ""
 msgid "Invalid redirect regex in row #{}: {}"
 msgstr ""
 
-#: app.py:301
+#: app.py:299
 msgid "Invalid request arguments"
 msgstr ""
 
-#: integrations/doctype/connected_app/connected_app.py:172
+#: integrations/doctype/connected_app/connected_app.py:173
 msgid "Invalid state."
 msgstr ""
 
-#: core/doctype/data_import/importer.py:415
+#: core/doctype/data_import/importer.py:411
 msgid "Invalid template file for import"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:162
+#: integrations/doctype/ldap_settings/ldap_settings.py:164
 #: integrations/doctype/ldap_settings/ldap_settings.py:335
 msgid "Invalid username or password"
 msgstr ""
@@ -16317,7 +16816,7 @@ msgctxt "DocType"
 msgid "Is Virtual"
 msgstr ""
 
-#: core/doctype/file/utils.py:155 utils/file_manager.py:315
+#: core/doctype/file/utils.py:155 utils/file_manager.py:311
 msgid "It is risky to delete this file: {0}. Please contact your System Manager."
 msgstr ""
 
@@ -16333,7 +16832,7 @@ msgctxt "Navbar Item"
 msgid "Item Type"
 msgstr ""
 
-#: utils/nestedset.py:234
+#: utils/nestedset.py:228
 msgid "Item cannot be added to its own descendants"
 msgstr ""
 
@@ -16469,7 +16968,7 @@ msgstr ""
 msgid "Job Stopped Successfully"
 msgstr ""
 
-#: core/doctype/rq_job/rq_job.py:122
+#: core/doctype/rq_job/rq_job.py:117
 msgid "Job is not running."
 msgstr ""
 
@@ -16678,7 +17177,7 @@ msgctxt "LDAP Settings"
 msgid "LDAP Mobile Field"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:160
+#: integrations/doctype/ldap_settings/ldap_settings.py:162
 msgid "LDAP Not Installed"
 msgstr ""
 
@@ -16694,7 +17193,7 @@ msgctxt "LDAP Settings"
 msgid "LDAP Search String"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:127
+#: integrations/doctype/ldap_settings/ldap_settings.py:129
 msgid "LDAP Search String must be enclosed in '()' and needs to contian the user placeholder {0}, eg sAMAccountName={0}"
 msgstr ""
 
@@ -16746,7 +17245,7 @@ msgid "LDAP Username Field"
 msgstr ""
 
 #: integrations/doctype/ldap_settings/ldap_settings.py:308
-#: integrations/doctype/ldap_settings/ldap_settings.py:427
+#: integrations/doctype/ldap_settings/ldap_settings.py:425
 msgid "LDAP is not enabled."
 msgstr ""
 
@@ -16762,14 +17261,15 @@ msgctxt "LDAP Settings"
 msgid "LDAP search path for Users"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:99
+#: integrations/doctype/ldap_settings/ldap_settings.py:101
 msgid "LDAP settings incorrect. validation response was: {0}"
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:474
-#: public/js/frappe/widgets/widget_dialog.js:222
-#: public/js/frappe/widgets/widget_dialog.js:612
+#: public/js/frappe/widgets/widget_dialog.js:255
 #: public/js/frappe/widgets/widget_dialog.js:645
+#: public/js/frappe/widgets/widget_dialog.js:678
+#: templates/form_grid/fields.html:37
 msgid "Label"
 msgstr ""
 
@@ -16905,7 +17405,7 @@ msgctxt "Customize Form Field"
 msgid "Label and Type"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:141
+#: custom/doctype/custom_field/custom_field.py:142
 msgid "Label is mandatory"
 msgstr ""
 
@@ -16921,6 +17421,7 @@ msgstr ""
 
 #. Name of a DocType
 #: core/doctype/language/language.json printing/page/print/print.js:104
+#: public/js/frappe/form/templates/print_layout.html:11
 msgid "Language"
 msgstr ""
 
@@ -16996,6 +17497,10 @@ msgctxt "User"
 msgid "Last Login"
 msgstr ""
 
+#: email/doctype/notification/notification.js:31
+msgid "Last Modified Date"
+msgstr ""
+
 #: desk/doctype/dashboard_chart/dashboard_chart.js:242
 #: public/js/frappe/views/dashboard/dashboard_view.js:479
 msgid "Last Modified On"
@@ -17059,12 +17564,12 @@ msgctxt "Dashboard Chart"
 msgid "Last Synced On"
 msgstr ""
 
-#: model/__init__.py:145 model/meta.py:50 public/js/frappe/model/meta.js:202
+#: model/meta.py:50 public/js/frappe/model/meta.js:202
 #: public/js/frappe/model/model.js:120
 msgid "Last Updated By"
 msgstr ""
 
-#: model/__init__.py:141 model/meta.py:49 public/js/frappe/model/meta.js:201
+#: model/meta.py:49 public/js/frappe/model/meta.js:201
 #: public/js/frappe/model/model.js:116
 msgid "Last Updated On"
 msgstr ""
@@ -17100,6 +17605,7 @@ msgid "Layout will be reset to standard layout, are you sure you want to do this
 msgstr ""
 
 #: desk/page/leaderboard/leaderboard.js:15
+#: desk/page/user_profile/user_profile_sidebar.html:55
 msgid "Leaderboard"
 msgstr ""
 
@@ -17139,7 +17645,7 @@ msgid "Leave blank to repeat always"
 msgstr ""
 
 #: core/doctype/communication/mixins.py:206
-#: email/doctype/email_account/email_account.py:626
+#: email/doctype/email_account/email_account.py:654
 msgid "Leave this conversation"
 msgstr ""
 
@@ -17184,7 +17690,7 @@ msgctxt "Form Tour Step"
 msgid "Left Center"
 msgstr ""
 
-#: email/doctype/email_unsubscribe/email_unsubscribe.py:59
+#: email/doctype/email_unsubscribe/email_unsubscribe.py:58
 msgid "Left this conversation"
 msgstr ""
 
@@ -17216,8 +17722,12 @@ msgstr ""
 msgid "Length of passed data array is greater than value of maximum allowed label points!"
 msgstr ""
 
-#: database/schema.py:133
+#: database/schema.py:132
 msgid "Length of {0} should be between 1 and 1000"
+msgstr ""
+
+#: public/js/frappe/widgets/chart_widget.js:674
+msgid "Less"
 msgstr ""
 
 #: public/js/frappe/widgets/onboarding_widget.js:439
@@ -17234,7 +17744,7 @@ msgstr ""
 msgid "Let's Set Up Your Website."
 msgstr ""
 
-#: utils/password_strength.py:113
+#: utils/password_strength.py:111
 msgid "Let's avoid repeated words and characters"
 msgstr ""
 
@@ -17258,6 +17768,7 @@ msgstr ""
 #. Name of a DocType
 #: printing/doctype/letter_head/letter_head.json
 #: printing/page/print/print.js:127 public/js/frappe/form/print_utils.js:18
+#: public/js/frappe/form/templates/print_layout.html:16
 #: public/js/frappe/list/bulk_operations.js:43
 msgid "Letter Head"
 msgstr ""
@@ -17286,7 +17797,11 @@ msgctxt "Letter Head"
 msgid "Letter Head Name"
 msgstr ""
 
-#: printing/doctype/letter_head/letter_head.py:45
+#: printing/doctype/letter_head/letter_head.js:30
+msgid "Letter Head Scripts"
+msgstr ""
+
+#: printing/doctype/letter_head/letter_head.py:48
 msgid "Letter Head cannot be both disabled and default"
 msgstr ""
 
@@ -17298,6 +17813,7 @@ msgid "Letter Head in HTML"
 msgstr ""
 
 #: core/page/permission_manager/permission_manager.js:213
+#: public/js/frappe/roles_editor.js:66
 msgid "Level"
 msgstr ""
 
@@ -17319,7 +17835,7 @@ msgctxt "Help Article"
 msgid "Level"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:450
+#: core/page/permission_manager/permission_manager.js:461
 msgid "Level 0 is for document level permissions, higher levels for field level permissions."
 msgstr ""
 
@@ -17405,7 +17921,7 @@ msgstr ""
 msgid "Liked"
 msgstr ""
 
-#: model/__init__.py:149 model/meta.py:53 public/js/frappe/model/meta.js:205
+#: model/meta.py:53 public/js/frappe/model/meta.js:205
 #: public/js/frappe/model/model.js:124
 msgid "Liked By"
 msgstr ""
@@ -17536,8 +18052,8 @@ msgctxt "Dynamic Link"
 msgid "Link Document Type"
 msgstr ""
 
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:403
-#: workflow/doctype/workflow_action/workflow_action.py:202
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:402
+#: workflow/doctype/workflow_action/workflow_action.py:197
 msgid "Link Expired"
 msgstr ""
 
@@ -17619,10 +18135,18 @@ msgctxt "Workspace Shortcut"
 msgid "Link To"
 msgstr ""
 
+#: public/js/frappe/widgets/widget_dialog.js:358
+msgid "Link To in Row"
+msgstr ""
+
 #. Label of a Select field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
 msgctxt "Workspace Link"
 msgid "Link Type"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:354
+msgid "Link Type in Row"
 msgstr ""
 
 #: website/doctype/about_us_settings/about_us_settings.js:6
@@ -17794,6 +18318,7 @@ msgctxt "Assignment Rule"
 msgid "Load Balancing"
 msgstr ""
 
+#: public/js/frappe/list/base_list.js:377
 #: website/doctype/blog_post/templates/blog_post_list.html:50
 msgid "Load More"
 msgstr ""
@@ -17804,11 +18329,19 @@ msgid "Load More Communications"
 msgstr ""
 
 #: core/page/permission_manager/permission_manager.js:165
-#: public/js/frappe/list/base_list.js:465
+#: public/js/frappe/form/controls/multicheck.js:13
+#: public/js/frappe/form/linked_with.js:13
+#: public/js/frappe/list/base_list.js:467
+#: public/js/frappe/list/list_view.js:332 public/js/frappe/ui/listing.html:16
+#: public/js/frappe/views/reports/query_report.js:1001
 msgid "Loading"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:262
+#: public/js/frappe/widgets/widget_dialog.js:107
+msgid "Loading Filters..."
+msgstr ""
+
+#: core/doctype/data_import/data_import.js:257
 msgid "Loading import file..."
 msgstr ""
 
@@ -17816,7 +18349,17 @@ msgstr ""
 msgid "Loading user profile"
 msgstr ""
 
+#: public/js/frappe/ui/toolbar/about.js:8
+msgid "Loading versions..."
+msgstr ""
+
 #: public/js/frappe/form/sidebar/share.js:51
+#: public/js/frappe/list/list_sidebar.js:216
+#: public/js/frappe/list/list_sidebar_group_by.js:125
+#: public/js/frappe/views/kanban/kanban_board.html:11
+#: public/js/frappe/widgets/chart_widget.js:50
+#: public/js/frappe/widgets/number_card_widget.js:174
+#: public/js/frappe/widgets/quick_list_widget.js:126
 msgid "Loading..."
 msgstr ""
 
@@ -17860,7 +18403,7 @@ msgid "Log Setting User"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/log_settings/log_settings.json
+#: core/doctype/log_settings/log_settings.json public/js/frappe/logtypes.js:20
 msgid "Log Settings"
 msgstr ""
 
@@ -17880,7 +18423,7 @@ msgstr ""
 
 #: public/js/frappe/web_form/webform_script.js:16
 #: templates/discussions/discussions_section.html:60
-#: templates/discussions/reply_section.html:43
+#: templates/discussions/reply_section.html:44
 #: templates/includes/navbar/dropdown_login.html:15
 #: templates/includes/navbar/navbar_login.html:24
 #: website/page_renderers/not_permitted_page.py:22 www/login.html:42
@@ -17915,7 +18458,7 @@ msgstr ""
 msgid "Login Failed please try again"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:134
+#: email/doctype/email_account/email_account.py:141
 msgid "Login Id is required"
 msgstr ""
 
@@ -17937,11 +18480,11 @@ msgctxt "Web Form"
 msgid "Login Required"
 msgstr ""
 
-#: www/login.py:137
+#: www/login.py:136
 msgid "Login To {0}"
 msgstr ""
 
-#: twofactor.py:265
+#: twofactor.py:259
 msgid "Login Verification Code from {}"
 msgstr ""
 
@@ -17957,11 +18500,15 @@ msgstr ""
 msgid "Login is required to see web form list view. Enable {0} to see list settings"
 msgstr ""
 
-#: auth.py:324 auth.py:327
+#: templates/includes/login/login.js:70
+msgid "Login link sent to your email"
+msgstr ""
+
+#: auth.py:316 auth.py:319
 msgid "Login not allowed at this time"
 msgstr ""
 
-#: twofactor.py:165
+#: twofactor.py:163
 msgid "Login session expired, refresh page to retry"
 msgstr ""
 
@@ -17997,7 +18544,7 @@ msgctxt "System Settings"
 msgid "Login with email link expiry (in minutes)"
 msgstr ""
 
-#: auth.py:133
+#: auth.py:129
 msgid "Login with username and password is not allowed."
 msgstr ""
 
@@ -18013,7 +18560,7 @@ msgctxt "Activity Log"
 msgid "Logout"
 msgstr ""
 
-#: core/doctype/user/user.js:179
+#: core/doctype/user/user.js:172
 msgid "Logout All Sessions"
 msgstr ""
 
@@ -18075,6 +18622,10 @@ msgstr ""
 
 #: www/third_party_apps.html:57
 msgid "Looks like you haven’t added any third party apps."
+msgstr ""
+
+#: public/js/frappe/ui/notifications/notifications.js:308
+msgid "Looks like you haven’t received any notifications."
 msgstr ""
 
 #: public/js/frappe/form/sidebar/assign_to.js:190
@@ -18157,7 +18708,7 @@ msgctxt "System Settings"
 msgid "Make sure to configure a Social Login Key before disabling to prevent lockout"
 msgstr ""
 
-#: utils/password_strength.py:94
+#: utils/password_strength.py:92
 msgid "Make use of longer keyboard patterns"
 msgstr ""
 
@@ -18231,7 +18782,7 @@ msgctxt "DocField"
 msgid "Mandatory Depends On (JS)"
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:412
+#: website/doctype/web_form/web_form.py:411
 msgid "Mandatory Information missing:"
 msgstr ""
 
@@ -18271,13 +18822,17 @@ msgstr ""
 msgid "Map Columns"
 msgstr ""
 
+#: public/js/frappe/data_import/import_preview.js:290
+msgid "Map columns from {0} to fields in {1}"
+msgstr ""
+
 #. Description of the 'Dynamic Route' (Check) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
 msgid "Map route parameters into form variables. Example <code>/project/&lt;name&gt;</code>"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:877
+#: core/doctype/data_import/importer.py:874
 msgid "Mapping column {0} to field {1}"
 msgstr ""
 
@@ -18310,7 +18865,7 @@ msgid "Mark all as read"
 msgstr ""
 
 #: core/doctype/communication/communication.js:78
-#: core/doctype/communication/communication_list.js:21
+#: core/doctype/communication/communication_list.js:19
 msgid "Mark as Read"
 msgstr ""
 
@@ -18319,8 +18874,12 @@ msgid "Mark as Spam"
 msgstr ""
 
 #: core/doctype/communication/communication.js:78
-#: core/doctype/communication/communication_list.js:24
+#: core/doctype/communication/communication_list.js:22
 msgid "Mark as Unread"
+msgstr ""
+
+#: website/doctype/web_page/web_page.js:92
+msgid "Markdown"
 msgstr ""
 
 #. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
@@ -18446,7 +19005,7 @@ msgctxt "Number Card"
 msgid "Maximum"
 msgstr ""
 
-#: core/doctype/file/file.py:317
+#: core/doctype/file/file.py:318
 msgid "Maximum Attachment Limit of {0} has been reached for {1} {2}."
 msgstr ""
 
@@ -18475,7 +19034,7 @@ msgid ""
 "(Note: For no limit leave this field empty or set 0)"
 msgstr ""
 
-#: model/rename_doc.py:675
+#: model/rename_doc.py:657
 msgid "Maximum {0} rows allowed"
 msgstr ""
 
@@ -18483,8 +19042,12 @@ msgstr ""
 msgid "Me"
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:14
+msgid "Meaning of Submit, Cancel, Amend"
+msgstr ""
+
 #: public/js/frappe/form/sidebar/assign_to.js:194
-#: public/js/frappe/utils/utils.js:1720
+#: public/js/frappe/utils/utils.js:1722
 #: website/report/website_analytics/website_analytics.js:40
 msgid "Medium"
 msgstr ""
@@ -18537,18 +19100,19 @@ msgctxt "Notification Settings"
 msgid "Mentions"
 msgstr ""
 
-#: public/js/frappe/ui/page.js:155
+#: public/js/frappe/ui/page.html:40 public/js/frappe/ui/page.js:155
 msgid "Menu"
 msgstr ""
 
-#: public/js/frappe/form/toolbar.js:222 public/js/frappe/model/model.js:719
+#: public/js/frappe/form/toolbar.js:222 public/js/frappe/model/model.js:724
 msgid "Merge with existing"
 msgstr ""
 
-#: utils/nestedset.py:310
+#: utils/nestedset.py:304
 msgid "Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"
 msgstr ""
 
+#: core/doctype/data_import/data_import.js:489
 #: public/js/frappe/ui/messages.js:175
 #: public/js/frappe/views/communication.js:110 www/message.html:3
 #: www/message.html:25
@@ -18580,7 +19144,7 @@ msgctxt "Communication"
 msgid "Message"
 msgstr ""
 
-#: __init__.py:567 public/js/frappe/ui/messages.js:267
+#: __init__.py:612 public/js/frappe/ui/messages.js:265
 msgctxt "Default title of the message dialog"
 msgid "Message"
 msgstr ""
@@ -18674,7 +19238,7 @@ msgstr ""
 msgid "Message clipped"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:299
+#: email/doctype/email_account/email_account.py:317
 msgid "Message from server: {0}"
 msgstr ""
 
@@ -18812,7 +19376,7 @@ msgctxt "Scheduled Job Type"
 msgid "Method"
 msgstr ""
 
-#: desk/doctype/number_card/number_card.py:69
+#: desk/doctype/number_card/number_card.py:70
 msgid "Method is required to create a number card"
 msgstr ""
 
@@ -18874,10 +19438,10 @@ msgctxt "Package Release"
 msgid "Minor"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:100
-#: integrations/doctype/ldap_settings/ldap_settings.py:105
-#: integrations/doctype/ldap_settings/ldap_settings.py:114
-#: integrations/doctype/ldap_settings/ldap_settings.py:122
+#: integrations/doctype/ldap_settings/ldap_settings.py:102
+#: integrations/doctype/ldap_settings/ldap_settings.py:107
+#: integrations/doctype/ldap_settings/ldap_settings.py:116
+#: integrations/doctype/ldap_settings/ldap_settings.py:124
 #: integrations/doctype/ldap_settings/ldap_settings.py:332
 msgid "Misconfigured"
 msgstr ""
@@ -18894,11 +19458,11 @@ msgstr ""
 msgid "Missing Fields"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:123
+#: email/doctype/auto_email_report/auto_email_report.py:129
 msgid "Missing Filters Required"
 msgstr ""
 
-#: desk/form/assign_to.py:105
+#: desk/form/assign_to.py:107
 msgid "Missing Permission"
 msgstr ""
 
@@ -18907,7 +19471,7 @@ msgid "Missing Value"
 msgstr ""
 
 #: public/js/frappe/ui/field_group.js:118
-#: public/js/frappe/widgets/widget_dialog.js:336
+#: public/js/frappe/widgets/widget_dialog.js:369
 #: public/js/workflow_builder/store.js:97
 #: workflow/doctype/workflow/workflow.js:71
 msgid "Missing Values Required"
@@ -19161,7 +19725,7 @@ msgctxt "Module Profile"
 msgid "Module Profile Name"
 msgstr ""
 
-#: desk/doctype/module_onboarding/module_onboarding.py:68
+#: desk/doctype/module_onboarding/module_onboarding.py:69
 msgid "Module onboarding progress reset"
 msgstr ""
 
@@ -19169,7 +19733,7 @@ msgstr ""
 msgid "Module to Export"
 msgstr ""
 
-#: modules/utils.py:261
+#: modules/utils.py:255
 msgid "Module {} not found"
 msgstr ""
 
@@ -19305,9 +19869,16 @@ msgctxt "Server Script"
 msgid "Monthly Long"
 msgstr ""
 
+#: desk/page/user_profile/user_profile_controller.js:402
+msgid "Monthly Rank"
+msgstr ""
+
 #: public/js/frappe/form/link_selector.js:39
 #: public/js/frappe/form/multi_select_dialog.js:43
 #: public/js/frappe/form/multi_select_dialog.js:70
+#: public/js/frappe/ui/toolbar/search.js:285
+#: public/js/frappe/ui/toolbar/search.js:300
+#: public/js/frappe/widgets/chart_widget.js:674
 #: templates/includes/list/list.html:23
 #: templates/includes/search_template.html:13
 msgid "More"
@@ -19360,6 +19931,7 @@ msgstr ""
 #: core/doctype/communication/communication.js:86
 #: core/doctype/communication/communication.js:194
 #: core/doctype/communication/communication.js:212
+#: public/js/frappe/form/grid_row_form.js:42
 msgid "Move"
 msgstr ""
 
@@ -19404,7 +19976,7 @@ msgctxt "Form Tour Step"
 msgid "Mozilla doesn't support :has() so you can pass parent selector here as workaround"
 msgstr ""
 
-#: utils/nestedset.py:334
+#: utils/nestedset.py:328
 msgid "Multiple root nodes not allowed."
 msgstr ""
 
@@ -19440,11 +20012,11 @@ msgctxt "DocType"
 msgid "Must be of type \"Attach Image\""
 msgstr ""
 
-#: desk/query_report.py:202
+#: desk/query_report.py:200
 msgid "Must have report permission to access this report."
 msgstr ""
 
-#: core/doctype/report/report.py:148
+#: core/doctype/report/report.py:145
 msgid "Must specify a Query to run"
 msgstr ""
 
@@ -19455,7 +20027,7 @@ msgid "Mute Sounds"
 msgstr ""
 
 #: templates/includes/web_sidebar.html:41
-#: website/doctype/web_form/web_form.py:401
+#: website/doctype/web_form/web_form.py:400
 #: website/doctype/website_settings/website_settings.py:181 www/list.py:21
 #: www/me.html:4 www/me.html:8 www/update_password.py:10
 msgid "My Account"
@@ -19522,11 +20094,15 @@ msgctxt "Workspace"
 msgid "Name"
 msgstr ""
 
+#: integrations/doctype/webhook/webhook.js:29
+msgid "Name (Doc Name)"
+msgstr ""
+
 #: desk/utils.py:22
 msgid "Name already taken, please set a new name"
 msgstr ""
 
-#: model/naming.py:460
+#: model/naming.py:453
 msgid "Name cannot contain special characters like {0}"
 msgstr ""
 
@@ -19538,11 +20114,11 @@ msgstr ""
 msgid "Name of the new Print Format"
 msgstr ""
 
-#: model/naming.py:454
+#: model/naming.py:448
 msgid "Name of {0} cannot be {1}"
 msgstr ""
 
-#: utils/password_strength.py:178
+#: utils/password_strength.py:174
 msgid "Names and surnames by themselves are easy to guess."
 msgstr ""
 
@@ -19600,7 +20176,7 @@ msgctxt "Document Naming Settings"
 msgid "Naming Series"
 msgstr ""
 
-#: model/naming.py:243
+#: model/naming.py:241
 msgid "Naming Series mandatory"
 msgstr ""
 
@@ -19670,19 +20246,19 @@ msgctxt "Role"
 msgid "Navigation Settings"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:303
+#: desk/doctype/workspace/workspace.py:297
 msgid "Need Workspace Manager role to edit private workspace of other users"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:349
+#: desk/doctype/workspace/workspace.py:341
 msgid "Need Workspace Manager role to hide/unhide public workspaces"
 msgstr ""
 
-#: model/document.py:607
+#: model/document.py:606
 msgid "Negative Value"
 msgstr ""
 
-#: utils/nestedset.py:95
+#: utils/nestedset.py:93
 msgid "Nested set error. Please contact the Administrator."
 msgstr ""
 
@@ -19722,8 +20298,24 @@ msgstr ""
 msgid "New Activity"
 msgstr ""
 
-#: templates/includes/comments/comments.py:64
+#: public/js/frappe/form/templates/address_list.html:42
+msgid "New Address"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:58
+msgid "New Chart"
+msgstr ""
+
+#: templates/includes/comments/comments.py:62
 msgid "New Comment on {0}: {1}"
+msgstr ""
+
+#: public/js/frappe/form/templates/contact_list.html:90
+msgid "New Contact"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:70
+msgid "New Custom Block"
 msgstr ""
 
 #: printing/page/print/print.js:288 printing/page/print/print.js:335
@@ -19762,15 +20354,19 @@ msgstr ""
 msgid "New Kanban Board"
 msgstr ""
 
+#: public/js/frappe/widgets/widget_dialog.js:62
+msgid "New Links"
+msgstr ""
+
 #: desk/doctype/notification_log/notification_log.py:156
 msgid "New Mention on {0}"
 msgstr ""
 
-#: www/contact.py:51
+#: www/contact.py:50
 msgid "New Message from Website Contact Page"
 msgstr ""
 
-#: public/js/frappe/form/toolbar.js:206 public/js/frappe/model/model.js:727
+#: public/js/frappe/form/toolbar.js:206 public/js/frappe/model/model.js:732
 msgid "New Name"
 msgstr ""
 
@@ -19788,7 +20384,15 @@ msgstr ""
 msgid "New Notification"
 msgstr ""
 
-#: core/doctype/user/user.js:167 www/update-password.html:19
+#: public/js/frappe/widgets/widget_dialog.js:64
+msgid "New Number Card"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:66
+msgid "New Onboarding"
+msgstr ""
+
+#: core/doctype/user/user.js:160 www/update-password.html:19
 msgid "New Password"
 msgstr ""
 
@@ -19797,8 +20401,21 @@ msgstr ""
 msgid "New Print Format Name"
 msgstr ""
 
+#: public/js/frappe/widgets/widget_dialog.js:68
+msgid "New Quick List"
+msgstr ""
+
 #: public/js/frappe/views/reports/report_view.js:1310
 msgid "New Report name"
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:60
+msgid "New Shortcut"
+msgstr ""
+
+#: core/doctype/version/version_view.html:14
+#: core/doctype/version/version_view.html:76
+msgid "New Value"
 msgstr ""
 
 #: workflow/page/workflow_builder/workflow_builder.js:61
@@ -19813,7 +20430,7 @@ msgstr ""
 msgid "New password cannot be same as old password"
 msgstr ""
 
-#: utils/change_log.py:322
+#: utils/change_log.py:320
 msgid "New updates are available"
 msgstr ""
 
@@ -19839,7 +20456,8 @@ msgstr ""
 #: public/js/frappe/ui/toolbar/search_utils.js:217
 #: public/js/frappe/ui/toolbar/search_utils.js:218
 #: public/js/frappe/views/treeview.js:350
-#: website/doctype/web_form/web_form.py:310
+#: public/js/frappe/widgets/widget_dialog.js:72
+#: website/doctype/web_form/web_form.py:309
 msgid "New {0}"
 msgstr ""
 
@@ -19856,15 +20474,15 @@ msgstr ""
 msgid "New {0} {1} created"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:373
+#: automation/doctype/auto_repeat/auto_repeat.py:374
 msgid "New {0}: {1}"
 msgstr ""
 
-#: utils/change_log.py:314
+#: utils/change_log.py:312
 msgid "New {} releases for the following apps are available"
 msgstr ""
 
-#: core/doctype/user/user.py:764
+#: core/doctype/user/user.py:790
 msgid "Newly created user {0} has no roles enabled."
 msgstr ""
 
@@ -19911,15 +20529,21 @@ msgstr ""
 msgid "Newsletter should have atleast one recipient"
 msgstr ""
 
-#: email/doctype/newsletter/newsletter.py:392
+#: email/doctype/newsletter/newsletter.py:390
 msgid "Newsletters"
 msgstr ""
 
 #: public/js/frappe/form/form_tour.js:318
+#: public/js/frappe/web_form/web_form.js:91
 #: public/js/onboarding_tours/onboarding_tours.js:15
 #: public/js/onboarding_tours/onboarding_tours.js:240
 #: templates/includes/slideshow.html:38 website/utils.py:247
 #: website/web_template/slideshow/slideshow.html:44
+msgid "Next"
+msgstr ""
+
+#: public/js/frappe/ui/slides.js:359
+msgctxt "Go to next slide"
 msgid "Next"
 msgstr ""
 
@@ -19957,6 +20581,10 @@ msgctxt "Auto Repeat"
 msgid "Next Schedule Date"
 msgstr ""
 
+#: automation/doctype/auto_repeat/auto_repeat_schedule.html:6
+msgid "Next Scheduled Date"
+msgstr ""
+
 #. Label of a Link field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
 msgctxt "Workflow Transition"
@@ -19981,17 +20609,21 @@ msgctxt "Google Contacts"
 msgid "Next Sync Token"
 msgstr ""
 
+#: public/js/frappe/form/workflow.js:45
+msgid "Next actions"
+msgstr ""
+
 #. Label of a Check field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
 msgid "Next on Click"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:137
+#: integrations/doctype/webhook/webhook.py:138
 #: public/js/form_builder/utils.js:341
 #: public/js/frappe/form/controls/link.js:472
 #: public/js/frappe/list/list_sidebar_group_by.js:223
-#: public/js/frappe/views/reports/query_report.js:1513
+#: public/js/frappe/views/reports/query_report.js:1516
 #: website/doctype/help_article/templates/help_article.html:26
 msgid "No"
 msgstr ""
@@ -20054,22 +20686,38 @@ msgid "No Copy"
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:162
-#: email/doctype/auto_email_report/auto_email_report.py:263
+#: email/doctype/auto_email_report/auto_email_report.py:288
 #: public/js/frappe/data_import/import_preview.js:142
+#: public/js/frappe/form/grid.js:63
 #: public/js/frappe/form/multi_select_dialog.js:223
 #: public/js/frappe/utils/datatable.js:10
+#: public/js/frappe/widgets/chart_widget.js:57
 msgid "No Data"
+msgstr ""
+
+#: desk/page/user_profile/user_profile.html:11
+#: desk/page/user_profile/user_profile.html:22
+#: desk/page/user_profile/user_profile.html:33
+msgid "No Data to Show"
+msgstr ""
+
+#: public/js/frappe/widgets/quick_list_widget.js:131
+msgid "No Data..."
 msgstr ""
 
 #: public/js/frappe/views/inbox/inbox_view.js:176
 msgid "No Email Account"
 msgstr ""
 
+#: public/js/frappe/views/inbox/inbox_view.js:196
+msgid "No Email Accounts Assigned"
+msgstr ""
+
 #: public/js/frappe/views/inbox/inbox_view.js:183
 msgid "No Emails"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:362
+#: integrations/doctype/ldap_settings/ldap_settings.py:360
 msgid "No Entry for the User {0} found within LDAP!"
 msgstr ""
 
@@ -20077,7 +20725,7 @@ msgstr ""
 msgid "No Filters Set"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:356
+#: integrations/doctype/google_calendar/google_calendar.py:357
 msgid "No Google Calendar Event to sync."
 msgstr ""
 
@@ -20089,21 +20737,29 @@ msgstr ""
 msgid "No Items Found"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:364
+#: integrations/doctype/ldap_settings/ldap_settings.py:362
 msgid "No LDAP User found for email: {0}"
+msgstr ""
+
+#: public/js/workflow_builder/store.js:51
+msgid "No Label"
 msgstr ""
 
 #: printing/page/print/print.js:675 printing/page/print/print.js:757
 #: public/js/frappe/list/bulk_operations.js:82
-#: public/js/frappe/list/bulk_operations.js:126 utils/weasyprint.py:54
+#: public/js/frappe/list/bulk_operations.js:126 utils/weasyprint.py:52
 msgid "No Letterhead"
 msgstr ""
 
-#: model/naming.py:436
+#: model/naming.py:430
 msgid "No Name Specified for {0}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1680
+#: public/js/frappe/ui/notifications/notifications.js:308
+msgid "No New notifications"
+msgstr ""
+
+#: core/doctype/doctype/doctype.py:1678
 msgid "No Permissions Specified"
 msgstr ""
 
@@ -20119,8 +20775,20 @@ msgstr ""
 msgid "No Permitted Charts on this Dashboard"
 msgstr ""
 
+#: printing/doctype/print_settings/print_settings.js:13
+msgid "No Preview"
+msgstr ""
+
+#: printing/page/print/print.js:679
+msgid "No Preview Available"
+msgstr ""
+
 #: printing/page/print/print.js:835
 msgid "No Printer is Available."
+msgstr ""
+
+#: core/doctype/rq_worker/rq_worker_list.js:3
+msgid "No RQ Workers connected. Try restarting the bench."
 msgstr ""
 
 #: public/js/frappe/form/link_selector.js:135
@@ -20131,7 +20799,7 @@ msgstr ""
 msgid "No Results found"
 msgstr ""
 
-#: core/doctype/user/user.py:765
+#: core/doctype/user/user.py:791
 msgid "No Roles Specified"
 msgstr ""
 
@@ -20141,6 +20809,18 @@ msgstr ""
 
 #: desk/reportview.py:565
 msgid "No Tags"
+msgstr ""
+
+#: public/js/frappe/ui/notifications/notifications.js:428
+msgid "No Upcoming Events"
+msgstr ""
+
+#: desk/page/user_profile/user_profile_controller.js:441
+msgid "No activities to show"
+msgstr ""
+
+#: public/js/frappe/form/templates/address_list.html:37
+msgid "No address added yet."
 msgstr ""
 
 #: email/doctype/notification/notification.js:180
@@ -20155,7 +20835,7 @@ msgstr ""
 msgid "No changes in document"
 msgstr ""
 
-#: model/rename_doc.py:370
+#: model/rename_doc.py:364
 msgid "No changes made because old and new name are the same."
 msgstr ""
 
@@ -20167,11 +20847,11 @@ msgstr ""
 msgid "No changes to sync"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:286
+#: core/doctype/data_import/importer.py:282
 msgid "No changes to update"
 msgstr ""
 
-#: website/doctype/blog_post/blog_post.py:376
+#: website/doctype/blog_post/blog_post.py:372
 msgid "No comments yet"
 msgstr ""
 
@@ -20179,15 +20859,19 @@ msgstr ""
 msgid "No comments yet. "
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:426
+#: public/js/frappe/form/templates/contact_list.html:85
+msgid "No contacts added yet."
+msgstr ""
+
+#: automation/doctype/auto_repeat/auto_repeat.py:427
 msgid "No contacts linked to document"
 msgstr ""
 
-#: desk/query_report.py:335
+#: desk/query_report.py:331
 msgid "No data to export"
 msgstr ""
 
-#: contacts/doctype/address/address.py:251
+#: contacts/doctype/address/address.py:249
 msgid "No default Address Template found. Please create a new one from Setup > Printing and Branding > Address Template."
 msgstr ""
 
@@ -20199,11 +20883,27 @@ msgstr ""
 msgid "No email account associated with the User. Please add an account under User > Email Inbox."
 msgstr ""
 
+#: core/doctype/data_import/data_import.js:484
+msgid "No failed logs"
+msgstr ""
+
+#: public/js/frappe/views/kanban/kanban_view.js:368
+msgid "No fields found that can be used as a Kanban Column. Use the Customize Form to add a Custom Field of type \"Select\"."
+msgstr ""
+
 #: utils/file_manager.py:143
 msgid "No file attached"
 msgstr ""
 
-#: desk/form/utils.py:102
+#: public/js/frappe/list/list_sidebar_group_by.js:134
+msgid "No filters found"
+msgstr ""
+
+#: public/js/frappe/ui/filters/filter_list.js:296
+msgid "No filters selected"
+msgstr ""
+
+#: desk/form/utils.py:101
 msgid "No further records"
 msgstr ""
 
@@ -20219,8 +20919,12 @@ msgstr ""
 msgid "No need for symbols, digits, or uppercase letters."
 msgstr ""
 
-#: integrations/doctype/google_contacts/google_contacts.py:192
+#: integrations/doctype/google_contacts/google_contacts.py:195
 msgid "No new Google Contacts synced."
+msgstr ""
+
+#: public/js/frappe/ui/toolbar/navbar.html:41
+msgid "No new notifications"
 msgstr ""
 
 #: printing/page/print_format_builder/print_format_builder.js:415
@@ -20245,7 +20949,7 @@ msgctxt "SMS Log"
 msgid "No of Sent SMS"
 msgstr ""
 
-#: __init__.py:1067 client.py:109 client.py:151
+#: __init__.py:1115 client.py:109 client.py:151
 msgid "No permission for {0}"
 msgstr ""
 
@@ -20254,11 +20958,11 @@ msgctxt "{0} = verb, {1} = object"
 msgid "No permission to '{0}' {1}"
 msgstr ""
 
-#: model/db_query.py:943
+#: model/db_query.py:935
 msgid "No permission to read {0}"
 msgstr ""
 
-#: share.py:224
+#: share.py:220
 msgid "No permission to {0} {1} {2}"
 msgstr ""
 
@@ -20266,20 +20970,36 @@ msgstr ""
 msgid "No records deleted"
 msgstr ""
 
-#: contacts/report/addresses_and_contacts/addresses_and_contacts.py:121
+#: contacts/report/addresses_and_contacts/addresses_and_contacts.py:116
 msgid "No records present in {0}"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:221
+#: public/js/frappe/list/list_sidebar_stat.html:3
+msgid "No records tagged."
+msgstr ""
+
+#: public/js/frappe/data_import/data_exporter.js:224
 msgid "No records will be exported"
 msgstr ""
 
-#: www/printview.py:426
+#: www/printview.py:436
 msgid "No template found at path: {0}"
+msgstr ""
+
+#: public/js/frappe/form/controls/multiselect_list.js:226
+msgid "No values to show"
 msgstr ""
 
 #: website/web_template/discussions/discussions.html:2
 msgid "No {0}"
+msgstr ""
+
+#: public/js/frappe/list/list_view_select.js:157
+msgid "No {0} Found"
+msgstr ""
+
+#: public/js/frappe/web_form/web_form_list.js:233
+msgid "No {0} found"
 msgstr ""
 
 #: public/js/frappe/list/list_view.js:466
@@ -20335,8 +21055,13 @@ msgctxt "Recorder Query"
 msgid "Normalized Query"
 msgstr ""
 
-#: core/doctype/user/user.py:972 utils/oauth.py:272
+#: core/doctype/user/user.py:996 templates/includes/login/login.js:258
+#: utils/oauth.py:265
 msgid "Not Allowed"
+msgstr ""
+
+#: templates/includes/login/login.js:260
+msgid "Not Allowed: Disabled User"
 msgstr ""
 
 #: public/js/frappe/ui/filters/filter.js:36
@@ -20351,7 +21076,7 @@ msgstr ""
 msgid "Not Equals"
 msgstr ""
 
-#: app.py:363 www/404.html:3
+#: app.py:361 www/404.html:3
 msgid "Not Found"
 msgstr ""
 
@@ -20379,15 +21104,15 @@ msgctxt "DocField"
 msgid "Not Nullable"
 msgstr ""
 
-#: __init__.py:961 app.py:354 desk/calendar.py:26 geo/utils.py:97
+#: __init__.py:1011 app.py:352 desk/calendar.py:26 geo/utils.py:97
 #: public/js/frappe/web_form/webform_script.js:15
-#: website/doctype/web_form/web_form.py:603
-#: website/page_renderers/not_permitted_page.py:20 www/login.py:177
+#: website/doctype/web_form/web_form.py:602
+#: website/page_renderers/not_permitted_page.py:20 www/login.py:174
 #: www/qrcode.py:22 www/qrcode.py:25 www/qrcode.py:37
 msgid "Not Permitted"
 msgstr ""
 
-#: desk/query_report.py:513
+#: desk/query_report.py:506
 msgid "Not Permitted to read {0}"
 msgstr ""
 
@@ -20439,19 +21164,23 @@ msgstr ""
 msgid "Not a valid Comma Separated Value (CSV File)"
 msgstr ""
 
-#: core/doctype/user/user.py:197
+#: core/doctype/user/user.py:227
 msgid "Not a valid User Image."
 msgstr ""
 
-#: model/workflow.py:118
+#: model/workflow.py:114
 msgid "Not a valid Workflow Action"
+msgstr ""
+
+#: templates/includes/login/login.js:256
+msgid "Not a valid user"
 msgstr ""
 
 #: workflow/doctype/workflow/workflow_list.js:7
 msgid "Not active"
 msgstr ""
 
-#: permissions.py:370
+#: permissions.py:364
 msgid "Not allowed for {0}: {1}"
 msgstr ""
 
@@ -20463,15 +21192,15 @@ msgstr ""
 msgid "Not allowed to create custom Virtual DocType."
 msgstr ""
 
-#: www/printview.py:141
+#: www/printview.py:140
 msgid "Not allowed to print cancelled documents"
 msgstr ""
 
-#: www/printview.py:138
+#: www/printview.py:137
 msgid "Not allowed to print draft documents"
 msgstr ""
 
-#: permissions.py:213
+#: permissions.py:211
 msgid "Not allowed via controller permission check"
 msgstr ""
 
@@ -20479,20 +21208,20 @@ msgstr ""
 msgid "Not found"
 msgstr ""
 
-#: core/doctype/page/page.py:62
+#: core/doctype/page/page.py:63
 msgid "Not in Developer Mode"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:328
+#: core/doctype/doctype/doctype.py:329
 msgid "Not in Developer Mode! Set in site_config.json or make 'Custom' DocType."
 msgstr ""
 
 #: api/v1.py:88 api/v1.py:93
-#: core/doctype/system_settings/system_settings.py:208 handler.py:109
+#: core/doctype/system_settings/system_settings.py:207 handler.py:109
 #: public/js/frappe/request.js:157 public/js/frappe/request.js:167
 #: public/js/frappe/request.js:172
 #: public/js/frappe/views/kanban/kanban_board.bundle.js:68
-#: website/doctype/web_form/web_form.py:616 website/js/website.js:97
+#: website/doctype/web_form/web_form.py:615 website/js/website.js:97
 msgid "Not permitted"
 msgstr ""
 
@@ -20501,7 +21230,7 @@ msgid "Not permitted to view {0}"
 msgstr ""
 
 #. Name of a DocType
-#: automation/doctype/auto_repeat/auto_repeat.py:395
+#: automation/doctype/auto_repeat/auto_repeat.py:396
 #: desk/doctype/note/note.json
 msgid "Note"
 msgstr ""
@@ -20573,7 +21302,9 @@ msgstr ""
 msgid "Nothing left to undo"
 msgstr ""
 
-#: public/js/frappe/list/base_list.js:359 templates/includes/list/list.html:7
+#: public/js/frappe/list/base_list.js:361
+#: public/js/frappe/views/reports/query_report.js:104
+#: templates/includes/list/list.html:7
 #: website/doctype/blog_post/templates/blog_post_list.html:41
 msgid "Nothing to show"
 msgstr ""
@@ -20652,6 +21383,10 @@ msgstr ""
 msgid "Notification Subscribed Document"
 msgstr ""
 
+#: public/js/frappe/form/templates/timeline_message_box.html:7
+msgid "Notification sent to"
+msgstr ""
+
 #: public/js/frappe/ui/notifications/notifications.js:49
 #: public/js/frappe/ui/notifications/notifications.js:180
 msgid "Notifications"
@@ -20661,6 +21396,10 @@ msgstr ""
 #: core/doctype/role/role.json
 msgctxt "Role"
 msgid "Notifications"
+msgstr ""
+
+#: public/js/frappe/ui/notifications/notifications.js:292
+msgid "Notifications Disabled"
 msgstr ""
 
 #. Description of the 'Default Outgoing' (Check) field in DocType 'Email
@@ -20719,7 +21458,7 @@ msgstr ""
 
 #. Name of a DocType
 #: desk/doctype/number_card/number_card.json
-#: public/js/frappe/widgets/widget_dialog.js:597
+#: public/js/frappe/widgets/widget_dialog.js:630
 msgid "Number Card"
 msgstr ""
 
@@ -20734,7 +21473,7 @@ msgctxt "Workspace Number Card"
 msgid "Number Card Name"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:627
+#: public/js/frappe/widgets/widget_dialog.js:660
 msgid "Number Cards"
 msgstr ""
 
@@ -20769,7 +21508,7 @@ msgctxt "Dropbox Settings"
 msgid "Number of DB Backups"
 msgstr ""
 
-#: integrations/doctype/dropbox_settings/dropbox_settings.py:53
+#: integrations/doctype/dropbox_settings/dropbox_settings.py:54
 msgid "Number of DB backups cannot be less than 1"
 msgstr ""
 
@@ -20785,11 +21524,11 @@ msgctxt "Recorder"
 msgid "Number of Queries"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:440 public/js/frappe/doctype/index.js:59
+#: core/doctype/doctype/doctype.py:439 public/js/frappe/doctype/index.js:59
 msgid "Number of attachment fields are more than {}, limit updated to {}."
 msgstr ""
 
-#: core/doctype/system_settings/system_settings.py:161
+#: core/doctype/system_settings/system_settings.py:160
 msgid "Number of backups must be greater than zero."
 msgstr ""
 
@@ -20851,7 +21590,7 @@ msgctxt "Google Settings"
 msgid "OAuth Client ID"
 msgstr ""
 
-#: email/oauth.py:31
+#: email/oauth.py:30
 msgid "OAuth Error"
 msgstr ""
 
@@ -20898,12 +21637,16 @@ msgctxt "System Settings"
 msgid "OTP Issuer Name"
 msgstr ""
 
-#: twofactor.py:468
+#: twofactor.py:460
 msgid "OTP Secret Reset - {0}"
 msgstr ""
 
-#: twofactor.py:487
+#: twofactor.py:479
 msgid "OTP Secret has been reset. Re-registration will be required on next login."
+msgstr ""
+
+#: templates/includes/login/login.js:363
+msgid "OTP setup using OTP App was not completed. Please contact Administrator."
 msgstr ""
 
 #. Option for the 'SSL/TLS Mode' (Select) field in DocType 'LDAP Settings'
@@ -20925,6 +21668,10 @@ msgctxt "Social Login Key"
 msgid "Office 365"
 msgstr ""
 
+#: core/doctype/server_script/server_script.js:33
+msgid "Official Documentation"
+msgstr ""
+
 #. Label of a Int field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
 msgctxt "Form Tour Step"
@@ -20941,7 +21688,7 @@ msgstr ""
 msgid "Old Password"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:362
+#: custom/doctype/custom_field/custom_field.py:361
 msgid "Old and new fieldnames are same."
 msgstr ""
 
@@ -20965,10 +21712,26 @@ msgctxt "Server Script"
 msgid "On Payment Authorization"
 msgstr ""
 
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
+#: core/doctype/server_script/server_script.json
+msgctxt "Server Script"
+msgid "On Payment Failed"
+msgstr ""
+
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
+#: core/doctype/server_script/server_script.json
+msgctxt "Server Script"
+msgid "On Payment Paid"
+msgstr ""
+
 #. Description of the 'Is Dynamic URL?' (Check) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "On checking this option, URL will be treated like a jinja template string"
+msgstr ""
+
+#: public/js/frappe/views/communication.js:893
+msgid "On {0}, {1} wrote:"
 msgstr ""
 
 #. Label of a Check field in DocType 'Workspace Link'
@@ -21018,11 +21781,15 @@ msgctxt "DocType"
 msgid "Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended."
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:35
+msgid "Once you have set this, the users will only be able access documents (eg. Blog Post) where the link exists (eg. Blogger)."
+msgstr ""
+
 #: www/complete_signup.html:7
 msgid "One Last Step"
 msgstr ""
 
-#: twofactor.py:283
+#: twofactor.py:277
 msgid "One Time Password (OTP) Registration Code from {}"
 msgstr ""
 
@@ -21038,19 +21805,19 @@ msgstr ""
 msgid "Only 200 inserts allowed in one request"
 msgstr ""
 
-#: email/doctype/email_queue/email_queue.py:80
+#: email/doctype/email_queue/email_queue.py:81
 msgid "Only Administrator can delete Email Queue"
 msgstr ""
 
-#: core/doctype/page/page.py:66
+#: core/doctype/page/page.py:67
 msgid "Only Administrator can edit"
 msgstr ""
 
-#: core/doctype/report/report.py:71
+#: core/doctype/report/report.py:72
 msgid "Only Administrator can save a standard report. Please rename and save."
 msgstr ""
 
-#: recorder.py:227
+#: recorder.py:304
 msgid "Only Administrator is allowed to use Recorder"
 msgstr ""
 
@@ -21060,7 +21827,7 @@ msgctxt "Workflow Document State"
 msgid "Only Allow Edit For"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1557
+#: core/doctype/doctype/doctype.py:1555
 msgid "Only Options allowed for Data field are:"
 msgstr ""
 
@@ -21078,7 +21845,7 @@ msgstr ""
 msgid "Only Workspace Manager can sort or edit this page"
 msgstr ""
 
-#: modules/utils.py:66
+#: modules/utils.py:64
 msgid "Only allowed to export customizations in developer mode"
 msgstr ""
 
@@ -21095,20 +21862,20 @@ msgctxt "Workspace Link"
 msgid "Only for"
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:194
+#: core/doctype/data_export/exporter.py:192
 msgid "Only mandatory fields are necessary for new records. You can delete non-mandatory columns if you wish."
 msgstr ""
 
-#: contacts/doctype/contact/contact.py:129
-#: contacts/doctype/contact/contact.py:153
+#: contacts/doctype/contact/contact.py:130
+#: contacts/doctype/contact/contact.py:154
 msgid "Only one {0} can be set as primary."
 msgstr ""
 
-#: desk/reportview.py:319
+#: desk/reportview.py:317
 msgid "Only reports of type Report Builder can be deleted"
 msgstr ""
 
-#: desk/reportview.py:290
+#: desk/reportview.py:288
 msgid "Only reports of type Report Builder can be edited"
 msgstr ""
 
@@ -21124,8 +21891,12 @@ msgstr ""
 msgid "Only users involved in the document are listed"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:100
+#: email/doctype/auto_email_report/auto_email_report.py:106
 msgid "Only {0} emailed reports are allowed per user."
+msgstr ""
+
+#: templates/includes/login/login.js:292
+msgid "Oops! Something went wrong."
 msgstr ""
 
 #: core/doctype/deleted_document/deleted_document.js:7
@@ -21172,6 +21943,10 @@ msgstr ""
 msgid "Open Awesomebar"
 msgstr ""
 
+#: public/js/frappe/form/templates/timeline_message_box.html:67
+msgid "Open Communication"
+msgstr ""
+
 #: templates/emails/new_notification.html:10
 msgid "Open Document"
 msgstr ""
@@ -21194,6 +21969,10 @@ msgstr ""
 
 #: public/js/frappe/ui/keyboard.js:220
 msgid "Open Settings"
+msgstr ""
+
+#: public/js/frappe/ui/toolbar/about.js:8
+msgid "Open Source Applications for the Web"
 msgstr ""
 
 #. Label of a Check field in DocType 'Top Bar Item'
@@ -21222,6 +22001,7 @@ msgid "Open your authentication app on your mobile phone."
 msgstr ""
 
 #: desk/doctype/todo/todo_list.js:23
+#: public/js/frappe/form/templates/form_links.html:18
 #: public/js/frappe/ui/toolbar/search_utils.js:277
 #: public/js/frappe/ui/toolbar/search_utils.js:278
 #: public/js/frappe/ui/toolbar/search_utils.js:289
@@ -21257,7 +22037,7 @@ msgctxt "Activity Log"
 msgid "Operation"
 msgstr ""
 
-#: utils/data.py:2057
+#: utils/data.py:2038
 msgid "Operator must be one of {0}"
 msgstr ""
 
@@ -21281,7 +22061,7 @@ msgstr ""
 msgid "Option 3"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1575
+#: core/doctype/doctype/doctype.py:1573
 msgid "Option {0} for field {1} is not a child table"
 msgstr ""
 
@@ -21295,6 +22075,10 @@ msgstr ""
 #: email/doctype/notification/notification.json
 msgctxt "Notification"
 msgid "Optional: The alert will be sent if this expression is true"
+msgstr ""
+
+#: templates/form_grid/fields.html:43
+msgid "Options"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Custom Field'
@@ -21349,7 +22133,7 @@ msgctxt "Custom Field"
 msgid "Options Help"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1597
+#: core/doctype/doctype/doctype.py:1595
 msgid "Options for Rating field can range from 3 to 10"
 msgstr ""
 
@@ -21361,7 +22145,7 @@ msgstr ""
 msgid "Options for {0} must be set before setting the default value."
 msgstr ""
 
-#: public/js/form_builder/store.js:177
+#: public/js/form_builder/store.js:182
 msgid "Options is required for field {0} of type {1}"
 msgstr ""
 
@@ -21402,6 +22186,11 @@ msgstr ""
 
 #: public/js/frappe/form/print_utils.js:26
 msgid "Orientation"
+msgstr ""
+
+#: core/doctype/version/version_view.html:13
+#: core/doctype/version/version_view.html:75
+msgid "Original Value"
 msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
@@ -21480,6 +22269,11 @@ msgctxt "System Console"
 msgid "Output"
 msgstr ""
 
+#: desk/page/user_profile/user_profile.html:6
+#: public/js/frappe/form/templates/form_dashboard.html:5
+msgid "Overview"
+msgstr ""
+
 #: core/report/transaction_log_report/transaction_log_report.py:100
 #: social/doctype/energy_point_rule/energy_point_rule.js:42
 msgid "Owner"
@@ -21492,7 +22286,8 @@ msgid "PATCH"
 msgstr ""
 
 #: printing/page/print/print.js:71
-#: public/js/frappe/views/reports/query_report.js:1637
+#: public/js/frappe/form/templates/print_layout.html:44
+#: public/js/frappe/views/reports/query_report.js:1640
 msgid "PDF"
 msgstr ""
 
@@ -21520,11 +22315,11 @@ msgctxt "Print Settings"
 msgid "PDF Settings"
 msgstr ""
 
-#: utils/print_format.py:177
+#: utils/print_format.py:171
 msgid "PDF generation failed"
 msgstr ""
 
-#: utils/pdf.py:95
+#: utils/pdf.py:93
 msgid "PDF generation failed because of broken image links"
 msgstr ""
 
@@ -21661,6 +22456,10 @@ msgctxt "Web Form Field"
 msgid "Page Break"
 msgstr ""
 
+#: website/doctype/web_page/web_page.js:92
+msgid "Page Builder"
+msgstr ""
+
 #. Option for the 'Content Type' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
 msgctxt "Web Page"
@@ -21733,7 +22532,7 @@ msgstr ""
 msgid "Page has expired!"
 msgstr ""
 
-#: printing/doctype/print_settings/print_settings.py:71
+#: printing/doctype/print_settings/print_settings.py:70
 #: public/js/frappe/list/bulk_operations.js:90
 msgid "Page height and width cannot be zero"
 msgstr ""
@@ -21746,6 +22545,8 @@ msgstr ""
 msgid "Page with title {0} already exist."
 msgstr ""
 
+#: public/html/print_template.html:25
+#: public/js/frappe/views/reports/print_tree.html:89
 #: public/js/frappe/web_form/web_form.js:264
 #: templates/print_formats/standard.html:34
 msgid "Page {0} of {1}"
@@ -21782,7 +22583,7 @@ msgctxt "Number Card"
 msgid "Parent Document Type"
 msgstr ""
 
-#: desk/doctype/number_card/number_card.py:61
+#: desk/doctype/number_card/number_card.py:62
 msgid "Parent Document Type is required to create a number card"
 msgstr ""
 
@@ -21798,7 +22599,7 @@ msgctxt "Form Tour Step"
 msgid "Parent Field"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:911
+#: core/doctype/doctype/doctype.py:912
 msgid "Parent Field (Tree)"
 msgstr ""
 
@@ -21808,7 +22609,7 @@ msgctxt "DocType"
 msgid "Parent Field (Tree)"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:917
+#: core/doctype/doctype/doctype.py:918
 msgid "Parent Field must be a valid fieldname"
 msgstr ""
 
@@ -21832,15 +22633,15 @@ msgstr ""
 msgid "Parent Table"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.py:404
+#: desk/doctype/dashboard_chart/dashboard_chart.py:394
 msgid "Parent document type is required to create a dashboard chart"
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:255
+#: core/doctype/data_export/exporter.py:253
 msgid "Parent is the name of the document to which the data will get added to."
 msgstr ""
 
-#: permissions.py:809
+#: permissions.py:802
 msgid "Parentfield not specified in {0}: {1}"
 msgstr ""
 
@@ -21882,8 +22683,8 @@ msgctxt "Contact"
 msgid "Passive"
 msgstr ""
 
-#: core/doctype/user/user.js:154 core/doctype/user/user.js:201
-#: core/doctype/user/user.js:221 desk/page/setup_wizard/setup_wizard.js:474
+#: core/doctype/user/user.js:147 core/doctype/user/user.js:194
+#: core/doctype/user/user.js:214 desk/page/setup_wizard/setup_wizard.js:474
 #: www/login.html:21
 msgid "Password"
 msgstr ""
@@ -21925,11 +22726,11 @@ msgctxt "Web Form Field"
 msgid "Password"
 msgstr ""
 
-#: core/doctype/user/user.py:1036
+#: core/doctype/user/user.py:1059
 msgid "Password Email Sent"
 msgstr ""
 
-#: core/doctype/user/user.py:418
+#: core/doctype/user/user.py:447
 msgid "Password Reset"
 msgstr ""
 
@@ -21943,7 +22744,7 @@ msgstr ""
 msgid "Password cannot be filtered"
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:358
+#: integrations/doctype/ldap_settings/ldap_settings.py:356
 msgid "Password changed successfully."
 msgstr ""
 
@@ -21953,7 +22754,7 @@ msgctxt "LDAP Settings"
 msgid "Password for Base DN"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:165
+#: email/doctype/email_account/email_account.py:172
 msgid "Password is required or select Awaiting Password"
 msgstr ""
 
@@ -21965,7 +22766,7 @@ msgstr ""
 msgid "Password not found for {0} {1} {2}"
 msgstr ""
 
-#: core/doctype/user/user.py:1035
+#: core/doctype/user/user.py:1058
 msgid "Password reset instructions have been sent to your email"
 msgstr ""
 
@@ -21973,11 +22774,11 @@ msgstr ""
 msgid "Password set"
 msgstr ""
 
-#: auth.py:241
+#: auth.py:235
 msgid "Password size exceeded the maximum allowed size"
 msgstr ""
 
-#: core/doctype/user/user.py:828
+#: core/doctype/user/user.py:854
 msgid "Password size exceeded the maximum allowed size."
 msgstr ""
 
@@ -21985,7 +22786,7 @@ msgstr ""
 msgid "Passwords do not match"
 msgstr ""
 
-#: core/doctype/user/user.js:187
+#: core/doctype/user/user.js:180
 msgid "Passwords do not match!"
 msgstr ""
 
@@ -22014,7 +22815,7 @@ msgstr ""
 msgid "Patch Log"
 msgstr ""
 
-#: modules/patch_handler.py:137
+#: modules/patch_handler.py:136
 msgid "Patch type {} not found in patches.txt"
 msgstr ""
 
@@ -22159,7 +22960,7 @@ msgstr ""
 msgid "Permanently Submit {0}?"
 msgstr ""
 
-#: public/js/frappe/model/model.js:698
+#: public/js/frappe/model/model.js:703
 msgid "Permanently delete {0}?"
 msgstr ""
 
@@ -22172,7 +22973,7 @@ msgstr ""
 msgid "Permission Inspector"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:446
+#: core/page/permission_manager/permission_manager.js:457
 msgid "Permission Level"
 msgstr ""
 
@@ -22180,6 +22981,10 @@ msgstr ""
 #: custom/doctype/custom_field/custom_field.json
 msgctxt "Custom Field"
 msgid "Permission Level"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:22
+msgid "Permission Levels"
 msgstr ""
 
 #. Label of a shortcut in the Users Workspace
@@ -22212,7 +23017,7 @@ msgid "Permission Type"
 msgstr ""
 
 #. Label of a Card Break in the Users Workspace
-#: core/doctype/user/user.js:129 core/doctype/user/user.js:138
+#: core/doctype/user/user.js:122 core/doctype/user/user.js:131
 #: core/page/permission_manager/permission_manager.js:214
 #: core/workspace/users/users.json
 msgid "Permissions"
@@ -22254,8 +23059,28 @@ msgctxt "System Settings"
 msgid "Permissions"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1771 core/doctype/doctype/doctype.py:1781
+#: core/doctype/doctype/doctype.py:1769 core/doctype/doctype/doctype.py:1779
 msgid "Permissions Error"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:10
+msgid "Permissions are automatically applied to Standard Reports and searches."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:5
+msgid "Permissions are set on Roles and Document Types (called DocTypes) by setting rights like Read, Write, Create, Delete, Submit, Cancel, Amend, Report, Import, Export, Print, Email and Set User Permissions."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:26
+msgid "Permissions at higher levels are Field Level permissions. All Fields have a Permission Level set against them and the rules defined at that permissions apply to the field. This is useful in case you want to hide or make certain field read-only for certain Roles."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:24
+msgid "Permissions at level 0 are Document Level permissions, i.e. they are primary for access to the document."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:6
+msgid "Permissions get applied on Users based on what Roles they are assigned."
 msgstr ""
 
 #. Name of a report
@@ -22398,15 +23223,15 @@ msgctxt "Address"
 msgid "Plant"
 msgstr ""
 
-#: email/oauth.py:30
+#: email/oauth.py:29
 msgid "Please Authorize OAuth for Email Account {}"
 msgstr ""
 
-#: website/doctype/website_theme/website_theme.py:79
+#: website/doctype/website_theme/website_theme.py:76
 msgid "Please Duplicate this Website Theme to customize."
 msgstr ""
 
-#: integrations/doctype/ldap_settings/ldap_settings.py:159
+#: integrations/doctype/ldap_settings/ldap_settings.py:161
 msgid "Please Install the ldap3 library via pip to use ldap functionality."
 msgstr ""
 
@@ -22418,7 +23243,7 @@ msgstr ""
 msgid "Please Update SMS Settings"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:569
+#: automation/doctype/auto_repeat/auto_repeat.py:570
 msgid "Please add a subject to your email"
 msgstr ""
 
@@ -22426,7 +23251,7 @@ msgstr ""
 msgid "Please add a valid comment."
 msgstr ""
 
-#: core/doctype/user/user.py:1017
+#: core/doctype/user/user.py:1041
 msgid "Please ask your administrator to verify your sign-up"
 msgstr ""
 
@@ -22434,15 +23259,15 @@ msgstr ""
 msgid "Please attach a file first."
 msgstr ""
 
-#: printing/doctype/letter_head/letter_head.py:73
+#: printing/doctype/letter_head/letter_head.py:76
 msgid "Please attach an image file to set HTML for Footer."
 msgstr ""
 
-#: printing/doctype/letter_head/letter_head.py:61
+#: printing/doctype/letter_head/letter_head.py:64
 msgid "Please attach an image file to set HTML for Letter Head."
 msgstr ""
 
-#: core/doctype/package_import/package_import.py:38
+#: core/doctype/package_import/package_import.py:39
 msgid "Please attach the package"
 msgstr ""
 
@@ -22454,11 +23279,11 @@ msgstr ""
 msgid "Please check the filter values set for Dashboard Chart: {}"
 msgstr ""
 
-#: model/base_document.py:858
+#: model/base_document.py:862
 msgid "Please check the value of \"Fetch From\" set for field {0}"
 msgstr ""
 
-#: core/doctype/user/user.py:1015
+#: core/doctype/user/user.py:1039
 msgid "Please check your email for verification"
 msgstr ""
 
@@ -22466,11 +23291,15 @@ msgstr ""
 msgid "Please check your email login credentials."
 msgstr ""
 
-#: twofactor.py:246
+#: twofactor.py:242
 msgid "Please check your registered email address for instructions on how to proceed. Do not close this window as you will have to return to it."
 msgstr ""
 
-#: twofactor.py:291
+#: core/doctype/data_import/data_import.js:158
+msgid "Please click on 'Export Errored Rows', fix the errors and import again."
+msgstr ""
+
+#: twofactor.py:285
 msgid "Please click on the following link and follow the instructions on the page. {0}"
 msgstr ""
 
@@ -22478,16 +23307,12 @@ msgstr ""
 msgid "Please click on the following link to set your new password"
 msgstr ""
 
-#: integrations/doctype/dropbox_settings/dropbox_settings.py:344
+#: integrations/doctype/dropbox_settings/dropbox_settings.py:343
 msgid "Please close this window"
 msgstr ""
 
 #: www/confirm_workflow_action.html:4
 msgid "Please confirm your action to {0} this document."
-msgstr ""
-
-#: core/doctype/server_script/server_script.js:33
-msgid "Please contact your system administrator to enable this feature."
 msgstr ""
 
 #: desk/doctype/number_card/number_card.js:44
@@ -22510,7 +23335,7 @@ msgstr ""
 msgid "Please duplicate this to make changes"
 msgstr ""
 
-#: core/doctype/system_settings/system_settings.py:154
+#: core/doctype/system_settings/system_settings.py:153
 msgid "Please enable atleast one Social Login Key or LDAP or Login With Email Link before disabling username/password based login."
 msgstr ""
 
@@ -22530,19 +23355,19 @@ msgstr ""
 msgid "Please enable {} before continuing."
 msgstr ""
 
-#: utils/oauth.py:191
+#: utils/oauth.py:186
 msgid "Please ensure that your profile has an email address"
 msgstr ""
 
-#: integrations/doctype/social_login_key/social_login_key.py:73
+#: integrations/doctype/social_login_key/social_login_key.py:74
 msgid "Please enter Access Token URL"
 msgstr ""
 
-#: integrations/doctype/social_login_key/social_login_key.py:71
+#: integrations/doctype/social_login_key/social_login_key.py:72
 msgid "Please enter Authorize URL"
 msgstr ""
 
-#: integrations/doctype/social_login_key/social_login_key.py:69
+#: integrations/doctype/social_login_key/social_login_key.py:70
 msgid "Please enter Base URL"
 msgstr ""
 
@@ -22550,7 +23375,7 @@ msgstr ""
 msgid "Please enter Client ID before social login is enabled"
 msgstr ""
 
-#: integrations/doctype/social_login_key/social_login_key.py:82
+#: integrations/doctype/social_login_key/social_login_key.py:81
 msgid "Please enter Client Secret before social login is enabled"
 msgstr ""
 
@@ -22558,7 +23383,7 @@ msgstr ""
 msgid "Please enter OpenID Configuration URL"
 msgstr ""
 
-#: integrations/doctype/social_login_key/social_login_key.py:75
+#: integrations/doctype/social_login_key/social_login_key.py:76
 msgid "Please enter Redirect URL"
 msgstr ""
 
@@ -22566,7 +23391,7 @@ msgstr ""
 msgid "Please enter a valid email address."
 msgstr ""
 
-#: www/update-password.html:233
+#: www/update-password.html:232
 msgid "Please enter the password"
 msgstr ""
 
@@ -22575,7 +23400,7 @@ msgctxt "Email Account"
 msgid "Please enter the password for: <b>{0}</b>"
 msgstr ""
 
-#: core/doctype/sms_settings/sms_settings.py:42
+#: core/doctype/sms_settings/sms_settings.py:43
 msgid "Please enter valid mobile nos"
 msgstr ""
 
@@ -22587,11 +23412,11 @@ msgstr ""
 msgid "Please enter your old password."
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:401
+#: automation/doctype/auto_repeat/auto_repeat.py:402
 msgid "Please find attached {0}: {1}"
 msgstr ""
 
-#: core/doctype/navbar_settings/navbar_settings.py:44
+#: core/doctype/navbar_settings/navbar_settings.py:43
 msgid "Please hide the standard navbar items instead of deleting them"
 msgstr ""
 
@@ -22603,7 +23428,7 @@ msgstr ""
 msgid "Please make sure the Reference Communication Docs are not circularly linked."
 msgstr ""
 
-#: model/document.py:810
+#: model/document.py:799
 msgid "Please refresh to get the latest document."
 msgstr ""
 
@@ -22647,8 +23472,12 @@ msgstr ""
 msgid "Please select Entity Type first"
 msgstr ""
 
-#: core/doctype/system_settings/system_settings.py:105
+#: core/doctype/system_settings/system_settings.py:103
 msgid "Please select Minimum Password Score"
+msgstr ""
+
+#: public/js/frappe/views/reports/query_report.js:1092
+msgid "Please select X and Y fields"
 msgstr ""
 
 #: utils/__init__.py:115
@@ -22659,11 +23488,11 @@ msgstr ""
 msgid "Please select a file or url"
 msgstr ""
 
-#: model/rename_doc.py:670
+#: model/rename_doc.py:652
 msgid "Please select a valid csv file with data"
 msgstr ""
 
-#: utils/data.py:285
+#: utils/data.py:286
 msgid "Please select a valid date filter"
 msgstr ""
 
@@ -22671,11 +23500,11 @@ msgstr ""
 msgid "Please select applicable Doctypes"
 msgstr ""
 
-#: model/db_query.py:1140
+#: model/db_query.py:1134
 msgid "Please select atleast 1 column from {0} to sort/group"
 msgstr ""
 
-#: core/doctype/document_naming_settings/document_naming_settings.py:215
+#: core/doctype/document_naming_settings/document_naming_settings.py:214
 msgid "Please select prefix first"
 msgstr ""
 
@@ -22694,11 +23523,11 @@ msgstr ""
 msgid "Please select {0}"
 msgstr ""
 
-#: integrations/doctype/dropbox_settings/dropbox_settings.py:306
+#: integrations/doctype/dropbox_settings/dropbox_settings.py:305
 msgid "Please set Dropbox access keys in site config or doctype"
 msgstr ""
 
-#: contacts/doctype/contact/contact.py:200
+#: contacts/doctype/contact/contact.py:201
 msgid "Please set Email Address"
 msgstr ""
 
@@ -22710,23 +23539,23 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:226
+#: email/doctype/auto_email_report/auto_email_report.py:251
 msgid "Please set filters value in Report Filter table."
 msgstr ""
 
-#: model/naming.py:533
+#: model/naming.py:523
 msgid "Please set the document name"
 msgstr ""
 
-#: desk/doctype/dashboard/dashboard.py:125
+#: desk/doctype/dashboard/dashboard.py:122
 msgid "Please set the following documents in this Dashboard as standard first."
 msgstr ""
 
-#: core/doctype/document_naming_settings/document_naming_settings.py:121
+#: core/doctype/document_naming_settings/document_naming_settings.py:120
 msgid "Please set the series to be used."
 msgstr ""
 
-#: core/doctype/system_settings/system_settings.py:118
+#: core/doctype/system_settings/system_settings.py:116
 msgid "Please setup SMS before setting it as an authentication method, via SMS Settings"
 msgstr ""
 
@@ -22734,27 +23563,27 @@ msgstr ""
 msgid "Please setup a message first"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:389
+#: email/doctype/email_account/email_account.py:407
 msgid "Please setup default Email Account from Settings > Email Account"
 msgstr ""
 
-#: core/doctype/user/user.py:369
+#: core/doctype/user/user.py:398
 msgid "Please setup default outgoing Email Account from Settings > Email Account"
 msgstr ""
 
-#: public/js/frappe/model/model.js:785
+#: public/js/frappe/model/model.js:790
 msgid "Please specify"
 msgstr ""
 
-#: permissions.py:785
+#: permissions.py:778
 msgid "Please specify a valid parent DocType for {0}"
 msgstr ""
 
-#: email/doctype/notification/notification.py:86
+#: email/doctype/notification/notification.py:87
 msgid "Please specify which date field must be checked"
 msgstr ""
 
-#: email/doctype/notification/notification.py:89
+#: email/doctype/notification/notification.py:90
 msgid "Please specify which value field must be checked"
 msgstr ""
 
@@ -22870,10 +23699,13 @@ msgstr ""
 
 #: templates/discussions/comment_box.html:29
 #: templates/discussions/reply_card.html:15
+#: templates/discussions/reply_section.html:29
+#: templates/discussions/reply_section.html:53
+#: templates/discussions/topic_modal.html:11
 msgid "Post"
 msgstr ""
 
-#: templates/discussions/reply_section.html:39
+#: templates/discussions/reply_section.html:40
 msgid "Post it here, our mentors will help you out."
 msgstr ""
 
@@ -22927,11 +23759,11 @@ msgctxt "Web Form Field"
 msgid "Precision"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1345
+#: core/doctype/doctype/doctype.py:1347
 msgid "Precision should be between 1 and 6"
 msgstr ""
 
-#: utils/password_strength.py:191
+#: utils/password_strength.py:187
 msgid "Predictable substitutions like '@' instead of 'a' don't help very much."
 msgstr ""
 
@@ -22975,7 +23807,7 @@ msgstr ""
 msgid "Prepared Report User"
 msgstr ""
 
-#: desk/query_report.py:296
+#: desk/query_report.py:294
 msgid "Prepared report render failed"
 msgstr ""
 
@@ -22987,12 +23819,17 @@ msgstr ""
 msgid "Prepend the template to the email message"
 msgstr ""
 
+#: public/js/frappe/ui/keyboard.js:135
+msgid "Press Alt Key to trigger additional shortcuts in Menu and Sidebar"
+msgstr ""
+
 #: public/js/frappe/list/list_filter.js:134
 msgid "Press Enter to save"
 msgstr ""
 
 #: email/doctype/newsletter/newsletter.js:14
 #: email/doctype/newsletter/newsletter.js:42
+#: public/js/frappe/form/controls/markdown_editor.js:17
 #: public/js/frappe/form/controls/markdown_editor.js:31
 #: public/js/frappe/ui/capture.js:228
 msgid "Preview"
@@ -23062,9 +23899,19 @@ msgctxt "Document Naming Settings"
 msgid "Preview of generated names"
 msgstr ""
 
+#: email/doctype/email_group/email_group.js:90
+msgid "Preview:"
+msgstr ""
+
+#: public/js/frappe/web_form/web_form.js:95
 #: public/js/onboarding_tours/onboarding_tours.js:16
 #: templates/includes/slideshow.html:34
 #: website/web_template/slideshow/slideshow.html:40
+msgid "Previous"
+msgstr ""
+
+#: public/js/frappe/ui/slides.js:351
+msgctxt "Go to previous slide"
 msgid "Previous"
 msgstr ""
 
@@ -23078,7 +23925,7 @@ msgctxt "Transaction Log"
 msgid "Previous Hash"
 msgstr ""
 
-#: public/js/frappe/form/form.js:2162
+#: public/js/frappe/form/form.js:2165
 msgid "Previous Submission"
 msgstr ""
 
@@ -23088,17 +23935,38 @@ msgctxt "Workflow State"
 msgid "Primary"
 msgstr ""
 
+#: public/js/frappe/form/templates/address_list.html:21
+msgid "Primary Address"
+msgstr ""
+
 #. Label of a Link field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
 msgctxt "Website Theme"
 msgid "Primary Color"
 msgstr ""
 
+#: public/js/frappe/form/templates/contact_list.html:17
+msgid "Primary Contact"
+msgstr ""
+
+#: public/js/frappe/form/templates/contact_list.html:63
+msgid "Primary Email"
+msgstr ""
+
+#: public/js/frappe/form/templates/contact_list.html:43
+msgid "Primary Mobile"
+msgstr ""
+
+#: public/js/frappe/form/templates/contact_list.html:35
+msgid "Primary Phone"
+msgstr ""
+
 #: core/doctype/success_action/success_action.js:56
 #: printing/page/print/print.js:65 public/js/frappe/form/success_action.js:81
+#: public/js/frappe/form/templates/print_layout.html:46
 #: public/js/frappe/form/toolbar.js:321 public/js/frappe/form/toolbar.js:333
 #: public/js/frappe/list/bulk_operations.js:79
-#: public/js/frappe/views/reports/query_report.js:1623
+#: public/js/frappe/views/reports/query_report.js:1626
 #: public/js/frappe/views/reports/report_view.js:1463
 #: public/js/frappe/views/treeview.js:473 www/printview.html:18
 msgid "Print"
@@ -23215,7 +24083,7 @@ msgctxt "Print Format"
 msgid "Print Format Type"
 msgstr ""
 
-#: www/printview.py:407
+#: www/printview.py:418
 msgid "Print Format {0} is disabled"
 msgstr ""
 
@@ -23287,6 +24155,7 @@ msgstr ""
 #: printing/doctype/print_settings/print_settings.json
 #: printing/doctype/print_style/print_style.js:6
 #: printing/page/print/print.js:160 public/js/frappe/form/print_utils.js:69
+#: public/js/frappe/form/templates/print_layout.html:35
 msgid "Print Settings"
 msgstr ""
 
@@ -23388,7 +24257,7 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: utils/print_format.py:179
+#: utils/print_format.py:173
 msgid "Printing failed"
 msgstr ""
 
@@ -23483,6 +24352,12 @@ msgstr ""
 
 #: public/js/frappe/views/kanban/kanban_view.js:405
 msgid "Project"
+msgstr ""
+
+#: core/doctype/version/version_view.html:12
+#: core/doctype/version/version_view.html:37
+#: core/doctype/version/version_view.html:74
+msgid "Property"
 msgstr ""
 
 #. Label of a Data field in DocType 'Property Setter'
@@ -23826,7 +24701,7 @@ msgctxt "Report"
 msgid "Query Report"
 msgstr ""
 
-#: utils/safe_exec.py:437
+#: utils/safe_exec.py:434
 msgid "Query must be of SELECT or read-only WITH type."
 msgstr ""
 
@@ -23854,7 +24729,7 @@ msgctxt "DocType"
 msgid "Queue in Background (BETA)"
 msgstr ""
 
-#: utils/background_jobs.py:433
+#: utils/background_jobs.py:428
 msgid "Queue should be one of {0}"
 msgstr ""
 
@@ -23898,13 +24773,13 @@ msgctxt "Prepared Report"
 msgid "Queued By"
 msgstr ""
 
-#: core/doctype/submission_queue/submission_queue.py:173
+#: core/doctype/submission_queue/submission_queue.py:174
 msgid "Queued for Submission. You can track the progress over {0}."
 msgstr ""
 
-#: integrations/doctype/dropbox_settings/dropbox_settings.py:64
-#: integrations/doctype/google_drive/google_drive.py:156
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.py:81
+#: integrations/doctype/dropbox_settings/dropbox_settings.py:65
+#: integrations/doctype/google_drive/google_drive.py:153
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.py:82
 msgid "Queued for backup. It may take a few minutes to an hour."
 msgstr ""
 
@@ -23920,7 +24795,7 @@ msgstr ""
 msgid "Queuing emails..."
 msgstr ""
 
-#: desk/doctype/bulk_update/bulk_update.py:88
+#: desk/doctype/bulk_update/bulk_update.py:86
 msgid "Queuing {0} for Submission"
 msgstr ""
 
@@ -23934,6 +24809,10 @@ msgstr ""
 #: core/doctype/doctype/doctype.json
 msgctxt "DocType"
 msgid "Quick Entry"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:3
+msgid "Quick Help for Setting Permissions"
 msgstr ""
 
 #. Label of a Code field in DocType 'Workspace Quick List'
@@ -23985,6 +24864,10 @@ msgstr ""
 msgid "Range"
 msgstr ""
 
+#: desk/page/user_profile/user_profile_controller.js:402
+msgid "Rank"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
 msgctxt "Server Script"
@@ -24027,7 +24910,7 @@ msgctxt "Web Form Field"
 msgid "Rating"
 msgstr ""
 
-#: printing/doctype/print_format/print_format.py:89
+#: printing/doctype/print_format/print_format.py:87
 msgid "Raw Commands"
 msgstr ""
 
@@ -24059,11 +24942,15 @@ msgstr ""
 msgid "Raw Printing Setting"
 msgstr ""
 
+#: public/js/frappe/form/templates/print_layout.html:37
+msgid "Raw Printing Settings"
+msgstr ""
+
 #: desk/doctype/console_log/console_log.js:6
 msgid "Re-Run in Console"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:632
+#: email/doctype/email_account/email_account.py:660
 msgid "Re:"
 msgstr ""
 
@@ -24174,6 +25061,7 @@ msgctxt "DocField"
 msgid "Read Only Depends On (JS)"
 msgstr ""
 
+#: public/js/frappe/ui/toolbar/navbar.html:16
 #: templates/includes/navbar/navbar_items.html:97
 msgid "Read Only Mode"
 msgstr ""
@@ -24200,7 +25088,7 @@ msgstr ""
 msgid "Read mode"
 msgstr ""
 
-#: utils/safe_exec.py:91
+#: utils/safe_exec.py:90
 msgid "Read the documentation to know more"
 msgstr ""
 
@@ -24235,7 +25123,7 @@ msgstr ""
 msgid "Rebuild Tree"
 msgstr ""
 
-#: utils/nestedset.py:180
+#: utils/nestedset.py:176
 msgid "Rebuilding of tree is not supported for {}"
 msgstr ""
 
@@ -24251,7 +25139,7 @@ msgctxt "Communication"
 msgid "Received"
 msgstr ""
 
-#: integrations/doctype/token_cache/token_cache.py:49
+#: integrations/doctype/token_cache/token_cache.py:50
 msgid "Received an invalid token type."
 msgstr ""
 
@@ -24273,7 +25161,11 @@ msgctxt "SMS Settings"
 msgid "Receiver Parameter"
 msgstr ""
 
-#: utils/password_strength.py:125
+#: desk/page/user_profile/user_profile.html:39
+msgid "Recent Activity"
+msgstr ""
+
+#: utils/password_strength.py:123
 msgid "Recent years are easy to guess."
 msgstr ""
 
@@ -24320,6 +25212,10 @@ msgstr ""
 #. Name of a DocType
 #: core/doctype/recorder_query/recorder_query.json
 msgid "Recorder Query"
+msgstr ""
+
+#: core/doctype/user_permission/user_permission_help.html:2
+msgid "Records for following doctypes will be filtered"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
@@ -24382,7 +25278,7 @@ msgctxt "Website Settings"
 msgid "Redirects"
 msgstr ""
 
-#: sessions.py:149
+#: sessions.py:142
 msgid "Redis cache server not running. Please contact Administrator / Tech support"
 msgstr ""
 
@@ -24469,7 +25365,7 @@ msgctxt "Submission Queue"
 msgid "Reference DocType"
 msgstr ""
 
-#: email/doctype/email_unsubscribe/email_unsubscribe.py:25
+#: email/doctype/email_unsubscribe/email_unsubscribe.py:26
 msgid "Reference DocType and Reference Name are required"
 msgstr ""
 
@@ -24494,6 +25390,10 @@ msgstr ""
 #: website/doctype/discussion_topic/discussion_topic.json
 msgctxt "Discussion Topic"
 msgid "Reference Doctype"
+msgstr ""
+
+#: automation/doctype/auto_repeat/auto_repeat_schedule.html:4
+msgid "Reference Document"
 msgstr ""
 
 #. Label of a Data field in DocType 'Access Log'
@@ -24777,7 +25677,7 @@ msgctxt "ToDo"
 msgid "Reference Type"
 msgstr ""
 
-#: social/doctype/energy_point_rule/energy_point_rule.py:144
+#: social/doctype/energy_point_rule/energy_point_rule.py:145
 msgid "Reference document has been cancelled"
 msgstr ""
 
@@ -24802,8 +25702,10 @@ msgid "Referrer"
 msgstr ""
 
 #: printing/page/print/print.js:73 public/js/frappe/desk.js:133
-#: public/js/frappe/form/form.js:1174 public/js/frappe/list/base_list.js:65
-#: public/js/frappe/views/reports/query_report.js:1612
+#: public/js/frappe/form/form.js:1174
+#: public/js/frappe/form/templates/print_layout.html:6
+#: public/js/frappe/list/base_list.js:65
+#: public/js/frappe/views/reports/query_report.js:1615
 #: public/js/frappe/views/treeview.js:479
 #: public/js/frappe/widgets/chart_widget.js:290
 #: public/js/frappe/widgets/number_card_widget.js:307
@@ -24850,12 +25752,17 @@ msgctxt "Token Cache"
 msgid "Refresh Token"
 msgstr ""
 
+#: public/js/frappe/list/list_view.js:505
+msgctxt "Document count in list view"
+msgid "Refreshing"
+msgstr ""
+
 #: core/doctype/system_settings/system_settings.js:52
-#: core/doctype/user/user.js:345 desk/page/setup_wizard/setup_wizard.js:204
+#: core/doctype/user/user.js:339 desk/page/setup_wizard/setup_wizard.js:204
 msgid "Refreshing..."
 msgstr ""
 
-#: core/doctype/user/user.py:979
+#: core/doctype/user/user.py:1003
 msgid "Registered but disabled"
 msgstr ""
 
@@ -24911,7 +25818,11 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: public/js/frappe/list/base_list.js:239
+#: public/js/frappe/form/controls/attach.js:16
+msgid "Reload File"
+msgstr ""
+
+#: public/js/frappe/list/base_list.js:241
 msgid "Reload List"
 msgstr ""
 
@@ -24954,12 +25865,18 @@ msgstr ""
 msgid "Reminder"
 msgstr ""
 
-#: automation/doctype/reminder/reminder.py:38
+#: automation/doctype/reminder/reminder.py:39
 msgid "Reminder cannot be created in past."
 msgstr ""
 
 #: public/js/frappe/form/reminders.js:96
 msgid "Reminder set at {0}"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_sidebar.html:14
+#: public/js/frappe/ui/filters/edit_filter.html:4
+#: public/js/frappe/ui/group_by/group_by.html:4
+msgid "Remove"
 msgstr ""
 
 #: core/doctype/rq_job/rq_job_list.js:8
@@ -24982,27 +25899,27 @@ msgstr ""
 msgid "Remove column"
 msgstr ""
 
-#: core/doctype/file/file.py:155
+#: core/doctype/file/file.py:156
 msgid "Removed {0}"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.js:134
+#: custom/doctype/custom_field/custom_field.js:135
 #: public/js/frappe/form/toolbar.js:234 public/js/frappe/form/toolbar.js:238
-#: public/js/frappe/form/toolbar.js:398 public/js/frappe/model/model.js:737
+#: public/js/frappe/form/toolbar.js:398 public/js/frappe/model/model.js:742
 #: public/js/frappe/views/treeview.js:295
 msgid "Rename"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.js:115
-#: custom/doctype/custom_field/custom_field.js:133
+#: custom/doctype/custom_field/custom_field.js:116
+#: custom/doctype/custom_field/custom_field.js:134
 msgid "Rename Fieldname"
 msgstr ""
 
-#: public/js/frappe/model/model.js:724
+#: public/js/frappe/model/model.js:729
 msgid "Rename {0}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:684
+#: core/doctype/doctype/doctype.py:687
 msgid "Renamed files and replaced code in controllers, please check!"
 msgstr ""
 
@@ -25056,11 +25973,11 @@ msgctxt "Event"
 msgid "Repeat this Event"
 msgstr ""
 
-#: utils/password_strength.py:112
+#: utils/password_strength.py:110
 msgid "Repeats like \"aaa\" are easy to guess"
 msgstr ""
 
-#: utils/password_strength.py:107
+#: utils/password_strength.py:105
 msgid "Repeats like \"abcabcabc\" are only slightly harder to guess than \"abc\""
 msgstr ""
 
@@ -25202,7 +26119,7 @@ msgctxt "Onboarding Step"
 msgid "Report Description"
 msgstr ""
 
-#: core/doctype/report/report.py:148
+#: core/doctype/report/report.py:145
 msgid "Report Document Error"
 msgstr ""
 
@@ -25247,7 +26164,7 @@ msgstr ""
 msgid "Report Manager"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1793
+#: public/js/frappe/views/reports/query_report.js:1796
 msgid "Report Name"
 msgstr ""
 
@@ -25281,7 +26198,7 @@ msgctxt "Report"
 msgid "Report Name"
 msgstr ""
 
-#: desk/doctype/number_card/number_card.py:65
+#: desk/doctype/number_card/number_card.py:66
 msgid "Report Name, Report Field and Fucntion are required to create a number card"
 msgstr ""
 
@@ -25309,7 +26226,7 @@ msgctxt "Report"
 msgid "Report Type"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1746
+#: core/doctype/doctype/doctype.py:1744
 msgid "Report cannot be set for Single types"
 msgstr ""
 
@@ -25327,15 +26244,15 @@ msgstr ""
 msgid "Report initiated, click to view status"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:102
+#: email/doctype/auto_email_report/auto_email_report.py:108
 msgid "Report limit reached"
 msgstr ""
 
-#: core/doctype/prepared_report/prepared_report.py:202
+#: core/doctype/prepared_report/prepared_report.py:203
 msgid "Report timed out."
 msgstr ""
 
-#: desk/query_report.py:568
+#: desk/query_report.py:561
 msgid "Report updated successfully"
 msgstr ""
 
@@ -25343,7 +26260,7 @@ msgstr ""
 msgid "Report was not saved (there were errors)"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1831
+#: public/js/frappe/views/reports/query_report.js:1834
 msgid "Report with more than 10 columns looks better in Landscape mode."
 msgstr ""
 
@@ -25352,7 +26269,7 @@ msgstr ""
 msgid "Report {0}"
 msgstr ""
 
-#: desk/reportview.py:326
+#: desk/reportview.py:324
 msgid "Report {0} deleted"
 msgstr ""
 
@@ -25360,7 +26277,7 @@ msgstr ""
 msgid "Report {0} is disabled"
 msgstr ""
 
-#: desk/reportview.py:303
+#: desk/reportview.py:301
 msgid "Report {0} saved"
 msgstr ""
 
@@ -25458,7 +26375,7 @@ msgctxt "Webhook"
 msgid "Request Timeout"
 msgstr ""
 
-#. Label of a Data field in DocType 'Webhook'
+#. Label of a Small Text field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
 msgctxt "Webhook"
 msgid "Request URL"
@@ -25522,7 +26439,7 @@ msgstr ""
 msgid "Reset Fields"
 msgstr ""
 
-#: core/doctype/user/user.js:161 core/doctype/user/user.js:164
+#: core/doctype/user/user.js:154 core/doctype/user/user.js:157
 msgid "Reset LDAP Password"
 msgstr ""
 
@@ -25530,11 +26447,11 @@ msgstr ""
 msgid "Reset Layout"
 msgstr ""
 
-#: core/doctype/user/user.js:212
+#: core/doctype/user/user.js:205
 msgid "Reset OTP Secret"
 msgstr ""
 
-#: core/doctype/user/user.js:145 www/login.html:179 www/me.html:35
+#: core/doctype/user/user.js:138 www/login.html:179 www/me.html:35
 #: www/me.html:44 www/update-password.html:3 www/update-password.html:9
 msgid "Reset Password"
 msgstr ""
@@ -25620,7 +26537,7 @@ msgstr ""
 msgid "Restore"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:492
+#: core/page/permission_manager/permission_manager.js:503
 msgid "Restore Original Permissions"
 msgstr ""
 
@@ -25634,7 +26551,7 @@ msgctxt "Deleted Document"
 msgid "Restored"
 msgstr ""
 
-#: core/doctype/deleted_document/deleted_document.py:73
+#: core/doctype/deleted_document/deleted_document.py:74
 msgid "Restoring Deleted Document"
 msgstr ""
 
@@ -25701,6 +26618,7 @@ msgid "Resume Sending"
 msgstr ""
 
 #: core/doctype/data_import/data_import.js:110
+#: desk/page/setup_wizard/setup_wizard.js:285
 msgid "Retry"
 msgstr ""
 
@@ -25747,7 +26665,7 @@ msgctxt "Energy Point Log"
 msgid "Reverted"
 msgstr ""
 
-#: database/schema.py:162
+#: database/schema.py:159
 msgid "Reverting length to {0} for '{1}' in '{2}'. Setting the length as {3} will cause truncation of data."
 msgstr ""
 
@@ -25768,10 +26686,18 @@ msgctxt "Energy Point Settings"
 msgid "Review Levels"
 msgstr ""
 
+#: desk/page/user_profile/user_profile_controller.js:402
+msgid "Review Points"
+msgstr ""
+
 #. Label of a Int field in DocType 'Review Level'
 #: social/doctype/review_level/review_level.json
 msgctxt "Review Level"
 msgid "Review Points"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_sidebar.html:87
+msgid "Reviews"
 msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
@@ -25788,6 +26714,10 @@ msgstr ""
 #: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 msgctxt "OAuth Bearer Token"
 msgid "Revoked"
+msgstr ""
+
+#: website/doctype/web_page/web_page.js:92
+msgid "Rich Text"
 msgstr ""
 
 #. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
@@ -25852,7 +26782,7 @@ msgstr ""
 #. Name of a DocType
 #: core/doctype/role/role.json core/doctype/user_type/user_type.py:109
 #: core/page/permission_manager/permission_manager.js:212
-#: core/page/permission_manager/permission_manager.js:439
+#: core/page/permission_manager/permission_manager.js:450
 msgid "Role"
 msgstr ""
 
@@ -25954,7 +26884,7 @@ msgctxt "Role Permission for Page and Report"
 msgid "Role Permission for Page and Report"
 msgstr ""
 
-#: public/js/frappe/roles_editor.js:100
+#: public/js/frappe/roles_editor.js:101
 msgid "Role Permissions"
 msgstr ""
 
@@ -25992,6 +26922,18 @@ msgctxt "User"
 msgid "Role Profile"
 msgstr ""
 
+#. Label of a Link field in DocType 'User Role Profile'
+#: core/doctype/user_role_profile/user_role_profile.json
+msgctxt "User Role Profile"
+msgid "Role Profile"
+msgstr ""
+
+#. Label of a Table MultiSelect field in DocType 'User'
+#: core/doctype/user/user.json
+msgctxt "User"
+msgid "Role Profiles"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'Custom DocPerm'
 #: core/doctype/custom_docperm/custom_docperm.json
 msgctxt "Custom DocPerm"
@@ -26004,7 +26946,7 @@ msgctxt "DocPerm"
 msgid "Role and Level"
 msgstr ""
 
-#: core/doctype/user/user.py:314
+#: core/doctype/user/user.py:343
 msgid "Role has been set as per the user type {0}"
 msgstr ""
 
@@ -26092,7 +27034,11 @@ msgctxt "Role Permission for Page and Report"
 msgid "Roles Html"
 msgstr ""
 
-#: utils/nestedset.py:283
+#: core/page/permission_manager/permission_manager_help.html:7
+msgid "Roles can be set for users from their User page."
+msgstr ""
+
+#: utils/nestedset.py:277
 msgid "Root {0} cannot be deleted"
 msgstr ""
 
@@ -26216,15 +27162,19 @@ msgctxt "Role"
 msgid "Route: Example \"/desk\""
 msgstr ""
 
-#: model/base_document.py:729 model/base_document.py:770 model/document.py:591
+#: model/base_document.py:731 model/base_document.py:772 model/document.py:591
 msgid "Row"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1768 core/doctype/doctype/doctype.py:1778
+#: core/doctype/version/version_view.html:73
+msgid "Row #"
+msgstr ""
+
+#: core/doctype/doctype/doctype.py:1766 core/doctype/doctype/doctype.py:1776
 msgid "Row # {0}: Non administrator user can not set the role {1} to the custom doctype"
 msgstr ""
 
-#: model/base_document.py:887
+#: model/base_document.py:893
 msgid "Row #{0}:"
 msgstr ""
 
@@ -26250,7 +27200,19 @@ msgctxt "Property Setter"
 msgid "Row Name"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:349
+#: core/doctype/data_import/data_import.js:489
+msgid "Row Number"
+msgstr ""
+
+#: core/doctype/version/version_view.html:68
+msgid "Row Values Changed"
+msgstr ""
+
+#: core/doctype/data_import/data_import.js:367
+msgid "Row {0}"
+msgstr ""
+
+#: custom/doctype/customize_form/customize_form.py:348
 msgid "Row {0}: Not allowed to disable Mandatory for standard fields"
 msgstr ""
 
@@ -26258,10 +27220,18 @@ msgstr ""
 msgid "Row {0}: Not allowed to enable Allow on Submit for standard fields"
 msgstr ""
 
+#: core/doctype/version/version_view.html:32
+msgid "Rows Added"
+msgstr ""
+
 #. Label of a Section Break field in DocType 'Audit Trail'
 #: core/doctype/audit_trail/audit_trail.json
 msgctxt "Audit Trail"
 msgid "Rows Added"
+msgstr ""
+
+#: core/doctype/version/version_view.html:32
+msgid "Rows Removed"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Audit Trail'
@@ -26294,7 +27264,7 @@ msgctxt "Energy Point Rule"
 msgid "Rule Name"
 msgstr ""
 
-#: permissions.py:665
+#: permissions.py:658
 msgid "Rule for this doctype, role, permlevel and if-owner combination already exists."
 msgstr ""
 
@@ -26407,7 +27377,11 @@ msgstr ""
 msgid "SMS sent to following numbers: {0}"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:182
+#: templates/includes/login/login.js:377
+msgid "SMS was not sent. Please contact Administrator."
+msgstr ""
+
+#: email/doctype/email_account/email_account.py:189
 msgid "SMTP Server is required"
 msgstr ""
 
@@ -26458,6 +27432,10 @@ msgctxt "LDAP Settings"
 msgid "SSL/TLS Mode"
 msgstr ""
 
+#: public/js/frappe/color_picker/color_picker.js:20
+msgid "SWATCHES"
+msgstr ""
+
 #. Name of a role
 #: contacts/doctype/contact/contact.json
 msgid "Sales Manager"
@@ -26498,7 +27476,7 @@ msgctxt "Salutation"
 msgid "Salutation"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:109
+#: integrations/doctype/webhook/webhook.py:110
 msgid "Same Field is entered more than once"
 msgstr ""
 
@@ -26553,7 +27531,7 @@ msgstr ""
 #: public/js/frappe/views/kanban/kanban_settings.js:45
 #: public/js/frappe/views/kanban/kanban_settings.js:189
 #: public/js/frappe/views/kanban/kanban_view.js:340
-#: public/js/frappe/views/reports/query_report.js:1785
+#: public/js/frappe/views/reports/query_report.js:1788
 #: public/js/frappe/views/reports/report_view.js:1631
 #: public/js/frappe/views/workspace/workspace.js:493
 #: public/js/frappe/widgets/base_widget.js:140
@@ -26569,7 +27547,7 @@ msgctxt "Notification"
 msgid "Save"
 msgstr ""
 
-#: core/doctype/user/user.js:316
+#: core/doctype/user/user.js:310
 msgid "Save API Secret: {0}"
 msgstr ""
 
@@ -26586,7 +27564,11 @@ msgstr ""
 msgid "Save Customizations"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1788
+#: public/js/frappe/list/list_sidebar.html:73
+msgid "Save Filter"
+msgstr ""
+
+#: public/js/frappe/views/reports/query_report.js:1791
 msgid "Save Report"
 msgstr ""
 
@@ -26604,10 +27586,10 @@ msgstr ""
 msgid "Save the document."
 msgstr ""
 
-#: desk/form/save.py:46 model/rename_doc.py:108
+#: desk/form/save.py:46 model/rename_doc.py:106
 #: printing/page/print_format_builder/print_format_builder.js:845
 #: public/js/frappe/form/toolbar.js:260
-#: public/js/frappe/views/kanban/kanban_board.bundle.js:910
+#: public/js/frappe/views/kanban/kanban_board.bundle.js:917
 msgid "Saved"
 msgstr ""
 
@@ -26630,7 +27612,7 @@ msgstr ""
 msgid "Saving this will export this document as well as the steps linked here as json."
 msgstr ""
 
-#: public/js/form_builder/store.js:228
+#: public/js/form_builder/store.js:233
 #: public/js/print_format_builder/store.js:36
 #: public/js/workflow_builder/store.js:73
 msgid "Saving..."
@@ -26734,7 +27716,7 @@ msgctxt "Newsletter"
 msgid "Scheduled To Send"
 msgstr ""
 
-#: core/doctype/server_script/server_script.py:274
+#: core/doctype/server_script/server_script.py:277
 msgid "Scheduled execution for script {0} has updated"
 msgstr ""
 
@@ -26752,7 +27734,7 @@ msgstr ""
 msgid "Scheduler Inactive"
 msgstr ""
 
-#: utils/scheduler.py:196
+#: utils/scheduler.py:194
 msgid "Scheduler can not be re-enabled when maintenance mode is active."
 msgstr ""
 
@@ -26875,7 +27857,15 @@ msgctxt "Web Form"
 msgid "Scripting / Style"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'Letter Head'
+#: printing/doctype/letter_head/letter_head.json
+msgctxt "Letter Head"
+msgid "Scripts"
+msgstr ""
+
+#: desk/page/leaderboard/leaderboard.js:211
 #: public/js/frappe/form/link_selector.js:46
+#: public/js/frappe/list/list_sidebar.html:59
 #: public/js/frappe/ui/toolbar/search.js:49
 #: public/js/frappe/ui/toolbar/search.js:68
 #: templates/includes/search_template.html:26 www/search.py:19
@@ -26929,12 +27919,17 @@ msgstr ""
 msgid "Search for anything"
 msgstr ""
 
+#: public/js/frappe/ui/toolbar/awesome_bar.js:300
 #: public/js/frappe/ui/toolbar/awesome_bar.js:306
 msgid "Search for {0}"
 msgstr ""
 
 #: public/js/frappe/ui/toolbar/awesome_bar.js:166
 msgid "Search in a document type"
+msgstr ""
+
+#: public/js/frappe/ui/toolbar/navbar.html:24
+msgid "Search or type a command (Ctrl + G)"
 msgstr ""
 
 #: templates/includes/search_box.html:8
@@ -27003,6 +27998,10 @@ msgctxt "User"
 msgid "Security Settings"
 msgstr ""
 
+#: public/js/frappe/ui/notifications/notifications.js:302
+msgid "See all Activity"
+msgstr ""
+
 #: public/js/frappe/views/reports/query_report.js:784
 msgid "See all past reports."
 msgstr ""
@@ -27013,10 +28012,11 @@ msgid "See on Website"
 msgstr ""
 
 #: website/doctype/web_form/templates/web_form.html:150
+msgctxt "Button in web form"
 msgid "See previous responses"
 msgstr ""
 
-#: integrations/doctype/slack_webhook_url/slack_webhook_url.py:48
+#: integrations/doctype/slack_webhook_url/slack_webhook_url.py:49
 msgid "See the document at {0}"
 msgstr ""
 
@@ -27124,7 +28124,13 @@ msgctxt "Web Template Field"
 msgid "Select"
 msgstr ""
 
+#: public/js/frappe/data_import/data_exporter.js:148
+#: public/js/frappe/form/controls/multicheck.js:166
+msgid "Select All"
+msgstr ""
+
 #: public/js/frappe/views/communication.js:150
+#: public/js/frappe/views/communication.js:529
 #: public/js/frappe/views/interaction.js:93
 #: public/js/frappe/views/interaction.js:155
 msgid "Select Attachments"
@@ -27139,6 +28145,7 @@ msgstr ""
 msgid "Select Column"
 msgstr ""
 
+#: printing/page/print_format_builder/print_format_builder_field.html:41
 #: public/js/frappe/form/print_utils.js:43
 msgid "Select Columns"
 msgstr ""
@@ -27198,8 +28205,17 @@ msgstr ""
 msgid "Select Document Type or Role to start."
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:34
+msgid "Select Document Types to set which User Permissions are used to limit access."
+msgstr ""
+
 #: public/js/frappe/doctype/index.js:199 public/js/frappe/form/toolbar.js:762
 msgid "Select Field"
+msgstr ""
+
+#: public/js/frappe/ui/group_by/group_by.html:32
+#: public/js/frappe/ui/group_by/group_by.js:141
+msgid "Select Field..."
 msgstr ""
 
 #: public/js/frappe/form/grid_row.js:459
@@ -27208,11 +28224,11 @@ msgstr ""
 msgid "Select Fields"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:143
+#: public/js/frappe/data_import/data_exporter.js:146
 msgid "Select Fields To Insert"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:144
+#: public/js/frappe/data_import/data_exporter.js:147
 msgid "Select Fields To Update"
 msgstr ""
 
@@ -27220,12 +28236,16 @@ msgstr ""
 msgid "Select Filters"
 msgstr ""
 
-#: desk/doctype/event/event.py:97
+#: desk/doctype/event/event.py:96
 msgid "Select Google Calendar to which event should be synced."
 msgstr ""
 
-#: contacts/doctype/contact/contact.py:75
+#: contacts/doctype/contact/contact.py:76
 msgid "Select Google Contacts to which contact should be synced."
+msgstr ""
+
+#: public/js/frappe/ui/group_by/group_by.html:10
+msgid "Select Group By..."
 msgstr ""
 
 #: public/js/frappe/list/list_view_select.js:185
@@ -27242,7 +28262,7 @@ msgctxt "Form Tour"
 msgid "Select List View"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:154
+#: public/js/frappe/data_import/data_exporter.js:157
 msgid "Select Mandatory"
 msgstr ""
 
@@ -27307,11 +28327,11 @@ msgstr ""
 msgid "Select a DocType to make a new format"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:130
+#: integrations/doctype/webhook/webhook.py:131
 msgid "Select a document to check if it meets conditions."
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:142
+#: integrations/doctype/webhook/webhook.py:143
 msgid "Select a document to preview request data"
 msgstr ""
 
@@ -27319,16 +28339,20 @@ msgstr ""
 msgid "Select a group node first."
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1881
+#: core/doctype/doctype/doctype.py:1877
 msgid "Select a valid Sender Field for creating documents from Email"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1865
+#: core/doctype/doctype/doctype.py:1861
 msgid "Select a valid Subject field for creating documents from Email"
 msgstr ""
 
 #: public/js/frappe/form/form_tour.js:315
 msgid "Select an Image"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_start.html:2
+msgid "Select an existing format to edit or start a new format."
 msgstr ""
 
 #. Description of the 'Brand Image' (Attach Image) field in DocType 'Website
@@ -27375,7 +28399,7 @@ msgctxt "Custom Field"
 msgid "Select the label after which you want to insert new field."
 msgstr ""
 
-#: public/js/frappe/utils/diffview.js:101
+#: public/js/frappe/utils/diffview.js:102
 msgid "Select two versions to view the diff."
 msgstr ""
 
@@ -27386,7 +28410,7 @@ msgstr ""
 msgid "Select {0}"
 msgstr ""
 
-#: model/workflow.py:121
+#: model/workflow.py:117
 msgid "Self approval is not allowed"
 msgstr ""
 
@@ -27586,7 +28610,7 @@ msgctxt "Contact Us Settings"
 msgid "Send enquiries to this email address"
 msgstr ""
 
-#: www/login.html:210
+#: templates/includes/login/login.js:73 www/login.html:210
 msgid "Send login link"
 msgstr ""
 
@@ -27670,7 +28694,7 @@ msgctxt "DocType"
 msgid "Sender Email Field"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1884
+#: core/doctype/doctype/doctype.py:1880
 msgid "Sender Field should have Email in options"
 msgstr ""
 
@@ -27800,16 +28824,16 @@ msgctxt "Document Naming Settings"
 msgid "Series List for this Transaction"
 msgstr ""
 
-#: core/doctype/document_naming_settings/document_naming_settings.py:116
+#: core/doctype/document_naming_settings/document_naming_settings.py:115
 msgid "Series Updated for {}"
 msgstr ""
 
-#: core/doctype/document_naming_settings/document_naming_settings.py:226
+#: core/doctype/document_naming_settings/document_naming_settings.py:223
 msgid "Series counter for {} updated to {} successfully"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1069
-#: core/doctype/document_naming_settings/document_naming_settings.py:171
+#: core/doctype/doctype/doctype.py:1070
+#: core/doctype/document_naming_settings/document_naming_settings.py:170
 msgid "Series {0} already used in {1}"
 msgstr ""
 
@@ -27859,11 +28883,11 @@ msgctxt "Server Script"
 msgid "Server Script"
 msgstr ""
 
-#: utils/safe_exec.py:90
+#: utils/safe_exec.py:89
 msgid "Server Scripts are disabled. Please enable server scripts from bench configuration."
 msgstr ""
 
-#: core/doctype/server_script/server_script.js:32
+#: core/doctype/server_script/server_script.js:36
 msgid "Server Scripts feature is not available on this site."
 msgstr ""
 
@@ -27909,7 +28933,7 @@ msgstr ""
 msgid "Session Defaults Saved"
 msgstr ""
 
-#: app.py:345
+#: app.py:343
 msgid "Session Expired"
 msgstr ""
 
@@ -27919,7 +28943,7 @@ msgctxt "System Settings"
 msgid "Session Expiry (idle timeout)"
 msgstr ""
 
-#: core/doctype/system_settings/system_settings.py:112
+#: core/doctype/system_settings/system_settings.py:110
 msgid "Session Expiry must be in format {0}"
 msgstr ""
 
@@ -28011,7 +29035,7 @@ msgctxt "Role Permission for Page and Report"
 msgid "Set Role For"
 msgstr ""
 
-#: core/doctype/user/user.js:122
+#: core/doctype/user/user.js:115
 #: core/page/permission_manager/permission_manager.js:65
 msgid "Set User Permissions"
 msgstr ""
@@ -28122,11 +29146,11 @@ msgid ""
 "}</code></pre>"
 msgstr ""
 
-#: contacts/doctype/address_template/address_template.py:32
+#: contacts/doctype/address_template/address_template.py:33
 msgid "Setting this Address Template as default as there is no other default"
 msgstr ""
 
-#: desk/doctype/global_search_settings/global_search_settings.py:85
+#: desk/doctype/global_search_settings/global_search_settings.py:86
 msgid "Setting up Global Search documents."
 msgstr ""
 
@@ -28136,6 +29160,7 @@ msgstr ""
 
 #. Label of a Card Break in the Integrations Workspace
 #: integrations/workspace/integrations/integrations.json
+#: public/js/frappe/form/templates/print_layout.html:25
 #: public/js/frappe/ui/toolbar/toolbar.js:254
 #: public/js/frappe/views/workspace/workspace.js:521
 msgid "Settings"
@@ -28184,12 +29209,24 @@ msgctxt "DocType"
 msgid "Setup"
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:27
+msgid "Setup > Customize Form"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:8
+msgid "Setup > User"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:33
+msgid "Setup > User Permissions"
+msgstr ""
+
 #. Title of an Onboarding Step
 #: custom/onboarding_step/workflows/workflows.json
 msgid "Setup Approval Workflows"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1658
+#: public/js/frappe/views/reports/query_report.js:1661
 #: public/js/frappe/views/reports/report_view.js:1609
 msgid "Setup Auto Email"
 msgstr ""
@@ -28220,6 +29257,10 @@ msgctxt "Document Naming Settings"
 msgid "Setup Series for transactions"
 msgstr ""
 
+#: public/js/frappe/form/templates/form_sidebar.html:110
+msgid "Share"
+msgstr ""
+
 #. Label of a Check field in DocType 'Custom DocPerm'
 #: core/doctype/custom_docperm/custom_docperm.json
 msgctxt "Custom DocPerm"
@@ -28248,6 +29289,10 @@ msgstr ""
 msgid "Share With"
 msgstr ""
 
+#: public/js/frappe/form/templates/set_sharing.html:49
+msgid "Share this document with"
+msgstr ""
+
 #: public/js/frappe/form/sidebar/share.js:45
 msgid "Share {0} with"
 msgstr ""
@@ -28264,7 +29309,7 @@ msgctxt "Communication"
 msgid "Shared"
 msgstr ""
 
-#: desk/form/assign_to.py:127
+#: desk/form/assign_to.py:129
 msgid "Shared with the following Users with Read access:{0}"
 msgstr ""
 
@@ -28272,6 +29317,10 @@ msgstr ""
 #: contacts/doctype/address/address.json
 msgctxt "Address"
 msgid "Shipping"
+msgstr ""
+
+#: public/js/frappe/form/templates/address_list.html:25
+msgid "Shipping Address"
 msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
@@ -28286,8 +29335,12 @@ msgctxt "Blogger"
 msgid "Short Name"
 msgstr ""
 
-#: utils/password_strength.py:93
+#: utils/password_strength.py:91
 msgid "Short keyboard patterns are easy to guess"
+msgstr ""
+
+#: public/js/frappe/form/grid_row_form.js:42
+msgid "Shortcuts"
 msgstr ""
 
 #. Label of a Table field in DocType 'Workspace'
@@ -28298,7 +29351,8 @@ msgid "Shortcuts"
 msgstr ""
 
 #: public/js/frappe/widgets/base_widget.js:46
-#: public/js/frappe/widgets/base_widget.js:176 www/login.html:30
+#: public/js/frappe/widgets/base_widget.js:176
+#: templates/includes/login/login.js:86 www/login.html:30
 msgid "Show"
 msgstr ""
 
@@ -28312,6 +29366,10 @@ msgstr ""
 #: printing/doctype/print_format/print_format.json
 msgctxt "Print Format"
 msgid "Show Absolute Values"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_sidebar.html:78
+msgid "Show All"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
@@ -28354,12 +29412,6 @@ msgstr ""
 
 #: www/error.html:41 www/error.html:59
 msgid "Show Error"
-msgstr ""
-
-#. Label of a Check field in DocType 'Data Import'
-#: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
-msgid "Show Failed Logs"
 msgstr ""
 
 #: public/js/frappe/form/layout.js:545
@@ -28423,6 +29475,16 @@ msgctxt "Web Form"
 msgid "Show List"
 msgstr ""
 
+#: desk/page/user_profile/user_profile_controller.js:472
+msgid "Show More Activity"
+msgstr ""
+
+#. Label of a Check field in DocType 'Data Import'
+#: core/doctype/data_import/data_import.json
+msgctxt "Data Import"
+msgid "Show Only Failed Logs"
+msgstr ""
+
 #. Label of a Check field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
 msgctxt "Number Card"
@@ -28473,6 +29535,7 @@ msgctxt "Access Log"
 msgid "Show Report"
 msgstr ""
 
+#: public/js/frappe/list/list_filter.js:15
 #: public/js/frappe/list/list_filter.js:87
 msgid "Show Saved"
 msgstr ""
@@ -28495,6 +29558,7 @@ msgctxt "Web Page"
 msgid "Show Sidebar"
 msgstr ""
 
+#: public/js/frappe/list/list_sidebar.html:66
 #: public/js/frappe/list/list_view.js:1566
 msgid "Show Tags"
 msgstr ""
@@ -28525,6 +29589,10 @@ msgstr ""
 msgid "Show Tour"
 msgstr ""
 
+#: core/doctype/data_import/data_import.js:454
+msgid "Show Traceback"
+msgstr ""
+
 #: public/js/frappe/data_import/import_preview.js:200
 msgid "Show Warnings"
 msgstr ""
@@ -28541,6 +29609,10 @@ msgstr ""
 
 #: core/doctype/version/version.js:6
 msgid "Show all Versions"
+msgstr ""
+
+#: public/js/frappe/form/footer/form_timeline.js:67
+msgid "Show all activity"
 msgstr ""
 
 #: website/doctype/blog_post/templates/blog_post_list.html:24
@@ -28584,7 +29656,7 @@ msgctxt "Slack Webhook URL"
 msgid "Show link to document"
 msgstr ""
 
-#: public/js/frappe/form/layout.js:265
+#: public/js/frappe/form/layout.js:247 public/js/frappe/form/layout.js:265
 msgid "Show more details"
 msgstr ""
 
@@ -28601,8 +29673,16 @@ msgctxt "Website Settings"
 msgid "Show title in browser window as \"Prefix - title\""
 msgstr ""
 
+#: public/js/frappe/widgets/onboarding_widget.js:148
+msgid "Show {0} List"
+msgstr ""
+
 #: public/js/frappe/views/reports/report_view.js:475
 msgid "Showing only Numeric fields from Report"
+msgstr ""
+
+#: public/js/frappe/data_import/import_preview.js:149
+msgid "Showing only first {0} rows out of {1}"
 msgstr ""
 
 #. Label of a Check field in DocType 'Role'
@@ -28635,7 +29715,7 @@ msgctxt "Email Group"
 msgid "Sign Up and Confirmation"
 msgstr ""
 
-#: core/doctype/user/user.py:972
+#: core/doctype/user/user.py:996
 msgid "Sign Up is disabled"
 msgstr ""
 
@@ -28730,10 +29810,15 @@ msgctxt "DocType"
 msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
 msgstr ""
 
-#: database/database.py:238
+#: database/database.py:237
 msgid "Site is running in read only mode for maintenance or site update, this action can not be performed right now. Please try again later."
 msgstr ""
 
+#: public/js/frappe/views/file/file_view.js:317
+msgid "Size"
+msgstr ""
+
+#: public/js/frappe/widgets/onboarding_widget.js:82
 #: public/js/onboarding_tours/onboarding_tours.js:18
 msgid "Skip"
 msgstr ""
@@ -28760,19 +29845,19 @@ msgctxt "Patch Log"
 msgid "Skipped"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:905
+#: core/doctype/data_import/importer.py:902
 msgid "Skipping Duplicate Column {0}"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:930
+#: core/doctype/data_import/importer.py:927
 msgid "Skipping Untitled Column"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:916
+#: core/doctype/data_import/importer.py:913
 msgid "Skipping column {0}"
 msgstr ""
 
-#: modules/utils.py:162
+#: modules/utils.py:158
 msgid "Skipping fixture syncing for doctype {0} from file {1}"
 msgstr ""
 
@@ -28798,7 +29883,7 @@ msgctxt "Notification"
 msgid "Slack Channel"
 msgstr ""
 
-#: integrations/doctype/slack_webhook_url/slack_webhook_url.py:64
+#: integrations/doctype/slack_webhook_url/slack_webhook_url.py:65
 msgid "Slack Webhook Error"
 msgstr ""
 
@@ -28875,6 +29960,10 @@ msgctxt "Currency"
 msgid "Smallest circulating fraction unit (coin). For e.g. 1 cent for USD and it should be entered as 0.01"
 msgstr ""
 
+#: printing/doctype/letter_head/letter_head.js:32
+msgid "Snippet and more variables:  {0}"
+msgstr ""
+
 #. Name of a DocType
 #: website/doctype/social_link_settings/social_link_settings.json
 msgid "Social Link Settings"
@@ -28915,6 +30004,10 @@ msgctxt "Communication"
 msgid "Soft-Bounced"
 msgstr ""
 
+#: printing/page/print_format_builder/print_format_builder_column_selector.html:4
+msgid "Some columns might get cut off when printing to PDF. Try to keep number of columns under 10."
+msgstr ""
+
 #: public/js/frappe/desk.js:20
 msgid "Some of the features might not work in your browser. Please update your browser to the latest version."
 msgstr ""
@@ -28923,8 +30016,12 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:116
+#: integrations/doctype/google_calendar/google_calendar.py:117
 msgid "Something went wrong during the token generation. Click on {0} to generate a new one."
+msgstr ""
+
+#: templates/includes/login/login.js:294
+msgid "Something went wrong."
 msgstr ""
 
 #: public/js/frappe/views/pageview.js:110
@@ -28977,7 +30074,7 @@ msgstr ""
 msgid "Sort field {0} must be a valid fieldname"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1706
+#: public/js/frappe/ui/toolbar/about.js:8 public/js/frappe/utils/utils.js:1706
 #: website/report/website_analytics/website_analytics.js:38
 msgid "Source"
 msgstr ""
@@ -29010,6 +30107,10 @@ msgctxt "Translation"
 msgid "Source Text"
 msgstr ""
 
+#: public/js/frappe/views/workspace/blocks/spacer.js:23
+msgid "Spacer"
+msgstr ""
+
 #. Option for the 'Email Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
 msgctxt "Communication"
@@ -29036,7 +30137,8 @@ msgctxt "Website Settings"
 msgid "Splash Image"
 msgstr ""
 
-#: desk/reportview.py:365 templates/print_formats/standard_macros.html:44
+#: desk/reportview.py:363 public/js/frappe/web_form/web_form_list.js:175
+#: templates/print_formats/standard_macros.html:44
 msgid "Sr"
 msgstr ""
 
@@ -29090,19 +30192,19 @@ msgctxt "Web Template"
 msgid "Standard"
 msgstr ""
 
-#: model/delete_doc.py:79
+#: model/delete_doc.py:78
 msgid "Standard DocType can not be deleted."
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:224
+#: core/doctype/doctype/doctype.py:223
 msgid "Standard DocType cannot have default print format, use Customize Form"
 msgstr ""
 
-#: desk/doctype/dashboard/dashboard.py:59
+#: desk/doctype/dashboard/dashboard.py:58
 msgid "Standard Not Set"
 msgstr ""
 
-#: printing/doctype/print_format/print_format.py:74
+#: printing/doctype/print_format/print_format.py:73
 msgid "Standard Print Format cannot be updated"
 msgstr ""
 
@@ -29110,11 +30212,11 @@ msgstr ""
 msgid "Standard Print Style cannot be changed. Please duplicate to edit."
 msgstr ""
 
-#: desk/reportview.py:316
+#: desk/reportview.py:314
 msgid "Standard Reports cannot be deleted"
 msgstr ""
 
-#: desk/reportview.py:287
+#: desk/reportview.py:285
 msgid "Standard Reports cannot be edited"
 msgstr ""
 
@@ -29124,11 +30226,15 @@ msgctxt "Portal Settings"
 msgid "Standard Sidebar Menu"
 msgstr ""
 
-#: core/doctype/role/role.py:61
+#: website/doctype/web_page/web_page.js:92
+msgid "Standard rich text editor with controls"
+msgstr ""
+
+#: core/doctype/role/role.py:62
 msgid "Standard roles cannot be disabled"
 msgstr ""
 
-#: core/doctype/role/role.py:48
+#: core/doctype/role/role.py:49
 msgid "Standard roles cannot be renamed"
 msgstr ""
 
@@ -29140,7 +30246,7 @@ msgstr ""
 msgid "Standings"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:91 printing/page/print/print.js:289
+#: core/doctype/recorder/recorder_list.js:87 printing/page/print/print.js:289
 #: printing/page/print/print.js:336
 msgid "Start"
 msgstr ""
@@ -29175,6 +30281,10 @@ msgstr ""
 
 #: core/doctype/data_import/data_import.js:110
 msgid "Start Import"
+msgstr ""
+
+#: core/doctype/recorder/recorder_list.js:201
+msgid "Start Recordig"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'
@@ -29221,6 +30331,10 @@ msgstr ""
 #: desk/doctype/event/event.json
 msgctxt "Event"
 msgid "Starts on"
+msgstr ""
+
+#: workflow/doctype/workflow/workflow.js:162
+msgid "State"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
@@ -29290,6 +30404,7 @@ msgid "Statistics"
 msgstr ""
 
 #: public/js/frappe/form/dashboard.js:43
+#: public/js/frappe/form/templates/form_dashboard.html:13
 msgid "Stats"
 msgstr ""
 
@@ -29305,14 +30420,15 @@ msgctxt "Number Card"
 msgid "Stats Time Interval"
 msgstr ""
 
-#: social/doctype/energy_point_log/energy_point_log.py:391
+#: social/doctype/energy_point_log/energy_point_log.py:389
 msgid "Stats based on last month's performance (from {0} to {1})"
 msgstr ""
 
-#: social/doctype/energy_point_log/energy_point_log.py:393
+#: social/doctype/energy_point_log/energy_point_log.py:391
 msgid "Stats based on last week's performance (from {0} to {1})"
 msgstr ""
 
+#: core/doctype/data_import/data_import.js:489
 #: public/js/frappe/views/reports/report_view.js:911
 msgid "Status"
 msgstr ""
@@ -29480,7 +30596,7 @@ msgstr ""
 msgid "Steps to verify your login"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:91
+#: core/doctype/recorder/recorder_list.js:87
 msgid "Stop"
 msgstr ""
 
@@ -29503,7 +30619,7 @@ msgctxt "User"
 msgid "Stores the datetime when the last reset password key was generated."
 msgstr ""
 
-#: utils/password_strength.py:99
+#: utils/password_strength.py:97
 msgid "Straight rows of keys are easy to guess"
 msgstr ""
 
@@ -29644,7 +30760,7 @@ msgctxt "DocType"
 msgid "Subject Field"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1874
+#: core/doctype/doctype/doctype.py:1870
 msgid "Subject Field type should be Data, Text, Long Text, Small Text, Text Editor"
 msgstr ""
 
@@ -29659,12 +30775,16 @@ msgstr ""
 #: public/js/frappe/ui/capture.js:299
 #: social/doctype/energy_point_log/energy_point_log.js:39
 #: social/doctype/energy_point_settings/energy_point_settings.js:47
-#: website/doctype/web_form/templates/web_form.html:44
 msgid "Submit"
 msgstr ""
 
 #: public/js/frappe/list/list_view.js:1940
 msgctxt "Button in list view actions menu"
+msgid "Submit"
+msgstr ""
+
+#: website/doctype/web_form/templates/web_form.html:44
+msgctxt "Button in web form"
 msgid "Submit"
 msgstr ""
 
@@ -29732,7 +30852,12 @@ msgctxt "Web Form"
 msgid "Submit Button Label"
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:39
+msgid "Submit an Issue"
+msgstr ""
+
 #: website/doctype/web_form/templates/web_form.html:153
+msgctxt "Button in web form"
 msgid "Submit another response"
 msgstr ""
 
@@ -29773,7 +30898,7 @@ msgctxt "Communication"
 msgid "Submitted"
 msgstr ""
 
-#: workflow/doctype/workflow/workflow.py:106
+#: workflow/doctype/workflow/workflow.py:104
 msgid "Submitted Document cannot be converted back to draft. Transition row {0}"
 msgstr ""
 
@@ -29786,7 +30911,7 @@ msgctxt "Freeze message while submitting a document"
 msgid "Submitting"
 msgstr ""
 
-#: desk/doctype/bulk_update/bulk_update.py:91
+#: desk/doctype/bulk_update/bulk_update.py:89
 msgid "Submitting {0}"
 msgstr ""
 
@@ -29808,13 +30933,15 @@ msgctxt "Module Onboarding"
 msgid "Subtitle"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:470
+#: core/doctype/data_import/data_import.js:465
 #: desk/doctype/bulk_update/bulk_update.js:31
-#: desk/doctype/desktop_icon/desktop_icon.py:452
-#: public/js/frappe/form/grid.js:1135
+#: desk/doctype/desktop_icon/desktop_icon.py:446
+#: public/js/frappe/form/grid.js:1139
 #: public/js/frappe/views/translation_manager.js:21
+#: templates/includes/login/login.js:231 templates/includes/login/login.js:237
+#: templates/includes/login/login.js:270 templates/includes/login/login.js:278
 #: templates/pages/integrations/gcalendar-success.html:9
-#: workflow/doctype/workflow_action/workflow_action.py:171
+#: workflow/doctype/workflow_action/workflow_action.py:166
 msgid "Success"
 msgstr ""
 
@@ -29887,11 +31014,11 @@ msgctxt "RQ Worker"
 msgid "Successful Job Count"
 msgstr ""
 
-#: model/workflow.py:306
+#: model/workflow.py:299
 msgid "Successful Transactions"
 msgstr ""
 
-#: model/rename_doc.py:684
+#: model/rename_doc.py:666
 msgid "Successful: {0} to {1}"
 msgstr ""
 
@@ -29904,11 +31031,15 @@ msgstr ""
 msgid "Successfully Updated"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:434
+#: core/doctype/data_import/data_import.js:429
 msgid "Successfully imported {0}"
 msgstr ""
 
-#: desk/doctype/form_tour/form_tour.py:86
+#: core/doctype/data_import/data_import.js:144
+msgid "Successfully imported {0} out of {1} records."
+msgstr ""
+
+#: desk/doctype/form_tour/form_tour.py:87
 msgid "Successfully reset onboarding status for all users."
 msgstr ""
 
@@ -29916,27 +31047,15 @@ msgstr ""
 msgid "Successfully updated translations"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:442
+#: core/doctype/data_import/data_import.js:437
 msgid "Successfully updated {0}"
 msgstr ""
 
 #: core/doctype/data_import/data_import.js:149
-msgid "Successfully {0} 1 record."
+msgid "Successfully updated {0} out of {1} records."
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:156
-msgid "Successfully {0} {1} record out of {2}. Click on Export Errored Rows, fix the errors and import again."
-msgstr ""
-
-#: core/doctype/data_import/data_import.js:161
-msgid "Successfully {0} {1} records out of {2}. Click on Export Errored Rows, fix the errors and import again."
-msgstr ""
-
-#: core/doctype/data_import/data_import.js:151
-msgid "Successfully {0} {1} records."
-msgstr ""
-
-#: core/doctype/user/user.py:679
+#: core/doctype/user/user.py:711
 msgid "Suggested Username: {0}"
 msgstr ""
 
@@ -29957,7 +31076,7 @@ msgctxt "Number Card"
 msgid "Sum"
 msgstr ""
 
-#: public/js/frappe/ui/group_by/group_by.js:330
+#: public/js/frappe/ui/group_by/group_by.js:328
 msgid "Sum of {0}"
 msgstr ""
 
@@ -30046,7 +31165,7 @@ msgstr ""
 msgid "Sync on Migrate"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:295
+#: integrations/doctype/google_calendar/google_calendar.py:296
 msgid "Sync token was invalid and has been reset, Retry syncing."
 msgstr ""
 
@@ -30079,7 +31198,7 @@ msgstr ""
 msgid "Syncing {0} of {1}"
 msgstr ""
 
-#: utils/data.py:2418
+#: utils/data.py:2403
 msgid "Syntax Error"
 msgstr ""
 
@@ -30094,7 +31213,7 @@ msgstr ""
 msgid "System Console"
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.py:358
+#: custom/doctype/custom_field/custom_field.py:357
 msgid "System Generated Fields can not be renamed"
 msgstr ""
 
@@ -30298,6 +31417,7 @@ msgid "Tab Break"
 msgstr ""
 
 #: core/doctype/data_export/exporter.py:23
+#: printing/page/print_format_builder/print_format_builder_field.html:38
 msgid "Table"
 msgstr ""
 
@@ -30329,6 +31449,10 @@ msgstr ""
 #: website/doctype/web_template_field/web_template_field.json
 msgctxt "Web Template Field"
 msgid "Table Break"
+msgstr ""
+
+#: core/doctype/version/version_view.html:72
+msgid "Table Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType Link'
@@ -30365,11 +31489,11 @@ msgctxt "DocField"
 msgid "Table MultiSelect"
 msgstr ""
 
-#: public/js/frappe/form/grid.js:1134
+#: public/js/frappe/form/grid.js:1138
 msgid "Table updated"
 msgstr ""
 
-#: model/document.py:1366
+#: model/document.py:1349
 msgid "Table {0} cannot be empty"
 msgstr ""
 
@@ -30389,8 +31513,9 @@ msgstr ""
 msgid "Tag Link"
 msgstr ""
 
-#: model/__init__.py:148 model/meta.py:52
+#: model/meta.py:52 public/js/frappe/form/templates/form_sidebar.html:100
 #: public/js/frappe/list/bulk_operations.js:386
+#: public/js/frappe/list/list_sidebar.html:50
 #: public/js/frappe/list/list_sidebar.js:226 public/js/frappe/model/meta.js:204
 #: public/js/frappe/model/model.js:123
 #: public/js/frappe/ui/toolbar/awesome_bar.js:171
@@ -30479,8 +31604,8 @@ msgctxt "Web Template"
 msgid "Template"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:468
-#: core/doctype/data_import/importer.py:596
+#: core/doctype/data_import/importer.py:464
+#: core/doctype/data_import/importer.py:591
 msgid "Template Error"
 msgstr ""
 
@@ -30506,7 +31631,7 @@ msgstr ""
 msgid "Templates"
 msgstr ""
 
-#: core/doctype/user/user.py:983
+#: core/doctype/user/user.py:1007
 msgid "Temporarily Disabled"
 msgstr ""
 
@@ -30514,7 +31639,7 @@ msgstr ""
 msgid "Test email sent to {0}"
 msgstr ""
 
-#: core/doctype/file/test_file.py:357
+#: core/doctype/file/test_file.py:355
 msgid "Test_Folder"
 msgstr ""
 
@@ -30618,7 +31743,7 @@ msgstr ""
 msgid "The Auto Repeat for this document has been disabled."
 msgstr ""
 
-#: public/js/frappe/form/grid.js:1157
+#: public/js/frappe/form/grid.js:1161
 msgid "The CSV format is case sensitive"
 msgstr ""
 
@@ -30631,15 +31756,15 @@ msgid ""
 "</a>"
 msgstr ""
 
-#: email/doctype/notification/notification.py:129
+#: email/doctype/notification/notification.py:130
 msgid "The Condition '{0}' is invalid"
 msgstr ""
 
-#: core/doctype/file/file.py:205
+#: core/doctype/file/file.py:206
 msgid "The File URL you've entered is incorrect"
 msgstr ""
 
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:364
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:363
 msgid "The User record for this request has been auto-deleted due to inactivity by system admins."
 msgstr ""
 
@@ -30667,11 +31792,11 @@ msgid ""
 "</a>"
 msgstr ""
 
-#: database/database.py:424
+#: database/database.py:425
 msgid "The changes have been reverted."
 msgstr ""
 
-#: core/doctype/data_import/importer.py:962
+#: core/doctype/data_import/importer.py:959
 msgid "The column {0} has {1} different date formats. Automatically setting {2} as the default format as it is the most common. Please change other values in this column to this format."
 msgstr ""
 
@@ -30705,19 +31830,23 @@ msgstr ""
 msgid "The field {0} is mandatory"
 msgstr ""
 
-#: core/doctype/file/file.py:143
+#: core/doctype/file/file.py:144
 msgid "The fieldname you've specified in Attached To Field is invalid"
 msgstr ""
 
-#: automation/doctype/assignment_rule/assignment_rule.py:61
+#: automation/doctype/assignment_rule/assignment_rule.py:60
 msgid "The following Assignment Days have been repeated: {0}"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:1035
+#: printing/doctype/letter_head/letter_head.js:30
+msgid "The following Header Script will add the current date to an element in 'Header HTML' with class 'header-content'"
+msgstr ""
+
+#: core/doctype/data_import/importer.py:1030
 msgid "The following values are invalid: {0}. Values must be one of {1}"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:998
+#: core/doctype/data_import/importer.py:993
 msgid "The following values do not exist for {0}: {1}"
 msgstr ""
 
@@ -30729,7 +31858,7 @@ msgstr ""
 msgid "The link will expire in {0} minutes"
 msgstr ""
 
-#: www/login.py:178
+#: www/login.py:175
 msgid "The link you trying to login is invalid or expired."
 msgstr ""
 
@@ -30767,7 +31896,7 @@ msgstr ""
 msgid "The password of your account has expired."
 msgstr ""
 
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:395
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:394
 msgid "The process for deletion of {0} data associated with {1} has been initiated."
 msgstr ""
 
@@ -30780,15 +31909,15 @@ msgid ""
 "</a>"
 msgstr ""
 
-#: core/doctype/user/user.py:943
+#: core/doctype/user/user.py:967
 msgid "The reset password link has been expired"
 msgstr ""
 
-#: core/doctype/user/user.py:945
+#: core/doctype/user/user.py:969
 msgid "The reset password link has either been used before or is invalid"
 msgstr ""
 
-#: app.py:364 public/js/frappe/request.js:147
+#: app.py:362 public/js/frappe/request.js:147
 msgid "The resource you are looking for is not available"
 msgstr ""
 
@@ -30796,12 +31925,16 @@ msgstr ""
 msgid "The role {0} should be a custom role."
 msgstr ""
 
-#: core/doctype/audit_trail/audit_trail.py:45
+#: core/doctype/audit_trail/audit_trail.py:46
 msgid "The selected document {0} is not a {1}."
 msgstr ""
 
-#: utils/response.py:321
+#: utils/response.py:325
 msgid "The system is being updated. Please refresh again after a few moments."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:9
+msgid "The system provides many pre-defined roles. You can add new roles to set finer permissions."
 msgstr ""
 
 #: public/js/frappe/form/grid_row.js:635
@@ -30829,7 +31962,7 @@ msgctxt "Webhook"
 msgid "The webhook will be triggered if this expression is true"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:168
+#: automation/doctype/auto_repeat/auto_repeat.py:169
 msgid "The {0} is already on auto repeat {1}"
 msgstr ""
 
@@ -30862,8 +31995,20 @@ msgctxt "Website Theme"
 msgid "Theme URL"
 msgstr ""
 
+#: workflow/doctype/workflow/workflow.js:125
+msgid "There are documents which have workflow states that do not exist in this Workflow. It is recommended that you add these states to the Workflow and change their states before removing these states."
+msgstr ""
+
+#: public/js/frappe/ui/notifications/notifications.js:428
+msgid "There are no upcoming events for you."
+msgstr ""
+
 #: website/web_template/discussions/discussions.html:3
 msgid "There are no {0} for this {1}, why don't you start one!"
+msgstr ""
+
+#: public/js/frappe/views/reports/query_report.js:887
+msgid "There are {0} with the same filters already in the queue:"
 msgstr ""
 
 #: website/doctype/web_form/web_form.js:72
@@ -30875,7 +32020,7 @@ msgstr ""
 msgid "There can be only one Fold in a form"
 msgstr ""
 
-#: contacts/doctype/address/address.py:185
+#: contacts/doctype/address/address.py:183
 msgid "There is an error in your Address Template {0}"
 msgstr ""
 
@@ -30883,15 +32028,19 @@ msgstr ""
 msgid "There is no data to be exported"
 msgstr ""
 
-#: core/doctype/file/file.py:571 utils/file_manager.py:376
+#: core/doctype/file/file.py:570 utils/file_manager.py:372
 msgid "There is some problem with the file url: {0}"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.py:150
+#: public/js/frappe/views/reports/query_report.js:884
+msgid "There is {0} with the same filters already in the queue:"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager.py:155
 msgid "There must be atleast one permission rule."
 msgstr ""
 
-#: core/doctype/user/user.py:499
+#: core/doctype/user/user.py:528
 msgid "There should remain at least one System Manager"
 msgstr ""
 
@@ -30915,7 +32064,7 @@ msgstr ""
 msgid "There were errors while sending email. Please try again."
 msgstr ""
 
-#: model/naming.py:449
+#: model/naming.py:443
 msgid "There were some errors setting the name, please contact the administrator"
 msgstr ""
 
@@ -30962,11 +32111,11 @@ msgstr ""
 msgid "This Kanban Board will be private"
 msgstr ""
 
-#: __init__.py:957
+#: __init__.py:1007
 msgid "This action is only allowed for {}"
 msgstr ""
 
-#: public/js/frappe/form/toolbar.js:107 public/js/frappe/model/model.js:720
+#: public/js/frappe/form/toolbar.js:107 public/js/frappe/model/model.js:725
 msgid "This cannot be undone"
 msgstr ""
 
@@ -31002,18 +32151,22 @@ msgstr ""
 msgid "This document is already amended, you cannot ammend it again"
 msgstr ""
 
-#: model/document.py:1518
-msgid "This document is currently queued for execution. Please try again"
+#: model/document.py:1516
+msgid "This document is currently locked and queued for execution. Please try again after some time."
 msgstr ""
 
 #: templates/emails/auto_repeat_fail.html:7
 msgid "This email is autogenerated"
 msgstr ""
 
-#: printing/doctype/network_printer_settings/network_printer_settings.py:29
+#: printing/doctype/network_printer_settings/network_printer_settings.py:30
 msgid ""
 "This feature can not be used as dependencies are missing.\n"
 "\t\t\t\tPlease contact your system manager to enable this by installing pycups!"
+msgstr ""
+
+#: public/js/frappe/form/templates/form_sidebar.html:23
+msgid "This feature is brand new and still experimental"
 msgstr ""
 
 #. Description of the 'Depends On' (Code) field in DocType 'Customize Form
@@ -31052,19 +32205,19 @@ msgctxt "Website Slideshow"
 msgid "This goes above the slideshow."
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1995
+#: public/js/frappe/views/reports/query_report.js:1998
 msgid "This is a background report. Please set the appropriate filters and then generate a new one."
 msgstr ""
 
-#: utils/password_strength.py:162
+#: utils/password_strength.py:158
 msgid "This is a top-10 common password."
 msgstr ""
 
-#: utils/password_strength.py:164
+#: utils/password_strength.py:160
 msgid "This is a top-100 common password."
 msgstr ""
 
-#: utils/password_strength.py:166
+#: utils/password_strength.py:162
 msgid "This is a very common password."
 msgstr ""
 
@@ -31083,7 +32236,7 @@ msgctxt "Blog Post"
 msgid "This is an example Google SERP Preview."
 msgstr ""
 
-#: utils/password_strength.py:168
+#: utils/password_strength.py:164
 msgid "This is similar to a commonly used password."
 msgstr ""
 
@@ -31094,7 +32247,7 @@ msgctxt "Document Naming Settings"
 msgid "This is the number of the last created transaction with this prefix"
 msgstr ""
 
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:404
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.py:403
 msgid "This link has already been activated for verification."
 msgstr ""
 
@@ -31180,7 +32333,7 @@ msgstr ""
 msgid "This will terminate the job immediately and might be dangerous, are you sure? "
 msgstr ""
 
-#: core/doctype/user/user.py:1209
+#: core/doctype/user/user.py:1227
 msgid "Throttled"
 msgstr ""
 
@@ -31350,7 +32503,7 @@ msgctxt "System Settings"
 msgid "Time in seconds to retain QR code image on server. Min:<strong>240</strong>"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.py:413
+#: desk/doctype/dashboard_chart/dashboard_chart.py:403
 msgid "Time series based on is required to create a dashboard chart"
 msgstr ""
 
@@ -31446,7 +32599,8 @@ msgctxt "Transaction Log"
 msgid "Timestamp"
 msgstr ""
 
-#: public/js/form_builder/store.js:89
+#: core/doctype/doctype/boilerplate/controller_list.html:14
+#: core/doctype/doctype/boilerplate/controller_list.html:23
 #: public/js/frappe/views/workspace/workspace.js:605
 #: public/js/frappe/views/workspace/workspace.js:934
 #: public/js/frappe/views/workspace/workspace.js:1181
@@ -31676,7 +32830,7 @@ msgid ""
 "</div>"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:101
+#: email/doctype/auto_email_report/auto_email_report.py:107
 msgid "To allow more reports update limit in System Settings."
 msgstr ""
 
@@ -31686,12 +32840,23 @@ msgctxt "Communication"
 msgid "To and CC"
 msgstr ""
 
+#. Description of the 'Use First Day of Period' (Check) field in DocType 'Auto
+#. Email Report'
+#: email/doctype/auto_email_report/auto_email_report.json
+msgctxt "Auto Email Report"
+msgid "To begin the date range at the start of the chosen period. For example, if 'Year' is selected as the period, the report will start from January 1st of the current year."
+msgstr ""
+
 #: automation/doctype/auto_repeat/auto_repeat.js:35
 msgid "To configure Auto Repeat, enable \"Allow Auto Repeat\" from {0}."
 msgstr ""
 
 #: www/login.html:73
 msgid "To enable it follow the instructions in the following link: {0}"
+msgstr ""
+
+#: core/doctype/server_script/server_script.js:37
+msgid "To enable server scripts, read the {0}."
 msgstr ""
 
 #: desk/doctype/onboarding_step/onboarding_step.js:18
@@ -31741,7 +32906,7 @@ msgctxt "Notification"
 msgid "To use Slack Channel, add a <a href=\"#List/Slack%20Webhook%20URL/List\">Slack Webhook URL</a>."
 msgstr ""
 
-#: public/js/frappe/utils/diffview.js:43
+#: public/js/frappe/utils/diffview.js:44
 msgid "To version"
 msgstr ""
 
@@ -31837,11 +33002,11 @@ msgctxt "Connected App"
 msgid "Token URI"
 msgstr ""
 
-#: utils/oauth.py:184
+#: utils/oauth.py:179
 msgid "Token is missing"
 msgstr ""
 
-#: desk/doctype/bulk_update/bulk_update.py:70 model/workflow.py:253
+#: desk/doctype/bulk_update/bulk_update.py:69 model/workflow.py:246
 msgid "Too Many Documents"
 msgstr ""
 
@@ -31849,11 +33014,11 @@ msgstr ""
 msgid "Too Many Requests"
 msgstr ""
 
-#: database/database.py:423
+#: database/database.py:424
 msgid "Too many changes to database in single action."
 msgstr ""
 
-#: core/doctype/user/user.py:984
+#: core/doctype/user/user.py:1008
 msgid "Too many users signed up recently, so the registration is disabled. Please try back in an hour"
 msgstr ""
 
@@ -31928,8 +33093,12 @@ msgctxt "Discussion Reply"
 msgid "Topic"
 msgstr ""
 
-#: desk/query_report.py:503
+#: desk/query_report.py:497 public/js/frappe/views/reports/print_grid.html:45
 msgid "Total"
+msgstr ""
+
+#: public/js/frappe/ui/capture.js:251
+msgid "Total Images"
 msgstr ""
 
 #. Label of a Int field in DocType 'Newsletter'
@@ -32048,7 +33217,7 @@ msgid ""
 "Note: If you're sending to multiple recipients, even if 1 recipient reads the email, it'll be considered \"Opened\""
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1745
+#: public/js/frappe/utils/utils.js:1757
 msgid "Tracking URL generated and copied to clipboard"
 msgstr ""
 
@@ -32187,11 +33356,15 @@ msgctxt "Document Naming Settings"
 msgid "Try a Naming Series"
 msgstr ""
 
-#: utils/password_strength.py:108
+#: printing/page/print/print.js:188
+msgid "Try the new Print Format Builder"
+msgstr ""
+
+#: utils/password_strength.py:106
 msgid "Try to avoid repeated words and characters"
 msgstr ""
 
-#: utils/password_strength.py:100
+#: utils/password_strength.py:98
 msgid "Try to use a longer keyboard pattern with more turns"
 msgstr ""
 
@@ -32242,6 +33415,10 @@ msgstr ""
 #: core/doctype/system_settings/system_settings.json
 msgctxt "System Settings"
 msgid "Two Factor Authentication method"
+msgstr ""
+
+#: public/js/frappe/views/file/file_view.js:317
+msgid "Type"
 msgstr ""
 
 #. Label of a Select field in DocType 'Communication'
@@ -32322,6 +33499,10 @@ msgctxt "Workspace Shortcut"
 msgid "Type"
 msgstr ""
 
+#: desk/page/user_profile/user_profile.html:17
+msgid "Type Distribution"
+msgstr ""
+
 #: public/js/frappe/form/controls/comment.js:78
 msgid "Type a reply / comment"
 msgstr ""
@@ -32331,6 +33512,8 @@ msgid "Type something in the search box to search"
 msgstr ""
 
 #: templates/discussions/comment_box.html:8
+#: templates/discussions/reply_section.html:53
+#: templates/discussions/topic_modal.html:11
 msgid "Type title"
 msgstr ""
 
@@ -32447,7 +33630,7 @@ msgctxt "DocType"
 msgid "URL for documentation or help"
 msgstr ""
 
-#: core/doctype/file/file.py:216
+#: core/doctype/file/file.py:217
 msgid "URL must start with http:// or https://"
 msgstr ""
 
@@ -32461,7 +33644,7 @@ msgctxt "Website Slideshow Item"
 msgid "URL to go to on clicking the slideshow image"
 msgstr ""
 
-#: core/doctype/document_naming_settings/document_naming_settings.py:68
+#: core/doctype/document_naming_settings/document_naming_settings.py:67
 msgid "Unable to find DocType {0}"
 msgstr ""
 
@@ -32489,7 +33672,7 @@ msgstr ""
 msgid "Unable to update event"
 msgstr ""
 
-#: core/doctype/file/file.py:458
+#: core/doctype/file/file.py:457
 msgid "Unable to write file format for {0}"
 msgstr ""
 
@@ -32516,6 +33699,7 @@ msgid "Undo last action"
 msgstr ""
 
 #: public/js/frappe/form/sidebar/form_sidebar.js:232
+#: public/js/frappe/form/templates/form_sidebar.html:132
 msgid "Unfollow"
 msgstr ""
 
@@ -32546,15 +33730,19 @@ msgctxt "DocField"
 msgid "Unique"
 msgstr ""
 
+#: website/report/website_analytics/website_analytics.js:60
+msgid "Unknown"
+msgstr ""
+
 #: public/js/frappe/model/model.js:199
 msgid "Unknown Column: {0}"
 msgstr ""
 
-#: utils/data.py:1215
+#: utils/data.py:1190
 msgid "Unknown Rounding Method: {}"
 msgstr ""
 
-#: auth.py:301
+#: auth.py:293
 msgid "Unknown User"
 msgstr ""
 
@@ -32583,8 +33771,13 @@ msgctxt "Communication"
 msgid "Unread Notification Sent"
 msgstr ""
 
-#: utils/safe_exec.py:438
+#: utils/safe_exec.py:435
 msgid "Unsafe SQL query"
+msgstr ""
+
+#: public/js/frappe/data_import/data_exporter.js:158
+#: public/js/frappe/form/controls/multicheck.js:166
+msgid "Unselect All"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
@@ -32599,7 +33792,7 @@ msgctxt "Communication"
 msgid "Unshared"
 msgstr ""
 
-#: email/queue.py:68
+#: email/queue.py:66
 msgid "Unsubscribe"
 msgstr ""
 
@@ -32615,7 +33808,7 @@ msgctxt "Email Queue"
 msgid "Unsubscribe Param"
 msgstr ""
 
-#: email/queue.py:126
+#: email/queue.py:122
 msgid "Unsubscribed"
 msgstr ""
 
@@ -32653,7 +33846,7 @@ msgstr ""
 msgid "Unzipping files..."
 msgstr ""
 
-#: desk/doctype/event/event.py:259
+#: desk/doctype/event/event.py:256
 msgid "Upcoming Events for Today"
 msgstr ""
 
@@ -32745,7 +33938,7 @@ msgstr ""
 msgid "Update {0} records"
 msgstr ""
 
-#: desk/doctype/desktop_icon/desktop_icon.py:452
+#: desk/doctype/desktop_icon/desktop_icon.py:446
 #: public/js/frappe/web_form/web_form.js:423
 msgid "Updated"
 msgstr ""
@@ -32780,7 +33973,7 @@ msgctxt "System Settings"
 msgid "Updates"
 msgstr ""
 
-#: utils/response.py:320
+#: utils/response.py:324
 msgid "Updating"
 msgstr ""
 
@@ -32797,7 +33990,7 @@ msgstr ""
 msgid "Updating counter may lead to document name conflicts if not done properly"
 msgstr ""
 
-#: desk/page/setup_wizard/setup_wizard.py:23
+#: desk/page/setup_wizard/setup_wizard.py:22
 msgid "Updating global settings"
 msgstr ""
 
@@ -32809,7 +34002,7 @@ msgstr ""
 msgid "Updating related fields..."
 msgstr ""
 
-#: desk/doctype/bulk_update/bulk_update.py:98
+#: desk/doctype/bulk_update/bulk_update.py:96
 msgid "Updating {0}"
 msgstr ""
 
@@ -32819,6 +34012,8 @@ msgstr ""
 
 #: public/js/frappe/file_uploader/file_uploader.bundle.js:121
 #: public/js/frappe/file_uploader/file_uploader.bundle.js:122
+#: public/js/frappe/form/grid.js:63
+#: public/js/frappe/form/templates/form_sidebar.html:13
 msgid "Upload"
 msgstr ""
 
@@ -32834,11 +34029,11 @@ msgctxt "File"
 msgid "Uploaded To Google Drive"
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:199
+#: integrations/doctype/google_drive/google_drive.py:196
 msgid "Uploading backup to Google Drive."
 msgstr ""
 
-#: integrations/doctype/google_drive/google_drive.py:204
+#: integrations/doctype/google_drive/google_drive.py:201
 msgid "Uploading successful."
 msgstr ""
 
@@ -32858,6 +34053,12 @@ msgstr ""
 #: email/doctype/email_account/email_account.json
 msgctxt "Email Account"
 msgid "Use ASCII encoding for password"
+msgstr ""
+
+#. Label of a Check field in DocType 'Auto Email Report'
+#: email/doctype/auto_email_report/auto_email_report.json
+msgctxt "Auto Email Report"
+msgid "Use First Day of Period"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Template'
@@ -32936,11 +34137,11 @@ msgctxt "Email Account"
 msgid "Use different Email ID"
 msgstr ""
 
-#: model/db_query.py:434
+#: model/db_query.py:424
 msgid "Use of function {0} in field is restricted"
 msgstr ""
 
-#: model/db_query.py:413
+#: model/db_query.py:403
 msgid "Use of sub-query or function is restricted"
 msgstr ""
 
@@ -32964,6 +34165,7 @@ msgstr ""
 #: core/doctype/user/user.json
 #: core/report/permitted_documents_for_user/permitted_documents_for_user.js:8
 #: desk/page/user_profile/user_profile_controller.js:65
+#: public/js/frappe/form/templates/set_sharing.html:3
 #: templates/emails/energy_points_summary.html:38
 msgid "User"
 msgstr ""
@@ -33137,7 +34339,7 @@ msgctxt "Access Log"
 msgid "User "
 msgstr ""
 
-#: core/doctype/has_role/has_role.py:24
+#: core/doctype/has_role/has_role.py:25
 msgid "User '{0}' already has the role '{1}'"
 msgstr ""
 
@@ -33257,6 +34459,10 @@ msgctxt "User"
 msgid "User Image"
 msgstr ""
 
+#: public/js/frappe/ui/toolbar/navbar.html:109
+msgid "User Menu"
+msgstr ""
+
 #. Label of a Data field in DocType 'Personal Data Download Request'
 #: website/doctype/personal_data_download_request/personal_data_download_request.json
 msgctxt "Personal Data Download Request"
@@ -33274,7 +34480,8 @@ msgctxt "User"
 msgid "User Permission"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1772
+#: core/page/permission_manager/permission_manager_help.html:30
+#: public/js/frappe/views/reports/query_report.js:1775
 #: public/js/frappe/views/reports/report_view.js:1657
 msgid "User Permissions"
 msgstr ""
@@ -33288,6 +34495,10 @@ msgstr ""
 #: core/workspace/users/users.json
 msgctxt "User Permission"
 msgid "User Permissions"
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:32
+msgid "User Permissions are used to limit users to specific records."
 msgstr ""
 
 #: core/doctype/user_permission/user_permission_list.js:124
@@ -33306,8 +34517,17 @@ msgid "User Role"
 msgstr ""
 
 #. Name of a DocType
+#: core/doctype/user_role_profile/user_role_profile.json
+msgid "User Role Profile"
+msgstr ""
+
+#. Name of a DocType
 #: core/doctype/user_select_document_type/user_select_document_type.json
 msgid "User Select Document Type"
+msgstr ""
+
+#: desk/page/user_profile/user_profile_sidebar.html:52
+msgid "User Settings"
 msgstr ""
 
 #. Name of a DocType
@@ -33367,11 +34587,15 @@ msgstr ""
 msgid "User does not exist"
 msgstr ""
 
+#: templates/includes/login/login.js:293
+msgid "User does not exist."
+msgstr ""
+
 #: core/doctype/user_type/user_type.py:82
 msgid "User does not have permission to create the new {0}"
 msgstr ""
 
-#: core/doctype/docshare/docshare.py:55
+#: core/doctype/docshare/docshare.py:56
 msgid "User is mandatory for Share"
 msgstr ""
 
@@ -33381,15 +34605,15 @@ msgctxt "Document Naming Settings"
 msgid "User must always select"
 msgstr ""
 
-#: model/delete_doc.py:224
+#: model/delete_doc.py:225
 msgid "User not allowed to delete {0}: {1}"
 msgstr ""
 
-#: core/doctype/user_permission/user_permission.py:59
+#: core/doctype/user_permission/user_permission.py:60
 msgid "User permission already exists"
 msgstr ""
 
-#: www/login.py:153
+#: www/login.py:151
 msgid "User with email address {0} does not exist"
 msgstr ""
 
@@ -33397,23 +34621,23 @@ msgstr ""
 msgid "User with email: {0} does not exist in the system. Please ask 'System Administrator' to create the user for you."
 msgstr ""
 
-#: core/doctype/user/user.py:504
+#: core/doctype/user/user.py:533
 msgid "User {0} cannot be deleted"
 msgstr ""
 
-#: core/doctype/user/user.py:242
+#: core/doctype/user/user.py:272
 msgid "User {0} cannot be disabled"
 msgstr ""
 
-#: core/doctype/user/user.py:564
+#: core/doctype/user/user.py:593
 msgid "User {0} cannot be renamed"
 msgstr ""
 
-#: permissions.py:139
+#: permissions.py:137
 msgid "User {0} does not have access to this document"
 msgstr ""
 
-#: permissions.py:162
+#: permissions.py:160
 msgid "User {0} does not have doctype access via role permission for document {1}"
 msgstr ""
 
@@ -33422,7 +34646,7 @@ msgstr ""
 msgid "User {0} has requested for data deletion"
 msgstr ""
 
-#: utils/oauth.py:272
+#: utils/oauth.py:265
 msgid "User {0} is disabled"
 msgstr ""
 
@@ -33452,7 +34676,7 @@ msgctxt "User Social Login"
 msgid "Username"
 msgstr ""
 
-#: core/doctype/user/user.py:644
+#: core/doctype/user/user.py:678
 msgid "Username {0} already exists"
 msgstr ""
 
@@ -33475,7 +34699,7 @@ msgctxt "Energy Point Rule"
 msgid "Users assigned to the reference document will get points."
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:345
+#: core/page/permission_manager/permission_manager.js:349
 msgid "Users with role {0}:"
 msgstr ""
 
@@ -33500,6 +34724,14 @@ msgctxt "OAuth Authorization Code"
 msgid "Valid"
 msgstr ""
 
+#: templates/includes/login/login.js:53 templates/includes/login/login.js:66
+msgid "Valid Login id required."
+msgstr ""
+
+#: templates/includes/login/login.js:40
+msgid "Valid email and name required"
+msgstr ""
+
 #. Label of a Check field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 msgctxt "Onboarding Step"
@@ -33516,9 +34748,16 @@ msgctxt "OAuth Authorization Code"
 msgid "Validity"
 msgstr ""
 
+#: core/doctype/prepared_report/prepared_report.js:8
+#: desk/doctype/dashboard_chart/dashboard_chart.js:305
+#: desk/doctype/dashboard_chart/dashboard_chart.js:439
+#: desk/doctype/number_card/number_card.js:205
+#: desk/doctype/number_card/number_card.js:333
 #: email/doctype/auto_email_report/auto_email_report.js:92
 #: public/js/frappe/list/bulk_operations.js:292
 #: public/js/frappe/list/bulk_operations.js:354
+#: public/js/frappe/list/list_view_permission_restrictions.html:4
+#: website/doctype/web_form/web_form.js:188
 msgid "Value"
 msgstr ""
 
@@ -33595,7 +34834,7 @@ msgctxt "Notification"
 msgid "Value To Be Set"
 msgstr ""
 
-#: model/base_document.py:949 model/document.py:648
+#: model/base_document.py:955 model/document.py:647
 msgid "Value cannot be changed for {0}"
 msgstr ""
 
@@ -33611,7 +34850,7 @@ msgstr ""
 msgid "Value for a check field can be either 0 or 1"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:611
+#: custom/doctype/customize_form/customize_form.py:607
 msgid "Value for field {0} is too long in {1}. Length should be lesser than {2} characters"
 msgstr ""
 
@@ -33626,11 +34865,11 @@ msgctxt "Assignment Rule"
 msgid "Value from this field will be set as the due date in the ToDo"
 msgstr ""
 
-#: model/base_document.py:731
+#: model/base_document.py:733
 msgid "Value missing for"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:698
+#: core/doctype/data_import/importer.py:695
 msgid "Value must be one of {0}"
 msgstr ""
 
@@ -33640,20 +34879,24 @@ msgctxt "Onboarding Step"
 msgid "Value to Validate"
 msgstr ""
 
-#: model/base_document.py:1016
+#: model/base_document.py:1022
 msgid "Value too big"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:711
+#: core/doctype/data_import/importer.py:708
 msgid "Value {0} missing for {1}"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:742 utils/data.py:877
+#: core/doctype/data_import/importer.py:739 utils/data.py:858
 msgid "Value {0} must be in the valid duration format: d h m s"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:729
+#: core/doctype/data_import/importer.py:726
 msgid "Value {0} must in {1} format"
+msgstr ""
+
+#: core/doctype/version/version_view.html:8
+msgid "Values Changed"
 msgstr ""
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
@@ -33662,7 +34905,7 @@ msgctxt "Print Settings"
 msgid "Verdana"
 msgstr ""
 
-#: twofactor.py:362
+#: twofactor.py:356
 msgid "Verfication Code"
 msgstr ""
 
@@ -33670,7 +34913,11 @@ msgstr ""
 msgid "Verification Link"
 msgstr ""
 
-#: twofactor.py:251
+#: templates/includes/login/login.js:391
+msgid "Verification code email not sent. Please contact Administrator."
+msgstr ""
+
+#: twofactor.py:247
 msgid "Verification code has been sent to your registered email address."
 msgstr ""
 
@@ -33680,12 +34927,16 @@ msgctxt "Translation"
 msgid "Verified"
 msgstr ""
 
-#: public/js/frappe/ui/messages.js:352
+#: public/js/frappe/ui/messages.js:350
 msgid "Verify"
 msgstr ""
 
-#: public/js/frappe/ui/messages.js:351
+#: public/js/frappe/ui/messages.js:349
 msgid "Verify Password"
+msgstr ""
+
+#: templates/includes/login/login.js:172
+msgid "Verifying..."
 msgstr ""
 
 #. Name of a DocType
@@ -33722,11 +34973,16 @@ msgstr ""
 msgid "View Blog Post"
 msgstr ""
 
-#: templates/includes/comments/comments.py:58
+#: templates/includes/comments/comments.py:56
 msgid "View Comment"
 msgstr ""
 
+#: public/js/frappe/ui/notifications/notifications.js:213
+msgid "View Full Log"
+msgstr ""
+
 #: public/js/frappe/views/treeview.js:467
+#: public/js/frappe/widgets/quick_list_widget.js:245
 msgid "View List"
 msgstr ""
 
@@ -33735,7 +34991,7 @@ msgstr ""
 msgid "View Log"
 msgstr ""
 
-#: core/doctype/user/user.js:133
+#: core/doctype/user/user.js:126
 #: core/doctype/user_permission/user_permission.js:24
 msgid "View Permitted Documents"
 msgstr ""
@@ -33796,6 +35052,11 @@ msgstr ""
 msgid "View this in your browser"
 msgstr ""
 
+#: public/js/frappe/web_form/web_form.js:450
+msgctxt "Button in web form"
+msgid "View your response"
+msgstr ""
+
 #: automation/doctype/auto_repeat/auto_repeat.js:43
 #: desk/doctype/calendar_view/calendar_view_list.js:10
 #: desk/doctype/dashboard/dashboard_list.js:10
@@ -33825,11 +35086,11 @@ msgctxt "DocField"
 msgid "Virtual"
 msgstr ""
 
-#: model/virtual_doctype.py:78
+#: model/virtual_doctype.py:76
 msgid "Virtual DocType {} requires a static method called {} found {}"
 msgstr ""
 
-#: model/virtual_doctype.py:91
+#: model/virtual_doctype.py:89
 msgid "Virtual DocType {} requires overriding an instance method called {} found {}"
 msgstr ""
 
@@ -33855,7 +35116,7 @@ msgctxt "Web Page View"
 msgid "Visitor ID"
 msgstr ""
 
-#: templates/discussions/reply_section.html:38
+#: templates/discussions/reply_section.html:39
 msgid "Want to discuss?"
 msgstr ""
 
@@ -33883,6 +35144,10 @@ msgstr ""
 
 #: website/doctype/help_article/templates/help_article.html:24
 msgid "Was this article helpful?"
+msgstr ""
+
+#: public/js/frappe/widgets/onboarding_widget.js:127
+msgid "Watch Tutorial"
 msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
@@ -34109,7 +35374,8 @@ msgid "Webhook URL"
 msgstr ""
 
 #. Name of a Workspace
-#: email/doctype/newsletter/newsletter.py:451
+#: email/doctype/newsletter/newsletter.py:449
+#: public/js/frappe/ui/toolbar/about.js:8
 #: website/workspace/website/website.json
 msgid "Website"
 msgstr ""
@@ -34440,15 +35706,15 @@ msgid "Welcome URL"
 msgstr ""
 
 #. Name of a Workspace
-#: core/workspace/welcome_workspace/welcome_workspace.json desk/desktop.py:468
+#: core/workspace/welcome_workspace/welcome_workspace.json desk/desktop.py:469
 msgid "Welcome Workspace"
 msgstr ""
 
-#: core/doctype/user/user.py:361
+#: core/doctype/user/user.py:390
 msgid "Welcome email sent"
 msgstr ""
 
-#: core/doctype/user/user.py:436
+#: core/doctype/user/user.py:465
 msgid "Welcome to {0}"
 msgstr ""
 
@@ -34466,7 +35732,11 @@ msgctxt "System Settings"
 msgid "When uploading files, force the use of the web-based image capture. If this is unchecked, the default behavior is to use the mobile native camera when use from a mobile is detected."
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:446
+#: core/page/permission_manager/permission_manager_help.html:18
+msgid "When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number."
+msgstr ""
+
+#: public/js/frappe/widgets/widget_dialog.js:479
 msgid "Which view of the associated DocType should this shortcut take you to?"
 msgstr ""
 
@@ -34475,6 +35745,10 @@ msgstr ""
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
 msgctxt "Workspace Shortcut"
 msgid "Which view of the associated DocType should this shortcut take you to?"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_column_selector.html:8
+msgid "Width"
 msgstr ""
 
 #. Label of a Data field in DocType 'Custom Field'
@@ -34505,6 +35779,10 @@ msgstr ""
 #: core/doctype/report_column/report_column.json
 msgctxt "Report Column"
 msgid "Width"
+msgstr ""
+
+#: printing/page/print_format_builder/print_format_builder_column_selector.html:2
+msgid "Widths can be set in px or %."
 msgstr ""
 
 #. Label of a Check field in DocType 'Report Filter'
@@ -34562,6 +35840,7 @@ msgid "Worker Name"
 msgstr ""
 
 #. Name of a DocType
+#: public/js/workflow_builder/store.js:129
 #: workflow/doctype/workflow/workflow.json
 msgid "Workflow"
 msgstr ""
@@ -34593,7 +35872,7 @@ msgstr ""
 
 #. Name of a DocType
 #: workflow/doctype/workflow_action/workflow_action.json
-#: workflow/doctype/workflow_action/workflow_action.py:486
+#: workflow/doctype/workflow_action/workflow_action.py:476
 msgid "Workflow Action"
 msgstr ""
 
@@ -34620,6 +35899,8 @@ msgctxt "Workflow Document State"
 msgid "Workflow Action is not created for optional states"
 msgstr ""
 
+#: public/js/workflow_builder/store.js:129
+#: workflow/doctype/workflow/workflow.js:25
 #: workflow/page/workflow_builder/workflow_builder.js:4
 msgid "Workflow Builder"
 msgstr ""
@@ -34674,15 +35955,15 @@ msgctxt "Workflow"
 msgid "Workflow State Field"
 msgstr ""
 
-#: model/workflow.py:63
+#: model/workflow.py:61
 msgid "Workflow State not set"
 msgstr ""
 
-#: model/workflow.py:201 model/workflow.py:209
+#: model/workflow.py:197 model/workflow.py:205
 msgid "Workflow State transition not allowed from {0} to {1}"
 msgstr ""
 
-#: model/workflow.py:327
+#: model/workflow.py:320
 msgid "Workflow Status"
 msgstr ""
 
@@ -34755,7 +36036,7 @@ msgstr ""
 msgid "Workspace Shortcut"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:283
+#: desk/doctype/workspace/workspace.py:281
 msgid "Workspace not found"
 msgstr ""
 
@@ -34801,7 +36082,7 @@ msgctxt "User Document Type"
 msgid "Write"
 msgstr ""
 
-#: model/base_document.py:859
+#: model/base_document.py:865
 msgid "Wrong Fetch From value"
 msgstr ""
 
@@ -34923,12 +36204,12 @@ msgctxt "Kanban Board Column"
 msgid "Yellow"
 msgstr ""
 
-#: integrations/doctype/webhook/webhook.py:127
-#: integrations/doctype/webhook/webhook.py:137
+#: integrations/doctype/webhook/webhook.py:128
+#: integrations/doctype/webhook/webhook.py:138
 #: public/js/form_builder/utils.js:336
 #: public/js/frappe/form/controls/link.js:472
 #: public/js/frappe/list/list_sidebar_group_by.js:223
-#: public/js/frappe/views/reports/query_report.js:1513
+#: public/js/frappe/views/reports/query_report.js:1516
 #: website/doctype/help_article/templates/help_article.html:25
 msgid "Yes"
 msgstr ""
@@ -34981,11 +36262,11 @@ msgstr ""
 msgid "You are connected to internet."
 msgstr ""
 
-#: permissions.py:420
+#: permissions.py:413
 msgid "You are not allowed to access this {0} record because it is linked to {1} '{2}' in field {3}"
 msgstr ""
 
-#: permissions.py:409
+#: permissions.py:402
 msgid "You are not allowed to access this {0} record because it is linked to {1} '{2}' in row {3}, field {4}"
 msgstr ""
 
@@ -34993,19 +36274,19 @@ msgstr ""
 msgid "You are not allowed to create columns"
 msgstr ""
 
-#: core/doctype/report/report.py:93
+#: core/doctype/report/report.py:94
 msgid "You are not allowed to delete Standard Report"
 msgstr ""
 
-#: website/doctype/website_theme/website_theme.py:74
+#: website/doctype/website_theme/website_theme.py:72
 msgid "You are not allowed to delete a standard Website Theme"
 msgstr ""
 
-#: core/doctype/report/report.py:380
+#: core/doctype/report/report.py:377
 msgid "You are not allowed to edit the report."
 msgstr ""
 
-#: permissions.py:617
+#: permissions.py:610
 msgid "You are not allowed to export {} doctype"
 msgstr ""
 
@@ -35017,7 +36298,7 @@ msgstr ""
 msgid "You are not allowed to send emails related to this document"
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:463
+#: website/doctype/web_form/web_form.py:462
 msgid "You are not allowed to update this Web Form Document"
 msgstr ""
 
@@ -35029,11 +36310,11 @@ msgstr ""
 msgid "You are not permitted to access this page without login."
 msgstr ""
 
-#: www/app.py:25
+#: www/app.py:23
 msgid "You are not permitted to access this page."
 msgstr ""
 
-#: __init__.py:874
+#: __init__.py:927
 msgid "You are not permitted to access this resource."
 msgstr ""
 
@@ -35041,7 +36322,7 @@ msgstr ""
 msgid "You are now following this document. You will receive daily updates via email. You can change this in User Settings."
 msgstr ""
 
-#: core/doctype/installed_applications/installed_applications.py:59
+#: core/doctype/installed_applications/installed_applications.py:60
 msgid "You are only allowed to update order, do not remove or add apps."
 msgstr ""
 
@@ -35058,6 +36339,10 @@ msgstr ""
 msgid "You can add dynamic properties from the document by using Jinja templating."
 msgstr ""
 
+#: printing/doctype/letter_head/letter_head.js:32
+msgid "You can also access wkhtmltopdf variables (valid only in PDF print):"
+msgstr ""
+
 #: templates/emails/new_user.html:22
 msgid "You can also copy-paste following link in your browser"
 msgstr ""
@@ -35070,6 +36355,10 @@ msgstr ""
 msgid "You can also copy-paste this {0} to your browser"
 msgstr ""
 
+#: core/page/permission_manager/permission_manager_help.html:17
+msgid "You can change Submitted documents by cancelling them and then, amending them."
+msgstr ""
+
 #: public/js/frappe/logtypes.js:21
 msgid "You can change the retention policy from {0}."
 msgstr ""
@@ -35078,7 +36367,7 @@ msgstr ""
 msgid "You can continue with the onboarding after exploring this page"
 msgstr ""
 
-#: core/doctype/file/file.py:684
+#: core/doctype/file/file.py:683
 msgid "You can increase the limit from System Settings."
 msgstr ""
 
@@ -35094,27 +36383,35 @@ msgstr ""
 msgid "You can only set the 3 custom doctypes in the Document Types table."
 msgstr ""
 
-#: handler.py:226
+#: handler.py:224
 msgid "You can only upload JPG, PNG, PDF, TXT or Microsoft documents."
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:201
+#: core/doctype/data_export/exporter.py:199
 msgid "You can only upload upto 5000 records in one go. (may be less in some cases)"
 msgstr ""
 
-#: desk/query_report.py:336
+#: website/doctype/web_page/web_page.js:92
+msgid "You can select one from the following,"
+msgstr ""
+
+#: desk/query_report.py:332
 msgid "You can try changing the filters of your report."
+msgstr ""
+
+#: core/page/permission_manager/permission_manager_help.html:27
+msgid "You can use Customize Form to set levels on fields."
 msgstr ""
 
 #: public/js/frappe/form/link_selector.js:30
 msgid "You can use wildcard %"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:387
+#: custom/doctype/customize_form/customize_form.py:385
 msgid "You can't set 'Options' for field {0}"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:391
+#: custom/doctype/customize_form/customize_form.py:389
 msgid "You can't set 'Translatable' for field {0}"
 msgstr ""
 
@@ -35128,15 +36425,15 @@ msgctxt "Form timeline"
 msgid "You cancelled this document {1}"
 msgstr ""
 
-#: desk/doctype/dashboard_chart/dashboard_chart.py:417
+#: desk/doctype/dashboard_chart/dashboard_chart.py:407
 msgid "You cannot create a dashboard chart from single DocTypes"
 msgstr ""
 
-#: social/doctype/energy_point_log/energy_point_log.py:44
+#: social/doctype/energy_point_log/energy_point_log.py:45
 msgid "You cannot give review points to yourself"
 msgstr ""
 
-#: custom/doctype/customize_form/customize_form.py:383
+#: custom/doctype/customize_form/customize_form.py:381
 msgid "You cannot unset 'Read Only' for field {0}"
 msgstr ""
 
@@ -35174,7 +36471,7 @@ msgstr ""
 msgid "You do not have enough permissions to access this resource. Please contact your manager to get access."
 msgstr ""
 
-#: app.py:355
+#: app.py:353
 msgid "You do not have enough permissions to complete the action"
 msgstr ""
 
@@ -35182,11 +36479,12 @@ msgstr ""
 msgid "You do not have enough points"
 msgstr ""
 
-#: social/doctype/energy_point_log/energy_point_log.py:296
+#: public/js/frappe/form/sidebar/review.js:31
+#: social/doctype/energy_point_log/energy_point_log.py:294
 msgid "You do not have enough review points"
 msgstr ""
 
-#: www/printview.py:369
+#: www/printview.py:370
 msgid "You do not have permission to view this document"
 msgstr ""
 
@@ -35198,11 +36496,11 @@ msgstr ""
 msgid "You don't have access to Report: {0}"
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:699
+#: website/doctype/web_form/web_form.py:698
 msgid "You don't have permission to access the {0} DocType."
 msgstr ""
 
-#: utils/response.py:278
+#: utils/response.py:265 utils/response.py:282
 msgid "You don't have permission to access this file"
 msgstr ""
 
@@ -35210,7 +36508,7 @@ msgstr ""
 msgid "You don't have permission to get a report on: {0}"
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:167
+#: website/doctype/web_form/web_form.py:168
 msgid "You don't have the permissions to access this document"
 msgstr ""
 
@@ -35242,7 +36540,7 @@ msgstr ""
 msgid "You have received a ❤️ like on your blog post"
 msgstr ""
 
-#: twofactor.py:455
+#: twofactor.py:447
 msgid "You have to enable Two Factor Auth from System Settings."
 msgstr ""
 
@@ -35250,11 +36548,19 @@ msgstr ""
 msgid "You have unsaved changes in this form. Please save before you continue."
 msgstr ""
 
-#: core/doctype/log_settings/log_settings.py:127
+#: public/js/frappe/ui/toolbar/navbar.html:45
+msgid "You have unseen notifications"
+msgstr ""
+
+#: core/doctype/log_settings/log_settings.py:126
 msgid "You have unseen {0}"
 msgstr ""
 
-#: public/js/frappe/list/list_view.js:468
+#: public/js/frappe/views/dashboard/dashboard_view.js:191
+msgid "You haven't added any Dashboard Charts or Number Cards yet."
+msgstr ""
+
+#: public/js/frappe/list/list_view.js:470
 msgid "You haven't created a {0} yet"
 msgstr ""
 
@@ -35267,27 +36573,27 @@ msgstr ""
 msgid "You last edited this"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:314
+#: public/js/frappe/widgets/widget_dialog.js:347
 msgid "You must add atleast one link."
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:669
+#: website/doctype/web_form/web_form.py:668
 msgid "You must be logged in to use this form."
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:503
+#: website/doctype/web_form/web_form.py:502
 msgid "You must login to submit this form"
 msgstr ""
 
-#: desk/doctype/workspace/workspace.py:72
+#: desk/doctype/workspace/workspace.py:73
 msgid "You need to be Workspace Manager to edit this document"
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:90
+#: website/doctype/web_form/web_form.py:91
 msgid "You need to be in developer mode to edit a Standard Web Form"
 msgstr ""
 
-#: utils/response.py:259
+#: utils/response.py:255
 msgid "You need to be logged in and have System Manager Role to be able to access backups."
 msgstr ""
 
@@ -35295,8 +36601,12 @@ msgstr ""
 msgid "You need to be logged in to access this page"
 msgstr ""
 
-#: website/doctype/web_form/web_form.py:158
+#: website/doctype/web_form/web_form.py:159
 msgid "You need to be logged in to access this {0}."
+msgstr ""
+
+#: public/js/frappe/widgets/links_widget.js:63
+msgid "You need to create these first: "
 msgstr ""
 
 #: www/login.html:73
@@ -35307,15 +36617,15 @@ msgstr ""
 msgid "You need to have \"Share\" permission"
 msgstr ""
 
-#: utils/print_format.py:156
+#: utils/print_format.py:150
 msgid "You need to install pycups to use this feature!"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:140
+#: email/doctype/email_account/email_account.py:147
 msgid "You need to set one IMAP folder for {0}"
 msgstr ""
 
-#: model/rename_doc.py:385
+#: model/rename_doc.py:377
 msgid "You need write permission to rename"
 msgstr ""
 
@@ -35375,12 +36685,20 @@ msgstr ""
 msgid "Your account has been deleted"
 msgstr ""
 
-#: auth.py:476
+#: auth.py:466
 msgid "Your account has been locked and will resume after {0} seconds"
 msgstr ""
 
-#: desk/form/assign_to.py:282
+#: desk/form/assign_to.py:276
 msgid "Your assignment on {0} {1} has been removed by {2}"
+msgstr ""
+
+#: core/doctype/file/file.js:66
+msgid "Your browser does not support the audio element."
+msgstr ""
+
+#: core/doctype/file/file.js:48
+msgid "Your browser does not support the video element."
 msgstr ""
 
 #: templates/pages/integrations/gcalendar-success.html:11
@@ -35418,8 +36736,12 @@ msgstr ""
 msgid "Your query has been received. We will reply back shortly. If you have any additional information, please reply to this mail."
 msgstr ""
 
-#: app.py:346
+#: app.py:344
 msgid "Your session has expired, please login again to continue."
+msgstr ""
+
+#: public/js/frappe/ui/toolbar/navbar.html:15
+msgid "Your site is undergoing maintenance or being updated."
 msgstr ""
 
 #: templates/emails/verification_code.html:1
@@ -35431,7 +36753,7 @@ msgstr ""
 msgid "Your website is all set up!"
 msgstr ""
 
-#: utils/data.py:1518
+#: utils/data.py:1493
 msgid "Zero"
 msgstr ""
 
@@ -35454,11 +36776,11 @@ msgctxt "Desktop Icon"
 msgid "_report"
 msgstr ""
 
-#: database/database.py:315
+#: database/database.py:314
 msgid "`as_iterator` only works with `as_list=True` or `as_dict=True`"
 msgstr ""
 
-#: utils/background_jobs.py:94
+#: utils/background_jobs.py:93
 msgid "`job_id` paramater is required for deduplication."
 msgstr ""
 
@@ -35509,7 +36831,7 @@ msgctxt "Permission Inspector"
 msgid "amend"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:396 utils/data.py:1526
+#: public/js/frappe/utils/utils.js:396 utils/data.py:1501
 msgid "and"
 msgstr ""
 
@@ -35537,6 +36859,7 @@ msgctxt "Workflow State"
 msgid "arrow-up"
 msgstr ""
 
+#: public/js/frappe/ui/sort_selector.html:5
 #: public/js/frappe/ui/sort_selector.js:48
 msgid "ascending"
 msgstr ""
@@ -35565,7 +36888,7 @@ msgctxt "Workflow State"
 msgid "barcode"
 msgstr ""
 
-#: model/document.py:1337
+#: model/document.py:1320
 msgid "beginning with"
 msgstr ""
 
@@ -35609,6 +36932,16 @@ msgstr ""
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
 msgid "bullhorn"
+msgstr ""
+
+#: public/js/frappe/form/workflow.js:35
+msgid "by Role"
+msgstr ""
+
+#. Label of a Code field in DocType 'Recorder'
+#: core/doctype/recorder/recorder.json
+msgctxt "Recorder"
+msgid "cProfile Output"
 msgstr ""
 
 #: public/js/frappe/ui/toolbar/search_utils.js:286
@@ -35716,6 +37049,10 @@ msgctxt "Workflow State"
 msgid "comment"
 msgstr ""
 
+#: public/js/frappe/form/templates/timeline_message_box.html:33
+msgid "commented"
+msgstr ""
+
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
@@ -35787,6 +37124,7 @@ msgctxt "Permission Inspector"
 msgid "delete"
 msgstr ""
 
+#: public/js/frappe/ui/sort_selector.html:5
 #: public/js/frappe/ui/sort_selector.js:48
 msgid "descending"
 msgstr ""
@@ -35883,7 +37221,7 @@ msgstr ""
 msgid "email inbox"
 msgstr ""
 
-#: permissions.py:414 permissions.py:425
+#: permissions.py:407 permissions.py:418
 #: public/js/frappe/form/controls/link.js:481
 msgid "empty"
 msgstr ""
@@ -36063,7 +37401,7 @@ msgctxt "Workspace"
 msgid "grey"
 msgstr ""
 
-#: utils/backups.py:379
+#: utils/backups.py:373
 msgid "gzip not found in PATH! This is required to take a backup."
 msgstr ""
 
@@ -36181,7 +37519,7 @@ msgstr ""
 msgid "just now"
 msgstr ""
 
-#: desk/desktop.py:254 desk/query_report.py:279
+#: desk/desktop.py:255 desk/query_report.py:277
 msgid "label"
 msgstr ""
 
@@ -36238,6 +37576,10 @@ msgstr ""
 msgid "logged in"
 msgstr ""
 
+#: website/doctype/web_form/web_form.js:353
+msgid "login_required"
+msgstr ""
+
 #. Option for the 'Queue' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
 msgctxt "RQ Job"
@@ -36267,7 +37609,7 @@ msgctxt "Workflow State"
 msgid "map-marker"
 msgstr ""
 
-#: model/rename_doc.py:214
+#: model/rename_doc.py:212
 msgid "merged {0} into {1}"
 msgstr ""
 
@@ -36342,7 +37684,7 @@ msgctxt "OAuth Authorization Code"
 msgid "nonce"
 msgstr ""
 
-#: model/document.py:1336
+#: model/document.py:1319
 msgid "none of"
 msgstr ""
 
@@ -36354,6 +37696,10 @@ msgstr ""
 
 #: public/js/frappe/utils/pretty_date.js:25
 msgid "now"
+msgstr ""
+
+#: public/js/frappe/form/grid_pagination.js:116
+msgid "of"
 msgstr ""
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
@@ -36422,7 +37768,7 @@ msgctxt "Webhook"
 msgid "on_update_after_submit"
 msgstr ""
 
-#: model/document.py:1335
+#: model/document.py:1318
 msgid "one of"
 msgstr ""
 
@@ -36599,7 +37945,7 @@ msgstr ""
 msgid "removed rows for {0}"
 msgstr ""
 
-#: model/rename_doc.py:217
+#: model/rename_doc.py:214
 msgid "renamed from {0} to {1}"
 msgstr ""
 
@@ -36646,7 +37992,7 @@ msgctxt "Custom Role"
 msgid "response"
 msgstr ""
 
-#: core/doctype/deleted_document/deleted_document.py:60
+#: core/doctype/deleted_document/deleted_document.py:61
 msgid "restored {0} as {1}"
 msgstr ""
 
@@ -36927,6 +38273,10 @@ msgctxt "Social Link Settings"
 msgid "twitter"
 msgstr ""
 
+#: public/js/frappe/change_log.html:7
+msgid "updated to {0}"
+msgstr ""
+
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
 msgctxt "Workflow State"
@@ -36953,12 +38303,12 @@ msgctxt "Audit Trail"
 msgid "version_table"
 msgstr ""
 
-#: automation/doctype/assignment_rule/assignment_rule.py:383
+#: automation/doctype/assignment_rule/assignment_rule.py:380
 msgid "via Assignment Rule"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:259
-#: core/doctype/data_import/importer.py:280
+#: core/doctype/data_import/importer.py:255
+#: core/doctype/data_import/importer.py:276
 msgid "via Data Import"
 msgstr ""
 
@@ -36968,7 +38318,7 @@ msgctxt "Event"
 msgid "via Google Meet"
 msgstr ""
 
-#: email/doctype/notification/notification.py:214
+#: email/doctype/notification/notification.py:215
 msgid "via Notification"
 msgstr ""
 
@@ -37068,7 +38418,7 @@ msgstr ""
 msgid "{0} ${type}"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:77
+#: public/js/frappe/data_import/data_exporter.js:79
 #: public/js/frappe/views/gantt/gantt_view.js:54
 msgid "{0} ({1})"
 msgstr ""
@@ -37108,11 +38458,11 @@ msgstr ""
 msgid "{0} Fields"
 msgstr ""
 
-#: integrations/doctype/google_calendar/google_calendar.py:360
+#: integrations/doctype/google_calendar/google_calendar.py:361
 msgid "{0} Google Calendar Events synced."
 msgstr ""
 
-#: integrations/doctype/google_contacts/google_contacts.py:190
+#: integrations/doctype/google_contacts/google_contacts.py:193
 msgid "{0} Google Contacts synced."
 msgstr ""
 
@@ -37143,7 +38493,7 @@ msgstr ""
 msgid "{0} Name"
 msgstr ""
 
-#: model/base_document.py:1046
+#: model/base_document.py:1052
 msgid "{0} Not allowed to change {1} after submission from {2} to {3}"
 msgstr ""
 
@@ -37152,6 +38502,10 @@ msgstr ""
 #: public/js/frappe/utils/utils.js:921
 #: public/js/frappe/widgets/chart_widget.js:325
 msgid "{0} Report"
+msgstr ""
+
+#: public/js/frappe/views/reports/query_report.js:878
+msgid "{0} Reports"
 msgstr ""
 
 #: public/js/frappe/list/list_settings.js:32
@@ -37165,7 +38519,7 @@ msgstr ""
 msgid "{0} Tree"
 msgstr ""
 
-#: public/js/frappe/list/base_list.js:206
+#: public/js/frappe/list/base_list.js:208
 msgid "{0} View"
 msgstr ""
 
@@ -37187,15 +38541,15 @@ msgstr ""
 msgid "{0} already exists. Select another name"
 msgstr ""
 
-#: email/doctype/email_unsubscribe/email_unsubscribe.py:37
+#: email/doctype/email_unsubscribe/email_unsubscribe.py:36
 msgid "{0} already unsubscribed"
 msgstr ""
 
-#: email/doctype/email_unsubscribe/email_unsubscribe.py:50
+#: email/doctype/email_unsubscribe/email_unsubscribe.py:49
 msgid "{0} already unsubscribed for {1} {2}"
 msgstr ""
 
-#: utils/data.py:1709
+#: utils/data.py:1684
 msgid "{0} and {1}"
 msgstr ""
 
@@ -37229,11 +38583,11 @@ msgstr ""
 msgid "{0} are currently {1}"
 msgstr ""
 
-#: printing/doctype/print_format/print_format.py:89
+#: printing/doctype/print_format/print_format.py:87
 msgid "{0} are required"
 msgstr ""
 
-#: desk/form/assign_to.py:289
+#: desk/form/assign_to.py:283
 msgid "{0} assigned a new task {1} {2} to you"
 msgstr ""
 
@@ -37246,7 +38600,7 @@ msgctxt "Form timeline"
 msgid "{0} attached {1}"
 msgstr ""
 
-#: core/doctype/system_settings/system_settings.py:139
+#: core/doctype/system_settings/system_settings.py:140
 msgid "{0} can not be more than {1}"
 msgstr ""
 
@@ -37259,7 +38613,7 @@ msgctxt "Form timeline"
 msgid "{0} cancelled this document {1}"
 msgstr ""
 
-#: public/js/form_builder/store.js:185
+#: public/js/form_builder/store.js:190
 msgid "{0} cannot be hidden and mandatory without any default value"
 msgstr ""
 
@@ -37284,7 +38638,7 @@ msgctxt "Form timeline"
 msgid "{0} changed {1} to {2}"
 msgstr ""
 
-#: website/doctype/blog_post/blog_post.py:380
+#: website/doctype/blog_post/blog_post.py:376
 msgid "{0} comments"
 msgstr ""
 
@@ -37336,11 +38690,11 @@ msgstr ""
 msgid "{0} does not exist in row {1}"
 msgstr ""
 
-#: database/mariadb/schema.py:131 database/postgres/schema.py:184
+#: database/mariadb/schema.py:126 database/postgres/schema.py:178
 msgid "{0} field cannot be set as unique in {1}, as there are non-unique existing values"
 msgstr ""
 
-#: core/doctype/data_import/importer.py:1017
+#: core/doctype/data_import/importer.py:1012
 msgid "{0} format could not be determined from the values in this column. Defaulting to {1}."
 msgstr ""
 
@@ -37372,19 +38726,19 @@ msgstr ""
 msgid "{0} h"
 msgstr ""
 
-#: core/doctype/user_permission/user_permission.py:76
+#: core/doctype/user_permission/user_permission.py:77
 msgid "{0} has already assigned default value for {1}."
 msgstr ""
 
-#: email/doctype/newsletter/newsletter.py:382
+#: email/doctype/newsletter/newsletter.py:380
 msgid "{0} has been successfully added to the Email Group."
 msgstr ""
 
-#: email/queue.py:127
+#: email/queue.py:123
 msgid "{0} has left the conversation in {1} {2}"
 msgstr ""
 
-#: __init__.py:2427
+#: __init__.py:2458
 msgid "{0} has no versions tracked."
 msgstr ""
 
@@ -37401,19 +38755,19 @@ msgstr ""
 msgid "{0} in row {1} cannot have both URL and child items"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:912
+#: core/doctype/doctype/doctype.py:913
 msgid "{0} is a mandatory field"
 msgstr ""
 
-#: core/doctype/file/file.py:503
+#: core/doctype/file/file.py:502
 msgid "{0} is a not a valid zip file"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1555
+#: core/doctype/doctype/doctype.py:1553
 msgid "{0} is an invalid Data field."
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:147
+#: automation/doctype/auto_repeat/auto_repeat.py:148
 msgid "{0} is an invalid email address in 'Recipients'"
 msgstr ""
 
@@ -37450,15 +38804,15 @@ msgstr ""
 msgid "{0} is like {1}"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:169
+#: email/doctype/email_account/email_account.py:176
 msgid "{0} is mandatory"
 msgstr ""
 
-#: core/doctype/document_naming_rule/document_naming_rule.py:49
+#: core/doctype/document_naming_rule/document_naming_rule.py:50
 msgid "{0} is not a field of doctype {1}"
 msgstr ""
 
-#: www/printview.py:350
+#: www/printview.py:353
 msgid "{0} is not a raw printing format."
 msgstr ""
 
@@ -37470,7 +38824,7 @@ msgstr ""
 msgid "{0} is not a valid DocType for Dynamic Link"
 msgstr ""
 
-#: email/doctype/email_group/email_group.py:130 utils/__init__.py:189
+#: email/doctype/email_group/email_group.py:131 utils/__init__.py:189
 msgid "{0} is not a valid Email Address"
 msgstr ""
 
@@ -37482,23 +38836,23 @@ msgstr ""
 msgid "{0} is not a valid Phone Number"
 msgstr ""
 
-#: model/workflow.py:186
+#: model/workflow.py:182
 msgid "{0} is not a valid Workflow State. Please update your Workflow and try again."
 msgstr ""
 
-#: permissions.py:798
+#: permissions.py:791
 msgid "{0} is not a valid parent DocType for {1}"
 msgstr ""
 
-#: permissions.py:818
+#: permissions.py:811
 msgid "{0} is not a valid parentfield for {1}"
 msgstr ""
 
-#: email/doctype/auto_email_report/auto_email_report.py:109
+#: email/doctype/auto_email_report/auto_email_report.py:115
 msgid "{0} is not a valid report format. Report format should one of the following {1}"
 msgstr ""
 
-#: core/doctype/file/file.py:483
+#: core/doctype/file/file.py:482
 msgid "{0} is not a zip file"
 msgstr ""
 
@@ -37518,7 +38872,7 @@ msgstr ""
 msgid "{0} is not set"
 msgstr ""
 
-#: printing/doctype/print_format/print_format.py:166
+#: printing/doctype/print_format/print_format.py:163
 msgid "{0} is now default print format for {1} doctype"
 msgstr ""
 
@@ -37526,8 +38880,8 @@ msgstr ""
 msgid "{0} is one of {1}"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:263 model/naming.py:201
-#: printing/doctype/print_format/print_format.py:93 utils/csvutils.py:131
+#: email/doctype/email_account/email_account.py:277 model/naming.py:199
+#: printing/doctype/print_format/print_format.py:90 utils/csvutils.py:131
 msgid "{0} is required"
 msgstr ""
 
@@ -37560,7 +38914,7 @@ msgstr ""
 msgid "{0} m"
 msgstr ""
 
-#: desk/notifications.py:373
+#: desk/notifications.py:375
 msgid "{0} mentioned you in a comment in {1} {2}"
 msgstr ""
 
@@ -37572,7 +38926,7 @@ msgstr ""
 msgid "{0} months ago"
 msgstr ""
 
-#: model/document.py:1564
+#: model/document.py:1568
 msgid "{0} must be after {1}"
 msgstr ""
 
@@ -37588,25 +38942,25 @@ msgstr ""
 msgid "{0} must be unique"
 msgstr ""
 
-#: core/doctype/language/language.py:42
+#: core/doctype/language/language.py:43
 msgid ""
 "{0} must begin and end with a letter and can only contain letters,\n"
 "\t\t\t\thyphen or underscore."
 msgstr ""
 
-#: workflow/doctype/workflow/workflow.py:93
+#: workflow/doctype/workflow/workflow.py:91
 msgid "{0} not a valid State"
 msgstr ""
 
-#: model/rename_doc.py:388
+#: model/rename_doc.py:380
 msgid "{0} not allowed to be renamed"
 msgstr ""
 
-#: desk/doctype/desktop_icon/desktop_icon.py:371
+#: desk/doctype/desktop_icon/desktop_icon.py:365
 msgid "{0} not found"
 msgstr ""
 
-#: core/doctype/report/report.py:416 public/js/frappe/list/list_view.js:956
+#: core/doctype/report/report.py:413 public/js/frappe/list/list_view.js:956
 msgid "{0} of {1}"
 msgstr ""
 
@@ -37618,12 +38972,12 @@ msgstr ""
 msgid "{0} of {1} sent"
 msgstr ""
 
-#: utils/data.py:1529
+#: utils/data.py:1504
 msgctxt "Money in words"
 msgid "{0} only."
 msgstr ""
 
-#: utils/data.py:1699
+#: utils/data.py:1674
 msgid "{0} or {1}"
 msgstr ""
 
@@ -37643,7 +38997,7 @@ msgstr ""
 msgid "{0} records deleted"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:225
+#: public/js/frappe/data_import/data_exporter.js:228
 msgid "{0} records will be exported"
 msgstr ""
 
@@ -37671,7 +39025,11 @@ msgstr ""
 msgid "{0} reverted {1}"
 msgstr ""
 
-#: desk/query_report.py:583
+#: public/js/frappe/roles_editor.js:62
+msgid "{0} role does not have permission on any doctype"
+msgstr ""
+
+#: desk/query_report.py:576
 msgid "{0} saved successfully"
 msgstr ""
 
@@ -37679,23 +39037,23 @@ msgstr ""
 msgid "{0} self assigned this task: {1}"
 msgstr ""
 
-#: share.py:238
+#: share.py:233
 msgid "{0} shared a document {1} {2} with you"
 msgstr ""
 
-#: core/doctype/docshare/docshare.py:79
+#: core/doctype/docshare/docshare.py:77
 msgid "{0} shared this document with everyone"
 msgstr ""
 
-#: core/doctype/docshare/docshare.py:82
+#: core/doctype/docshare/docshare.py:80
 msgid "{0} shared this document with {1}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:316
+#: core/doctype/doctype/doctype.py:315
 msgid "{0} should be indexed because it's referred in dashboard connections"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:136
+#: automation/doctype/auto_repeat/auto_repeat.py:137
 msgid "{0} should not be same as {1}"
 msgstr ""
 
@@ -37708,22 +39066,22 @@ msgctxt "Form timeline"
 msgid "{0} submitted this document {1}"
 msgstr ""
 
-#: email/doctype/email_group/email_group.py:61
-#: email/doctype/email_group/email_group.py:132
+#: email/doctype/email_group/email_group.py:62
+#: email/doctype/email_group/email_group.py:133
 msgid "{0} subscribers added"
 msgstr ""
 
-#: email/queue.py:70
+#: email/queue.py:68
 msgid "{0} to stop receiving emails of this type"
 msgstr ""
 
 #: public/js/frappe/form/controls/date_range.js:46
 #: public/js/frappe/form/controls/date_range.js:62
-#: public/js/frappe/form/formatters.js:218
+#: public/js/frappe/form/formatters.js:234
 msgid "{0} to {1}"
 msgstr ""
 
-#: core/doctype/docshare/docshare.py:91
+#: core/doctype/docshare/docshare.py:89
 msgid "{0} un-shared this document with {1}"
 msgstr ""
 
@@ -37763,19 +39121,19 @@ msgstr ""
 msgid "{0} {1} added to Dashboard {2}"
 msgstr ""
 
-#: model/base_document.py:581 model/rename_doc.py:112
+#: model/base_document.py:581 model/rename_doc.py:110
 msgid "{0} {1} already exists"
 msgstr ""
 
-#: model/base_document.py:892
+#: model/base_document.py:898
 msgid "{0} {1} cannot be \"{2}\". It should be one of \"{3}\""
 msgstr ""
 
-#: utils/nestedset.py:343
+#: utils/nestedset.py:337
 msgid "{0} {1} cannot be a leaf node as it has children"
 msgstr ""
 
-#: model/rename_doc.py:377
+#: model/rename_doc.py:371
 msgid "{0} {1} does not exist, select a new target to merge"
 msgstr ""
 
@@ -37783,51 +39141,51 @@ msgstr ""
 msgid "{0} {1} is linked with the following submitted documents: {2}"
 msgstr ""
 
-#: model/document.py:170 permissions.py:569
+#: model/document.py:173 permissions.py:564
 msgid "{0} {1} not found"
 msgstr ""
 
-#: model/delete_doc.py:231
+#: model/delete_doc.py:232
 msgid "{0} {1}: Submitted Record cannot be deleted. You must {2} Cancel {3} it first."
 msgstr ""
 
-#: model/base_document.py:1007
+#: model/base_document.py:1013
 msgid "{0}, Row {1}"
 msgstr ""
 
-#: model/base_document.py:1012
+#: model/base_document.py:1018
 msgid "{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1737
+#: core/doctype/doctype/doctype.py:1735
 msgid "{0}: Cannot set Amend without Cancel"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1755
+#: core/doctype/doctype/doctype.py:1753
 msgid "{0}: Cannot set Assign Amend if not Submittable"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1753
+#: core/doctype/doctype/doctype.py:1751
 msgid "{0}: Cannot set Assign Submit if not Submittable"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1732
+#: core/doctype/doctype/doctype.py:1730
 msgid "{0}: Cannot set Cancel without Submit"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1739
+#: core/doctype/doctype/doctype.py:1737
 msgid "{0}: Cannot set Import without Create"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1735
+#: core/doctype/doctype/doctype.py:1733
 msgid "{0}: Cannot set Submit, Cancel, Amend without Write"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1759
+#: core/doctype/doctype/doctype.py:1757
 msgid "{0}: Cannot set import as {1} is not importable"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:393
+#: automation/doctype/auto_repeat/auto_repeat.py:394
 msgid "{0}: Failed to attach new recurring document. To enable attaching document in the auto repeat notification email, enable {1} in Print Settings"
 msgstr ""
 
@@ -37847,15 +39205,15 @@ msgstr ""
 msgid "{0}: Fieldname {1} appears multiple times in rows {2}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1358
+#: core/doctype/doctype/doctype.py:1360
 msgid "{0}: Fieldtype {1} for {2} cannot be unique"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1694
+#: core/doctype/doctype/doctype.py:1690
 msgid "{0}: No basic permissions set"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1708
+#: core/doctype/doctype/doctype.py:1704
 msgid "{0}: Only one rule allowed with the same Role, Level and {1}"
 msgstr ""
 
@@ -37871,7 +39229,11 @@ msgstr ""
 msgid "{0}: Options {1} must be the same as doctype name {2} for the field {3}"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:1723
+#: public/js/frappe/form/workflow.js:45
+msgid "{0}: Other permission rules may also apply"
+msgstr ""
+
+#: core/doctype/doctype/doctype.py:1719
 msgid "{0}: Permission at level 0 must be set before higher levels are set"
 msgstr ""
 
@@ -37889,7 +39251,7 @@ msgstr ""
 msgid "{0}: {1}"
 msgstr ""
 
-#: workflow/doctype/workflow_action/workflow_action.py:172
+#: workflow/doctype/workflow_action/workflow_action.py:167
 msgid "{0}: {1} is set to state {2}"
 msgstr ""
 
@@ -37925,32 +39287,32 @@ msgstr ""
 msgid "{} Complete"
 msgstr ""
 
-#: utils/data.py:2412
+#: utils/data.py:2397
 msgid "{} Invalid python code on line {}"
 msgstr ""
 
-#: utils/data.py:2421
+#: utils/data.py:2406
 msgid "{} Possibly invalid python code. <br>{}"
 msgstr ""
 
-#: core/doctype/log_settings/log_settings.py:54
+#: core/doctype/log_settings/log_settings.py:55
 msgid "{} does not support automated log clearing."
 msgstr ""
 
-#: core/doctype/audit_trail/audit_trail.py:40
+#: core/doctype/audit_trail/audit_trail.py:41
 msgid "{} field cannot be empty."
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:193
 #: email/doctype/email_account/email_account.py:200
+#: email/doctype/email_account/email_account.py:208
 msgid "{} has been disabled. It can only be enabled if {} is checked."
 msgstr ""
 
-#: utils/data.py:123
+#: utils/data.py:124
 msgid "{} is not a valid date string."
 msgstr ""
 
-#: commands/utils.py:532
+#: commands/utils.py:528
 msgid "{} not found in PATH! This is required to access the console."
 msgstr ""
 
@@ -37958,7 +39320,7 @@ msgstr ""
 msgid "{} not found in PATH! This is required to restore the database."
 msgstr ""
 
-#: utils/backups.py:445
+#: utils/backups.py:439
 msgid "{} not found in PATH! This is required to take a backup."
 msgstr ""
 


### PR DESCRIPTION
So far, we didn't extract translatable strings from JS template strings like this: 

```javascript
let test = `<p>${__("Test" null, "Optional context")}</p>`;
```

Since this feels natural in JS and is used quite a lot, we should support it.