### PR TITLE
fix: download_multi_pdf doesn't print letter head

### DIFF
--- a/frappe/utils/print_format.py
+++ b/frappe/utils/print_format.py
@@ -33,7 +33,7 @@ def download_multi_pdf(
 	"""
 	Calls _download_multi_pdf with the given parameters and returns the response
 	"""
-	return _download_multi_pdf(doctype, name, format, no_letterhead, options)
+	return _download_multi_pdf(doctype, name, format, no_letterhead, letterhead, options)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
introduced via https://github.com/frappe/frappe/pull/25358
fix: add missing arg while invoking _download_multi_pdf