### PR TITLE
perf: make more resources in the critical path cacheable

### DIFF
--- a/frappe/public/js/frappe/request.js
+++ b/frappe/public/js/frappe/request.js
@@ -10,11 +10,12 @@ frappe.request.ajax_count = 0;
 frappe.request.waiting_for_ajax = [];
 frappe.request.logs = {};
 
-frappe.xcall = function (method, params) {
+frappe.xcall = function (method, params, type) {
 	return new Promise((resolve, reject) => {
 		frappe.call({
 			method: method,
 			args: params,
+			type: type || "POST",
 			callback: (r) => {
 				resolve(r.message);
 			},

--- a/frappe/public/js/frappe/ui/notifications/notifications.js
+++ b/frappe/public/js/frappe/ui/notifications/notifications.js
@@ -325,10 +325,11 @@ class NotificationsView extends BaseNotificationsView {
 	}
 
 	get_notifications_list(limit) {
-		return frappe.call(
-			"frappe.desk.doctype.notification_log.notification_log.get_notification_logs",
-			{ limit: limit }
-		);
+		return frappe.call({
+			method: "frappe.desk.doctype.notification_log.notification_log.get_notification_logs",
+			args: { limit: limit },
+			type: "GET",
+		});
 	}
 
 	get_item_link(notification_doc) {
@@ -385,10 +386,14 @@ class EventsView extends BaseNotificationsView {
 	make() {
 		let today = frappe.datetime.get_today();
 		frappe
-			.xcall("frappe.desk.doctype.event.event.get_events", {
-				start: today,
-				end: today,
-			})
+			.xcall(
+				"frappe.desk.doctype.event.event.get_events",
+				{
+					start: today,
+					end: today,
+				},
+				"GET"
+			)
 			.then((event_list) => {
 				this.render_events_html(event_list);
 			});

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -98,7 +98,7 @@ frappe.views.Workspace = class Workspace {
 	}
 
 	get_pages() {
-		return frappe.xcall("frappe.desk.desktop.get_workspace_sidebar_items");
+		return frappe.xcall("frappe.desk.desktop.get_workspace_sidebar_items", null, "GET");
 	}
 
 	show() {
@@ -123,8 +123,13 @@ frappe.views.Workspace = class Workspace {
 
 	get_data(page) {
 		return frappe
-			.call("frappe.desk.desktop.get_desktop_page", {
-				page: page,
+			.call({
+				method: "frappe.desk.desktop.get_desktop_page",
+				args: {
+					// send sorted min requirements to increase chance of cache hit
+					page: { name: page.name, title: page.title, public: page.public },
+				},
+				type: "GET",
 			})
 			.then((data) => {
 				this.page_data = data.message;


### PR DESCRIPTION
Get ~500ms `/app` page load on refresh.


Is now achieved together with:

- https://github.com/frappe/frappe/pull/26752
- https://github.com/frappe/erpnext/pull/41871
- https://github.com/frappe/frappe/pull/26737


# Nginx Config

**Example**

```nginx
server {
  location "/api/method/frappe.desk.doctype.notification_log.notification_log.get_notification_logs" {
    proxy_hide_header Cache-Control;
    proxy_hide_header Set-Cookie;
    proxy_ignore_headers Cache-Control;
    proxy_ignore_headers Set-Cookie;

    add_header Cache-Control "private,max-age=60";
  }
  location "/api/method/frappe.desk.doctype.event.event.get_events" {
    proxy_hide_header Cache-Control;
    proxy_hide_header Set-Cookie;
    proxy_ignore_headers Cache-Control;
    proxy_ignore_headers Set-Cookie;

    add_header Cache-Control "private,max-age=300";
  }
  # 8 h
  location "/api/method/frappe.desk.desktop.get_workspace_sidebar_items" {
    proxy_hide_header Cache-Control;
    proxy_hide_header Set-Cookie;
    proxy_ignore_headers Cache-Control;
    proxy_ignore_headers Set-Cookie;

    add_header Cache-Control "private,max-age=28800";
  }
  location "/api/method/frappe.desk.desktop.get_desktop_page" {
    proxy_hide_header Cache-Control;
    proxy_hide_header Set-Cookie;
    proxy_ignore_headers Cache-Control;
    proxy_ignore_headers Set-Cookie;

    add_header Cache-Control "private,max-age=60";
  }
}
```

`no-docs`
