### PR TITLE
fix: Delete standard file for notification is dev mode

### DIFF
--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -112,6 +112,7 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Module",
+   "mandatory_depends_on": "is_standard",
    "options": "Module Def"
   },
   {
@@ -291,7 +292,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:03:31.519921",
+ "modified": "2024-04-09 11:29:41.565446",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import shutil
 
 import frappe
 from frappe import _
@@ -11,6 +12,7 @@ from frappe.core.doctype.sms_settings.sms_settings import send_sms
 from frappe.desk.doctype.notification_log.notification_log import enqueue_create_notification
 from frappe.integrations.doctype.slack_webhook_url.slack_webhook_url import send_slack_message
 from frappe.model.document import Document
+from frappe.modules import get_doc_path
 from frappe.modules.utils import export_module_json, get_doc_module
 from frappe.utils import add_to_date, cast, nowdate, validate_email_address
 from frappe.utils.jinja import validate_template
@@ -441,6 +443,13 @@ def get_context(context):
 
 	def on_trash(self):
 		frappe.cache.hdel("notifications", self.document_type)
+		self.remove_standard_files()
+
+	def remove_standard_files(self):
+		if self.is_standard and not frappe.conf.developer_mode:
+			return
+		path = get_doc_path(self.module, "Notification", self.name)
+		shutil.rmtree(path)
 
 
 @frappe.whitelist()

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -28,9 +28,7 @@ class Notification(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.email.doctype.notification_recipient.notification_recipient import (
-			NotificationRecipient,
-		)
+		from frappe.email.doctype.notification_recipient.notification_recipient import NotificationRecipient
 		from frappe.types import DF
 
 		attach_print: DF.Check


### PR DESCRIPTION
closes: #25559

NOTE: Make `Module` field mandatory if `Is standard` is selected.