### PR TITLE
fix(google): bump google client dependencies for py3.12 support

### DIFF
--- a/frappe/integrations/doctype/google_drive/google_drive.py
+++ b/frappe/integrations/doctype/google_drive/google_drive.py
@@ -4,8 +4,8 @@
 import os
 from urllib.parse import quote
 
-from apiclient.http import MediaFileUpload
 from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
 
 import frappe
 from frappe import _

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,9 @@ dependencies = [
     # integration dependencies
     "boto3~=1.28.10",
     "dropbox~=11.36.2",
-    "google-api-python-client~=2.2.0",
-    "google-auth-oauthlib~=0.4.4",
-    "google-auth~=1.29.0",
+    "google-api-python-client~=2.131.0",
+    "google-auth-oauthlib~=1.2.0",
+    "google-auth~=2.29.0",
     "posthog~=3.0.1",
 ]
 


### PR DESCRIPTION
The pinned version for Google's python API client library is ~3 years old now, and it fails in a py3.12 environment during the `bench migrate` / `bench install-app` / `bench reinstall` commands:

<details>
<summary>Traceback</summary>

`pkgutil.ImpImporter` has been [removed in 3.12](https://docs.python.org/3/whatsnew/3.12.html#importlib)

```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "./apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "./apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "./env/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./env/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "./env/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./env/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./env/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./env/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./env/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/commands/site.py", line 380, in reinstall
    _reinstall(site, admin_password, db_root_username, db_root_password, yes, verbose=context.verbose)
  File "./apps/frappe/frappe/commands/site.py", line 411, in _reinstall
    _new_site(
  File "./apps/frappe/frappe/installer.py", line 112, in _new_site
    install_app(app, verbose=verbose, set_as_patched=not source_sql, force=False)
  File "./apps/frappe/frappe/installer.py", line 301, in install_app
    sync_for(name, force=force, reset_permissions=True)
  File "./apps/frappe/frappe/model/sync.py", line 111, in sync_for
    import_file_by_path(
  File "./apps/frappe/frappe/modules/import_file.py", line 146, in import_file_by_path
    import_doc(
  File "./apps/frappe/frappe/modules/import_file.py", line 239, in import_doc
    doc.insert()
  File "./apps/frappe/frappe/model/document.py", line 315, in insert
    self.run_post_save_methods()
  File "./apps/frappe/frappe/model/document.py", line 1128, in run_post_save_methods
    self.run_method("on_update")
  File "./apps/frappe/frappe/model/document.py", line 962, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/model/document.py", line 1322, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/model/document.py", line 1304, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/model/document.py", line 959, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/core/doctype/doctype/doctype.py", line 531, in on_update
    self.run_module_method("on_doctype_update")
  File "./apps/frappe/frappe/core/doctype/doctype/doctype.py", line 629, in run_module_method
    module = load_doctype_module(self.name, self.module)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/modules/utils.py", line 250, in load_doctype_module
    doctype_python_modules[key] = frappe.get_module(module_name)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./apps/frappe/frappe/__init__.py", line 1476, in get_module
    return importlib.import_module(modulename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "./apps/frappe/frappe/integrations/doctype/google_drive/google_drive.py", line 7, in <module>
    from apiclient.http import MediaFileUpload
  File "./env/lib/python3.12/site-packages/googleapiclient/http.py", line 64, in <module>
    from googleapiclient.model import JsonModel
  File "./env/lib/python3.12/site-packages/googleapiclient/model.py", line 30, in <module>
    import pkg_resources
  File "./env/lib/python3.12/site-packages/pkg_resources/__init__.py", line 2191, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?

```
</details>

Alternative solutions:
- Upgrading `setuptools>=70.0.0` in the Python environment also fixes the above issue.

---

Note: The `google-auth-oauthlib` dependency doesn't seem to be used in Frappe anymore, although it has some helper methods that we could use to replace/wrap the requests session for acquiring tokens.

---

Related PR: https://github.com/frappe/erpnext/pull/41690