### PR TITLE
fix: open URL type shortcut in workspace in a new tab

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -49,12 +49,7 @@ export default class ShortcutWidget extends Widget {
 			}
 
 			if (this.type == "URL") {
-				if (frappe.open_in_new_tab) {
-					window.open(this.url, "_blank");
-					frappe.open_in_new_tab = false;
-				} else {
-					window.location.href = this.url;
-				}
+				window.open(this.url, "_blank");
 				return;
 			}
 


### PR DESCRIPTION
didn't make sense to open an external URL (which this shortcut was made for) in the same tab