### PR TITLE
get doctype name statically

### DIFF
--- a/frappe/types/exporter.py
+++ b/frappe/types/exporter.py
@@ -29,6 +29,10 @@ type_code_block_template = """{start_block}
 
 from typing import TYPE_CHECKING
 
+@staticmethod
+def get_doctype_name():
+{indent}return "{doctype}"
+
 if TYPE_CHECKING:
 {imports}
 
@@ -112,6 +116,8 @@ class TypeExporter:
 				end_block=end_block,
 				fields=textwrap.indent(fields_code_block, self.indent),
 				imports=textwrap.indent(imports, self.indent),
+				indent=self.indent,
+				doctype=self.doctype,
 			),
 			self.indent,
 		)


### PR DESCRIPTION
This pull request introduces a new static method, `get_doctype_name`, to the base Document class in Frappe. The goal of this enhancement is to facilitate type-safe interactions with documents, particularly when using the `frappe.get_doc` function. By implementing `get_doctype_name`, developers can retrieve the Doctype name directly from the class, improving maintainability and readability of the code that interacts with Frappe's ORM layer.

## Questions for the Maintainers

Before finalizing this implementation, I'd like to verify if there's an existing method or pattern within Frappe that already addresses this requirement. If so, guidance on how to better integrate or utilize existing functionalities would be greatly appreciated.

## Use Case
Currently, when developers need to dynamically fetch documents, they have to manually pass the Doctype name as a string, which can lead to errors if there are changes in the Doctype name or if the name is misspelled. This feature aims to eliminate such issues by allowing the following type-safe method of fetching documents:

```python
from typing import TypeVar, Type
from frappe.model.document import Document

T = TypeVar("T", bound=Document)

def get_doc_typed(cls: Type[T], name: str) -> T:
    doctype_name = cls.get_doctype_name()
    return frappe.get_doc(doctype_name, name)


# example:
from frappe.core.doctype.user_group.user_group import UserGroup
my_group = get_doc_typed(UserGroup, "Example")  # type of my_group is UserGroup
```