### PR TITLE
fix(notification): html template example in notification.js

### DIFF
--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -97,8 +97,8 @@ Last comment: {{ comments[-1].comment }} by {{ comments[-1].by }}
 &lt;h4&gt;Details&lt;/h4&gt;
 
 &lt;ul&gt;
-&lt;li&gt;Customer: {{ doc.customer }}
-&lt;li&gt;Amount: {{ doc.grand_total }}
+&lt;li&gt;Customer: {{ doc.customer }}&lt;/li&gt;
+&lt;li&gt;Amount: {{ doc.grand_total }}&lt;/li&gt;
 &lt;/ul&gt;
 </pre>
 			`;


### PR DESCRIPTION
Closing `</li>` tag was missing in the example html shown on the page.
 
<img width="803" alt="Screenshot 2024-04-17 at 8 53 54 PM" src="https://github.com/frappe/frappe/assets/144778/79f49c7e-874b-4c7a-aaa2-d3771da1fba1">
