### PR TITLE
fix: default filter setup on todo list

### DIFF
--- a/frappe/desk/doctype/todo/todo_list.js
+++ b/frappe/desk/doctype/todo/todo_list.js
@@ -25,5 +25,5 @@ frappe.listview_settings["ToDo"] = {
 		action: function (doc) {
 			frappe.set_route("Form", doc.reference_type, doc.reference_name);
 		},
-	}
+	},
 };

--- a/frappe/desk/doctype/todo/todo_list.js
+++ b/frappe/desk/doctype/todo/todo_list.js
@@ -3,9 +3,9 @@ frappe.listview_settings["ToDo"] = {
 	add_fields: ["reference_type", "reference_name"],
 
 	onload: function (me) {
-		if (!frappe.route_options) {
+		if (!Object.keys(frappe.route_options).length) {
 			frappe.route_options = {
-				owner: frappe.session.user,
+				allocated_to: frappe.session.user,
 				status: "Open",
 			};
 		}
@@ -25,20 +25,5 @@ frappe.listview_settings["ToDo"] = {
 		action: function (doc) {
 			frappe.set_route("Form", doc.reference_type, doc.reference_name);
 		},
-	},
-
-	refresh: function (me) {
-		if (me.todo_sidebar_setup) return;
-
-		// add assigned by me
-		me.page.add_sidebar_item(
-			__("Assigned By Me"),
-			function () {
-				me.filter_area.add([[me.doctype, "assigned_by", "=", frappe.session.user]]);
-			},
-			'.list-link[data-view="Kanban"]'
-		);
-
-		me.todo_sidebar_setup = true;
-	},
+	}
 };

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -732,27 +732,6 @@ frappe.ui.Page = class Page {
 		this.inner_toolbar.empty().addClass("hide");
 	}
 
-	//-- Sidebar --//
-
-	add_sidebar_item(label, action, insert_after, prepend) {
-		var parent = this.sidebar.find(".sidebar-menu.standard-actions");
-		var li = $("<li>");
-		var link = $("<a>").html(label).on("click", action).appendTo(li);
-
-		if (insert_after) {
-			li.insertAfter(parent.find(insert_after));
-		} else {
-			if (prepend) {
-				li.prependTo(parent);
-			} else {
-				li.appendTo(parent);
-			}
-		}
-		return link;
-	}
-
-	//---//
-
 	clear_user_actions() {
 		this.menu.find(".user-action").remove();
 	}


### PR DESCRIPTION
Since `frappe.route_options` is an empty object by default, the condition needs to be updated from `!frappe.route_options` to `!Object.keys(frappe.route_options).length`.

Also, `allocated_to` is a better default filter for the To Do list compared to the previous `owner` filter.

Further, `todo_list.js` contained the only use of `page.add_sidebar_item()` in all the current Frappe and ERPNext codebase, and that function neither makes sense nor works anymore, so it's removed.