### PR TITLE
perf: remove specific elements instead of re-rendering entire list

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1471,8 +1471,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 				// this doc was changed and should not be visible
 				// in the listview according to filters applied
 				// let's remove it manually
-				this.data = this.data.filter((d) => names.indexOf(d.name) === -1);
-				this.render_list();
+				this.data = this.data.filter((d) => !names.includes(d.name));
+				for (let name of names) {
+					this.$result
+						.find(`.list-row-checkbox[data-name='${name}']`)
+						.closest(".list-row-container")
+						.remove();
+				}
 				return;
 			}
 


### PR DESCRIPTION
### Scenario

1. User has list view open
2. Records get removed by backend process or other user
3. SocketIO event is triggered

### Before

1. Remove deleted records from list controller
2. Re-render the entire list

### After

1. Remove deleted records from list controller
2. Remove the specific list rows without re-rendering the entire list