### PR TITLE
fix(contact list): add space before designation

### DIFF
--- a/frappe/public/js/frappe/form/templates/contact_list.html
+++ b/frappe/public/js/frappe/form/templates/contact_list.html
@@ -7,7 +7,7 @@
 				<span class="text-muted">&nbsp;({%= __("Primary") %})</span>
 			{% } %}
 			{% if(contact.designation){ %}
-			 <span class="text-muted">&ndash; {%= contact.designation %}</span>
+			 <span class="text-muted">&nbsp;&ndash; {%= contact.designation %}</span>
 			{% } %}
 			<a href="/app/Form/Contact/{%= encodeURIComponent(contact.name) %}"
 				class="btn btn-xs btn-default ml-auto">


### PR DESCRIPTION
This fix is not required in v15+ since the layout is different there.

The difference in the form looks like this:

```diff
- Raffael Meyer (Primary)– Developer
+ Raffael Meyer (Primary) – Developer
```