### PR TITLE
fix: init db conn for unbuffered cursor if not set

### DIFF
--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -532,7 +532,7 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		from pymysql.cursors import SSCursor
 
 		try:
-			if not self._cursor:
+			if not self._conn:
 				self.connect()
 
 			original_cursor = self._cursor

--- a/frappe/database/mariadb/database.py
+++ b/frappe/database/mariadb/database.py
@@ -532,6 +532,9 @@ class MariaDBDatabase(MariaDBConnectionUtil, MariaDBExceptionUtil, Database):
 		from pymysql.cursors import SSCursor
 
 		try:
+			if not self._cursor:
+				self.connect()
+
 			original_cursor = self._cursor
 			new_cursor = self._cursor = self._conn.cursor(SSCursor)
 			yield


### PR DESCRIPTION
self/db._cursor is only initialized on first sql query,
https://github.com/frappe/frappe/blob/2415936fa268608fd5f20df8979d481860b2b29e/frappe/database/database.py#L213

Because of this using unbuffered cursor without any previous db queries in same context won't work
```
File "apps/erpnext/erpnext/stock/report/stock_ageing/stock_ageing.py", line 232, in generate
with frappe.db.unbuffered_cursor():
self = <erpnext.stock.report.stock_ageing.stock_ageing.FIFOSlots object at 0x7f6c74fb4070>
stock_ledger_entries = None
File "/usr/lib/python3.10/contextlib.py", line 135, in __enter__
return next(self.gen)
self = <contextlib._GeneratorContextManager object at 0x7f6c74fb4970>
File "apps/frappe/frappe/database/mariadb/database.py", line 459, in unbuffered_cursor
self._cursor = original_cursor
self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f6c75cd7d00>
SSCursor = <class 'pymysql.cursors.SSCursor'>
builtins.UnboundLocalError: local variable 'original_cursor' referenced before assignment
```
> no-docs