### PR TITLE
fix: set list row height to 40px

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -82,7 +82,7 @@
 
 .list-row {
 	padding: 15px 15px 15px 0px;
-	height: 38px;
+	height: 40px;
 	cursor: pointer;
 	transition: color 0.2s;
 	-webkit-transition: color 0.2s;
@@ -157,9 +157,12 @@
 		}
 	}
 
-	.select-like,
 	.file-select {
 		padding-left: 11px;
+	}
+
+	.select-like {
+		padding: 10px 0 10px 11px;
 	}
 }
 


### PR DESCRIPTION
### Set list row height to 40px (according to espresso)

<details>
<summary>Before:</summary>

<img width="1512" alt="image" src="https://github.com/frappe/frappe/assets/9355208/e09ef3fc-7eac-485a-83fd-e582304d6a94">

</details>


After:

<img width="1512" alt="image" src="https://github.com/frappe/frappe/assets/9355208/d98192fe-1f14-4d37-9e45-7fb49933de69">







### Make checkbox container area larger to avoid accidental click routing to form



<details>
<summary>Before:</summary>

<img width="678" alt="image" src="https://github.com/frappe/frappe/assets/9355208/f9c2a2af-da59-42ba-81d4-eed162305396">

</details>


After:

<img width="631" alt="image" src="https://github.com/frappe/frappe/assets/9355208/b9b2f949-15a6-4df4-9687-b89f2ecee4ad">



CC @barredterra 