### PR TITLE
ci: bump mariadb to 11.x

### DIFF
--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -48,7 +48,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: travis
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
       - name: Clone

--- a/.github/workflows/patch-mariadb-tests.yml
+++ b/.github/workflows/patch-mariadb-tests.yml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:11.3
         env:
           MARIADB_ROOT_PASSWORD: travis
         ports:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -59,7 +59,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: travis
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
 
       postgres:
         image: postgres:12.4

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -54,7 +54,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:11.3
         env:
           MARIADB_ROOT_PASSWORD: travis
         ports:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -60,7 +60,7 @@ jobs:
           MARIADB_ROOT_PASSWORD: travis
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=3
 
     steps:
       - name: Clone

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.6
+        image: mariadb:11.3
         env:
           MARIADB_ROOT_PASSWORD: travis
         ports:


### PR DESCRIPTION
Next Framework version will use 11.7 LTS, preparing for the jump.

New version has some cool stuff:
- UUID data type
- Much better explain/analyze
- Better query optimizer


Not worrying about breaking changes as of now, as we aren't deploying to prod. Mainly breaking stuff is with name of knobs, eh. 