### PR TITLE
fix(link-preview): Correct synchronization of preview data on change.

### DIFF
--- a/frappe/public/js/frappe/ui/link_preview.js
+++ b/frappe/public/js/frappe/ui/link_preview.js
@@ -74,9 +74,9 @@ frappe.ui.LinkPreview = class {
 				}
 
 				this.popover_timeout = setTimeout(() => {
-					if (this.popover && this.popover.options) {
+					if (this.popover && this.popover.config) {
 						let new_content = this.get_popover_html(preview_data);
-						this.popover.options.content = new_content;
+						this.popover.config.content = new_content;
 					} else {
 						this.init_preview_popover(preview_data);
 					}


### PR DESCRIPTION
 - Use 'config' attribute instead deprecated 'options' which is always undefined and prevent updating the preview data.

Closes #26640 

-->

> Some **details** for making this change.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
## Steps to reproduce the issue

1. Check the "Show Preview Popup" in a given doctype.
2. In a Link field to that doctype you should have a proview when hovering it. This works great.
3. Change the value of the Link field and click outside and hover again, the previewed data **is not updated**.

## Additional information

This is due to a deprecated attribute used in the related Popover component which is 'options', instead of 'config'. The code reponsible of refreashing the popover content is never accessed due to the usage of the deprecated 'options' used in a condition.

Which causes the options attribute to be always evaluated to undefined and thus the condition to false.
