### PR TITLE
feat: add response processing to webhook

### DIFF
--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -16,7 +16,8 @@ frappe.ui.form.on("Server Script", {
 			});
 		}
 
-		frm.call("get_autocompletion_items")
+		frappe
+			.call("frappe.core.doctype.server_script.server_script.get_autocompletion_items")
 			.then((r) => r.message)
 			.then((items) => {
 				frm.set_df_property("script", "autocompletions", items);

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -212,49 +212,50 @@ class ServerScript(Document):
 		if locals["conditions"]:
 			return locals["conditions"]
 
-	@frappe.whitelist()
-	def get_autocompletion_items(self):
-		"""Generate a list of autocompletion strings from the context dict
-		that is used while executing a Server Script.
 
-		e.g., ["frappe.utils.cint", "frappe.get_all", ...]
-		"""
+@frappe.whitelist()
+def get_autocompletion_items(self):
+	"""Generate a list of autocompletion strings from the context dict
+	that is used while executing a Server Script.
 
-		def get_keys(obj):
-			out = []
-			for key in obj:
-				if key.startswith("_"):
+	e.g., ["frappe.utils.cint", "frappe.get_all", ...]
+	"""
+
+	def get_keys(obj):
+		out = []
+		for key in obj:
+			if key.startswith("_"):
+				continue
+			value = obj[key]
+			if isinstance(value, NamespaceDict | dict) and value:
+				if key == "form_dict":
+					out.append(["form_dict", 7])
 					continue
-				value = obj[key]
-				if isinstance(value, NamespaceDict | dict) and value:
-					if key == "form_dict":
-						out.append(["form_dict", 7])
-						continue
-					for subkey, score in get_keys(value):
-						fullkey = f"{key}.{subkey}"
-						out.append([fullkey, score])
+				for subkey, score in get_keys(value):
+					fullkey = f"{key}.{subkey}"
+					out.append([fullkey, score])
+			else:
+				if isinstance(value, type) and issubclass(value, Exception):
+					score = 0
+				elif isinstance(value, ModuleType):
+					score = 10
+				elif isinstance(value, FunctionType | MethodType):
+					score = 9
+				elif isinstance(value, type):
+					score = 8
+				elif isinstance(value, dict):
+					score = 7
 				else:
-					if isinstance(value, type) and issubclass(value, Exception):
-						score = 0
-					elif isinstance(value, ModuleType):
-						score = 10
-					elif isinstance(value, FunctionType | MethodType):
-						score = 9
-					elif isinstance(value, type):
-						score = 8
-					elif isinstance(value, dict):
-						score = 7
-					else:
-						score = 6
-					out.append([key, score])
-			return out
+					score = 6
+				out.append([key, score])
+		return out
 
-		items = frappe.cache.get_value("server_script_autocompletion_items")
-		if not items:
-			items = get_keys(get_safe_globals())
-			items = [{"value": d[0], "score": d[1]} for d in items]
-			frappe.cache.set_value("server_script_autocompletion_items", items)
-		return items
+	items = frappe.cache.get_value("server_script_autocompletion_items")
+	if not items:
+		items = get_keys(get_safe_globals())
+		items = [{"value": d[0], "score": d[1]} for d in items]
+		frappe.cache.set_value("server_script_autocompletion_items", items)
+	return items
 
 
 def execute_api_server_script(script: ServerScript, *args, **kwargs):

--- a/frappe/integrations/doctype/webhook/webhook.js
+++ b/frappe/integrations/doctype/webhook/webhook.js
@@ -85,6 +85,33 @@ frappe.ui.form.on("Webhook", {
 			"background_jobs_queue",
 			"frappe.integrations.doctype.webhook.webhook.get_all_queues"
 		);
+		frappe
+			.call("frappe.core.doctype.server_script.server_script.get_autocompletion_items")
+			.then((r) => r.message)
+			.then((items) => {
+				frm.set_df_property("script", "autocompletions", items);
+			});
+
+		frm.trigger("check_safe_exec");
+	},
+
+	check_safe_exec(frm) {
+		frappe.xcall("frappe.core.doctype.server_script.server_script.enabled").then((enabled) => {
+			if (enabled === false) {
+				frm.set_df_property("script", "hidden", true);
+				let docs_link =
+					"https://frappeframework.com/docs/user/en/desk/scripting/server-script";
+				let docs = `<a href=${docs_link}>${__("Official Documentation")}</a>`;
+
+				frm.dashboard.clear_comment();
+				let msg = __("Response processing feature is not available on this site.") + " ";
+				msg += __(
+					"To enable reponse processing (via Server Scripts feature), read the {0}.",
+					[docs]
+				);
+				frm.dashboard.add_comment(msg, "yellow", true);
+			}
+		});
 	},
 
 	request_structure: (frm) => {

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -31,6 +31,8 @@
   "sb_webhook_data",
   "webhook_data",
   "webhook_json",
+  "webhook_response_section",
+  "script",
   "preview_tab",
   "preview_document",
   "column_break_26",
@@ -218,6 +220,17 @@
    "fieldname": "background_jobs_queue",
    "fieldtype": "Autocomplete",
    "label": "Background Jobs Queue"
+  },
+  {
+   "fieldname": "webhook_response_section",
+   "fieldtype": "Section Break",
+   "label": "Webhook Response"
+  },
+  {
+   "description": "You have access to the document (<code>doc</code>) and response (<code>resp</code>) objects",
+   "fieldname": "script",
+   "fieldtype": "Code",
+   "label": "Script"
   }
  ],
  "links": [
@@ -226,7 +239,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-03-23 16:04:03.108172",
+ "modified": "2024-06-07 08:03:22.859202",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.json
+++ b/frappe/integrations/doctype/webhook/webhook.json
@@ -230,7 +230,8 @@
    "description": "You have access to the document (<code>doc</code>) and response (<code>resp</code>) objects",
    "fieldname": "script",
    "fieldtype": "Code",
-   "label": "Script"
+   "label": "Script",
+   "options": "Python"
   }
  ],
  "links": [
@@ -239,7 +240,7 @@
    "link_fieldname": "webhook"
   }
  ],
- "modified": "2024-06-07 08:03:22.859202",
+ "modified": "2024-06-07 09:55:36.764760",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Webhook",

--- a/frappe/integrations/doctype/webhook/webhook.py
+++ b/frappe/integrations/doctype/webhook/webhook.py
@@ -15,7 +15,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils.background_jobs import get_queues_timeout
 from frappe.utils.jinja import validate_template
-from frappe.utils.safe_exec import get_safe_globals, safe_exec
+from frappe.utils.safe_exec import get_safe_globals, is_safe_exec_enabled, safe_exec
 
 WEBHOOK_SECRET_HEADER = "X-Frappe-Webhook-Signature"
 
@@ -182,7 +182,7 @@ def enqueue_webhook(doc, webhook) -> None:
 			)
 			r.raise_for_status()
 			frappe.logger().debug({"webhook_success": r.text})
-			if webhook.script:
+			if webhook.script and is_safe_exec_enabled():
 				try:
 					doc.reload()
 					safe_exec(


### PR DESCRIPTION
# Context

Return Example: `{"orders":{"success":[{"idOrder":"MAT-DN-2024-08787","order":2083}],"failed":[]}}`

We would want to record at a minimum:

- That the sync was successful
- That the remote system order ID is `2083` in this case

# Proposed Solution

Add script to webhook that is run after successful (i.e. no exception raised) webhook request.

Idem potency in this model is within the responsibility of the script author.
