### PR TITLE
fix: in_reply_to

### DIFF
--- a/frappe/core/doctype/communication/email.py
+++ b/frappe/core/doctype/communication/email.py
@@ -49,6 +49,7 @@ def make(
 	send_after=None,
 	print_language=None,
 	now=False,
+	in_reply_to=None,
 	**kwargs,
 ) -> dict[str, str]:
 	"""Make a new communication. Checks for email permissions for specified Document.
@@ -106,6 +107,7 @@ def make(
 		send_after=send_after,
 		print_language=print_language,
 		now=now,
+		in_reply_to=in_reply_to,
 	)
 
 
@@ -134,6 +136,7 @@ def _make(
 	send_after=None,
 	print_language=None,
 	now=False,
+	in_reply_to=None,
 ) -> dict[str, str]:
 	"""Internal method to make a new communication that ignores Permission checks."""
 
@@ -189,6 +192,7 @@ def _make(
 			print_letterhead=print_letterhead,
 			print_language=print_language,
 			now=now,
+			in_reply_to=in_reply_to,
 		)
 
 	emails_not_sent_to = comm.exclude_emails_list(include_sender=send_me_a_copy)

--- a/frappe/core/doctype/communication/mixins.py
+++ b/frappe/core/doctype/communication/mixins.py
@@ -318,6 +318,7 @@ class CommunicationEmailMixin:
 		is_inbound_mail_communcation=None,
 		print_language=None,
 		now=False,
+		in_reply_to=None,
 	):
 		if input_dict := self.sendmail_input_dict(
 			print_html=print_html,
@@ -327,4 +328,4 @@ class CommunicationEmailMixin:
 			is_inbound_mail_communcation=is_inbound_mail_communcation,
 			print_language=print_language,
 		):
-			frappe.sendmail(now=now, **input_dict)
+			frappe.sendmail(now=now, in_reply_to=in_reply_to, **input_dict)

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -280,7 +280,7 @@ def get_communication_data(
 			C.sender, C.sender_full_name, C.cc, C.bcc,
 			C.creation AS creation, C.subject, C.delivery_status,
 			C._liked_by, C.reference_doctype, C.reference_name,
-			C.read_by_recipient, C.rating, C.recipients
+			C.read_by_recipient, C.rating, C.recipients, C.message_id
 		"""
 
 	conditions = ""

--- a/frappe/email/email_body.py
+++ b/frappe/email/email_body.py
@@ -301,6 +301,8 @@ class EMail:
 
 	def set_in_reply_to(self, in_reply_to):
 		"""Used to send the Message-Id of a received email back as In-Reply-To"""
+		if in_reply_to and not in_reply_to.strip().startswith("<"):
+			in_reply_to = "<" + in_reply_to + ">"
 		self.set_header("In-Reply-To", in_reply_to)
 
 	def make(self):

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -549,8 +549,9 @@ class FormTimeline extends BaseTimeline {
 			is_a_reply: Boolean(communication_doc),
 			title: communication_doc ? __("Reply") : null,
 			last_email: communication_doc,
-			subject: communication_doc && communication_doc.subject,
+			subject: communication_doc?.subject,
 			reply_all: reply_all,
+			in_reply_to: communication_doc?.message_id,
 		};
 
 		const email_accounts = frappe.boot.email_accounts

--- a/frappe/public/js/frappe/views/communication.js
+++ b/frappe/public/js/frappe/views/communication.js
@@ -795,6 +795,7 @@ frappe.views.CommunicationComposer = class {
 				print_letterhead: me.is_print_letterhead_checked(),
 				send_after: form_values.send_after ? form_values.send_after : null,
 				print_language: form_values.print_language,
+				in_reply_to: me.in_reply_to,
 			},
 			btn,
 			callback(r) {


### PR DESCRIPTION
1. Communication composer UI will remember message ID of parent email for replies and send it as `in_reply_to` to frappe.sendmail.

2. Fixes invalid header:


> 3.6.4 - Identification fields

> ```
> in-reply-to     =       "In-Reply-To:" 1*msg-id CRLF
> msg-id          =       [CFWS] "<" id-left "@" id-right ">" [CFWS]
> ```

ref: https://www.ietf.org/rfc/rfc2822.txt


TODO: 


- [ ] test it out on real servers.