### PR TITLE
feat: add new payment processing hooks

### DIFF
--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -65,6 +65,37 @@ if doc.allocated_to:
 </code>
 </pre>
 
+<h5>Payment processing</h5>
+<p>Payment processing events have a special state. See the <a href="https://github.com/frappe/payments/blob/develop/payments/controllers/payment_controller.py">PaymentController in Frappe Payments</a> for details.</p>
+<pre>
+	<code>
+# retreive payment session state
+ps = doc.flags.payment_session
+
+if ps.flags.status_changed_to in ps.flowstates.success:
+		if ps.changed: # could be an idempotent run
+        doc.set_as_paid()
+		# custom process return values
+    doc.flags.payment_result = {
+        "message": "Thank you for your payment",
+        "action": {"href": "https://shop.example.com", "label": "Return to shop"},
+    }
+if ps.flags.status_changed_to in ps.flowstates.pre_authorized:
+    # do something else
+if ps.flags.status_changed_to in ps.flowstates.processing:
+    # do something else
+if ps.flags.status_changed_to in ps.flowstates.declined:
+    # do something else
+</code>
+</pre>
+<p>The <i>On Payment Failed</i> (<code>on_payment_failed</code>) event only transports the error message which the controller implementation had extracted from the transaction.</p>
+<pre>
+	<code>
+msg = doc.flags.payment_failure_message
+doc.my_failure_message_field = msg
+</code>
+</pre>
+
 <hr>
 
 <h4>API Call</h4>

--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -72,20 +72,20 @@ if doc.allocated_to:
 # retreive payment session state
 ps = doc.flags.payment_session
 
-if ps.flags.status_changed_to in ps.flowstates.success:
-		if ps.changed: # could be an idempotent run
-        doc.set_as_paid()
+if ps.changed: # could be an idempotent run
+	if ps.flags.status_changed_to in ps.flowstates.success:
+		doc.set_as_paid()
 		# custom process return values
-    doc.flags.payment_result = {
-        "message": "Thank you for your payment",
-        "action": {"href": "https://shop.example.com", "label": "Return to shop"},
-    }
-if ps.flags.status_changed_to in ps.flowstates.pre_authorized:
-    # do something else
-if ps.flags.status_changed_to in ps.flowstates.processing:
-    # do something else
-if ps.flags.status_changed_to in ps.flowstates.declined:
-    # do something else
+		doc.flags.payment_result = {
+			"message": "Thank you for your payment",
+			"action": {"href": "https://shop.example.com", "label": "Return to shop"},
+		}
+	if ps.flags.status_changed_to in ps.flowstates.pre_authorized:
+		# do something else
+	if ps.flags.status_changed_to in ps.flowstates.processing:
+		# do something else
+	if ps.flags.status_changed_to in ps.flowstates.declined:
+		# do something else
 </code>
 </pre>
 <p>The <i>On Payment Failed</i> (<code>on_payment_failed</code>) event only transports the error message which the controller implementation had extracted from the transaction.</p>

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -57,7 +57,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Discard\nAfter Discard\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Discard\nAfter Discard\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Failed\nOn Payment Charge Processed\nOn Payment Mandate Charge Processed\nOn Payment Mandate Acquisition Processed\nOn Payment Paid (Legacy Gateway)\nOn Payment Authorization (Legacy Gateway)"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -151,7 +151,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2024-04-15 20:12:41.971315",
+ "modified": "2024-05-08 03:21:54.169380",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -57,7 +57,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Discard\nAfter Discard\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Failed\nOn Payment Charge Processed\nOn Payment Mandate Charge Processed\nOn Payment Mandate Acquisition Processed\nOn Payment Paid (Legacy Gateway)\nOn Payment Authorization (Legacy Gateway)"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Discard\nAfter Discard\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed\nOn Payment Charge Processed\nOn Payment Mandate Charge Processed\nOn Payment Mandate Acquisition Processed"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -49,9 +49,12 @@ class ServerScript(Document):
 			"Before Save (Submitted Document)",
 			"After Save (Submitted Document)",
 			"Before Print",
-			"On Payment Authorization",
-			"On Payment Paid",
 			"On Payment Failed",
+			"On Payment Charge Processed",
+			"On Payment Mandate Charge Processed",
+			"On Payment Mandate Acquisition Processed",
+			"On Payment Paid (Legacy Gateway)",
+			"On Payment Authorization (Legacy Gateway)",
 		]
 		enable_rate_limit: DF.Check
 		event_frequency: DF.Literal[

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -49,12 +49,12 @@ class ServerScript(Document):
 			"Before Save (Submitted Document)",
 			"After Save (Submitted Document)",
 			"Before Print",
+			"On Payment Authorization",
+			"On Payment Paid",
 			"On Payment Failed",
 			"On Payment Charge Processed",
 			"On Payment Mandate Charge Processed",
 			"On Payment Mandate Acquisition Processed",
-			"On Payment Paid (Legacy Gateway)",
-			"On Payment Authorization (Legacy Gateway)",
 		]
 		enable_rate_limit: DF.Check
 		event_frequency: DF.Literal[

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -22,9 +22,12 @@ EVENT_MAP = {
 	"before_update_after_submit": "Before Save (Submitted Document)",
 	"on_update_after_submit": "After Save (Submitted Document)",
 	"before_print": "Before Print",
-	"on_payment_paid": "On Payment Paid",
 	"on_payment_failed": "On Payment Failed",
-	"on_payment_authorized": "On Payment Authorization",
+	"on_payment_charge_processed": "On Payment Charge Processed",
+	"on_payment_mandated_charge_processed": "On Payment Mandate Charge Processed",
+	"on_payment_mandate_acquisition_processed": "On Payment Mandate Acquisition Processed",
+	"on_payment_paid": "On Payment Paid (Legacy Gateway)",
+	"on_payment_authorized": "On Payment Authorization (Legacy Gateway)",
 }
 
 

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -22,12 +22,12 @@ EVENT_MAP = {
 	"before_update_after_submit": "Before Save (Submitted Document)",
 	"on_update_after_submit": "After Save (Submitted Document)",
 	"before_print": "Before Print",
+	"on_payment_paid": "On Payment Paid",
 	"on_payment_failed": "On Payment Failed",
+	"on_payment_authorized": "On Payment Authorization",
 	"on_payment_charge_processed": "On Payment Charge Processed",
 	"on_payment_mandated_charge_processed": "On Payment Mandate Charge Processed",
 	"on_payment_mandate_acquisition_processed": "On Payment Mandate Acquisition Processed",
-	"on_payment_paid": "On Payment Paid (Legacy Gateway)",
-	"on_payment_authorized": "On Payment Authorization (Legacy Gateway)",
 }
 
 


### PR DESCRIPTION
# Context

https://github.com/frappe/payments/pull/53 implements a new version of payment controllers which are more suitable for webshop checkouts and have a better frontend user flow.

The new version comes with a well-defined assortment of ref doc hooks for post-processing a payment flow within the business logic.


## Proposal

- This PR adds the new post-processing hooks
- It also marks the previous ones as "Legacy Gateway"

`no-docs`