### PR TITLE
fix(grid): prevent crash

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1227,7 +1227,7 @@ export default class Grid {
 		}
 
 		for (let row of this.grid_rows) {
-			let docfield = row.docfields.find((d) => d.fieldname === fieldname);
+			let docfield = row?.docfields?.find((d) => d.fieldname === fieldname);
 			if (docfield) {
 				docfield[property] = value;
 			} else {


### PR DESCRIPTION
```js
TypeError: Cannot read properties of undefined (reading 'docfields')
  at Grid.update_docfield_property(../../../../../apps/frappe/frappe/public/js/frappe/form/grid.js:1225:23)
  at Grid.toggle_enable(../../../../../apps/frappe/frappe/public/js/frappe/form/grid.js:749:8)
  at erpnext.TransactionController.toggle_conversion_factor(../../../../../apps/erpnext/erpnext/public/js/controllers/transaction.js:1243:36)
  at erpnext.TransactionController.conversion_factor(../../../../../apps/erpnext/erpnext/public/js/controllers/transaction.js:1198:9)
  at erpnext.selling.SellingController.conversion_factor(../../../../../apps/erpnext/erpnext/public/js/utils/sales_common.js:343:11)
  at <anonymous>(../../../../../apps/erpnext/erpnext/public/js/controllers/transaction.js:1254:16)
```

Resolves FRAPPE-7GB
