### PR TITLE
fix: make checkbox clickable in image view of doctype lists

### DIFF
--- a/frappe/public/scss/desk/list.scss
+++ b/frappe/public/scss/desk/list.scss
@@ -257,6 +257,7 @@ input.list-row-checkbox {
 	margin-bottom: 0px;
 	--checkbox-right-margin: calc(var(--checkbox-size) / 2 + #{$level-margin-right});
 	background-color: var(--card-bg);
+	z-index: 1;
 }
 
 input.list-check-all {


### PR DESCRIPTION
The issue addressed by this PR is that checkboxes in the image view of doctype lists can't be clicked as they are obscured by overlaying images. This prevents users from using the multi-select functionality. By applying a z-index: 1 to the checkbox  in list.scss, the checkboxes are brought forward above the image layers, making them accessible and clickable. This is already done for the like icon on the card.

## GIF for before and after

Before:
![WhatsApp GIF 2024-04-13 at 04 07 08](https://github.com/frappe/frappe/assets/246454/1c4b8cf5-ff0a-4afa-bb39-73b65a2177ec)

After:
![WhatsApp GIF 2024-04-13 at 04 08 22](https://github.com/frappe/frappe/assets/246454/f64e2671-7c23-4499-9ae1-97f31a4ac9af)
