### PR TITLE
perf: cap max count on list views

### DIFF
--- a/cypress/integration/list_paging.js
+++ b/cypress/integration/list_paging.js
@@ -37,6 +37,6 @@ context("List Paging", () => {
 		cy.get(".list-paging-area .list-count").should("contain.text", "500 of");
 		cy.get(".list-paging-area .btn-more").click();
 
-		cy.get(".list-paging-area .list-count").should("contain.text", "1000 of");
+		cy.get(".list-paging-area .list-count").should("contain.text", "1,000 of");
 	});
 });

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -14,6 +14,7 @@ from frappe.model.base_document import get_controller
 from frappe.model.db_query import DatabaseQuery
 from frappe.model.utils import is_virtual_doctype
 from frappe.utils import add_user_info, cint, format_duration
+from frappe.utils.data import sbool
 
 
 @frappe.whitelist()
@@ -53,7 +54,8 @@ def get_count() -> int:
 		controller = get_controller(args.doctype)
 		data = frappe.call(controller.get_count, args=args, **args)
 	else:
-		distinct = "distinct " if args.distinct == "true" else ""
+		args.distinct = sbool(args.distinct)
+		distinct = "distinct " if args.distinct else ""
 		args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
 		data = execute(**args)[0].get("total_count")
 

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -52,14 +52,24 @@ def get_count() -> int:
 
 	if is_virtual_doctype(args.doctype):
 		controller = get_controller(args.doctype)
-		data = frappe.call(controller.get_count, args=args, **args)
+		count = frappe.call(controller.get_count, args=args, **args)
 	else:
 		args.distinct = sbool(args.distinct)
 		distinct = "distinct " if args.distinct else ""
-		args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
-		data = execute(**args)[0].get("total_count")
+		args.limit = cint(args.limit)
+		if args.limit:
+			# Only "count until this limit"
+			args.fields = ["*"]
+			partial_query = execute(**args, run=0)
+			count = frappe.db.sql(
+				f"""with records as ( {partial_query} )
+					select count(*) from records""",
+			)[0][0]
+		else:
+			args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
+			count = execute(**args)[0].get("total_count")
 
-	return data
+	return count
 
 
 def execute(doctype, *args, **kwargs):

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -59,7 +59,7 @@ def get_count() -> int:
 		args.limit = cint(args.limit)
 		if args.limit:
 			# Only "count until this limit"
