### PR TITLE
fix(search): Don't break when query doesn't return title

### DIFF
--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -260,6 +260,8 @@ def build_for_autosuggest(res: list[tuple], doctype: str) -> list[LinkSearchResu
 	if meta.show_title_field_in_link:
 		for item in res:
 			item = list(item)
+			if len(item) == 1:
+				item = [item[0], item[0]]
 			label = item[1]  # use title as label
 			item[1] = item[0]  # show name in description instead of title
 			if len(item) >= 3 and item[2] == label:


### PR DESCRIPTION
untested ⋅ closes #25115

Some methods used in set_query do not return lists of [value, label, description] and thus break when doctype has title (meta.show_title_field_in_link).

Example with: `frappe.core.doctype.user_permission.user_permission.get_applicable_for_doctype_list`
https://github.com/frappe/frappe/blob/f2b07d6c13d5fb3f8c13ce94c39a3af1f648ed7b/frappe/core/doctype/user_permission/user_permission.py#L172

Which obviously raises an IndexError here:

https://github.com/frappe/frappe/blob/f2b07d6c13d5fb3f8c13ce94c39a3af1f648ed7b/frappe/desk/search.py#L263