### PR TITLE
fix: default tree view

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -231,11 +231,15 @@ frappe.router = {
 			} else if (frappe.model.is_single(doctype_route.doctype)) {
 				route = ["Form", doctype_route.doctype, doctype_route.doctype];
 			} else if (meta.default_view) {
-				route = [
-					"List",
-					doctype_route.doctype,
-					this.list_views_route[meta.default_view.toLowerCase()],
-				];
+				if (meta.default_view === "Tree") {
+					route = ["Tree", doctype_route.doctype];
+				} else {
+					route = [
+						"List",
+						doctype_route.doctype,
+						this.list_views_route[meta.default_view.toLowerCase()],
+					];
+				}
 			} else {
 				route = ["List", doctype_route.doctype, "List"];
 			}


### PR DESCRIPTION
Create a DocType with custom tree JS and set the DocType's default view to "Tree".

When navigating to `/app/tree-doctype` (`["List", "Tree DocType", "Tree"]`), some tree view is loaded, but not the same as `/app/tree-doctype/view/tree`. The custom JS is not loaded: 

![Bildschirmfoto 2024-05-17 um 20 35 45](https://github.com/frappe/frappe/assets/14891507/95e3a609-a2cb-4e60-a849-e922ff28552b)

When we instead set the route as `["Tree", "Tree DocType"]` the loaded view is correct (notice the custom buttons):

![Bildschirmfoto 2024-05-17 um 20 35 18](https://github.com/frappe/frappe/assets/14891507/121f8fe4-335b-44ab-b93b-73584c457cbd)

Closes #23316, #23105