### PR TITLE
refactor: filters for export on prepared report

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.js
+++ b/frappe/core/doctype/prepared_report/prepared_report.js
@@ -41,14 +41,8 @@ frappe.ui.form.on("Prepared Report", {
 
 		if (frm.doc.status == "Completed") {
 			frm.page.set_primary_action(__("Show Report"), () => {
-				frappe.route_options = filters;
-				frappe.set_route(
-					"query-report",
-					frm.doc.report_name,
-					frappe.utils.make_query_string({
-						prepared_report_name: frm.doc.name,
-					})
-				);
+				frappe.route_options = { prepared_report_name: frm.doc.name };
+				frappe.set_route("query-report", frm.doc.report_name);
 			});
 		}
 	},

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1522,12 +1522,6 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				this.make_access_log("Export", file_format);
 
 				let filters = this.get_filter_values(true);
-				if (frappe.urllib.get_dict("prepared_report_name")) {
-					filters = Object.assign(
-						frappe.urllib.get_dict("prepared_report_name"),
-						filters
-					);
-				}
 				let boolean_labels = { 1: __("Yes"), 0: __("No") };
 				let applied_filters = Object.fromEntries(
 					Object.entries(filters).map(([key, value]) => [
@@ -1537,6 +1531,13 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 							: value,
 					])
 				);
+				let query_params = this.get_query_params();
+				if ("prepared_report_name" in query_params) {
+					filters = Object.assign(
+						{ prepared_report_name: query_params["prepared_report_name"] },
+						filters
+					);
+				}
 
 				const visible_idx = this.datatable?.bodyRenderer.visibleRowIndices || [];
 				if (visible_idx.length + 1 === this.data?.length) {


### PR DESCRIPTION
This is the url generated by frappe.router.set_route on, prepared report > "Show Report"

![image](https://github.com/frappe/frappe/assets/50401596/756155a6-5763-4ab9-b151-2a80b2cfb0e5)

frappe.urllib.get_dict("prepared_report_name") fails to parse this and prepared_report_name is left empty leaving the export data process in below state

![HbVHLlY](https://github.com/frappe/frappe/assets/50401596/c73ba6aa-87d5-4f5d-b2c8-0171451339d9)


ref: https://support.frappe.io/helpdesk/tickets/11816

> no-docs