### PR TITLE
fix(grid_row): don't crash when undefined

### DIFF
--- a/frappe/public/js/frappe/form/controls/table.js
+++ b/frappe/public/js/frappe/form/controls/table.js
@@ -117,7 +117,7 @@ frappe.ui.form.ControlTable = class ControlTable extends frappe.ui.form.Control 
 	get_field(field_name) {
 		let fieldname;
 		field_name = field_name.toLowerCase();
-		this.grid.meta.fields.some((field) => {
+		this.grid?.meta?.fields.some((field) => {
 			if (frappe.model.no_value_type.includes(field.fieldtype)) {
 				return false;
 			}


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'fields')
  at frappe.ui.form.ControlTable.get_field(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/table.js:120:18)
  at HTMLInputElement.<anonymous>(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/table.js:46:13)
  at jQuery.event.dispatch(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:5135:27)
  at elemData.handle(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:4939:28)
  at sentryWrapped(../../../../../apps/frappe/node_modules/src/helpers.ts:98:1)

Sentry FRAPPE-698

