### PR TITLE
fix: commit regardless of framework's transaction_writes count

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -399,11 +399,7 @@ def handle_exception(e):
 
 def sync_database(rollback: bool) -> bool:
 	# if HTTP method would change server state, commit if necessary
-	if (
-		frappe.db
-		and (frappe.local.flags.commit or frappe.local.request.method in UNSAFE_HTTP_METHODS)
-		and frappe.db.transaction_writes
-	):
+	if frappe.db and (frappe.local.flags.commit or frappe.local.request.method in UNSAFE_HTTP_METHODS):
 		frappe.db.commit()
 		rollback = False
 	elif frappe.db:


### PR DESCRIPTION
- There is code that depends on "commit", everything that happens with `db.after_commit`.
- There are operations that will not write anything to DB but just
  enqueue the function, if it's enqueue_after_commit then it will break.
- Empty commit/rollback both are basically free. MySQL treats transaction as read-only until a write is made. 