### PR TITLE
fix: exclude irrelevant regional links

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -156,7 +156,7 @@ class Workspace(Document):
 
 				current_card = link
 				card_links = []
-			else:
+			elif not link.get("only_for") or link.get("only_for") == frappe.get_system_settings("country"):
 				card_links.append(link)
 
 		current_card["links"] = card_links


### PR DESCRIPTION
- Avoid showing irrelevant (and broken) regional links

When not India, this is now correct: (similar for an UAE report in ERPNext)
![image](https://github.com/frappe/frappe/assets/7548295/7f3e007d-d918-4df7-8f60-020965c9a3ed)
