### PR TITLE
fix: rename fields for html, col, section, etc.

### DIFF
--- a/frappe/custom/doctype/custom_field/custom_field.py
+++ b/frappe/custom/doctype/custom_field/custom_field.py
@@ -258,7 +258,8 @@ def rename_fieldname(custom_field: str, fieldname: str):
 		frappe.msgprint(_("Old and new fieldnames are same."), alert=True)
 		return
 
-	frappe.db.rename_column(parent_doctype, old_fieldname, new_fieldname)
+	if frappe.db.has_column(field.dt, old_fieldname):
+		frappe.db.rename_column(parent_doctype, old_fieldname, new_fieldname)
 
 	# Update in DB after alter column is successful, alter column will implicitly commit, so it's
 	# best to commit change on field too to avoid any possible mismatch between two.


### PR DESCRIPTION
version 14

fixes: https://discuss.frappe.io/t/unable-to-rename-field/122008

**Before:**


https://github.com/frappe/frappe/assets/141945075/5a68ec9d-f8e9-498c-892f-da7147f86460

**After:**


https://github.com/frappe/frappe/assets/141945075/082a9939-a035-4bcd-8fee-cba4e46d55b2

