### PR TITLE
test: Drop threshold for JS builds to be 1% (33 KB)

### DIFF
--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -897,7 +897,7 @@ class TestBenchBuild(BaseTestCommands):
 			self.assertEqual(result.exception, None)
 
 		CURRENT_SIZE = 3.3  # MB
-		JS_ASSET_THRESHOLD = 0.05
+		JS_ASSET_THRESHOLD = 0.01
 
 		hooks = frappe.get_hooks()
 		default_bundle = hooks["app_include_js"]


### PR DESCRIPTION
Multiple recent cases of unknowingly pushing more JS in `/app`'s JS.


This threshold is sufficient for 100s of lines of manually written JS but even smallest library inclusion will most likely trigger this.