### PR TITLE
perf: compact prepared report files

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -219,7 +219,7 @@ def create_json_gz_file(data, dt, dn):
 	# Storing data in CSV file causes information loss
 	# Reports like P&L Statement were completely unsuable because of this
 	json_filename = "{}.json.gz".format(frappe.utils.data.format_datetime(frappe.utils.now(), "Y-m-d-H:M"))
-	encoded_content = frappe.safe_encode(frappe.as_json(data))
+	encoded_content = frappe.safe_encode(frappe.as_json(data, indent=None, separators=(",", ":")))
 	compressed_content = gzip.compress(encoded_content)
 
 	# Call save() file function to upload and attach the file


### PR DESCRIPTION
No one reads these, no need to indent them.
