### PR TITLE
feat: workspace extraction improvements

### DIFF
--- a/frappe/gettext/extractors/workspace.py
+++ b/frappe/gettext/extractors/workspace.py
@@ -44,3 +44,12 @@ def extract(fileobj, *args, **kwargs):
 		)
 		for shortcut in data.get("shortcuts", [])
 	)
+	yield from (
+		(
+			None,
+			"pgettext",
+			(shortcut.get("link_to") if shortcut.get("type") == "DocType" else None, shortcut.get("format")),
+			[f"Count format of shortcut in the {workspace_name} Workspace"],
+		)
+		for shortcut in data.get("shortcuts", [])
+	)

--- a/frappe/gettext/extractors/workspace.py
+++ b/frappe/gettext/extractors/workspace.py
@@ -39,6 +39,15 @@ def extract(fileobj, *args, **kwargs):
 		(
 			None,
 			"pgettext",
+			(link.get("link_to") if link.get("link_type") == "DocType" else None, link.get("description")),
+			[f"Description of a {link.get('type')} in the {workspace_name} Workspace"],
+		)
+		for link in data.get("links", [])
+	)
+	yield from (
+		(
+			None,
+			"pgettext",
 			(shortcut.get("link_to") if shortcut.get("type") == "DocType" else None, shortcut.get("label")),
 			[f"Label of a shortcut in the {workspace_name} Workspace"],
 		)


### PR DESCRIPTION
This pr allows translation of the Workspace Shortcut format string.
- 3 strings in Frappe
- 18 strings in ErpNext
And add extraction of description of link
- 14 strings in Frappe