### PR TITLE
fix: race condition on deletes

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -474,6 +474,7 @@ class Database:
 		pluck=False,
 		distinct=False,
 		skip_locked=False,
+		wait=True,
 	):
 		"""Return a document property or list of properties.
 
@@ -488,6 +489,7 @@ class Database:
 		:param pluck: pluck first column instead of returning as nested list or dict.
 		:param for_update: All the affected/read rows will be locked.
 		:param skip_locked: Skip selecting currently locked rows.
+		:param wait: Wait for aquiring lock
 
 		Example:
 
@@ -519,6 +521,7 @@ class Database:
 			distinct=distinct,
 			limit=1,
 			skip_locked=skip_locked,
+			wait=wait,
 		)
 
 		if not run:
@@ -552,6 +555,7 @@ class Database:
 		distinct=False,
 		limit=None,
 		skip_locked=False,
+		wait=True,
 	):
 		"""Return multiple document properties.
 
@@ -592,6 +596,7 @@ class Database:
 				limit=limit,
 				as_dict=as_dict,
 				skip_locked=skip_locked,
+				wait=True,
 				for_update=for_update,
 			)
 
@@ -619,6 +624,7 @@ class Database:
 						limit=limit,
 						for_update=for_update,
 						skip_locked=skip_locked,
+						wait=wait,
 					)
 				except Exception as e:
 					if ignore and (
@@ -856,6 +862,7 @@ class Database:
 		update=None,
 		for_update=False,
 		skip_locked=False,
+		wait=True,
 		run=True,
 		pluck=False,
 		distinct=False,
@@ -867,6 +874,7 @@ class Database:
 			order_by=order_by,
 			for_update=for_update,
 			skip_locked=skip_locked,
+			wait=wait,
 			fields=fields,
 			distinct=distinct,
 			limit=limit,
@@ -892,6 +900,7 @@ class Database:
 		as_dict=False,
 		for_update=False,
 		skip_locked=False,
+		wait=True,
 	):
 		if names := list(filter(None, names)):
 			return frappe.qb.get_query(
@@ -904,6 +913,7 @@ class Database:
 				validate_filters=True,
 				for_update=for_update,
 				skip_locked=skip_locked,
+				wait=wait,
 			).run(debug=debug, run=run, as_dict=as_dict, pluck=pluck)
 		return {}
 

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -12,7 +12,12 @@ from psycopg2.errorcodes import (
 	UNDEFINED_TABLE,
 	UNIQUE_VIOLATION,
 )
-from psycopg2.errors import ReadOnlySqlTransaction, SequenceGeneratorLimitExceeded, SyntaxError
+from psycopg2.errors import (
+	LockNotAvailable,
+	ReadOnlySqlTransaction,
+	SequenceGeneratorLimitExceeded,
+	SyntaxError,
+)
 from psycopg2.extensions import ISOLATION_LEVEL_REPEATABLE_READ
 
 import frappe
@@ -53,7 +58,7 @@ class PostgresExceptionUtil:
 	@staticmethod
 	def is_timedout(e):
 		# http://initd.org/psycopg/docs/extensions.html?highlight=datatype#psycopg2.extensions.QueryCanceledError
-		return isinstance(e, psycopg2.extensions.QueryCanceledError)
+		return isinstance(e, (psycopg2.extensions.QueryCanceledError | LockNotAvailable))
 
 	@staticmethod
 	def is_read_only_mode_error(e) -> bool:

--- a/frappe/database/query.py
+++ b/frappe/database/query.py
@@ -48,6 +48,7 @@ class Engine:
 		*,
 		validate_filters: bool = False,
 		skip_locked: bool = False,
+		wait: bool = True,
 	) -> QueryBuilder:
 		self.is_mariadb = frappe.db.db_type == "mariadb"
 		self.is_postgres = frappe.db.db_type == "postgres"
@@ -84,7 +85,7 @@ class Engine:
 			self.query = self.query.distinct()
 
 		if for_update:
