### PR TITLE
fix: Get filter value based on depends_on field

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -248,7 +248,7 @@ frappe.ui.Filter = class {
 			let args = {};
 			if (this.filters_config[condition].depends_on) {
 				const field_name = this.filters_config[condition].depends_on;
-				const filter_value = this.filter_list.get_filter_value(fieldname);
+				const filter_value = this.filter_list.get_filter_value(field_name);
 				args[field_name] = filter_value;
 			}
 			let setup_field = (field) => {


### PR DESCRIPTION
![DlBBcOv](https://github.com/frappe/frappe/assets/836784/525f296c-cab9-4fef-9d11-37bac63965c9)

The fiscal year values are not loading because the company is passed as `["2024-04-01","2025-03-31"]` based on other date filter values.