### PR TITLE
fix: spelling of "recording" in button

### DIFF
--- a/frappe/core/doctype/recorder/recorder_list.js
+++ b/frappe/core/doctype/recorder/recorder_list.js
@@ -198,7 +198,7 @@ frappe.listview_settings["Recorder"] = {
 				});
 			},
 			__("Configure Recorder"),
-			__("Start Recordig")
+			__("Start Recording")
 		);
 	},
 

--- a/frappe/locale/ar.po
+++ b/frappe/locale/ar.po
@@ -30228,7 +30228,7 @@ msgid "Start Import"
 msgstr "بدء الاستيراد"
 
 #: core/doctype/recorder/recorder_list.js:201
-msgid "Start Recordig"
+msgid "Start Recording"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'

--- a/frappe/locale/de.po
+++ b/frappe/locale/de.po
@@ -30460,7 +30460,7 @@ msgid "Start Import"
 msgstr "Starten Sie den Import"
 
 #: core/doctype/recorder/recorder_list.js:201
-msgid "Start Recordig"
+msgid "Start Recording"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'

--- a/frappe/locale/es.po
+++ b/frappe/locale/es.po
@@ -30251,7 +30251,7 @@ msgid "Start Import"
 msgstr "Comience a Importar"
 
 #: core/doctype/recorder/recorder_list.js:201
-msgid "Start Recordig"
+msgid "Start Recording"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'

--- a/frappe/locale/fr.po
+++ b/frappe/locale/fr.po
@@ -30229,7 +30229,7 @@ msgid "Start Import"
 msgstr "Démarrer l'import"
 
 #: core/doctype/recorder/recorder_list.js:201
-msgid "Start Recordig"
+msgid "Start Recording"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'

--- a/frappe/locale/main.pot
+++ b/frappe/locale/main.pot
@@ -30284,7 +30284,7 @@ msgid "Start Import"
 msgstr ""
 
 #: core/doctype/recorder/recorder_list.js:201
-msgid "Start Recordig"
+msgid "Start Recording"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

The "Start Recording" button in recorder was spelled as "Recordig".

