### PR TITLE
feat: add option to set default email recipients

### DIFF
--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -203,7 +203,7 @@ frappe.views.CommunicationComposer = class {
 	}
 
 	get_default_recipients(fieldname) {
-		if (this.frm.events.get_email_recipients) {
+		if (this.frm?.events.get_email_recipients) {
 			return (this.frm.events.get_email_recipients(this.frm, fieldname) || []).join(", ");
 		} else {
 			return "";

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -54,6 +54,7 @@ frappe.views.CommunicationComposer = class {
 				fieldtype: "MultiSelect",
 				reqd: 0,
 				fieldname: "recipients",
+				default: this.get_default_recipients("recipients"),
 			},
 			{
 				fieldtype: "Button",
@@ -72,11 +73,13 @@ frappe.views.CommunicationComposer = class {
 				label: __("CC"),
 				fieldtype: "MultiSelect",
 				fieldname: "cc",
+				default: this.get_default_recipients("cc"),
 			},
 			{
 				label: __("BCC"),
 				fieldtype: "MultiSelect",
 				fieldname: "bcc",
+				default: this.get_default_recipients("bcc"),
 			},
 			{
 				label: __("Schedule Send At"),
@@ -197,6 +200,14 @@ frappe.views.CommunicationComposer = class {
 		}
 
 		return fields;
+	}
+
+	get_default_recipients(fieldname) {
+		if (this.frm.events.get_email_recipients) {
+			return (this.frm.events.get_email_recipients(this.frm, fieldname) || []).join(", ");
+		} else {
+			return "";
+		}
 	}
 
 	guess_language() {


### PR DESCRIPTION
Currently, when emailing a document, users have to manually select recipients, CC and BCC (recipients sometimes get filled from the document). However, in standard processes like Sales Order -> Delivery Note -> Sales Invoice, the email addresses are often pre-defined. This is done in advance by the account manager. It should not be the responsibility of the storekeeper or accountant to figure out the correct recipient and CC addresses.

This PR enables us to set default recipients via a _Client Script_. Every form can programmatically supply it's own default recipients.

`CommunicationComposer` (the email dialog) will check if there is a client script supplying default recipients. This will allow us to do things like:

```js
frappe.ui.form.on("Quotation", {
	get_email_recipients: function (frm, field) {
		// field can be "recipients", "cc" or "bcc"
		if (field === "bcc") {
			return [frm.doc.custom_bcc]
		}
	},
	// ...
};
```

Docs: https://frappeframework.com/docs/user/en/api/form#form-events, https://frappeframework.com/docs/user/en/desk/scripting/client-script#3-6-set-default-email-recipients