### PR TITLE
fix: Append symbol on number card

### DIFF
--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -224,7 +224,8 @@ export default class NumberCardWidget extends Widget {
 		const symbol = number_parts[1] || "";
 		number_parts[0] = window.convert_old_to_new_number_format(number_parts[0]);
 		const formatted_number = frappe.format(number_parts[0], df, null, doc);
-		this.formatted_number = $(formatted_number).text() || formatted_number + " " + __(symbol);
+		this.formatted_number =
+			($(formatted_number).text() || formatted_number) + " " + __(symbol);
 	}
 
 	_generate_common_doc(rows) {


### PR DESCRIPTION
symbol was not appended on currency fields if first condition is true

> no-docs