### PR TITLE
feat: connect to redis sentinel for redis queue

### DIFF
--- a/frappe/utils/redis_queue.py
+++ b/frappe/utils/redis_queue.py
@@ -17,6 +17,20 @@ class RedisQueue:
 
 	@classmethod
 	def get_connection(cls, username=None, password=None):
+		if frappe.conf.redis_queue_sentinel_enabled:
+			from frappe.utils.redis_wrapper import get_sentinel_connection
+
+			sentinels = [tuple(node.split(":")) for node in frappe.conf.get("redis_queue_sentinels", [])]
+			sentinel = get_sentinel_connection(
+				sentinels=sentinels,
+				sentinel_username=frappe.conf.get("redis_queue_sentinel_username"),
+				sentinel_password=frappe.conf.get("redis_queue_sentinel_password"),
+				master_username=frappe.conf.get("redis_queue_master_username", username),
+				master_password=frappe.conf.get("redis_queue_master_password", password),
+			)
+			conn = sentinel.master_for(frappe.conf.get("redis_queue_master_service"))
+			conn.ping()
+			return conn
 		conn = redis.from_url(frappe.conf.redis_queue, username=username, password=password)
 		conn.ping()
 		return conn


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Use redis sentinel for redis queue connection. 
It is setup for production only.
Uses extra keys from common_site_config.json

> Explain the **details** for making this change. What existing problem does the pull request solve?

At the moment we can connect to single redis master for queue. With this we can connect to sentinel cluster.

https://redis.io/docs/management/sentinel

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

To try it with frappe_docker/devcontainer make following changes to .devcontainer/docker-compose.yml

```yaml
version: "3.7"
services:
  mariadb:
    image: docker.io/mariadb:10.6
    command:
      - --character-set-server=utf8mb4
      - --collation-server=utf8mb4_unicode_ci
      - --skip-character-set-client-handshake
      - --skip-innodb-read-only-compressed # Temporary fix for MariaDB 10.6
    environment:
      - MYSQL_ROOT_PASSWORD=123
    volumes:
      - mariadb-data:/var/lib/mysql

  redis-cache:
    image: redis:alpine

  redis-queue:
    image: redis:alpine


## Change begins here ##
  redis-queue-sentinel:
    image: docker.io/bitnami/redis-sentinel:7.2
    environment:
      - REDIS_SENTINEL_PASSWORD=sentinelpassword
      - REDIS_MASTER_HOST=redis-queue-master
      - REDIS_MASTER_PASSWORD=masterpassword

  redis-queue-master:
    image: docker.io/bitnami/redis:7.2
    environment:
      - REDIS_PASSWORD=masterpassword
## Change ends here ##

  frappe:
    image: docker.io/frappe/bench:latest
    command: sleep infinity
    environment:
      - SHELL=/bin/bash
    volumes:
      - ..:/workspace:cached
      - ${HOME}/.ssh:/home/frappe/.ssh
    working_dir: /workspace/development
    ports:
      - 8000-8005:8000-8005
      - 9000-9005:9000-9005

volumes:
  mariadb-data:
```

add redis_cache_* keys to common_site_config.json

```json
{
 "background_workers": 1,
 "db_host": "mariadb",
 "db_type": "mariadb",
 "developer_mode": 1,
 "file_watcher_port": 6788,
 "frappe_user": "frappe",
 "gunicorn_workers": 25,
 "live_reload": true,
 "rebase_on_pull": false,
 "redis_socketio": "redis://redis-queue:6379",
 "redis_cache": "redis://redis-cache:6379",
 "redis_queue": "redis://redis-queue:6379",
 "redis_queue_sentinel_enabled": 1,
 "redis_queue_sentinels": ["redis-queue-sentinel:26379"],
 "redis_queue_sentinel_password": "sentinelpassword",
 "redis_queue_master_service": "mymaster",
 "redis_queue_master_password": "masterpassword",
 "restart_supervisor_on_update": false,
 "restart_systemd_on_update": false,
 "serve_default_site": true,
 "shallow_clone": true,
 "socketio_port": 9000,
 "use_redis_auth": false,
 "webserver_port": 8000
}
```

Note: Nothing has changed to the `redis_queue` key. It will be used by socketio.

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

Docs: https://frappeframework.com/app/wiki-page-patch/372939da4e
