### PR TITLE
fix(Data Import): don't rely on permission for Data Import Log

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -404,15 +404,9 @@ frappe.ui.form.on("Data Import", {
 
 	render_import_log(frm) {
 		frappe.call({
-			method: "frappe.client.get_list",
+			method: "frappe.core.doctype.data_import.data_import.get_import_logs",
 			args: {
-				doctype: "Data Import Log",
-				filters: {
-					data_import: frm.doc.name,
-				},
-				fields: ["success", "docname", "messages", "exception", "row_indexes"],
-				limit_page_length: 5000,
-				order_by: "log_index",
+				data_import: frm.doc.name,
 			},
 			callback: function (r) {
 				let logs = r.message;

--- a/frappe/core/doctype/data_import/data_import.py
+++ b/frappe/core/doctype/data_import/data_import.py
@@ -218,6 +218,20 @@ def get_import_status(data_import_name):
 	return import_status
 
 
+@frappe.whitelist()
+def get_import_logs(data_import: str):
+	doc = frappe.get_doc("Data Import", data_import)
+	doc.check_permission("read")
+
+	return frappe.get_all(
+		"Data Import Log",
+		fields=["success", "docname", "messages", "exception", "row_indexes"],
+		filters={"data_import": data_import},
+		limit_page_length=5000,
+		order_by="log_index",
+	)
+
+
 def import_file(doctype, file_path, import_type, submit_after_import=False, console=False):
 	"""
 	Import documents in from CSV or XLSX using data import.

--- a/frappe/core/doctype/data_import_log/data_import_log.json
+++ b/frappe/core/doctype/data_import_log/data_import_log.json
@@ -58,9 +58,8 @@
   }
  ],
  "in_create": 1,
- "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:02:17.334396",
+ "modified": "2024-04-29 18:44:17.050909",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Data Import Log",
@@ -79,6 +78,7 @@
    "write": 1
   }
  ],
+ "read_only": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []


### PR DESCRIPTION
### Problem

This error occurs on opening a **Data Import** as a non-System Manager (perms granted via Role Permission Manager):

![Bildschirmfoto 2024-04-29 um 19 12 01](https://github.com/frappe/frappe/assets/14891507/54ce2d68-ab2d-4f85-8c83-1f2dae7d809b)

### Proposed solution

A user who has read permissions on a **Data Import** should be able to view it, without requiring additional read permissions on **Data Import Log**.

**Data Import Log** is just a helper doctype, similar to a child table, and it would be hard to grant appropriate permissions here. The permissions should depend on the related **Data Import**.

### Changes

- Move fetching of logs to the backend
- Check read permissions on **Data Import** only