### PR TITLE
fix: ensure has_value_changed works for Datetime, Date and Time fields

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -4,7 +4,6 @@ import hashlib
 import json
 import time
 from collections.abc import Generator, Iterable
-from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Optional
 
 from werkzeug.exceptions import NotFound
@@ -456,6 +455,8 @@ class Document(BaseDocument):
 
 	def has_value_changed(self, fieldname):
 		"""Return True if value has changed before and after saving."""
+		from datetime import date, datetime, timedelta
+
 		previous = self.get_doc_before_save()
 
 		if not previous:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import time
 from collections.abc import Generator, Iterable
+from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Optional
 
 from werkzeug.exceptions import NotFound
@@ -22,7 +23,7 @@ from frappe.model.utils import is_virtual_doctype
 from frappe.model.workflow import set_workflow_state_on_action, validate_workflow
 from frappe.types import DF
 from frappe.utils import compare, cstr, date_diff, file_lock, flt, now
-from frappe.utils.data import get_absolute_url
+from frappe.utils.data import get_absolute_url, get_datetime, get_timedelta, getdate
 from frappe.utils.global_search import update_global_search
 
 if TYPE_CHECKING:
@@ -456,7 +457,21 @@ class Document(BaseDocument):
 	def has_value_changed(self, fieldname):
 		"""Return True if value has changed before and after saving."""
 		previous = self.get_doc_before_save()
-		return previous.get(fieldname) != self.get(fieldname) if previous else True
+
+		if not previous:
+			return True
+
+		previous_value = previous.get(fieldname)
+		current_value = self.get(fieldname)
+
+		if isinstance(previous_value, datetime):
+			current_value = get_datetime(current_value)
+		elif isinstance(previous_value, date):
+			current_value = getdate(current_value)
+		elif isinstance(previous_value, timedelta):
+			current_value = get_timedelta(current_value)
+
+		return previous_value != current_value
 
 	def set_new_name(self, force=False, set_name=None, set_child_names=True):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -101,8 +101,13 @@ class TestDocument(FrappeTestCase):
 	def test_value_changed(self):
 		d = self.test_insert()
 		d.subject = "subject changed again"
-		d.save()
+		d.load_doc_before_save()
+		d.update_modified()
+
 		self.assertTrue(d.has_value_changed("subject"))
+		self.assertTrue(d.has_value_changed("modified"))
+
+		self.assertFalse(d.has_value_changed("creation"))
 		self.assertFalse(d.has_value_changed("event_type"))
 
 	def test_mandatory(self):

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -605,6 +605,7 @@ class TestDateUtils(FrappeTestCase):
 		self.assertIsInstance(get_timedelta(str(datetime_input)), timedelta)
 		self.assertIsInstance(get_timedelta(str(timedelta_input)), timedelta)
 		self.assertIsInstance(get_timedelta(str(time_input)), timedelta)
+		self.assertIsInstance(get_timedelta(get_timedelta("100:2:12")), timedelta)
 
 	def test_to_timedelta(self):
 		self.assertEqual(to_timedelta("00:00:01"), timedelta(seconds=1))

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -161,13 +161,13 @@ def get_datetime(
 		return parser.parse(datetime_str)
 
 
-def get_timedelta(time: str | None = None) -> datetime.timedelta | None:
+def get_timedelta(time: str | datetime.timedelta | None = None) -> datetime.timedelta | None:
 	"""Return `datetime.timedelta` object from string value of a valid time format.
 
 	Return None if `time` is not a valid format.
 
 	Args:
-	        time (str): A valid time representation. This string is parsed
+	        time (str | datetime.timedelta): A valid time representation. This string is parsed
 	        using `dateutil.parser.parse`. Examples of valid inputs are:
 	        '0:0:0', '17:21:00', '2012-01-19 17:21:00'. Checkout
 	        https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse
@@ -175,6 +175,9 @@ def get_timedelta(time: str | None = None) -> datetime.timedelta | None:
 	Return:
 	        datetime.timedelta: Timedelta object equivalent of the passed `time` string
 	"""
+	if isinstance(time, datetime.timedelta):
+		return time
+
 	time = time or "0:0:0"
 
 	try:


### PR DESCRIPTION
`self.get(fieldname)` may return a `str` for **Datetime**, **Data** and **Time** fields and should be converted to `datetime`, `date` resp. `timedelta` objects before comparison.