### PR TITLE
fix: don't automatically add system manager

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -279,9 +279,6 @@ class User(Document):
 		if not cint(self.enabled) and self.name in STANDARD_USERS:
 			frappe.throw(_("User {0} cannot be disabled").format(self.name))
 
-		if not cint(self.enabled):
-			self.a_system_manager_should_exist()
-
 		# clear sessions if disabled
 		if not cint(self.enabled) and getattr(frappe.local, "login_manager", None):
 			frappe.local.login_manager.logout(user=self.name)
@@ -528,19 +525,10 @@ class User(Document):
 			retry=3,
 		)
 
-	def a_system_manager_should_exist(self):
-		if self.is_system_manager_disabled():
-			return
-
-		if not self.get_other_system_managers():
-			throw(_("There should remain at least one System Manager"))
-
 	def on_trash(self):
 		frappe.clear_cache(user=self.name)
 		if self.name in STANDARD_USERS:
 			throw(_("User {0} cannot be deleted").format(self.name))
-
-		self.a_system_manager_should_exist()
 
 		# disable the user and log him/her out
 		self.enabled = 0

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -159,7 +159,7 @@ class User(Document):
 		if self.name not in STANDARD_USERS:
 			self.email = self.name
 			self.validate_email_type(self.name)
-		self.add_system_manager_role()
+
 		self.move_role_profile_name_to_role_profiles()
 		self.populate_role_profile_roles()
 		self.check_roles_added()

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -286,35 +286,6 @@ class User(Document):
 		# toggle notifications based on the user's status
 		toggle_notifications(self.name, enable=cint(self.enabled), ignore_permissions=True)
 
-	def add_system_manager_role(self):
-		if self.is_system_manager_disabled():
-			return
-
-		# if adding system manager, do nothing
-		if not cint(self.enabled) or (
-			"System Manager" in [user_role.role for user_role in self.get("roles")]
-		):
-			return
-
-		if (
-			self.name not in STANDARD_USERS
-			and self.user_type == "System User"
-			and not self.get_other_system_managers()
-			and cint(frappe.db.get_single_value("System Settings", "setup_complete"))
-		):
-			msgprint(_("Adding System Manager to this User as there must be atleast one System Manager"))
-			self.append("roles", {"doctype": "Has Role", "role": "System Manager"})
-
-		if self.name == "Administrator":
-			# Administrator should always have System Manager Role
-			self.extend(
-				"roles",
-				[
-					{"doctype": "Has Role", "role": "System Manager"},
-					{"doctype": "Has Role", "role": "Administrator"},
-				],
-			)
-
 	def is_system_manager_disabled(self):
 		return frappe.db.get_value("Role", {"name": "System Manager"}, ["disabled"])
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -395,20 +395,6 @@ class User(Document):
 
 		return link
 
-	def get_other_system_managers(self):
-		user_doctype = DocType("User").as_("user")
-		user_role_doctype = DocType("Has Role").as_("user_role")
-		return (
-			frappe.qb.from_(user_doctype)
-			.from_(user_role_doctype)
-			.select(user_doctype.name)
-			.where(user_role_doctype.role == "System Manager")
-			.where(user_doctype.enabled == 1)
-			.where(user_role_doctype.parent == user_doctype.name)
-			.where(user_role_doctype.parent.notin(["Administrator", self.name]))
-			.limit(1)
-		).run()
-
 	def get_fullname(self):
 		"""get first_name space last_name"""
 		return (self.first_name or "") + (self.first_name and " " or "") + (self.last_name or "")

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -286,9 +286,6 @@ class User(Document):
 		# toggle notifications based on the user's status
 		toggle_notifications(self.name, enable=cint(self.enabled), ignore_permissions=True)
 
-	def is_system_manager_disabled(self):
-		return frappe.db.get_value("Role", {"name": "System Manager"}, ["disabled"])
-
 	def email_new_password(self, new_password=None):
 		if new_password and not self.flags.in_insert:
 			_update_password(user=self.name, pwd=new_password, logout_all_sessions=self.logout_all_sessions)

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -220,6 +220,7 @@ def create_or_update_user(args):  # nosemgrep
 			}
 		)
 		user.append_roles(*_get_default_roles())
+		user.append_roles("System Manager")
 		user.flags.no_welcome_mail = True
 		user.insert()
 


### PR DESCRIPTION
The possibility of accidentally turning an unprivileged user into a System Manager is more dangerous than useful. All sites have an Administrator who can add a missing System Manager role, if required.