### PR TITLE
perf: cache site config for ~5 minutes

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -36,7 +36,7 @@ from frappe.query_builder import (
 	patch_query_aggregation,
 	patch_query_execute,
 )
-from frappe.utils.caching import request_cache
+from frappe.utils.caching import request_cache, site_cache
 from frappe.utils.data import cint, cstr, sbool
 
 # Local application imports
@@ -385,6 +385,7 @@ def connect_replica() -> bool:
 	return True
 
 
+@site_cache(ttl=5 * 60)
 def get_site_config(sites_path: str | None = None, site_path: str | None = None) -> dict[str, Any]:
 	"""Return `site_config.json` combined with `sites/common_site_config.json`.
 	`site_config` is a set of site wide settings like database name, password, email etc."""


### PR DESCRIPTION
\* Possibly Breaking *

On typical requests like `get_list` just computing site config takes 4%
of time. This is mostly 2 `open` calls and 2 `json.loads` calls.

This allows realtime config updates but who really needs this? Most web
services I know read config once at startup and never again. They either 
ask you to restart or have `reload` signal for reloading configuration.

Caching 5 minutes is middle ground between old behaviour and some perf
benefits.
