### PR TITLE
feat: increase verbosity of post_schema_updates

### DIFF
--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -136,17 +136,34 @@ class SiteMigration:
 		* Sync Installed Applications Version History
 		* Execute `after_migrate` hooks
 		"""
+		print("Syncing jobs...")
 		sync_jobs()
+
+		print("Syncing fixtures...")
 		sync_fixtures()
+
+		print("Syncing dashboards...")
 		sync_dashboards()
+
+		print("Syncing customizations...")
 		sync_customizations()
+
+		print("Syncing languages...")
 		sync_languages()
+
+		print("Flushing deferred inserts...")
 		flush_deferred_inserts()
+
+		print("Removing orphan doctypes...")
 		frappe.model.sync.remove_orphan_doctypes()
 
+		print("Syncing portal menu...")
 		frappe.get_single("Portal Settings").sync_menu()
+
+		print("Updating installed applications...")
 		frappe.get_single("Installed Applications").update_versions()
 
+		print("Executing `after_migrate` hooks...")
 		for app in frappe.get_installed_apps():
 			for fn in frappe.get_hooks("after_migrate", app_name=app):
 				frappe.get_attr(fn)()


### PR DESCRIPTION
After running the patches, which is very verbose, `post_schema_updates` can take quite some time during which the user was left in the dark about what is happening. They might even assume the process has frozen and exit it prematurely.

> no-docs