### PR TITLE
fix: allow disabling logging on CRON jobs

### DIFF
--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.json
@@ -39,7 +39,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.frequency==='All'",
+   "depends_on": "eval:[\"All\", \"Cron\"].includes(doc.frequency)",
    "fieldname": "create_log",
    "fieldtype": "Check",
    "label": "Create Log"
@@ -102,7 +102,7 @@
    "link_fieldname": "scheduled_job_type"
   }
  ],
- "modified": "2024-03-23 16:03:37.925078",
+ "modified": "2024-03-30 11:39:49.693632",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Scheduled Job Type",

--- a/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
+++ b/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2021, Frappe Technologies and contributors
 # License: MIT. See LICENSE
 
+import contextlib
 import json
 from datetime import datetime, timedelta
 from random import randint
@@ -48,8 +49,8 @@ class ScheduledJobType(Document):
 	# end: auto-generated types
 
 	def validate(self):
-		if self.frequency != "All":
-			# force logging for all events other than continuous ones (ALL)
+		if self.frequency not in ("All", "Cron"):
+			# force logging for all events other than All/Cron
 			self.create_log = 1
 
 		if self.frequency == "Cron":


### PR DESCRIPTION
Some crons are very very small duration and don't require logging
either. We should let users decide if they want to disable logging.
