### PR TITLE
fix: skip setting of contact full name if its too long

### DIFF
--- a/frappe/patches/v15_0/set_contact_full_name.py
+++ b/frappe/patches/v15_0/set_contact_full_name.py
@@ -16,10 +16,16 @@ def execute():
 	total = len(contacts)
 	for idx, (name, first, middle, last, company) in enumerate(contacts):
 		update_progress_bar("Setting full name for contacts", idx, total)
-		frappe.db.set_value(
-			"Contact",
-			name,
-			"full_name",
-			get_full_name(first, middle, last, company),
-			update_modified=False,
-		)
+		try:
+			frappe.db.set_value(
+				"Contact",
+				name,
+				"full_name",
+				get_full_name(first, middle, last, company),
+				update_modified=False,
+			)
+		except frappe.db.DataError as e:
+			if frappe.db.is_data_too_long(e):
+				print("Full name is too long for DB column, skipping")
+				continue
+			raise e


### PR DESCRIPTION
Support ticket 11455

An update failed because a company name was too long
