### PR TITLE
feat(CSV export): allow custom decimal separator

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1519,6 +1519,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 				include_filters,
 				csv_delimiter,
 				csv_quoting,
+				csv_decimal_sep,
 			}) => {
 				this.make_access_log("Export", file_format);
 
@@ -1551,6 +1552,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 					visible_idx,
 					csv_delimiter,
 					csv_quoting,
+					csv_decimal_sep,
 					include_indentation,
 					include_filters,
 				};

--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -1584,6 +1584,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 							if (data.file_format == "CSV") {
 								args.csv_delimiter = data.csv_delimiter;
 								args.csv_quoting = data.csv_quoting;
+								args.csv_decimal_sep = data.csv_decimal_sep;
 							}
 
 							if (this.add_totals_row) {


### PR DESCRIPTION
In Europe, some software expects the comma character as decimal separator, in line with the prevailing number format.

![Bildschirmfoto 2024-04-25 um 12 28 35](https://github.com/frappe/frappe/assets/14891507/b2153a35-dd08-47e3-bab8-c3e31476bb00)

> no-docs