### PR TITLE
refactor: replace `in_list(array, member)` with `array.includes(member)`

### DIFF
--- a/frappe/printing/page/print_format_builder/print_format_builder_field.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_field.html
@@ -10,7 +10,7 @@
 		data-columns="{%= me.get_visible_columns_string(field) %}"
 		data-doctype="{%= field.options %}"
 	{% } %}>
-	{% if !in_list(["Table", "HTML", "Custom HTML"], field.fieldtype) %}
+	{% if !["Table", "HTML", "Custom HTML"].includes(field.fieldtype) %}
 	<a class="field-settings pull-right">
 		<span>
 			<svg class="icon icon-sm"><use href="#icon-setting-gear"></use></svg>

--- a/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html
+++ b/frappe/printing/page/print_format_builder/print_format_builder_sidebar.html
@@ -4,7 +4,7 @@
 </div>
 <div class="print-format-builder-sidebar-fields">
 	{% for (var i=0, l=fields.length; i < l; i++) { var f = fields[i]; %}
-		{% if(!in_list(["Section Break", "Tab Break", "Column Break", "Fold"], f.fieldtype)) { %}
+		{% if(!["Section Break", "Tab Break", "Column Break", "Fold"].includes(f.fieldtype)) { %}
 		<div class="print-format-builder-field-placeholder"
 			data-fieldname="{%= f.fieldname %}">
 			<div title="{{f.label}}" class="field-label btn btn-default btn-sm sidebar-field ellipsis

--- a/frappe/public/js/form_builder/components/FieldProperties.vue
+++ b/frappe/public/js/form_builder/components/FieldProperties.vue
@@ -26,7 +26,7 @@ let docfield_df = computed(() => {
 		}
 
 		if (
-			in_list(["fetch_from", "fetch_if_empty"], df.fieldname) &&
+			["fetch_from", "fetch_if_empty"].includes(df.fieldname) &&
 			in_list(frappe.model.no_value_type, store.form.selected_field.fieldtype)
 		) {
 			return false;
@@ -41,7 +41,7 @@ let docfield_df = computed(() => {
 			df.options = "";
 			args.value = {};
 
-			if (in_list(["Table", "Link"], store.form.selected_field.fieldtype)) {
+			if (["Table", "Link"].includes(store.form.selected_field.fieldtype)) {
 				df.fieldtype = "Link";
 				df.options = "DocType";
 

--- a/frappe/public/js/workflow_builder/components/Properties.vue
+++ b/frappe/public/js/workflow_builder/components/Properties.vue
@@ -18,13 +18,13 @@ let properties = computed(() => {
 	if (store.workflow.selected && "action" in store.workflow.selected.data) {
 		title.value = "Transition Properties";
 		return store.transitionfields.filter((df) =>
-			in_list(["action", "allowed", "allow_self_approval", "condition"], df.fieldname)
+			["action", "allowed", "allow_self_approval", "condition"].includes(df.fieldname)
 		);
 	} else if (store.workflow.selected && "state" in store.workflow.selected.data) {
 		title.value = "State Properties";
 		let allow_edit = store.statefields.find((df) => df.fieldname == "allow_edit");
 		store.statefields = store.statefields.filter(
-			(df) => !in_list(["allow_edit", "workflow_builder_id"], df.fieldname)
+			(df) => !["allow_edit", "workflow_builder_id"].includes(df.fieldname)
 		);
 		store.statefields.splice(2, 0, allow_edit);
 
@@ -41,7 +41,7 @@ let properties = computed(() => {
 	}
 	title.value = "Workflow Details";
 	return store.workflowfields.filter(
-		(df) => !in_list(["states", "transitions", "workflow_data", "workflow_name"], df.fieldname)
+		(df) => !["states", "transitions", "workflow_data", "workflow_name"].includes(df.fieldname)
 	);
 });
 </script>


### PR DESCRIPTION
`in_list` is [discouraged by our semgrep rules](https://github.com/frappe/semgrep-rules/blob/92e1241cd9894caf478f644e8383f908824b1950/rules/code_quality.yml#L12-L18) and leads to a warning whenever we edit these files