### PR TITLE
fix(Grid): arrow key nav not working on single doctypes

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -219,11 +219,10 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 				this.df.fieldtype
 			)
 		) {
-			if (this.frm?.meta?.issingle) {
+			if (!this.frm?.meta?.issingle) {
 				// singles dont have any "real" length requirements
-				return;
+				this.$input.attr("maxlength", this.df.length || 140);
 			}
-			this.$input.attr("maxlength", this.df.length || 140);
 		}
 
 		this.$input


### PR DESCRIPTION
**Problem:** Arrow key navigation does not work on single DocTypes (Customize Form for example) because data properties are not being set

**Solution:** Do not skip the whole function just to exclude one attribute