### PR TITLE
feat: allow setting a custom rate limit for `login via email link` feature

### DIFF
--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -40,6 +40,7 @@
   "column_break_uhqk",
   "login_with_email_link",
   "login_with_email_link_expiry",
+  "rate_limit_email_link_login",
   "brute_force_security",
   "allow_consecutive_login_attempts",
   "column_break_34",
@@ -656,12 +657,19 @@
    "fieldname": "store_attached_pdf_document",
    "fieldtype": "Check",
    "label": "Store Attached PDF Document"
+  },
+  {
+   "depends_on": "login_with_email_link",
+   "description": "You can set a high value here if multiple users will be logging in from the same network.",
+   "fieldname": "rate_limit_email_link_login",
+   "fieldtype": "Int",
+   "label": "Rate limit for email link login"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-03-14 15:18:01.465057",
+ "modified": "2024-03-22 15:43:48.347441",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -82,6 +82,7 @@ class SystemSettings(Document):
 		]
 		otp_issuer_name: DF.Data | None
 		password_reset_limit: DF.Int
+		rate_limit_email_link_login: DF.Int
 		reset_password_link_expiry_duration: DF.Duration | None
 		reset_password_template: DF.Link | None
 		rounding_method: DF.Literal["Banker's Rounding (legacy)", "Banker's Rounding", "Commercial Rounding"]

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -155,8 +155,12 @@ def _generate_temporary_login_link(email: str, expiry: int):
 	return get_url(f"/api/method/frappe.www.login.login_via_key?key={key}")
 
 
+def get_login_with_email_link_ratelimit() -> int:
+	return frappe.get_system_settings("rate_limit_email_link_login") or 5
+
+
 @frappe.whitelist(allow_guest=True, methods=["GET"])
-@rate_limit(limit=5, seconds=60 * 60)
+@rate_limit(limit=get_login_with_email_link_ratelimit, seconds=60 * 60)
 def login_via_key(key: str):
 	cache_key = f"one_time_login_key:{key}"
 	email = frappe.cache.get_value(cache_key)


### PR DESCRIPTION
Current method causes issues if multiple users connected to the same network need to login.

Allow users to configure the limit in System Settings.

![image](https://github.com/frappe/frappe/assets/10119037/5ad8551c-3241-4c39-8ec6-088de1606f66)


Support ticket 11962 for example
