### PR TITLE
feat: add debug tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: debug-statements
+        exclude: ^frappe/tests/utils\.py$
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.2.0

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -752,6 +752,7 @@ def transform_database(context, table, engine, row_format, failfast):
 )
 @click.option("--test", multiple=True, help="Specific test")
 @click.option("--module", help="Run tests in a module")
+@click.option("--pdb", is_flag=True, default=False, help="Open pdb on AssertionError")
 @click.option("--profile", is_flag=True, default=False)
 @click.option("--coverage", is_flag=True, default=False)
 @click.option("--skip-test-records", is_flag=True, default=False, help="Don't create test records")
@@ -776,8 +777,13 @@ def run_tests(
 	skip_before_tests=False,
 	failfast=False,
 	case=None,
+	pdb=False,
 ):
 	"""Run python unit-tests"""
+
+	pdb_on_exceptions = None
+	if pdb:
+		pdb_on_exceptions = (AssertionError,)
 
 	with CodeCoverage(coverage, app):
 		import frappe
@@ -810,6 +816,7 @@ def run_tests(
 			case=case,
 			skip_test_records=skip_test_records,
 			skip_before_tests=skip_before_tests,
+			pdb_on_exceptions=pdb_on_exceptions,
 		)
 
 		if len(ret.failures) == 0 and len(ret.errors) == 0:

--- a/frappe/test_runner.py
+++ b/frappe/test_runner.py
@@ -53,6 +53,7 @@ def main(
 	case=None,
 	skip_test_records=False,
 	skip_before_tests=False,
+	pdb_on_exceptions=False,
 ):
 	global unittest_runner
 
