### PR TITLE
feat: allow linking of request http errors

### DIFF
--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -29,7 +29,10 @@ def make_request(method: str, url: str, auth=None, headers=None, data=None, json
 		else:
 			return
 	except Exception as exc:
-		frappe.log_error()
+		if frappe.flags.integration_request_doc:
+			frappe.flags.integration_request_doc.log_error()
+		else:
+			frappe.log_error()
 		raise exc
 
 


### PR DESCRIPTION
# Context

Http Errors on Integration Request are not generally linked to any doctype making analysis ever so slightly more cumbersome.

# Proposed Solution
- [x] Add possibility to declare a flag that carries the doctype in question
- [x] Use that flag as reference document when writing to the _Error Log_

This is load bearing for quicker Payment failure analysis for https://github.com/frappe/payments/pull/53

`no-docs`
