### PR TITLE
perf: optimize hash naming for MySQL storage

### DIFF
--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -3,6 +3,8 @@
 
 import datetime
 import re
+import struct
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Optional
 
@@ -262,7 +264,10 @@ def make_autoname(key="", doctype="", doc="", *, ignore_validate=False):
 	                DE/09/01/00001 where 09 is the year, 01 is the month and 00001 is the series
 	"""
 	if key == "hash":
-		return frappe.generate_hash(length=10)
+		# Makeshift "ULID": first 4 chars are based on timestamp, other 8 are random
+		ts = hex(struct.unpack("<Q", struct.pack("<d", time.time()))[0])
+
+		return ts[-8:-5] + frappe.generate_hash(length=7)
 
 	series = NamingSeries(key)
 	return series.generate_next_name(doc, ignore_validate=ignore_validate)


### PR DESCRIPTION
InnoDB is "index organized"* and the primary key is that index. So random names can send rows all over the place.

Typically documents created closer in time should live closer on mysql pages too.


Test: I created a DocType with 300 documents and each containing 1000 child table rows.

| operation               | before | after | difference | 
| ---                     | ---                 | ---                | --- | 
| read a single document w/ 1000 child table rows; MySQL pages read  | 885    | 8   | 100x reduction |
| create a new hash name (microseconds) | 1.65 | 3.94 | 2.3x increase |  

Pages read numbers are mostly meaningless as they depend on # of rows read. The general idea is previously number of pages read was proportional to the number of rows read because of random distribution of data. The proportionality factor being how many rows can fit in single 16KB page. 

Notes:
- This data is from bufferpool stats, not 100% accurate.
- mariadb was restarted everytime before executing query. So data shouldn't be in pool by default.
- Default page size in mariadb is 16kb, you need A LOT of data to trigger this. Make sure you hit at least >100mb table size before testing anything.  


TODO:
- [x] verify test results with more reliable setup.
- [x] any side effects?



\* - https://15445.courses.cs.cmu.edu/fall2023/slides/04-storage2.pdf (page 25)