### PR TITLE
fix: don't show bulk actions for doctype with workflow

### DIFF
--- a/cypress/integration/list_view.js
+++ b/cypress/integration/list_view.js
@@ -22,21 +22,19 @@ context("List View", () => {
 		const actions = [
 			"Approve",
 			"Reject",
-			"Edit",
 			"Export",
 			"Assign To",
 			"Clear Assignment",
 			"Apply Assignment Rule",
 			"Add Tags",
 			"Print",
-			"Delete",
 		];
 		cy.go_to_list("ToDo");
 		cy.clear_filters();
 		cy.get(".list-header-subject > .list-subject > .list-check-all").click();
 		cy.findByRole("button", { name: "Actions" }).click();
 		cy.get(".dropdown-menu li:visible .dropdown-item")
-			.should("have.length", 10)
+			.should("have.length", 8)
 			.each((el, index) => {
 				cy.wrap(el).contains(actions[index]);
 			})

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -2038,7 +2038,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		};
 
 		// bulk edit
-		if (has_editable_fields(doctype)) {
+		if (has_editable_fields(doctype) && !frappe.model.has_workflow(doctype)) {
 			actions_menu_items.push(bulk_edit());
 		}
 
@@ -2073,7 +2073,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		// bulk delete
-		if (frappe.model.can_delete(doctype)) {
+		if (frappe.model.can_delete(doctype) && !frappe.model.has_workflow(doctype)) {
 			actions_menu_items.push(bulk_delete());
 		}
 


### PR DESCRIPTION
The "bulk submit" and "bulk cancel" actions are only displayed if the doctype does not have an associated workflow. This should also be the case for "bulk edit" and "bulk delete", since these could otherwise be used to circumvent the workflow.