### PR TITLE
perf: dont set defaults unless required

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -171,7 +171,8 @@ class User(Document):
 		self.validate_username()
 		self.remove_disabled_roles()
 		self.validate_user_email_inbox()
-		ask_pass_update()
+		if self.user_emails:
+			ask_pass_update()
 		self.validate_allowed_modules()
 		self.validate_user_image()
 		self.set_time_zone()


### PR DESCRIPTION
On site with many signups this causes cache trashing because every
signup clears cache.

```
775424   File "/home/frappe/frappe-bench/apps/press/press/press/doctype/team/team.py", line 304, in create_user
775425     user.save(ignore_permissions=True)
775426   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 336, in save
775427     return self._save(*args, **kwargs)
775428   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 358, in _save
775429     return self.insert()
775430   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 289, in insert
775431     self.run_before_save_methods()
775432   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1093, in run_before_save_methods
775433     self.run_method("validate")
775434   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 964, in run_method
775435     out = Document.hook(fn)(self, *args, **kwargs)
775436   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1324, in composer
775437     return composed(self, method, *args, **kwargs)
775438   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1306, in runner
775439     add_to_return_value(self, fn(self, *args, **kwargs))
775440   File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 961, in fn
775441     return method_object(*args, **kwargs)
775442   File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 173, in validate
775443     ask_pass_update()
775444   File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/user/user.py", line 960, in ask_pass_update
775445     set_default("email_user_password", ",".join(password_list))
775446   File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/__init__.py", line 385, in set_default
775447     return frappe.db.set_default(key, val)
775448   File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 1005, in set_default
775449     frappe.defaults.set_default(key, val, parent, parenttype)
775450   File "/home/frappe/frappe-bench/apps/frappe/frappe/defaults.py", line 167, in set_default
775451     add_default(key, value, parent)
775452   File "/home/frappe/frappe-bench/apps/frappe/frappe/defaults.py", line 184, in add_default
775453     _clear_cache(parent)
775454   File "/home/frappe/frappe-bench/apps/frappe/frappe/defaults.py", line 264, in _clear_cache
775455     frappe.clear_cache(user=parent if parent not in common_default_keys else None)
```