### PR TITLE
fix: Avoid add "null" to cc in communication in timeline

### DIFF
--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -575,8 +575,8 @@ class FormTimeline extends BaseTimeline {
 			}
 			if (reply_all) {
 				// if reply_all then add cc and bcc as well.
-				args.cc += (communication_doc.cc || "");
-				args.bcc = communication_doc.bcc;
+				args.cc += cstr(communication_doc.cc);
+				args.bcc = cstr(communication_doc.bcc);
 			}
 		}
 

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -575,7 +575,7 @@ class FormTimeline extends BaseTimeline {
 			}
 			if (reply_all) {
 				// if reply_all then add cc and bcc as well.
-				args.cc += communication_doc.cc;
+				args.cc += (communication_doc.cc || "");
 				args.bcc = communication_doc.bcc;
 			}
 		}


### PR DESCRIPTION
Hi,
in this issue: https://github.com/frappe/frappe/issues/24908 I have described the "null" problem in timeline communication.

![image](https://github.com/frappe/frappe/assets/121026420/9fb26aae-5980-46fe-a316-0b94b541933f)

closes #24908