### PR TITLE
feat: support array request type

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -295,13 +295,14 @@ def make_form_dict(request: Request):
 		args.update(request.args or {})
 		args.update(request.form or {})
 
-	if not isinstance(args, dict):
+	if isinstance(args, dict):
+		frappe.local.form_dict = frappe._dict(args)
+		# _ is passed by $.ajax so that the request is not cached by the browser. So, remove _ from form_dict
+		frappe.local.form_dict.pop("_", None)
+	elif isinstance(args, list):
+		frappe.local.form_dict["data"] = args
+	else:
 		frappe.throw(_("Invalid request arguments"))
-
-	frappe.local.form_dict = frappe._dict(args)
-
-	# _ is passed by $.ajax so that the request is not cached by the browser. So, remove _ from form_dict
-	frappe.local.form_dict.pop("_", None)
 
 
 def handle_exception(e):

--- a/frappe/tests/test_api.py
+++ b/frappe/tests/test_api.py
@@ -322,6 +322,14 @@ class TestMethodAPI(FrappeAPITestCase):
 		self.assertIn("ZeroDivisionError", response.json["exception"])  # WHY?
 		self.assertIn("Traceback", response.json["exc"])
 
+	def test_array_response(self):
+		method = "frappe.tests.test_api.test_array"
+
+		test_data = list(range(5))
+		response = self.post(self.method_path(method), test_data)
+
+		self.assertEqual(response.json["message"], test_data)
+
 
 class TestReadOnlyMode(FrappeAPITestCase):
 	"""During migration if read only mode can be enabled.
@@ -463,3 +471,8 @@ def test(*, fail=False, handled=True, message="Failed"):
 			1 / 0
 	else:
 		frappe.msgprint(message)
+
+
+@frappe.whitelist(allow_guest=True)
+def test_array(data):
+	return data


### PR DESCRIPTION
There can be external APIs like webhooks that only send array request,
in which case Frappe has no mechanism to accept such requests.

After this PR such request data can be accessed using `data` list
argument on function.

I've considered directly storing list in form_dict but it's not
feasible:
1. It breaks semantics, "form_dict" can't be a list. That ship has long
   sailed.
2. Way too much code expects form_dict to be a dict.
