### PR TITLE
fix(importer): added `%Y.%m.%d.` + tests for guess_date_format

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2316,6 +2316,7 @@ def guess_date_format(date_string: str) -> str:
 		r"%y.%m.%d",
 		r"%d %b %Y",
 		r"%d %B %Y",
+		r"%Y.%m.%d.",
 	]
 
 	TIME_FORMATS = [


### PR DESCRIPTION
### Description:
This pull request introduces a minor update to the `DATE_FORMATS` array in the `frappe/utils/data.py` by adding a new date format `"%Y.%m.%d."` to cater to the specific needs observed in Hungarian date formatting, where dates end with a period (e.g., `2024.04.04.`). 

Additionally, I have expanded the unit testing for the `guess_date_format`. This is reflected in changes to the `frappe/tests/test_utils.py`.

**Key Changes:**
- **Date Format Addition:** Included a new date format `"%Y.%m.%d."` in the `DATE_FORMATS` array to support the Hungarian date format.
- **Unit Tests:** Added test case in `TestDateUtils` class to verify the guessing logic handles a broad set of date and time formats correctly.

**Caveats & Future Directions:**
- The current implementation of `guess_date_format` might still encounter ambiguities with certain date formats (e.g., `23-04-24` can be parsed in multiple ways). A proposed future enhancement is to allow users to specify the date format explicitly during data import, thus minimizing errors and improving data integrity.

**How to test:**
Ensure you have set up your development environment correctly and follow these steps:
1. Checkout this branch.
2. Run the updated unit tests using `bench --site [your-site-name] run-tests --module frappe.tests.test_utils.TestDateUtils`.
3. Review the test output and verify that all new tests pass without errors.

Orginal pull req: #25940
Your feedback is welcomed!