### PR TITLE
fix: show edit button only to workspace managers for public workspaces

### DIFF
--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -455,24 +455,25 @@ frappe.views.Workspace = class Workspace {
 		}
 
 		this.clear_page_actions();
-
-		this.page.set_secondary_action(
-			__("Edit"),
-			async () => {
-				if (!this.editor || !this.editor.readOnly) return;
-				this.is_read_only = false;
-				this.toggle_hidden_workspaces(true);
-				await this.editor.readOnly.toggle();
-				this.editor.isReady.then(() => {
-					this.body.addClass("edit-mode");
-					this.initialize_editorjs_undo();
-					this.setup_customization_buttons(current_page);
-					this.show_sidebar_actions();
-					this.make_blocks_sortable();
-				});
-			},
-			"es-line-edit"
-		);
+		if (current_page.is_editable) {
+			this.page.set_secondary_action(
+				__("Edit"),
+				async () => {
+					if (!this.editor || !this.editor.readOnly) return;
+					this.is_read_only = false;
+					this.toggle_hidden_workspaces(true);
+					await this.editor.readOnly.toggle();
+					this.editor.isReady.then(() => {
+						this.body.addClass("edit-mode");
+						this.initialize_editorjs_undo();
+						this.setup_customization_buttons(current_page);
+						this.show_sidebar_actions();
+						this.make_blocks_sortable();
+					});
+				},
+				"es-line-edit"
+			);
+		}
 		// need to add option for icons in inner buttons as well
 		if (this.has_create_access)
 			this.page.add_inner_button(__("Create Workspace"), () => {


### PR DESCRIPTION
closes #26836 
