### PR TITLE
fix error when inserting multiple link types into child table

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -773,6 +773,8 @@ class BaseDocument:
 
 			if docname:
 				if df.fieldtype == "Link":
+					if type(docname) != str:
+						docname = docname.name
 					doctype = df.options
 					if not doctype:
 						frappe.throw(_("Options not set for link field {0}").format(df.fieldname))


### PR DESCRIPTION
closes #39941 (reported in frappe/erpnext.

2 lines of code to fix a rare issue when with child table elements containing link type fields.   

more info below or refer issue 39941 in frappe/erpnext

in  the get_invalid_links() method in base_document.py,
The following code sets docname to an object instead of a string in rare case where child table element contains a link

for df in self.meta.get_link_fields() + self.meta.get("fields", {"fieldtype": ("=", "Dynamic Link")}):
    docname = self.get(df.fieldname)

this creates an issue inserting the child table elements.  This PR fixes by setting docname = docname.name if docname is not a string.

