### PR TITLE
chore: don't allow printing more than 50 documents for now

### DIFF
--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -35,6 +35,11 @@ export default class BulkOperations {
 			return;
 		}
 
+		if (valid_docs.length > 50) {
+			frappe.msgprint(__("You can only print upto 50 documents at a time"));
+			return;
+		}
+
 		const dialog = new frappe.ui.Dialog({
 			title: __("Print Documents"),
 			fields: [


### PR DESCRIPTION
The 2 minute timeout gets exhausted pretty quickly, until we can move
this to the background, this will atleast prevent people from seeing
an error after the request times out.

![image](https://github.com/frappe/frappe/assets/10119037/84b1de09-c73e-489d-9c35-142cc3c7e930)

