### PR TITLE
fix: allow setting dynamic filters for number cards even without developer mode

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -319,7 +319,7 @@ frappe.ui.form.on("Number Card", {
 	},
 
 	render_dynamic_filters_table(frm) {
-		if (!frappe.boot.developer_mode || frm.doc.type == "Custom") {
+		if (frm.doc.type == "Custom") {
 			return;
 		}
 


### PR DESCRIPTION
This fixes e4b3a3fa02cb81d7d2c05d9c546c8c561fc8d246 - forgot to remove both the conditions
