### PR TITLE
fix: remove fetch_from from link field

### DIFF
--- a/frappe/core/doctype/doctype/doctype.py
+++ b/frappe/core/doctype/doctype/doctype.py
@@ -1266,6 +1266,8 @@ def validate_fields(meta: Meta):
 			return
 
 		if d.fieldtype in ("Link", *table_fields):
+			d.fetch_from = None
+
 			if not d.options:
 				frappe.throw(
 					_("{0}: Options required for Link or Table type field {1} in row {2}").format(

--- a/frappe/public/js/form_builder/components/FieldProperties.vue
+++ b/frappe/public/js/form_builder/components/FieldProperties.vue
@@ -25,9 +25,11 @@ let docfield_df = computed(() => {
 			df.fieldtype = "Fetch From";
 		}
 
+		const selected_fieldtype = store.form.selected_field.fieldtype;
 		if (
 			["fetch_from", "fetch_if_empty"].includes(df.fieldname) &&
-			in_list(frappe.model.no_value_type, store.form.selected_field.fieldtype)
+			(in_list(frappe.model.no_value_type, selected_fieldtype) ||
+				selected_fieldtype === "Link")
 		) {
 			return false;
 		}


### PR DESCRIPTION
Remove fetch_from for link fields because this has all sorts of weird validation behaviour.

Steps to replicate:
1. Create a link field with fetch from set
2. Try to save something

Should fail with validation errors. This also goes in infinite loop sometimes on custom field link fields with fetch_from set 
> no-docs