### PR TITLE
fix: overlap filter dialog box

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter_list.js
+++ b/frappe/public/js/frappe/ui/filters/filter_list.js
@@ -62,7 +62,7 @@ frappe.ui.FilterGroup = class {
 	}
 
 	set_popover_events() {
-		$(document.body).on("click", (e) => {
+		$(document.body).on("mousedown", (e) => {
 			if (this.wrapper && this.wrapper.is(":visible")) {
 				const in_datepicker =
 					$(e.target).is(".datepicker--cell") ||

--- a/frappe/public/scss/desk/filters.scss
+++ b/frappe/public/scss/desk/filters.scss
@@ -6,7 +6,7 @@
 	min-width: 500px;
 	min-height: 50px;
 	@include get_textstyle("base", "regular");
-	z-index: 1019;
+	z-index: 5;
 	border: 1px solid var(--border-color);
 }
 

--- a/frappe/public/scss/desk/filters.scss
+++ b/frappe/public/scss/desk/filters.scss
@@ -6,7 +6,7 @@
 	min-width: 500px;
 	min-height: 50px;
 	@include get_textstyle("base", "regular");
-	z-index: 5;
+	z-index: 1019;
 	border: 1px solid var(--border-color);
 }
 


### PR DESCRIPTION
Version 15 and 14

fixes: #17616

<br>

Before:


https://github.com/frappe/frappe/assets/141945075/a2da4dc7-50af-4f0b-8a4f-474550612a78


<br>

After: set the z-index.


https://github.com/frappe/frappe/assets/141945075/307222b3-1a28-4119-9a14-3457ece826dd


<br>

Thank You!