### PR TITLE
feat: debug stuck process by sending SIGUSR1

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -11,6 +11,7 @@ be used to build database driven apps.
 Read the documentation: https://frappeframework.com/docs
 """
 import copy
+import faulthandler
 import functools
 import gc
 import importlib
@@ -18,6 +19,7 @@ import inspect
 import json
 import os
 import re
+import signal
 import traceback
 import warnings
 from collections.abc import Callable
@@ -304,6 +306,7 @@ def init(site: str, sites_path: str = ".", new_site: bool = False, force=False) 
 	if not _qb_patched.get(local.conf.db_type):
 		patch_query_execute()
 		patch_query_aggregation()
+		_register_fault_handler()
 
 	setup_module_map(include_all_apps=not (frappe.request or frappe.job or frappe.flags.in_migrate))
 
@@ -2540,6 +2543,10 @@ def validate_and_sanitize_search_inputs(fn):
 		return fn(**kwargs)
 
 	return wrapper
+
+
+def _register_fault_handler():
+	faulthandler.register(signal.SIGUSR1)
 
 
 from frappe.utils.error import log_error

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import smtplib
+from contextlib import suppress
 
 import frappe
 from frappe import _
@@ -71,7 +72,7 @@ class SMTPServer:
 		SMTP = smtplib.SMTP_SSL if self.use_ssl else smtplib.SMTP
 
 		try:
-			_session = SMTP(self.server, self.port)
+			_session = SMTP(self.server, self.port, timeout=2 * 60)
 			if not _session:
 				frappe.msgprint(
 					_("Could not connect to outgoing email server"), raise_exception=frappe.OutgoingEmailError
@@ -122,8 +123,9 @@ class SMTPServer:
 				return False
 
 	def quit(self):
-		if self.is_session_active():
-			self._session.quit()
+		with suppress(TimeoutError):
+			if self.is_session_active():
+				self._session.quit()
 
 	@classmethod
 	def throw_invalid_credentials_exception(cls):


### PR DESCRIPTION
Usage:

`kill -SIGUSR1 <PID>`

PID - PID of gunicorn **worker**, RQ work horse or scheduler. 

Output in stderr (note that faulthandler prints stack traces in reverse order)

```
Current thread 0x00007c81e2a79b80 (most recent call first):
  File "/home/ankush/benches/develop/apps/frappe/frappe/core/doctype/user/user.py", line 139 in onload
  File "/home/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 961 in fn
  File "/home/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 1306 in runner
  File "/home/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 1324 in composer
  File "/home/ankush/benches/develop/apps/frappe/frappe/model/document.py", line 964 in run_method
  File "/home/ankush/benches/develop/apps/frappe/frappe/desk/form/load.py", line 351 in run_onload
  File "/home/ankush/benches/develop/apps/frappe/frappe/desk/form/load.py", line 45 in getdoc
  File "/home/ankush/benches/develop/apps/frappe/frappe/utils/typing_validations.py", line 31 in wrapper
  File "/home/ankush/benches/develop/apps/frappe/frappe/__init__.py", line 1798 in call
  File "/home/ankush/benches/develop/apps/frappe/frappe/handler.py", line 85 in execute_cmd
  File "/home/ankush/benches/develop/apps/frappe/frappe/handler.py", line 49 in handle
  File "/home/ankush/benches/develop/apps/frappe/frappe/api/v1.py", line 36 in handle_rpc_call
  File "/home/ankush/benches/develop/apps/frappe/frappe/api/__init__.py", line 49 in handle
  File "/home/ankush/benches/develop/apps/frappe/frappe/app.py", line 110 in application
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/werkzeug/wrappers/request.py", line 189 in application
  File "/home/ankush/benches/develop/apps/frappe/frappe/app.py", line 74 in application
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/werkzeug/middleware/shared_data.py", line 249 in __call__
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/werkzeug/middleware/shared_data.py", line 249 in __call__
  File "/home/ankush/benches/develop/apps/frappe/frappe/middlewares.py", line 16 in __call__
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 178 in handle_request
  File "/home/ankush/benches/develop/env/lib/python3.11/site-packages/gunicorn/workers/sync.py", line 135 in handle
```

- You can't get stack of master processes with this. You don't need it most of the time _anyway._
- Use pgrep + xargs to send signal to all of them  (if you are unsure about PID or just lazy )
- This overrides SIGUSR1 behaviour from gunicorn but we don't need it, eh. https://docs.gunicorn.org/en/stable/signals.html 



docs: https://frappeframework.com/docs/user/en/profiling#debugging-stuck-process 



closes https://github.com/frappe/frappe/issues/25496