### PR TITLE
fix: distinct parsing in perm level code

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -640,7 +640,7 @@ class DatabaseQuery:
 				# field: 'distinct name'
 				# column: 'name'
 				else:
-					column = field.split(" ", 2)[1].replace("`", "")
+					column = field.split(" ", 1)[1].replace("`", "")
 			else:
 				# field: 'count(`tabPhoto`.name) as total_count'
 				# column: 'tabPhoto.name'

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -1257,6 +1257,20 @@ class TestReportView(FrappeTestCase):
 		self.assertIsInstance(count, int)
 		self.assertLessEqual(count, limit)
 
+		# doctype with space in name
+		limit = 2
+		frappe.local.form_dict = frappe._dict(
+			{
+				"doctype": "Role Profile",
+				"fields": [],
+				"distinct": "true",
+				"limit": limit,
+			}
+		)
+		count = execute_cmd("frappe.desk.reportview.get_count")
+		self.assertIsInstance(count, int)
+		self.assertLessEqual(count, limit)
+
 	def test_reportview_get(self):
 		user = frappe.get_doc("User", "test@example.com")
 		add_child_table_to_blog_post()


### PR DESCRIPTION
- Doctype with spaces in name end up doing more splits than necessary
- So `distinct tabSales Invoice.name` becomes `["distinct", "tabSales", "Invoice.name"]`