### PR TITLE
perf: "load more" and "increase page length"

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -393,20 +393,22 @@ frappe.views.BaseList = class BaseList {
 			.find(`.btn-paging[data-value="${this.page_length}"]`)
 			.addClass("btn-info");
 
-		this.$paging_area.on("click", ".btn-paging, .btn-more", (e) => {
+		this.$paging_area.on("click", ".btn-paging", (e) => {
 			const $this = $(e.currentTarget);
 
-			if ($this.is(".btn-paging")) {
-				// set active button
-				this.$paging_area.find(".btn-paging").removeClass("btn-info");
-				$this.addClass("btn-info");
+			// set active button
+			this.$paging_area.find(".btn-paging").removeClass("btn-info");
+			$this.addClass("btn-info");
 
-				this.start = 0;
-				this.page_length = this.selected_page_count = $this.data().value;
-			} else if ($this.is(".btn-more")) {
-				this.start = this.start + this.page_length;
-				this.page_length = this.selected_page_count || 20;
-			}
+			this.start = 0;
+			this.page_length = this.selected_page_count = $this.data().value;
+
+			this.refresh();
+		});
+
+		this.$paging_area.on("click", ".btn-more", (e) => {
+			this.start += this.page_length;
+			this.page_length = this.selected_page_count || 20;
 			this.refresh();
 		});
 	}

--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -45,6 +45,7 @@ frappe.views.BaseList = class BaseList {
 
 		this.start = 0;
 		this.page_length = frappe.is_large_screen() ? 100 : 20;
+		this.selected_page_count = this.page_length;
 		this.data = [];
 		this.method = "frappe.desk.reportview.get";
 
@@ -395,20 +396,32 @@ frappe.views.BaseList = class BaseList {
 
 		this.$paging_area.on("click", ".btn-paging", (e) => {
 			const $this = $(e.currentTarget);
-
-			// set active button
+			// Set the active button
+			// This is always necessary because the current page length might
+			// have resulted from a previous "load more".
 			this.$paging_area.find(".btn-paging").removeClass("btn-info");
 			$this.addClass("btn-info");
 
-			this.start = 0;
-			this.page_length = this.selected_page_count = $this.data().value;
+			const old_page_length = this.page_length;
+			const new_page_length = $this.data().value;
 
-			this.refresh();
+			this.selected_page_count = new_page_length;
+			if (this.page_length > new_page_length) {
+				this.start = 0;
+				this.page_length = new_page_length;
+			} else {
+				this.start = this.page_length;
+				this.page_length = new_page_length - this.page_length;
+			}
+
+			if (old_page_length !== new_page_length) {
+				this.refresh();
+			}
 		});
 
 		this.$paging_area.on("click", ".btn-more", (e) => {
-			this.start += this.page_length;
-			this.page_length = this.selected_page_count || 20;
+			this.start = this.data.length;
+			this.page_length = this.selected_page_count;
 			this.refresh();
 		});
 	}


### PR DESCRIPTION
Depends on #25080 (review this first, to get a smaller diff here)

Only request the required additional data, not all data.

Example flow:

1. Page length is 20
2. User clicks on "load more" -> request 20 records, starting from 20
3. User clicks on "load more" again -> request 20 records, starting from 40
4. User clicks on "load more" again -> request 20 records, starting from 60
5. User changes page length to 100 -> request 40 records, starting from 60
6. User clicks on "load more" -> request 100 records, starting from 100

Already covered by tests: https://github.com/frappe/frappe/blob/develop/cypress/integration/list_paging.js