### PR TITLE
fix(grid): don't add next row while paging

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1378,16 +1378,20 @@ export default class GridRow {
 		if (cur_frm) cur_frm.cur_grid = null;
 		this.wrapper.removeClass("grid-row-open");
 	}
+	has_prev() {
+		return this.doc.idx > 1;
+	}
 	open_prev() {
 		if (!this.doc) return;
 		this.open_row_at_index(this.doc.idx - 2);
 	}
+	has_next() {
+		return this.doc.idx < this.grid.data.length;
+	}
 	open_next() {
 		if (!this.doc) return;
 
-		if (!this.open_row_at_index(this.doc.idx)) {
-			this.grid.add_new_row(null, null, true);
-		}
+		this.open_row_at_index(this.doc.idx);
 	}
 	open_row_at_index(row_index) {
 		if (!this.grid.data[row_index]) return;

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -252,19 +252,25 @@ frappe.ui.keys.on("enter", function (e) {
 });
 
 frappe.ui.keys.on("ctrl+down", function (e) {
-	var grid_row = frappe.ui.form.get_open_grid_form();
-	grid_row &&
+	const grid_row = frappe.ui.form.get_open_grid_form();
+	if (grid_row?.has_next()) {
 		grid_row.toggle_view(false, function () {
 			grid_row.open_next();
 		});
+	} else {
+		e.preventDefault();
+	}
 });
 
 frappe.ui.keys.on("ctrl+up", function (e) {
-	var grid_row = frappe.ui.form.get_open_grid_form();
-	grid_row &&
+	const grid_row = frappe.ui.form.get_open_grid_form();
+	if (grid_row?.has_prev()) {
 		grid_row.toggle_view(false, function () {
 			grid_row.open_prev();
 		});
+	} else {
+		e.preventDefault();
+	}
 });
 
 frappe.ui.keys.add_shortcut({


### PR DESCRIPTION
Using `ctrl`+`up`/`down` shortcuts to page through grid rows.

### Before

When you have the last row open and hit `ctrl`+`down`, the row closes and a new row is added.

![next_row_old](https://github.com/frappe/frappe/assets/14891507/c9158c1c-b85e-4723-9fb3-e4df9282f43e)

This is unintuitive and interrupts the current user's flow: I didn't want to add a row, thereby modifying the document. I only wanted to view the row details. I'll have to manually remove the row that was added unintentionally.

### After

When you have the last row open and hit `ctrl`+`down`, nothing happens. You'll notice that you have reached the end and can go in the other direction again, by hitting `ctrl`+`up`.

![next_row_new](https://github.com/frappe/frappe/assets/14891507/97edec9f-99c7-43c7-a5f4-2ede97a4cf23)

(The impression of the row closing comes from the GIF loop in this case)