### PR TITLE
fix: No need to sort keys while saving JSON to DB

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -385,7 +385,7 @@ class BaseDocument:
 					value = cint(value)
 
 				elif df.fieldtype == "JSON" and isinstance(value, dict):
-					value = json.dumps(value, separators=(",", ": "))
+					value = json.dumps(value, separators=(",", ":"))
 
 				elif df.fieldtype in float_like_fields and not isinstance(value, float):
 					value = flt(value)

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -385,7 +385,7 @@ class BaseDocument:
 					value = cint(value)
 
 				elif df.fieldtype == "JSON" and isinstance(value, dict):
-					value = json.dumps(value, sort_keys=True, indent=4, separators=(",", ": "))
+					value = json.dumps(value, separators=(",", ": "))
 
 				elif df.fieldtype in float_like_fields and not isinstance(value, float):
 					value = flt(value)


### PR DESCRIPTION
- No need to sort keys while saving JSON to DB. Sometimes key order is important for applications.
- Also, adding indent while saving data to DB seems unnecessary .




fixes: https://github.com/frappe/builder/issues/84