### PR TITLE
fix!: better "Export customizations"

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -218,7 +218,10 @@ frappe.ui.form.on("Customize Form", {
 								fieldtype: "Check",
 								fieldname: "with_permissions",
 								label: __("Export Custom Permissions"),
-								default: 1,
+								description: __(
+									"Exported permissions will be force-synced on every migrate overriding any other customization."
+								),
+								default: 0,
 							},
 						],
 						function (data) {

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -110,6 +110,8 @@ def sync_customizations(app=None):
 							data = json.loads(f.read())
 						if data.get("sync_on_migrate"):
 							sync_customizations_for_doctype(data, folder, fname)
+						elif frappe.flags.in_install and app:
+							sync_customizations_for_doctype(data, folder, fname)
 
 
 def sync_customizations_for_doctype(data: dict, folder: str, filename: str = ""):

--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -147,12 +147,13 @@ def sync_customizations_for_doctype(data: dict, folder: str, filename: str = "")
 				case "Property Setter":
 					# Property setter implement their own deduplication, we can just sync them as is
 					for d in data[key]:
-						if d.get(doctype_fieldname) == doc_type:
-							d["doctype"] = custom_doctype
+						if d.get("doc_type") == doc_type:
+							d["doctype"] = "Property Setter"
 							doc = frappe.get_doc(d)
+							doc.flags.validate_fields_for_doctype = False
 							doc.insert()
 				case "Custom DocPerm":
-					# Docperm have no "sync" as of now.
+					# TODO/XXX: Docperm have no "sync" as of now. They get OVERRIDDEN on sync.
 					frappe.db.delete("Custom DocPerm", {"parent": doc_type})
 
 					for d in data[key]:

--- a/frappe/tests/test_modules.py
+++ b/frappe/tests/test_modules.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import unittest
+from contextlib import contextmanager
+from pathlib import Path
 
 import frappe
 from frappe import scrub
@@ -31,55 +33,15 @@ def delete_path(path):
 class TestUtils(FrappeTestCase):
 	def setUp(self):
 		self._dev_mode = frappe.local.conf.developer_mode
-		self._in_import = frappe.local.flags.in_import
-
 		frappe.local.conf.developer_mode = True
 
-		if self._testMethodName == "test_export_module_json_no_export":
-			frappe.local.flags.in_import = True
-
-		if self._testMethodName in ("test_export_customizations", "test_sync_customizations"):
-			df = {
-				"fieldname": "test_export_customizations_field",
-				"label": "Custom Data Field",
-				"fieldtype": "Data",
-			}
-			self.custom_field = create_custom_field("Note", df=df)
-
-		if self._testMethodName == "test_export_doc":
-			self.note = frappe.new_doc("Note")
-			self.note.title = frappe.generate_hash(length=10)
-			self.note.save()
-
-		if self._testMethodName == "test_make_boilerplate":
-			self.doctype = new_doctype("Test DocType Boilerplate")
-			self.doctype.insert()
-
 	def tearDown(self):
+		frappe.db.rollback()
 		frappe.local.conf.developer_mode = self._dev_mode
-		frappe.local.flags.in_import = self._in_import
-
-		if self._testMethodName in ("test_export_customizations", "test_sync_customizations"):
-			self.custom_field.delete()
-			trim_table("Note", dry_run=False)
-			delattr(self, "custom_field")
-			delete_path(frappe.get_module_path("Desk", "Note"))
-
-		if self._testMethodName == "test_export_doc":
-			self.note.delete()
-			delattr(self, "note")
-
-		if self._testMethodName == "test_make_boilerplate":
-			self.doctype.delete(force=True)
-			scrubbed = frappe.scrub(self.doctype.name)
-			self.addCleanup(
-				delete_path,
-				path=frappe.get_app_path("frappe", "core", "doctype", scrubbed),
-			)
-			frappe.db.sql_ddl("DROP TABLE `tabTest DocType Boilerplate`")
-			delattr(self, "doctype")
+		frappe.local.flags.pop("in_import", None)
 
 	def test_export_module_json_no_export(self):
+		frappe.local.flags.in_import = True
 		doc = frappe.get_last_doc("DocType")
 		self.assertIsNone(export_module_json(doc=doc, is_standard=True, module=doc.module))
 
@@ -115,36 +77,34 @@ class TestUtils(FrappeTestCase):
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
 	)
 	def test_export_customizations(self):
-		file_path = export_customizations(module="Custom", doctype="Note")
-		self.addCleanup(delete_file, path=file_path)
-		self.assertTrue(file_path.endswith("/custom/custom/note.json"))
-		self.assertTrue(os.path.exists(file_path))
+		with note_customizations():
+			file_path = export_customizations(module="Custom", doctype="Note")
+			self.addCleanup(delete_file, path=file_path)
+			self.assertTrue(file_path.endswith("/custom/custom/note.json"))
+			self.assertTrue(os.path.exists(file_path))
 
 	@unittest.skipUnless(
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
 	)
 	def test_sync_customizations(self):
