### PR TITLE
fix: bypass IP restriction for the methods required for our socketio backend

### DIFF
--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -421,7 +421,18 @@ def clear_cookies():
 
 
 def validate_ip_address(user):
-	"""check if IP Address is valid"""
+	"""
+	Method to check if the user has IP restrictions enabled, and if so is the IP address they are
+	connecting from allowlisted.
+
+	Certain methods called from our socketio backend need direct access, and so the IP is not
+	checked for those
+	"""
+	if hasattr(frappe.local, "request") and frappe.local.request.path.startswith(
+		"/api/method/frappe.realtime."
+	):
+		return True
+
 	from frappe.core.doctype.user.user import get_restricted_ip_list
 
 	# Only fetch required fields - for perf


### PR DESCRIPTION
Reference: support ticket 15683

Socketio backend needs some information from the user, exposed via these endpoints:
- Permission check
- Basic user information

For now this seems to be the best way, maybe in the future if we rewrite the socketio backend in python we can have this be a direct method call.