### PR TITLE
fix(code): Only add copy button if missing

### DIFF
--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -19,6 +19,10 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 			return; // Don't show copy button in write mode
 		}
 
+		if (this.copy_button) {
+			return;
+		}
+
 		this.copy_button = $(
 			`<button
 				class="btn icon-btn"


### PR DESCRIPTION
Little mistake in #26467, the button was added on every refresh.

![image](https://github.com/frappe/frappe/assets/10946971/1da64d7f-c0d0-499f-9b72-1ef37ed7590e)

![image](https://github.com/frappe/frappe/assets/10946971/1df147be-fa34-4667-ac17-b80e4f0a5041)
