### PR TITLE
feat: Impersonate a user

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -326,6 +326,12 @@ class LoginManager:
 		self.user = user
 		self.post_login()
 
+	def impersonate(self, user):
+		current_user = frappe.session.user
+		self.login_as(user)
+		# Flag this session as impersonated session, so other code can log this.
+		frappe.local.session_obj.set_impersonsated(current_user)
+
 	def logout(self, arg="", user=None):
 		if not user:
 			user = frappe.session.user

--- a/frappe/core/doctype/activity_log/activity_log.json
+++ b/frappe/core/doctype/activity_log/activity_log.json
@@ -71,7 +71,7 @@
    "fieldname": "operation",
    "fieldtype": "Select",
    "label": "Operation",
-   "options": "\nLogin\nLogout"
+   "options": "\nLogin\nLogout\nImpersonate"
   },
   {
    "fieldname": "status",
@@ -158,7 +158,7 @@
  "icon": "fa fa-comment",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-08-28 20:22:10.992615",
+ "modified": "2024-02-24 16:31:16.253153",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Activity Log",

--- a/frappe/core/doctype/activity_log/activity_log.py
+++ b/frappe/core/doctype/activity_log/activity_log.py
@@ -24,7 +24,7 @@ class ActivityLog(Document):
 		ip_address: DF.Data | None
 		link_doctype: DF.Link | None
 		link_name: DF.DynamicLink | None
-		operation: DF.Literal["", "Login", "Logout"]
+		operation: DF.Literal["", "Login", "Logout", "Impersonate"]
 		reference_doctype: DF.Link | None
 		reference_name: DF.DynamicLink | None
 		reference_owner: DF.ReadOnly | None

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -108,6 +108,7 @@ frappe.ui.form.on("User", {
 		}
 
 		frm.toggle_display(["sb1", "sb3", "modules_access"], false);
+		frm.trigger("setup_impersonation");
 
 		if (!frm.is_new()) {
 			if (has_access_to_edit_user()) {
@@ -338,6 +339,33 @@ frappe.ui.form.on("User", {
 		if (doc.name === frappe.session.user && attr_tuples.some(has_effectively_changed)) {
 			frappe.msgprint(__("Refreshing..."));
 			window.location.reload();
+		}
+	},
+	setup_impersonation: function (frm) {
+		if (frappe.session.user === "Administrator" && frm.doc.name != "Administrator") {
+			frm.add_custom_button("Login as User", () => {
+				if (frm.doc.restrict_ip) {
+					frappe.msgprint({
+						message:
+							"There's IP restriction for this user, you can not impersonate as this user.",
+						title: "IP restriction is enabled",
+					});
+					return;
+				}
+				frappe.confirm(
+					__(
+						"Current session will be logged out and you will login as {0}. Are you sure?",
+						[frm.doc.name.bold()]
+					),
+					() => {
+						frappe
+							.xcall("frappe.core.doctype.user.user.impersonate", {
+								user: frm.doc.name,
+							})
+							.then(() => window.location.reload());
+					}
+				);
+			});
 		}
 	},
 });

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -343,7 +343,7 @@ frappe.ui.form.on("User", {
 	},
 	setup_impersonation: function (frm) {
 		if (frappe.session.user === "Administrator" && frm.doc.name != "Administrator") {
-			frm.add_custom_button("Login as User", () => {
+			frm.add_custom_button(__("Impersonate"), () => {
 				if (frm.doc.restrict_ip) {
 					frappe.msgprint({
 						message:
@@ -352,18 +352,26 @@ frappe.ui.form.on("User", {
 					});
 					return;
 				}
-				frappe.confirm(
-					__(
-						"Current session will be logged out and you will login as {0}. Are you sure?",
-						[frm.doc.name.bold()]
-					),
-					() => {
+				frappe.prompt(
+					[
+						{
+							fieldname: "reason",
+							fieldtype: "Small Text",
+							label: "Reason for impersonating",
+							description: __("Note: This will be shared with user."),
+							reqd: 1,
+						},
+					],
+					(values) => {
 						frappe
 							.xcall("frappe.core.doctype.user.user.impersonate", {
 								user: frm.doc.name,
+								reason: values.reason,
 							})
 							.then(() => window.location.reload());
-					}
+					},
+					__("Impersonate as {0}", [frm.doc.name]),
+					__("Confirm")
 				);
 			});
 		}

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1343,3 +1343,9 @@ def get_enabled_users():
 		return enabled_users
 
 	return frappe.cache.get_value("enabled_users", _get_enabled_users)
+
+
+@frappe.whitelist(methods=["POST"])
+def impersonate(user: str):
+	frappe.only_for("Administrator")
+	frappe.local.login_manager.login_as(user)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1347,7 +1347,15 @@ def get_enabled_users():
 
 @frappe.whitelist(methods=["POST"])
 def impersonate(user: str):
-	from frappe.sessions import Session
-
 	frappe.only_for("Administrator")
+
+	frappe.get_doc(
+		{
+			"doctype": "Activity Log",
+			"user": user,
+			"status": "Success",
+			"subject": _("User {0} impersonated as {1}").format(frappe.session.user, user),
+			"operation": "Impersonate",
+		}
+	).insert(ignore_permissions=True, ignore_links=True)
 	frappe.local.login_manager.impersonate(user)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -1347,5 +1347,7 @@ def get_enabled_users():
 
 @frappe.whitelist(methods=["POST"])
 def impersonate(user: str):
+	from frappe.sessions import Session
+
 	frappe.only_for("Administrator")
-	frappe.local.login_manager.login_as(user)
+	frappe.local.login_manager.impersonate(user)

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -30,10 +30,18 @@ class Version(Document):
 		else:
 			return self.set_diff(old, new)
 
+	@staticmethod
+	def set_impersonator(data):
+		if not frappe.session:
+			return
+		if impersonator := frappe.session.data.get("impersonated_by"):
+			data["impersonated_by"] = impersonator
+
 	def set_diff(self, old: Document, new: Document) -> bool:
 		"""Set the data property with the diff of the docs if present"""
 		diff = get_diff(old, new)
 		if diff:
+			self.set_impersonator(diff)
 			self.ref_doctype = new.doctype
 			self.docname = new.name
 			self.data = frappe.as_json(diff, indent=None, separators=(",", ":"))
@@ -51,6 +59,7 @@ class Version(Document):
 			"updater_reference": updater_reference,
 			"created_by": doc.owner,
 		}
+		self.set_impersonator(data)
 		self.ref_doctype = doc.doctype
 		self.docname = doc.name
 		self.data = frappe.as_json(data, indent=None, separators=(",", ":"))

--- a/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
+++ b/frappe/public/js/frappe/form/footer/version_timeline_content_builder.js
@@ -227,7 +227,12 @@ function get_version_timeline_content(version_doc, frm) {
 			}
 		}
 	});
+	const impersonated_by = data.impersonated_by;
 
+	if (impersonated_by) {
+		const impersonated_msg = __("Impersonated by {0}", [get_user_link(impersonated_by)]);
+		out = out.map((message) => `${message} · ${impersonated_msg.bold()}`);
+	}
 	return out;
 }
 

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -16,6 +16,11 @@
 						{%= __("Read Only Mode") %}
 					</span>
 				{% } %}
+				{% if (frappe.boot.user.impersonated_by) { %}
+					<span class="indicator-pill red no-indicator-dot" title="{%= __("You are impersonating as another user.") %}">
+						{%= __("Impersonating {0}", [frappe.boot.user.name]) %}
+					</span>
+				{% } %}
 				<div class="input-group search-bar text-muted hidden">
 					<input
 						id="navbar-search"

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -391,9 +391,6 @@ class Session:
 		# Forcefully flush session
 		self.update(force=True)
 
-	def impersonated_by(self) -> str | None:
-		return self.data.data.impersonated_by
-
 
 def get_expiry_period_for_query():
 	if frappe.db.db_type == "postgres":

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -166,6 +166,7 @@ def get():
 	bootinfo["setup_complete"] = cint(frappe.get_system_settings("setup_complete"))
 
 	bootinfo["desk_theme"] = frappe.db.get_value("User", frappe.session.user, "desk_theme") or "Light"
+	bootinfo["user"]["impersonated_by"] = frappe.session.data.get("impersonated_by")
 
 	return bootinfo
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -385,6 +385,14 @@ class Session:
 
 		return updated_in_db
 
+	def set_impersonsated(self, original_user):
+		self.data.data.impersonated_by = original_user
+		# Forcefully flush session
+		self.update(force=True)
+
+	def impersonated_by(self) -> str | None:
+		return self.data.data.impersonated_by
+
 
 def get_expiry_period_for_query():
 	if frappe.db.db_type == "postgres":


### PR DESCRIPTION
This is often requested feature from support teams who need to login as another user to check some problem. Building a full fledged impersonation abstraction is probably not feasible, this PR just allows admin to login as any user.

Measures taken to avoid potential abuse:
- Activity log is immediately created
- User who impersonate get persistent pill on navbar indicating that they are impersonating as some other user.
- Any changes made in desk where "track changes" is enabled will also log who "actually" made the change and it will show up in timeline.
- user you impersonate will be notified 



![image](https://github.com/frappe/frappe/assets/9079960/13df6625-344a-44e4-9ccb-f9f0913f3e11)

![image](https://github.com/frappe/frappe/assets/9079960/f32a12c6-0c67-4b8b-86cc-b3b12e5358e1)

![image](https://github.com/frappe/frappe/assets/9079960/34690563-46bc-49ec-a7ba-a87b28bc6226)
![image](https://github.com/frappe/frappe/assets/9079960/991fc048-5daf-4889-bd1d-46dc54aad372)
![image](https://github.com/frappe/frappe/assets/9079960/eaa1103b-6e31-4323-b654-96e7ac67901f)




TODO:
- [x] security review @sagarvora 
- [x] tests
- [x] Notify user
- [x] docs: https://docs.erpnext.com/docs/user/manual/en/adding-users#4-impersonating-a-user