### PR TITLE
fix: apply perms on letter head selection

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -120,7 +120,7 @@ def get_bootinfo():
 
 def get_letter_heads():
 	letter_heads = {}
-	for letter_head in frappe.get_all("Letter Head", fields=["name", "content", "footer"]):
+	for letter_head in frappe.get_list("Letter Head", fields=["name", "content", "footer"]):
 		letter_heads.setdefault(
 			letter_head.name, {"header": letter_head.content, "footer": letter_head.footer}
 		)

--- a/frappe/public/js/frappe/form/print_utils.js
+++ b/frappe/public/js/frappe/form/print_utils.js
@@ -13,11 +13,11 @@ frappe.ui.get_print_settings = function (pdf, callback, letter_head, pick_column
 			label: __("With Letter head"),
 		},
 		{
-			fieldtype: "Select",
+			fieldtype: "Link",
 			fieldname: "letter_head",
 			label: __("Letter Head"),
 			depends_on: "with_letter_head",
-			options: Object.keys(frappe.boot.letter_heads),
+			options: "Letter Head",
 			default: letter_head || default_letter_head,
 		},
 		{


### PR DESCRIPTION
By default, all desk users have read access on all **Letter Head**s. However, this can be further restricted by custom **Role-** and **User Permissions**. The print settings dialog and the Letter Head list in `frappe.boot.letter_heads` didn't respect these permissions.

Fixes:

- Use a "Link" field for the selection of **Letter Head** -> the standard way, which respects user permissions.
- Use `get_list` for constructing `frappe.boot.letter_heads`.