### PR TITLE
fix: ordered `fields` on get_list returning list

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -133,7 +133,7 @@ class DatabaseQuery:
 			limit_page_length = page_length
 		if limit:
 			limit_page_length = limit
-		if as_list and not isinstance(self.fields, (list, tuple)) and len(self.fields) > 1:
+		if as_list and not isinstance(self.fields, (list | tuple)) and len(self.fields) > 1:
 			frappe.throw(_("Fields must be a list or tuple when as_list is enabled"))
 
 		self.filters = filters or []

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -133,6 +133,8 @@ class DatabaseQuery:
 			limit_page_length = page_length
 		if limit:
 			limit_page_length = limit
+		if as_list and not isinstance(self.fields, (list, tuple)) and len(self.fields) > 1:
+			frappe.throw(_("Fields must be a list or tuple when as_list is enabled"))
 
 		self.filters = filters or []
 		self.or_filters = or_filters or []


### PR DESCRIPTION
Mandate list or tuple for fields parameter if `as_list` is true and number of fields are more than one.