### PR TITLE
fix: handle case where mimetype is None

### DIFF
--- a/frappe/utils/pdf.py
+++ b/frappe/utils/pdf.py
@@ -276,7 +276,7 @@ def _get_base64_image(src):
 		path = parsed_url.path
 		query = parse_qs(parsed_url.query)
 		mime_type = mimetypes.guess_type(path)[0]
-		if not mime_type.startswith("image/"):
+		if mime_type is None or not mime_type.startswith("image/"):
 			return
 		filename = query.get("fid") and query["fid"][0] or None
 		file = find_file_by_url(path, name=filename)


### PR DESCRIPTION
Resolves this error message observed in v14 logs:

```
2024-03-25 08:40:28,122 ERROR pdf Failed to convert inline images to base64
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/pdf.py", line 201, in _get_base64_image
    if not mime_type.startswith("image/"):
AttributeError: 'NoneType' object has no attribute 'startswith'
```