### PR TITLE
feat: role replication

### DIFF
--- a/frappe/core/doctype/role_replication/role_replication.js
+++ b/frappe/core/doctype/role_replication/role_replication.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2024, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Role Replication", {
+	refresh(frm) {
+		frm.disable_save();
+		frm.page.set_primary_action(__("Replicate"), ($btn) => {
+			$btn.text(__("Replicating..."));
+			frappe.run_serially([
+				() => frappe.dom.freeze("Replicating..."),
+				() => frm.call("replicate_role"),
+				() => frappe.dom.unfreeze(),
+				() => frappe.msgprint(__("Replication completed.")),
+				() => $btn.text(__("Replicate")),
+			]);
+		});
+	},
+});

--- a/frappe/core/doctype/role_replication/role_replication.json
+++ b/frappe/core/doctype/role_replication/role_replication.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "creation": "2024-06-24 18:25:23.163914",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "existing_role",
+  "column_break_ydyj",
+  "new_role"
+ ],
+ "fields": [
+  {
+   "fieldname": "existing_role",
+   "fieldtype": "Link",
+   "label": "Existing Role",
+   "options": "Role"
+  },
+  {
+   "fieldname": "column_break_ydyj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Input existing role name if you would like to extend it with access of another role.",
+   "fieldname": "new_role",
+   "fieldtype": "Data",
+   "label": "New Role"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-06-24 19:26:54.279801",
+ "modified_by": "Administrator",
+ "module": "Core",
+ "name": "Role Replication",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/core/doctype/role_replication/role_replication.py
+++ b/frappe/core/doctype/role_replication/role_replication.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.core.page.permission_manager.permission_manager import get_permissions
+from frappe.model.document import Document
+
+
+class RoleReplication(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		existing_role: DF.Link | None
+		new_role: DF.Data | None
+	# end: auto-generated types
+
+	@frappe.whitelist()
+	def replicate_role(self):
+		frappe.only_for("System Manager")
+
+		new_role = frappe.db.get_value("Role", self.new_role, "name")
+		if not new_role:
+			new_role = frappe.get_doc({"doctype": "Role", "role_name": self.new_role}).insert().name
+
+		perms = get_permissions(role=self.existing_role)
+		for perm in perms:
+			perm.update(
+				{
+					"name": None,
+					"creation": None,
+					"modified": None,
+					"modified_by": None,
+					"owner": None,
+					"linked_doctypes": None,
+					"role": new_role,
+				}
+			)
+			frappe.get_doc({"doctype": "Custom DocPerm", **perm}).insert()

--- a/frappe/core/doctype/role_replication/test_role_replication.py
+++ b/frappe/core/doctype/role_replication/test_role_replication.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestRoleReplication(FrappeTestCase):
+	pass


### PR DESCRIPTION
![image](https://github.com/frappe/frappe/assets/52111700/38565114-9f7c-4747-b618-c514f6dc431d)

Role Replication allows users to easily replicate/extend role based access.

Often, we might have to give access to a user which is very similar to an existing role but with slight variation. For example, a purchase executive might not need all the access granted to Purchase User role. In such cases, we have to create a new role and then assign the access to each doctype individually via Role Permission Manager. This is hectic and takes a lot of time.

For example, to create a role that would have access to create a Purchase Order, you will need to grant access to:

- Supplier
- Company
- Purchase Taxes and Charges Template
- Payment Terms
- Payment Terms Template
- Accounts
- Buying Settings

and the list goes on, based on the link fields you have in the doctype and code based dependency, fetch from etc.

On the contrary, it is easier to have a another role with same access as Purchase User and then strip it down based on use case. Role Replication allows you to replicate the role with it's access rights.