### PR TITLE
fix: dont add trailing decimal separator

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -66,7 +66,11 @@ function convert_old_to_new_number_format(v, old_number_format, new_number_forma
 	let old_group_regex = new RegExp(old_info.group_sep === "." ? "\\." : old_info.group_sep, "g");
 	v_before_decimal = v_before_decimal.replace(old_group_regex, new_info.group_sep);
 
-	v = v_before_decimal + new_info.decimal_str + v_after_decimal;
+	v = v_before_decimal;
+	if (v_after_decimal) {
+		v = v + new_info.decimal_str + v_after_decimal;
+	}
+
 	return v;
 }
 


### PR DESCRIPTION
```
Uncaught (in promise) Error: Syntax error, unrecognized expression: 910.
    jQuery 7
    set_formatted_number number_card_widget.js:226
    get_number_for_report_card number_card_widget.js:216
    get_number number_card_widget.js:139
    get_data number_card_widget.js:181
    render_card number_card_widget.js:167
    make_card number_card_widget.js:45
    promise callback*make_card number_card_widget.js:31
    set_body number_card_widget.js:27
    refresh number_card_widget.js:22
    make_widget base_widget.js:94
    make base_widget.js:71
    pt base_widget.js:6
    Qi number_card_widget.js:8
    make_widget widget_group.js:27
    add_widget widget_group.js:82
    make_widgets widget_group.js:77
    make_widgets widget_group.js:76
    make widget_group.js:49
    Kn widget_group.js:39
    render_cards dashboard_view.js:140
    promise callback*render_cards dashboard_view.js:129
    refresh dashboard_view.js:83
    promise callback*frappe.run_serially/< dom.js:262
    run_serially dom.js:260
    refresh dashboard_view.js:83
    show_dashboard dashboard_view.js:72
    show dashboard_view.js:35
    on_page_load dashboard_view.js:16
    jQuery 6```