### PR TITLE
fix: whitelisted method for custom alert trigger from safe exec

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -471,6 +471,11 @@ def trigger_notifications(doc, method=None):
 				frappe.db.commit()
 
 
+@frappe.whitelist()
+def trigger_notification(doc, alert):
+	evaluate_alert(doc, alert, "Custom")
+
+
 def evaluate_alert(doc: Document, alert, event):
 	from jinja2 import TemplateError
 


### PR DESCRIPTION
# Context

- Server script: `frappe.enqueue("frappe.email.doctype.notification.notification.trigger_notification", enqueue_after_commit=True, doc=doc, alert="My Custom Notification")`
- Currently not possible
-  doc.queue_action("run_notifications", enqueue_after_commit=True, method="Custom")` is not an alternative as it doesn't allow to control for sequence
