### PR TITLE
fix: field wildcard for child object

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -216,7 +216,8 @@ def update_wildcard_field_param(data):
 	if (isinstance(data.fields, str) and data.fields == "*") or (
 		isinstance(data.fields, list | tuple) and len(data.fields) == 1 and data.fields[0] == "*"
 	):
-		data.fields = get_permitted_fields(data.doctype, parenttype=data.parenttype)
+		parent_type = data.parenttype or data.parent_doctype
+		data.fields = get_permitted_fields(data.doctype, parenttype=parent_type)
 		return True
 
 	return False


### PR DESCRIPTION
Hi,

When loading child objects with fields=["*"] via the REST API, only standard fields are returned. [india081947](https://github.com/india081947) has already described the same bug in [#25441](https://github.com/frappe/frappe/issues/25441). 


## Example

request: `{{base-url}}/api/resource/Web Form Field?fields=["*"]&parent=Web Form`

### function trace:

1. [frappe.api.v1.document_list](https://github.com/frappe/frappe/blob/75412ba8728a50adff254687a56d2d9d3cec07c9/frappe/api/v1.py#L10)
2. [frappe.client.get_list](https://github.com/frappe/frappe/blob/75412ba8728a50adff254687a56d2d9d3cec07c9/frappe/client.py#L28) : here the parent-doctype-name is saved with the key ["parent_doctype"](https://github.com/frappe/frappe/blob/75412ba8728a50adff254687a56d2d9d3cec07c9/frappe/client.py#L54)
3. [frappe.desk.reportview.validate_args ](https://github.com/frappe/frappe/blob/75412ba8728a50adff254687a56d2d9d3cec07c9/frappe/desk/reportview.py#L89)
4. [frappe.desk.reportview.validate_fields](https://github.com/frappe/frappe/blob/75412ba8728a50adff254687a56d2d9d3cec07c9/frappe/desk/reportview.py#L104) 
5. [frappe.desk.reportview.update_wildcard_field_param](https://github.com/frappe/frappe/blob/75412ba8728a50adff254687a56d2d9d3cec07c9/frappe/desk/reportview.py#L215) : here the parent-doctype-name is loaded with the key ["parenttype"](https://github.com/frappe/frappe/blob/75412ba8728a50adff254687a56d2d9d3cec07c9/frappe/desk/reportview.py#L219), but this key does not exist -> `None`

### response with bug

```json
{
    "data": [
        {
            "name": "e3bn1at0sb",
            "owner": "Administrator",
            "creation": "2016-09-19 05:16:59.242754",
            "modified": "2024-04-25 18:05:49.539971",
            "modified_by": "Administrator",
            "docstatus": 0,
            "idx": 1
        }
    ]
}
```

### response without bug

```json
{
    "data": [
        {
            "name": "e3bn1at0sb",
            "owner": "Administrator",
            "creation": "2016-09-19 05:16:59.242754",
            "modified": "2024-04-25 18:05:49.539971",
            "modified_by": "Administrator",
            "docstatus": 0,
            "idx": 1,
            "parent": "edit-profile",
            "parentfield": "web_form_fields",
            "parenttype": "Web Form",
            "fieldname": "first_name",
            "fieldtype": "Data",
            "label": "First Name",
            "allow_read_on_all_link_options": 0,
            "reqd": 1,
            "read_only": 0,
            "show_in_filter": 0,
            "hidden": 0,
            "options": null,
            "max_length": 0,
            "max_value": 0,
            "precision": null,
            "depends_on": null,
            "mandatory_depends_on": null,
            "read_only_depends_on": null,
            "description": null,
            "default": null
        }
    ]
}
```