### PR TITLE
feat: Store printed PDF attachments on communication

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -48,6 +48,7 @@ def make(
 	communication_type=None,
 	send_after=None,
 	print_language=None,
+	now=False,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -104,6 +105,7 @@ def make(
 		add_signature=False,
 		send_after=send_after,
 		print_language=print_language,
+		now=now,
 	)
 
 
@@ -131,6 +133,7 @@ def _make(
 	add_signature=True,
 	send_after=None,
 	print_language=None,
+	now=False,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -185,6 +188,7 @@ def _make(
 			send_me_a_copy=send_me_a_copy,
 			print_letterhead=print_letterhead,
 			print_language=print_language,
+			now=now,
 		)
 
 	emails_not_sent_to = comm.exclude_emails_list(include_sender=send_me_a_copy)

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -308,6 +308,7 @@ class CommunicationEmailMixin:
 		print_letterhead=None,
 		is_inbound_mail_communcation=None,
 		print_language=None,
+		now=False,
 	):
 		if input_dict := self.sendmail_input_dict(
 			print_html=print_html,
@@ -317,4 +318,4 @@ class CommunicationEmailMixin:
 			is_inbound_mail_communcation=is_inbound_mail_communcation,
 			print_language=print_language,
 		):
-			frappe.sendmail(**input_dict)
+			frappe.sendmail(now=now, **input_dict)

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import frappe
 from frappe.core.doctype.communication.communication import Communication, get_emails, parse_email
-from frappe.core.doctype.communication.email import add_attachments
+from frappe.core.doctype.communication.email import add_attachments, make
 from frappe.email.doctype.email_queue.email_queue import EmailQueue
 from frappe.tests.utils import FrappeTestCase
 

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -68,6 +68,7 @@
   "disable_standard_email_footer",
   "hide_footer_in_auto_email_reports",
   "attach_view_link",
+  "store_attached_pdf_document",
   "welcome_email_template",
   "reset_password_template",
   "files_tab",
@@ -648,12 +649,19 @@
    "fieldtype": "Int",
    "label": "Link Field Results Limit",
    "non_negative": 1
+  },
+  {
+   "default": "1",
+   "description": "When sending document using email, store the PDF on Communication. Warning: This can increase your storage usage.",
+   "fieldname": "store_attached_pdf_document",
+   "fieldtype": "Check",
+   "label": "Store Attached PDF Document"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-01-26 11:29:20.924425",
+ "modified": "2024-03-14 15:18:01.465057",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -87,6 +87,7 @@ class SystemSettings(Document):
 		rounding_method: DF.Literal["Banker's Rounding (legacy)", "Banker's Rounding", "Commercial Rounding"]
 		session_expiry: DF.Data | None
 		setup_complete: DF.Check
+		store_attached_pdf_document: DF.Check
 		strip_exif_metadata_from_uploaded_images: DF.Check
 		time_format: DF.Literal["HH:mm:ss", "HH:mm"]
 		time_zone: DF.Literal[None]

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -8,9 +8,13 @@ from unittest.mock import patch
 import requests
 
 import frappe
+from frappe.core.doctype.communication.email import make
+from frappe.desk.form.load import get_attachments
 from frappe.email.doctype.email_account.test_email_account import TestEmailAccount
 from frappe.email.doctype.email_queue.email_queue import QueueBuilder
-from frappe.tests.utils import FrappeTestCase
+from frappe.query_builder.utils import db_type_is
+from frappe.tests.test_query_builder import run_only_if
+from frappe.tests.utils import FrappeTestCase, change_settings
 
 test_dependencies = ["Email Account"]
 
@@ -342,10 +346,15 @@ class TestEmailIntegrationTest(FrappeTestCase):
 		frappe.flags.testing_email = False
 		return super().tearDown()
 
-	def get_last_sent_emails(self):
+	@classmethod
+	def get_last_sent_emails(cls):
 		return requests.get(
-			f"{self.SMTP4DEV_WEB}/api/Messages?sortColumn=receivedDate&sortIsDescending=true"
+			f"{cls.SMTP4DEV_WEB}/api/Messages?sortColumn=receivedDate&sortIsDescending=true"
 		).json()
+
+	@classmethod
+	def get_message(cls, message_id):
+		return requests.get(f"{cls.SMTP4DEV_WEB}/api/Messages/{message_id}").json()
 
 	def test_send_email(self):
 		sender = "a@example.io"
@@ -368,3 +377,46 @@ class TestEmailIntegrationTest(FrappeTestCase):
 			self.assertEqual(sent_mail["from"], sender)
 			self.assertEqual(sent_mail["subject"], subject)
 		self.assertSetEqual(set(recipients.split(",")), {m["to"] for m in sent_mails})
+
+	@run_only_if(db_type_is.MARIADB)
+	@change_settings("System Settings", store_attached_pdf_document=1)
+	def test_store_attachments(self):
+		""" "attach print" feature just tells email queue which document to attach, this is not
+		actually stored unless system setting says so."""
+
+		name = make(
+			sender="test_sender@example.com",
+			recipients="test_recipient@example.com,test_recipient2@example.com",
+			content="test mail 001",
+			subject="test-mail-002",
+			doctype="Email Account",
+			name="_Test Email Account 1",
+			print_format="Standard",
+			send_email=True,
+			now=True,
+		).get("name")
+
+		communication = frappe.get_doc("Communication", name)
+
+		attachments = get_attachments(communication.doctype, communication.name)
+		self.assertEqual(len(attachments), 1)
+
+		file = frappe.get_doc("File", attachments[0].name)
+		self.assertGreater(file.file_size, 1000)
+		self.assertIn("pdf", file.file_name.lower())
+		sent_mails = self.get_last_sent_emails()
+		self.assertEqual(len(sent_mails), 2)
+
+		for mail in sent_mails:
+			email_content = self.get_message(mail["id"])
+
+			attachment_found = False
+			for part in email_content["parts"]:
+				for child_part in part["childParts"]:
+					if child_part["isAttachment"]:
+						attachment_found = True
+						self.assertIn("pdf", child_part["name"])
+						break
+
+			if not attachment_found:
+				self.fail("Attachment not found", email_content)


### PR DESCRIPTION
Problem: If you check "attach print" in communication or notification, they are not actually stored on the document but generated and sent on the fly. This makes tracing the document hard and debugging the issues even harder.

Fix:
- System setting has new config - `Store Attached PDF Document`
- Upon checking this any printed PDF attachments that were created on the fly will be now stored on the communication or email queue doc. 

closes https://github.com/frappe/frappe/issues/20111