### PR TITLE
perf: Reuse cached user for `get_user_lang`

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -97,20 +97,14 @@ def get_parent_language(lang: str) -> str:
 def get_user_lang(user: str | None = None) -> str:
 	"""Set frappe.local.lang from user preferences on session beginning or resumption"""
 	user = user or frappe.session.user
-	lang = frappe.cache.hget("lang", user)
 
-	if not lang:
-		# User.language => Session Defaults => frappe.local.lang => 'en'
-		lang = (
-			frappe.db.get_value("User", user, "language")
-			or frappe.db.get_default("lang")
-			or frappe.local.lang
-			or "en"
-		)
-
-		frappe.cache.hset("lang", user, lang)
-
-	return lang
+	# User.language => Session Defaults => frappe.local.lang => 'en'
+	return (
+		frappe.get_cached_value("User", user, "language")
+		or frappe.db.get_default("lang")
+		or frappe.local.lang
+		or "en"
+	)
 
 
 def get_lang_code(lang: str) -> str | None:


### PR DESCRIPTION
Saves ~1% of overhead.

User doc is almost always cached to create session so we can reuse it in
same request without additional redis call.