-		custom_field = frappe.get_doc(
-			"Custom Field", {"dt": "Note", "fieldname": "test_export_customizations_field"}
-		)
+		with note_customizations() as custom_field:
+			file_path = export_customizations(module="Custom", doctype="Note", sync_on_migrate=True)
+			custom_field.db_set("modified", now_datetime())
+			custom_field.reload()
 
-		file_path = export_customizations(module="Custom", doctype="Note", sync_on_migrate=True)
-		custom_field.db_set("modified", now_datetime())
-		custom_field.reload()
+			self.assertTrue(file_path.endswith("/custom/custom/note.json"))
+			self.assertTrue(os.path.exists(file_path))
+			last_modified_before = custom_field.modified
 
-		self.assertTrue(file_path.endswith("/custom/custom/note.json"))
-		self.assertTrue(os.path.exists(file_path))
-		last_modified_before = custom_field.modified
+			sync_customizations(app="frappe")
 
-		sync_customizations(app="frappe")
+			self.assertTrue(file_path.endswith("/custom/custom/note.json"))
+			self.assertTrue(os.path.exists(file_path))
+			custom_field.reload()
+			last_modified_after = custom_field.modified
 
-		self.assertTrue(file_path.endswith("/custom/custom/note.json"))
-		self.assertTrue(os.path.exists(file_path))
-		custom_field.reload()
-		last_modified_after = custom_field.modified
-
-		self.assertNotEqual(last_modified_after, last_modified_before)
-		self.addCleanup(delete_file, path=file_path)
+			self.assertNotEqual(last_modified_after, last_modified_before)
+			self.addCleanup(delete_file, path=file_path)
 
 	def test_reload_doc(self):
 		frappe.db.set_value("DocType", "Note", "migration_hash", "", update_modified=False)
@@ -171,24 +131,50 @@ class TestUtils(FrappeTestCase):
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
 	)
 	def test_export_doc(self):
-		exported_doc_path = frappe.get_app_path(
-			"frappe", "desk", "note", self.note.name, f"{self.note.name}.json"
+		note = frappe.new_doc("Note")
+		note.title = frappe.generate_hash(length=10)
+		note.save()
+		export_doc(doctype="Note", name=note.name)
+		exported_doc_path = Path(
+			frappe.get_app_path("frappe", "desk", "note", note.name, f"{note.name}.json")
 		)
-		folder_path = os.path.abspath(os.path.dirname(exported_doc_path))
-		export_doc(doctype="Note", name=self.note.name)
-		self.addCleanup(delete_path, path=folder_path)
 		self.assertTrue(os.path.exists(exported_doc_path))
+		self.addCleanup(delete_path, path=exported_doc_path.parent.parent)
 
 	@unittest.skipUnless(
 		os.access(frappe.get_app_path("frappe"), os.W_OK), "Only run if frappe app paths is writable"
 	)
 	def test_make_boilerplate(self):
-		scrubbed = frappe.scrub(self.doctype.name)
-		self.assertFalse(
-			os.path.exists(frappe.get_app_path("frappe", "core", "doctype", scrubbed, f"{scrubbed}.json"))
-		)
-		self.doctype.custom = False
-		self.doctype.save()
-		self.assertTrue(
-			os.path.exists(frappe.get_app_path("frappe", "core", "doctype", scrubbed, f"{scrubbed}.json"))
-		)
+		with temp_doctype() as doctype:
+			scrubbed = frappe.scrub(doctype.name)
+			path = frappe.get_app_path("frappe", "core", "doctype", scrubbed, f"{scrubbed}.json")
+			self.assertFalse(os.path.exists(path))
+			doctype.custom = False
+			doctype.save()
+			self.assertTrue(os.path.exists(path))
+
+
+@contextmanager
+def temp_doctype():
+	try:
+		doctype = new_doctype().insert()
+		yield doctype
+	finally:
+		doctype.delete(force=True)
+		frappe.db.sql_ddl(f"DROP TABLE `tab{doctype.name}`")
+
+
+@contextmanager
+def note_customizations():
+	try:
+		df = {
+			"fieldname": "test_export_customizations_field",
+			"label": "Custom Data Field",
+			"fieldtype": "Data",
+		}
+		custom_field = create_custom_field("Note", df=df)
+		yield custom_field
+	finally:
+		custom_field.delete()
+		trim_table("Note", dry_run=False)
+		delete_path(frappe.get_module_path("Desk", "Note"))


### PR DESCRIPTION
If you use "Export customization" feature, the sync process will always override with customization stored in code. This is undesirable in most use cases.


Fixes:
- [x] Property setters are synced and not overridden
- [x] Custom docperms can't do this, but they are now not exported by default
- [x] A warning is added about custom docperm behaviour
- [x] `sync_on_migrate=False` now at least syncs on install. If it was set to false the code wasn't doing anything :hankey:  

Closes https://github.com/frappe/frappe/issues/25458


This also isn't ideal. Deleted prop setters won't be "synced" every with this design... but that seems better than wiping out random unknown changes.