### PR TITLE
feat: Discard transactions

### DIFF
--- a/frappe/core/doctype/server_script/server_script.json
+++ b/frappe/core/doctype/server_script/server_script.json
@@ -57,7 +57,7 @@
    "fieldname": "doctype_event",
    "fieldtype": "Select",
    "label": "DocType Event",
-   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed"
+   "options": "Before Insert\nBefore Validate\nBefore Save\nAfter Insert\nAfter Save\nBefore Rename\nAfter Rename\nBefore Submit\nAfter Submit\nBefore Cancel\nAfter Cancel\nBefore Discard\nAfter Discard\nBefore Delete\nAfter Delete\nBefore Save (Submitted Document)\nAfter Save (Submitted Document)\nBefore Print\nOn Payment Authorization\nOn Payment Paid\nOn Payment Failed"
   },
   {
    "depends_on": "eval:doc.script_type==='API'",
@@ -151,7 +151,7 @@
    "link_fieldname": "server_script"
   }
  ],
- "modified": "2024-04-08 16:18:52.901097",
+ "modified": "2024-04-15 20:12:41.971315",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Server Script",

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -42,6 +42,8 @@ class ServerScript(Document):
 			"After Submit",
 			"Before Cancel",
 			"After Cancel",
+			"Before Discard",
+			"After Discard",
 			"Before Delete",
 			"After Delete",
 			"Before Save (Submitted Document)",

