### PR TITLE
fix: update file attached_to details in submitted doc

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -174,6 +174,7 @@ doc_events = {
 			"frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.apply",
 			"frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date",
+			"frappe.core.doctype.file.utils.attach_files_to_document",
 		],
 		"on_change": [
 			"frappe.social.doctype.energy_point_rule.energy_point_rule.process_energy_points",


### PR DESCRIPTION
- Attached to Doctype
- Attached to Name
- Attached to Field

The above fields are not get updated when make an attachment in the submitted doc(through allow on submit). If directly uploaded the file in form view it works as expected. But through web form it's not updated those fields. So the attachments are not visible in the form sidebar even it shows the file url in the field.
