### PR TITLE
fix: Private images in PDFs from background jobs

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -39,13 +39,18 @@ def make_test_doc(ignore_permissions=False):
 
 
 @contextmanager
-def make_test_image_file():
+def make_test_image_file(private=False):
 	file_path = frappe.get_app_path("frappe", "tests/data/sample_image_for_optimization.jpg")
 	with open(file_path, "rb") as f:
 		file_content = f.read()
 
 	test_file = frappe.get_doc(
-		{"doctype": "File", "file_name": "sample_image_for_optimization.jpg", "content": file_content}
+		{
+			"doctype": "File",
+			"file_name": "sample_image_for_optimization.jpg",
+			"content": file_content,
+			"is_private": private,
+		}
 	).insert()
 	# remove those flags
 	_test_file: "File" = frappe.get_doc("File", test_file.name)

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -411,3 +411,19 @@ def decode_file_content(content: bytes) -> bytes:
 	if b"," in content:
 		content = content.split(b",")[1]
 	return safe_b64decode(content)
+
+
+def find_file_by_url(path: str, name: str = None) -> Optional["File"]:
+	filters = {"file_url": str(path)}
+	if name:
+		filters["name"] = str(name)
+
+	files = frappe.get_all("File", filters=filters, fields="*")
+
+	# this file might be attached to multiple documents
+	# if the file is accessible from any one of those documents
+	# then it should be downloadable
+	for file_data in files:
+		file: "File" = frappe.get_doc(doctype="File", **file_data)
+		if file.is_downloadable():
+			return file

--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -6,6 +6,7 @@ from pypdf import PdfReader
 
 import frappe
 import frappe.utils.pdf as pdfgen
+from frappe.core.doctype.file.test_file import make_test_image_file
 from frappe.tests.utils import FrappeTestCase
 
 
@@ -50,3 +51,16 @@ class TestPdf(FrappeTestCase):
 		frappe.set_user("Administrator")
 		pdf = pdfgen.get_pdf(self.html)
 		self.assertTrue(pdf)
+
+	def test_private_images_in_pdf(self):
+		with make_test_image_file(private=True) as file:
+			html = f""" <div>
+				<img src="{file.file_url}" class='responsive'>
+				<img src="{file.unique_url}" class='responsive'>
+			</div>
+			"""
+
+			pdf = pdfgen.get_pdf(html)
+
+		# If image was actually retrieved then size will be  in few kbs, else bytes.
+		self.assertGreaterEqual(len(pdf), 10_000)


### PR DESCRIPTION
Private images currently render fine if PDF is generated during a
request as we pass the cookiejar to WKHTML.

Background jobs however fail completeley because they can't retrieve
private images without cookiejar. So this _never_ worked from background jobs. 

This PR converts all image types to base64 encoded sources in HTML
itself, so wkhtmltopdf doesn't have to a fire a request.

Tested locally.

TODO:
- [x] unit tests (somehow?)
- [x] test with different formats
- [x] exception handling/fallbacks


closes https://github.com/frappe/frappe/issues/21202