### PR TITLE
fix: allow creation of workspace based on desk user role perms

### DIFF
--- a/frappe/desk/desktop.py
+++ b/frappe/desk/desktop.py
@@ -469,7 +469,11 @@ def get_workspace_sidebar_items():
 		pages = [frappe.get_doc("Workspace", "Welcome Workspace").as_dict()]
 		pages[0]["label"] = _("Welcome Workspace")
 
-	return {"pages": pages, "has_access": has_access}
+	return {
+		"pages": pages,
+		"has_access": has_access,
+		"has_create_access": frappe.has_permission(doctype="Workspace", ptype="create"),
+	}
 
 
 def get_table_with_counts():

--- a/frappe/desk/doctype/workspace/workspace.json
+++ b/frappe/desk/doctype/workspace/workspace.json
@@ -219,7 +219,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:04:05.604044",
+ "modified": "2024-05-30 17:30:36.791171",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace",
@@ -235,6 +235,18 @@
    "read": 1,
    "report": 1,
    "role": "Workspace Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Desk User",
    "share": 1,
    "write": 1
   }

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -23,9 +23,7 @@ class Workspace(Document):
 	if TYPE_CHECKING:
 		from frappe.core.doctype.has_role.has_role import HasRole
 		from frappe.desk.doctype.workspace_chart.workspace_chart import WorkspaceChart
-		from frappe.desk.doctype.workspace_custom_block.workspace_custom_block import (
-			WorkspaceCustomBlock,
-		)
+		from frappe.desk.doctype.workspace_custom_block.workspace_custom_block import WorkspaceCustomBlock
 		from frappe.desk.doctype.workspace_link.workspace_link import WorkspaceLink
 		from frappe.desk.doctype.workspace_number_card.workspace_number_card import WorkspaceNumberCard
 		from frappe.desk.doctype.workspace_quick_list.workspace_quick_list import WorkspaceQuickList
@@ -250,6 +248,12 @@ def new_page(new_page):
 		not page.get("public") and page.get("for_user") != frappe.session.user and not is_workspace_manager()
 	):
 		frappe.throw(_("Cannot create private workspace of other users"), frappe.PermissionError)
+
+	elif not frappe.has_permission(doctype="Workspace", ptype="create"):
+		frappe.flags.error_message = _("User {0} does not have the permission to create a Workspace.").format(
+			frappe.bold(frappe.session.user)
+		)
+		raise frappe.PermissionError
 
 	doc = frappe.new_doc("Workspace")
 	doc.title = page.get("title")

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -68,6 +68,7 @@ frappe.views.Workspace = class Workspace {
 		this.cached_pages = $.extend(true, {}, this.sidebar_pages);
 		this.all_pages = this.sidebar_pages.pages;
 		this.has_access = this.sidebar_pages.has_access;
+		this.has_create_access = this.sidebar_pages.has_create_access;
 
 		this.all_pages.forEach((page) => {
 			page.is_editable = !page.public || this.has_access;
@@ -473,9 +474,10 @@ frappe.views.Workspace = class Workspace {
 			"es-line-edit"
 		);
 		// need to add option for icons in inner buttons as well
-		this.page.add_inner_button(__("Create Workspace"), () => {
-			this.initialize_new_page();
-		});
+		if (this.has_create_access)
+			this.page.add_inner_button(__("Create Workspace"), () => {
+				this.initialize_new_page(true);
+			});
 	}
 
 	initialize_editorjs_undo() {


### PR DESCRIPTION
Currently, there is no way of restricting the creation of Workspaces depending on certain roles and permissions.

Adds the ability to check and restrict Workspace creation only to configured roles.