### PR TITLE
Implement Snapshots

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -16,6 +16,7 @@
   "is_submittable",
   "istable",
   "issingle",
+  "is_restorable",
   "is_tree",
   "is_calendar_and_gantt",
   "editable_grid",
@@ -142,6 +143,12 @@
    "oldfieldname": "issingle",
    "oldfieldtype": "Check",
    "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_restorable",
+   "fieldtype": "Check",
+   "label": "Is Restorable"
   },
   {
    "default": "1",
@@ -750,7 +757,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2023-12-01 18:37:16.799471",
+ "modified": "2024-03-14 12:20:08.299575",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -111,7 +111,7 @@ class DocType(Document):
 		custom: DF.Check
 		default_email_template: DF.Link | None
 		default_print_format: DF.Data | None
-		default_view: DF.Literal[None]
+		default_view: DF.LiteralNone
 		description: DF.SmallText | None
 		document_type: DF.Literal["", "Document", "Setup", "System", "Other"]
 		documentation: DF.Data | None
@@ -128,6 +128,7 @@ class DocType(Document):
 		index_web_pages_for_search: DF.Check
 		is_calendar_and_gantt: DF.Check
 		is_published_field: DF.Data | None
+		is_restorable: DF.Check
 		is_submittable: DF.Check
 		is_tree: DF.Check
 		is_virtual: DF.Check

--- a/frappe/core/doctype/version/version.json
+++ b/frappe/core/doctype/version/version.json
@@ -10,6 +10,7 @@
   "column_break_3",
   "docname",
   "data",
+  "image",
   "section_break_4",
   "table_html"
  ],
@@ -41,6 +42,12 @@
    "label": "Data"
   },
   {
+    "fieldname": "image",
+    "fieldtype": "JSON",
+    "hidden": 1,
+    "label": "Image"
+  },
+  {
    "fieldname": "section_break_4",
    "fieldtype": "Section Break"
   },
@@ -54,10 +61,11 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2023-12-08 15:52:37.525003",
+ "modified": "2024-03-12 15:25:34.227772",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Version",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -45,6 +45,7 @@ class Version(Document):
 			self.ref_doctype = new.doctype
 			self.docname = new.name
 			self.data = frappe.as_json(diff, indent=None, separators=(",", ":"))
+			self.image = frappe.as_json(old, indent=None, separators=(",", ":"))
 			return True
 		else:
 			return False
@@ -63,6 +64,7 @@ class Version(Document):
 		self.ref_doctype = doc.doctype
 		self.docname = doc.name
 		self.data = frappe.as_json(data, indent=None, separators=(",", ":"))
+		self.image = frappe.as_json(doc, indent=None, separators=(",", ":"))
 		return True
 
 	def get_data(self):

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -360,39 +360,39 @@ frappe.ui.form.Toolbar = class Toolbar {
 							if (versions.length) {
 								this.page.add_menu_item(__("Restore"), () => {
 									const modal = `
-            <div class="modal fade" id="version-modal" tabindex="-1" role="dialog" aria-labelledby="version-modal-label" aria-hidden="true">
-              <div class="modal-dialog" role="document">
-                <div class="modal-content">
-                  <div class="modal-header">
-                    <h5 class="modal-title" id="version-modal-label">Select Version</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                      <span aria-hidden="true">&times;</span>
-                    </button>
-                  </div>
-                  <div class="modal-body">
-                    <form id="restore-form">
-                      ${versions
-							.map(
-								(version) => `
-                        <div class="form-check">
-                          <input class="form-check-input" type="radio" name="versionId" id="version-${version.name}" value="${version.name}">
-                          <label class="form-check-label" for="version-${version.name}">
-                            ${version.creation}
-                          </label>
-                        </div>
-                      `
-							)
-							.join("")}
-                    </form>
-                  </div>
-                  <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    <button type="submit" form="restore-form" class="btn btn-primary">Restore</button>
-                  </div>
-                </div>
-              </div>
-            </div>
-            `;
+									<div class="modal fade" id="version-modal" tabindex="-1" role="dialog" aria-labelledby="version-modal-label" aria-hidden="true">
+										<div class="modal-dialog" role="document">
+											<div class="modal-content">
+											<div class="modal-header">
+												<h5 class="modal-title" id="version-modal-label">Select Version</h5>
+												<button type="button" class="close" data-dismiss="modal" aria-label="Close">
+												<span aria-hidden="true">&times;</span>
+												</button>
+											</div>
+											<div class="modal-body">
+												<form id="restore-form">
+												${versions
+													.map(
+														(version) => `
+													<div class="form-check">
+													<input class="form-check-input" type="radio" name="versionId" id="version-${version.name}" value="${version.name}">
+													<label class="form-check-label" for="version-${version.name}">
+														${version.creation}
+													</label>
+													</div>
+												`
+													)
+													.join("")}
+												</form>
+											</div>
+											<div class="modal-footer">
+												<button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+												<button type="submit" form="restore-form" class="btn btn-primary">Restore</button>
+											</div>
+											</div>
+										</div>
+									</div>
+									`;
 									$("footer").append($(modal));
 									$("#restore-form").on("submit", (e) => {
 										e.preventDefault();
@@ -591,9 +591,14 @@ frappe.ui.form.Toolbar = class Toolbar {
 	restore(version, doc) {
 		frappe.db.get_value("Version", version, "image").then((version_doc) => {
 			const image = JSON.parse(version_doc.message.image);
-			for (let field in image) {
-				if (field !== "modified")
+
+			// Ensure that fields mentioned in both versions are reset based on old version
+			const fields = new Set([...Object.keys(doc), ...Object.keys(image)]);
+
+			for (let field of fields) {
+				if (field !== "modified") {
 					frappe.model.set_value(doc.doctype, doc.name, field, image[field]);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
Closes #25277.

### DB Changes

The current PR adds the following fields to Frappe doctypes:
- To `DocType`: `is_restorable`, checks whether a specific doctype supports restoring
- To `Version`: `image`, stores the snapshot of a particular version

### Details
To toggle restoring ability, go to a doctype and tick "Is Restorable":
<img width="1264" alt="image" src="https://github.com/frappe/frappe/assets/62411302/5c3ccc2c-f31e-487c-91e8-277b8ad2a358">


Every change to a doctypes is recorded - _regardless_ of whether the doctype is marked as restorable or not. When the doctype is marked as restorable, the "Restore" button shows up:

<img width="313" alt="image" src="https://github.com/frappe/frappe/assets/62411302/e8b70b4e-f640-4b43-a318-7820f6df1181">


Clicking on Restore shows a timeline of all previous versions of this document:

<img width="571" alt="image" src="https://github.com/frappe/frappe/assets/62411302/bc9769fe-826a-486d-a4b4-d0851e8c58d0">

When the user selects one and confirms, **database change does not occur**. Instead, the changes are loaded onto the current model - the user can preview it, and save it normally should they like.

<img width="1440" alt="image" src="https://github.com/frappe/frappe/assets/62411302/b43f6cf9-460e-469e-bdcd-13daa4122282">

### Improvement
- After restoration occurs, it would be nice if the currently loaded version timestamp is shown somewhere in the screen.
- The full timestamp feels a little ugly, but I'm not sure if any other option makes sense.
- If this is approved, we should move the "Is Restorable" field out of the Connections tab
- Built-in diffing? This isn't very hard to implement.