-			self.query = self.query.for_update(skip_locked=skip_locked)
+			self.query = self.query.for_update(skip_locked=skip_locked, nowait=not wait)
 
 		if group_by:
 			self.query = self.query.groupby(group_by)

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -104,7 +104,17 @@ def delete_doc(
 					pass
 
 		else:
-			doc = frappe.get_doc(doctype, name, for_update=True)
+			# Lock the doc without waiting
+			try:
+				frappe.db.get_value(doctype, name, for_update=True, wait=False)
+			except frappe.QueryTimeoutError:
+				frappe.throw(
+					_(
+						"This document can not be deleted right now as it's being modified by another user. Please try again after some time."
+					),
+					exc=frappe.QueryTimeoutError,
+				)
+			doc = frappe.get_doc(doctype, name)
 
 			if not for_reload:
 				update_flags(doc, flags, ignore_permissions)

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -104,7 +104,7 @@ def delete_doc(
 					pass
 
 		else:
-			doc = frappe.get_doc(doctype, name)
+			doc = frappe.get_doc(doctype, name, for_update=True)
 
 			if not for_reload:
 				update_flags(doc, flags, ignore_permissions)

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -57,15 +57,13 @@ class TestDB(FrappeTestCase):
 			self.fail("Long running queries not timing out")
 
 	def test_skip_locking(self):
-		first_conn = frappe.local.db
-		name = frappe.db.get_value("User", "Administrator", "name", for_update=True, skip_locked=True)
-		self.assertEqual(name, "Administrator")
+		with self.primary_connection():
+			name = frappe.db.get_value("User", "Administrator", "name", for_update=True, skip_locked=True)
+			self.assertEqual(name, "Administrator")
 
-		frappe.connect()  # Create a 2nd connection
-		second_conn = frappe.local.db
-		self.assertIsNot(first_conn, second_conn)
-		name = frappe.db.get_value("User", "Administrator", "name", for_update=True, skip_locked=True)
-		self.assertFalse(name)
+		with self.secondary_connection():
+			name = frappe.db.get_value("User", "Administrator", "name", for_update=True, skip_locked=True)
+			self.assertFalse(name)
 
 	@patch.dict(frappe.conf, {"http_timeout": 20, "enable_db_statement_timeout": 1})
 	def test_db_timeout_computation(self):

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -15,7 +15,7 @@ from frappe.database.utils import FallBackDateTimeStr
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Concat_ws
 from frappe.tests.test_query_builder import db_type_is, run_only_if
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase, timeout
 from frappe.utils import add_days, now, random_string, set_request
 from frappe.utils.testutils import clear_custom_fields
 
@@ -58,12 +58,24 @@ class TestDB(FrappeTestCase):
 
 	def test_skip_locking(self):
 		with self.primary_connection():
-			name = frappe.db.get_value("User", "Administrator", "name", for_update=True, skip_locked=True)
+			name = frappe.db.get_value("User", "Administrator", for_update=True, skip_locked=True)
 			self.assertEqual(name, "Administrator")
 
 		with self.secondary_connection():
-			name = frappe.db.get_value("User", "Administrator", "name", for_update=True, skip_locked=True)
+			name = frappe.db.get_value("User", "Administrator", for_update=True, skip_locked=True)
 			self.assertFalse(name)
+
+	@timeout(5, "Lock timeout should have been 0")
+	def test_no_wait(self):
+		with self.primary_connection():
+			name = frappe.db.get_value("User", "Administrator", for_update=True)
+			self.assertEqual(name, "Administrator")
+
+		with self.secondary_connection():
+			self.assertRaises(
+				frappe.QueryTimeoutError,
+				lambda: frappe.db.get_value("User", "Administrator", for_update=True, wait=False),
+			)
 
 	@patch.dict(frappe.conf, {"http_timeout": 20, "enable_db_statement_timeout": 1})
 	def test_db_timeout_computation(self):

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -9,7 +9,7 @@ from frappe.app import make_form_dict
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.doctype.note.note import Note
 from frappe.model.naming import make_autoname, parse_naming_series, revert_series_if_last
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase, timeout
 from frappe.utils import cint, now_datetime, set_request
 from frappe.website.serve import get_response
 
@@ -491,6 +491,20 @@ class TestDocument(FrappeTestCase):
 		c.db_set(key, val)
 		changed_val = frappe.db.get_single_value(c.doctype, key)
 		self.assertEqual(val, changed_val)
+
+	@timeout(5, "Deletion stuck on lock timeout")
+	def test_delete_race_condition(self):
+		note = frappe.new_doc("Note")
+		note.title = note.content = frappe.generate_hash()
+		note.insert()
+		frappe.db.commit()  # ensure that second connection can see the document
+
+		with self.primary_connection():
+			n1 = frappe.get_doc(note.doctype, note.name)
+			n1.save()
+
+		with self.secondary_connection():
+			self.assertRaises(frappe.QueryTimeoutError, frappe.delete_doc, note.doctype, note.name)
 
 
 class TestDocumentWebView(FrappeTestCase):

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -119,6 +119,11 @@ class FrappeTestCase(unittest.TestCase):
 			yield
 		finally:
 			frappe.local.db = current_conn
+			self.addCleanup(self._rollback_connections)
+
+	def _rollback_connections(self):
+		self._primary_connection.rollback()
+		self._secondary_connection.rollback()
 
 	def assertQueryEqual(self, first: str, second: str):
 		self.assertEqual(self.normalize_sql(first), self.normalize_sql(second))

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -34,6 +34,8 @@ class FrappeTestCase(unittest.TestCase):
 	def setUpClass(cls) -> None:
 		cls.TEST_SITE = getattr(frappe.local, "site", None) or cls.TEST_SITE
 		cls.ADMIN_PASSWORD = frappe.get_conf(cls.TEST_SITE).admin_password
+		cls._primary_connection = frappe.local.db
+		cls._secondary_connection = None
 		# flush changes done so far to avoid flake
 		frappe.db.commit()
 		if cls.SHOW_TRANSACTION_COMMIT_WARNINGS:
@@ -91,6 +93,32 @@ class FrappeTestCase(unittest.TestCase):
 		import sqlparse
 
 		return (sqlparse.format(query.strip(), keyword_case="upper", reindent=True, strip_comments=True),)
+
+	@contextmanager
+	def primary_connection(self):
+		"""Switch to primary DB connection
+
+		This is used for simulating multiple users performing actions by simulating two DB connections"""
+		try:
+			current_conn = frappe.local.db
+			frappe.local.db = self._primary_connection
+			yield
+		finally:
+			frappe.local.db = current_conn
+
+	@contextmanager
+	def secondary_connection(self):
+		"""Switch to secondary DB connection."""
+		if self._secondary_connection is None:
+			frappe.connect()  # get second connection
+			self._secondary_connection = frappe.local.db
+
+		try:
+			current_conn = frappe.local.db
+			frappe.local.db = self._secondary_connection
+			yield
+		finally:
+			frappe.local.db = current_conn
 
 	def assertQueryEqual(self, first: str, second: str):
 		self.assertEqual(self.normalize_sql(first), self.normalize_sql(second))


### PR DESCRIPTION
Problem is best understood in form of a timeline:
| Timestamp | User A action | User B action
| --- | --- | ---  | 
| 1 | Submits a draft document | --- |
| 2 | (submission ongoing) | deletes the same draft document |
| 3 | submission completed | --- | 
| 4 | ---                  | gets lock, deletes the document assuming nothing changed |

So a document with docstatus 1 in DB gets deleted. 

If you look at binary logs MySQL is thinking:
1. Draft created
2. Draft submitted
3. Submitted document deleted, even though in deleted document it will appear as draft document because of `REPEATABLE READ` isolation.

This is reliably reproducible using two consoles (to slow down the transaction commits)

Fix:
- Just locking doc before delete is enough for preventing submission but not for preventing normal save + delete.
- Lock the document with NOWAIT mode to fail immediately if document is locked.

Co-Authored-By: @rohitwaghchaure 


TODO:

- [x] add test utils for simulating parallel execution. (either thread or using switching connections) 
- [x] add tests for this