### PR TITLE
fix: allow any sequence container

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -7,6 +7,7 @@ import datetime
 import json
 import re
 from collections import Counter
+from collections.abc import Sequence
 
 import frappe
 import frappe.defaults
@@ -133,7 +134,7 @@ class DatabaseQuery:
 			limit_page_length = page_length
 		if limit:
 			limit_page_length = limit
-		if as_list and not isinstance(self.fields, (list | tuple)) and len(self.fields) > 1:
+		if as_list and not isinstance(self.fields, (Sequence | str)) and len(self.fields) > 1:
 			frappe.throw(_("Fields must be a list or tuple when as_list is enabled"))
 
 		self.filters = filters or []

--- a/frappe/tests/test_db_query.py
+++ b/frappe/tests/test_db_query.py
@@ -268,6 +268,11 @@ class TestDBQuery(FrappeTestCase):
 				result in DatabaseQuery("DocType").execute(filters={"name": ["not in", "DocType,DocField"]})
 			)
 
+	def test_string_as_field(self):
+		self.assertEqual(
+			frappe.get_all("DocType", as_list=True), frappe.get_all("DocType", fields="name", as_list=True)
+		)
+
 	def test_none_filter(self):
 		query = frappe.qb.get_query("DocType", fields="name", filters={"restrict_to_domain": None})
 		sql = str(query).replace("`", "").replace('"', "")


### PR DESCRIPTION
We allow string as `fields` and it's used a lot and is valid usage, so no need to block it. 