### PR TITLE
fix: replaced created by with owner in base_document

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -544,7 +544,7 @@ class BaseDocument:
 
 		if not self.creation:
 			self.creation = self.modified = now()
-			self.created_by = self.modified_by = frappe.session.user
+			self.owner = self.modified_by = frappe.session.user
 
 		# if doctype is "DocType", don't insert null values as we don't know who is valid yet
 		d = self.get_valid_dict(

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1717,7 +1717,7 @@ def _document_values_generator(
 ) -> Generator[tuple[Any], None, None]:
 	for doc in documents:
 		doc.creation = doc.modified = now()
-		doc.created_by = doc.modified_by = frappe.session.user
+		doc.owner = doc.modified_by = frappe.session.user
 		doc_values = doc.get_valid_dict(
 			convert_dates_to_str=True,
 			ignore_nulls=True,


### PR DESCRIPTION
Replaced `created_by` with `owner` in base_document.py and document.py