### PR TITLE
fix: fix tracking checks

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -326,7 +326,7 @@ class SendMailContext:
 			}
 			tracker_url = get_url(f"{email_read_tracker_url}?{get_signed_params(params)}")
 
-		elif frappe.conf.use_ssl and self.email_account_doc.track_email_status:
+		elif self.email_account_doc.track_email_status and self.queue_doc.communication:
 			tracker_url = f"{get_url()}/api/method/frappe.core.doctype.communication.email.mark_email_as_seen?name={self.queue_doc.communication}"
 
 		if tracker_url:


### PR DESCRIPTION
email/communication tracking links are rarely added

fixes: https://github.com/frappe/frappe/issues/26729

If the ssl check is necessary, maybe `get_url().startswith("https")`
Looks like a test is broken

version-15-hotfix
version-14-hotfix