### PR TITLE
feat: drop sentry's RQ integration

### DIFF
--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -56,7 +56,7 @@ class TestRQJob(FrappeTestCase):
 	def test_func_obj_serialization(self):
 		job = frappe.enqueue(method=test_func, queue="short")
 		rq_job = frappe.get_doc("RQ Job", job.id)
-		self.assertEqual(rq_job.job_name, "test_func")
+		self.assertEqual(rq_job.job_name, "frappe.core.doctype.rq_job.test_rq_job.test_func")
 
 	@timeout
 	def test_get_list_filtering(self):

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -23,7 +23,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fi
 import frappe
 import frappe.monitor
 from frappe import _
-from frappe.utils import CallbackManager, cint, cstr, get_bench_id
+from frappe.utils import CallbackManager, cint, get_bench_id
 from frappe.utils.commands import log
 from frappe.utils.deprecations import deprecation_warning
 from frappe.utils.redis_queue import RedisQueue
@@ -142,12 +142,18 @@ def enqueue(
 	if not timeout:
 		timeout = get_queues_timeout().get(queue) or 300
 
+	# Prepare a more readable name than <function $name at $address>
+	if isinstance(method, Callable):
+		method_name = f"{method.__module__}.{method.__qualname__}"
+	else:
+		method_name = method
+
 	queue_args = {
 		"site": frappe.local.site,
 		"user": frappe.session.user,
-		"method": method,
+		"method": method_name,
 		"event": event,
-		"job_name": job_name or cstr(method),
+		"job_name": job_name or method_name,
 		"is_async": is_async,
 		"kwargs": kwargs,
 	}
@@ -639,7 +645,6 @@ def _start_sentry():
 	from sentry_sdk.integrations.dedupe import DedupeIntegration
 	from sentry_sdk.integrations.excepthook import ExcepthookIntegration
 	from sentry_sdk.integrations.modules import ModulesIntegration
-	from sentry_sdk.integrations.rq import RqIntegration
 
 	from frappe.utils.sentry import FrappeIntegration, before_send
 
@@ -649,7 +654,6 @@ def _start_sentry():
 		DedupeIntegration(),
 		ModulesIntegration(),
 		ArgvIntegration(),
-		RqIntegration(),
 	]
 
 	experiments = {}

--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -59,6 +59,7 @@ def set_scope(scope):
 		waitdiff = datetime.utcnow() - job.enqueued_at
 		context.uuid = job.id
 		context.wait = waitdiff.total_seconds()
+		context.kwargs = kwargs
 
 		scope.set_extra("job", context)
 		scope.set_transaction_name(transaction_name)


### PR DESCRIPTION
It overrides what we set with information that isn't really useful for us.
Set a more readable method name, and add in some additional job metadata.

Resolves #25471
