### PR TITLE
fix: paragraph spacing in quill

### DIFF
--- a/frappe/public/scss/common/quill.scss
+++ b/frappe/public/scss/common/quill.scss
@@ -292,6 +292,12 @@
 	}
 }
 
+.ql-editor {
+	p:not(:first-child) {
+		margin-top: 0.75rem;
+	}
+}
+
 .ql-editor td {
 	border: 1px solid var(--dark-border-color);
 }


### PR DESCRIPTION
### Before

Paragraphs are visually identical to wrapped lines within the same paragraph. If we want space between two paragraphs, we need to insert an empty paragraph.

> [!NOTE]
> In the screenshots it says "Third paragraph below an empty line", but it is actually the "Fourth paragraph below an empty paragraph"

![Bildschirmfoto 2024-03-21 um 10 34 48](https://github.com/frappe/frappe/assets/14891507/fa8a0e1a-406a-4db6-8bdb-5aff793bf573)
![Bildschirmfoto 2024-03-21 um 10 35 29](https://github.com/frappe/frappe/assets/14891507/06d63fb6-066c-4642-9209-b69951aa0a47)

### After

Paragraphs have `.75rem` padding.

![Bildschirmfoto 2024-03-21 um 10 32 11](https://github.com/frappe/frappe/assets/14891507/bc0c421e-be8d-4373-9f3d-f274ff3a444f)

![Bildschirmfoto 2024-03-21 um 10 32 09](https://github.com/frappe/frappe/assets/14891507/bbe7f824-6f4e-4b8d-bda5-8978badf2716)