### PR TITLE
fix: auto add modified index when sort_field is set to it

### DIFF
--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -84,6 +84,12 @@ class MariaDBTable(DBTable):
 			for col in self.add_index
 			if not frappe.db.get_column_index(self.table_name, col.fieldname, unique=False)
 		]
+
+		if self.meta.sort_field == "modified" and frappe.db.get_column_index(
+			self.table_name, "modified", unique=False
+		):
+			add_index_query.append("ADD INDEX `modified`(`modified`)")
+
 		drop_index_query = []
 
 		for col in {*self.drop_index, *self.drop_unique}:

--- a/frappe/email/smtp.py
+++ b/frappe/email/smtp.py
@@ -109,7 +109,7 @@ class SMTPServer:
 			frappe.request.after_response.add(self.quit)
 		elif frappe.job:
 			frappe.job.after_job.add(self.quit)
-		else:
+		elif not frappe.flags.in_test:
 			# Console?
 			import atexit
 


### PR DESCRIPTION
This is 2nd most common sort order, so we should support adding index
for it automatically.

Not quite sure on generalizing this behaviour *YET*
