### PR TITLE
fix(UX): Show reference name in error log list view

### DIFF
--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -48,6 +48,8 @@
   {
    "fieldname": "reference_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Reference Name",
    "read_only": 1
   },
@@ -70,7 +72,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:03:25.381120",
+ "modified": "2024-06-05 05:34:35.048489",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Error Log",


### PR DESCRIPTION
Just what the title implies.
