### PR TITLE
fix(modal): Stack modals when minimized

### DIFF
--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -127,6 +127,10 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 			});
 	}
 
+	get $backdrop() {
+		return $(this.$wrapper.data("bs.modal")?._backdrop);
+	}
+
 	set_modal_size() {
 		if (!this.fields) {
 			this.size = "";
@@ -241,7 +245,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		this.$wrapper.removeClass("modal-minimize");
 
 		if (this.minimizable && this.is_minimized) {
-			$(".modal-backdrop").toggle();
+			this.$backdrop.show();
 			this.is_minimized = false;
 		}
 
@@ -256,7 +260,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 	hide() {
 		if (this.animate && this.animation_speed === "slow") {
 			this.$wrapper.addClass("slow");
-			$(".modal-backdrop").addClass("slow");
+			this.$backdrop.addClass("slow");
 		}
 		this.$wrapper.modal("hide");
 		this.is_visible = false;
@@ -279,7 +283,7 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 	}
 
 	toggle_minimize() {
-		$(".modal-backdrop").toggle();
+		this.$backdrop.toggle();
 		let modal = this.$wrapper.closest(".modal").toggleClass("modal-minimize");
 		modal.attr("tabindex") ? modal.removeAttr("tabindex") : modal.attr("tabindex", -1);
 		this.is_minimized = !this.is_minimized;

--- a/frappe/public/scss/common/modal.scss
+++ b/frappe/public/scss/common/modal.scss
@@ -306,3 +306,24 @@ body.modal-open[style^="padding-right"] {
 		margin-right: var(--margin-md);
 	}
 }
+
+// Stack minimized modals
+@for $i from 1 through 5 {
+	// 5n + 1, 5n + 2, ...
+	body > .modal:nth-child(5n + #{$i} of .show.modal-minimize) {
+		--minimized-modal-index: #{$i};
+	}
+}
+.modal-minimize ~ .modal-minimize {
+	.modal-dialog {
+		bottom: calc(44px * (var(--minimized-modal-index) - 1));
+	}
+	.modal-header {
+		border-bottom: 0px;
+	}
+	.modal-content {
+		// Rounded chip style
+		border-radius: var(--border-radius-md);
+		overflow: hidden;
+	}
+}


### PR DESCRIPTION
![](https://github.com/frappe/frappe/assets/10946971/a2b7f768-49a1-42fc-82f9-51492b0fd372)

Works for any number of modals, allows easy access to the last 5 modals. Over-engineered a little bit. Doesn't work well with long titles. https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#the_of_selector_syntax

Test with:

```js
new frappe.ui.Dialog({ title: "Lorem ipsum dolor sit amet", minimizable: true }).show()
```