### PR TITLE
fix: remove mariadb sandbox mode comment before restoring backups

### DIFF
--- a/frappe/database/db_manager.py
+++ b/frappe/database/db_manager.py
@@ -50,25 +50,38 @@ class DbManager:
 		return self.db.sql("SHOW DATABASES", pluck=True)
 
 	@staticmethod
-	def restore_database(verbose, target, source, user, password):
+	def restore_database(verbose: bool, target: str, source: str, user: str, password: str) -> None:
+		"""
+		Function to restore the given SQL file to the target database.
+		:param target: The database to restore to.
+		:param source: The SQL dump to restore
+		:param user: The database username
+		:param password: The database password
+		:return: Nothing
+		"""
+
 		import shlex
 		from shutil import which
 
 		from frappe.database import get_command
 		from frappe.utils import execute_in_shell
 
+		# Ensure that the entire process fails if any part of the pipeline fails
 		command = ["set -o pipefail;"]
 
+		# Handle gzipped backups
 		if source.endswith(".gz"):
 			if gzip := which("gzip"):
 				command.extend([gzip, "-cd", source, "|"])
-				source = []
 			else:
 				raise Exception("`gzip` not installed")
-
 		else:
-			source = ["<", source]
+			command.extend(["cat", source, "|"])
 
+		# Newer versions of MariaDB add in a line that'll break on older versions, so remove it
+		command.extend(["sed", r"'/\/\*!999999\\- enable the sandbox mode \*\//d'", "|"])
+
+		# Generate the restore command
 		bin, args, bin_name = get_command(
 			socket=frappe.conf.db_socket,
 			host=frappe.conf.db_host,
@@ -84,6 +97,6 @@ class DbManager:
 			)
 		command.append(bin)
 		command.append(shlex.join(args))
-		command.extend(source)
+
 		execute_in_shell(" ".join(command), check_exit_code=True, verbose=verbose)
 		frappe.cache.delete_keys("")  # Delete all keys associated with this site.


### PR DESCRIPTION
Reference: https://mariadb.org/mariadb-dump-file-compatibility-change/

Newer versions of MariaDB include a line in the dumps that break restoring on older versions
This doesn't allow people to restore newer dumps onto Frappe Cloud, or anywhere else with an older version.

For now just remove the line to allow any backups to be restored anywhere
