### PR TITLE
fix!: map columns correctly in query report via fieldnames

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -146,7 +146,7 @@ class Report(Document):
 
 		check_safe_sql_query(self.query)
 
-		result = [list(t) for t in frappe.db.sql(self.query, filters)]
+		result = frappe.db.sql(self.query, filters, as_dict=1)
 		columns = self.get_columns() or [cstr(c[0]) for c in frappe.db.get_description()]
 
 		return [columns, result]


### PR DESCRIPTION
This pr helps in mapping the report columns correctly as defined in the column table for `query report` type. Previously it used to map the columns in the sequence they're defined ..not corresponding with the fieldnames

before:

https://github.com/frappe/frappe/assets/32034600/573c87f8-a211-4e0c-a032-649fa5f4d058


after:

https://github.com/frappe/frappe/assets/32034600/a12329e4-a60c-4683-ac7b-065dcc7712d5


This could be considered a breaking change if people have written queries without providing appropriate fieldnames in the column table.
