### PR TITLE
fix: exclude some untranslatable select options

### DIFF
--- a/frappe/gettext/extractors/doctype.py
+++ b/frappe/gettext/extractors/doctype.py
@@ -1,5 +1,13 @@
 import json
 
+EXCLUDE_SELECT_OPTIONS = [
+	"naming_series",
+	"number_format",
+	"float_precision",
+	"currency_precision",
+	"minimum_password_score",
+]
+
 
 def extract(fileobj, *args, **kwargs):
 	"""
@@ -26,13 +34,14 @@ def extract(fileobj, *args, **kwargs):
 
 	for field in fields:
 		fieldtype = field.get("fieldtype")
+		fieldname = field.get("fieldname")
 		label = field.get("label")
 
 		if label:
 			messages.append((label, f"Label of a {fieldtype} field in DocType '{doctype}'"))
 			_label = label
 		else:
-			_label = field.get("fieldname")
+			_label = fieldname
 
 		if description := field.get("description"):
 			messages.append(
@@ -41,6 +50,9 @@ def extract(fileobj, *args, **kwargs):
 
 		if message := field.get("options"):
 			if fieldtype == "Select":
+				if fieldname in EXCLUDE_SELECT_OPTIONS:
+					continue
+
 				select_options = [option for option in message.split("\n") if option and not option.isdigit()]
 
 				if select_options and "icon" in select_options[0]:


### PR DESCRIPTION
Some standard select fields have options that are not translatable. Exclude these to avoid confusion of the translators and users of erroneous translations.

A downside is that these field names become reserved keywords for all apps. Probably this will need some fine tuning later, but works for now.