### PR TITLE
feat: hook for print format template loader

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -162,8 +162,8 @@ def get_rendered_template(
 		def get_template_from_string():
 			return jenv.from_string(get_print_format(doc.doctype, print_format))
 
-		hook_func = frappe.get_hooks("get_print_format_template")
-		if len(hook_func):
+		template = None
+		if hook_func := frappe.get_hooks("get_print_format_template"):
 			template = frappe.get_attr(hook_func[-1])(jenv=jenv, print_format=print_format)
 
 		if template:

--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -162,7 +162,13 @@ def get_rendered_template(
 		def get_template_from_string():
 			return jenv.from_string(get_print_format(doc.doctype, print_format))
 
-		if print_format.custom_format:
+		hook_func = frappe.get_hooks("get_print_format_template")
+		if len(hook_func):
+			template = frappe.get_attr(hook_func[-1])(jenv=jenv, print_format=print_format)
+
+		if template:
+			pass
+		elif print_format.custom_format:
 			template = get_template_from_string()
 
 		elif print_format.format_data:


### PR DESCRIPTION
currently logic for how print format template should be loaded is hardcoded added hook to allow for custom logic to be implemented by other apps.

if hook returns falsy value, then default logic will be used.

`no-docs`