### PR TITLE
fix: lstrip for query writes detection

### DIFF
--- a/frappe/database/database.py
+++ b/frappe/database/database.py
@@ -430,7 +430,7 @@ class Database:
 		if query and is_query_type(query, ("commit", "rollback")):
 			self.transaction_writes = 0
 
-		if query[:6].lower() in ("update", "insert", "delete"):
+		if query.lstrip()[:6].lower() in ("update", "insert", "delete"):
 			self.transaction_writes += 1
 			if self.transaction_writes > self.MAX_WRITES_PER_TRANSACTION:
 				if self.auto_commit_on_many_writes:


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:


There was a problem with the write detection for `frappe.db.sql`
This PR should be backported to v14 and v15
<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?


This PR comes to solve a problem where a write operation is not detected because of the way it is formatted. A common way to formate a query is the following:
```
UPDATE_QUERY = """
    UPDATE `tabMyDoctype`
    SET my_field = "My Value"
    WHERE name = %(name)s
"""
```
And this method of detecting writes was not working (and leaded us to a 2hs debug session of why the endpoint was not doing a commit in the `after_request` method)
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
