### PR TITLE
fix: keep 3 recent versions of website themes around

### DIFF
--- a/frappe/website/doctype/website_theme/test_website_theme.py
+++ b/frappe/website/doctype/website_theme/test_website_theme.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 from contextlib import contextmanager
+from pathlib import Path
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -24,13 +25,17 @@ def website_theme_fixture(**theme):
 	theme.delete()
 
 
+def get_theme_file(theme):
+	return Path(frappe.get_site_path("public", theme.theme_url[1:]))
+
+
 class TestWebsiteTheme(FrappeTestCase):
 	def test_website_theme(self):
 		with website_theme_fixture(
 			google_font="Inter",
 			custom_scss="body { font-size: 16.5px; }",  # this will get minified!
 		) as theme:
-			theme_path = frappe.get_site_path("public", theme.theme_url[1:])
+			theme_path = get_theme_file(theme)
 			with open(theme_path) as theme_file:
 				css = theme_file.read()
 
@@ -43,6 +48,17 @@ class TestWebsiteTheme(FrappeTestCase):
 	def test_imports_to_ignore(self):
 		with website_theme_fixture(ignored_apps=[{"app": "frappe"}]) as theme:
 			self.assertTrue('@import "frappe/public/scss/website"' not in theme.theme_scss)
+
+	def test_backup_files(self):
+		with website_theme_fixture(custom_scss="body { font-size: 16.5px; }") as theme:
+			first = get_theme_file(theme)
+			second = get_theme_file(theme.save())
+			self.assertTrue(first.exists() and second.exists())
+
+			third = get_theme_file(theme.save())
+			fourth = get_theme_file(theme.save())
+			self.assertFalse(first.exists())
+			self.assertTrue(second.exists() and third.exists() and fourth.exists())
 
 	def test_after_migrate_hook(self):
 		with website_theme_fixture(google_font="Inter") as theme:

--- a/frappe/website/doctype/website_theme/website_theme.py
+++ b/frappe/website/doctype/website_theme/website_theme.py
@@ -4,6 +4,7 @@
 from os.path import abspath, splitext
 from os.path import exists as path_exists
 from os.path import join as join_path
+from pathlib import Path
 from typing import Optional
 
 import frappe
@@ -124,9 +125,15 @@ class WebsiteTheme(Document):
 	def delete_old_theme_files(self, folder_path):
 		import os
 
+		theme_files: list[Path] = []
 		for fname in os.listdir(folder_path):
 			if fname.startswith(frappe.scrub(self.name) + "_") and fname.endswith(".css"):
-				os.remove(os.path.join(folder_path, fname))
+				theme_files.append(Path(folder_path) / fname)
+
+		theme_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
+		# Keep 3 recent files
+		for old_file in theme_files[2:]:
+			old_file.unlink()
 
 	@frappe.whitelist()
 	def set_as_default(self):


### PR DESCRIPTION
For whatever unknown reason (https://github.com/frappe/frappe/issues/22205) website theme cache can be invalid or it might fail to generate correctly.

In such cases website becomes unusable, this PR tries to keep it usable.
