### PR TITLE
fix(OAuth2): refresh token is optional

### DIFF
--- a/frappe/integrations/doctype/token_cache/token_cache.py
+++ b/frappe/integrations/doctype/token_cache/token_cache.py
@@ -53,8 +53,10 @@ class TokenCache(Document):
 
 		self.token_type = token_type
 		self.access_token = cstr(data.get("access_token", ""))
-		self.refresh_token = cstr(data.get("refresh_token", ""))
 		self.expires_in = cint(data.get("expires_in", 0))
+
+		if "refresh_token" in data:
+			self.refresh_token = cstr(data.get("refresh_token"))
 
 		new_scopes = data.get("scope")
 		if new_scopes:


### PR DESCRIPTION
Don't overwrite refresh_token with an empty string, if no new refresh_token is received (i.e. the old one is still valid).

Ref: https://www.rfc-editor.org/rfc/rfc6749#section-5.1

For example, [Google only sends one refresh token on first authorization](https://stackoverflow.com/a/10857806). The access token is pretty short lived. When it expires, we try to refresh it and receive a new access token – but no new refresh token. In this case we used to overwrite the refresh token, which remained valid, with an empty string. So the next refresh will not be successful anymore, the integration breaks after two cycles.

With this PR, we only change the refresh token when we actually receive a new one.
