### PR TITLE
fix: don't underline shortcuts during In-Context Translation

### DIFF
--- a/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
+++ b/frappe/public/js/frappe/ui/alt_keyboard_shortcuts.js
@@ -152,6 +152,11 @@ frappe.ui.keys.AltShortcutGroup = class AltShortcutGroup {
 	}
 
 	underline_text(shortcut) {
+		if (frappe.boot.lang === "eo") {
+			// The language code "eo" is used to trigger the In-Context Translation feature.
+			// In this case we don't want shortcuts to rip apart the ID of the translatable text.
+			return;
+		}
 		shortcut.$text_el.attr("data-label", encodeURIComponent(shortcut.text));
 		let underline_el_found = false;
 		let text_html = shortcut.text


### PR DESCRIPTION
Resolves https://github.com/frappe/frappe/pull/25677#issuecomment-2022641680