### PR TITLE
fix: calculation according to the decimal digit

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -355,7 +355,9 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					var numbers = txt.match(/[+-]?([0-9]*[.])?[0-9]+/g);
 					var maxDecimalPlaces = 0;
 					if (numbers) {
-						maxDecimalPlaces = Math.max(...numbers.map(num => getDecimalPlaces(parseFloat(num))));
+						maxDecimalPlaces = Math.max(
+							...numbers.map(num => getDecimalPlaces(parseFloat(num)))
+						);
 					}
 
 					// Use a default precision of 2 decimal places if no decimal places are found
@@ -373,7 +375,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 						match: rounded_val,
 						index: 80,
 						default: "Calculator",
-						onclick: function() {
+						onclick: function () {
 							frappe.msgprint(formatted_value, __("Result123"));
 						},
 					});

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -338,6 +338,11 @@ frappe.search.AwesomeBar = class AwesomeBar {
 	}
 
 	make_calculator(txt) {
+		function getDecimalPlaces(num) {
+			if (Math.floor(num) === num) return 0;
+			return num.toString().split(".")[1].length || 0;
+		}
+
 		var first = txt.substr(0, 1);
 		if (first == parseInt(first) || first === "(" || first === "=") {
 			if (first === "=") {
@@ -345,41 +350,35 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			}
 			try {
 				var val = eval(txt);
-				{
-					function getDecimalPlaces(num) {
-						if (Math.floor(num) === num) return 0;
-						return num.toString().split(".")[1].length || 0;
-					}
 
-					// Split the input to find the numbers and their decimal places
-					var numbers = txt.match(/[+-]?([0-9]*[.])?[0-9]+/g);
-					var maxDecimalPlaces = 0;
-					if (numbers) {
-						maxDecimalPlaces = Math.max(
-							...numbers.map((num) => getDecimalPlaces(parseFloat(num)))
-						);
-					}
-
-					// Use a default precision of 2 decimal places if no decimal places are found
-					if (maxDecimalPlaces === 0) {
-						maxDecimalPlaces = 2;
-					}
-
-					// Adjust the result to the maximum number of decimal places found or default precision
-					var rounded_val = parseFloat(val.toFixed(maxDecimalPlaces));
-
-					var formatted_value = __("{0} = {1}", [txt, (rounded_val + "").bold()]);
-					this.options.push({
-						label: formatted_value,
-						value: __("{0} = {1}", [txt, rounded_val]),
-						match: rounded_val,
-						index: 80,
-						default: "Calculator",
-						onclick: function () {
-							frappe.msgprint(formatted_value, __("Result123"));
-						},
-					});
+				// Split the input to find the numbers and their decimal places
+				var numbers = txt.match(/[+-]?([0-9]*[.])?[0-9]+/g);
+				var maxDecimalPlaces = 0;
+				if (numbers) {
+					maxDecimalPlaces = Math.max(
+						...numbers.map((num) => getDecimalPlaces(parseFloat(num)))
+					);
 				}
+
+				// Use a default precision of 2 decimal places if no decimal places are found
+				if (maxDecimalPlaces === 0) {
+					maxDecimalPlaces = 2;
+				}
+
+				// Adjust the result to the maximum number of decimal places found or default precision
+				var rounded_val = parseFloat(val.toFixed(maxDecimalPlaces));
+
+				var formatted_value = __("{0} = {1}", [txt, (rounded_val + "").bold()]);
+				this.options.push({
+					label: formatted_value,
+					value: __("{0} = {1}", [txt, rounded_val]),
+					match: rounded_val,
+					index: 80,
+					default: "Calculator",
+					onclick: function () {
+						frappe.msgprint(formatted_value, __("Result123"));
+					},
+				});
 			} catch (e) {
 				// pass
 			}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -345,17 +345,39 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			}
 			try {
 				var val = eval(txt);
-				var formatted_value = __("{0} = {1}", [txt, (val + "").bold()]);
-				this.options.push({
-					label: formatted_value,
-					value: __("{0} = {1}", [txt, val]),
-					match: val,
-					index: 80,
-					default: "Calculator",
-					onclick: function () {
-						frappe.msgprint(formatted_value, __("Result"));
-					},
-				});
+				{
+					function getDecimalPlaces(num) {
+						if (Math.floor(num) === num) return 0;
+						return num.toString().split(".")[1].length || 0;
+					}
+
+					// Split the input to find the numbers and their decimal places
+					var numbers = txt.match(/[+-]?([0-9]*[.])?[0-9]+/g);
+					var maxDecimalPlaces = 0;
+					if (numbers) {
+						maxDecimalPlaces = Math.max(...numbers.map(num => getDecimalPlaces(parseFloat(num))));
+					}
+
+					// Use a default precision of 2 decimal places if no decimal places are found
+					if (maxDecimalPlaces === 0) {
+						maxDecimalPlaces = 2;
+					}
+
+					// Adjust the result to the maximum number of decimal places found or default precision
+					var rounded_val = parseFloat(val.toFixed(maxDecimalPlaces));
+
+					var formatted_value = __("{0} = {1}", [txt, (rounded_val + "").bold()]);
+					this.options.push({
+						label: formatted_value,
+						value: __("{0} = {1}", [txt, rounded_val]),
+						match: rounded_val,
+						index: 80,
+						default: "Calculator",
+						onclick: function() {
+							frappe.msgprint(formatted_value, __("Result123"));
+						},
+					});
+				}
 			} catch (e) {
 				// pass
 			}

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -376,7 +376,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					index: 80,
 					default: "Calculator",
 					onclick: function () {
-						frappe.msgprint(formatted_value, __("Result123"));
+						frappe.msgprint(formatted_value, __("Result"));
 					},
 				});
 			} catch (e) {

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -356,7 +356,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 					var maxDecimalPlaces = 0;
 					if (numbers) {
 						maxDecimalPlaces = Math.max(
-							...numbers.map(num => getDecimalPlaces(parseFloat(num)))
+							...numbers.map((num) => getDecimalPlaces(parseFloat(num)))
 						);
 					}
 


### PR DESCRIPTION
fixes: #26509

leading to incorrect results such as `10.850000000000001` instead of `10.85`. The updated function now dynamically adjusts the precision based on the input numbers, ensuring accurate results by calculating the maximum number of decimal places required. Additionally, a default precision of two decimal places is used if the inputs do not specify any. These changes ensure that the calculator provides reliable and precise outputs for various types of calculations.


https://github.com/frappe/frappe/assets/141945075/1617e0f1-3e16-4610-a28d-2e8c4daa80da

