### PR TITLE
perf: memory leak on kanban refresh

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_board.bundle.js
@@ -303,7 +303,7 @@ frappe.provide("frappe.views");
 			// update cards internally
 			opts.cards = cards;
 
-			if (self.wrapper.find(".kanban").length > 0 && self.cur_list.start !== 0) {
+			if (self.wrapper.find(".kanban").length > 0) {
 				store.dispatch("update_cards", cards);
 			} else {
 				init();


### PR DESCRIPTION
closes https://github.com/frappe/frappe/issues/24156

Every filter change refreshes entire kanban board from scratch because of this condition. 

![image](https://github.com/frappe/frappe/assets/9079960/6bdcd81e-6fb7-4fa6-94ee-33807e9fcfc4)
