### PR TITLE
fix: remove slashes from the report link in workspace card

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1300,7 +1300,7 @@ Object.assign(frappe.utils, {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;
 				} else if (!item.doctype) {
-					route = "/report/" + item.name;
+					route = "report/" + item.name;
 				} else {
 					route = frappe.router.slug(item.doctype) + "/view/report/" + item.name;
 				}


### PR DESCRIPTION
Version 15 and 14,

fixes: #25589

**Before:**
- If by mistake, the user has not clicked the option of "Is Query Report", and clicking on the report, it redirects to the report doctype with double slashes but that time worked but when the user open with a new tab then faces an issue.


https://github.com/frappe/frappe/assets/141945075/84707798-9e03-41c7-bfe8-b9a1c942c3e9


<br>

**After:** remove slashes.


https://github.com/frappe/frappe/assets/141945075/3feb3ac9-297b-4f85-a0ec-8821c630359f


<br>
Thank You!