### PR TITLE
test: cypress not running on node14

### DIFF
--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -8,6 +8,7 @@ from shutil import which
 import click
 
 import frappe
+import frappe.commands
 from frappe.commands import get_site, pass_context
 from frappe.coverage import CodeCoverage
 from frappe.exceptions import SiteNotSpecifiedError
@@ -924,7 +925,7 @@ def run_ui_tests(
 				"@cypress/code-coverage@^3",
 			]
 		)
-		frappe.commands.popen(f"yarn add {packages} --no-lockfile")
+		frappe.commands.popen(f"yarn add {packages} --no-lockfile", raise_err=True)
 
 	# run for headless mode
 	run_or_open = "run --browser chrome" if headless else "open"

--- a/frappe/commands/utils.py
+++ b/frappe/commands/utils.py
@@ -917,12 +917,12 @@ def run_ui_tests(
 		click.secho("Installing Cypress...", fg="yellow")
 		packages = " ".join(
 			[
-				"cypress@^13",
-				"@4tw/cypress-drag-drop@^2",
-				"cypress-real-events",
-				"@testing-library/cypress@^10",
+				"cypress@13.10.0",
+				"@4tw/cypress-drag-drop@2.2.5",
+				"cypress-real-events@1.12.0",
+				"@testing-library/cypress@10.0.1",
 				"@testing-library/dom@8.17.1",
-				"@cypress/code-coverage@^3",
+				"@cypress/code-coverage@3.12.39",
 			]
 		)
 		frappe.commands.popen(f"yarn add {packages} --no-lockfile", raise_err=True)


### PR DESCRIPTION
Pinning last working versions: https://github.com/frappe/frappe/actions/runs/9266938893/job/25492248061 


```
├─ @4tw/cypress-drag-drop@2.2.5
├─ @cypress/code-coverage@3.12.39
├─ @testing-library/cypress@10.0.1
├─ @testing-library/dom@8.17.1
├─ cypress-real-events@1.12.0
└─ cypress@13.10.0
```