### PR TITLE
fix: Use CssParser to correctly pass options to wkhtmltopdf

### DIFF
--- a/frappe/tests/test_pdf.py
+++ b/frappe/tests/test_pdf.py
@@ -37,8 +37,31 @@ class TestPdf(FrappeTestCase):
 	def test_read_options_from_html(self):
 		_, html_options = pdfgen.read_options_from_html(self.html)
 		self.assertTrue(html_options["margin-top"] == "0")
-		self.assertTrue(html_options["margin-left"] == "10")
+		self.assertTrue(html_options["margin-left"] == "10mm")
 		self.assertTrue(html_options["margin-right"] == "0")
+
+		html_1 = """<style>
+			.print-format {
+				margin-top: 0mm;
+				margin-left: 10mm;
+			}
+			.print-format .more-info {
+				margin-right: 15mm;
+			}
+			.print-format, .more-info {
+				margin-bottom: 20mm;
+			}
+			</style>
+			<div class="more-info">Hello</div>
+		"""
+		_, options = pdfgen.read_options_from_html(html_1)
+
+		self.assertTrue(options["margin-top"] == "0")
+		self.assertTrue(options["margin-left"] == "10mm")
+		self.assertTrue(options["margin-bottom"] == "20mm")
+		# margin-right was for .more-info (child of .print-format)
+		# so it should not be extracted into options
+		self.assertFalse(options.get("margin-right"))
 
 	def test_pdf_encryption(self):
 		password = "qwe"

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -208,7 +208,7 @@ def read_options_from_html(html):
 
 	valid_styles = get_print_format_styles(soup)
 
-	for attr in (
+	attrs = (
 		"margin-top",
 		"margin-bottom",
 		"margin-left",
@@ -218,11 +218,8 @@ def read_options_from_html(html):
 		"orientation",
 		"page-width",
 		"page-height",
-	):
-		for style in valid_styles:
-			if attr == style.name:
-				options[attr] = style.value
-
+	)
+	options |= {style.name: style.value for style in valid_styles if style.name in attrs}
 	return str(soup), options
 
 

--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -5,10 +5,10 @@ import contextlib
 import io
 import mimetypes
 import os
-import re
 import subprocess
 from urllib.parse import parse_qs, urlparse
 
+import cssutils
 import pdfkit
 from bs4 import BeautifulSoup
 from packaging.version import Version
@@ -206,7 +206,8 @@ def read_options_from_html(html):
 
 	toggle_visible_pdf(soup)
 
-	# use regex instead of soup-parser
+	valid_styles = get_print_format_styles(soup)
+
 	for attr in (
 		"margin-top",
 		"margin-bottom",
@@ -218,15 +219,49 @@ def read_options_from_html(html):
 		"page-width",
 		"page-height",
 	):
-		try:
-			pattern = re.compile(r"(\.print-format)([\S|\s][^}]*?)(" + str(attr) + r":)(.+)(mm;)")
-			match = pattern.findall(html)
-			if match:
-				options[attr] = str(match[-1][3]).strip()
-		except Exception:
-			pass
+		for style in valid_styles:
+			if attr == style.name:
+				options[attr] = style.value
 
 	return str(soup), options
+
+
+def get_print_format_styles(soup: BeautifulSoup) -> list[cssutils.css.Property]:
+	"""
+	Get styles purely on class 'print-format'.
+	Valid:
+	1) .print-format { ... }
+	2) .print-format, p { ... } | p, .print-format { ... }
+
+	Invalid (applied on child elements):
+	1) .print-format p { ... } | .print-format > p { ... }
+	2) .print-format #abc { ... }
+
+	Returns:
+	[cssutils.css.Property(name='margin-top', value='50mm', priority=''), ...]
+	"""
+	stylesheet = ""
+	style_tags = soup.find_all("style")
+
+	# Prepare a css stylesheet from all the style tags' contents
+	for style_tag in style_tags:
+		stylesheet += style_tag.string
+
+	# Use css parser to tokenize the classes and their styles
+	parsed_sheet = cssutils.parseString(stylesheet)
+
+	# Get all styles that are only for .print-format
+	valid_styles = []
+	for rule in parsed_sheet:
+		if not isinstance(rule, cssutils.css.CSSStyleRule):
+			continue
+
+		# Allow only .print-format { ... } and .print-format, p { ... }
+		# Disallow .print-format p { ... } and .print-format > p { ... }
+		if ".print-format" in [x.strip() for x in rule.selectorText.split(",")]:
+			valid_styles.extend(entry for entry in rule.style)
+
+	return valid_styles
 
 
 def inline_private_images(html) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "chardet~=5.1.0",
     "croniter~=2.0.1",
     "cryptography~=42.0.0",
+    "cssutils~=2.9.0",
     "email-reply-parser~=0.5.12",
     "gunicorn~=21.2.0",
     "html5lib~=1.1",


### PR DESCRIPTION
## Issue:
- Regex in `pdf.py` incorrectly fetches .print-format's child styles and also extracts the wrong attribute value
- Assume custom print format:
  ```html
    {%- from "templates/print_formats/standard_macros.html" import add_header -%}

	<div {% if print_settings.repeat_header_footer %} id="header-html" class="hidden-pdf" {% endif %}>
	    {{ add_header(0, 1, doc, letter_head, no_letterhead, footer, print_settings) }}
	</div>
	
	<!-- CONTENT -->
	<div id="text">
		<div>
			<strong>{{ _("Order Confirmation") }}: {{ doc.name }}</strong>
		</div>
	</div>
  ```
- Assume css:
	```css
	.print-format #text{width:100%;margin-top:10mm;margin-left:25mm;font-size:14px;margin-right:20mm;}
	```
- Due to the regex in `pdf.py`these are the options passed to wkhtmltopdf:
	```py
		{
			'print-media-type': None, 
			'background': None, 
			'images': None, 
			'quiet': None, 
			'encoding': 'UTF-8', 
			'margin-right': '20', 
			'margin-left': '25mm;font-size:14px;margin-right:20',   #invalid
			'header-html': '/tmp/frappe-pdf-1de86139a955c4463f40be4dc8626e4f6b3b8488ed287fcee6e85187.html',
			'margin-bottom': '15mm', 
			'margin-top': '10mm;margin-left:25mm;font-size:14px;margin-right:20',  #invalid
			'cookie-jar': '/tmp/58999d273a4da9f40b37c6b280b488d4029fd1b06e45f4b949e80275.jar', 
			'page-size': 'A4'
		}
	```
- This in turn does not render the pdf:
	```
	  File "env/lib/python3.11/site-packages/pdfkit/pdfkit.py", line 201, in to_pdf
		    self.handle_error(exit_code, stderr)
		  File "env/lib/python3.11/site-packages/pdfkit/pdfkit.py", line 158, in handle_error
		    raise IOError("wkhtmltopdf exited with non-zero code {0}. error:\n{1}".format(exit_code, error_msg))
		OSError: wkhtmltopdf exited with non-zero code 1. error:
		Invalid argument(s) parsed to --margin-left
	```

## Fix
- Consider styles only directly applied to `.print-format`, no child styles. Eg. `.print-format .abc { ... }`
- A CssParser is more maintainable and more readable as well as less prone to errors while extracting values
- Method: We extract style tag contents out of the html and tokenize them. We then filter the styles for the right selector and extract the attributes we want from them.
- This way we make sure that the right value is extracted and only the ones applicable to .print-format directly


