### PR TITLE
feat(format): Localize duration format

### DIFF
--- a/frappe/locale/fr.po
+++ b/frappe/locale/fr.po
@@ -37167,10 +37167,10 @@ msgctxt "Workspace"
 msgid "cyan"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1114
+#: public/js/frappe/utils/utils.js:1114 utils/data.py:814
 msgctxt "Days (Field: Duration)"
 msgid "d"
-msgstr "ré"
+msgstr "j"
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
@@ -37506,10 +37506,10 @@ msgstr ""
 msgid "gzip not found in PATH! This is required to take a backup."
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1118
+#: public/js/frappe/utils/utils.js:1118 utils/data.py:817
 msgctxt "Hours (Field: Duration)"
 msgid "h"
-msgstr ""
+msgstr "h"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
@@ -37693,10 +37693,10 @@ msgctxt "RQ Worker"
 msgid "long"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1122
+#: public/js/frappe/utils/utils.js:1122 utils/data.py:821
 msgctxt "Minutes (Field: Duration)"
 msgid "m"
-msgstr ""
+msgstr "m"
 
 #. Option for the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
@@ -38109,10 +38109,10 @@ msgctxt "Workflow State"
 msgid "road"
 msgstr "route"
 
-#: public/js/frappe/utils/utils.js:1126
+#: public/js/frappe/utils/utils.js:1126 utils/data.py:825
 msgctxt "Seconds (Field: Duration)"
 msgid "s"
-msgstr ""
+msgstr "s"
 
 #. Option for the 'Code challenge method' (Select) field in DocType 'OAuth
 #. Authorization Code'

--- a/frappe/tests/test_formatter.py
+++ b/frappe/tests/test_formatter.py
@@ -17,3 +17,15 @@ class TestFormatter(FrappeTestCase):
 		self.assertEqual(format(100000, df, doc, format="#,###.##"), "$ 100,000.00")
 
 		frappe.db.set_default("currency", None)
+
+	def test_duration_formatting(self):
+		self.assertEqual(format(1, "Duration"), "1s")
+		self.assertEqual(format(60, "Duration"), "1m")
+		self.assertEqual(format(3600, "Duration"), "1h")
+		self.assertEqual(format(24 * 3600, "Duration"), "1d")
+
+		try:
+			frappe.local.lang = "fr"
+			self.assertEqual(format(24 * 3600, "Duration"), "1j")
+		finally:
+			frappe.local.lang = "en"

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -811,16 +811,20 @@ def format_duration(seconds, hide_days=False):
 	duration = ""
 	if total_duration:
 		if total_duration.get("days"):
-			duration += str(total_duration.get("days")) + "d"
+			unit = frappe._("d", context="Days (Field: Duration)")
+			duration += str(total_duration.get("days")) + unit
 		if total_duration.get("hours"):
+			unit = frappe._("h", context="Hours (Field: Duration)")
 			duration += " " if len(duration) else ""
-			duration += str(total_duration.get("hours")) + "h"
+			duration += str(total_duration.get("hours")) + unit
 		if total_duration.get("minutes"):
+			unit = frappe._("m", context="Minutes (Field: Duration)")
 			duration += " " if len(duration) else ""
-			duration += str(total_duration.get("minutes")) + "m"
+			duration += str(total_duration.get("minutes")) + unit
 		if total_duration.get("seconds"):
+			unit = frappe._("s", context="Seconds (Field: Duration)")
 			duration += " " if len(duration) else ""
-			duration += str(total_duration.get("seconds")) + "s"
+			duration += str(total_duration.get("seconds")) + unit
 
 	return duration
 


### PR DESCRIPTION
~~Possibly breaking?~~

Maybe breaks importing back a Duration that was exported? Or does Frappe export Duration fields directly as a integer?

https://github.com/frappe/frappe/blob/d4bb72b74ffec2396d5966f398382cec3c653a68/frappe/utils/data.py#L828-L832

https://github.com/frappe/frappe/blob/d4bb72b74ffec2396d5966f398382cec3c653a68/frappe/core/doctype/data_import/importer.py#L769-L770