### PR TITLE
fix: filter select perm in get_doctypes_with_read

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,14 @@ repos:
     rev: v0.2.0
     hooks:
       - id: ruff
+        name: "Run ruff import sorter"
+        args: ["--select=I", "--fix"]
+
+      - id: ruff
         name: "Run ruff linter"
 
       - id: ruff-format
-        name: "Format Python code"
+        name: "Run ruff formatter"
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/frappe/permissions.py
+++ b/frappe/permissions.py
@@ -451,7 +451,7 @@ def has_controller_permissions(doc, ptype, user=None, debug=False) -> bool:
 
 
 def get_doctypes_with_read():
-	return list({cstr(p.parent) for p in get_valid_perms() if p.parent})
+	return list({cstr(p.parent) for p in get_valid_perms() if p.parent and p.read})
 
 
 def get_valid_perms(doctype=None, user=None):

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -7,7 +7,7 @@ import frappe.defaults
 import frappe.model.meta
 from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.doctype.user_permission.user_permission import clear_user_permissions
-from frappe.core.page.permission_manager.permission_manager import reset, update
+from frappe.core.page.permission_manager.permission_manager import add, remove, reset, update
 from frappe.desk.form.load import getdoc
 from frappe.permissions import (
 	ALL_USER_ROLE,
@@ -744,4 +744,23 @@ class TestPermissions(FrappeTestCase):
 			doctype = new_doctype(permissions=[{"select": 1, "role": "_Test Role", "read": 0}]).insert().name
 
 		with self.set_user("test@example.com"):
+			self.assertNotIn(doctype, get_doctypes_with_read())
+
+	def test_overrides_work_as_expected(self):
+		"""custom docperms should completely override standard ones"""
+		standard_role = "Desk User"
+		custom_role = frappe.new_doc("Role", role_name=frappe.generate_hash()).insert().name
+		with self.set_user("Administrator"):
+			doctype = new_doctype(permissions=[{"role": standard_role, "read": 1}]).insert().name
+
+		with self.set_user("test@example.com"):
+			self.assertIn(doctype, get_doctypes_with_read())
+
+		with self.set_user("Administrator"):
+			# Allow perm to some other role and remove standard role
+			add(doctype, custom_role, 0)
+			remove(doctype, standard_role, 0)
+
+		with self.set_user("test@example.com"):
+			# No one has this role, so user shouldn't have permission.
 			self.assertNotIn(doctype, get_doctypes_with_read())

--- a/frappe/tests/test_permissions.py
+++ b/frappe/tests/test_permissions.py
@@ -5,6 +5,7 @@
 import frappe
 import frappe.defaults
 import frappe.model.meta
+from frappe.core.doctype.doctype.test_doctype import new_doctype
 from frappe.core.doctype.user_permission.user_permission import clear_user_permissions
 from frappe.core.page.permission_manager.permission_manager import reset, update
 from frappe.desk.form.load import getdoc
@@ -17,6 +18,7 @@ from frappe.permissions import (
 	add_user_permission,
 	clear_user_permissions_for_doctype,
 	get_doc_permissions,
+	get_doctypes_with_read,
 	remove_user_permission,
 	update_permission_property,
 )
@@ -736,3 +738,10 @@ class TestPermissions(FrappeTestCase):
 		)
 		frappe.set_user(system_user)
 		assertHasRole(GUEST_ROLE, ALL_USER_ROLE, SYSTEM_USER_ROLE)
+
+	def test_get_doctypes_with_read(self):
+		with self.set_user("Administrator"):
+			doctype = new_doctype(permissions=[{"select": 1, "role": "_Test Role", "read": 0}]).insert().name
+
+		with self.set_user("test@example.com"):
+			self.assertNotIn(doctype, get_doctypes_with_read())


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/26015

Extracted from https://github.com/frappe/frappe/pull/26018
