### PR TITLE
fix: hash collision retry logic

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -569,8 +569,8 @@ class BaseDocument:
 			if frappe.db.is_primary_key_violation(e):
 				if self.meta.autoname == "hash":
 					# hash collision? try again
-					frappe.flags.retry_count = (frappe.flags.retry_count or 0) + 1
-					if frappe.flags.retry_count > 5 and not frappe.flags.in_test:
+					self.flags.retry_count = (self.flags.retry_count or 0) + 1
+					if self.flags.retry_count > 5:
 						raise
 					self.name = None
 					self.db_insert()

--- a/frappe/tests/test_naming.py
+++ b/frappe/tests/test_naming.py
@@ -20,6 +20,8 @@ from frappe.model.naming import (
 	parse_naming_series,
 	revert_series_if_last,
 )
+from frappe.query_builder.utils import db_type_is
+from frappe.tests.test_query_builder import run_only_if
 from frappe.tests.utils import FrappeTestCase, patch_hooks
 from frappe.utils import now_datetime, nowdate, nowtime
 
@@ -378,6 +380,15 @@ class TestNaming(FrappeTestCase):
 
 		name = parse_naming_series(series, doc=webhook)
 		self.assertTrue(name.startswith("KOOH---"), f"incorrect name generated {name}")
+
+	@run_only_if(db_type_is.MARIADB)
+	def test_hash_collision(self):
+		doctype = new_doctype(autoname="hash").insert().name
+		name = frappe.generate_hash()
+		for _ in range(10):
+			frappe.flags.in_import = True
+			frappe.new_doc(doctype).update({"name": name}).insert()
+		frappe.flags.pop("in_import", None)
 
 	def test_custom_parser(self):
 		# check naming with custom parser


### PR DESCRIPTION
Retry counter is global so if there are 5 hash collisions while doing many many inserts this code doesn't work as expected.

Fix: keep counter local to document.