### PR TITLE
fix: list view click and drag select rows

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1283,6 +1283,8 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		*/
 		this.dragClick = false;
 		this.$result.on("mousedown", ".list-row-checkbox", (e) => {
+			e.stopPropagation?.();
+			e.preventDefault?.();
 			this.dragClick = true;
 			this.check = !e.target.checked;
 		});


### PR DESCRIPTION
FIXES: list view - click and drag selecting rows is not working in firefox.