### PR TITLE
fix: Avoid concurrent TODO updates

### DIFF
--- a/frappe/desk/doctype/todo/todo.py
+++ b/frappe/desk/doctype/todo/todo.py
@@ -90,15 +90,17 @@ class ToDo(Document):
 			return
 
 		try:
-			assignments = frappe.get_all(
+			assignments = frappe.db.get_values(
 				"ToDo",
-				filters={
+				{
 					"reference_type": self.reference_type,
 					"reference_name": self.reference_name,
 					"status": ("not in", ("Cancelled", "Closed")),
 					"allocated_to": ("is", "set"),
 				},
-				pluck="allocated_to",
+				"allocated_to",
+				pluck=True,
+				for_update=True,
 			)
 			assignments.reverse()
 


### PR DESCRIPTION
Timestamp | User A | User B | Comment
-- | -- | -- | --
1 | Assign Self | Assign Self |  
2 | insert TODO | insert TODO |  
3 | Assignments=A | Assignments=B | Read assignments
3 | update _assign=A |   | Randomly one wins here
4 |   | update _assign=B |  

