### PR TITLE
perf: Don't update session in cache after every request

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -409,7 +409,6 @@ def sync_database(rollback: bool) -> bool:
 	# update session
 	if session := getattr(frappe.local, "session_obj", None):
 		if session.update():
-			frappe.db.commit()
 			rollback = False
 
 	return rollback

--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -416,7 +416,7 @@ def get_workspace_sidebar_items():
 	has_access = "Workspace Manager" in frappe.get_roles()
 
 	# don't get domain restricted pages
-	blocked_modules = frappe.get_doc("User", frappe.session.user).get_blocked_modules()
+	blocked_modules = frappe.get_cached_doc("User", frappe.session.user).get_blocked_modules()
 	blocked_modules.append("Dummy Module")
 
 	# adding None to allowed_domains to include pages without domain restriction


### PR DESCRIPTION
It's just reading and writing same information except last_update inside data which is never read back from this.
