### PR TITLE
fix: query_report server side export mismerge

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1492,8 +1492,8 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					);
 				}
 
-				const visible_idx = this.datatable.bodyRenderer.visibleRowIndices;
-				if (visible_idx.length + 1 === this.data.length) {
+				const visible_idx = this.datatable?.bodyRenderer.visibleRowIndices || [];
+				if (visible_idx.length + 1 === this.data?.length) {
 					visible_idx.push(visible_idx.length);
 				}
 


### PR DESCRIPTION
Don't crash if nothing is rendered (high number of rows)

Uncaught TypeError: Cannot read properties of null (reading 'bodyRenderer')
    at frappe.ui.Dialog.primary_action (query_report.js:1495:40)
    at HTMLButtonElement.<anonymous> (dialog.js:163:20)
    at HTMLButtonElement.dispatch (jquery.js:5430:27)
    at et.handle (jquery.js:5234:28)
