### PR TITLE
test: set typical viewport dimensions

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -8,6 +8,8 @@ module.exports = defineConfig({
 	pageLoadTimeout: 15000,
 	video: true,
 	videoUploadOnPasses: false,
+	viewportWidth: 1920,
+	viewportHeight: 1200,
 	retries: {
 		runMode: 1,
 		openMode: 1,


### PR DESCRIPTION
16:10 (mac, most business laptops) and more width than default 1000 (way too less for our apps)
