### PR TITLE
fix: Avoid permission check on unsaved doc

### DIFF
--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -361,15 +361,15 @@ def attach_files_to_document(doc: "Document", event) -> None:
 
 
 def relink_files(doc, fieldname, temp_doc_name):
-	if not temp_doc_name:
-		return
-	from frappe.utils.data import add_to_date, now_datetime
-
 	"""
 	Relink files attached to incorrect document name to the new document name
 	by check if file with temp name exists that was created in last 60 minutes
 	"""
-	mislinked_file = frappe.db.exists(
+	if not temp_doc_name:
+		return
+	from frappe.utils.data import add_to_date, now_datetime
+
+	mislinked_file = frappe.db.get_value(
 		"File",
 		{
 			"file_url": doc.get(fieldname),
@@ -382,7 +382,7 @@ def relink_files(doc, fieldname, temp_doc_name):
 			),
 		},
 	)
-	"""If file exists, attach it to the new docname"""
+	# If file exists, attach it to the new docname
 	if mislinked_file:
 		frappe.db.set_value(
 			"File",

--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -252,7 +252,8 @@ def check_write_permission(doctype: str | None = None, name: str | None = None):
 			doc.check_permission("write")
 		except frappe.DoesNotExistError:
 			# doc has not been inserted yet, name is set to "new-some-doctype"
-			check_doctype = True
+			# If doc inserts fine then only this attachment will be linked see file/utils.py:relink_mismatched_files
+			return
 
 	if check_doctype:
 		frappe.has_permission(doctype, "write", throw=True)


### PR DESCRIPTION
Use case:
- User has "if owner" perm
- Doc isn't created
- We skip doc perm check because doc doesn't exist
- We check if user has write perm to doctype, which isn't available
  because it's only "if owner"

Fix: We can avoid perm check entirely here, files are only re-attached
if doc saves successfully which implies that reference doc was indeed
saved after perm check.


This is an edge case for handling attachments on unsaved docs. 
Refer: https://github.com/frappe/frappe/pull/22693