### PR TITLE
fix: Show Title Field in Link Fields when Link field is Subject

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -875,7 +875,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			column_html = this.settings.formatters[fieldname](value, df, doc);
 		} else {
 			column_html = {
-				Subject: this.get_subject_html(doc),
+				Subject: this.get_subject_html(doc, value_display),
 				Field: field_html(),
 			}[col.type];
 		}
@@ -1032,7 +1032,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		return div.innerHTML;
 	}
 
-	get_subject_html(doc) {
+	get_subject_html(doc, value_display) {
 		let subject_field = this.columns[0].df;
 		let value = doc[subject_field.fieldname];
 		if (this.settings.formatters && this.settings.formatters[subject_field.fieldname]) {
@@ -1065,7 +1065,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		link.href = this.get_form_link(doc);
 		// "Text Editor" and some other fieldtypes can have html tags in them so strip and show text.
 		// If no text is found show "No Text Found in {Field Label}"
-		let textValue = frappe.utils.html2text(value);
+		let textValue = frappe.utils.html2text(value_display);
 		link.title = textValue;
 		link.textContent = textValue;
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:
<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

method **get_column_html(col, doc) {** alredy format link title for all columns, but here https://github.com/frappe/frappe/blob/d7dbf774e7cf956c70c176f122e5bfa00ced9752/frappe/public/js/frappe/list/list_view.js#L880 
title for subject column not passed.
I pass alredy computed title to method  https://github.com/frappe/frappe/blob/d7dbf774e7cf956c70c176f122e5bfa00ced9752/frappe/public/js/frappe/list/list_view.js#L1035

> Screenshots/GIFs
before
![image](https://github.com/frappe/frappe/assets/4525776/4b2a9f3c-0088-464b-91b3-5729ade0041b)
after
![image](https://github.com/frappe/frappe/assets/4525776/dd510522-90a9-4f75-8b07-161e15984365)

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

close  #25567