### PR TITLE
refactor: validate_link_and_fetch

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -577,32 +577,36 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			return value;
 		}
 
-		return this.validate_link_and_fetch(this.df, this.get_options(), this.docname, value);
+		return this.validate_link_and_fetch(value);
 	}
-	validate_link_and_fetch(df, options, docname, value) {
-		if (!options) return;
+	validate_link_and_fetch(value) {
+		const options = this.get_options();
+		if (!options) {
+			return;
+		}
 
-		const fetch_map = this.fetch_map;
-		const columns_to_fetch = Object.values(fetch_map);
+		const columns_to_fetch = Object.values(this.fetch_map);
 
 		// if default and no fetch, no need to validate
-		if (!columns_to_fetch.length && df.__default_value === value) {
+		if (!columns_to_fetch.length && this.df.__default_value === value) {
 			return value;
 		}
 
-		function update_dependant_fields(response) {
+		const update_dependant_fields = (response) => {
 			let field_value = "";
-			for (const [target_field, source_field] of Object.entries(fetch_map)) {
-				if (value) field_value = response[source_field];
+			for (const [target_field, source_field] of Object.entries(this.fetch_map)) {
+				if (value) {
+					field_value = response[source_field];
+				}
 				frappe.model.set_value(
-					df.parent,
-					docname,
+					this.df.parent,
+					this.docname,
 					target_field,
 					field_value,
-					df.fieldtype
+					this.df.fieldtype
 				);
 			}
-		}
+		};
 
 		// to avoid unnecessary request
 		if (value) {
@@ -613,7 +617,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					fields: columns_to_fetch,
 				})
 				.then((response) => {
-					if (!docname || !columns_to_fetch.length) return response.name;
+					if (!this.docname || !columns_to_fetch.length) {
+						return response.name;
+					}
 					update_dependant_fields(response);
 					return response.name;
 				});

--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -110,14 +110,7 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 			return all_rows_except_last;
 		}
 
-		const validate_promise = this.validate_link_and_fetch(
-			this.df,
-			this.get_options(),
-			this.docname,
-			link_value
-		);
-
-		return validate_promise.then((validated_value) => {
+		return this.validate_link_and_fetch(link_value).then((validated_value) => {
 			if (validated_value === link_value) {
 				return rows;
 			} else {


### PR DESCRIPTION
Remove redundant parameters (no need to pass member properties as parameters to a member function).
