### PR TITLE
fix: handle invalid fetch from split

### DIFF
--- a/frappe/custom/doctype/property_setter/patches/remove_invalid_fetch_from_expressions.py
+++ b/frappe/custom/doctype/property_setter/patches/remove_invalid_fetch_from_expressions.py
@@ -1,26 +1,28 @@
+from contextlib import suppress
+
 import frappe
 
 
 def execute():
 	"""Remove invalid fetch from expressions"""
+	with suppress(Exception):
+		property_setters = frappe.get_all(
+			"Property Setter", {"doctype_or_field": "DocField", "property": "fetch_from"}, ["name", "value"]
+		)
+		for ps in property_setters:
+			if not is_valid_expression(ps.value):
+				frappe.db.delete("Property Setter", {"name": ps.name})
 
-	property_setters = frappe.get_all(
-		"Property Setter", {"doctype_or_field": "DocField", "property": "fetch_from"}, ["name", "value"]
-	)
-	for ps in property_setters:
-		if not is_valid_expression(ps.value):
-			frappe.db.delete("Property Setter", {"name": ps.name})
-
-	custom_fields = frappe.get_all("Custom Field", {"fetch_from": ("is", "set")}, ["name", "fetch_from"])
-	for cf in custom_fields:
-		if not is_valid_expression(cf.fetch_from):
-			frappe.db.set_value("Custom Field", cf.name, "fetch_from", "")
+		custom_fields = frappe.get_all("Custom Field", {"fetch_from": ("is", "set")}, ["name", "fetch_from"])
+		for cf in custom_fields:
+			if not is_valid_expression(cf.fetch_from):
+				frappe.db.set_value("Custom Field", cf.name, "fetch_from", "")
 
 
 def is_valid_expression(expr) -> bool:
 	if not expr or "." not in expr:
 		return False
-	source_field, target_field = expr.split(".")
+	source_field, target_field = expr.split(".", maxsplit=1)
 	if not source_field or not target_field:
 		return False
 	return True


### PR DESCRIPTION
Some users have manged to write fetch expr with 2 dots :shrug:
