### PR TITLE
fix: link filter falsy fix

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -593,8 +593,13 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		let filters = {};
 		link_filters.forEach((filter) => {
 			let [_, fieldname, operator, value] = filter;
-			value = String(value).replace(/%/g, "");
-			if (value.startsWith("eval:")) {
+			if (operator === "like") {
+				value = String(value).replace(/%/g, "");
+			}
+
+			if (value?.startsWith?.("eval:")) {
+				value = String(value).replace(/%/g, "");
+				// console.log(typeof value, value)
 				// get the value to calculate
 				value = value.split("eval:")[1];
 				let context = {
@@ -603,6 +608,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					frappe,
 				};
 				value = frappe.utils.eval(value, context);
+				console.log(typeof value, value);
 			}
 			filters[fieldname] = [operator, value];
 		});

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -598,8 +598,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 			}
 
 			if (value?.startsWith?.("eval:")) {
-				value = String(value).replace(/%/g, "");
-				// console.log(typeof value, value)
 				// get the value to calculate
 				value = value.split("eval:")[1];
 				let context = {

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -606,7 +606,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					frappe,
 				};
 				value = frappe.utils.eval(value, context);
-				console.log(typeof value, value);
 			}
 			filters[fieldname] = [operator, value];
 		});


### PR DESCRIPTION
**Issue:**
While applying filters, for e.g


even though we set ```["Item", "has_variants", "=", 0]```
<img width="1289" alt="Screenshot 2024-05-01 at 11 48 15 PM" src="https://github.com/frappe/frappe/assets/65544983/4e15158c-773f-4ced-934f-c13ad2b66098">


The filter was applied as ```Has variants = Yes```


<img width="1271" alt="Screenshot 2024-05-01 at 11 48 51 PM" src="https://github.com/frappe/frappe/assets/65544983/68e24166-d341-4c28-b82c-091c6d2b4fbc">


**Reason**

When value is 0 (number), it then becomes "0" (string), which is NOT falsy as expected, but truthy.
