### PR TITLE
fix: automatic logo width

### DIFF
--- a/frappe/core/doctype/navbar_settings/navbar_settings.json
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.json
@@ -7,8 +7,6 @@
  "field_order": [
   "logo_section",
   "app_logo",
-  "column_break_3",
-  "logo_width",
   "section_break_2",
   "settings_dropdown",
   "help_dropdown",
@@ -44,15 +42,6 @@
    "label": "Application Logo"
   },
   {
-   "fieldname": "column_break_3",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "logo_width",
-   "fieldtype": "Int",
-   "label": "Logo Width"
-  },
-  {
    "fieldname": "announcements_section",
    "fieldtype": "Section Break",
    "label": "Announcements"
@@ -67,7 +56,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 17:03:30.561647",
+ "modified": "2024-05-01 14:09:54.587137",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Navbar Settings",

--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -19,7 +19,6 @@ class NavbarSettings(Document):
 		announcement_widget: DF.TextEditor | None
 		app_logo: DF.AttachImage | None
 		help_dropdown: DF.Table[NavbarItem]
-		logo_width: DF.Int
 		settings_dropdown: DF.Table[NavbarItem]
 	# end: auto-generated types
 

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -4,7 +4,6 @@
 			<a class="navbar-brand navbar-home" href="/app">
 				<img
 					class="app-logo"
-					style="width: {{ navbar_settings.logo_width || 28 }}px"
 					src="{{ frappe.boot.app_logo_url }}"
 					alt="{{ __("App Logo") }}"
 				>


### PR DESCRIPTION
### Before

Logo is set to a fixed with and height. Unless the logo is square, it will be distorted. The user has to figure out

(1) that the logo width is supposed to be entered in pixels,
(2) what the fixed height of the logo is, and
(3) what the width of their logo must be, relative to the fixed height.

This is all unnecessary, because CSS has `width: auto`.

![Bildschirmfoto 2024-05-01 um 14 27 06](https://github.com/frappe/frappe/assets/14891507/48e46c94-0794-41f0-945b-3eb14804d57d)

### After

The user can upload any logo, the height is fixed to fit in the navbar, the browser automatically sets the appropriate width.

![Bildschirmfoto 2024-05-01 um 14 25 20](https://github.com/frappe/frappe/assets/14891507/e20040da-6245-40bb-8bf4-b044ef2bd8c0)
