### PR TITLE
feat: set the only email address as primary

### DIFF
--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -129,6 +129,9 @@ class Contact(Document):
 		if len([email.email_id for email in self.email_ids if email.is_primary]) > 1:
 			frappe.throw(_("Only one {0} can be set as primary.").format(frappe.bold("Email ID")))
 
+		if len(self.email_ids) == 1:
+			self.email_ids[0].is_primary = 1
+
 		primary_email_exists = False
 		for d in self.email_ids:
 			if d.is_primary == 1:


### PR DESCRIPTION
Some features rely on the Contact having the primary email set. If the Contact has only one email address, we can mark it as primary automatically. Only if there are more than one  addresses available, the user has to choose which one should be set as primary.

https://github.com/frappe/frappe/assets/14891507/792817e0-652d-43b8-b0e0-1d4e019100bd

> no-docs (for now)

Internal ref: MRC-140