### PR TITLE
Implement Custom Response Types in Whitelisted Functions

### DIFF
--- a/frappe/utils/response.py
+++ b/frappe/utils/response.py
@@ -84,6 +84,7 @@ def build_response(response_type=None):
 		"page": as_page,
 		"redirect": redirect,
 		"binary": as_binary,
+		"custom": as_custom,
 	}
 
 	return response_type_map[frappe.response.get("type") or response_type]()
@@ -155,6 +156,27 @@ def as_binary():
 	filename = filename.encode("utf-8").decode("unicode-escape", "ignore")
 	response.headers.add("Content-Disposition", None, filename=filename)
 	response.data = frappe.response["filecontent"]
+	return response
+
+
+def as_custom():
+	response = Response()
+	if status_code := frappe.local.response.get("http_status_code"):
+		response.status_code = status_code
+	if headers := frappe.response.get("headers"):
+		for key, value in headers:
+			response.headers.add(key, value)
+	if mimetype := frappe.response.get("content_type"):
+		response.mimetype = mimetype
+	if filename := frappe.response.get("filename"):
+		filename = filename.encode("utf-8").decode("unicode-escape", "ignore")
+		response.headers.add(
+			"Content-Disposition",
+			frappe.response.get("display_content_as", "attachment"),
+			filename=filename,
+		)
+	if filecontent := frappe.response.get("filecontent"):
+		response.data = filecontent
 	return response
 
 


### PR DESCRIPTION
This pull request introduces the ability to handle custom response types in whitelisted functions within the Frappe framework. This feature allows developers to specify detailed response configurations directly from their server-side functions, enabling richer and more versatile API responses.

### Motivation:
Previously, Frappe's whitelisted functions were limited to returning JSON data or files. There was no straightforward way to modify the HTTP headers, status code, or content type of the response from within the function. This limitation made it challenging to meet certain API specifications or to integrate smoothly with external systems that expect specific response formats and protocols.

### Feature Details:
With this update, developers can now define custom responses by setting properties on frappe.local.response. This includes the HTTP status code, content type, headers, and even the file content. This is particularly useful for APIs that need to serve different types of content, such as XML, CSV, plain text, or customized binary formats.

### Example Usage:
Below is an example of how a developer might use this new feature to return a markdown content response from a whitelisted function:

```python
@frappe.whitelist()
def example():
    frappe.local.response.type = "custom"
    frappe.local.response.http_status_code = 200
    frappe.local.response.content_type = "text/markdown"
    frappe.local.response.filecontent = "# Hello World"
    frappe.local.response.headers = {
        "my-custom-header": "123"
    }
    # frappe.local.response.filename = "example.md"
    # frappe.local.response.display_content_as = "attachment"
```

### Request for Comments:
Feedback on this implementation and its potential implications for existing setups would be greatly appreciated to ensure that the feature meets the diverse needs of the Frappe community.