### PR TITLE
chore(openpyxl): don't set `read_only=True` while reading an excel file

### DIFF
--- a/frappe/utils/xlsxutils.py
+++ b/frappe/utils/xlsxutils.py
@@ -85,7 +85,7 @@ def read_xlsx_file_from_attached_file(file_url=None, fcontent=None, filepath=Non
 		return
 
 	rows = []
-	wb1 = load_workbook(filename=filename, read_only=True, data_only=True)
+	wb1 = load_workbook(filename=filename, data_only=True)
 	ws1 = wb1.active
 	for row in ws1.iter_rows():
 		rows.append([cell.value for cell in row])


### PR DESCRIPTION
The way openpyxl parses files in read only and without read only mode is very different, and read only seems to break with certain files
It tries to head information about the max rows/columns from the header in the case of read only
which can be wrong sometimes.

![image](https://github.com/frappe/frappe/assets/10119037/387578b7-402f-4310-a395-b47d2a9ca00a)

First one is with read_only, second without
