### PR TITLE
ci: fix ocassional patch test failure

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Run Patch Tests
         run: |
           cd ~/frappe-bench/
+          sed -i 's/^worker:/# worker:/g' Procfile
           wget https://frappeframework.com/files/v13-frappe.sql.gz
           bench --site test_site --force restore ~/frappe-bench/v13-frappe.sql.gz
 
@@ -126,6 +127,7 @@ jobs:
             git checkout -q -f $branch_name
 
             pgrep honcho | xargs kill
+            sleep 3
             rm -rf ~/frappe-bench/env
             bench -v setup env
             bench start &>> ~/frappe-bench/bench_start.log &
@@ -138,6 +140,7 @@ jobs:
 
           echo "Updating to last commit"
           pgrep honcho | xargs kill
+          sleep 3
           rm -rf ~/frappe-bench/env
           git checkout -q -f "$GITHUB_SHA"
           bench -v setup env


### PR DESCRIPTION
Some files in /env are touched during deletion which causes test to fail.

Hunch: running processes still not killed OR background jobs.
