### PR TITLE
fix: disable internal columns like _comments from report column selec…

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -896,7 +896,9 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 			.filter(standard_fields_filter);
 
 		// filter out docstatus field from picker
-		let std_fields = frappe.model.std_fields.filter((df) => df.fieldname !== "docstatus");
+		let std_fields = frappe.model.std_fields.filter(
+			(df) => df.fieldname !== "docstatus" && df.fieldname[0] !== "_"
+		);
 
 		// add status field derived from docstatus, if status is not a standard field
 		let has_status_values = false;

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -897,7 +897,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 
 		// filter out docstatus field from picker
 		let std_fields = frappe.model.std_fields.filter(
-			(df) => df.fieldname !== "docstatus" && df.fieldname[0] !== "_"
+			(df) => !["docstatus", "_comments"].includes(df.fieldname)
 		);
 
 		// add status field derived from docstatus, if status is not a standard field


### PR DESCRIPTION
1. The **Pick Columns** dialog of Report View shows internal fields like _comments, _user_tags, and _liked_by.
2. Adding **Comments** column to the report view does not display proper data as they are HTML and hence won’t render correctly in the report view. Even if you export it, it won’t be human-readable.

![image](https://github.com/frappe/frappe/assets/31363128/c21026b2-ccc6-45fe-bf23-ebc0c165f684)

**Fix:** Such fields will no longer appear in the Pick Columns dialog.