### PR TITLE
fix: kanban column indicator duplicate select option

### DIFF
--- a/frappe/desk/doctype/kanban_board_column/kanban_board_column.json
+++ b/frappe/desk/doctype/kanban_board_column/kanban_board_column.json
@@ -31,7 +31,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Indicator",
-   "options": "Blue\nCyan\nGray\nGreen\nLight Blue\nOrange\nPink\nPurple\nRed\nRed\nYellow"
+   "options": "Blue\nCyan\nGray\nGreen\nLight Blue\nOrange\nPink\nPurple\nRed\nYellow"
   },
   {
    "fieldname": "order",

--- a/frappe/desk/doctype/kanban_board_column/kanban_board_column.py
+++ b/frappe/desk/doctype/kanban_board_column/kanban_board_column.py
@@ -15,7 +15,7 @@ class KanbanBoardColumn(Document):
 
 		column_name: DF.Data | None
 		indicator: DF.Literal[
-			"Blue", "Cyan", "Gray", "Green", "Light Blue", "Orange", "Pink", "Purple", "Red", "Red", "Yellow"
+			"Blue", "Cyan", "Gray", "Green", "Light Blue", "Orange", "Pink", "Purple", "Red", "Yellow"
 		]
 		order: DF.Code | None
 		parent: DF.Data


### PR DESCRIPTION
Red was defined twice in the select options for the kanban column indicator.
This created an issue generating schemas using frappe_graphql.

I removed the duplicate.
