### PR TITLE
fix!: Don't let users with write access to UP bypass UP

### DIFF
--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -332,11 +332,6 @@ def has_user_permission(doc, user=None, debug=False):
 		debug and _debug_log("User is not affected by any user permissions")
 		return True
 
-	# user can create own role permissions, so nothing applies
-	if get_role_permissions("User Permission", user=user).get("write"):
-		debug and _debug_log("User permission bypassed because user can modify user permissions.")
-		return True
-
 	# don't apply strict user permissions for single doctypes since they contain empty link fields
 	apply_strict_user_permissions = (
 		False if doc.meta.issingle else frappe.get_system_settings("apply_strict_user_permissions")

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -421,13 +421,6 @@ class TestPermissions(FrappeTestCase):
 		clear_user_permissions_for_doctype("Salutation")
 		clear_user_permissions_for_doctype("Contact")
 
-	def test_user_permissions_not_applied_if_user_can_edit_user_permissions(self):
-		add_user_permission("Blogger", "_Test Blogger 1", "test1@example.com")
-
-		# test1@example.com has rights to create user permissions
-		# so it should not matter if explicit user permissions are not set
-		self.assertTrue(frappe.get_doc("Blogger", "_Test Blogger").has_permission("read"))
-
 	def test_user_permission_is_not_applied_if_user_roles_does_not_have_permission(self):
 		add_user_permission("Blog Post", "-test-blog-post-1", "test3@example.com")
 		frappe.set_user("test3@example.com")


### PR DESCRIPTION
IDK why we truly need this, except maybe debugging sometimes. This just
causes confusion and people keep reporting this as security issue.
