### PR TITLE
refactor!: Better custom filter implementation

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -194,12 +194,9 @@ class Report(Document):
 		user=None,
 		as_dict=False,
 		ignore_prepared_report=False,
-		are_default_filters=True,
 	):
 		if self.report_type in ("Query Report", "Script Report", "Custom Report"):
-			columns, result = self.run_query_report(
-				filters, user, ignore_prepared_report, are_default_filters
-			)
+			columns, result = self.run_query_report(filters, user, ignore_prepared_report)
 		else:
 			columns, result = self.run_standard_report(filters, limit, user)
 
@@ -208,16 +205,13 @@ class Report(Document):
 
 		return columns, result
 
-	def run_query_report(
-		self, filters=None, user=None, ignore_prepared_report=False, are_default_filters=True
-	):
+	def run_query_report(self, filters=None, user=None, ignore_prepared_report=False):
 		columns, result = [], []
 		data = frappe.desk.query_report.run(
 			self.name,
 			filters=filters,
 			user=user,
 			ignore_prepared_report=ignore_prepared_report,
-			are_default_filters=are_default_filters,
 		)
 
 		for d in data.get("columns"):

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -190,7 +190,6 @@ def run(
 	custom_columns=None,
 	is_tree=False,
 	parent_field=None,
-	are_default_filters=True,
 ):
 	report = get_report_doc(report_name)
 	if not user:
@@ -203,7 +202,7 @@ def run(
 
 	result = None
 
-	if sbool(are_default_filters) and report.custom_filters:
+	if filters is None and report.custom_filters:
 		filters = report.custom_filters
 
 	try:
@@ -224,9 +223,6 @@ def run(
 		raise
 
 	result["add_total_row"] = report.add_total_row and not result.get("skip_total_row", False)
-
-	if sbool(are_default_filters) and report.custom_filters:
-		result["custom_filters"] = report.custom_filters
 
 	return result
 
@@ -326,7 +322,7 @@ def export_query():
 	if isinstance(visible_idx, str):
 		visible_idx = json.loads(visible_idx)
 
-	data = run(report_name, form_params.filters, custom_columns=custom_columns, are_default_filters=False)
+	data = run(report_name, form_params.filters, custom_columns=custom_columns)
 	data = frappe._dict(data)
 	data.filters = form_params.applied_filters
 

--- a/frappe/email/doctype/auto_email_report/auto_email_report.py
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.py
@@ -151,7 +151,6 @@ class AutoEmailReport(Document):
 			filters=self.filters,
 			as_dict=True,
 			ignore_prepared_report=True,
-			are_default_filters=False,
 		)
 
 		# add serial numbers

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -625,21 +625,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		this.toggle_message(true);
 		this.toggle_report(false);
 		let filters = this.get_filter_values(true);
-
-		// for custom reports,
-		// are_default_filters is true if the filters haven't been modified and for all filters,
-		// the filter value is the default value or there's no default value for the filter and the current value is empty.
-		// are_default_filters is false otherwise.
-
-		let are_default_filters = this.filters
-			.map((filter) => {
-				return (
-					!have_filters_changed &&
-					(filter.default === filter.value || (!filter.default && !filter.value))
-				);
-			})
-			.every((res) => res === true);
-
 		this.show_loading_screen();
 
 		// only one refresh at a time
@@ -663,7 +648,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					ignore_prepared_report: this.ignore_prepared_report,
 					is_tree: this.report_settings.tree,
 					parent_field: this.report_settings.parent_field,
-					are_default_filters: are_default_filters,
 				},
 				callback: resolve,
 				always: () => this.page.btn_secondary.prop("disabled", false),
@@ -675,11 +659,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				clearInterval(this.interval);
 
 				this.execution_time = data.execution_time || 0.1;
-
-				if (data.custom_filters) {
-					this.set_filters(data.custom_filters);
-					this.previous_filters = data.custom_filters;
-				}
 
 				if (data.prepared_report) {
 					this.prepared_report = true;


### PR DESCRIPTION
Not sure why need to pass this weird flag `are_default_filters`
everywhere.

- If filters are not specified -> Use stored filters
- If they are specified -> Use whatever is specified.
- On client - set custom filters in UI

As user of API why the fuck should I have to know about this flag? and why is the flag silently changing filters?

- [ ] set on client
- [ ] tests