### PR TITLE
ci: dont auto apply fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,7 @@ repos:
     rev: v0.2.0
     hooks:
       - id: ruff
-        name: "Run ruff linter and apply fixes"
-        args: ["--fix"]
+        name: "Run ruff linter"
 
       - id: ruff-format
         name: "Format Python code"


### PR DESCRIPTION
I've personally encountered ~5 instances of bad auto fixes, let
developers apply the fixes.
