### PR TITLE
perf: make get requests cacheable

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -267,7 +267,7 @@ frappe.request.call = function (opts) {
 			},
 			opts.headers
 		),
-		cache: false,
+		cache: true,
 	};
 
 	if (opts.args && opts.args.doctype) {


### PR DESCRIPTION
# Context

- With the prior setting jquery always appends _=timestamp() to each GET request
- This busts all and any attempts at caching those requests
- The backend does not currently implement any cache control (actively denies to cache: https://github.com/frappe/frappe/pull/26737/files#diff-67ecddbbe3746cf9e7688078b93535b18e7c220c88a0aae0c4965de04c2a7cc1R260)
- Therfore even with cache enabled in jquery, nothing is cache by default

# Proposed Solution

- Enable "the (still opt-in) possibility to configure cache" on specific GET requests by switching this flag

## Additional Nginx config required

... to enable cache on a particular route

```nginx
location "/api/method/erpnext.accounts.utils.get_fiscal_year" {
  proxy_hide_header Cache-Control;
  proxy_hide_header Set-Cookie;
  proxy_ignore_headers Cache-Control;
  proxy_ignore_headers Set-Cookie;
  add_header Cache-Control "max-age=2880";
  proxy_cache frappe;
  proxy_cache_valid 200 302 8h;
  proxy_cache_valid 404 1m;
  proxy_cache_lock on;
  add_header X-Cache-Status $upstream_cache_status;
  proxy_cache_key $scheme$host$request_uri;
}
```

**Note**: Firefox does cache this client side, ~~chrome apparently doesn't. Hence the proxy cache as fallback which is only suitable for non-private resources like fiscal year!~~ It does, apparently just not on a `*.localhost` domain?!? - In production, it does and that's what counts.