### PR TITLE
fix: always show is_standard on web form

### DIFF
--- a/frappe/website/doctype/web_form/web_form.js
+++ b/frappe/website/doctype/web_form/web_form.js
@@ -24,9 +24,6 @@ frappe.ui.form.on("Web Form", {
 	},
 
 	refresh: function (frm) {
-		// show is-standard only if developer mode
-		frm.get_field("is_standard").toggle(frappe.boot.developer_mode);
-
 		if (frm.doc.is_standard && !frappe.boot.developer_mode) {
 			frm.set_read_only();
 			frm.disable_save();


### PR DESCRIPTION
This causes more confusion when it's hidden.
