### PR TITLE
fix: ensure date defaults are legal

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -33,6 +33,7 @@ from frappe.modules.import_file import get_file_path
 from frappe.permissions import ALL_USER_ROLE, AUTOMATIC_ROLES, SYSTEM_USER_ROLE
 from frappe.query_builder.functions import Concat
 from frappe.utils import cint, flt, is_a_property, random_string
+from frappe.utils.data import guess_date_format
 from frappe.website.utils import clear_cache
 
 if TYPE_CHECKING:
@@ -1338,6 +1339,13 @@ def validate_fields(meta: Meta):
 						frappe.bold(d.fieldname)
 					)
 				)
+		if d.fieldtype in ['Date', 'Datetime'] and d.default != 'now' and not guess_date_format(d.default):
+			frappe.throw(
+				_('Default value for {0} must be either "now" or a valid date: "{1}" is not accepted.').format(
+					frappe.bold(d.fieldname),
+					d.default
+				)
+			)
 
 	def check_precision(d):
 		if (

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1339,13 +1339,23 @@ def validate_fields(meta: Meta):
 						frappe.bold(d.fieldname)
 					)
 				)
-		if d.fieldtype in ['Date', 'Datetime'] and d.default != 'now' and not guess_date_format(d.default):
-			frappe.throw(
-				_('Default value for {0} must be either "now" or a valid date: "{1}" is not accepted.').format(
-					frappe.bold(d.fieldname),
-					d.default
-				)
-			)
+		if d.fieldtype in ["Date", "Datetime"]:
+			d.default = d.default.lower()
+			if not guess_date_format(d.default):
+				if d.fieldtype == 'Datetime' and d.default != 'now':
+					frappe.throw(
+						_('Default value for {0} must be either "now" or a valid datetime: "{1}" is not accepted.').format(
+							frappe.bold(d.fieldname),
+							d.default
+						)
+					)
+				elif d.fieldtype == 'Date' and d.default != 'today':
+					frappe.throw(
+						_('Default value for {0} must be either "today" or a valid date: "{1}" is not accepted.').format(
+							frappe.bold(d.fieldname),
+							d.default
+						)
+					)
 
 	def check_precision(d):
 		if (


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Ensures that a default value for a date field is either "now" or a valid date.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Currently, entering a default that is not "now" or a valid date results in a blank value in a new form. This is an issue because autocorrect often changes "now" to "Now", which leads to breaking behavior. Alternatively, we could make it non case-sensitive.

> Screenshots/GIFs

<img width="612" alt="image" src="https://github.com/frappe/frappe/assets/62411302/9cffe644-f730-4fad-a65b-b0f2b0212c7a">

