### PR TITLE
fix(sentry): correctly skip `frappe.ValidationError` and its children

### DIFF
--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -126,7 +126,7 @@ def capture_exception(message: str | None = None) -> None:
 			exc_info = sys.exc_info()
 			if any(exc_info):
 				# Don't report validation errors
-				if isinstance(exc_info[0], frappe.ValidationError):
+				if isinstance(exc_info[1], frappe.ValidationError):
 					return
 
 				event, hint = event_from_exception(


### PR DESCRIPTION
With the current checks, we're comparing against the *class* itself, not the exception object, which doesn't make sense.
