### PR TITLE
fix: text editor fields exports HTML tags

### DIFF
--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -144,7 +144,7 @@ class Exporter:
 					value = format_duration(flt(value), df.hide_days)
 
 				if df.fieldtype == "Text Editor":
-					value = frappe.utils.strip_html(value)
+					value = frappe.core.utils.html2text(value)
 				row[i] = value
 		return rows
 

--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -118,7 +118,6 @@ class Exporter:
 		for doc in data:
 			rows = []
 			rows = self.add_data_row(self.doctype, None, doc, rows, 0)
-
 			if table_fields:
 				# add child table data
 				for f in table_fields:
@@ -144,6 +143,8 @@ class Exporter:
 				if df.fieldtype == "Duration":
 					value = format_duration(flt(value), df.hide_days)
 
+				if df.fieldtype == "Text Editor":
+					value = frappe.utils.strip_html(value)
 				row[i] = value
 		return rows
 


### PR DESCRIPTION
**Issue**
When we have a fieldtype of "text editor", and then when we export that document, in the CSV file we get the HTML tags.
![image](https://github.com/frappe/frappe/assets/65544983/f8bb9b5a-acc4-40fe-84d3-c7b3ea236ef0)


**Solution**
This PR solves the issue by handling "text editor"  fieldtype in the Exporter class

closes: #26569