### PR TITLE
revert: fix: pointless conditions about systemd/supervisor

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1779,7 +1779,13 @@ def get_url(uri: str | None = None, full_address: bool = False) -> str:
 
 	port = frappe.conf.http_port or frappe.conf.webserver_port
 
-	if host_name and not url_contains_port(host_name) and port:
+	if (
+		not frappe.conf.restart_supervisor_on_update
+		and not frappe.conf.restart_systemd_on_update
+		and host_name
+		and not url_contains_port(host_name)
+		and port
+	):
 		host_name = host_name + ":" + str(port)
 
 	return urljoin(host_name, uri) if uri else host_name


### PR DESCRIPTION
[this commit](https://github.com/frappe/frappe/pull/26152/commits/73087544439ce76cec58495db3c9a3d795a7fed0) added port numbers in urls which broke links on pdf.

<img width="804" alt="Screenshot 2024-05-01 at 12 54 52 AM" src="https://github.com/frappe/frappe/assets/39730881/4fcd2773-8a37-46fa-8b69-196e88102388">
