### PR TITLE
fix: PhotoSwipe template

### DIFF
--- a/frappe/public/js/frappe/views/image/photoswipe_dom.html
+++ b/frappe/public/js/frappe/views/image/photoswipe_dom.html
@@ -13,7 +13,7 @@
 
 		<!-- Container that holds slides.
 			PhotoSwipe keeps only 3 of them in the DOM to save memory.
-			Don't modify these 3 pswp__item elements, data is added later on. -->
+			Do not modify these 3 pswp__item elements, data is added later on. -->
 		<div class="pswp__container">
 			<div class="pswp__item"></div>
 			<div class="pswp__item"></div>


### PR DESCRIPTION
https://github.com/frappe/frappe/blob/b0cc93e9d718f76e8ff489b638e4b09a09bb017d/frappe/public/js/frappe/microtemplate.js#L88

with the `photoswipe_dom.html` template leads to

```
Uncaught (in promise) TypeError: frappe.template.compile(...) is not a function
    at frappe.render (microtemplate.js:103:42)
    at frappe.render_template (microtemplate.js:118:16)
    at GalleryView.prepare (image_view.js:210:22)
    at image_view.js:202:7
```

because of the _'_ in _Don't_.