### PR TITLE
fix: depend on condition in "Allow in Quick Entry"

### DIFF
--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -186,6 +186,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break', 'Table'], doc.fieldtype)",
    "fieldname": "allow_in_quick_entry",
    "fieldtype": "Check",
    "label": "Allow in Quick Entry"
@@ -581,7 +582,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-01 15:55:44.007917",
+ "modified": "2024-03-21 17:35:32.602933",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocField",

--- a/frappe/core/doctype/docfield/docfield.json
+++ b/frappe/core/doctype/docfield/docfield.json
@@ -186,7 +186,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!in_list(['Section Break', 'Column Break', 'Tab Break', 'Table'], doc.fieldtype)",
+   "depends_on": "eval:!in_list(['Tab Break', 'Table'], doc.fieldtype)",
    "fieldname": "allow_in_quick_entry",
    "fieldtype": "Check",
    "label": "Allow in Quick Entry"


### PR DESCRIPTION
Version 15 and 14,

fixes: #14880

When the user selects the field type Section Break, Column Break, Tab Break, and Table then "Allow in Quick Entry" will hide.

Thank You!