### PR TITLE
fix: pass user and shared params when checking for cache keys

### DIFF
--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -184,6 +184,34 @@ class TestRedisCache(FrappeAPITestCase):
 		frappe.clear_cache()
 		calculate_area(10)
 		self.assertEqual(function_call_count, 2)
+	
+	def test_user_cache(self):
+		function_call_count = 0
+		PI = 3.1415
+		ENGINEERING_PI = _E = 3
+
+		@redis_cache(user=True)
+		def calculate_area(radius: float) -> float:
+			nonlocal function_call_count
+			PI_APPROX = ENGINEERING_PI if frappe.session.user == "Engineer" else PI
+			function_call_count += 1
+			return PI_APPROX * radius**2
+
+		with self.set_user("Engineer"):
+			self.assertEqual(calculate_area(1), ENGINEERING_PI)
+			self.assertEqual(function_call_count, 1)
+
+		with self.set_user("Mathematician"):
+			self.assertEqual(calculate_area(1), PI)
+			self.assertEqual(function_call_count, 2)
+
+		with self.set_user("Engineer"):
+			self.assertEqual(calculate_area(1), ENGINEERING_PI)
+			self.assertEqual(function_call_count, 2)
+
+		with self.set_user("Mathematician"):
+			self.assertEqual(calculate_area(1), PI)
+			self.assertEqual(function_call_count, 2)
 
 
 class TestDocumentCache(FrappeAPITestCase):

--- a/frappe/tests/test_caching.py
+++ b/frappe/tests/test_caching.py
@@ -184,7 +184,7 @@ class TestRedisCache(FrappeAPITestCase):
 		frappe.clear_cache()
 		calculate_area(10)
 		self.assertEqual(function_call_count, 2)
-	
+
 	def test_user_cache(self):
 		function_call_count = 0
 		PI = 3.1415

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -138,6 +138,7 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: 
 	args:
 	        ttl: time to expiry in seconds, defaults to 1 hour
 	        user: `true` should cache be specific to session user.
+			shared: `true` should cache be shared across sites
 	"""
 
 	def wrapper(func: Callable | None = None) -> Callable:
@@ -152,7 +153,7 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: 
 		@wraps(func)
 		def redis_cache_wrapper(*args, **kwargs):
 			func_call_key = func_key + "::" + str(__generate_request_cache_key(args, kwargs))
-			if frappe.cache.exists(func_call_key):
+			if frappe.cache.exists(func_call_key, user=user, shared=shared):
 				return frappe.cache.get_value(func_call_key, user=user, shared=shared)
 			val = func(*args, **kwargs)
 			ttl = getattr(func, "ttl", 3600)

--- a/frappe/utils/caching.py
+++ b/frappe/utils/caching.py
@@ -138,7 +138,7 @@ def redis_cache(ttl: int | None = 3600, user: str | bool | None = None, shared: 
 	args:
 	        ttl: time to expiry in seconds, defaults to 1 hour
 	        user: `true` should cache be specific to session user.
-			shared: `true` should cache be shared across sites
+	        shared: `true` should cache be shared across sites
 	"""
 
 	def wrapper(func: Callable | None = None) -> Callable:


### PR DESCRIPTION
User specific cache for `redis_cache` decorator was not working. 

When checking for cache key existence, the `user` and `shared` params were not being passed to the `exists` function. 

cc: @ankush 