### PR TITLE
fix(layout): handle `fieldobj` being null

### DIFF
--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -212,6 +212,10 @@ frappe.ui.form.Layout = class Layout {
 
 		const parent = this.column.form.get(0);
 		const fieldobj = this.init_field(df, parent, render);
+
+		// An invalid control name will return in a null fieldobj
+		if (!fieldobj) return;
+
 		this.fields_list.push(fieldobj);
 		this.fields_dict[df.fieldname] = fieldobj;
 
@@ -234,7 +238,11 @@ frappe.ui.form.Layout = class Layout {
 			layout: this,
 		});
 
-		fieldobj.layout = this;
+		// make_control can return null for invalid control names
+		if (fieldobj) {
+			fieldobj.layout = this;
+		}
+
 		return fieldobj;
 	}
 


### PR DESCRIPTION
`make_control` doesn't return anything when the control name is invalid
Handle in `make_field` and `init_field`

Resolves FRAPPE-13T / support ticket 12919
