### PR TITLE
fix: incorrect status on data import

### DIFF
--- a/frappe/core/doctype/data_import/data_import_list.js
+++ b/frappe/core/doctype/data_import/data_import_list.js
@@ -27,10 +27,6 @@ frappe.listview_settings["Data Import"] = {
 		if (imports_in_progress.includes(doc.name)) {
 			status = "In Progress";
 		}
-		if (status === "Pending") {
-			status = "Not Started";
-		}
-
 		return [__(status), colors[status], "status,=," + doc.status];
 	},
 	formatters: {

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -221,10 +221,10 @@ class Importer:
 			else:
 				failures.append(log)
 		if len(failures) >= total_payload_count and len(successes) == 0:
-			status = "Error" 
+			status = "Error"
 		elif len(failures) > 0 and len(successes) > 0:
 			status = "Partial Success"
-		elif len(len(successes) == total_payload_count):
+		elif len(successes) == total_payload_count:
 			status = "Success"
 
 		if self.console:

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -102,9 +102,13 @@ class Importer:
 		log_index = 0
 
 		# Do not remove rows in case of retry after an error or pending data import
-		if self.data_import.status == "Partial Success" and len(import_log) >= self.data_import.payload_count:
+		if (
+			self.data_import.status in ("Partial Success", "Error")
+			and len(import_log) >= self.data_import.payload_count
+		):
 			# remove previous failures from import log only in case of retry after partial success
 			import_log = [log for log in import_log if log.get("success")]
+			frappe.db.delete("Data Import Log", {"success": 0, "data_import": self.data_import.name})
 
 		# get successfully imported rows
 		imported_rows = []

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -213,12 +213,18 @@ class Importer:
 		)
 
 		# set status
-		failures = [log for log in import_log if not log.get("success")]
-		if len(failures) == total_payload_count:
-			status = "Pending"
-		elif len(failures) > 0:
+		successes = []
+		failures = []
+		for log in import_log:
+			if log.get("success"):
+				successes.append(log)
+			else:
+				failures.append(log)
+		if len(failures) >= total_payload_count and len(successes) == 0:
+			status = "Error" 
+		elif len(failures) > 0 and len(successes) > 0:
 			status = "Partial Success"
-		else:
+		elif len(len(successes) == total_payload_count):
 			status = "Success"
 
 		if self.console:

--- a/frappe/core/doctype/data_import/importer.py
+++ b/frappe/core/doctype/data_import/importer.py
@@ -226,6 +226,8 @@ class Importer:
 			status = "Partial Success"
 		elif len(successes) == total_payload_count:
 			status = "Success"
+		else:
+			status = "Pending"
 
 		if self.console:
 			self.print_import_log(import_log)


### PR DESCRIPTION
- Used to show the status as "Not Started" if a prior import session was partially successful
- `data_import_list.js` needs some rethinking just displaying the past few logs isn't super helpful the import logs aren't individually identifiable on that screen
- could start deleting the logs of a previously failed imported record, if it's successful on a subsequent run or atleast flag it to not display it

Refer to internal ticket 9486 and 12166 for further information
