### PR TITLE
Enhancement: Add a Global Mute for SMS like in Mute Emails.

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2143,7 +2143,9 @@ def as_json(obj: dict | list, indent=1, separators=None, ensure_ascii=True) -> s
 
 def are_emails_muted():
 	return flags.mute_emails or cint(conf.get("mute_emails"))
-
+	
+def are_sms_muted():
+	return flags.mute_sms or cint(conf.get("mute_sms"))
 
 def get_test_records(doctype):
 	"""Return list of objects from `test_records.json` in the given doctype's folder."""

--- a/frappe/core/doctype/sms_settings/sms_settings.py
+++ b/frappe/core/doctype/sms_settings/sms_settings.py
@@ -123,6 +123,9 @@ def get_headers(sms_settings=None):
 
 
 def send_request(gateway_url, params, headers=None, use_post=False, use_json=False):
+	if frappe.are_sms_muted():
+		return
+		
 	import requests
 
 	if not headers:


### PR DESCRIPTION
We should also add a global mute for sms. Helpful for when we are developing in our local to stop accidental sending of message if you did not turn the notification doctype off.

Not exactly sure how to properly create a site config flag though, just throwing this off for now. Need review