### PR TITLE
fix: don't excessively shorten_number

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -1339,10 +1339,19 @@ Object.assign(frappe.utils, {
 
 		// return number if total digits is lesser than min_length
 		const len = String(number).match(/\d/g).length;
-		if (len < min_length) return number.toString();
+		if (len < min_length) {
+			return number.toString();
+		}
 
 		const number_system = this.get_number_system(country);
 		let x = Math.abs(Math.round(number));
+
+		// if rounding was sufficient to get below min_length, return the rounded number
+		const x_string = x.toString();
+		if (x_string.length < min_length) {
+			return x_string;
+		}
+
 		for (const map of number_system) {
 			if (x >= map.divisor) {
 				let result = number / map.divisor;


### PR DESCRIPTION
### Reproduce

Create two Number Cards, "With decimals" and "Without decimals", calling these two custom methods:

```python
import frappe


@frappe.whitelist()
def with_decimals(filters=None):
	return {
		"value": 1234.56789,
		"fieldtype": "Float",
	}


@frappe.whitelist()
def without_decimals(filters=None):
	return {
		"value": 1234.0,
		"fieldtype": "Float",
	}
```

### Before

![Bildschirmfoto 2024-06-14 um 15 39 28](https://github.com/frappe/frappe/assets/14891507/cd39ba77-7e5c-4ae4-8516-71df4b75aabd)

The number with decimals is shortened to `"1 K"`, losing 23.457 % in precision. The number without decimals remains unchanged.

### Analysis

The call `shorten_number(1234.56789, "Germany", 5)` is expected to return a rough representation of the number (`1234.56789`), using less than `5` digits. This can already be achieved by rounding to the nearest integer.

### After

![Bildschirmfoto 2024-06-14 um 15 39 05](https://github.com/frappe/frappe/assets/14891507/e962c4be-4261-4576-8921-6027a13a2c73)

The number with decimals is rounded to the nearest integer, which is less than five digits, losing only 0.035 % in precision.