### PR TITLE
fix: allow page length 2500

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -362,7 +362,7 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	setup_paging_area() {
-		const paging_values = [20, 100, 500];
+		const paging_values = [20, 100, 500, 2500];
 		this.$paging_area = $(
 			`<div class="list-paging-area level">
 				<div class="level-left">


### PR DESCRIPTION
Multiple of our customers have recently expressed their struggle with loading many records: select page length 500, then klick load more, scroll down, load more, scroll down, ...

A long page length is useful for reports, when your filters result in a couple thousand records and you need to load and check (or print) all rows.

Why 2500? We always have 5x increments: 20, 100, 500, 2500

On my development site, the request take 115 ms for the server to process and about 4 seconds for the browser to render. This seems acceptable.