### PR TITLE
fix(checkbox): Fix checkbox size on small screens

### DIFF
--- a/frappe/public/scss/desk/css_variables.scss
+++ b/frappe/public/scss/desk/css_variables.scss
@@ -25,7 +25,6 @@
 
 	// checkbox
 	--checkbox-right-margin: var(--margin-xs);
-	--checkbox-size: 14px;
 	--checkbox-focus-shadow: var(--focus-default);
 
 	// date-picker


### PR DESCRIPTION
Because checkbox size is defined in _common/css\_variables.scss_, this declaration was both redundant and detrimental. Indeed, it is located after the media query that changes the checkbox size on small screens, and thus had higher "specificity" and overrode the expected value.

It is redundant:

https://github.com/frappe/frappe/blob/342d0238e4de96a141474ee1e968a6f7477d25ff/frappe/public/scss/common/css_variables.scss#L136

It is detrimental:

https://github.com/frappe/frappe/blob/342d0238e4de96a141474ee1e968a6f7477d25ff/frappe/public/scss/common/css_variables.scss#L157-L159