### PR TITLE
fix: wrap read_only functions correctly

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -941,6 +941,7 @@ def is_whitelisted(method):
 
 def read_only():
 	def innfn(fn):
+		@functools.wraps(fn)
 		def wrapper_fn(*args, **kwargs):
 			# frappe.read_only could be called from nested functions, in such cases don't swap the
 			# connection again.

--- a/frappe/desk/notifications.py
+++ b/frappe/desk/notifications.py
@@ -241,7 +241,7 @@ def get_filters_for(doctype):
 
 @frappe.whitelist()
 @frappe.read_only()
-def get_open_count(doctype, name, items=None):
+def get_open_count(doctype: str, name: str, items=None):
 	"""Get count for internal and external links for given transactions
 
 	:param doctype: Reference DocType


### PR DESCRIPTION
`functools.wraps` preserves signature useful for introspection.
