### PR TITLE
fix: MacOS shortcuts

### DIFF
--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -453,7 +453,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 			},
 			true,
 			{
-				shortcut: "ctrl+z",
+				shortcut: "Ctrl+Z",
 				condition: () => !this.frm.is_form_builder(),
 				description: __("Undo last action"),
 			}
@@ -465,7 +465,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 			},
 			true,
 			{
-				shortcut: "ctrl+y",
+				shortcut: "Ctrl+Y",
 				condition: () => !this.frm.is_form_builder(),
 				description: __("Redo last action"),
 			}

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -98,7 +98,7 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 					.map(frappe.utils.to_title_case)
 					.join("+");
 				if (frappe.utils.is_mac()) {
-					shortcut_label = shortcut_label.replace("Ctrl", "⌘");
+					shortcut_label = shortcut_label.replace("Ctrl", "⌘").replace("Alt", "⌥");
 				}
 				return `<tr>
 					<td width="40%"><kbd>${shortcut_label}</kbd></td>

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -218,7 +218,7 @@ frappe.ui.keys.add_shortcut({
 	shortcut: "alt+s",
 	action: function (e) {
 		e.preventDefault();
-		$(".dropdown-navbar-user a").eq(0).click();
+		$(".dropdown-navbar-user button").eq(0).click();
 	},
 	description: __("Open Settings"),
 });
@@ -235,7 +235,7 @@ frappe.ui.keys.add_shortcut({
 	shortcut: "alt+h",
 	action: function (e) {
 		e.preventDefault();
-		$(".dropdown-help a").eq(0).click();
+		$(".dropdown-help button").eq(0).click();
 	},
 	description: __("Open Help"),
 });

--- a/frappe/public/js/frappe/ui/keyboard.js
+++ b/frappe/public/js/frappe/ui/keyboard.js
@@ -100,6 +100,9 @@ frappe.ui.keys.show_keyboard_shortcut_dialog = () => {
 				if (frappe.utils.is_mac()) {
 					shortcut_label = shortcut_label.replace("Ctrl", "⌘").replace("Alt", "⌥");
 				}
+
+				shortcut_label = shortcut_label.replace("Shift", "⇧");
+
 				return `<tr>
 					<td width="40%"><kbd>${shortcut_label}</kbd></td>
 					<td width="60%">${shortcut.description || ""}</td>

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -536,7 +536,9 @@ frappe.ui.Page = class Page {
 		}
 		// label
 		if (frappe.utils.is_mac()) {
-			shortcut_obj.shortcut_label = shortcut_obj.shortcut.replace("Ctrl", "⌘");
+			shortcut_obj.shortcut_label = shortcut_obj.shortcut
+				.replace("Ctrl", "⌘")
+				.replace("Alt", "⌥");
 		} else {
 			shortcut_obj.shortcut_label = shortcut_obj.shortcut;
 		}

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -542,6 +542,9 @@ frappe.ui.Page = class Page {
 		} else {
 			shortcut_obj.shortcut_label = shortcut_obj.shortcut;
 		}
+
+		shortcut_obj.shortcut_label = shortcut_obj.shortcut_label.replace("Shift", "⇧");
+
 		// actual shortcut string
 		shortcut_obj.shortcut = shortcut_obj.shortcut.toLowerCase();
 		// action is button click

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -26,7 +26,7 @@
 						id="navbar-search"
 						type="text"
 						class="form-control"
-						placeholder="{%= __("Search or type a command (Ctrl + G)") %}"
+						placeholder="{%= __('Search or type a command ({0})', [frappe.utils.is_mac() ? '⌘ + G' : 'Ctrl + G']) %}"
 						aria-haspopup="true"
 					>
 					<span class="search-icon">


### PR DESCRIPTION
- Fix MacOS shortcuts
	- "Command" symbol in Navbar
	- Show "Alt" symbol instead of text
- Show "Shift" symbol instead of text
- Fix navbar "Settings" and "Help" shortcuts

![Bildschirmfoto 2024-03-07 um 11 32 03](https://github.com/frappe/frappe/assets/14891507/108c24c6-7af2-4cf5-b88b-cab58f2636bc)
![Bildschirmfoto 2024-03-07 um 11 31 21](https://github.com/frappe/frappe/assets/14891507/c8d81d91-3500-45a0-b8ca-261b756b7257)
