### PR TITLE
perf: Faster "show title in link field" on list view

### DIFF
--- a/frappe/public/js/frappe/list/base_list.js
+++ b/frappe/public/js/frappe/list/base_list.js
@@ -462,15 +462,22 @@ frappe.views.BaseList = class BaseList {
 	}
 
 	get_args() {
+		let filters = this.get_filters_for_args();
+		let group_by = this.get_group_by();
+		let group_by_required =
+			Array.isArray(filters) &&
+			filters.some((filter) => {
+				return filter[0] !== this.doctype;
+			});
 		return {
 			doctype: this.doctype,
 			fields: this.get_fields(),
-			filters: this.get_filters_for_args(),
+			filters,
 			order_by: this.sort_selector && this.sort_selector.get_sql_string(),
 			start: this.start,
 			page_length: this.page_length,
 			view: this.view,
-			group_by: this.get_group_by(),
+			group_by: group_by_required ? group_by : null,
 		};
 	}
 


### PR DESCRIPTION
Ideally, this query should be converted to ["Top N" variant](https://use-the-index-luke.com/sql/partial-results/top-n-queries) and just pick
first 20 records, join only them with other table and send data back.

Currently we always group by `name` in list view. This makes "show title
in link field" join queries insanely slow as it first queries entire
table and then applies limit.

