### PR TITLE
fix!: remove "remove empty rows" behaviour

### DIFF
--- a/cypress/integration/file_uploader.js
+++ b/cypress/integration/file_uploader.js
@@ -13,7 +13,7 @@ context("FileUploader", () => {
 			.then((frappe) => {
 				new frappe.ui.FileUploader();
 			});
-		cy.wait(500);
+		cy.wait(1000);
 	}
 
 	it("upload dialog api works", () => {

--- a/frappe/public/js/frappe/form/save.js
+++ b/frappe/public/js/frappe/form/save.js
@@ -16,8 +16,6 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 	var freeze_message = working_label ? __(working_label) : "";
 
 	var save = function () {
-		remove_empty_rows();
-
 		$(frm.wrapper).addClass("validated-form");
 		if ((action !== "Save" || frm.is_dirty()) && check_mandatory()) {
 			_call({
@@ -38,51 +36,6 @@ frappe.ui.form.save = function (frm, action, callback, btn) {
 				frappe.show_alert({ message: __("No changes in document"), indicator: "orange" });
 			$(btn).prop("disabled", false);
 		}
-	};
-
-	var remove_empty_rows = function () {
-		/*
-			This function removes empty rows. Note that in this function, a row is considered
-			empty if the fields with `in_list_view: 1` are undefined or falsy because that's
-			what users also consider to be an empty row
-		*/
-		const docs = frappe.model.get_all_docs(frm.doc);
-
-		// we should only worry about table data
-		const tables = docs.filter((d) => {
-			return frappe.model.is_table(d.doctype);
-		});
-
-		let modified_table_fields = [];
-
-		tables.map((doc) => {
-			const cells = frappe.meta.docfield_list[doc.doctype] || [];
-
-			const in_list_view_cells = cells.filter((df) => {
-				return cint(df.in_list_view) === 1;
-			});
-
-			const is_empty_row = function (cells) {
-				for (let i = 0; i < cells.length; i++) {
-					if (
-						locals[doc.doctype][doc.name] &&
-						locals[doc.doctype][doc.name][cells[i].fieldname]
-					) {
-						return false;
-					}
-				}
-				return true;
-			};
-
-			if (is_empty_row(in_list_view_cells)) {
-				frappe.model.clear_doc(doc.doctype, doc.name);
-				modified_table_fields.push(doc.parentfield);
-			}
-		});
-
-		modified_table_fields.forEach((field) => {
-			frm.refresh_field(field);
-		});
 	};
 
 	var cancel = function () {


### PR DESCRIPTION
This doesn't make sense:
1. A field which is not in list view can be modified
2. A modified field can actually have falsy value

This also fixes behavior where multi-select field erases the selections if first column is not "in list view", totally whack behavior for which someone added a note in docs instead of fixing it. 

Alternate to https://github.com/frappe/frappe/pull/25912 
closes https://github.com/frappe/frappe/issues/24556