### PR TITLE
fix(file): has_permissions should respect attached_to_field's field permissions

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -816,7 +816,7 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 			return False
 
 		meta = frappe.get_meta(doc.attached_to_doctype)
-		if doc.attached_to_field not in meta.get_permitted_fieldnames(user=frappe.session.user):
+		if doc.attached_to_field not in meta.get_permitted_fieldnames(user=user, permission_type=ptype):
 			return False
 
 		if ptype in ["write", "create", "delete"]:

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -815,6 +815,10 @@ def has_permission(doc, ptype=None, user=None, debug=False):
 			frappe.clear_last_message()
 			return False
 
+		meta = frappe.get_meta(doc.attached_to_doctype)
+		if doc.attached_to_field not in meta.get_permitted_fieldnames(user=frappe.session.user):
+			return False
+
 		if ptype in ["write", "create", "delete"]:
 			return ref_doc.has_permission("write", debug=debug, user=user)
 		else:


### PR DESCRIPTION
Current behavior is that as long as a user is logged in, they can download any file including those marked private. Crucially, this includes files explicitly attached to Attach fields that they otherwise cannot see. They can do this from the attachments list in the sidebar, from the links in the timeline (comments of type "Attachment") and from the File list.

This PR ensures users cannot download files attached via Attach fields that they have no access to (e.g. due to permlevel), since `is_downloadable` is called to check whether the user is allowed to download the file.

Related issue: #5894. This issue seems to call for general permissions on downloads, which is a bit trickier, but uses the example of the custom field's permissions that should now be fixed.