### PR TITLE
fix: delete old user notification settings when merging users

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -543,6 +543,10 @@ class User(Document):
 			frappe.throw(_("You can disable the user instead of deleting it."), frappe.LinkExistsError)
 
 	def before_rename(self, old_name, new_name, merge=False):
+		# if merging, delete the old user notification settings
+		if merge:
+			frappe.delete_doc("Notification Settings", old_name, ignore_permissions=True)
+
 		frappe.clear_cache(user=old_name)
 		self.validate_rename(old_name, new_name)
 


### PR DESCRIPTION
### Summary
This pull request fixes an issue where merging users in the Frappe framework resulted in an error due to existing notification settings for the user being merged. The change ensures that the old user's notification settings are deleted during the merge process, preventing conflicts and allowing the merge to be completed successfully.

#### Detailed Explanation
**Issue:**
When attempting to merge two users, an error was encountered if the user being merged had existing notification settings. For example, merging `user2` (`user2@example.com`) into `user1` (`user1@example.com`) would fail with the following error:

```
Action Failed<br><br>Another Notification Settings with name user2@example.com exists, select another name
```

**Error Traceback**
```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "tabNotification Settings_pkey"
DETAIL:  Key (name)=(user2@example.com) already exists.
'''