### PR TITLE
fix: handle meta.fields being undefined

### DIFF
--- a/frappe/public/js/frappe/form/controls/table_multiselect.js
+++ b/frappe/public/js/frappe/form/controls/table_multiselect.js
@@ -148,7 +148,7 @@ frappe.ui.form.ControlTableMultiSelect = class ControlTableMultiSelect extends (
 	get_link_field() {
 		if (!this._link_field) {
 			const meta = frappe.get_meta(this.df.options);
-			this._link_field = meta.fields.find((df) => df.fieldtype === "Link");
+			this._link_field = meta.fields?.find((df) => df.fieldtype === "Link");
 			if (!this._link_field) {
 				throw new Error("Table MultiSelect requires a Table with atleast one Link field");
 			}


### PR DESCRIPTION
Sentry FRAPPE-43B / Support 11652


```
TypeError: Cannot read properties of undefined (reading 'fields')
  at frappe.ui.form.ControlTableMultiSelect.get_link_field(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/table_multiselect.js:151:28)
  at frappe.ui.form.ControlTableMultiSelect.set_formatted_input(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/table_multiselect.js:124:27)
  at frappe.ui.form.ControlTableMultiSelect.set_input(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/data.js:246:8)
  at update_input(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/base_input.js:80:8)
  at frappe.ui.form.ControlTableMultiSelect.refresh_input(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/base_input.js:101:5)
  at frappe.ui.form.ControlTableMultiSelect.refresh(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/base_control.js:140:9)
  at frappe.ui.form.Layout.attach_doc_and_docfields(../../../../../apps/frappe/frappe/public/js/frappe/form/layout.js:472:59)
  at frappe.ui.form.Layout.refresh(../../../../../apps/frappe/frappe/public/js/frappe/form/layout.js:334:8)
  at frappe.ui.form.Form.refresh_fields(../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:666:15)
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:610:16)```
