### PR TITLE
Resolves front-end bug in 'customize_form.js', triggered by delete actions on child-tables

### DIFF
--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -339,8 +339,8 @@ frappe.ui.form.on("Customize Form Field", {
 frappe.ui.form.on("DocType Link", {
 	before_links_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		let parenttype = row.parenttype;	// used in the event links_remove
-		let parent = row.parent;	// used in the event links_remove
+		parenttype = row.parenttype;	// used in the event links_remove
+		parent = row.parent;	// used in the event links_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard link. You can hide it if you want"));
 			throw "cannot delete standard link";
@@ -361,8 +361,8 @@ frappe.ui.form.on("DocType Link", {
 frappe.ui.form.on("DocType Action", {
 	before_actions_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		let parenttype = row.parenttype;	// used in the event actions_remove
-		let parent = row.parent;	// used in the event actions_remove
+		parenttype = row.parenttype;	// used in the event actions_remove
+		parent = row.parent;	// used in the event actions_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard action. You can hide it if you want"));
 			throw "cannot delete standard action";
@@ -383,8 +383,8 @@ frappe.ui.form.on("DocType Action", {
 frappe.ui.form.on("DocType State", {
 	before_states_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		let parenttype = row.parenttype;	// used in the event states_remove
-		let parent = row.parent;	// used in the event states_remove
+		parenttype = row.parenttype;	// used in the event states_remove
+		parent = row.parent;	// used in the event states_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard document state."));
 			throw "cannot delete standard document state";

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -335,6 +335,8 @@ frappe.ui.form.on("Customize Form Field", {
 	},
 });
 
+let parenttype, parent;		// used in the form events for the child tables: links, actions and states
+
 // can't delete standard links
 frappe.ui.form.on("DocType Link", {
 	before_links_remove: function (frm, doctype, name) {

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -335,14 +335,14 @@ frappe.ui.form.on("Customize Form Field", {
 	},
 });
 
-let parenttype, parent;		// used in the form events for the child tables: links, actions and states
+let parenttype, parent; // used in the form events for the child tables: links, actions and states
 
 // can't delete standard links
 frappe.ui.form.on("DocType Link", {
 	before_links_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		parenttype = row.parenttype;	// used in the event links_remove
-		parent = row.parent;	// used in the event links_remove
+		parenttype = row.parenttype; // used in the event links_remove
+		parent = row.parent; // used in the event links_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard link. You can hide it if you want"));
 			throw "cannot delete standard link";
@@ -363,8 +363,8 @@ frappe.ui.form.on("DocType Link", {
 frappe.ui.form.on("DocType Action", {
 	before_actions_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		parenttype = row.parenttype;	// used in the event actions_remove
-		parent = row.parent;	// used in the event actions_remove
+		parenttype = row.parenttype; // used in the event actions_remove
+		parent = row.parent; // used in the event actions_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard action. You can hide it if you want"));
 			throw "cannot delete standard action";
@@ -385,8 +385,8 @@ frappe.ui.form.on("DocType Action", {
 frappe.ui.form.on("DocType State", {
 	before_states_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		parenttype = row.parenttype;	// used in the event states_remove
-		parent = row.parent;	// used in the event states_remove
+		parenttype = row.parenttype; // used in the event states_remove
+		parent = row.parent; // used in the event states_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard document state."));
 			throw "cannot delete standard document state";

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -339,8 +339,8 @@ frappe.ui.form.on("Customize Form Field", {
 frappe.ui.form.on("DocType Link", {
 	before_links_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		parenttype = row.parenttype;	// used in the event links_remove
-		parent = row.parent;	// used in the event links_remove
+		let parenttype = row.parenttype;	// used in the event links_remove
+		let parent = row.parent;	// used in the event links_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard link. You can hide it if you want"));
 			throw "cannot delete standard link";
@@ -361,8 +361,8 @@ frappe.ui.form.on("DocType Link", {
 frappe.ui.form.on("DocType Action", {
 	before_actions_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		parenttype = row.parenttype;	// used in the event actions_remove
-		parent = row.parent;	// used in the event actions_remove
+		let parenttype = row.parenttype;	// used in the event actions_remove
+		let parent = row.parent;	// used in the event actions_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard action. You can hide it if you want"));
 			throw "cannot delete standard action";
@@ -383,8 +383,8 @@ frappe.ui.form.on("DocType Action", {
 frappe.ui.form.on("DocType State", {
 	before_states_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
-		parenttype = row.parenttype;	// used in the event states_remove
-		parent = row.parent;	// used in the event states_remove
+		let parenttype = row.parenttype;	// used in the event states_remove
+		let parent = row.parent;	// used in the event states_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard document state."));
 			throw "cannot delete standard document state";

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -356,7 +356,7 @@ frappe.ui.form.on("DocType Link", {
 		// replicate the changed rows from the browser's copy of the parent doc to the current 'Customize Form' doc
 		let parent_doc = locals[parenttype][parent];
 		frm.doc.links = parent_doc.links;
-	}
+	},
 });
 
 // can't delete standard actions
@@ -378,7 +378,7 @@ frappe.ui.form.on("DocType Action", {
 		// replicate the changed rows from the browser's copy of the parent doc to the current 'Customize Form' doc
 		let parent_doc = locals[parenttype][parent];
 		frm.doc.actions = parent_doc.actions;
-	}
+	},
 });
 
 // can't delete standard states
@@ -400,7 +400,7 @@ frappe.ui.form.on("DocType State", {
 		// replicate the changed rows from the browser's copy of the parent doc to the current 'Customize Form' doc
 		let parent_doc = locals[parenttype][parent];
 		frm.doc.states = parent_doc.states;
-	}
+	},
 });
 
 frappe.customize_form.save_customization = function (frm) {

--- a/frappe/custom/doctype/customize_form/customize_form.js
+++ b/frappe/custom/doctype/customize_form/customize_form.js
@@ -339,6 +339,8 @@ frappe.ui.form.on("Customize Form Field", {
 frappe.ui.form.on("DocType Link", {
 	before_links_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
+		parenttype = row.parenttype;	// used in the event links_remove
+		parent = row.parent;	// used in the event links_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard link. You can hide it if you want"));
 			throw "cannot delete standard link";
@@ -348,12 +350,19 @@ frappe.ui.form.on("DocType Link", {
 		let f = frappe.model.get_doc(cdt, cdn);
 		f.custom = 1;
 	},
+	links_remove: function (frm, doctype, name) {
+		// replicate the changed rows from the browser's copy of the parent doc to the current 'Customize Form' doc
+		let parent_doc = locals[parenttype][parent];
+		frm.doc.links = parent_doc.links;
+	}
 });
 
 // can't delete standard actions
 frappe.ui.form.on("DocType Action", {
 	before_actions_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
+		parenttype = row.parenttype;	// used in the event actions_remove
+		parent = row.parent;	// used in the event actions_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard action. You can hide it if you want"));
 			throw "cannot delete standard action";
@@ -363,12 +372,19 @@ frappe.ui.form.on("DocType Action", {
 		let f = frappe.model.get_doc(cdt, cdn);
 		f.custom = 1;
 	},
+	actions_remove: function (frm, doctype, name) {
+		// replicate the changed rows from the browser's copy of the parent doc to the current 'Customize Form' doc
+		let parent_doc = locals[parenttype][parent];
+		frm.doc.actions = parent_doc.actions;
+	}
 });
 
 // can't delete standard states
 frappe.ui.form.on("DocType State", {
 	before_states_remove: function (frm, doctype, name) {
 		let row = frappe.get_doc(doctype, name);
+		parenttype = row.parenttype;	// used in the event states_remove
+		parent = row.parent;	// used in the event states_remove
 		if (!(row.custom || row.__islocal)) {
 			frappe.msgprint(__("Cannot delete standard document state."));
 			throw "cannot delete standard document state";
@@ -378,6 +394,11 @@ frappe.ui.form.on("DocType State", {
 		let f = frappe.model.get_doc(cdt, cdn);
 		f.custom = 1;
 	},
+	states_remove: function (frm, doctype, name) {
+		// replicate the changed rows from the browser's copy of the parent doc to the current 'Customize Form' doc
+		let parent_doc = locals[parenttype][parent];
+		frm.doc.states = parent_doc.states;
+	}
 });
 
 frappe.customize_form.save_customization = function (frm) {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1436,7 +1436,10 @@ export default class GridRow {
 		let field = this.on_grid_fields_dict[fieldname];
 		// reset field value
 		if (field) {
-			field.docname = this.doc.name;
+			// the below if statement is added to factor in the exception when this.doc is undefined -
+			// - after row removals via customize_form.js on links, actions and states child-tables
+			if (this.doc)
+				field.docname = this.doc.name;
 			field.refresh();
 		}
 

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1438,8 +1438,7 @@ export default class GridRow {
 		if (field) {
 			// the below if statement is added to factor in the exception when this.doc is undefined -
 			// - after row removals via customize_form.js on links, actions and states child-tables
-			if (this.doc)
-				field.docname = this.doc.name;
+			if (this.doc) field.docname = this.doc.name;
 			field.refresh();
 		}
 


### PR DESCRIPTION
`closes #26041`

The following video (uploaded by the user who opened the issue) demonstrates the bug:-
https://github.com/frappe/frappe/assets/48678570/09351117-66bd-4934-a58a-9630f836c522

The bug affects the following 3 child tables in the Customize Form view:-
"DocType Link"
"DocType Action"
"DocType State"

The issue emerges when we try to delete any rows that are added to the above child tables in the Doctype opened via the Customize Form.

After debugging and tracing the ecosystem of the issue, it is found that:-
the exception occurs when the delete function removes rows of the above mentioned child tables (of their respective parent doctype) from the local copy of the browser.
As per design, this works fine in the case of Doctype edits, but in the case of Customise Form edits, the 'parent' doc of the opened Form view, is 'Customize Form', which is different from the 'parent' of the child table that is being edited.
Hence the delete does not reflect on the opened form, and the grid_row of the child table become 'undefined'.

The fix:-
Replicate the changed child-table field of the 'parent' doctype, to the opened child-table field of 'Customise-Form'.
(frm.doc.links = parent_doc.links;)
Please refer to the commit message, for full details.