### PR TITLE
feat: Include `before_print` in doctype event of Server Script

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -57,7 +57,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -151,7 +151,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2024-03-23 16:03:38.075313",
+ "modified": "2024-04-08 16:18:52.901097",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -46,6 +46,7 @@ class ServerScript(Document):
 			"After Delete",
 			"Before Save (Submitted Document)",
 			"After Save (Submitted Document)",
+			"Before Print",
 			"On Payment Authorization",
 			"On Payment Paid",
 			"On Payment Failed",

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -19,6 +19,7 @@ EVENT_MAP = {
 	"after_delete": "After Delete",
 	"before_update_after_submit": "Before Save (Submitted Document)",
 	"on_update_after_submit": "After Save (Submitted Document)",
+	"before_print": "Before Print",
 	"on_payment_paid": "On Payment Paid",
 	"on_payment_failed": "On Payment Failed",
 	"on_payment_authorized": "On Payment Authorization",


### PR DESCRIPTION
![Screenshot from 2024-04-08 17-36-25](https://github.com/frappe/frappe/assets/113279972/38c1f16f-758e-4342-a89a-e8ecc0e77276)




