### PR TITLE
refactor: Use JSON for session data

### DIFF
--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -234,3 +234,4 @@ frappe.core.doctype.data_import.patches.remove_stale_docfields_from_legacy_versi
 frappe.patches.v15_0.validate_newsletter_recipients
 frappe.patches.v15_0.sanitize_workspace_titles
 frappe.patches.v15_0.migrate_role_profile_to_table_multi_select
+frappe.patches.v15_0.migrate_session_data

--- a/frappe/patches/v15_0/migrate_session_data.py
+++ b/frappe/patches/v15_0/migrate_session_data.py
@@ -1,0 +1,24 @@
+import frappe
+from frappe.utils import update_progress_bar
+
+
+def execute():
+	frappe.db.auto_commit_on_many_writes = True
+
+	Sessions = frappe.qb.DocType("Sessions")
+
+	current_sessions = (frappe.qb.from_(Sessions).select(Sessions.sid, Sessions.sessiondata)).run(
+		as_dict=True
+	)
+
+	for i, session in enumerate(current_sessions):
+		try:
+			new_data = frappe.as_json(frappe.safe_eval(session.sessiondata))
+		except Exception:
+			# Rerunning patch or already converted.
+			continue
+
+		(
+			frappe.qb.update(Sessions).where(Sessions.sid == session.sid).set(Sessions.sessiondata, new_data)
+		).run()
+		update_progress_bar("Patching sessions", i, len(current_sessions))


### PR DESCRIPTION
JSON is proper format compared to using safe_eval which is a hack to convert
string repr of dict object back into python object.
