### PR TITLE
fix: specify print_language in communication attachments

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -47,6 +47,7 @@ def make(
 	email_template=None,
 	communication_type=None,
 	send_after=None,
+	print_language=None,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -102,6 +103,7 @@ def make(
 		communication_type=communication_type,
 		add_signature=False,
 		send_after=send_after,
+		print_language=print_language,
 	)
 
 
@@ -128,6 +130,7 @@ def _make(
 	communication_type=None,
 	add_signature=True,
 	send_after=None,
+	print_language=None,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -181,6 +184,7 @@ def _make(
 			print_format=print_format,
 			send_me_a_copy=send_me_a_copy,
 			print_letterhead=print_letterhead,
+			print_language=print_language,
 		)
 
 	emails_not_sent_to = comm.exclude_emails_list(include_sender=send_me_a_copy)

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -184,7 +184,7 @@ class CommunicationEmailMixin:
 			)
 		return self._incoming_email_account
 
-	def mail_attachments(self, print_format=None, print_html=None):
+	def mail_attachments(self, print_format=None, print_html=None, print_language=None):
 		final_attachments = []
 
 		if print_format or print_html:
@@ -194,7 +194,7 @@ class CommunicationEmailMixin:
 				"print_format_attachment": 1,
 				"doctype": self.reference_doctype,
 				"name": self.reference_name,
-				"lang": frappe.local.lang,
+				"lang": print_language or frappe.local.lang,
 			}
 			final_attachments.append(d)
 
@@ -257,6 +257,7 @@ class CommunicationEmailMixin:
 		send_me_a_copy=None,
 		print_letterhead=None,
 		is_inbound_mail_communcation=None,
+		print_language=None,
 	) -> dict:
 		outgoing_email_account = self.get_outgoing_email_account()
 		if not outgoing_email_account:
@@ -273,7 +274,9 @@ class CommunicationEmailMixin:
 		if not (recipients or cc):
 			return {}
 
-		final_attachments = self.mail_attachments(print_format=print_format, print_html=print_html)
+		final_attachments = self.mail_attachments(
+			print_format=print_format, print_html=print_html, print_language=print_language
+		)
 		incoming_email_account = self.get_incoming_email_account()
 		return {
 			"recipients": recipients,
@@ -304,6 +307,7 @@ class CommunicationEmailMixin:
 		send_me_a_copy=None,
 		print_letterhead=None,
 		is_inbound_mail_communcation=None,
+		print_language=None,
 	):
 		if input_dict := self.sendmail_input_dict(
 			print_html=print_html,
@@ -311,5 +315,6 @@ class CommunicationEmailMixin:
 			send_me_a_copy=send_me_a_copy,
 			print_letterhead=print_letterhead,
 			is_inbound_mail_communcation=is_inbound_mail_communcation,
+			print_language=print_language,
 		):
 			frappe.sendmail(**input_dict)

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -145,6 +145,14 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "Select",
 				fieldname: "select_print_format",
 			},
+			{
+				label: __("Print Language"),
+				fieldtype: "Link",
+				options: "Language",
+				fieldname: "print_language",
+				default: frappe.boot.lang,
+				depends_on: "attach_document_print",
+			},
 			{ fieldtype: "Column Break" },
 			{
 				label: __("Select Attachments"),
@@ -737,6 +745,7 @@ frappe.views.CommunicationComposer = class {
 				read_receipt: form_values.send_read_receipt,
 				print_letterhead: me.is_print_letterhead_checked(),
 				send_after: form_values.send_after ? form_values.send_after : null,
+				print_language: form_values.print_language,
 			},
 			btn,
 			callback(r) {


### PR DESCRIPTION
You can now specify print attachments while sending document email

![image](https://github.com/frappe/frappe/assets/9079960/d35a2b3e-fb7b-48a3-b026-57e6f0baf8ab)

