### PR TITLE
fix(ar): render fullcalendar in english

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -250,8 +250,13 @@ frappe.views.Calendar = class Calendar {
 	setup_options(defaults) {
 		var me = this;
 		defaults.meridiem = "false";
+		let lang = frappe.boot.lang;
+		if (lang == "ar") {
+			// arabic doesn't work with fullcalendar - doesn't show anything.
+			lang = "en";
+		}
 		this.cal_options = {
-			locale: frappe.boot.lang,
+			locale: lang,
 			header: {
 				left: "prev, title, next",
 				right: "today, month, agendaWeek, agendaDay",


### PR DESCRIPTION
It doesn't work in arabic - doesn't show anything.

Looks like upstream bug, best we can try for now is to render it in
English instead.
