### PR TITLE
fix: use name for RQ worker instead of PID

### DIFF
--- a/frappe/core/doctype/rq_worker/rq_worker.json
+++ b/frappe/core/doctype/rq_worker/rq_worker.json
@@ -114,7 +114,7 @@
  "in_create": 1,
  "is_virtual": 1,
  "links": [],
- "modified": "2024-01-13 10:36:13.034784",
+ "modified": "2024-02-29 19:31:08.502527",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "RQ Worker",
@@ -141,5 +141,6 @@
    "color": "Yellow",
    "title": "busy"
   }
- ]
+ ],
+ "title_field": "pid"
 }

--- a/frappe/core/doctype/rq_worker/rq_worker.py
+++ b/frappe/core/doctype/rq_worker/rq_worker.py
@@ -38,7 +38,7 @@ class RQWorker(Document):
 
 	def load_from_db(self):
 		all_workers = get_workers()
-		workers = [w for w in all_workers if w.pid == cint(self.name)]
+		workers = [w for w in all_workers if w.name == self.name]
 		if not workers:
 			raise frappe.DoesNotExistError
 		d = serialize_worker(workers[0])
@@ -85,7 +85,7 @@ def serialize_worker(worker: Worker) -> frappe._dict:
 		current_job = None
 
 	return frappe._dict(
-		name=worker.pid,
+		name=worker.name,
 		queue=queue,
 		queue_type=queue_types,
 		worker_name=worker.name,

--- a/frappe/core/doctype/rq_worker/test_rq_worker.py
+++ b/frappe/core/doctype/rq_worker/test_rq_worker.py
@@ -14,4 +14,4 @@ class TestRQWorker(FrappeTestCase):
 
 	def test_worker_serialization(self):
 		workers = RQWorker.get_list({})
-		frappe.get_doc("RQ Worker", workers[0].pid)
+		frappe.get_doc("RQ Worker", workers[0].name)

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -291,7 +291,6 @@ def start_worker(
 		if queue:
 			queue = [q.strip() for q in queue.split(",")]
 		queues = get_queue_list(queue, build_queue_name=True)
-		queue_name = queue and generate_qname(queue)
 
 	if os.environ.get("CI"):
 		setup_loghandlers("ERROR")
@@ -302,7 +301,7 @@ def start_worker(
 	if quiet:
 		logging_level = "WARNING"
 
-	worker = Worker(queues, name=get_worker_name(queue_name), connection=redis_connection)
+	worker = Worker(queues, connection=redis_connection)
 	worker.work(
 		logging_level=logging_level,
 		burst=burst,


### PR DESCRIPTION
Also avoid complex naming schemes.

closes https://github.com/frappe/frappe/issues/25174