### PR TITLE
perf: Skip running webhook code if method is not supported

### DIFF
--- a/frappe/integrations/doctype/webhook/__init__.py
+++ b/frappe/integrations/doctype/webhook/__init__.py
@@ -3,6 +3,16 @@
 
 import frappe
 
+supported_events = {
+	"after_insert",
+	"on_update",
+	"on_submit",
+	"on_cancel",
+	"on_trash",
+	"on_update_after_submit",
+	"on_change",
+}
+
 
 def get_all_webhooks():
 	# query webhooks
@@ -22,6 +32,8 @@ def get_all_webhooks():
 
 def run_webhooks(doc, method):
 	"""Run webhooks for this method"""
+	if method not in supported_events:
+		return
 
 	frappe_flags = frappe.local.flags
 


### PR DESCRIPTION
E.g. `doc.run_method("autoname")` triggers webhook code for no reason.
