### PR TITLE
fix(grid_row): check child table dependent properties whenever a row is selected

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -730,20 +730,12 @@ export default class GridRow {
 	}
 
 	set_dependant_property(df) {
-		if (
-			!df.reqd &&
-			df.mandatory_depends_on &&
-			this.evaluate_depends_on_value(df.mandatory_depends_on)
-		) {
-			df.reqd = 1;
+		if (df.mandatory_depends_on) {
+			df.reqd = !!this.evaluate_depends_on_value(df.mandatory_depends_on);
 		}
 
-		if (
-			!df.read_only &&
-			df.read_only_depends_on &&
-			this.evaluate_depends_on_value(df.read_only_depends_on)
-		) {
-			df.read_only = 1;
+		if (df.read_only_depends_on) {
+			df.read_only = !!this.evaluate_depends_on_value(df.read_only_depends_on);
 		}
 	}
 
@@ -995,6 +987,13 @@ export default class GridRow {
 				if (frappe.ui.form.editable_row !== me) {
 					var out = me.toggle_editable_row();
 				}
+
+				// Set dependant property for current row
+				Object.keys(me.columns).forEach((column) => {
+					me.set_dependant_property(me.columns[column].df);
+				});
+				me.render_row(true);
+
 				var col = this;
 				let first_input_field = $(col).find('input[type="Text"]:first');
 				let input_in_focus = false;


### PR DESCRIPTION
By default, we have a single docfield for every row here. So the value
of fields like `read_only` isn't true to the current row, but whatever
was last set. This breaks use cases where we have conditional read-only
or mandatory based on another value in the row - whatever was set last 
ends up applying to every row (and basically since we skip the actual
evaluation if its already true - if any one row triggered read_only or
mandatory - all were forced into that)

Now everytime a row is selected, we set the dependent properties and for
that data so that it works as expected.

Resolves #25984, and support ticket 13288
