### PR TITLE
fix: add warning to document.get since it doesn't match dict.get and make more robust

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -216,12 +216,19 @@ class BaseDocument:
 		if isinstance(key, dict):
 			return _filter(self.get_all_children(), key, limit=limit)
 
-		if filters:
-			if isinstance(filters, dict):
+		if filters is not None:
+			if filters and isinstance(filters, dict):
 				return _filter(self.__dict__.get(key, []), filters, limit=limit)
 
-			# perhaps you wanted to set a default instead
-			default = filters
+			if default is None:
+				# perhaps you wanted to set a default instead
+				import inspect
+
+				frm = inspect.stack()[1]
+				file = "/".join(frm.filename.split("/")[6:])
+				code = "".join(frm.code_context).strip()
+				frappe.log(f"Warning: doc.get filters used as default: {file}[{frm.lineno}]: {code}")
+				default = filters
 
 		value = self.__dict__.get(key, default)
 


### PR DESCRIPTION
It would be very easy to mistake document.get for python dict.get or frappe _dict.get but they have very different usage:

`document.get(key, filters=None, limit=None, default=None)`

`dict.get(key[, default])`

Potential fix / illustration for https://github.com/frappe/frappe/issues/26280

version-14-hotfix
version-15-hotfix