### PR TITLE
fix: restoring site breaks when checking backup version

### DIFF
--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -808,6 +808,7 @@ def get_old_backup_version(sql_file_path: str) -> Version | None:
 	header = get_db_dump_header(sql_file_path).split("\n")
 	if match := re.search(r"Frappe (\d+\.\d+\.\d+)", header[0]):
 		return Version(match[1])
+	return None
 
 
 def get_backup_version(sql_file_path: str) -> Version | None:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -809,7 +809,7 @@ def get_old_backup_version(sql_file_path: str) -> Version | None:
 	if match := re.search(r"Frappe (\d+\.\d+\.\d+)", header[0]):
 		backup_version = match[1]
 
-	return Version(backup_version) if backup_version else None
+	return Version(backup_version) if match else None
 
 
 def get_backup_version(sql_file_path: str) -> Version | None:

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -809,8 +809,6 @@ def get_old_backup_version(sql_file_path: str) -> Version | None:
 	if match := re.search(r"Frappe (\d+\.\d+\.\d+)", header[0]):
 		return Version(match[1])
 
-	return Version(backup_version) if match else None
-
 
 def get_backup_version(sql_file_path: str) -> Version | None:
 	"""Return the frappe version used to create the specified database dump."""

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -807,7 +807,7 @@ def get_old_backup_version(sql_file_path: str) -> Version | None:
 	"""
 	header = get_db_dump_header(sql_file_path).split("\n")
 	if match := re.search(r"Frappe (\d+\.\d+\.\d+)", header[0]):
-		backup_version = match[1]
+		return Version(match[1])
 
 	return Version(backup_version) if match else None
 


### PR DESCRIPTION
When restoring a site from a backup SQL file, the restore fails due to an error when checking the version of the backup file. The `backup_version` variable exists if and only if the `if match` branch executes, but it is used in a condition in a scope where it may not exist. Changing the variable to `match` leads to correct behaviour.