### PR TITLE
fix: show tooltip on edit table row

### DIFF
--- a/cypress/integration/form.js
+++ b/cypress/integration/form.js
@@ -138,7 +138,7 @@ context("Form", () => {
 						);
 					});
 
-				cy.get("@table").find('[data-idx="1"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="1"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get("@table-form")
 					.find('.frappe-control[data-fieldname="is_primary_phone"]')
@@ -146,7 +146,7 @@ context("Form", () => {
 				cy.get("@table-form").find(".grid-footer-toolbar").click();
 
 				// set property on form_render event of child table
-				cy.get("@table").find('[data-idx="1"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="1"] .btn-open-row').click();
 				cy.get("@table")
 					.find('[data-idx="1"]')
 					.invoke("attr", "data-name")

--- a/cypress/integration/grid.js
+++ b/cypress/integration/grid.js
@@ -24,14 +24,14 @@ context("Grid", () => {
 				let field = frm.get_field("phone_nos");
 				field.grid.update_docfield_property("is_primary_phone", "hidden", true);
 
-				cy.get("@table").find('[data-idx="1"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="1"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get("@table-form")
 					.find('.frappe-control[data-fieldname="is_primary_phone"]')
 					.should("be.hidden");
 				cy.get("@table-form").find(".grid-footer-toolbar").click();
 
-				cy.get("@table").find('[data-idx="2"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="2"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get("@table-form")
 					.find('.frappe-control[data-fieldname="is_primary_phone"]')
@@ -48,14 +48,14 @@ context("Grid", () => {
 				let field = frm.get_field("phone_nos");
 				field.grid.toggle_display("is_primary_mobile_no", false);
 
-				cy.get("@table").find('[data-idx="1"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="1"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get("@table-form")
 					.find('.frappe-control[data-fieldname="is_primary_mobile_no"]')
 					.should("be.hidden");
 				cy.get("@table-form").find(".grid-footer-toolbar").click();
 
-				cy.get("@table").find('[data-idx="2"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="2"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get("@table-form")
 					.find('.frappe-control[data-fieldname="is_primary_mobile_no"]')
@@ -72,14 +72,14 @@ context("Grid", () => {
 				let field = frm.get_field("phone_nos");
 				field.grid.toggle_enable("phone", false);
 
-				cy.get("@table").find('[data-idx="1"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="1"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get("@table-form")
 					.find('.frappe-control[data-fieldname="phone"] .control-value')
 					.should("have.class", "like-disabled-input");
 				cy.get("@table-form").find(".grid-footer-toolbar").click();
 
-				cy.get("@table").find('[data-idx="2"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="2"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get("@table-form")
 					.find('.frappe-control[data-fieldname="phone"] .control-value')
@@ -96,14 +96,14 @@ context("Grid", () => {
 				let field = frm.get_field("phone_nos");
 				field.grid.toggle_reqd("phone", false);
 
-				cy.get("@table").find('[data-idx="1"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="1"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get_field("phone").as("phone-field");
 				cy.get("@phone-field").focus().clear().wait(500).blur();
 				cy.get("@phone-field").should("not.have.class", "has-error");
 				cy.get("@table-form").find(".grid-footer-toolbar").click();
 
-				cy.get("@table").find('[data-idx="2"] .edit-grid-row').click();
+				cy.get("@table").find('[data-idx="2"] .btn-open-row').click();
 				cy.get(".grid-row-open").as("table-form");
 				cy.get_field("phone").as("phone-field");
 				cy.get("@phone-field").focus().clear().wait(500).blur();

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -335,10 +335,10 @@ export default class GridRow {
 				this.open_form_button = $('<div class="col"></div>').appendTo(this.row);
 
 				if (!this.configure_columns) {
+					const edit_msg = __("Edit", "", "Edit grid row");
 					this.open_form_button = $(`
-						<div class="btn-open-row">
+						<div class="btn-open-row" data-toggle="tooltip" data-placement="right" title="${edit_msg}">
 							<a>${frappe.utils.icon("edit", "xs")}</a>
-							<div class="hidden-md edit-grid-row">${__("Edit", "", "Edit grid row")}</div>
 						</div>
 					`)
 						.appendTo(this.open_form_button)
@@ -346,6 +346,8 @@ export default class GridRow {
 							me.toggle_view();
 							return false;
 						});
+
+					this.open_form_button.tooltip({ delay: { show: 600, hide: 100 } });
 				}
 
 				if (this.is_too_small()) {

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -77,12 +77,6 @@
 		.row-index {
 			display: none;
 		}
-
-		.btn-open-row {
-			.edit-grid-row {
-				display: none;
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
### Before

![Bildschirmfoto 2024-02-23 um 16 53 02](https://github.com/frappe/frappe/assets/14891507/11085b40-0945-4015-a718-5a0a85a23551)

Row's "Edit" label overflows the column boundary.

### After

![Bildschirmfoto 2024-02-23 um 16 52 42](https://github.com/frappe/frappe/assets/14891507/d672d4bb-79a6-4815-ab68-1aee53bd9087)

Row's "Edit" label is shown as a tooltip on hover.