### PR TITLE
perf: num2words, babel, gettext, sentry imports

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -36,7 +36,12 @@ _sites_path = os.environ.get("SITES_PATH", ".")
 
 # If gc.freeze is done then importing modules before forking allows us to share the memory
 if frappe._tune_gc:
+	import gettext
+
+	import babel
+	import babel.messages
 	import bleach
+	import num2words
 	import pydantic
 
 	import frappe.boot

--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -4,6 +4,8 @@
 bootstrap client session
 """
 
+import os
+
 import frappe
 import frappe.defaults
 import frappe.desk.desk_page
@@ -109,6 +111,9 @@ def get_bootinfo():
 	bootinfo.subscription_conf = add_subscription_conf()
 	bootinfo.marketplace_apps = get_marketplace_apps()
 	bootinfo.changelog_feed = get_changelog_feed_items()
+
+	if sentry_dsn := get_sentry_dsn():
+		bootinfo.sentry_dsn = sentry_dsn
 
 	return bootinfo
 
@@ -470,3 +475,10 @@ def add_subscription_conf():
 		return frappe.conf.subscription
 	except Exception:
 		return ""
+
+
+def get_sentry_dsn():
+	if not frappe.get_system_settings("enable_telemetry"):
+		return
+
+	return os.getenv("FRAPPE_SENTRY_DSN")

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -442,7 +442,6 @@ after_job = [
 extend_bootinfo = [
 	"frappe.utils.telemetry.add_bootinfo",
 	"frappe.core.doctype.user_permission.user_permission.send_user_permissions",
-	"frappe.utils.sentry.add_bootinfo",
 ]
 
 get_changelog_feed = "frappe.desk.doctype.changelog_feed.changelog_feed.get_feed"

--- a/frappe/utils/sentry.py
+++ b/frappe/utils/sentry.py
@@ -140,13 +140,3 @@ def capture_exception(message: str | None = None) -> None:
 
 	except Exception:
 		frappe.logger().error("Failed to capture exception", exc_info=True)
-		pass
-
-
-def add_bootinfo(bootinfo):
-	"""Called from hook, sends DSN so client side can setup error monitoring."""
-	if not frappe.get_system_settings("enable_telemetry"):
-		return
-
-	if sentry_dsn := os.getenv("FRAPPE_SENTRY_DSN"):
-		bootinfo.sentry_dsn = sentry_dsn


### PR DESCRIPTION
num2words - 260KB - Used frequently on ERPNext sites.
babel - 1.1MB Gets imported because of dates, localization
sentry - 2.8MB should be loaded only if envvar is set
gettext - required for reading translations
