### PR TITLE
fix(report_view): allow exporting all rows even if count is disabled

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1553,12 +1553,22 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 					const selected_items = this.get_checked_items(true);
 
 					let extra_fields = null;
-					if (this.total_count > (this.count_without_children || args.page_length)) {
+					if (this.list_view_settings.disable_count) {
 						extra_fields = [
 							{
 								fieldtype: "Check",
 								fieldname: "export_all_rows",
-								label: __("Export All {0} rows?", [`<b>${this.total_count}</b>`]),
+								label: __("Export all matching rows?"),
+							},
+						];
+					} else if (
+						this.total_count > (this.count_without_children || args.page_length)
+					) {
+						extra_fields = [
+							{
+								fieldtype: "Check",
+								fieldname: "export_all_rows",
+								label: __("Export all {0} rows?", [`<b>${this.total_count}</b>`]),
 							},
 						];
 					}


### PR DESCRIPTION
Before showing this checkbox, we were checking the total count.
However there's cases where customers have the length disabled, and they still want to export all rows.

Reference: support ticket 13593
