### PR TITLE
fix(link): list view filter with "show title in link field"

### DIFF
--- a/frappe/public/js/frappe/ui/filters/filter.js
+++ b/frappe/public/js/frappe/ui/filters/filter.js
@@ -424,6 +424,12 @@ frappe.ui.filter_utils = {
 
 		let val = field.get_value() ?? field.value;
 
+		if (!val && ["Link", "Dynamic Link"].includes(field.df.fieldtype)) {
+			// HACK: link field with show title are async so their input value is "" but they have
+			// some actual value set.
+			val = field.value;
+		}
+
 		if (typeof val === "string") {
 			val = strip(val);
 		}


### PR DESCRIPTION
Steps to repro:
- Setup show title in link field
- on list view filter by that field
- Use the URL and open the page again
- filters will be erased

This is happening because:
- title->value map needs a db call to complete
- in meantime if we ask for input value we get empty value (because input is empty) and then we end up returning `""`
