### PR TITLE
fix: Increase folder link field size

### DIFF
--- a/frappe/core/doctype/file/file.json
+++ b/frappe/core/doctype/file/file.json
@@ -107,6 +107,7 @@
    "fieldtype": "Link",
    "hidden": 1,
    "label": "Folder",
+   "length": 255,
    "options": "File",
    "read_only": 1
   },
@@ -189,7 +190,7 @@
  "icon": "fa fa-file",
  "idx": 1,
  "links": [],
- "modified": "2024-03-23 16:03:25.814224",
+ "modified": "2024-05-09 11:46:42.917146",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "File",

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1027,7 +1027,7 @@ class BaseDocument:
 
 		frappe.throw(
 			_("{0}: '{1}' ({3}) will get truncated, as max characters allowed is {2}").format(
-				reference, _(df.label, context=df.parent), max_length, value
+				reference, frappe.bold(_(df.label, context=df.parent)), max_length, value
 			),
 			frappe.CharacterLengthExceededError,
 			title=_("Value too big"),


### PR DESCRIPTION
File `name` is 255 because it's bootstrapped using mariadb.sql, so users
can create 255 char long folders but can't store anything in it. 