### PR TITLE
fix: Form builder fields reset when cancelling create child table dialog

### DIFF
--- a/frappe/public/js/form_builder/components/controls/TableControl.vue
+++ b/frappe/public/js/form_builder/components/controls/TableControl.vue
@@ -24,7 +24,7 @@ function open_new_child_doctype_dialog() {
 				is_child: 1,
 				is_custom,
 			});
-		});
+		}, 10);
 	};
 }
 </script>

--- a/frappe/public/js/form_builder/components/controls/TableControl.vue
+++ b/frappe/public/js/form_builder/components/controls/TableControl.vue
@@ -16,9 +16,16 @@ let table_columns = computedAsync(async () => {
 
 function open_new_child_doctype_dialog() {
 	let is_custom = props.isCustomizeForm;
-	frappe.model.with_doctype("DocType").then(() => {
-		frappe.listview_settings["DocType"].new_doctype_dialog({ is_child: 1, is_custom });
-	});
+	let new_window = window.open("/app/doctype", "_blank");
+	new_window.onload = () => {
+		// set timeout to ensure that frappe is initialized
+		setTimeout(() => {
+			new_window.frappe.listview_settings["DocType"].new_doctype_dialog({
+				is_child: 1,
+				is_custom,
+			});
+		});
+	};
 }
 </script>
 


### PR DESCRIPTION
**Issue:**
When we create a new field with fieldtype of "Table" and then when we click on "Create Child Table" after clicking the "cancel" button on the dialog, the fields in the Form Builder resets.

https://github.com/frappe/frappe/assets/65544983/dec996c3-608d-4f41-845d-910394c688a7



**Solution:**
Open a new window and on that open the dialog to create a child table

https://github.com/frappe/frappe/assets/65544983/82f16aea-a7d7-4006-ba55-fb01663e1b36


