### PR TITLE
perf: Merge `worker-pool` and `scheduler`

### DIFF
--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -174,8 +174,11 @@ def purge_jobs(site=None, queue=None, event=None):
 @click.command("schedule")
 def start_scheduler():
 	"""Start scheduler process which is responsible for enqueueing the scheduled job types."""
+	import time
+
 	from frappe.utils.scheduler import start_scheduler
 
+	time.sleep(0.5)  # Delayed start. TODO: find better way to handle this.
 	start_scheduler()
 
 
@@ -195,7 +198,10 @@ def start_scheduler():
 	type=click.Choice(["round_robin", "random"]),
 	help="Dequeuing strategy to use",
 )
-def start_worker(queue, quiet=False, rq_username=None, rq_password=None, burst=False, strategy=None):
+@click.option("--no-scheduler", is_flag=True, default=False, help="Do not start scheduler")
+def start_worker(
+	queue, quiet=False, rq_username=None, rq_password=None, burst=False, strategy=None, no_scheduler=False
+):
 	"""Start a background worker"""
 	from frappe.utils.background_jobs import start_worker
 
@@ -206,6 +212,7 @@ def start_worker(queue, quiet=False, rq_username=None, rq_password=None, burst=F
 		rq_password=rq_password,
 		burst=burst,
 		strategy=strategy,
+		no_scheduler=no_scheduler,
 	)
 
 
@@ -222,12 +229,7 @@ def start_worker_pool(queue, quiet=False, num_workers=2, burst=False):
 	"""Start a pool of background workers"""
 	from frappe.utils.background_jobs import start_worker_pool
 
-	start_worker_pool(
-		queue=queue,
-		quiet=quiet,
-		burst=burst,
-		num_workers=num_workers,
-	)
+	start_worker_pool(queue=queue, quiet=quiet, burst=burst, num_workers=num_workers)
 
 
 @click.command("ready-for-migration")

--- a/frappe/commands/scheduler.py
+++ b/frappe/commands/scheduler.py
@@ -198,10 +198,7 @@ def start_scheduler():
 	type=click.Choice(["round_robin", "random"]),
 	help="Dequeuing strategy to use",
 )
-@click.option("--no-scheduler", is_flag=True, default=False, help="Do not start scheduler")
-def start_worker(
-	queue, quiet=False, rq_username=None, rq_password=None, burst=False, strategy=None, no_scheduler=False
-):
+def start_worker(queue, quiet=False, rq_username=None, rq_password=None, burst=False, strategy=None):
 	"""Start a background worker"""
 	from frappe.utils.background_jobs import start_worker
 
@@ -212,7 +209,6 @@ def start_worker(
 		rq_password=rq_password,
 		burst=burst,
 		strategy=strategy,
-		no_scheduler=no_scheduler,
 	)
 
 

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -100,7 +100,9 @@ class TestRQJob(FrappeTestCase):
 			for q in ["default", "short"]:
 				frappe.enqueue(self.BG_JOB, sleep=1, queue=q)
 
-		_, stderr = execute_in_shell("bench worker --queue short,default --burst", check_exit_code=True)
+		_, stderr = execute_in_shell(
+			"bench worker --queue short,default --burst --no-scheduler", check_exit_code=True
+		)
 		self.assertIn("quitting", cstr(stderr))
 
 	@timeout

--- a/frappe/core/doctype/rq_job/test_rq_job.py
+++ b/frappe/core/doctype/rq_job/test_rq_job.py
@@ -100,9 +100,7 @@ class TestRQJob(FrappeTestCase):
 			for q in ["default", "short"]:
 				frappe.enqueue(self.BG_JOB, sleep=1, queue=q)
 
-		_, stderr = execute_in_shell(
-			"bench worker --queue short,default --burst --no-scheduler", check_exit_code=True
-		)
+		_, stderr = execute_in_shell("bench worker --queue short,default --burst", check_exit_code=True)
 		self.assertIn("quitting", cstr(stderr))
 
 	@timeout

--- a/frappe/tests/test_scheduler.py
+++ b/frappe/tests/test_scheduler.py
@@ -77,6 +77,7 @@ class TestScheduler(TestCase):
 		job_log.db_set(
 			"creation", add_days(_get_last_creation_timestamp("Activity Log"), 5), update_modified=False
 		)
