### PR TITLE
fix: Guess currency from report row if available

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -234,8 +234,8 @@ export default class NumberCardWidget extends Widget {
 		// Whatever is left should be same in all objects
 		const common_doc = Object.assign({}, rows[0]);
 		rows.forEach((row) => {
-			for (const [key, value] of Object.entries(row)) {
-				if (value !== common_doc[key]) {
+			for (const [key, value] of Object.entries(common_doc)) {
+				if (value !== row[key]) {
 					delete common_doc[key];
 				}
 			}

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -213,19 +213,34 @@ export default class NumberCardWidget extends Widget {
 		}, []);
 		const col = res.columns.find((col) => col.fieldname == field);
 		this.number = frappe.report_utils.get_result_of_fn(this.card_doc.report_function, vals);
-		this.set_formatted_number(col);
+		this.set_formatted_number(col, this._generate_common_doc(res.result));
 	}
 
-	set_formatted_number(df) {
+	set_formatted_number(df, doc) {
 		const default_country = frappe.sys_defaults.country;
 		const shortened_number = frappe.utils.shorten_number(this.number, default_country, 5);
 		let number_parts = shortened_number.split(" ");
 
 		const symbol = number_parts[1] || "";
 		number_parts[0] = window.convert_old_to_new_number_format(number_parts[0]);
-		const formatted_number = $(frappe.format(number_parts[0], df)).text();
+		const formatted_number = $(frappe.format(number_parts[0], df, null, doc)).text();
 
 		this.formatted_number = formatted_number + " " + __(symbol);
+	}
+
+	_generate_common_doc(rows) {
+		if (!rows || !rows.length) return {};
+		// init with first doc, for each other doc if values are common then keep else discard
+		// Whatever is left should be same in all objects
+		const common_doc = Object.assign({}, rows[0]);
+		rows.forEach((row) => {
+			for (const [key, value] of Object.entries(row)) {
+				if (value !== common_doc[key]) {
+					delete common_doc[key];
+				}
+			}
+		});
+		return common_doc;
 	}
 
 	render_number() {


### PR DESCRIPTION
In number card using report the curency can be defined on a row in
report, but since we don't pass report data currency fields get
formatted with default currency of global company.

Fix:
- Use intersection of all results rows to generate a "common" document and pass it to formatter.


Before:
![image](https://github.com/frappe/frappe/assets/9079960/b791d192-113f-4eaa-afbb-3de5b8ad5507)


After:
![image](https://github.com/frappe/frappe/assets/9079960/0eaa14bc-5d34-40a9-bb8c-841878d157d0)


