### PR TITLE
fix(markdown_editor): don't crash when input_wrapper is undefined 

### DIFF
--- a/frappe/public/js/frappe/form/controls/markdown_editor.js
+++ b/frappe/public/js/frappe/form/controls/markdown_editor.js
@@ -8,7 +8,7 @@ frappe.ui.form.ControlMarkdownEditor = class ControlMarkdownEditor extends (
 
 		let editor_class = this.constructor.editor_class;
 		this.ace_editor_target.wrap(`<div class="${editor_class}-container">`);
-		this.markdown_container = this.$input_wrapper.find(`.${editor_class}-container`);
+		this.markdown_container = this.$input_wrapper?.find(`.${editor_class}-container`);
 
 		this.editor.getSession().setUseWrapMode(true);
 
@@ -30,10 +30,10 @@ frappe.ui.form.ControlMarkdownEditor = class ControlMarkdownEditor extends (
 
 			$btn.text(this.showing_preview ? __("Edit") : __("Preview"));
 		});
-		this.markdown_container.prepend(this.preview_toggle_btn);
+		this.markdown_container?.prepend(this.preview_toggle_btn);
 
 		this.markdown_preview = $(`<div class="${editor_class}-preview border rounded">`).hide();
-		this.markdown_container.append(this.markdown_preview);
+		this.markdown_container?.append(this.markdown_preview);
 
 		this.setup_image_drop();
 	}


### PR DESCRIPTION
Sentry FRAPPE-6K1

Error Log: 
```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'find')
    at _a9.make_ace_editor (markdown_editor.js:12:49)
    at code.js:4:35
```

> no-docs
