### PR TITLE
feat: don't require editing MariaDB configuration to setup frappe

### DIFF
--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -25,7 +25,7 @@ class DbManager:
 	def create_database(self, target):
 		if target in self.get_database_list():
 			self.drop_database(target)
-		self.db.sql(f"CREATE DATABASE `{target}`")
+		self.db.sql(f"CREATE DATABASE `{target}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
 
 	def drop_database(self, target):
 		self.db.sql_ddl(f"DROP DATABASE IF EXISTS `{target}`")

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -5,11 +5,6 @@ import click
 import frappe
 from frappe.database.db_manager import DbManager
 
-REQUIRED_MARIADB_CONFIG = {
-	"character_set_server": "utf8mb4",
-	"collation_server": "utf8mb4_unicode_ci",
-}
-
 
 def get_mariadb_variables():
 	return frappe._dict(frappe.db.sql("show variables"))
@@ -71,8 +66,8 @@ def bootstrap_database(verbose, source_sql=None):
 	import sys
 
 	frappe.connect()
-	if not check_database_settings():
-		print("Database settings do not match expected values; stopping database setup.")
+	if not check_compatible_versions():
+		print("MariaDB version compatibility checks failed, make sure you're running a supported version; stopping database setup.")
 		sys.exit(1)
 
 	import_db_from_sql(source_sql, verbose)
@@ -103,30 +98,6 @@ def import_db_from_sql(source_sql=None, verbose=False):
 	)
 	if verbose:
 		print("Imported from database %s" % source_sql)
-
-
-def check_database_settings():
-	check_compatible_versions()
-
-	# Check each expected value vs. actuals:
-	mariadb_variables = get_mariadb_variables()
-	result = True
-	for key, expected_value in REQUIRED_MARIADB_CONFIG.items():
-		if mariadb_variables.get(key) != expected_value:
-			print(f"For key {key}. Expected value {expected_value}, found value {mariadb_variables.get(key)}")
-			result = False
-
-	if not result:
-		print(
-			(
-				"{sep2}Creation of your site - {site} failed because MariaDB is not properly {sep}"
-				"configured.{sep2}"
-				"Please verify the above settings in MariaDB's my.cnf.  Restart MariaDB.{sep}"
-				"And then run `bench new-site {site}` again.{sep2}"
-			).format(site=frappe.local.site, sep2="\n\n", sep="\n")
-		)
-
-	return result
 
 
 def check_compatible_versions():

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -66,9 +66,7 @@ def bootstrap_database(verbose, source_sql=None):
 	import sys
 
 	frappe.connect()
-	if not check_compatible_versions():
-		print("MariaDB version compatibility checks failed, make sure you're running a supported version; stopping database setup.")
-		sys.exit(1)
+	check_compatible_versions()
 
 	import_db_from_sql(source_sql, verbose)
 


### PR DESCRIPTION
In order to gain flexibility to write Dokos install script and packages, the --no-setup-db parameter of the bench new-site command is a very great improvement!

However, in order to free installation from the need of adding to /etc/mysql/my.cnf

```
[mysqld]
character-set-client-handshake = FALSE
character-set-server = utf8mb4
collation-server = utf8mb4_unicode_ci

[mysql]
default-character-set = utf8mb4
```

the function `create_database` should pass these requirements : `CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`
and thus we don't need to check GLOBAL mysql VARIABLES.

With this PR, the following :
```
sudo mysql -u root -e "CREATE USER '$db_name'@'localhost' IDENTIFIED BY '$db_pwd';"
sudo mysql -u root -e "CREATE DATABASE IF NOT EXISTS $db_name CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
sudo mysql -u root -e "GRANT ALL PRIVILEGES ON $db_name . * TO '$db_name'@'localhost';"
sudo mysql -u root -e "FLUSH PRIVILEGES;"

bench new-site $site_name --db-name $db_name --db-password $db_pwd --no-setup-db --admin-password $admin_pwd
```

could work without changing /etc/mysql/my.cnf .
Actually, we could remove from documentation the requirement to change /etc/mysql/my.cnf