### PR TITLE
feat: add extractor for label of number card

### DIFF
--- a/frappe/gettext/extractors/workspace.py
+++ b/frappe/gettext/extractors/workspace.py
@@ -23,6 +23,10 @@ def extract(fileobj, *args, **kwargs):
 		for chart in data.get("charts", [])
 	)
 	yield from (
+		(None, "_", number_card.get("label"), [f"Label of a number card in the {workspace_name} Workspace"])
+		for number_card in data.get("number_cards", [])
+	)
+	yield from (
 		(
 			None,
 			"pgettext",


### PR DESCRIPTION
Add extractor for Number Card label´s in Workspace.

This no add any string in main.pot of Frappe project. But will be add some in ERPNext project

> no-docs