### PR TITLE
fix: Move Monitor dump to after_response

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -79,7 +79,6 @@ def after_response_wrapper(app):
 			app(environ, start_response),
 			(
 				frappe.rate_limiter.update,
-				frappe.monitor.stop,
 				frappe.recorder.dump,
 				frappe.request.after_response.run,
 				frappe.destroy,

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -423,6 +423,10 @@ before_request = [
 	"frappe.rate_limiter.apply",
 ]
 
+after_request = [
+	"frappe.monitor.stop",
+]
+
 # Background Job Hooks
 before_job = [
 	"frappe.recorder.record",

--- a/frappe/tests/test_perf.py
+++ b/frappe/tests/test_perf.py
@@ -217,7 +217,7 @@ class TestOverheadCalls(FrappeAPITestCase):
 
 	def test_ping_overheads(self):
 		self.get(self.method("ping"), {"sid": "Guest"})
-		with self.assertRedisCallCounts(12), self.assertQueryCount(self.BASE_SQL_CALLS):
+		with self.assertRedisCallCounts(13), self.assertQueryCount(self.BASE_SQL_CALLS):
 			self.get(self.method("ping"), {"sid": "Guest"})
 
 	def test_list_view_overheads(self):


### PR DESCRIPTION
It needs access to response to capture status code and size etc
