### PR TITLE
feat: kanban style

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_column.html
+++ b/frappe/public/js/frappe/views/kanban/kanban_column.html
@@ -1,4 +1,4 @@
-<div class="kanban-column" data-column-value="{{title}}">
+<div class="kanban-column" data-column-value="{{title}}" style="background-color: var(--bg-{{indicator}});">
 	<div class="kanban-column-header">
 		<span class="kanban-column-title">
 			<span class="indicator-pill {{indicator}}"></span>

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -142,7 +142,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	setup_view() {
-		if (this.board.columns.length > 5) {
+		if (this.board.columns.filter((col) => col.status !== "Archived").length > 5) {
 			this.page.container.addClass("full-width");
 		}
 		this.setup_realtime_updates();

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -136,6 +136,9 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 		this.hide_card_layout = true;
 		this.hide_sort_selector = true;
 		super.setup_page();
+
+		this.page.disable_sidebar_toggle = true;
+		this.page.setup_sidebar_toggle();
 	}
 
 	setup_view() {

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -15,6 +15,7 @@
 
 .kanban {
 	display: flex;
+	gap: 0.5em;
 	overflow-y: hidden;
 
 	-ms-overflow-style: none; /* IE and Edge */
@@ -31,7 +32,6 @@
 		border-radius: var(--border-radius);
 		padding: var(--padding-md);
 		min-height: calc(100vh - 150px);
-		margin: 0.5em 0.25em 0.5em 0.25em;
 
 		.add-card {
 			@include flex(flex, center, center, null);

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -27,8 +27,7 @@
 	.kanban-column {
 		@include transition();
 
-		flex: 0 0 260px;
-		max-width: 260px;
+		flex: 1 0 260px;
 		border-radius: var(--border-radius);
 		padding: var(--padding-md);
 		min-height: calc(100vh - 150px);

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -39,7 +39,7 @@
 			@include transition();
 
 			color: var(--text-light);
-			background-color: var(--kanban-new-card-bg);
+			background-color: var(--bg-color);
 			height: 27px;
 			font-size: var(--text-md);
 			margin-bottom: var(--margin-sm);

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -31,8 +31,8 @@
 		max-width: 260px;
 		border-radius: var(--border-radius);
 		padding: var(--padding-md);
-		min-height: calc(100vh - 250px);
-		max-height: calc(100vh - var(--navbar-height) - var(--page-bottom-margin) - 80px);
+		min-height: calc(100vh - 150px);
+		margin: 0.5em 0.25em 0.5em 0.25em;
 
 		.add-card {
 			@include flex(flex, center, center, null);

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -179,7 +179,7 @@
 
 					.kanban-card-body {
 						cursor: grab;
-						padding: var(--padding-sm);
+						padding: var(--padding-md);
 
 						.kanban-title-area {
 							margin-bottom: 12px;

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -105,10 +105,6 @@
 					margin: 0;
 				}
 			}
-
-			&:hover {
-				cursor: pointer;
-			}
 		}
 
 		.kanban-column-title {
@@ -123,6 +119,7 @@
 			.kanban-title {
 				@include get_textstyle("lg", "semibold");
 				margin-left: var(--margin-sm);
+				cursor: grab;
 			}
 		}
 


### PR DESCRIPTION
Reviving the style fixes from https://github.com/frappe/frappe/pull/17424

### Changes

- Hide sidebar toggle
- Toggle full-width if more than five columns are visible (not available)
- Show correct cursor on column header
- Increase column height, add margin
- Increase card padding
- Set column background based on indicator
    - I know, colors are controversial, but many people find them useful for visual separation of columns. If you don't like them, just don't set any indicator color.

### Before

<img width="1510" alt="Bildschirmfoto 2024-05-22 um 16 10 59" src="https://github.com/frappe/frappe/assets/14891507/b7094416-2c34-4d68-b1b3-8b720005973f">


### After

Gray:

<img width="1510" alt="Bildschirmfoto 2024-05-22 um 17 32 10" src="https://github.com/frappe/frappe/assets/14891507/1bebda45-40c5-4932-8a53-f472871d4a17">

Colorful:

<img width="1510" alt="Bildschirmfoto 2024-05-22 um 17 30 38" src="https://github.com/frappe/frappe/assets/14891507/d856a185-6691-4ff2-a321-c42aba614906">


<details>
<summary>Kanban style</summary>

![](https://64.media.tumblr.com/86e27cd5cc5b97daef98f17bb8a834d9/tumblr_mje2cdZO7z1s7acuso1_500.gif)

</details>

> no-docs