### PR TITLE
test: check redis calls and overhead

### DIFF
--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -27,6 +27,7 @@ import frappe
 from frappe.frappeclient import FrappeClient
 from frappe.model.base_document import get_controller
 from frappe.query_builder.utils import db_type_is
+from frappe.tests.test_api import FrappeAPITestCase
 from frappe.tests.test_query_builder import run_only_if
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import cint
@@ -196,3 +197,39 @@ class TestPerformance(FrappeTestCase):
 	def test_no_cyclic_references(self):
 		doc = frappe.get_doc("User", "Administrator")
 		self.assertEqual(sys.getrefcount(doc), 2)  # Note: This always returns +1
+
+	def test_get_doc_cache_calls(self):
+		frappe.get_doc("User", "Administrator")
+		with self.assertRedisCallCounts(1):
+			frappe.get_doc("User", "Administrator")
+
+
+class TestOverheadCalls(FrappeAPITestCase):
+	"""Test that typical redis and db calls remain same overtime.
+
+	If this tests fail on your PR, make sure you're not introducing something in hot-path of these
+	endpoints. Only update values if you're really sure that's the right call.
+	Every call increase here is an actual increase in cost!
+	"""
+
+	BASE_SQL_CALLS = 2  # rollback + begin
+
+	def test_ping_overheads(self):
+		self.get(self.method("ping"))
+		with self.assertRedisCallCounts(12), self.assertQueryCount(self.BASE_SQL_CALLS):
+			self.get(self.method("ping"))
+
+	def test_list_view_overheads(self):
+		sid = self.sid
+		self.get(self.resource("ToDo"), {"sid": sid})
+		self.get(self.resource("ToDo"), {"sid": sid})
+		with self.assertRedisCallCounts(24), self.assertQueryCount(self.BASE_SQL_CALLS + 1):
+			self.get(self.resource("ToDo"), {"sid": sid})
+
+	def test_get_doc_overheads(self):
+		sid = self.sid
+		tables = len(frappe.get_meta("User").get_table_fields())
+		self.get(self.resource("User", "Administrator"), {"sid": sid})
+		self.get(self.resource("User", "Administrator"), {"sid": sid})
+		with self.assertRedisCallCounts(19), self.assertQueryCount(self.BASE_SQL_CALLS + 1 + tables):
+			self.get(self.resource("User", "Administrator"), {"sid": sid})

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -204,6 +204,7 @@ class TestPerformance(FrappeTestCase):
 			frappe.get_doc("User", "Administrator")
 
 
+@run_only_if(db_type_is.MARIADB)
 class TestOverheadCalls(FrappeAPITestCase):
 	"""Test that typical redis and db calls remain same overtime.
 
@@ -215,9 +216,9 @@ class TestOverheadCalls(FrappeAPITestCase):
 	BASE_SQL_CALLS = 2  # rollback + begin
 
 	def test_ping_overheads(self):
-		self.get(self.method("ping"))
+		self.get(self.method("ping"), {"sid": "Guest"})
 		with self.assertRedisCallCounts(12), self.assertQueryCount(self.BASE_SQL_CALLS):
-			self.get(self.method("ping"))
+			self.get(self.method("ping"), {"sid": "Guest"})
 
 	def test_list_view_overheads(self):
 		sid = self.sid


### PR DESCRIPTION
Added basic tests to ensure that # of redis and DB calls don't increase over time.

These should be _fairly_ reliable in counting queries/commands, hence no test retries added.

Some notes:
- DB patching was changed to allow patching class across threads. (frappe.db is object and not the actual class)
- Some warmup code runs twice because of db callbacs :skull: 