### PR TITLE
feat: Extensible SocketIO

### DIFF
--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -543,7 +543,3 @@ default_log_clearing_doctypes = {
 	"Activity Log": 90,
 	"Route History": 90,
 }
-
-# Technically we have event handlers but `frappe` gets special treatment
-# SocketIO server uses this to identify which apps to lookup for event handlers.
-has_realtime_event_handlers = False

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -543,3 +543,7 @@ default_log_clearing_doctypes = {
 	"Activity Log": 90,
 	"Route History": 90,
 }
+
+# Technically we have event handlers but `frappe` gets special treatment
+# SocketIO server uses this to identify which apps to lookup for event handlers.
+has_realtime_event_handlers = False

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -135,16 +135,10 @@ def can_subscribe_doctype(doctype: str) -> bool:
 
 @frappe.whitelist(allow_guest=True)
 def get_user_info():
-	installed_apps = frappe.get_installed_apps()
-
-	apps_with_event = [
-		app for app in installed_apps if any(frappe.get_hooks("has_realtime_event_handlers", app_name=app))
-	]
-
 	return {
 		"user": frappe.session.user,
 		"user_type": frappe.session.data.user_type,
-		"installed_apps": apps_with_event,
+		"installed_apps": frappe.get_installed_apps(),
 	}
 
 

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -114,21 +114,9 @@ def emit_via_redis(event, message, room):
 
 
 @frappe.whitelist(allow_guest=True)
-def can_subscribe_doc(doctype: str, docname: str) -> bool:
-	from frappe.exceptions import PermissionError
-
-	if not frappe.has_permission(doctype=doctype, doc=docname, ptype="read"):
-		raise PermissionError()
-
-	return True
-
-
-@frappe.whitelist(allow_guest=True)
-def can_subscribe_doctype(doctype: str) -> bool:
-	from frappe.exceptions import PermissionError
-
-	if not frappe.has_permission(doctype=doctype, ptype="read"):
-		raise PermissionError()
+def has_permission(doctype: str, name: str) -> bool:
+	if not frappe.has_permission(doctype=doctype, doc=name, ptype="read"):
+		raise frappe.PermissionError
 
 	return True
 

--- a/frappe/realtime.py
+++ b/frappe/realtime.py
@@ -135,9 +135,16 @@ def can_subscribe_doctype(doctype: str) -> bool:
 
 @frappe.whitelist(allow_guest=True)
 def get_user_info():
+	installed_apps = frappe.get_installed_apps()
+
+	apps_with_event = [
+		app for app in installed_apps if any(frappe.get_hooks("has_realtime_event_handlers", app_name=app))
+	]
+
 	return {
 		"user": frappe.session.user,
 		"user_type": frappe.session.data.user_type,
+		"installed_apps": apps_with_event,
 	}
 
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "socket.io": "^4.7.1",
     "socket.io-client": "^4.7.1",
     "sortablejs": "^1.15.0",
-    "superagent": "^8.0.0",
     "touch": "^3.1.0",
     "vue": "^3.3.0",
     "vue-router": "^4.1.5",

--- a/realtime/handlers.js
+++ b/realtime/handlers.js
@@ -1,10 +1,10 @@
-const { frappe_request } = require("../utils");
+const { frappe_request } = require("./utils");
 const log = console.log;
 
 const WEBSITE_ROOM = "website";
 const SITE_ROOM = "all";
 
