### PR TITLE
fix(socketio): pass auth token if available instead of cookie

### DIFF
--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -38,7 +38,7 @@ function authenticate_with_frappe(socket, next) {
 		}
 
 		let headers = {};
-		 if (socket.authorization_header) {
+		if (socket.authorization_header) {
 			headers["Authorization"] = socket.authorization_header;
 		} else if (socket.sid) {
 			headers["Cookie"] = `sid=${socket.sid}`;

--- a/realtime/middlewares/authenticate.js
+++ b/realtime/middlewares/authenticate.js
@@ -38,10 +38,10 @@ function authenticate_with_frappe(socket, next) {
 		}
 
 		let headers = {};
-		if (socket.sid) {
-			headers["Cookie"] = `sid=${socket.sid}`;
-		} else if (socket.authorization_header) {
+		 if (socket.authorization_header) {
 			headers["Authorization"] = socket.authorization_header;
+		} else if (socket.sid) {
+			headers["Cookie"] = `sid=${socket.sid}`;
 		}
 
 		return fetch(get_url(socket, path), {


### PR DESCRIPTION
For mobile apps, the cookie sent for a Socket connection has the SID as "Guest". Even though an Authorization token was sent, since the cookie SID was "Guest", it was used for the request.

This PR changes the order of application of headers to the request in authenticate.js. If an auth token is passed, send that in the header, else send the cookie SID.