@@ -78,6 +79,7 @@ def main(
 	try:
 		frappe.flags.print_messages = verbose
 		frappe.flags.in_test = True
+		frappe.flags.pdb_on_exceptions = pdb_on_exceptions
 
 		# workaround! since there is no separate test db
 		frappe.clear_cache()
@@ -289,6 +291,11 @@ def _run_unittest(
 					final_test_suite.addTest(test_case)
 		else:
 			final_test_suite.addTest(test_suite)
+
+		if frappe.flags.pdb_on_exceptions:
+			for test_case in iterate_suite(final_test_suite):
+				if hasattr(test_case, "_apply_debug_decorator"):
+					test_case._apply_debug_decorator(frappe.flags.pdb_on_exceptions)
 
 	if junit_xml_output:
 		runner = unittest_runner(verbosity=1 + cint(verbose), failfast=failfast)

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -30,33 +30,33 @@ def debug_on(*exceptions):
 	it defaults to catching AssertionError.
 
 	Args:
-		*exceptions: Variable length argument list of exception classes to catch.
-			If none provided, defaults to (AssertionError,).
+	        *exceptions: Variable length argument list of exception classes to catch.
+	                If none provided, defaults to (AssertionError,).
 
 	Returns:
-		function: A decorator function.
+	        function: A decorator function.
 
 	Usage:
-		1. Basic usage (catches AssertionError):
-			@debug_on()
-			def test_assertion_error():
-				assert False, "This will start the debugger"
+	        1. Basic usage (catches AssertionError):
+	                @debug_on()
+	                def test_assertion_error():
+	                        assert False, "This will start the debugger"
 
-		2. Catching specific exceptions:
-			@debug_on(ValueError, TypeError)
-			def test_specific_exceptions():
-				raise ValueError("This will start the debugger")
+	        2. Catching specific exceptions:
+	                @debug_on(ValueError, TypeError)
+	                def test_specific_exceptions():
+	                        raise ValueError("This will start the debugger")
 
-		3. Using on a method in a test class:
-			class TestMyFunctionality(unittest.TestCase):
-				@debug_on(ZeroDivisionError)
-				def test_division_by_zero(self):
-					result = 1 / 0
+	        3. Using on a method in a test class:
+	                class TestMyFunctionality(unittest.TestCase):
+	                        @debug_on(ZeroDivisionError)
+	                        def test_division_by_zero(self):
+	                                result = 1 / 0
 
 	Note:
-		When an exception is caught, this decorator will print the exception traceback
-		and then start the post-mortem debugger, allowing you to inspect the state of
-		the program at the point where the exception was raised.
+	        When an exception is caught, this decorator will print the exception traceback
+	        and then start the post-mortem debugger, allowing you to inspect the state of
+	        the program at the point where the exception was raised.
 	"""
 	if not exceptions:
 		exceptions = (AssertionError,)

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -22,6 +22,42 @@ datetime_like_types = (datetime.datetime, datetime.date, datetime.time, datetime
 
 
 def debug_on(*exceptions):
+	"""
+	A decorator to automatically start the debugger when specified exceptions occur.
+
+	This decorator allows you to automatically invoke the debugger (pdb) when certain
+	exceptions are raised in the decorated function. If no exceptions are specified,
+	it defaults to catching AssertionError.
+
+	Args:
+		*exceptions: Variable length argument list of exception classes to catch.
+			If none provided, defaults to (AssertionError,).
+
+	Returns:
+		function: A decorator function.
+
+	Usage:
+		1. Basic usage (catches AssertionError):
+			@debug_on()
+			def test_assertion_error():
+				assert False, "This will start the debugger"
+
+		2. Catching specific exceptions:
+			@debug_on(ValueError, TypeError)
+			def test_specific_exceptions():
+				raise ValueError("This will start the debugger")
+
+		3. Using on a method in a test class:
+			class TestMyFunctionality(unittest.TestCase):
+				@debug_on(ZeroDivisionError)
+				def test_division_by_zero(self):
+					result = 1 / 0
+
+	Note:
+		When an exception is caught, this decorator will print the exception traceback
+		and then start the post-mortem debugger, allowing you to inspect the state of
+		the program at the point where the exception was raised.
+	"""
 	if not exceptions:
 		exceptions = (AssertionError,)
 

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -105,24 +105,10 @@ class FrappeTestCase(unittest.TestCase):
 		cls.addClassCleanup(_restore_thread_locals, copy.deepcopy(frappe.local.flags))
 		cls.addClassCleanup(_rollback_db)
 
-		cls._apply_debug_decorator()
-
 		return super().setUpClass()
 
-	@classmethod
-	def _apply_debug_decorator(cls):
-		import sys
-
-		pdb_flag = next((arg for arg in sys.argv if arg.startswith('--pdb')), None)
-		if pdb_flag:
-			exceptions = (AssertionError,)
-			if pdb_flag.startswith('--pdb-on='):
-				exception_names = pdb_flag.split('=')[1].split(',')
-				exceptions = tuple(getattr(__builtins__, name.strip()) for name in exception_names)
-			
-			for attr in dir(cls):
-				if attr.startswith('test_'):
-					setattr(cls, attr, debug_on(*exceptions)(getattr(cls, attr)))
+	def _apply_debug_decorator(self, exceptions=()):
+		setattr(self, self._testMethodName, debug_on(*exceptions)(getattr(self, self._testMethodName)))
 
 	def assertSequenceSubset(self, larger: Sequence, smaller: Sequence, msg=None):
 		"""Assert that `expected` is a subset of `actual`."""

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -1,7 +1,11 @@
 import copy
 import datetime
+import functools
 import os
+import pdb
 import signal
+import sys
+import traceback
 import unittest
 from collections.abc import Sequence
 from contextlib import contextmanager
@@ -15,6 +19,26 @@ from frappe.utils import cint
 from frappe.utils.data import convert_utc_to_timezone, get_datetime, get_system_timezone
 
 datetime_like_types = (datetime.datetime, datetime.date, datetime.time, datetime.timedelta)
+
+
+def debug_on(*exceptions):
+	if not exceptions:
+		exceptions = (AssertionError,)
+
+	def decorator(f):
+		@functools.wraps(f)
+		def wrapper(*args, **kwargs):
+			try:
+				return f(*args, **kwargs)
+			except exceptions as e:
+				info = sys.exc_info()
+				traceback.print_exception(*info)
+				pdb.post_mortem(info[2])
+				raise e
+
+		return wrapper
+
+	return decorator
 
 
 class FrappeTestCase(unittest.TestCase):


### PR DESCRIPTION
Maybe this is something of interest, drops in a pdb session on test failures.

Good for fast test iteration:
`bench run-tests --doctype "Purchase Order" --test test_purchase_order_advance_payment_status`


- ~~Lacks documentation~~
- ~~Is unhandy to use &mdash; but invaluably useful~~
- ~~Might need to be integrated into the FrappeTestCase, enabled by an environment flag, when run with `run-tests [...] --pdb`~~ (Done)
 
 ```example
 bench run-tests \
   --module "erpnext.stock.doctype.material_request.test_material_request" \
   --case TestMaterialRequest \
   --test test_completed_qty_for_transfer \
   --pdb
 ```
 
`no-docs`

fyi @barredterra 
