### PR TITLE
fix(backup): delete failed backup even if something fails during the backup process

### DIFF
--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -188,14 +188,12 @@ class BackupGenerator:
 			self.set_backup_file_name()
 
 		if not (last_db and last_file and last_private_file and site_config_backup_path):
-			self.take_dump()
-			self.add_to_rollback(lambda: os.remove(self.backup_path_db))
-			self.copy_site_config()
-			self.add_to_rollback(lambda: os.remove(self.backup_path_conf))
+			self.delete_if_step_fails(self.take_dump, self.backup_path_db)
+			self.delete_if_step_fails(self.copy_site_config, self.backup_path_conf)
 			if not ignore_files:
-				self.backup_files()
-				self.add_to_rollback(lambda: os.remove(self.backup_path_files))
-				self.add_to_rollback(lambda: os.remove(self.backup_path_private_files))
+				self.delete_if_step_fails(
+					self.backup_files, self.backup_path_files, self.backup_path_private_files
+				)
 
 			if frappe.get_system_settings("encrypt_backup"):
 				self.backup_encryption()
@@ -491,6 +489,24 @@ download only after 24 hours."""
 		"""
 		if self.rollback_callback:
 			self.rollback_callback.add(func)
+
+	def delete_if_step_fails(self, step: Callable, *paths: str):
+		"""
+		Deletes the given path if the given step fails
+
+		:param step: The step to execute
+		:param paths: The paths to delete
+		:return: Nothing
+		"""
+		try:
+			step()
+		except Exception as e:
+			for path in paths:
+				if os.path.exists(path):
+					os.remove(path)
+			raise e
+		for path in paths:
+			self.add_to_rollback(lambda: os.remove(path))
 
 
 def _get_tables(doctypes: list[str], existing_tables: list[str]) -> list[str]:


### PR DESCRIPTION
Currently if `tar` exits with non-zero code while compressing the site
files (`tar: file changed as we read it`), the backup fails, and the DB
and site config backup are deleted. But the files archive still remains,
causing the disk to get full eventually.

This change ensures that the files will get deleted even if the current
step fails.

Support ticket 13890
