### PR TITLE
fix(TextEditor): Show editable rich editor in grid row

### DIFF
--- a/frappe/public/js/frappe/form/controls/text_editor.js
+++ b/frappe/public/js/frappe/form/controls/text_editor.js
@@ -196,7 +196,7 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 	}
 
 	get_quill_options() {
-		return {
+		const options = {
 			modules: {
 				toolbar: Object.keys(this.df).includes("get_toolbar_options")
 					? this.df.get_toolbar_options()
@@ -211,6 +211,14 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
 			bounds: this.quill_container[0],
 			placeholder: this.df.placeholder || "",
 		};
+
+		// In a grid row where space is constrained, hide the toolbar.
+		if (this.grid_row) {
+			options.theme = null;
+			options.modules.toolbar = [];
+		}
+
+		return options;
 	}
 
 	get_mention_options() {

--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -1101,12 +1101,6 @@ export default class GridRow {
 			parent = column.field_area,
 			df = column.df;
 
-		// no text editor in grid
-		if (df.fieldtype == "Text Editor") {
-			df = Object.assign({}, df);
-			df.fieldtype = "Text";
-		}
-
 		var field = frappe.ui.form.make_control({
 			df: df,
 			parent: parent,

--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -230,7 +230,8 @@
 			height: 46px !important;
 		}
 
-		.form-control {
+		.form-control,
+		.ql-editor {
 			border-radius: 0px;
 			border: 0px;
 			padding-top: 10px;
@@ -300,6 +301,14 @@
 
 	.grid-static-col[data-fieldtype="Text Editor"] {
 		overflow: hidden;
+		margin: 0 !important;
+
+		.ql-editor {
+			overflow-y: auto !important;
+			min-height: 0 !important;
+			max-height: unset !important;
+			line-height: 1.3 !important;
+		}
 	}
 }
 


### PR DESCRIPTION
# Before
![image](https://github.com/frappe/frappe/assets/10946971/9b24bddc-e479-4bf0-bb03-28e0afe769f4)

# After
![image](https://github.com/frappe/frappe/assets/10946971/90880863-9f27-40be-8c78-8278dfffb951)

---

https://github.com/frappe/frappe/blob/500992615fe2f87717c5c384914fbaf6222d051c/frappe/public/js/frappe/form/grid_row.js#L1103-L1107