### PR TITLE
chore: minor code cleanup

### DIFF
--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -1034,21 +1034,17 @@ class DatabaseQuery:
 			self._fetch_shared_documents = True
 			self.match_filters.append(match_filters)
 
-	def get_permission_query_conditions(self):
+	def get_permission_query_conditions(self) -> str:
 		conditions = []
 		hooks = frappe.get_hooks("permission_query_conditions", {})
 		condition_methods = hooks.get(self.doctype, []) + hooks.get("*", [])
-		if condition_methods:
-			for method in condition_methods:
-				c = frappe.call(frappe.get_attr(method), self.user, doctype=self.doctype)
-				if c:
-					conditions.append(c)
+		for method in condition_methods:
+			if c := frappe.call(frappe.get_attr(method), self.user, doctype=self.doctype):
+				conditions.append(c)
 
-		permision_script_name = get_server_script_map().get("permission_query", {}).get(self.doctype)
-		if permision_script_name:
-			script = frappe.get_doc("Server Script", permision_script_name)
-			condition = script.get_permission_query_conditions(self.user)
-			if condition:
+		if permission_script_name := get_server_script_map().get("permission_query", {}).get(self.doctype):
+			script = frappe.get_doc("Server Script", permission_script_name)
+			if condition := script.get_permission_query_conditions(self.user):
 				conditions.append(condition)
 
 		return " and ".join(conditions) if conditions else ""

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -441,9 +441,6 @@ def has_controller_permissions(doc, ptype, user=None, debug=False) -> bool:
 	hooks = frappe.get_hooks("has_permission")
 	methods = hooks.get(doc.doctype, []) + hooks.get("*", [])
 
-	if not methods:
-		return True
-
 	for method in reversed(methods):
 		controller_permission = frappe.call(method, doc=doc, ptype=ptype, user=user, debug=debug)
 		debug and _debug_log(f"Controller permission check from {method}: {controller_permission}")


### PR DESCRIPTION
- Use walrus operator where possible
- Drop redundant checks - we anyway can't iterate over an empty list
