### PR TITLE
fix: cache github release data per bench

### DIFF
--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -132,7 +132,7 @@ def site_cache(ttl: int | None = None, maxsize: int | None = None) -> Callable:
 	return time_cache_wrapper
 
 
-def redis_cache(ttl: int | None = 3600, user: str | bool | None = None) -> Callable:
+def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: bool = False) -> Callable:
 	"""Decorator to cache method calls and its return values in Redis
 
 	args:
@@ -153,10 +153,10 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None) -> Calla
 		def redis_cache_wrapper(*args, **kwargs):
 			func_call_key = func_key + "::" + str(__generate_request_cache_key(args, kwargs))
 			if frappe.cache.exists(func_call_key):
-				return frappe.cache.get_value(func_call_key, user=user)
+				return frappe.cache.get_value(func_call_key, user=user, shared=shared)
 			val = func(*args, **kwargs)
 			ttl = getattr(func, "ttl", 3600)
-			frappe.cache.set_value(func_call_key, val, expires_in_sec=ttl, user=user)
+			frappe.cache.set_value(func_call_key, val, expires_in_sec=ttl, user=user, shared=shared)
 			return val
 
 		return redis_cache_wrapper


### PR DESCRIPTION
Reduce API calls to github as public calls are limited.

Speeds up https://github.com/frappe/frappe/pull/26314
