### PR TITLE
fix(DX): Don't run CI if there are no tests

### DIFF
--- a/frappe/tests/test_translate.py
+++ b/frappe/tests/test_translate.py
@@ -17,6 +17,7 @@ from frappe.translate import (
 	extract_messages_from_javascript_code,
 	extract_messages_from_python_code,
 	get_language,
+	get_messages_for_app,
 	get_parent_language,
 	get_translation_dict_from_file,
 )
@@ -313,6 +314,8 @@ def verify_translation_files(app):
 	for file in translations_dir.glob("*.csv"):
 		lang = file.stem  # basename of file = lang
 		get_translation_dict_from_file(file, lang, app, throw=True)
+
+	get_messages_for_app(app)
 
 
 expected_output = [

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -659,6 +659,11 @@ jobs:
       - name: Clone
         uses: actions/checkout@v3
 
+      - name: Find tests
+        run: |
+          echo "Finding tests"
+          grep -rn "def test" > /dev/null
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/frappe/utils/jinja.py
+++ b/frappe/utils/jinja.py
@@ -66,7 +66,7 @@ def validate_template(html):
 	try:
 		jenv.from_string(html)
 	except TemplateSyntaxError as e:
-		frappe.throw(frappe._(f"Syntax error in template as line {e.lineno}: {e.message}"))
+		frappe.throw(f"Syntax error in template as line {e.lineno}: {e.message}")
 
 
 def render_template(template, context=None, is_path=None, safe_render=True):


### PR DESCRIPTION
New apps keep burning CI just to install the app and run nothing.
This adds a small check before install to avoid unnecessary CI runs.
