### PR TITLE
chore: specify typing modules for ruff

### DIFF
--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -369,9 +369,9 @@ ignore = [
     "F403", # can't detect undefined names from * import
     "F405", # can't detect undefined names from * import
     "F722", # syntax error in forward type annotation
-    "F821", # undefined name
     "W191", # indentation contains tabs
 ]
+typing-modules = ["frappe.types.DF"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,10 +125,10 @@ ignore = [
     "F403", # can't detect undefined names from * import
     "F405", # can't detect undefined names from * import
     "F722", # syntax error in forward type annotation
-    "F821", # undefined name
     "W191", # indentation contains tabs
     "RUF001", # string contains ambiguous unicode character
 ]
+typing-modules = ["frappe.types.DF"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
Resolves #25313

Ref: https://docs.astral.sh/ruff/settings/#lint_typing-modules