### PR TITLE
fix: misleading CLI error message for missing command

### DIFF
--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -1010,3 +1010,10 @@ class TestSchedulerCLI(BaseTestCommands):
 		self.execute("bench --site {site} scheduler resume")
 		self.assertEqual(self.returncode, 0)
 		self.assertRegex(self.stdout, r"Scheduler is resumed for site .*")
+
+
+class TestCLIImplementation(BaseTestCommands):
+	def test_missing_commands(self):
+		self.execute("bench --site {site} migrat")
+		self.assertNotEqual(self.returncode, 0)
+		self.assertRegex(self.stderr, r"No such.*migrat.*migrate")


### PR DESCRIPTION
closes https://github.com/frappe/bench/issues/1488

Before:
![image](https://github.com/frappe/frappe/assets/9079960/9f2b19a6-3bca-452a-a050-181c282497ee)


After:
![image](https://github.com/frappe/frappe/assets/9079960/dde606e4-18d3-4378-b31c-5fc45357fdf6)
