### PR TITLE
fix: don't extract icon names

### DIFF
--- a/frappe/gettext/extractors/doctype.py
+++ b/frappe/gettext/extractors/doctype.py
@@ -3,9 +3,6 @@ import json
 EXCLUDE_SELECT_OPTIONS = [
 	"naming_series",
 	"number_format",
-	"float_precision",
-	"currency_precision",
-	"minimum_password_score",
 ]
 
 

--- a/frappe/gettext/extractors/doctype.py
+++ b/frappe/gettext/extractors/doctype.py
@@ -3,6 +3,7 @@ import json
 EXCLUDE_SELECT_OPTIONS = [
 	"naming_series",
 	"number_format",
+	"icon",  # primarily for the Workflow State doctype
 ]
 
 
@@ -51,9 +52,6 @@ def extract(fileobj, *args, **kwargs):
 					continue
 
 				select_options = [option for option in message.split("\n") if option and not option.isdigit()]
-
-				if select_options and "icon" in select_options[0]:
-					continue
 
 				messages.extend(
 					(


### PR DESCRIPTION
- Remove redundant excluded fields
    These are already caught by the `option.isdigit()` check.
- Don't extract icon names (**Workflow State** doctype)

Tested the impact on Frappe, ERPNext and HRMS -> the results are as expected.
