### PR TITLE
Fixed -  Fetch From, Need to Select Twice to Set Doctype

### DIFF
--- a/frappe/public/js/form_builder/components/controls/FetchFromControl.vue
+++ b/frappe/public/js/form_builder/components/controls/FetchFromControl.vue
@@ -63,7 +63,8 @@ let field_df = computedAsync(async () => {
 watch(
 	() => props.value,
 	(value) => {
-		[doctype.value, fieldname.value] = value?.split(".") || ["", ""];
+		if(value)
+			[doctype.value, fieldname.value] = value?.split(".") || ["", ""];
 	},
 	{ immediate: true }
 );


### PR DESCRIPTION
closes #26555

By explicitly checking if (value), we ensure that doctype.value and fieldname.value are only updated when value is valid. This helps maintain a consistent state and prevents potential issues that could arise from attempting to destructure a null or undefined value