### PR TITLE
fix(report builder): responsive footer

### DIFF
--- a/frappe/public/js/frappe/views/reports/report_view.js
+++ b/frappe/public/js/frappe/views/reports/report_view.js
@@ -98,7 +98,7 @@ frappe.views.ReportView = class ReportView extends frappe.views.ListView {
 		);
 		this.$paging_area
 			.find(".level-left")
-			.append(`<span class="comparison-message text-muted">${message}</span>`);
+			.after(`<span class="comparison-message text-muted">${message}</span>`);
 	}
 
 	setup_sort_selector() {


### PR DESCRIPTION
### Before

![Bildschirmfoto 2024-04-29 um 18 01 52](https://github.com/frappe/frappe/assets/14891507/a1016a40-8e83-45b5-9f7b-3b979199eb34)

### After

![Bildschirmfoto 2024-04-29 um 18 01 36](https://github.com/frappe/frappe/assets/14891507/bf23b548-07bb-4d5d-9e29-8b21db455a2a)
