### PR TITLE
refactor: align list style to frappe-ui

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -740,6 +740,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 						${right}
 					</div>
 				</div>
+				<div class="list-row-border"></div>
 			</div>
 		`;
 	}

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -63,6 +63,7 @@
 	display: flex;
 	flex-direction: column;
 	outline: none;
+	padding: 0 var(--padding-xs);
 
 	&:focus {
 		.list-row {
@@ -159,7 +160,7 @@
 	cursor: default;
 	background-color: var(--subtle-fg);
 	height: 30px;
-	margin: 0.5rem 0;
+	margin: 0.5rem var(--padding-xs);
 	border-radius: var(--border-radius-md);
 
 	.list-check-all {

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -59,7 +59,6 @@
 }
 
 .list-row-container {
-	border-bottom: 1px solid $border-color;
 	display: flex;
 	flex-direction: column;
 	outline: none;
@@ -69,6 +68,15 @@
 		.list-row {
 			background-color: var(--highlight-color);
 		}
+	}
+
+	.list-row-border {
+		border-bottom: 1px solid $border-color;
+		margin: 0 10px;
+	}
+
+	&:last-child .list-row-border {
+		display: none;
 	}
 }
 

--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -63,7 +63,6 @@
 	display: flex;
 	flex-direction: column;
 	outline: none;
-	padding: 4px 5px;
 
 	&:focus {
 		.list-row {
@@ -160,8 +159,7 @@
 	cursor: default;
 	background-color: var(--subtle-fg);
 	height: 30px;
-	padding: 8px, 10px, 8px, 0px;
-	margin: 8px 5px 0px 5px;
+	margin: 0.5rem 0;
 	border-radius: var(--border-radius-md);
 
 	.list-check-all {
@@ -250,6 +248,7 @@ input.list-row-checkbox {
 	margin-top: 0px;
 	margin-bottom: 0px;
 	--checkbox-right-margin: calc(var(--checkbox-size) / 2 + #{$level-margin-right});
+	background-color: var(--card-bg);
 }
 
 input.list-check-all {

--- a/frappe/public/scss/desk/page.scss
+++ b/frappe/public/scss/desk/page.scss
@@ -110,7 +110,7 @@
 
 .page-form {
 	margin: 0;
-	padding: var(--padding-sm);
+	padding: var(--padding-xs);
 	display: flex;
 	flex-wrap: wrap;
 	background-color: var(--card-bg);


### PR DESCRIPTION
### Before

![before](https://github.com/frappe/frappe/assets/14891507/715a2269-23c3-473f-81b3-1929beb9f707)

### After

![after](https://github.com/frappe/frappe/assets/14891507/04ba86a2-e3ab-4782-9b51-2ee56a871c78)

- white background for checkbox
- slightly different margins

Corresponding to https://frappeui.com ListView element.