-function frappe_handlers(realtime, socket) {
+function frappe_handlers(socket) {
 	socket.join(user_room(socket.user));
 	socket.join(WEBSITE_ROOM);
 

--- a/realtime/handlers.js
+++ b/realtime/handlers.js
@@ -1,6 +1,3 @@
-const { frappe_request } = require("./utils");
-const log = console.log;
-
 const WEBSITE_ROOM = "website";
 const SITE_ROOM = "all";
 
@@ -14,19 +11,15 @@ function frappe_handlers(socket) {
 
 	socket.has_permission = (doctype, name) => {
 		return new Promise((resolve) => {
-			frappe_request("/api/method/frappe.realtime.has_permission", socket)
-				.type("form")
-				.query({
-					doctype,
-					name,
-				})
-				.end(function (err, res) {
-					if (res?.status == 200) {
+			socket
+				.frappe_request("/api/method/frappe.realtime.has_permission", { doctype, name })
+				.then((res) => res.json())
+				.then(({ message }) => {
+					if (message) {
 						resolve();
-					} else if (res.status != 403) {
-						log("Something went wrong", err, res);
 					}
-				});
+				})
+				.catch((err) => console.log("Can't check permissions", err));
 		});
 	};
 

--- a/realtime/handlers.js
+++ b/realtime/handlers.js
@@ -12,13 +12,27 @@ function frappe_handlers(socket) {
 		socket.join(SITE_ROOM);
 	}
 
+	socket.has_permission = (doctype, name) => {
+		return new Promise((resolve) => {
+			frappe_request("/api/method/frappe.realtime.has_permission", socket)
+				.type("form")
+				.query({
+					doctype,
+					name,
+				})
+				.end(function (err, res) {
+					if (res?.status == 200) {
+						resolve();
+					} else if (res.status != 403) {
+						log("Something went wrong", err, res);
+					}
+				});
+		});
+	};
+
 	socket.on("doctype_subscribe", function (doctype) {
-		can_subscribe_doctype({
-			socket,
-			doctype,
-			callback: () => {
-				socket.join(doctype_room(doctype));
-			},
+		socket.has_permission(doctype).then(() => {
+			socket.join(doctype_room(doctype));
 		});
 	});
 
@@ -42,14 +56,8 @@ function frappe_handlers(socket) {
 	});
 
 	socket.on("doc_subscribe", function (doctype, docname) {
-		can_subscribe_doc({
-			socket,
-			doctype,
-			docname,
-			callback: () => {
-				let room = doc_room(doctype, docname);
-				socket.join(room);
-			},
+		socket.has_permission(doctype, docname).then(() => {
+			socket.join(doc_room(doctype, docname));
 		});
 	});
 
@@ -59,23 +67,18 @@ function frappe_handlers(socket) {
 	});
 
 	socket.on("doc_open", function (doctype, docname) {
-		can_subscribe_doc({
-			socket,
-			doctype,
-			docname,
-			callback: () => {
-				let room = open_doc_room(doctype, docname);
-				socket.join(room);
-				if (!socket.subscribed_documents) socket.subscribed_documents = [];
-				socket.subscribed_documents.push([doctype, docname]);
+		socket.has_permission(doctype, docname).then(() => {
+			let room = open_doc_room(doctype, docname);
+			socket.join(room);
+			if (!socket.subscribed_documents) socket.subscribed_documents = [];
+			socket.subscribed_documents.push([doctype, docname]);
 
-				// show who is currently viewing the form
-				notify_subscribed_doc_users({
-					socket: socket,
-					doctype: doctype,
-					docname: docname,
-				});
-			},
+			// show who is currently viewing the form
+			notify_subscribed_doc_users({
+				socket: socket,
+				doctype: doctype,
+				docname: docname,
+			});
 		});
 	});
 
@@ -110,28 +113,6 @@ function notify_disconnected_documents(socket) {
 	}
 }
 
-function can_subscribe_doctype(args) {
-	if (!args) return;
-	if (!args.doctype) return;
-	frappe_request("/api/method/frappe.realtime.can_subscribe_doctype", args.socket)
-		.type("form")
-		.query({
-			doctype: args.doctype,
-		})
-		.end(function (err, res) {
-			if (!res || res.status == 403 || err) {
-				if (err) {
-					log(err);
-				}
-				return false;
-			} else if (res.status == 200) {
-				args.callback && args.callback(err, res);
-				return true;
-			}
-			log("ERROR (can_subscribe_doctype): ", err, res);
-		});
-}
-
 function notify_subscribed_doc_users(args) {
 	if (!(args && args.doctype && args.docname)) {
 		return;
@@ -158,30 +139,6 @@ function notify_subscribed_doc_users(args) {
 		docname: args.docname,
 		users: Array.from(new Set(users)),
 	});
-}
-
-function can_subscribe_doc(args) {
-	if (!args) return;
-	if (!args.doctype || !args.docname) return;
-	frappe_request("/api/method/frappe.realtime.can_subscribe_doc", args.socket)
-		.type("form")
-		.query({
-			doctype: args.doctype,
-			docname: args.docname,
-		})
-		.end(function (err, res) {
-			if (!res) {
-				log("No response for doc_subscribe");
-			} else if (res.status == 403) {
-				return;
-			} else if (err) {
-				log(err);
-			} else if (res.status == 200) {
-				args.callback(err, res);
-			} else {
-				log("Something went wrong", err, res);
-			}
-		});
 }
 
 const doc_room = (doctype, docname) => "doc:" + doctype + "/" + docname;

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -1,6 +1,8 @@
 const { Server } = require("socket.io");
 const http = require("node:http");
 
+const fs = require("fs");
+const path = require("path");
 const { get_conf, get_redis_subscriber } = require("../node_utils");
 const conf = get_conf();
 
@@ -29,6 +31,15 @@ realtime.use(authenticate);
 const frappe_handlers = require("./handlers/frappe_handlers");
 function on_connection(socket) {
 	frappe_handlers(realtime, socket);
+
+	socket.installed_apps.forEach((app) => {
+		let file = `../../${app}/realtime/handlers.js`;
+		let abs_path = path.resolve(__dirname, file);
+		if (fs.existsSync(abs_path)) {
+			let handler_factory = require(file);
+			handler_factory(socket);
+		}
+	});
 
 	// ESBUild "open in editor" on error
 	socket.on("open_in_editor", async (data) => {

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -33,16 +33,12 @@ function on_connection(socket) {
 	frappe_handlers(realtime, socket);
 
 	socket.installed_apps.forEach((app) => {
-		let file = `../../${app}/realtime/handlers.js`;
-		let abs_path = path.resolve(__dirname, file);
-		if (fs.existsSync(abs_path)) {
-			try {
-				let handler_factory = require(file);
-				handler_factory(socket);
-			} catch (err) {
-				console.warn(`failed to load event handlers from ${abs_path}`);
-				console.warn(err);
-			}
+		let app_handler = get_app_handlers(app);
+		try {
+			app_handler && app_handler(socket);
+		} catch (err) {
+			console.warn(`failed to setup event handlers from ${app}`);
+			console.warn(err);
 		}
 	});
 
@@ -51,6 +47,27 @@ function on_connection(socket) {
 		await subscriber.connect();
 		subscriber.publish("open_in_editor", JSON.stringify(data));
 	});
+}
+
+const _app_handlers = {};
+function get_app_handlers(app) {
+	if (app in _app_handlers) {
+		return _app_handlers[app];
+	}
+
+	let file = `../../${app}/realtime/handlers.js`;
+	let abs_path = path.resolve(__dirname, file);
+	let handler = null;
+	if (fs.existsSync(abs_path)) {
+		try {
+			handler = require(file);
+		} catch (err) {
+			console.warn(`failed to load event handlers from ${abs_path}`);
+			console.warn(err);
+		}
+	}
+	_app_handlers[app] = handler;
+	return handler;
 }
 
 realtime.on("connection", on_connection);

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -27,11 +27,7 @@ const authenticate = require("./middlewares/authenticate");
 realtime.use(authenticate);
 // =======================
 
-// load and register handlers
-const frappe_handlers = require("./handlers/frappe_handlers");
 function on_connection(socket) {
-	frappe_handlers(realtime, socket);
-
 	socket.installed_apps.forEach((app) => {
 		let app_handler = get_app_handlers(app);
 		try {

--- a/realtime/index.js
+++ b/realtime/index.js
@@ -36,8 +36,13 @@ function on_connection(socket) {
 		let file = `../../${app}/realtime/handlers.js`;
 		let abs_path = path.resolve(__dirname, file);
 		if (fs.existsSync(abs_path)) {
-			let handler_factory = require(file);
-			handler_factory(socket);
+			try {
+				let handler_factory = require(file);
+				handler_factory(socket);
+			} catch (err) {
+				console.warn(`failed to load event handlers from ${abs_path}`);
+				console.warn(err);
+			}
 		}
 	});
 

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -40,9 +40,10 @@ function authenticate_with_frappe(socket, next) {
 
 	auth_req
 		.type("form")
-		.then((res) => {
-			socket.user = res.body.message.user;
-			socket.user_type = res.body.message.user_type;
+		.then(({ body: { message } }) => {
+			socket.user = message.user;
+			socket.user_type = message.user_type;
+			socket.installed_apps = message.installed_apps;
 			socket.sid = cookies.sid;
 			socket.authorization_header = authorization_header;
 			next();

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -1,8 +1,6 @@
 const cookie = require("cookie");
-const request = require("superagent");
-const { get_url } = require("../utils");
-
 const { get_conf } = require("../../node_utils");
+const { get_url } = require("../utils");
 const conf = get_conf();
 
 function authenticate_with_frappe(socket, next) {
@@ -30,22 +28,35 @@ function authenticate_with_frappe(socket, next) {
 		next(new Error("No authentication method used. Use cookie or authorization header."));
 		return;
 	}
+	socket.sid = cookies.sid;
+	socket.authorization_header = authorization_header;
 
-	let auth_req = request.get(get_url(socket, "/api/method/frappe.realtime.get_user_info"));
-	if (cookies.sid) {
-		auth_req = auth_req.query({ sid: cookies.sid });
-	} else {
-		auth_req = auth_req.set("Authorization", authorization_header);
-	}
+	socket.frappe_request = (path, args = {}, opts = {}) => {
+		let query_args = new URLSearchParams(args);
+		if (query_args.toString()) {
+			path = path + "?" + query_args.toString();
+		}
 
-	auth_req
-		.type("form")
-		.then(({ body: { message } }) => {
+		let headers = {};
+		if (socket.sid) {
+			headers["Cookie"] = `sid=${socket.sid}`;
+		} else if (socket.authorization_header) {
+			headers["Authorization"] = socket.authorization_header;
+		}
+
+		return fetch(get_url(socket, path), {
+			...opts,
+			headers,
+		});
+	};
+
+	socket
+		.frappe_request("/api/method/frappe.realtime.get_user_info")
+		.then((res) => res.json())
+		.then(({ message }) => {
 			socket.user = message.user;
 			socket.user_type = message.user_type;
 			socket.installed_apps = message.installed_apps;
-			socket.sid = cookies.sid;
-			socket.authorization_header = authorization_header;
 			next();
 		})
 		.catch((e) => {

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -1,6 +1,5 @@
 const { get_conf } = require("../node_utils");
 const conf = get_conf();
-const request = require("superagent");
 
 function get_url(socket, path) {
 	if (!path) {
@@ -17,17 +16,6 @@ function get_url(socket, path) {
 	return url + path;
 }
 
-// Authenticates a partial request created using superagent
-function frappe_request(path, socket) {
-	const partial_req = request.get(get_url(socket, path));
-	if (socket.sid) {
-		return partial_req.query({ sid: socket.sid });
-	} else if (socket.authorization_header) {
-		return partial_req.set("Authorization", socket.authorization_header);
-	}
-}
-
 module.exports = {
 	get_url,
-	frappe_request,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,7 +449,7 @@ array-buffer-byte-length@^1.0.0:
     call-bind "^1.0.2"
     is-array-buffer "^3.0.1"
 
-asap@^2.0.0, asap@~2.0.3:
+asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
@@ -458,11 +458,6 @@ assert-never@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/assert-never/-/assert-never-1.2.1.tgz#11f0e363bf146205fb08193b5c7b90f4d1cf44fe"
   integrity sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 at-least-node@^1.0.0:
   version "1.0.0"
@@ -705,13 +700,6 @@ colord@^2.9.1:
   resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
   integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
@@ -721,11 +709,6 @@ commander@^9.0.0:
   version "9.5.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
   integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
-
-component-emitter@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.1.tgz#ef1d5796f7d93f135ee6fb684340b26403c97d17"
-  integrity sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -751,11 +734,6 @@ cookie@^0.4.0, cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
-
-cookiejar@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
-  integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
 copy-anything@^2.0.1:
   version "2.0.6"
@@ -989,7 +967,7 @@ debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.2, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
+debug@^4.3.2, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -1061,19 +1039,6 @@ define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
-dezalgo@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.4.tgz#751235260469084c132157dfa857f386d4c33d81"
-  integrity sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==
-  dependencies:
-    asap "^2.0.0"
-    wrappy "1"
 
 doctypes@^1.1.0:
   version "1.1.0"
@@ -1408,11 +1373,6 @@ fast-glob@^3.2.5:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-safe-stringify@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
-  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
-
 fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
@@ -1453,25 +1413,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-formidable@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-2.1.2.tgz#fa973a2bec150e4ce7cac15589d7a25fc30ebd89"
-  integrity sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==
-  dependencies:
-    dezalgo "^1.0.4"
-    hexoid "^1.0.0"
-    once "^1.4.0"
-    qs "^6.11.0"
 
 fraction.js@^4.3.6:
   version "4.3.7"
@@ -1672,11 +1613,6 @@ hasown@^2.0.0:
   integrity sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==
   dependencies:
     function-bind "^1.1.2"
-
-hexoid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hexoid/-/hexoid-1.0.0.tgz#ad10c6573fb907de23d9ec63a711267d9dc9bc18"
-  integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
 
 highlight.js@^10.4.1:
   version "10.7.3"
@@ -2122,13 +2058,6 @@ lru-cache@^4.1.2:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
-
 magic-string@^0.30.5:
   version "0.30.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.5.tgz#1994d980bd1c8835dc6e78db7cbd4ae4f24746f9"
@@ -2170,11 +2099,6 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-methods@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
-  integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
-
 micromatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
@@ -2188,17 +2112,12 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12, mime-types@~2.1.34:
+mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
-
-mime@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
-  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mime@^1.4.1:
   version "1.6.0"
@@ -2345,7 +2264,7 @@ object.assign@^4.1.4:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -2872,13 +2791,6 @@ pug@^3.0.1:
     pug-runtime "^3.0.1"
     pug-strip-comments "^2.0.0"
 
-qs@^6.11.0:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
-  integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
-  dependencies:
-    side-channel "^1.0.4"
-
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -3076,13 +2988,6 @@ semver@^6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^7.3.8:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
 
 set-function-length@^1.1.1:
   version "1.1.1"
@@ -3292,22 +3197,6 @@ stylus@^0.x:
     glob "^7.1.6"
     sax "~1.3.0"
     source-map "^0.7.3"
-
-superagent@^8.0.0:
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-8.1.2.tgz#03cb7da3ec8b32472c9d20f6c2a57c7f3765f30b"
-  integrity sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==
-  dependencies:
-    component-emitter "^1.3.0"
-    cookiejar "^2.1.4"
-    debug "^4.3.4"
-    fast-safe-stringify "^2.1.1"
-    form-data "^4.0.0"
-    formidable "^2.1.2"
-    methods "^1.1.2"
-    mime "2.6.0"
-    qs "^6.11.0"
-    semver "^7.3.8"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -3569,7 +3458,7 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yallist@4.0.0, yallist@^4.0.0:
+yallist@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
You can now specify custom event handlers for SocketIO.

Usage:

1. Create a file called `/app/realtime/handlers.js` with single module
   export a function that will setup handlers using socket.

Here's sample code:

```js
// This is /app_root/realtime/handlers.js`

function chat_app_handlers(socket) {
    socket.on("hello_chat", () => {
	console.log("hello world!");
    });
    // You're supposed to setup all event listeners on this socket object in this function
}

module.exports = chat_app_handlers;
```

2. Restart SocketIO server and see if it worked by sending event from
   client. In desk based app you can do `frappe.realtime.emit("hello_chat")`.


Warnings:

- Event handlers can crash entire socketio server, since you're given `socket`
  object you need to be very careful with how you write event code. 
- There's no resolution here, every app who wants to write custom event should
  ensure their event names are unique enough, maybe prefix with your app name
  like `chat_subscribe_channel` instead of `subscribe_channel`.
- Middlewares are not yet possible... will be worked upon __some other day__ [tm]


closes https://github.com/frappe/frappe/issues/21528
docs: https://frappeframework.com/docs/user/en/api/realtime#custom-event-handlers 