### PR TITLE
fix: patch unordered list

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -305,6 +305,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 		let value = this.quill ? this.quill.root.innerHTML : "";
 		// hack to retain space sequence.
 		value = value.replace(/(\s)(\s)/g, " &nbsp;");
+		value = this.patch_unordered_list(value);
 
 		try {
 			if (!$(value).find(".ql-editor").length) {
@@ -315,6 +316,33 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 		}
 
 		return value;
+	}
+
+	patch_unordered_list(value) {
+		/*
+		Quill uses the <ol> element for ordered AND unordered lists. Unordered
+		lists are identified by the data-list attribute. This creates problems
+		when cleaning up the html and the style of the list is lost.
+
+		To fix this, we convert the unordered lists to <ul> elements.
+		*/
+		const valueElement = document.createElement("div");
+		valueElement.innerHTML = value;
+
+		const firstBulletLiElements = valueElement.querySelectorAll(
+			"ol li[data-list=bullet]:first-child"
+		);
+		firstBulletLiElements.forEach((li) => {
+			const parent = li.parentNode;
+			const children = Array.from(parent.children);
+			const ul = document.createElement("ul");
+			children.forEach((child) => {
+				ul.appendChild(child);
+			});
+			parent.parentNode.replaceChild(ul, parent);
+		});
+
+		return valueElement.innerHTML;
 	}
 
 	set_focus() {


### PR DESCRIPTION
Quill uses the `<ol>` element for ordered AND unordered lists. Unordered lists are identified by the `data-list` attribute and styled accordingly. However, this creates problems when using the HTML without Quill's stylesheets.

To fix this, we convert the unordered lists to use the correct `<ul>` elements.

We already had this patch in the past, but for some reason it was removed in https://github.com/frappe/frappe/pull/10598

### Before

https://github.com/frappe/frappe/assets/14891507/88d615c4-b859-46bb-9144-02406377d45c

### After

https://github.com/frappe/frappe/assets/14891507/fb0cec7f-e706-42ca-9faf-ccd669ff36a2