-			args.fields = ["*"]
+			args.fields = [f"`tab{args.doctype}`.name"]
 			partial_query = execute(**args, run=0)
 			count = frappe.db.sql(
 				f"""with records as ( {partial_query} )

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -57,16 +57,14 @@ def get_count() -> int:
 		args.distinct = sbool(args.distinct)
 		distinct = "distinct " if args.distinct else ""
 		args.limit = cint(args.limit)
+		fieldname = f"{distinct}`tab{args.doctype}`.name"
+
 		if args.limit:
-			# Only "count until this limit"
-			args.fields = [f"`tab{args.doctype}`.name"]
+			args.fields = [fieldname]
 			partial_query = execute(**args, run=0)
-			count = frappe.db.sql(
-				f"""with records as ( {partial_query} )
-					select count(*) from records""",
-			)[0][0]
+			count = frappe.db.sql(f"""select count(*) from ( {partial_query} ) p""")[0][0]
 		else:
-			args.fields = [f"count({distinct}`tab{args.doctype}`.name) as total_count"]
+			args.fields = [f"count({fieldname}) as total_count"]
 			count = execute(**args)[0].get("total_count")
 
 	return count

--- a/frappe/public/js/frappe/db.js
+++ b/frappe/public/js/frappe/db.js
@@ -96,6 +96,7 @@ frappe.db = {
 	},
 	count: function (doctype, args = {}) {
 		let filters = args.filters || {};
+		let limit = args.limit;
 
 		// has a filter with childtable?
 		const distinct =
@@ -111,6 +112,7 @@ frappe.db = {
 			filters,
 			fields,
 			distinct,
+			limit,
 		});
 	},
 	get_link_options(doctype, txt = "", filters = {}) {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -501,9 +501,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	freeze() {
 		if (this.list_view_settings && !this.list_view_settings.disable_count) {
-			this.$result
-				.find(".list-count")
-				.html(`<span>${__("Refreshing", null, "Document count in list view")}...</span>`);
+			this.get_count_element().html(
+				`<span>${__("Refreshing", null, "Document count in list view")}...</span>`
+			);
 		}
 	}
 
@@ -619,27 +619,31 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	render_count() {
 		if (this.list_view_settings.disable_count) return;
 
-		this.get_count_str().then((str) => {
-			let me = this;
-			let count_element = this.$result.find(".list-count");
-			count_element.html(`<span>${str}</span>`);
+		let me = this;
+		let $count = this.get_count_element();
+		this.get_count_str().then((count) => {
+			$count.html(`<span>${count}</span>`);
 			if (this.count_upper_bound) {
-				count_element.attr(
+				$count.attr(
 					"title",
 					__(
 						"The count shown is an estimated count. Click here to see the accurate count."
 					)
 				);
-				count_element.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
-				count_element.on("click", () => {
+				$count.tooltip({ delay: { show: 600, hide: 100 }, trigger: "hover" });
+				$count.on("click", () => {
 					me.count_upper_bound = 0;
-					count_element.off("click");
-					count_element.tooltip("disable");
+					$count.off("click");
+					$count.tooltip("disable");
 					me.freeze();
 					me.render_count();
 				});
 			}
 		});
+	}
+
+	get_count_element() {
+		return this.$result.find(".list-count");
 	}
 
 	get_header_html() {

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -28,6 +28,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			this.process_document_refreshes.bind(this),
 			2000
 		);
+		this.count_upper_bound = 1001;
 	}
 
 	has_permissions() {
@@ -946,13 +947,21 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		return frappe.db
 			.count(this.doctype, {
 				filters: this.get_filters_for_args(),
-				limit: 1001,
+				limit: this.count_upper_bound,
 			})
 			.then((total_count) => {
 				this.total_count = total_count || current_count;
 				this.count_without_children =
 					count_without_children !== current_count ? count_without_children : undefined;
-				let str = __("{0} of {1}", [current_count, this.total_count]);
+
+				let estimated_count = this.total_count;
+				if (this.total_count === this.count_upper_bound) {
+					estimated_count = `${format_number(estimated_count - 1, null, 0)}+`;
+				}
+				let str = __("{0} of {1}", [
+					format_number(current_count, null, 0),
+					estimated_count,
+				]);
 				if (this.count_without_children) {
 					str = __("{0} of {1} ({2} rows with children)", [
 						count_without_children,

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -974,7 +974,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 				let count_str;
 				if (this.total_count === this.count_upper_bound) {
-					count_str = `${format_number(count_str - 1, null, 0)}+`;
+					count_str = `${format_number(this.total_count - 1, null, 0)}+`;
 				} else {
 					count_str = format_number(this.total_count, null, 0);
 				}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -946,6 +946,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		return frappe.db
 			.count(this.doctype, {
 				filters: this.get_filters_for_args(),
+				limit: 1001,
 			})
 			.then((total_count) => {
 				this.total_count = total_count || current_count;

--- a/frappe/public/js/frappe/views/file/file_view.js
+++ b/frappe/public/js/frappe/views/file/file_view.js
@@ -231,6 +231,7 @@ frappe.views.FileView = class FileView extends frappe.views.ListView {
 		} else {
 			super.render();
 			this.render_header();
+			this.render_count();
 		}
 	}
 

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -220,19 +220,14 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		this.setup_datatable(this.data);
 	}
 
-	render_count() {
-		if (this.list_view_settings?.disable_count) {
-			return;
-		}
-		let $list_count = this.$paging_area.find(".list-count");
-		if (!$list_count.length) {
-			$list_count = $("<span>")
+	get_count_element() {
+		let $count = this.$paging_area.find(".list-count");
+		if (!$count.length) {
+			$count = $("<span>")
 				.addClass("text-muted list-count")
 				.prependTo(this.$paging_area.find(".level-right"));
 		}
-		this.get_count_str().then((str) => {
-			$list_count.text(str);
-		});
+		return $count;
 	}
 
 	on_update(data) {

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1187,7 +1187,7 @@ class TestReportView(FrappeTestCase):
 				"distinct": "false",
 			}
 		)
-		list_filter_response = execute_cmd("frappe.desk.reportview.get_count")
+		count = execute_cmd("frappe.desk.reportview.get_count")
 		frappe.local.form_dict = frappe._dict(
 			{
 				"doctype": "DocType",
@@ -1196,8 +1196,8 @@ class TestReportView(FrappeTestCase):
 			}
 		)
 		dict_filter_response = execute_cmd("frappe.desk.reportview.get_count")
-		self.assertIsInstance(list_filter_response, int)
-		self.assertEqual(list_filter_response, dict_filter_response)
+		self.assertIsInstance(count, int)
+		self.assertEqual(count, dict_filter_response)
 
 		# test with child table filter
 		frappe.local.form_dict = frappe._dict(
@@ -1217,6 +1217,21 @@ class TestReportView(FrappeTestCase):
 			" where `tabDocField`.`fieldtype` = 'Data'"
 		)[0][0]
 		self.assertEqual(child_filter_response, current_value)
+
+		# test with limit
+		limit = 2
+		frappe.local.form_dict = frappe._dict(
+			{
+				"doctype": "DocType",
+				"filters": [["DocType", "is_virtual", "=", 1]],
+				"fields": [],
+				"distinct": "false",
+				"limit": limit,
+			}
+		)
+		count = execute_cmd("frappe.desk.reportview.get_count")
+		self.assertIsInstance(count, int)
+		self.assertLessEqual(count, limit)
 
 	def test_reportview_get(self):
 		user = frappe.get_doc("User", "test@example.com")


### PR DESCRIPTION
Problem: In InnoDB counting is essentially O(N) operation, it can be pretty fast on indexes so it doesn't feel like it most of the time but when filters don't use any index it usually means doing a full table scan.

`get_count` accounts for 4% of all requests on FC - https://github.com/frappe/frappe/issues/21742 . This isn't even considering outliers that were removed from data. Users with large DB often need to disable count on list views for site to stay usable.

This makes Count sad.
![image](https://github.com/frappe/frappe/assets/9079960/a6b46223-66ee-49ee-bf90-0a6f092cdf2a)


Fix: Adding a limit will stop the scan as soon as that many records are matched.

Implementation:
- We only show accurate count up to 1000 values now
- User can click on the count to get an accurate count if really required. Most users don't care about this at all!

![count](https://github.com/frappe/frappe/assets/9079960/d6879a65-93c3-45f9-8626-013992782d3d)


Outcome:
- If filters don't match more than 1k records then this PR makes no difference. 
- If filters match more than 1k records then all that extra cost is now not paid. So for site with millions of matching records get_count will finish much faster. The main benefit is user won't NEED to disable the count.


Count is happy now. 

![image](https://github.com/frappe/frappe/assets/9079960/d98c90cc-faf9-451e-b7f2-063dbfdcf7d8)
