### PR TITLE
feat: Add `on_add_row` event for grid in Dialog

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -838,7 +838,9 @@ export default class Grid {
 					acc[d.fieldname] = d.default;
 					return acc;
 				}, {});
-				this.df.data.push({ idx: this.df.data.length + 1, __islocal: true, ...defaults });
+				let idx = this.df.data.length + 1;
+				this.df.data.push({ idx: idx, __islocal: true, ...defaults });
+				this.df.on_add_row && this.df.on_add_row(idx);
 				this.refresh();
 			}
 

--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -838,9 +838,10 @@ export default class Grid {
 					acc[d.fieldname] = d.default;
 					return acc;
 				}, {});
-				let idx = this.df.data.length + 1;
-				this.df.data.push({ idx: idx, __islocal: true, ...defaults });
-				this.df.on_add_row && this.df.on_add_row(idx);
+
+				const row_idx = this.df.data.length + 1;
+				this.df.data.push({ idx: row_idx, __islocal: true, ...defaults });
+				this.df.on_add_row && this.df.on_add_row(row_idx);
 				this.refresh();
 			}
 


### PR DESCRIPTION
Documentation: https://frappeframework.com/docs/user/en/api/dialog?editWiki=1&wikiPagePatch=aj13edb2n0

- Add an event `on_add_row` to a grid that is not inside a form (eg. in a dialog)
- This can be used to manipulate data and add presets to the dialog grid dynamically

**Usage:**
```js
const dialog = new frappe.ui.Dialog({
	title: __("Create Logs"),
	fields: [
		{
			fieldname: "logs",
			fieldtype: "Table",
			label: __("Logs"),
			in_place_edit: true,
			reqd: 1,
			fields: table_fields,
			// set data on row addition, idx = visible idx of the row
			// set `log_type` as alternating IN/OUT in dialog table on row addition
			on_add_row: (idx) => {
				let data_id = idx - 1;
				let logs = dialog.fields_dict.logs;
				let log_type = (data_id % 2) == 0 ? "IN" : "OUT";

				logs.df.data[data_id].log_type = log_type;
				logs.grid.refresh();
			},
		},
	],
	primary_action: (values) => {},
	primary_action_label: __("Create"),
});
```

