### PR TITLE
fix: Email tracking without "use_ssl"

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -237,6 +237,7 @@ class SendMailContext:
 		self.sent_to_atleast_one_recipient = any(
 			rec.recipient for rec in self.queue_doc.recipients if rec.is_mail_sent()
 		)
+		self.email_account_doc = None
 
 	def fetch_smtp_server(self):
 		self.email_account_doc = self.queue_doc.get_email_account(raise_error=True)
@@ -326,7 +327,11 @@ class SendMailContext:
 			}
 			tracker_url = get_url(f"{email_read_tracker_url}?{get_signed_params(params)}")
 
-		elif frappe.conf.use_ssl and self.email_account_doc.track_email_status:
+		elif (
+			self.email_account_doc
+			and self.email_account_doc.track_email_status
+			and self.queue_doc.communication
+		):
 			tracker_url = f"{get_url()}/api/method/frappe.core.doctype.communication.email.mark_email_as_seen?name={self.queue_doc.communication}"
 
 		if tracker_url:

--- a/frappe/tests/test_email.py
+++ b/frappe/tests/test_email.py
@@ -119,7 +119,6 @@ class TestEmail(FrappeTestCase):
 		self.assertTrue("CC: test1@example.com" in message)
 
 	def test_cc_footer(self):
-		frappe.conf.use_ssl = True
 		# test if sending with cc's makes it into header
 		frappe.sendmail(
 			recipients=["test@example.com"],
@@ -150,10 +149,6 @@ class TestEmail(FrappeTestCase):
 			"This email was sent to test@example.com and copied to test1@example.com"
 			in frappe.safe_decode(frappe.flags.sent_mail)
 		)
-
-		# check for email tracker
-		self.assertTrue("mark_email_as_seen" in frappe.safe_decode(frappe.flags.sent_mail))
-		frappe.conf.use_ssl = False
 
 	def test_expose(self):
 		from frappe.utils import set_request


### PR DESCRIPTION
Everyone uses TLS these days, idk why this config exists.

closes https://github.com/frappe/frappe/issues/26717
