### PR TITLE
Account for hidden Tags column

### DIFF
--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -12,6 +12,7 @@ export default class ListSettings {
 		this.fields =
 			this.settings && this.settings.fields ? JSON.parse(this.settings.fields) : [];
 		this.subject_field = null;
+		this.tag_field = null;
 
 		frappe.model.with_doctype("List View Settings", () => {
 			this.make();
@@ -104,9 +105,11 @@ export default class ListSettings {
 			if (idx == parseInt(total_fields)) {
 				break;
 			}
-			let is_sortable = idx == 0 ? `` : `sortable`;
-			let show_sortable_handle = idx == 0 ? `hide` : ``;
-			let can_remove = idx == 0 || is_status_field(me.fields[idx]) ? `hide` : ``;
+			//idx 0 is the subject field and idx 1 is the tags field these fields
+			let is_sortable = idx == 0 || idx == 1 ? `` : `sortable`;
+			let show_sortable_handle = idx == 0 || idx == 1 ? `hide` : ``;
+			let can_remove = idx == 0 || idx == 1 || is_status_field(me.fields[idx]) ? `hide` : ``;
+			let show_hide_icon = idx != 1 ? `hide` : ``;
 
 			fields += `
 				<div class="control-input flex align-center form-control fields_order ${is_sortable}"
@@ -115,6 +118,7 @@ export default class ListSettings {
 
 					<div class="row">
 						<div class="col-1">
+							${frappe.utils.icon("es-line-hide", "xs", "", "", "hide-icon " + show_hide_icon)}
 							${frappe.utils.icon("drag", "xs", "", "", "sortable-handle " + show_sortable_handle)}
 						</div>
 						<div class="col-10" style="padding-left:0px;">
@@ -253,6 +257,7 @@ export default class ListSettings {
 
 			me.fields = [];
 			me.set_subject_field(me.meta);
+			me.set_tag_field();
 			me.set_status_field();
 
 			for (let idx in values) {
@@ -260,7 +265,10 @@ export default class ListSettings {
 
 				if (me.fields.length === parseInt(me.dialog.get_values().total_fields)) {
 					break;
-				} else if (value != me.subject_field.fieldname) {
+				} else if (
+					value != me.subject_field.fieldname &&
+					value != me.tag_field.fieldname
+				) {
 					let field = frappe.meta.get_docfield(me.doctype, value);
 					if (field) {
 						me.fields.push({
@@ -311,6 +319,7 @@ export default class ListSettings {
 		let me = this;
 
 		me.set_subject_field(meta);
+		me.set_tag_field();
 		me.set_status_field();
 
 		meta.fields.forEach((field) => {
@@ -345,6 +354,17 @@ export default class ListSettings {
 		}
 
 		me.fields.push(me.subject_field);
+	}
+
+	set_tag_field() {
+		let me = this;
+
+		me.tag_field = {
+			label: __("Tags"),
+			fieldname: "_user_tags",
+		};
+
+		me.fields.push(me.tag_field);
 	}
 
 	set_status_field() {

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -105,7 +105,7 @@ export default class ListSettings {
 			if (idx == parseInt(total_fields)) {
 				break;
 			}
-			//idx 0 is for name field and idx 1 is for tags field
+			//idx 0 is the subject field and idx 1 is the tags field these fields
 			let is_sortable = idx == 0 || idx == 1 ? `` : `sortable`;
 			let show_sortable_handle = idx == 0 || idx == 1 ? `hide` : ``;
 			let can_remove = idx == 0 || idx == 1 || is_status_field(me.fields[idx]) ? `hide` : ``;

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -12,6 +12,7 @@ export default class ListSettings {
 		this.fields =
 			this.settings && this.settings.fields ? JSON.parse(this.settings.fields) : [];
 		this.subject_field = null;
+		this.tag_field = null;
 
 		frappe.model.with_doctype("List View Settings", () => {
 			this.make();
@@ -104,9 +105,11 @@ export default class ListSettings {
 			if (idx == parseInt(total_fields)) {
 				break;
 			}
-			let is_sortable = idx == 0 ? `` : `sortable`;
-			let show_sortable_handle = idx == 0 ? `hide` : ``;
-			let can_remove = idx == 0 || is_status_field(me.fields[idx]) ? `hide` : ``;
+			//idx 0 is the subject field and idx 1 is the tags field
+			let is_sortable = idx == 0 || idx == 1 ? `` : `sortable`;
+			let show_sortable_handle = idx == 0 || idx == 1  ? `hide` : ``;
+			let can_remove = idx == 0 ||  idx == 1  || is_status_field(me.fields[idx]) ? `hide` : ``;
+			let show_hide_icon = idx != 1 ? `hide` : ``;
 
 			fields += `
 				<div class="control-input flex align-center form-control fields_order ${is_sortable}"
@@ -115,6 +118,7 @@ export default class ListSettings {
 
 					<div class="row">
 						<div class="col-1">
+	  						${frappe.utils.icon("es-line-hide", "xs", "", "", "hide-icon " + show_hide_icon)}
 							${frappe.utils.icon("drag", "xs", "", "", "sortable-handle " + show_sortable_handle)}
 						</div>
 						<div class="col-10" style="padding-left:0px;">
@@ -253,6 +257,7 @@ export default class ListSettings {
 
 			me.fields = [];
 			me.set_subject_field(me.meta);
+			me.set_tag_field();
 			me.set_status_field();
 
 			for (let idx in values) {
@@ -260,7 +265,7 @@ export default class ListSettings {
 
 				if (me.fields.length === parseInt(me.dialog.get_values().total_fields)) {
 					break;
-				} else if (value != me.subject_field.fieldname) {
+				} else if (value != me.subject_field.fieldname && value != me.tag_field.fieldname) {
 					let field = frappe.meta.get_docfield(me.doctype, value);
 					if (field) {
 						me.fields.push({
@@ -311,6 +316,7 @@ export default class ListSettings {
 		let me = this;
 
 		me.set_subject_field(meta);
+		me.set_tag_field();
 		me.set_status_field();
 
 		meta.fields.forEach((field) => {
@@ -347,6 +353,17 @@ export default class ListSettings {
 		me.fields.push(me.subject_field);
 	}
 
+	set_tag_field() {
+		let me = this;
+
+		me.tag_field = {
+			label: __("Tags"),
+			fieldname: "_user_tags",
+		};
+
+		me.fields.push(me.tag_field);
+	}
+	
 	set_status_field() {
 		let me = this;
 

--- a/frappe/public/js/frappe/list/list_settings.js
+++ b/frappe/public/js/frappe/list/list_settings.js
@@ -105,10 +105,10 @@ export default class ListSettings {
 			if (idx == parseInt(total_fields)) {
 				break;
 			}
-			//idx 0 is the subject field and idx 1 is the tags field
+			//idx 0 is for name field and idx 1 is for tags field
 			let is_sortable = idx == 0 || idx == 1 ? `` : `sortable`;
-			let show_sortable_handle = idx == 0 || idx == 1  ? `hide` : ``;
-			let can_remove = idx == 0 ||  idx == 1  || is_status_field(me.fields[idx]) ? `hide` : ``;
+			let show_sortable_handle = idx == 0 || idx == 1 ? `hide` : ``;
+			let can_remove = idx == 0 || idx == 1 || is_status_field(me.fields[idx]) ? `hide` : ``;
 			let show_hide_icon = idx != 1 ? `hide` : ``;
 
 			fields += `
@@ -118,7 +118,7 @@ export default class ListSettings {
 
 					<div class="row">
 						<div class="col-1">
-	  						${frappe.utils.icon("es-line-hide", "xs", "", "", "hide-icon " + show_hide_icon)}
+							${frappe.utils.icon("es-line-hide", "xs", "", "", "hide-icon " + show_hide_icon)}
 							${frappe.utils.icon("drag", "xs", "", "", "sortable-handle " + show_sortable_handle)}
 						</div>
 						<div class="col-10" style="padding-left:0px;">
@@ -265,7 +265,10 @@ export default class ListSettings {
 
 				if (me.fields.length === parseInt(me.dialog.get_values().total_fields)) {
 					break;
-				} else if (value != me.subject_field.fieldname && value != me.tag_field.fieldname) {
+				} else if (
+					value != me.subject_field.fieldname &&
+					value != me.tag_field.fieldname
+				) {
 					let field = frappe.meta.get_docfield(me.doctype, value);
 					if (field) {
 						me.fields.push({
@@ -363,7 +366,7 @@ export default class ListSettings {
 
 		me.fields.push(me.tag_field);
 	}
-	
+
 	set_status_field() {
 		let me = this;
 


### PR DESCRIPTION
The list view settings max number fields was inconsistent with the number of fields displayed in the list view due to the hidden Tags column.  I have accounted for this static field in the settings view.

The max columns count now aligns with what will be displayed.

<img width="641" alt="image" src="https://github.com/frappe/frappe/assets/1790167/a13a4a20-73f1-4f79-96ec-1cd92f09be53">