### PR TITLE
perf: shorter debounce for awesomeplete

### DIFF
--- a/frappe/public/js/frappe/form/controls/autocomplete.js
+++ b/frappe/public/js/frappe/form/controls/autocomplete.js
@@ -98,7 +98,7 @@ frappe.ui.form.ControlAutocomplete = class ControlAutoComplete extends frappe.ui
 				} else {
 					this.awesomplete.list = this.get_data();
 				}
-			}, 500)
+			}, 100)
 		);
 
 		this.$input.on("focus", () => {


### PR DESCRIPTION
Alternative to #26491

Originally, I wanted to remove the debounce entirely, but couldn't get cypress to accept it. So, let's try to just make it much shorter.