### PR TITLE
fix: multiselect fieldtype working

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect.js
+++ b/frappe/public/js/frappe/form/controls/multiselect.js
@@ -84,7 +84,7 @@ frappe.ui.form.ControlMultiSelect = class ControlMultiSelect extends (
 		const values = this.get_values() || [];
 
 		// return values which are not already selected
-		if (data) data.filter((d) => !values.includes(d));
+		if (data) data = data.filter((d) => !values.includes(d.value));
 		return data;
 	}
 


### PR DESCRIPTION
### Problem Description:
Previously, when using the MultiSelect field type, users could select the same value multiple times, leading to redundant and  confusing entries.

### Solution:
This PR fixes the above problem.
Now, once a value is selected, it will no longer be available for selection again, ensuring each value can be selected only once.