### PR TITLE
fix: make rename_doc work pre_model_sync

### DIFF
--- a/frappe/model/rename_doc.py
+++ b/frappe/model/rename_doc.py
@@ -451,26 +451,28 @@ def get_link_fields(doctype: str) -> list[dict]:
 		frappe.flags.link_fields = {}
 
 	if doctype not in frappe.flags.link_fields:
-		virtual_doctypes = frappe.get_all("DocType", {"is_virtual": 1}, pluck="name")
-
 		dt = frappe.qb.DocType("DocType")
 		df = frappe.qb.DocType("DocField")
 		cf = frappe.qb.DocType("Custom Field")
 		ps = frappe.qb.DocType("Property Setter")
 
-		standard_fields = (
+		standard_fields_query = (
 			frappe.qb.from_(df)
 			.inner_join(dt)
 			.on(df.parent == dt.name)
 			.select(df.parent, df.fieldname, dt.issingle.as_("issingle"))
-			.where(
-				(df.options == doctype)
-				& (df.fieldtype == "Link")
-				& (df.is_virtual == 0)
-				& (dt.is_virtual == 0)
-			)
-			.run(as_dict=True)
+			.where((df.options == doctype) & (df.fieldtype == "Link"))
 		)
+
+		if frappe.db.has_column("DocField", "is_virtual"):
+			standard_fields_query = standard_fields_query.where(df.is_virtual == 0)
+
+		virtual_doctypes = []
+		if frappe.db.has_column("DocType", "is_virtual"):
+			virtual_doctypes = frappe.get_all("DocType", {"is_virtual": 1}, pluck="name")
+			standard_fields_query = standard_fields_query.where(dt.is_virtual == 0)
+
+		standard_fields = standard_fields_query.run(as_dict=True)
 
 		cf_issingle = frappe.qb.from_(dt).select(dt.issingle).where(dt.name == cf.dt).as_("issingle")
 		custom_fields = (


### PR DESCRIPTION
While migrating older sites, `DocType.is_virtual` is not available `[pre_model_sync]`.

`rename_doc` is used in patches, which can then break migrations.

This PR makes `rename_doc` work without `is_virtual`, by making these parts of the code dependent on this column being available.