### PR TITLE
perf: Reduce 1 redis call while dumping monitor logs

### DIFF
--- a/frappe/monitor.py
+++ b/frappe/monitor.py
@@ -11,6 +11,7 @@ import pytz
 import rq
 
 import frappe
+from frappe.utils.data import cint
 
 MONITOR_REDIS_KEY = "monitor-transactions"
 MONITOR_MAX_ENTRIES = 1000000
@@ -115,10 +116,10 @@ class Monitor:
 			traceback.print_exc()
 
 	def store(self):
-		if frappe.cache.llen(MONITOR_REDIS_KEY) > MONITOR_MAX_ENTRIES:
-			frappe.cache.ltrim(MONITOR_REDIS_KEY, 1, -1)
 		serialized = json.dumps(self.data, sort_keys=True, default=str, separators=(",", ":"))
-		frappe.cache.rpush(MONITOR_REDIS_KEY, serialized)
+		length = frappe.cache.rpush(MONITOR_REDIS_KEY, serialized)
+		if cint(length) > MONITOR_MAX_ENTRIES:
+			frappe.cache.ltrim(MONITOR_REDIS_KEY, 1, -1)
 
 
 def flush():

--- a/frappe/utils/redis_wrapper.py
+++ b/frappe/utils/redis_wrapper.py
@@ -149,10 +149,10 @@ class RedisWrapper(redis.Redis):
 			pass
 
 	def lpush(self, key, value):
-		super().lpush(self.make_key(key), value)
+		return super().lpush(self.make_key(key), value)
 
 	def rpush(self, key, value):
-		super().rpush(self.make_key(key), value)
+		return super().rpush(self.make_key(key), value)
 
 	def lpop(self, key):
 		return super().lpop(self.make_key(key))


### PR DESCRIPTION
rpush returns value of llen, no need to make that call separately. ~1.5% overhead over smallest requests.

![image](https://github.com/frappe/frappe/assets/9079960/288f6f0f-28bd-41c7-9f9a-b6e528e217fc)
