### PR TITLE
fix(exporter): we want `DF.Literal[None]`, not `DF.LiteralNone`

### DIFF
--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -183,7 +183,7 @@ class TypeExporter:
 		elif field.fieldtype == "Select":
 			if not field.options:
 				# Could be dynamic
-				return "None"
+				return "[None]"
 			options = [o.strip() for o in field.options.split("\n")]
 			return json.dumps(options)
 


### PR DESCRIPTION
Broke in #25211 