### PR TITLE
fix: Use current language in attachment prints

### DIFF
--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -194,6 +194,7 @@ class CommunicationEmailMixin:
 				"print_format_attachment": 1,
 				"doctype": self.reference_doctype,
 				"name": self.reference_name,
+				"lang": frappe.local.lang,
 			}
 			final_attachments.append(d)
 


### PR DESCRIPTION
Steps:

- User see something (in their lang)
- User sends email, now attachment info is stored but lang isn't stored. 
- lang is set to frappe.local.conf as fallback or `en` so it always ends up being english on most sites. 

Fix:

- When user sends email remember their language and set it in communication