### PR TITLE
feat: add cache control

### DIFF
--- a/frappe/app.py
+++ b/frappe/app.py
@@ -8,6 +8,7 @@ import os
 import re
 
 from werkzeug.exceptions import HTTPException, NotFound
+from werkzeug.http import generate_etag, is_resource_modified, quote_etag
 from werkzeug.middleware.profiler import ProfilerMiddleware
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.middleware.shared_data import SharedDataMiddleware
@@ -148,8 +149,13 @@ def application(request: Request):
 			# We can not handle exceptions safely here.
 			frappe.logger().error("Failed to run after request hook", exc_info=True)
 
-		log_request(request, response)
-		process_response(response)
+	log_request(request, response)
+	# return 304 if unmodified
+	if not response.direct_passthrough:
+		etag = generate_etag(response.data)
+		if not is_resource_modified(request.environ, etag):
+			return Response(status=304, headers={"ETag": quote_etag(etag)})
+	process_response(response)
 
 	return response
 
@@ -237,8 +243,26 @@ def process_response(response):
 	if not response:
 		return
 
-	# set cookies
-	if hasattr(frappe.local, "cookie_manager"):
+	# cache control
+	# read: https://simonhearne.com/2022/caching-header-best-practices/
+	if frappe.local.response.can_cache:
+		response.headers.extend(
+			{
+				# default: 5m (proxy), 5m (client), 3h (allow stale resources for this long if upstream is down)
+				"Cache-Control": "public,s-maxage=300,max-age=300,stale-while-revalidate=10800",
+				# for revalidation of a stale resource
+				"ETag": quote_etag(generate_etag(response.data)),
+			}
+		)
+	else:
+		response.headers.extend(
+			{
+				"Cache-Control": "no-store,no-cache,must-revalidate,max-age=0",
+			}
+		)
+
+	# Set cookies, only if response is non-cacheable to avoid proxy cache invalidation
+	if hasattr(frappe.local, "cookie_manager") and not frappe.local.response.can_cache:
 		frappe.local.cookie_manager.flush_cookies(response=response)
 
 	# rate limiter headers

--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -267,7 +267,7 @@ frappe.request.call = function (opts) {
 			},
 			opts.headers
 		),
-		cache: true,
+		cache: window.dev_server ? false : true,
 	};
 
 	if (opts.args && opts.args.doctype) {

--- a/frappe/website/page_renderers/redirect_page.py
+++ b/frappe/website/page_renderers/redirect_page.py
@@ -17,6 +17,5 @@ class RedirectPage:
 			self.http_status_code,
 			{
 				"Location": frappe.flags.redirect_location or (frappe.local.response or {}).get("location"),
-				"Cache-Control": "no-store, no-cache, must-revalidate",
 			},
 		)

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -517,6 +517,7 @@ def cache_html(func):
 				html = page_cache[frappe.local.lang]
 			if html:
 				frappe.local.response.from_cache = True
+				frappe.local.response.can_cache = True
 				return html
 		html = func(*args, **kwargs)
 		context = args[0].context
@@ -524,6 +525,7 @@ def cache_html(func):
 			page_cache = frappe.cache.hget("website_page", args[0].path) or {}
 			page_cache[frappe.local.lang] = html
 			frappe.cache.hset("website_page", args[0].path, page_cache)
+			frappe.local.response.can_cache = True
 
 		return html
 


### PR DESCRIPTION
# Context

- Site local server
- Cloud proxy

Due to latency issues, there needs to be a way to serve static content from the edge

# Proposed Solution

- Add Cache-Control together with Etag
- The proxy needs to independently predict the effectively rendered language in order to serve the right cache key
- Therefore: set a `user_lang` cookie which records the effectively delivered language, this removes too much ambiguity from headers like Accept-Language, already after the first roundtrip

# Usage Nginx

At the beginning of the `server` (?) / `location` block:

```nginx
http {

  map $cookie_preferred_language $selected_lang {
    default        $cookie_user_lang;
  }

  server {
    proxy_cache frappe;
    proxy_cache_key $scheme$host$request_uri|$selected_lang;
    proxy_cache_valid 200 302 1d;
    proxy_cache_valid 404 1m;
    proxy_cache_lock on;

    add_header X-Cache-Status $upstream_cache_status;
  } 
}
```

### Considerations

Nginx is really quite limited in terms of header and cookie manipulation in relation to its cache subsystem. Better to use Varnish on the edge. rules & example: tbd

`no-docs`