### PR TITLE
fix: scheduled type syncing

### DIFF
--- a/frappe/core/doctype/server_script/test_server_script.py
+++ b/frappe/core/doctype/server_script/test_server_script.py
@@ -3,7 +3,8 @@
 import requests
 
 import frappe
-from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
+from frappe.core.doctype.scheduled_job_type.scheduled_job_type import ScheduledJobType, sync_jobs
+from frappe.core.doctype.server_script.server_script import ServerScript
 from frappe.frappeclient import FrappeClient, FrappeException
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import get_site_url
@@ -342,3 +343,44 @@ frappe.qb.from_(todo).select(todo.name).where(todo.name == "{todo.name}").run()
 		updated_cron_job_name = frappe.db.get_value("Scheduled Job Type", {"server_script": cron_script.name})
 		updated_cron_job = frappe.get_doc("Scheduled Job Type", updated_cron_job_name)
 		self.assertEqual(updated_cron_job.next_execution.day, 2)
+
+	def test_server_script_state_changes(self):
+		script: ServerScript = frappe.get_doc(
+			doctype="Server Script",
+			name="scheduled_script_state_change",
+			script_type="Scheduler Event",
+			script="""frappe.flags = {"test": True}""",
+			event_frequency="Hourly",
+		).insert()
+
+		job: ScheduledJobType = frappe.get_doc("Scheduled Job Type", {"server_script": script.name})
+
+		script.script_type = "API"
+		script.save()
+		self.assertTrue(job.reload().stopped)
+
+		script.script_type = "Scheduler Event"
+		script.save()
+		self.assertFalse(job.reload().stopped)
+
+		# Change to different frequency
+		script.event_frequency = "Monthly"
+		script.save()
+		self.assertEqual(job.reload().frequency, "Monthly")
+
+		# change cron expr
+		script.event_frequency = "Cron"
+		script.cron_format = "* * * * *"
+		script.save()
+		self.assertEqual(job.reload().frequency, "Cron")
+		self.assertEqual(job.reload().cron_format, script.cron_format)
+
+		# manually disable
+
+		script.disabled = 1
+		script.save()
+		self.assertTrue(job.reload().stopped)
+
+		script.disabled = 0
+		script.save()
+		self.assertFalse(job.reload().stopped)

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -21,7 +21,7 @@ from frappe.model.naming import set_new_name, validate_name
 from frappe.model.utils import is_virtual_doctype
 from frappe.model.workflow import set_workflow_state_on_action, validate_workflow
 from frappe.types import DF
-from frappe.utils import Truthy, compare, cstr, date_diff, file_lock, flt, now
+from frappe.utils import compare, cstr, date_diff, file_lock, flt, now
 from frappe.utils.data import get_absolute_url, get_datetime, get_timedelta, getdate
 from frappe.utils.global_search import update_global_search
 
@@ -468,7 +468,7 @@ class Document(BaseDocument):
 		previous = self.get_doc_before_save()
 
 		if not previous:
-			return Truthy(context="New Document")
+			return True
 
 		previous_value = previous.get(fieldname)
 		current_value = self.get(fieldname)
@@ -480,10 +480,17 @@ class Document(BaseDocument):
 		elif isinstance(previous_value, timedelta):
 			current_value = get_timedelta(current_value)
 
-		if previous_value != current_value:
-			return Truthy(value=previous_value)
+		return previous_value != current_value
 
-		return False
+	def get_value_before_save(self, fieldname):
+		"""Returns value of a field before saving
+
+		Note: This function only works in save context like doc.save, doc.submit.
+		"""
+		previous = self.get_doc_before_save()
+		if not previous:
+			return
+		return previous.get(fieldname)
 
 	def set_new_name(self, force=False, set_name=None, set_child_names=True):
 		"""Calls `frappe.naming.set_new_name` for parent and child docs."""

--- a/frappe/utils/__init__.py
+++ b/frappe/utils/__init__.py
@@ -1168,21 +1168,3 @@ class CallbackManager:
 
 	def reset(self):
 		self._functions.clear()
-
-
-class Truthy:
-	def __init__(self, value=True, context=UNSET):
-		self.value = value
-		self.context = context
-
-	def __bool__(self):
-		return True
-
-	def __eq__(self, other: object) -> bool:
-		return True == other  # noqa: E712
-
-	def __repr__(self) -> str:
-		_val = "UNSET" if self.value is UNSET else self.value
-		_ctx = "UNSET" if self.context is UNSET else self.context
-
-		return f"Truthy(value={_val}, context={_ctx})"


### PR DESCRIPTION
- Scheduled Job sync when type was changed from scheduled to some other
  type didn't work.
- It updates on every save with message, bad DX IMO (can't save script
  and edit without dismissing)
- This was because of complex walrus which was triggering rest of code
  even when nothing changed. Maybe walrus opponents were onto something.
- `Truthy` couples two different operations and hence makes code
  complicated. In most cases where these checks are required it's not
  performance critical, we can do 1 more function call to avoid this
  coupling of change + actual value.



There are two distinct cases that need to be handled while syncing:

1. Switching away from scheduled type - Stop script and nothing 
    else (not handled correctly)
3. Switching other script fields -> sync script. (handled right 
    now but overly executed)