### PR TITLE
fix: calendar in Arabic

### DIFF
--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -245,7 +245,7 @@ frappe.views.Calendar = class Calendar {
 
 	get_system_datetime(date) {
 		date._offset = moment(date).tz(frappe.sys_defaults.time_zone)._offset;
-		return frappe.datetime.convert_to_system_tz(date);
+		return frappe.datetime.convert_to_system_tz(moment(date).locale("en"));
 	}
 	setup_options(defaults) {
 		var me = this;

--- a/frappe/public/js/frappe/views/calendar/calendar.js
+++ b/frappe/public/js/frappe/views/calendar/calendar.js
@@ -250,13 +250,8 @@ frappe.views.Calendar = class Calendar {
 	setup_options(defaults) {
 		var me = this;
 		defaults.meridiem = "false";
-		let lang = frappe.boot.lang;
-		if (lang == "ar") {
-			// arabic doesn't work with fullcalendar - doesn't show anything.
-			lang = "en";
-		}
 		this.cal_options = {
-			locale: lang,
+			locale: frappe.boot.lang,
 			header: {
 				left: "prev, title, next",
 				right: "today, month, agendaWeek, agendaDay",


### PR DESCRIPTION
- Revert "fix(ar): render fullcalendar in english (#26207)"
- fix(calendar): always use english dates for API calls
