### PR TITLE
 fix: 🐛 don't create __init__.py files when gathering pages

### DIFF
--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -124,7 +124,6 @@ def get_pages_from_path(start, app, app_path):
 						os.path.join(basepath, fname), app, start, basepath, app_path, fname
 					)
 					pages[page_info.route] = page_info
-					# print frappe.as_json(pages[-1])
 
 	return pages
 

--- a/frappe/website/router.py
+++ b/frappe/website/router.py
@@ -110,10 +110,6 @@ def get_pages_from_path(start, app, app_path):
 	start_path = os.path.join(app_path, start)
 	if os.path.exists(start_path):
 		for basepath, folders, files in os.walk(start_path):  # noqa: B007
-			# add missing __init__.py
-			if "__init__.py" not in files and frappe.conf.get("developer_mode"):
-				open(os.path.join(basepath, "__init__.py"), "a").close()
-
 			for fname in files:
 				fname = frappe.utils.cstr(fname)
 				if "." not in fname:


### PR DESCRIPTION
During `bench migrate` or even just opening the sitemap for the first time, frappe gathers information about all available pages.

While doing this (and when it is in developer_mode) it generates an `__init__.py` file for each and every subfolder of a page if none exists.

This is bad behaviour because:
* these files are only necessary when others python files exist in the same folder (or subfolder) so as to not be part of an implicit namespace package
* they don't belong in any folderstructure without *.py files
    * frappe itself has such a case in `frappe/templates/pages/integrations` where only the file `gcalendar-success.html` should be present
* the function doing this doesn't tell this to it's callers which results in file generation in opening the sitemap
* ruff will warn with `INP001` anyway when an `__init__.py` is missing
    * https://docs.astral.sh/ruff/rules/implicit-namespace-package/

Closes #25167