### PR TITLE
feat: declare system dependencies for frappix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,18 @@ hypothesis = "~=6.77.0"
 responses = "==0.23.1"
 freezegun = "~=1.2.2"
 
+[tool.frappix]
+sys-dependencies = [
+    "mariadb",
+    "restic",
+    "wkhtmltopdf-bin",
+    "which",
+    "gzip",
+    "bash",
+    "redis",
+    "nodejs-18_x",
+]
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
# Context

The python code and framework depends on several system dependencies to run.

Similar, downstream applications may depend on extra system dependencies that
are currently not implemented in python.

# Proposed Solution

- Declare an extra tool section in pyproject that lets users transparently declare system dependencies
- The respective version will be resolved from a pinned package set
- Pinning that package set is a global contraint on a development environment or deployment and should not be left to the individual app
