### PR TITLE
chore: replace PFB Beta link with Print Designer

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -184,13 +184,20 @@ frappe.ui.form.PrintView = class {
 		this.set_breadcrumbs();
 		this.setup_customize_dialog();
 
-		// print format builder beta
-		this.page.add_inner_message(`
-			<a style="line-height: 2.4" href="/app/print-format-builder-beta?doctype=${this.frm.doctype}">
-				${__("Try the new Print Format Builder")}
+		// print designer link
+		if (Object.keys(frappe.boot.versions).includes("print_designer")) {
+			this.page.add_inner_message(`
+			<a style="line-height: 2.4" href="/app/print-designer?doctype=${this.frm.doctype}">
+				${__("Try the new Print Designer")}
 			</a>
-		`);
-
+			`);
+		} else {
+			this.page.add_inner_message(`
+			<a style="line-height: 2.4" href="https://frappecloud.com/marketplace/apps/print_designer?utm_source=framework-desk&utm_medium=print-view&utm_campaign=try-link">
+				${__("Try the new Print Designer")}
+			</a>
+			`);
+		}
 		let tasks = [
 			this.set_default_print_format,
 			this.set_default_print_language,


### PR DESCRIPTION
Replaced Print Format Builder Beta link in print view to Print Designer. if App is installed it opens Print Designer, if not it opens Frappe Cloud Marketplace Link.


https://github.com/frappe/frappe/assets/39730881/3423c4d7-e87e-4670-b12c-d0d3f8d9cc67


https://github.com/frappe/frappe/assets/39730881/e70b6447-fd7f-4f46-b660-56e335cc2edc

