### PR TITLE
ci: limit timeout to 30 minutes

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: checkrun
     if: ${{ needs.checkrun.outputs.build == 'strawberry' }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     env:
       NODE_ENV: "production"
 


### PR DESCRIPTION
Sometimes tests get stuck and never end, cause unknown.
