### PR TITLE
fix(report_utils): ensure that delimiter and separator can't be empty

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_utils.js
+++ b/frappe/public/js/frappe/views/reports/report_utils.js
@@ -264,8 +264,18 @@ frappe.report_utils = {
 
 		dialog.fields_dict["file_format"].df.onchange = () => update_csv_preview(dialog);
 		dialog.fields_dict["csv_quoting"].df.onchange = () => update_csv_preview(dialog);
-		dialog.fields_dict["csv_delimiter"].df.onchange = () => update_csv_preview(dialog);
-		dialog.fields_dict["csv_decimal_sep"].df.onchange = () => update_csv_preview(dialog);
+		dialog.fields_dict["csv_delimiter"].df.onchange = () => {
+			if (!dialog.get_value("csv_delimiter")) {
+				dialog.set_value("csv_delimiter", ",");
+			}
+			update_csv_preview(dialog);
+		};
+		dialog.fields_dict["csv_decimal_sep"].df.onchange = () => {
+			if (!dialog.get_value("csv_decimal_sep")) {
+				dialog.set_value("csv_decimal_sep", ".");
+			}
+			update_csv_preview(dialog);
+		};
 
 		return dialog;
 	},


### PR DESCRIPTION
This results in them setting as `undefined`, which ends up as a string
in python, and the delimiter ends up as `'u'`, and the separator as
`'undefined'`.
