### PR TITLE
refactor(web list): use CSS class `d-none` instead of `hidden`

### DIFF
--- a/frappe/templates/includes/list/list.html
+++ b/frappe/templates/includes/list/list.html
@@ -19,7 +19,7 @@
 				{{ item }}
 			{% endfor %}
 		</div>
-		<div class="more-block py-6 {% if not show_more -%} hidden {%- endif %}">
+		<div class="more-block py-6 {% if not show_more -%} d-none {%- endif %}">
 			<button class="btn btn-light btn-more btn-sm">{{ _("More") }}</button>
 		</div>
 	</div>


### PR DESCRIPTION
`hidden` is just a wrapper for `d-none`:

https://github.com/frappe/frappe/blob/c5b691e54ff3c5afd200b0eeb495967bbf78bc96/frappe/public/scss/common/global.scss#L144-L146

But `d-none` will work even if the wrapper is not available (for example, when using a custom app's CSS for your website), so it's better to use it directly.

I'm only changing this specific case because it works without side effects here and solves my problem.
