### PR TITLE
fix(number_card): ensure value is returned

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -223,9 +223,8 @@ export default class NumberCardWidget extends Widget {
 
 		const symbol = number_parts[1] || "";
 		number_parts[0] = window.convert_old_to_new_number_format(number_parts[0]);
-		const formatted_number = $(frappe.format(number_parts[0], df, null, doc)).text();
-
-		this.formatted_number = formatted_number + " " + __(symbol);
+		const formatted_number = frappe.format(number_parts[0], df, null, doc);
+		this.formatted_number = $(formatted_number).text() || formatted_number + " " + __(symbol);
 	}
 
 	_generate_common_doc(rows) {


### PR DESCRIPTION
In the case of a number card based on a query report, an integer with
a very basic DF is passed, leading to the "formatted" value being just
the integer as a string, which becomes an empty string after $().text()

Reference: support ticket 15836
