### PR TITLE
fix: reserved keywords as col name in dynamic link checks

### DIFF
--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -338,7 +338,7 @@ def check_if_doc_is_dynamically_linked(doc, method="Delete"):
 			df["table"] = ", `parent`, `parenttype`, `idx`" if meta.istable else ""
 			for refdoc in frappe.db.sql(
 				"""select `name`, `docstatus` {table} from `tab{parent}` where
-				{options}=%s and {fieldname}=%s""".format(**df),
+				`{options}`=%s and `{fieldname}`=%s""".format(**df),
 				(doc.doctype, doc.name),
 				as_dict=True,
 			):

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -202,9 +202,11 @@ class Document(BaseDocument):
 		if hasattr(self, "__setup__"):
 			self.__setup__()
 
+		return self
+
 	def reload(self):
 		"""Reload document from database"""
-		self.load_from_db()
+		return self.load_from_db()
 
 	def get_latest(self):
 		if not getattr(self, "_doc_before_save", None):

--- a/frappe/model/dynamic_links.py
+++ b/frappe/model/dynamic_links.py
@@ -43,7 +43,7 @@ def get_dynamic_link_map(for_delete=False):
 			else:
 				try:
 					links = frappe.db.sql_list(
-						"""select distinct {options} from `tab{parent}`""".format(**df)
+						"""select distinct `{options}` from `tab{parent}`""".format(**df)
 					)
 					for doctype in links:
 						dynamic_link_map.setdefault(doctype, []).append(df)


### PR DESCRIPTION
If fieldname is `order` then this doesn't work. Wrapped in grave quotes to avoid this. 