### PR TITLE
fix(File Uploader): "dialog.get_primary_btn is not a function"

### DIFF
--- a/frappe/public/js/frappe/file_uploader/FileUploader.vue
+++ b/frappe/public/js/frappe/file_uploader/FileUploader.vue
@@ -188,7 +188,7 @@
 				/>
 			</div>
 			<div class="flex align-center" v-if="show_upload_button && currently_uploading === -1">
-				<button class="btn btn-primary btn-sm margin-right" @click="upload_files">
+				<button class="btn btn-primary btn-sm margin-right" @click="() => upload_files()">
 					<span v-if="files.length === 1">
 						{{ __("Upload file") }}
 					</span>


### PR DESCRIPTION
Passing an event object to the `upload_files` function breaks it as a result of trying to call a non-existent `get_primary_btn` method. This PR makes the calling of said method optional.