### PR TITLE
fix: check for create perm in workspace

### DIFF
--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -2,6 +2,7 @@ context("Workspace 2.0", () => {
 	before(() => {
 		cy.visit("/login");
 		cy.login();
+		cy.set_value("DocType", "Workspace", { in_create: false });
 	});
 
 	it("Navigate to page from sidebar", () => {

--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -2,11 +2,15 @@ context("Workspace 2.0", () => {
 	before(() => {
 		cy.visit("/login");
 		cy.login();
-		cy.set_value("DocType", "Workspace", { in_create: false });
 	});
 
 	it("Navigate to page from sidebar", () => {
 		cy.visit("/app/build");
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				frappe.boot.user.can_create.push("Workspace");
+			});
 		cy.get(".codex-editor__redactor .ce-block");
 		cy.get('.sidebar-item-container[item-name="Website"]').first().click();
 		cy.location("pathname").should("eq", "/app/website");

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -17,6 +17,12 @@ context("Workspace Blocks", () => {
 		}).as("new_page");
 
 		cy.visit("/app/website");
+		cy.window()
+			.its("frappe")
+			.then((frappe) => {
+				frappe.boot.user.can_create.push("Workspace");
+			});
+
 		cy.get(".codex-editor__redactor .ce-block");
 		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
 		cy.fill_field("title", "Test Block Page", "Data");

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -473,9 +473,10 @@ frappe.views.Workspace = class Workspace {
 			"es-line-edit"
 		);
 		// need to add option for icons in inner buttons as well
-		this.page.add_inner_button(__("Create Workspace"), () => {
-			this.initialize_new_page();
-		});
+		if (frappe.model.can_create("Workspace"))
+			this.page.add_inner_button(__("Create Workspace"), () => {
+				this.initialize_new_page();
+			});
 	}
 
 	initialize_editorjs_undo() {


### PR DESCRIPTION
**Bug**
Creation of workspace is allowed for all roles irrespective of the "create" permissions set for Workspaces.

<br>

**Fix**
Check for the create permission in user's bootinfo before allowing for creation of a new workspace.
