### PR TITLE
Revert "chore: add v15 to POT file mix"

### DIFF
--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -1,6 +1,3 @@
-# This workflow is agnostic to branches. Only maintain on develop branch.
-# To add/remove branches just modify the matrix.
-
 name: Regenerate POT file (translatable strings)
 on:
   schedule:

--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ["develop", "version-15-hotfix"]
+        branch: ["develop"]
     permissions:
       contents: write
 


### PR DESCRIPTION
Reverts frappe/frappe#25983


This workflow can't really be agnostic of branches, the script needs to exist in checked out code. 