### PR TITLE
fix: Export `None` as type if select as no options

### DIFF
--- a/frappe/automation/doctype/assignment_rule/assignment_rule.py
+++ b/frappe/automation/doctype/assignment_rule/assignment_rule.py
@@ -31,8 +31,8 @@ class AssignmentRule(Document):
 		description: DF.SmallText
 		disabled: DF.Check
 		document_type: DF.Link
-		due_date_based_on: DF.Literal
-		field: DF.Literal
+		due_date_based_on: DF.Literal[None]
+		field: DF.Literal[None]
 		last_user: DF.Link | None
 		priority: DF.Int
 		rule: DF.Literal["Round Robin", "Load Balancing", "Based on Field"]

--- a/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
+++ b/frappe/automation/doctype/milestone_tracker/milestone_tracker.py
@@ -18,7 +18,7 @@ class MilestoneTracker(Document):
 
 		disabled: DF.Check
 		document_type: DF.Link
-		track_field: DF.Literal
+		track_field: DF.Literal[None]
 	# end: auto-generated types
 
 	def on_update(self):

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -111,7 +111,7 @@ class DocType(Document):
 		custom: DF.Check
 		default_email_template: DF.Link | None
 		default_print_format: DF.Data | None
-		default_view: DF.Literal
+		default_view: DF.Literal[None]
 		description: DF.SmallText | None
 		document_type: DF.Literal["", "Document", "Setup", "System", "Other"]
 		documentation: DF.Data | None

--- a/frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.py
+++ b/frappe/core/doctype/document_naming_rule_condition/document_naming_rule_condition.py
@@ -15,7 +15,7 @@ class DocumentNamingRuleCondition(Document):
 		from frappe.types import DF
 
 		condition: DF.Literal["=", "!=", ">", "<", ">=", "<="]