--- a/frappe/core/doctype/server_script/server_script_utils.py
+++ b/frappe/core/doctype/server_script/server_script_utils.py
@@ -15,6 +15,8 @@ EVENT_MAP = {
 	"on_submit": "After Submit",
 	"before_cancel": "Before Cancel",
 	"on_cancel": "After Cancel",
+	"before_discard": "Before Discard",
+	"on_discard": "After Discard",
 	"on_trash": "Before Delete",
 	"after_delete": "After Delete",
 	"before_update_after_submit": "Before Save (Submitted Document)",

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -59,6 +59,17 @@ def cancel(doctype=None, name=None, workflow_state_fieldname=None, workflow_stat
 	frappe.msgprint(frappe._("Cancelled"), indicator="red", alert=True)
 
 
+@frappe.whitelist()
+def discard(doctype=None, name=None):
+	"""discard a doclist"""
+	doc = frappe.get_doc(doctype, name)
+	capture_doc(doc, "Discard")
+
+	doc.discard()
+	send_updated_docs(doc)
+	frappe.msgprint(frappe._("Discarded"), indicator="red", alert=True)
+
+
 def send_updated_docs(doc):
 	from .load import get_docinfo
 

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -60,8 +60,8 @@ def cancel(doctype=None, name=None, workflow_state_fieldname=None, workflow_stat
 
 
 @frappe.whitelist()
-def discard(doctype=None, name=None):
-	"""discard a doclist"""
+def discard(doctype: str, name: str | int):
+	"""dicard a draft document"""
 	doc = frappe.get_doc(doctype, name)
 	capture_doc(doc, "Discard")
 

--- a/frappe/desk/form/save.py
+++ b/frappe/desk/form/save.py
@@ -61,7 +61,7 @@ def cancel(doctype=None, name=None, workflow_state_fieldname=None, workflow_stat
 
 @frappe.whitelist()
 def discard(doctype: str, name: str | int):
-	"""dicard a draft document"""
+	"""discard a draft document"""
 	doc = frappe.get_doc(doctype, name)
 	capture_doc(doc, "Discard")
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -848,7 +848,7 @@ class Document(BaseDocument):
 				self._action = "submit"
 				self.check_permission("submit")
 			elif self.docstatus.is_cancelled():
-				self.check_permission("cancel")
+				self.check_permission("write")
 			else:
 				raise frappe.ValidationError(_("Invalid docstatus"), self.docstatus)
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1075,6 +1075,7 @@ class Document(BaseDocument):
 
 		self.run_method("before_discard")
 		self.db_set("docstatus", DocStatus.cancelled())
+		delattr(self, "_action")
 		self.run_method("on_discard")
 
 	@frappe.whitelist()

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -836,7 +836,6 @@ frappe.ui.form.Form = class FrappeForm {
 	discard(btn, callback, on_error) {
 		const me = this;
 		return new Promise((resolve) => {
-			// this.validate_form_action("Discard") // ?
 			frappe.confirm(__("Discard {0}", [this.docname]), function () {
 				me.script_manager.trigger("before_discard").then(function () {
 					return me._discard(btn, callback, on_error, false); // ?

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -833,6 +833,18 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 	}
 
+	discard(btn, callback, on_error) {
+		var me = this;
+		return new Promise((resolve) => {
+			// this.validate_form_action("Discard") // ?
+			frappe.confirm(__("Discard {0}", [this.docname]), function () {
+				me.script_manager.trigger("before_discard").then(function () {
+					return me._discard(btn, callback, on_error, false); // ?
+				});
+			});
+		});
+	}
+
 	savesubmit(btn, callback, on_error) {
 		var me = this;
 		return new Promise((resolve) => {
@@ -1010,6 +1022,40 @@ frappe.ui.form.Form = class FrappeForm {
 			frappe.confirm(
 				__("Permanently Cancel {0}?", [this.docname]),
 				cancel_doc,
+				me.handle_save_fail(btn, on_error)
+			);
+		}
+	}
+
+	_discard(btn, on_error, skip_confirm) {
+		const me = this;
+		const discard_doc = () => {
+			frappe.validated = true;
+			me.script_manager.trigger("before_discard").then(() => {
+				if (!frappe.validated) {
+					return me.handle_save_fail(btn, on_error);
+				}
+
+				var after_discard = function (r) {
+					if (r.exc) {
+						me.handle_save_fail(btn, on_error);
+					} else {
+						frappe.utils.play_sound("cancel");
+						me.refresh();
+						me.script_manager.trigger("after_discard");
+					}
+					me.reload_doc();
+				};
+				frappe.ui.form.discard(me, after_discard, btn);
+			});
+		};
+
+		if (skip_confirm) {
+			discard_doc();
+		} else {
+			frappe.confirm(
+				__("Permanently Discard {0}?", [this.docname]),
+				discard_doc,
 				me.handle_save_fail(btn, on_error)
 			);
 		}

--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -834,7 +834,7 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	discard(btn, callback, on_error) {
-		var me = this;
+		const me = this;
 		return new Promise((resolve) => {
 			// this.validate_form_action("Discard") // ?
 			frappe.confirm(__("Discard {0}", [this.docname]), function () {
@@ -1046,7 +1046,19 @@ frappe.ui.form.Form = class FrappeForm {
 					}
 					me.reload_doc();
 				};
-				frappe.ui.form.discard(me, after_discard, btn);
+				//frappe.ui.form.discard(me, after_discard, btn);
+				frappe.call({
+					freeze: true,
+					method: "frappe.desk.form.save.discard",
+					args: {
+						doctype: me.doc.doctype,
+						name: me.doc.name,
+					},
+					btn: btn,
+					callback: function (r) {
+						after_discard(r);
+					},
+				});
 			});
 		};
 

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -274,23 +274,6 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 	}
 };
 
-frappe.ui.form.discard = function (frm, callback, btn) {
-	var args = {
-		doctype: frm.doc.doctype,
-		name: frm.doc.name,
-	};
-
-	return frappe.call({
-		freeze: true,
-		method: "frappe.desk.form.save.discard",
-		args: args,
-		btn: btn,
-		callback: function (r) {
-			callback && callback(r);
-		},
-	});
-};
-
 frappe.ui.form.remove_old_form_route = () => {
 	let current_route = frappe.get_route().join("/");
 	frappe.route_history = frappe.route_history.filter(

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -274,6 +274,23 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 	}
 };
 
+frappe.ui.form.discard = function (frm, callback, btn) {
+	var args = {
+		doctype: frm.doc.doctype,
+		name: frm.doc.name,
+	};
+
+	return frappe.call({
+		freeze: true,
+		method: "frappe.desk.form.save.discard",
+		args: args,
+		btn: btn,
+		callback: function (r) {
+			callback && callback(r);
+		},
+	});
+};
+
 frappe.ui.form.remove_old_form_route = () => {
 	let current_route = frappe.get_route().join("/");
 	frappe.route_history = frappe.route_history.filter(

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -310,7 +310,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
 		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
 
-		if (is_submittable && docstatus == 0) {
+		if (is_submittable && docstatus == 0 && !this.has_workflow()) {
 			this.page.add_menu_item(
 				__("Discard"),
 				function () {
@@ -594,9 +594,7 @@ frappe.ui.form.Toolbar = class Toolbar {
 	}
 	has_workflow() {
 		if (this._has_workflow === undefined)
-			this._has_workflow = frappe.get_list("Workflow", {
-				document_type: this.frm.doctype,
-			}).length;
+			this._has_workflow = frappe.model.has_workflow(this.frm.doctype);
 		return this._has_workflow;
 	}
 	get_docstatus() {

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -310,6 +310,16 @@ frappe.ui.form.Toolbar = class Toolbar {
 		const allow_print_for_draft = cint(print_settings.allow_print_for_draft);
 		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
 
+		if (is_submittable && docstatus == 0) {
+			this.page.add_menu_item(
+				__("Discard"),
+				function () {
+					me.frm._discard();
+				},
+				true
+			);
+		}
+
 		if (
 			!is_submittable ||
 			docstatus == 1 ||

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -98,12 +98,36 @@ class TestDocument(FrappeTestCase):
 
 		self.assertEqual(frappe.db.get_value(d.doctype, d.name, "subject"), "subject changed")
 
-	def test_discard(self):
+	def test_discard_transitions(self):
 		d = self.test_insert()
 		self.assertEqual(d.docstatus, 0)
 
-		d.discard()
-		self.assertEqual(d.docstatus, 2)
+		# invalid: Submit > Discard, Cancel > Discard
+		d.submit()
+		self.assertRaises(frappe.ValidationError, d.discard)
+		d.reload()
+
+		d.cancel()
+		self.assertRaises(frappe.ValidationError, d.discard)
+
+		# valid: Draft > Discard
+		d2 = self.test_insert()
+		d2.discard()
+		self.assertEqual(d2.docstatus, 2)
+
+	def test_save_on_discard_throws(self):
+		from frappe.desk.doctype.event.event import Event
+
+		d3 = self.test_insert()
+
+		def test_on_discard(d3):
+			d3.subject = d3.subject + "update"
+			d3.save()
+
+		d3.on_discard = (test_on_discard)(d3)
+		d3.on_discard = test_on_discard.__get__(d3, Event)
+
+		self.assertRaises(frappe.ValidationError, d3.discard)
 
 	def test_value_changed(self):
 		d = self.test_insert()

--- a/frappe/tests/test_document.py
+++ b/frappe/tests/test_document.py
@@ -98,6 +98,13 @@ class TestDocument(FrappeTestCase):
 
 		self.assertEqual(frappe.db.get_value(d.doctype, d.name, "subject"), "subject changed")
 
+	def test_discard(self):
+		d = self.test_insert()
+		self.assertEqual(d.docstatus, 0)
+
+		d.discard()
+		self.assertEqual(d.docstatus, 2)
+
 	def test_value_changed(self):
 		d = self.test_insert()
 		d.subject = "subject changed again"


### PR DESCRIPTION
Fixes: https://github.com/frappe/frappe/issues/21515

Added discard action under menu items on draft transactions. This action will do transition validation, check write perms, run hooks and do db_set with docstatus 2.

![image](https://github.com/frappe/frappe/assets/50401596/d5a76aa4-ac64-469a-a57e-c0aff1469550)

Added Events
---
Override doc methods: before_discard, on_discard
Client Script: before_discard, after_discard (following same naming conventions as cancel)
Server Script Doctype Events: Before Discard, After Discard
 
Right now it just validates write perms, perhaps we can add separate permissions later.


docs: https://frappeframework.com/docs/user/en/api/form#form-events
