### PR TITLE
perf: avoid two layer cache of timezone

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -366,16 +366,9 @@ def get_eta(from_time: DateTimeLikeObject, percent_complete) -> str:
 	return str(datetime.timedelta(seconds=(100 - percent_complete) / percent_complete * diff))
 
 
-def _get_system_timezone():
-	return frappe.get_system_settings("time_zone") or "Asia/Kolkata"  # Default to India ?!
-
-
 def get_system_timezone() -> str:
 	"""Return the system timezone."""
-	if frappe.local.flags.in_test:
-		return _get_system_timezone()
-
-	return frappe.cache.get_value("time_zone", _get_system_timezone)
+	return frappe.get_system_settings("time_zone") or "Asia/Kolkata"  # Default to India ?!
 
 
 def convert_utc_to_timezone(utc_timestamp: datetime.datetime, time_zone: str) -> datetime.datetime:


### PR DESCRIPTION
It's same thing, system settings are always fetched, no idea what's point of additional layer of caching on top of it.

~1% overhead on small requests.