### PR TITLE
fix: Renaming when doctype is used as a virtual link docfield fails

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -463,7 +463,12 @@ def get_link_fields(doctype: str) -> list[dict]:
 			.inner_join(dt)
 			.on(df.parent == dt.name)
 			.select(df.parent, df.fieldname, dt.issingle.as_("issingle"))
-			.where((df.options == doctype) & (df.fieldtype == "Link") & (df.is_virtual == 0 or dt.is_virutal == 0))
+			.where(
+				(df.options == doctype)
+				& (df.fieldtype == "Link")
+				& (df.is_virtual == 0)
+				& (dt.is_virutal == 0)
+			)
 			.run(as_dict=True)
 		)
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -467,7 +467,7 @@ def get_link_fields(doctype: str) -> list[dict]:
 				(df.options == doctype)
 				& (df.fieldtype == "Link")
 				& (df.is_virtual == 0)
-				& (dt.is_virutal == 0)
+				& (dt.is_virtual == 0)
 			)
 			.run(as_dict=True)
 		)

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -463,7 +463,7 @@ def get_link_fields(doctype: str) -> list[dict]:
 			.inner_join(dt)
 			.on(df.parent == dt.name)
 			.select(df.parent, df.fieldname, dt.issingle.as_("issingle"))
-			.where((df.options == doctype) & (df.fieldtype == "Link") & (dt.is_virtual == 0))
+			.where((df.options == doctype) & (df.fieldtype == "Link") & (df.is_virtual == 0))
 			.run(as_dict=True)
 		)
 

--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -463,7 +463,7 @@ def get_link_fields(doctype: str) -> list[dict]:
 			.inner_join(dt)
 			.on(df.parent == dt.name)
 			.select(df.parent, df.fieldname, dt.issingle.as_("issingle"))
-			.where((df.options == doctype) & (df.fieldtype == "Link") & (df.is_virtual == 0))
+			.where((df.options == doctype) & (df.fieldtype == "Link") & (df.is_virtual == 0 or dt.is_virutal == 0))
 			.run(as_dict=True)
 		)
 


### PR DESCRIPTION
Reproduction steps: 
- Create a doctype "A"
- Create another doctype "B" with a virtual link docfield with the option set to "A"
- Create a document of type "A" 
- Attempt to rename document of type "A"

Stacktrace:
```
Traceback (most recent call last):
  File "apps/frappe/frappe/model/document.py", line 1658, in execute_action
    getattr(doc, __action)(**kwargs)
  File "apps/frappe/frappe/model/document.py", line 1040, in _rename
    self.name = rename_doc(doc=self, new=name, merge=merge, force=force, validate=validate_rename)
  File "apps/frappe/frappe/model/rename_doc.py", line 182, in rename_doc
    update_link_field_values(link_fields, old, new, doctype)
  File "apps/frappe/frappe/model/rename_doc.py", line 441, in update_link_field_values
    frappe.db.set_value(parent, {docfield: old}, docfield, new, update_modified=False)
  File "apps/frappe/frappe/database/database.py", line 994, in set_value
    query.run(debug=debug)
  File "apps/frappe/frappe/query_builder/utils.py", line 87, in execute_query
    result = frappe.db.sql(query, params, *args, **kwargs)  # nosemgrep
  File "apps/frappe/frappe/database/database.py", line 234, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 558, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 822, in _read_query_result
    result.read()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 1200, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 772, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'a' in 'where clause'")
```

Fix:
`get_link_fields` needs to reference the docfield not the doctype for checking whether the field is virtual