### PR TITLE
fix: filter dropdown icon

### DIFF
--- a/frappe/public/scss/desk/frappe_datatable.scss
+++ b/frappe/public/scss/desk/frappe_datatable.scss
@@ -8,7 +8,7 @@
 	--dt-text-light: var(--text-light);
 	--dt-spacer-1: 0.25rem;
 	--dt-spacer-2: var(--padding-xs);
-	--dt-spacer-3: 1rem;
+	--dt-spacer-3: 1.5rem;
 	--dt-border-radius: var(--border-radius);
 	--dt-cell-bg: var(--fg-color);
 	--dt-border-color: var(--table-border-color);


### PR DESCRIPTION
Version 15 and Version 14 latest 

fixes: #15871

- When you look at reports, the titles of the columns may seem hidden on the right side when you hover over the filter dropdown icon.

**Before:**

- Only shown the "Delivered Qt"

<img width="1440" alt="Screenshot 2024-02-20 at 2 15 18 PM" src="https://github.com/frappe/frappe/assets/141945075/335bed0d-dadb-4515-9b0d-a7ae376f135b">


**After:**

- Now will show the full title name.

https://github.com/frappe/frappe/assets/141945075/156e727c-dec0-4ad6-bcea-4f2e8e207883

Thank You!