+		schedule_jobs_based_on_activity.clear_cache()
 
 		# inactive site with recent job, don't run
 		self.assertFalse(

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -358,8 +358,9 @@ def start_worker_pool(
 	# If gc.freeze is done then importing modules before forking allows us to share the memory
 	import frappe.database.query  # sqlparse and indirect imports
 	import frappe.query_builder  # pypika
-	import frappe.utils.data  # common utils
+	import frappe.utils  # common utils
 	import frappe.utils.safe_exec
+	import frappe.utils.scheduler
 	import frappe.utils.typing_validations  # any whitelisted method uses this
 	import frappe.website.path_resolver  # all the page types and resolver
 

--- a/frappe/utils/background_jobs.py
+++ b/frappe/utils/background_jobs.py
@@ -278,10 +278,7 @@ def execute_job(site, method, event, job_name, kwargs, user=None, is_async=True,
 
 
 class FrappeWorker(Worker):
-	_run_frappe_scheduler = True
-
-	def work(self, *args, no_scheduler=False, **kwargs):
-		self._run_frappe_scheduler = not no_scheduler
+	def work(self, *args, **kwargs):
 		self.start_frappe_scheduler()
 		return super().work(*args, **kwargs)
 
@@ -291,10 +288,9 @@ class FrappeWorker(Worker):
 		return super().run_maintenance_tasks(*args, **kwargs)
 
 	def start_frappe_scheduler(self):
-		if self._run_frappe_scheduler:
-			from frappe.utils.scheduler import start_scheduler
+		from frappe.utils.scheduler import start_scheduler
 
-			Thread(target=start_scheduler, daemon=True).start()
+		Thread(target=start_scheduler, daemon=True).start()
 
 
 def start_worker(
@@ -304,7 +300,6 @@ def start_worker(
 	rq_password: str | None = None,
 	burst: bool = False,
 	strategy: DequeueStrategy | None = DequeueStrategy.DEFAULT,
-	no_scheduler=False,
 ) -> None:  # pragma: no cover
 	"""Wrapper to start rq worker. Connects to redis and monitors these queues."""
 
@@ -331,14 +326,13 @@ def start_worker(
 	if quiet:
 		logging_level = "WARNING"
 
-	worker = FrappeWorker(queues, connection=redis_connection)
+	worker = Worker(queues, connection=redis_connection)
 	worker.work(
 		logging_level=logging_level,
 		burst=burst,
 		date_format="%Y-%m-%d %H:%M:%S",
 		log_format="%(asctime)s,%(msecs)03d %(message)s",
 		dequeue_strategy=strategy,
-		no_scheduler=no_scheduler,
 	)
 
 
@@ -387,7 +381,7 @@ def start_worker_pool(
 		queues=queues,
 		connection=redis_connection,
 		num_workers=num_workers,
-		worker_class=FrappeWorker,
+		worker_class=FrappeWorker,  # Auto starts scheduler with workerpool
 	)
 	pool.start(logging_level=logging_level, burst=burst)
 

--- a/frappe/utils/scheduler.py
+++ b/frappe/utils/scheduler.py
@@ -62,10 +62,6 @@ def start_scheduler() -> NoReturn:
 def enqueue_events_for_all_sites() -> None:
 	"""Loop through sites and enqueue events that are not already queued"""
 
-	if os.path.exists(os.path.join(".", ".restarting")):
-		# Don't add task to queue if webserver is in restart mode
-		return
-
 	with frappe.init_site():
 		sites = get_sites()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "setproctitle~=1.3.3",
     "requests-oauthlib~=1.3.1",
     "requests~=2.32.0",
-    "rq~=1.15.1",
+    "rq==1.15.1",
     "rsa>=4.1",
     "semantic-version~=2.10.0",
     "sentry-sdk~=1.37.1",


### PR DESCRIPTION
Scheduler is a daemon process that runs once every minute to do enqueue job and
then does nothing. This still incurs ~70MB RAM cost (70MB RSS, 55MB USS).

This can be avoided by making it part of workers itself.

Rough Design (very similar to RQ):
- There's a single global filelock
- Each worker before starting work tries to aquire this lock, only one succeeds.
- Workers still check every 10 minutes if scheduler lock is available, if available one of them wins and runs scheduler. 

We run ~3000 benches currently, that's at least ~150GB of RAM usage.
