### PR TITLE
feat: UUID naming support

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -570,7 +570,7 @@
    "fieldtype": "Select",
    "label": "Naming Rule",
    "length": 40,
-   "options": "\nSet by user\nAutoincrement\nBy fieldname\nBy \"Naming Series\" field\nExpression\nExpression (old style)\nRandom\nBy script"
+   "options": "\nSet by user\nAutoincrement\nBy fieldname\nBy \"Naming Series\" field\nExpression\nExpression (old style)\nRandom\nUUID\nBy script"
   },
   {
    "fieldname": "migration_hash",
@@ -750,7 +750,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2024-03-23 16:03:21.405959",
+ "modified": "2024-03-29 16:09:26.114720",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -147,6 +147,7 @@ class DocType(Document):
 			"Expression",
 			"Expression (old style)",
 			"Random",
+			"UUID",
 			"By script",
 		]
 		nsm_parent_field: DF.Data | None

--- a/frappe/database/mariadb/schema.py
+++ b/frappe/database/mariadb/schema.py
@@ -47,6 +47,9 @@ class MariaDBTable(DBTable):
 			# issue link: https://jira.mariadb.org/browse/MDEV-20070
 			name_column = "name bigint primary key"
 
+		elif not self.meta.issingle and self.meta.autoname == "UUID":
+			name_column = "name uuid primary key"
+
 		additional_definitions = ",\n".join(additional_definitions)
 
 		# create table

--- a/frappe/model/naming.py
+++ b/frappe/model/naming.py
@@ -4,10 +4,11 @@
 import base64
 import datetime
 import re
-import struct
 import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Optional
+
+from uuid_utils import uuid7
 
 import frappe
 from frappe import _
@@ -149,6 +150,10 @@ def set_new_name(doc):
 		doc.name = frappe.db.get_next_sequence_val(doc.doctype)
 		return
 
+	if meta.autoname == "UUID":
+		doc.name = str(uuid7())
+		return
+
 	if getattr(doc, "amended_from", None):
 		_set_amended_name(doc)
 		if doc.name:
@@ -179,10 +184,7 @@ def is_autoincremented(doctype: str, meta: Optional["Meta"] = None) -> bool:
 	if not meta:
 		meta = frappe.get_meta(doctype)
 
-	if not getattr(meta, "issingle", False) and meta.autoname == "autoincrement":
-		return True
-
-	return False
+	return not getattr(meta, "issingle", False) and meta.autoname == "autoincrement"
 
 
 def set_name_from_naming_options(autoname, doc):

--- a/frappe/public/js/frappe/doctype/index.js
+++ b/frappe/public/js/frappe/doctype/index.js
@@ -78,6 +78,7 @@ frappe.model.DocTypeController = class DocTypeController extends frappe.ui.form.
 				Expression: "format:",
 				"Expression (sld style)": "",
 				Random: "hash",
+				UUID: "UUID",
 				"By script": "",
 			};
 			this.frm.set_value(

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -149,7 +149,8 @@ class TestDBUpdate(FrappeTestCase):
 
 		doctype.autoname = "hash"
 		doctype.save()
-		self.assertEqual(frappe.db.get_column_type(doctype.name, "name"), "varchar(140)")
+		varchar = "varchar" if frappe.db.db_type == "mariadb" else "character varying"
+		self.assertIn(varchar, frappe.db.get_column_type(doctype.name, "name"))
 		doc.reload()  # ensure that docs are still accesible
 
 

--- a/frappe/tests/test_db_update.py
+++ b/frappe/tests/test_db_update.py
@@ -139,6 +139,19 @@ class TestDBUpdate(FrappeTestCase):
 		doctype.delete()
 		frappe.db.commit()
 
+	def test_uuid_varchar_migration(self):
+		doctype = new_doctype().insert()
+		doctype.autoname = "UUID"
+		doctype.save()
+		self.assertEqual(frappe.db.get_column_type(doctype.name, "name"), "uuid")
+
+		doc = frappe.new_doc(doctype.name).insert()
+
+		doctype.autoname = "hash"
+		doctype.save()
+		self.assertEqual(frappe.db.get_column_type(doctype.name, "name"), "varchar(140)")
+		doc.reload()  # ensure that docs are still accesible
+
 
 def get_fieldtype_from_def(field_def):
 	fieldtuple = frappe.db.type_map.get(field_def.fieldtype, ("", 0))

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -9,7 +9,7 @@ from frappe.app import make_form_dict
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.desk.doctype.note.note import Note
 from frappe.model.naming import make_autoname, parse_naming_series, revert_series_if_last
-from frappe.tests.utils import FrappeTestCase, timeout
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cint, now_datetime, set_request
 from frappe.website.serve import get_response
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     "terminaltables~=3.1.10",
     "traceback-with-variables~=2.0.4",
     "typing_extensions>=4.6.1,<5",
+    "uuid-utils~=0.6.1",
     "xlrd~=2.0.1",
     "zxcvbn~=4.4.28",
     "markdownify~=0.11.6",


### PR DESCRIPTION
This PR adds native UUID column support for `name` field.

We use soon-to-be-formalized UUIDv7 which is *like* ULID only but part of official UUID spec.

> We prefer using an Universally Unique Lexicographically Sortable Identifier ([ULID](https://github.com/ulid/spec)) for these idempotency keys instead of a random version 4 UUID. ULIDs contain a 48-bit timestamp followed by 80 bits of random data. The timestamp allows ULIDs to be sorted, which works much better with the b-tree data structure databases use for indexing. In one high-throughput system at Shopify we’ve seen a 50 percent decrease in INSERT statement duration by switching from UUIDv4 to ULID for idempotency keys.
https://shopify.engineering/building-resilient-payment-systems


Why?
- UUIDv7 is 16 bytes vs `varchar(140)` which is 562 bytes. So random hash is one of the worst ways to add random names.
- UUIDv7 has timestamp prefix, so record created at roughly same time have roughly same prefix. This helps MySQL as it's index organized, ref #25309.


Note: This requires mariadb 10.7+, won't work otherwise. Ideally, use 10.11 which has some optimizations for UUIDv7.

TODO / scope for this PR:
- [x] Basic working POC
- [x] Applications can set UUID name (useful for APIs)
- [x] MariaDB support for new doctypes
- [x] Postgres support for new doctypes
- [x] Support `alter` on empty tables?
- [x] Tests

partly addresses https://github.com/frappe/frappe/issues/25310 separate PR for link field work in future. 