### PR TITLE
feat: connect to redis sentinel for redis cache

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -504,9 +504,9 @@ def setup_redis_cache_connection():
 	global cache
 
 	if not cache:
-		from frappe.utils.redis_wrapper import RedisWrapper
+		from frappe.utils.redis_wrapper import setup_cache
 
-		cache = RedisWrapper.from_url(conf.get("redis_cache"))
+		cache = setup_cache()
 
 
 def get_traceback(with_context: bool = False) -> str:

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -5,6 +5,7 @@ import re
 
 import redis
 from redis.commands.search import Search
+from redis.sentinel import Sentinel
 
 import frappe
 from frappe.utils import cstr
@@ -345,3 +346,43 @@ class RedisWrapper(redis.Redis):
 
 	def ft(self, index_name="idx"):
 		return RedisearchWrapper(client=self, index_name=self.make_key(index_name))
+
+
+def setup_cache():
+	if frappe.conf.redis_cache_sentinel_enabled:
+		sentinels = [tuple(node.split(":")) for node in frappe.conf.get("redis_cache_sentinels", [])]
+		sentinel = get_sentinel_connection(
+			sentinels=sentinels,
+			sentinel_username=frappe.conf.get("redis_cache_sentinel_username"),
+			sentinel_password=frappe.conf.get("redis_cache_sentinel_password"),
+			master_username=frappe.conf.get("redis_cache_master_username"),
+			master_password=frappe.conf.get("redis_cache_master_password"),
+		)
+		return sentinel.master_for(
+			frappe.conf.get("redis_cache_master_service"),
+			redis_class=RedisWrapper,
+		)
+
+	return RedisWrapper.from_url(frappe.conf.get("redis_cache"))
+
+
+def get_sentinel_connection(
+	sentinels: list[tuple[str, int]],
+	sentinel_username=None,
+	sentinel_password=None,
+	master_username=None,
+	master_password=None,
+):
+	sentinel_kwargs = {}
+	if sentinel_username:
+		sentinel_kwargs["username"] = sentinel_username
+
+	if sentinel_password:
+		sentinel_kwargs["password"] = sentinel_password
+
+	return Sentinel(
+		sentinels=sentinels,
+		sentinel_kwargs=sentinel_kwargs,
+		username=master_username,
+		password=master_password,
+	)


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Use redis sentinel for redis cache connection. It is setup for production only using extra keys from common_site_config.json

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

At the moment we can connect to single redis master for cache. With this we can connect to sentinel cluster.

https://redis.io/docs/management/sentinel

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

To try it with frappe_docker/devcontainer make following changes to .devcontainer/docker-compose.yml

```yaml
version: "3.7"
services:
  mariadb:
    image: docker.io/mariadb:10.6
    command:
      - --character-set-server=utf8mb4
      - --collation-server=utf8mb4_unicode_ci
      - --skip-character-set-client-handshake
      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
    environment:
      - MYSQL_ROOT_PASSWORD=123
    volumes:
      - mariadb-data:/var/lib/mysql

  redis-cache:
    image: redis:alpine

  redis-queue:
    image: redis:alpine


## Change begins here ##
  redis-cache-sentinel:
    image: docker.io/bitnami/redis-sentinel:7.2
    environment:
      - REDIS_SENTINEL_PASSWORD=sentinelpassword
      - REDIS_MASTER_HOST=redis-cache-master
      - REDIS_MASTER_PASSWORD=masterpassword

  redis-cache-master:
    image: docker.io/bitnami/redis:7.2
    environment:
      - REDIS_PASSWORD=masterpassword
## Change ends here ##

  frappe:
    image: docker.io/frappe/bench:latest
    command: sleep infinity
    environment:
      - SHELL=/bin/bash
    volumes:
      - ..:/workspace:cached
      - ${HOME}/.ssh:/home/frappe/.ssh
    working_dir: /workspace/development
    ports:
      - 8000-8005:8000-8005
      - 9000-9005:9000-9005

volumes:
  mariadb-data:
```

add redis_cache_* keys to common_site_config.json

```json
{
 "background_workers": 1,
 "db_host": "mariadb",
 "db_type": "mariadb",
 "developer_mode": 1,
 "file_watcher_port": 6788,
 "frappe_user": "frappe",
 "gunicorn_workers": 25,
 "live_reload": true,
 "rebase_on_pull": false,
 "redis_socketio": "redis://redis-queue:6379",
 "redis_cache": "redis://redis-cache:6379",
 "redis_cache_sentinel_enabled": 1,
 "redis_cache_sentinels": ["redis-cache-sentinel:26379"],
 "redis_cache_sentinel_password": "sentinelpassword",
 "redis_cache_master_service": "mymaster",
 "redis_cache_master_password": "masterpassword",
 "redis_queue": "redis://redis-queue:6379",
 "restart_supervisor_on_update": false,
 "restart_systemd_on_update": false,
 "serve_default_site": true,
 "shallow_clone": true,
 "socketio_port": 9000,
 "use_redis_auth": false,
 "webserver_port": 8000
}
```

Note: Nothing has changed to the `redis_cache` key. It will be used during development setup by `bench watch` command.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

To do:

- [ ] Docs

