### PR TITLE
feat(web): Add dynamic web template fields

### DIFF
--- a/frappe/website/doctype/web_template/web_template.py
+++ b/frappe/website/doctype/web_template/web_template.py
@@ -124,6 +124,15 @@ class WebTemplate(Document):
 			values = {}
 		values = frappe.parse_json(values)
 		values.update({"values": values})
+
+		dynamic_values = {}
+		for field in self.get("fields", {"dynamic_template": 1}):
+			k = field.fieldname
+			if k in values:
+				dynamic_values[k] = frappe.render_template(values[k], values)
+
+		values.update(dynamic_values)
+
 		template = self.get_template(self.standard)
 
 		return frappe.render_template(template, values)

--- a/frappe/website/doctype/web_template_field/web_template_field.json
+++ b/frappe/website/doctype/web_template_field/web_template_field.json
@@ -9,6 +9,7 @@
   "fieldname",
   "fieldtype",
   "reqd",
+  "dynamic_template",
   "options",
   "default"
  ],
@@ -50,11 +51,18 @@
    "fieldname": "default",
    "fieldtype": "Small Text",
    "label": "Default"
+  },
+  {
+   "default": "0",
+   "fieldname": "dynamic_template",
+   "fieldtype": "Check",
+   "label": "Dynamic Template",
+   "depends_on": "eval:doc.fieldtype?.match?.(/Data|Text|Editor/)"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-10-26 17:38:40.798713",
+ "modified": "2024-02-20 12:01:55.162363",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Template Field",
@@ -63,5 +71,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/frappe/website/doctype/web_template_field/web_template_field.py
+++ b/frappe/website/doctype/web_template_field/web_template_field.py
@@ -15,6 +15,7 @@ class WebTemplateField(Document):
 		from frappe.types import DF
 
 		default: DF.SmallText | None
+		dynamic_template: DF.Check
 		fieldname: DF.Data | None
 		fieldtype: DF.Literal[
 			"Attach Image",


### PR DESCRIPTION
When checking the "Dynamic template" option in the field of a Web Template, it's content will be rendered before rendering the whole web block.

For example, checking the option for the Markdown web template would allow users of this block (in a Web Page) to use Jinja templates inside the text.
