### PR TITLE
feat: allow wildcard for doctype in permission hooks

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1036,10 +1036,8 @@ class DatabaseQuery:
 
 	def get_permission_query_conditions(self):
 		conditions = []
-		condition_methods = frappe.get_hooks("permission_query_conditions", {}).get(
-			self.doctype,
-			frappe.get_hooks("permission_query_conditions", {}).get("*", []),
-		)
+		condition_methods = frappe.get_hooks("permission_query_conditions", {}).get(self.doctype, [])
+		condition_methods += frappe.get_hooks("permission_query_conditions", {}).get("*", [])
 		if condition_methods:
 			for method in condition_methods:
 				c = frappe.call(frappe.get_attr(method), self.user, doctype=self.doctype)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1036,7 +1036,10 @@ class DatabaseQuery:
 
 	def get_permission_query_conditions(self):
 		conditions = []
-		condition_methods = frappe.get_hooks("permission_query_conditions", {}).get(self.doctype, [])
+		condition_methods = frappe.get_hooks("permission_query_conditions", {}).get(
+			self.doctype,
+			frappe.get_hooks("permission_query_conditions", {}).get("*", []),
+		)
 		if condition_methods:
 			for method in condition_methods:
 				c = frappe.call(frappe.get_attr(method), self.user)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1036,8 +1036,8 @@ class DatabaseQuery:
 
 	def get_permission_query_conditions(self):
 		conditions = []
-		condition_methods = frappe.get_hooks("permission_query_conditions", {}).get(self.doctype, [])
-		condition_methods += frappe.get_hooks("permission_query_conditions", {}).get("*", [])
+		hooks = frappe.get_hooks("permission_query_conditions", {})
+		condition_methods = hooks.get(self.doctype, []) + hooks.get("*", [])
 		if condition_methods:
 			for method in condition_methods:
 				c = frappe.call(frappe.get_attr(method), self.user, doctype=self.doctype)

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1042,7 +1042,7 @@ class DatabaseQuery:
 		)
 		if condition_methods:
 			for method in condition_methods:
-				c = frappe.call(frappe.get_attr(method), self.user)
+				c = frappe.call(frappe.get_attr(method), self.user, doctype=self.doctype)
 				if c:
 					conditions.append(c)
 

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -443,7 +443,10 @@ def has_controller_permissions(doc, ptype, user=None, debug=False) -> bool:
 	if not user:
 		user = frappe.session.user
 
-	methods = frappe.get_hooks("has_permission").get(doc.doctype, [])
+	methods = frappe.get_hooks("has_permission").get(
+		doc.doctype,
+		frappe.get_hooks("has_permission").get("*", []),
+	)
 
 	if not methods:
 		return True

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -443,10 +443,8 @@ def has_controller_permissions(doc, ptype, user=None, debug=False) -> bool:
 	if not user:
 		user = frappe.session.user
 
-	methods = frappe.get_hooks("has_permission").get(
-		doc.doctype,
-		frappe.get_hooks("has_permission").get("*", []),
-	)
+	methods = frappe.get_hooks("has_permission").get(doc.doctype, [])
+	methods += frappe.get_hooks("has_permission").get("*", [])
 
 	if not methods:
 		return True

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -443,8 +443,8 @@ def has_controller_permissions(doc, ptype, user=None, debug=False) -> bool:
 	if not user:
 		user = frappe.session.user
 
-	methods = frappe.get_hooks("has_permission").get(doc.doctype, [])
-	methods += frappe.get_hooks("has_permission").get("*", [])
+	hooks = frappe.get_hooks("has_permission")
+	methods = hooks.get(doc.doctype, []) + hooks.get("*", [])
 
 	if not methods:
 		return True

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -44,6 +44,14 @@ class TestHooks(FrappeTestCase):
 
 		hooks.has_permission["Address"] = address_has_permission_hook
 
+		wildcard_has_permission_hook = hooks.has_permission.get("*", [])
+		if isinstance(wildcard_has_permission_hook, str):
+			wildcard_has_permission_hook = [wildcard_has_permission_hook]
+
+		wildcard_has_permission_hook.append("frappe.tests.test_hooks.custom_has_permission")
+
+		hooks.has_permission["*"] = wildcard_has_permission_hook
+
 		# Clear cache
 		frappe.cache.delete_value("app_hooks")
 
@@ -53,11 +61,18 @@ class TestHooks(FrappeTestCase):
 		user.add_roles("System Manager")
 		address = frappe.new_doc("Address")
 
+		# Create Note
+		note = frappe.new_doc("Note")
+
 		# Test!
 		self.assertTrue(frappe.has_permission("Address", doc=address, user=username))
+		self.assertTrue(frappe.has_permission("Note", doc=note, user=username))
 
 		address.flags.dont_touch_me = True
 		self.assertFalse(frappe.has_permission("Address", doc=address, user=username))
+
+		note.flags.dont_touch_me = True
+		self.assertFalse(frappe.has_permission("Note", doc=note, user=username))
 
 	def test_ignore_links_on_delete(self):
 		email_unsubscribe = frappe.get_doc(

--- a/frappe/tests/test_hooks.py
+++ b/frappe/tests/test_hooks.py
@@ -63,6 +63,7 @@ class TestHooks(FrappeTestCase):
 
 		# Create Note
 		note = frappe.new_doc("Note")
+		note.public = 1
 
 		# Test!
 		self.assertTrue(frappe.has_permission("Address", doc=address, user=username))


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Feature for `permission_query_conditions` and `has_permission` hooks to accept `"*"` wildcard along with specific doctypes.

> Explain the **details** for making this change. What existing problem does the pull request solve?

```python
permission_query_conditions = {
	"*": "app.permissions.get_permission_query_conditions",
}

has_permission = {
	"*": "app.permissions.has_permission",
}
```

Combining the list with `+=` operator. so we get the doctype hook as well as wildcard hooks combined.

> Screenshots/GIFs

docs: https://frappeframework.com/app/wiki-page-patch/f9a1b577f3

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
