### PR TITLE
perf: render list

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1060,7 +1060,9 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		div.appendChild(selectLikeSpan);
 
 		const ellipsisSpan = document.createElement("span");
-		ellipsisSpan.classList.add("level-item", seen, "ellipsis");
+		if (seen) {
+			ellipsisSpan.classList.add("level-item", seen, "ellipsis");
+		}
 
 		const link = document.createElement("a");
 		link.classList.add("ellipsis");

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1012,15 +1012,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	get_like_html(doc) {
-		const ef = this._element_factory;
 		const liked_by = doc._liked_by ? JSON.parse(doc._liked_by) : [];
 		const is_liked = liked_by.includes(frappe.session.user);
 		const title = liked_by.map((u) => frappe.user_info(u).fullname).join(", ");
 
 		const div = document.createElement("div");
-		const like = ef.get_like_element(doc.name, is_liked, liked_by, title);
-
-		div.appendChild(like);
+		div.appendChild(
+			this._element_factory.get_like_element(doc.name, is_liked, liked_by, title)
+		);
 
 		return div.innerHTML;
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1047,23 +1047,30 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		const seen = this.get_seen_class(doc);
 
 		const div = document.createElement("div");
-		div.innerHTML = `
-			<span class="level-item select-like">
-				<input class="list-row-checkbox" type="checkbox">
-			</span>
-			<span class="level-item ${seen} ellipsis">
-				<a class="ellipsis"></a>
-			</span>
-		`;
+		const selectLikeSpan = document.createElement("span");
+		selectLikeSpan.classList.add("level-item", "select-like");
 
-		const checkbox = div.querySelector(".list-row-checkbox");
-		checkbox.dataset.doctype = this.doctype;
-		checkbox.dataset.name = doc.name;
+		const checkboxInput = document.createElement("input");
+		checkboxInput.classList.add("list-row-checkbox");
+		checkboxInput.type = "checkbox";
+		checkboxInput.dataset.doctype = this.doctype;
+		checkboxInput.dataset.name = doc.name;
+		selectLikeSpan.appendChild(checkboxInput);
 
-		const link = div.querySelector(".level-item a");
+		div.appendChild(selectLikeSpan);
+
+		const ellipsisSpan = document.createElement("span");
+		ellipsisSpan.classList.add("level-item", seen, "ellipsis");
+
+		const link = document.createElement("a");
+		link.classList.add("ellipsis");
 		link.dataset.doctype = this.doctype;
 		link.dataset.name = doc.name;
 		link.href = this.get_form_link(doc);
+
+		ellipsisSpan.appendChild(link);
+		div.appendChild(ellipsisSpan);
+
 		// "Text Editor" and some other fieldtypes can have html tags in them so strip and show text.
 		// If no text is found show "No Text Found in {Field Label}"
 		let textValue = frappe.utils.html2text(value);

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1018,18 +1018,28 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		const title = liked_by.map((u) => frappe.user_info(u).fullname).join(", ");
 
 		const div = document.createElement("div");
-		div.innerHTML = `
-			<span class="like-action ${heart_class}">
-				${frappe.utils.icon("es-solid-heart", "sm", "like-icon")}
-			</span>
-			<span class="likes-count">${liked_by.length}</span>
-		`;
+		const like = document.createElement("span");
+		like.classList.add("like-action", heart_class);
+		const like_icon = document.createElement("svg");
+		like_icon.classList.add("es-icon", "es-solid", "icon-sm", "like-icon");
 
-		const like = div.querySelector(".like-action");
+		const use = document.createElement("use");
+		use.setAttribute("href", "#es-solid-heart");
+		use.classList.add("like-icon");
+		like_icon.appendChild(use);
+
+		like.appendChild(like_icon);
+		like.dataset.doctype = this.doctype;
+		like.dataset.name = doc.name;
 		like.setAttribute("data-liked-by", doc._liked_by || "[]");
-		like.setAttribute("data-doctype", this.doctype);
-		like.setAttribute("data-name", doc.name);
 		like.setAttribute("title", title);
+
+		const likes_count = document.createElement("span");
+		likes_count.classList.add("likes-count");
+		likes_count.textContent = liked_by.length;
+
+		div.appendChild(like);
+		div.appendChild(likes_count);
 
 		return div.innerHTML;
 	}

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1006,11 +1006,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	get_seen_class(doc) {
-		return JSON.parse(doc._seen || "[]").includes(frappe.session.user) ? "" : "bold";
+		const seen_by = doc._seen ? JSON.parse(doc._seen) : [];
+		return seen_by.includes(frappe.session.user) ? "" : "bold";
 	}
 
 	get_like_html(doc) {
-		const liked_by = JSON.parse(doc._liked_by || "[]");
+		const liked_by = doc._liked_by ? JSON.parse(doc._liked_by) : [];
 		const heart_class = liked_by.includes(frappe.session.user)
 			? "liked-by liked"
 			: "not-liked";

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1071,9 +1071,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		ellipsisSpan.appendChild(link);
 		div.appendChild(ellipsisSpan);
 
-		// "Text Editor" and some other fieldtypes can have html tags in them so strip and show text.
-		// If no text is found show "No Text Found in {Field Label}"
-		let textValue = frappe.utils.html2text(value);
+		let textValue;
+		if (frappe.model.html_fieldtypes.includes(subject_field.fieldtype)) {
+			// NOTE: this is very slow, so only do it for HTML fields
+			textValue = frappe.utils.html2text(value);
+		} else {
+			textValue = value;
+		}
+
 		link.title = textValue;
 		link.textContent = textValue;
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -936,10 +936,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		let comment_count = null;
 		if (this.list_view_settings && !this.list_view_settings.disable_comment_count) {
-			comment_count = $(`<span class="comment-count d-flex align-items-center"></span>`);
-			$(comment_count).append(`
+			comment_count = `<span class="comment-count d-flex align-items-center">
 				${frappe.utils.icon("es-line-chat-alt")}
-				${doc._comment_count > 99 ? "99+" : doc._comment_count || 0}`);
+				${doc._comment_count > 99 ? "99+" : doc._comment_count || 0}
+			</span>`;
 		}
 
 		html += `
@@ -948,7 +948,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					${settings_button || assigned_to}
 				</div>
 				<span class="modified">${modified}</span>
-				${comment_count ? $(comment_count).prop("outerHTML") : ""}
+				${comment_count || ""}
 				${comment_count ? '<span class="mx-2">·</span>' : ""}
 				<span class="list-row-like hidden-xs style="margin-bottom: 1px;">
 					${this.get_like_html(doc)}

--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -108,6 +108,16 @@ $.extend(frappe.model, {
 		"docstatus",
 	],
 
+	html_fieldtypes: [
+		"Text Editor",
+		"Text",
+		"Small Text",
+		"Long Text",
+		"HTML Editor",
+		"Markdown Editor",
+		"Code",
+	],
+
 	std_fields: [
 		{ fieldname: "name", fieldtype: "Link", label: __("ID") },
 		{ fieldname: "owner", fieldtype: "Link", label: __("Created By"), options: "User" },


### PR DESCRIPTION
- Get rid of unnecessary jQuery
- Construct HTML from scratch instead of parsing from string and re-querying the needed elements
- Strip HTML tags from title field only if the fieldtype is expected to contain HTML (which usually is not the case)
- Avoid useless JSON parsing (`JSON.parse("[]")`)

### Stats

Total execution time by method, rendering 100 rows (without html subject field), average from 3 tests

`get_subject_html`: 3x speedup

- Before: > 30 ms
- Now: < 10 ms

`get_meta_html`: 2x speedup

- Before: ~ 15 ms
- Now: ~ 7 ms

---

Total execution time, rendering 2500 rows, average from 3 tests:

Before: ~ 1.40 seconds
After: < 500 ms