### PR TITLE
fix(grid): don't crash if row doesn't exist

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -236,7 +236,7 @@ export default class Grid {
 					this.df.data = this.get_data();
 					this.df.data = this.df.data.filter((row) => row.idx != doc.idx);
 				}
-				this.grid_rows_by_docname[doc.name].remove();
+				this.grid_rows_by_docname[doc.name]?.remove();
 				dirty = true;
 			});
 			tasks.push(() => frappe.timeout(0.1));


### PR DESCRIPTION
Reference - support ticket 12006

Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'remove') at grid.js:239:41
