### PR TITLE
fix(grid): ensure that `doc.name` is truthy before proceeding

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -795,7 +795,7 @@ export default class Grid {
 	}
 
 	set_value(fieldname, value, doc) {
-		if (this.display_status !== "None" && this.grid_rows_by_docname[doc.name]) {
+		if (this.display_status !== "None" && doc.name && this.grid_rows_by_docname[doc.name]) {
 			this.grid_rows_by_docname[doc.name].refresh_field(fieldname, value);
 		}
 	}


### PR DESCRIPTION
Sentry FRAPPE-4AB

TypeError: Cannot read properties of undefined (reading 'new-purchase-invoice-item-didecgszoh')
  at Pt.set_value(../../../../../apps/frappe/frappe/public/js/frappe/form/grid.js:793:46)
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/form/form.js:316:40)
  at ? (/assets/frappe/dist/js/desk.bundle.Q44OSHRJ.js:742:9603)
