### PR TITLE
fix(lint): drop F821

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,6 @@ ignore = [
     "F403", # can't detect undefined names from * import
     "F405", # can't detect undefined names from * import
     "F722", # syntax error in forward type annotation
-    "F821", # undefined name
     "W191", # indentation contains tabs
     "RUF001", # string contains ambiguous unicode character
 ]


### PR DESCRIPTION
v14 never had typed doctype classes, so this wasn't needed here.
Its just hiding actual errors: #25576
