### PR TITLE
fix(Geo): change Canadian all numeric dates to ISO 8601 format

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -497,7 +497,7 @@
   "currency_fraction_units": 100,
   "currency_name": "Canadian Dollar",
   "currency_symbol": "$",
-  "date_format": "mm-dd-yyyy",
+  "date_format": "yyyy-mm-dd",
   "number_format": "#,###.##",
   "timezones": [
    "America/Atikokan",


### PR DESCRIPTION
<!--

Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->



Should be applied to `develop` but backport to version 15 would be appreciated.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

This updates the Canadian date format to the nationally recommended one. The current default is not a common or recommended all-numeric date format.