-		field: DF.Literal
+		field: DF.Literal[None]
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/frappe/core/doctype/module_def/module_def.py
+++ b/frappe/core/doctype/module_def/module_def.py
@@ -19,7 +19,7 @@ class ModuleDef(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		app_name: DF.Literal
+		app_name: DF.Literal[None]
 		custom: DF.Check
 		module_name: DF.Data
 		package: DF.Link | None

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -89,7 +89,7 @@ class SystemSettings(Document):
 		setup_complete: DF.Check
 		strip_exif_metadata_from_uploaded_images: DF.Check
 		time_format: DF.Literal["HH:mm:ss", "HH:mm"]
-		time_zone: DF.Literal
+		time_zone: DF.Literal[None]
 		two_factor_method: DF.Literal["OTP App", "SMS", "Email"]
 		welcome_email_template: DF.Link | None
 	# end: auto-generated types

--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -29,7 +29,7 @@ class UserType(Document):
 		role: DF.Link | None
 		select_doctypes: DF.Table[UserSelectDocumentType]
 		user_doctypes: DF.Table[UserDocumentType]
-		user_id_field: DF.Literal
+		user_id_field: DF.Literal[None]
 		user_type_modules: DF.Table[UserTypeModule]
 	# end: auto-generated types
 

--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -89,7 +89,7 @@ class CustomField(Document):
 		in_list_view: DF.Check
 		in_preview: DF.Check
 		in_standard_filter: DF.Check
-		insert_after: DF.Literal
+		insert_after: DF.Literal[None]
 		is_system_generated: DF.Check
 		is_virtual: DF.Check
 		label: DF.Data | None

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -44,7 +44,7 @@ class CustomizeForm(Document):
 		autoname: DF.Data | None
 		default_email_template: DF.Link | None
 		default_print_format: DF.Link | None
-		default_view: DF.Literal
+		default_view: DF.Literal[None]
 		doc_type: DF.Link | None
 		editable_grid: DF.Check
 		email_append_to: DF.Check
@@ -75,7 +75,7 @@ class CustomizeForm(Document):
 		sender_name_field: DF.Data | None
 		show_preview_popup: DF.Check
 		show_title_field_in_link: DF.Check
-		sort_field: DF.Literal
+		sort_field: DF.Literal[None]
 		sort_order: DF.Literal["ASC", "DESC"]
 		states: DF.Table[DocTypeState]
 		subject_field: DF.Data | None

--- a/frappe/custom/doctype/doctype_layout_field/doctype_layout_field.py
+++ b/frappe/custom/doctype/doctype_layout_field/doctype_layout_field.py
@@ -14,7 +14,7 @@ class DocTypeLayoutField(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		fieldname: DF.Literal
+		fieldname: DF.Literal[None]
 		label: DF.Data | None
 		parent: DF.Data
 		parentfield: DF.Data

--- a/frappe/desk/doctype/bulk_update/bulk_update.py
+++ b/frappe/desk/doctype/bulk_update/bulk_update.py
@@ -21,7 +21,7 @@ class BulkUpdate(Document):
 
 		condition: DF.SmallText | None
 		document_type: DF.Link
-		field: DF.Literal
+		field: DF.Literal[None]
 		limit: DF.Int
 		update_value: DF.SmallText
 	# end: auto-generated types

--- a/frappe/desk/doctype/calendar_view/calendar_view.py
+++ b/frappe/desk/doctype/calendar_view/calendar_view.py
@@ -14,10 +14,10 @@ class CalendarView(Document):
 		from frappe.types import DF
 
 		all_day: DF.Check
-		end_date_field: DF.Literal
+		end_date_field: DF.Literal[None]
 		reference_doctype: DF.Link
-		start_date_field: DF.Literal
-		subject_field: DF.Literal
+		start_date_field: DF.Literal[None]
+		subject_field: DF.Literal[None]
 	# end: auto-generated types
 
 	pass

--- a/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
+++ b/frappe/desk/doctype/dashboard_chart/dashboard_chart.py
@@ -335,8 +335,8 @@ class DashboardChart(Document):
 		from frappe.desk.doctype.dashboard_chart_field.dashboard_chart_field import DashboardChartField
 		from frappe.types import DF
 
-		aggregate_function_based_on: DF.Literal
-		based_on: DF.Literal
+		aggregate_function_based_on: DF.Literal[None]
+		based_on: DF.Literal[None]
 		chart_name: DF.Data
 		chart_type: DF.Literal["Count", "Sum", "Average", "Group By", "Custom", "Report"]
 		color: DF.Color | None
@@ -345,9 +345,9 @@ class DashboardChart(Document):
 		dynamic_filters_json: DF.Code | None
 		filters_json: DF.Code
 		from_date: DF.Date | None
-		group_by_based_on: DF.Literal
+		group_by_based_on: DF.Literal[None]
 		group_by_type: DF.Literal["Count", "Sum", "Average"]
-		heatmap_year: DF.Literal
+		heatmap_year: DF.Literal[None]
 		is_public: DF.Check
 		is_standard: DF.Check
 		last_synced_on: DF.Datetime | None
@@ -363,8 +363,8 @@ class DashboardChart(Document):
 		to_date: DF.Date | None
 		type: DF.Literal["Line", "Bar", "Percentage", "Pie", "Donut", "Heatmap"]
 		use_report_chart: DF.Check
-		value_based_on: DF.Literal
-		x_field: DF.Literal
+		value_based_on: DF.Literal[None]
+		x_field: DF.Literal[None]
 		y_axis: DF.Table[DashboardChartField]
 	# end: auto-generated types
 

--- a/frappe/desk/doctype/dashboard_chart_field/dashboard_chart_field.py
+++ b/frappe/desk/doctype/dashboard_chart_field/dashboard_chart_field.py
@@ -18,7 +18,7 @@ class DashboardChartField(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		y_field: DF.Literal
+		y_field: DF.Literal[None]
 	# end: auto-generated types
 
 	pass

--- a/frappe/desk/doctype/form_tour_step/form_tour_step.py
+++ b/frappe/desk/doctype/form_tour_step/form_tour_step.py
@@ -17,7 +17,7 @@ class FormTourStep(Document):
 		child_doctype: DF.Data | None
 		description: DF.HTMLEditor
 		element_selector: DF.Data | None
-		fieldname: DF.Literal
+		fieldname: DF.Literal[None]
 		fieldtype: DF.Data | None
 		has_next_condition: DF.Check
 		hide_buttons: DF.Check
@@ -32,7 +32,7 @@ class FormTourStep(Document):
 		ondemand_description: DF.HTMLEditor | None
 		parent: DF.Data
 		parent_element_selector: DF.Data | None
-		parent_fieldname: DF.Literal
+		parent_fieldname: DF.Literal[None]
 		parentfield: DF.Data
 		parenttype: DF.Data
 		popover_element: DF.Check

--- a/frappe/desk/doctype/kanban_board/kanban_board.py
+++ b/frappe/desk/doctype/kanban_board/kanban_board.py
@@ -19,7 +19,7 @@ class KanbanBoard(Document):
 		from frappe.types import DF
 
 		columns: DF.Table[KanbanBoardColumn]
-		field_name: DF.Literal
+		field_name: DF.Literal[None]
 		fields: DF.Code | None
 		filters: DF.Code | None
 		kanban_board_name: DF.Data

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -22,7 +22,7 @@ class NumberCard(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		aggregate_function_based_on: DF.Literal
+		aggregate_function_based_on: DF.Literal[None]
 		color: DF.Color | None
 		document_type: DF.Link | None
 		dynamic_filters_json: DF.Code | None
@@ -35,7 +35,7 @@ class NumberCard(Document):
 		method: DF.Data | None
 		module: DF.Link | None
 		parent_document_type: DF.Link | None
-		report_field: DF.Literal
+		report_field: DF.Literal[None]
 		report_function: DF.Literal["Sum", "Average", "Minimum", "Maximum"]
 		report_name: DF.Link | None
 		show_percentage_stats: DF.Check

--- a/frappe/desk/doctype/onboarding_step/onboarding_step.py
+++ b/frappe/desk/doctype/onboarding_step/onboarding_step.py
@@ -24,7 +24,7 @@ class OnboardingStep(Document):
 		callback_message: DF.SmallText | None
 		callback_title: DF.Data | None
 		description: DF.MarkdownEditor | None
-		field: DF.Literal
+		field: DF.Literal[None]
 		form_tour: DF.Link | None
 		intro_video_url: DF.Data | None
 		is_complete: DF.Check

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -53,14 +53,14 @@ class AutoEmailReport(Document):
 		filters: DF.Text | None
 		format: DF.Literal["HTML", "XLSX", "CSV"]
 		frequency: DF.Literal["Daily", "Weekdays", "Weekly", "Monthly"]
-		from_date_field: DF.Literal
+		from_date_field: DF.Literal[None]
 		no_of_rows: DF.Int
 		reference_report: DF.Data | None
 		report: DF.Link
 		report_type: DF.ReadOnly | None
 		send_if_data: DF.Check
 		sender: DF.Link | None
-		to_date_field: DF.Literal
+		to_date_field: DF.Literal[None]
 		use_first_day_of_period: DF.Check
 		user: DF.Link
 	# end: auto-generated types

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -34,7 +34,7 @@ class Notification(Document):
 		attach_print: DF.Check
 		channel: DF.Literal["Email", "Slack", "System Notification", "SMS"]
 		condition: DF.Code | None
-		date_changed: DF.Literal
+		date_changed: DF.Literal[None]
 		days_in_advance: DF.Int
 		document_type: DF.Link
 		enabled: DF.Check
@@ -62,10 +62,10 @@ class Notification(Document):
 		send_to_all_assignees: DF.Check
 		sender: DF.Link | None
 		sender_email: DF.Data | None
-		set_property_after_alert: DF.Literal
+		set_property_after_alert: DF.Literal[None]
 		slack_webhook_url: DF.Link | None
 		subject: DF.Data | None
-		value_changed: DF.Literal
+		value_changed: DF.Literal[None]
 	# end: auto-generated types
 
 	def onload(self):

--- a/frappe/email/doctype/notification_recipient/notification_recipient.py
+++ b/frappe/email/doctype/notification_recipient/notification_recipient.py
@@ -19,7 +19,7 @@ class NotificationRecipient(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		receiver_by_document_field: DF.Literal
+		receiver_by_document_field: DF.Literal[None]
 		receiver_by_role: DF.Link | None
 	# end: auto-generated types
 

--- a/frappe/integrations/doctype/webhook_data/webhook_data.py
+++ b/frappe/integrations/doctype/webhook_data/webhook_data.py
@@ -14,7 +14,7 @@ class WebhookData(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		fieldname: DF.Literal
+		fieldname: DF.Literal[None]
 		key: DF.Data
 		parent: DF.Data
 		parentfield: DF.Data

--- a/frappe/printing/doctype/network_printer_settings/network_printer_settings.py
+++ b/frappe/printing/doctype/network_printer_settings/network_printer_settings.py
@@ -16,7 +16,7 @@ class NetworkPrinterSettings(Document):
 		from frappe.types import DF
 
 		port: DF.Int
-		printer_name: DF.Literal
+		printer_name: DF.Literal[None]
 		server_ip: DF.Data
 	# end: auto-generated types
 

--- a/frappe/social/doctype/energy_point_rule/energy_point_rule.py
+++ b/frappe/social/doctype/energy_point_rule/energy_point_rule.py
@@ -25,15 +25,15 @@ class EnergyPointRule(Document):
 		apply_only_once: DF.Check
 		condition: DF.Code | None
 		enabled: DF.Check
-		field_to_check: DF.Literal
+		field_to_check: DF.Literal[None]
 		for_assigned_users: DF.Check
 		for_doc_event: DF.Literal["New", "Submit", "Cancel", "Value Change", "Custom"]
 		max_points: DF.Int
-		multiplier_field: DF.Literal
+		multiplier_field: DF.Literal[None]
 		points: DF.Int
 		reference_doctype: DF.Link
 		rule_name: DF.Data
-		user_field: DF.Literal
+		user_field: DF.Literal[None]
 	# end: auto-generated types
 
 	def on_update(self):

--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -183,7 +183,7 @@ class TypeExporter:
 		elif field.fieldtype == "Select":
 			if not field.options:
 				# Could be dynamic
-				return
+				return "None"
 			options = [o.strip() for o in field.options.split("\n")]
 			return json.dumps(options)
 

--- a/frappe/website/doctype/top_bar_item/top_bar_item.py
+++ b/frappe/website/doctype/top_bar_item/top_bar_item.py
@@ -17,7 +17,7 @@ class TopBarItem(Document):
 		label: DF.Data
 		open_in_new_tab: DF.Check
 		parent: DF.Data
-		parent_label: DF.Literal
+		parent_label: DF.Literal[None]
 		parentfield: DF.Data
 		parenttype: DF.Data
 		right: DF.Check

--- a/frappe/website/doctype/web_form_field/web_form_field.py
+++ b/frappe/website/doctype/web_form_field/web_form_field.py
@@ -18,7 +18,7 @@ class WebFormField(Document):
 		default: DF.Data | None
 		depends_on: DF.Code | None
 		description: DF.Text | None
-		fieldname: DF.Literal
+		fieldname: DF.Literal[None]
 		fieldtype: DF.Literal[
 			"Attach",
 			"Attach Image",

--- a/frappe/website/doctype/web_form_list_column/web_form_list_column.py
+++ b/frappe/website/doctype/web_form_list_column/web_form_list_column.py
@@ -14,7 +14,7 @@ class WebFormListColumn(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		fieldname: DF.Literal
+		fieldname: DF.Literal[None]
 		fieldtype: DF.Data | None
 		label: DF.Data | None
 		name: DF.Int | None

--- a/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
+++ b/frappe/workflow/doctype/workflow_document_state/workflow_document_state.py
@@ -24,7 +24,7 @@ class WorkflowDocumentState(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		state: DF.Link
-		update_field: DF.Literal
+		update_field: DF.Literal[None]
 		update_value: DF.Data | None
 		workflow_builder_id: DF.Data | None
 	# end: auto-generated types


### PR DESCRIPTION
Select options can be dynamic, in that case we should at least the
default value `None` as a value `DF.Literal` otherwise is invalid type
annotation.
