### PR TITLE
perf: Slightly efficient scheduling

### DIFF
--- a/frappe/tests/test_scheduler.py
+++ b/frappe/tests/test_scheduler.py
@@ -1,17 +1,22 @@
 import os
 import time
+from datetime import datetime, timedelta
 from unittest import TestCase
 from unittest.mock import patch
 
 import frappe
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import ScheduledJobType, sync_jobs
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, get_datetime
+from frappe.utils.data import now_datetime
 from frappe.utils.doctor import purge_pending_jobs
 from frappe.utils.scheduler import (
+	DEFAULT_SCHEDULER_TICK,
 	_get_last_creation_timestamp,
 	enqueue_events,
 	is_dormant,
 	schedule_jobs_based_on_activity,
+	sleep_duration,
 )
 
 
@@ -23,7 +28,7 @@ def test_method():
 	pass
 
 
-class TestScheduler(TestCase):
+class TestScheduler(FrappeTestCase):
 	def setUp(self):
 		frappe.db.rollback()
 
@@ -92,6 +97,21 @@ class TestScheduler(TestCase):
 				check_time=add_days(_get_last_creation_timestamp("Activity Log"), 6)
 			)
 		)
+
+	def test_real_time_alignment(self):
+		test_cases = {
+			timedelta(minutes=0): DEFAULT_SCHEDULER_TICK,
+			timedelta(minutes=0, seconds=12): DEFAULT_SCHEDULER_TICK - 12,
+			timedelta(minutes=1, seconds=12): DEFAULT_SCHEDULER_TICK - (1 * 60 + 12),
+			timedelta(hours=23, minutes=59): 60,
+			timedelta(hours=23, minutes=59, seconds=30): 30,
+			timedelta(minutes=0, seconds=1): DEFAULT_SCHEDULER_TICK - 1,
+			timedelta(minutes=2): DEFAULT_SCHEDULER_TICK - 2 * 60,
+		}
+		for delta, expected_sleep in test_cases.items():
+			fake_time = datetime(2024, 1, 1) + delta
+			with self.freeze_time(fake_time, is_utc=True):
+				self.assertEqual(sleep_duration(DEFAULT_SCHEDULER_TICK), expected_sleep, delta)
 
 
 def get_test_job(method="frappe.tests.test_scheduler.test_timeout_10", frequency="All") -> ScheduledJobType:

--- a/frappe/tests/utils.py
+++ b/frappe/tests/utils.py
@@ -226,14 +226,15 @@ class FrappeTestCase(unittest.TestCase):
 			frappe.connect()
 
 	@contextmanager
-	def freeze_time(self, time_to_freeze, *args, **kwargs):
+	def freeze_time(self, time_to_freeze, is_utc=False, *args, **kwargs):
 		from freezegun import freeze_time
 
-		# Freeze time expects UTC or tzaware objects. We have neither, so convert to UTC.
-		timezone = pytz.timezone(get_system_timezone())
-		fake_time_with_tz = timezone.localize(get_datetime(time_to_freeze)).astimezone(pytz.utc)
+		if not is_utc:
+			# Freeze time expects UTC or tzaware objects. We have neither, so convert to UTC.
+			timezone = pytz.timezone(get_system_timezone())
+			time_to_freeze = timezone.localize(get_datetime(time_to_freeze)).astimezone(pytz.utc)
 
-		with freeze_time(fake_time_with_tz, *args, **kwargs):
+		with freeze_time(time_to_freeze, *args, **kwargs):
 			yield
 
 


### PR DESCRIPTION
Problem:
- Scheduler tick is 1 minute
- Most frequent jobs are at least 4 minutes apart.

3/4 times we are wasting CPU cycle for EACH site.

Fix:
- Check every 4 minutes.
- Align the tick to real clock to fix problem of jobs executing
  randomly in any part of the minute.

Cons: Anything not aligned with the scheduler interval will be delayed.
