### PR TITLE
fix: compute modal title server side

### DIFF
--- a/frappe/templates/includes/contact.js
+++ b/frappe/templates/includes/contact.js
@@ -33,7 +33,7 @@ frappe.ready(function() {
 			},
 			callback: function(r) {
 				if (!r.exc) {
-					frappe.msgprint('{{ _("Thank you for your message") }}');
+					frappe.msgprint('{{ _("Thank you for your message") }}', '{{ _("Message Sent") }}');
 				}
 				$(':input').val('');
 			},


### PR DESCRIPTION
The contact form shows a modal telling the user that the message was sent successfully.

The success message was computed on the server side, while the title was computed on the client side. This led to inconsistent translations.

This PR fixes this by computing the title on the server side as well.