### PR TITLE
fix: traceback colours

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -619,6 +619,14 @@ def console(context, autoreload=False):
 	if failed_to_import:
 		print("\nFailed to import:\n{}".format(", ".join(failed_to_import)))
 
+	# ref: https://stackoverflow.com/a/74681224
+	try:
+		from IPython.core import ultratb
+
+		ultratb.VerboseTB._tb_highlight = "bg:ansibrightblack"
+	except Exception:
+		pass
+
 	terminal.colors = "neutral"
 	terminal.display_banner = False
 	terminal()


### PR DESCRIPTION
default ipython colours use yellow on white font, which looks horrible
and is practically unreadable on most colourschemes.


![image](https://github.com/frappe/frappe/assets/9079960/4876664e-50aa-4466-8d91-76f0655484e5)


ref https://stackoverflow.com/questions/70766518/how-to-change-ipython-error-highlighting-color