### PR TITLE
fix!: Only use `webserver_port` in developer mode

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -1331,7 +1331,10 @@ def start_ngrok(context, bind_tls, use_default_authtoken):
 
 		ngrok.set_auth_token(ngrok_authtoken)
 
-	port = frappe.conf.http_port or frappe.conf.webserver_port
+	port = frappe.conf.http_port
+	if not port and frappe.conf.developer_mode:
+		port = frappe.conf.webserver_port
+
 	tunnel = ngrok.connect(addr=str(port), host_header=site, bind_tls=bind_tls)
 	print(f"Public URL: {tunnel.public_url}")
 	print("Inspect logs at http://127.0.0.1:4040")

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -1777,9 +1777,12 @@ def get_url(uri: str | None = None, full_address: bool = False) -> str:
 	if not uri and full_address:
 		uri = frappe.get_request_header("REQUEST_URI", "")
 
-	port = frappe.conf.http_port or frappe.conf.webserver_port
+	port = frappe.conf.http_port
+	if not port and frappe.conf.developer_mode:
+		port = frappe.conf.webserver_port
 
 	if (
+		# XXX: This config is used as proxy for "is production mode enabled?"
 		not frappe.conf.restart_supervisor_on_update
 		and not frappe.conf.restart_systemd_on_update
 		and host_name

--- a/realtime/utils.js
+++ b/realtime/utils.js
@@ -8,9 +8,7 @@ function get_url(socket, path) {
 	let url = socket.request.headers.origin;
 	if (conf.developer_mode) {
 		let [protocol, host, port] = url.split(":");
-		if (port != conf.webserver_port) {
-			port = conf.webserver_port;
-		}
+		port = conf.webserver_port;
 		url = `${protocol}:${host}:${port}`;
 	}
 	return url + path;


### PR DESCRIPTION
`http_port` => Port on which site is visible to public
`webserver_port` => Gunicorn/werkzeug server port, used in development

Don't think this is ideal too, but haven't quite figured out better way to do this. We should just open a connection and verify or introduce a separate config key?