### PR TITLE
chore: replace fb link with frappe school link in about dialog

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/about.js
+++ b/frappe/public/js/frappe/ui/toolbar/about.js
@@ -13,10 +13,10 @@ frappe.ui.misc.about = function () {
 					<p><i class='fa fa-github fa-fw'></i>
 						${__("Source")}:
 						<a href='https://github.com/frappe' target='_blank'>https://github.com/frappe</a></p>
+					<p><i class='fa fa-graduation-cap fa-fw'></i>
+						Frappe School: <a href='https://frappe.school' target='_blank'>https://frappe.school</a></p>
 					<p><i class='fa fa-linkedin fa-fw'></i>
 						Linkedin: <a href='https://linkedin.com/company/frappe-tech' target='_blank'>https://linkedin.com/company/frappe-tech</a></p>
-					<p><i class='fa fa-facebook fa-fw'></i>
-						Facebook: <a href='https://facebook.com/erpnext' target='_blank'>https://facebook.com/erpnext</a></p>
 					<p><i class='fa fa-twitter fa-fw'></i>
 						Twitter: <a href='https://twitter.com/frappetech' target='_blank'>https://twitter.com/frappetech</a></p>
 					<p><i class='fa fa-youtube fa-fw'></i>


### PR DESCRIPTION
Replaces ERPNext Facebook link (useless IMO) with Frappe School link in about dialog:

![CleanShot 2024-02-27 at 14 20 31@2x](https://github.com/frappe/frappe/assets/34810212/44a0cda2-c8b4-441d-8d77-0f5ce73d1d6c)
