### PR TITLE
fix: mariadb procedures are not included in the backup file and there…

### DIFF
--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -111,6 +111,7 @@ def get_command(
 					"--single-transaction",
 					"--quick",
 					"--lock-tables=false",
+					"--routines",
 				]
 			)
 		else:


### PR DESCRIPTION
…fore are not present when restoring

fixed by add --routines parameter 

Note:
A user may encounter an error like this to perform a backup  : b'mariadb-dump: sitename has insufficient privileges to SHOW CREATE FUNCTION ...

Solution : 
GRANT EXECUTE, ALTER ROUTINE, CREATE ROUTINE, SELECT ON YOURDATBASE.* TO 'YOURDATBASEUSER'@'localhost';