### PR TITLE
fix: Add `is_virtual` in bootstrap schema

### DIFF
--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -176,6 +176,7 @@ CREATE TABLE `tabDocType` (
   `idx` int(8) NOT NULL DEFAULT 0,
   `search_fields` varchar(255) DEFAULT NULL,
   `issingle` int(1) NOT NULL DEFAULT 0,
+  `is_virtual` int(1) NOT NULL DEFAULT 0,
   `is_tree` int(1) NOT NULL DEFAULT 0,
   `istable` int(1) NOT NULL DEFAULT 0,
   `editable_grid` int(1) NOT NULL DEFAULT 1,

--- a/frappe/database/postgres/framework_postgres.sql
+++ b/frappe/database/postgres/framework_postgres.sql
@@ -179,6 +179,7 @@ CREATE TABLE "tabDocType" (
   "idx" bigint NOT NULL DEFAULT 0,
   "search_fields" varchar(255) DEFAULT NULL,
   "issingle" smallint NOT NULL DEFAULT 0,
+  "is_virtual" smallint NOT NULL DEFAULT 0,
   "is_tree" smallint NOT NULL DEFAULT 0,
   "istable" smallint NOT NULL DEFAULT 0,
   "editable_grid" smallint NOT NULL DEFAULT 1,

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -17,6 +17,7 @@ def before_install():
 	frappe.reload_doc("desk", "doctype", "form_tour_step")
 	frappe.reload_doc("desk", "doctype", "form_tour")
 	frappe.reload_doc("core", "doctype", "doctype")
+	frappe.clear_cache()
 
 
 def after_install():


### PR DESCRIPTION
This is what's actually causing test to fail. `Recorder` is getting marked as non-virtual doctype hence get_list doesn't work and tests fail.

![image](https://github.com/frappe/frappe/assets/9079960/d822545e-ae62-49bc-9846-2e1b19863d3b)
