### PR TITLE
fix: translation get label from fieldname

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -689,7 +689,7 @@ class BaseDocument:
 		"""
 		df = self.meta.get_field(fieldname)
 		if df:
-			return df.label
+			return _(df.label) if df.label else None
 
 	def update_modified(self):
 		"""Update modified timestamp"""


### PR DESCRIPTION
The labels of the fields in the message to show unique validation are not translatable.

<img width="1003" alt="Screenshot 2024-02-22 at 2 56 05 PM" src="https://github.com/frappe/frappe/assets/101831262/d00d7fad-dafa-44e7-9b57-32d2c518a1bc">



