### PR TITLE
fix: keep order in `get_values_from_single`

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -688,16 +688,18 @@ class Database:
 
 			if not run:
 				return r
-			if as_dict:
-				if r:
-					r = frappe._dict(r)
-					if update:
-						r.update(update)
-					return [r]
-				else:
-					return []
-			else:
-				return r and [[i[1] for i in r]] or []
+
+			if not r:
+				return []
+
+			r = frappe._dict(r)
+			if update:
+				r.update(update)
+
+			if not as_dict:
+				return [[r.get(field) for field in fields]]
+
+			return [r]
 
 	def get_singles_dict(self, doctype, debug=False, *, for_update=False, cast=False):
 		"""Get Single DocType as dict.

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -183,6 +183,13 @@ class TestDB(FrappeTestCase):
 		# teardown
 		clear_custom_fields("Print Settings")
 
+	def test_get_single_value_destructuring(self):
+		[[lang, date_format]] = frappe.db.get_values_from_single(
+			["language", "date_format"], None, "System Settings"
+		)
+		self.assertEqual(lang, frappe.db.get_single_value("System Settings", "language"))
+		self.assertEqual(date_format, frappe.db.get_single_value("System Settings", "date_format"))
+
 	def test_log_touched_tables(self):
 		frappe.flags.in_migrate = True
 		frappe.flags.touched_tables = set()


### PR DESCRIPTION
Before:

```python
In [1]: frappe.db.get_values_from_single(["language", "date_format"], None, "System Settings")
Out[1]: [['dd-mm-yyyy', 'de']]

In [2]: frappe.db.get_values_from_single(["does_not_exist", "date_format"], None, "System Settings")
Out[2]: [['dd-mm-yyyy']]
```

After:

```python
In [1]: frappe.db.get_values_from_single(["language", "date_format"], None, "System Settings")
Out[1]: [['de', 'dd-mm-yyyy']]

In [2]: frappe.db.get_values_from_single(["does_not_exist", "date_format"], None, "System Settings")
Out[2]: [[None, 'dd-mm-yyyy']]
```