### PR TITLE
fix: like filter from meta filters

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -596,10 +596,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		let filters = {};
 		link_filters.forEach((filter) => {
 			let [_, fieldname, operator, value] = filter;
-			if (operator === "like") {
-				value = String(value).replace(/%/g, "");
-			}
-
 			if (value?.startsWith?.("eval:")) {
 				// get the value to calculate
 				value = value.split("eval:")[1];


### PR DESCRIPTION
This isn't required, in fact it causes value to get removed so query will be `like value` which is almost never what a user wants.