### PR TITLE
fix: handle interface error during report timeout

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -1245,7 +1245,7 @@ class Database:
 
 	@staticmethod
 	def is_column_missing(e):
-		return frappe.db.is_missing_column(e)
+		raise NotImplementedError
 
 	def get_descendants(self, doctype, name):
 		"""Return descendants of the group node in tree"""

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -97,6 +97,10 @@ class MariaDBExceptionUtil:
 			and isinstance(e, pymysql.IntegrityError)
 		)
 
+	@staticmethod
+	def is_interface_error(e: pymysql.Error):
+		return isinstance(e, pymysql.InterfaceError)
+
 
 class MariaDBConnectionUtil:
 	def get_connection(self):

--- a/frappe/database/postgres/database.py
+++ b/frappe/database/postgres/database.py
@@ -13,6 +13,7 @@ from psycopg2.errorcodes import (
 	UNIQUE_VIOLATION,
 )
 from psycopg2.errors import (
+	InterfaceError,
 	LockNotAvailable,
 	ReadOnlySqlTransaction,
 	SequenceGeneratorLimitExceeded,
@@ -115,6 +116,10 @@ class PostgresExceptionUtil:
 	@staticmethod
 	def is_db_table_size_limit(e) -> bool:
 		return False
+
+	@staticmethod
+	def is_interface_error(e):
+		return isinstance(e, InterfaceError)
 
 
 class PostgresDatabase(PostgresExceptionUtil, Database):

--- a/frappe/database/utils.py
+++ b/frappe/database/utils.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
-from functools import cached_property
-from types import NoneType
+from functools import cached_property, wraps
 
 import frappe
 from frappe.query_builder.builder import MariaDB, Postgres
 from frappe.query_builder.functions import Function
 
 Query = str | MariaDB | Postgres
-QueryValues = tuple | list | dict | NoneType
+QueryValues = tuple | list | dict | None
 
 EmptyQueryValues = object()
 FallBackDateTimeStr = "0001-01-01 00:00:00.000000"
@@ -72,3 +71,26 @@ class LazyMogrify(LazyString):
 
 	def _setup(self) -> str:
 		return frappe.db.mogrify(self.query, self.values)
+
+
+def dangerously_reconnect_on_connection_abort(func):
+	"""Reconnect on connection failure.
+
+	As the name suggest, it's dangerous to use this function as it will NOT restore DB transaction
+	so make sure you're using it right.
+
+	Ideal use case: Some kinda logging or final steps in a background jobs. Anything more than that
+	will risk bugs from DB transactions.
+	"""
+
+	@wraps(func)
+	def wrapper(*args, **kwargs):
+		try:
+			return func(*args, **kwargs)
+		except Exception as e:
+			if frappe.db.is_interface_error(e):
+				frappe.db.connect()
+				return func(*args, **kwargs)
+			raise
+
+	return wrapper


### PR DESCRIPTION
During large reports it's possible that mysql connection gets dropped, in that case we should still ensure that errors get logged. 