### PR TITLE
fix: add in_install flag to print_format validate

### DIFF
--- a/frappe/printing/doctype/print_format/print_format.py
+++ b/frappe/printing/doctype/print_format/print_format.py
@@ -68,6 +68,7 @@ class PrintFormat(Document):
 			self.standard == "Yes"
 			and not frappe.local.conf.get("developer_mode")
 			and not frappe.flags.in_migrate
+			and not frappe.flags.in_install
 			and not frappe.flags.in_test
 		):
 			frappe.throw(frappe._("Standard Print Format cannot be updated"))


### PR DESCRIPTION
don't validate "Standard Print Format cannot be updated" during installation