### PR TITLE
chore: Clarify the description of workflow is_active button

### DIFF
--- a/frappe/locale/af.po
+++ b/frappe/locale/af.po
@@ -14616,7 +14616,7 @@ msgstr "As Eienaar"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "As dit nagegaan word, word alle ander werkstrome inaktief."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/ar.po
+++ b/frappe/locale/ar.po
@@ -15138,7 +15138,7 @@ msgstr ""
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "إذا تم، جميع مهام سير العمل الأخرى تصبح خاملة."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/de.po
+++ b/frappe/locale/de.po
@@ -15341,7 +15341,7 @@ msgstr "Wenn eine Rolle auf Stufe 0 keinen Zugriff hat, sind höhere Stufen bede
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Wenn aktiviert, werden alle anderen Workflows inaktiv."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/es.po
+++ b/frappe/locale/es.po
@@ -15162,7 +15162,7 @@ msgstr ""
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Si se selecciona, los otros flujos de trabajo serán desactivados."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/fa.po
+++ b/frappe/locale/fa.po
@@ -15139,7 +15139,7 @@ msgstr "اگر نقشی در سطح 0 دسترسی نداشته باشد، سط�
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "اگر علامت زده شود، همه گردش‌های کاری دیگر غیرفعال می‌شوند."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/fi.po
+++ b/frappe/locale/fi.po
@@ -14616,7 +14616,7 @@ msgstr "mikäli omistaja"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Valittuna kaikki muut työketjut asetetaan passiivisiksi"
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/fr.po
+++ b/frappe/locale/fr.po
@@ -15139,7 +15139,7 @@ msgstr ""
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Si coché, tous les autres flux de production deviennent inactifs."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/id.po
+++ b/frappe/locale/id.po
@@ -14616,7 +14616,7 @@ msgstr "Jika Owner"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Jika dicentang, semua alur kerja lain menjadi tidak aktif."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/it.po
+++ b/frappe/locale/it.po
@@ -14616,7 +14616,7 @@ msgstr "Se Proprietario"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Se selezionata, tutti gli altri flussi di lavoro diventano inattivi."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/main.pot
+++ b/frappe/locale/main.pot
@@ -15188,7 +15188,7 @@ msgstr ""
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr ""
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/nl.po
+++ b/frappe/locale/nl.po
@@ -14616,7 +14616,7 @@ msgstr "Als de eigenaar"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Indien aangevinkt, worden alle andere workflows inactief."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/pl.po
+++ b/frappe/locale/pl.po
@@ -14616,7 +14616,7 @@ msgstr "Jeśli Właściciela"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Jeśli zaznaczone, to wszystkie pozostałe obiegi stają się nieaktywne."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/pt.po
+++ b/frappe/locale/pt.po
@@ -14616,7 +14616,7 @@ msgstr "Se o Dono"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Se for selecionado, todos os outros fluxos de trabalho tornam-se inativos."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/pt_BR.po
+++ b/frappe/locale/pt_BR.po
@@ -14616,7 +14616,7 @@ msgstr "Se proprietário"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Se marcada, todos os outros fluxos de trabalho tornam-se inativos."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/ru.po
+++ b/frappe/locale/ru.po
@@ -14616,7 +14616,7 @@ msgstr "Если владелец"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Если этот флажок установлен, то все остальные рабочие процессы становятся неактивными."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/tr.po
+++ b/frappe/locale/tr.po
@@ -14616,7 +14616,7 @@ msgstr "Sahibi ise"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Eğer işaretli ise, diğer tüm iş akışları inaktif hale gelir."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/vi.po
+++ b/frappe/locale/vi.po
@@ -14616,7 +14616,7 @@ msgstr "Nếu chủ"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "Nếu được kiểm tra, tất cả các công việc khác trở nên không hoạt động."
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/zh.po
+++ b/frappe/locale/zh.po
@@ -14616,7 +14616,7 @@ msgstr "如果业主"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "如果勾选，那么其他的工作流将变为非活动。"
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/locale/zh_TW.po
+++ b/frappe/locale/zh_TW.po
@@ -14616,7 +14616,7 @@ msgstr "如果業主"
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
 msgctxt "Workflow"
-msgid "If checked, all other workflows become inactive."
+msgid "If checked, all other workflows for the selected DocType become inactive."
 msgstr "如果選中，所有其他的工作流程變得無效。"
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print

--- a/frappe/workflow/doctype/workflow/workflow.json
+++ b/frappe/workflow/doctype/workflow/workflow.json
@@ -41,7 +41,7 @@
   },
   {
    "default": "0",
-   "description": "If checked, all other workflows become inactive.",
+   "description": "If checked, all other workflows for the selected DocType become inactive.",
    "fieldname": "is_active",
    "fieldtype": "Check",
    "label": "Is Active"


### PR DESCRIPTION
When working with Workflow, I was so confuse about the "is_active" checkbox description.

The current checkbox description is `If checked, all other workflows become inactive.`.

It's not true. Only other workflows of **the current selected Doctype** become inactive.

So, I think, the description should be updated accordingly.

![Screenshot 2024-03-17 at 09 09 57](https://github.com/frappe/frappe/assets/19431276/2250c05c-f982-4b12-9add-3d0fec341c19)



