### PR TITLE
fix!: disable transaction commits during doc events

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -48,7 +48,9 @@ MULTI_WORD_PATTERN = re.compile(r'([`"])(tab([A-Z]\w+)( [A-Z]\w+)+)\1')
 SQL_ITERATOR_BATCH_SIZE = 100
 
 
-TRANSACTION_DISABLED_MSG = "Commit/rollback are disabled during certain events. This command will be ignored."
+TRANSACTION_DISABLED_MSG = """Commit/rollback are disabled during certain events. This command will
+be ignored. Commit/Rollback from here WILL CAUSE very hard to debug problems with atomicity and
+concurrent data update bugs."""
 
 
 class Database:

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1300,7 +1300,11 @@ class Document(BaseDocument):
 			def runner(self, method, *args, **kwargs):
 				add_to_return_value(self, fn(self, *args, **kwargs))
 				for f in hooks:
-					add_to_return_value(self, f(self, method, *args, **kwargs))
+					try:
+						frappe.db.disable_transaction_control = True
+						add_to_return_value(self, f(self, method, *args, **kwargs))
+					finally:
+						frappe.db.disable_transaction_control = False
 
 				return self.__dict__.pop("_return_value", None)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1301,10 +1301,10 @@ class Document(BaseDocument):
 				add_to_return_value(self, fn(self, *args, **kwargs))
 				for f in hooks:
 					try:
-						frappe.db.disable_transaction_control = True
+						frappe.db._disable_transaction_control += 1
 						add_to_return_value(self, f(self, method, *args, **kwargs))
 					finally:
-						frappe.db.disable_transaction_control = False
+						frappe.db._disable_transaction_control -= 1
 
 				return self.__dict__.pop("_return_value", None)
 

--- a/frappe/tests/test_db.py
+++ b/frappe/tests/test_db.py
@@ -15,7 +15,7 @@ from frappe.database.utils import FallBackDateTimeStr
 from frappe.query_builder import Field
 from frappe.query_builder.functions import Concat_ws
 from frappe.tests.test_query_builder import db_type_is, run_only_if
-from frappe.tests.utils import FrappeTestCase, timeout
+from frappe.tests.utils import FrappeTestCase, patch_hooks, timeout
 from frappe.utils import add_days, now, random_string, set_request
 from frappe.utils.testutils import clear_custom_fields
 
@@ -458,6 +458,19 @@ class TestDB(FrappeTestCase):
 			note.name,
 		)
 		self.assertEqual(1, frappe.db.transaction_writes - writes)
+
+	def test_transactions_disabled_during_writes(self):
+		hook_name = f"{bad_hook.__module__}.{bad_hook.__name__}"
+		nested_hook_name = f"{bad_nested_hook.__module__}.{bad_nested_hook.__name__}"
+
+		with patch_hooks(
+			{"doc_events": {"*": {"before_validate": hook_name, "on_update": nested_hook_name}}}
+		):
+			note = frappe.new_doc("Note", title=frappe.generate_hash())
+			note.insert()
+		self.assertGreater(frappe.db.transaction_writes, 0)  # This would've reset for commit/rollback
+
+		self.assertFalse(frappe.db._disable_transaction_control)
 
 	def test_pk_collision_ignoring(self):
 		# note has `name` generated from title
@@ -1005,6 +1018,17 @@ class TestConcurrency(FrappeTestCase):
 
 		with self.secondary_connection():
 			self.assertRaises(frappe.QueryTimeoutError, frappe.delete_doc, note.doctype, note.name)
+
+
+def bad_hook(*args, **kwargs):
+	frappe.db.commit()
+	frappe.db.rollback()
+
+
+def bad_nested_hook(doc, *args, **kwargs):
+	doc.run_method("before_validate")
+	frappe.db.commit()
+	frappe.db.rollback()
 
 
 class TestSqlIterator(FrappeTestCase):


### PR DESCRIPTION
- Events like doc.save and doc.submit need to be atomic
- Document hooks can make it not so atomic.

This is extending server script behavior where server script hooks are
not allowed to commit/rollback.

Summary:
- First party code on controller CAN do transaction commits
- Third party code or ANY events triggered via hooks can not do transaction commits.  



Example problem:

![image](https://github.com/frappe/frappe/assets/9079960/b79aa51a-3c0e-4f2b-8023-71235758ae6f)
