### PR TITLE
fix: prevent TypeError if doc not defined

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -209,7 +209,7 @@ frappe.views.CommunicationComposer = class {
 		// 3. user lang
 		// 4. system lang
 		// 3 and 4 are resolved already in boot
-		let document_lang = this.frm.doc?.language;
+		let document_lang = this.frm?.doc?.language;
 		let print_format = this.dialog.get_value("select_print_format");
 
 		let print_format_lang;


### PR DESCRIPTION
Happens here on a local setup if I click `Compose Email` button

```
communication.js:212 Uncaught TypeError: Cannot read properties of undefined (reading 'doc')
    at frappe.views.CommunicationComposer.guess_language (communication.js:212:32)
    at frappe.views.CommunicationComposer.setup_print (communication.js:536:8)
    at frappe.views.CommunicationComposer.prepare (communication.js:239:8)
    at frappe.views.CommunicationComposer.make (communication.js:41:8)
    at new frappe.views.CommunicationComposer (communication.js:16:8)
    at Object.primary_action (communication__list_js:34:3)
    at HTMLButtonElement.<anonymous> (list_view.js:1426:19)
    at HTMLButtonElement.dispatch (jquery.js:5135:27)
    at elemData.handle (jquery.js:4939:28)
```