### PR TITLE
fix: multistep webform page navigation

### DIFF
--- a/frappe/public/js/frappe/web_form/web_form.js
+++ b/frappe/public/js/frappe/web_form/web_form.js
@@ -195,7 +195,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	validate_section() {
 		if (this.allow_incomplete) return true;
 
-		let fields = $(`.form-page:eq(${this.current_section}) .form-control`);
+		let fields = $(`${this.get_page(this.current_section)} .form-control`);
 		let errors = [];
 		let invalid_values = [];
 
@@ -205,7 +205,7 @@ export default class WebForm extends frappe.ui.FieldGroup {
 
 			field = this.fields_dict[fieldname];
 
-			if (field.get_value) {
+			if (field && field.get_value) {
 				let value = field.get_value();
 				if (
 					field.df.reqd &&
@@ -306,8 +306,8 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	is_next_section_empty(section) {
 		if (section + 1 > this.page_breaks.length + 1) return true;
 
-		let _section = $(`.form-page:eq(${section + 1})`);
-		let visible_controls = _section.find(".frappe-control:not(.hide-control)");
+		let _page = $(`${this.get_page(section + 1)}`);
+		let visible_controls = _page.find(".frappe-control:not(.hide-control)");
 
 		return !visible_controls.length ? true : false;
 	}
@@ -315,8 +315,8 @@ export default class WebForm extends frappe.ui.FieldGroup {
 	is_previous_section_empty(section) {
 		if (section - 1 > this.page_breaks.length + 1) return true;
 
-		let _section = $(`.form-page:eq(${section - 1})`);
-		let visible_controls = _section.find(".frappe-control:not(.hide-control)");
+		let _page = $(`${this.get_page(section - 1)}`);
+		let visible_controls = _page.find(".frappe-control:not(.hide-control)");
 
 		return !visible_controls.length ? true : false;
 	}
@@ -335,14 +335,18 @@ export default class WebForm extends frappe.ui.FieldGroup {
 		this.current_section == 0 ? $(".btn-previous").hide() : $(".btn-previous").show();
 	}
 
+	get_page(idx) {
+		return idx > 0 ? `.page-break:eq(${idx - 1})` : `.form-page:eq(${idx})`;
+	}
+
 	show_form_page() {
-		$(`.form-page:eq(${this.current_section})`).show();
+		$(this.get_page(this.current_section)).show();
 	}
 
 	hide_form_pages() {
 		for (let idx = 0; idx <= this.page_breaks.length; idx++) {
 			if (idx !== this.current_section) {
-				$(`.form-page:eq(${idx})`).hide();
+				$(this.get_page(idx)).hide();
 			}
 		}
 	}


### PR DESCRIPTION
Steps to reproduce: 
1. Create a multistep webform with a child table in one of the steps
2. Edit using the child table edit button option. Try adding a few fields
![Screenshot from 2024-04-26 15-18-25](https://github.com/frappe/frappe/assets/50401596/9e477f6c-e146-441e-8e2e-8c633637c291)
3. Hit next. The form will be submitted without going to the next page/step.
![image](https://github.com/frappe/frappe/assets/50401596/87042313-8656-42e3-9f64-16bd19654b85)


---

Problem: 
Consider a webform with 3 pages. The pages will have the following classes,

p1: form-page
p2: form-page page-break
p3: form-page page-break

`form-page` is used for selecting pages for navigation.

If any one of these pages have a child table entry the view will be broken because the child-table-edit dialog uses the same layout component as webform and hence when it's rendered the components with form-page as class are duplicated multiple times. So on hitting the edit button for child table the pages would look something like this,

p1: form-page
&nbsp;&nbsp;&nbsp;&nbsp;form-page (child table)
&nbsp;&nbsp;&nbsp;&nbsp;form-page (child table)
&nbsp;&nbsp;&nbsp;&nbsp;...
p2: form-page page-break
p3: form-page page-break

Fix: Using `page-break` classname(since page-break is unique for webform pages) for navigation between pages (the first page is still form-page, since there is no page-break before that)



> no-docs