### PR TITLE
ci(version-15): use 3.10

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 'Setup Environment'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
       - uses: actions/checkout@v4
 
       - name: Validate Docs

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Check for valid Python & Merge Conflicts
         run: |

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.10'
 
       - name: Check for valid Python & Merge Conflicts
         run: |

--- a/frappe/tests/test_auth.py
+++ b/frappe/tests/test_auth.py
@@ -158,10 +158,12 @@ class TestAuth(FrappeTestCase):
 			self.fail("Rate limting not working")
 
 	def test_correct_cookie_expiry_set(self):
+		import pytz
+
 		client = FrappeClient(self.HOST_NAME, self.test_user_email, self.test_user_password)
 
 		expiry_time = next(x for x in client.session.cookies if x.name == "sid").expires
-		current_time = datetime.datetime.now(tz=datetime.UTC).timestamp()
+		current_time = datetime.datetime.now(tz=pytz.UTC).timestamp()
 		self.assertAlmostEqual(get_expiry_in_seconds(), expiry_time - current_time, delta=60 * 60)
 
 


### PR DESCRIPTION
Avoid possible compatibility issues by checking against msv.

Develop will continue to use latest python version for faster CI and future proofing.
