### PR TITLE
feat: download Contact as vCard

### DIFF
--- a/frappe/contacts/doctype/contact/contact.js
+++ b/frappe/contacts/doctype/contact/contact.js
@@ -88,6 +88,17 @@ frappe.ui.form.on("Contact", {
 				);
 			}
 		}
+
+		if (!frm.is_dirty()) {
+			frm.page.add_menu_item(__("Download vCard"), function () {
+				window.open(
+					`/api/method/frappe.contacts.doctype.contact.contact.download_vcard?contact=${encodeURIComponent(
+						frm.doc.name
+					)}`,
+					"_blank"
+				);
+			});
+		}
 	},
 	validate: function (frm) {
 		// clear linked customer / supplier / sales partner on saving...

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -218,6 +218,24 @@ def download_vcard(contact: str):
 	frappe.response["type"] = "binary"
 
 
+@frappe.whitelist()
+def download_vcards(contacts: str):
+	"""Download vCard for the contact"""
+	from frappe.utils.data import now
+
+	vcards = []
+	for contact_id in frappe.parse_json(contacts):
+		contact = frappe.get_doc("Contact", contact_id)
+		vcard = contact.get_vcard()
+		vcards.append(vcard.serialize())
+
+	timestamp = now()[:19]  # remove milliseconds
+
+	frappe.response["filename"] = f"{timestamp} Contacts.vcf"
+	frappe.response["filecontent"] = "\n".join(vcards).encode("utf-8")
+	frappe.response["type"] = "binary"
+
+
 def get_default_contact(doctype, name):
 	"""Return default contact for the given doctype, name."""
 	out = frappe.db.sql(

--- a/frappe/contacts/doctype/contact/contact.py
+++ b/frappe/contacts/doctype/contact/contact.py
@@ -225,6 +225,8 @@ def download_vcard(contact: str):
 @frappe.whitelist()
 def download_vcards(contacts: str):
 	"""Download vCard for the contact"""
+	import json
+
 	from frappe.utils.data import now
 
 	contact_ids = frappe.parse_json(contacts)
@@ -236,9 +238,11 @@ def download_vcards(contacts: str):
 		vcard = contact.get_vcard()
 		vcards.append(vcard.serialize())
 
-	# Separate loop in order to avoid access logs for errored exports
-	for contact_id in contact_ids:
-		make_access_log(doctype="Contact", document=contact_id, file_type="vcf")
+	make_access_log(
+		doctype="Contact",
+		filters=json.dumps([["name", "in", contact_ids]], ensure_ascii=False, indent="\t"),
+		file_type="vcf",
+	)
 
 	timestamp = now()[:19]  # remove milliseconds
 

--- a/frappe/contacts/doctype/contact/contact_list.js
+++ b/frappe/contacts/doctype/contact/contact_list.js
@@ -1,3 +1,11 @@
 frappe.listview_settings["Contact"] = {
 	add_fields: ["image"],
+	onload: function (listview) {
+		listview.page.add_action_item(__("Download vCards"), function () {
+			const contacts = listview.get_checked_items();
+			open_url_post("/api/method/frappe.contacts.doctype.contact.contact.download_vcards", {
+				contacts: contacts.map((c) => c.name),
+			});
+		});
+	},
 };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
     "google-auth-oauthlib~=0.4.4",
     "google-auth~=1.29.0",
     "posthog~=3.0.1",
+    "vobject~=0.9.7",
 ]
 
 [project.urls]


### PR DESCRIPTION
> vCard is a file format standard for electronic business cards. vCard is used as a data interchange format in smartphone contacts, personal digital assistants, personal information managers and CRM systems. (Loosely based on Wikipedia.)

This PR adds "Download vCard" buttons to the **Contact** list view and form view.

Download and Import selected contacts on Mac:

https://github.com/frappe/frappe/assets/14891507/605b005a-9ff9-470c-a8a9-bf3bed61d0d8


Resulting vCard file content from above demo:

```
BEGIN:VCARD
VERSION:3.0
EMAIL;TYPE=pref:RafaelaMaartens@example.com
FN:Rafaëla Maartens
N:Maartens;Rafaëla;;;
TEL;TYPE=home:123456
TEL;TYPE=cell:78910112
TITLE:The boss
END:VCARD

BEGIN:VCARD
VERSION:3.0
EMAIL;TYPE=pref:NuguseYohannes@example.com
FN:Nuguse Yohannes
N:Yohannes;Nuguse;;;
TITLE:Cheffe
END:VCARD
```