### PR TITLE
refactor: render list progressively

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -604,16 +604,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	render_list() {
 		// clear rows
 		this.$result.find(".list-row-container").remove();
+
 		if (this.data.length > 0) {
 			// append rows
-			this.$result.append(
-				this.data
-					.map((doc, i) => {
-						doc._idx = i;
-						return this.get_list_row_html(doc);
-					})
-					.join("")
-			);
+			let idx = 0;
+			for (let doc of this.data) {
+				doc._idx = idx++;
+				this.$result.append(this.get_list_row_html(doc));
+			}
 		}
 	}
 


### PR DESCRIPTION
### Before

1. Create all list elements
2. Render all list elements

### After

For each element:

1. Create
2. Render

Should result in a smoother UX, because we immediately render some data. The user can start scrolling while the data is still being rendered. Especially useful on slow devices.