### PR TITLE
fix: Column 'creation' in order clause was ambiguous

### DIFF
--- a/frappe/contacts/doctype/address/address.py
+++ b/frappe/contacts/doctype/address/address.py
@@ -358,7 +358,7 @@ def get_address_display_list(doctype: str, name: str) -> list[dict]:
 			["Dynamic Link", "parenttype", "=", "Address"],
 		],
 		fields=["*"],
-		order_by="is_primary_address DESC, creation ASC",
+		order_by="is_primary_address DESC, `tabAddress`.creation ASC",
 	)
 	for a in address_list:
 		a["display"] = get_address_display(a)

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -386,7 +386,7 @@ def get_contact_display_list(doctype: str, name: str) -> list[dict]:
 			["Dynamic Link", "parenttype", "=", "Contact"],
 		],
 		fields=["*"],
-		order_by="is_primary_contact DESC, creation ASC",
+		order_by="is_primary_contact DESC, `tabContact`.creation ASC",
 	)
 
 	for contact in contact_list:


### PR DESCRIPTION

![Fm87ucV](https://github.com/frappe/frappe/assets/836784/daa7f9ef-b29f-416b-91db-899b030f8f91)


### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 110, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1718, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/form/load.py", line 45, in getdoc
    run_onload(doc)
  File "apps/frappe/frappe/desk/form/load.py", line 351, in run_onload
    doc.run_method("onload")
  File "apps/frappe/frappe/model/document.py", line 960, in run_method
    out = Document.hook(fn)(self, args, *kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1320, in composer
    return composed(self, method, args, *kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1302, in runner
    add_to_return_value(self, fn(self, args, *kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 957, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/selling/doctype/customer/customer.py", line 93, in onload
    load_address_and_contact(self)
  File "apps/frappe/frappe/contacts/address_and_contact.py", line 14, in load_address_and_contact
    doc.set_onload("contact_list", get_contact_display_list(doc.doctype, doc.name))
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/contacts/doctype/contact/contact.py", line 381, in get_contact_display_list
    contact_list = frappe.get_list(
                   ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1982, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/db_query.py", line 192, in execute
    result = self.build_and_run()
             ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/db_query.py", line 233, in build_and_run
    return frappe.db.sql(
           ^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 234, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
             ^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 322, in query
    conn.query(q)
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 558, in query
    self.affected_rows = self._read_query_result(unbuffered=unbuffered)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 822, in readquery_result
    result.read()
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 1200, in read
    first_packet = self.connection._read_packet()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/pymysql/connections.py", line 772, in readpacket
    packet.raise_for_error()
  File "env/lib/python3.11/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.11/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1052, "Column 'creation' in order clause is ambiguous")```
### Request Data
```