### PR TITLE
Added missing folder property to upload object (as in method 'upload_file)

### DIFF
--- a/frappe/handler.py
+++ b/frappe/handler.py
@@ -138,6 +138,7 @@ def uploadfile():
 						"attached_to_name": frappe.form_dict.docname,
 						"attached_to_doctype": frappe.form_dict.doctype,
 						"attached_to_field": frappe.form_dict.docfield,
+						"folder": frappe.form_dict.folder or "Home",
 						"file_url": frappe.form_dict.file_url,
 						"file_name": frappe.form_dict.filename,
 						"is_private": frappe.utils.cint(frappe.form_dict.is_private),


### PR DESCRIPTION
Added missing "folder" property to JSON upload object. In API v2 the method 'upload_file' also provides the property. There is no known reason to not include it and the API remains fully backwards compatible.