### PR TITLE
fix(ModuleDef): Add list view filter options to app_name Select

### DIFF
--- a/frappe/core/doctype/module_def/module_def_list.js
+++ b/frappe/core/doctype/module_def/module_def_list.js
@@ -1,0 +1,16 @@
+frappe.listview_settings["Module Def"] = {
+	onload: function (list_view) {
+		frappe.call({
+			method: "frappe.core.doctype.module_def.module_def.get_installed_apps",
+			callback: (r) => {
+				const field = list_view.page.fields_dict.app_name;
+				if (!field) return;
+
+				const options = JSON.parse(r.message);
+				options.unshift(""); // Add empty option
+				field.df.options = options;
+				field.set_options();
+			},
+		});
+	},
+};


### PR DESCRIPTION
closes #25243

Note: Restoring the filter value on page load, because a Select with no `options` cannot accept a value, and thus `set_value/set_formatted_input` clears the value of the Select. This problem is not in the scope of #25243, so I did not fix it.