### PR TITLE
fix: translation of dashboard chart and number card label

### DIFF
--- a/frappe/public/js/frappe/widgets/base_widget.js
+++ b/frappe/public/js/frappe/widgets/base_widget.js
@@ -98,7 +98,9 @@ export default class Widget {
 		let base = this.title || this.label || this.name;
 		let title = max_chars ? frappe.ellipsis(base, max_chars) : base;
 
-		this.title_field[0].innerHTML = `<span class="ellipsis" title="${__(title)}">${__(title)}</span>`;
+		this.title_field[0].innerHTML = `<span class="ellipsis" title="${__(title)}">${__(
+			title
+		)}</span>`;
 		if (max_chars) {
 			this.title_field[0].setAttribute("title", this.title || this.label);
 		}

--- a/frappe/public/js/frappe/widgets/base_widget.js
+++ b/frappe/public/js/frappe/widgets/base_widget.js
@@ -98,7 +98,7 @@ export default class Widget {
 		let base = this.title || this.label || this.name;
 		let title = max_chars ? frappe.ellipsis(base, max_chars) : base;
 
-		this.title_field[0].innerHTML = `<span class="ellipsis" title="${title}">${title}</span>`;
+		this.title_field[0].innerHTML = `<span class="ellipsis" title="${__(title)}">${__(title)}</span>`;
 		if (max_chars) {
 			this.title_field[0].setAttribute("title", this.title || this.label);
 		}


### PR DESCRIPTION
**Version**: 15 and 14

**Before:**


https://github.com/frappe/frappe/assets/141945075/1e08ad50-9302-48a0-9306-1098e04fa595



<br>

**After:**


https://github.com/frappe/frappe/assets/141945075/cdea1d3e-893a-4e08-a36a-027bd7fae8c2

