### PR TITLE
fix: send_workflow_action_email

### DIFF
--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -329,7 +329,7 @@ def get_users_next_action_data(transitions, doc):
 	def user_has_permission(user: str) -> bool:
 		from frappe.permissions import has_permission
 
-		return has_permission(doctype=doc, user=user, print_logs=False)
+		return has_permission(doctype=doc, user=user)
 
 	for transition in transitions:
 		users = get_users_with_role(transition.allowed)
@@ -380,10 +380,10 @@ def send_workflow_action_email(doc, transitions):
 	users_data = get_users_next_action_data(transitions, doc)
 	common_args = get_common_email_args(doc)
 	message = common_args.pop("message", None)
-	for d in users_data:
+	for user, data in users_data.items():
 		email_args = {
-			"recipients": [d.get("email")],
-			"args": {"actions": list(deduplicate_actions(d.get("possible_actions"))), "message": message},
+			"recipients": [data.get("email")],
+			"args": {"actions": list(deduplicate_actions(data.get("possible_actions"))), "message": message},
 			"reference_name": doc.name,
 			"reference_doctype": doc.doctype,
 		}

--- a/frappe/workflow/doctype/workflow_action/workflow_action.py
+++ b/frappe/workflow/doctype/workflow_action/workflow_action.py
@@ -380,7 +380,7 @@ def send_workflow_action_email(doc, transitions):
 	users_data = get_users_next_action_data(transitions, doc)
 	common_args = get_common_email_args(doc)
 	message = common_args.pop("message", None)
-	for user, data in users_data.items():
+	for user, data in users_data.items():  # noqa: B007
 		email_args = {
 			"recipients": [data.get("email")],
 			"args": {"actions": list(deduplicate_actions(data.get("possible_actions"))), "message": message},


### PR DESCRIPTION
Version 15:

Frappe Framework: v15.14.0 (version-15)
ERPNext: v15.14.2 (version-15)

fixes: https://discuss.frappe.io/t/workflow-email-next-state-not-being-sent/117262

___

- When you enable "Send Email Alert" in the workflow, emails aren't being sent, and there's an error message saying "has_permission() got an unexpected keyword argument 'print_logs'."

- and another Issue is likely with the users_data dictionary. When you iterate over it using for d in users_data:, d represents the key of each dictionary entry, which is a string (the user's name). So when you try to access d.get("email"), it's trying to treat the string d as a dictionary, which results in the error.


https://github.com/frappe/frappe/assets/141945075/d5146c99-0f51-4cc3-b9b0-ecc2e3babec3

Thank You!