### PR TITLE
fix: let's colored tags in listview

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -759,7 +759,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		if (col.type === "Tag") {
 			const tags_display_class = !this.tags_shown ? "hide" : "";
 			let tags_html = doc._user_tags
-				? this.get_tags_html(doc._user_tags, 2)
+				? this.get_tags_html(doc._user_tags, 2, true)
 				: '<div class="tags-empty">-</div>';
 			return `
 				<div class="list-row-col tag-col ${tags_display_class} hidden-xs ellipsis">


### PR DESCRIPTION
Tag background color is shown in gray ...

Before:
![image](https://github.com/frappe/frappe/assets/94137451/8b60e8ae-ac52-43aa-906e-9081d5ac4191)

After:
![image](https://github.com/frappe/frappe/assets/94137451/70b115b4-6527-478c-b8ed-fef069689df9)
