### PR TITLE
refactor(code): Fix "copy text" button in dialogs and read_only_depends_on

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -32,9 +32,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 			</button>`
 		);
 		this.copy_button.on("click", () => {
-			frappe.utils.copy_to_clipboard(
-				frappe.model.get_value(this.doctype, this.docname, this.df.fieldname)
-			);
+			frappe.utils.copy_to_clipboard(this.get_model_value() || this.get_value());
 		});
 		this.copy_button.appendTo(this.$wrapper);
 	}

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -4,32 +4,39 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 		this.load_lib().then(() => this.make_ace_editor());
 	}
 
-	make_wrapper() {
-		super.make_wrapper();
-		this.setup_copy_button();
+	refresh() {
+		super.refresh();
+		if (this.df.fieldtype === "Code") {
+			// Don't show for derived classes
+			this.setup_copy_button();
+		}
 	}
 
 	setup_copy_button() {
-		if (this.df.fieldtype === "Code" && this.get_status() !== "Write") {
-			this.button = $(
-				`<button
-					class="btn icon-btn"
-					style="position: absolute; top: 32px; right: 5px;"
-					onmouseover="this.classList.add('btn-default')"
-					onmouseout="this.classList.remove('btn-default')"
-				>
-					<svg class="es-icon es-line  icon-sm" style="" aria-hidden="true">
-						<use class="" href="#es-line-copy-light"></use>
-					</svg>
-				</button>`
-			);
-			this.button.on("click", () => {
-				frappe.utils.copy_to_clipboard(
-					frappe.model.get_value(this.doctype, this.docname, this.df.fieldname)
-				);
-			});
-			this.button.appendTo(this.$wrapper);
+		if (this.get_status() === "Write") {
+			this.copy_button?.remove();
+			this.copy_button = null;
+			return; // Don't show copy button in write mode
 		}
+
+		this.copy_button = $(
+			`<button
+				class="btn icon-btn"
+				style="position: absolute; top: 32px; right: 5px;"
+				onmouseover="this.classList.add('btn-default')"
+				onmouseout="this.classList.remove('btn-default')"
+			>
+				<svg class="es-icon es-line  icon-sm" style="" aria-hidden="true">
+					<use class="" href="#es-line-copy-light"></use>
+				</svg>
+			</button>`
+		);
+		this.copy_button.on("click", () => {
+			frappe.utils.copy_to_clipboard(
+				frappe.model.get_value(this.doctype, this.docname, this.df.fieldname)
+			);
+		});
+		this.copy_button.appendTo(this.$wrapper);
 	}
 
 	make_ace_editor() {

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -6,10 +6,10 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 
 	make_wrapper() {
 		super.make_wrapper();
-		this.set_copy_button();
+		this.setup_copy_button();
 	}
 
-	set_copy_button() {
+	setup_copy_button() {
 		if (this.df.fieldtype === "Code" && this.get_status() !== "Write") {
 			this.button = $(
 				`<button

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -10,12 +10,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 	}
 
 	set_copy_button() {
-		if (!this.frm?.doc) {
-			return;
-		}
-
-		const codeField = this.df.fieldtype === "Code";
-		if ((codeField && this.df.read_only === 1) || (codeField && this.frm.doc.docstatus > 0)) {
+		if (this.df.fieldtype === "Code" && this.get_status() !== "Write") {
 			this.button = $(
 				`<button
 					class="btn icon-btn"


### PR DESCRIPTION
* Use _BaseControl_.`get_status` instead of using custom code to detect read-only field, which won't work in dialogs.
* Use _BaseControl_.`get_model_value` and _BaseControl_.`get_value` instead of `frappe.model.get_value`, which won't work in dialogs.
* Rename method to `setup_copy_button`, the name used in _ControlData_.
* Show/hide dynamically based on `read_only_depends_on` by moving `setup_copy_button` call to `refresh`.