### PR TITLE
refactor!: override_doctype -> Must extend base class

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -87,16 +87,24 @@ def import_controller(doctype):
 
 	module_path = None
 	class_overrides = frappe.get_hooks("override_doctype_class")
+
+	module = load_doctype_module(doctype, module_name)
+	classname = doctype.replace(" ", "").replace("-", "")
+	class_ = getattr(module, classname, None)
+
 	if class_overrides and class_overrides.get(doctype):
 		import_path = class_overrides[doctype][-1]
-		module_path, classname = import_path.rsplit(".", 1)
-		module = frappe.get_module(module_path)
+		module_path, custom_classname = import_path.rsplit(".", 1)
+		custom_module = frappe.get_module(module_path)
+		custom_class_ = getattr(custom_module, custom_classname, None)
+		if not issubclass(custom_class_, class_):
+			original_class_path = frappe.bold(f"{class_.__module__}.{class_.__name__}")
+			frappe.throw(
+				f"{doctype}: {frappe.bold(import_path)} must be a subclass of {original_class_path}",
+				title=_("Invalid Override"),
+			)
+		class_ = custom_class_
 
-	else:
-		module = load_doctype_module(doctype, module_name)
-		classname = doctype.replace(" ", "").replace("-", "")
-
-	class_ = getattr(module, classname, None)
 	if class_ is None:
 		raise ImportError(
 			doctype

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1779,13 +1779,7 @@ def get_url(uri: str | None = None, full_address: bool = False) -> str:
 
 	port = frappe.conf.http_port or frappe.conf.webserver_port
 
-	if (
-		not frappe.conf.restart_supervisor_on_update
-		and not frappe.conf.restart_systemd_on_update
-		and host_name
-		and not url_contains_port(host_name)
-		and port
-	):
+	if host_name and not url_contains_port(host_name) and port:
 		host_name = host_name + ":" + str(port)
 
 	return urljoin(host_name, uri) if uri else host_name


### PR DESCRIPTION
There is almost never a real need to completely override a class. After
this change we'll only allow extending and not overriding completely.


This feature is abused to create some extremely stupid overrides. 

![image](https://github.com/frappe/frappe/assets/9079960/6eee4e02-4727-447d-84b9-8535d0d7d0b6)
