### PR TITLE
feat: allow skipping msgprint

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -565,6 +565,7 @@ def msgprint(
 	primary_action: str | None = None,
 	is_minimizable: bool = False,
 	wide: bool = False,
+	skip_msgprint: bool = False,
 	*,
 	realtime=False,
 ) -> None:
@@ -580,6 +581,7 @@ def msgprint(
 	:param primary_action: [optional] Bind a primary server/client side action.
 	:param is_minimizable: [optional] Allow users to minimize the modal
 	:param wide: [optional] Show wide modal
+	:param skip_msgprint: [optional] Skip showing message using `msgprint` - only raise exception.
 	:param realtime: Publish message immediately using websocket.
 	"""
 	import inspect
@@ -598,7 +600,7 @@ def msgprint(
 				exc.__frappe_exc_id = out.__frappe_exc_id
 			raise exc
 
-	if flags.mute_messages:
+	if flags.mute_messages or skip_msgprint:
 		_raise_exception()
 		return
 
@@ -669,6 +671,7 @@ def throw(
 	wide: bool = False,
 	as_list: bool = False,
 	primary_action=None,
+	skip_msgprint: bool = False,
 ) -> None:
 	"""Throw execption and show message (`msgprint`).
 
@@ -679,6 +682,7 @@ def throw(
 	:param wide: [optional] Show wide modal
 	:param as_list: [optional] If `msg` is a list, render as un-ordered list.
 	:param primary_action: [optional] Bind a primary server/client side action.
+	:param skip_msgprint: [optional] Skip showing message using `msgprint`.
 	"""
 	msgprint(
 		msg,
@@ -689,6 +693,7 @@ def throw(
 		wide=wide,
 		as_list=as_list,
 		primary_action=primary_action,
+		skip_msgprint=skip_msgprint,
 	)
 
 

--- a/frappe/desk/doctype/event/event.py
+++ b/frappe/desk/doctype/event/event.py
@@ -451,7 +451,7 @@ def get_events(start, end, user=None, for_reminder=False, filters=None) -> list[
 
 				# last day of month issue, start from prev month!
 				try:
-					getdate(date)
+					getdate(date, skip_msgprint=True)
 				except Exception:
 					date = date.split("-")
 					date = date[0] + "-" + str(cint(date[1]) - 1) + "-" + date[2]

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -101,7 +101,9 @@ def is_invalid_date_string(date_string: str) -> bool:
 
 
 def getdate(
-	string_date: Optional["DateTimeLikeObject"] = None, parse_day_first: bool = False
+	string_date: Optional["DateTimeLikeObject"] = None,
+	parse_day_first: bool = False,
+	skip_msgprint: bool = False,
 ) -> datetime.date | None:
 	"""
 	Convert string date (yyyy-mm-dd) to datetime.date object.
@@ -123,6 +125,7 @@ def getdate(
 		frappe.throw(
 			frappe._("{} is not a valid date string.").format(frappe.bold(string_date)),
 			title=frappe._("Invalid Date"),
+			skip_msgprint=skip_msgprint,
 		)
 
 


### PR DESCRIPTION
If we're handling the exception on our own, we don't need to show the user anything
Example: https://github.com/frappe/frappe/blob/version-15/frappe/desk/doctype/event/event.py#L398

Reference: support ticket 12506

Docs: https://frappeframework.com/docs/user/en/api/py-dialog
