### PR TITLE
refactor: remove dead code (likes-count)

### DIFF
--- a/frappe/public/js/frappe/form/templates/form_sidebar.html
+++ b/frappe/public/js/frappe/form/templates/form_sidebar.html
@@ -161,16 +161,6 @@
 	</li>
 </ul>
 <hr>
-<!-- <ul class="list-unstyled sidebar-menu">
-	<li class="liked-by-parent">
-		<span class="liked-by like-action">
-			<svg class="icon icon-sm">
-				<use href="#icon-heart" class="like-icon"></use>
-			</svg>
-			<span class="likes-count"></span>
-		</span>
-	</li>
-</ul> -->
 <ul class="list-unstyled sidebar-menu text-muted">
 	<li class="pageview-count"></li>
 	<li class="modified-by"></li>

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1021,7 +1021,6 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			<span class="like-action ${heart_class}">
 				${frappe.utils.icon("es-solid-heart", "sm", "like-icon")}
 			</span>
-			<span class="likes-count">${liked_by.length}</span>
 		`;
 
 		const like = div.querySelector(".like-action");
@@ -1402,7 +1401,14 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 	}
 
 	setup_like() {
-		this.$result.on("click", ".like-action", frappe.ui.click_toggle_like);
+		this.$result.on("click", ".like-action", (e) => {
+			const $this = $(e.currentTarget);
+			const { doctype, name } = $this.data();
+			frappe.ui.toggle_like($this, doctype, name);
+
+			return false;
+		});
+
 		this.$result.on("click", ".list-liked-by-me", (e) => {
 			const $this = $(e.currentTarget);
 			$this.toggleClass("active");

--- a/frappe/public/js/frappe/ui/like.js
+++ b/frappe/public/js/frappe/ui/like.js
@@ -64,21 +64,7 @@ frappe.ui.toggle_like = function ($btn, doctype, name, callback) {
 };
 
 frappe.ui.click_toggle_like = function () {
-	var $btn = $(this);
-	var $count = $btn.siblings(".likes-count");
-	var not_liked = $btn.hasClass("not-liked");
-	var doctype = $btn.attr("data-doctype");
-	var name = $btn.attr("data-name");
-
-	frappe.ui.toggle_like($btn, doctype, name, function () {
-		if (not_liked) {
-			$count.text(cint($count.text()) + 1);
-		} else {
-			$count.text(cint($count.text()) - 1);
-		}
-	});
-
-	return false;
+	console.warn("`frappe.ui.click_toggle_like` is deprecated and has no effect.");
 };
 
 frappe.ui.setup_like_popover = ($parent, selector) => {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -237,10 +237,6 @@ $level-margin-right: 8px;
 	height: 10px;
 }
 
-.likes-count {
-	display: none;
-}
-
 .list-liked-by-me {
 	margin-bottom: 1px;
 }


### PR DESCRIPTION
`likes-count` was set to `display: none` via css. We don't need to render and manage state of something that is never displayed.