### PR TITLE
fix: dashboard link number color for timeless night

### DIFF
--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -215,7 +215,7 @@
 			background-color: var(--gray-100);
 			font-size: var(--text-xs);
 			padding: 0 var(--padding-sm);
-			color: var(--indicator-red);
+			color: var(--gray-700);
 			border-radius: var(--border-radius);
 			cursor: pointer;
 		}


### PR DESCRIPTION
**version 15**

fixes: #26057

- there is no `var(--indicator-red)`.

**Before:**

![image](https://github.com/frappe/frappe/assets/141945075/8ce8d8a7-fdc3-4309-804c-29f4ff2a111b)


**After:**

![image](https://github.com/frappe/frappe/assets/141945075/9a925ad5-9103-4f3b-a4ec-e3975d52af1e)

![image](https://github.com/frappe/frappe/assets/141945075/5489e9ee-3fca-40e1-8098-5ffb74fabf7e)

