### PR TITLE
fix: added important to bold class.

### DIFF
--- a/frappe/public/scss/desk/global.scss
+++ b/frappe/public/scss/desk/global.scss
@@ -340,7 +340,7 @@ select.input-xs {
 }
 
 .bold {
-	font-weight: 600;
+	font-weight: var(--weight-semibold) !important;
 }
 
 .text-color {


### PR DESCRIPTION
it is kind of unintuitive that we are adding semi-bold weight ( 600 ) to bold class :D
IMO, it also make sense to have !important to the bold class.

<img width="1041" alt="Screenshot 2024-02-21 at 11 29 56 AM" src="https://github.com/frappe/frappe/assets/39730881/48b5c25c-99d4-4d66-98dd-77adee9c16d7">
