### PR TITLE
fix(Error Log): Truncate title and convert text to string

### DIFF
--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -24,6 +24,14 @@ class ErrorLog(Document):
 		trace_id: DF.Data | None
 	# end: auto-generated types
 
+	def validate(self):
+		self.method = str(self.method)
+		self.error = str(self.error)
+
+		if len(self.method) > 140:
+			self.error = f"{self.method}\n{self.error}"
+			self.method = self.method[:140]
+
 	def onload(self):
 		if not self.seen and not frappe.flags.read_only:
 			self.db_set("seen", 1, update_modified=0)


### PR DESCRIPTION
It was a little bit goofy that inserting an Error Log could itself throw a ValidationError, preventing it to be written in the DB.