### PR TITLE
fix: patch QB before setup_module_map

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -299,11 +299,12 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	local.qb = get_query_builder(local.conf.db_type)
 	local.qb.get_query = get_query
 	setup_redis_cache_connection()
-	setup_module_map(include_all_apps=not (frappe.request or frappe.job or frappe.flags.in_migrate))
 
 	if not _qb_patched.get(local.conf.db_type):
 		patch_query_execute()
 		patch_query_aggregation()
+
+	setup_module_map(include_all_apps=not (frappe.request or frappe.job or frappe.flags.in_migrate))
 
 	local.initialised = True
 

--- a/frappe/query_builder/utils.py
+++ b/frappe/query_builder/utils.py
@@ -138,7 +138,6 @@ def patch_query_execute():
 	# To support running union queries
 	_SetOperation.run = execute_query
 	_SetOperation.walk = prepare_query
-	frappe._qb_patched[frappe.conf.db_type] = True
 
 
 def patch_query_aggregation():
@@ -149,4 +148,3 @@ def patch_query_aggregation():
 	frappe.qb.min = _min
 	frappe.qb.avg = _avg
 	frappe.qb.sum = _sum
-	frappe._qb_patched[frappe.conf.db_type] = True


### PR DESCRIPTION
This function if cache isn't available CAN result in a DB query, this
will cause cold starts to fail because QB is not yet patched.

Steps to reproduce:
1. Start bench without cache
2. Web server won't respond


```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 135, in handle
    self.handle_request(listener, req, client, addr)
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 178, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/middlewares.py", line 16, in __call__
    return super().__call__(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/werkzeug/middleware/shared_data.py", line 249, in __call__
    return self.app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/werkzeug/middleware/shared_data.py", line 249, in __call__
    return self.app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/app.py", line 74, in application
    app(environ, start_response),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 189, in application
    resp = f(*args[:-2] + (request,))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/app.py", line 128, in application
    response = handle_exception(e)
               ^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/app.py", line 318, in handle_exception
    allow_traceback = frappe.get_system_settings("allow_error_traceback") if frappe.db else False
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 2397, in get_system_settings
    local.system_settings = get_cached_doc("System Settings")
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 1234, in get_cached_doc
    doc = get_doc(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 1360, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 83, in get_doc
    controller = get_controller(doctype)
                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/model/base_document.py", line 71, in get_controller
    site_controllers[doctype] = import_controller(doctype)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/model/base_document.py", line 82, in import_controller
    doctype_info = frappe.db.get_value("DocType", doctype, fieldname="*")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 507, in get_value
    result = self.get_values(
             ^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 608, in get_values
    out = self._get_values_from_table(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ankush/benches/develop/apps/frappe/frappe/database/database.py", line 878, in _get_values_from_table
    return query.run(as_dict=as_dict, debug=debug, update=update, run=run, pluck=pluck)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'Field' object is not callable
```