### PR TITLE
fix: Enqueue action after commit

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1536,11 +1536,16 @@ class Document(BaseDocument):
 				primary_action=primary_action,
 			)
 
+		enqueue_after_commit = kwargs.pop("enqueue_after_commit", None)
+		if enqueue_after_commit is None:
+			enqueue_after_commit = True
+
 		return enqueue(
 			"frappe.model.document.execute_action",
 			__doctype=self.doctype,
 			__name=self.name,
 			__action=action,
+			enqueue_after_commit=enqueue_after_commit,
 			**kwargs,
 		)
 


### PR DESCRIPTION
sentry FRAPPE-3HS 

What's happening:
- Salary slip is submitting JV which is enqueued immediately
- JV doesn't exist yet as transaction isn't commited

```
DoesNotExistError: Journal Entry JV/23-24-00444 not found
  File "frappe/utils/background_jobs.py", line 218, in execute_job
    retval = method(**kwargs)
  File "frappe/model/document.py", line 1655, in execute_action
    doc = frappe.get_doc(__doctype, __name)
  File "__init__.py", line 1363, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "frappe/model/document.py", line 85, in get_doc
    return controller(*args, **kwargs)
  File "erpnext/accounts/doctype/journal_entry/journal_entry.py", line 111, in __init__
    super(JournalEntry, self).__init__(*args, **kwargs)
  File "erpnext/controllers/accounts_controller.py", line 96, in __init__
    super(AccountsController, self).__init__(*args, **kwargs)
  File "frappe/model/document.py", line 126, in __init__
    self.load_from_db()
  File "frappe/model/document.py", line 172, in load_from_db
    frappe.throw(
  File "__init__.py", line 677, in throw
    msgprint(
  File "__init__.py", line 642, in msgprint
    _raise_exception()
  File "__init__.py", line 593, in _raise_exception
    raise exc
```