### PR TITLE
refactor: make use of `orjson` over `json` in some places

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -290,11 +290,11 @@ def set_cors_headers(response):
 
 
 def make_form_dict(request: Request):
-	import json
+	import orjson
 
 	request_data = request.get_data(as_text=True)
 	if request_data and request.is_json:
-		args = json.loads(request_data)
+		args = orjson.loads(request_data)
 	else:
 		args = {}
 		args.update(request.args or {})

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -512,7 +512,7 @@ def get_data_for_custom_field(doctype, field, names=None):
 	filters = {}
 	if names:
 		if isinstance(names, str | bytearray):
-			names = frappe.json.loads(names)
+			names = json.loads(names)
 		filters.update({"name": ["in", names]})
 
 	return frappe._dict(frappe.get_list(doctype, filters=filters, fields=["name", field], as_list=1))

--- a/frappe/tests/test_utils.py
+++ b/frappe/tests/test_utils.py
@@ -2,7 +2,6 @@
 # License: MIT. See LICENSE
 
 import io
-import json
 import os
 import sys
 from datetime import date, datetime, time, timedelta
@@ -12,6 +11,7 @@ from io import StringIO
 from mimetypes import guess_type
 from unittest.mock import patch
 
+import orjson
 import pytz
 from hypothesis import given
 from hypothesis import strategies as st
@@ -750,14 +750,14 @@ class TestResponse(FrappeTestCase):
 
 		BAD_OBJECT = {"Enum": TEST}
 
-		processed_object = json.loads(json.dumps(GOOD_OBJECT, default=json_handler))
+		processed_object = orjson.loads(orjson.dumps(GOOD_OBJECT, default=json_handler).decode())
 
 		self.assertTrue(all([isinstance(x, str) for x in processed_object["time_types"]]))
 		self.assertTrue(all([isinstance(x, float) for x in processed_object["float"]]))
 		self.assertTrue(all([isinstance(x, list | str) for x in processed_object["iter"]]))
 		self.assertIsInstance(processed_object["string"], str)
 		with self.assertRaises(TypeError):
-			json.dumps(BAD_OBJECT, default=json_handler)
+			orjson.dumps(BAD_OBJECT, default=json_handler)
 
 
 class TestTimeDeltaUtils(FrappeTestCase):

--- a/frappe/www/app.py
+++ b/frappe/www/app.py
@@ -4,9 +4,10 @@ import os
 
 no_cache = 1
 
-import json
 import re
 from urllib.parse import urlencode
+
+import orjson
 
 import frappe
 import frappe.sessions
@@ -43,7 +44,7 @@ def get_context(context):
 
 	# TODO: Find better fix
 	boot_json = CLOSING_SCRIPT_TAG_PATTERN.sub("", boot_json)
-	boot_json = json.dumps(boot_json)
+	boot_json = orjson.dumps(boot_json).decode()
 
 	hooks = frappe.get_hooks()
 	include_js = hooks.get("app_include_js", []) + frappe.conf.get("app_include_js", [])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "num2words~=0.5.12",
     "oauthlib~=3.2.2",
     "openpyxl~=3.1.2",
+    "orjson~=3.9.15",
     "passlib~=1.7.4",
     "pdfkit~=1.0.0",
     "phonenumbers==8.13.13",


### PR DESCRIPTION
- feat: use `orjson` instead of `json` in some places
- refactor: `frappe.json` -> `json`


Draft for now, just to see how CI reacts
