### PR TITLE
fix: redirect report builder from workspace

### DIFF
--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -80,6 +80,10 @@ class Workspace(Document):
 		except Exception:
 			frappe.throw(_("Content data shoud be a list"))
 
+		for d in self.get('links'):
+			if d.link_type == "Report" and d.is_query_report != 1:
+				d.report_ref_doctype = frappe.get_value("Report", d.link_to, 'ref_doctype')
+
 	def clear_cache(self):
 		super().clear_cache()
 		if self.for_user:

--- a/frappe/desk/doctype/workspace/workspace.py
+++ b/frappe/desk/doctype/workspace/workspace.py
@@ -80,9 +80,9 @@ class Workspace(Document):
 		except Exception:
 			frappe.throw(_("Content data shoud be a list"))
 
-		for d in self.get('links'):
+		for d in self.get("links"):
 			if d.link_type == "Report" and d.is_query_report != 1:
-				d.report_ref_doctype = frappe.get_value("Report", d.link_to, 'ref_doctype')
+				d.report_ref_doctype = frappe.get_value("Report", d.link_to, "ref_doctype")
 
 	def clear_cache(self):
 		super().clear_cache()

--- a/frappe/desk/doctype/workspace_link/workspace_link.json
+++ b/frappe/desk/doctype/workspace_link/workspace_link.json
@@ -13,6 +13,7 @@
   "link_details_section",
   "link_type",
   "link_to",
+  "report_ref_doctype",
   "column_break_7",
   "dependencies",
   "only_for",
@@ -116,12 +117,19 @@
    "ignore_xss_filter": 1,
    "label": "Description",
    "max_height": "7rem"
+  },
+  {
+   "fieldname": "report_ref_doctype",
+   "fieldtype": "Link",
+   "label": "Report Ref DocType",
+   "options": "DocType",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:04:06.025772",
+ "modified": "2024-06-10 16:04:00.746903",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Workspace Link",

--- a/frappe/desk/doctype/workspace_link/workspace_link.py
+++ b/frappe/desk/doctype/workspace_link/workspace_link.py
@@ -28,6 +28,7 @@ class WorkspaceLink(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		report_ref_doctype: DF.Link | None
 		type: DF.Literal["Link", "Card Break"]
 	# end: auto-generated types
 

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1300,7 +1300,8 @@ Object.assign(frappe.utils, {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;
 				} else if (!item.is_query_report && item.report_ref_doctype) {
-					route = frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
+					route = 
+							frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
 				} else {
 					route = "/report/" + item.name;
 				}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1300,7 +1300,7 @@ Object.assign(frappe.utils, {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;
 				} else if (!item.is_query_report && item.report_ref_doctype) {
-					route = 
+					route =
 						frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
 				} else {
 					route = "/report/" + item.name;

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1301,7 +1301,7 @@ Object.assign(frappe.utils, {
 					route = "query-report/" + item.name;
 				} else if (!item.is_query_report && item.report_ref_doctype) {
 					route = 
-							frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
+						frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
 				} else {
 					route = "/report/" + item.name;
 				}

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1299,10 +1299,10 @@ Object.assign(frappe.utils, {
 			} else if (type === "report") {
 				if (item.is_query_report) {
 					route = "query-report/" + item.name;
-				} else if (!item.doctype) {
-					route = "report/" + item.name;
+				} else if (!item.is_query_report && item.report_ref_doctype) {
+					route = frappe.router.slug(item.report_ref_doctype) + "/view/report/" + item.name;
 				} else {
-					route = frappe.router.slug(item.doctype) + "/view/report/" + item.name;
+					route = "/report/" + item.name;
 				}
 			} else if (type === "page") {
 				route = item.name;

--- a/frappe/public/js/frappe/widgets/links_widget.js
+++ b/frappe/public/js/frappe/widgets/links_widget.js
@@ -92,6 +92,7 @@ export default class LinksWidget extends Widget {
 				type: item.link_type,
 				doctype: item.doctype,
 				is_query_report: item.is_query_report,
+				report_ref_doctype: item.report_ref_doctype,
 			};
 
 			if (item.link_type.toLowerCase() == "report" && !item.is_query_report) {


### PR DESCRIPTION
Version 15 and 14,

fixes: #16530

**Before:**
- When selecting the builder report, it did not redirect to the builder report.


https://github.com/frappe/frappe/assets/141945075/677f5164-c87d-41aa-acc8-55b3d793fbfd


**After:**
- The issue is now fixed. When a user selects the builder report, it will redirect to the builder report.


https://github.com/frappe/frappe/assets/141945075/cfa09477-d89f-425f-9df7-851210de5425
