### PR TITLE
fix: Evaluate assets in sequence

### DIFF
--- a/frappe/public/js/frappe/assets.js
+++ b/frappe/public/js/frappe/assets.js
@@ -91,6 +91,7 @@ class AssetManager {
 		const version_string =
 			frappe.boot.developer_mode || window.dev_server ? Date.now() : window._version_number;
 
+		let fetched_assets = {};
 		async function fetch_item(path) {
 			// Add the version to the URL to bust the cache for non-bundled assets
 			let url = new URL(path, window.location.origin);
@@ -99,13 +100,16 @@ class AssetManager {
 				url.searchParams.append("v", version_string);
 			}
 			const response = await fetch(url.toString());
-			const body = await response.text();
-			me.eval_assets(path, body);
+			fetched_assets[path] = await response.text();
 		}
 
 		frappe.dom.freeze();
 		const fetch_promises = items.map(fetch_item);
 		Promise.all(fetch_promises).then(() => {
+			items.forEach((path) => {
+				let body = fetched_assets[path];
+				me.eval_assets(path, body);
+			});
 			frappe.dom.unfreeze();
 			callback?.();
 		});


### PR DESCRIPTION
Fetching can be done in parallel and out of order but execution should
depend on order specified in args otherwise it breaks things like
calendar which has 2 JS file and 2nd one depends on first one.
