### PR TITLE
refactor: Add "Mail" option to communication_medium field in Communication

### DIFF
--- a/frappe/core/doctype/communication/communication.json
+++ b/frappe/core/doctype/communication/communication.json
@@ -79,7 +79,7 @@
    "fieldname": "communication_medium",
    "fieldtype": "Select",
    "label": "Type",
-   "options": "\nEmail\nChat\nPhone\nSMS\nEvent\nMeeting\nVisit\nOther"
+   "options": "\nEmail\nChat\nPhone\nSMS\nMail\nEvent\nMeeting\nVisit\nOther"
   },
   {
    "depends_on": "eval:doc.communication_medium===\"Email\"",


### PR DESCRIPTION
Added "Mail" option to communication_medium field in Communication to accommodate postal mail.

This is a minor change to facilitate the Mail app I am developing. The mail app, which could be pulled into frappe core, if desired, allows for sending letters, postcards, cheques etc via postal mail either via third-party APIs (Postgrid to start with) and/or manually. 


