### PR TITLE
fix: formatting

### DIFF
--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -9,9 +9,7 @@ import frappe
 from frappe.utils.data import cstr
 
 
-def publish_progress(
-	percent, title=None, doctype=None, docname=None, description=None, task_id=None
-):
+def publish_progress(percent, title=None, doctype=None, docname=None, description=None, task_id=None):
 	publish_realtime(
 		"progress",
 		{"percent": percent, "title": title, "description": description},


### PR DESCRIPTION
Broke in 30a2f2743df74edefeeafc6efe12ac6f2dedf246 since it was written pre-ruff but backported post-ruff