### PR TITLE
perf: reduce import overhead on background jobs

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -441,7 +441,7 @@ after_job = [
 	"frappe.recorder.dump",
 	"frappe.monitor.stop",
 	"frappe.utils.file_lock.release_document_locks",
-	"frappe.utils.telemetry.flush",
+	"frappe.utils.background_jobs.flush_telemetry",
 ]
 
 extend_bootinfo = [

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -324,6 +324,17 @@ def start_worker_pool(
 	"""
 
 	_start_sentry()
+
+	# If gc.freeze is done then importing modules before forking allows us to share the memory
+	import frappe.database.query  # sqlparse and indirect imports
+	import frappe.query_builder  # pypika
+	import frappe.utils.data  # common utils
+	import frappe.utils.safe_exec
+	import frappe.utils.typing_validations  # any whitelisted method uses this
+	import frappe.website.path_resolver  # all the page types and resolver
+
+	# end: module pre-loading
+
 	_freeze_gc()
 
 	with frappe.init_site():

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -5,7 +5,6 @@ import re
 
 import redis
 from redis.commands.search import Search
-from redis.sentinel import Sentinel
 
 import frappe
 from frappe.utils import cstr
@@ -373,6 +372,8 @@ def get_sentinel_connection(
 	master_username=None,
 	master_password=None,
 ):
+	from redis.sentinel import Sentinel
+
 	sentinel_kwargs = {}
 	if sentinel_username:
 		sentinel_kwargs["username"] = sentinel_username

--- a/frappe/utils/telemetry.py
+++ b/frappe/utils/telemetry.py
@@ -60,16 +60,6 @@ def capture(event, app, **kwargs):
 		ph and ph.capture(distinct_id=frappe.local.site, event=f"{app}_{event}", **kwargs)
 
 
-def flush():
-	"""Forcefully flush pending events.
-
-	This is required in context of background jobs where process might die before posthog gets time
-	to push events."""
-	ph: Posthog = getattr(frappe.local, "posthog", None)
-	with suppress(Exception):
-		ph and ph.flush()
-
-
 def capture_doc(doc, action):
 	with suppress(Exception):
 		age = site_age()


### PR DESCRIPTION
Avoids 7MB of overhead and cleanup costs for each background job.


Memory profile of worker horse doing `frappe.ping`

![image](https://github.com/frappe/frappe/assets/9079960/44936e55-5025-45d7-b16c-1a8e53c7c346)



After

![image](https://github.com/frappe/frappe/assets/9079960/09107448-e111-405e-8afd-9dc27b3e53f6)


Also, several other modules are loaded instantly on new jobs. In worker pool we can save on this CPU cost by preloading (paying shared memory cost). This increases memory usage of 8 workers by 20MB but reduces import overheads on each job by almost 60-70%

![image](https://github.com/frappe/frappe/assets/9079960/15ccc562-3608-4b33-b049-1053637f7cfb)




---

performing 100 job (`frappe.ping`) - good enough proxy for overheads. 


Before:
```
λ bench worker-pool --num-workers=8 --burst > /dev/null  
8.67s user 5.18s system 491% cpu 2.815 total
```

After:
```
λ time bench worker-pool --num-workers=8 --burst > /dev/null
1.71s user 2.56s system 179% cpu 2.376 total
```


performing 100 job (`frappe.email.queue.flush`) - realistic work

Before:
```
λ time bench worker-pool --num-workers=8 --burst > /dev/null
26.98s user 11.11s system 597% cpu 6.378 total
```

After:
```
λ time bench worker-pool --num-workers=8 --burst > /dev/null
8.61s user 4.73s system 510% cpu 2.613 total
```