### PR TITLE
fix(uninstall): don't allow uninstalling an app if we have other apps dependent on it

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -374,6 +374,14 @@ def remove_app(app_name, dry_run=False, yes=False, no_backup=False, force=False)
 			click.secho(f"App {app_name} not installed on Site {site}", fg="yellow")
 			return
 
+	# Don't allow uninstalling if we have dependent apps installed
+	for app in frappe.get_installed_apps():
+		if app != app_name:
+			hooks = frappe.get_hooks(app_name=app)
+			if hooks.required_apps and any(app_name in required_app for required_app in hooks.required_apps):
+				click.secho(f"App {app_name} is a dependency of {app}. Uninstall {app} first.", fg="yellow")
+				return
+
 	print(f"Uninstalling App {app_name} from Site {site}...")
 
 	if not dry_run and not yes:


### PR DESCRIPTION
Support ticket 10929 / Sentry FRAPPE-3T8

People uninstalled ERPNext while having HRMS/India Compliance installed, leading to breakage
