### PR TITLE
ci: skip videos for successful tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -8,7 +8,6 @@ module.exports = defineConfig({
 	defaultCommandTimeout: 20000,
 	pageLoadTimeout: 15000,
 	video: true,
-	videoUploadOnPasses: false,
 	viewportHeight: 960,
 	viewportWidth: 1400,
 	retries: {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require("cypress");
+const fs = require("fs");
 
 module.exports = defineConfig({
 	projectId: "92odwv",
@@ -18,6 +19,19 @@ module.exports = defineConfig({
 		// We've imported your old cypress plugins here.
 		// You may want to clean this up later by importing these.
 		setupNodeEvents(on, config) {
+			// Delete videos for specs without failing or retried tests
+			// https://docs.cypress.io/guides/guides/screenshots-and-videos#Delete-videos-for-specs-without-failing-or-retried-tests
+			on("after:spec", (spec, results) => {
+				if (results && results.video) {
+					const failures = results.tests.some((test) =>
+						test.attempts.some((attempt) => attempt.state === "failed")
+					);
+					if (!failures) {
+						fs.unlinkSync(results.video);
+					}
+				}
+			});
+
 			return require("./cypress/plugins/index.js")(on, config);
 		},
 		testIsolation: false,


### PR DESCRIPTION
Nobody will spend hours watching successful test cases. We're only interested in the failing ones ~, so we can save some time here.~ Okay, seems like it doesn't really save time, but (hopefully) at least a bit of space, bandwidth and energy! 😄 