### PR TITLE
perf: make website bundle with less bloat

### DIFF
--- a/frappe/public/js/frappe/format.js
+++ b/frappe/public/js/frappe/format.js
@@ -16,6 +16,6 @@ function format(str, args) {
 	);
 }
 
-if (jQuery) {
-	jQuery.format = format;
+if (window.jQuery) {
+	window.jQuery.format = format;
 }

--- a/frappe/public/js/frappe/socketio_client.js
+++ b/frappe/public/js/frappe/socketio_client.js
@@ -86,21 +86,21 @@ class RealTimeClient {
 
 		this.setup_listeners();
 
-		$(document).on("form-load form-rename", function (e, frm) {
+		document.addEventListener("form-load form-rename", function (e, frm) {
 			if (!frm.doc || frm.is_new()) {
 				return;
 			}
 			me.doc_subscribe(frm.doctype, frm.docname);
 		});
 
-		$(document).on("form-refresh", function (e, frm) {
+		document.addEventListener("form-refresh", function (e, frm) {
 			if (!frm.doc || frm.is_new()) {
 				return;
 			}
 			me.doc_open(frm.doctype, frm.docname);
 		});
 
-		$(document).on("form-unload", function (e, frm) {
+		document.addEventListener("form-unload", function (e, frm) {
 			if (!frm.doc || frm.is_new()) {
 				return;
 			}

--- a/frappe/public/js/frappe/translate.js
+++ b/frappe/public/js/frappe/translate.js
@@ -18,7 +18,7 @@ frappe._ = function (txt, replace, context = null) {
 	}
 
 	if (replace && typeof replace === "object") {
-		translated_text = $.format(translated_text, replace);
+		translated_text = format(translated_text, replace); // eslint-disable-line no-undef
 	}
 	return translated_text;
 };
@@ -28,7 +28,7 @@ window.__ = frappe._;
 frappe.get_languages = function () {
 	if (!frappe.languages) {
 		frappe.languages = [];
-		$.each(frappe.boot.lang_dict, function (lang, value) {
+		Object.entries(frappe.boot.lang_dict).forEach(([lang, value]) => {
 			frappe.languages.push({ label: lang, value: value });
 		});
 		frappe.languages = frappe.languages.sort(function (a, b) {

--- a/frappe/public/js/frappe/utils/common.js
+++ b/frappe/public/js/frappe/utils/common.js
@@ -122,25 +122,26 @@ frappe.avatar_group = function (users, limit = 4, options = {}) {
 		`;
 	}
 
-	const $avatar_group = $(`<div class="avatar-group ${options.align || "right"} ${
-		options.overlap != false ? "overlap" : ""
-	}">
-			${html}
-			${avatar_action_html}
-		</div>`);
+	const avatarGroupElement = document.createElement("div");
+	avatarGroupElement.classList.add("avatar-group", options.align || "right");
+	if (options.overlap !== false) {
+		avatarGroupElement.classList.add("overlap");
+	}
+	avatarGroupElement.innerHTML = `${html}${avatar_action_html}`;
 
-	$avatar_group.find(".avatar-action").on("click", options.action);
-	return $avatar_group;
+	avatarGroupElement.querySelector(".avatar-action").addEventListener("click", options.action);
+	return avatarGroupElement;
 };
 
 frappe.ui.scroll = function (element, animate, additional_offset) {
-	var header_offset = $(".navbar").height() + $(".page-head").height();
-	var top = $(element).offset().top - header_offset - cint(additional_offset);
-	if (animate) {
-		$("html, body").animate({ scrollTop: top });
-	} else {
-		$(window).scrollTop(top);
-	}
+	var header_offset =
+		document.querySelector(".navbar").offsetHeight +
+		document.querySelector(".page-head").offsetHeight;
+	var top = element.getBoundingClientRect().top - header_offset - cint(additional_offset);
+	window.scrollTo({
+		top: top,
+		behavior: "smooth",
+	});
 };
 
 frappe.palette = [
@@ -271,11 +272,11 @@ frappe.get_cookies = function getCookies() {
 };
 
 frappe.is_mobile = function () {
-	return $(document).width() < 768;
+	return document.documentElement.clientWidth < 768;
 };
 
 frappe.is_large_screen = function () {
-	return $(document).height() > 1180;
+	return document.documentElement.clientHeight > 1180;
 };
 
 frappe.utils.xss_sanitise = function (string, options) {

--- a/frappe/public/js/website.bundle.js
+++ b/frappe/public/js/website.bundle.js
@@ -1,0 +1,6 @@
+import "./frappe/provide.js";
+import "./frappe/format.js";
+import "./frappe/utils/common.js";
+import "./frappe/translate.js";
+import "./frappe/socketio_client.js";
+import "../../website/js/website.js";


### PR DESCRIPTION
Websites, such as a payment checkout page, take very unreasonable
amount of time and network resources to load.

This is because frappe-web.bundle does not differentiate at all.

However, a guest visitor, unlike a regular user, won't have the
heavy stuff cached.

This PR bundles a lightwight website bundle that can be used
in, again for example, payment checkout pages or other views.

---

I don't really know how to setup the local server for lighthouse test, but with a **DEVELOPMENT** sever we go

# From
![swappy-20240405_212549](https://github.com/frappe/frappe/assets/7548295/f39b4f08-ce06-45b8-8369-1c6f0c1ee6bc)

# To
(no more serious bloat warnings)

![image](https://github.com/frappe/frappe/assets/7548295/e8f9fadf-43bc-4a51-97ca-54d6447f018a)

