### PR TITLE
fix: refresh fields after changing form to read-only

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -1842,6 +1842,7 @@ frappe.ui.form.Form = class FrappeForm {
 				email: p.email,
 			};
 		});
+		this.refresh_fields();
 	}
 
 	trigger(event, doctype, docname) {


### PR DESCRIPTION
If no refresh occurs, the form behaves in a strange way such as:
* fields only become read only after chaning and leaving them
* clicking "Add Row" in a child table vanishes after clicking it

Frappe itself already has the problem that this method gets called, but doesn't have the desired effect.

# Examples:
* `frappe/core/doctype/page/page.js`
* `frappe/core/doctype/doctype/doctype.js`

In ERPNext some calls to it can be found where `refresh_fields()` is implicitely called afterwards. I guess to circumvent this problem.

# Affected Versions:
* version-14
* version-15

# Screencast
https://github.com/frappe/frappe/assets/9027507/265ab753-21c1-4695-9ba6-4e1908a2b7d2

