### PR TITLE
feat: Frappe Mail Connector

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -1,4 +1,24 @@
 frappe.email_defaults = {
+	"Frappe Mail": {
+		domain: null,
+		password: null,
+		awaiting_password: 0,
+		ascii_encode_password: 0,
+		login_id_is_different: 0,
+		login_id: null,
+		use_imap: 0,
+		use_ssl: 0,
+		validate_ssl_certificate: 0,
+		use_starttls: 0,
+		email_server: null,
+		incoming_port: 0,
+		always_use_account_email_id_as_sender: 1,
+		use_tls: 0,
+		use_ssl_for_outgoing: 0,
+		smtp_server: null,
+		smtp_port: null,
+		no_smtp_authentication: 0,
+	},
 	GMail: {
 		email_server: "imap.gmail.com",
 		incoming_port: 993,
@@ -144,11 +164,11 @@ frappe.ui.form.on("Email Account", {
 			frm.refresh_field("imap_folder");
 		}
 		set_default_max_attachment_size(frm);
-		frm.events.show_oauth_authorization_message(frm);
 	},
 
 	refresh: function (frm) {
 		frm.events.enable_incoming(frm);
+		frm.events.show_oauth_authorization_message(frm);
 
 		if (frappe.route_flags.delete_user_from_locals && frappe.route_flags.linked_user) {
 			delete frappe.route_flags.delete_user_from_locals;
@@ -167,6 +187,15 @@ frappe.ui.form.on("Email Account", {
 
 	authorize_api_access: function (frm) {
 		oauth_access(frm);
+	},
+
+	validate_frappe_mail_settings: function (frm) {
+		if (frm.doc.service == "Frappe Mail") {
+			frappe.call({
+				doc: frm.doc,
+				method: "validate_frappe_mail_settings",
+			});
+		}
 	},
 
 	show_oauth_authorization_message(frm) {

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -159,7 +159,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Service",
-   "options": "\nGMail\nSendgrid\nSparkPost\nYahoo Mail\nOutlook.com\nYandex.Mail"
+   "options": "\nFrappe Mail\nGMail\nSendgrid\nSparkPost\nYahoo Mail\nOutlook.com\nYandex.Mail"
   },
   {
    "fieldname": "mailbox_settings",
@@ -637,7 +637,7 @@
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-17 14:46:38.836631",
+ "modified": "2024-06-10 18:18:08.403133",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -8,25 +8,24 @@
  "engine": "InnoDB",
  "field_order": [
   "account_section",
-  "service",
-  "frappe_mail_site",
-  "domain",
+  "email_id",
+  "email_account_name",
   "enable_incoming",
   "enable_outgoing",
   "column_break_3",
-  "email_id",
-  "email_account_name",
-  "authentication_section",
-  "api_key",
-  "column_break_ghqa",
-  "api_secret",
+  "service",
+  "domain",
+  "frappe_mail_site",
   "authentication_column",
   "auth_method",
   "authorize_api_access",
+  "validate_frappe_mail_settings",
   "password",
   "awaiting_password",
   "ascii_encode_password",
   "column_break_10",
+  "api_key",
+  "api_secret",
   "connected_app",
   "connected_user",
   "login_id_is_different",
@@ -100,6 +99,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: doc.service != \"Frappe Mail\"",
    "fieldname": "login_id_is_different",
    "fieldtype": "Check",
    "hide_days": 1,
@@ -115,7 +115,7 @@
    "label": "Alternative Email ID"
   },
   {
-   "depends_on": "eval: doc.auth_method === \"Basic\"",
+   "depends_on": "eval: doc.auth_method === \"Basic\" && doc.service != \"Frappe Mail\"",
    "fieldname": "password",
    "fieldtype": "Password",
    "hide_days": 1,
@@ -124,7 +124,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval: doc.auth_method === \"Basic\"",
+   "depends_on": "eval: doc.auth_method === \"Basic\" && doc.service != \"Frappe Mail\"",
    "fieldname": "awaiting_password",
    "fieldtype": "Check",
    "hide_days": 1,
@@ -133,7 +133,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval: doc.auth_method === \"Basic\"",
+   "depends_on": "eval: doc.auth_method === \"Basic\" && doc.service != \"Frappe Mail\"",
    "fieldname": "ascii_encode_password",
    "fieldtype": "Check",
    "hide_days": 1,
@@ -543,7 +543,6 @@
    "label": "Brand Logo"
   },
   {
-   "depends_on": "eval: doc.service != \"Frappe Mail\"",
    "fieldname": "authentication_column",
    "fieldtype": "Section Break",
    "label": "Authentication"
@@ -635,28 +634,6 @@
    "label": "Incoming"
   },
   {
-   "fieldname": "api_key",
-   "fieldtype": "Data",
-   "label": "API Key",
-   "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\""
-  },
-  {
-   "fieldname": "api_secret",
-   "fieldtype": "Password",
-   "label": "API Secret",
-   "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\""
-  },
-  {
-   "depends_on": "eval: doc.service == \"Frappe Mail\"",
-   "fieldname": "authentication_section",
-   "fieldtype": "Section Break",
-   "label": "Authentication"
-  },
-  {
-   "fieldname": "column_break_ghqa",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "https://frappemail.com",
    "depends_on": "eval: doc.service == \"Frappe Mail\"",
    "fieldname": "frappe_mail_site",
@@ -687,12 +664,32 @@
    "fieldname": "last_synced_at",
    "fieldtype": "Datetime",
    "label": "Last Synced At"
+  },
+  {
+   "depends_on": "eval: (doc.service == \"Frappe Mail\" && doc.auth_method != \"Basic\" && !doc.__islocal && !doc.__unsaved)",
+   "fieldname": "validate_frappe_mail_settings",
+   "fieldtype": "Button",
+   "label": "Validate Frappe Mail Settings"
+  },
+  {
+   "depends_on": "eval: doc.service == \"Frappe Mail\" && doc.auth_method == \"Basic\"",
+   "fieldname": "api_key",
+   "fieldtype": "Data",
+   "label": "API Key",
+   "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\" && doc.auth_method == \"Basic\""
+  },
+  {
+   "depends_on": "eval: doc.service == \"Frappe Mail\" && doc.auth_method == \"Basic\"",
+   "fieldname": "api_secret",
+   "fieldtype": "Password",
+   "label": "API Secret",
+   "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\" && doc.auth_method == \"Basic\""
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-22 08:51:12.977896",
+ "modified": "2024-06-28 08:45:43.565934",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -2,7 +2,7 @@
  "actions": [],
  "allow_rename": 1,
  "autoname": "field:email_account_name",
- "creation": "2014-09-11 12:04:34.163728",
+ "creation": "2024-06-11 16:39:01.323289",
  "doctype": "DocType",
  "document_type": "Setup",
  "engine": "InnoDB",
@@ -15,6 +15,11 @@
   "column_break_3",
   "domain",
   "service",
+  "frappe_mail_site",
+  "authentication_section",
+  "api_key",
+  "column_break_ghqa",
+  "api_secret",
   "authentication_column",
   "auth_method",
   "authorize_api_access",
@@ -50,19 +55,21 @@
   "notify_if_unreplied",
   "unreplied_for_mins",
   "send_notification_to",
-  "outgoing_smtp_tab",
-  "outgoing_mail_settings",
-  "column_break_bidn",
-  "use_tls",
-  "use_ssl_for_outgoing",
-  "smtp_server",
-  "smtp_port",
-  "column_break_38",
+  "outgoing_tab",
+  "section_break_nesl",
+  "column_break_y6hx",
+  "column_break_h5pd",
   "default_outgoing",
   "always_use_account_email_id_as_sender",
   "always_use_account_name_as_sender_name",
   "send_unsubscribe_message",
   "track_email_status",
+  "outgoing_mail_settings",
+  "use_tls",
+  "use_ssl_for_outgoing",
+  "smtp_server",
+  "smtp_port",
+  "column_break_38",
   "no_smtp_authentication",
   "signature_section",
   "add_signature",
@@ -289,6 +296,7 @@
    "mandatory_depends_on": "notify_if_unreplied"
   },
   {
+   "depends_on": "eval: doc.service != \"Frappe Mail\"",
    "fieldname": "outgoing_mail_settings",
    "fieldtype": "Section Break",
    "hide_days": 1,
@@ -533,6 +541,7 @@
    "label": "Brand Logo"
   },
   {
+   "depends_on": "eval: doc.service != \"Frappe Mail\"",
    "fieldname": "authentication_column",
    "fieldtype": "Section Break",
    "label": "Authentication"
@@ -624,20 +633,58 @@
    "label": "Incoming (POP/IMAP)"
   },
   {
-   "depends_on": "enable_outgoing",
-   "fieldname": "outgoing_smtp_tab",
-   "fieldtype": "Tab Break",
-   "label": "Outgoing (SMTP)"
+   "fieldname": "api_key",
+   "fieldtype": "Data",
+   "label": "API Key",
+   "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\""
   },
   {
-   "fieldname": "column_break_bidn",
+   "fieldname": "api_secret",
+   "fieldtype": "Password",
+   "label": "API Secret",
+   "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\""
+  },
+  {
+   "depends_on": "eval: doc.service == \"Frappe Mail\"",
+   "fieldname": "authentication_section",
+   "fieldtype": "Section Break",
+   "label": "Authentication"
+  },
+  {
+   "fieldname": "column_break_ghqa",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "https://frappemail.com",
+   "depends_on": "eval: doc.service == \"Frappe Mail\"",
+   "fieldname": "frappe_mail_site",
+   "fieldtype": "Data",
+   "label": "Frappe Mail Site",
+   "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\""
+  },
+  {
+   "depends_on": "enable_outgoing",
+   "fieldname": "outgoing_tab",
+   "fieldtype": "Tab Break",
+   "label": "Outgoing"
+  },
+  {
+   "fieldname": "section_break_nesl",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_y6hx",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_h5pd",
    "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-10 18:18:08.403133",
+ "modified": "2024-06-11 16:54:22.255325",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -673,14 +673,6 @@
    "label": "Outgoing"
   },
   {
-   "fieldname": "section_break_nesl",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_y6hx",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "column_break_h5pd",
    "fieldtype": "Column Break"
   },
@@ -696,14 +688,21 @@
    "depends_on": "eval: doc.service == \"Frappe Mail\"",
    "fieldname": "last_synced_at",
    "fieldtype": "Datetime",
-   "label": "Last Synced At",
-   "read_only": 1
+   "label": "Last Synced At"
+  },
+  {
+   "fieldname": "section_break_nesl",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_y6hx",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-19 11:50:56.886640",
+ "modified": "2024-06-20 16:29:23.704289",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -8,14 +8,14 @@
  "engine": "InnoDB",
  "field_order": [
   "account_section",
-  "email_id",
-  "email_account_name",
+  "service",
+  "frappe_mail_site",
+  "domain",
   "enable_incoming",
   "enable_outgoing",
   "column_break_3",
-  "domain",
-  "service",
-  "frappe_mail_site",
+  "email_id",
+  "email_account_name",
   "authentication_section",
   "api_key",
   "column_break_ghqa",
@@ -59,10 +59,8 @@
   "unreplied_for_mins",
   "send_notification_to",
   "outgoing_tab",
-  "section_break_nesl",
-  "column_break_y6hx",
-  "column_break_h5pd",
   "default_outgoing",
+  "column_break_h5pd",
   "always_use_account_email_id_as_sender",
   "always_use_account_name_as_sender_name",
   "send_unsubscribe_message",
@@ -689,20 +687,12 @@
    "fieldname": "last_synced_at",
    "fieldtype": "Datetime",
    "label": "Last Synced At"
-  },
-  {
-   "fieldname": "section_break_nesl",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_y6hx",
-   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-20 16:29:23.704289",
+ "modified": "2024-06-22 08:51:12.977896",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -32,8 +32,11 @@
   "login_id_is_different",
   "login_id",
   "incoming_popimap_tab",
-  "mailbox_settings",
+  "section_break_uc6h",
   "default_incoming",
+  "column_break_uynb",
+  "attachment_limit",
+  "mailbox_settings",
   "use_imap",
   "use_ssl",
   "validate_ssl_certificate",
@@ -41,7 +44,6 @@
   "email_server",
   "incoming_port",
   "column_break_18",
-  "attachment_limit",
   "email_sync_option",
   "initial_sync_count",
   "section_break_25",
@@ -169,6 +171,7 @@
    "options": "\nFrappe Mail\nGMail\nSendgrid\nSparkPost\nYahoo Mail\nOutlook.com\nYandex.Mail"
   },
   {
+   "depends_on": "eval: doc.service != \"Frappe Mail\"",
    "fieldname": "mailbox_settings",
    "fieldtype": "Section Break",
    "hide_days": 1,
@@ -630,7 +633,7 @@
    "depends_on": "enable_incoming",
    "fieldname": "incoming_popimap_tab",
    "fieldtype": "Tab Break",
-   "label": "Incoming (POP/IMAP)"
+   "label": "Incoming"
   },
   {
    "fieldname": "api_key",
@@ -679,12 +682,20 @@
   {
    "fieldname": "column_break_h5pd",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_uc6h",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_uynb",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-11 16:54:22.255325",
+ "modified": "2024-06-18 19:24:11.767869",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -36,6 +36,7 @@
   "default_incoming",
   "column_break_uynb",
   "attachment_limit",
+  "last_synced_at",
   "mailbox_settings",
   "use_imap",
   "use_ssl",
@@ -690,12 +691,19 @@
   {
    "fieldname": "column_break_uynb",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval: doc.service == \"Frappe Mail\"",
+   "fieldname": "last_synced_at",
+   "fieldtype": "Datetime",
+   "label": "Last Synced At",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-18 19:24:11.767869",
+ "modified": "2024-06-19 11:50:56.886640",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -96,13 +96,7 @@ class EmailAccount(Document):
 		send_notification_to: DF.SmallText | None
 		send_unsubscribe_message: DF.Check
 		service: DF.Literal[
-			"",
-			"GMail",
-			"Sendgrid",
-			"SparkPost",
-			"Yahoo Mail",
-			"Outlook.com",
-			"Yandex.Mail",
+			"", "Frappe Mail", "GMail", "Sendgrid", "SparkPost", "Yahoo Mail", "Outlook.com", "Yandex.Mail"
 		]
 		signature: DF.TextEditor | None
 		smtp_port: DF.Data | None

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -61,6 +61,8 @@ class EmailAccount(Document):
 		add_signature: DF.Check
 		always_use_account_email_id_as_sender: DF.Check
 		always_use_account_name_as_sender_name: DF.Check
+		api_key: DF.Data | None
+		api_secret: DF.Password | None
 		append_emails_to_sent_folder: DF.Check
 		append_to: DF.Link | None
 		ascii_encode_password: DF.Check
@@ -84,6 +86,7 @@ class EmailAccount(Document):
 		enable_incoming: DF.Check
 		enable_outgoing: DF.Check
 		footer: DF.TextEditor | None
+		frappe_mail_site: DF.Data | None
 		imap_folder: DF.Table[IMAPFolder]
 		incoming_port: DF.Data | None
 		initial_sync_count: DF.Literal["100", "250", "500"]
@@ -152,7 +155,11 @@ class EmailAccount(Document):
 			self.awaiting_password = 0
 			self.password = None
 
-		if not frappe.local.flags.in_install and not self.awaiting_password:
+		if (
+			not frappe.local.flags.in_install
+			and not self.awaiting_password
+			and not self.service == "Frappe Mail"
+		):
 			if validate_oauth or self.password or self.smtp_server in ("127.0.0.1", "localhost"):
 				if self.enable_incoming:
 					self.get_incoming_server()

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -91,6 +91,7 @@ class EmailAccount(Document):
 		imap_folder: DF.Table[IMAPFolder]
 		incoming_port: DF.Data | None
 		initial_sync_count: DF.Literal["100", "250", "500"]
+		last_synced_at: DF.Datetime | None
 		login_id: DF.Data | None
 		login_id_is_different: DF.Check
 		no_failed: DF.Int
@@ -604,8 +605,9 @@ class EmailAccount(Document):
 				fm_client = FrappeMail(
 					self.frappe_mail_site, self.email_id, self.api_key, self.get_password("api_secret")
 				)
-				messages = fm_client.pull(self.email_id)
+				messages = fm_client.pull(self.email_id, last_synced_at=self.last_synced_at)
 				process_mail(messages)
+				self.db_set("last_synced_at", messages["last_synced_at"], update_modified=False)
 			else:
 				email_sync_rule = self.build_email_sync_rule()
 				email_server = self.get_incoming_server(in_receive=True, email_sync_rule=email_sync_rule)

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -135,8 +135,14 @@ class EmailAccount(Document):
 		if self.email_id:
 			validate_email_address(self.email_id, True)
 
-		if self.service == "Frappe Mail" and self.use_imap:
-			self.use_imap = 0
+		if self.service == "Frappe Mail":
+			if self.use_imap:
+				self.use_imap = 0
+
+			fm_client = FrappeMail(
+				self.frappe_mail_site, self.email_id, self.api_key, self.get_password("api_secret")
+			)
+			fm_client.validate(for_inbound=self.enable_incoming, for_outbound=self.enable_outgoing)
 
 		if self.login_id_is_different:
 			if not self.login_id:
@@ -605,7 +611,7 @@ class EmailAccount(Document):
 				fm_client = FrappeMail(
 					self.frappe_mail_site, self.email_id, self.api_key, self.get_password("api_secret")
 				)
-				messages = fm_client.pull(self.email_id, last_synced_at=self.last_synced_at)
+				messages = fm_client.pull(last_synced_at=self.last_synced_at)
 				process_mail(messages)
 				self.db_set("last_synced_at", messages["last_synced_at"], update_modified=False)
 			else:

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -139,6 +139,9 @@ class EmailAccount(Document):
 			if self.use_imap:
 				self.use_imap = 0
 
+			if not self.always_use_account_email_id_as_sender:
+				self.always_use_account_email_id_as_sender = 1
+
 			fm_client = FrappeMail(
 				self.frappe_mail_site, self.email_id, self.api_key, self.get_password("api_secret")
 			)

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -7,6 +7,7 @@ import traceback
 from contextlib import suppress
 from email.parser import Parser
 from email.policy import SMTP
+from typing import TYPE_CHECKING
 
 import frappe
 from frappe import _, safe_encode, task
@@ -16,6 +17,7 @@ from frappe.email.doctype.email_account.email_account import EmailAccount
 from frappe.email.email_body import add_attachment, get_email, get_formatted_html
 from frappe.email.queue import get_unsubcribed_url, get_unsubscribe_message
 from frappe.email.smtp import SMTPServer
+from frappe.frappeclient import FrappeClient
 from frappe.model.document import Document
 from frappe.query_builder import DocType, Interval
 from frappe.query_builder.functions import Now
@@ -33,6 +35,9 @@ from frappe.utils import (
 )
 from frappe.utils.deprecations import deprecated
 from frappe.utils.verified_command import get_signed_params
+
+if TYPE_CHECKING:
+	from requests import Response
 
 
 class EmailQueue(Document):
@@ -168,8 +173,14 @@ class EmailQueue(Document):
 				message = ctx.build_message(recipient.recipient)
 				if method := get_hook_method("override_email_send"):
 					method(self, self.sender, recipient.recipient, message)
-				else:
-					if not frappe.flags.in_test or frappe.flags.testing_email:
+				elif not frappe.flags.in_test or frappe.flags.testing_email:
+					if ctx.email_account_doc.service == "Frappe Mail":
+						ctx.frappe_mail.send(
+							sender=self.sender,
+							recipients=recipient.recipient,
+							message=message.decode("utf-8"),
+						)
+					else:
 						ctx.smtp_server.session.sendmail(
 							from_addr=self.sender,
 							to_addrs=recipient.recipient,
@@ -240,7 +251,10 @@ class SendMailContext:
 
 	def fetch_smtp_server(self):
 		self.email_account_doc = self.queue_doc.get_email_account(raise_error=True)
-		if not self.smtp_server:
+
+		if self.email_account_doc.service == "Frappe Mail":
+			self.frappe_mail = FrappeMail(self.email_account_doc)
+		elif not self.smtp_server:
 			self.smtp_server = self.email_account_doc.get_smtp_server()
 
 	def __enter__(self):
@@ -802,3 +816,46 @@ class QueueBuilder:
 			d["recipients"] = self.final_recipients()
 
 		return d
+
+
+class FrappeMail:
+	def __init__(self, email_account: "EmailAccount") -> None:
+		self.client = self.get_client(email_account)
+		self.frappe_mail_site = email_account.frappe_mail_site
+
+	@staticmethod
+	def get_client(email_account: "EmailAccount") -> FrappeClient:
+		"""Returns FrappeClient object for the given email account."""
+
+		if hasattr(frappe.local, "frappe_mail_clients"):
+			if client := frappe.local.frappe_mail_clients.get(email_account.name):
+				return client
+		else:
+			frappe.local.frappe_mail_clients = {}
+
+		url = email_account.frappe_mail_site
+		api_key = email_account.api_key
+		api_secret = email_account.get_password("api_secret")
+
+		client = FrappeClient(url, api_key=api_key, api_secret=api_secret)
+		frappe.local.frappe_mail_clients[email_account.name] = client
+
+		return client
+
+	def request(
+		self,
+		method: str,
+		endpoint: str,
+		data: dict | None = None,
+		timeout: int | tuple[int, int] = (60, 120),
+	) -> "Response":
+		url = f"{self.frappe_mail_site}/{endpoint}"
+		response = self.client.session.request(
+			method=method, url=url, headers=self.client.headers, json=data, timeout=timeout
+		)
+		return response
+
+	def send(self, sender: str, recipients: str, message: str):
+		endpoint = "outbound/send-raw"
+		data = {"from": sender, "to": recipients, "raw_message": message}
+		self.request("POST", endpoint, data)

--- a/frappe/email/frappemail.py
+++ b/frappe/email/frappemail.py
@@ -89,7 +89,7 @@ class FrappeMail:
 	def pull(self, limit: int = 50, last_synced_at: str | None = None) -> dict[str, list[str] | str]:
 		"""Pulls emails from the mailbox using the Frappe Mail API."""
 
-		endpoint = "inbound/pull"
+		endpoint = "inbound/pull-raw"
 		data = {"mailbox": self.mailbox, "limit": limit, "last_synced_at": last_synced_at}
 		headers = {"X-Site": frappe.utils.get_url()}
 		response = self.request("GET", endpoint=endpoint, data=data, headers=headers).json()["message"]

--- a/frappe/email/frappemail.py
+++ b/frappe/email/frappemail.py
@@ -56,12 +56,14 @@ class FrappeMail:
 		json_data = {"from": sender, "to": recipients, "raw_message": message}
 		self.request("POST", endpoint=endpoint, json=json_data)
 
-	def pull(self, mailbox: str, limit: int = 50) -> dict[str, list]:
+	def pull(
+		self, mailbox: str, limit: int = 50, last_synced_at: str | None = None
+	) -> dict[str, list[str] | str]:
 		"""Returns the emails for the given mailbox."""
 
 		endpoint = "inbound/pull"
-		data = {"mailbox": mailbox, "limit": limit}
+		data = {"mailbox": mailbox, "limit": limit, "last_synced_at": last_synced_at}
 		headers = {"X-Site": frappe.utils.get_url()}
-		response = self.request("GET", endpoint=endpoint, data=data, headers=headers)
+		response = self.request("GET", endpoint=endpoint, data=data, headers=headers).json()["message"]
 
-		return {"latest_messages": response.json().get("message", [])}
+		return {"latest_messages": response["mails"], "last_synced_at": response["last_synced_at"]}

--- a/frappe/email/frappemail.py
+++ b/frappe/email/frappemail.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+from urllib.parse import urljoin
 
 import frappe
 from frappe.frappeclient import FrappeClient
@@ -24,7 +25,7 @@ class FrappeMail:
 		self.client = self.get_client(site, mailbox, api_key, api_secret)
 
 	@staticmethod
-	def get_client(site: str, mailbox: str, api_key: str, api_secret: str) -> FrappeClient:
+	def get_client(site: str, mailbox: str, api_key: str, api_secret: str) -> "FrappeClient":
 		"""Returns FrappeClient object for the given email account."""
 
 		if hasattr(frappe.local, "frappe_mail_clients"):
@@ -51,7 +52,7 @@ class FrappeMail:
 	) -> "Response":
 		"""Makes a HTTP request to the Frappe Mail API."""
 
-		url = f"{self.site}/{endpoint}"
+		url = urljoin(self.site, endpoint)
 		headers = headers or {}
 		headers.update(self.client.headers)
 		response = self.client.session.request(

--- a/frappe/email/frappemail.py
+++ b/frappe/email/frappemail.py
@@ -7,6 +7,15 @@ if TYPE_CHECKING:
 	from requests import Response
 
 
+class FrappeMailException(Exception):
+	"""Exception raised for errors in the Frappe Mail API."""
+
+	def __init__(self, message: str, status_code: int) -> None:
+		self.message = message
+		self.status_code = status_code
+		super().__init__(message)
+
+
 class FrappeMail:
 	"""Class to interact with the Frappe Mail API."""
 
@@ -38,6 +47,7 @@ class FrappeMail:
 		json: dict | None = None,
 		headers: dict[str, str] | None = None,
 		timeout: int | tuple[int, int] = (60, 120),
+		raise_exception: bool = True,
 	) -> "Response":
 		"""Makes a HTTP request to the Frappe Mail API."""
 
@@ -47,6 +57,10 @@ class FrappeMail:
 		response = self.client.session.request(
 			method=method, url=url, params=params, data=data, json=json, headers=headers, timeout=timeout
 		)
+
+		if not response.ok and raise_exception:
+			raise FrappeMailException(response.text, response.status_code)
+
 		return response
 
 	def send(self, sender: str, recipients: str, message: str) -> None:

--- a/frappe/email/frappemail.py
+++ b/frappe/email/frappemail.py
@@ -1,0 +1,67 @@
+from typing import TYPE_CHECKING
+
+import frappe
+from frappe.frappeclient import FrappeClient
+
+if TYPE_CHECKING:
+	from requests import Response
+
+
+class FrappeMail:
+	"""Class to interact with the Frappe Mail API."""
+
+	def __init__(self, site: str, mailbox: str, api_key: str, api_secret: str) -> None:
+		self.site = site
+		self.client = self.get_client(site, mailbox, api_key, api_secret)
+
+	@staticmethod
+	def get_client(site: str, mailbox: str, api_key: str, api_secret: str) -> FrappeClient:
+		"""Returns FrappeClient object for the given email account."""
+
+		if hasattr(frappe.local, "frappe_mail_clients"):
+			if client := frappe.local.frappe_mail_clients.get(mailbox):
+				return client
+		else:
+			frappe.local.frappe_mail_clients = {}
+
+		client = FrappeClient(url=site, api_key=api_key, api_secret=api_secret)
+		frappe.local.frappe_mail_clients[mailbox] = client
+
+		return client
+
+	def request(
+		self,
+		method: str,
+		endpoint: str,
+		params: dict | None = None,
+		data: dict | None = None,
+		json: dict | None = None,
+		headers: dict[str, str] | None = None,
+		timeout: int | tuple[int, int] = (60, 120),
+	) -> "Response":
+		"""Makes a HTTP request to the Frappe Mail API."""
+
+		url = f"{self.site}/{endpoint}"
+		headers = headers or {}
+		headers.update(self.client.headers)
+		response = self.client.session.request(
+			method=method, url=url, params=params, data=data, json=json, headers=headers, timeout=timeout
+		)
+		return response
+
+	def send(self, sender: str, recipients: str, message: str) -> None:
+		"""Sends an email using the Frappe Mail API."""
+
+		endpoint = "outbound/send-raw"
+		json_data = {"from": sender, "to": recipients, "raw_message": message}
+		self.request("POST", endpoint=endpoint, json=json_data)
+
+	def pull(self, mailbox: str, limit: int = 50) -> dict[str, list]:
+		"""Returns the emails for the given mailbox."""
+
+		endpoint = "inbound/pull"
+		data = {"mailbox": mailbox, "limit": limit}
+		headers = {"X-Site": frappe.utils.get_url()}
+		response = self.request("GET", endpoint=endpoint, data=data, headers=headers)
+
+		return {"latest_messages": response.json().get("message", [])}

--- a/frappe/integrations/doctype/connected_app/connected_app.json
+++ b/frappe/integrations/doctype/connected_app/connected_app.json
@@ -139,7 +139,7 @@
    "link_fieldname": "connected_app"
   }
  ],
- "modified": "2024-03-23 16:01:30.633764",
+ "modified": "2024-07-05 08:24:50.182706",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Connected App",
@@ -162,6 +162,7 @@
    "role": "All"
   }
  ],
+ "show_title_field_in_link": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
Integrates Frappe Mail with the Email Account DocType, enabling seamless sending and receiving of emails via the Frappe Mail API.

- **Connect to Frappe Mail**

    - **Basic (API Key and Secret)**
      
      https://github.com/frappe/frappe/assets/63660334/1c1a6f6e-691f-4295-b6f4-80fae6f750b3

    - **OAuth**

      https://github.com/frappe/frappe/assets/63660334/2fe9a7ce-c9c9-4c1f-9395-a9346666984a

- **Validate on Save**

    When saving the Email Account, the API credentials and mailbox (for inbound and outbound emails) are validated with the Frappe Mail site.

    ![image](https://github.com/frappe/frappe/assets/63660334/5b831c68-d9ce-455e-b574-1bd3b2435a37)

- **Outbound**

    The framework's Email Queue sends an HTTP request to the Frappe Mail API (outbound/send) with a JSON object containing the sender, recipient(s), and raw message. Frappe Mail parses the raw message, signs it with the mailbox domain's DKIM signature, and pushes it to an agent for delivery.

    ![image](https://github.com/frappe/frappe/assets/63660334/9933b20f-9d1c-4ae0-8186-27220f79c13e)

- **Inbound**

    Inbound email handling varies based on the protocol:
    - **POP**: The pulled email is removed to prevent duplicate pulls.
    - **IMAP**: Unique Identifiers (UIDs) ensure only new emails are pulled. The maximum UID is maintained in the system and updated with each pull.

    Frappe Mail uses Mail Sync History to keep track of pulled emails, ensuring that each pull retrieves the next set of emails.
    - **Handling Multiple Sites/Devices**
        The Mail Sync History includes a Source field to differentiate between devices. When making a pull request to Frappe Mail, an `X-Site` header can be passed to identify the requesting device or source. The default source is the request IP if the `X-Site` header is not provided.

    - **Failed while parsing/processing the raw message**
        The `EmailAccount.last_synced_at` timestamp is passed when requesting emails from Frappe Mail. This timestamp is only updated when the pull request is completed, ensuring no emails are skipped.
