### PR TITLE
fix: handle null in CSV preview

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -284,6 +284,10 @@ frappe.report_utils = {
 			.map((row) => {
 				return row
 					.map((col) => {
+						if (col === null) {
+							return "";
+						}
+
 						if (typeof col == "string" && col.includes('"')) {
 							col = col.replace(/"/g, '""');
 						}


### PR DESCRIPTION
Removes these `null`s from the preview:

![Bildschirmfoto 2024-04-24 um 12 11 19](https://github.com/frappe/frappe/assets/14891507/eecccfff-ba91-46be-a606-fdd0420707e1)
