### PR TITLE
fix: don't run `setattr` for a virtual (read-only) field

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -834,7 +834,8 @@ class BaseDocument:
 					values = frappe.get_doc(doctype, docname).as_dict()
 
 				if values:
-					setattr(self, df.fieldname, values.name)
+					if not df.get("is_virtual"):
+						setattr(self, df.fieldname, values.name)
 
 					for _df in fields_to_fetch:
 						if self.is_new() or not self.docstatus.is_submitted() or _df.allow_on_submit:


### PR DESCRIPTION
Creating a virtual link field prohibits docs from being inserted/saved.

You will get the exception
```
AttributeError: can't set attribute '<name of attribute>'
```
instead.


Setting of properties without a setter (in case of virtual fields) just doesn't work and makes no sense anyway.
Due to this, this PR skips setting these fields.


Please backport this to version-14 and version-15.