### PR TITLE
fix: datepicker time row color for timeless night

### DIFF
--- a/frappe/public/scss/common/datepicker.scss
+++ b/frappe/public/scss/common/datepicker.scss
@@ -90,7 +90,7 @@
 	}
 
 	&--time-row {
-		background-image: linear-gradient(to right, var(--gray-900), var(--gray-900));
+		background-image: linear-gradient(to right, var(--gray-600), var(--gray-600));
 		background-repeat: no-repeat;
 		background-size: 100% 1px;
 		background-position: left 50%;


### PR DESCRIPTION
Version 15

fixes: #26056

**Before:**

- time row line color does not show in timeless night. only issus is in the timeless night.

    - _Frappe Light:_

    ![image](https://github.com/frappe/frappe/assets/141945075/87132a91-6a5e-4d00-baf9-1ab355357c48)

    - _Timeless Night:_

    ![image](https://github.com/frappe/frappe/assets/141945075/d5b10c42-f070-4512-ae69-4f3fa3cacf2f)


**After:**
- set the color, and it will work for both themes.

    - _Frappe Light:_

    ![image](https://github.com/frappe/frappe/assets/141945075/157aa6cc-aa7a-4326-af01-d6f70a77437c)

    - _Timeless Night:_

    ![image](https://github.com/frappe/frappe/assets/141945075/03b444fa-e18d-4667-9523-cb4c974a16a3)
