### PR TITLE
feat: add vim and emacs mode for ace-editor

### DIFF
--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -48,6 +48,7 @@
   "desk_settings_section",
   "mute_sounds",
   "desk_theme",
+  "code_editor_type",
   "banner_image",
   "change_password",
   "new_password",
@@ -726,6 +727,13 @@
    "fieldname": "workspace_section",
    "fieldtype": "Section Break",
    "label": "Workspace"
+  },
+  {
+   "default": "vscode",
+   "fieldname": "code_editor_type",
+   "fieldtype": "Select",
+   "label": "Code Editor Type",
+   "options": "vscode\nvim\nemacs"
   }
  ],
  "icon": "fa fa-user",
@@ -788,7 +796,7 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2024-03-23 16:03:59.833565",
+ "modified": "2024-04-12 23:25:04.628007",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -63,6 +63,7 @@ class User(Document):
 		birth_date: DF.Date | None
 		block_modules: DF.Table[BlockModule]
 		bypass_restrict_ip_check_if_2fa_enabled: DF.Check
+		code_editor_type: DF.Literal["vscode", "vim", "emacs"]
 		default_workspace: DF.Link | None
 		defaults: DF.Table[DefaultValue]
 		desk_theme: DF.Literal["Light", "Dark", "Automatic"]

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -177,7 +177,9 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 
 		const ace_language_mode = language_map[language] || "";
 		this.editor.session.setMode(ace_language_mode);
-		this.editor.setKeyboardHandler("ace/keyboard/vscode");
+		this.editor.setKeyboardHandler(
+			`ace/keyboard/${frappe.boot.user.code_editor_type || "vscode"}`
+		);
 	}
 
 	parse(value) {

--- a/frappe/utils/user.py
+++ b/frappe/utils/user.py
@@ -216,6 +216,7 @@ class UserPermissions:
 			[
 				"creation",
 				"desk_theme",
+				"code_editor_type",
 				"document_follow_notify",
 				"email",
 				"email_signature",


### PR DESCRIPTION
Can be toggled from user settings `Code Editor Type`, default is vscode

> no-docs