### PR TITLE
fix: Skip letter heads if no permission

### DIFF
--- a/frappe/boot.py
+++ b/frappe/boot.py
@@ -120,6 +120,9 @@ def get_bootinfo():
 
 def get_letter_heads():
 	letter_heads = {}
+
+	if not frappe.has_permission("Letter Head"):
+		return letter_heads
 	for letter_head in frappe.get_list("Letter Head", fields=["name", "content", "footer"]):
 		letter_heads.setdefault(
 			letter_head.name, {"header": letter_head.content, "footer": letter_head.footer}


### PR DESCRIPTION
https://github.com/frappe/frappe/pull/26563 This cases boot to fail for users if they don't have letterhead access. 