### PR TITLE
feat: Add new Backup optional parameters to export Procedures,Functions

### DIFF
--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -65,7 +65,16 @@ def get_db(socket=None, host=None, user=None, password=None, port=None, cur_db_n
 
 
 def get_command(
-	socket=None, host=None, port=None, user=None, password=None, db_name=None, extra=None, dump=False
+	socket=None,
+	host=None,
+	port=None,
+	user=None,
+	password=None,
+	db_name=None,
+	extra=None,
+	dump=False,
+	routines=False,
+	events=False,
 ):
 	import frappe
 
@@ -113,6 +122,11 @@ def get_command(
 					"--lock-tables=false",
 				]
 			)
+			if routines:
+				command.append("--routines")
+
+			if events:
+				command.append("--events")
 		else:
 			command.extend(
 				[

--- a/frappe/tests/test_commands.py
+++ b/frappe/tests/test_commands.py
@@ -769,6 +769,16 @@ class TestBackups(BaseTestCommands):
 		self.execute("bench --site {site} backup --verbose")
 		self.assertEqual(self.returncode, 0)
 
+	def test_backup_routines(self):
+		"""Take a routines backup (--routines)"""
+		self.execute("bench --site {site} backup --routines")
+		self.assertEqual(self.returncode, 0)
+
+	def test_backup_events(self):
+		"""Take a events backup (--events)"""
+		self.execute("bench --site {site} backup --events")
+		self.assertEqual(self.returncode, 0)
+
 	def test_backup_only_specific_doctypes(self):
 		"""Take a backup with (include) backup options set in the site config `frappe.conf.backup.includes`"""
 		self.execute(

--- a/frappe/utils/backups.py
+++ b/frappe/utils/backups.py
@@ -58,6 +58,8 @@ class BackupGenerator:
 		include_doctypes="",
 		exclude_doctypes="",
 		verbose=False,
+		routines=False,
+		events=False,
 		old_backup_metadata=False,
 		rollback_callback=None,
 	):
@@ -85,6 +87,8 @@ class BackupGenerator:
 		site = frappe.local.site or frappe.generate_hash(length=8)
 		self.site_slug = site.replace(".", "_")
 		self.verbose = verbose
+		self.routines = routines
+		self.events = events
 		self.setup_backup_directory()
 		self.setup_backup_tables()
 		_verbose = verbose
@@ -448,6 +452,8 @@ class BackupGenerator:
 			db_name=self.db_name,
 			extra=extra,
 			dump=True,
+			routines=self.routines,
+			events=self.events,
 		)
 		if not bin:
 			frappe.throw(
@@ -568,6 +574,8 @@ def scheduled_backup(
 	compress=False,
 	force=False,
 	verbose=False,
+	routines=False,
+	events=False,
 	old_backup_metadata=False,
 	rollback_callback=None,
 ):
@@ -588,6 +596,8 @@ def scheduled_backup(
 		compress=compress,
 		force=force,
 		verbose=verbose,
+		routines=routines,
+		events=events,
 		old_backup_metadata=old_backup_metadata,
 		rollback_callback=rollback_callback,
 	)
@@ -607,6 +617,8 @@ def new_backup(
 	compress=False,
 	force=False,
 	verbose=False,
+	routines=False,
+	events=False,
 	old_backup_metadata=False,
 	rollback_callback=None,
 ):
@@ -628,6 +640,8 @@ def new_backup(
 		include_doctypes=include_doctypes,
 		exclude_doctypes=exclude_doctypes,
 		verbose=verbose,
+		routines=routines,
+		events=events,
 		compress_files=compress,
 		old_backup_metadata=old_backup_metadata,
 		rollback_callback=rollback_callback,


### PR DESCRIPTION
->add optional parameters to bench _backup_:
  
 1. "**--routines**"  to export Stored Procedures,Functions
  2. "**--events**"    to export events

->add one optional parameter to bench _restore_"**--skip-definer**" to Omit DEFINER and SQL SECURITY clauses from view and stored program CREATE statements