### PR TITLE
fix: Treeview DB lookup should perform the same preperation operation…

### DIFF
--- a/frappe/desk/treeview.py
+++ b/frappe/desk/treeview.py
@@ -42,7 +42,7 @@ def get_children(doctype, parent="", **filters):
 
 
 def _get_children(doctype, parent="", ignore_permissions=False):
-	parent_field = "parent_" + doctype.lower().replace(" ", "_")
+	parent_field = "parent_" + frappe.scrub(doctype)
 	filters = [[f"ifnull(`{parent_field}`,'')", "=", parent], ["docstatus", "<", 2]]
 
 	meta = frappe.get_meta(doctype)
@@ -72,7 +72,7 @@ def make_tree_args(**kwarg):
 	kwarg.pop("cmd", None)
 
 	doctype = kwarg["doctype"]
-	parent_field = "parent_" + doctype.lower().replace(" ", "_")
+	parent_field = "parent_" + frappe.scrub(doctype)
 
 	if kwarg["is_root"] == "false":
 		kwarg["is_root"] = False

--- a/frappe/public/js/frappe/views/treeview.js
+++ b/frappe/public/js/frappe/views/treeview.js
@@ -334,7 +334,8 @@ frappe.views.TreeView = class TreeView {
 		});
 
 		var args = $.extend({}, me.args);
-		args["parent_" + me.doctype.toLowerCase().replace(/ /g, "_")] = me.args["parent"];
+		args["parent_" + me.doctype.toLowerCase().replace(/ /g, "_").replace(/-/g, "_")] =
+			me.args["parent"];
 
 		d.set_value("is_group", 0);
 		d.set_values(args);


### PR DESCRIPTION
…as method update_nsm in file nestedset.py

**Symptoms:**
DB error when using tree view for custom doctypes, which names contain hyphens, underscores or spaces. 

**Reason:**
Method "update_nsm" in file frappe/utils/nestedset.py builds SQL DB fields according to certain logic, see https://github.com/frappe/frappe/blob/71dfffa7ec009ee9f3e51702f09db05cb58217f5/frappe/utils/nestedset.py#L44 
For frappe.scrub see: https://github.com/frappe/frappe/blob/71dfffa7ec009ee9f3e51702f09db05cb58217f5/frappe/__init__.py#L1515-L1517

However, method "_get_children" in frappe/desk/treeview.py uses another methodology to lookup the data in the database, see https://github.com/frappe/frappe/blob/71dfffa7ec009ee9f3e51702f09db05cb58217f5/frappe/desk/treeview.py#L46

**Example for different conversion:**
Doctype name: "AAA-BBB-CCC"
method "update_nsm":  "AAA-BBB-CCC" --> "parent_aaa_bbb_ccc"
method "_get_children":  "AAA-BBB-CCC" --> "parent_aaa-bbb-ccc"

**Resolution:** 
Updated method "_get_children" in frappe/desk/treeview.py to use same methodology of frappes "on-board resources".


Also created fix for ERPNext: See https://github.com/frappe/erpnext/pull/41234
