### PR TITLE
fix: refactor document.get definition (#26280)

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -1908,7 +1908,7 @@ def copy_doc(doc: "Document", ignore_no_copy: bool = True) -> "Document":
 	import copy
 
 	def remove_no_copy_fields(d):
-		for df in d.meta.get("fields", {"no_copy": 1}):
+		for df in d.meta.get("fields", filters={"no_copy": 1}):
 			if hasattr(d, df.fieldname):
 				d.set(df.fieldname, None)
 

--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -725,7 +725,7 @@ class DocType(Document):
 
 	def preserve_naming_series_options_in_property_setter(self):
 		"""Preserve naming_series as property setter if it does not exist"""
-		naming_series = self.get("fields", {"fieldname": "naming_series"})
+		naming_series = self.get("fields", filters={"fieldname": "naming_series"})
 
 		if not naming_series:
 			return
@@ -1048,11 +1048,11 @@ def validate_series(dt, autoname=None, name=None):
 	if not name:
 		name = dt.name
 
-	if not autoname and dt.get("fields", {"fieldname": "naming_series"}):
+	if not autoname and dt.get("fields", filters={"fieldname": "naming_series"}):
 		dt.autoname = "naming_series:"
 	elif dt.autoname and dt.autoname.startswith("naming_series:"):
 		fieldname = dt.autoname.split("naming_series:", 1)[0] or "naming_series"
-		if not dt.get("fields", {"fieldname": fieldname}):
+		if not dt.get("fields", filters={"fieldname": fieldname}):
 			frappe.throw(
 				_("Fieldname called {0} must exist to enable autonaming").format(frappe.bold(fieldname)),
 				title=_("Field Missing"),
@@ -1468,7 +1468,7 @@ def validate_fields(meta: Meta):
 		if not meta.image_field:
 			return
 
-		df = meta.get("fields", {"fieldname": meta.image_field})
+		df = meta.get("fields", filters={"fieldname": meta.image_field})
 		if not df:
 			frappe.throw(_("Image field must be a valid fieldname"), InvalidFieldNameError)
 		if df[0].fieldtype != "Attach Image":
@@ -1500,7 +1500,7 @@ def validate_fields(meta: Meta):
 		if meta.timeline_field not in fieldname_list:
 			frappe.throw(_("Timeline field must be a valid fieldname"), InvalidFieldNameError)
 
-		df = meta.get("fields", {"fieldname": meta.timeline_field})[0]
+		df = meta.get("fields", filters={"fieldname": meta.timeline_field})[0]
 		if df.fieldtype not in ("Link", "Dynamic Link"):
 			frappe.throw(_("Timeline field must be a Link or Dynamic Link"), InvalidFieldNameError)
 

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -300,7 +300,7 @@ def attach_files_to_document(doc: "Document", event) -> None:
 	is created.
 	"""
 
-	attach_fields = doc.meta.get("fields", {"fieldtype": ["in", ["Attach", "Attach Image"]]})
+	attach_fields = doc.meta.get("fields", filters={"fieldtype": ["in", ["Attach", "Attach Image"]]})
 
 	for df in attach_fields:
 		# this method runs in on_update hook of all documents
@@ -394,7 +394,7 @@ def relink_files(doc, fieldname, temp_doc_name):
 def relink_mismatched_files(doc: "Document") -> None:
 	if not doc.get("__temporary_name", None):
 		return
-	attach_fields = doc.meta.get("fields", {"fieldtype": ["in", ["Attach", "Attach Image"]]})
+	attach_fields = doc.meta.get("fields", filters={"fieldtype": ["in", ["Attach", "Attach Image"]]})
 	for df in attach_fields:
 		if doc.get(df.fieldname):
 			relink_files(doc, df.fieldname, doc.__temporary_name)

--- a/frappe/custom/doctype/customize_form/customize_form.py
+++ b/frappe/custom/doctype/customize_form/customize_form.py
@@ -266,7 +266,7 @@ class CustomizeForm(Document):
 
 		# docfield
 		for df in self.get("fields"):
-			meta_df = meta.get("fields", {"fieldname": df.fieldname})
+			meta_df = meta.get("fields", filters={"fieldname": df.fieldname})
 			if not meta_df or not is_standard_or_system_generated_field(meta_df[0]):
 				continue
 
@@ -484,7 +484,7 @@ class CustomizeForm(Document):
 
 	def update_in_custom_field(self, df, i):
 		meta = frappe.get_meta(self.doc_type)
-		meta_df = meta.get("fields", {"fieldname": df.fieldname})
+		meta_df = meta.get("fields", filters={"fieldname": df.fieldname})
 		if not meta_df or is_standard_or_system_generated_field(meta_df[0]):
 			# not a custom field
 			return
@@ -520,7 +520,7 @@ class CustomizeForm(Document):
 			df.fieldname for df in self.get("fields")
 		}
 		for fieldname in fields_to_remove:
-			df = meta.get("fields", {"fieldname": fieldname})[0]
+			df = meta.get("fields", filters={"fieldname": fieldname})[0]
 			if not is_standard_or_system_generated_field(df):
 				frappe.delete_doc("Custom Field", df.name)
 

--- a/frappe/custom/doctype/customize_form/test_customize_form.py
+++ b/frappe/custom/doctype/customize_form/test_customize_form.py
@@ -62,7 +62,7 @@ class TestCustomizeForm(FrappeTestCase):
 
 		self.assertEqual(len(d.get("fields")), len(frappe.get_doc("DocType", d.doc_type).fields) + 1)
 		self.assertEqual(d.get("fields")[-1].fieldname, self.field.fieldname)
-		self.assertEqual(d.get("fields", {"fieldname": "event_type"})[0].in_list_view, 1)
+		self.assertEqual(d.get("fields", filters={"fieldname": "event_type"})[0].in_list_view, 1)
 
 		return d
 
@@ -98,7 +98,7 @@ class TestCustomizeForm(FrappeTestCase):
 			None,
 		)
 
-		repeat_this_event_field = d.get("fields", {"fieldname": "repeat_this_event"})[0]
+		repeat_this_event_field = d.get("fields", filters={"fieldname": "repeat_this_event"})[0]
 		repeat_this_event_field.reqd = 1
 		d.run_method("save_customization")
 		self.assertEqual(
@@ -110,7 +110,7 @@ class TestCustomizeForm(FrappeTestCase):
 			"1",
 		)
 
-		repeat_this_event_field = d.get("fields", {"fieldname": "repeat_this_event"})[0]
+		repeat_this_event_field = d.get("fields", filters={"fieldname": "repeat_this_event"})[0]
 		repeat_this_event_field.reqd = 0
 		d.run_method("save_customization")
 		self.assertEqual(
@@ -126,14 +126,14 @@ class TestCustomizeForm(FrappeTestCase):
 		d = self.get_customize_form("Event")
 		self.assertEqual(frappe.db.get_value("Custom Field", self.field.name, "reqd"), 0)
 
-		custom_field = d.get("fields", {"fieldname": self.field.fieldname})[0]
+		custom_field = d.get("fields", filters={"fieldname": self.field.fieldname})[0]
 		custom_field.reqd = 1
 		custom_field.no_copy = 1
 		d.run_method("save_customization")
 		self.assertEqual(frappe.db.get_value("Custom Field", self.field.name, "reqd"), 1)
 		self.assertEqual(frappe.db.get_value("Custom Field", self.field.name, "no_copy"), 1)
 
-		custom_field = d.get("fields", {"is_custom_field": True})[0]
+		custom_field = d.get("fields", filters={"is_custom_field": True})[0]
 		custom_field.reqd = 0
 		custom_field.no_copy = 0
 		d.run_method("save_customization")
@@ -169,7 +169,7 @@ class TestCustomizeForm(FrappeTestCase):
 
 	def test_save_customization_remove_field(self):
 		d = self.get_customize_form("Event")
-		custom_field = d.get("fields", {"fieldname": self.field.fieldname})[0]
+		custom_field = d.get("fields", filters={"fieldname": self.field.fieldname})[0]
 		d.get("fields").remove(custom_field)
 		d.run_method("save_customization")
 
@@ -183,29 +183,29 @@ class TestCustomizeForm(FrappeTestCase):
 		d.doc_type = "Event"
 		d.run_method("reset_to_defaults")
 
-		self.assertEqual(d.get("fields", {"fieldname": "repeat_this_event"})[0].in_list_view, 0)
+		self.assertEqual(d.get("fields", filters={"fieldname": "repeat_this_event"})[0].in_list_view, 0)
 
 		frappe.local.test_objects["Property Setter"] = []
 		make_test_records_for_doctype("Property Setter")
 
 	def test_set_allow_on_submit(self):
 		d = self.get_customize_form("Event")
-		d.get("fields", {"fieldname": "subject"})[0].allow_on_submit = 1
-		d.get("fields", {"fieldname": "custom_test_field"})[0].allow_on_submit = 1
+		d.get("fields", filters={"fieldname": "subject"})[0].allow_on_submit = 1
+		d.get("fields", filters={"fieldname": "custom_test_field"})[0].allow_on_submit = 1
 		d.run_method("save_customization")
 
 		d = self.get_customize_form("Event")
 
 		# don't allow for standard fields
-		self.assertEqual(d.get("fields", {"fieldname": "subject"})[0].allow_on_submit or 0, 0)
+		self.assertEqual(d.get("fields", filters={"fieldname": "subject"})[0].allow_on_submit or 0, 0)
 
 		# allow for custom field
-		self.assertEqual(d.get("fields", {"fieldname": "custom_test_field"})[0].allow_on_submit, 1)
+		self.assertEqual(d.get("fields", filters={"fieldname": "custom_test_field"})[0].allow_on_submit, 1)
 
 	def test_title_field_pattern(self):
 		d = self.get_customize_form("Web Form")
 
-		df = d.get("fields", {"fieldname": "title"})[0]
+		df = d.get("fields", filters={"fieldname": "title"})[0]
 
 		# invalid fieldname
 		df.default = """{doc_type} - {introduction_test}"""
@@ -235,7 +235,7 @@ class TestCustomizeForm(FrappeTestCase):
 		d = self.get_customize_form("Notification Log")
 
 		new_document_length = 255
-		document_name = d.get("fields", {"fieldname": "document_name"})[0]
+		document_name = d.get("fields", filters={"fieldname": "document_name"})[0]
 		document_name.length = new_document_length
 		d.run_method("save_customization")
 

--- a/frappe/desk/doctype/todo/test_todo.py
+++ b/frappe/desk/doctype/todo/test_todo.py
@@ -31,7 +31,7 @@ class TestToDo(FrappeTestCase):
 		frappe.db.delete("ToDo")
 
 		todo_meta = frappe.get_doc("DocType", "ToDo")
-		todo_meta.get("fields", dict(fieldname="assigned_by_full_name"))[0].fetch_from = ""
+		todo_meta.get("fields", filters=dict(fieldname="assigned_by_full_name"))[0].fetch_from = ""
 		todo_meta.save()
 
 		frappe.clear_cache(doctype="ToDo")
@@ -40,7 +40,7 @@ class TestToDo(FrappeTestCase):
 		self.assertFalse(todo.assigned_by_full_name)
 
 		todo_meta = frappe.get_doc("DocType", "ToDo")
-		todo_meta.get("fields", dict(fieldname="assigned_by_full_name"))[
+		todo_meta.get("fields", filters=dict(fieldname="assigned_by_full_name"))[
 			0
 		].fetch_from = "assigned_by.full_name"
 		todo_meta.save()
@@ -112,7 +112,7 @@ class TestToDo(FrappeTestCase):
 
 		# Allow user changes
 		todo_meta = frappe.get_doc("DocType", "ToDo")
-		field = todo_meta.get("fields", dict(fieldname="assigned_by_full_name"))[0]
+		field = todo_meta.get("fields", filters=dict(fieldname="assigned_by_full_name"))[0]
 		field.fetch_from = "assigned_by.full_name"
 		field.fetch_if_empty = 1
 		todo_meta.save()
@@ -129,7 +129,7 @@ class TestToDo(FrappeTestCase):
 		self.assertEqual(todo.assigned_by_full_name, "Admin")
 
 		# Overwrite user changes
-		todo.meta.get("fields", dict(fieldname="assigned_by_full_name"))[0].fetch_if_empty = 0
+		todo.meta.get("fields", filters=dict(fieldname="assigned_by_full_name"))[0].fetch_if_empty = 0
 		todo.meta.save()
 
 		todo.reload()

--- a/frappe/desk/form/linked_with.py
+++ b/frappe/desk/form/linked_with.py
@@ -437,7 +437,7 @@ def get_linked_docs(doctype: str, name: str, linkinfo: dict | None = None) -> di
 				d.fieldname
 				for d in linkmeta.get(
 					"fields",
-					{
+					filters={
 						"in_list_view": 1,
 						"fieldtype": ["not in", ("Image", "HTML", "Button", *frappe.model.table_fields)],
 					},

--- a/frappe/desk/form/meta.py
+++ b/frappe/desk/form/meta.py
@@ -183,7 +183,7 @@ class FormMeta(Meta):
 
 	def add_search_fields(self):
 		"""add search fields found in the doctypes indicated by link fields' options"""
-		for df in self.get("fields", {"fieldtype": "Link", "options": ["!=", "[Select]"]}):
+		for df in self.get("fields", filters={"fieldtype": "Link", "options": ["!=", "[Select]"]}):
 			if df.options:
 				try:
 					search_fields = frappe.get_meta(df.options).search_fields
@@ -213,7 +213,7 @@ class FormMeta(Meta):
 		frappe.throw(msg, title=_("Missing DocType"))
 
 	def add_linked_document_type(self):
-		for df in self.get("fields", {"fieldtype": "Link"}):
+		for df in self.get("fields", filters={"fieldtype": "Link"}):
 			if df.options:
 				try:
 					df.linked_document_type = frappe.get_meta(df.options).document_type

--- a/frappe/desk/search.py
+++ b/frappe/desk/search.py
@@ -150,9 +150,9 @@ def search_widget(
 			if not meta.translated_doctype and (f == "name" or (fmeta and fmeta.fieldtype in field_types)):
 				or_filters.append([doctype, f.strip(), "like", f"%{txt}%"])
 
-	if meta.get("fields", {"fieldname": "enabled", "fieldtype": "Check"}):
+	if meta.get("fields", filters={"fieldname": "enabled", "fieldtype": "Check"}):
 		filters.append([doctype, "enabled", "=", 1])
-	if meta.get("fields", {"fieldname": "disabled", "fieldtype": "Check"}):
+	if meta.get("fields", filters={"fieldname": "disabled", "fieldtype": "Check"}):
 		filters.append([doctype, "disabled", "!=", 1])
 
 	# format a list of fields combining search fields and filter fields

--- a/frappe/model/db_query.py
+++ b/frappe/model/db_query.py
@@ -724,7 +724,7 @@ class DatabaseQuery:
 			f.update(get_additional_filter_field(additional_filters_config, f, f.value))
 
 		meta = frappe.get_meta(f.doctype)
-		df = meta.get("fields", {"fieldname": f.fieldname})
+		df = meta.get("fields", filters={"fieldname": f.fieldname})
 		df = df[0] if df else None
 
 		# primary key is never nullable, modified is usually indexed by default and always present

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -624,14 +624,14 @@ class Document(BaseDocument):
 				)
 
 		for df in self.meta.get(
-			"fields", {"non_negative": ("=", 1), "fieldtype": ("in", ["Int", "Float", "Currency"])}
+			"fields", filters={"non_negative": ("=", 1), "fieldtype": ("in", ["Int", "Float", "Currency"])}
 		):
 			if flt(self.get(df.fieldname)) < 0:
 				msg = get_msg(df)
 				frappe.throw(msg, frappe.NonNegativeError, title=_("Negative Value"))
 
 	def _fix_rating_value(self):
-		for field in self.meta.get("fields", {"fieldtype": "Rating"}):
+		for field in self.meta.get("fields", filters={"fieldtype": "Rating"}):
 			value = self.get(field.fieldname)
 			if not isinstance(value, float):
 				value = flt(value)

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -169,32 +169,34 @@ class Meta(Document):
 		return serialize(self)
 
 	def get_link_fields(self):
-		return self.get("fields", {"fieldtype": "Link", "options": ["!=", "[Select]"]})
+		return self.get("fields", filters={"fieldtype": "Link", "options": ["!=", "[Select]"]})
 
 	def get_data_fields(self):
-		return self.get("fields", {"fieldtype": "Data"})
+		return self.get("fields", filters={"fieldtype": "Data"})
 
 	def get_phone_fields(self):
-		return self.get("fields", {"fieldtype": "Phone"})
+		return self.get("fields", filters={"fieldtype": "Phone"})
 
 	def get_dynamic_link_fields(self):
 		if not hasattr(self, "_dynamic_link_fields"):
-			self._dynamic_link_fields = self.get("fields", {"fieldtype": "Dynamic Link"})
+			self._dynamic_link_fields = self.get("fields", filters={"fieldtype": "Dynamic Link"})
 		return self._dynamic_link_fields
 
 	def get_select_fields(self):
-		return self.get("fields", {"fieldtype": "Select", "options": ["not in", ["[Select]", "Loading..."]]})
+		return self.get(
+			"fields", filters={"fieldtype": "Select", "options": ["not in", ["[Select]", "Loading..."]]}
+		)
 
 	def get_image_fields(self):
-		return self.get("fields", {"fieldtype": "Attach Image"})
+		return self.get("fields", filters={"fieldtype": "Attach Image"})
 
 	def get_code_fields(self):
-		return self.get("fields", {"fieldtype": "Code"})
+		return self.get("fields", filters={"fieldtype": "Code"})
 
 	def get_set_only_once_fields(self):
 		"""Return fields with `set_only_once` set"""
 		if not hasattr(self, "_set_only_once_fields"):
-			self._set_only_once_fields = self.get("fields", {"set_only_once": 1})
+			self._set_only_once_fields = self.get("fields", filters={"set_only_once": 1})
 			fieldnames = [d.fieldname for d in self._set_only_once_fields]
 
 			for df in self.standard_set_once_fields:
@@ -208,7 +210,7 @@ class Meta(Document):
 
 	def get_global_search_fields(self):
 		"""Return list of fields with `in_global_search` set and `name` if set."""
-		fields = self.get("fields", {"in_global_search": 1, "fieldtype": ["not in", no_value_fields]})
+		fields = self.get("fields", filters={"in_global_search": 1, "fieldtype": ["not in", no_value_fields]})
 		if getattr(self, "show_name_in_global_search", None):
 			fields.append(frappe._dict(fieldtype="Data", fieldname="name", label="Name"))
 
@@ -440,7 +442,7 @@ class Meta(Document):
 		if self.name == "DocType":
 			self._table_fields = DOCTYPE_TABLE_FIELDS
 		else:
-			self._table_fields = self.get("fields", {"fieldtype": ["in", table_fields]})
+			self._table_fields = self.get("fields", filters={"fieldtype": ["in", table_fields]})
 
 	def sort_fields(self):
 		"""
@@ -547,7 +549,7 @@ class Meta(Document):
 	def get_fields_to_check_permissions(self, user_permission_doctypes):
 		fields = self.get(
 			"fields",
-			{
+			filters={
 				"fieldtype": "Link",
 				"parent": self.name,
 				"ignore_user_permissions": ("!=", 1),

--- a/frappe/website/doctype/website_settings/website_settings.py
+++ b/frappe/website/doctype/website_settings/website_settings.py
@@ -88,7 +88,7 @@ class WebsiteSettings(Document):
 		"""validate url in top bar items"""
 		for top_bar_item in self.get("top_bar_items"):
 			if top_bar_item.parent_label:
-				parent_label_item = self.get("top_bar_items", {"label": top_bar_item.parent_label})
+				parent_label_item = self.get("top_bar_items", filters={"label": top_bar_item.parent_label})
 
 				if not parent_label_item:
 					# invalid item
@@ -108,7 +108,7 @@ class WebsiteSettings(Document):
 		"""validate url in top bar items"""
 		for footer_item in self.get("footer_items"):
 			if footer_item.parent_label:
-				parent_label_item = self.get("footer_items", {"label": footer_item.parent_label})
+				parent_label_item = self.get("footer_items", filters={"label": footer_item.parent_label})
 
 				if not parent_label_item:
 					# invalid item


### PR DESCRIPTION
fix: change document.get definition to match dict.get and add positional deprecation warning to the filters keyword

fixes: https://github.com/frappe/frappe/issues/26280

Have attempted to fix all core files using the new `filters=` arg

See also https://github.com/frappe/frappe/issues/26279

version-14-hotfix
version-15-hotfix
