### PR TITLE
feat: after refresh event on query reports

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -743,6 +743,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 			.finally(() => {
 				this.hide_loading_screen();
 				this.update_url_with_filters();
+				this.report_settings.after_refresh?.(this);
 			});
 	}
 


### PR DESCRIPTION
There's no way to run something after report has refreshed right now.
This hook simplifies that.


added for https://github.com/frappe/press/commit/195f6f3c21d0e5edf6729eb33bab4704e1977eb1