### PR TITLE
perf: Avoid ordering in count query

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -58,6 +58,7 @@ def get_count() -> int:
 		distinct = "distinct " if args.distinct else ""
 		args.limit = cint(args.limit)
 		fieldname = f"{distinct}`tab{args.doctype}`.name"
+		args.order_by = None
 
 		if args.limit:
 			args.fields = [fieldname]


### PR DESCRIPTION
Order doesn't matter for count. This PR now makes https://github.com/frappe/frappe/pull/25348 way more effective

Insane difference:

![image](https://github.com/frappe/frappe/assets/9079960/5f390cb4-9f9f-403b-8fdc-e3872fca6b72)



No idea why mariadb isn't smart enough to figure this out. 