### PR TITLE
fix(webhook): `r` is referenced here before its initialized

### DIFF
--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -156,7 +156,7 @@ def get_context(doc):
 
 
 def enqueue_webhook(doc, webhook) -> None:
-	request_url = headers = data = None
+	request_url = headers = data = r = None
 	try:
 		webhook: Webhook = frappe.get_doc("Webhook", webhook.get("name"))
 		request_url = webhook.request_url


### PR DESCRIPTION
Broke in #21064

Sentry: FRAPPE-2SH
