### PR TITLE
fix: awesome-bar math functionality doesn't respect localized number format, can‘t cope with commas

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -344,6 +344,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				txt = txt.substr(1);
 			}
 			try {
+				txt = txt.replace(/(\d{1,3},)/g, (match, p1) => p1.replace(',', ''));
 				var val = eval(txt);
 				var formatted_value = __("{0} = {1}", [txt, (val + "").bold()]);
 				this.options.push({

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -344,7 +344,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 				txt = txt.substr(1);
 			}
 			try {
-				txt = txt.replace(/(\d{1,3},)/g, (match, p1) => p1.replace(',', ''));
+				txt = txt.replace(/(\d{1,3},)/g, (match, p1) => p1.replace(",", ""));
 				var val = eval(txt);
 				var formatted_value = __("{0} = {1}", [txt, (val + "").bold()]);
 				this.options.push({


### PR DESCRIPTION
### Issues
- closes #22219

### Changes Proposed
- before calculating the expression in a string by the eval method, replace the `,` with  ` ` to resolve that

Before
![image](https://github.com/frappe/frappe/assets/48467846/1b0dd23d-9fa2-46d8-9173-72d56046a302)

After
![image](https://github.com/frappe/frappe/assets/48467846/08afe9d7-f1b4-43fe-8b31-41b181134fe1)
