### PR TITLE
fix: Avoid renaming language or changing title manually

### DIFF
--- a/frappe/core/doctype/language/language.json
+++ b/frappe/core/doctype/language/language.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "allow_rename": 1,
  "autoname": "field:language_code",
  "creation": "2014-08-22 16:12:17.249590",
  "doctype": "DocType",
@@ -27,7 +26,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Language Name",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "flag",
@@ -51,7 +51,7 @@
  "icon": "fa fa-globe",
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:03:28.477169",
+ "modified": "2024-06-06 18:25:01.010821",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Language",

--- a/frappe/public/js/frappe/form/toolbar.js
+++ b/frappe/public/js/frappe/form/toolbar.js
@@ -77,7 +77,8 @@ frappe.ui.form.Toolbar = class Toolbar {
 			this.frm.perm[0].write &&
 			!this.frm.doc.__islocal &&
 			doc_field.fieldtype === "Data" &&
-			!doc_field.read_only
+			!doc_field.read_only &&
+			!doc_field.set_only_once
 		) {
 			return true;
 		} else {


### PR DESCRIPTION
- No user should be able to rename a language or change its title.
- Its not a doctype that can be manually created and was not intended to be touched by a desk user
- Avoid the popup form showing when clicking on Title. Language name is set to `set_only_once`, so that should not change via the Rename popup

> Happened IRL and created complete chaos when Print Format shows language as "Deutsch" but a user renames en-US 's title from "English (United States)" to "Deutsch". So the language was always english, "but should be german"