### PR TITLE
fix: "Not assigned" filter

### DIFF
--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -106,7 +106,7 @@ class ToDo(Document):
 				frappe.db.set_single_value(
 					self.reference_type,
 					"_assign",
-					json.dumps(assignments),
+					json.dumps(assignments) if assignments else "",
 					update_modified=False,
 				)
 			else:
@@ -114,7 +114,7 @@ class ToDo(Document):
 					self.reference_type,
 					self.reference_name,
 					"_assign",
-					json.dumps(assignments),
+					json.dumps(assignments) if assignments else "",
 					update_modified=False,
 				)
 


### PR DESCRIPTION
This filter doesn't work because `"[]"` is empty assignment list but truthy value.
