### PR TITLE
fix: data_type handling in frappe.call

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -122,6 +122,7 @@ frappe.call = function (opts) {
 		silent: opts.silent,
 		api_version: opts.api_version,
 		url,
+		dataType: opts.data_type,
 	});
 };
 
@@ -279,7 +280,7 @@ frappe.request.call = function (opts) {
 	return $.ajax(ajax_args)
 		.done(function (data, textStatus, xhr) {
 			try {
-				if (typeof data === "string") data = JSON.parse(data);
+				if (typeof data === "string" && ajax_args.dataType === "json") data = JSON.parse(data);
 
 				// sync attached docs
 				if (data.docs || data.docinfo) {


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

<!-- You can skip this if you're fixing a typo or updating existing documentation -->


<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->


<!-- Add images/recordings to better visualize the change: expected/current behviour -->

Using `frappe.call` on an API that does not return JSON data (such as `frappe.utils.print_format.download_pdf`) causes AJAX to throw a parse error. 

Within `frappe.request.call` there is a line to set the dataType argument for AJAX to be that of `opts.dataType || "json"` However, `frappe.call` does not pass down a dataType to `frappe.request.call`, so `opts.dataType` is always undefined and json always used -- even if the API does not return JSON.

This change, then
1. Adds support for `data_type` to `frappe.call`s `opts` object which is then passed down to `frappe.request.call`
1. `frappe.request.call` attempts to run `json.parse` on the response if the type is a string, this throws an error if the response is a string that is not a representation of JSON, so add and extra condition to only do the parse if the response type is a string and the dataType is JSON.