### PR TITLE
fix: handle parent rename in child workspace

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -299,6 +299,7 @@ def update_page(name, title, icon, indicator_color, parent, public):
 		)
 
 	if doc:
+		child_docs = frappe.get_all("Workspace", filters={"parent_page": doc.title, "public": doc.public})
 		doc.title = title
 		doc.icon = icon
 		doc.indicator_color = indicator_color
@@ -314,7 +315,6 @@ def update_page(name, title, icon, indicator_color, parent, public):
 			rename_doc("Workspace", name, new_name, force=True, ignore_permissions=True)
 
 		# update new name and public in child pages
-		child_docs = frappe.get_all("Workspace", filters={"parent_page": doc.title, "public": doc.public})
 		if child_docs:
 			for child in child_docs:
 				child_doc = frappe.get_doc("Workspace", child.name)


### PR DESCRIPTION
This is happening because in https://github.com/frappe/frappe/commit/033c6b357e6e0d0a16b5473515e18283618bb218 the line that fetches child pages was moved below (after it's changed) so it doesn't find any and doesn't update them. 