### PR TITLE
fix: advertise insights to system manager only

### DIFF
--- a/frappe/public/js/frappe/list/list_sidebar.js
+++ b/frappe/public/js/frappe/list/list_sidebar.js
@@ -39,7 +39,9 @@ frappe.views.ListSidebar = class ListSidebar {
 			});
 		}
 
-		this.add_insights_banner();
+		if (frappe.user.has_role("System Manager")) {
+			this.add_insights_banner();
+		}
 	}
 
 	setup_views() {


### PR DESCRIPTION
No point in confusing unprivileged report users