### PR TITLE
fix(integrations): add back `response.raise_for_status()`

### DIFF
--- a/frappe/integrations/utils.py
+++ b/frappe/integrations/utils.py
@@ -19,6 +19,8 @@ def make_request(method: str, url: str, auth=None, headers=None, data=None, json
 		response = frappe.flags.integration_request = s.request(
 			method, url, data=data, auth=auth, headers=headers, json=json, params=params
 		)
+		response.raise_for_status()
+
 		content_type = response.headers.get("content-type")
 		if content_type == "text/plain; charset=utf-8":
 			return parse_qs(response.text)


### PR DESCRIPTION
It got removed in 59ca074780e087a9a1ff508d8b5f11a0571d5a20, however it
should still be here, the point of that commit was to fix other
behaviour, don't exactly remember why it was removed.
