### PR TITLE
feat!: simplify admin password prompt for new site

### DIFF
--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -143,18 +143,7 @@ def install_basic_docs():
 
 
 def get_admin_password():
-	def ask_admin_password():
-		admin_password = getpass.getpass("Set Administrator password: ")
-		admin_password2 = getpass.getpass("Re-enter Administrator password: ")
-		if admin_password != admin_password2:
-			print("\nPasswords do not match")
-			return ask_admin_password()
-		return admin_password
-
-	admin_password = frappe.conf.get("admin_password")
-	if not admin_password:
-		return ask_admin_password()
-	return admin_password
+	return frappe.conf.get("admin_password") or getpass.getpass("Set Administrator password: ")
 
 
 def before_tests():


### PR DESCRIPTION
Resetting incorrect admin passwords is straightforward with the `bench set-admin-password` command, eliminating the need to enter passwords twice. This simplifies the process and reduces hassle.

> no-docs