### PR TITLE
feat: add description of doctype to extractor

### DIFF
--- a/frappe/gettext/extractors/doctype.py
+++ b/frappe/gettext/extractors/doctype.py
@@ -14,11 +14,11 @@ def extract(fileobj, *args, **kwargs):
 
 	doctype = data.get("name")
 
-	doctype_description = data.get("description")
-
 	yield None, "_", doctype, ["Name of a DocType"]
 
-	yield None, "_", doctype_description, ["Description of a DocType"]
+	doctype_description = data.get("description")
+	if doctype_description:
+		yield None, "_", doctype_description, ["Description of a DocType"]
 
 	messages = []
 	fields = data.get("fields", [])

--- a/frappe/gettext/extractors/doctype.py
+++ b/frappe/gettext/extractors/doctype.py
@@ -14,7 +14,11 @@ def extract(fileobj, *args, **kwargs):
 
 	doctype = data.get("name")
 
+	doctype_description = data.get("description")
+
 	yield None, "_", doctype, ["Name of a DocType"]
+
+	yield None, "_", doctype_description, ["Description of a DocType"]
 
 	messages = []
 	fields = data.get("fields", [])


### PR DESCRIPTION
Add the DocType description to the extractor.
This adds 37 new strings to ERPNext project and 28 to Frappe project

no-docs