### PR TITLE
fix: meta tag in web form (Open Graph spec compliance)

### DIFF
--- a/frappe/website/doctype/web_form/test_web_form.py
+++ b/frappe/website/doctype/web_form/test_web_form.py
@@ -64,7 +64,10 @@ class TestWebForm(FrappeTestCase):
 		set_request(method="GET", path="manage-events/new")
 		content = self.normalize_html(get_response_content("manage-events/new"))
 
-		self.assertIn(self.normalize_html('<meta name="name" content="Test Meta Form Title">'), content)
+		self.assertIn(self.normalize_html('<meta name="title" content="Test Meta Form Title">'), content)
+		self.assertIn(
+			self.normalize_html('<meta property="og:title" content="Test Meta Form Title">'), content
+		)
 		self.assertIn(
 			self.normalize_html('<meta property="og:description" content="Test Meta Form Description">'),
 			content,

--- a/frappe/website/doctype/web_form/web_form.py
+++ b/frappe/website/doctype/web_form/web_form.py
@@ -256,7 +256,7 @@ def get_context(context):
 			description = self.introduction_text[:140]
 
 		context.metatags = {
-			"name": self.meta_title or self.title,
+			"title": self.meta_title or self.title,
 			"description": description,
 			"image": self.meta_image,
 		}


### PR DESCRIPTION
You can validate the previous setting was wrong for example with https://opengraph.xyz or simply against the opengraph specificacion https://ogp.me/