### PR TITLE
fix: remove DocType as translation context

### DIFF
--- a/frappe/gettext/extractors/doctype.py
+++ b/frappe/gettext/extractors/doctype.py
@@ -73,7 +73,7 @@ def extract(fileobj, *args, **kwargs):
 			messages.append((link_doctype, f"Linked DocType in {doctype}'s connections"))
 
 	# By using "pgettext" as the function name we can supply the doctype as context
-	yield from ((None, "pgettext", (doctype, message), [comment]) for message, comment in messages)
+	yield from ((None, "_", message, [comment]) for message, comment in messages)
 
 	# Role names do not get context because they are used with multiple doctypes
 	yield from (

--- a/frappe/locale/main.pot
+++ b/frappe/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Frappe Framework VERSION\n"
 "Report-Msgid-Bugs-To: developers@frappe.io\n"
-"POT-Creation-Date: 2024-06-23 09:33+0000\n"
-"PO-Revision-Date: 2024-06-23 09:33+0000\n"
+"POT-Creation-Date: 2024-06-26 19:20+0053\n"
+"PO-Revision-Date: 2024-06-26 19:20+0053\n"
 "Last-Translator: developers@frappe.io\n"
 "Language-Team: developers@frappe.io\n"
 "MIME-Version: 1.0\n"
@@ -23,14 +23,12 @@ msgstr ""
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
 msgid "!="
 msgstr ""
 
 #. Description of the 'Org History Heading' (Data) field in DocType 'About Us
 #. Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "\"Company History\""
 msgstr ""
 
@@ -41,7 +39,6 @@ msgstr ""
 #. Description of the 'Team Members Heading' (Data) field in DocType 'About Us
 #. Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "\"Team Members\" or \"Management\""
 msgstr ""
 
@@ -68,7 +65,6 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "&lt;head&gt; HTML"
 msgstr ""
 
@@ -92,7 +88,7 @@ msgstr ""
 msgid "'Recipients' not specified"
 msgstr ""
 
-#: utils/__init__.py:243
+#: utils/__init__.py:252
 msgid "'{0}' is not a valid URL"
 msgstr ""
 
@@ -104,7 +100,7 @@ msgstr ""
 msgid "(Mandatory)"
 msgstr ""
 
-#: model/rename_doc.py:688
+#: model/rename_doc.py:687
 msgid "** Failed: {0} to {1}: {2}"
 msgstr ""
 
@@ -116,13 +112,11 @@ msgstr ""
 #. Description of the 'Doc Status' (Select) field in DocType 'Workflow Document
 #. State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "0 - Draft; 1 - Submitted; 2 - Cancelled"
 msgstr ""
 
 #. Description of the 'Priority' (Int) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "0 is highest"
 msgstr ""
 
@@ -132,7 +126,6 @@ msgstr ""
 
 #. Description of the 'Fraction Units' (Int) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid ""
 "1 Currency = [?] Fraction\n"
 "For e.g. 1 USD = 100 Cent"
@@ -233,14 +226,12 @@ msgstr ""
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
 msgid "<"
 msgstr ""
 
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
 msgid "<="
 msgstr ""
 
@@ -250,14 +241,12 @@ msgstr ""
 
 #. Content of the 'Help' (HTML) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "<div class=\"alert\">Please don't update it as it can mess up your form. Use the Customize Form View and Custom Fields to set properties!</div>"
 msgstr ""
 
 #. Content of the 'Help HTML' (HTML) field in DocType 'Document Naming
 #. Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid ""
 "<div class=\"well\">\n"
 "    Edit list of Series in the box. Rules:\n"
@@ -301,7 +290,6 @@ msgstr ""
 
 #. Content of the 'Custom HTML Help' (HTML) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid ""
 "<h3>Custom CSS Help</h3>\n"
 "\n"
@@ -329,7 +317,6 @@ msgstr ""
 #. Content of the 'Print Format Help' (HTML) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
 #, python-format
-msgctxt "Print Format"
 msgid ""
 "<h3>Print Format Help</h3>\n"
 "<hr>\n"
@@ -402,7 +389,6 @@ msgstr ""
 #. Description of the 'Template' (Code) field in DocType 'Address Template'
 #: contacts/doctype/address_template/address_template.json
 #, python-format
-msgctxt "Address Template"
 msgid ""
 "<h4>Default Template</h4>\n"
 "<p>Uses <a href=\"http://jinja.pocoo.org/docs/templates/\">Jinja Templating</a> and all the fields of Address (including Custom Fields if any) will be available</p>\n"
@@ -420,7 +406,6 @@ msgstr ""
 
 #. Content of the 'Email Reply Help' (HTML) field in DocType 'Email Template'
 #: email/doctype/email_template/email_template.json
-msgctxt "Email Template"
 msgid ""
 "<h4>Email Reply Example</h4>\n"
 "\n"
@@ -445,14 +430,12 @@ msgstr ""
 
 #. Content of the 'html_5' (HTML) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "<h5 class=\"text-muted uppercase\">Or</h5>"
 msgstr ""
 
 #. Content of the 'Message Examples' (HTML) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
 #, python-format
-msgctxt "Notification"
 msgid ""
 "<h5>Message Example</h5>\n"
 "\n"
@@ -476,7 +459,6 @@ msgstr ""
 
 #. Content of the 'html_condition' (HTML) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid ""
 "<p><strong>Condition Examples:</strong></p>\n"
 "<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; 40000\n"
@@ -485,7 +467,6 @@ msgstr ""
 
 #. Content of the 'html_7' (HTML) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid ""
 "<p><strong>Condition Examples:</strong></p>\n"
 "<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; 40000\n"
@@ -494,7 +475,6 @@ msgstr ""
 
 #. Content of the 'Condition Description' (HTML) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid ""
 "<p>Multiple webforms can be created for a single doctype. Add filters specific to this webform to display correct record after submission.</p><p>For Example:</p>\n"
 "<p>If you create a separate webform every year to capture feedback from employees add a \n"
@@ -503,7 +483,6 @@ msgstr ""
 
 #. Description of the 'Context Script' (Code) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid ""
 "<p>Set context before rendering a template. Example:</p><p>\n"
 "</p><div><pre><code>\n"
@@ -513,7 +492,6 @@ msgstr ""
 
 #. Content of the 'JS Message' (HTML) field in DocType 'Custom HTML Block'
 #: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
 msgid ""
 "<p>To interact with above HTML you will have to use `root_element` as a parent selector.</p><p>For example:</p><pre class=\"p-3 bg-gray-100 border-radius rounded-sm mb-0\" style=\"width: fit-content;\"><code>// here root_element is provided by default\n"
 "let some_class_element = root_element.querySelector('.some-class');\n"
@@ -527,28 +505,9 @@ msgstr ""
 
 #. Description of the 'Cron Format' (Data) field in DocType 'Scheduled Job
 #. Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid ""
-"<pre>*  *  *  *  *\n"
-"┬  ┬  ┬  ┬  ┬\n"
-"│  │  │  │  │\n"
-"│  │  │  │  └ day of week (0 - 6) (0 is Sunday)\n"
-"│  │  │  └───── month (1 - 12)\n"
-"│  │  └────────── day of month (1 - 31)\n"
-"│  └─────────────── hour (0 - 23)\n"
-"└──────────────────── minute (0 - 59)\n"
-"\n"
-"---\n"
-"\n"
-"* - Any value\n"
-"/ - Step values\n"
-"</pre>\n"
-msgstr ""
-
 #. Description of the 'Cron Format' (Data) field in DocType 'Server Script'
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid ""
 "<pre>*  *  *  *  *\n"
 "┬  ┬  ┬  ┬  ┬\n"
@@ -568,7 +527,6 @@ msgstr ""
 
 #. Content of the 'Example' (HTML) field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid ""
 "<pre><code>doc.grand_total &gt; 0</code></pre>\n"
 "\n"
@@ -593,21 +551,18 @@ msgstr ""
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
 msgid "="
 msgstr ""
 
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
 msgid ">"
 msgstr ""
 
 #. Option for the 'Condition' (Select) field in DocType 'Document Naming Rule
 #. Condition'
 #: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
 msgid ">="
 msgstr ""
 
@@ -634,7 +589,6 @@ msgstr ""
 
 #. Description of the 'Scopes' (Text) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "A list of resources which the Client App will have access to after the user allows it.<br> e.g. project"
 msgstr ""
 
@@ -648,7 +602,6 @@ msgstr ""
 
 #. Description of the 'Symbol' (Data) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "A symbol for this currency. For e.g. $"
 msgstr ""
 
@@ -662,159 +615,118 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A0"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A1"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A2"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A3"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A4"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A5"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A6"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A7"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A8"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "A9"
 msgstr ""
 
 #. Option for the 'Email Sync Option' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "ALL"
 msgstr ""
 
 #. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "API"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'S3 Backup Settings'
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
-msgid "API Access"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'User'
+#. Label of a Section Break field in DocType 'S3 Backup Settings'
 #: core/doctype/user/user.json
-msgctxt "User"
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgid "API Access"
 msgstr ""
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "API Endpoint"
 msgstr ""
 
 #. Label of a Code field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "API Endpoint Args"
 msgstr ""
 
+#. Label of a Data field in DocType 'User'
 #. Label of a Data field in DocType 'Google Settings'
 #. Label of a Section Break field in DocType 'Google Settings'
-#: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
-msgid "API Key"
-msgstr ""
-
 #. Label of a Data field in DocType 'Push Notification Settings'
-#: integrations/doctype/push_notification_settings/push_notification_settings.json
-msgctxt "Push Notification Settings"
-msgid "API Key"
-msgstr ""
-
-#. Label of a Data field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
+#: integrations/doctype/google_settings/google_settings.json
+#: integrations/doctype/push_notification_settings/push_notification_settings.json
 msgid "API Key"
 msgstr ""
 
 #. Description of the 'Authentication' (Section Break) field in DocType 'Push
 #. Notification Settings'
 #: integrations/doctype/push_notification_settings/push_notification_settings.json
-msgctxt "Push Notification Settings"
 msgid "API Key and Secret to interact with the relay server. These will be auto-generated when the first push notification is sent from any of the apps installed on this site."
 msgstr ""
 
 #. Description of the 'API Key' (Data) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "API Key cannot be regenerated"
 msgstr ""
 
 #. Label of a Data field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "API Method"
 msgstr ""
 
-#. Label of a Password field in DocType 'Push Notification Settings'
-#: integrations/doctype/push_notification_settings/push_notification_settings.json
-msgctxt "Push Notification Settings"
-msgid "API Secret"
-msgstr ""
-
 #. Label of a Password field in DocType 'User'
+#. Label of a Password field in DocType 'Push Notification Settings'
 #: core/doctype/user/user.json
-msgctxt "User"
+#: integrations/doctype/push_notification_settings/push_notification_settings.json
 msgid "API Secret"
-msgstr ""
-
-#. Option for the 'Sort Order' (Select) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "ASC"
 msgstr ""
 
 #. Option for the 'Default Sort Order' (Select) field in DocType 'DocType'
+#. Option for the 'Sort Order' (Select) field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "ASC"
 msgstr ""
 
@@ -858,18 +770,17 @@ msgstr ""
 
 #. Label of a Data field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Access Key ID"
 msgstr ""
 
 #. Label of a Password field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Access Key Secret"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/access_log/access_log.json
+#. Linked DocType in User's connections
+#: core/doctype/access_log/access_log.json core/doctype/user/user.json
 msgid "Access Log"
 msgstr ""
 
@@ -879,27 +790,15 @@ msgctxt "Access Log"
 msgid "Access Log"
 msgstr ""
 
-#. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Access Log"
-msgstr ""
-
 #. Label of a Data field in DocType 'OAuth Bearer Token'
-#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
-msgid "Access Token"
-msgstr ""
-
 #. Label of a Password field in DocType 'Token Cache'
+#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Access Token"
 msgstr ""
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Access Token URL"
 msgstr ""
 
@@ -909,13 +808,11 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Account"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Account Deletion Settings"
 msgstr ""
 
@@ -932,49 +829,28 @@ msgstr ""
 msgid "Accounts User"
 msgstr ""
 
+#. Label of a Select field in DocType 'Amended Document Naming Settings'
+#. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
+#. Label of a Data field in DocType 'Navbar Item'
+#. Label of a Select field in DocType 'Onboarding Step'
+#. Label of a Select field in DocType 'Email Flag Queue'
+#. Label of a Link field in DocType 'Workflow Transition'
+#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
+#: core/doctype/navbar_item/navbar_item.json
+#: desk/doctype/onboarding_step/onboarding_step.json
+#: email/doctype/email_flag_queue/email_flag_queue.json
 #: email/doctype/email_group/email_group.js:34
 #: email/doctype/email_group/email_group.js:63
 #: email/doctype/email_group/email_group.js:72
 #: printing/page/print_format_builder_beta/print_format_builder_beta.js:37
 #: public/js/frappe/form/sidebar/review.js:59
-#: workflow/page/workflow_builder/workflow_builder.js:37
-msgid "Action"
-msgstr ""
-
-#. Label of a Select field in DocType 'Amended Document Naming Settings'
-#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
-msgctxt "Amended Document Naming Settings"
-msgid "Action"
-msgstr ""
-
-#. Label of a Select field in DocType 'Email Flag Queue'
-#: email/doctype/email_flag_queue/email_flag_queue.json
-msgctxt "Email Flag Queue"
-msgid "Action"
-msgstr ""
-
-#. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
-#. Label of a Data field in DocType 'Navbar Item'
-#: core/doctype/navbar_item/navbar_item.json
-msgctxt "Navbar Item"
-msgid "Action"
-msgstr ""
-
-#. Label of a Select field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Action"
-msgstr ""
-
-#. Label of a Link field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
+#: workflow/page/workflow_builder/workflow_builder.js:37
 msgid "Action"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'DocType Action'
 #: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
 msgid "Action / Route"
 msgstr ""
 
@@ -989,19 +865,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Action Label"
 msgstr ""
 
 #. Label of a Int field in DocType 'Success Action'
 #: core/doctype/success_action/success_action.json
-msgctxt "Success Action"
 msgid "Action Timeout (Seconds)"
 msgstr ""
 
 #. Label of a Select field in DocType 'DocType Action'
 #: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
 msgid "Action Type"
 msgstr ""
 
@@ -1013,6 +886,9 @@ msgstr ""
 msgid "Action {0} failed on {1} {2}. View it {3}"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'DocType'
+#. Label of a Table field in DocType 'DocType'
+#. Label of a Table field in DocType 'Customize Form'
 #: core/doctype/communication/communication.js:66
 #: core/doctype/communication/communication.js:74
 #: core/doctype/communication/communication.js:82
@@ -1020,7 +896,8 @@ msgstr ""
 #: core/doctype/communication/communication.js:99
 #: core/doctype/communication/communication.js:108
 #: core/doctype/communication/communication.js:131
-#: core/doctype/rq_job/rq_job_list.js:14 core/doctype/rq_job/rq_job_list.js:39
+#: core/doctype/doctype/doctype.json core/doctype/rq_job/rq_job_list.js:14
+#: core/doctype/rq_job/rq_job_list.js:39
 #: core/report/database_storage_usage_by_tables/database_storage_usage_by_tables.js:48
 #: custom/doctype/customize_form/customize_form.js:108
 #: custom/doctype/customize_form/customize_form.js:116
@@ -1029,6 +906,7 @@ msgstr ""
 #: custom/doctype/customize_form/customize_form.js:140
 #: custom/doctype/customize_form/customize_form.js:148
 #: custom/doctype/customize_form/customize_form.js:283
+#: custom/doctype/customize_form/customize_form.json
 #: public/js/frappe/ui/page.html:56
 #: public/js/frappe/views/reports/query_report.js:191
 #: public/js/frappe/views/reports/query_report.js:204
@@ -1037,84 +915,48 @@ msgstr ""
 msgid "Actions"
 msgstr ""
 
-#. Label of a Table field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Actions"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'DocType'
-#. Label of a Table field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Actions"
-msgstr ""
-
 #. Label of a Check field in DocType 'Package Import'
 #: core/doctype/package_import/package_import.json
-msgctxt "Package Import"
 msgid "Activate"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:207 core/doctype/user/user_list.js:12
-#: workflow/doctype/workflow/workflow_list.js:5
-msgid "Active"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Active"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Kanban Board Column'
-#: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
-msgid "Active"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'OAuth Bearer Token'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/recorder/recorder_list.js:207 core/doctype/user/user_list.js:12
+#: desk/doctype/kanban_board_column/kanban_board_column.json
 #: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
+#: workflow/doctype/workflow/workflow_list.js:5
 msgid "Active"
 msgstr ""
 
 #. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Active Directory"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Domain Settings'
 #. Label of a Table field in DocType 'Domain Settings'
 #: core/doctype/domain_settings/domain_settings.json
-msgctxt "Domain Settings"
 msgid "Active Domains"
-msgstr ""
-
-#: www/third_party_apps.html:32
-msgid "Active Sessions"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
+#: www/third_party_apps.html:32
 msgid "Active Sessions"
 msgstr ""
 
-#: public/js/frappe/form/dashboard.js:22
+#. Group in User's connections
+#: core/doctype/user/user.json public/js/frappe/form/dashboard.js:22
 #: public/js/frappe/form/footer/form_timeline.js:58
 msgid "Activity"
 msgstr ""
 
-#. Group in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Activity"
-msgstr ""
-
 #. Name of a DocType
-#: core/doctype/activity_log/activity_log.json
+#. Linked DocType in User's connections
+#: core/doctype/activity_log/activity_log.json core/doctype/user/user.json
 msgid "Activity Log"
 msgstr ""
 
@@ -1122,12 +964,6 @@ msgstr ""
 #. Label of a Link in the Users Workspace
 #: core/workspace/build/build.json core/workspace/users/users.json
 msgctxt "Activity Log"
-msgid "Activity Log"
-msgstr ""
-
-#. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
 msgid "Activity Log"
 msgstr ""
 
@@ -1168,7 +1004,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Add Background Image"
 msgstr ""
 
@@ -1179,13 +1014,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Add Border at Bottom"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Add Border at Top"
 msgstr ""
 
@@ -1215,13 +1048,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Add Container"
 msgstr ""
 
 #. Label of a Button field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Add Custom Tags"
 msgstr ""
 
@@ -1232,7 +1063,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Add Gray Background"
 msgstr ""
 
@@ -1259,7 +1089,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Email Group'
 #: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
 msgid "Add Query Parameters"
 msgstr ""
 
@@ -1275,25 +1104,19 @@ msgstr ""
 msgid "Add Row"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:121
-msgid "Add Signature"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
+#: public/js/frappe/views/communication.js:121
 msgid "Add Signature"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Add Space at Bottom"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Add Space at Top"
 msgstr ""
 
@@ -1317,13 +1140,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Add Total Row"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Add Unsubscribe Link"
 msgstr ""
 
@@ -1333,7 +1154,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Add Video Conferencing"
 msgstr ""
 
@@ -1406,7 +1226,6 @@ msgstr ""
 #. Description of the '&lt;head&gt; HTML' (Code) field in DocType 'Website
 #. Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Added HTML in the &lt;head&gt; section of the web page, primarily used for website verification and SEO"
 msgstr ""
 
@@ -1424,61 +1243,33 @@ msgid "Added {0} ({1})"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Additional Permissions"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocPerm'
+#: core/doctype/custom_docperm/custom_docperm.json
 #: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
 msgid "Additional Permissions"
 msgstr ""
 
 #. Name of a DocType
-#: contacts/doctype/address/address.json
-msgid "Address"
-msgstr ""
-
 #. Label of a Link field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Address"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Contact Us Settings'
-#: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
-msgid "Address"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Website Settings'
+#: contacts/doctype/address/address.json contacts/doctype/contact/contact.json
+#: website/doctype/contact_us_settings/contact_us_settings.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Address"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Address Line 1"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact Us Settings'
+#: contacts/doctype/address/address.json
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Address Line 1"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Address Line 2"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact Us Settings'
+#: contacts/doctype/address/address.json
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Address Line 2"
 msgstr ""
 
@@ -1488,14 +1279,9 @@ msgid "Address Template"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Address Title"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact Us Settings'
+#: contacts/doctype/address/address.json
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Address Title"
 msgstr ""
 
@@ -1505,14 +1291,12 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Address Type"
 msgstr ""
 
 #. Description of the 'Address' (Small Text) field in DocType 'Website
 #. Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Address and other legal information you may want to put in the footer."
 msgstr ""
 
@@ -1565,20 +1349,14 @@ msgid "Administrator accessed {0} on {1} via IP Address {2}."
 msgstr ""
 
 #. Label of a Section Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Advanced"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'System Settings'
+#: core/doctype/doctype/doctype.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Advanced"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User Permission'
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
 msgid "Advanced Control"
 msgstr ""
 
@@ -1589,61 +1367,51 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Advanced Settings"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Cancel"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Delete"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Discard"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Insert"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Rename"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Save"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Save (Submitted Document)"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "After Submission"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "After Submit"
 msgstr ""
 
@@ -1652,14 +1420,9 @@ msgid "Aggregate Field is required to create a number card"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Aggregate Function Based On"
-msgstr ""
-
 #. Label of a Select field in DocType 'Number Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Aggregate Function Based On"
 msgstr ""
 
@@ -1669,7 +1432,6 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Alert"
 msgstr ""
 
@@ -1680,19 +1442,16 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Align"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Align Labels to the Right"
 msgstr ""
 
 #. Label of a Check field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
-msgctxt "Top Bar Item"
 msgid "Align Right"
 msgstr ""
 
@@ -1701,12 +1460,15 @@ msgid "Align Value"
 msgstr ""
 
 #. Name of a role
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: contacts/doctype/address/address.json contacts/doctype/contact/contact.json
 #: contacts/doctype/gender/gender.json
 #: contacts/doctype/salutation/salutation.json
 #: core/doctype/communication/communication.json core/doctype/file/file.json
 #: core/doctype/language/language.json core/doctype/module_def/module_def.json
-#: desk/doctype/event/event.json
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/server_script/server_script.json desk/doctype/event/event.json
 #: desk/doctype/notification_log/notification_log.json
 #: desk/doctype/notification_settings/notification_settings.json
 #: desk/doctype/tag/tag.json desk/doctype/tag_link/tag_link.json
@@ -1719,31 +1481,10 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "All"
-msgstr ""
-
-#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "All"
-msgstr ""
-
-#: public/js/frappe/ui/notifications/notifications.js:401
-msgid "All Day"
-msgstr ""
-
 #. Label of a Check field in DocType 'Calendar View'
-#: desk/doctype/calendar_view/calendar_view.json
-msgctxt "Calendar View"
-msgid "All Day"
-msgstr ""
-
 #. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
+#: desk/doctype/calendar_view/calendar_view.json desk/doctype/event/event.json
+#: public/js/frappe/ui/notifications/notifications.js:401
 msgid "All Day"
 msgstr ""
 
@@ -1769,7 +1510,6 @@ msgstr ""
 
 #. Description of the 'Document States' (Table) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "All possible Workflow States and roles of the workflow. Docstatus Options: 0 is \"Saved\", 1 is \"Submitted\" and 2 is \"Cancelled\""
 msgstr ""
 
@@ -1779,29 +1519,19 @@ msgstr ""
 
 #. Label of a Link field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
-msgctxt "ToDo"
 msgid "Allocated To"
 msgstr ""
 
 #. Label of a Check field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Allot Points To Assigned Users"
 msgstr ""
 
-#: templates/includes/oauth_confirmation.html:15
-msgid "Allow"
-msgstr ""
-
-#. Option for the 'Sign ups' (Select) field in DocType 'Social Login Key'
-#: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
-msgid "Allow"
-msgstr ""
-
 #. Label of a Link field in DocType 'User Permission'
+#. Option for the 'Sign ups' (Select) field in DocType 'Social Login Key'
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
+#: integrations/doctype/social_login_key/social_login_key.json
+#: templates/includes/oauth_confirmation.html:15
 msgid "Allow"
 msgstr ""
 
@@ -1809,57 +1539,42 @@ msgstr ""
 msgid "Allow API Indexing Access"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Allow Auto Repeat"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Allow Auto Repeat"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Allow Bulk Edit"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Allow Bulk Edit"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Allow Comments"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow Consecutive Login Attempts "
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Allow Delete"
 msgstr ""
 
 #. Label of a Button field in DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
 msgid "Allow Dropbox Access"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Allow Editing After Submit"
 msgstr ""
 
@@ -1878,211 +1593,153 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Allow Guest"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Allow Guest to View"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Allow Guest to comment"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow Guests to Upload Files"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Allow Import (via Data Import Tool)"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Allow Import (via Data Import Tool)"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Allow Incomplete Forms"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow Login After Fail"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow Login using Mobile Number"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow Login using User Name"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Allow Modules"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Allow Multiple Responses"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow Older Web View Links (Insecure)"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Allow Print"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Allow Print for Cancelled"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat.py:396
-msgid "Allow Print for Draft"
-msgstr ""
-
 #. Label of a Check field in DocType 'Print Settings'
+#: automation/doctype/auto_repeat/auto_repeat.py:396
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Allow Print for Draft"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Allow Read On All Link Options"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Allow Rename"
-msgstr ""
-
-#. Label of a Table MultiSelect field in DocType 'Module Onboarding'
-#: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
-msgid "Allow Roles"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Role Permission for Page and
 #. Report'
+#. Label of a Table MultiSelect field in DocType 'Module Onboarding'
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
-msgctxt "Role Permission for Page and Report"
+#: desk/doctype/module_onboarding/module_onboarding.json
 msgid "Allow Roles"
 msgstr ""
 
 #. Label of a Check field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Allow Self Approval"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow Sending Usage Data for Improving Applications"
 msgstr ""
 
 #. Description of the 'Allow Self Approval' (Check) field in DocType 'Workflow
 #. Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Allow approval for creator of the document"
 msgstr ""
 
+#. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Allow document creation via Email"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Allow document creation via Email"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Allow events in timeline"
 msgstr ""
 
+#. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Allow in Quick Entry"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Allow in Quick Entry"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Allow in Quick Entry"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Allow on Submit"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Allow on Submit"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Allow on Submit"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow only one session per user"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Allow page break inside tables"
 msgstr ""
 
@@ -2093,7 +1750,6 @@ msgstr ""
 #. Description of the 'Allow Incomplete Forms' (Check) field in DocType 'Web
 #. Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Allow saving if mandatory fields are not filled"
 msgstr ""
 
@@ -2103,50 +1759,42 @@ msgstr ""
 
 #. Description of the 'Login After' (Int) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Allow user to login only after this hour (0-24)"
 msgstr ""
 
 #. Description of the 'Login Before' (Int) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Allow user to login only before this hour (0-24)"
 msgstr ""
 
 #. Description of the 'Login with email link' (Check) field in DocType 'System
 #. Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allow users to log in without a password, using a login link sent to their email"
 msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Allowed"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Allowed File Extensions"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Allowed In Mentions"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "Allowed Modules"
 msgstr ""
 
 #. Label of a Table MultiSelect field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Allowed Roles"
 msgstr ""
 
@@ -2172,57 +1820,39 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Alternative Email ID"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Always add \"Draft\" Heading for printing draft documents"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Always use this email address as sender address"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Always use this name as sender name"
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Amend"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Amend"
-msgstr ""
-
 #. Label of a Check field in DocType 'User Document Type'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json
 #: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
 msgid "Amend"
 msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Amended Document Naming
 #. Settings'
-#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
-msgctxt "Amended Document Naming Settings"
-msgid "Amend Counter"
-msgstr ""
-
 #. Option for the 'Default Amendment Naming' (Select) field in DocType
 #. 'Document Naming Settings'
+#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Amend Counter"
 msgstr ""
 
@@ -2233,19 +1863,13 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Amended Documents"
 msgstr ""
 
-#. Label of a Link field in DocType 'Personal Data Download Request'
-#: website/doctype/personal_data_download_request/personal_data_download_request.json
-msgctxt "Personal Data Download Request"
-msgid "Amended From"
-msgstr ""
-
 #. Label of a Link field in DocType 'Transaction Log'
+#. Label of a Link field in DocType 'Personal Data Download Request'
 #: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
+#: website/doctype/personal_data_download_request/personal_data_download_request.json
 msgid "Amended From"
 msgstr ""
 
@@ -2256,7 +1880,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Amendment Naming Override"
 msgstr ""
 
@@ -2270,7 +1893,6 @@ msgstr ""
 
 #. Description of the 'FavIcon' (Attach) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "An icon file with .ico extension. Should be 16 x 16 px. Generated using a favicon generator. [favicon-generator.org]"
 msgstr ""
 
@@ -2280,7 +1902,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Analytics"
 msgstr ""
 
@@ -2290,31 +1911,26 @@ msgstr ""
 
 #. Label of a Text Editor field in DocType 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
-msgctxt "Navbar Settings"
 msgid "Announcement Widget"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
-msgctxt "Navbar Settings"
 msgid "Announcements"
 msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
 msgid "Annual"
 msgstr ""
 
 #. Label of a Code field in DocType 'Personal Data Deletion Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
 msgid "Anonymization Matrix"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Anonymous"
 msgstr ""
 
@@ -2328,7 +1944,6 @@ msgstr ""
 
 #. Description of the 'Raw Commands' (Code) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Any string-based printer languages can be used. Writing raw commands requires knowledge of the printer's native language provided by the printer manufacturer. Please refer to the developer manual provided by the printer manufacturer on how to write their native commands. These commands are rendered on the server side using the Jinja Templating Language."
 msgstr ""
 
@@ -2337,20 +1952,14 @@ msgid "Apart from System Manager, roles with Set User Permissions right can set 
 msgstr ""
 
 #. Label of a Data field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "App"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Theme Ignore App'
+#: desk/doctype/desktop_icon/desktop_icon.json
 #: website/doctype/website_theme_ignore_app/website_theme_ignore_app.json
-msgctxt "Website Theme Ignore App"
 msgid "App"
 msgstr ""
 
 #. Label of a Data field in DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
 msgid "App Access Key"
 msgstr ""
 
@@ -2360,63 +1969,39 @@ msgstr ""
 
 #. Label of a Data field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "App Client ID"
 msgstr ""
 
 #. Label of a Data field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "App Client Secret"
 msgstr ""
 
 #. Label of a Data field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid "App ID"
 msgstr ""
 
-#: public/js/frappe/ui/toolbar/navbar.html:8
-msgid "App Logo"
-msgstr ""
-
 #. Label of a Attach Image field in DocType 'Website Settings'
+#: public/js/frappe/ui/toolbar/navbar.html:8
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "App Logo"
-msgstr ""
-
-#: core/doctype/installed_applications/installed_applications.js:27
-msgid "App Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Changelog Feed'
-#: desk/doctype/changelog_feed/changelog_feed.json
-msgctxt "Changelog Feed"
-msgid "App Name"
 msgstr ""
 
 #. Label of a Select field in DocType 'Module Def'
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "App Name"
-msgstr ""
-
+#. Label of a Data field in DocType 'Changelog Feed'
 #. Label of a Data field in DocType 'OAuth Client'
-#: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
-msgid "App Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Settings'
+#: core/doctype/installed_applications/installed_applications.js:27
+#: core/doctype/module_def/module_def.json
+#: desk/doctype/changelog_feed/changelog_feed.json
+#: integrations/doctype/oauth_client/oauth_client.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "App Name"
 msgstr ""
 
 #. Label of a Password field in DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
 msgid "App Secret Key"
 msgstr ""
 
@@ -2429,26 +2014,16 @@ msgid "App {0} is not installed"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Append Emails to Sent Folder"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Append Emails to Sent Folder"
 msgstr ""
 
 #. Label of a Link field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Append To"
-msgstr ""
-
 #. Label of a Link field in DocType 'IMAP Folder'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/imap_folder/imap_folder.json
-msgctxt "IMAP Folder"
 msgid "Append To"
 msgstr ""
 
@@ -2458,7 +2033,6 @@ msgstr ""
 
 #. Description of the 'Append To' (Link) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Append as communication against this DocType (must have fields: \"Sender\" and \"Subject\"). These fields can be defined in the email settings section of the appended doctype."
 msgstr ""
 
@@ -2468,38 +2042,29 @@ msgstr ""
 
 #. Label of a Link field in DocType 'User Permission'
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
 msgid "Applicable For"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Navbar Settings'
 #. Label of a Section Break field in DocType 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
-msgctxt "Navbar Settings"
 msgid "Application Logo"
 msgstr ""
 
 #. Label of a Data field in DocType 'Installed Application'
-#: core/doctype/installed_application/installed_application.json
-msgctxt "Installed Application"
-msgid "Application Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'System Settings'
+#: core/doctype/installed_application/installed_application.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Application Name"
 msgstr ""
 
 #. Label of a Data field in DocType 'Installed Application'
 #: core/doctype/installed_application/installed_application.json
-msgctxt "Installed Application"
 msgid "Application Version"
 msgstr ""
 
 #. Label of a Select field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "Applied On"
 msgstr ""
 
@@ -2510,7 +2075,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Apply Document Permissions"
 msgstr ""
 
@@ -2520,51 +2084,40 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Apply Only Once"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Apply Strict User Permissions"
 msgstr ""
 
 #. Label of a Select field in DocType 'Client Script'
 #: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
 msgid "Apply To"
 msgstr ""
 
 #. Label of a Check field in DocType 'User Permission'
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
 msgid "Apply To All Document Types"
 msgstr ""
 
 #. Label of a Link field in DocType 'User Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "Apply User Permission On"
 msgstr ""
 
 #. Description of the 'If user is the owner' (Check) field in DocType 'Custom
 #. DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Apply this rule if the User is the Owner"
-msgstr ""
-
 #. Description of the 'If user is the owner' (Check) field in DocType 'DocPerm'
+#: core/doctype/custom_docperm/custom_docperm.json
 #: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
 msgid "Apply this rule if the User is the Owner"
 msgstr ""
 
 #. Description of the 'Apply Only Once' (Check) field in DocType 'Energy Point
 #. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Apply this rule only once per document"
 msgstr ""
 
@@ -2582,7 +2135,6 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
 msgid "Appreciation"
 msgstr ""
 
@@ -2601,7 +2153,6 @@ msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Archived"
 msgstr ""
 
@@ -2617,7 +2168,7 @@ msgstr ""
 msgid "Are you sure you want to delete all rows?"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:898
+#: public/js/frappe/views/workspace/workspace.js:899
 msgid "Are you sure you want to delete page {0}?"
 msgstr ""
 
@@ -2676,13 +2227,11 @@ msgstr ""
 
 #. Label of a Code field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Arguments"
 msgstr ""
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Arial"
 msgstr ""
 
@@ -2700,7 +2249,6 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Assign Condition"
 msgstr ""
 
@@ -2719,7 +2267,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Assign To Users"
 msgstr ""
 
@@ -2744,30 +2291,19 @@ msgid "Assign to the user set in this field"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Assigned"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Assigned"
-msgstr ""
-
-#: desk/report/todo/todo.py:41
-msgid "Assigned By"
 msgstr ""
 
 #. Label of a Link field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
+#: desk/doctype/todo/todo.json desk/report/todo/todo.py:41
 msgid "Assigned By"
 msgstr ""
 
 #. Label of a Read Only field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
-msgctxt "ToDo"
 msgid "Assigned By Full Name"
 msgstr ""
 
@@ -2788,31 +2324,27 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Assignment"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Assignment Completed"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Assignment Completed"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Assignment Rule'
 #. Label of a Table field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Assignment Days"
 msgstr ""
 
 #. Name of a DocType
+#. Linked DocType in DocType's connections
+#. Label of a Link field in DocType 'ToDo'
 #: automation/doctype/assignment_rule/assignment_rule.json
+#: core/doctype/doctype/doctype.json desk/doctype/todo/todo.json
 msgid "Assignment Rule"
 msgstr ""
 
@@ -2820,18 +2352,6 @@ msgstr ""
 #. Label of a shortcut in the Tools Workspace
 #: automation/workspace/tools/tools.json
 msgctxt "Assignment Rule"
-msgid "Assignment Rule"
-msgstr ""
-
-#. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Assignment Rule"
-msgstr ""
-
-#. Label of a Link field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
 msgid "Assignment Rule"
 msgstr ""
 
@@ -2851,7 +2371,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Assignment Rules"
 msgstr ""
 
@@ -2867,13 +2386,9 @@ msgstr ""
 msgid "Assignment of {0} removed by {1}"
 msgstr ""
 
-#: public/js/frappe/form/sidebar/assign_to.js:253
-msgid "Assignments"
-msgstr ""
-
 #. Label of a Check field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
+#: public/js/frappe/form/sidebar/assign_to.js:253
 msgid "Assignments"
 msgstr ""
 
@@ -2889,31 +2404,15 @@ msgstr ""
 msgid "At least one field of Parent Document Type is mandatory"
 msgstr ""
 
-#: public/js/frappe/form/controls/attach.js:5
-msgid "Attach"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Attach"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Attach"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Attach"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: public/js/frappe/form/controls/attach.js:5
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Attach"
 msgstr ""
 
@@ -2921,45 +2420,26 @@ msgstr ""
 msgid "Attach Document Print"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Attach Image"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Attach Image"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Attach Image"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Attach Image"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Attach Image"
 msgstr ""
 
 #. Label of a Attach field in DocType 'Package Import'
 #: core/doctype/package_import/package_import.json
-msgctxt "Package Import"
 msgid "Attach Package"
 msgstr ""
 
 #. Label of a Check field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Attach Print"
 msgstr ""
 
@@ -2969,25 +2449,21 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Attached File"
 msgstr ""
 
 #. Label of a Link field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Attached To DocType"
 msgstr ""
 
 #. Label of a Data field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Attached To Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Attached To Name"
 msgstr ""
 
@@ -2996,32 +2472,18 @@ msgid "Attached To Name must be a string or an integer"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Attachment"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Attachment"
-msgstr ""
-
 #. Label of a Attach field in DocType 'Newsletter Attachment'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
 #: email/doctype/newsletter_attachment/newsletter_attachment.json
-msgctxt "Newsletter Attachment"
 msgid "Attachment"
 msgstr ""
 
 #. Label of a Int field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Attachment Limit (MB)"
-msgstr ""
-
 #. Label of a Int field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Attachment Limit (MB)"
 msgstr ""
 
@@ -3032,37 +2494,23 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Attachment Link"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Attachment Removed"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Attachment Removed"
-msgstr ""
-
-#: email/doctype/newsletter/templates/newsletter.html:47
-#: public/js/frappe/form/templates/form_sidebar.html:65
-#: website/doctype/web_form/templates/web_form.html:103
-msgid "Attachments"
 msgstr ""
 
 #. Label of a Code field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Attachments"
-msgstr ""
-
 #. Label of a Table field in DocType 'Newsletter'
+#: email/doctype/email_queue/email_queue.json
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
+#: email/doctype/newsletter/templates/newsletter.html:47
+#: public/js/frappe/form/templates/form_sidebar.html:65
+#: website/doctype/web_form/templates/web_form.html:103
 msgid "Attachments"
 msgstr ""
 
@@ -3080,7 +2528,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Audience"
 msgstr ""
 
@@ -3096,24 +2543,15 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Auth URL Data"
 msgstr ""
 
-#. Label of a Card Break in the Integrations Workspace
-#: integrations/workspace/integrations/integrations.json
-msgid "Authentication"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Authentication"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Push Notification Settings'
+#. Label of a Card Break in the Integrations Workspace
+#: email/doctype/email_account/email_account.json
 #: integrations/doctype/push_notification_settings/push_notification_settings.json
-msgctxt "Push Notification Settings"
+#: integrations/workspace/integrations/integrations.json
 msgid "Authentication"
 msgstr ""
 
@@ -3127,43 +2565,24 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Author"
 msgstr ""
 
 #. Label of a Password field in DocType 'Google Calendar'
-#: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
-msgid "Authorization Code"
-msgstr ""
-
 #. Label of a Password field in DocType 'Google Contacts'
-#: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
-msgid "Authorization Code"
-msgstr ""
-
 #. Label of a Data field in DocType 'Google Drive'
-#: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
-msgid "Authorization Code"
-msgstr ""
-
 #. Label of a Data field in DocType 'OAuth Authorization Code'
-#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
-msgid "Authorization Code"
-msgstr ""
-
 #. Option for the 'Grant Type' (Select) field in DocType 'OAuth Client'
+#: integrations/doctype/google_calendar/google_calendar.json
+#: integrations/doctype/google_contacts/google_contacts.json
+#: integrations/doctype/google_drive/google_drive.json
+#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Authorization Code"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Authorization URI"
 msgstr ""
 
@@ -3173,43 +2592,36 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Authorize API Access"
 msgstr ""
 
 #. Label of a Button field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Authorize API Indexing  Access"
 msgstr ""
 
 #. Label of a Button field in DocType 'Google Calendar'
 #: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
 msgid "Authorize Google Calendar Access"
 msgstr ""
 
 #. Label of a Button field in DocType 'Google Contacts'
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
 msgid "Authorize Google Contacts Access"
 msgstr ""
 
 #. Label of a Button field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "Authorize Google Drive Access"
 msgstr ""
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Authorize URL"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
 msgid "Authorized"
 msgstr ""
 
@@ -3221,16 +2633,11 @@ msgstr ""
 msgid "Authors / Maintainers"
 msgstr ""
 
-#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
-#: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "Auto"
-msgstr ""
-
 #. Option for the 'Skip Authorization' (Select) field in DocType 'OAuth
 #. Provider Settings'
+#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
-msgctxt "OAuth Provider Settings"
+#: social/doctype/energy_point_log/energy_point_log.json
 msgid "Auto"
 msgstr ""
 
@@ -3245,33 +2652,23 @@ msgctxt "Auto Email Report"
 msgid "Auto Email Report"
 msgstr ""
 
-#. Label of a Data field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Auto Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Auto Name"
 msgstr ""
 
 #. Name of a DocType
+#. Linked DocType in DocType's connections
 #: automation/doctype/auto_repeat/auto_repeat.json
-#: public/js/frappe/utils/common.js:442
+#: core/doctype/doctype/doctype.json public/js/frappe/utils/common.js:442
 msgid "Auto Repeat"
 msgstr ""
 
 #. Label of a Link in the Tools Workspace
 #: automation/workspace/tools/tools.json
 msgctxt "Auto Repeat"
-msgid "Auto Repeat"
-msgstr ""
-
-#. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Auto Repeat"
 msgstr ""
 
@@ -3302,13 +2699,11 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Auto Reply"
 msgstr ""
 
 #. Label of a Text Editor field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Auto Reply Message"
 msgstr ""
 
@@ -3318,55 +2713,40 @@ msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Auto follow documents that are assigned to you"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Auto follow documents that are shared with you"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Auto follow documents that you Like"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Auto follow documents that you comment on"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Auto follow documents that you create"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Autocomplete"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Autocomplete"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Autocomplete"
 msgstr ""
 
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Autoincrement"
 msgstr ""
 
@@ -3378,17 +2758,11 @@ msgstr ""
 #. Option for the 'Communication Type' (Select) field in DocType
 #. 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Automated Message"
 msgstr ""
 
-#: public/js/frappe/ui/theme_switcher.js:69
-msgid "Automatic"
-msgstr ""
-
 #. Option for the 'Desk Theme' (Select) field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/user/user.json public/js/frappe/ui/theme_switcher.js:69
 msgid "Automatic"
 msgstr ""
 
@@ -3407,7 +2781,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Automatically delete account within (hours)"
 msgstr ""
 
@@ -3418,25 +2791,16 @@ msgstr ""
 
 #. Label of a Attach Image field in DocType 'Blogger'
 #: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
 msgid "Avatar"
-msgstr ""
-
-#: public/js/frappe/form/controls/password.js:89
-#: public/js/frappe/ui/group_by/group_by.js:21
-msgid "Average"
 msgstr ""
 
 #. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #. Option for the 'Group By Type' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Average"
-msgstr ""
-
 #. Option for the 'Function' (Select) field in DocType 'Number Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
+#: public/js/frappe/form/controls/password.js:89
+#: public/js/frappe/ui/group_by/group_by.js:21
 msgid "Average"
 msgstr ""
 
@@ -3462,13 +2826,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'User Email'
 #: core/doctype/user_email/user_email.json
-msgctxt "User Email"
 msgid "Awaiting Password"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Awaiting password"
 msgstr ""
 
@@ -3487,83 +2849,64 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B0"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B1"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B10"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B2"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B3"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B4"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B5"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B6"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B7"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B8"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "B9"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:79
-msgid "BCC"
-msgstr ""
-
 #. Label of a Code field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "BCC"
-msgstr ""
-
 #. Label of a Code field in DocType 'Notification Recipient'
+#: core/doctype/communication/communication.json
 #: email/doctype/notification_recipient/notification_recipient.json
-msgctxt "Notification Recipient"
+#: public/js/frappe/views/communication.js:79
 msgid "BCC"
 msgstr ""
 
@@ -3584,23 +2927,19 @@ msgid "Back to Login"
 msgstr ""
 
 #. Label of a Color field in DocType 'Social Link Settings'
-#: website/doctype/social_link_settings/social_link_settings.json
-msgctxt "Social Link Settings"
-msgid "Background Color"
-msgstr ""
-
 #. Label of a Link field in DocType 'Website Theme'
+#: website/doctype/social_link_settings/social_link_settings.json
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Background Color"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Background Image"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'System Health Report'
+#: desk/doctype/system_health_report/system_health_report.json
 #: public/js/frappe/ui/toolbar/toolbar.js:178
 msgid "Background Jobs"
 msgstr ""
@@ -3611,33 +2950,20 @@ msgctxt "RQ Job"
 msgid "Background Jobs"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'System Health Report'
-#: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
-msgid "Background Jobs"
-msgstr ""
-
 #. Label of a Data field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Background Jobs Check"
 msgstr ""
 
 #. Label of a Autocomplete field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Background Jobs Queue"
 msgstr ""
 
-#. Label of a Table field in DocType 'System Health Report'
-#: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
-msgid "Background Workers"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'System Settings'
+#. Label of a Table field in DocType 'System Health Report'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/system_health_report/system_health_report.json
 msgid "Background Workers"
 msgstr ""
 
@@ -3656,7 +2982,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Backup Details"
 msgstr ""
 
@@ -3666,31 +2991,23 @@ msgstr ""
 
 #. Label of a Check field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Backup Files"
 msgstr ""
 
 #. Label of a Data field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "Backup Folder ID"
 msgstr ""
 
 #. Label of a Data field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "Backup Folder Name"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dropbox Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "Backup Frequency"
-msgstr ""
-
 #. Label of a Select field in DocType 'S3 Backup Settings'
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Backup Frequency"
 msgstr ""
 
@@ -3701,25 +3018,18 @@ msgstr ""
 #. Description of the 'Backup Files' (Check) field in DocType 'S3 Backup
 #. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Backup public and private files along with the database."
 msgstr ""
 
-#. Label of a Section Break field in DocType 'System Health Report'
-#: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
-msgid "Backups"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'System Settings'
+#. Label of a Section Break field in DocType 'System Health Report'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/system_health_report/system_health_report.json
 msgid "Backups"
 msgstr ""
 
 #. Label of a Float field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Backups (MB)"
 msgstr ""
 
@@ -3729,179 +3039,137 @@ msgstr ""
 
 #. Option for the 'Rounding Method' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Banker's Rounding"
 msgstr ""
 
 #. Option for the 'Rounding Method' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Banker's Rounding (legacy)"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Banner"
 msgstr ""
 
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Banner HTML"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Banner Image"
-msgstr ""
-
 #. Label of a Attach Image field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
+#: core/doctype/user/user.json website/doctype/web_form/web_form.json
 msgid "Banner Image"
 msgstr ""
 
 #. Description of the 'Banner HTML' (Code) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Banner is above the Top Menu Bar."
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Bar"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Barcode"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Barcode"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Barcode"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Base Distinguished Name (DN)"
 msgstr ""
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Base URL"
 msgstr ""
 
-#: printing/page/print/print.js:273 printing/page/print/print.js:327
-msgid "Based On"
-msgstr ""
-
 #. Label of a Link field in DocType 'Language'
-#: core/doctype/language/language.json
-msgctxt "Language"
+#: core/doctype/language/language.json printing/page/print/print.js:273
+#: printing/page/print/print.js:327
 msgid "Based On"
 msgstr ""
 
 #. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Based on Field"
 msgstr ""
 
 #. Label of a Link field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Based on Permissions For User"
 msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Basic"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Basic Info"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Cancel"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Delete"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Discard"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Insert"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Print"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Rename"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Save"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Save (Submitted Document)"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Submit"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Before Validate"
 msgstr ""
 
 #. Option for the 'Level' (Select) field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Beginner"
 msgstr ""
 
@@ -3911,7 +3179,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Beta"
 msgstr ""
 
@@ -3925,7 +3192,6 @@ msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Billing"
 msgstr ""
 
@@ -3935,31 +3201,20 @@ msgstr ""
 
 #. Label of a Data field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Binary Logging"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'About Us Team Member'
-#: website/doctype/about_us_team_member/about_us_team_member.json
-msgctxt "About Us Team Member"
-msgid "Bio"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Blogger'
-#: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
-msgid "Bio"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'User'
+#. Label of a Small Text field in DocType 'About Us Team Member'
+#. Label of a Small Text field in DocType 'Blogger'
 #: core/doctype/user/user.json
-msgctxt "User"
+#: website/doctype/about_us_team_member/about_us_team_member.json
+#: website/doctype/blogger/blogger.json
 msgid "Bio"
 msgstr ""
 
 #. Label of a Date field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Birth Date"
 msgstr ""
 
@@ -3973,20 +3228,13 @@ msgid "Block Module"
 msgstr ""
 
 #. Label of a Table field in DocType 'Module Profile'
-#: core/doctype/module_profile/module_profile.json
-msgctxt "Module Profile"
-msgid "Block Modules"
-msgstr ""
-
 #. Label of a Table field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/module_profile/module_profile.json core/doctype/user/user.json
 msgid "Block Modules"
 msgstr ""
 
 #. Label of a Check field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "Blocked"
 msgstr ""
 
@@ -4000,7 +3248,9 @@ msgid "Blog"
 msgstr ""
 
 #. Name of a DocType
+#. Label of a Link field in DocType 'Blog Post'
 #: website/doctype/blog_category/blog_category.json
+#: website/doctype/blog_post/blog_post.json
 msgid "Blog Category"
 msgstr ""
 
@@ -4010,32 +3260,22 @@ msgctxt "Blog Category"
 msgid "Blog Category"
 msgstr ""
 
-#. Label of a Link field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Blog Category"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Blog Intro"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Blog Introduction"
 msgstr ""
 
-#. Name of a DocType
-#: website/doctype/blog_post/blog_post.json
-msgid "Blog Post"
-msgstr ""
-
 #. Linked DocType in Blog Category's connections
+#. Name of a DocType
+#. Linked DocType in Blogger's connections
 #: website/doctype/blog_category/blog_category.json
-msgctxt "Blog Category"
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/blogger/blogger.json
 msgid "Blog Post"
 msgstr ""
 
@@ -4043,12 +3283,6 @@ msgstr ""
 #. Label of a shortcut in the Website Workspace
 #: website/workspace/website/website.json
 msgctxt "Blog Post"
-msgid "Blog Post"
-msgstr ""
-
-#. Linked DocType in Blogger's connections
-#: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
 msgid "Blog Post"
 msgstr ""
 
@@ -4059,22 +3293,17 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Blog Title"
 msgstr ""
 
+#. Linked DocType in User's connections
 #. Name of a role
+#. Label of a Link field in DocType 'Blog Post'
 #. Name of a DocType
-#: website/doctype/blog_category/blog_category.json
+#: core/doctype/user/user.json website/doctype/blog_category/blog_category.json
 #: website/doctype/blog_post/blog_post.json
 #: website/doctype/blog_settings/blog_settings.json
 #: website/doctype/blogger/blogger.json
-msgid "Blogger"
-msgstr ""
-
-#. Label of a Link field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Blogger"
 msgstr ""
 
@@ -4085,50 +3314,29 @@ msgctxt "Blogger"
 msgid "Blogger"
 msgstr ""
 
-#. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Blogger"
-msgstr ""
-
 #. Subtitle of the Module Onboarding 'Website'
 #: website/module_onboarding/website/website.json
 msgid "Blogs, Website View Tracking, and more."
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Blue"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Blue"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Bold"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Bold"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Bold"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
 #: core/doctype/comment/comment.json
-msgctxt "Comment"
 msgid "Bot"
 msgstr ""
 
@@ -4142,114 +3350,82 @@ msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Bottom"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
+#: printing/doctype/print_format/print_format.json
 msgid "Bottom Center"
 msgstr ""
 
 #. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Bottom Center"
-msgstr ""
-
-#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Bottom Left"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Bottom Right"
-msgstr ""
-
 #. Option for the 'Page Number' (Select) field in DocType 'Print Format'
+#: desk/doctype/form_tour_step/form_tour_step.json
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Bottom Right"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Bounced"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Brand"
 msgstr ""
 
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Brand HTML"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Brand Image"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Brand Logo"
 msgstr ""
 
 #. Description of the 'Brand HTML' (Code) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid ""
 "Brand is what appears on the top-left of the toolbar. If it is an image, make sure it\n"
 "has a transparent background and use the &lt;img /&gt; tag. Keep size as 200px x 30px"
 msgstr ""
 
 #. Label of a Code field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Breadcrumbs"
-msgstr ""
-
 #. Label of a Code field in DocType 'Web Page'
+#: website/doctype/web_form/web_form.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Breadcrumbs"
-msgstr ""
-
-#: website/doctype/blog_post/templates/blog_post_list.html:18
-#: website/doctype/blog_post/templates/blog_post_list.html:21
-msgid "Browse by category"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Settings'
+#: website/doctype/blog_post/templates/blog_post_list.html:18
+#: website/doctype/blog_post/templates/blog_post_list.html:21
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Browse by category"
 msgstr ""
 
+#. Label of a Data field in DocType 'Web Page View'
+#: website/doctype/web_page_view/web_page_view.json
 #: website/report/website_analytics/website_analytics.js:36
 msgid "Browser"
 msgstr ""
 
 #. Label of a Data field in DocType 'Web Page View'
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
-msgid "Browser"
-msgstr ""
-
-#. Label of a Data field in DocType 'Web Page View'
-#: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
 msgid "Browser Version"
 msgstr ""
 
@@ -4259,13 +3435,11 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Brute Force Security"
 msgstr ""
 
 #. Label of a Data field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Bucket Name"
 msgstr ""
 
@@ -4275,7 +3449,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Bufferpool Size"
 msgstr ""
 
@@ -4299,7 +3472,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "Bulk Actions"
 msgstr ""
 
@@ -4354,51 +3526,34 @@ msgstr ""
 msgid "Bulk {0} is enqueued in background."
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Button"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Button"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Button"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Button Gradients"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Button Rounded Corners"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Button Shadows"
 msgstr ""
 
-#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "By \"Naming Series\" field"
-msgstr ""
-
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "By \"Naming Series\" field"
 msgstr ""
 
@@ -4410,55 +3565,40 @@ msgstr ""
 #. Description of the 'Send Email for Successful Backup' (Check) field in
 #. DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "By default, emails are only sent for failed backups."
 msgstr ""
 
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "By fieldname"
 msgstr ""
 
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "By fieldname"
-msgstr ""
-
 #. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "By script"
-msgstr ""
-
-#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "By script"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Bypass Restricted IP Address Check If Two Factor Auth Enabled"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Bypass Two Factor Auth for users who login from restricted IP Address"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Bypass restricted IP Address check If Two Factor Auth Enabled"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "C5E"
 msgstr ""
 
@@ -4466,25 +3606,16 @@ msgstr ""
 msgid "CANCELLED"
 msgstr ""
 
-#: public/js/frappe/views/communication.js:73
-msgid "CC"
-msgstr ""
-
 #. Label of a Code field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "CC"
-msgstr ""
-
 #. Label of a Code field in DocType 'Notification Recipient'
+#: core/doctype/communication/communication.json
 #: email/doctype/notification_recipient/notification_recipient.json
-msgctxt "Notification Recipient"
+#: public/js/frappe/views/communication.js:73
 msgid "CC"
 msgstr ""
 
 #. Label of a Data field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "CMD"
 msgstr ""
 
@@ -4493,63 +3624,44 @@ msgid "COLOR PICKER"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Custom HTML Block'
-#: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
-msgid "CSS"
-msgstr ""
-
 #. Label of a Code field in DocType 'Print Style'
-#: printing/doctype/print_style/print_style.json
-msgctxt "Print Style"
-msgid "CSS"
-msgstr ""
-
 #. Label of a Code field in DocType 'Web Page'
+#: desk/doctype/custom_html_block/custom_html_block.json
+#: printing/doctype/print_style/print_style.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "CSS"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "CSS Class"
 msgstr ""
 
 #. Description of the 'Element Selector' (Data) field in DocType 'Form Tour
 #. Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "CSS selector for the element you want to highlight."
 msgstr ""
 
-#. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "CSV"
-msgstr ""
-
 #. Option for the 'File Type' (Select) field in DocType 'Data Export'
+#. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
 #: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "CSV"
 msgstr ""
 
 #. Label of a Data field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "CTA Label"
 msgstr ""
 
 #. Label of a Data field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "CTA URL"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Cache"
 msgstr ""
 
@@ -4561,78 +3673,58 @@ msgstr ""
 msgid "Calculate"
 msgstr ""
 
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: desk/doctype/form_tour/form_tour.json
+#: desk/doctype/workspace_shortcut/workspace_shortcut.json
+msgid "Calendar"
+msgstr ""
+
 #. Label of a Link in the Tools Workspace
 #: automation/workspace/tools/tools.json
 msgctxt "Event"
 msgid "Calendar"
 msgstr ""
 
-#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Calendar"
-msgstr ""
-
-#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
-#: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
-msgid "Calendar"
-msgstr ""
-
 #. Label of a Data field in DocType 'Google Calendar'
 #: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
 msgid "Calendar Name"
 msgstr ""
 
+#. Linked DocType in DocType's connections
 #. Name of a DocType
+#: core/doctype/doctype/doctype.json
 #: desk/doctype/calendar_view/calendar_view.json
 msgid "Calendar View"
 msgstr ""
 
-#. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Calendar View"
-msgstr ""
-
-#: contacts/doctype/contact/contact.js:55
-msgid "Call"
-msgstr ""
-
 #. Option for the 'Event Category' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
+#: contacts/doctype/contact/contact.js:55 desk/doctype/event/event.json
 msgid "Call"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Call To Action"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Call To Action URL"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Call to Action"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Callback Message"
 msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Callback Title"
 msgstr ""
 
@@ -4640,26 +3732,17 @@ msgstr ""
 msgid "Camera"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1723
-#: website/report/website_analytics/website_analytics.js:39
-msgid "Campaign"
-msgstr ""
-
 #. Label of a Link field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Campaign"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Page View'
+#: email/doctype/newsletter/newsletter.json
+#: public/js/frappe/utils/utils.js:1723
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
+#: website/report/website_analytics/website_analytics.js:39
 msgid "Campaign"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Marketing Campaign'
 #: website/doctype/marketing_campaign/marketing_campaign.json
-msgctxt "Marketing Campaign"
 msgid "Campaign Description (Optional)"
 msgstr ""
 
@@ -4694,7 +3777,6 @@ msgstr ""
 #. Description of the 'Apply User Permission On' (Link) field in DocType 'User
 #. Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "Can only list down the document types which has been linked to the User document type."
 msgstr ""
 
@@ -4702,8 +3784,18 @@ msgstr ""
 msgid "Can't rename {0} to {1} because {0} doesn't exist."
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:130
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#. Label of a Check field in DocType 'User Document Type'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json core/doctype/doctype/doctype_list.js:130
+#: core/doctype/user_document_type/user_document_type.json
+#: email/doctype/notification/notification.json
 #: public/js/frappe/form/reminders.js:54
+#: social/doctype/energy_point_rule/energy_point_rule.json
 msgid "Cancel"
 msgstr ""
 
@@ -4712,39 +3804,8 @@ msgctxt "Button in list view actions menu"
 msgid "Cancel"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Cancel"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Cancel"
-msgstr ""
-
-#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
-#. Rule'
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "Cancel"
-msgstr ""
-
-#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Cancel"
-msgstr ""
-
 #: public/js/frappe/ui/messages.js:68
 msgctxt "Secondary button in warning dialog"
-msgid "Cancel"
-msgstr ""
-
-#. Label of a Check field in DocType 'User Document Type'
-#: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
 msgid "Cancel"
 msgstr ""
 
@@ -4765,38 +3826,17 @@ msgctxt "Title of confirmation dialog"
 msgid "Cancel {0} documents?"
 msgstr ""
 
-#: desk/form/save.py:59 public/js/frappe/model/indicator.js:78
-#: public/js/frappe/ui/filters/filter.js:502
-msgid "Cancelled"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Cancelled"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Cancelled"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Cancelled"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Cancelled"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json desk/doctype/event/event.json
+#: desk/doctype/todo/todo.json desk/form/save.py:59
+#: integrations/doctype/integration_request/integration_request.json
+#: public/js/frappe/model/indicator.js:78
+#: public/js/frappe/ui/filters/filter.js:502
 msgid "Cancelled"
 msgstr ""
 
@@ -5037,13 +4077,11 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Number Card Link'
 #: desk/doctype/number_card_link/number_card_link.json
-msgctxt "Number Card Link"
 msgid "Card"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
 msgid "Card Break"
 msgstr ""
 
@@ -5057,35 +4095,24 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Dashboard'
 #: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
 msgid "Cards"
 msgstr ""
 
-#: public/js/frappe/views/interaction.js:72
-msgid "Category"
-msgstr ""
-
 #. Label of a Data field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Category"
-msgstr ""
-
 #. Label of a Link field in DocType 'Help Article'
+#: desk/doctype/desktop_icon/desktop_icon.json
+#: public/js/frappe/views/interaction.js:72
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Category"
 msgstr ""
 
 #. Label of a Text field in DocType 'Help Category'
 #: website/doctype/help_category/help_category.json
-msgctxt "Help Category"
 msgid "Category Description"
 msgstr ""
 
 #. Label of a Data field in DocType 'Help Category'
 #: website/doctype/help_category/help_category.json
-msgctxt "Help Category"
 msgid "Category Name"
 msgstr ""
 
@@ -5094,14 +4121,9 @@ msgid "Cent"
 msgstr ""
 
 #. Option for the 'Align' (Select) field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "Center"
-msgstr ""
-
 #. Option for the 'Text Align' (Select) field in DocType 'Web Page'
+#: printing/doctype/letter_head/letter_head.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Center"
 msgstr ""
 
@@ -5115,7 +4137,6 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'Transaction Log'
 #: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
 msgid "Chaining Hash"
 msgstr ""
 
@@ -5131,13 +4152,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Change Label (via Custom Translation)"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Change Password"
 msgstr ""
 
@@ -5153,7 +4172,6 @@ msgstr ""
 #. Description of the 'Update Series Counter' (Section Break) field in DocType
 #. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid ""
 "Change the starting / current sequence number of an existing series. <br>\n"
 "\n"
@@ -5175,71 +4193,47 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Channel"
 msgstr ""
 
 #. Label of a Link field in DocType 'Dashboard Chart Link'
 #: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
-msgctxt "Dashboard Chart Link"
 msgid "Chart"
 msgstr ""
 
 #. Label of a Code field in DocType 'Dashboard Settings'
 #: desk/doctype/dashboard_settings/dashboard_settings.json
-msgctxt "Dashboard Settings"
 msgid "Chart Configuration"
 msgstr ""
 
 #. Label of a Data field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Chart Name"
-msgstr ""
-
 #. Label of a Link field in DocType 'Workspace Chart'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/workspace_chart/workspace_chart.json
-msgctxt "Workspace Chart"
 msgid "Chart Name"
 msgstr ""
 
 #. Label of a Code field in DocType 'Dashboard'
-#: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
-msgid "Chart Options"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Dashboard Chart'
+#: desk/doctype/dashboard/dashboard.json
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Chart Options"
 msgstr ""
 
 #. Label of a Link field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Chart Source"
-msgstr ""
-
-#: public/js/frappe/views/reports/report_view.js:474
-msgid "Chart Type"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
+#: public/js/frappe/views/reports/report_view.js:474
 msgid "Chart Type"
 msgstr ""
 
 #. Label of a Table field in DocType 'Dashboard'
-#: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
-msgid "Charts"
-msgstr ""
-
 #. Label of a Table field in DocType 'Workspace'
-#: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: desk/doctype/dashboard/dashboard.json desk/doctype/workspace/workspace.json
 msgid "Charts"
 msgstr ""
 
@@ -5247,49 +4241,23 @@ msgstr ""
 #. Option for the 'Communication Type' (Select) field in DocType
 #. 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Chat"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Check"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Check"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Check"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Check"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Check"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Check"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Check"
 msgstr ""
 
@@ -5316,7 +4284,6 @@ msgstr ""
 #. Description of the 'User must always select' (Check) field in DocType
 #. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Check this if you want to force the user to select a series before saving. There will be no default if you check this."
 msgstr ""
 
@@ -5335,7 +4302,6 @@ msgstr ""
 #. Description of the 'Hide Custom DocTypes and Reports' (Check) field in
 #. DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Checking this will hide custom doctypes and reports cards in Links section"
 msgstr ""
 
@@ -5349,7 +4315,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Transaction Log'
 #: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
 msgid "Checksum Version"
 msgstr ""
 
@@ -5359,7 +4324,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Child Doctype"
 msgstr ""
 
@@ -5367,13 +4331,8 @@ msgstr ""
 msgid "Child Table {0} for field {1}"
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:52
-msgid "Child Tables are shown as a Grid in other DocTypes"
-msgstr ""
-
 #. Description of the 'Is Child Table' (Check) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:52
 msgid "Child Tables are shown as a Grid in other DocTypes"
 msgstr ""
 
@@ -5381,7 +4340,7 @@ msgstr ""
 msgid "Choose Existing Card or create New Card"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1398
+#: public/js/frappe/views/workspace/workspace.js:1399
 msgid "Choose a block or continue typing"
 msgstr ""
 
@@ -5396,19 +4355,16 @@ msgstr ""
 #. Description of the 'Two Factor Authentication method' (Select) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Choose authentication method to be used by all users"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "City"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "City/Town"
 msgstr ""
 
@@ -5444,7 +4400,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Logs To Clear'
 #: core/doctype/logs_to_clear/logs_to_clear.json
-msgctxt "Logs To Clear"
 msgid "Clear Logs After (days)"
 msgstr ""
 
@@ -5531,66 +4486,54 @@ msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Clicked"
 msgstr ""
 
 #. Label of a Link field in DocType 'OAuth Authorization Code'
-#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
-msgid "Client"
-msgstr ""
-
 #. Label of a Link field in DocType 'OAuth Bearer Token'
+#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 #: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
 msgid "Client"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Client Code"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Connected App'
-#: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
-msgid "Client Credentials"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Social Login Key'
+#: integrations/doctype/connected_app/connected_app.json
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Client Credentials"
 msgstr ""
 
 #. Label of a Data field in DocType 'Google Settings'
-#: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
-msgid "Client ID"
-msgstr ""
-
 #. Label of a Data field in DocType 'Social Login Key'
+#: integrations/doctype/google_settings/google_settings.json
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Client ID"
 msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Client Id"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Client Information"
 msgstr ""
 
+#. Linked DocType in DocType's connections
+#. Linked DocType in Module Def's connections
 #. Name of a DocType
+#. Label of a Code field in DocType 'DocType Layout'
+#. Label of a Code field in DocType 'Web Form'
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
 #: custom/doctype/client_script/client_script.json
+#: custom/doctype/doctype_layout/doctype_layout.json
+#: website/doctype/web_form/web_form.json
 #: website/doctype/web_page/web_page.js:103
 msgid "Client Script"
 msgstr ""
@@ -5602,51 +4545,17 @@ msgctxt "Client Script"
 msgid "Client Script"
 msgstr ""
 
-#. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Client Script"
-msgstr ""
-
-#. Label of a Code field in DocType 'DocType Layout'
-#: custom/doctype/doctype_layout/doctype_layout.json
-msgctxt "DocType Layout"
-msgid "Client Script"
-msgstr ""
-
-#. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Client Script"
-msgstr ""
-
-#. Label of a Code field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Client Script"
-msgstr ""
-
 #. Label of a Password field in DocType 'Connected App'
-#: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
-msgid "Client Secret"
-msgstr ""
-
 #. Label of a Password field in DocType 'Google Settings'
-#: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
-msgid "Client Secret"
-msgstr ""
-
 #. Label of a Password field in DocType 'Social Login Key'
+#: integrations/doctype/connected_app/connected_app.json
+#: integrations/doctype/google_settings/google_settings.json
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Client Secret"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Client URLs"
 msgstr ""
 
@@ -5657,31 +4566,16 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Close Condition"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Closed"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Closed"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Closed"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'ToDo'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication/communication.json desk/doctype/event/event.json
 #: desk/doctype/todo/todo.json
-msgctxt "ToDo"
 msgid "Closed"
 msgstr ""
 
@@ -5691,51 +4585,31 @@ msgstr ""
 msgid "Cmd+Enter to add comment"
 msgstr ""
 
-#. Label of a Data field in DocType 'Country'
-#: geo/doctype/country/country.json
-msgctxt "Country"
-msgid "Code"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Code"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Code"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Code"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Data field in DocType 'Country'
 #. Option for the 'Response Type' (Select) field in DocType 'OAuth Client'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: geo/doctype/country/country.json
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Code"
 msgstr ""
 
 #. Label of a Data field in DocType 'OAuth Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "Code Challenge"
 msgstr ""
 
 #. Label of a Select field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Code Editor Type"
 msgstr ""
 
 #. Label of a Select field in DocType 'OAuth Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "Code challenge method"
 msgstr ""
 
@@ -5754,147 +4628,64 @@ msgstr ""
 msgid "Collapse All"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Collapsible"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Collapsible"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Collapsible"
 msgstr ""
 
 #. Label of a Code field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Collapsible Depends On"
-msgstr ""
-
 #. Label of a Code field in DocType 'Customize Form Field'
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Collapsible Depends On"
 msgstr ""
 
 #. Label of a Code field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Collapsible Depends On (JS)"
 msgstr ""
 
+#. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Label of a Data field in DocType 'DocType'
+#. Label of a Select field in DocType 'DocType State'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Color field in DocType 'Dashboard Chart'
+#. Label of a Color field in DocType 'Dashboard Chart Field'
+#. Label of a Data field in DocType 'Desktop Icon'
+#. Label of a Color field in DocType 'Event'
+#. Label of a Color field in DocType 'Number Card'
+#. Label of a Color field in DocType 'ToDo'
+#. Label of a Color field in DocType 'Workspace Shortcut'
 #. Name of a DocType
+#. Label of a Color field in DocType 'Color'
+#. Label of a Color field in DocType 'Social Link Settings'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json core/doctype/doctype/doctype.json
+#: core/doctype/doctype_state/doctype_state.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/dashboard_chart_field/dashboard_chart_field.json
+#: desk/doctype/desktop_icon/desktop_icon.json desk/doctype/event/event.json
+#: desk/doctype/number_card/number_card.json desk/doctype/todo/todo.json
+#: desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: public/js/frappe/views/reports/query_report.js:1156
 #: public/js/frappe/widgets/widget_dialog.js:544
 #: public/js/frappe/widgets/widget_dialog.js:696
 #: website/doctype/color/color.json
-msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'Color'
-#: website/doctype/color/color.json
-msgctxt "Color"
-msgid "Color"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Color"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'Dashboard Chart Field'
-#: desk/doctype/dashboard_chart_field/dashboard_chart_field.json
-msgctxt "Dashboard Chart Field"
-msgid "Color"
-msgstr ""
-
-#. Label of a Data field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Color"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Color"
-msgstr ""
-
-#. Label of a Data field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Color"
-msgstr ""
-
-#. Label of a Select field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'Social Link Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
-msgctxt "Social Link Settings"
-msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Color"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Color"
-msgstr ""
-
-#. Label of a Color field in DocType 'Workspace Shortcut'
-#: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
-msgid "Color"
-msgstr ""
-
-#: printing/page/print_format_builder/print_format_builder_column_selector.html:7
-msgid "Column"
 msgstr ""
 
 #. Label of a Data field in DocType 'Recorder Suggested Index'
 #: core/doctype/recorder_suggested_index/recorder_suggested_index.json
-msgctxt "Recorder Suggested Index"
+#: printing/page/print_format_builder/print_format_builder_column_selector.html:7
 msgid "Column"
 msgstr ""
 
@@ -5902,33 +4693,16 @@ msgstr ""
 msgid "Column <b>{0}</b> already exist."
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Column Break"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Column Break"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Column Break"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Column Break"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Column Break"
 msgstr ""
 
@@ -5936,13 +4710,9 @@ msgstr ""
 msgid "Column Labels:"
 msgstr ""
 
-#: core/doctype/data_export/exporter.py:25
-msgid "Column Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Kanban Board Column'
+#: core/doctype/data_export/exporter.py:25
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Column Name"
 msgstr ""
 
@@ -5962,40 +4732,21 @@ msgstr ""
 msgid "Column {0}"
 msgstr ""
 
-#. Label of a Int field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Columns"
-msgstr ""
-
-#. Label of a Int field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Columns"
-msgstr ""
-
 #. Label of a Int field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Columns"
-msgstr ""
-
-#. Label of a Table field in DocType 'Kanban Board'
-#: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
-msgid "Columns"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Report'
 #. Label of a Table field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
+#. Label of a Int field in DocType 'Custom Field'
+#. Label of a Int field in DocType 'Customize Form Field'
+#. Label of a Table field in DocType 'Kanban Board'
+#: core/doctype/docfield/docfield.json core/doctype/report/report.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/kanban_board/kanban_board.json
 msgid "Columns"
 msgstr ""
 
 #. Label of a HTML Editor field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "Columns / Fields"
 msgstr ""
 
@@ -6009,53 +4760,37 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Comm10E"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/comment/comment.json core/doctype/version/version_view.html:3
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
+#. Option for the 'Communication Type' (Select) field in DocType
+#. 'Communication'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
+#: core/doctype/version/version_view.html:3
 #: public/js/frappe/form/controls/comment.js:9
 #: public/js/frappe/form/sidebar/assign_to.js:236
 #: templates/includes/comments/comments.html:34
 msgid "Comment"
 msgstr ""
 
-#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Comment"
-msgstr ""
-
-#. Option for the 'Communication Type' (Select) field in DocType
-#. 'Communication'
-#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Comment"
-msgstr ""
-
 #. Label of a Data field in DocType 'Comment'
 #: core/doctype/comment/comment.json
-msgctxt "Comment"
 msgid "Comment By"
 msgstr ""
 
 #. Label of a Data field in DocType 'Comment'
 #: core/doctype/comment/comment.json
-msgctxt "Comment"
 msgid "Comment Email"
 msgstr ""
 
 #. Label of a Select field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Comment Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Comment Type"
 msgstr ""
 
@@ -6065,13 +4800,11 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Comment limit"
 msgstr ""
 
 #. Description of the 'Comment limit' (Int) field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Comment limit per hour"
 msgstr ""
 
@@ -6083,7 +4816,6 @@ msgstr ""
 
 #. Description of the 'Timeline Field' (Data) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Comments and Communications will be associated with this linked document"
 msgstr ""
 
@@ -6093,19 +4825,16 @@ msgstr ""
 
 #. Option for the 'Rounding Method' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Commercial Rounding"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "Commit"
 msgstr ""
 
 #. Label of a Check field in DocType 'Console Log'
 #: desk/doctype/console_log/console_log.json
-msgctxt "Console Log"
 msgid "Committed"
 msgstr ""
 
@@ -6114,33 +4843,15 @@ msgid "Common names and surnames are easy to guess."
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/communication/communication.json tests/test_translate.py:35
-#: tests/test_translate.py:103
-msgid "Communication"
-msgstr ""
-
 #. Option for the 'Communication Type' (Select) field in DocType
 #. 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Communication"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Flag Queue'
-#: email/doctype/email_flag_queue/email_flag_queue.json
-msgctxt "Email Flag Queue"
-msgid "Communication"
-msgstr ""
-
-#. Label of a Link field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Communication"
-msgstr ""
-
 #. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
+#. Label of a Data field in DocType 'Email Flag Queue'
+#. Label of a Link field in DocType 'Email Queue'
+#: core/doctype/communication/communication.json core/doctype/user/user.json
+#: email/doctype/email_flag_queue/email_flag_queue.json
+#: email/doctype/email_queue/email_queue.json tests/test_translate.py:35
+#: tests/test_translate.py:103
 msgid "Communication"
 msgstr ""
 
@@ -6157,7 +4868,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Communication Type"
 msgstr ""
 
@@ -6172,13 +4882,11 @@ msgstr ""
 
 #. Label of a Text Editor field in DocType 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "Company Introduction"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Company Name"
 msgstr ""
 
@@ -6188,7 +4896,7 @@ msgstr ""
 msgid "Compare Versions"
 msgstr ""
 
-#: core/doctype/server_script/server_script.py:153
+#: core/doctype/server_script/server_script.py:156
 msgid "Compilation warning"
 msgstr ""
 
@@ -6196,13 +4904,9 @@ msgstr ""
 msgid "Compiled Successfully"
 msgstr ""
 
-#: www/complete_signup.html:21
-msgid "Complete"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Scheduled Job Log'
 #: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgctxt "Scheduled Job Log"
+#: www/complete_signup.html:21
 msgid "Complete"
 msgstr ""
 
@@ -6219,55 +4923,32 @@ msgctxt "Finish the setup wizard"
 msgid "Complete Setup"
 msgstr ""
 
-#: core/doctype/doctype/boilerplate/controller_list.html:31 utils/goal.py:117
-msgid "Completed"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Completed"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Completed"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Completed"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Prepared Report'
-#: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
-msgid "Completed"
-msgstr ""
-
+#. Option for the 'Status' (Select) field in DocType 'Event'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
 #. Option for the 'Status' (Select) field in DocType 'Workflow Action'
-#: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/doctype/boilerplate/controller_list.html:31
+#: core/doctype/prepared_report/prepared_report.json
+#: desk/doctype/event/event.json
+#: integrations/doctype/integration_request/integration_request.json
+#: utils/goal.py:117 workflow/doctype/workflow_action/workflow_action.json
 msgid "Completed"
 msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Action'
 #: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
 msgid "Completed By Role"
 msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Action'
 #: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
 msgid "Completed By User"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Web Template'
 #: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
 msgid "Component"
 msgstr ""
 
@@ -6275,83 +4956,47 @@ msgstr ""
 msgid "Compose Email"
 msgstr ""
 
+#. Label of a Select field in DocType 'Document Naming Rule Condition'
+#. Label of a Small Text field in DocType 'Bulk Update'
+#. Label of a Code field in DocType 'Notification'
+#. Label of a Data field in DocType 'Notification Recipient'
+#. Label of a Small Text field in DocType 'Webhook'
+#. Label of a Code field in DocType 'Energy Point Rule'
+#. Label of a Code field in DocType 'Workflow Transition'
+#: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
+#: desk/doctype/bulk_update/bulk_update.json
 #: desk/doctype/dashboard_chart/dashboard_chart.js:305
 #: desk/doctype/dashboard_chart/dashboard_chart.js:439
 #: desk/doctype/number_card/number_card.js:205
 #: desk/doctype/number_card/number_card.js:336
-#: website/doctype/web_form/web_form.js:197
-msgid "Condition"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Bulk Update'
-#: desk/doctype/bulk_update/bulk_update.json
-msgctxt "Bulk Update"
-msgid "Condition"
-msgstr ""
-
-#. Label of a Select field in DocType 'Document Naming Rule Condition'
-#: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
-msgid "Condition"
-msgstr ""
-
-#. Label of a Code field in DocType 'Energy Point Rule'
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "Condition"
-msgstr ""
-
-#. Label of a Code field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Condition"
-msgstr ""
-
-#. Label of a Data field in DocType 'Notification Recipient'
 #: email/doctype/notification_recipient/notification_recipient.json
-msgctxt "Notification Recipient"
-msgid "Condition"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
-msgid "Condition"
-msgstr ""
-
-#. Label of a Code field in DocType 'Workflow Transition'
+#: social/doctype/energy_point_rule/energy_point_rule.json
+#: website/doctype/web_form/web_form.js:197
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Condition"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Condition Description"
 msgstr ""
 
 #. Label of a JSON field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Condition JSON"
 msgstr ""
 
 #. Label of a Table field in DocType 'Document Naming Rule'
-#: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
-msgid "Conditions"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Workflow Transition'
+#: core/doctype/document_naming_rule/document_naming_rule.json
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Conditions"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Configuration"
 msgstr ""
 
@@ -6370,7 +5015,6 @@ msgstr ""
 #. Description of the 'Amended Documents' (Section Break) field in DocType
 #. 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid ""
 "Configure how amended documents will be named.<br>\n"
 "\n"
@@ -6418,7 +5062,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Email Group'
 #: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
 msgid "Confirmation Email Template"
 msgstr ""
 
@@ -6435,26 +5078,17 @@ msgstr ""
 msgid "Connect to {}"
 msgstr ""
 
+#. Label of a Link field in DocType 'Email Account'
 #. Name of a DocType
-#: integrations/doctype/connected_app/connected_app.json
-msgid "Connected App"
-msgstr ""
-
-#. Label of a Link field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Connected App"
-msgstr ""
-
 #. Label of a Link field in DocType 'Token Cache'
+#: email/doctype/email_account/email_account.json
+#: integrations/doctype/connected_app/connected_app.json
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Connected App"
 msgstr ""
 
 #. Label of a Link field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Connected User"
 msgstr ""
 
@@ -6475,31 +5109,16 @@ msgstr ""
 msgid "Connection lost. Some features might not work."
 msgstr ""
 
-#: public/js/frappe/form/dashboard.js:54
-msgid "Connections"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Connections"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'Module Def'
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Connections"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
+#: core/doctype/user/user.json public/js/frappe/form/dashboard.js:54
 msgid "Connections"
 msgstr ""
 
 #. Label of a Code field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "Console"
 msgstr ""
 
@@ -6514,25 +5133,18 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Constraints"
 msgstr ""
 
 #. Name of a DocType
-#: contacts/doctype/contact/contact.json
-#: core/doctype/communication/communication.js:113
-msgid "Contact"
-msgstr ""
-
 #. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
+#: contacts/doctype/contact/contact.json
+#: core/doctype/communication/communication.js:113 core/doctype/user/user.json
 msgid "Contact"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Contact Details"
 msgstr ""
 
@@ -6543,7 +5155,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Contact Numbers"
 msgstr ""
 
@@ -6574,7 +5185,6 @@ msgstr ""
 #. Description of the 'Query Options' (Small Text) field in DocType 'Contact Us
 #. Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Contact options, like \"Sales Query, Support Query\" etc each on a new line or separated by commas."
 msgstr ""
 
@@ -6586,93 +5196,48 @@ msgstr ""
 msgid "Contains {0} security fixes"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:1738
-#: website/report/website_analytics/website_analytics.js:41
-msgid "Content"
-msgstr ""
-
-#. Label of a Text Editor field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Content"
-msgstr ""
-
 #. Label of a HTML Editor field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Content"
-msgstr ""
-
-#. Label of a Text Editor field in DocType 'Help Article'
-#: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
-msgid "Content"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Content"
-msgstr ""
-
 #. Label of a Text Editor field in DocType 'Note'
-#: desk/doctype/note/note.json
-msgctxt "Note"
-msgid "Content"
-msgstr ""
-
+#. Label of a Long Text field in DocType 'Workspace'
+#. Label of a Section Break field in DocType 'Newsletter'
+#. Label of a Text Editor field in DocType 'Blog Post'
+#. Label of a Text Editor field in DocType 'Help Article'
 #. Label of a Tab Break field in DocType 'Web Page'
 #. Label of a Section Break field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Content"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Page View'
-#: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
-msgid "Content"
-msgstr ""
-
-#. Label of a Long Text field in DocType 'Workspace'
+#: core/doctype/comment/comment.json desk/doctype/note/note.json
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: email/doctype/newsletter/newsletter.json
+#: public/js/frappe/utils/utils.js:1738
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/help_article/help_article.json
+#: website/doctype/web_page/web_page.json
+#: website/doctype/web_page_view/web_page_view.json
+#: website/report/website_analytics/website_analytics.js:41
 msgid "Content"
 msgstr ""
 
 #. Label of a HTML Editor field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Content (HTML)"
 msgstr ""
 
 #. Label of a Markdown Editor field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Content (Markdown)"
 msgstr ""
 
 #. Label of a Data field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Content Hash"
 msgstr ""
 
-#. Label of a Select field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Content Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Content Type"
-msgstr ""
-
+#. Label of a Select field in DocType 'Blog Post'
 #. Label of a Select field in DocType 'Web Page'
+#: email/doctype/newsletter/newsletter.json
+#: website/doctype/blog_post/blog_post.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Content Type"
 msgstr ""
 
@@ -6685,20 +5250,14 @@ msgid "Content type for building the page"
 msgstr ""
 
 #. Label of a Data field in DocType 'Translation'
-#: core/doctype/translation/translation.json
-msgctxt "Translation"
-msgid "Context"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Web Page'
+#: core/doctype/translation/translation.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Context"
 msgstr ""
 
 #. Label of a Code field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Context Script"
 msgstr ""
 
@@ -6715,25 +5274,21 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Translation'
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
 msgid "Contributed"
 msgstr ""
 
 #. Label of a Data field in DocType 'Translation'
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
 msgid "Contribution Document Name"
 msgstr ""
 
 #. Label of a Select field in DocType 'Translation'
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
 msgid "Contribution Status"
 msgstr ""
 
 #. Description of the 'Sign ups' (Select) field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Controls whether new users can sign up using this Social Login Key. If unset, Website Settings is respected."
 msgstr ""
 
@@ -6759,7 +5314,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Copyright"
 msgstr ""
 
@@ -6791,28 +5345,16 @@ msgstr ""
 msgid "Couldn't save, please check the data you have entered"
 msgstr ""
 
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Group By Type' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Function' (Select) field in DocType 'Number Card'
+#. Label of a Int field in DocType 'System Health Report Workers'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/number_card/number_card.json
+#: desk/doctype/system_health_report_workers/system_health_report_workers.json
 #: public/js/frappe/ui/group_by/group_by.js:19
 #: public/js/frappe/ui/group_by/group_by.js:316
 #: workflow/doctype/workflow/workflow.js:162
-msgid "Count"
-msgstr ""
-
-#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
-#. Option for the 'Group By Type' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Count"
-msgstr ""
-
-#. Option for the 'Function' (Select) field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Count"
-msgstr ""
-
-#. Label of a Int field in DocType 'System Health Report Workers'
-#: desk/doctype/system_health_report_workers/system_health_report_workers.json
-msgctxt "System Health Report Workers"
 msgid "Count"
 msgstr ""
 
@@ -6820,65 +5362,42 @@ msgstr ""
 msgid "Count Customizations"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:523
-msgid "Count Filter"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Workspace Shortcut'
 #. Label of a Code field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: public/js/frappe/widgets/widget_dialog.js:523
 msgid "Count Filter"
 msgstr ""
 
 #. Label of a Int field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
 msgid "Counter"
 msgstr ""
 
-#. Name of a DocType
-#: geo/doctype/country/country.json
-msgid "Country"
-msgstr ""
-
 #. Label of a Link field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Country"
-msgstr ""
-
 #. Label of a Link field in DocType 'Address Template'
-#: contacts/doctype/address_template/address_template.json
-msgctxt "Address Template"
-msgid "Country"
-msgstr ""
-
-#. Label of a Data field in DocType 'Contact Us Settings'
-#: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
-msgid "Country"
-msgstr ""
-
 #. Label of a Link field in DocType 'System Settings'
+#. Name of a DocType
+#. Label of a Data field in DocType 'Contact Us Settings'
+#: contacts/doctype/address/address.json
+#: contacts/doctype/address_template/address_template.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: geo/doctype/country/country.json
+#: website/doctype/contact_us_settings/contact_us_settings.json
 msgid "Country"
 msgstr ""
 
-#: utils/__init__.py:117
+#: utils/__init__.py:126
 msgid "Country Code Required"
 msgstr ""
 
 #. Label of a Data field in DocType 'Country'
 #: geo/doctype/country/country.json
-msgctxt "Country"
 msgid "Country Name"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "County"
 msgstr ""
 
@@ -6888,33 +5407,21 @@ msgctxt "Number system"
 msgid "Cr"
 msgstr ""
 
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#. Label of a Check field in DocType 'User Document Type'
 #: core/doctype/communication/communication.js:117
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json
+#: core/doctype/user_document_type/user_document_type.json
 #: desk/doctype/dashboard_chart_source/dashboard_chart_source.js:15
 #: printing/page/print_format_builder_beta/print_format_builder_beta.js:46
 #: public/js/frappe/form/reminders.js:49
 #: public/js/frappe/views/file/file_view.js:112
 #: public/js/frappe/views/interaction.js:18
 #: public/js/frappe/views/reports/query_report.js:1188
-#: public/js/frappe/views/workspace/workspace.js:1230
+#: public/js/frappe/views/workspace/workspace.js:1231
 #: workflow/page/workflow_builder/workflow_builder.js:46
-msgid "Create"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Create"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Create"
-msgstr ""
-
-#. Label of a Check field in DocType 'User Document Type'
-#: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
 msgid "Create"
 msgstr ""
 
@@ -6939,7 +5446,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Create Contacts from Incoming Emails"
 msgstr ""
 
@@ -6948,19 +5454,17 @@ msgstr ""
 msgid "Create Custom Fields"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:938
+#: public/js/frappe/views/workspace/workspace.js:939
 msgid "Create Duplicate"
 msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Create Entry"
 msgstr ""
 
 #. Label of a Check field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
 msgid "Create Log"
 msgstr ""
 
@@ -6987,7 +5491,7 @@ msgstr ""
 msgid "Create User Email"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:478
+#: public/js/frappe/views/workspace/workspace.js:479
 msgid "Create Workspace"
 msgstr ""
 
@@ -7045,25 +5549,16 @@ msgstr ""
 msgid "Create your workflow visually using the Workflow Builder."
 msgstr ""
 
-#: public/js/frappe/views/file/file_view.js:337
-msgid "Created"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Created"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
+#: public/js/frappe/views/file/file_view.js:337
 msgid "Created"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Submission Queue'
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
 msgid "Created At"
 msgstr ""
 
@@ -7093,7 +5588,6 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
 msgid "Criticism"
 msgstr ""
 
@@ -7102,26 +5596,16 @@ msgid "Criticize"
 msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Cron"
-msgstr ""
-
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Cron"
 msgstr ""
 
 #. Label of a Data field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Cron Format"
-msgstr ""
-
 #. Label of a Data field in DocType 'Server Script'
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Cron Format"
 msgstr ""
 
@@ -7141,57 +5625,31 @@ msgstr ""
 msgid "Ctrl+Enter to add comment"
 msgstr ""
 
+#. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Name of a DocType
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: desk/page/setup_wizard/setup_wizard.js:403
 #: geo/doctype/currency/currency.json
-msgid "Currency"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Currency"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Currency"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Currency"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Currency"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Currency"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Currency"
 msgstr ""
 
 #. Label of a Data field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Currency Name"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Currency Precision"
 msgstr ""
 
@@ -7202,19 +5660,16 @@ msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Current"
 msgstr ""
 
 #. Label of a Link field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Current Job ID"
 msgstr ""
 
 #. Label of a Int field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Current Value"
 msgstr ""
 
@@ -7230,125 +5685,67 @@ msgstr ""
 msgid "Currently you have {0} review points"
 msgstr ""
 
-#: core/doctype/user_type/user_type_list.js:7
-#: public/js/frappe/form/reminders.js:20
-msgid "Custom"
-msgstr ""
-
-#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Custom"
-msgstr ""
-
-#. Label of a Check field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Custom"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType Action'
-#: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
-msgid "Custom"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType Link'
-#: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
-msgid "Custom"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Custom"
-msgstr ""
-
-#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
-#. Rule'
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "Custom"
-msgstr ""
-
-#. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
-#: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
-msgid "Custom"
-msgstr ""
-
 #. Label of a Check field in DocType 'Module Def'
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Custom"
-msgstr ""
-
-#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Custom"
-msgstr ""
-
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
+#. Label of a Check field in DocType 'Desktop Icon'
 #. Option for the 'Type' (Select) field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Custom"
-msgstr ""
-
-#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
-#: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
-msgid "Custom"
-msgstr ""
-
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
+#. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
+#. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
+#: core/doctype/doctype_action/doctype_action.json
+#: core/doctype/doctype_link/doctype_link.json
+#: core/doctype/doctype_state/doctype_state.json
+#: core/doctype/module_def/module_def.json
+#: core/doctype/user_type/user_type_list.js:7
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/desktop_icon/desktop_icon.json
+#: desk/doctype/number_card/number_card.json
+#: email/doctype/notification/notification.json
+#: integrations/doctype/ldap_settings/ldap_settings.json
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
+#: printing/doctype/print_settings/print_settings.json
+#: public/js/frappe/form/reminders.js:20
+#: social/doctype/energy_point_rule/energy_point_rule.json
 msgid "Custom"
 msgstr ""
 
 #. Label of a Check field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Custom Base URL"
 msgstr ""
 
 #. Label of a Link field in DocType 'Workspace Custom Block'
 #: desk/doctype/workspace_custom_block/workspace_custom_block.json
-msgctxt "Workspace Custom Block"
 msgid "Custom Block Name"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Workspace'
 #. Label of a Table field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Custom Blocks"
 msgstr ""
 
 #. Label of a Code field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Custom CSS"
-msgstr ""
-
 #. Label of a Code field in DocType 'Web Form'
+#: printing/doctype/print_format/print_format.json
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Custom CSS"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Custom Configuration"
 msgstr ""
 
 #. Label of a Check field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Custom Delimiters"
 msgstr ""
 
@@ -7364,7 +5761,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'User Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "Custom Document Types (Select Permission)"
 msgstr ""
 
@@ -7376,7 +5772,10 @@ msgstr ""
 msgid "Custom Documents"
 msgstr ""
 
+#. Linked DocType in DocType's connections
+#. Linked DocType in Module Def's connections
 #. Name of a DocType
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
 #: custom/doctype/custom_field/custom_field.json
 msgid "Custom Field"
 msgstr ""
@@ -7384,18 +5783,6 @@ msgstr ""
 #. Label of a Link in the Build Workspace
 #: core/workspace/build/build.json
 msgctxt "Custom Field"
-msgid "Custom Field"
-msgstr ""
-
-#. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Custom Field"
-msgstr ""
-
-#. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
 msgid "Custom Field"
 msgstr ""
 
@@ -7418,19 +5805,16 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Custom Footer"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Custom Format"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Custom Group Search"
 msgstr ""
 
@@ -7450,7 +5834,6 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Custom HTML Help"
 msgstr ""
 
@@ -7459,38 +5842,29 @@ msgid "Custom LDAP Directoy Selected, please ensure 'LDAP Group Member attribute
 msgstr ""
 
 #. Label of a Data field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Custom Label"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Form List Column'
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_form_list_column/web_form_list_column.json
-msgctxt "Web Form List Column"
 msgid "Custom Label"
 msgstr ""
 
 #. Label of a Table field in DocType 'Portal Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Custom Menu Items"
 msgstr ""
 
 #. Label of a Code field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Custom Options"
 msgstr ""
 
 #. Label of a Code field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Custom Overrides"
 msgstr ""
 
 #. Option for the 'Report Type' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Custom Report"
 msgstr ""
 
@@ -7505,13 +5879,11 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Custom SCSS"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Portal Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Custom Sidebar Menu"
 msgstr ""
 
@@ -7525,44 +5897,22 @@ msgstr ""
 msgid "Custom field renamed to {0} successfully."
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:82
-msgid "Custom?"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Custom?"
-msgstr ""
-
 #. Label of a Check field in DocType 'Website Theme'
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:82
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Custom?"
-msgstr ""
-
-#. Label of a Card Break in the Build Workspace
-#. Title of the Module Onboarding 'Customization'
-#: core/workspace/build/build.json
-#: custom/module_onboarding/customization/customization.json
-msgid "Customization"
 msgstr ""
 
 #. Group in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Customization"
-msgstr ""
-
 #. Group in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Customization"
-msgstr ""
-
+#. Label of a Card Break in the Build Workspace
+#. Title of the Module Onboarding 'Customization'
 #. Label of a Tab Break field in DocType 'Web Form'
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
+#: core/workspace/build/build.json
+#: custom/module_onboarding/customization/customization.json
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Customization"
 msgstr ""
 
@@ -7571,7 +5921,7 @@ msgstr ""
 msgid "Customization onboarding is all done!"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:524
+#: public/js/frappe/views/workspace/workspace.js:525
 msgid "Customizations Discarded"
 msgstr ""
 
@@ -7641,44 +5991,28 @@ msgid "Cut"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Cyan"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Cyan"
 msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
-msgid "DELETE"
-msgstr ""
-
 #. Option for the 'Request Method' (Select) field in DocType 'Webhook'
+#: core/doctype/recorder/recorder.json
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "DELETE"
-msgstr ""
-
-#. Option for the 'Sort Order' (Select) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "DESC"
 msgstr ""
 
 #. Option for the 'Default Sort Order' (Select) field in DocType 'DocType'
+#. Option for the 'Sort Order' (Select) field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "DESC"
 msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "DLE"
 msgstr ""
 
@@ -7686,84 +6020,34 @@ msgstr ""
 msgid "DRAFT"
 msgstr ""
 
-#: public/js/frappe/utils/common.js:398
-#: website/report/website_analytics/website_analytics.js:23
-msgid "Daily"
-msgstr ""
-
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
+#. Option for the 'Frequency' (Select) field in DocType 'User'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
 #. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Daily"
-msgstr ""
-
 #. Option for the 'Backup Frequency' (Select) field in DocType 'Dropbox
 #. Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
-#. 'Energy Point Settings'
-#: social/doctype/energy_point_settings/energy_point_settings.json
-msgctxt "Energy Point Settings"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Repeat On' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Daily"
-msgstr ""
-
 #. Option for the 'Frequency' (Select) field in DocType 'Google Drive'
-#: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Daily"
-msgstr ""
-
 #. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
 #. Settings'
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
+#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
+#. 'Energy Point Settings'
+#: automation/doctype/auto_repeat/auto_repeat.json
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Daily"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/server_script/server_script.json core/doctype/user/user.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/event/event.json desk/doctype/number_card/number_card.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
+#: integrations/doctype/google_drive/google_drive.json
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
+#: public/js/frappe/utils/common.js:398
+#: social/doctype/energy_point_settings/energy_point_settings.json
+#: website/report/website_analytics/website_analytics.js:23
 msgid "Daily"
 msgstr ""
 
@@ -7776,32 +6060,24 @@ msgid "Daily Events should finish on the Same Day."
 msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Daily Long"
-msgstr ""
-
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Daily Long"
 msgstr ""
 
 #. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Danger"
 msgstr ""
 
 #. Option for the 'Desk Theme' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Dark"
 msgstr ""
 
 #. Label of a Link field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Dark Color"
 msgstr ""
 
@@ -7809,9 +6085,14 @@ msgstr ""
 msgid "Dark Theme"
 msgstr ""
 
+#. Label of a Check field in DocType 'Role'
 #. Name of a DocType
-#: core/page/dashboard_view/dashboard_view.js:10
-#: desk/doctype/dashboard/dashboard.json
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: core/doctype/role/role.json core/page/dashboard_view/dashboard_view.js:10
+#: desk/doctype/dashboard/dashboard.json desk/doctype/form_tour/form_tour.json
+#: desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: public/js/frappe/ui/toolbar/search_utils.js:562
 msgid "Dashboard"
 msgstr ""
@@ -7819,25 +6100,6 @@ msgstr ""
 #. Label of a Link in the Build Workspace
 #: core/workspace/build/build.json
 msgctxt "Dashboard"
-msgid "Dashboard"
-msgstr ""
-
-#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Dashboard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
-msgid "Dashboard"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
-#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
-#: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Dashboard"
 msgstr ""
 
@@ -7877,7 +6139,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Dashboard'
 #: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
 msgid "Dashboard Name"
 msgstr ""
 
@@ -7888,84 +6149,35 @@ msgstr ""
 
 #. Label of a Tab Break field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Dashboards"
 msgstr ""
 
 #. Label of a Card Break in the Tools Workspace
-#: automation/workspace/tools/tools.json
-msgid "Data"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Data"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Data"
-msgstr ""
-
 #. Label of a Code field in DocType 'Deleted Document'
-#: core/doctype/deleted_document/deleted_document.json
-msgctxt "Deleted Document"
-msgid "Data"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Data"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Data"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Data"
-msgstr ""
-
 #. Label of a Long Text field in DocType 'Transaction Log'
-#: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
-msgid "Data"
-msgstr ""
-
 #. Label of a Code field in DocType 'Version'
-#: core/doctype/version/version.json
-msgctxt "Version"
-msgid "Data"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Data"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
-#: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
-msgid "Data"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Label of a Table field in DocType 'Webhook'
-#: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
-msgid "Data"
-msgstr ""
-
 #. Label of a Code field in DocType 'Webhook Request Log'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: automation/workspace/tools/tools.json
+#: core/doctype/deleted_document/deleted_document.json
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: core/doctype/transaction_log/transaction_log.json
+#: core/doctype/version/version.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: integrations/doctype/webhook/webhook.json
 #: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
+#: website/doctype/web_form_field/web_form_field.json
+#: website/doctype/web_template_field/web_template_field.json
 msgid "Data"
 msgstr ""
 
@@ -7979,13 +6191,9 @@ msgid "Data Export"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/data_import/data_import.json
-msgid "Data Import"
-msgstr ""
-
 #. Label of a Link field in DocType 'Data Import Log'
+#: core/doctype/data_import/data_import.json
 #: core/doctype/data_import_log/data_import_log.json
-msgctxt "Data Import Log"
 msgid "Data Import"
 msgstr ""
 
@@ -8009,19 +6217,16 @@ msgstr ""
 #. Label of a Data field in DocType 'System Health Report'
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Database"
 msgstr ""
 
 #. Label of a Select field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Database Engine"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "Database Processes"
 msgstr ""
 
@@ -8044,88 +6249,45 @@ msgstr ""
 
 #. Label of a Data field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Database Version"
 msgstr ""
 
+#. Label of a Datetime field in DocType 'Activity Log'
+#. Label of a Datetime field in DocType 'Communication'
+#. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication/communication.json
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: desk/report/todo/todo.py:38 email/doctype/newsletter/newsletter.js:109
 #: public/js/frappe/views/interaction.js:80
-msgid "Date"
-msgstr ""
-
-#. Label of a Datetime field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Date"
-msgstr ""
-
-#. Label of a Datetime field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Date"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Date"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Date"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Date"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Date"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Date"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Date"
-msgstr ""
-
-#. Label of a Data field in DocType 'Country'
-#: geo/doctype/country/country.json
-msgctxt "Country"
-msgid "Date Format"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
+#. Label of a Data field in DocType 'Country'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: geo/doctype/country/country.json
 msgid "Date Format"
-msgstr ""
-
-#: desk/page/leaderboard/leaderboard.js:165
-msgid "Date Range"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Audit Trail'
 #: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
+#: desk/page/leaderboard/leaderboard.js:165
 msgid "Date Range"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Date and Number Format"
 msgstr ""
 
@@ -8137,79 +6299,46 @@ msgstr ""
 msgid "Dates are often easy to guess."
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Datetime"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Datetime"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Datetime"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Datetime"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Datetime"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Datetime"
-msgstr ""
-
-#: public/js/frappe/views/calendar/calendar.js:277
-msgid "Day"
 msgstr ""
 
 #. Label of a Select field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Day"
-msgstr ""
-
 #. Label of a Select field in DocType 'Auto Repeat Day'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
 #: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
+#: public/js/frappe/views/calendar/calendar.js:277
 msgid "Day"
 msgstr ""
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Day of Week"
 msgstr ""
 
 #. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Days After"
 msgstr ""
 
 #. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Days Before"
 msgstr ""
 
 #. Label of a Int field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Days Before or After"
 msgstr ""
 
@@ -8236,7 +6365,6 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Scheduled Job Log'
 #: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgctxt "Scheduled Job Log"
 msgid "Debug Log"
 msgstr ""
 
@@ -8248,43 +6376,19 @@ msgstr ""
 msgid "Decimal Separator must be a single character"
 msgstr ""
 
-#: templates/form_grid/fields.html:30
-msgid "Default"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Default"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Default"
-msgstr ""
-
-#. Option for the 'Font' (Select) field in DocType 'Print Settings'
-#: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
-msgid "Default"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Default"
-msgstr ""
-
+#. Label of a Small Text field in DocType 'Customize Form Field'
+#. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #. Label of a Data field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Default"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: printing/doctype/print_settings/print_settings.json
+#: templates/form_grid/fields.html:30
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Default"
 msgstr ""
 
@@ -8294,19 +6398,13 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Default Amendment Naming"
 msgstr ""
 
-#. Label of a Link field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Default Email Template"
-msgstr ""
-
 #. Label of a Link field in DocType 'DocType'
+#. Label of a Link field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Default Email Template"
 msgstr ""
 
@@ -8314,79 +6412,56 @@ msgstr ""
 msgid "Default Inbox"
 msgstr ""
 
-#: email/doctype/email_account/email_account.py:201
-msgid "Default Incoming"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
+#: email/doctype/email_account/email_account.py:201
 msgid "Default Incoming"
 msgstr ""
 
 #. Label of a Check field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Default Letter Head"
 msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Amended Document Naming
 #. Settings'
-#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
-msgctxt "Amended Document Naming Settings"
-msgid "Default Naming"
-msgstr ""
-
 #. Option for the 'Default Amendment Naming' (Select) field in DocType
 #. 'Document Naming Settings'
+#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Default Naming"
-msgstr ""
-
-#: email/doctype/email_account/email_account.py:209
-msgid "Default Outgoing"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
+#: email/doctype/email_account/email_account.py:209
 msgid "Default Outgoing"
 msgstr ""
 
 #. Label of a Data field in DocType 'Portal Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Default Portal Home"
 msgstr ""
 
-#. Label of a Link field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Default Print Format"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Link field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Default Print Format"
 msgstr ""
 
 #. Label of a Link field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Default Print Language"
 msgstr ""
 
 #. Label of a Data field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Default Redirect URI"
 msgstr ""
 
 #. Label of a Link field in DocType 'Portal Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Default Role at Time of Signup"
 msgstr ""
 
@@ -8400,19 +6475,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Default Sort Field"
 msgstr ""
 
 #. Label of a Select field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Default Sort Order"
 msgstr ""
 
 #. Label of a Data field in DocType 'Print Format Field Template'
 #: printing/doctype/print_format_field_template/print_format_field_template.json
-msgctxt "Print Format Field Template"
 msgid "Default Template For Field"
 msgstr ""
 
@@ -8422,43 +6494,30 @@ msgstr ""
 
 #. Label of a Link field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Default User Role"
 msgstr ""
 
 #. Label of a Link field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Default User Type"
 msgstr ""
 
 #. Label of a Text field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Default Value"
-msgstr ""
-
 #. Label of a Data field in DocType 'Property Setter'
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "Default Value"
-msgstr ""
-
-#. Label of a Select field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Default View"
 msgstr ""
 
 #. Label of a Select field in DocType 'DocType'
+#. Label of a Select field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Default View"
 msgstr ""
 
 #. Label of a Link field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Default Workspace"
 msgstr ""
 
@@ -8476,7 +6535,6 @@ msgstr ""
 
 #. Description of the 'Heading' (Data) field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Default: \"Contact Us\""
 msgstr ""
 
@@ -8486,14 +6544,8 @@ msgid "DefaultValue"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Defaults"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/docfield/docfield.json core/doctype/user/user.json
 msgid "Defaults"
 msgstr ""
 
@@ -8513,16 +6565,21 @@ msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Delayed"
 msgstr ""
 
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#. Label of a Check field in DocType 'User Document Type'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json
+#: core/doctype/user_document_type/user_document_type.json
 #: core/doctype/user_permission/user_permission_list.js:189
 #: public/js/frappe/form/footer/form_timeline.js:613
 #: public/js/frappe/form/grid.js:63 public/js/frappe/form/toolbar.js:434
 #: public/js/frappe/views/reports/report_view.js:1654
 #: public/js/frappe/views/treeview.js:308
-#: public/js/frappe/views/workspace/workspace.js:836
+#: public/js/frappe/views/workspace/workspace.js:837
 #: templates/discussions/reply_card.html:35
 #: templates/discussions/reply_section.html:29
 msgid "Delete"
@@ -8530,24 +6587,6 @@ msgstr ""
 
 #: public/js/frappe/list/list_view.js:1926
 msgctxt "Button in list view actions menu"
-msgid "Delete"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Delete"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Delete"
-msgstr ""
-
-#. Label of a Check field in DocType 'User Document Type'
-#: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
 msgid "Delete"
 msgstr ""
 
@@ -8567,7 +6606,7 @@ msgstr ""
 msgid "Delete Kanban Board"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:837
+#: public/js/frappe/views/workspace/workspace.js:838
 msgid "Delete Workspace"
 msgstr ""
 
@@ -8594,34 +6633,20 @@ msgid "Delete {0} items permanently?"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Deleted"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Deleted"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Request'
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
-msgid "Deleted"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Step'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 #: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
-msgctxt "Personal Data Deletion Step"
 msgid "Deleted"
 msgstr ""
 
 #. Label of a Data field in DocType 'Deleted Document'
 #: core/doctype/deleted_document/deleted_document.json
-msgctxt "Deleted Document"
 msgid "Deleted DocType"
 msgstr ""
 
@@ -8638,7 +6663,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Deleted Document'
 #: core/doctype/deleted_document/deleted_document.json
-msgctxt "Deleted Document"
 msgid "Deleted Name"
 msgstr ""
 
@@ -8660,7 +6684,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Personal Data Deletion Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
 msgid "Deletion Steps "
 msgstr ""
 
@@ -8671,7 +6694,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Delimiter Options"
 msgstr ""
 
@@ -8685,33 +6707,22 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Delivery Status"
-msgstr ""
-
-#: templates/includes/oauth_confirmation.html:14
-msgid "Deny"
 msgstr ""
 
 #. Option for the 'Sign ups' (Select) field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
+#: templates/includes/oauth_confirmation.html:14
 msgid "Deny"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Department"
 msgstr ""
 
-#: www/attribution.html:29
-msgid "Dependencies"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
+#: desk/doctype/workspace_link/workspace_link.json www/attribution.html:29
 msgid "Dependencies"
 msgstr ""
 
@@ -8720,14 +6731,9 @@ msgid "Dependencies & Licenses"
 msgstr ""
 
 #. Label of a Code field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Depends On"
-msgstr ""
-
 #. Label of a Code field in DocType 'Customize Form Field'
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Depends On"
 msgstr ""
 
@@ -8739,148 +6745,72 @@ msgstr ""
 msgid "Descendants Of (inclusive)"
 msgstr ""
 
-#: desk/report/todo/todo.py:39 public/js/frappe/form/reminders.js:44
-#: public/js/frappe/widgets/widget_dialog.js:260 www/attribution.html:24
-msgid "Description"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Assignment Rule'
-#: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
-msgid "Description"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Blog Category'
-#: website/doctype/blog_category/blog_category.json
-msgctxt "Blog Category"
-msgid "Description"
-msgstr ""
-
-#. Label of a Text field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Description"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Description"
-msgstr ""
-
+#. Label of a Small Text field in DocType 'Reminder'
 #. Label of a Small Text field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Description"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Description"
-msgstr ""
-
+#. Label of a Text field in DocType 'Customize Form Field'
+#. Label of a Small Text field in DocType 'Desktop Icon'
 #. Label of a Text Editor field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Description"
-msgstr ""
-
 #. Label of a HTML Editor field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Description"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Onboarding Step'
 #. Label of a Markdown Editor field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Description"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Print Heading'
-#: printing/doctype/print_heading/print_heading.json
-msgctxt "Print Heading"
-msgid "Description"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Reminder'
-#: automation/doctype/reminder/reminder.json
-msgctxt "Reminder"
-msgid "Description"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Tag'
-#: desk/doctype/tag/tag.json
-msgctxt "Tag"
-msgid "Description"
-msgstr ""
-
 #. Label of a Text Editor field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Description"
-msgstr ""
-
-#. Label of a Text field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Description"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Description"
-msgstr ""
-
-#. Label of a Text field in DocType 'Website Slideshow Item'
-#: website/doctype/website_slideshow_item/website_slideshow_item.json
-msgctxt "Website Slideshow Item"
-msgid "Description"
-msgstr ""
-
 #. Label of a HTML Editor field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
+#. Label of a Small Text field in DocType 'Print Heading'
+#. Label of a Small Text field in DocType 'Blog Category'
+#. Label of a Text field in DocType 'Web Form Field'
+#. Label of a Small Text field in DocType 'Web Page'
+#. Label of a Text field in DocType 'Website Slideshow Item'
+#: automation/doctype/assignment_rule/assignment_rule.json
+#: automation/doctype/reminder/reminder.json
+#: core/doctype/docfield/docfield.json core/doctype/doctype/doctype.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/desktop_icon/desktop_icon.json desk/doctype/event/event.json
+#: desk/doctype/form_tour_step/form_tour_step.json
+#: desk/doctype/onboarding_step/onboarding_step.json desk/doctype/tag/tag.json
+#: desk/doctype/todo/todo.json desk/doctype/workspace_link/workspace_link.json
+#: desk/report/todo/todo.py:39
+#: printing/doctype/print_heading/print_heading.json
+#: public/js/frappe/form/reminders.js:44
+#: public/js/frappe/widgets/widget_dialog.js:260
+#: website/doctype/blog_category/blog_category.json
+#: website/doctype/web_form_field/web_form_field.json
+#: website/doctype/web_page/web_page.json
+#: website/doctype/website_slideshow_item/website_slideshow_item.json
+#: www/attribution.html:24
 msgid "Description"
 msgstr ""
 
 #. Description of the 'Blog Intro' (Small Text) field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Description for listing page, in plain text, only a couple of lines. (max 200 characters)"
 msgstr ""
 
 #. Description of the 'Description' (Section Break) field in DocType
 #. 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Description to inform the user about any action that is going to be performed"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Designation"
 msgstr ""
 
 #. Label of a Check field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "Desk Access"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Desk Settings"
 msgstr ""
 
 #. Label of a Select field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Desk Theme"
 msgstr ""
 
@@ -8924,27 +6854,15 @@ msgstr ""
 msgid "Desktop Icon already exists"
 msgstr ""
 
+#. Label of a Code field in DocType 'Scheduled Job Log'
+#. Label of a Tab Break field in DocType 'Customize Form'
+#. Label of a Section Break field in DocType 'Event'
+#: core/doctype/scheduled_job_log/scheduled_job_log.json
+#: custom/doctype/customize_form/customize_form.json
+#: desk/doctype/event/event.json
 #: desk/page/user_profile/user_profile_sidebar.html:45
 #: public/js/form_builder/store.js:259 public/js/form_builder/utils.js:38
 #: public/js/frappe/form/layout.js:135 public/js/frappe/views/treeview.js:271
-msgid "Details"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Details"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Details"
-msgstr ""
-
-#. Label of a Code field in DocType 'Scheduled Job Log'
-#: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgctxt "Scheduled Job Log"
 msgid "Details"
 msgstr ""
 
@@ -8962,67 +6880,56 @@ msgstr ""
 
 #. Description of the 'States' (Section Break) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Different \"States\" this document can exist in. Like \"Open\", \"Pending Approval\" etc."
 msgstr ""
 
 #. Label of a Int field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
 msgid "Digits"
 msgstr ""
 
 #. Label of a Select field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Directory Server"
 msgstr ""
 
 #. Label of a Check field in DocType 'List View Settings'
 #: desk/doctype/list_view_settings/list_view_settings.json
-msgctxt "List View Settings"
 msgid "Disable Auto Refresh"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Disable Change Log Notification"
 msgstr ""
 
 #. Label of a Check field in DocType 'List View Settings'
 #: desk/doctype/list_view_settings/list_view_settings.json
-msgctxt "List View Settings"
 msgid "Disable Comment Count"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Disable Comments"
 msgstr ""
 
 #. Label of a Check field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Disable Contact Us Page"
 msgstr ""
 
 #. Label of a Check field in DocType 'List View Settings'
 #: desk/doctype/list_view_settings/list_view_settings.json
-msgctxt "List View Settings"
 msgid "Disable Count"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Disable Document Sharing"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Disable Likes"
 msgstr ""
 
@@ -9032,13 +6939,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Disable SMTP server authentication"
 msgstr ""
 
 #. Label of a Check field in DocType 'List View Settings'
 #: desk/doctype/list_view_settings/list_view_settings.json
-msgctxt "List View Settings"
 msgid "Disable Sidebar Stats"
 msgstr ""
 
@@ -9048,105 +6953,51 @@ msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Disable Standard Email Footer"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Disable System Update Notification"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Disable Username/Password Login"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Disable signups"
 msgstr ""
 
-#: core/doctype/user/user_list.js:14
-#: public/js/frappe/form/templates/address_list.html:29
-#: public/js/frappe/model/indicator.js:108
-#: public/js/frappe/model/indicator.js:115
-msgid "Disabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Disabled"
-msgstr ""
-
 #. Label of a Check field in DocType 'Assignment Rule'
-#: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
-msgid "Disabled"
-msgstr ""
-
 #. Label of a Check field in DocType 'Auto Repeat'
 #. Option for the 'Status' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Disabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Blogger'
-#: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
-msgid "Disabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Document Naming Rule'
-#: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
-msgid "Disabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "Disabled"
-msgstr ""
-
 #. Label of a Check field in DocType 'Milestone Tracker'
-#: automation/doctype/milestone_tracker/milestone_tracker.json
-msgctxt "Milestone Tracker"
-msgid "Disabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Disabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Print Style'
-#: printing/doctype/print_style/print_style.json
-msgctxt "Print Style"
-msgid "Disabled"
-msgstr ""
-
+#. Label of a Check field in DocType 'Address'
+#. Label of a Check field in DocType 'Document Naming Rule'
 #. Label of a Check field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Disabled"
-msgstr ""
-
 #. Label of a Check field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
-msgid "Disabled"
-msgstr ""
-
 #. Label of a Check field in DocType 'Server Script'
+#. Label of a Check field in DocType 'Letter Head'
+#. Label of a Check field in DocType 'Print Format'
+#. Label of a Check field in DocType 'Print Style'
+#. Label of a Check field in DocType 'Blogger'
+#: automation/doctype/assignment_rule/assignment_rule.json
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: automation/doctype/milestone_tracker/milestone_tracker.json
+#: contacts/doctype/address/address.json
+#: core/doctype/document_naming_rule/document_naming_rule.json
+#: core/doctype/report/report.json core/doctype/role/role.json
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
+#: core/doctype/user/user_list.js:14
+#: printing/doctype/letter_head/letter_head.json
+#: printing/doctype/print_format/print_format.json
+#: printing/doctype/print_style/print_style.json
+#: public/js/frappe/form/templates/address_list.html:29
+#: public/js/frappe/model/indicator.js:108
+#: public/js/frappe/model/indicator.js:115 website/doctype/blogger/blogger.json
 msgid "Disabled"
 msgstr ""
 
@@ -9157,7 +7008,7 @@ msgstr ""
 #: public/js/frappe/form/toolbar.js:316
 #: public/js/frappe/views/communication.js:30
 #: public/js/frappe/views/dashboard/dashboard_view.js:70
-#: public/js/frappe/views/workspace/workspace.js:515
+#: public/js/frappe/views/workspace/workspace.js:516
 #: public/js/frappe/web_form/web_form.js:187
 msgid "Discard"
 msgstr ""
@@ -9181,7 +7032,6 @@ msgstr ""
 
 #. Description of the 'Suggested Indexes' (Table) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "Disclaimer: These indexes are suggested based on data and queries performed during this recording. These suggestions may or may not help."
 msgstr ""
 
@@ -9206,40 +7056,31 @@ msgctxt "Stop showing the onboarding widget."
 msgid "Dismiss"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Display"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocField'
+#. Label of a Section Break field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Display"
 msgstr ""
 
 #. Label of a Code field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Display Depends On"
 msgstr ""
 
 #. Label of a Code field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Display Depends On (JS)"
 msgstr ""
 
 #. Label of a Check field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Do Not Create New User "
 msgstr ""
 
 #. Description of the 'Do Not Create New User ' (Check) field in DocType 'LDAP
 #. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Do not create new user if user with email does not exist in the system"
 msgstr ""
 
@@ -9261,30 +7102,23 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Doc Event"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Doc Events"
 msgstr ""
 
 #. Label of a Select field in DocType 'Workflow Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Doc Status"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/docfield/docfield.json
-msgid "DocField"
-msgstr ""
-
 #. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
+#: core/doctype/docfield/docfield.json
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "DocField"
 msgstr ""
 
@@ -9306,34 +7140,38 @@ msgid ""
 "\t\t\t\t"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/data_export/exporter.py:26 core/doctype/doctype/doctype.json
-#: core/report/permitted_documents_for_user/permitted_documents_for_user.js:15
-#: website/doctype/website_slideshow/website_slideshow.js:18
-msgid "DocType"
-msgstr ""
-
 #. Label of a Link field in DocType 'Amended Document Naming Settings'
-#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
-msgctxt "Amended Document Naming Settings"
-msgid "DocType"
-msgstr ""
-
 #. Label of a Link field in DocType 'Audit Trail'
-#: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
-msgid "DocType"
-msgstr ""
-
+#. Name of a DocType
+#. Group in Module Def's connections
+#. Linked DocType in Module Def's connections
+#. Label of a Link field in DocType 'Permission Inspector'
+#. Label of a Link field in DocType 'Version'
 #. Label of a Link field in DocType 'Client Script'
-#: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
-msgid "DocType"
-msgstr ""
-
 #. Label of a Link field in DocType 'Custom Field'
+#. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
+#. Label of a Link field in DocType 'Property Setter'
+#. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
+#. Label of a Link field in DocType 'Workspace Quick List'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
+#. Label of a Link field in DocType 'Webhook'
+#. Label of a Link field in DocType 'Print Format'
+#: core/doctype/amended_document_naming_settings/amended_document_naming_settings.json
+#: core/doctype/audit_trail/audit_trail.json
+#: core/doctype/data_export/exporter.py:26 core/doctype/doctype/doctype.json
+#: core/doctype/module_def/module_def.json
+#: core/doctype/permission_inspector/permission_inspector.json
+#: core/doctype/version/version.json
+#: core/report/permitted_documents_for_user/permitted_documents_for_user.js:15
+#: custom/doctype/client_script/client_script.json
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
+#: custom/doctype/property_setter/property_setter.json
+#: desk/doctype/workspace_link/workspace_link.json
+#: desk/doctype/workspace_quick_list/workspace_quick_list.json
+#: desk/doctype/workspace_shortcut/workspace_shortcut.json
+#: integrations/doctype/webhook/webhook.json
+#: printing/doctype/print_format/print_format.json
+#: website/doctype/website_slideshow/website_slideshow.js:18
 msgid "DocType"
 msgstr ""
 
@@ -9344,81 +7182,20 @@ msgctxt "DocType"
 msgid "DocType"
 msgstr ""
 
-#. Group in Module Def's connections
-#. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "DocType"
-msgstr ""
-
-#. Label of a Link field in DocType 'Permission Inspector'
-#: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
-msgid "DocType"
-msgstr ""
-
-#. Label of a Link field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "DocType"
-msgstr ""
-
-#. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
-#. Label of a Link field in DocType 'Property Setter'
-#: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
-msgid "DocType"
-msgstr ""
-
-#. Label of a Link field in DocType 'Version'
-#: core/doctype/version/version.json
-msgctxt "Version"
-msgid "DocType"
-msgstr ""
-
-#. Label of a Link field in DocType 'Webhook'
-#: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
-msgid "DocType"
-msgstr ""
-
-#. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
-msgid "DocType"
-msgstr ""
-
-#. Label of a Link field in DocType 'Workspace Quick List'
-#: desk/doctype/workspace_quick_list/workspace_quick_list.json
-msgctxt "Workspace Quick List"
-msgid "DocType"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
-#: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
-msgid "DocType"
-msgstr ""
-
 #: core/doctype/doctype/doctype.py:1546
 msgid "DocType <b>{0}</b> provided for the field <b>{1}</b> must have atleast one Link field"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/doctype_action/doctype_action.json
-msgid "DocType Action"
-msgstr ""
-
 #. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
+#: core/doctype/doctype_action/doctype_action.json
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "DocType Action"
 msgstr ""
 
 #. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #. Label of a Select field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "DocType Event"
 msgstr ""
 
@@ -9433,13 +7210,9 @@ msgid "DocType Layout Field"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/doctype_link/doctype_link.json
-msgid "DocType Link"
-msgstr ""
-
 #. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
+#: core/doctype/doctype_link/doctype_link.json
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "DocType Link"
 msgstr ""
 
@@ -9448,19 +7221,14 @@ msgid "DocType Name"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/doctype_state/doctype_state.json
-msgid "DocType State"
-msgstr ""
-
 #. Option for the 'Applied On' (Select) field in DocType 'Property Setter'
+#: core/doctype/doctype_state/doctype_state.json
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "DocType State"
 msgstr ""
 
 #. Label of a Select field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "DocType View"
 msgstr ""
 
@@ -9495,7 +7263,6 @@ msgstr ""
 
 #. Description of the 'Document Type' (Link) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "DocType on which this Workflow is applicable."
 msgstr ""
 
@@ -9519,13 +7286,9 @@ msgstr ""
 msgid "DocTypes can not be modified, please use {0} instead"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:684
-msgid "Doctype"
-msgstr ""
-
 #. Label of a Link field in DocType 'Document Follow'
 #: email/doctype/document_follow/document_follow.json
-msgctxt "Document Follow"
+#: public/js/frappe/widgets/widget_dialog.js:684
 msgid "Doctype"
 msgstr ""
 
@@ -9537,55 +7300,32 @@ msgstr ""
 msgid "Doctype required"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1316
+#: public/js/frappe/views/workspace/workspace.js:1317
 msgid "Doctype with same route already exist. Please choose different title."
 msgstr ""
 
-#. Label of a Dynamic Link field in DocType 'Audit Trail'
-#: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
-msgid "Document"
-msgstr ""
-
-#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Document"
-msgstr ""
-
 #. Label of a Data field in DocType 'Milestone'
-#: automation/doctype/milestone/milestone.json
-msgctxt "Milestone"
-msgid "Document"
-msgstr ""
-
-#. Label of a Link field in DocType 'Notification Subscribed Document'
-#: desk/doctype/notification_subscribed_document/notification_subscribed_document.json
-msgctxt "Notification Subscribed Document"
-msgid "Document"
-msgstr ""
-
+#. Label of a Dynamic Link field in DocType 'Audit Trail'
+#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
 #. Label of a Dynamic Link field in DocType 'Permission Inspector'
+#. Label of a Link field in DocType 'Notification Subscribed Document'
+#: automation/doctype/milestone/milestone.json
+#: core/doctype/audit_trail/audit_trail.json core/doctype/doctype/doctype.json
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
+#: desk/doctype/notification_subscribed_document/notification_subscribed_document.json
 msgid "Document"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Document Actions"
-msgstr ""
-
-#. Name of a DocType
-#: email/doctype/document_follow/document_follow.json
-msgid "Document Follow"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User'
 #. Linked DocType in User's connections
+#. Name of a DocType
 #: core/doctype/user/user.json
-msgctxt "User"
+#: email/doctype/document_follow/document_follow.json
 msgid "Document Follow"
 msgstr ""
 
@@ -9595,19 +7335,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Document Link"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Document Linking"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Document Links"
 msgstr ""
 
@@ -9627,44 +7364,19 @@ msgstr ""
 msgid "Document Links Row #{0}: Table Fieldname is mandatory for internal links"
 msgstr ""
 
-#: core/doctype/user_permission/user_permission_list.js:36
-#: public/js/frappe/form/form_tour.js:60
-msgid "Document Name"
-msgstr ""
-
-#. Label of a Dynamic Link field in DocType 'DocShare'
-#: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
-msgid "Document Name"
-msgstr ""
-
-#. Label of a Dynamic Link field in DocType 'Document Follow'
-#: email/doctype/document_follow/document_follow.json
-msgctxt "Document Follow"
-msgid "Document Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Reminder'
-#: automation/doctype/reminder/reminder.json
-msgctxt "Reminder"
-msgid "Document Name"
-msgstr ""
-
-#. Label of a Dynamic Link field in DocType 'Tag Link'
-#: desk/doctype/tag_link/tag_link.json
-msgctxt "Tag Link"
-msgid "Document Name"
-msgstr ""
-
+#. Label of a Dynamic Link field in DocType 'DocShare'
 #. Label of a Data field in DocType 'Transaction Log'
-#: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
-msgid "Document Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Version'
-#: core/doctype/version/version.json
-msgctxt "Version"
+#. Label of a Dynamic Link field in DocType 'Tag Link'
+#. Label of a Dynamic Link field in DocType 'Document Follow'
+#: automation/doctype/reminder/reminder.json
+#: core/doctype/docshare/docshare.json
+#: core/doctype/transaction_log/transaction_log.json
+#: core/doctype/user_permission/user_permission_list.js:36
+#: core/doctype/version/version.json desk/doctype/tag_link/tag_link.json
+#: email/doctype/document_follow/document_follow.json
+#: public/js/frappe/form/form_tour.js:60
 msgid "Document Name"
 msgstr ""
 
@@ -9708,7 +7420,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "Document Share"
 msgstr ""
 
@@ -9719,7 +7430,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Document Share Key Expiry (in Days)"
 msgstr ""
 
@@ -9730,21 +7440,12 @@ msgstr ""
 msgid "Document Share Report"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Document States"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Document States"
-msgstr ""
-
+#. Label of a Section Break field in DocType 'Customize Form'
 #. Label of a Table field in DocType 'Workflow'
+#: core/doctype/doctype/doctype.json
+#: custom/doctype/customize_form/customize_form.json
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Document States"
 msgstr ""
 
@@ -9755,142 +7456,60 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Tag Link'
 #: desk/doctype/tag_link/tag_link.json
-msgctxt "Tag Link"
 msgid "Document Tag"
 msgstr ""
 
 #. Label of a Data field in DocType 'Tag Link'
 #: desk/doctype/tag_link/tag_link.json
-msgctxt "Tag Link"
 msgid "Document Title"
 msgstr ""
 
+#. Label of a Link field in DocType 'Assignment Rule'
+#. Label of a Link field in DocType 'Milestone'
+#. Label of a Link field in DocType 'Reminder'
+#. Label of a Link field in DocType 'Data Import'
+#. Label of a Link field in DocType 'DocShare'
+#. Label of a Link field in DocType 'Document Naming Rule'
+#. Label of a Link field in DocType 'Session Default'
+#. Label of a Link field in DocType 'User Document Type'
+#. Label of a Link field in DocType 'User Select Document Type'
+#. Label of a Link field in DocType 'DocType Layout'
+#. Label of a Link field in DocType 'Bulk Update'
+#. Label of a Link field in DocType 'Dashboard Chart'
+#. Label of a Link field in DocType 'Global Search DocType'
+#. Label of a Link field in DocType 'Notification Log'
+#. Label of a Link field in DocType 'Number Card'
+#. Option for the 'Type' (Select) field in DocType 'Number Card'
+#. Label of a Link field in DocType 'Tag Link'
+#. Label of a Link field in DocType 'Notification'
+#. Label of a Link field in DocType 'Print Format Field Template'
+#. Label of a Data field in DocType 'Personal Data Deletion Step'
+#. Label of a Link field in DocType 'Workflow'
+#: automation/doctype/assignment_rule/assignment_rule.json
+#: automation/doctype/milestone/milestone.json
+#: automation/doctype/reminder/reminder.json
+#: core/doctype/data_import/data_import.json
+#: core/doctype/docshare/docshare.json
+#: core/doctype/document_naming_rule/document_naming_rule.json
+#: core/doctype/session_default/session_default.json
+#: core/doctype/user_document_type/user_document_type.json
 #: core/doctype/user_permission/user_permission_list.js:26
+#: core/doctype/user_select_document_type/user_select_document_type.json
 #: core/page/permission_manager/permission_manager.js:49
 #: core/page/permission_manager/permission_manager.js:211
 #: core/page/permission_manager/permission_manager.js:443
-#: public/js/frappe/roles_editor.js:66
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Assignment Rule'
-#: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Bulk Update'
-#: desk/doctype/bulk_update/bulk_update.json
-msgctxt "Bulk Update"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Data Import'
-#: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'DocShare'
-#: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'DocType Layout'
 #: custom/doctype/doctype_layout/doctype_layout.json
-msgctxt "DocType Layout"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Document Naming Rule'
-#: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Global Search DocType'
+#: desk/doctype/bulk_update/bulk_update.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/global_search_doctype/global_search_doctype.json
-msgctxt "Global Search DocType"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Milestone'
-#: automation/doctype/milestone/milestone.json
-msgctxt "Milestone"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Number Card'
-#. Option for the 'Type' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Data field in DocType 'Personal Data Deletion Step'
-#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
-msgctxt "Personal Data Deletion Step"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Print Format Field Template'
-#: printing/doctype/print_format_field_template/print_format_field_template.json
-msgctxt "Print Format Field Template"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Reminder'
-#: automation/doctype/reminder/reminder.json
-msgctxt "Reminder"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Session Default'
-#: core/doctype/session_default/session_default.json
-msgctxt "Session Default"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Tag Link'
 #: desk/doctype/tag_link/tag_link.json
-msgctxt "Tag Link"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'User Document Type'
-#: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'User Select Document Type'
-#: core/doctype/user_select_document_type/user_select_document_type.json
-msgctxt "User Select Document Type"
-msgid "Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Workflow'
+#: email/doctype/notification/notification.json
+#: printing/doctype/print_format_field_template/print_format_field_template.json
+#: public/js/frappe/roles_editor.js:66
+#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Document Type"
 msgstr ""
 
@@ -9908,7 +7527,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Milestone Tracker'
 #: automation/doctype/milestone_tracker/milestone_tracker.json
-msgctxt "Milestone Tracker"
 msgid "Document Type to Track"
 msgstr ""
 
@@ -9918,19 +7536,16 @@ msgstr ""
 
 #. Label of a Table field in DocType 'User Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "Document Types"
 msgstr ""
 
 #. Label of a Table field in DocType 'User Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "Document Types (Select Permissions Only)"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "Document Types and Permissions"
 msgstr ""
 
@@ -9984,19 +7599,13 @@ msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Documentation Link"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Documentation URL"
-msgstr ""
-
 #. Label of a Data field in DocType 'Module Onboarding'
+#: core/doctype/docfield/docfield.json
 #: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
 msgid "Documentation URL"
 msgstr ""
 
@@ -10017,31 +7626,16 @@ msgid "Documents that were already restored"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/domain/domain.json
-msgid "Domain"
-msgstr ""
-
 #. Label of a Data field in DocType 'Domain'
-#: core/doctype/domain/domain.json
-msgctxt "Domain"
-msgid "Domain"
-msgstr ""
-
-#. Label of a Link field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Domain"
-msgstr ""
-
 #. Label of a Link field in DocType 'Has Domain'
-#: core/doctype/has_domain/has_domain.json
-msgctxt "Has Domain"
+#. Label of a Link field in DocType 'Email Account'
+#: core/doctype/domain/domain.json core/doctype/has_domain/has_domain.json
+#: email/doctype/email_account/email_account.json
 msgid "Domain"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Domain Name"
 msgstr ""
 
@@ -10052,14 +7646,12 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Domain Settings'
 #: core/doctype/domain_settings/domain_settings.json
-msgctxt "Domain Settings"
 msgid "Domains HTML"
 msgstr ""
 
 #. Description of the 'Ignore XSS Filter' (Check) field in DocType 'Custom
 #. Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
 msgid "Don't HTML Encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field"
 msgstr ""
 
@@ -10068,33 +7660,22 @@ msgid "Don't Import"
 msgstr ""
 
 #. Label of a Check field in DocType 'Workflow'
-#: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
-msgid "Don't Override Status"
-msgstr ""
-
 #. Label of a Check field in DocType 'Workflow Document State'
+#: workflow/doctype/workflow/workflow.json
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Don't Override Status"
 msgstr ""
 
 #. Label of a Check field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Don't Send Emails"
 msgstr ""
 
+#. Description of the 'Ignore XSS Filter' (Check) field in DocType 'DocField'
 #. Description of the 'Ignore XSS Filter' (Check) field in DocType 'Customize
 #. Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field"
-msgstr ""
-
-#. Description of the 'Ignore XSS Filter' (Check) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Don't encode HTML tags like &lt;script&gt; or just characters like &lt; or &gt;, as they could be intentionally used in this field"
 msgstr ""
 
@@ -10109,7 +7690,6 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Donut"
 msgstr ""
 
@@ -10151,7 +7731,6 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Download Template"
 msgstr ""
 
@@ -10169,7 +7748,7 @@ msgstr ""
 #: public/js/frappe/views/workspace/blocks/header.js:46
 #: public/js/frappe/views/workspace/blocks/paragraph.js:136
 #: public/js/frappe/views/workspace/blocks/spacer.js:44
-#: public/js/frappe/views/workspace/workspace.js:578
+#: public/js/frappe/views/workspace/workspace.js:579
 #: public/js/frappe/widgets/base_widget.js:33
 msgid "Drag"
 msgstr ""
@@ -10180,13 +7759,11 @@ msgstr ""
 
 #. Label of a Password field in DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
 msgid "Dropbox Access Token"
 msgstr ""
 
 #. Label of a Password field in DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
 msgid "Dropbox Refresh Token"
 msgstr ""
 
@@ -10207,26 +7784,23 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
-msgctxt "Navbar Settings"
 msgid "Dropdowns"
 msgstr ""
 
 #. Label of a Date field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
-msgctxt "ToDo"
 msgid "Due Date"
 msgstr ""
 
 #. Label of a Select field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Due Date Based On"
 msgstr ""
 
 #: public/js/frappe/form/grid_row_form.js:42
 #: public/js/frappe/form/toolbar.js:388
-#: public/js/frappe/views/workspace/workspace.js:821
-#: public/js/frappe/views/workspace/workspace.js:988
+#: public/js/frappe/views/workspace/workspace.js:822
+#: public/js/frappe/views/workspace/workspace.js:989
 msgid "Duplicate"
 msgstr ""
 
@@ -10242,8 +7816,8 @@ msgstr ""
 msgid "Duplicate Name"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:560
-#: public/js/frappe/views/workspace/workspace.js:822
+#: public/js/frappe/views/workspace/workspace.js:561
+#: public/js/frappe/views/workspace/workspace.js:823
 msgid "Duplicate Workspace"
 msgstr ""
 
@@ -10251,126 +7825,70 @@ msgstr ""
 msgid "Duplicate current row"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1003
+#: public/js/frappe/views/workspace/workspace.js:1004
 msgid "Duplicate of {0} named as {1} is created successfully"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Duration"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Duration"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Duration"
-msgstr ""
-
 #. Label of a Float field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
-msgid "Duration"
-msgstr ""
-
 #. Label of a Float field in DocType 'Recorder Query'
-#: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
-msgid "Duration"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Duration"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json core/doctype/recorder/recorder.json
+#: core/doctype/recorder_query/recorder_query.json
+#: core/doctype/report_column/report_column.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Duration"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Dynamic Filters"
 msgstr ""
 
 #. Label of a Code field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Dynamic Filters JSON"
-msgstr ""
-
 #. Label of a Code field in DocType 'Number Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Dynamic Filters JSON"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Dynamic Filters Section"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/dynamic_link/dynamic_link.json
-msgid "Dynamic Link"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Dynamic Link"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Dynamic Link"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Dynamic Link"
-msgstr ""
-
+#. Name of a DocType
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Dynamic Link"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/dynamic_link/dynamic_link.json
+#: core/doctype/report_column/report_column.json
 #: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Dynamic Link"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Dynamic Report Filters"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Dynamic Route"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Dynamic Template"
 msgstr ""
 
@@ -10383,6 +7901,8 @@ msgstr ""
 msgid "Each document created in ERPNext can have a unique ID generated for it, using a prefix defined for it. Though each document has some prefix pre-configured, you can further customize it using tools like Naming Series Tool and Document Naming Rule.\n"
 msgstr ""
 
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
+#: core/doctype/comment/comment.json
 #: core/page/dashboard_view/dashboard_view.js:169
 #: printing/page/print_format_builder/print_format_builder_start.html:8
 #: printing/page/print_format_builder_beta/print_format_builder_beta.js:46
@@ -10396,7 +7916,7 @@ msgstr ""
 #: public/js/frappe/views/reports/query_report.js:815
 #: public/js/frappe/views/reports/query_report.js:1635
 #: public/js/frappe/views/workspace/workspace.js:460
-#: public/js/frappe/views/workspace/workspace.js:815
+#: public/js/frappe/views/workspace/workspace.js:816
 #: public/js/frappe/widgets/base_widget.js:64
 #: public/js/frappe/widgets/chart_widget.js:298
 #: public/js/frappe/widgets/number_card_widget.js:331
@@ -10409,12 +7929,6 @@ msgstr ""
 
 #: public/js/frappe/list/list_view.js:2012
 msgctxt "Button in list view actions menu"
-msgid "Edit"
-msgstr ""
-
-#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
 msgid "Edit"
 msgstr ""
 
@@ -10512,23 +8026,15 @@ msgstr ""
 msgid "Edit Shortcut"
 msgstr ""
 
-#: public/js/frappe/utils/web_template.js:5
-msgid "Edit Values"
-msgstr ""
-
 #. Label of a Button field in DocType 'Web Page Block'
-#: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
-msgid "Edit Values"
-msgstr ""
-
 #. Label of a Button field in DocType 'Website Settings'
+#: public/js/frappe/utils/web_template.js:5
+#: website/doctype/web_page_block/web_page_block.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Edit Values"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:816
+#: public/js/frappe/views/workspace/workspace.js:817
 msgid "Edit Workspace"
 msgstr ""
 
@@ -10554,19 +8060,10 @@ msgstr ""
 msgid "Edit {0}"
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:57
-msgid "Editable Grid"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Editable Grid"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#. Label of a Check field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:57
+#: custom/doctype/customize_form/customize_form.json
 msgid "Editable Grid"
 msgstr ""
 
@@ -10582,7 +8079,6 @@ msgstr ""
 #. Description of the 'SMS Gateway URL' (Small Text) field in DocType 'SMS
 #. Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Eg. smsgateway.com/api/send_sms.cgi"
 msgstr ""
 
@@ -10592,93 +8088,58 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Element Selector"
 msgstr ""
 
 #. Label of a Card Break in the Tools Workspace
+#. Option for the 'Type' (Select) field in DocType 'Communication'
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#. Option for the 'Two Factor Authentication method' (Select) field in DocType
+#. 'System Settings'
+#. Label of a Tab Break field in DocType 'System Settings'
+#. Label of a Data field in DocType 'User'
+#. Label of a Section Break field in DocType 'User'
+#. Label of a Data field in DocType 'Event Participants'
+#. Label of a Data field in DocType 'Email Group Member'
+#. Label of a Data field in DocType 'Email Unsubscribe'
+#. Option for the 'Channel' (Select) field in DocType 'Notification'
+#. Label of a Data field in DocType 'Personal Data Deletion Request'
 #: automation/workspace/tools/tools.json
+#: core/doctype/communication/communication.json
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json
 #: core/doctype/success_action/success_action.js:57
+#: core/doctype/system_settings/system_settings.json
+#: core/doctype/user/user.json
+#: desk/doctype/event_participants/event_participants.json
+#: email/doctype/email_group_member/email_group_member.json
+#: email/doctype/email_unsubscribe/email_unsubscribe.json
 #: email/doctype/newsletter/newsletter.js:156
+#: email/doctype/notification/notification.json
 #: public/js/frappe/form/success_action.js:85
 #: public/js/frappe/form/toolbar.js:352
 #: templates/includes/comments/comments.html:25 templates/signup.html:9
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
 #: www/login.html:7 www/login.py:97
 msgid "Email"
 msgstr ""
 
-#. Option for the 'Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Email"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Email"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Email"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Group Member'
-#: email/doctype/email_group_member/email_group_member.json
-msgctxt "Email Group Member"
-msgid "Email"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Unsubscribe'
-#: email/doctype/email_unsubscribe/email_unsubscribe.json
-msgctxt "Email Unsubscribe"
-msgid "Email"
-msgstr ""
-
-#. Label of a Data field in DocType 'Event Participants'
-#: desk/doctype/event_participants/event_participants.json
-msgctxt "Event Participants"
-msgid "Email"
-msgstr ""
-
-#. Option for the 'Channel' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Email"
-msgstr ""
-
-#. Label of a Data field in DocType 'Personal Data Deletion Request'
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
-msgid "Email"
-msgstr ""
-
-#. Option for the 'Two Factor Authentication method' (Select) field in DocType
-#. 'System Settings'
-#. Label of a Tab Break field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
-msgid "Email"
-msgstr ""
-
-#. Label of a Data field in DocType 'User'
-#. Label of a Section Break field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Email"
-msgstr ""
-
-#. Name of a DocType
-#: core/doctype/communication/communication.js:199
-#: email/doctype/email_account/email_account.json
-msgid "Email Account"
-msgstr ""
-
 #. Label of a Link field in DocType 'Communication'
+#. Label of a Link field in DocType 'User Email'
+#. Name of a DocType
+#. Linked DocType in Email Domain's connections
+#. Label of a Data field in DocType 'Email Flag Queue'
+#. Label of a Link field in DocType 'Email Queue'
+#. Label of a Link field in DocType 'Unhandled Email'
+#: core/doctype/communication/communication.js:199
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
+#: core/doctype/user_email/user_email.json
+#: email/doctype/email_account/email_account.json
+#: email/doctype/email_domain/email_domain.json
+#: email/doctype/email_flag_queue/email_flag_queue.json
+#: email/doctype/email_queue/email_queue.json
+#: email/doctype/unhandled_email/unhandled_email.json
 msgid "Email Account"
 msgstr ""
 
@@ -10688,43 +8149,12 @@ msgctxt "Email Account"
 msgid "Email Account"
 msgstr ""
 
-#. Linked DocType in Email Domain's connections
-#: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
-msgid "Email Account"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Flag Queue'
-#: email/doctype/email_flag_queue/email_flag_queue.json
-msgctxt "Email Flag Queue"
-msgid "Email Account"
-msgstr ""
-
-#. Label of a Link field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Email Account"
-msgstr ""
-
-#. Label of a Link field in DocType 'Unhandled Email'
-#: email/doctype/unhandled_email/unhandled_email.json
-msgctxt "Unhandled Email"
-msgid "Email Account"
-msgstr ""
-
-#. Label of a Link field in DocType 'User Email'
-#: core/doctype/user_email/user_email.json
-msgctxt "User Email"
-msgid "Email Account"
-msgstr ""
-
 #: email/doctype/email_account/email_account.py:316
 msgid "Email Account Disabled."
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Email Account Name"
 msgstr ""
 
@@ -10736,38 +8166,20 @@ msgstr ""
 msgid "Email Account not setup. Please create a new Email Account from Settings > Email Account"
 msgstr ""
 
-#: desk/page/setup_wizard/setup_wizard.js:470 www/complete_signup.html:11
-#: www/login.html:164 www/login.html:196
-msgid "Email Address"
-msgstr ""
-
 #. Label of a Data field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Email Address"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Email Address"
-msgstr ""
-
 #. Label of a Data field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Email Address"
-msgstr ""
-
 #. Label of a Data field in DocType 'Google Contacts'
+#: contacts/doctype/address/address.json contacts/doctype/contact/contact.json
+#: desk/page/setup_wizard/setup_wizard.js:470
+#: email/doctype/email_account/email_account.json
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
+#: www/complete_signup.html:11 www/login.html:164 www/login.html:196
 msgid "Email Address"
 msgstr ""
 
 #. Description of the 'Email Address' (Data) field in DocType 'Google Contacts'
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
 msgid "Email Address whose Google Contacts are to be synced."
 msgstr ""
 
@@ -10793,12 +8205,15 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Email Footer Address"
 msgstr ""
 
 #. Name of a DocType
+#. Label of a Link field in DocType 'Email Group Member'
+#. Label of a Link field in DocType 'Newsletter Email Group'
 #: email/doctype/email_group/email_group.json
+#: email/doctype/email_group_member/email_group_member.json
+#: email/doctype/newsletter_email_group/newsletter_email_group.json
 msgid "Email Group"
 msgstr ""
 
@@ -10808,62 +8223,34 @@ msgctxt "Email Group"
 msgid "Email Group"
 msgstr ""
 
-#. Label of a Link field in DocType 'Email Group Member'
-#: email/doctype/email_group_member/email_group_member.json
-msgctxt "Email Group Member"
-msgid "Email Group"
-msgstr ""
-
-#. Label of a Link field in DocType 'Newsletter Email Group'
-#: email/doctype/newsletter_email_group/newsletter_email_group.json
-msgctxt "Newsletter Email Group"
-msgid "Email Group"
-msgstr ""
-
-#. Name of a DocType
-#: email/doctype/email_group_member/email_group_member.json
-msgid "Email Group Member"
-msgstr ""
-
 #. Linked DocType in Email Group's connections
+#. Name of a DocType
 #: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
+#: email/doctype/email_group_member/email_group_member.json
 msgid "Email Group Member"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact Email'
-#: contacts/doctype/contact_email/contact_email.json
-msgctxt "Contact Email"
-msgid "Email ID"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Rule'
-#: email/doctype/email_rule/email_rule.json
-msgctxt "Email Rule"
-msgid "Email ID"
-msgstr ""
-
 #. Label of a Data field in DocType 'User Email'
+#. Label of a Data field in DocType 'Email Rule'
+#: contacts/doctype/contact_email/contact_email.json
 #: core/doctype/user_email/user_email.json
-msgctxt "User Email"
+#: email/doctype/email_rule/email_rule.json
 msgid "Email ID"
 msgstr ""
 
 #. Label of a Table field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Email IDs"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Email Id"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Email Inbox"
 msgstr ""
 
@@ -10888,13 +8275,11 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Email Template'
 #: email/doctype/email_template/email_template.json
-msgctxt "Email Template"
 msgid "Email Reply Help"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Email Retry Limit"
 msgstr ""
 
@@ -10903,75 +8288,49 @@ msgstr ""
 msgid "Email Rule"
 msgstr ""
 
-#. Label of a Check field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Email Sent"
-msgstr ""
-
 #. Label of a Check field in DocType 'Newsletter'
+#. Label of a Check field in DocType 'Blog Post'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
+#: website/doctype/blog_post/blog_post.json
 msgid "Email Sent"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Email Sent At"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Email Settings"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Email Settings"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Email Settings"
-msgstr ""
-
+#. Label of a Section Break field in DocType 'Customize Form'
 #. Label of a Section Break field in DocType 'Notification Settings'
+#. Label of a Section Break field in DocType 'Auto Email Report'
+#: core/doctype/doctype/doctype.json
+#: custom/doctype/customize_form/customize_form.json
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Email Settings"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Email Signature"
 msgstr ""
 
 #. Label of a Select field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Email Status"
 msgstr ""
 
 #. Label of a Select field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Email Sync Option"
 msgstr ""
 
+#. Label of a Link field in DocType 'Communication'
 #. Name of a DocType
+#: core/doctype/communication/communication.json
 #: email/doctype/email_template/email_template.json
 #: public/js/frappe/views/communication.js:95
-msgid "Email Template"
-msgstr ""
-
-#. Label of a Link field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Email Template"
 msgstr ""
 
@@ -10983,13 +8342,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "Email Threads on Assigned Document"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Email To"
 msgstr ""
 
@@ -11016,7 +8373,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Emails"
 msgstr ""
 
@@ -11026,7 +8382,6 @@ msgstr ""
 
 #. Description of the 'Send Email Alert' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Emails will be sent with next possible workflow actions"
 msgstr ""
 
@@ -11035,26 +8390,13 @@ msgid "Embed code copied"
 msgstr ""
 
 #. Label of a Check field in DocType 'Google Calendar'
-#: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
-msgid "Enable"
-msgstr ""
-
 #. Label of a Check field in DocType 'Google Contacts'
-#: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
-msgid "Enable"
-msgstr ""
-
 #. Label of a Check field in DocType 'Google Drive'
-#: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
-msgid "Enable"
-msgstr ""
-
 #. Label of a Check field in DocType 'Google Settings'
+#: integrations/doctype/google_calendar/google_calendar.json
+#: integrations/doctype/google_contacts/google_contacts.json
+#: integrations/doctype/google_drive/google_drive.json
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid "Enable"
 msgstr ""
 
@@ -11064,37 +8406,31 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Enable Auto Reply"
 msgstr ""
 
 #. Label of a Check field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Enable Automatic Backup"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Enable Automatic Linking in Documents"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Enable Comments"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Enable Email Notification"
 msgstr ""
 
 #. Label of a Check field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "Enable Email Notifications"
 msgstr ""
 
@@ -11106,75 +8442,55 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Enable Google indexing"
 msgstr ""
 
+#. Label of a Check field in DocType 'Email Account'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_account/email_account.py:202
 msgid "Enable Incoming"
 msgstr ""
 
-#. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Enable Incoming"
-msgstr ""
-
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Enable Onboarding"
 msgstr ""
 
+#. Label of a Check field in DocType 'User Email'
+#. Label of a Check field in DocType 'Email Account'
+#: core/doctype/user_email/user_email.json
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_account/email_account.py:210
 msgid "Enable Outgoing"
 msgstr ""
 
-#. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Enable Outgoing"
-msgstr ""
-
-#. Label of a Check field in DocType 'User Email'
-#: core/doctype/user_email/user_email.json
-msgctxt "User Email"
-msgid "Enable Outgoing"
-msgstr ""
-
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Enable Password Policy"
 msgstr ""
 
 #. Label of a Check field in DocType 'Role Permission for Page and Report'
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
-msgctxt "Role Permission for Page and Report"
 msgid "Enable Prepared Report"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Enable Print Server"
 msgstr ""
 
 #. Label of a Check field in DocType 'Push Notification Settings'
 #: integrations/doctype/push_notification_settings/push_notification_settings.json
-msgctxt "Push Notification Settings"
 msgid "Enable Push Notification Relay"
 msgstr ""
 
 #. Label of a Check field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Enable Rate Limit"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Enable Raw Printing"
 msgstr ""
 
@@ -11184,7 +8500,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Enable Scheduled Jobs"
 msgstr ""
 
@@ -11194,19 +8509,16 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Enable Security"
 msgstr ""
 
 #. Label of a Check field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Enable Social Login"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Enable Social Sharing"
 msgstr ""
 
@@ -11214,13 +8526,8 @@ msgstr ""
 msgid "Enable Tracking Page Views"
 msgstr ""
 
-#: twofactor.py:449
-msgid "Enable Two Factor Auth"
-msgstr ""
-
 #. Label of a Check field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: core/doctype/system_settings/system_settings.json twofactor.py:449
 msgid "Enable Two Factor Auth"
 msgstr ""
 
@@ -11240,13 +8547,11 @@ msgstr ""
 #. Description of the 'Enable Email Notification' (Check) field in DocType
 #. 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Enable email notification for any comment or likes received on your Blog Post."
 msgstr ""
 
 #. Description of the 'Modal Trigger' (Check) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid ""
 "Enable if on click\n"
 "opens modal."
@@ -11254,90 +8559,36 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Enable in-app website tracking"
 msgstr ""
 
+#. Label of a Check field in DocType 'Language'
+#. Label of a Check field in DocType 'User'
+#. Label of a Check field in DocType 'Client Script'
+#. Label of a Check field in DocType 'Notification Settings'
+#. Label of a Check field in DocType 'Auto Email Report'
+#. Label of a Check field in DocType 'Notification'
+#. Label of a Check field in DocType 'Currency'
+#. Label of a Check field in DocType 'Dropbox Settings'
+#. Label of a Check field in DocType 'LDAP Settings'
+#. Label of a Check field in DocType 'Webhook'
+#. Label of a Check field in DocType 'Energy Point Rule'
+#. Label of a Check field in DocType 'Energy Point Settings'
+#. Label of a Check field in DocType 'Portal Menu Item'
+#: core/doctype/language/language.json core/doctype/user/user.json
+#: custom/doctype/client_script/client_script.json
+#: desk/doctype/notification_settings/notification_settings.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: email/doctype/notification/notification.json
+#: geo/doctype/currency/currency.json
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
+#: integrations/doctype/ldap_settings/ldap_settings.json
+#: integrations/doctype/webhook/webhook.json
 #: public/js/frappe/model/indicator.js:106
 #: public/js/frappe/model/indicator.js:117
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Client Script'
-#: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Currency'
-#: geo/doctype/currency/currency.json
-msgctxt "Currency"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Dropbox Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Energy Point Settings'
 #: social/doctype/energy_point_settings/energy_point_settings.json
-msgctxt "Energy Point Settings"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'LDAP Settings'
-#: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Language'
-#: core/doctype/language/language.json
-msgctxt "Language"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Notification Settings'
-#: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Portal Menu Item'
 #: website/doctype/portal_menu_item/portal_menu_item.json
-msgctxt "Portal Menu Item"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Enabled"
-msgstr ""
-
-#. Label of a Check field in DocType 'Webhook'
-#: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Enabled"
 msgstr ""
 
@@ -11350,16 +8601,11 @@ msgid "Enabled email inbox for user {0}"
 msgstr ""
 
 #. Description of the 'Is Calendar and Gantt' (Check) field in DocType
-#. 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Enables Calendar and Gantt views."
-msgstr ""
-
-#. Description of the 'Is Calendar and Gantt' (Check) field in DocType
 #. 'DocType'
+#. Description of the 'Is Calendar and Gantt' (Check) field in DocType
+#. 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Enables Calendar and Gantt views."
 msgstr ""
 
@@ -11375,27 +8621,20 @@ msgstr ""
 #. Description of the 'Relay Settings' (Section Break) field in DocType 'Push
 #. Notification Settings'
 #: integrations/doctype/push_notification_settings/push_notification_settings.json
-msgctxt "Push Notification Settings"
 msgid "Enabling this will register your site on a central relay server to send push notifications for all installed apps through Firebase Cloud Messaging. This server only stores user tokens and error logs, and no messages are saved. "
 msgstr ""
 
 #. Description of the 'Queue in Background (BETA)' (Check) field in DocType
-#. 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Enabling this will submit documents in background"
-msgstr ""
-
-#. Description of the 'Queue in Background (BETA)' (Check) field in DocType
 #. 'DocType'
+#. Description of the 'Queue in Background (BETA)' (Check) field in DocType
+#. 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Enabling this will submit documents in background"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Encrypt Backups"
 msgstr ""
 
@@ -11407,31 +8646,17 @@ msgstr ""
 msgid "Encryption key is invalid! Please check site_config.json"
 msgstr ""
 
-#: public/js/frappe/utils/common.js:416
-msgid "End Date"
-msgstr ""
-
-#. Label of a Date field in DocType 'Audit Trail'
-#: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
-msgid "End Date"
-msgstr ""
-
 #. Label of a Date field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "End Date"
-msgstr ""
-
+#. Label of a Date field in DocType 'Audit Trail'
 #. Label of a Datetime field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/audit_trail/audit_trail.json
+#: public/js/frappe/utils/common.js:416 website/doctype/web_page/web_page.json
 msgid "End Date"
 msgstr ""
 
 #. Label of a Select field in DocType 'Calendar View'
 #: desk/doctype/calendar_view/calendar_view.json
-msgctxt "Calendar View"
 msgid "End Date Field"
 msgstr ""
 
@@ -11440,60 +8665,43 @@ msgid "End Date cannot be before Start Date!"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Job'
-#: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
-msgid "Ended At"
-msgstr ""
-
 #. Label of a Datetime field in DocType 'Submission Queue'
+#: core/doctype/rq_job/rq_job.json
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
 msgid "Ended At"
 msgstr ""
 
 #. Label of a Data field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Endpoint URL"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Endpoints"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Ends on"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Energy Point"
 msgstr ""
 
+#. Linked DocType in User's connections
 #. Name of a DocType
+#: core/doctype/user/user.json
 #: social/doctype/energy_point_log/energy_point_log.json
 msgid "Energy Point Log"
 msgstr ""
 
-#. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Energy Point Log"
-msgstr ""
-
-#. Name of a DocType
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgid "Energy Point Rule"
-msgstr ""
-
 #. Linked DocType in DocType's connections
+#. Name of a DocType
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: social/doctype/energy_point_rule/energy_point_rule.json
 msgid "Energy Point Rule"
 msgstr ""
 
@@ -11506,21 +8714,16 @@ msgstr ""
 msgid "Energy Point Update on {0}"
 msgstr ""
 
+#. Label of a Check field in DocType 'Notification Settings'
+#: desk/doctype/notification_settings/notification_settings.json
 #: desk/page/user_profile/user_profile.html:28
 #: desk/page/user_profile/user_profile_controller.js:402
 #: templates/emails/energy_points_summary.html:39
 msgid "Energy Points"
 msgstr ""
 
-#. Label of a Check field in DocType 'Notification Settings'
-#: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
-msgid "Energy Points"
-msgstr ""
-
 #. Label of a Data field in DocType 'Submission Queue'
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
 msgid "Enqueued By"
 msgstr ""
 
@@ -11546,7 +8749,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Enter Form Type"
 msgstr ""
 
@@ -11561,7 +8763,6 @@ msgstr ""
 
 #. Description of the 'User Defaults' (Table) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Enter default value fields (keys) and values. If you add multiple values for a field, the first one will be picked. These defaults are also used to set \"match\" permission rules. To see list of fields, go to \"Customize Form\"."
 msgstr ""
 
@@ -11572,21 +8773,18 @@ msgstr ""
 #. Description of the 'Static Parameters' (Table) field in DocType 'SMS
 #. Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Enter static url parameters here (Eg. sender=ERPNext, username=ERPNext, password=1234 etc.)"
 msgstr ""
 
 #. Description of the 'Message Parameter' (Data) field in DocType 'SMS
 #. Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Enter url parameter for message"
 msgstr ""
 
 #. Description of the 'Receiver Parameter' (Data) field in DocType 'SMS
 #. Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Enter url parameter for receiver nos"
 msgstr ""
 
@@ -11606,62 +8804,30 @@ msgstr ""
 msgid "Equals"
 msgstr ""
 
-#: desk/page/backups/backups.js:35 model/base_document.py:731
-#: model/base_document.py:737 public/js/frappe/ui/messages.js:22
-msgid "Error"
-msgstr ""
-
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Error"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Data Import'
-#: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
-msgid "Error"
-msgstr ""
-
+#. Label of a Code field in DocType 'Error Log'
+#. Option for the 'Status' (Select) field in DocType 'Prepared Report'
 #. Option for the 'Status' (Select) field in DocType 'Email Queue'
 #. Label of a Code field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Error"
-msgstr ""
-
 #. Label of a Code field in DocType 'Email Queue Recipient'
-#: email/doctype/email_queue_recipient/email_queue_recipient.json
-msgctxt "Email Queue Recipient"
-msgid "Error"
-msgstr ""
-
-#. Label of a Code field in DocType 'Error Log'
-#: core/doctype/error_log/error_log.json
-msgctxt "Error Log"
-msgid "Error"
-msgstr ""
-
 #. Label of a Code field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Error"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Prepared Report'
+#. Label of a Text field in DocType 'Webhook Request Log'
+#: core/doctype/communication/communication.json
+#: core/doctype/data_import/data_import.json
+#: core/doctype/error_log/error_log.json
 #: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
+#: desk/page/backups/backups.js:35 email/doctype/email_queue/email_queue.json
+#: email/doctype/email_queue_recipient/email_queue_recipient.json
+#: integrations/doctype/integration_request/integration_request.json
+#: integrations/doctype/webhook_request_log/webhook_request_log.json
+#: model/base_document.py:731 model/base_document.py:737
+#: public/js/frappe/ui/messages.js:22
 msgid "Error"
 msgstr ""
 
 #: public/js/frappe/web_form/web_form.js:240
 msgctxt "Title of error message in web form"
-msgid "Error"
-msgstr ""
-
-#. Label of a Text field in DocType 'Webhook Request Log'
-#: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
 msgid "Error"
 msgstr ""
 
@@ -11682,7 +8848,6 @@ msgstr ""
 
 #. Label of a Text field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
 msgid "Error Message"
 msgstr ""
 
@@ -11742,53 +8907,35 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Errors"
 msgstr ""
 
-#. Name of a DocType
-#: desk/doctype/event/event.json
-msgid "Event"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Event"
-msgstr ""
-
+#. Name of a DocType
 #. Option for the 'Event Category' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
+#: core/doctype/communication/communication.json desk/doctype/event/event.json
 msgid "Event"
 msgstr ""
 
 #. Label of a Select field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Event Category"
 msgstr ""
 
 #. Label of a Select field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Event Frequency"
 msgstr ""
 
-#. Name of a DocType
-#: desk/doctype/event_participants/event_participants.json
-msgid "Event Participants"
-msgstr ""
-
 #. Label of a Table field in DocType 'Event'
+#. Name of a DocType
 #: desk/doctype/event/event.json
-msgctxt "Event"
+#: desk/doctype/event_participants/event_participants.json
 msgid "Event Participants"
 msgstr ""
 
 #. Label of a Check field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "Event Reminders"
 msgstr ""
 
@@ -11797,15 +8944,9 @@ msgstr ""
 msgid "Event Synced with Google Calendar."
 msgstr ""
 
-#. Label of a Select field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Event Type"
-msgstr ""
-
 #. Label of a Data field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
+#. Label of a Select field in DocType 'Event'
+#: core/doctype/recorder/recorder.json desk/doctype/event/event.json
 msgid "Event Type"
 msgstr ""
 
@@ -11825,71 +8966,58 @@ msgid ""
 "Once custom fields are added, you can use them for reports and analytics charts as well.\n"
 msgstr ""
 
-#: public/js/frappe/form/templates/set_sharing.html:11
-msgid "Everyone"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocShare'
 #: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
+#: public/js/frappe/form/templates/set_sharing.html:11
 msgid "Everyone"
 msgstr ""
 
 #. Description of the 'Custom Options' (Code) field in DocType 'Dashboard
 #. Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"]"
 msgstr ""
 
 #. Label of a Int field in DocType 'Recorder Query'
 #: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
 msgid "Exact Copies"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Example"
 msgstr ""
 
 #. Description of the 'Default Portal Home' (Data) field in DocType 'Portal
 #. Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Example: \"/desk\""
 msgstr ""
 
 #. Description of the 'Path' (Data) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Example: #Tree/Account"
 msgstr ""
 
 #. Description of the 'Digits' (Int) field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
 msgid "Example: 00001"
 msgstr ""
 
 #. Description of the 'Session Expiry (idle timeout)' (Data) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Example: Setting this to 24:00 will log out a user if they are not active for 24:00 hours."
 msgstr ""
 
 #. Description of the 'Description' (Small Text) field in DocType 'Assignment
 #. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Example: {{ subject }}"
 msgstr ""
 
 #. Option for the 'File Type' (Select) field in DocType 'Data Export'
 #: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
 msgid "Excel"
 msgstr ""
 
@@ -11898,31 +9026,18 @@ msgid "Excellent"
 msgstr ""
 
 #. Label of a Text field in DocType 'Data Import Log'
-#: core/doctype/data_import_log/data_import_log.json
-msgctxt "Data Import Log"
-msgid "Exception"
-msgstr ""
-
 #. Label of a Code field in DocType 'RQ Job'
-#: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
-msgid "Exception"
-msgstr ""
-
 #. Label of a Long Text field in DocType 'Submission Queue'
+#: core/doctype/data_import_log/data_import_log.json
+#: core/doctype/rq_job/rq_job.json
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
 msgid "Exception"
-msgstr ""
-
-#: desk/doctype/system_console/system_console.js:17
-#: desk/doctype/system_console/system_console.js:22
-msgid "Execute"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Console'
+#: desk/doctype/system_console/system_console.js:17
+#: desk/doctype/system_console/system_console.js:22
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "Execute"
 msgstr ""
 
@@ -11940,7 +9055,6 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Executive"
 msgstr ""
 
@@ -11964,59 +9078,47 @@ msgstr ""
 
 #. Option for the 'Level' (Select) field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Expert"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'OAuth Authorization Code'
-#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
-msgid "Expiration time"
-msgstr ""
-
 #. Label of a Datetime field in DocType 'OAuth Bearer Token'
+#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
 #: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
 msgid "Expiration time"
 msgstr ""
 
 #. Label of a Date field in DocType 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
 msgid "Expire Notification On"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Expired"
 msgstr ""
 
 #. Label of a Int field in DocType 'OAuth Bearer Token'
-#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
-msgid "Expires In"
-msgstr ""
-
 #. Label of a Int field in DocType 'Token Cache'
+#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Expires In"
 msgstr ""
 
 #. Label of a Date field in DocType 'Document Share Key'
 #: core/doctype/document_share_key/document_share_key.json
-msgctxt "Document Share Key"
 msgid "Expires On"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Expiry time of QR Code Image Page"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:37
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json core/doctype/recorder/recorder_list.js:37
 #: public/js/frappe/data_import/data_exporter.js:91
 #: public/js/frappe/data_import/data_exporter.js:242
 #: public/js/frappe/views/reports/query_report.js:1670
@@ -12026,18 +9128,6 @@ msgstr ""
 
 #: public/js/frappe/list/list_view.js:2034
 msgctxt "Button in list view actions menu"
-msgid "Export"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Export"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
 msgid "Export"
 msgstr ""
 
@@ -12070,7 +9160,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "Export From"
 msgstr ""
 
@@ -12106,13 +9195,11 @@ msgstr ""
 #. Description of the 'Export without main header' (Check) field in DocType
 #. 'Data Export'
 #: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
 msgid "Export the data without any header notes and column descriptions"
 msgstr ""
 
 #. Label of a Check field in DocType 'Data Export'
 #: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
 msgid "Export without main header"
 msgstr ""
 
@@ -12126,106 +9213,74 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Expose Recipients"
 msgstr ""
 
+#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Expression"
 msgstr ""
 
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Expression"
-msgstr ""
-
 #. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Expression (old style)"
-msgstr ""
-
-#. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Expression (old style)"
 msgstr ""
 
 #. Description of the 'Condition' (Data) field in DocType 'Notification
 #. Recipient'
 #: email/doctype/notification_recipient/notification_recipient.json
-msgctxt "Notification Recipient"
 msgid "Expression, Optional"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Extra Parameters"
 msgstr ""
 
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Facebook"
 msgstr ""
 
 #. Option for the 'SocketIO Ping Check' (Select) field in DocType 'System
 #. Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Fail"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Failed"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Failed"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Scheduled Job Log'
-#: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgctxt "Scheduled Job Log"
-msgid "Failed"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Submission Queue'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/scheduled_job_log/scheduled_job_log.json
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
+#: integrations/doctype/integration_request/integration_request.json
 msgid "Failed"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Failed Emails"
 msgstr ""
 
 #. Label of a Int field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Failed Job Count"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report Workers'
 #: desk/doctype/system_health_report_workers/system_health_report_workers.json
-msgctxt "System Health Report Workers"
 msgid "Failed Jobs"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Failed Logins (Last 30 days)"
 msgstr ""
 
@@ -12313,7 +9368,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Failing Scheduled Jobs (last 7 days)"
 msgstr ""
 
@@ -12323,65 +9377,44 @@ msgstr ""
 
 #. Label of a Percent field in DocType 'System Health Report Failing Jobs'
 #: desk/doctype/system_health_report_failing_jobs/system_health_report_failing_jobs.json
-msgctxt "System Health Report Failing Jobs"
 msgid "Failure Rate"
 msgstr ""
 
 #. Label of a Attach field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "FavIcon"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Fax"
-msgstr ""
-
-#: website/doctype/blog_post/templates/blog_post_row.html:19
-msgid "Featured"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
+#: website/doctype/blog_post/templates/blog_post_row.html:19
 msgid "Featured"
-msgstr ""
-
-#: public/js/frappe/form/templates/form_sidebar.html:33
-msgid "Feedback"
 msgstr ""
 
 #. Option for the 'Communication Type' (Select) field in DocType
 #. 'Communication'
 #. Label of a Section Break field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
+#: public/js/frappe/form/templates/form_sidebar.html:33
 msgid "Feedback"
 msgstr ""
 
 #. Label of a Data field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Feedback Request"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Fetch From"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Fetch From"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'DocField'
+#. Label of a Small Text field in DocType 'Custom Field'
+#. Label of a Small Text field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Fetch From"
 msgstr ""
 
@@ -12393,21 +9426,12 @@ msgstr ""
 msgid "Fetch attached images from document"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Fetch on Save if Empty"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Fetch on Save if Empty"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Fetch on Save if Empty"
 msgstr ""
 
@@ -12415,53 +9439,25 @@ msgstr ""
 msgid "Fetching default Global Search documents."
 msgstr ""
 
+#. Label of a Select field in DocType 'Assignment Rule'
+#. Label of a Select field in DocType 'Document Naming Rule Condition'
+#. Label of a Select field in DocType 'Bulk Update'
+#. Label of a Select field in DocType 'Number Card'
+#. Label of a Select field in DocType 'Onboarding Step'
+#. Label of a Select field in DocType 'Web Form Field'
+#. Label of a Select field in DocType 'Web Form List Column'
+#: automation/doctype/assignment_rule/assignment_rule.json
+#: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
+#: desk/doctype/bulk_update/bulk_update.json
+#: desk/doctype/number_card/number_card.json
+#: desk/doctype/onboarding_step/onboarding_step.json
 #: desk/page/leaderboard/leaderboard.js:131
 #: public/js/frappe/list/bulk_operations.js:297
 #: public/js/frappe/list/list_view_permission_restrictions.html:3
 #: public/js/frappe/views/reports/query_report.js:236
 #: public/js/frappe/views/reports/query_report.js:1724
-msgid "Field"
-msgstr ""
-
-#. Label of a Select field in DocType 'Assignment Rule'
-#: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
-msgid "Field"
-msgstr ""
-
-#. Label of a Select field in DocType 'Bulk Update'
-#: desk/doctype/bulk_update/bulk_update.json
-msgctxt "Bulk Update"
-msgid "Field"
-msgstr ""
-
-#. Label of a Select field in DocType 'Document Naming Rule Condition'
-#: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
-msgid "Field"
-msgstr ""
-
-#. Label of a Select field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Field"
-msgstr ""
-
-#. Label of a Select field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Field"
-msgstr ""
-
-#. Label of a Select field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Field"
-msgstr ""
-
-#. Label of a Select field in DocType 'Web Form List Column'
 #: website/doctype/web_form_list_column/web_form_list_column.json
-msgctxt "Web Form List Column"
 msgid "Field"
 msgstr ""
 
@@ -12479,7 +9475,6 @@ msgstr ""
 
 #. Label of a Text field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
 msgid "Field Description"
 msgstr ""
 
@@ -12487,15 +9482,10 @@ msgstr ""
 msgid "Field Missing"
 msgstr ""
 
-#. Label of a Select field in DocType 'Kanban Board'
-#: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
-msgid "Field Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Property Setter'
+#. Label of a Select field in DocType 'Kanban Board'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
+#: desk/doctype/kanban_board/kanban_board.json
 msgid "Field Name"
 msgstr ""
 
@@ -12505,17 +9495,12 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Field To Check"
-msgstr ""
-
-#: templates/form_grid/fields.html:40
-msgid "Field Type"
 msgstr ""
 
 #. Label of a Select field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
+#: templates/form_grid/fields.html:40
 msgid "Field Type"
 msgstr ""
 
@@ -12525,13 +9510,11 @@ msgstr ""
 
 #. Description of the 'Workflow State Field' (Data) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Field that represents the Workflow State of the transaction (if field is not present, a new hidden Custom Field will be created)"
 msgstr ""
 
 #. Label of a Select field in DocType 'Milestone Tracker'
 #: automation/doctype/milestone_tracker/milestone_tracker.json
-msgctxt "Milestone Tracker"
 msgid "Field to Track"
 msgstr ""
 
@@ -12551,50 +9534,22 @@ msgstr ""
 msgid "Field {0} not found."
 msgstr ""
 
-#: custom/doctype/custom_field/custom_field.js:120
-#: public/js/frappe/form/grid_row.js:431
-msgid "Fieldname"
-msgstr ""
-
-#. Label of a Data field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Fieldname"
-msgstr ""
-
-#. Label of a Select field in DocType 'DocType Layout Field'
-#: custom/doctype/doctype_layout_field/doctype_layout_field.json
-msgctxt "DocType Layout Field"
-msgid "Fieldname"
-msgstr ""
-
-#. Label of a Select field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Fieldname"
-msgstr ""
-
 #. Label of a Data field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Fieldname"
-msgstr ""
-
 #. Label of a Data field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Fieldname"
-msgstr ""
-
-#. Label of a Data field in DocType 'Web Template Field'
-#: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
-msgid "Fieldname"
-msgstr ""
-
+#. Label of a Data field in DocType 'Custom Field'
+#. Label of a Select field in DocType 'DocType Layout Field'
+#. Label of a Select field in DocType 'Form Tour Step'
 #. Label of a Select field in DocType 'Webhook Data'
+#. Label of a Data field in DocType 'Web Template Field'
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.js:120
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/doctype_layout_field/doctype_layout_field.json
+#: desk/doctype/form_tour_step/form_tour_step.json
 #: integrations/doctype/webhook_data/webhook_data.json
-msgctxt "Webhook Data"
+#: public/js/frappe/form/grid_row.js:431
+#: website/doctype/web_template_field/web_template_field.json
 msgid "Fieldname"
 msgstr ""
 
@@ -12634,59 +9589,30 @@ msgstr ""
 msgid "Fieldname {0} is restricted"
 msgstr ""
 
-#: public/js/frappe/list/list_settings.js:132
-#: public/js/frappe/views/kanban/kanban_settings.js:111
-msgid "Fields"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Customize Form'
-#. Label of a Table field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Fields"
-msgstr ""
-
 #. Label of a Table field in DocType 'DocType'
 #. Label of a Section Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Fields"
-msgstr ""
-
+#. Label of a Section Break field in DocType 'Customize Form'
+#. Label of a Table field in DocType 'Customize Form'
 #. Label of a Table field in DocType 'DocType Layout'
-#: custom/doctype/doctype_layout/doctype_layout.json
-msgctxt "DocType Layout"
-msgid "Fields"
-msgstr ""
-
 #. Label of a Code field in DocType 'Kanban Board'
-#: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
-msgid "Fields"
-msgstr ""
-
 #. Label of a HTML field in DocType 'List View Settings'
 #. Label of a Code field in DocType 'List View Settings'
-#: desk/doctype/list_view_settings/list_view_settings.json
-msgctxt "List View Settings"
-msgid "Fields"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Personal Data Deletion Step'
-#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
-msgctxt "Personal Data Deletion Step"
-msgid "Fields"
-msgstr ""
-
 #. Label of a Table field in DocType 'Web Template'
+#: core/doctype/doctype/doctype.json
+#: custom/doctype/customize_form/customize_form.json
+#: custom/doctype/doctype_layout/doctype_layout.json
+#: desk/doctype/kanban_board/kanban_board.json
+#: desk/doctype/list_view_settings/list_view_settings.json
+#: public/js/frappe/list/list_settings.js:132
+#: public/js/frappe/views/kanban/kanban_settings.js:111
+#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 #: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
 msgid "Fields"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Data Export'
 #: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
 msgid "Fields Multicheck"
 msgstr ""
 
@@ -12700,43 +9626,21 @@ msgstr ""
 
 #. Description of the 'Search Fields' (Data) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Fields separated by comma (,) will be included in the \"Search By\" list of Search dialog box"
 msgstr ""
 
-#. Label of a Data field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Fieldtype"
-msgstr ""
-
 #. Label of a Select field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Fieldtype"
-msgstr ""
-
 #. Label of a Select field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Fieldtype"
-msgstr ""
-
+#. Label of a Data field in DocType 'Form Tour Step'
 #. Label of a Select field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Fieldtype"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Form List Column'
-#: website/doctype/web_form_list_column/web_form_list_column.json
-msgctxt "Web Form List Column"
-msgid "Fieldtype"
-msgstr ""
-
 #. Label of a Select field in DocType 'Web Template Field'
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: desk/doctype/form_tour_step/form_tour_step.json
+#: website/doctype/web_form_field/web_form_field.json
+#: website/doctype/web_form_list_column/web_form_list_column.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Fieldtype"
 msgstr ""
 
@@ -12749,7 +9653,8 @@ msgid "Fieldtype cannot be changed from {0} to {1} in row {2}"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/file/file.json
+#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
+#: core/doctype/file/file.json desk/doctype/form_tour/form_tour.json
 msgid "File"
 msgstr ""
 
@@ -12759,31 +9664,19 @@ msgctxt "File"
 msgid "File"
 msgstr ""
 
-#. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "File"
-msgstr ""
-
 #: core/doctype/file/utils.py:127
 msgid "File '{0}' not found"
 msgstr ""
 
 #. Label of a Check field in DocType 'Dropbox Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "File Backup"
-msgstr ""
-
 #. Label of a Check field in DocType 'Google Drive'
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "File Backup"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "File Information"
 msgstr ""
 
@@ -12793,47 +9686,30 @@ msgstr ""
 
 #. Label of a Data field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "File Name"
 msgstr ""
 
 #. Label of a Int field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "File Size"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "File Storage"
 msgstr ""
 
-#: public/js/frappe/data_import/data_exporter.js:19
-msgid "File Type"
-msgstr ""
-
 #. Label of a Data field in DocType 'Access Log'
-#: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
-msgid "File Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Data Export'
-#: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
-msgid "File Type"
-msgstr ""
-
 #. Label of a Data field in DocType 'File'
-#: core/doctype/file/file.json
-msgctxt "File"
+#: core/doctype/access_log/access_log.json
+#: core/doctype/data_export/data_export.json core/doctype/file/file.json
+#: public/js/frappe/data_import/data_exporter.js:19
 msgid "File Type"
 msgstr ""
 
 #. Label of a Code field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "File URL"
 msgstr ""
 
@@ -12866,15 +9742,14 @@ msgstr ""
 msgid "File {0} does not exist"
 msgstr ""
 
-#. Label of a Link in the Tools Workspace
-#: automation/workspace/tools/tools.json
-msgctxt "File"
+#. Label of a Tab Break field in DocType 'System Settings'
+#: core/doctype/system_settings/system_settings.json
 msgid "Files"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#. Label of a Link in the Tools Workspace
+#: automation/workspace/tools/tools.json
+msgctxt "File"
 msgid "Files"
 msgstr ""
 
@@ -12896,35 +9771,27 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Filter Data"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Data Export'
 #: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
 msgid "Filter List"
 msgstr ""
 
 #. Label of a Text field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Filter Meta"
-msgstr ""
-
-#: public/js/frappe/list/list_filter.js:33
-msgid "Filter Name"
 msgstr ""
 
 #. Label of a Data field in DocType 'List Filter'
 #: desk/doctype/list_filter/list_filter.json
-msgctxt "List Filter"
+#: public/js/frappe/list/list_filter.js:33
 msgid "Filter Name"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
 msgid "Filter Values"
 msgstr ""
 
@@ -12942,7 +9809,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Personal Data Deletion Step'
 #: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
-msgctxt "Personal Data Deletion Step"
 msgid "Filtered By"
 msgstr ""
 
@@ -12956,82 +9822,45 @@ msgid "Filtered by \"{0}\""
 msgstr ""
 
 #. Label of a Code field in DocType 'Access Log'
-#: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
-msgid "Filters"
-msgstr ""
-
-#. Label of a Text field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Filters"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Filters"
-msgstr ""
-
-#. Label of a Code field in DocType 'Kanban Board'
-#: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
-msgid "Filters"
-msgstr ""
-
-#. Label of a Long Text field in DocType 'List Filter'
-#: desk/doctype/list_filter/list_filter.json
-msgctxt "List Filter"
-msgid "Filters"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Filters"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Prepared Report'
 #. Label of a Small Text field in DocType 'Prepared Report'
-#: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
-msgid "Filters"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Report'
 #. Label of a Table field in DocType 'Report'
+#. Label of a Section Break field in DocType 'Dashboard Chart'
+#. Label of a Code field in DocType 'Kanban Board'
+#. Label of a Long Text field in DocType 'List Filter'
+#. Label of a Text field in DocType 'Auto Email Report'
+#. Label of a Section Break field in DocType 'Notification'
+#: core/doctype/access_log/access_log.json
+#: core/doctype/prepared_report/prepared_report.json
 #: core/doctype/report/report.json
-msgctxt "Report"
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/kanban_board/kanban_board.json
+#: desk/doctype/list_filter/list_filter.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: email/doctype/notification/notification.json
 msgid "Filters"
 msgstr ""
 
 #. Label of a Code field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Filters Configuration"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Filters Display"
 msgstr ""
 
 #. Label of a Code field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Filters JSON"
-msgstr ""
-
 #. Label of a Code field in DocType 'Number Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Filters JSON"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Filters Section"
 msgstr ""
 
@@ -13045,7 +9874,6 @@ msgstr ""
 
 #. Description of the 'Script' (Code) field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Filters will be accessible via <code>filters</code>. <br><br>Send output as <code>result = [result]</code>, or for old style <code>data = [columns], [result]</code>"
 msgstr ""
 
@@ -13070,41 +9898,28 @@ msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Submission Queue'
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
 msgid "Finished"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
 msgid "Finished At"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "First Day of the Week"
 msgstr ""
 
-#: www/complete_signup.html:15
-msgid "First Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "First Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: contacts/doctype/contact/contact.json core/doctype/user/user.json
+#: www/complete_signup.html:15
 msgid "First Name"
 msgstr ""
 
 #. Label of a Data field in DocType 'Success Action'
 #: core/doctype/success_action/success_action.json
-msgctxt "Success Action"
 msgid "First Success Message"
 msgstr ""
 
@@ -13122,79 +9937,39 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Language'
 #: core/doctype/language/language.json
-msgctxt "Language"
 msgid "Flag"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Float"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Float"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Float"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Float"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Float"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Float"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Float Precision"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Fold"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Fold"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Fold"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Fold"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
 #: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Fold"
 msgstr ""
 
@@ -13208,13 +9983,11 @@ msgstr ""
 
 #. Label of a Link field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Folder"
 msgstr ""
 
 #. Label of a Data field in DocType 'IMAP Folder'
 #: email/doctype/imap_folder/imap_folder.json
-msgctxt "IMAP Folder"
 msgid "Folder Name"
 msgstr ""
 
@@ -13228,7 +10001,6 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Folio"
 msgstr ""
 
@@ -13267,97 +10039,63 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Font"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Font Properties"
 msgstr ""
 
 #. Label of a Int field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Font Size"
-msgstr ""
-
 #. Label of a Float field in DocType 'Print Settings'
-#: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
-msgid "Font Size"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Theme'
+#: printing/doctype/print_format/print_format.json
+#: printing/doctype/print_settings/print_settings.json
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Font Size"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Fonts"
 msgstr ""
 
-#. Label of a Text Editor field in DocType 'About Us Settings'
-#: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
-msgid "Footer"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Footer"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "Footer"
-msgstr ""
-
+#. Label of a Text Editor field in DocType 'About Us Settings'
 #. Option for the 'Type' (Select) field in DocType 'Web Template'
-#: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
-msgid "Footer"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'Website Settings'
+#: email/doctype/email_account/email_account.json
+#: printing/doctype/letter_head/letter_head.json
+#: website/doctype/about_us_settings/about_us_settings.json
+#: website/doctype/web_template/web_template.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Footer"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Footer \"Powered By\""
 msgstr ""
 
 #. Label of a Select field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Footer Based On"
 msgstr ""
 
 #. Label of a Text Editor field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Footer Content"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Footer Details"
 msgstr ""
 
 #. Label of a HTML Editor field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Footer HTML"
 msgstr ""
 
@@ -13367,38 +10105,32 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Footer Image"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #. Label of a Table field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Footer Items"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Footer Logo"
 msgstr ""
 
 #. Label of a Code field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Footer Script"
 msgstr ""
 
 #. Label of a Link field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Footer Template"
 msgstr ""
 
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Footer Template Values"
 msgstr ""
 
@@ -13409,19 +10141,16 @@ msgstr ""
 #. Description of the 'Footer HTML' (HTML Editor) field in DocType 'Letter
 #. Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Footer will display correctly only in PDF"
 msgstr ""
 
 #. Description of the 'Row Name' (Data) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "For DocType Link / DocType Action"
 msgstr ""
 
 #. Label of a Select field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "For Document Event"
 msgstr ""
 
@@ -13433,49 +10162,29 @@ msgstr ""
 msgid "For Example: {} Open"
 msgstr ""
 
+#. Description of the 'Options' (Small Text) field in DocType 'DocField'
 #. Description of the 'Options' (Small Text) field in DocType 'Customize Form
 #. Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid ""
-"For Links, enter the DocType as range.\n"
-"For Select, enter list of Options, each on a new line."
-msgstr ""
-
-#. Description of the 'Options' (Small Text) field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid ""
 "For Links, enter the DocType as range.\n"
 "For Select, enter list of Options, each on a new line."
-msgstr ""
-
-#: core/doctype/user_permission/user_permission_list.js:10
-#: core/doctype/user_permission/user_permission_list.js:148
-msgid "For User"
 msgstr ""
 
 #. Label of a Link field in DocType 'List Filter'
-#: desk/doctype/list_filter/list_filter.json
-msgctxt "List Filter"
-msgid "For User"
-msgstr ""
-
 #. Label of a Link field in DocType 'Notification Log'
-#: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
-msgid "For User"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workspace'
+#: core/doctype/user_permission/user_permission_list.js:10
+#: core/doctype/user_permission/user_permission_list.js:148
+#: desk/doctype/list_filter/list_filter.json
+#: desk/doctype/notification_log/notification_log.json
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "For User"
 msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'User Permission'
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
 msgid "For Value"
 msgstr ""
 
@@ -13494,20 +10203,17 @@ msgstr ""
 
 #. Description of the 'Format' (Data) field in DocType 'Workspace Shortcut'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "For example: {} Open"
 msgstr ""
 
 #. Description of the 'Client Script' (Code) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "For help see <a href=\"https://frappeframework.com/docs/user/en/guides/portal-development/web-forms\" target=\"_blank\">Client Script API and Examples</a>"
 msgstr ""
 
 #. Description of the 'Enable Automatic Linking in Documents' (Check) field in
 #. DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "For more information, <a class=\"text-muted\" href=\"https://erpnext.com/docs/user/manual/en/setting-up/email/linking-emails-to-document\">click here</a>."
 msgstr ""
 
@@ -13518,7 +10224,6 @@ msgstr ""
 #. Description of the 'Email To' (Small Text) field in DocType 'Auto Email
 #. Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "For multiple addresses, enter the address on different line. e.g. test@test.com ⏎ test1@test.com"
 msgstr ""
 
@@ -13530,34 +10235,23 @@ msgstr ""
 msgid "For {0} at level {1} in {2} in row {3}"
 msgstr ""
 
+#. Label of a Check field in DocType 'Package Import'
 #. Option for the 'Skip Authorization' (Select) field in DocType 'OAuth
 #. Provider Settings'
-#: integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
-msgctxt "OAuth Provider Settings"
-msgid "Force"
-msgstr ""
-
-#. Label of a Check field in DocType 'Package Import'
 #: core/doctype/package_import/package_import.json
-msgctxt "Package Import"
+#: integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
 msgid "Force"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Force Re-route to Default View"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Force Re-route to Default View"
 msgstr ""
 
 #. Label of a Check field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "Force Show"
 msgstr ""
 
@@ -13567,13 +10261,11 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Force User to Reset Password"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Force Web Capture Mode for Uploads"
 msgstr ""
 
@@ -13581,84 +10273,43 @@ msgstr ""
 msgid "Forgot Password?"
 msgstr ""
 
-#: printing/page/print/print.js:83
-msgid "Form"
-msgstr ""
-
-#. Option for the 'Apply To' (Select) field in DocType 'Client Script'
-#: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
-msgid "Form"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Form"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Form"
-msgstr ""
-
+#. Option for the 'Apply To' (Select) field in DocType 'Client Script'
+#. Label of a Tab Break field in DocType 'Customize Form'
 #. Option for the 'View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Form"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Form"
-msgstr ""
-
-#. Label of a HTML field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json
+#: custom/doctype/client_script/client_script.json
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Form Builder"
+#: desk/doctype/form_tour/form_tour.json printing/page/print/print.js:83
+#: website/doctype/web_form/web_form.json
+msgid "Form"
 msgstr ""
 
 #. Label of a HTML field in DocType 'DocType'
+#. Label of a HTML field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Form Builder"
 msgstr ""
 
 #. Label of a Code field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "Form Dict"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Form Settings"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Form Settings"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
+#. Label of a Section Break field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json core/doctype/role/role.json
+#: custom/doctype/customize_form/customize_form.json
 msgid "Form Settings"
 msgstr ""
 
 #. Name of a DocType
-#: desk/doctype/form_tour/form_tour.json
-msgid "Form Tour"
-msgstr ""
-
 #. Label of a Link field in DocType 'Onboarding Step'
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Form Tour"
 msgstr ""
 
@@ -13669,29 +10320,19 @@ msgstr ""
 
 #. Option for the 'Request Structure' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Form URL-Encoded"
 msgstr ""
 
-#: public/js/frappe/widgets/widget_dialog.js:567
-msgid "Format"
-msgstr ""
-
-#. Label of a Select field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Format"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workspace Shortcut'
+#. Label of a Select field in DocType 'Auto Email Report'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: email/doctype/auto_email_report/auto_email_report.json
+#: public/js/frappe/widgets/widget_dialog.js:567
 msgid "Format"
 msgstr ""
 
 #. Label of a Code field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Format Data"
 msgstr ""
 
@@ -13701,30 +10342,23 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Forward To Email Address"
 msgstr ""
 
 #. Label of a Data field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Fraction"
 msgstr ""
 
 #. Label of a Int field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Fraction Units"
-msgstr ""
-
-#: www/login.html:61 www/login.html:142 www/login.py:48 www/login.py:137
-msgid "Frappe"
 msgstr ""
 
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
+#: www/login.html:61 www/login.html:142 www/login.py:48 www/login.py:137
 msgid "Frappe"
 msgstr ""
 
@@ -13746,102 +10380,52 @@ msgstr ""
 msgid "Frappe page builder using components"
 msgstr ""
 
+#. Label of a Select field in DocType 'Auto Repeat'
+#. Label of a Select field in DocType 'Scheduled Job Type'
+#. Label of a Select field in DocType 'User'
+#. Label of a Select field in DocType 'Auto Email Report'
+#. Label of a Select field in DocType 'Google Drive'
+#: automation/doctype/auto_repeat/auto_repeat.json
 #: automation/doctype/auto_repeat/auto_repeat_schedule.html:5
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/user/user.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: integrations/doctype/google_drive/google_drive.json
 #: public/js/frappe/utils/common.js:395
 msgid "Frequency"
 msgstr ""
 
-#. Label of a Select field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Frequency"
-msgstr ""
-
-#. Label of a Select field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Frequency"
-msgstr ""
-
-#. Label of a Select field in DocType 'Google Drive'
-#: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
-msgid "Frequency"
-msgstr ""
-
-#. Label of a Select field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Frequency"
-msgstr ""
-
-#. Label of a Select field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Frequency"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Friday"
-msgstr ""
-
-#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Friday"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
-#: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
-msgid "Friday"
-msgstr ""
-
-#. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Friday"
-msgstr ""
-
 #. Option for the 'First Day of the Week' (Select) field in DocType 'System
 #. Settings'
+#. Label of a Check field in DocType 'Event'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
+#: automation/doctype/auto_repeat_day/auto_repeat_day.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Friday"
 msgstr ""
 
+#. Label of a Data field in DocType 'Communication'
+#. Label of a Section Break field in DocType 'Newsletter'
+#: core/doctype/communication/communication.json
+#: email/doctype/newsletter/newsletter.json
 #: public/js/frappe/views/communication.js:185
 #: public/js/frappe/views/inbox/inbox_view.js:70
 msgid "From"
 msgstr ""
 
-#. Label of a Data field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "From"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "From"
-msgstr ""
-
-#: website/report/website_analytics/website_analytics.js:8
-msgid "From Date"
-msgstr ""
-
 #. Label of a Date field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
+#: website/report/website_analytics/website_analytics.js:8
 msgid "From Date"
 msgstr ""
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "From Date Field"
 msgstr ""
 
@@ -13851,13 +10435,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "From Full Name"
 msgstr ""
 
 #. Label of a Link field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "From User"
 msgstr ""
 
@@ -13867,41 +10449,19 @@ msgstr ""
 
 #. Option for the 'Width' (Select) field in DocType 'Dashboard Chart Link'
 #: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
-msgctxt "Dashboard Chart Link"
 msgid "Full"
 msgstr ""
 
-#: desk/page/setup_wizard/setup_wizard.js:464 templates/signup.html:4
-msgid "Full Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'About Us Team Member'
-#: website/doctype/about_us_team_member/about_us_team_member.json
-msgctxt "About Us Team Member"
-msgid "Full Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Full Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Blogger'
-#: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
-msgid "Full Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Full Name"
-msgstr ""
-
+#. Label of a Data field in DocType 'Activity Log'
 #. Label of a Data field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#. Label of a Data field in DocType 'About Us Team Member'
+#. Label of a Data field in DocType 'Blogger'
+#: contacts/doctype/contact/contact.json
+#: core/doctype/activity_log/activity_log.json core/doctype/user/user.json
+#: desk/page/setup_wizard/setup_wizard.js:464 templates/signup.html:4
+#: website/doctype/about_us_team_member/about_us_team_member.json
+#: website/doctype/blogger/blogger.json
 msgid "Full Name"
 msgstr ""
 
@@ -13912,18 +10472,13 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Full Width"
-msgstr ""
-
-#: public/js/frappe/views/reports/query_report.js:246
-#: public/js/frappe/widgets/widget_dialog.js:705
-msgid "Function"
 msgstr ""
 
 #. Label of a Select field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
+#: public/js/frappe/views/reports/query_report.js:246
+#: public/js/frappe/widgets/widget_dialog.js:705
 msgid "Function"
 msgstr ""
 
@@ -13945,58 +10500,36 @@ msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "GET"
 msgstr ""
 
 #. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "GMail"
 msgstr ""
 
 #. Option for the 'License Type' (Select) field in DocType 'Package'
 #: core/doctype/package/package.json
-msgctxt "Package"
 msgid "GNU Affero General Public License"
 msgstr ""
 
 #. Option for the 'License Type' (Select) field in DocType 'Package'
 #: core/doctype/package/package.json
-msgctxt "Package"
 msgid "GNU General Public License"
-msgstr ""
-
-#: public/js/frappe/views/gantt/gantt_view.js:10
-msgid "Gantt"
 msgstr ""
 
 #. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
+#: public/js/frappe/views/gantt/gantt_view.js:10
 msgid "Gantt"
 msgstr ""
 
-#. Name of a DocType
-#: contacts/doctype/gender/gender.json
-msgid "Gender"
-msgstr ""
-
 #. Label of a Link field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Gender"
-msgstr ""
-
+#. Name of a DocType
 #. Label of a Data field in DocType 'Gender'
-#: contacts/doctype/gender/gender.json
-msgctxt "Gender"
-msgid "Gender"
-msgstr ""
-
 #. Label of a Link field in DocType 'User'
+#: contacts/doctype/contact/contact.json contacts/doctype/gender/gender.json
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Gender"
 msgstr ""
 
@@ -14011,7 +10544,6 @@ msgstr ""
 
 #. Label of a Button field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Generate Keys"
 msgstr ""
 
@@ -14028,21 +10560,12 @@ msgstr ""
 msgid "Generate Tracking URL"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Geolocation"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Geolocation"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Geolocation"
 msgstr ""
 
@@ -14056,7 +10579,6 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Get Contacts"
 msgstr ""
 
@@ -14083,7 +10605,6 @@ msgstr ""
 #. Description of the 'Try a Naming Series' (Data) field in DocType 'Document
 #. Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Get a preview of generated names with a series."
 msgstr ""
 
@@ -14094,26 +10615,22 @@ msgstr ""
 #. Description of the 'Email Threads on Assigned Document' (Check) field in
 #. DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "Get notified when an email is received on any of the documents assigned to you."
 msgstr ""
 
 #. Description of the 'User Image' (Attach Image) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Get your globally recognized avatar from Gravatar.com"
 msgstr ""
 
 #. Label of a Data field in DocType 'Installed Application'
 #: core/doctype/installed_application/installed_application.json
-msgctxt "Installed Application"
 msgid "Git Branch"
 msgstr ""
 
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "GitHub"
 msgstr ""
 
@@ -14146,7 +10663,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Email Unsubscribe'
 #: email/doctype/email_unsubscribe/email_unsubscribe.json
-msgctxt "Email Unsubscribe"
 msgid "Global Unsubscribe"
 msgstr ""
 
@@ -14166,7 +10682,6 @@ msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Go to Page"
 msgstr ""
 
@@ -14192,7 +10707,6 @@ msgstr ""
 
 #. Description of the 'Success URL' (Data) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Go to this URL after completing the form"
 msgstr ""
 
@@ -14220,37 +10734,29 @@ msgstr ""
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Google"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Google Analytics ID"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Google Analytics anonymise IP"
-msgstr ""
-
-#. Name of a DocType
-#: integrations/doctype/google_calendar/google_calendar.json
-msgid "Google Calendar"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Event'
 #. Label of a Link field in DocType 'Event'
+#. Name of a DocType
+#. Label of a Section Break field in DocType 'Google Calendar'
 #: desk/doctype/event/event.json
-msgctxt "Event"
+#: integrations/doctype/google_calendar/google_calendar.json
 msgid "Google Calendar"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Google Calendar'
 #. Label of a Link in the Integrations Workspace
-#: integrations/doctype/google_calendar/google_calendar.json
 #: integrations/workspace/integrations/integrations.json
 msgctxt "Google Calendar"
 msgid "Google Calendar"
@@ -14286,19 +10792,13 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Google Calendar Event ID"
 msgstr ""
 
 #. Label of a Data field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Google Calendar ID"
-msgstr ""
-
 #. Label of a Data field in DocType 'Google Calendar'
+#: desk/doctype/event/event.json
 #: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
 msgid "Google Calendar ID"
 msgstr ""
 
@@ -14306,21 +10806,16 @@ msgstr ""
 msgid "Google Calendar has been configured."
 msgstr ""
 
-#. Name of a DocType
-#: integrations/doctype/google_contacts/google_contacts.json
-msgid "Google Contacts"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Contact'
 #. Label of a Link field in DocType 'Contact'
+#. Name of a DocType
+#. Label of a Section Break field in DocType 'Google Contacts'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
+#: integrations/doctype/google_contacts/google_contacts.json
 msgid "Google Contacts"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Google Contacts'
 #. Label of a Link in the Integrations Workspace
-#: integrations/doctype/google_contacts/google_contacts.json
 #: integrations/workspace/integrations/integrations.json
 msgctxt "Google Contacts"
 msgid "Google Contacts"
@@ -14336,18 +10831,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Google Contacts Id"
 msgstr ""
 
 #. Name of a DocType
+#. Label of a Section Break field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
 msgid "Google Drive"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Google Drive'
 #. Label of a Link in the Integrations Workspace
-#: integrations/doctype/google_drive/google_drive.json
 #: integrations/workspace/integrations/integrations.json
 msgctxt "Google Drive"
 msgid "Google Drive"
@@ -14371,31 +10864,23 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid "Google Drive Picker"
 msgstr ""
 
 #. Label of a Check field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid "Google Drive Picker Enabled"
 msgstr ""
 
 #. Label of a Data field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Google Font"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Theme'
+#: printing/doctype/print_format/print_format.json
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Google Font"
 msgstr ""
 
 #. Label of a Data field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Google Meet Link"
 msgstr ""
 
@@ -14425,13 +10910,11 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Google Snippet Preview"
 msgstr ""
 
 #. Label of a Select field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Grant Type"
 msgstr ""
 
@@ -14441,26 +10924,16 @@ msgid "Graph"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Gray"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Gray"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Green"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Green"
 msgstr ""
 
@@ -14469,42 +10942,27 @@ msgid "Grid Shortcuts"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType Action'
-#: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
-msgid "Group"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType Link'
-#: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
-msgid "Group"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Sidebar Item'
+#: core/doctype/doctype_action/doctype_action.json
+#: core/doctype/doctype_link/doctype_link.json
 #: website/doctype/website_sidebar_item/website_sidebar_item.json
-msgctxt "Website Sidebar Item"
 msgid "Group"
-msgstr ""
-
-#: website/report/website_analytics/website_analytics.js:32
-msgid "Group By"
 msgstr ""
 
 #. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
+#: website/report/website_analytics/website_analytics.js:32
 msgid "Group By"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Group By Based On"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Group By Type"
 msgstr ""
 
@@ -14518,7 +10976,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Group Object Class"
 msgstr ""
 
@@ -14533,128 +10990,66 @@ msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "HEAD"
 msgstr ""
 
 #. Option for the 'Time Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "HH:mm"
 msgstr ""
 
 #. Option for the 'Time Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "HH:mm:ss"
 msgstr ""
 
-#: printing/doctype/print_format/print_format.py:91
-#: website/doctype/web_page/web_page.js:92
-msgid "HTML"
-msgstr ""
-
-#. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "HTML"
-msgstr ""
-
-#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "HTML"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "HTML"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Custom HTML Block'
-#: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
-msgid "HTML"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "HTML"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "HTML"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Section Break field in DocType 'Custom HTML Block'
+#. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Content Type' (Select) field in DocType 'Newsletter'
+#. Option for the 'Message Type' (Select) field in DocType 'Notification'
 #. Option for the 'Letter Head Based On' (Select) field in DocType 'Letter
 #. Head'
 #. Option for the 'Footer Based On' (Select) field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "HTML"
-msgstr ""
-
-#. Option for the 'Content Type' (Select) field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "HTML"
-msgstr ""
-
-#. Option for the 'Message Type' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "HTML"
-msgstr ""
-
 #. Label of a Code field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "HTML"
-msgstr ""
-
+#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "HTML"
-msgstr ""
-
 #. Option for the 'Content Type' (Select) field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "HTML"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#: core/doctype/docfield/docfield.json
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "HTML Editor"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "HTML Editor"
+#: desk/doctype/custom_html_block/custom_html_block.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: email/doctype/newsletter/newsletter.json
+#: email/doctype/notification/notification.json
+#: printing/doctype/letter_head/letter_head.json
+#: printing/doctype/print_format/print_format.json
+#: printing/doctype/print_format/print_format.py:91
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/web_form_field/web_form_field.json
+#: website/doctype/web_page/web_page.js:92
+#: website/doctype/web_page/web_page.json
+msgid "HTML"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "HTML Editor"
 msgstr ""
 
 #. Label of a HTML Editor field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "HTML Page"
 msgstr ""
 
 #. Description of the 'Header' (HTML Editor) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "HTML for header section. Optional"
 msgstr ""
 
@@ -14664,41 +11059,29 @@ msgstr ""
 
 #. Option for the 'Width' (Select) field in DocType 'Dashboard Chart Link'
 #: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
-msgctxt "Dashboard Chart Link"
 msgid "Half"
 msgstr ""
 
-#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Half Yearly"
-msgstr ""
-
 #. Option for the 'Repeat On' (Select) field in DocType 'Event'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
 #: desk/doctype/event/event.json
-msgctxt "Event"
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Half Yearly"
-msgstr ""
-
-#: public/js/frappe/utils/common.js:402
-msgid "Half-yearly"
 msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
+#: public/js/frappe/utils/common.js:402
 msgid "Half-yearly"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Handled Emails"
 msgstr ""
 
 #. Label of a Check field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Has  Attachment"
 msgstr ""
 
@@ -14709,7 +11092,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Has Next Condition"
 msgstr ""
 
@@ -14720,7 +11102,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Has Web View"
 msgstr ""
 
@@ -14728,33 +11109,19 @@ msgstr ""
 msgid "Have an account? Login"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "Header"
-msgstr ""
-
 #. Label of a Check field in DocType 'SMS Parameter'
-#: core/doctype/sms_parameter/sms_parameter.json
-msgctxt "SMS Parameter"
-msgid "Header"
-msgstr ""
-
+#. Label of a Section Break field in DocType 'Letter Head'
 #. Label of a HTML Editor field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Header"
-msgstr ""
-
 #. Label of a HTML Editor field in DocType 'Website Slideshow'
+#: core/doctype/sms_parameter/sms_parameter.json
+#: printing/doctype/letter_head/letter_head.json
+#: website/doctype/web_page/web_page.json
 #: website/doctype/website_slideshow/website_slideshow.json
-msgctxt "Website Slideshow"
 msgid "Header"
 msgstr ""
 
 #. Label of a HTML Editor field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Header HTML"
 msgstr ""
 
@@ -14764,19 +11131,16 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Header Script"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Header and Breadcrumbs"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Header, Robots"
 msgstr ""
 
@@ -14785,54 +11149,28 @@ msgid "Header/Footer scripts can be used to add dynamic behaviours."
 msgstr ""
 
 #. Label of a Table field in DocType 'Webhook'
-#: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
-msgid "Headers"
-msgstr ""
-
 #. Label of a Code field in DocType 'Webhook Request Log'
+#: integrations/doctype/webhook/webhook.json
 #: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
 msgid "Headers"
-msgstr ""
-
-#: printing/page/print_format_builder/print_format_builder.js:602
-msgid "Heading"
-msgstr ""
-
-#. Label of a Data field in DocType 'Contact Us Settings'
-#: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
-msgid "Heading"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Heading"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Heading"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Heading"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Data field in DocType 'Contact Us Settings'
 #. Label of a Data field in DocType 'Website Slideshow Item'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: printing/page/print_format_builder/print_format_builder.js:602
+#: website/doctype/contact_us_settings/contact_us_settings.json
 #: website/doctype/website_slideshow_item/website_slideshow_item.json
-msgctxt "Website Slideshow Item"
 msgid "Heading"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Heatmap"
 msgstr ""
 
@@ -14840,21 +11178,13 @@ msgstr ""
 msgid "Hello"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'Server Script'
+#. Label of a HTML field in DocType 'Property Setter'
+#: core/doctype/server_script/server_script.json
+#: custom/doctype/property_setter/property_setter.json
 #: public/js/frappe/form/templates/form_sidebar.html:40
 #: public/js/frappe/form/workflow.js:23
 #: public/js/frappe/ui/toolbar/navbar.html:87 public/js/frappe/utils/help.js:27
-msgid "Help"
-msgstr ""
-
-#. Label of a HTML field in DocType 'Property Setter'
-#: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
-msgid "Help"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Help"
 msgstr ""
 
@@ -14871,7 +11201,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Help Category'
 #: website/doctype/help_category/help_category.json
-msgctxt "Help Category"
 msgid "Help Articles"
 msgstr ""
 
@@ -14886,19 +11215,14 @@ msgctxt "Help Category"
 msgid "Help Category"
 msgstr ""
 
-#: public/js/frappe/ui/toolbar/navbar.html:84
-msgid "Help Dropdown"
-msgstr ""
-
 #. Label of a Table field in DocType 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
-msgctxt "Navbar Settings"
+#: public/js/frappe/ui/toolbar/navbar.html:84
 msgid "Help Dropdown"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Help HTML"
 msgstr ""
 
@@ -14908,25 +11232,21 @@ msgstr ""
 
 #. Description of the 'Content' (Text Editor) field in DocType 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
 msgid "Help: To link to another record in the system, use \"/app/note/[Note Name]\" as the Link URL. (don't use \"http://\")"
 msgstr ""
 
 #. Label of a Int field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Helpful"
 msgstr ""
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Helvetica"
 msgstr ""
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Helvetica Neue"
 msgstr ""
 
@@ -14938,162 +11258,90 @@ msgstr ""
 msgid "Hi {0}"
 msgstr ""
 
-#: printing/page/print_format_builder/print_format_builder_field.html:3
-msgid "Hidden"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Hidden"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Hidden"
-msgstr ""
-
-#. Label of a Check field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Hidden"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Hidden"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType Action'
-#: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
-msgid "Hidden"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType Link'
-#: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
-msgid "Hidden"
-msgstr ""
-
 #. Label of a Check field in DocType 'Navbar Item'
-#: core/doctype/navbar_item/navbar_item.json
-msgctxt "Navbar Item"
-msgid "Hidden"
-msgstr ""
-
-#. Label of a Check field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Hidden"
-msgstr ""
-
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
+#. Label of a Check field in DocType 'Desktop Icon'
 #. Label of a Check field in DocType 'Workspace Link'
+#. Label of a Check field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/doctype_action/doctype_action.json
+#: core/doctype/doctype_link/doctype_link.json
+#: core/doctype/navbar_item/navbar_item.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/desktop_icon/desktop_icon.json
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
+#: printing/page/print_format_builder/print_format_builder_field.html:3
+#: website/doctype/web_form_field/web_form_field.json
 msgid "Hidden"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Hidden Fields"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:827
+#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
+#: printing/doctype/print_format/print_format.json
+#: public/js/frappe/views/workspace/workspace.js:828
 #: public/js/frappe/widgets/base_widget.js:46
 #: public/js/frappe/widgets/base_widget.js:178
 #: templates/includes/login/login.js:82
 msgid "Hide"
 msgstr ""
 
-#. Option for the 'Page Number' (Select) field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Hide"
-msgstr ""
-
 #. Label of a Check field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Hide Block"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Hide Border"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Hide Border"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Hide Border"
 msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Hide Buttons"
 msgstr ""
 
 #. Label of a Check field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Hide CTA"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Hide Copy"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Hide Copy"
 msgstr ""
 
 #. Label of a Check field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Hide Custom DocTypes and Reports"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Hide Days"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Hide Days"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Hide Days"
-msgstr ""
-
-#: core/doctype/user_permission/user_permission_list.js:96
-msgid "Hide Descendants"
 msgstr ""
 
 #. Label of a Check field in DocType 'User Permission'
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
+#: core/doctype/user_permission/user_permission_list.js:96
 msgid "Hide Descendants"
 msgstr ""
 
@@ -15103,7 +11351,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Hide Login"
 msgstr ""
 
@@ -15114,7 +11361,6 @@ msgstr ""
 
 #. Description of the 'Hide Buttons' (Check) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Hide Previous, Next and Close button on highlight dialog."
 msgstr ""
 
@@ -15122,33 +11368,22 @@ msgstr ""
 msgid "Hide Saved"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Hide Seconds"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Hide Seconds"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Hide Seconds"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Hide Sidebar, Menu, and Comments"
 msgstr ""
 
 #. Label of a Check field in DocType 'Portal Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Hide Standard Menu"
 msgstr ""
 
@@ -15160,14 +11395,13 @@ msgstr ""
 msgid "Hide Weekends"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:828
+#: public/js/frappe/views/workspace/workspace.js:829
 msgid "Hide Workspace"
 msgstr ""
 
 #. Description of the 'Hide Descendants' (Check) field in DocType 'User
 #. Permission'
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
 msgid "Hide descendant records of <b>For Value</b>."
 msgstr ""
 
@@ -15177,35 +11411,26 @@ msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Hide footer in auto email reports"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Hide footer signup"
 msgstr ""
 
-#: public/js/frappe/form/sidebar/assign_to.js:224
-msgid "High"
-msgstr ""
-
 #. Option for the 'Priority' (Select) field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
+#: desk/doctype/todo/todo.json public/js/frappe/form/sidebar/assign_to.js:224
 msgid "High"
 msgstr ""
 
 #. Description of the 'Priority' (Int) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Higher priority rule will be applied first"
 msgstr ""
 
 #. Label of a Text field in DocType 'Company History'
 #: website/doctype/company_history/company_history.json
-msgctxt "Company History"
 msgid "Highlight"
 msgstr ""
 
@@ -15213,6 +11438,7 @@ msgstr ""
 msgid "Hint: Include symbols, numbers and capital letters in the password"
 msgstr ""
 
+#. Label of a Tab Break field in DocType 'Website Settings'
 #: public/js/frappe/views/file/file_view.js:67
 #: public/js/frappe/views/file/file_view.js:88
 #: public/js/frappe/views/pageview.js:153 templates/doc.html:19
@@ -15220,32 +11446,21 @@ msgstr ""
 #: website/doctype/blog_post/blog_post.py:153
 #: website/doctype/blog_post/blog_post.py:265
 #: website/doctype/blog_post/blog_post.py:267
+#: website/doctype/website_settings/website_settings.json
 #: website/web_template/primary_navbar/primary_navbar.html:9 www/contact.py:22
 #: www/error.html:30 www/login.html:150 www/message.html:34
 msgid "Home"
 msgstr ""
 
-#. Label of a Tab Break field in DocType 'Website Settings'
-#: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
-msgid "Home"
-msgstr ""
-
 #. Label of a Data field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
-msgid "Home Page"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Settings'
+#: core/doctype/role/role.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Home Page"
 msgstr ""
 
 #. Label of a Code field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Home Settings"
 msgstr ""
 
@@ -15263,45 +11478,28 @@ msgid "Home/Test Folder 2"
 msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Hourly"
-msgstr ""
-
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Hourly"
-msgstr ""
-
 #. Option for the 'Frequency' (Select) field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/server_script/server_script.json core/doctype/user/user.json
 msgid "Hourly"
 msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Hourly Long"
-msgstr ""
-
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Hourly Long"
 msgstr ""
 
 #. Description of the 'Password Reset Link Generation Limit' (Int) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Hourly rate limit for generating password reset links"
 msgstr ""
 
 #. Description of the 'Number Format' (Select) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "How should this currency be formatted? If not set, will use system defaults"
 msgstr ""
 
@@ -15325,153 +11523,87 @@ msgstr ""
 
 #. Description of the 'Field Name' (Data) field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "ID (name) of the entity whose property is to be set"
 msgstr ""
 
 #. Description of the 'Section ID' (Data) field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "IDs must contain only alphanumeric characters, not contain spaces, and should be unique."
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "IMAP Details"
 msgstr ""
 
+#. Label of a Data field in DocType 'Communication'
+#. Label of a Table field in DocType 'Email Account'
 #. Name of a DocType
+#: core/doctype/communication/communication.json
+#: email/doctype/email_account/email_account.json
 #: email/doctype/imap_folder/imap_folder.json
 msgid "IMAP Folder"
 msgstr ""
 
-#. Label of a Data field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "IMAP Folder"
-msgstr ""
-
-#. Label of a Table field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "IMAP Folder"
-msgstr ""
-
 #. Label of a Data field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "IP Address"
-msgstr ""
-
 #. Label of a Data field in DocType 'Comment'
+#: core/doctype/activity_log/activity_log.json
 #: core/doctype/comment/comment.json
-msgctxt "Comment"
 msgid "IP Address"
-msgstr ""
-
-#: public/js/frappe/views/workspace/workspace.js:645
-#: public/js/frappe/views/workspace/workspace.js:973
-#: public/js/frappe/views/workspace/workspace.js:1218
-msgid "Icon"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Icon"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Icon"
-msgstr ""
-
-#. Label of a Data field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Icon"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Icon"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Icon"
-msgstr ""
-
-#. Label of a Data field in DocType 'Social Login Key'
-#: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
-msgid "Icon"
-msgstr ""
-
-#. Label of a Select field in DocType 'Workflow State'
-#: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
-msgid "Icon"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Data field in DocType 'Desktop Icon'
 #. Label of a Icon field in DocType 'Workspace'
-#: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
-msgid "Icon"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
-msgid "Icon"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workspace Shortcut'
+#. Label of a Data field in DocType 'Social Login Key'
+#. Label of a Select field in DocType 'Workflow State'
+#: core/doctype/docfield/docfield.json core/doctype/doctype/doctype.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/desktop_icon/desktop_icon.json
+#: desk/doctype/workspace/workspace.json
+#: desk/doctype/workspace_link/workspace_link.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: integrations/doctype/social_login_key/social_login_key.json
+#: public/js/frappe/views/workspace/workspace.js:646
+#: public/js/frappe/views/workspace/workspace.js:974
+#: public/js/frappe/views/workspace/workspace.js:1219
+#: workflow/doctype/workflow_state/workflow_state.json
 msgid "Icon"
 msgstr ""
 
 #. Description of the 'Icon' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Icon will appear on the button"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Identity Details"
 msgstr ""
 
 #. Label of a Int field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "Idx"
 msgstr ""
 
 #. Description of the 'Apply Strict User Permissions' (Check) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "If Apply Strict User Permission is checked and User Permission is defined for a DocType for a User, then all the documents where value of the link is blank, will not be shown to that User"
 msgstr ""
 
 #. Description of the 'Don't Override Status' (Check) field in DocType
 #. 'Workflow'
-#: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
-msgid "If Checked workflow status will not override status in list view"
-msgstr ""
-
 #. Description of the 'Don't Override Status' (Check) field in DocType
 #. 'Workflow Document State'
+#: workflow/doctype/workflow/workflow.json
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "If Checked workflow status will not override status in list view"
 msgstr ""
 
@@ -15485,142 +11617,117 @@ msgstr ""
 
 #. Description of the 'Is Active' (Check) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "If checked, all other workflows become inactive."
 msgstr ""
 
 #. Description of the 'Show Absolute Values' (Check) field in DocType 'Print
 #. Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "If checked, negative numeric values of Currency, Quantity or Count would be shown as positive"
 msgstr ""
 
 #. Description of the 'Skip Authorization' (Check) field in DocType 'OAuth
 #. Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "If checked, users will not see the Confirm Access dialog."
 msgstr ""
 
 #. Description of the 'Disabled' (Check) field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "If disabled, this role will be removed from all users."
 msgstr ""
 
 #. Description of the 'Bypass Restricted IP Address Check If Two Factor Auth
 #. Enabled' (Check) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "If enabled,  user can login from any IP Address using Two Factor Auth, this can also be set for all users in System Settings"
 msgstr ""
 
 #. Description of the 'Bypass restricted IP Address check If Two Factor Auth
 #. Enabled' (Check) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "If enabled, all users can login from any IP Address using Two Factor Auth. This can also be set only for specific user(s) in User Page"
 msgstr ""
 
 #. Description of the 'Track Changes' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "If enabled, changes to the document are tracked and shown in timeline"
 msgstr ""
 
 #. Description of the 'Track Views' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "If enabled, document views are tracked, this can happen multiple times"
 msgstr ""
 
 #. Description of the 'Track Seen' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "If enabled, the document is marked as seen, the first time a user opens it"
 msgstr ""
 
 #. Description of the 'Send System Notification' (Check) field in DocType
 #. 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "If enabled, the notification will show up in the notifications dropdown on the top right corner of the navigation bar."
 msgstr ""
 
 #. Description of the 'Enable Password Policy' (Check) field in DocType 'System
 #. Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "If enabled, the password strength will be enforced based on the Minimum Password Score value. A value of 2 being medium strong and 4 being very strong."
 msgstr ""
 
 #. Description of the 'Bypass Two Factor Auth for users who login from
 #. restricted IP Address' (Check) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "If enabled, users who login from Restricted IP Address, won't be prompted for Two Factor Auth"
 msgstr ""
 
 #. Description of the 'Notify Users On Every Login' (Check) field in DocType
 #. 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
 msgid "If enabled, users will be notified every time they login. If not enabled, users will only be notified once."
 msgstr ""
 
 #. Description of the 'Default Workspace' (Link) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "If left empty, the default workspace will be the last visited workspace"
 msgstr ""
 
 #. Description of the 'Port' (Data) field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "If non standard port (e.g. 587)"
 msgstr ""
 
 #. Description of the 'Port' (Data) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "If non standard port (e.g. 587). If on Google Cloud, try port 2525."
 msgstr ""
 
 #. Description of the 'Port' (Data) field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)"
-msgstr ""
-
 #. Description of the 'Port' (Data) field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "If non-standard port (e.g. POP3: 995/110, IMAP: 993/143)"
 msgstr ""
 
 #. Description of the 'Currency Precision' (Select) field in DocType 'System
 #. Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "If not set, the currency precision will depend on number format"
 msgstr ""
 
 #. Description of the 'Roles' (Table) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "If set, only user with these roles can access this chart. If not set, DocType or Report permissions will be used."
 msgstr ""
 
 #. Description of the 'Condition' (Code) field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "If the condition is satisfied user will be rewarded with the points. eg. doc.status == 'Closed'\n"
 msgstr ""
 
 #. Description of the 'User Type' (Link) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "If the user has any role checked, then the user becomes a \"System User\". \"System User\" has access to the desktop"
 msgstr ""
 
@@ -15628,36 +11735,22 @@ msgstr ""
 msgid "If these instructions where not helpful, please add in your suggestions on GitHub Issues."
 msgstr ""
 
-#. Description of the 'Fetch on Save if Empty' (Check) field in DocType 'Custom
-#. Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "If unchecked, the value will always be re-fetched on save."
-msgstr ""
-
-#. Description of the 'Fetch on Save if Empty' (Check) field in DocType
-#. 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "If unchecked, the value will always be re-fetched on save."
-msgstr ""
-
 #. Description of the 'Fetch on Save if Empty' (Check) field in DocType
 #. 'DocField'
+#. Description of the 'Fetch on Save if Empty' (Check) field in DocType 'Custom
+#. Field'
+#. Description of the 'Fetch on Save if Empty' (Check) field in DocType
+#. 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "If unchecked, the value will always be re-fetched on save."
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "If user is the owner"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocPerm'
+#: core/doctype/custom_docperm/custom_docperm.json
 #: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
 msgid "If user is the owner"
 msgstr ""
 
@@ -15683,7 +11776,6 @@ msgstr ""
 
 #. Description of the 'Parent Label' (Select) field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
-msgctxt "Top Bar Item"
 msgid "If you set this, this Item will come in a drop-down under the selected parent."
 msgstr ""
 
@@ -15693,69 +11785,43 @@ msgstr ""
 
 #. Description of the 'Delimiter Options' (Data) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "If your CSV uses a different delimiter, add that character here, ensuring no spaces or additional characters are included."
 msgstr ""
 
 #. Description of the 'Source Text' (Code) field in DocType 'Translation'
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
 msgid "If your data is in HTML, please copy paste the exact HTML code with the tags."
 msgstr ""
 
+#. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Ignore User Permissions"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Ignore User Permissions"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Ignore User Permissions"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Ignore XSS Filter"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Ignore XSS Filter"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Ignore XSS Filter"
 msgstr ""
 
 #. Description of the 'Attachment Limit (MB)' (Int) field in DocType 'Email
 #. Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Ignore attachments over this size"
-msgstr ""
-
 #. Description of the 'Attachment Limit (MB)' (Int) field in DocType 'Email
 #. Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Ignore attachments over this size"
 msgstr ""
 
 #. Label of a Table field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Ignored Apps"
 msgstr ""
 
@@ -15776,89 +11842,47 @@ msgid "Illegal template"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Image"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Image"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Image"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Image"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Image"
-msgstr ""
-
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
 #. Option for the 'Letter Head Based On' (Select) field in DocType 'Letter
 #. Head'
 #. Label of a Attach Image field in DocType 'Letter Head'
 #. Option for the 'Footer Based On' (Select) field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "Image"
-msgstr ""
-
 #. Label of a Attach Image field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Image"
-msgstr ""
-
 #. Label of a Attach field in DocType 'Website Slideshow Item'
-#: website/doctype/website_slideshow_item/website_slideshow_item.json
-msgctxt "Website Slideshow Item"
-msgid "Image"
-msgstr ""
-
-#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: contacts/doctype/contact/contact.json core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: printing/doctype/letter_head/letter_head.json
+#: website/doctype/web_page/web_page.json
+#: website/doctype/website_slideshow_item/website_slideshow_item.json
 msgid "Image"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Image Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Image Field"
 msgstr ""
 
 #. Label of a Float field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Image Height"
 msgstr ""
 
 #. Label of a Attach field in DocType 'About Us Team Member'
 #: website/doctype/about_us_team_member/about_us_team_member.json
-msgctxt "About Us Team Member"
 msgid "Image Link"
 msgstr ""
 
 #. Label of a Float field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Image Width"
 msgstr ""
 
@@ -15882,13 +11906,8 @@ msgstr ""
 msgid "Images"
 msgstr ""
 
-#: core/doctype/user/user.js:356
-msgid "Impersonate"
-msgstr ""
-
 #. Option for the 'Operation' (Select) field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
+#: core/doctype/activity_log/activity_log.json core/doctype/user/user.js:356
 msgid "Impersonate"
 msgstr ""
 
@@ -15910,29 +11929,19 @@ msgstr ""
 
 #. Option for the 'Grant Type' (Select) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Implicit"
 msgstr ""
 
-#: core/doctype/recorder/recorder_list.js:16
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json core/doctype/recorder/recorder_list.js:16
 #: email/doctype/email_group/email_group.js:31
 msgid "Import"
 msgstr ""
 
 #: public/js/frappe/list/list_view.js:1673
 msgctxt "Button in list view menu"
-msgid "Import"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Import"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
 msgid "Import"
 msgstr ""
 
@@ -15949,31 +11958,26 @@ msgstr ""
 
 #. Label of a Attach field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import File"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import File Errors and Warnings"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import Log"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import Log Preview"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import Preview"
 msgstr ""
 
@@ -15988,13 +11992,11 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import Type"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import Warnings"
 msgstr ""
 
@@ -16004,7 +12006,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Import from Google Sheets"
 msgstr ""
 
@@ -16039,7 +12040,6 @@ msgstr ""
 #. Description of the 'Force User to Reset Password' (Int) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "In Days"
 msgstr ""
 
@@ -16048,33 +12048,19 @@ msgstr ""
 msgid "In ERPNext, you can add your Employees as Users, and give them restricted access. Tools like Role Permission and User Permission allow you to define rules which give restricted access to the user to masters and transactions."
 msgstr ""
 
+#. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "In Filter"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "In Filter"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "In Global Search"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "In Global Search"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "In Global Search"
 msgstr ""
 
@@ -16084,47 +12070,24 @@ msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "In List Filter"
 msgstr ""
 
-#: core/doctype/doctype/doctype.js:97
-msgid "In List View"
-msgstr ""
-
+#. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "In List View"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json core/doctype/doctype/doctype.js:97
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "In List View"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "In List View"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "In Preview"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "In Preview"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "In Preview"
 msgstr ""
 
@@ -16138,19 +12101,13 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "In Reply To"
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "In Standard Filter"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "In Standard Filter"
 msgstr ""
 
@@ -16161,14 +12118,12 @@ msgstr ""
 
 #. Description of the 'Font Size' (Float) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "In points. Default is 9."
 msgstr ""
 
 #. Description of the 'Allow Login After Fail' (Int) field in DocType 'System
 #. Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "In seconds"
 msgstr ""
 
@@ -16180,13 +12135,9 @@ msgstr ""
 msgid "Inavlid Values"
 msgstr ""
 
-#: email/doctype/email_account/email_account_list.js:19
-msgid "Inbox"
-msgstr ""
-
 #. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
+#: email/doctype/email_account/email_account_list.js:19
 msgid "Inbox"
 msgstr ""
 
@@ -16198,13 +12149,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Include Name Field"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Include Search in Top Bar"
 msgstr ""
 
@@ -16214,7 +12163,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Include Web View Link in Email"
 msgstr ""
 
@@ -16232,37 +12180,28 @@ msgstr ""
 
 #. Label of a Tab Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Incoming (POP/IMAP)"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Incoming (POP/IMAP) Settings"
 msgstr ""
 
 #. Label of a Column Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Incoming Emails (Last 7 days)"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Incoming Server"
-msgstr ""
-
 #. Label of a Data field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Incoming Server"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Incoming Settings"
 msgstr ""
 
@@ -16302,33 +12241,19 @@ msgstr ""
 msgid "Incorrect value: {0} must be {1} {2}"
 msgstr ""
 
-#: model/meta.py:48 public/js/frappe/model/meta.js:200
-#: public/js/frappe/model/model.js:124
-#: public/js/frappe/views/reports/report_view.js:938
-msgid "Index"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Index"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Index"
-msgstr ""
-
 #. Label of a Int field in DocType 'Recorder Query'
+#. Label of a Check field in DocType 'Custom Field'
+#: core/doctype/docfield/docfield.json
 #: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
+#: custom/doctype/custom_field/custom_field.json model/meta.py:48
+#: public/js/frappe/model/meta.js:200 public/js/frappe/model/model.js:124
+#: public/js/frappe/views/reports/report_view.js:938
 msgid "Index"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Index Web Pages for Search"
 msgstr ""
 
@@ -16338,49 +12263,36 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Indexing authorization code"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Indexing refresh token"
 msgstr ""
 
 #. Label of a Select field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Indicator"
 msgstr ""
 
 #. Label of a Select field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Indicator Color"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:652
-#: public/js/frappe/views/workspace/workspace.js:980
-#: public/js/frappe/views/workspace/workspace.js:1224
+#: public/js/frappe/views/workspace/workspace.js:653
+#: public/js/frappe/views/workspace/workspace.js:981
+#: public/js/frappe/views/workspace/workspace.js:1225
 msgid "Indicator color"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Info"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Info"
-msgstr ""
-
 #. Option for the 'Style' (Select) field in DocType 'Workflow State'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Info"
 msgstr ""
 
@@ -16390,13 +12302,11 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Initial Sync Count"
 msgstr ""
 
 #. Option for the 'Database Engine' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "InnoDB"
 msgstr ""
 
@@ -16408,13 +12318,9 @@ msgstr ""
 msgid "Insert Above"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1730
-msgid "Insert After"
-msgstr ""
-
 #. Label of a Select field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
+#: public/js/frappe/views/reports/query_report.js:1730
 msgid "Insert After"
 msgstr ""
 
@@ -16440,13 +12346,11 @@ msgstr ""
 
 #. Option for the 'Import Type' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Insert New Records"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Insert Style"
 msgstr ""
 
@@ -16461,13 +12365,8 @@ msgid "Installed Application"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/installed_applications/installed_applications.json
-msgid "Installed Applications"
-msgstr ""
-
 #. Label of a Table field in DocType 'Installed Applications'
 #: core/doctype/installed_applications/installed_applications.json
-msgctxt "Installed Applications"
 msgid "Installed Applications"
 msgstr ""
 
@@ -16478,7 +12377,6 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Instructions"
 msgstr ""
 
@@ -16506,45 +12404,20 @@ msgstr ""
 msgid "Insufficient attachment limit"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Int"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Int"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Int"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Int"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Int"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Int"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Int"
 msgstr ""
 
@@ -16553,49 +12426,34 @@ msgstr ""
 msgid "Integration Request"
 msgstr ""
 
-#. Name of a Workspace
-#: integrations/workspace/integrations/integrations.json
-msgid "Integrations"
-msgstr ""
-
 #. Group in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Integrations"
-msgstr ""
-
+#. Name of a Workspace
 #. Label of a Tab Break field in DocType 'Website Settings'
+#: core/doctype/user/user.json
+#: integrations/workspace/integrations/integrations.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Integrations"
 msgstr ""
 
 #. Description of the 'Delivery Status' (Select) field in DocType
 #. 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Integrations can use this field to set email delivery status"
 msgstr ""
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Inter"
-msgstr ""
-
-#: desk/page/user_profile/user_profile_sidebar.html:37
-msgid "Interests"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
+#: desk/page/user_profile/user_profile_sidebar.html:37
 msgid "Interests"
 msgstr ""
 
 #. Option for the 'Level' (Select) field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Intermediate"
 msgstr ""
 
@@ -16614,27 +12472,20 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Intro Video URL"
 msgstr ""
 
 #. Description of the 'Company Introduction' (Text Editor) field in DocType
 #. 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "Introduce your company to the website visitor."
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Contact Us Settings'
 #. Label of a Text Editor field in DocType 'Contact Us Settings'
-#: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
-msgid "Introduction"
-msgstr ""
-
 #. Label of a Text Editor field in DocType 'Web Form'
+#: website/doctype/contact_us_settings/contact_us_settings.json
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Introduction"
 msgstr ""
 
@@ -16646,20 +12497,17 @@ msgstr ""
 #. Description of the 'Introduction' (Text Editor) field in DocType 'Contact Us
 #. Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Introductory information for the Contact Us Page"
 msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Introspection URI"
 msgstr ""
 
 #. Option for the 'Validity' (Select) field in DocType 'OAuth Authorization
 #. Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "Invalid"
 msgstr ""
 
@@ -16774,7 +12622,7 @@ msgstr ""
 msgid "Invalid Password"
 msgstr ""
 
-#: utils/__init__.py:110
+#: utils/__init__.py:119
 msgid "Invalid Phone Number"
 msgstr ""
 
@@ -16900,7 +12748,6 @@ msgstr ""
 
 #. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Inverse"
 msgstr ""
 
@@ -16914,111 +12761,69 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Is Active"
 msgstr ""
 
 #. Label of a Check field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Is Attachments Folder"
 msgstr ""
 
+#. Label of a Check field in DocType 'DocType'
 #. Label of a Check field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Is Calendar and Gantt"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Is Calendar and Gantt"
-msgstr ""
-
-#: core/doctype/doctype/doctype_list.js:49
-msgid "Is Child Table"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Is Child Table"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType Link'
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:49
 #: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
 msgid "Is Child Table"
 msgstr ""
 
 #. Label of a Check field in DocType 'Module Onboarding'
-#: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
-msgid "Is Complete"
-msgstr ""
-
 #. Label of a Check field in DocType 'Onboarding Step'
+#: desk/doctype/module_onboarding/module_onboarding.json
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Is Complete"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Flag Queue'
 #: email/doctype/email_flag_queue/email_flag_queue.json
-msgctxt "Email Flag Queue"
 msgid "Is Completed"
 msgstr ""
 
 #. Label of a Check field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
-msgid "Is Custom"
-msgstr ""
-
 #. Label of a Check field in DocType 'User Document Type'
+#: core/doctype/role/role.json
 #: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
 msgid "Is Custom"
 msgstr ""
 
 #. Label of a Check field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Is Custom Field"
 msgstr ""
 
-#: core/doctype/user_permission/user_permission_list.js:69
-msgid "Is Default"
-msgstr ""
-
 #. Label of a Check field in DocType 'Address Template'
-#: contacts/doctype/address_template/address_template.json
-msgctxt "Address Template"
-msgid "Is Default"
-msgstr ""
-
-#. Label of a Check field in DocType 'Dashboard'
-#: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
-msgid "Is Default"
-msgstr ""
-
 #. Label of a Check field in DocType 'User Permission'
+#. Label of a Check field in DocType 'Dashboard'
+#: contacts/doctype/address_template/address_template.json
 #: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
+#: core/doctype/user_permission/user_permission_list.js:69
+#: desk/doctype/dashboard/dashboard.json
 msgid "Is Default"
 msgstr ""
 
 #. Label of a Check field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Is Dynamic URL?"
 msgstr ""
 
 #. Label of a Check field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Is Folder"
 msgstr ""
 
@@ -17028,73 +12833,58 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Is Hidden"
 msgstr ""
 
 #. Label of a Check field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Is Home Folder"
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
 msgid "Is Mandatory Field"
 msgstr ""
 
 #. Label of a Check field in DocType 'Workflow Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Is Optional State"
 msgstr ""
 
 #. Label of a Check field in DocType 'Contact Email'
 #: contacts/doctype/contact_email/contact_email.json
-msgctxt "Contact Email"
 msgid "Is Primary"
 msgstr ""
 
 #. Label of a Check field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Is Primary Contact"
 msgstr ""
 
 #. Label of a Check field in DocType 'Contact Phone'
 #: contacts/doctype/contact_phone/contact_phone.json
-msgctxt "Contact Phone"
 msgid "Is Primary Mobile"
 msgstr ""
 
 #. Label of a Check field in DocType 'Contact Phone'
 #: contacts/doctype/contact_phone/contact_phone.json
-msgctxt "Contact Phone"
 msgid "Is Primary Phone"
 msgstr ""
 
 #. Label of a Check field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Is Private"
 msgstr ""
 
 #. Label of a Check field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Is Public"
-msgstr ""
-
 #. Label of a Check field in DocType 'Number Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Is Public"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Is Published Field"
 msgstr ""
 
@@ -17104,165 +12894,90 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
 msgid "Is Query Report"
 msgstr ""
 
 #. Label of a Check field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
 msgid "Is Remote Request?"
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:64
-msgid "Is Single"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#. Label of a Check field in DocType 'Onboarding Step'
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:64
+#: desk/doctype/onboarding_step/onboarding_step.json
 msgid "Is Single"
 msgstr ""
 
 #. Label of a Check field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Is Single"
-msgstr ""
-
-#. Label of a Check field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Is Skipped"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Rule'
 #: email/doctype/email_rule/email_rule.json
-msgctxt "Email Rule"
 msgid "Is Spam"
 msgstr ""
 
-#. Label of a Check field in DocType 'Dashboard'
-#: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
-msgid "Is Standard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Is Standard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Is Standard"
-msgstr ""
-
 #. Label of a Check field in DocType 'Navbar Item'
-#: core/doctype/navbar_item/navbar_item.json
-msgctxt "Navbar Item"
-msgid "Is Standard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Is Standard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Is Standard"
-msgstr ""
-
 #. Label of a Select field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Is Standard"
-msgstr ""
-
 #. Label of a Check field in DocType 'User Type'
-#: core/doctype/user_type/user_type.json
-msgctxt "User Type"
-msgid "Is Standard"
-msgstr ""
-
+#. Label of a Check field in DocType 'Dashboard'
+#. Label of a Check field in DocType 'Dashboard Chart'
+#. Label of a Check field in DocType 'Form Tour'
+#. Label of a Check field in DocType 'Number Card'
+#. Label of a Check field in DocType 'Notification'
 #. Label of a Check field in DocType 'Web Form'
+#: core/doctype/navbar_item/navbar_item.json core/doctype/report/report.json
+#: core/doctype/user_type/user_type.json desk/doctype/dashboard/dashboard.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/form_tour/form_tour.json
+#: desk/doctype/number_card/number_card.json
+#: email/doctype/notification/notification.json
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Is Standard"
-msgstr ""
-
-#: core/doctype/doctype/doctype_list.js:39
-msgid "Is Submittable"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:39
 msgid "Is Submittable"
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Is System Generated"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Is System Generated"
-msgstr ""
-
 #. Label of a Check field in DocType 'Property Setter'
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "Is System Generated"
 msgstr ""
 
 #. Label of a Check field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Is Table"
 msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Is Table Field"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Is Tree"
 msgstr ""
 
 #. Label of a Data field in DocType 'Web Page View'
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
 msgid "Is Unique"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Is Virtual"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Is Virtual"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Is Virtual"
 msgstr ""
 
@@ -17272,13 +12987,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Navbar Item'
 #: core/doctype/navbar_item/navbar_item.json
-msgctxt "Navbar Item"
 msgid "Item Label"
 msgstr ""
 
 #. Label of a Select field in DocType 'Navbar Item'
 #: core/doctype/navbar_item/navbar_item.json
-msgctxt "Navbar Item"
 msgid "Item Type"
 msgstr ""
 
@@ -17288,43 +13001,26 @@ msgstr ""
 
 #. Option for the 'Print Format Type' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "JS"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Custom HTML Block'
 #: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
 msgid "JS Message"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "JSON"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "JSON"
-msgstr ""
-
 #. Label of a Code field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "JSON"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
 #. Option for the 'Request Structure' (Select) field in DocType 'Webhook'
+#: core/doctype/docfield/docfield.json core/doctype/report/report.json
+#: custom/doctype/custom_field/custom_field.json
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "JSON"
 msgstr ""
 
 #. Label of a Code field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "JSON Request Body"
 msgstr ""
 
@@ -17334,37 +13030,22 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "JavaScript"
 msgstr ""
 
 #. Description of the 'Javascript' (Code) field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "JavaScript Format: frappe.query_reports['REPORTNAME'] = {}"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Custom HTML Block'
-#: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
-msgid "Javascript"
-msgstr ""
-
 #. Label of a Code field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Javascript"
-msgstr ""
-
+#. Label of a Section Break field in DocType 'Custom HTML Block'
 #. Label of a Code field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Javascript"
-msgstr ""
-
 #. Label of a Code field in DocType 'Website Script'
+#: core/doctype/report/report.json
+#: desk/doctype/custom_html_block/custom_html_block.json
+#: website/doctype/web_page/web_page.json
 #: website/doctype/website_script/website_script.json
-msgctxt "Website Script"
 msgid "Javascript"
 msgstr ""
 
@@ -17374,43 +13055,33 @@ msgstr ""
 
 #. Option for the 'Print Format Type' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Jinja"
 msgstr ""
 
 #. Label of a Data field in DocType 'Prepared Report'
-#: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
-msgid "Job ID"
-msgstr ""
-
 #. Label of a Data field in DocType 'RQ Job'
+#: core/doctype/prepared_report/prepared_report.json
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Job ID"
 msgstr ""
 
 #. Label of a Link field in DocType 'Submission Queue'
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
 msgid "Job Id"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Job Info"
 msgstr ""
 
 #. Label of a Data field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Job Name"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Job Status"
 msgstr ""
 
@@ -17438,31 +13109,18 @@ msgid "K"
 msgstr ""
 
 #. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Kanban"
-msgstr ""
-
 #. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Kanban"
-msgstr ""
-
-#. Name of a DocType
-#: desk/doctype/kanban_board/kanban_board.json
-msgid "Kanban Board"
 msgstr ""
 
 #. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Kanban Board"
-msgstr ""
-
+#. Name of a DocType
 #. Label of a Link field in DocType 'Workspace Shortcut'
+#: core/doctype/doctype/doctype.json
+#: desk/doctype/kanban_board/kanban_board.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Kanban Board"
 msgstr ""
 
@@ -17471,13 +13129,9 @@ msgstr ""
 msgid "Kanban Board Column"
 msgstr ""
 
-#: public/js/frappe/views/kanban/kanban_view.js:388
-msgid "Kanban Board Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Kanban Board'
 #: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
+#: public/js/frappe/views/kanban/kanban_view.js:388
 msgid "Kanban Board Name"
 msgstr ""
 
@@ -17497,38 +13151,17 @@ msgid "Keeps track of all communications"
 msgstr ""
 
 #. Label of a Data field in DocType 'DefaultValue'
-#: core/doctype/defaultvalue/defaultvalue.json
-msgctxt "DefaultValue"
-msgid "Key"
-msgstr ""
-
 #. Label of a Data field in DocType 'Document Share Key'
-#: core/doctype/document_share_key/document_share_key.json
-msgctxt "Document Share Key"
-msgid "Key"
-msgstr ""
-
 #. Label of a Data field in DocType 'Query Parameters'
-#: integrations/doctype/query_parameters/query_parameters.json
-msgctxt "Query Parameters"
-msgid "Key"
-msgstr ""
-
 #. Label of a Data field in DocType 'Webhook Data'
-#: integrations/doctype/webhook_data/webhook_data.json
-msgctxt "Webhook Data"
-msgid "Key"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Webhook Header'
-#: integrations/doctype/webhook_header/webhook_header.json
-msgctxt "Webhook Header"
-msgid "Key"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Meta Tag'
+#: core/doctype/defaultvalue/defaultvalue.json
+#: core/doctype/document_share_key/document_share_key.json
+#: integrations/doctype/query_parameters/query_parameters.json
+#: integrations/doctype/webhook_data/webhook_data.json
+#: integrations/doctype/webhook_header/webhook_header.json
 #: website/doctype/website_meta_tag/website_meta_tag.json
-msgctxt "Website Meta Tag"
 msgid "Key"
 msgstr ""
 
@@ -17569,37 +13202,31 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Auth"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Custom Settings"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Email Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP First Name Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Group Mapping'
 #: integrations/doctype/ldap_group_mapping/ldap_group_mapping.json
-msgctxt "LDAP Group Mapping"
 msgid "LDAP Group"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Group Field"
 msgstr ""
 
@@ -17611,31 +13238,26 @@ msgstr ""
 #. Label of a Section Break field in DocType 'LDAP Settings'
 #. Label of a Table field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Group Mappings"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Group Member attribute"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Last Name Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Middle Name Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Mobile Field"
 msgstr ""
 
@@ -17645,13 +13267,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Phone Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Search String"
 msgstr ""
 
@@ -17661,25 +13281,21 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Search and Paths"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Security"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Server Settings"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Server Url"
 msgstr ""
 
@@ -17696,13 +13312,11 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP User Creation and Mapping"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP Username Field"
 msgstr ""
 
@@ -17713,13 +13327,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP search path for Groups"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "LDAP search path for Users"
 msgstr ""
 
@@ -17727,143 +13339,61 @@ msgstr ""
 msgid "LDAP settings incorrect. validation response was: {0}"
 msgstr ""
 
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#. Label of a Data field in DocType 'DocField'
+#. Label of a Data field in DocType 'DocType Action'
+#. Label of a Data field in DocType 'Report Column'
+#. Label of a Data field in DocType 'Report Filter'
+#. Label of a Data field in DocType 'Custom Field'
+#. Label of a Data field in DocType 'Customize Form Field'
+#. Label of a Data field in DocType 'DocType Layout Field'
+#. Label of a Data field in DocType 'Desktop Icon'
+#. Label of a Data field in DocType 'Form Tour Step'
+#. Label of a Data field in DocType 'Number Card'
+#. Label of a Data field in DocType 'Workspace Chart'
+#. Label of a Data field in DocType 'Workspace Custom Block'
+#. Label of a Data field in DocType 'Workspace Link'
+#. Label of a Data field in DocType 'Workspace Number Card'
+#. Label of a Data field in DocType 'Workspace Quick List'
+#. Label of a Data field in DocType 'Workspace Shortcut'
+#. Label of a Data field in DocType 'Top Bar Item'
+#. Label of a Data field in DocType 'Web Template Field'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
+#: core/doctype/docfield/docfield.json
+#: core/doctype/doctype_action/doctype_action.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: custom/doctype/doctype_layout_field/doctype_layout_field.json
+#: desk/doctype/desktop_icon/desktop_icon.json
+#: desk/doctype/form_tour_step/form_tour_step.json
+#: desk/doctype/number_card/number_card.json
+#: desk/doctype/workspace_chart/workspace_chart.json
+#: desk/doctype/workspace_custom_block/workspace_custom_block.json
+#: desk/doctype/workspace_link/workspace_link.json
+#: desk/doctype/workspace_number_card/workspace_number_card.json
+#: desk/doctype/workspace_quick_list/workspace_quick_list.json
+#: desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: printing/page/print_format_builder/print_format_builder.js:474
 #: public/js/frappe/widgets/widget_dialog.js:255
 #: public/js/frappe/widgets/widget_dialog.js:645
 #: public/js/frappe/widgets/widget_dialog.js:678
 #: templates/form_grid/fields.html:37
-msgid "Label"
-msgstr ""
-
-#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Label"
-msgstr ""
-
-#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'DocType Action'
-#: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'DocType Layout Field'
-#: custom/doctype/doctype_layout_field/doctype_layout_field.json
-msgctxt "DocType Layout Field"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
-msgctxt "Top Bar Item"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace Chart'
-#: desk/doctype/workspace_chart/workspace_chart.json
-msgctxt "Workspace Chart"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace Custom Block'
-#: desk/doctype/workspace_custom_block/workspace_custom_block.json
-msgctxt "Workspace Custom Block"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace Number Card'
-#: desk/doctype/workspace_number_card/workspace_number_card.json
-msgctxt "Workspace Number Card"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace Quick List'
-#: desk/doctype/workspace_quick_list/workspace_quick_list.json
-msgctxt "Workspace Quick List"
-msgid "Label"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace Shortcut'
-#: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Label"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
 msgid "Label Help"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Label and Type"
 msgstr ""
 
@@ -17873,7 +13403,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Landing Page"
 msgstr ""
 
@@ -17882,86 +13411,64 @@ msgid "Landscape"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/language/language.json printing/page/print/print.js:104
-#: public/js/frappe/form/templates/print_layout.html:11
-msgid "Language"
-msgstr ""
-
 #. Label of a Link field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
-msgid "Language"
-msgstr ""
-
 #. Label of a Link field in DocType 'Translation'
-#: core/doctype/translation/translation.json
-msgctxt "Translation"
-msgid "Language"
-msgstr ""
-
 #. Label of a Link field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/language/language.json
+#: core/doctype/system_settings/system_settings.json
+#: core/doctype/translation/translation.json core/doctype/user/user.json
+#: printing/page/print/print.js:104
+#: public/js/frappe/form/templates/print_layout.html:11
 msgid "Language"
 msgstr ""
 
 #. Label of a Data field in DocType 'Language'
 #: core/doctype/language/language.json
-msgctxt "Language"
 msgid "Language Code"
 msgstr ""
 
 #. Label of a Data field in DocType 'Language'
 #: core/doctype/language/language.json
-msgctxt "Language"
 msgid "Language Name"
 msgstr ""
 
 #. Label of a Code field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Last 10 active users"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Last Active"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "Last Backup On"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
 msgid "Last Execution"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Last Heartbeat"
 msgstr ""
 
 #. Label of a Read Only field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Last IP"
 msgstr ""
 
 #. Label of a Text field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Last Known Versions"
 msgstr ""
 
 #. Label of a Read Only field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Last Login"
 msgstr ""
 
@@ -17976,59 +13483,43 @@ msgstr ""
 
 #. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Last Month"
 msgstr ""
 
-#: www/complete_signup.html:19
-msgid "Last Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Last Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: contacts/doctype/contact/contact.json core/doctype/user/user.json
+#: www/complete_signup.html:19
 msgid "Last Name"
 msgstr ""
 
 #. Label of a Date field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Last Password Reset Date"
 msgstr ""
 
 #. Label of a Date field in DocType 'Energy Point Settings'
 #: social/doctype/energy_point_settings/energy_point_settings.json
-msgctxt "Energy Point Settings"
 msgid "Last Point Allocation Date"
 msgstr ""
 
 #. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Last Quarter"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Last Reset Password Key Generated On"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Google Contacts'
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
 msgid "Last Sync On"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Last Synced On"
 msgstr ""
 
@@ -18044,19 +13535,16 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Last User"
 msgstr ""
 
 #. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Last Week"
 msgstr ""
 
 #. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Last Year"
 msgstr ""
 
@@ -18108,7 +13596,6 @@ msgstr ""
 
 #. Description of the 'Repeat Till' (Date) field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Leave blank to repeat always"
 msgstr ""
 
@@ -18119,25 +13606,15 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Ledger"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Left"
-msgstr ""
-
 #. Option for the 'Align' (Select) field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "Left"
-msgstr ""
-
 #. Option for the 'Text Align' (Select) field in DocType 'Web Page'
+#: desk/doctype/form_tour_step/form_tour_step.json
+#: printing/doctype/letter_head/letter_head.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Left"
 msgstr ""
 
@@ -18148,13 +13625,11 @@ msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Left Bottom"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Left Center"
 msgstr ""
 
@@ -18164,25 +13639,15 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Legal"
 msgstr ""
 
-#. Label of a Int field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Length"
-msgstr ""
-
-#. Label of a Int field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Length"
-msgstr ""
-
 #. Label of a Int field in DocType 'DocField'
+#. Label of a Int field in DocType 'Custom Field'
+#. Label of a Int field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Length"
 msgstr ""
 
@@ -18229,11 +13694,12 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Letter"
 msgstr ""
 
+#. Label of a Link field in DocType 'Report'
 #. Name of a DocType
+#: core/doctype/report/report.json
 #: printing/doctype/letter_head/letter_head.json
 #: printing/page/print/print.js:127 public/js/frappe/form/print_utils.js:18
 #: public/js/frappe/form/templates/print_layout.html:16
@@ -18241,27 +13707,18 @@ msgstr ""
 msgid "Letter Head"
 msgstr ""
 
-#. Label of a Link field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Letter Head"
-msgstr ""
-
 #. Label of a Select field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Letter Head Based On"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Letter Head Image"
 msgstr ""
 
 #. Label of a Data field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Letter Head Name"
 msgstr ""
 
@@ -18276,30 +13733,17 @@ msgstr ""
 #. Description of the 'Header HTML' (HTML Editor) field in DocType 'Letter
 #. Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Letter Head in HTML"
 msgstr ""
 
+#. Label of a Int field in DocType 'Custom DocPerm'
+#. Label of a Int field in DocType 'DocPerm'
+#. Label of a Select field in DocType 'Help Article'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json
 #: core/page/permission_manager/permission_manager.js:213
 #: public/js/frappe/roles_editor.js:66
-msgid "Level"
-msgstr ""
-
-#. Label of a Int field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Level"
-msgstr ""
-
-#. Label of a Int field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Level"
-msgstr ""
-
-#. Label of a Select field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Level"
 msgstr ""
 
@@ -18309,47 +13753,33 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Review Level'
 #: social/doctype/review_level/review_level.json
-msgctxt "Review Level"
 msgid "Level Name"
 msgstr ""
 
-#: www/attribution.html:36
-msgid "License"
-msgstr ""
-
 #. Label of a Markdown Editor field in DocType 'Package'
-#: core/doctype/package/package.json
-msgctxt "Package"
+#: core/doctype/package/package.json www/attribution.html:36
 msgid "License"
 msgstr ""
 
 #. Label of a Select field in DocType 'Package'
 #: core/doctype/package/package.json
-msgctxt "Package"
 msgid "License Type"
 msgstr ""
 
 #. Option for the 'Desk Theme' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Light"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Light Blue"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Light Blue"
 msgstr ""
 
 #. Label of a Link field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Light Color"
 msgstr ""
 
@@ -18357,31 +13787,21 @@ msgstr ""
 msgid "Light Theme"
 msgstr ""
 
-#: public/js/frappe/ui/filters/filter.js:18
-msgid "Like"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Like"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
+#: public/js/frappe/ui/filters/filter.js:18
 msgid "Like"
 msgstr ""
 
 #. Label of a Int field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Like limit"
 msgstr ""
 
 #. Description of the 'Like limit' (Int) field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Like limit per hour"
 msgstr ""
 
@@ -18400,133 +13820,75 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Likes"
 msgstr ""
 
 #. Label of a Int field in DocType 'Bulk Update'
 #: desk/doctype/bulk_update/bulk_update.json
-msgctxt "Bulk Update"
 msgid "Limit"
 msgstr ""
 
 #. Label of a Check field in DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
 msgid "Limit Number of DB Backups"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Line"
 msgstr ""
 
-#. Label of a Long Text field in DocType 'Changelog Feed'
-#: desk/doctype/changelog_feed/changelog_feed.json
-msgctxt "Changelog Feed"
-msgid "Link"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Link"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Link"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Link"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Link"
-msgstr ""
-
-#. Label of a Data field in DocType 'Notification Log'
-#: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
-msgid "Link"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Link"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Link"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Link"
-msgstr ""
-
-#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
-#: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
-msgid "Link"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Long Text field in DocType 'Changelog Feed'
+#. Label of a Small Text field in DocType 'Desktop Icon'
+#. Label of a Data field in DocType 'Notification Log'
 #. Option for the 'Type' (Select) field in DocType 'Workspace Link'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/changelog_feed/changelog_feed.json
+#: desk/doctype/desktop_icon/desktop_icon.json
+#: desk/doctype/notification_log/notification_log.json
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
+#: website/doctype/web_form_field/web_form_field.json
+#: website/doctype/web_template_field/web_template_field.json
 msgid "Link"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Link Cards"
 msgstr ""
 
 #. Label of a Int field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
 msgid "Link Count"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
 msgid "Link Details"
 msgstr ""
 
 #. Label of a Link field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Link DocType"
-msgstr ""
-
 #. Label of a Link field in DocType 'Communication Link'
-#: core/doctype/communication_link/communication_link.json
-msgctxt "Communication Link"
-msgid "Link DocType"
-msgstr ""
-
 #. Label of a Link field in DocType 'DocType Link'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication_link/communication_link.json
 #: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
 msgid "Link DocType"
 msgstr ""
 
 #. Label of a Link field in DocType 'Dynamic Link'
 #: core/doctype/dynamic_link/dynamic_link.json
-msgctxt "Dynamic Link"
 msgid "Link Document Type"
 msgstr ""
 
@@ -18537,79 +13899,45 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Link Field Results Limit"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType Link'
 #: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
 msgid "Link Fieldname"
 msgstr ""
 
-#. Label of a JSON field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Link Filters"
-msgstr ""
-
-#. Label of a JSON field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Link Filters"
-msgstr ""
-
-#. Label of a JSON field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Link Filters"
-msgstr ""
-
 #. Label of a JSON field in DocType 'DocField'
+#. Label of a JSON field in DocType 'Custom Field'
+#. Label of a JSON field in DocType 'Customize Form'
+#. Label of a JSON field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form/customize_form.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Link Filters"
 msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Link Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Communication Link'
-#: core/doctype/communication_link/communication_link.json
-msgctxt "Communication Link"
-msgid "Link Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Dynamic Link'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication_link/communication_link.json
 #: core/doctype/dynamic_link/dynamic_link.json
-msgctxt "Dynamic Link"
 msgid "Link Name"
 msgstr ""
 
 #. Label of a Read Only field in DocType 'Communication Link'
-#: core/doctype/communication_link/communication_link.json
-msgctxt "Communication Link"
-msgid "Link Title"
-msgstr ""
-
 #. Label of a Read Only field in DocType 'Dynamic Link'
+#: core/doctype/communication_link/communication_link.json
 #: core/doctype/dynamic_link/dynamic_link.json
-msgctxt "Dynamic Link"
 msgid "Link Title"
 msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
-msgid "Link To"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Workspace Shortcut'
+#: desk/doctype/workspace_link/workspace_link.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Link To"
 msgstr ""
 
@@ -18619,7 +13947,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
 msgid "Link Type"
 msgstr ""
 
@@ -18633,31 +13960,23 @@ msgstr ""
 
 #. Description of the 'Home Page' (Data) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Link that is the website home page. Standard Links (home, login, products, blog, about, contact)"
 msgstr ""
 
 #. Description of the 'URL' (Data) field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
-msgctxt "Top Bar Item"
 msgid "Link to the page you want to open. Leave blank if you want to make it a group parent."
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Linked"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Communication'
+#: core/doctype/activity_log/activity_log.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Linked"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Linked Documents"
 msgstr ""
 
@@ -18665,69 +13984,36 @@ msgstr ""
 msgid "Linked With"
 msgstr ""
 
-#: contacts/doctype/address/address.js:39
-#: contacts/doctype/contact/contact.js:87 public/js/frappe/form/toolbar.js:377
-msgid "Links"
-msgstr ""
-
 #. Label of a Table field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Links"
-msgstr ""
-
 #. Label of a Table field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Links"
-msgstr ""
-
-#. Label of a Table field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Links"
-msgstr ""
-
 #. Label of a Table field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Links"
-msgstr ""
-
+#. Label of a Table field in DocType 'Customize Form'
 #. Label of a Table field in DocType 'Workspace'
-#: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: contacts/doctype/address/address.js:39 contacts/doctype/address/address.json
+#: contacts/doctype/contact/contact.js:87 contacts/doctype/contact/contact.json
+#: core/doctype/doctype/doctype.json
+#: custom/doctype/customize_form/customize_form.json
+#: desk/doctype/workspace/workspace.json public/js/frappe/form/toolbar.js:377
 msgid "Links"
 msgstr ""
 
 #. Option for the 'Apply To' (Select) field in DocType 'Client Script'
-#: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
-msgid "List"
-msgstr ""
-
 #. Option for the 'View' (Select) field in DocType 'Form Tour'
 #. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "List"
-msgstr ""
-
 #. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: custom/doctype/client_script/client_script.json
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "List"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "List / Search Settings"
 msgstr ""
 
 #. Label of a Table field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "List Columns"
 msgstr ""
 
@@ -18738,30 +14024,20 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "List Setting Message"
+msgstr ""
+
+#. Label of a Section Break field in DocType 'Role'
+#. Label of a Section Break field in DocType 'Customize Form'
+#. Label of a Section Break field in DocType 'Web Form'
+#: core/doctype/role/role.json
+#: custom/doctype/customize_form/customize_form.json
+#: website/doctype/web_form/web_form.json
+msgid "List Settings"
 msgstr ""
 
 #: public/js/frappe/list/list_view.js:1753
 msgctxt "Button in list view menu"
-msgid "List Settings"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "List Settings"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
-msgid "List Settings"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "List Settings"
 msgstr ""
 
@@ -18775,21 +14051,15 @@ msgid "List a document type"
 msgstr ""
 
 #. Description of the 'Breadcrumbs' (Code) field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "List as [{\"label\": _(\"Jobs\"), \"route\":\"jobs\"}]"
-msgstr ""
-
 #. Description of the 'Breadcrumbs' (Code) field in DocType 'Web Page'
+#: website/doctype/web_form/web_form.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "List as [{\"label\": _(\"Jobs\"), \"route\":\"jobs\"}]"
 msgstr ""
 
 #. Description of the 'Send Notification to' (Small Text) field in DocType
 #. 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "List of email addresses, separated by comma or new line."
 msgstr ""
 
@@ -18804,7 +14074,6 @@ msgstr ""
 
 #. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Load Balancing"
 msgstr ""
 
@@ -18856,25 +14125,21 @@ msgstr ""
 
 #. Label of a Data field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Location"
 msgstr ""
 
 #. Label of a Code field in DocType 'Package Import'
 #: core/doctype/package_import/package_import.json
-msgctxt "Package Import"
 msgid "Log"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "Log Data"
 msgstr ""
 
 #. Label of a Link field in DocType 'Logs To Clear'
 #: core/doctype/logs_to_clear/logs_to_clear.json
-msgctxt "Logs To Clear"
 msgid "Log DocType"
 msgstr ""
 
@@ -18884,7 +14149,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Data Import Log'
 #: core/doctype/data_import_log/data_import_log.json
-msgctxt "Data Import Log"
 msgid "Log Index"
 msgstr ""
 
@@ -18912,6 +14176,10 @@ msgstr ""
 msgid "Logged Out"
 msgstr ""
 
+#. Option for the 'Operation' (Select) field in DocType 'Activity Log'
+#. Label of a Tab Break field in DocType 'System Settings'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/system_settings/system_settings.json
 #: public/js/frappe/web_form/webform_script.js:16
 #: templates/discussions/discussions_section.html:60
 #: templates/discussions/reply_section.html:44
@@ -18921,27 +14189,13 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
-#. Option for the 'Operation' (Select) field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Login"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
-msgid "Login"
-msgstr ""
-
 #. Label of a Int field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Login After"
 msgstr ""
 
 #. Label of a Int field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Login Before"
 msgstr ""
 
@@ -18955,19 +14209,16 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Login Methods"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Login Page"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Login Required"
 msgstr ""
 
@@ -19025,13 +14276,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Login with email link"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Login with email link expiry (in minutes)"
 msgstr ""
 
@@ -19041,7 +14290,6 @@ msgstr ""
 
 #. Option for the 'Operation' (Select) field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
 msgid "Logout"
 msgstr ""
 
@@ -19051,24 +14299,17 @@ msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Logout All Sessions on Password Reset"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Logout From All Devices After Changing Password"
 msgstr ""
 
-#. Label of a Card Break in the Users Workspace
-#: core/workspace/users/users.json
-msgid "Logs"
-msgstr ""
-
 #. Group in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
+#. Label of a Card Break in the Users Workspace
+#: core/doctype/user/user.json core/workspace/users/users.json
 msgid "Logs"
 msgstr ""
 
@@ -19079,25 +14320,15 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Log Settings'
 #: core/doctype/log_settings/log_settings.json
-msgctxt "Log Settings"
 msgid "Logs to Clear"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Long Text"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Long Text"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Long Text"
 msgstr ""
 
@@ -19117,13 +14348,8 @@ msgstr ""
 msgid "Loving Frappe Framework?"
 msgstr ""
 
-#: public/js/frappe/form/sidebar/assign_to.js:216
-msgid "Low"
-msgstr ""
-
 #. Option for the 'Priority' (Select) field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
+#: desk/doctype/todo/todo.json public/js/frappe/form/sidebar/assign_to.js:216
 msgid "Low"
 msgstr ""
 
@@ -19134,25 +14360,21 @@ msgstr ""
 
 #. Option for the 'License Type' (Select) field in DocType 'Package'
 #: core/doctype/package/package.json
-msgctxt "Package"
 msgid "MIT License"
 msgstr ""
 
 #. Label of a Text Editor field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Main Section"
 msgstr ""
 
 #. Label of a HTML Editor field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Main Section (HTML)"
 msgstr ""
 
 #. Label of a Markdown Editor field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Main Section (Markdown)"
 msgstr ""
 
@@ -19168,32 +14390,24 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Package Release'
 #: core/doctype/package_release/package_release.json
-msgctxt "Package Release"
 msgid "Major"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Make \"name\" searchable in Global Search"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Make Attachments Public by Default"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Make Attachments Public by Default"
 msgstr ""
 
 #. Description of the 'Disable Username/Password Login' (Check) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Make sure to configure a Social Login Key before disabling to prevent lockout"
 msgstr ""
 
@@ -19217,57 +14431,30 @@ msgstr ""
 msgid "Manage your apps"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Mandatory"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Mandatory"
-msgstr ""
-
 #. Label of a Check field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Mandatory"
-msgstr ""
-
+#. Label of a Check field in DocType 'Customize Form Field'
 #. Label of a Check field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Mandatory"
-msgstr ""
-
 #. Label of a Check field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Mandatory"
 msgstr ""
 
 #. Label of a Code field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Mandatory Depends On"
-msgstr ""
-
 #. Label of a Code field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Mandatory Depends On"
-msgstr ""
-
 #. Label of a Code field in DocType 'Web Form Field'
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Mandatory Depends On"
 msgstr ""
 
 #. Label of a Code field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Mandatory Depends On (JS)"
 msgstr ""
 
@@ -19302,7 +14489,6 @@ msgstr ""
 
 #. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Map"
 msgstr ""
 
@@ -19317,7 +14503,6 @@ msgstr ""
 
 #. Description of the 'Dynamic Route' (Check) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Map route parameters into form variables. Example <code>/project/&lt;name&gt;</code>"
 msgstr ""
 
@@ -19327,31 +14512,26 @@ msgstr ""
 
 #. Label of a Float field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Margin Bottom"
 msgstr ""
 
 #. Label of a Float field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Margin Left"
 msgstr ""
 
 #. Label of a Float field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Margin Right"
 msgstr ""
 
 #. Label of a Float field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Margin Top"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "MariaDB Variables"
 msgstr ""
 
@@ -19373,61 +14553,31 @@ msgstr ""
 msgid "Mark as Unread"
 msgstr ""
 
-#: website/doctype/web_page/web_page.js:92
-msgid "Markdown"
-msgstr ""
-
-#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Markdown"
-msgstr ""
-
 #. Option for the 'Content Type' (Select) field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Markdown"
-msgstr ""
-
 #. Option for the 'Message Type' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Markdown"
-msgstr ""
-
+#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
 #. Option for the 'Content Type' (Select) field in DocType 'Web Page'
+#: email/doctype/newsletter/newsletter.json
+#: email/doctype/notification/notification.json
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/web_page/web_page.js:92
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Markdown"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Markdown Editor"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Markdown Editor"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Markdown Editor"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Markdown Editor"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Marked As Spam"
 msgstr ""
 
@@ -19438,55 +14588,43 @@ msgstr ""
 
 #. Description of the 'Limit' (Int) field in DocType 'Bulk Update'
 #: desk/doctype/bulk_update/bulk_update.json
-msgctxt "Bulk Update"
 msgid "Max 500 records at a time"
 msgstr ""
 
 #. Label of a Int field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Max Attachment Size (in MB)"
 msgstr ""
 
-#. Label of a Int field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Max Attachments"
-msgstr ""
-
 #. Label of a Int field in DocType 'DocType'
+#. Label of a Int field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Max Attachments"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Max File Size (MB)"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Max Height"
 msgstr ""
 
 #. Label of a Int field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Max Length"
 msgstr ""
 
 #. Label of a Int field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Max Value"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Max auto email report per user"
 msgstr ""
 
@@ -19496,7 +14634,6 @@ msgstr ""
 
 #. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Maximum"
 msgstr ""
 
@@ -19506,13 +14643,11 @@ msgstr ""
 
 #. Label of a Select field in DocType 'List View Settings'
 #: desk/doctype/list_view_settings/list_view_settings.json
-msgctxt "List View Settings"
 msgid "Maximum Number of Fields"
 msgstr ""
 
 #. Label of a Int field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Maximum Points"
 msgstr ""
 
@@ -19523,13 +14658,12 @@ msgstr ""
 #. Description of the 'Maximum Points' (Int) field in DocType 'Energy Point
 #. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid ""
 "Maximum points allowed after multiplying points with the multiplier value\n"
 "(Note: For no limit leave this field empty or set 0)"
 msgstr ""
 
-#: model/rename_doc.py:674
+#: model/rename_doc.py:673
 msgid "Maximum {0} rows allowed"
 msgstr ""
 
@@ -19541,63 +14675,43 @@ msgstr ""
 msgid "Meaning of Submit, Cancel, Amend"
 msgstr ""
 
-#: public/js/frappe/form/sidebar/assign_to.js:220
+#. Option for the 'Priority' (Select) field in DocType 'ToDo'
+#. Label of a Data field in DocType 'Web Page View'
+#: desk/doctype/todo/todo.json public/js/frappe/form/sidebar/assign_to.js:220
 #: public/js/frappe/utils/utils.js:1731
+#: website/doctype/web_page_view/web_page_view.json
 #: website/report/website_analytics/website_analytics.js:40
 msgid "Medium"
 msgstr ""
 
-#. Option for the 'Priority' (Select) field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Medium"
-msgstr ""
-
-#. Label of a Data field in DocType 'Web Page View'
-#: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
-msgid "Medium"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Meeting"
-msgstr ""
-
 #. Option for the 'Event Category' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
+#: core/doctype/communication/communication.json desk/doctype/event/event.json
 msgid "Meeting"
 msgstr ""
 
 #. Label of a Data field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Meets Condition?"
 msgstr ""
 
 #. Group in Email Group's connections
 #: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
 msgid "Members"
 msgstr ""
 
 #. Label of a Data field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Memory Usage"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Mention"
 msgstr ""
 
 #. Label of a Check field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "Mentions"
 msgstr ""
 
@@ -19613,35 +14727,34 @@ msgstr ""
 msgid "Merging is only possible between Group-to-Group or Leaf Node-to-Leaf Node"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:483
-#: public/js/frappe/ui/messages.js:175
-#: public/js/frappe/views/communication.js:114 www/message.html:3
-#: www/message.html:25
-msgid "Message"
-msgstr ""
-
+#. Label of a Text field in DocType 'Auto Repeat'
 #. Label of a Text Editor field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Message"
-msgstr ""
-
+#. Label of a Text Editor field in DocType 'Communication'
+#. Label of a Small Text field in DocType 'SMS Log'
+#. Label of a Data field in DocType 'Success Action'
+#. Label of a Text Editor field in DocType 'Notification Log'
 #. Label of a Section Break field in DocType 'Auto Email Report'
 #. Label of a Text Editor field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Message"
-msgstr ""
-
-#. Label of a Text field in DocType 'Auto Repeat'
+#. Label of a Code field in DocType 'Email Queue'
+#. Label of a Text Editor field in DocType 'Newsletter'
+#. Label of a Section Break field in DocType 'Notification'
+#. Label of a Code field in DocType 'Notification'
+#. Label of a Text field in DocType 'Workflow Document State'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Message"
-msgstr ""
-
-#. Label of a Text Editor field in DocType 'Communication'
+#: core/doctype/activity_log/activity_log.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
+#: core/doctype/data_import/data_import.js:483
+#: core/doctype/sms_log/sms_log.json
+#: core/doctype/success_action/success_action.json
+#: desk/doctype/notification_log/notification_log.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: email/doctype/email_queue/email_queue.json
+#: email/doctype/newsletter/newsletter.json
+#: email/doctype/notification/notification.json
+#: public/js/frappe/ui/messages.js:175
+#: public/js/frappe/views/communication.js:114
+#: workflow/doctype/workflow_document_state/workflow_document_state.json
+#: www/message.html:3 www/message.html:25
 msgid "Message"
 msgstr ""
 
@@ -19650,88 +14763,35 @@ msgctxt "Default title of the message dialog"
 msgid "Message"
 msgstr ""
 
-#. Label of a Code field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Message"
-msgstr ""
-
-#. Label of a Text Editor field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Message"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Notification'
-#. Label of a Code field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Message"
-msgstr ""
-
-#. Label of a Text Editor field in DocType 'Notification Log'
-#: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
-msgid "Message"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'SMS Log'
-#: core/doctype/sms_log/sms_log.json
-msgctxt "SMS Log"
-msgid "Message"
-msgstr ""
-
-#. Label of a Data field in DocType 'Success Action'
-#: core/doctype/success_action/success_action.json
-msgctxt "Success Action"
-msgid "Message"
-msgstr ""
-
-#. Label of a Text field in DocType 'Workflow Document State'
-#: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
-msgid "Message"
-msgstr ""
-
 #. Label of a HTML Editor field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Message (HTML)"
 msgstr ""
 
 #. Label of a Markdown Editor field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Message (Markdown)"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Message Examples"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Message ID"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Email Queue'
+#: core/doctype/communication/communication.json
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Message ID"
 msgstr ""
 
 #. Label of a Data field in DocType 'SMS Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Message Parameter"
 msgstr ""
 
 #. Label of a Select field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Message Type"
 msgstr ""
 
@@ -19749,91 +14809,54 @@ msgstr ""
 
 #. Description of the 'Success Message' (Text) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Message to be displayed on successful completion"
 msgstr ""
 
 #. Label of a Code field in DocType 'Unhandled Email'
 #: email/doctype/unhandled_email/unhandled_email.json
-msgctxt "Unhandled Email"
 msgid "Message-id"
 msgstr ""
 
 #. Label of a Code field in DocType 'Data Import Log'
 #: core/doctype/data_import_log/data_import_log.json
-msgctxt "Data Import Log"
 msgid "Messages"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Meta"
 msgstr ""
 
+#. Label of a Small Text field in DocType 'Blog Post'
+#. Label of a Small Text field in DocType 'Web Form'
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/web_form/web_form.json
 #: website/doctype/web_page/web_page.js:124
 msgid "Meta Description"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'Blog Post'
+#. Label of a Attach Image field in DocType 'Blog Post'
+#. Label of a Attach Image field in DocType 'Web Form'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Meta Description"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Meta Description"
-msgstr ""
-
 #: website/doctype/web_page/web_page.js:131
 msgid "Meta Image"
 msgstr ""
 
-#. Label of a Attach Image field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Meta Image"
-msgstr ""
-
-#. Label of a Attach Image field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Meta Image"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Meta Tags"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Meta Tags"
-msgstr ""
-
 #. Label of a Table field in DocType 'Website Route Meta'
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/web_page/web_page.json
 #: website/doctype/website_route_meta/website_route_meta.json
-msgctxt "Website Route Meta"
 msgid "Meta Tags"
-msgstr ""
-
-#: website/doctype/web_page/web_page.js:117
-msgid "Meta Title"
 msgstr ""
 
 #. Label of a Data field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Meta Title"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Form'
+#: website/doctype/blog_post/blog_post.json
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
+#: website/doctype/web_page/web_page.js:117
 msgid "Meta Title"
 msgstr ""
 
@@ -19842,38 +14865,16 @@ msgid "Meta title for SEO"
 msgstr ""
 
 #. Label of a Data field in DocType 'Access Log'
-#: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
-msgid "Method"
-msgstr ""
-
-#. Label of a Select field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Method"
-msgstr ""
-
-#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Method"
-msgstr ""
-
-#. Label of a Data field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Method"
-msgstr ""
-
 #. Label of a Select field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
-msgid "Method"
-msgstr ""
-
 #. Label of a Data field in DocType 'Scheduled Job Type'
+#. Label of a Data field in DocType 'Number Card'
+#. Label of a Select field in DocType 'Email Account'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
+#: core/doctype/access_log/access_log.json core/doctype/recorder/recorder.json
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
+#: desk/doctype/number_card/number_card.json
+#: email/doctype/email_account/email_account.json
+#: email/doctype/notification/notification.json
 msgid "Method"
 msgstr ""
 
@@ -19883,19 +14884,12 @@ msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Mid Center"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Middle Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: contacts/doctype/contact/contact.json core/doctype/user/user.json
 msgid "Middle Name"
 msgstr ""
 
@@ -19910,32 +14904,25 @@ msgctxt "Milestone"
 msgid "Milestone"
 msgstr ""
 
-#. Name of a DocType
-#: automation/doctype/milestone_tracker/milestone_tracker.json
-msgid "Milestone Tracker"
-msgstr ""
-
 #. Label of a Link field in DocType 'Milestone'
+#. Name of a DocType
 #: automation/doctype/milestone/milestone.json
-msgctxt "Milestone"
+#: automation/doctype/milestone_tracker/milestone_tracker.json
 msgid "Milestone Tracker"
 msgstr ""
 
 #. Option for the 'Function' (Select) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Minimum"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Minimum Password Score"
 msgstr ""
 
 #. Label of a Int field in DocType 'Package Release'
 #: core/doctype/package_release/package_release.json
-msgctxt "Package Release"
 msgid "Minor"
 msgstr ""
 
@@ -19982,26 +14969,16 @@ msgstr ""
 msgid "Mobile"
 msgstr ""
 
+#. Label of a Data field in DocType 'Contact'
+#. Label of a Data field in DocType 'User'
+#: contacts/doctype/contact/contact.json core/doctype/user/user.json
 #: tests/test_translate.py:86 tests/test_translate.py:89
 #: tests/test_translate.py:91 tests/test_translate.py:94
 msgid "Mobile No"
 msgstr ""
 
-#. Label of a Data field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Mobile No"
-msgstr ""
-
-#. Label of a Data field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Mobile No"
-msgstr ""
-
 #. Label of a Check field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Modal Trigger"
 msgstr ""
 
@@ -20015,180 +14992,78 @@ msgstr ""
 msgid "Modified By"
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:30
-msgid "Module"
-msgstr ""
-
 #. Label of a Data field in DocType 'Block Module'
-#: core/doctype/block_module/block_module.json
-msgctxt "Block Module"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Dashboard'
-#: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Dashboard Chart Source'
-#: desk/doctype/dashboard_chart_source/dashboard_chart_source.json
-msgctxt "Dashboard Chart Source"
-msgid "Module"
-msgstr ""
-
 #. Label of a Link field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Module Onboarding'
-#: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Module"
-msgstr ""
-
 #. Label of a Link field in DocType 'Page'
-#: core/doctype/page/page.json
-msgctxt "Page"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Print Format Field Template'
-#: printing/doctype/print_format_field_template/print_format_field_template.json
-msgctxt "Print Format Field Template"
-msgid "Module"
-msgstr ""
-
 #. Label of a Link field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Module"
-msgstr ""
-
 #. Label of a Link field in DocType 'User Type Module'
-#: core/doctype/user_type_module/user_type_module.json
-msgctxt "User Type Module"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Web Template'
-#: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
-msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Website Theme'
-#: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
-msgid "Module"
-msgstr ""
-
+#. Label of a Link field in DocType 'Dashboard'
+#. Label of a Link field in DocType 'Dashboard Chart'
+#. Label of a Link field in DocType 'Dashboard Chart Source'
+#. Label of a Link field in DocType 'Form Tour'
+#. Label of a Link field in DocType 'Module Onboarding'
+#. Label of a Link field in DocType 'Number Card'
 #. Label of a Link field in DocType 'Workspace'
+#. Label of a Link field in DocType 'Notification'
+#. Label of a Link field in DocType 'Print Format'
+#. Label of a Link field in DocType 'Print Format Field Template'
+#. Label of a Link field in DocType 'Web Form'
+#. Label of a Link field in DocType 'Web Template'
+#. Label of a Link field in DocType 'Website Theme'
+#: core/doctype/block_module/block_module.json
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:30
+#: core/doctype/page/page.json core/doctype/report/report.json
+#: core/doctype/user_type_module/user_type_module.json
+#: desk/doctype/dashboard/dashboard.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/dashboard_chart_source/dashboard_chart_source.json
+#: desk/doctype/form_tour/form_tour.json
+#: desk/doctype/module_onboarding/module_onboarding.json
+#: desk/doctype/number_card/number_card.json
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: email/doctype/notification/notification.json
+#: printing/doctype/print_format/print_format.json
+#: printing/doctype/print_format_field_template/print_format_field_template.json
+#: website/doctype/web_form/web_form.json
+#: website/doctype/web_template/web_template.json
+#: website/doctype/website_theme/website_theme.json
 msgid "Module"
-msgstr ""
-
-#. Label of a Link field in DocType 'Client Script'
-#: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
-msgid "Module (for export)"
-msgstr ""
-
-#. Label of a Link field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Module (for export)"
-msgstr ""
-
-#. Label of a Link field in DocType 'Property Setter'
-#: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
-msgid "Module (for export)"
 msgstr ""
 
 #. Label of a Link field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Module (for export)"
-msgstr ""
-
+#. Label of a Link field in DocType 'Client Script'
+#. Label of a Link field in DocType 'Custom Field'
+#. Label of a Link field in DocType 'Property Setter'
 #. Label of a Link field in DocType 'Web Page'
+#: core/doctype/server_script/server_script.json
+#: custom/doctype/client_script/client_script.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/property_setter/property_setter.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Module (for export)"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/module_def/module_def.json
+#. Linked DocType in Package's connections
+#: core/doctype/module_def/module_def.json core/doctype/package/package.json
 msgid "Module Def"
 msgstr ""
 
 #. Label of a Link in the Build Workspace
 #: core/workspace/build/build.json
 msgctxt "Module Def"
-msgid "Module Def"
-msgstr ""
-
-#. Linked DocType in Package's connections
-#: core/doctype/package/package.json
-msgctxt "Package"
 msgid "Module Def"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Module Profile'
 #: core/doctype/module_profile/module_profile.json
-msgctxt "Module Profile"
 msgid "Module HTML"
 msgstr ""
 
-#. Label of a Data field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Module Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Module Def'
+#. Label of a Data field in DocType 'Desktop Icon'
 #: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
+#: desk/doctype/desktop_icon/desktop_icon.json
 msgid "Module Name"
 msgstr ""
 
@@ -20204,7 +15079,8 @@ msgid "Module Onboarding"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/module_profile/module_profile.json
+#. Label of a Link field in DocType 'User'
+#: core/doctype/module_profile/module_profile.json core/doctype/user/user.json
 msgid "Module Profile"
 msgstr ""
 
@@ -20214,15 +15090,8 @@ msgctxt "Module Profile"
 msgid "Module Profile"
 msgstr ""
 
-#. Label of a Link field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Module Profile"
-msgstr ""
-
 #. Label of a Data field in DocType 'Module Profile'
 #: core/doctype/module_profile/module_profile.json
-msgctxt "Module Profile"
 msgid "Module Profile Name"
 msgstr ""
 
@@ -20238,51 +15107,28 @@ msgstr ""
 msgid "Module {} not found"
 msgstr ""
 
-#. Label of a Card Break in the Build Workspace
-#: core/workspace/build/build.json
-msgid "Modules"
-msgstr ""
-
 #. Group in Package's connections
-#: core/doctype/package/package.json
-msgctxt "Package"
+#. Label of a Card Break in the Build Workspace
+#: core/doctype/package/package.json core/workspace/build/build.json
 msgid "Modules"
 msgstr ""
 
 #. Label of a HTML field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Modules HTML"
 msgstr ""
 
 #. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Monday"
-msgstr ""
-
-#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Monday"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
-#: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
-msgid "Monday"
-msgstr ""
-
-#. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Monday"
-msgstr ""
-
 #. Option for the 'First Day of the Week' (Select) field in DocType 'System
 #. Settings'
+#. Label of a Check field in DocType 'Event'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
+#: automation/doctype/auto_repeat_day/auto_repeat_day.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Monday"
 msgstr ""
 
@@ -20293,7 +15139,6 @@ msgstr ""
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Monospace"
 msgstr ""
 
@@ -20301,77 +15146,35 @@ msgstr ""
 msgid "Month"
 msgstr ""
 
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
+#. Settings'
+#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
+#. 'Energy Point Settings'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/server_script/server_script.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/event/event.json desk/doctype/number_card/number_card.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 #: public/js/frappe/utils/common.js:400
+#: social/doctype/energy_point_settings/energy_point_settings.json
 #: website/report/website_analytics/website_analytics.js:25
 msgid "Monthly"
 msgstr ""
 
-#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
-#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Monthly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Monthly"
-msgstr ""
-
-#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Monthly"
-msgstr ""
-
-#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
-#. 'Energy Point Settings'
-#: social/doctype/energy_point_settings/energy_point_settings.json
-msgctxt "Energy Point Settings"
-msgid "Monthly"
-msgstr ""
-
-#. Option for the 'Repeat On' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Monthly"
-msgstr ""
-
-#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Monthly"
-msgstr ""
-
-#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
-#. Settings'
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
-msgid "Monthly"
-msgstr ""
-
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Monthly"
-msgstr ""
-
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Monthly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Monthly Long"
-msgstr ""
-
-#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Monthly Long"
 msgstr ""
 
@@ -20390,27 +15193,13 @@ msgstr ""
 msgid "More"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "More Information"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "More Information"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "More Information"
-msgstr ""
-
+#. Label of a Section Break field in DocType 'Activity Log'
+#. Label of a Section Break field in DocType 'Communication'
 #. Label of a Tab Break field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: contacts/doctype/contact/contact.json
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication/communication.json core/doctype/user/user.json
 msgid "More Information"
 msgstr ""
 
@@ -20422,7 +15211,6 @@ msgstr ""
 #. Description of the 'Footer' (Text Editor) field in DocType 'About Us
 #. Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "More content for the bottom of the page."
 msgstr ""
 
@@ -20471,14 +15259,12 @@ msgstr ""
 
 #. Description of the 'Next on Click' (Check) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Move to next step when clicked inside highlighted area."
 msgstr ""
 
 #. Description of the 'Parent Element Selector' (Data) field in DocType 'Form
 #. Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Mozilla doesn't support :has() so you can pass parent selector here as workaround"
 msgstr ""
 
@@ -20488,33 +15274,25 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Multiplier Field"
 msgstr ""
 
 #. Description of the 'Import from Google Sheets' (Data) field in DocType 'Data
 #. Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Must be a publicly accessible Google Sheets URL"
 msgstr ""
 
 #. Description of the 'LDAP Search String' (Data) field in DocType 'LDAP
 #. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Must be enclosed in '()' and include '{0}', which is a placeholder for the user/login name. i.e. (&(objectclass=user)(uid={0}))"
 msgstr ""
 
-#. Description of the 'Image Field' (Data) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Must be of type \"Attach Image\""
-msgstr ""
-
 #. Description of the 'Image Field' (Data) field in DocType 'DocType'
+#. Description of the 'Image Field' (Data) field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Must be of type \"Attach Image\""
 msgstr ""
 
@@ -20528,7 +15306,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Mute Sounds"
 msgstr ""
 
@@ -20553,7 +15330,6 @@ msgstr ""
 
 #. Option for the 'Database Engine' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "MyISAM"
 msgstr ""
 
@@ -20564,39 +15340,22 @@ msgstr ""
 #. Description of the 'LDAP Group Field' (Data) field in DocType 'LDAP
 #. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "NOTE: This box is due for depreciation. Please re-setup LDAP to work with the newer settings"
 msgstr ""
 
+#. Label of a Data field in DocType 'DocField'
+#. Label of a Data field in DocType 'Customize Form Field'
+#. Label of a Data field in DocType 'Workspace'
+#. Label of a Data field in DocType 'Slack Webhook URL'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/workspace/workspace.json
+#: integrations/doctype/slack_webhook_url/slack_webhook_url.json
 #: public/js/frappe/form/layout.js:75
 #: public/js/frappe/form/multi_select_dialog.js:241
 #: public/js/frappe/form/save.js:107
 #: public/js/frappe/views/file/file_view.js:97
 #: website/doctype/website_slideshow/website_slideshow.js:25
-msgid "Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Slack Webhook URL'
-#: integrations/doctype/slack_webhook_url/slack_webhook_url.json
-msgctxt "Slack Webhook URL"
-msgid "Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace'
-#: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Name"
 msgstr ""
 
@@ -20628,27 +15387,17 @@ msgstr ""
 msgid "Names and surnames by themselves are easy to guess."
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Naming"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Naming"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Document Naming Rule'
+#. Label of a Section Break field in DocType 'Customize Form'
+#: core/doctype/doctype/doctype.json
 #: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Naming"
 msgstr ""
 
 #. Description of the 'Auto Name' (Data) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid ""
 "Naming Options:\n"
 "<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>autoincrement</b> - Uses Databases' Auto Increment feature</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n"
@@ -20657,28 +15406,21 @@ msgstr ""
 
 #. Description of the 'Auto Name' (Data) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid ""
 "Naming Options:\n"
 "<ol><li><b>field:[fieldname]</b> - By Field</li><li><b>naming_series:</b> - By Naming Series (field called naming_series must be present)</li><li><b>Prompt</b> - Prompt user for a name</li><li><b>[series]</b> - Series by prefix (separated by a dot); for example PRE.#####</li>\n"
 "<li><b>format:EXAMPLE-{MM}morewords{fieldname1}-{fieldname2}-{#####}</b> - Replace all braced words (fieldnames, date words (DD, MM, YY), series) with their value. Outside braces, any characters can be used.</li></ol>"
 msgstr ""
 
-#. Label of a Select field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Naming Rule"
-msgstr ""
-
 #. Label of a Select field in DocType 'DocType'
+#. Label of a Select field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Naming Rule"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Naming Series"
 msgstr ""
 
@@ -20687,15 +15429,10 @@ msgid "Naming Series mandatory"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Web Template'
-#: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
-msgid "Navbar"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Website Settings'
 #. Label of a Tab Break field in DocType 'Website Settings'
+#: website/doctype/web_template/web_template.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Navbar"
 msgstr ""
 
@@ -20718,13 +15455,11 @@ msgstr ""
 #. Label of a Link field in DocType 'Website Settings'
 #. Label of a Section Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Navbar Template"
 msgstr ""
 
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Navbar Template Values"
 msgstr ""
 
@@ -20748,7 +15483,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "Navigation Settings"
 msgstr ""
 
@@ -20773,30 +15507,18 @@ msgstr ""
 msgid "Network Printer Settings"
 msgstr ""
 
-#: core/doctype/success_action/success_action.js:55
-#: core/page/dashboard_view/dashboard_view.js:173 desk/doctype/todo/todo.js:46
-#: public/js/frappe/form/success_action.js:77
-#: public/js/frappe/views/treeview.js:450
-#: website/doctype/web_form/templates/web_list.html:15 www/list.html:19
-msgid "New"
-msgstr ""
-
+#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
 #. Rule'
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "New"
-msgstr ""
-
-#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "New"
-msgstr ""
-
-#. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: core/doctype/success_action/success_action.js:55
+#: core/page/dashboard_view/dashboard_view.js:173 desk/doctype/todo/todo.js:46
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: email/doctype/notification/notification.json
+#: public/js/frappe/form/success_action.js:77
+#: public/js/frappe/views/treeview.js:450
+#: social/doctype/energy_point_rule/energy_point_rule.json
+#: website/doctype/web_form/templates/web_list.html:15 www/list.html:19
 msgid "New"
 msgstr ""
 
@@ -20830,7 +15552,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "New Document Form"
 msgstr ""
 
@@ -20872,13 +15593,9 @@ msgstr ""
 msgid "New Message from Website Contact Page"
 msgstr ""
 
-#: public/js/frappe/form/toolbar.js:207 public/js/frappe/model/model.js:742
-msgid "New Name"
-msgstr ""
-
 #. Label of a Read Only field in DocType 'Deleted Document'
 #: core/doctype/deleted_document/deleted_document.json
-msgctxt "Deleted Document"
+#: public/js/frappe/form/toolbar.js:207 public/js/frappe/model/model.js:742
 msgid "New Name"
 msgstr ""
 
@@ -20921,7 +15638,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "New Users (Last 30 days)"
 msgstr ""
 
@@ -20934,7 +15650,7 @@ msgstr ""
 msgid "New Workflow Name"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1185
+#: public/js/frappe/views/workspace/workspace.js:1186
 msgid "New Workspace"
 msgstr ""
 
@@ -20949,14 +15665,12 @@ msgstr ""
 #. Description of the 'Disable signups' (Check) field in DocType 'Website
 #. Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "New users will have to be manually registered by system managers."
 msgstr ""
 
 #. Description of the 'Set Value' (Small Text) field in DocType 'Property
 #. Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "New value to be set"
 msgstr ""
 
@@ -21061,13 +15775,11 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Next Action Email Template"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Success Action'
 #: core/doctype/success_action/success_action.json
-msgctxt "Success Action"
 msgid "Next Actions HTML"
 msgstr ""
 
@@ -21077,19 +15789,16 @@ msgstr ""
 
 #. Label of a Datetime field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
 msgid "Next Execution"
 msgstr ""
 
 #. Label of a Link field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Next Form Tour"
 msgstr ""
 
 #. Label of a Date field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Next Schedule Date"
 msgstr ""
 
@@ -21099,25 +15808,18 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Transition'
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Next State"
 msgstr ""
 
 #. Label of a Code field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Next Step Condition"
 msgstr ""
 
 #. Label of a Password field in DocType 'Google Calendar'
-#: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
-msgid "Next Sync Token"
-msgstr ""
-
 #. Label of a Password field in DocType 'Google Contacts'
+#: integrations/doctype/google_calendar/google_calendar.json
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
 msgid "Next Sync Token"
 msgstr ""
 
@@ -21127,11 +15829,18 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Next on Click"
 msgstr ""
 
+#. Option for the 'Standard' (Select) field in DocType 'Page'
+#. Option for the 'Is Standard' (Select) field in DocType 'Report'
+#. Option for the 'Require Trusted Certificate' (Select) field in DocType 'LDAP
+#. Settings'
+#. Option for the 'Standard' (Select) field in DocType 'Print Format'
+#: core/doctype/page/page.json core/doctype/report/report.json
+#: integrations/doctype/ldap_settings/ldap_settings.json
 #: integrations/doctype/webhook/webhook.py:140
+#: printing/doctype/print_format/print_format.json
 #: public/js/form_builder/utils.js:341
 #: public/js/frappe/form/controls/link.js:475
 #: public/js/frappe/list/list_sidebar_group_by.js:223
@@ -21150,50 +15859,16 @@ msgctxt "Dismiss confirmation dialog"
 msgid "No"
 msgstr ""
 
-#. Option for the 'Require Trusted Certificate' (Select) field in DocType 'LDAP
-#. Settings'
-#: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
-msgid "No"
-msgstr ""
-
-#. Option for the 'Standard' (Select) field in DocType 'Page'
-#: core/doctype/page/page.json
-msgctxt "Page"
-msgid "No"
-msgstr ""
-
-#. Option for the 'Standard' (Select) field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "No"
-msgstr ""
-
-#. Option for the 'Is Standard' (Select) field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "No"
-msgstr ""
-
 #: www/third_party_apps.html:54
 msgid "No Active Sessions"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "No Copy"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "No Copy"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "No Copy"
 msgstr ""
 
@@ -21359,7 +16034,7 @@ msgstr ""
 msgid "No changes made because old and new name are the same."
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1490
+#: public/js/frappe/views/workspace/workspace.js:1491
 msgid "No changes made on the page"
 msgstr ""
 
@@ -21453,19 +16128,16 @@ msgstr ""
 
 #. Label of a Int field in DocType 'SMS Log'
 #: core/doctype/sms_log/sms_log.json
-msgctxt "SMS Log"
 msgid "No of Requested SMS"
 msgstr ""
 
 #. Label of a Int field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "No of Rows (Max 500)"
 msgstr ""
 
 #. Label of a Int field in DocType 'SMS Log'
 #: core/doctype/sms_log/sms_log.json
-msgctxt "SMS Log"
 msgid "No of Sent SMS"
 msgstr ""
 
@@ -21535,28 +16207,18 @@ msgctxt "Title of the 'row number' column"
 msgid "No."
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Non Negative"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Non Negative"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Non Negative"
 msgstr ""
 
 #. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
 #. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "None"
 msgstr ""
 
@@ -21566,13 +16228,11 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Recorder Query'
 #: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
 msgid "Normalized Copies"
 msgstr ""
 
 #. Label of a Data field in DocType 'Recorder Query'
 #: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
 msgid "Normalized Query"
 msgstr ""
 
@@ -21603,7 +16263,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Help Article'
 #: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
 msgid "Not Helpful"
 msgstr ""
 
@@ -21621,7 +16280,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Not Nullable"
 msgstr ""
 
@@ -21656,19 +16314,11 @@ msgstr ""
 msgid "Not Seen"
 msgstr ""
 
-#: email/doctype/newsletter/newsletter_list.js:9
-msgid "Not Sent"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Not Sent"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Email Queue Recipient'
+#: email/doctype/email_queue/email_queue.json
 #: email/doctype/email_queue_recipient/email_queue_recipient.json
-msgctxt "Email Queue Recipient"
+#: email/doctype/newsletter/newsletter_list.js:9
 msgid "Not Sent"
 msgstr ""
 
@@ -21773,15 +16423,10 @@ msgstr ""
 
 #. Description of the 'Send Email for Successful Backup' (Check) field in
 #. DocType 'Dropbox Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "Note: By default emails for failed backups are sent."
-msgstr ""
-
 #. Description of the 'Send Email for Successful backup' (Check) field in
 #. DocType 'Google Drive'
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "Note: By default emails for failed backups are sent."
 msgstr ""
 
@@ -21796,14 +16441,12 @@ msgstr ""
 #. Description of the 'sb0' (Section Break) field in DocType 'Website
 #. Slideshow'
 #: website/doctype/website_slideshow/website_slideshow.json
-msgctxt "Website Slideshow"
 msgid "Note: For best results,  images must be of the same size and width must be greater than height."
 msgstr ""
 
 #. Description of the 'Allow only one session per user' (Check) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Note: Multiple sessions will be allowed in case of mobile device"
 msgstr ""
 
@@ -21843,46 +16486,25 @@ msgstr ""
 msgid "Nothing to update"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/communication/mixins.py:142
-#: email/doctype/notification/notification.json
-msgid "Notification"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Notification"
-msgstr ""
-
 #. Option for the 'Communication Type' (Select) field in DocType
 #. 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Notification"
-msgstr ""
-
 #. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Notification"
-msgstr ""
-
 #. Linked DocType in Module Def's connections
+#. Name of a DocType
+#. Label of a Section Break field in DocType 'S3 Backup Settings'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/communication/communication.json
+#: core/doctype/communication/mixins.py:142 core/doctype/doctype/doctype.json
 #: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
+#: email/doctype/notification/notification.json
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 msgid "Notification"
 msgstr ""
 
 #. Label of a Link in the Tools Workspace
 #: automation/workspace/tools/tools.json
 msgctxt "Notification"
-msgid "Notification"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'S3 Backup Settings'
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Notification"
 msgstr ""
 
@@ -21917,14 +16539,10 @@ msgstr ""
 msgid "Notification sent to"
 msgstr ""
 
-#: public/js/frappe/ui/notifications/notifications.js:50
-#: public/js/frappe/ui/notifications/notifications.js:187
-msgid "Notifications"
-msgstr ""
-
 #. Label of a Check field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
+#: public/js/frappe/ui/notifications/notifications.js:50
+#: public/js/frappe/ui/notifications/notifications.js:187
 msgid "Notifications"
 msgstr ""
 
@@ -21935,43 +16553,36 @@ msgstr ""
 #. Description of the 'Default Outgoing' (Check) field in DocType 'Email
 #. Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Notifications and bulk mails will be sent from this outgoing server."
 msgstr ""
 
 #. Label of a Check field in DocType 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
 msgid "Notify Users On Every Login"
 msgstr ""
 
 #. Label of a Check field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Notify by Email"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocShare'
 #: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
 msgid "Notify by email"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Notify if unreplied"
 msgstr ""
 
 #. Label of a Int field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Notify if unreplied for (in mins)"
 msgstr ""
 
 #. Label of a Check field in DocType 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
 msgid "Notify users with a popup when they log in"
 msgstr ""
 
@@ -21982,7 +16593,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Contact Phone'
 #: contacts/doctype/contact_phone/contact_phone.json
-msgctxt "Contact Phone"
 msgid "Number"
 msgstr ""
 
@@ -21999,42 +16609,30 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Workspace Number Card'
 #: desk/doctype/workspace_number_card/workspace_number_card.json
-msgctxt "Workspace Number Card"
 msgid "Number Card Name"
-msgstr ""
-
-#: public/js/frappe/widgets/widget_dialog.js:660
-msgid "Number Cards"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Workspace'
 #. Label of a Table field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: public/js/frappe/widgets/widget_dialog.js:660
 msgid "Number Cards"
 msgstr ""
 
-#. Label of a Select field in DocType 'Currency'
-#: geo/doctype/currency/currency.json
-msgctxt "Currency"
-msgid "Number Format"
-msgstr ""
-
 #. Label of a Select field in DocType 'System Settings'
+#. Label of a Select field in DocType 'Currency'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: geo/doctype/currency/currency.json
 msgid "Number Format"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Number of Backups"
 msgstr ""
 
 #. Label of a Int field in DocType 'Dropbox Settings'
 #: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
 msgid "Number of DB Backups"
 msgstr ""
 
@@ -22044,13 +16642,11 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Number of Groups"
 msgstr ""
 
 #. Label of a Int field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "Number of Queries"
 msgstr ""
 
@@ -22064,44 +16660,34 @@ msgstr ""
 
 #. Description of the 'Columns' (Int) field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Number of columns for a field in a Grid (Total Columns in a grid should be less than 11)"
 msgstr ""
 
-#. Description of the 'Columns' (Int) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)"
-msgstr ""
-
 #. Description of the 'Columns' (Int) field in DocType 'DocField'
+#. Description of the 'Columns' (Int) field in DocType 'Custom Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
 msgid "Number of columns for a field in a List View or a Grid (Total Columns should be less than 11)"
 msgstr ""
 
 #. Description of the 'Document Share Key Expiry (in Days)' (Int) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Number of days after which the document Web View link shared on email will be expired"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Number of keys"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Number of onsite backups"
 msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "OAuth"
 msgstr ""
 
@@ -22128,7 +16714,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid "OAuth Client ID"
 msgstr ""
 
@@ -22167,20 +16752,17 @@ msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "OPTIONS"
 msgstr ""
 
 #. Option for the 'Two Factor Authentication method' (Select) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "OTP App"
 msgstr ""
 
 #. Label of a Data field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "OTP Issuer Name"
 msgstr ""
 
@@ -22198,26 +16780,22 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report Errors'
 #: desk/doctype/system_health_report_errors/system_health_report_errors.json
-msgctxt "System Health Report Errors"
 msgid "Occurrences"
 msgstr ""
 
 #. Option for the 'SSL/TLS Mode' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Off"
 msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Office"
 msgstr ""
 
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Office 365"
 msgstr ""
 
@@ -22227,13 +16805,11 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Offset X"
 msgstr ""
 
 #. Label of a Int field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Offset Y"
 msgstr ""
 
@@ -22248,44 +16824,52 @@ msgstr ""
 #. Description of the 'Number of Backups' (Int) field in DocType 'System
 #. Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Older backups will be automatically deleted"
 msgstr ""
 
 #. Label of a Link field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Oldest Unscheduled Job"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
 msgid "On Hold"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "On Payment Authorization"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
+msgid "On Payment Charge Processed"
+msgstr ""
+
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
+#: core/doctype/server_script/server_script.json
 msgid "On Payment Failed"
 msgstr ""
 
 #. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
+msgid "On Payment Mandate Acquisition Processed"
+msgstr ""
+
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
+#: core/doctype/server_script/server_script.json
+msgid "On Payment Mandate Charge Processed"
+msgstr ""
+
+#. Option for the 'DocType Event' (Select) field in DocType 'Server Script'
+#: core/doctype/server_script/server_script.json
 msgid "On Payment Paid"
 msgstr ""
 
 #. Description of the 'Is Dynamic URL?' (Check) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "On checking this option, URL will be treated like a jinja template string"
 msgstr ""
 
@@ -22295,7 +16879,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
 msgid "Onboard"
 msgstr ""
 
@@ -22306,18 +16889,13 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Onboarding Status"
 msgstr ""
 
-#. Name of a DocType
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgid "Onboarding Step"
-msgstr ""
-
 #. Linked DocType in DocType's connections
+#. Name of a DocType
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: desk/doctype/onboarding_step/onboarding_step.json
 msgid "Onboarding Step"
 msgstr ""
 
@@ -22330,13 +16908,8 @@ msgstr ""
 msgid "Onboarding complete"
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:42
-msgid "Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended."
-msgstr ""
-
 #. Description of the 'Is Submittable' (Check) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:42
 msgid "Once submitted, submittable documents cannot be changed. They can only be Cancelled and Amended."
 msgstr ""
 
@@ -22356,7 +16929,7 @@ msgstr ""
 msgid "One of"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1325
+#: public/js/frappe/views/workspace/workspace.js:1326
 msgid "One of the child page with name {0} already exist in {1} Section. Please update the name of the child page first before moving"
 msgstr ""
 
@@ -22382,7 +16955,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Workflow Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Only Allow Edit For"
 msgstr ""
 
@@ -22392,7 +16964,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Only Send Records Updated in Last X Hours"
 msgstr ""
 
@@ -22400,7 +16971,7 @@ msgstr ""
 msgid "Only Workspace Manager can edit public workspaces"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:549
+#: public/js/frappe/views/workspace/workspace.js:550
 msgid "Only Workspace Manager can sort or edit this page"
 msgstr ""
 
@@ -22411,7 +16982,6 @@ msgstr ""
 #. Description of the 'Endpoint URL' (Data) field in DocType 'S3 Backup
 #. Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Only change this if you want to use other S3 compatible object storage backends."
 msgstr ""
 
@@ -22421,7 +16991,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Workspace Link'
 #: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
 msgid "Only for"
 msgstr ""
 
@@ -22462,43 +17031,22 @@ msgstr ""
 msgid "Oops! Something went wrong."
 msgstr ""
 
+#. Option for the 'Status' (Select) field in DocType 'Contact'
+#. Option for the 'Status' (Select) field in DocType 'Communication'
+#. Option for the 'Email Status' (Select) field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'Event'
+#. Option for the 'Status' (Select) field in DocType 'ToDo'
+#. Option for the 'Status' (Select) field in DocType 'Workflow Action'
+#: contacts/doctype/contact/contact.json
+#: core/doctype/communication/communication.json
 #: core/doctype/deleted_document/deleted_document.js:7
+#: desk/doctype/event/event.json desk/doctype/todo/todo.json
+#: workflow/doctype/workflow_action/workflow_action.json
 msgid "Open"
 msgstr ""
 
 #: desk/doctype/todo/todo_list.js:14
 msgctxt "Access"
-msgid "Open"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Communication'
-#. Option for the 'Email Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Open"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Open"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Open"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Open"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Workflow Action'
-#: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
 msgid "Open"
 msgstr ""
 
@@ -22516,7 +17064,6 @@ msgstr ""
 
 #. Label of a Table MultiSelect field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "Open Documents"
 msgstr ""
 
@@ -22526,7 +17073,6 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Notification Log'
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
 msgid "Open Reference Document"
 msgstr ""
 
@@ -22540,13 +17086,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
-msgctxt "Top Bar Item"
 msgid "Open URL in a New Tab"
 msgstr ""
 
 #. Description of the 'Quick Entry' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Open a dialog with mandatory fields to create a new record quickly"
 msgstr ""
 
@@ -22582,25 +17126,21 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "OpenID Configuration"
 msgstr ""
 
 #. Option for the 'Directory Server' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "OpenLDAP"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Opened"
 msgstr ""
 
 #. Label of a Select field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
 msgid "Operation"
 msgstr ""
 
@@ -22635,59 +17175,29 @@ msgstr ""
 
 #. Description of the 'CC' (Code) field in DocType 'Notification Recipient'
 #: email/doctype/notification_recipient/notification_recipient.json
-msgctxt "Notification Recipient"
 msgid "Optional: Always send to these ids. Each Email Address on a new row"
 msgstr ""
 
 #. Description of the 'Condition' (Code) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Optional: The alert will be sent if this expression is true"
 msgstr ""
 
-#: templates/form_grid/fields.html:43
-msgid "Options"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Options"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Options"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Options"
-msgstr ""
-
 #. Label of a Data field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Options"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Options"
-msgstr ""
-
+#. Label of a Small Text field in DocType 'Custom Field'
+#. Label of a Small Text field in DocType 'Customize Form Field'
 #. Label of a Text field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Options"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: templates/form_grid/fields.html:43
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Options"
 msgstr ""
 
@@ -22697,7 +17207,6 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
 msgid "Options Help"
 msgstr ""
 
@@ -22722,33 +17231,25 @@ msgid "Options not set for link field {0}"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Orange"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Orange"
 msgstr ""
 
 #. Label of a Code field in DocType 'Kanban Board Column'
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Order"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'About Us Settings'
 #. Label of a Table field in DocType 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "Org History"
 msgstr ""
 
 #. Label of a Data field in DocType 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "Org History Heading"
 msgstr ""
 
@@ -22762,62 +17263,39 @@ msgid "Original Value"
 msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Other"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Other"
-msgstr ""
-
 #. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Other"
-msgstr ""
-
 #. Option for the 'Event Category' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
+#: contacts/doctype/address/address.json
+#: core/doctype/communication/communication.json
+#: core/doctype/doctype/doctype.json desk/doctype/event/event.json
 msgid "Other"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Outgoing (SMTP)"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Outgoing (SMTP) Settings"
 msgstr ""
 
 #. Label of a Column Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Outgoing Emails (Last 7 days)"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Outgoing Server"
-msgstr ""
-
 #. Label of a Data field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Outgoing Server"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Domain'
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Outgoing Settings"
 msgstr ""
 
@@ -22827,25 +17305,15 @@ msgstr ""
 
 #. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Outlook.com"
 msgstr ""
 
-#. Label of a Code field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Output"
-msgstr ""
-
 #. Label of a Code field in DocType 'Permission Inspector'
-#: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
-msgid "Output"
-msgstr ""
-
 #. Label of a Code field in DocType 'System Console'
+#. Label of a Code field in DocType 'Integration Request'
+#: core/doctype/permission_inspector/permission_inspector.json
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
+#: integrations/doctype/integration_request/integration_request.json
 msgid "Output"
 msgstr ""
 
@@ -22861,7 +17329,6 @@ msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "PATCH"
 msgstr ""
 
@@ -22877,25 +17344,21 @@ msgstr ""
 
 #. Label of a Float field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "PDF Page Height (in mm)"
 msgstr ""
 
 #. Label of a Select field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "PDF Page Size"
 msgstr ""
 
 #. Label of a Float field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "PDF Page Width (in mm)"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "PDF Settings"
 msgstr ""
 
@@ -22917,54 +17380,34 @@ msgstr ""
 
 #. Label of a Data field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "PID"
 msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
-msgid "POST"
-msgstr ""
-
 #. Option for the 'Request Method' (Select) field in DocType 'Webhook'
+#: core/doctype/recorder/recorder.json
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "POST"
 msgstr ""
 
 #. Option for the 'Method' (Select) field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
-msgid "PUT"
-msgstr ""
-
 #. Option for the 'Request Method' (Select) field in DocType 'Webhook'
+#: core/doctype/recorder/recorder.json
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "PUT"
-msgstr ""
-
-#. Name of a DocType
-#: core/doctype/package/package.json www/attribution.html:34
-msgid "Package"
 msgstr ""
 
 #. Label of a Link field in DocType 'Module Def'
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
+#. Name of a DocType
+#. Label of a Link field in DocType 'Package Release'
+#: core/doctype/module_def/module_def.json core/doctype/package/package.json
+#: core/doctype/package_release/package_release.json www/attribution.html:34
 msgid "Package"
 msgstr ""
 
 #. Label of a Link in the Build Workspace
 #: core/workspace/build/build.json
 msgctxt "Package"
-msgid "Package"
-msgstr ""
-
-#. Label of a Link field in DocType 'Package Release'
-#: core/doctype/package_release/package_release.json
-msgctxt "Package Release"
 msgid "Package"
 msgstr ""
 
@@ -22981,18 +17424,13 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Package'
 #: core/doctype/package/package.json
-msgctxt "Package"
 msgid "Package Name"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/package_release/package_release.json
-msgid "Package Release"
-msgstr ""
-
 #. Linked DocType in Package's connections
+#. Name of a DocType
 #: core/doctype/package/package.json
-msgctxt "Package"
+#: core/doctype/package_release/package_release.json
 msgid "Package Release"
 msgstr ""
 
@@ -23006,68 +17444,40 @@ msgstr ""
 msgid "Packages are lightweight apps (collection of Module Defs) that can be created, imported, or released right from the UI"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/page/page.json
-msgid "Page"
-msgstr ""
-
 #. Label of a Link field in DocType 'Custom Role'
-#: core/doctype/custom_role/custom_role.json
-msgctxt "Custom Role"
-msgid "Page"
-msgstr ""
-
-#. Option for the 'View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Page"
-msgstr ""
-
+#. Name of a DocType
 #. Option for the 'Set Role For' (Select) field in DocType 'Role Permission for
 #. Page and Report'
 #. Label of a Link field in DocType 'Role Permission for Page and Report'
-#: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
-msgctxt "Role Permission for Page and Report"
-msgid "Page"
-msgstr ""
-
+#. Option for the 'View' (Select) field in DocType 'Form Tour'
 #. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
-msgid "Page"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
+#: core/doctype/custom_role/custom_role.json core/doctype/page/page.json
+#: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
+#: desk/doctype/form_tour/form_tour.json
+#: desk/doctype/workspace_link/workspace_link.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Page"
 msgstr ""
 
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Page Break"
 msgstr ""
 
-#: website/doctype/web_page/web_page.js:92
-msgid "Page Builder"
-msgstr ""
-
 #. Option for the 'Content Type' (Select) field in DocType 'Web Page'
+#: website/doctype/web_page/web_page.js:92
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Page Builder"
 msgstr ""
 
 #. Label of a Table field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Page Building Blocks"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Page'
 #: core/doctype/page/page.json
-msgctxt "Page"
 msgid "Page HTML"
 msgstr ""
 
@@ -23077,29 +17487,25 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Page'
 #: core/doctype/page/page.json
-msgctxt "Page"
 msgid "Page Name"
 msgstr ""
 
 #. Label of a Select field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Page Number"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Page Route"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1512
+#: public/js/frappe/views/workspace/workspace.js:1513
 msgid "Page Saved Successfully"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Page Settings"
 msgstr ""
 
@@ -23113,7 +17519,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "Page Title"
 msgstr ""
 
@@ -23139,7 +17544,7 @@ msgstr ""
 msgid "Page to show on the website\n"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1312
+#: public/js/frappe/views/workspace/workspace.js:1313
 msgid "Page with title {0} already exist."
 msgstr ""
 
@@ -23152,32 +17557,25 @@ msgstr ""
 
 #. Label of a Data field in DocType 'SMS Parameter'
 #: core/doctype/sms_parameter/sms_parameter.json
-msgctxt "SMS Parameter"
 msgid "Parameter"
 msgstr ""
 
 #: public/js/frappe/model/model.js:142
-#: public/js/frappe/views/workspace/workspace.js:619
-#: public/js/frappe/views/workspace/workspace.js:947
-#: public/js/frappe/views/workspace/workspace.js:1194
+#: public/js/frappe/views/workspace/workspace.js:620
+#: public/js/frappe/views/workspace/workspace.js:948
+#: public/js/frappe/views/workspace/workspace.js:1195
 msgid "Parent"
 msgstr ""
 
 #. Label of a Link field in DocType 'DocType Link'
 #: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
 msgid "Parent DocType"
 msgstr ""
 
 #. Label of a Link field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Parent Document Type"
-msgstr ""
-
 #. Label of a Link field in DocType 'Number Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Parent Document Type"
 msgstr ""
 
@@ -23187,23 +17585,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Parent Element Selector"
 msgstr ""
 
 #. Label of a Select field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Parent Field"
 msgstr ""
 
-#: core/doctype/doctype/doctype.py:916
-msgid "Parent Field (Tree)"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype.py:916
 msgid "Parent Field (Tree)"
 msgstr ""
 
@@ -23213,7 +17604,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Top Bar Item'
 #: website/doctype/top_bar_item/top_bar_item.json
-msgctxt "Top Bar Item"
 msgid "Parent Label"
 msgstr ""
 
@@ -23223,7 +17613,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Parent Page"
 msgstr ""
 
@@ -23249,85 +17638,50 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Personal Data Deletion Step'
 #: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
-msgctxt "Personal Data Deletion Step"
 msgid "Partial"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Partial Success"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Partially Sent"
 msgstr ""
 
-#: desk/doctype/event/event.js:30
-msgid "Participants"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
+#: desk/doctype/event/event.js:30 desk/doctype/event/event.json
 msgid "Participants"
 msgstr ""
 
 #. Option for the 'SocketIO Ping Check' (Select) field in DocType 'System
 #. Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Pass"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Passive"
 msgstr ""
 
-#: core/doctype/user/user.js:158 core/doctype/user/user.js:205
-#: core/doctype/user/user.js:225 desk/page/setup_wizard/setup_wizard.js:474
-#: www/login.html:21
-msgid "Password"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Password"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Password"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Password"
-msgstr ""
-
-#. Label of a Password field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Password"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'System Settings'
 #. Label of a Tab Break field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
-msgid "Password"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Password field in DocType 'Email Account'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
+#: core/doctype/docfield/docfield.json
+#: core/doctype/system_settings/system_settings.json
+#: core/doctype/user/user.js:158 core/doctype/user/user.js:205
+#: core/doctype/user/user.js:225 custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/page/setup_wizard/setup_wizard.js:474
+#: email/doctype/email_account/email_account.json
+#: website/doctype/web_form_field/web_form_field.json www/login.html:21
 msgid "Password"
 msgstr ""
 
@@ -23341,7 +17695,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Password Reset Link Generation Limit"
 msgstr ""
 
@@ -23355,7 +17708,6 @@ msgstr ""
 
 #. Label of a Password field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Password for Base DN"
 msgstr ""
 
@@ -23404,14 +17756,9 @@ msgid "Paste"
 msgstr ""
 
 #. Label of a Int field in DocType 'Package Release'
-#: core/doctype/package_release/package_release.json
-msgctxt "Package Release"
-msgid "Patch"
-msgstr ""
-
 #. Label of a Code field in DocType 'Patch Log'
+#: core/doctype/package_release/package_release.json
 #: core/doctype/patch_log/patch_log.json
-msgctxt "Patch Log"
 msgid "Patch"
 msgstr ""
 
@@ -23424,49 +17771,30 @@ msgstr ""
 msgid "Patch type {} not found in patches.txt"
 msgstr ""
 
-#: website/report/website_analytics/website_analytics.js:35
-msgid "Path"
-msgstr ""
-
-#. Label of a Data field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Path"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Package Release'
-#: core/doctype/package_release/package_release.json
-msgctxt "Package Release"
-msgid "Path"
-msgstr ""
-
 #. Label of a Data field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
-msgid "Path"
-msgstr ""
-
+#. Label of a Data field in DocType 'Onboarding Step'
 #. Label of a Data field in DocType 'Web Page View'
+#: core/doctype/package_release/package_release.json
+#: core/doctype/recorder/recorder.json
+#: desk/doctype/onboarding_step/onboarding_step.json
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
+#: website/report/website_analytics/website_analytics.js:35
 msgid "Path"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Path to CA Certs File"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Path to Server Certificate"
 msgstr ""
 
 #. Label of a Data field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Path to private Key File"
 msgstr ""
 
@@ -23476,100 +17804,69 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Payload Count"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Data Import'
-#: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
-msgid "Pending"
-msgstr ""
-
+#. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Step'
-#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
-msgctxt "Personal Data Deletion Step"
-msgid "Pending"
-msgstr ""
-
-#. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
+#: core/doctype/data_import/data_import.json
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
+#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 msgid "Pending"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
 msgid "Pending Approval"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Pending Emails"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report Queue'
 #: desk/doctype/system_health_report_queue/system_health_report_queue.json
-msgctxt "System Health Report Queue"
 msgid "Pending Jobs"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Personal Data Deletion
 #. Request'
 #: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
 msgid "Pending Verification"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Percent"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Percent"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Percent"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Percentage"
 msgstr ""
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Period"
 msgstr ""
 
-#. Label of a Int field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Perm Level"
-msgstr ""
-
 #. Label of a Int field in DocType 'DocField'
+#. Label of a Int field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Perm Level"
 msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Permanent"
 msgstr ""
 
@@ -23598,13 +17895,9 @@ msgstr ""
 msgid "Permission Inspector"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:457
-msgid "Permission Level"
-msgstr ""
-
 #. Label of a Int field in DocType 'Custom Field'
+#: core/page/permission_manager/permission_manager.js:457
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
 msgid "Permission Level"
 msgstr ""
 
@@ -23619,68 +17912,35 @@ msgstr ""
 
 #. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Permission Query"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Custom Role'
-#: core/doctype/custom_role/custom_role.json
-msgctxt "Custom Role"
-msgid "Permission Rules"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: core/doctype/custom_role/custom_role.json core/doctype/doctype/doctype.json
 msgid "Permission Rules"
 msgstr ""
 
 #. Label of a Select field in DocType 'Permission Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "Permission Type"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'Custom DocPerm'
+#. Label of a Section Break field in DocType 'DocField'
+#. Label of a Section Break field in DocType 'DocPerm'
+#. Label of a Table field in DocType 'DocType'
+#. Label of a Section Break field in DocType 'System Settings'
 #. Label of a Card Break in the Users Workspace
+#. Label of a Section Break field in DocType 'Customize Form Field'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docfield/docfield.json core/doctype/docperm/docperm.json
+#: core/doctype/doctype/doctype.json
+#: core/doctype/system_settings/system_settings.json
 #: core/doctype/user/user.js:133 core/doctype/user/user.js:142
 #: core/page/permission_manager/permission_manager.js:214
 #: core/workspace/users/users.json
-msgid "Permissions"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Permissions"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Customize Form Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Permissions"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Permissions"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Permissions"
-msgstr ""
-
-#. Label of a Table field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Permissions"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Permissions"
 msgstr ""
 
@@ -23717,13 +17977,11 @@ msgstr ""
 
 #. Label of a Table MultiSelect field in DocType 'Workflow Action'
 #: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
 msgid "Permitted Roles"
 msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Personal"
 msgstr ""
 
@@ -23743,66 +18001,30 @@ msgid "Personal Data Download Request"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Phone"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Phone"
-msgstr ""
-
 #. Label of a Data field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Phone"
-msgstr ""
-
-#. Label of a Data field in DocType 'Contact Us Settings'
-#: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
-msgid "Phone"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Phone"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Phone"
-msgstr ""
-
+#. Option for the 'Type' (Select) field in DocType 'Communication'
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Phone"
-msgstr ""
-
 #. Label of a Data field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Phone"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Data field in DocType 'Contact Us Settings'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: contacts/doctype/address/address.json contacts/doctype/contact/contact.json
+#: core/doctype/communication/communication.json
+#: core/doctype/docfield/docfield.json core/doctype/user/user.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/contact_us_settings/contact_us_settings.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Phone"
 msgstr ""
 
 #. Label of a Data field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Phone No."
 msgstr ""
 
-#: utils/__init__.py:109
+#: utils/__init__.py:118
 msgid "Phone Number {0} set in field {1} is not valid."
 msgstr ""
 
@@ -23814,37 +18036,28 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Pie"
 msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Pincode"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Pink"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Pink"
 msgstr ""
 
 #. Option for the 'Message Type' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Plain Text"
 msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Plant"
 msgstr ""
 
@@ -24108,7 +18321,7 @@ msgstr ""
 msgid "Please select X and Y fields"
 msgstr ""
 
-#: utils/__init__.py:116
+#: utils/__init__.py:125
 msgid "Please select a country code for field {1}."
 msgstr ""
 
@@ -24116,7 +18329,7 @@ msgstr ""
 msgid "Please select a file or url"
 msgstr ""
 
-#: model/rename_doc.py:669
+#: model/rename_doc.py:668
 msgid "Please select a valid csv file with data"
 msgstr ""
 
@@ -24143,7 +18356,6 @@ msgstr ""
 #. Description of the 'Directory Server' (Select) field in DocType 'LDAP
 #. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Please select the LDAP Directory being used"
 msgstr ""
 
@@ -24238,23 +18450,14 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Energy Point Settings'
 #: social/doctype/energy_point_settings/energy_point_settings.json
-msgctxt "Energy Point Settings"
 msgid "Point Allocation Periodicity"
 msgstr ""
 
-#: public/js/frappe/form/sidebar/review.js:75
-msgid "Points"
-msgstr ""
-
 #. Label of a Int field in DocType 'Energy Point Log'
-#: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "Points"
-msgstr ""
-
 #. Label of a Int field in DocType 'Energy Point Rule'
+#: public/js/frappe/form/sidebar/review.js:75
+#: social/doctype/energy_point_log/energy_point_log.json
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Points"
 msgstr ""
 
@@ -24265,37 +18468,25 @@ msgstr ""
 #. Option for the 'SocketIO Transport Mode' (Select) field in DocType 'System
 #. Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Polling"
 msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Popover Element"
 msgstr ""
 
 #. Label of a HTML Editor field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Popover or Modal Description"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Port"
-msgstr ""
-
 #. Label of a Data field in DocType 'Email Domain'
-#: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
-msgid "Port"
-msgstr ""
-
 #. Label of a Int field in DocType 'Network Printer Settings'
+#: email/doctype/email_account/email_account.json
+#: email/doctype/email_domain/email_domain.json
 #: printing/doctype/network_printer_settings/network_printer_settings.json
-msgctxt "Network Printer Settings"
 msgid "Port"
 msgstr ""
 
@@ -24306,7 +18497,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Portal Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Portal Menu"
 msgstr ""
 
@@ -24332,7 +18522,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Position"
 msgstr ""
 
@@ -24350,25 +18539,21 @@ msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Postal"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Postal Code"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Changelog Feed'
 #: desk/doctype/changelog_feed/changelog_feed.json
-msgctxt "Changelog Feed"
 msgid "Posting Timestamp"
 msgstr ""
 
 #. Group in Blog Category's connections
 #: website/doctype/blog_category/blog_category.json
-msgctxt "Blog Category"
 msgid "Posts"
 msgstr ""
 
@@ -24380,27 +18565,14 @@ msgstr ""
 msgid "Posts filed under {0}"
 msgstr ""
 
-#. Label of a Select field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Precision"
-msgstr ""
-
-#. Label of a Select field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Precision"
-msgstr ""
-
 #. Label of a Select field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Precision"
-msgstr ""
-
+#. Label of a Select field in DocType 'Custom Field'
+#. Label of a Select field in DocType 'Customize Form Field'
 #. Label of a Select field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Precision"
 msgstr ""
 
@@ -24414,36 +18586,25 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Preferred Billing Address"
 msgstr ""
 
 #. Label of a Check field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Preferred Shipping Address"
 msgstr ""
 
 #. Label of a Data field in DocType 'Document Naming Rule'
-#: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
-msgid "Prefix"
-msgstr ""
-
 #. Label of a Autocomplete field in DocType 'Document Naming Settings'
+#: core/doctype/document_naming_rule/document_naming_rule.json
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Prefix"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/prepared_report/prepared_report.json
-msgid "Prepared Report"
-msgstr ""
-
 #. Label of a Check field in DocType 'Report'
+#: core/doctype/prepared_report/prepared_report.json
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Prepared Report"
 msgstr ""
 
@@ -24472,65 +18633,37 @@ msgstr ""
 msgid "Press Enter to save"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'Data Import'
+#. Label of a Section Break field in DocType 'File'
+#. Label of a Section Break field in DocType 'Custom HTML Block'
+#. Label of a Tab Break field in DocType 'Webhook'
+#. Label of a Attach Image field in DocType 'Print Style'
+#: core/doctype/data_import/data_import.json core/doctype/file/file.json
+#: desk/doctype/custom_html_block/custom_html_block.json
 #: email/doctype/newsletter/newsletter.js:14
 #: email/doctype/newsletter/newsletter.js:42
+#: integrations/doctype/webhook/webhook.json
+#: printing/doctype/print_style/print_style.json
 #: public/js/frappe/form/controls/markdown_editor.js:17
 #: public/js/frappe/form/controls/markdown_editor.js:31
 #: public/js/frappe/ui/capture.js:236
 msgid "Preview"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Custom HTML Block'
-#: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
-msgid "Preview"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Data Import'
-#: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
-msgid "Preview"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'File'
-#: core/doctype/file/file.json
-msgctxt "File"
-msgid "Preview"
-msgstr ""
-
-#. Label of a Attach Image field in DocType 'Print Style'
-#: printing/doctype/print_style/print_style.json
-msgctxt "Print Style"
-msgid "Preview"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'Webhook'
-#: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
-msgid "Preview"
-msgstr ""
-
 #. Label of a HTML field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Preview HTML"
 msgstr ""
 
 #. Label of a Attach Image field in DocType 'Blog Category'
-#: website/doctype/blog_category/blog_category.json
-msgctxt "Blog Category"
-msgid "Preview Image"
-msgstr ""
-
 #. Label of a Attach Image field in DocType 'Blog Settings'
+#: website/doctype/blog_category/blog_category.json
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Preview Image"
 msgstr ""
 
 #. Label of a Button field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Preview Message"
 msgstr ""
 
@@ -24540,7 +18673,6 @@ msgstr ""
 
 #. Label of a Text field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Preview of generated names"
 msgstr ""
 
@@ -24566,7 +18698,6 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'Transaction Log'
 #: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
 msgid "Previous Hash"
 msgstr ""
 
@@ -24576,7 +18707,6 @@ msgstr ""
 
 #. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Primary"
 msgstr ""
 
@@ -24586,7 +18716,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Primary Color"
 msgstr ""
 
@@ -24610,6 +18739,10 @@ msgstr ""
 msgid "Primary key of doctype {0} can not be changed as there are existing values."
 msgstr ""
 
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json
 #: core/doctype/success_action/success_action.js:56
 #: printing/page/print/print.js:65 public/js/frappe/form/success_action.js:81
 #: public/js/frappe/form/templates/print_layout.html:46
@@ -24626,50 +18759,23 @@ msgctxt "Button in list view actions menu"
 msgid "Print"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Print"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Print"
-msgstr ""
-
 #: public/js/frappe/list/bulk_operations.js:47
 msgid "Print Documents"
 msgstr ""
 
+#. Label of a Link field in DocType 'Auto Repeat'
+#. Linked DocType in DocType's connections
+#. Linked DocType in Module Def's connections
+#. Label of a Link field in DocType 'Notification'
 #. Name of a DocType
+#. Label of a Link field in DocType 'Web Form'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
+#: email/doctype/notification/notification.json
 #: printing/doctype/print_format/print_format.json
 #: printing/page/print/print.js:94 printing/page/print/print.js:819
 #: public/js/frappe/list/bulk_operations.js:58
-msgid "Print Format"
-msgstr ""
-
-#. Label of a Link field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Print Format"
-msgstr ""
-
-#. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Print Format"
-msgstr ""
-
-#. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Print Format"
-msgstr ""
-
-#. Label of a Link field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
+#: website/doctype/web_form/web_form.json
 msgid "Print Format"
 msgstr ""
 
@@ -24679,24 +18785,14 @@ msgctxt "Print Format"
 msgid "Print Format"
 msgstr ""
 
-#. Label of a Link field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Print Format"
-msgstr ""
-
 #. Label of a Link in the Tools Workspace
 #. Label of a shortcut in the Build Workspace
+#. Label of a Check field in DocType 'Print Format'
 #: automation/workspace/tools/tools.json core/workspace/build/build.json
+#: printing/doctype/print_format/print_format.json
 #: printing/page/print_format_builder/print_format_builder.js:44
 #: printing/page/print_format_builder/print_format_builder.js:67
 #: printing/page/print_format_builder_beta/print_format_builder_beta.js:4
-msgid "Print Format Builder"
-msgstr ""
-
-#. Label of a Check field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Print Format Builder"
 msgstr ""
 
@@ -24707,7 +18803,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Print Format Builder Beta"
 msgstr ""
 
@@ -24722,13 +18817,11 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Print Format Help"
 msgstr ""
 
 #. Label of a Select field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Print Format Type"
 msgstr ""
 
@@ -24742,51 +18835,32 @@ msgid "Print Formats allow you can define looks for documents when printed or co
 msgstr ""
 
 #. Name of a DocType
+#. Label of a Data field in DocType 'Print Heading'
 #: printing/doctype/print_heading/print_heading.json
 msgid "Print Heading"
 msgstr ""
 
 #. Label of a Link in the Tools Workspace
-#. Label of a Data field in DocType 'Print Heading'
 #: automation/workspace/tools/tools.json
-#: printing/doctype/print_heading/print_heading.json
 msgctxt "Print Heading"
 msgid "Print Heading"
 msgstr ""
 
+#. Label of a Check field in DocType 'DocField'
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Print Hide"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Print Hide"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Print Hide"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Print Hide If No Value"
-msgstr ""
-
 #. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Print Hide If No Value"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Print Hide If No Value"
 msgstr ""
 
@@ -24800,21 +18874,16 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Print Server"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'Notification'
 #. Name of a DocType
+#: email/doctype/notification/notification.json
 #: printing/doctype/print_settings/print_settings.json
 #: printing/doctype/print_style/print_style.js:6
 #: printing/page/print/print.js:160 public/js/frappe/form/print_utils.js:69
 #: public/js/frappe/form/templates/print_layout.html:35
-msgid "Print Settings"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Print Settings"
 msgstr ""
 
@@ -24824,52 +18893,36 @@ msgctxt "Print Settings"
 msgid "Print Settings"
 msgstr ""
 
-#. Name of a DocType
-#: printing/doctype/print_style/print_style.json
-msgid "Print Style"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Print Settings'
 #. Label of a Link field in DocType 'Print Settings'
+#. Name of a DocType
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
+#: printing/doctype/print_style/print_style.json
 msgid "Print Style"
 msgstr ""
 
 #. Label of a Data field in DocType 'Print Style'
 #: printing/doctype/print_style/print_style.json
-msgctxt "Print Style"
 msgid "Print Style Name"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Print Style Preview"
 msgstr ""
 
-#. Label of a Data field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Print Width"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Print Width"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocField'
+#. Label of a Data field in DocType 'Custom Field'
+#. Label of a Data field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Print Width"
 msgstr ""
 
 #. Description of the 'Print Width' (Data) field in DocType 'Customize Form
 #. Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Print Width of the field, if the field is a column in a table"
 msgstr ""
 
@@ -24879,7 +18932,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Print with letterhead"
 msgstr ""
 
@@ -24893,7 +18945,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Network Printer Settings'
 #: printing/doctype/network_printer_settings/network_printer_settings.json
-msgctxt "Network Printer Settings"
 msgid "Printer Name"
 msgstr ""
 
@@ -24914,72 +18965,37 @@ msgstr ""
 msgid "Printing failed"
 msgstr ""
 
-#: desk/report/todo/todo.py:37 public/js/frappe/form/sidebar/assign_to.js:210
-msgid "Priority"
-msgstr ""
-
 #. Label of a Int field in DocType 'Assignment Rule'
-#: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
-msgid "Priority"
-msgstr ""
-
 #. Label of a Int field in DocType 'Document Naming Rule'
-#: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
-msgid "Priority"
-msgstr ""
-
-#. Label of a Int field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Priority"
-msgstr ""
-
 #. Label of a Select field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Priority"
-msgstr ""
-
+#. Label of a Int field in DocType 'Email Queue'
 #. Label of a Int field in DocType 'Web Page'
+#: automation/doctype/assignment_rule/assignment_rule.json
+#: core/doctype/document_naming_rule/document_naming_rule.json
+#: desk/doctype/todo/todo.json desk/report/todo/todo.py:37
+#: email/doctype/email_queue/email_queue.json
+#: public/js/frappe/form/sidebar/assign_to.js:210
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Priority"
-msgstr ""
-
-#: desk/doctype/note/note_list.js:8
-msgid "Private"
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom HTML Block'
-#: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
-msgid "Private"
-msgstr ""
-
 #. Option for the 'Event Type' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Private"
-msgstr ""
-
 #. Label of a Check field in DocType 'Kanban Board'
-#: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
+#: desk/doctype/custom_html_block/custom_html_block.json
+#: desk/doctype/event/event.json desk/doctype/kanban_board/kanban_board.json
+#: desk/doctype/note/note_list.js:8
 msgid "Private"
 msgstr ""
 
 #. Label of a Float field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Private Files (MB)"
 msgstr ""
 
 #. Description of the 'Auto Reply Message' (Text Editor) field in DocType
 #. 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "ProTip: Add <code>Reference: {{ reference_doctype }} {{ reference_name }}</code> to send document reference"
 msgstr ""
 
@@ -25001,7 +19017,6 @@ msgstr ""
 
 #. Group in User's connections
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Profile"
 msgstr ""
 
@@ -25013,38 +19028,25 @@ msgstr ""
 msgid "Project"
 msgstr ""
 
+#. Label of a Data field in DocType 'Property Setter'
 #: core/doctype/version/version_view.html:12
 #: core/doctype/version/version_view.html:37
 #: core/doctype/version/version_view.html:74
-msgid "Property"
-msgstr ""
-
-#. Label of a Data field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "Property"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Property Depends On"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Web Form Field'
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Property Depends On"
-msgstr ""
-
-#. Name of a DocType
-#: custom/doctype/property_setter/property_setter.json
-msgid "Property Setter"
 msgstr ""
 
 #. Linked DocType in Module Def's connections
+#. Name of a DocType
 #: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
+#: custom/doctype/property_setter/property_setter.json
 msgid "Property Setter"
 msgstr ""
 
@@ -25055,146 +19057,81 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "Property Type"
 msgstr ""
 
 #. Description of the 'Allowed File Extensions' (Small Text) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Provide a list of allowed file extensions for file uploads. Each line should contain one allowed file type. If unset, all file extensions are allowed. Example: <br>CSV<br>JPG<br>PNG"
 msgstr ""
 
 #. Label of a Data field in DocType 'User Social Login'
 #: core/doctype/user_social_login/user_social_login.json
-msgctxt "User Social Login"
 msgid "Provider"
 msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
-#: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
-msgid "Provider Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Social Login Key'
-#: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
-msgid "Provider Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Token Cache'
+#: integrations/doctype/connected_app/connected_app.json
+#: integrations/doctype/social_login_key/social_login_key.json
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Provider Name"
-msgstr ""
-
-#: desk/doctype/note/note_list.js:6 public/js/frappe/views/interaction.js:78
-#: public/js/frappe/views/workspace/workspace.js:626
-#: public/js/frappe/views/workspace/workspace.js:954
-#: public/js/frappe/views/workspace/workspace.js:1200
-msgid "Public"
 msgstr ""
 
 #. Option for the 'Event Type' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Public"
-msgstr ""
-
 #. Label of a Check field in DocType 'Note'
-#: desk/doctype/note/note.json
-msgctxt "Note"
-msgid "Public"
-msgstr ""
-
 #. Label of a Check field in DocType 'Workspace'
-#: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: desk/doctype/event/event.json desk/doctype/note/note.json
+#: desk/doctype/note/note_list.js:6 desk/doctype/workspace/workspace.json
+#: public/js/frappe/views/interaction.js:78
+#: public/js/frappe/views/workspace/workspace.js:627
+#: public/js/frappe/views/workspace/workspace.js:955
+#: public/js/frappe/views/workspace/workspace.js:1201
 msgid "Public"
 msgstr ""
 
 #. Label of a Float field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Public Files (MB)"
 msgstr ""
 
+#. Label of a Check field in DocType 'Package Release'
+#: core/doctype/package_release/package_release.json
 #: website/doctype/blog_post/blog_post.js:36
 #: website/doctype/web_form/web_form.js:86
 msgid "Publish"
 msgstr ""
 
-#. Label of a Check field in DocType 'Package Release'
-#: core/doctype/package_release/package_release.json
-msgctxt "Package Release"
-msgid "Publish"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Publish as a web page"
 msgstr ""
 
-#: website/doctype/blog_post/blog_post_list.js:5
-#: website/doctype/web_form/web_form_list.js:5
-#: website/doctype/web_page/web_page_list.js:5
-msgid "Published"
-msgstr ""
-
-#. Label of a Check field in DocType 'Blog Category'
-#: website/doctype/blog_category/blog_category.json
-msgctxt "Blog Category"
-msgid "Published"
-msgstr ""
-
-#. Label of a Check field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Published"
-msgstr ""
-
 #. Label of a Check field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Published"
-msgstr ""
-
-#. Label of a Check field in DocType 'Help Article'
-#: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
-msgid "Published"
-msgstr ""
-
-#. Label of a Check field in DocType 'Help Category'
-#: website/doctype/help_category/help_category.json
-msgctxt "Help Category"
-msgid "Published"
-msgstr ""
-
 #. Label of a Check field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Published"
-msgstr ""
-
+#. Label of a Check field in DocType 'Blog Category'
+#. Label of a Check field in DocType 'Blog Post'
+#. Label of a Check field in DocType 'Help Article'
+#. Label of a Check field in DocType 'Help Category'
 #. Label of a Check field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Published"
-msgstr ""
-
 #. Label of a Check field in DocType 'Web Page'
+#: core/doctype/comment/comment.json email/doctype/newsletter/newsletter.json
+#: website/doctype/blog_category/blog_category.json
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/blog_post/blog_post_list.js:5
+#: website/doctype/help_article/help_article.json
+#: website/doctype/help_category/help_category.json
+#: website/doctype/web_form/web_form.json
+#: website/doctype/web_form/web_form_list.js:5
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
+#: website/doctype/web_page/web_page_list.js:5
 msgid "Published"
 msgstr ""
 
 #. Label of a Date field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Published On"
 msgstr ""
 
@@ -25204,7 +19141,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Publishing Dates"
 msgstr ""
 
@@ -25214,25 +19150,21 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Google Calendar'
 #: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
 msgid "Pull from Google Calendar"
 msgstr ""
 
 #. Label of a Check field in DocType 'Google Contacts'
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
 msgid "Pull from Google Contacts"
 msgstr ""
 
 #. Label of a Check field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Pulled from Google Calendar"
 msgstr ""
 
 #. Label of a Check field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Pulled from Google Contacts"
 msgstr ""
 
@@ -25253,14 +19185,9 @@ msgid "Purchase User"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Purple"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Purple"
 msgstr ""
 
@@ -25282,13 +19209,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Google Calendar'
 #: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
 msgid "Push to Google Calendar"
 msgstr ""
 
 #. Label of a Check field in DocType 'Google Contacts'
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
 msgid "Push to Google Contacts"
 msgstr ""
 
@@ -25298,7 +19223,6 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "Python"
 msgstr ""
 
@@ -25314,76 +19238,45 @@ msgstr ""
 msgid "QZ Tray Failed: "
 msgstr ""
 
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 #: public/js/frappe/utils/common.js:401
 msgid "Quarterly"
 msgstr ""
 
-#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Quarterly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Quarterly"
-msgstr ""
-
-#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Quarterly"
-msgstr ""
-
-#. Option for the 'Repeat On' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Quarterly"
-msgstr ""
-
 #. Label of a Data field in DocType 'Recorder Query'
-#: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
-msgid "Query"
-msgstr ""
-
 #. Label of a Code field in DocType 'Report'
+#: core/doctype/recorder_query/recorder_query.json
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Query"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Query / Script"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Query Options"
 msgstr ""
 
+#. Label of a Table field in DocType 'Connected App'
 #. Name of a DocType
+#: integrations/doctype/connected_app/connected_app.json
 #: integrations/doctype/query_parameters/query_parameters.json
 msgid "Query Parameters"
 msgstr ""
 
-#. Label of a Table field in DocType 'Connected App'
-#: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
-msgid "Query Parameters"
-msgstr ""
-
-#: public/js/frappe/views/reports/query_report.js:17
-msgid "Query Report"
-msgstr ""
-
 #. Option for the 'Report Type' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
+#: public/js/frappe/views/reports/query_report.js:17
 msgid "Query Report"
 msgstr ""
 
@@ -25396,38 +19289,26 @@ msgid "Query must be of SELECT or read-only WITH type."
 msgstr ""
 
 #. Label of a Select field in DocType 'RQ Job'
-#: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
-msgid "Queue"
-msgstr ""
-
 #. Label of a Data field in DocType 'System Health Report Queue'
+#: core/doctype/rq_job/rq_job.json
 #: desk/doctype/system_health_report_queue/system_health_report_queue.json
-msgctxt "System Health Report Queue"
 msgid "Queue"
 msgstr ""
 
 #. Label of a Table field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Queue Status"
 msgstr ""
 
 #. Label of a Select field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Queue Type(s)"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Queue in Background (BETA)"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Queue in Background (BETA)"
 msgstr ""
 
@@ -25437,41 +19318,26 @@ msgstr ""
 
 #. Label of a Data field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Queue(s)"
 msgstr ""
 
-#: email/doctype/newsletter/newsletter.js:208
-msgid "Queued"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Queued"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Prepared Report'
-#: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
-msgid "Queued"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Submission Queue'
+#. Option for the 'Status' (Select) field in DocType 'Integration Request'
+#: core/doctype/prepared_report/prepared_report.json
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
+#: email/doctype/newsletter/newsletter.js:208
+#: integrations/doctype/integration_request/integration_request.json
 msgid "Queued"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
 msgid "Queued At"
 msgstr ""
 
 #. Label of a Data field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
 msgid "Queued By"
 msgstr ""
 
@@ -25495,7 +19361,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'System Health Report Workers'
 #: desk/doctype/system_health_report_workers/system_health_report_workers.json
-msgctxt "System Health Report Workers"
 msgid "Queues"
 msgstr ""
 
@@ -25507,15 +19372,10 @@ msgstr ""
 msgid "Queuing {0} for Submission"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Quick Entry"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Quick Entry"
 msgstr ""
 
@@ -25525,14 +19385,12 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Workspace Quick List'
 #: desk/doctype/workspace_quick_list/workspace_quick_list.json
-msgctxt "Workspace Quick List"
 msgid "Quick List Filter"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Workspace'
 #. Label of a Table field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Quick Lists"
 msgstr ""
 
@@ -25542,7 +19400,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "RAW Information Log"
 msgstr ""
 
@@ -25556,15 +19413,10 @@ msgstr ""
 msgid "RQ Worker"
 msgstr ""
 
-#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Random"
-msgstr ""
-
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Random"
 msgstr ""
 
@@ -25578,71 +19430,42 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Rate Limiting"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Rate Limits"
 msgstr ""
 
 #. Label of a Int field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Rating"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Rating"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Rating"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Rating"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/communication/communication.json
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Rating"
-msgstr ""
-
-#: printing/doctype/print_format/print_format.py:88
-msgid "Raw Commands"
 msgstr ""
 
 #. Label of a Code field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
+#: printing/doctype/print_format/print_format.py:88
 msgid "Raw Commands"
 msgstr ""
 
 #. Label of a Code field in DocType 'Unhandled Email'
 #: email/doctype/unhandled_email/unhandled_email.json
-msgctxt "Unhandled Email"
 msgid "Raw Email"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Raw Printing"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Print Settings'
+#: printing/doctype/print_format/print_format.json
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Raw Printing"
 msgstr ""
 
@@ -25668,104 +19491,48 @@ msgstr ""
 msgid "Re: {0}"
 msgstr ""
 
-#: client.py:459
-msgid "Read"
-msgstr ""
-
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Read"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Read"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Read"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocShare'
-#: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
-msgid "Read"
-msgstr ""
-
-#. Option for the 'Action' (Select) field in DocType 'Email Flag Queue'
-#: email/doctype/email_flag_queue/email_flag_queue.json
-msgctxt "Email Flag Queue"
-msgid "Read"
-msgstr ""
-
-#. Label of a Check field in DocType 'Notification Log'
-#: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
-msgid "Read"
-msgstr ""
-
 #. Label of a Check field in DocType 'User Document Type'
+#. Label of a Check field in DocType 'Notification Log'
+#. Option for the 'Action' (Select) field in DocType 'Email Flag Queue'
+#: client.py:459 core/doctype/communication/communication.json
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json core/doctype/docshare/docshare.json
 #: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
+#: desk/doctype/notification_log/notification_log.json
+#: email/doctype/email_flag_queue/email_flag_queue.json
 msgid "Read"
-msgstr ""
-
-#: public/js/form_builder/form_builder.bundle.js:83
-msgid "Read Only"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Read Only"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Read Only"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Label of a Check field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Read Only"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #. Label of a Check field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: public/js/form_builder/form_builder.bundle.js:83
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Read Only"
 msgstr ""
 
 #. Label of a Code field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Read Only Depends On"
-msgstr ""
-
 #. Label of a Code field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Read Only Depends On"
-msgstr ""
-
 #. Label of a Code field in DocType 'Web Form Field'
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Read Only Depends On"
 msgstr ""
 
 #. Label of a Code field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Read Only Depends On (JS)"
 msgstr ""
 
@@ -25776,19 +19543,16 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "Read Time"
 msgstr ""
 
 #. Label of a Check field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Read by Recipient"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Read by Recipient On"
 msgstr ""
 
@@ -25802,30 +19566,20 @@ msgstr ""
 
 #. Label of a Markdown Editor field in DocType 'Package'
 #: core/doctype/package/package.json
-msgctxt "Package"
 msgid "Readme"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Realtime (SocketIO)"
 msgstr ""
 
+#. Label of a Long Text field in DocType 'Unhandled Email'
+#. Label of a Text field in DocType 'Energy Point Log'
+#: email/doctype/unhandled_email/unhandled_email.json
 #: public/js/frappe/form/sidebar/review.js:85
 #: social/doctype/energy_point_log/energy_point_log.js:20
-msgid "Reason"
-msgstr ""
-
-#. Label of a Text field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "Reason"
-msgstr ""
-
-#. Label of a Long Text field in DocType 'Unhandled Email'
-#: email/doctype/unhandled_email/unhandled_email.json
-msgctxt "Unhandled Email"
 msgid "Reason"
 msgstr ""
 
@@ -25843,13 +19597,11 @@ msgstr ""
 
 #. Description of the 'Anonymous' (Check) field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Receive anonymous response"
 msgstr ""
 
 #. Option for the 'Sent or Received' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Received"
 msgstr ""
 
@@ -25859,19 +19611,16 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Notification Recipient'
 #: email/doctype/notification_recipient/notification_recipient.json
-msgctxt "Notification Recipient"
 msgid "Receiver By Document Field"
 msgstr ""
 
 #. Label of a Link field in DocType 'Notification Recipient'
 #: email/doctype/notification_recipient/notification_recipient.json
-msgctxt "Notification Recipient"
 msgid "Receiver By Role"
 msgstr ""
 
 #. Label of a Data field in DocType 'SMS Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Receiver Parameter"
 msgstr ""
 
@@ -25888,33 +19637,22 @@ msgid "Recents"
 msgstr ""
 
 #. Label of a Table field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Recipient"
-msgstr ""
-
 #. Label of a Data field in DocType 'Email Queue Recipient'
+#: email/doctype/email_queue/email_queue.json
 #: email/doctype/email_queue_recipient/email_queue_recipient.json
-msgctxt "Email Queue Recipient"
 msgid "Recipient"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Recipient Unsubscribed"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Recipients"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Notification'
 #. Label of a Table field in DocType 'Notification'
+#: automation/doctype/auto_repeat/auto_repeat.json
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Recipients"
 msgstr ""
 
@@ -25942,62 +19680,46 @@ msgid "Recursive Fetch From"
 msgstr ""
 
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Red"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Red"
 msgstr ""
 
 #. Label of a Select field in DocType 'Website Route Redirect'
 #: website/doctype/website_route_redirect/website_route_redirect.json
-msgctxt "Website Route Redirect"
 msgid "Redirect HTTP Status"
 msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Redirect URI"
 msgstr ""
 
 #. Label of a Data field in DocType 'OAuth Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "Redirect URI Bound To Auth Code"
 msgstr ""
 
 #. Label of a Text field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Redirect URIs"
 msgstr ""
 
-#. Label of a Data field in DocType 'Social Login Key'
-#: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
-msgid "Redirect URL"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'User'
+#. Label of a Data field in DocType 'Social Login Key'
 #: core/doctype/user/user.json
-msgctxt "User"
+#: integrations/doctype/social_login_key/social_login_key.json
 msgid "Redirect URL"
 msgstr ""
 
 #. Description of the 'Welcome URL' (Data) field in DocType 'Email Group'
 #: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
 msgid "Redirect to this URL after successful confirmation."
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Redirects"
 msgstr ""
 
@@ -26015,7 +19737,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Ref DocType"
 msgstr ""
 
@@ -26023,68 +19744,36 @@ msgstr ""
 msgid "Referance Doctype and Dashboard Name both can't be used at the same time."
 msgstr ""
 
-#: core/doctype/user_type/user_type_dashboard.py:5 desk/report/todo/todo.py:42
-#: public/js/frappe/views/interaction.js:54
-msgid "Reference"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Reference"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Address'
-#: contacts/doctype/address/address.json
-msgctxt "Address"
-msgid "Reference"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Reference"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Reference"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Reference"
-msgstr ""
-
+#. Label of a Section Break field in DocType 'Activity Log'
+#. Label of a Section Break field in DocType 'Communication'
 #. Label of a Section Break field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
+#. Label of a Section Break field in DocType 'Integration Request'
+#: contacts/doctype/address/address.json contacts/doctype/contact/contact.json
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication/communication.json
+#: core/doctype/user_type/user_type_dashboard.py:5 desk/doctype/todo/todo.json
+#: desk/report/todo/todo.py:42
+#: integrations/doctype/integration_request/integration_request.json
+#: public/js/frappe/views/interaction.js:54
 msgid "Reference"
 msgstr ""
 
 #. Label of a Select field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Reference Date"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Reference DocName"
 msgstr ""
 
 #. Label of a Link field in DocType 'Error Log'
-#: core/doctype/error_log/error_log.json
-msgctxt "Error Log"
-msgid "Reference DocType"
-msgstr ""
-
 #. Label of a Link field in DocType 'Submission Queue'
+#: core/doctype/error_log/error_log.json
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
 msgid "Reference DocType"
 msgstr ""
 
@@ -26092,311 +19781,133 @@ msgstr ""
 msgid "Reference DocType and Reference Name are required"
 msgstr ""
 
-#. Label of a Dynamic Link field in DocType 'Discussion Topic'
-#: website/doctype/discussion_topic/discussion_topic.json
-msgctxt "Discussion Topic"
-msgid "Reference Docname"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Submission Queue'
+#. Label of a Dynamic Link field in DocType 'Discussion Topic'
 #: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
+#: website/doctype/discussion_topic/discussion_topic.json
 msgid "Reference Docname"
-msgstr ""
-
-#: core/doctype/communication/communication.js:143
-#: core/report/transaction_log_report/transaction_log_report.py:88
-msgid "Reference Doctype"
 msgstr ""
 
 #. Label of a Link field in DocType 'Discussion Topic'
+#: core/doctype/communication/communication.js:143
+#: core/report/transaction_log_report/transaction_log_report.py:88
 #: website/doctype/discussion_topic/discussion_topic.json
-msgctxt "Discussion Topic"
 msgid "Reference Doctype"
 msgstr ""
 
-#: automation/doctype/auto_repeat/auto_repeat_schedule.html:4
-msgid "Reference Document"
-msgstr ""
-
-#. Label of a Data field in DocType 'Access Log'
-#: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
-msgid "Reference Document"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Reference Document"
-msgstr ""
-
+#. Label of a Data field in DocType 'Access Log'
 #. Label of a Link field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Reference Document"
-msgstr ""
-
 #. Label of a Link field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Reference Document"
-msgstr ""
-
 #. Label of a Data field in DocType 'Webhook Request Log'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: automation/doctype/auto_repeat/auto_repeat_schedule.html:4
+#: core/doctype/access_log/access_log.json
+#: desk/doctype/form_tour/form_tour.json
+#: desk/doctype/onboarding_step/onboarding_step.json
 #: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
 msgid "Reference Document"
 msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'Document Share Key'
-#: core/doctype/document_share_key/document_share_key.json
-msgctxt "Document Share Key"
-msgid "Reference Document Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Integration Request'
+#: core/doctype/document_share_key/document_share_key.json
 #: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
 msgid "Reference Document Name"
-msgstr ""
-
-#. Label of a Link field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Reference Document Type"
 msgstr ""
 
 #. Label of a Link field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Calendar View'
-#: desk/doctype/calendar_view/calendar_view.json
-msgctxt "Calendar View"
-msgid "Reference Document Type"
-msgstr ""
-
+#. Label of a Link field in DocType 'Activity Log'
 #. Label of a Link field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Link field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Data field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Data field in DocType 'Custom Role'
-#: core/doctype/custom_role/custom_role.json
-msgctxt "Custom Role"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Link field in DocType 'Document Share Key'
-#: core/doctype/document_share_key/document_share_key.json
-msgctxt "Document Share Key"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Email Unsubscribe'
-#: email/doctype/email_unsubscribe/email_unsubscribe.json
-msgctxt "Email Unsubscribe"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Energy Point Log'
-#: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Energy Point Rule'
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Event Participants'
-#: desk/doctype/event_participants/event_participants.json
-msgctxt "Event Participants"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Kanban Board'
-#: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'List Filter'
-#: desk/doctype/list_filter/list_filter.json
-msgctxt "List Filter"
-msgid "Reference Document Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'Portal Menu Item'
-#: website/doctype/portal_menu_item/portal_menu_item.json
-msgctxt "Portal Menu Item"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Link field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Link field in DocType 'Success Action'
-#: core/doctype/success_action/success_action.json
-msgctxt "Success Action"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Data field in DocType 'Transaction Log'
-#: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
-msgid "Reference Document Type"
-msgstr ""
-
 #. Label of a Link field in DocType 'View Log'
-#: core/doctype/view_log/view_log.json
-msgctxt "View Log"
-msgid "Reference Document Type"
-msgstr ""
-
+#. Label of a Link field in DocType 'Calendar View'
+#. Label of a Link field in DocType 'Event Participants'
+#. Label of a Link field in DocType 'Kanban Board'
+#. Label of a Link field in DocType 'List Filter'
+#. Label of a Link field in DocType 'Email Queue'
+#. Label of a Link field in DocType 'Email Unsubscribe'
+#. Label of a Link field in DocType 'Integration Request'
+#. Label of a Link field in DocType 'Energy Point Log'
+#. Label of a Link field in DocType 'Energy Point Rule'
+#. Label of a Link field in DocType 'Portal Menu Item'
 #. Label of a Link field in DocType 'Workflow Action'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/custom_role/custom_role.json
+#: core/doctype/document_share_key/document_share_key.json
+#: core/doctype/server_script/server_script.json
+#: core/doctype/success_action/success_action.json
+#: core/doctype/transaction_log/transaction_log.json
+#: core/doctype/view_log/view_log.json
+#: desk/doctype/calendar_view/calendar_view.json
+#: desk/doctype/event_participants/event_participants.json
+#: desk/doctype/kanban_board/kanban_board.json
+#: desk/doctype/list_filter/list_filter.json
+#: email/doctype/email_queue/email_queue.json
+#: email/doctype/email_unsubscribe/email_unsubscribe.json
+#: integrations/doctype/integration_request/integration_request.json
+#: social/doctype/energy_point_log/energy_point_log.json
+#: social/doctype/energy_point_rule/energy_point_rule.json
+#: website/doctype/portal_menu_item/portal_menu_item.json
 #: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
 msgid "Reference Document Type"
-msgstr ""
-
-#: core/doctype/communication/communication.js:152
-#: core/report/transaction_log_report/transaction_log_report.py:94
-msgid "Reference Name"
 msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Reference Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Reference Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Reference Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Data Import Log'
-#: core/doctype/data_import_log/data_import_log.json
-msgctxt "Data Import Log"
-msgid "Reference Name"
-msgstr ""
-
-#. Label of a Dynamic Link field in DocType 'Email Unsubscribe'
-#: email/doctype/email_unsubscribe/email_unsubscribe.json
-msgctxt "Email Unsubscribe"
-msgid "Reference Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Energy Point Log'
-#: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "Reference Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Error Log'
-#: core/doctype/error_log/error_log.json
-msgctxt "Error Log"
-msgid "Reference Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'Event Participants'
-#: desk/doctype/event_participants/event_participants.json
-msgctxt "Event Participants"
-msgid "Reference Name"
-msgstr ""
-
 #. Label of a Dynamic Link field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Reference Name"
-msgstr ""
-
+#. Label of a Dynamic Link field in DocType 'Email Unsubscribe'
+#. Label of a Data field in DocType 'Energy Point Log'
 #. Label of a Dynamic Link field in DocType 'Workflow Action'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.js:152
+#: core/doctype/communication/communication.json
+#: core/doctype/data_import_log/data_import_log.json
+#: core/doctype/error_log/error_log.json
+#: core/report/transaction_log_report/transaction_log_report.py:94
+#: desk/doctype/event_participants/event_participants.json
+#: desk/doctype/todo/todo.json
+#: email/doctype/email_unsubscribe/email_unsubscribe.json
+#: social/doctype/energy_point_log/energy_point_log.json
 #: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
 msgid "Reference Name"
 msgstr ""
 
 #. Label of a Read Only field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Reference Owner"
-msgstr ""
-
 #. Label of a Data field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Reference Owner"
-msgstr ""
-
 #. Label of a Read Only field in DocType 'Communication'
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Reference Owner"
-msgstr ""
-
-#. Label of a Data field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Reference Report"
-msgstr ""
-
-#. Label of a Link field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Reference Report"
 msgstr ""
 
 #. Label of a Data field in DocType 'Report'
+#. Label of a Link field in DocType 'Onboarding Step'
+#. Label of a Data field in DocType 'Auto Email Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
+#: desk/doctype/onboarding_step/onboarding_step.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Reference Report"
 msgstr ""
 
 #. Label of a Link field in DocType 'ToDo'
 #: desk/doctype/todo/todo.json
-msgctxt "ToDo"
 msgid "Reference Type"
 msgstr ""
 
@@ -26406,7 +19917,6 @@ msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'View Log'
 #: core/doctype/view_log/view_log.json
-msgctxt "View Log"
 msgid "Reference name"
 msgstr ""
 
@@ -26414,13 +19924,9 @@ msgstr ""
 msgid "Reference: {0} {1}"
 msgstr ""
 
-#: website/report/website_analytics/website_analytics.js:37
-msgid "Referrer"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Page View'
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
+#: website/report/website_analytics/website_analytics.js:37
 msgid "Referrer"
 msgstr ""
 
@@ -26441,37 +19947,19 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Refresh Google Sheet"
 msgstr ""
 
 #. Label of a Password field in DocType 'Google Calendar'
-#: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
-msgid "Refresh Token"
-msgstr ""
-
 #. Label of a Password field in DocType 'Google Contacts'
-#: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
-msgid "Refresh Token"
-msgstr ""
-
 #. Label of a Data field in DocType 'Google Drive'
-#: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
-msgid "Refresh Token"
-msgstr ""
-
 #. Label of a Data field in DocType 'OAuth Bearer Token'
-#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
-msgid "Refresh Token"
-msgstr ""
-
 #. Label of a Password field in DocType 'Token Cache'
+#: integrations/doctype/google_calendar/google_calendar.json
+#: integrations/doctype/google_contacts/google_contacts.json
+#: integrations/doctype/google_drive/google_drive.json
+#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Refresh Token"
 msgstr ""
 
@@ -26490,14 +19978,9 @@ msgid "Registered but disabled"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Rejected"
-msgstr ""
-
 #. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
+#: core/doctype/communication/communication.json
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
 msgid "Rejected"
 msgstr ""
 
@@ -26507,19 +19990,16 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Push Notification Settings'
 #: integrations/doctype/push_notification_settings/push_notification_settings.json
-msgctxt "Push Notification Settings"
 msgid "Relay Settings"
 msgstr ""
 
 #. Group in Package's connections
 #: core/doctype/package/package.json
-msgctxt "Package"
 msgid "Release"
 msgstr ""
 
 #. Label of a Markdown Editor field in DocType 'Package Release'
 #: core/doctype/package_release/package_release.json
-msgctxt "Package Release"
 msgid "Release Notes"
 msgstr ""
 
@@ -26533,14 +20013,9 @@ msgid "Relink Communication"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Relinked"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Relinked"
 msgstr ""
 
@@ -26563,25 +20038,16 @@ msgstr ""
 msgid "Reload Report"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Remember Last Selected Value"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Remember Last Selected Value"
-msgstr ""
-
-#: public/js/frappe/form/reminders.js:33
-msgid "Remind At"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Reminder'
 #: automation/doctype/reminder/reminder.json
-msgctxt "Reminder"
+#: public/js/frappe/form/reminders.js:33
 msgid "Remind At"
 msgstr ""
 
@@ -26666,43 +20132,36 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Repeat Header and Footer"
 msgstr ""
 
 #. Label of a Select field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Repeat On"
 msgstr ""
 
 #. Label of a Date field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Repeat Till"
 msgstr ""
 
 #. Label of a Int field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Repeat on Day"
 msgstr ""
 
 #. Label of a Table field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Repeat on Days"
 msgstr ""
 
 #. Label of a Check field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Repeat on Last Day of the Month"
 msgstr ""
 
 #. Label of a Check field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Repeat this Event"
 msgstr ""
 
@@ -26718,26 +20177,17 @@ msgstr ""
 msgid "Repeats {0}"
 msgstr ""
 
-#. Option for the 'Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Replied"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Contact'
+#. Option for the 'Status' (Select) field in DocType 'Communication'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
+#: core/doctype/communication/communication.json
 msgid "Replied"
-msgstr ""
-
-#: core/doctype/communication/communication.js:57
-#: public/js/frappe/form/footer/form_timeline.js:550
-msgid "Reply"
 msgstr ""
 
 #. Label of a Text Editor field in DocType 'Discussion Reply'
+#: core/doctype/communication/communication.js:57
+#: public/js/frappe/form/footer/form_timeline.js:550
 #: website/doctype/discussion_reply/discussion_reply.json
-msgctxt "Discussion Reply"
 msgid "Reply"
 msgstr ""
 
@@ -26745,56 +20195,33 @@ msgstr ""
 msgid "Reply All"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/report/report.json public/js/frappe/request.js:610
-msgid "Report"
-msgstr ""
-
-#. Label of a Link field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Report"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Report"
-msgstr ""
-
 #. Label of a Link field in DocType 'Custom Role'
-#: core/doctype/custom_role/custom_role.json
-msgctxt "Custom Role"
-msgid "Report"
-msgstr ""
-
-#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Report"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Report"
-msgstr ""
-
 #. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Report"
-msgstr ""
-
+#. Name of a DocType
+#. Option for the 'Set Role For' (Select) field in DocType 'Role Permission for
+#. Page and Report'
+#. Label of a Link field in DocType 'Role Permission for Page and Report'
+#. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #. Option for the 'Select List View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Report"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Number Card'
+#. Label of a Tab Break field in DocType 'System Health Report'
+#. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
+#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
+#. Label of a Link field in DocType 'Auto Email Report'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/custom_role/custom_role.json core/doctype/docperm/docperm.json
+#: core/doctype/doctype/doctype.json core/doctype/report/report.json
+#: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
+#: desk/doctype/system_health_report/system_health_report.json
+#: desk/doctype/workspace_link/workspace_link.json
+#: desk/doctype/workspace_shortcut/workspace_shortcut.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: public/js/frappe/request.js:610
 msgid "Report"
 msgstr ""
 
@@ -26805,45 +20232,11 @@ msgctxt "Report"
 msgid "Report"
 msgstr ""
 
-#. Option for the 'Set Role For' (Select) field in DocType 'Role Permission for
-#. Page and Report'
-#. Label of a Link field in DocType 'Role Permission for Page and Report'
-#: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
-msgctxt "Role Permission for Page and Report"
-msgid "Report"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'System Health Report'
-#: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
-msgid "Report"
-msgstr ""
-
-#. Option for the 'Link Type' (Select) field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
-msgid "Report"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
-#: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
-msgid "Report"
-msgstr ""
-
-#: public/js/frappe/list/list_view_select.js:66
-msgid "Report Builder"
-msgstr ""
-
 #. Option for the 'Report Type' (Select) field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Report Builder"
-msgstr ""
-
 #. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: core/doctype/report/report.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: public/js/frappe/list/list_view_select.js:66
 msgid "Report Builder"
 msgstr ""
 
@@ -26854,7 +20247,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Report Description"
 msgstr ""
 
@@ -26869,31 +20261,20 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Report Filters"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Report Hide"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Report Hide"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Report Hide"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "Report Information"
 msgstr ""
 
@@ -26903,37 +20284,17 @@ msgstr ""
 msgid "Report Manager"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1811
-msgid "Report Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Access Log'
-#: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
-msgid "Report Name"
-msgstr ""
-
-#. Label of a Link field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Report Name"
-msgstr ""
-
-#. Label of a Link field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Report Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Prepared Report'
-#: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
-msgid "Report Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Report'
+#. Label of a Link field in DocType 'Dashboard Chart'
+#. Label of a Link field in DocType 'Number Card'
+#: core/doctype/access_log/access_log.json
+#: core/doctype/prepared_report/prepared_report.json
 #: core/doctype/report/report.json
-msgctxt "Report"
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/number_card/number_card.json
+#: public/js/frappe/views/reports/query_report.js:1811
 msgid "Report Name"
 msgstr ""
 
@@ -26943,25 +20304,15 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Report Reference Doctype"
 msgstr ""
 
-#. Label of a Read Only field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Report Type"
-msgstr ""
-
-#. Label of a Data field in DocType 'Onboarding Step'
-#: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Report Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Report'
+#. Label of a Data field in DocType 'Onboarding Step'
+#. Label of a Read Only field in DocType 'Auto Email Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
+#: desk/doctype/onboarding_step/onboarding_step.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Report Type"
 msgstr ""
 
@@ -27024,13 +20375,9 @@ msgstr ""
 msgid "Report:"
 msgstr ""
 
-#: public/js/frappe/ui/toolbar/search_utils.js:547
-msgid "Reports"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: public/js/frappe/ui/toolbar/search_utils.js:547
 msgid "Reports"
 msgstr ""
 
@@ -27058,55 +20405,43 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Request Body"
 msgstr ""
 
 #. Label of a Code field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
 msgid "Request Data"
 msgstr ""
 
 #. Label of a Data field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
 msgid "Request Description"
 msgstr ""
 
-#. Label of a Code field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Request Headers"
-msgstr ""
-
 #. Label of a Code field in DocType 'Recorder'
+#. Label of a Code field in DocType 'Integration Request'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
+#: integrations/doctype/integration_request/integration_request.json
 msgid "Request Headers"
 msgstr ""
 
 #. Label of a Data field in DocType 'Integration Request'
 #: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
 msgid "Request ID"
 msgstr ""
 
 #. Label of a Int field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Request Limit"
 msgstr ""
 
 #. Label of a Select field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Request Method"
 msgstr ""
 
 #. Label of a Select field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Request Structure"
 msgstr ""
 
@@ -27114,45 +20449,35 @@ msgstr ""
 msgid "Request Timed Out"
 msgstr ""
 
-#: public/js/frappe/request.js:241
-msgid "Request Timeout"
-msgstr ""
-
 #. Label of a Int field in DocType 'Webhook'
-#: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
+#: integrations/doctype/webhook/webhook.json public/js/frappe/request.js:241
 msgid "Request Timeout"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Request URL"
 msgstr ""
 
 #. Label of a Code field in DocType 'SMS Log'
 #: core/doctype/sms_log/sms_log.json
-msgctxt "SMS Log"
 msgid "Requested Numbers"
 msgstr ""
 
 #. Label of a Select field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Require Trusted Certificate"
 msgstr ""
 
 #. Description of the 'LDAP search path for Groups' (Data) field in DocType
 #. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Requires any valid fdn path. i.e. ou=groups,dc=example,dc=com"
 msgstr ""
 
 #. Description of the 'LDAP search path for Users' (Data) field in DocType
 #. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "Requires any valid fdn path. i.e. ou=users,dc=example,dc=com"
 msgstr ""
 
@@ -27207,19 +20532,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Reset Password Key"
 msgstr ""
 
 #. Label of a Duration field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Reset Password Link Expiry Duration"
 msgstr ""
 
 #. Label of a Link field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Reset Password Template"
 msgstr ""
 
@@ -27248,32 +20570,21 @@ msgid "Reset your password"
 msgstr ""
 
 #. Label of a Text Editor field in DocType 'Email Template'
-#: email/doctype/email_template/email_template.json
-msgctxt "Email Template"
-msgid "Response"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Response"
-msgstr ""
-
 #. Label of a Code field in DocType 'Webhook Request Log'
+#: email/doctype/email_template/email_template.json
+#: integrations/doctype/integration_request/integration_request.json
 #: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
 msgid "Response"
 msgstr ""
 
 #. Label of a Code field in DocType 'Email Template'
 #: email/doctype/email_template/email_template.json
-msgctxt "Email Template"
 msgid "Response "
 msgstr ""
 
 #. Label of a Select field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Response Type"
 msgstr ""
 
@@ -27296,7 +20607,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Deleted Document'
 #: core/doctype/deleted_document/deleted_document.json
-msgctxt "Deleted Document"
 msgid "Restored"
 msgstr ""
 
@@ -27306,49 +20616,27 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Restrict IP"
 msgstr ""
 
 #. Label of a Link field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Restrict To Domain"
-msgstr ""
-
 #. Label of a Link field in DocType 'Module Def'
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Restrict To Domain"
-msgstr ""
-
 #. Label of a Link field in DocType 'Page'
-#: core/doctype/page/page.json
-msgctxt "Page"
-msgid "Restrict To Domain"
-msgstr ""
-
 #. Label of a Link field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
+#: core/doctype/page/page.json core/doctype/role/role.json
 msgid "Restrict To Domain"
 msgstr ""
 
 #. Label of a Link field in DocType 'Workspace'
-#: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
-msgid "Restrict to Domain"
-msgstr ""
-
 #. Label of a Link field in DocType 'Workspace Shortcut'
+#: desk/doctype/workspace/workspace.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Restrict to Domain"
 msgstr ""
 
 #. Description of the 'Restrict IP' (Small Text) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Restrict user from this IP address only. Multiple IP addresses can be added by separating with commas. Also accepts partial IP addresses like (111.111.111)"
 msgstr ""
 
@@ -27366,14 +20654,10 @@ msgstr ""
 msgid "Resume Sending"
 msgstr ""
 
+#. Label of a Int field in DocType 'Email Queue'
 #: core/doctype/data_import/data_import.js:110
 #: desk/page/setup_wizard/setup_wizard.js:285
-msgid "Retry"
-msgstr ""
-
-#. Label of a Int field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Retry"
 msgstr ""
 
@@ -27387,30 +20671,23 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "Reverse Icon Color"
 msgstr ""
 
+#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.js:10
 #: social/doctype/energy_point_log/energy_point_log.js:15
-msgid "Revert"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
 msgid "Revert"
 msgstr ""
 
 #. Label of a Link field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
 msgid "Revert Of"
 msgstr ""
 
 #. Label of a Check field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
 msgid "Reverted"
 msgstr ""
 
@@ -27420,7 +20697,6 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Energy Point Log'
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
 msgid "Review"
 msgstr ""
 
@@ -27431,17 +20707,12 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Energy Point Settings'
 #: social/doctype/energy_point_settings/energy_point_settings.json
-msgctxt "Energy Point Settings"
 msgid "Review Levels"
 msgstr ""
 
-#: desk/page/user_profile/user_profile_controller.js:402
-msgid "Review Points"
-msgstr ""
-
 #. Label of a Int field in DocType 'Review Level'
+#: desk/page/user_profile/user_profile_controller.js:402
 #: social/doctype/review_level/review_level.json
-msgctxt "Review Level"
 msgid "Review Points"
 msgstr ""
 
@@ -27451,7 +20722,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Revocation URI"
 msgstr ""
 
@@ -27461,47 +20731,25 @@ msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'OAuth Bearer Token'
 #: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
 msgid "Revoked"
 msgstr ""
 
-#: website/doctype/web_page/web_page.js:92
-msgid "Rich Text"
-msgstr ""
-
-#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Rich Text"
-msgstr ""
-
 #. Option for the 'Content Type' (Select) field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Rich Text"
-msgstr ""
-
+#. Option for the 'Content Type' (Select) field in DocType 'Blog Post'
 #. Option for the 'Content Type' (Select) field in DocType 'Web Page'
+#: email/doctype/newsletter/newsletter.json
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/web_page/web_page.js:92
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Rich Text"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Right"
-msgstr ""
-
 #. Option for the 'Align' (Select) field in DocType 'Letter Head'
-#: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
-msgid "Right"
-msgstr ""
-
 #. Option for the 'Text Align' (Select) field in DocType 'Web Page'
+#: desk/doctype/form_tour_step/form_tour_step.json
+#: printing/doctype/letter_head/letter_head.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Right"
 msgstr ""
 
@@ -27512,74 +20760,44 @@ msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Right Bottom"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Right Center"
 msgstr ""
 
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Robots.txt"
 msgstr ""
 
+#. Label of a Link field in DocType 'Custom DocPerm'
+#. Label of a Table field in DocType 'Custom Role'
+#. Label of a Link field in DocType 'DocPerm'
+#. Label of a Link field in DocType 'Has Role'
 #. Name of a DocType
-#: core/doctype/role/role.json core/doctype/user_type/user_type.py:109
+#. Label of a Link field in DocType 'User Type'
+#. Label of a Link field in DocType 'Onboarding Permission'
+#. Label of a Link field in DocType 'ToDo'
+#. Label of a Link field in DocType 'OAuth Client Role'
+#. Label of a Link field in DocType 'Review Level'
+#. Label of a Link field in DocType 'Portal Menu Item'
+#. Label of a Link field in DocType 'Workflow Action Permitted Role'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/custom_role/custom_role.json core/doctype/docperm/docperm.json
+#: core/doctype/has_role/has_role.json core/doctype/role/role.json
+#: core/doctype/user_type/user_type.json
+#: core/doctype/user_type/user_type.py:109
 #: core/page/permission_manager/permission_manager.js:212
 #: core/page/permission_manager/permission_manager.js:450
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Role"
-msgstr ""
-
-#. Label of a Table field in DocType 'Custom Role'
-#: core/doctype/custom_role/custom_role.json
-msgctxt "Custom Role"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'Has Role'
-#: core/doctype/has_role/has_role.json
-msgctxt "Has Role"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'OAuth Client Role'
-#: integrations/doctype/oauth_client_role/oauth_client_role.json
-msgctxt "OAuth Client Role"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'Onboarding Permission'
 #: desk/doctype/onboarding_permission/onboarding_permission.json
-msgctxt "Onboarding Permission"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'Portal Menu Item'
-#: website/doctype/portal_menu_item/portal_menu_item.json
-msgctxt "Portal Menu Item"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'Review Level'
+#: desk/doctype/todo/todo.json
+#: integrations/doctype/oauth_client_role/oauth_client_role.json
 #: social/doctype/review_level/review_level.json
-msgctxt "Review Level"
+#: website/doctype/portal_menu_item/portal_menu_item.json
+#: workflow/doctype/workflow_action_permitted_role/workflow_action_permitted_role.json
 msgid "Role"
 msgstr ""
 
@@ -27587,24 +20805,6 @@ msgstr ""
 #. Label of a shortcut in the Users Workspace
 #: core/workspace/users/users.json
 msgctxt "Role"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'User Type'
-#: core/doctype/user_type/user_type.json
-msgctxt "User Type"
-msgid "Role"
-msgstr ""
-
-#. Label of a Link field in DocType 'Workflow Action Permitted Role'
-#: workflow/doctype/workflow_action_permitted_role/workflow_action_permitted_role.json
-msgctxt "Workflow Action Permitted Role"
 msgid "Role"
 msgstr ""
 
@@ -27617,14 +20817,8 @@ msgid "Role 'Desk User' will be given to all system users."
 msgstr ""
 
 #. Label of a Data field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
-msgid "Role Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'Role Profile'
-#: core/doctype/role_profile/role_profile.json
-msgctxt "Role Profile"
+#: core/doctype/role/role.json core/doctype/role_profile/role_profile.json
 msgid "Role Name"
 msgstr ""
 
@@ -27639,13 +20833,9 @@ msgctxt "Role Permission for Page and Report"
 msgid "Role Permission for Page and Report"
 msgstr ""
 
-#: public/js/frappe/roles_editor.js:103
-msgid "Role Permissions"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'User Document Type'
 #: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
+#: public/js/frappe/roles_editor.js:103
 msgid "Role Permissions"
 msgstr ""
 
@@ -27661,7 +20851,10 @@ msgid "Role Permissions Manager"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/role_profile/role_profile.json
+#. Label of a Link field in DocType 'User'
+#. Label of a Link field in DocType 'User Role Profile'
+#: core/doctype/role_profile/role_profile.json core/doctype/user/user.json
+#: core/doctype/user_role_profile/user_role_profile.json
 msgid "Role Profile"
 msgstr ""
 
@@ -27671,33 +20864,15 @@ msgctxt "Role Profile"
 msgid "Role Profile"
 msgstr ""
 
-#. Label of a Link field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Role Profile"
-msgstr ""
-
-#. Label of a Link field in DocType 'User Role Profile'
-#: core/doctype/user_role_profile/user_role_profile.json
-msgctxt "User Role Profile"
-msgid "Role Profile"
-msgstr ""
-
 #. Label of a Table MultiSelect field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Role Profiles"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Role and Level"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocPerm'
+#: core/doctype/custom_docperm/custom_docperm.json
 #: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
 msgid "Role and Level"
 msgstr ""
 
@@ -27705,87 +20880,44 @@ msgstr ""
 msgid "Role has been set as per the user type {0}"
 msgstr ""
 
-#: core/page/permission_manager/permission_manager.js:59
-msgid "Roles"
-msgstr ""
-
+#. Label of a Table field in DocType 'Page'
+#. Label of a Table field in DocType 'Report'
+#. Label of a Table field in DocType 'Role Permission for Page and Report'
+#. Label of a Section Break field in DocType 'User'
 #. Label of a Section Break field in DocType 'Custom HTML Block'
 #. Label of a Table field in DocType 'Custom HTML Block'
-#: desk/doctype/custom_html_block/custom_html_block.json
-msgctxt "Custom HTML Block"
-msgid "Roles"
-msgstr ""
-
 #. Label of a Table field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Roles"
-msgstr ""
-
-#. Label of a Table field in DocType 'Page'
-#: core/doctype/page/page.json
-msgctxt "Page"
-msgid "Roles"
-msgstr ""
-
-#. Label of a Table field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Roles"
-msgstr ""
-
-#. Label of a Table field in DocType 'Role Permission for Page and Report'
-#: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
-msgctxt "Role Permission for Page and Report"
-msgid "Roles"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Roles"
-msgstr ""
-
 #. Label of a Table field in DocType 'Workspace'
 #. Label of a Tab Break field in DocType 'Workspace'
+#: core/doctype/page/page.json core/doctype/report/report.json
+#: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
+#: core/doctype/user/user.json
+#: core/page/permission_manager/permission_manager.js:59
+#: desk/doctype/custom_html_block/custom_html_block.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Roles"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Roles & Permissions"
 msgstr ""
 
 #. Label of a Table field in DocType 'Role Profile'
-#: core/doctype/role_profile/role_profile.json
-msgctxt "Role Profile"
-msgid "Roles Assigned"
-msgstr ""
-
 #. Label of a Table field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/role_profile/role_profile.json core/doctype/user/user.json
 msgid "Roles Assigned"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Role Profile'
-#: core/doctype/role_profile/role_profile.json
-msgctxt "Role Profile"
-msgid "Roles HTML"
-msgstr ""
-
 #. Label of a HTML field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/role_profile/role_profile.json core/doctype/user/user.json
 msgid "Roles HTML"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Role Permission for Page and Report'
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
-msgctxt "Role Permission for Page and Report"
 msgid "Roles Html"
 msgstr ""
 
@@ -27799,121 +20931,59 @@ msgstr ""
 
 #. Option for the 'Rule' (Select) field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Round Robin"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Rounding Method"
 msgstr ""
 
-#. Label of a Data field in DocType 'Blog Category'
-#: website/doctype/blog_category/blog_category.json
-msgctxt "Blog Category"
-msgid "Route"
-msgstr ""
-
-#. Label of a Data field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Route"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Route"
-msgstr ""
-
 #. Option for the 'Action Type' (Select) field in DocType 'DocType Action'
-#: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
-msgid "Route"
-msgstr ""
-
-#. Label of a Data field in DocType 'DocType Layout'
-#: custom/doctype/doctype_layout/doctype_layout.json
-msgctxt "DocType Layout"
-msgid "Route"
-msgstr ""
-
-#. Label of a Data field in DocType 'Help Article'
-#: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
-msgid "Route"
-msgstr ""
-
-#. Label of a Data field in DocType 'Help Category'
-#: website/doctype/help_category/help_category.json
-msgctxt "Help Category"
-msgid "Route"
-msgstr ""
-
 #. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
 #. Label of a Data field in DocType 'Navbar Item'
-#: core/doctype/navbar_item/navbar_item.json
-msgctxt "Navbar Item"
-msgid "Route"
-msgstr ""
-
-#. Label of a Data field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Route"
-msgstr ""
-
-#. Label of a Data field in DocType 'Portal Menu Item'
-#: website/doctype/portal_menu_item/portal_menu_item.json
-msgctxt "Portal Menu Item"
-msgid "Route"
-msgstr ""
-
+#. Label of a Data field in DocType 'DocType Layout'
 #. Label of a Data field in DocType 'Route History'
-#: desk/doctype/route_history/route_history.json
-msgctxt "Route History"
-msgid "Route"
-msgstr ""
-
+#. Label of a Data field in DocType 'Newsletter'
+#. Label of a Data field in DocType 'Blog Category'
+#. Label of a Data field in DocType 'Blog Post'
+#. Label of a Data field in DocType 'Help Article'
+#. Label of a Data field in DocType 'Help Category'
+#. Label of a Data field in DocType 'Portal Menu Item'
 #. Label of a Data field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Route"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Route"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Sidebar Item'
-#: website/doctype/website_sidebar_item/website_sidebar_item.json
-msgctxt "Website Sidebar Item"
-msgid "Route"
-msgstr ""
-
-#. Name of a DocType
+#: core/doctype/doctype/doctype.json
+#: core/doctype/doctype_action/doctype_action.json
+#: core/doctype/navbar_item/navbar_item.json
+#: custom/doctype/doctype_layout/doctype_layout.json
 #: desk/doctype/route_history/route_history.json
-msgid "Route History"
+#: email/doctype/newsletter/newsletter.json
+#: website/doctype/blog_category/blog_category.json
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/help_article/help_article.json
+#: website/doctype/help_category/help_category.json
+#: website/doctype/portal_menu_item/portal_menu_item.json
+#: website/doctype/web_form/web_form.json
+#: website/doctype/web_page/web_page.json
+#: website/doctype/website_sidebar_item/website_sidebar_item.json
+msgid "Route"
 msgstr ""
 
 #. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
+#. Name of a DocType
+#: core/doctype/user/user.json desk/doctype/route_history/route_history.json
 msgid "Route History"
 msgstr ""
 
 #. Label of a Table field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Route Redirects"
 msgstr ""
 
 #. Description of the 'Home Page' (Data) field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "Route: Example \"/app\""
 msgstr ""
 
@@ -27939,19 +21009,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Transaction Log'
 #: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
 msgid "Row Index"
 msgstr ""
 
 #. Label of a Code field in DocType 'Data Import Log'
 #: core/doctype/data_import_log/data_import_log.json
-msgctxt "Data Import Log"
 msgid "Row Indexes"
 msgstr ""
 
 #. Label of a Data field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "Row Name"
 msgstr ""
 
@@ -27975,47 +21042,32 @@ msgstr ""
 msgid "Row {0}: Not allowed to enable Allow on Submit for standard fields"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'Audit Trail'
+#: core/doctype/audit_trail/audit_trail.json
 #: core/doctype/version/version_view.html:32
 msgid "Rows Added"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Audit Trail'
 #: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
-msgid "Rows Added"
-msgstr ""
-
 #: core/doctype/version/version_view.html:32
-msgid "Rows Removed"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Audit Trail'
-#: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
 msgid "Rows Removed"
 msgstr ""
 
 #. Label of a Select field in DocType 'Assignment Rule'
-#: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
-msgid "Rule"
-msgstr ""
-
 #. Label of a Link field in DocType 'Energy Point Log'
+#: automation/doctype/assignment_rule/assignment_rule.json
 #: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
 msgid "Rule"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
 msgid "Rule Conditions"
 msgstr ""
 
 #. Label of a Data field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Rule Name"
 msgstr ""
 
@@ -28025,39 +21077,33 @@ msgstr ""
 
 #. Group in DocType's connections
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Rules"
 msgstr ""
 
 #. Description of the 'Transitions' (Table) field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Rules defining transition of state in the workflow."
 msgstr ""
 
 #. Description of the 'Transition Rules' (Section Break) field in DocType
 #. 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Rules for how states are transitions, like next state and which role is allowed to change state etc."
 msgstr ""
 
 #. Description of the 'Priority' (Int) field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
 msgid "Rules with higher priority number will be applied first."
 msgstr ""
 
 #. Label of a Int field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Run Jobs only Daily if Inactive For (Days)"
 msgstr ""
 
 #. Description of the 'Enable Scheduled Jobs' (Check) field in DocType 'System
 #. Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Run scheduled jobs only if checked"
 msgstr ""
 
@@ -28078,32 +21124,21 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'S3 Backup Settings'
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "S3 Bucket Details"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "SMS"
-msgstr ""
-
-#. Option for the 'Channel' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "SMS"
-msgstr ""
-
 #. Option for the 'Two Factor Authentication method' (Select) field in DocType
 #. 'System Settings'
+#. Option for the 'Channel' (Select) field in DocType 'Notification'
+#: core/doctype/communication/communication.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: email/doctype/notification/notification.json
 msgid "SMS"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'SMS Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "SMS Gateway URL"
 msgstr ""
 
@@ -28142,41 +21177,32 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "SQL"
 msgstr ""
 
 #. Description of the 'Condition' (Small Text) field in DocType 'Bulk Update'
 #: desk/doctype/bulk_update/bulk_update.json
-msgctxt "Bulk Update"
 msgid "SQL Conditions. Example: status=\"Open\""
 msgstr ""
 
-#: core/doctype/recorder/recorder.js:85
-msgid "SQL Explain"
-msgstr ""
-
 #. Label of a HTML field in DocType 'Recorder Query'
+#: core/doctype/recorder/recorder.js:85
 #: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
 msgid "SQL Explain"
 msgstr ""
 
 #. Label of a HTML field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "SQL Output"
 msgstr ""
 
 #. Label of a Table field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "SQL Queries"
 msgstr ""
 
 #. Label of a Select field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "SSL/TLS Mode"
 msgstr ""
 
@@ -28203,24 +21229,14 @@ msgstr ""
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Salesforce"
 msgstr ""
 
-#. Name of a DocType
-#: contacts/doctype/salutation/salutation.json
-msgid "Salutation"
-msgstr ""
-
 #. Label of a Link field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Salutation"
-msgstr ""
-
+#. Name of a DocType
 #. Label of a Data field in DocType 'Salutation'
+#: contacts/doctype/contact/contact.json
 #: contacts/doctype/salutation/salutation.json
-msgctxt "Salutation"
 msgid "Salutation"
 msgstr ""
 
@@ -28230,43 +21246,27 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Client Script'
 #: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
 msgid "Sample"
 msgstr ""
 
 #. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Saturday"
-msgstr ""
-
-#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Saturday"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
-#: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
-msgid "Saturday"
-msgstr ""
-
-#. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Saturday"
-msgstr ""
-
 #. Option for the 'First Day of the Week' (Select) field in DocType 'System
 #. Settings'
+#. Label of a Check field in DocType 'Event'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
+#: automation/doctype/auto_repeat_day/auto_repeat_day.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Saturday"
 msgstr ""
 
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: core/doctype/data_import/data_import.js:113
 #: desk/page/user_profile/user_profile_controller.js:319
+#: email/doctype/notification/notification.json
 #: printing/page/print/print.js:856
 #: printing/page/print_format_builder/print_format_builder.js:160
 #: public/js/frappe/form/footer/form_timeline.js:661
@@ -28281,17 +21281,11 @@ msgstr ""
 #: public/js/frappe/views/kanban/kanban_view.js:343
 #: public/js/frappe/views/reports/query_report.js:1803
 #: public/js/frappe/views/reports/report_view.js:1640
-#: public/js/frappe/views/workspace/workspace.js:500
+#: public/js/frappe/views/workspace/workspace.js:501
 #: public/js/frappe/widgets/base_widget.js:142
 #: public/js/frappe/widgets/quick_list_widget.js:117
 #: public/js/print_format_builder/print_format_builder.bundle.js:15
 #: public/js/workflow_builder/workflow_builder.bundle.js:33
-msgid "Save"
-msgstr ""
-
-#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Save"
 msgstr ""
 
@@ -28326,7 +21320,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Save on Completion"
 msgstr ""
 
@@ -28343,7 +21336,7 @@ msgstr ""
 
 #: public/js/frappe/list/list_settings.js:40
 #: public/js/frappe/views/kanban/kanban_settings.js:47
-#: public/js/frappe/views/workspace/workspace.js:512
+#: public/js/frappe/views/workspace/workspace.js:513
 msgid "Saving"
 msgstr ""
 
@@ -28392,63 +21385,41 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Schedule sending at a later time"
 msgstr ""
 
-#: email/doctype/newsletter/newsletter_list.js:7
-msgid "Scheduled"
-msgstr ""
-
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Scheduled"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Scheduled Job Log'
+#: core/doctype/communication/communication.json
 #: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgctxt "Scheduled Job Log"
+#: email/doctype/newsletter/newsletter_list.js:7
 msgid "Scheduled"
 msgstr ""
 
 #. Label of a Link field in DocType 'Scheduled Job Log'
 #: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgctxt "Scheduled Job Log"
 msgid "Scheduled Job"
 msgstr ""
 
 #. Name of a DocType
-#: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgid "Scheduled Job Log"
-msgstr ""
-
 #. Linked DocType in Scheduled Job Type's connections
+#: core/doctype/scheduled_job_log/scheduled_job_log.json
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
 msgid "Scheduled Job Log"
 msgstr ""
 
 #. Name of a DocType
+#. Linked DocType in Server Script's connections
+#. Label of a Link field in DocType 'System Health Report Failing Jobs'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/server_script/server_script.json
+#: desk/doctype/system_health_report_failing_jobs/system_health_report_failing_jobs.json
 msgid "Scheduled Job Type"
 msgstr ""
 
 #. Label of a Link in the Build Workspace
 #: core/workspace/build/build.json
 msgctxt "Scheduled Job Type"
-msgid "Scheduled Job Type"
-msgstr ""
-
-#. Linked DocType in Server Script's connections
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Scheduled Job Type"
-msgstr ""
-
-#. Label of a Link field in DocType 'System Health Report Failing Jobs'
-#: desk/doctype/system_health_report_failing_jobs/system_health_report_failing_jobs.json
-msgctxt "System Health Report Failing Jobs"
 msgid "Scheduled Job Type"
 msgstr ""
 
@@ -28460,17 +21431,15 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Scheduled Sending"
 msgstr ""
 
 #. Label of a Int field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Scheduled To Send"
 msgstr ""
 
-#: core/doctype/server_script/server_script.py:144
+#: core/doctype/server_script/server_script.py:147
 msgid "Scheduled execution for script {0} has updated"
 msgstr ""
 
@@ -28480,13 +21449,11 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Scheduler"
 msgstr ""
 
 #. Option for the 'Script Type' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Scheduler Event"
 msgstr ""
 
@@ -28496,7 +21463,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Scheduler Status"
 msgstr ""
 
@@ -28518,74 +21484,35 @@ msgstr ""
 
 #. Label of a Data field in DocType 'OAuth Scope'
 #: integrations/doctype/oauth_scope/oauth_scope.json
-msgctxt "OAuth Scope"
 msgid "Scope"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Connected App'
 #. Label of a Table field in DocType 'Connected App'
-#: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
-msgid "Scopes"
-msgstr ""
-
 #. Label of a Text field in DocType 'OAuth Authorization Code'
-#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
-msgid "Scopes"
-msgstr ""
-
 #. Label of a Text field in DocType 'OAuth Bearer Token'
-#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
-msgid "Scopes"
-msgstr ""
-
 #. Label of a Text field in DocType 'OAuth Client'
-#: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
-msgid "Scopes"
-msgstr ""
-
 #. Label of a Table field in DocType 'Token Cache'
+#: integrations/doctype/connected_app/connected_app.json
+#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
+#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
+#: integrations/doctype/oauth_client/oauth_client.json
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Scopes"
-msgstr ""
-
-#. Label of a Code field in DocType 'Client Script'
-#: custom/doctype/client_script/client_script.json
-msgctxt "Client Script"
-msgid "Script"
-msgstr ""
-
-#. Label of a Code field in DocType 'Console Log'
-#: desk/doctype/console_log/console_log.json
-msgctxt "Console Log"
-msgid "Script"
 msgstr ""
 
 #. Label of a Code field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
-msgid "Script"
-msgstr ""
-
 #. Label of a Code field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Script"
-msgstr ""
-
+#. Label of a Code field in DocType 'Client Script'
+#. Label of a Code field in DocType 'Console Log'
 #. Label of a Section Break field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Script"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'Website Theme'
+#: core/doctype/report/report.json
+#: core/doctype/server_script/server_script.json
+#: custom/doctype/client_script/client_script.json
+#: desk/doctype/console_log/console_log.json
+#: website/doctype/web_page/web_page.json
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Script"
 msgstr ""
 
@@ -28596,13 +21523,11 @@ msgstr ""
 
 #. Option for the 'Report Type' (Select) field in DocType 'Report'
 #: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Script Report"
 msgstr ""
 
 #. Label of a Select field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Script Type"
 msgstr ""
 
@@ -28612,28 +21537,23 @@ msgid "Script to attach to all web pages."
 msgstr ""
 
 #. Label of a Card Break in the Build Workspace
-#: core/workspace/build/build.json
-msgid "Scripting"
-msgstr ""
-
 #. Label of a Tab Break field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
+#: core/workspace/build/build.json website/doctype/web_page/web_page.json
 msgid "Scripting"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Scripting / Style"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Letter Head'
 #: printing/doctype/letter_head/letter_head.json
-msgctxt "Letter Head"
 msgid "Scripts"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'System Settings'
+#: core/doctype/system_settings/system_settings.json
 #: desk/page/leaderboard/leaderboard.js:211
 #: public/js/frappe/form/link_selector.js:46
 #: public/js/frappe/list/list_sidebar.html:59
@@ -28643,27 +21563,15 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
-msgid "Search"
-msgstr ""
-
 #. Label of a Check field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "Search Bar"
 msgstr ""
 
-#. Label of a Data field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Search Fields"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Search Fields"
 msgstr ""
 
@@ -28673,7 +21581,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Global Search Settings'
 #: desk/doctype/global_search_settings/global_search_settings.json
-msgctxt "Global Search Settings"
 msgid "Search Priorities"
 msgstr ""
 
@@ -28719,37 +21626,19 @@ msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Web Template'
 #: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
 msgid "Section"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Section Break"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Section Break"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Section Break"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Section Break"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Section Break"
 msgstr ""
 
@@ -28759,13 +21648,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Section ID"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Security Settings"
 msgstr ""
 
@@ -28791,107 +21678,48 @@ msgstr ""
 msgid "See the document at {0}"
 msgstr ""
 
-#: core/doctype/error_log/error_log_list.js:5
-msgid "Seen"
-msgstr ""
-
 #. Label of a Check field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Seen"
-msgstr ""
-
 #. Label of a Check field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Seen"
-msgstr ""
-
-#. Label of a Check field in DocType 'Energy Point Log'
-#: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "Seen"
-msgstr ""
-
 #. Label of a Check field in DocType 'Error Log'
-#: core/doctype/error_log/error_log.json
-msgctxt "Error Log"
-msgid "Seen"
-msgstr ""
-
 #. Label of a Check field in DocType 'Notification Settings'
+#. Label of a Check field in DocType 'Energy Point Log'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
+#: core/doctype/error_log/error_log.json
+#: core/doctype/error_log/error_log_list.js:5
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
+#: social/doctype/energy_point_log/energy_point_log.json
 msgid "Seen"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
 msgid "Seen By"
 msgstr ""
 
 #. Label of a Table field in DocType 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
 msgid "Seen By Table"
 msgstr ""
 
-#: printing/page/print/print.js:599
-msgid "Select"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Select"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Select"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Select"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Select"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Select"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Select"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Select"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Select"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docfield/docfield.json core/doctype/docperm/docperm.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: printing/page/print/print.js:599
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Select"
 msgstr ""
 
@@ -28929,41 +21757,29 @@ msgstr ""
 msgid "Select Currency"
 msgstr ""
 
-#: public/js/frappe/utils/dashboard_utils.js:240
-msgid "Select Dashboard"
-msgstr ""
-
 #. Label of a Link field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
+#: public/js/frappe/utils/dashboard_utils.js:240
 msgid "Select Dashboard"
 msgstr ""
 
 #. Option for the 'Timespan' (Select) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Select Date Range"
 msgstr ""
 
-#: public/js/frappe/doctype/index.js:171
-msgid "Select DocType"
-msgstr ""
-
 #. Label of a Link field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
+#: public/js/frappe/doctype/index.js:171 website/doctype/web_form/web_form.json
 msgid "Select DocType"
 msgstr ""
 
 #. Label of a Link field in DocType 'Data Export'
 #: core/doctype/data_export/data_export.json
-msgctxt "Data Export"
 msgid "Select Doctype"
 msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Select Document"
 msgstr ""
 
@@ -29029,7 +21845,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Select List View"
 msgstr ""
 
@@ -29047,7 +21862,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Select Page"
 msgstr ""
 
@@ -29062,7 +21876,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Select Report"
 msgstr ""
 
@@ -29076,7 +21889,6 @@ msgstr ""
 
 #. Label of a Autocomplete field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Select Transaction"
 msgstr ""
 
@@ -29086,7 +21898,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Select Workspace"
 msgstr ""
 
@@ -29129,7 +21940,6 @@ msgstr ""
 #. Description of the 'Brand Image' (Attach Image) field in DocType 'Website
 #. Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Select an image of approx width 150px with a transparent background for best results."
 msgstr ""
 
@@ -29166,7 +21976,6 @@ msgstr ""
 
 #. Description of the 'Insert After' (Select) field in DocType 'Custom Field'
 #: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
 msgid "Select the label after which you want to insert new field."
 msgstr ""
 
@@ -29193,99 +22002,74 @@ msgid "Send"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Send After"
-msgstr ""
-
 #. Label of a Datetime field in DocType 'Email Queue'
+#: core/doctype/communication/communication.json
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Send After"
 msgstr ""
 
 #. Label of a Select field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Send Alert On"
 msgstr ""
 
 #. Label of a Check field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Send Email Alert"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Send Email At"
 msgstr ""
 
 #. Description of the 'Send Print as PDF' (Check) field in DocType 'Print
 #. Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Send Email Print Attachments as PDF (Recommended)"
 msgstr ""
 
 #. Label of a Check field in DocType 'Dropbox Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "Send Email for Successful Backup"
-msgstr ""
-
 #. Label of a Check field in DocType 'S3 Backup Settings'
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Send Email for Successful Backup"
 msgstr ""
 
 #. Label of a Check field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "Send Email for Successful backup"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Send Me A Copy of Outgoing Emails"
 msgstr ""
 
 #. Label of a Data field in DocType 'Google Drive'
 #: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
 msgid "Send Notification To"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Send Notification to"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Send Notifications For Documents Followed By Me"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Send Notifications For Email Threads"
 msgstr ""
 
 #. Label of a Data field in DocType 'Dropbox Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "Send Notifications To"
-msgstr ""
-
 #. Label of a Data field in DocType 'S3 Backup Settings'
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
 #: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
 msgid "Send Notifications To"
 msgstr ""
 
@@ -29295,7 +22079,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Send Print as PDF"
 msgstr ""
 
@@ -29305,7 +22088,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Send System Notification"
 msgstr ""
 
@@ -29315,25 +22097,21 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Send To All Assignees"
 msgstr ""
 
 #. Label of a Check field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Send Unsubscribe Link"
 msgstr ""
 
 #. Label of a Check field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Send Web View Link"
 msgstr ""
 
 #. Label of a Check field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Send Welcome Email"
 msgstr ""
 
@@ -29351,33 +22129,28 @@ msgstr ""
 
 #. Description of the 'Reference Date' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Send alert if date matches this field's value"
 msgstr ""
 
 #. Description of the 'Value Changed' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Send alert if this field's value changes"
 msgstr ""
 
 #. Label of a Check field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Send an email reminder in the morning"
 msgstr ""
 
 #. Description of the 'Days Before or After' (Int) field in DocType
 #. 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Send days before or after the reference date"
 msgstr ""
 
 #. Description of the 'Forward To Email Address' (Data) field in DocType
 #. 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Send enquiries to this email address"
 msgstr ""
 
@@ -29395,73 +22168,39 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Send only if there is any data"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Send unsubscribe message in email"
 msgstr ""
 
-#. Label of a Link field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Sender"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Sender"
-msgstr ""
-
 #. Label of a Data field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Sender"
-msgstr ""
-
-#. Label of a Data field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Sender"
-msgstr ""
-
-#. Label of a Link field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Sender"
-msgstr ""
-
 #. Label of a Data field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
+#. Label of a Link field in DocType 'Auto Email Report'
+#. Label of a Data field in DocType 'Email Queue'
+#. Label of a Data field in DocType 'Newsletter'
+#. Label of a Link field in DocType 'Notification'
+#: desk/doctype/event/event.json desk/doctype/todo/todo.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: email/doctype/email_queue/email_queue.json
+#: email/doctype/newsletter/newsletter.json
+#: email/doctype/notification/notification.json
 msgid "Sender"
 msgstr ""
 
 #. Label of a Data field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Sender Email"
-msgstr ""
-
 #. Label of a Data field in DocType 'Notification'
+#: email/doctype/newsletter/newsletter.json
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Sender Email"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Sender Email Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Sender Email Field"
 msgstr ""
 
@@ -29469,49 +22208,29 @@ msgstr ""
 msgid "Sender Field should have Email in options"
 msgstr ""
 
-#. Label of a Data field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Sender Name"
-msgstr ""
-
 #. Label of a Data field in DocType 'SMS Log'
-#: core/doctype/sms_log/sms_log.json
-msgctxt "SMS Log"
+#. Label of a Data field in DocType 'Newsletter'
+#: core/doctype/sms_log/sms_log.json email/doctype/newsletter/newsletter.json
 msgid "Sender Name"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Sender Name Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Sender Name Field"
 msgstr ""
 
 #. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Sendgrid"
 msgstr ""
 
-#: email/doctype/newsletter/newsletter.js:201
-msgid "Sending"
-msgstr ""
-
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Sending"
-msgstr ""
-
 #. Option for the 'Status' (Select) field in DocType 'Email Queue'
+#: core/doctype/communication/communication.json
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
+#: email/doctype/newsletter/newsletter.js:201
 msgid "Sending"
 msgstr ""
 
@@ -29523,75 +22242,55 @@ msgstr ""
 msgid "Sending..."
 msgstr ""
 
+#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
+#. Option for the 'Sent or Received' (Select) field in DocType 'Communication'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue'
+#. Option for the 'Status' (Select) field in DocType 'Email Queue Recipient'
+#: core/doctype/communication/communication.json
+#: email/doctype/email_queue/email_queue.json
+#: email/doctype/email_queue_recipient/email_queue_recipient.json
 #: email/doctype/newsletter/newsletter.js:196
 #: email/doctype/newsletter/newsletter_list.js:5
 msgid "Sent"
 msgstr ""
 
-#. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
-#. Option for the 'Sent or Received' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Sent"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Sent"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Email Queue Recipient'
-#: email/doctype/email_queue_recipient/email_queue_recipient.json
-msgctxt "Email Queue Recipient"
-msgid "Sent"
-msgstr ""
-
 #. Label of a Date field in DocType 'SMS Log'
 #: core/doctype/sms_log/sms_log.json
-msgctxt "SMS Log"
 msgid "Sent On"
 msgstr ""
 
 #. Label of a Check field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Sent Read Receipt"
 msgstr ""
 
 #. Label of a Code field in DocType 'SMS Log'
 #: core/doctype/sms_log/sms_log.json
-msgctxt "SMS Log"
 msgid "Sent To"
 msgstr ""
 
 #. Label of a Select field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Sent or Received"
 msgstr ""
 
 #. Option for the 'Event Category' (Select) field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Sent/Received Email"
 msgstr ""
 
 #. Option for the 'Item Type' (Select) field in DocType 'Navbar Item'
 #: core/doctype/navbar_item/navbar_item.json
-msgctxt "Navbar Item"
 msgid "Separator"
 msgstr ""
 
 #. Label of a Float field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "Sequence Id"
 msgstr ""
 
 #. Label of a Text field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Series List for this Transaction"
 msgstr ""
 
@@ -29610,7 +22309,6 @@ msgstr ""
 
 #. Option for the 'Action Type' (Select) field in DocType 'DocType Action'
 #: core/doctype/doctype_action/doctype_action.json
-msgctxt "DocType Action"
 msgid "Server Action"
 msgstr ""
 
@@ -29620,30 +22318,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Network Printer Settings'
 #: printing/doctype/network_printer_settings/network_printer_settings.json
-msgctxt "Network Printer Settings"
 msgid "Server IP"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/server_script/server_script.json
-msgid "Server Script"
-msgstr ""
-
 #. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Server Script"
-msgstr ""
-
 #. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Server Script"
-msgstr ""
-
 #. Label of a Link field in DocType 'Scheduled Job Type'
+#. Name of a DocType
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
+#: core/doctype/server_script/server_script.json
 msgid "Server Script"
 msgstr ""
 
@@ -29667,14 +22351,9 @@ msgid "Server was too busy to process this request. Please try again."
 msgstr ""
 
 #. Label of a Select field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Service"
-msgstr ""
-
 #. Label of a Data field in DocType 'Integration Request'
+#: email/doctype/email_account/email_account.json
 #: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
 msgid "Service"
 msgstr ""
 
@@ -29690,13 +22369,9 @@ msgstr ""
 
 #. Label of a standard navbar item
 #. Type: Action
-#: hooks.py public/js/frappe/ui/toolbar/toolbar.js:331
-msgid "Session Defaults"
-msgstr ""
-
 #. Label of a Table field in DocType 'Session Default Settings'
-#: core/doctype/session_default_settings/session_default_settings.json
-msgctxt "Session Default Settings"
+#: core/doctype/session_default_settings/session_default_settings.json hooks.py
+#: public/js/frappe/ui/toolbar/toolbar.js:331
 msgid "Session Defaults"
 msgstr ""
 
@@ -29710,7 +22385,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Session Expiry (idle timeout)"
 msgstr ""
 
@@ -29725,7 +22399,6 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Set Banner from Image"
 msgstr ""
 
@@ -29735,7 +22408,6 @@ msgstr ""
 
 #. Description of the 'Chart Options' (Code) field in DocType 'Dashboard'
 #: desk/doctype/dashboard/dashboard.json
-msgctxt "Dashboard"
 msgid "Set Default Options for all charts on this Dashboard (Ex: \"colors\": [\"#d1d8dd\", \"#ff5858\"])"
 msgstr ""
 
@@ -29762,13 +22434,11 @@ msgstr ""
 #. Description of the 'Setup Series for transactions' (Section Break) field in
 #. DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Set Naming Series options on your transactions."
 msgstr ""
 
 #. Label of a Password field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Set New Password"
 msgstr ""
 
@@ -29791,7 +22461,6 @@ msgstr ""
 #. Label of a Section Break field in DocType 'Notification'
 #. Label of a Select field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Set Property After Alert"
 msgstr ""
 
@@ -29802,7 +22471,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Role Permission for Page and Report'
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.json
-msgctxt "Role Permission for Page and Report"
 msgid "Set Role For"
 msgstr ""
 
@@ -29813,7 +22481,6 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'Property Setter'
 #: custom/doctype/property_setter/property_setter.json
-msgctxt "Property Setter"
 msgid "Set Value"
 msgstr ""
 
@@ -29834,53 +22501,33 @@ msgstr ""
 msgid "Set as Default Theme"
 msgstr ""
 
-#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Set by user"
-msgstr ""
-
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
+#. Option for the 'Naming Rule' (Select) field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Set by user"
-msgstr ""
-
-#. Description of the 'Precision' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Set non-standard precision for a Float or Currency field"
-msgstr ""
-
-#. Description of the 'Precision' (Select) field in DocType 'Customize Form
-#. Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Set non-standard precision for a Float or Currency field"
 msgstr ""
 
 #. Description of the 'Precision' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Set non-standard precision for a Float or Currency field"
-msgstr ""
-
+#. Description of the 'Precision' (Select) field in DocType 'Custom Field'
+#. Description of the 'Precision' (Select) field in DocType 'Customize Form
+#. Field'
 #. Description of the 'Precision' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Set non-standard precision for a Float or Currency field"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Set only once"
 msgstr ""
 
 #. Description of the 'Filters Configuration' (Code) field in DocType 'Number
 #. Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid ""
 "Set the filters here. For example:\n"
 "<pre class=\"small text-muted\"><code>\n"
@@ -29904,7 +22551,6 @@ msgstr ""
 
 #. Description of the 'Method' (Data) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid ""
 "Set the path to a whitelisted function that will return the data for the number card in the format:\n"
 "\n"
@@ -29929,42 +22575,24 @@ msgstr ""
 msgid "Setting up your system"
 msgstr ""
 
+#. Label of a Tab Break field in DocType 'DocType'
+#. Label of a Tab Break field in DocType 'User'
+#. Group in User's connections
 #. Label of a Card Break in the Integrations Workspace
+#. Label of a Tab Break field in DocType 'Web Form'
+#. Label of a Tab Break field in DocType 'Web Page'
+#: core/doctype/doctype/doctype.json core/doctype/user/user.json
 #: integrations/workspace/integrations/integrations.json
 #: public/js/frappe/form/templates/print_layout.html:25
 #: public/js/frappe/ui/toolbar/toolbar.js:289
-#: public/js/frappe/views/workspace/workspace.js:528
-msgid "Settings"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Settings"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'User'
-#. Group in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Settings"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'Web Form'
+#: public/js/frappe/views/workspace/workspace.js:529
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Settings"
-msgstr ""
-
-#. Label of a Tab Break field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Settings"
 msgstr ""
 
 #. Label of a Table field in DocType 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
-msgctxt "Navbar Settings"
 msgid "Settings Dropdown"
 msgstr ""
 
@@ -29983,15 +22611,11 @@ msgstr ""
 msgid "Settings to control blog categories and interactions like comments and likes"
 msgstr ""
 
+#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
 #. Label of a Card Break in the Website Workspace
+#: core/doctype/doctype/doctype.json
 #: public/js/frappe/ui/toolbar/search_utils.js:567
 #: website/workspace/website/website.json
-msgid "Setup"
-msgstr ""
-
-#. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Setup"
 msgstr ""
 
@@ -30017,13 +22641,9 @@ msgstr ""
 msgid "Setup Auto Email"
 msgstr ""
 
-#: desk/page/setup_wizard/setup_wizard.js:204
-msgid "Setup Complete"
-msgstr ""
-
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/page/setup_wizard/setup_wizard.js:204
 msgid "Setup Complete"
 msgstr ""
 
@@ -30039,35 +22659,17 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Setup Series for transactions"
 msgstr ""
 
-#: public/js/frappe/form/templates/form_sidebar.html:110
-msgid "Share"
-msgstr ""
-
 #. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Share"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Share"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocShare'
-#: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
-msgid "Share"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Notification Log'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json core/doctype/docshare/docshare.json
 #: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
+#: public/js/frappe/form/templates/form_sidebar.html:110
 msgid "Share"
 msgstr ""
 
@@ -30084,14 +22686,9 @@ msgid "Share {0} with"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Shared"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Shared"
 msgstr ""
 
@@ -30101,7 +22698,6 @@ msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Shipping"
 msgstr ""
 
@@ -30111,13 +22707,11 @@ msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Shop"
 msgstr ""
 
 #. Label of a Data field in DocType 'Blogger'
 #: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
 msgid "Short Name"
 msgstr ""
 
@@ -30125,14 +22719,10 @@ msgstr ""
 msgid "Short keyboard patterns are easy to guess"
 msgstr ""
 
-#: public/js/frappe/form/grid_row_form.js:42
-msgid "Shortcuts"
-msgstr ""
-
 #. Label of a Table field in DocType 'Workspace'
 #. Label of a Tab Break field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: public/js/frappe/form/grid_row_form.js:42
 msgid "Shortcuts"
 msgstr ""
 
@@ -30144,13 +22734,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Blog Settings'
 #: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
 msgid "Show \"Call to Action\" in Blog"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Show Absolute Values"
 msgstr ""
 
@@ -30160,7 +22748,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Show Attachments"
 msgstr ""
 
@@ -30170,35 +22757,21 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Show Currency Symbol on Right Side"
 msgstr ""
 
-#: desk/doctype/dashboard/dashboard.js:6
-msgid "Show Dashboard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Show Dashboard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Show Dashboard"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/dashboard/dashboard.js:6
 msgid "Show Dashboard"
 msgstr ""
 
 #. Label of a Button field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "Show Document"
 msgstr ""
 
@@ -30212,26 +22785,22 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Show First Document Tour"
 msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #. Label of a Check field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Show Form Tour"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Show Full Error and Allow Reporting of Issues to the Developer"
 msgstr ""
 
 #. Label of a Check field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Show Full Form?"
 msgstr ""
 
@@ -30239,31 +22808,24 @@ msgstr ""
 msgid "Show Keyboard Shortcuts"
 msgstr ""
 
-#: public/js/frappe/views/kanban/kanban_settings.js:30
-msgid "Show Labels"
-msgstr ""
-
 #. Label of a Check field in DocType 'Kanban Board'
 #: desk/doctype/kanban_board/kanban_board.json
-msgctxt "Kanban Board"
+#: public/js/frappe/views/kanban/kanban_settings.js:30
 msgid "Show Labels"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Show Language Picker"
 msgstr ""
 
 #. Label of a Check field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Show Line Breaks after Sections"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Show List"
 msgstr ""
 
@@ -30273,13 +22835,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Show Only Failed Logs"
 msgstr ""
 
 #. Label of a Check field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Show Percentage Stats"
 msgstr ""
 
@@ -30294,21 +22854,15 @@ msgstr ""
 msgid "Show Preview"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Show Preview Popup"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Show Preview Popup"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "Show Processlist"
 msgstr ""
 
@@ -30316,14 +22870,10 @@ msgstr ""
 msgid "Show Related Errors"
 msgstr ""
 
-#: core/doctype/prepared_report/prepared_report.js:43
-#: core/doctype/report/report.js:13
-msgid "Show Report"
-msgstr ""
-
 #. Label of a Button field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
+#: core/doctype/prepared_report/prepared_report.js:43
+#: core/doctype/report/report.js:13
 msgid "Show Report"
 msgstr ""
 
@@ -30334,19 +22884,13 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Show Section Headings"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Show Sidebar"
-msgstr ""
-
 #. Label of a Check field in DocType 'Web Page'
+#: website/doctype/web_form/web_form.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Show Sidebar"
 msgstr ""
 
@@ -30357,19 +22901,13 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Show Title"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Show Title in Link Fields"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Show Title in Link Fields"
 msgstr ""
 
@@ -30395,7 +22933,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Show account deletion link in My Account page"
 msgstr ""
 
@@ -30413,38 +22950,32 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Show as cc"
 msgstr ""
 
 #. Label of a Check field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Show footer on login"
 msgstr ""
 
 #. Description of the 'Show Full Form?' (Check) field in DocType 'Onboarding
 #. Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Show full form instead of a quick entry modal"
 msgstr ""
 
 #. Label of a Select field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Show in Module Section"
 msgstr ""
 
 #. Label of a Check field in DocType 'Web Form Field'
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Show in filter"
 msgstr ""
 
 #. Label of a Check field in DocType 'Slack Webhook URL'
 #: integrations/doctype/slack_webhook_url/slack_webhook_url.json
-msgctxt "Slack Webhook URL"
 msgid "Show link to document"
 msgstr ""
 
@@ -30455,13 +22986,11 @@ msgstr ""
 #. Description of the 'Stats Time Interval' (Select) field in DocType 'Number
 #. Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Show percentage difference according to this time interval"
 msgstr ""
 
 #. Description of the 'Title Prefix' (Data) field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Show title in browser window as \"Prefix - title\""
 msgstr ""
 
@@ -30479,31 +23008,26 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "Sidebar"
 msgstr ""
 
 #. Label of a Table field in DocType 'Website Sidebar'
 #: website/doctype/website_sidebar/website_sidebar.json
-msgctxt "Website Sidebar"
 msgid "Sidebar Items"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Sidebar Settings"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Sidebar and Comments"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Email Group'
 #: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
 msgid "Sign Up and Confirmation"
 msgstr ""
 
@@ -30518,38 +23042,20 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Sign ups"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Signature"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Signature"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Signature"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Label of a Section Break field in DocType 'Email Account'
 #. Label of a Text Editor field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Signature"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: email/doctype/email_account/email_account.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Signature"
 msgstr ""
 
@@ -30564,27 +23070,23 @@ msgstr ""
 #. Description of the 'Unassign Condition' (Code) field in DocType 'Assignment
 #. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Simple Python Expression, Example: Status in (\"Closed\", \"Cancelled\")"
 msgstr ""
 
 #. Description of the 'Close Condition' (Code) field in DocType 'Assignment
 #. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Simple Python Expression, Example: Status in (\"Invalid\")"
 msgstr ""
 
 #. Description of the 'Assign Condition' (Code) field in DocType 'Assignment
 #. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Simple Python Expression, Example: status == 'Open' and type == 'Bug'"
 msgstr ""
 
 #. Label of a Int field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Simultaneous Sessions"
 msgstr ""
 
@@ -30592,13 +23094,8 @@ msgstr ""
 msgid "Single DocTypes cannot be customized."
 msgstr ""
 
-#: core/doctype/doctype/doctype_list.js:67
-msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
-msgstr ""
-
 #. Description of the 'Is Single' (Check) field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: core/doctype/doctype/doctype.json core/doctype/doctype/doctype_list.js:67
 msgid "Single Types have only one record no tables associated. Values are stored in tabSingles"
 msgstr ""
 
@@ -30612,7 +23109,6 @@ msgstr ""
 
 #. Label of a Float field in DocType 'System Health Report Tables'
 #: desk/doctype/system_health_report_tables/system_health_report_tables.json
-msgctxt "System Health Report Tables"
 msgid "Size (MB)"
 msgstr ""
 
@@ -30622,14 +23118,9 @@ msgid "Skip"
 msgstr ""
 
 #. Label of a Check field in DocType 'OAuth Client'
-#: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
-msgid "Skip Authorization"
-msgstr ""
-
 #. Label of a Select field in DocType 'OAuth Provider Settings'
+#: integrations/doctype/oauth_client/oauth_client.json
 #: integrations/doctype/oauth_provider_settings/oauth_provider_settings.json
-msgctxt "OAuth Provider Settings"
 msgid "Skip Authorization"
 msgstr ""
 
@@ -30639,7 +23130,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Patch Log'
 #: core/doctype/patch_log/patch_log.json
-msgctxt "Patch Log"
 msgid "Skipped"
 msgstr ""
 
@@ -30665,19 +23155,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Contact Us Settings'
 #: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
 msgid "Skype"
 msgstr ""
 
 #. Option for the 'Channel' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Slack"
 msgstr ""
 
 #. Label of a Link field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Slack Channel"
 msgstr ""
 
@@ -30699,19 +23186,16 @@ msgstr ""
 #. Label of a Link field in DocType 'Web Page'
 #. Option for the 'Content Type' (Select) field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Slideshow"
 msgstr ""
 
 #. Label of a Table field in DocType 'Website Slideshow'
 #: website/doctype/website_slideshow/website_slideshow.json
-msgctxt "Website Slideshow"
 msgid "Slideshow Items"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Slideshow'
 #: website/doctype/website_slideshow/website_slideshow.json
-msgctxt "Website Slideshow"
 msgid "Slideshow Name"
 msgstr ""
 
@@ -30720,46 +23204,27 @@ msgstr ""
 msgid "Slideshow like display for the website"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Small Text"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Small Text"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Small Text"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Small Text"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Small Text"
 msgstr ""
 
 #. Label of a Currency field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Smallest Currency Fraction Value"
 msgstr ""
 
 #. Description of the 'Smallest Currency Fraction Value' (Currency) field in
 #. DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Smallest circulating fraction unit (coin). For e.g. 1 cent for USD and it should be entered as 0.01"
 msgstr ""
 
@@ -30774,7 +23239,6 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Social Link Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
-msgctxt "Social Link Settings"
 msgid "Social Link Type"
 msgstr ""
 
@@ -30791,31 +23255,26 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "Social Login Provider"
 msgstr ""
 
 #. Label of a Table field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Social Logins"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "SocketIO Ping Check"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "SocketIO Transport Mode"
 msgstr ""
 
 #. Option for the 'Delivery Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Soft-Bounced"
 msgstr ""
 
@@ -30857,31 +23316,20 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Sort Field"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Sort Options"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Sort Options"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Sort Options"
 msgstr ""
 
 #. Label of a Select field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Sort Order"
 msgstr ""
 
@@ -30889,36 +23337,23 @@ msgstr ""
 msgid "Sort field {0} must be a valid fieldname"
 msgstr ""
 
-#: public/js/frappe/ui/toolbar/about.js:8 public/js/frappe/utils/utils.js:1715
-#: website/report/website_analytics/website_analytics.js:38
-msgid "Source"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Page View'
-#: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
-msgid "Source"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Website Route Redirect'
+#: public/js/frappe/ui/toolbar/about.js:8 public/js/frappe/utils/utils.js:1715
+#: website/doctype/web_page_view/web_page_view.json
 #: website/doctype/website_route_redirect/website_route_redirect.json
-msgctxt "Website Route Redirect"
+#: website/report/website_analytics/website_analytics.js:38
 msgid "Source"
 msgstr ""
 
 #. Label of a Data field in DocType 'Dashboard Chart Source'
 #: desk/doctype/dashboard_chart_source/dashboard_chart_source.json
-msgctxt "Dashboard Chart Source"
 msgid "Source Name"
-msgstr ""
-
-#: public/js/frappe/views/translation_manager.js:38
-msgid "Source Text"
 msgstr ""
 
 #. Label of a Code field in DocType 'Translation'
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
+#: public/js/frappe/views/translation_manager.js:38
 msgid "Source Text"
 msgstr ""
 
@@ -30928,13 +23363,11 @@ msgstr ""
 
 #. Option for the 'Email Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Spam"
 msgstr ""
 
 #. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "SparkPost"
 msgstr ""
 
@@ -30948,7 +23381,6 @@ msgstr ""
 
 #. Label of a Attach Image field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Splash Image"
 msgstr ""
 
@@ -30957,53 +23389,24 @@ msgstr ""
 msgid "Sr"
 msgstr ""
 
-#: core/doctype/recorder/recorder.js:82
-msgid "Stack Trace"
-msgstr ""
-
 #. Label of a HTML field in DocType 'Recorder Query'
+#: core/doctype/recorder/recorder.js:82
 #: core/doctype/recorder_query/recorder_query.json
-msgctxt "Recorder Query"
 msgid "Stack Trace"
-msgstr ""
-
-#: core/doctype/user_type/user_type_list.js:5
-msgid "Standard"
-msgstr ""
-
-#. Label of a Check field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Standard"
 msgstr ""
 
 #. Label of a Select field in DocType 'Page'
-#: core/doctype/page/page.json
-msgctxt "Page"
-msgid "Standard"
-msgstr ""
-
+#. Label of a Check field in DocType 'Desktop Icon'
 #. Label of a Select field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Standard"
-msgstr ""
-
 #. Label of a Check field in DocType 'Print Format Field Template'
-#: printing/doctype/print_format_field_template/print_format_field_template.json
-msgctxt "Print Format Field Template"
-msgid "Standard"
-msgstr ""
-
 #. Label of a Check field in DocType 'Print Style'
-#: printing/doctype/print_style/print_style.json
-msgctxt "Print Style"
-msgid "Standard"
-msgstr ""
-
 #. Label of a Check field in DocType 'Web Template'
+#: core/doctype/page/page.json core/doctype/user_type/user_type_list.js:5
+#: desk/doctype/desktop_icon/desktop_icon.json
+#: printing/doctype/print_format/print_format.json
+#: printing/doctype/print_format_field_template/print_format_field_template.json
+#: printing/doctype/print_style/print_style.json
 #: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
 msgid "Standard"
 msgstr ""
 
@@ -31037,7 +23440,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Portal Settings'
 #: website/doctype/portal_settings/portal_settings.json
-msgctxt "Portal Settings"
 msgid "Standard Sidebar Menu"
 msgstr ""
 
@@ -31074,31 +23476,17 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: public/js/frappe/utils/common.js:409
-msgid "Start Date"
-msgstr ""
-
-#. Label of a Date field in DocType 'Audit Trail'
-#: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
-msgid "Start Date"
-msgstr ""
-
 #. Label of a Date field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Start Date"
-msgstr ""
-
+#. Label of a Date field in DocType 'Audit Trail'
 #. Label of a Datetime field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/audit_trail/audit_trail.json
+#: public/js/frappe/utils/common.js:409 website/doctype/web_page/web_page.json
 msgid "Start Date"
 msgstr ""
 
 #. Label of a Select field in DocType 'Calendar View'
 #: desk/doctype/calendar_view/calendar_view.json
-msgctxt "Calendar View"
 msgid "Start Date Field"
 msgstr ""
 
@@ -31112,7 +23500,6 @@ msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Start Time"
 msgstr ""
 
@@ -31130,19 +23517,16 @@ msgstr ""
 
 #. Option for the 'SSL/TLS Mode' (Select) field in DocType 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "StartTLS"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Prepared Report'
 #: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
 msgid "Started"
 msgstr ""
 
 #. Label of a Datetime field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Started At"
 msgstr ""
 
@@ -31152,94 +23536,56 @@ msgstr ""
 
 #. Label of a Datetime field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Starts on"
 msgstr ""
 
-#: workflow/doctype/workflow/workflow.js:162
-msgid "State"
-msgstr ""
-
-#. Label of a Data field in DocType 'Contact Us Settings'
-#: website/doctype/contact_us_settings/contact_us_settings.json
-msgctxt "Contact Us Settings"
-msgid "State"
-msgstr ""
-
 #. Label of a Data field in DocType 'Token Cache'
-#: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
-msgid "State"
-msgstr ""
-
+#. Label of a Data field in DocType 'Contact Us Settings'
 #. Label of a Link field in DocType 'Workflow Document State'
-#: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
-msgid "State"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workflow State'
-#: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
-msgid "State"
-msgstr ""
-
 #. Label of a Link field in DocType 'Workflow Transition'
+#: integrations/doctype/token_cache/token_cache.json
+#: website/doctype/contact_us_settings/contact_us_settings.json
+#: workflow/doctype/workflow/workflow.js:162
+#: workflow/doctype/workflow_document_state/workflow_document_state.json
+#: workflow/doctype/workflow_state/workflow_state.json
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "State"
 msgstr ""
 
 #. Label of a Data field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "State/Province"
 msgstr ""
 
-#. Label of a Table field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "States"
-msgstr ""
-
 #. Label of a Table field in DocType 'DocType'
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "States"
-msgstr ""
-
+#. Label of a Table field in DocType 'Customize Form'
 #. Label of a Section Break field in DocType 'Workflow'
+#: core/doctype/doctype/doctype.json
+#: custom/doctype/customize_form/customize_form.json
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "States"
 msgstr ""
 
 #. Label of a Table field in DocType 'SMS Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Static Parameters"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Statistics"
 msgstr ""
 
+#. Label of a Section Break field in DocType 'Number Card'
+#: desk/doctype/number_card/number_card.json
 #: public/js/frappe/form/dashboard.js:43
 #: public/js/frappe/form/templates/form_dashboard.html:13
 msgid "Stats"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Stats"
-msgstr ""
-
 #. Label of a Select field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "Stats Time Interval"
 msgstr ""
 
@@ -31251,142 +23597,52 @@ msgstr ""
 msgid "Stats based on last week's performance (from {0} to {1})"
 msgstr ""
 
-#: core/doctype/data_import/data_import.js:483
-#: public/js/frappe/list/list_settings.js:356
-#: public/js/frappe/views/reports/report_view.js:908
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Status"
-msgstr ""
-
 #. Label of a Select field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Status"
-msgstr ""
-
+#. Label of a Select field in DocType 'Contact'
+#. Label of a Select field in DocType 'Activity Log'
 #. Label of a Section Break field in DocType 'Communication'
 #. Label of a Select field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Status"
-msgstr ""
-
 #. Label of a Select field in DocType 'Data Import'
-#: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Email Queue'
-#: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Email Queue Recipient'
-#: email/doctype/email_queue_recipient/email_queue_recipient.json
-msgctxt "Email Queue Recipient"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Kanban Board Column'
-#: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
-msgid "Status"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'OAuth Bearer Token'
-#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Personal Data Deletion Request'
-#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
-msgctxt "Personal Data Deletion Request"
-msgid "Status"
-msgstr ""
-
-#. Label of a Select field in DocType 'Personal Data Deletion Step'
-#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
-msgctxt "Personal Data Deletion Step"
-msgid "Status"
-msgstr ""
-
 #. Label of a Select field in DocType 'Prepared Report'
-#: core/doctype/prepared_report/prepared_report.json
-msgctxt "Prepared Report"
-msgid "Status"
-msgstr ""
-
 #. Label of a Select field in DocType 'RQ Job'
-#: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
-msgid "Status"
-msgstr ""
-
 #. Label of a Data field in DocType 'RQ Worker'
-#: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
-msgid "Status"
-msgstr ""
-
 #. Label of a Select field in DocType 'Scheduled Job Log'
-#: core/doctype/scheduled_job_log/scheduled_job_log.json
-msgctxt "Scheduled Job Log"
-msgid "Status"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Status"
-msgstr ""
-
 #. Label of a Select field in DocType 'Submission Queue'
-#: core/doctype/submission_queue/submission_queue.json
-msgctxt "Submission Queue"
-msgid "Status"
-msgstr ""
-
+#. Label of a Select field in DocType 'Event'
+#. Label of a Select field in DocType 'Kanban Board Column'
 #. Label of a Select field in DocType 'ToDo'
-#: desk/doctype/todo/todo.json
-msgctxt "ToDo"
-msgid "Status"
-msgstr ""
-
+#. Label of a Select field in DocType 'Email Queue'
+#. Label of a Select field in DocType 'Email Queue Recipient'
+#. Label of a Section Break field in DocType 'Newsletter'
+#. Label of a Select field in DocType 'Integration Request'
+#. Label of a Select field in DocType 'OAuth Bearer Token'
+#. Label of a Select field in DocType 'Personal Data Deletion Request'
+#. Label of a Select field in DocType 'Personal Data Deletion Step'
 #. Label of a Select field in DocType 'Workflow Action'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: contacts/doctype/contact/contact.json
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication/communication.json
+#: core/doctype/data_import/data_import.js:483
+#: core/doctype/data_import/data_import.json
+#: core/doctype/prepared_report/prepared_report.json
+#: core/doctype/rq_job/rq_job.json core/doctype/rq_worker/rq_worker.json
+#: core/doctype/scheduled_job_log/scheduled_job_log.json
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/submission_queue/submission_queue.json
+#: desk/doctype/event/event.json
+#: desk/doctype/kanban_board_column/kanban_board_column.json
+#: desk/doctype/todo/todo.json email/doctype/email_queue/email_queue.json
+#: email/doctype/email_queue_recipient/email_queue_recipient.json
+#: email/doctype/newsletter/newsletter.json
+#: integrations/doctype/integration_request/integration_request.json
+#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
+#: public/js/frappe/list/list_settings.js:356
+#: public/js/frappe/views/reports/report_view.js:908
+#: website/doctype/personal_data_deletion_request/personal_data_deletion_request.json
+#: website/doctype/personal_data_deletion_step/personal_data_deletion_step.json
 #: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
 msgid "Status"
 msgstr ""
 
@@ -31400,19 +23656,13 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Onboarding Step Map'
 #: desk/doctype/onboarding_step_map/onboarding_step_map.json
-msgctxt "Onboarding Step Map"
 msgid "Step"
 msgstr ""
 
 #. Label of a Table field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Steps"
-msgstr ""
-
 #. Label of a Table field in DocType 'Module Onboarding'
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
 msgid "Steps"
 msgstr ""
 
@@ -31426,38 +23676,32 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
 msgid "Stopped"
 msgstr ""
 
 #. Label of a Float field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Storage Usage (MB)"
 msgstr ""
 
 #. Label of a Table field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Storage Usage By Table"
 msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Store Attached PDF Document"
 msgstr ""
 
 #. Description of the 'Last Known Versions' (Text) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Stores the JSON of last known versions of various installed apps. It is used to show release notes."
 msgstr ""
 
 #. Description of the 'Last Reset Password Key Generated On' (Datetime) field
 #. in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Stores the datetime when the last reset password key was generated."
 msgstr ""
 
@@ -31467,7 +23711,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Strip EXIF tags from uploaded images"
 msgstr ""
 
@@ -31476,129 +23719,72 @@ msgid "Strong"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Style"
-msgstr ""
-
 #. Label of a Select field in DocType 'Workflow State'
+#: website/doctype/web_page/web_page.json
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Style"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Style Settings"
 msgstr ""
 
 #. Description of the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Style represents the button color: Success - Green, Danger - Red, Inverse - Black, Primary - Dark Blue, Info - Light Blue, Warning - Orange"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Stylesheet"
 msgstr ""
 
 #. Description of the 'Fraction' (Data) field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Sub-currency. For e.g. \"Cent\""
 msgstr ""
 
 #. Description of the 'Subdomain' (Small Text) field in DocType 'Website
 #. Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Sub-domain provided by erpnext.com"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Subdomain"
 msgstr ""
 
+#. Label of a Data field in DocType 'Auto Repeat'
+#. Label of a Small Text field in DocType 'Activity Log'
+#. Label of a Text field in DocType 'Comment'
+#. Label of a Small Text field in DocType 'Communication'
+#. Label of a Small Text field in DocType 'Event'
+#. Label of a Text field in DocType 'Notification Log'
+#. Label of a Data field in DocType 'Email Template'
+#. Label of a Small Text field in DocType 'Newsletter'
+#. Label of a Section Break field in DocType 'Newsletter'
+#. Label of a Data field in DocType 'Notification'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json desk/doctype/event/event.json
+#: desk/doctype/notification_log/notification_log.json
+#: email/doctype/email_template/email_template.json
+#: email/doctype/newsletter/newsletter.json
+#: email/doctype/notification/notification.json
 #: public/js/frappe/views/communication.js:107
 #: public/js/frappe/views/inbox/inbox_view.js:63
 msgid "Subject"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Data field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Text field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Template'
-#: email/doctype/email_template/email_template.json
-msgctxt "Email Template"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Newsletter'
-#. Label of a Section Break field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Data field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Text field in DocType 'Notification Log'
-#: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
-msgid "Subject"
-msgstr ""
-
-#. Label of a Select field in DocType 'Calendar View'
-#: desk/doctype/calendar_view/calendar_view.json
-msgctxt "Calendar View"
-msgid "Subject Field"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Subject Field"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
+#. Label of a Select field in DocType 'Calendar View'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
+#: desk/doctype/calendar_view/calendar_view.json
 msgid "Subject Field"
 msgstr ""
 
@@ -31611,11 +23797,23 @@ msgstr ""
 msgid "Submission Queue"
 msgstr ""
 
+#. Label of a Check field in DocType 'Custom DocPerm'
+#. Label of a Check field in DocType 'DocPerm'
+#. Label of a Check field in DocType 'DocShare'
+#. Label of a Check field in DocType 'User Document Type'
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
+#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
+#. Rule'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json core/doctype/docshare/docshare.json
+#: core/doctype/user_document_type/user_document_type.json
 #: core/doctype/user_permission/user_permission_list.js:138
+#: email/doctype/notification/notification.json
 #: public/js/frappe/form/quick_entry.js:201
 #: public/js/frappe/form/sidebar/review.js:116
 #: public/js/frappe/ui/capture.js:307
 #: social/doctype/energy_point_log/energy_point_log.js:39
+#: social/doctype/energy_point_rule/energy_point_rule.json
 #: social/doctype/energy_point_settings/energy_point_settings.js:47
 msgid "Submit"
 msgstr ""
@@ -31627,37 +23825,6 @@ msgstr ""
 
 #: website/doctype/web_form/templates/web_form.html:44
 msgctxt "Button in web form"
-msgid "Submit"
-msgstr ""
-
-#. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Submit"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Submit"
-msgstr ""
-
-#. Label of a Check field in DocType 'DocShare'
-#: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
-msgid "Submit"
-msgstr ""
-
-#. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
-#. Rule'
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "Submit"
-msgstr ""
-
-#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
-#: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Submit"
 msgstr ""
 
@@ -31676,21 +23843,13 @@ msgctxt "Submit password for Email Account"
 msgid "Submit"
 msgstr ""
 
-#. Label of a Check field in DocType 'User Document Type'
-#: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
-msgid "Submit"
-msgstr ""
-
 #. Label of a Check field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Submit After Import"
 msgstr ""
 
 #. Label of a Data field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Submit Button Label"
 msgstr ""
 
@@ -31705,7 +23864,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid "Submit on Creation"
 msgstr ""
 
@@ -31722,21 +23880,13 @@ msgctxt "Title of confirmation dialog"
 msgid "Submit {0} documents?"
 msgstr ""
 
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
 #: public/js/frappe/model/indicator.js:95
 #: public/js/frappe/ui/filters/filter.js:501
 #: website/doctype/web_form/templates/web_form.html:133
-msgid "Submitted"
-msgstr ""
-
-#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Submitted"
-msgstr ""
-
-#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Submitted"
 msgstr ""
 
@@ -31759,23 +23909,24 @@ msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Subsidiary"
 msgstr ""
 
-#. Label of a Data field in DocType 'Blog Settings'
-#: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
-msgid "Subtitle"
-msgstr ""
-
 #. Label of a Data field in DocType 'Module Onboarding'
+#. Label of a Data field in DocType 'Blog Settings'
 #: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
+#: website/doctype/blog_settings/blog_settings.json
 msgid "Subtitle"
 msgstr ""
 
+#. Option for the 'Status' (Select) field in DocType 'Activity Log'
+#. Option for the 'Status' (Select) field in DocType 'Data Import'
+#. Label of a Check field in DocType 'Data Import Log'
+#. Option for the 'Style' (Select) field in DocType 'Workflow State'
+#: core/doctype/activity_log/activity_log.json
 #: core/doctype/data_import/data_import.js:459
+#: core/doctype/data_import/data_import.json
+#: core/doctype/data_import_log/data_import_log.json
 #: desk/doctype/bulk_update/bulk_update.js:31
 #: desk/doctype/desktop_icon/desktop_icon.py:446
 #: public/js/frappe/form/grid.js:1142
@@ -31784,30 +23935,7 @@ msgstr ""
 #: templates/includes/login/login.js:269 templates/includes/login/login.js:277
 #: templates/pages/integrations/gcalendar-success.html:9
 #: workflow/doctype/workflow_action/workflow_action.py:166
-msgid "Success"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "Success"
-msgstr ""
-
-#. Option for the 'Status' (Select) field in DocType 'Data Import'
-#: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
-msgid "Success"
-msgstr ""
-
-#. Label of a Check field in DocType 'Data Import Log'
-#: core/doctype/data_import_log/data_import_log.json
-msgctxt "Data Import Log"
-msgid "Success"
-msgstr ""
-
-#. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Success"
 msgstr ""
 
@@ -31817,32 +23945,24 @@ msgid "Success Action"
 msgstr ""
 
 #. Label of a Data field in DocType 'Module Onboarding'
-#: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
-msgid "Success Message"
-msgstr ""
-
 #. Label of a Text field in DocType 'Web Form'
+#: desk/doctype/module_onboarding/module_onboarding.json
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Success Message"
 msgstr ""
 
 #. Label of a Data field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Success Title"
 msgstr ""
 
 #. Label of a Data field in DocType 'Token Cache'
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Success URI"
 msgstr ""
 
 #. Label of a Data field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Success URL"
 msgstr ""
 
@@ -31852,7 +23972,6 @@ msgstr ""
 
 #. Label of a Int field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Successful Job Count"
 msgstr ""
 
@@ -31860,7 +23979,7 @@ msgstr ""
 msgid "Successful Transactions"
 msgstr ""
 
-#: model/rename_doc.py:683
+#: model/rename_doc.py:682
 msgid "Successful: {0} to {1}"
 msgstr ""
 
@@ -31903,7 +24022,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "Suggested Indexes"
 msgstr ""
 
@@ -31911,20 +24029,12 @@ msgstr ""
 msgid "Suggested Username: {0}"
 msgstr ""
 
-#: public/js/frappe/ui/group_by/group_by.js:20
-msgid "Sum"
-msgstr ""
-
 #. Option for the 'Chart Type' (Select) field in DocType 'Dashboard Chart'
 #. Option for the 'Group By Type' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Sum"
-msgstr ""
-
 #. Option for the 'Function' (Select) field in DocType 'Number Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
+#: public/js/frappe/ui/group_by/group_by.js:20
 msgid "Sum"
 msgstr ""
 
@@ -31937,33 +24047,16 @@ msgid "Summary"
 msgstr ""
 
 #. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Sunday"
-msgstr ""
-
-#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Sunday"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
-#: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
-msgid "Sunday"
-msgstr ""
-
-#. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Sunday"
-msgstr ""
-
 #. Option for the 'First Day of the Week' (Select) field in DocType 'System
 #. Settings'
+#. Label of a Check field in DocType 'Event'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
+#: automation/doctype/auto_repeat_day/auto_repeat_day.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Sunday"
 msgstr ""
 
@@ -31989,19 +24082,13 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Currency'
 #: geo/doctype/currency/currency.json
-msgctxt "Currency"
 msgid "Symbol"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Google Calendar'
-#: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
-msgid "Sync"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Google Contacts'
+#: integrations/doctype/google_calendar/google_calendar.json
 #: integrations/doctype/google_contacts/google_contacts.json
-msgctxt "Google Contacts"
 msgid "Sync"
 msgstr ""
 
@@ -32023,13 +24110,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "Sync with Google Calendar"
 msgstr ""
 
 #. Label of a Check field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "Sync with Google Contacts"
 msgstr ""
 
@@ -32056,7 +24141,6 @@ msgstr ""
 
 #. Option for the 'Show in Module Section' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "System"
 msgstr ""
 
@@ -32251,19 +24335,16 @@ msgstr ""
 
 #. Option for the 'Channel' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "System Notification"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Notification Settings'
 #: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
 msgid "System Notifications"
 msgstr ""
 
 #. Label of a Check field in DocType 'Page'
 #: core/doctype/page/page.json
-msgctxt "Page"
 msgid "System Page"
 msgstr ""
 
@@ -32281,7 +24362,6 @@ msgstr ""
 #. Description of the 'Allow Roles' (Table MultiSelect) field in DocType
 #. 'Module Onboarding'
 #: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
 msgid "System managers are allowed by default"
 msgstr ""
 
@@ -32290,68 +24370,33 @@ msgctxt "Number system"
 msgid "T"
 msgstr ""
 
+#. Option for the 'Type' (Select) field in DocType 'DocField'
 #. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Tab Break"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid "Tab Break"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Tab Break"
-msgstr ""
-
-#: core/doctype/data_export/exporter.py:23
-#: printing/page/print_format_builder/print_format_builder_field.html:38
-msgid "Table"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Table"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Table"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Table"
-msgstr ""
-
 #. Label of a Data field in DocType 'Recorder Suggested Index'
-#: core/doctype/recorder_suggested_index/recorder_suggested_index.json
-msgctxt "Recorder Suggested Index"
-msgid "Table"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Label of a Data field in DocType 'System Health Report Tables'
-#: desk/doctype/system_health_report_tables/system_health_report_tables.json
-msgctxt "System Health Report Tables"
-msgid "Table"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/data_export/exporter.py:23 core/doctype/docfield/docfield.json
+#: core/doctype/recorder_suggested_index/recorder_suggested_index.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/system_health_report_tables/system_health_report_tables.json
+#: printing/page/print_format_builder/print_format_builder_field.html:38
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Table"
 msgstr ""
 
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Table Break"
 msgstr ""
 
@@ -32361,7 +24406,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'DocType Link'
 #: core/doctype/doctype_link/doctype_link.json
-msgctxt "DocType Link"
 msgid "Table Fieldname"
 msgstr ""
 
@@ -32371,25 +24415,15 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Version'
 #: core/doctype/version/version.json
-msgctxt "Version"
 msgid "Table HTML"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Table MultiSelect"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Table MultiSelect"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Table MultiSelect"
 msgstr ""
 
@@ -32407,7 +24441,6 @@ msgstr ""
 
 #. Option for the 'PDF Page Size' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Tabloid"
 msgstr ""
 
@@ -32444,14 +24477,9 @@ msgid "Take Photo"
 msgstr ""
 
 #. Label of a Data field in DocType 'Portal Menu Item'
-#: website/doctype/portal_menu_item/portal_menu_item.json
-msgctxt "Portal Menu Item"
-msgid "Target"
-msgstr ""
-
 #. Label of a Small Text field in DocType 'Website Route Redirect'
+#: website/doctype/portal_menu_item/portal_menu_item.json
 #: website/doctype/website_route_redirect/website_route_redirect.json
-msgctxt "Website Route Redirect"
 msgid "Target"
 msgstr ""
 
@@ -32459,56 +24487,35 @@ msgstr ""
 msgid "Task"
 msgstr ""
 
-#: www/about.html:45
-msgid "Team Members"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'About Us Settings'
 #. Label of a Table field in DocType 'About Us Settings'
-#: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
+#: website/doctype/about_us_settings/about_us_settings.json www/about.html:45
 msgid "Team Members"
 msgstr ""
 
 #. Label of a Data field in DocType 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "Team Members Heading"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'About Us Settings'
 #: website/doctype/about_us_settings/about_us_settings.json
-msgctxt "About Us Settings"
 msgid "Team Members Subtitle"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Telemetry"
 msgstr ""
 
-#. Label of a Code field in DocType 'Address Template'
-#: contacts/doctype/address_template/address_template.json
-msgctxt "Address Template"
-msgid "Template"
-msgstr ""
-
 #. Label of a Link field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Template"
-msgstr ""
-
+#. Label of a Code field in DocType 'Address Template'
 #. Label of a Code field in DocType 'Print Format Field Template'
-#: printing/doctype/print_format_field_template/print_format_field_template.json
-msgctxt "Print Format Field Template"
-msgid "Template"
-msgstr ""
-
 #. Label of a Code field in DocType 'Web Template'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: contacts/doctype/address_template/address_template.json
+#: printing/doctype/print_format_field_template/print_format_field_template.json
 #: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
 msgid "Template"
 msgstr ""
 
@@ -32519,19 +24526,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Print Format Field Template'
 #: printing/doctype/print_format_field_template/print_format_field_template.json
-msgctxt "Print Format Field Template"
 msgid "Template File"
 msgstr ""
 
 #. Label of a Code field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Template Options"
 msgstr ""
 
 #. Label of a Code field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Template Warnings"
 msgstr ""
 
@@ -32545,7 +24549,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Test Job ID"
 msgstr ""
 
@@ -32557,75 +24560,42 @@ msgstr ""
 msgid "Test_Folder"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Text"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Text"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Text"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
-#: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
-msgid "Text"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Template Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: website/doctype/web_form_field/web_form_field.json
 #: website/doctype/web_template_field/web_template_field.json
-msgctxt "Web Template Field"
 msgid "Text"
 msgstr ""
 
 #. Label of a Select field in DocType 'Web Page'
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
 msgid "Text Align"
 msgstr ""
 
 #. Label of a Link field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Text Color"
 msgstr ""
 
 #. Label of a Code field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Text Content"
 msgstr ""
 
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Text Editor"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Text Editor"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Text Editor"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Text Editor"
 msgstr ""
 
@@ -32673,7 +24643,6 @@ msgstr ""
 
 #. Description of the 'Client ID' (Data) field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid ""
 "The Client ID obtained from the Google Cloud Console under <a href=\"https://console.cloud.google.com/apis/credentials\">\n"
 "\"APIs &amp; Services\" &gt; \"Credentials\"\n"
@@ -32703,7 +24672,6 @@ msgstr ""
 #. Description of the 'Application Name' (Data) field in DocType 'System
 #. Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "The application name will be used in the Login page."
 msgstr ""
 
@@ -32713,7 +24681,6 @@ msgstr ""
 
 #. Description of the 'API Key' (Data) field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid ""
 "The browser API key obtained from the Google Cloud Console under <a href=\"https://console.cloud.google.com/apis/credentials\">\n"
 "\"APIs &amp; Services\" &gt; \"Credentials\"\n"
@@ -32746,15 +24713,10 @@ msgstr ""
 
 #. Description of the 'Parent Document Type' (Link) field in DocType 'Dashboard
 #. Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "The document type selected is a child table, so the parent document type is required."
-msgstr ""
-
 #. Description of the 'Parent Document Type' (Link) field in DocType 'Number
 #. Card'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "The document type selected is a child table, so the parent document type is required."
 msgstr ""
 
@@ -32804,19 +24766,16 @@ msgstr ""
 
 #. Description of the 'Calendar Name' (Data) field in DocType 'Google Calendar'
 #: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
 msgid "The name that will appear in Google Calendar"
 msgstr ""
 
 #. Description of the 'Track Steps' (Check) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "The next tour will start from where the user left off."
 msgstr ""
 
 #. Description of the 'Request Timeout' (Int) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "The number of seconds until the request expires"
 msgstr ""
 
@@ -32834,7 +24793,6 @@ msgstr ""
 
 #. Description of the 'App ID' (Data) field in DocType 'Google Settings'
 #: integrations/doctype/google_settings/google_settings.json
-msgctxt "Google Settings"
 msgid ""
 "The project number obtained from Google Cloud Console under <a href=\"https://console.cloud.google.com/iam-admin/settings\">\n"
 "\"IAM &amp; Admin\" &gt; \"Settings\"\n"
@@ -32880,7 +24838,6 @@ msgstr ""
 #. Description of the 'User Field' (Select) field in DocType 'Energy Point
 #. Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "The user from this field will be rewarded points"
 msgstr ""
 
@@ -32890,7 +24847,6 @@ msgstr ""
 
 #. Description of the 'Condition' (Small Text) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "The webhook will be triggered if this expression is true"
 msgstr ""
 
@@ -32899,15 +24855,10 @@ msgid "The {0} is already on auto repeat {1}"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Website Settings'
-#: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
-msgid "Theme"
-msgstr ""
-
 #. Label of a Data field in DocType 'Website Theme'
 #. Label of a Code field in DocType 'Website Theme'
+#: website/doctype/website_settings/website_settings.json
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Theme"
 msgstr ""
 
@@ -32917,13 +24868,11 @@ msgstr ""
 
 #. Label of a Tab Break field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Theme Configuration"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Theme'
 #: website/doctype/website_theme/website_theme.json
-msgctxt "Website Theme"
 msgid "Theme URL"
 msgstr ""
 
@@ -33007,20 +24956,17 @@ msgstr ""
 #. Description of the 'Announcement Widget' (Text Editor) field in DocType
 #. 'Navbar Settings'
 #: core/doctype/navbar_settings/navbar_settings.json
-msgctxt "Navbar Settings"
 msgid "These announcements will appear inside a dismissible alert below the Navbar."
 msgstr ""
 
 #. Description of the 'LDAP Custom Settings' (Section Break) field in DocType
 #. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "These settings are required if 'Custom' LDAP Directory is used"
 msgstr ""
 
 #. Description of the 'Defaults' (Section Break) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "These values will be automatically updated in transactions and also will be useful to restrict permissions for this user on transactions containing these values."
 msgstr ""
 
@@ -33030,7 +24976,6 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "Third Party Authentication"
 msgstr ""
 
@@ -33064,13 +25009,11 @@ msgstr ""
 
 #. Description of the 'Is Public' (Check) field in DocType 'Number Card'
 #: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
 msgid "This card will be available to all Users if this is set"
 msgstr ""
 
 #. Description of the 'Is Public' (Check) field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "This chart will be available to all Users if this is set"
 msgstr ""
 
@@ -33131,7 +25074,6 @@ msgstr ""
 #. Description of the 'Depends On' (Code) field in DocType 'Customize Form
 #. Field'
 #: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
 msgid ""
 "This field will appear only if the fieldname defined here has value OR the rules are true (examples):\n"
 "myfield\n"
@@ -33153,14 +25095,12 @@ msgstr ""
 
 #. Description of the 'Is Default' (Check) field in DocType 'Address Template'
 #: contacts/doctype/address_template/address_template.json
-msgctxt "Address Template"
 msgid "This format is used if country specific format is not found"
 msgstr ""
 
 #. Description of the 'Header' (HTML Editor) field in DocType 'Website
 #. Slideshow'
 #: website/doctype/website_slideshow/website_slideshow.json
-msgctxt "Website Slideshow"
 msgid "This goes above the slideshow."
 msgstr ""
 
@@ -33191,7 +25131,6 @@ msgstr ""
 #. Description of the 'Google Snippet Preview' (HTML) field in DocType 'Blog
 #. Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "This is an example Google SERP Preview."
 msgstr ""
 
@@ -33202,7 +25141,6 @@ msgstr ""
 #. Description of the 'Current Value' (Int) field in DocType 'Document Naming
 #. Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "This is the number of the last created transaction with this prefix"
 msgstr ""
 
@@ -33269,14 +25207,12 @@ msgstr ""
 #. Description of the 'Callback Message' (Small Text) field in DocType
 #. 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "This will be shown in a modal after routing"
 msgstr ""
 
 #. Description of the 'Report Description' (Data) field in DocType 'Onboarding
 #. Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "This will be shown to the user in a dialog after routing to the report"
 msgstr ""
 
@@ -33302,167 +25238,97 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Thumbnail URL"
 msgstr ""
 
 #. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Thursday"
-msgstr ""
-
-#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Thursday"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
-#: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
-msgid "Thursday"
-msgstr ""
-
-#. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Thursday"
-msgstr ""
-
 #. Option for the 'First Day of the Week' (Select) field in DocType 'System
 #. Settings'
+#. Label of a Check field in DocType 'Event'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
+#: automation/doctype/auto_repeat_day/auto_repeat_day.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Thursday"
-msgstr ""
-
-#: email/doctype/newsletter/newsletter.js:118
-msgid "Time"
-msgstr ""
-
-#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Time"
-msgstr ""
-
-#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Time"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Time"
-msgstr ""
-
 #. Label of a Datetime field in DocType 'Recorder'
-#: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
-msgid "Time"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Column'
-#: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
-msgid "Time"
-msgstr ""
-
 #. Option for the 'Fieldtype' (Select) field in DocType 'Report Filter'
-#: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
-msgid "Time"
-msgstr ""
-
+#. Option for the 'Field Type' (Select) field in DocType 'Custom Field'
+#. Option for the 'Type' (Select) field in DocType 'Customize Form Field'
 #. Option for the 'Fieldtype' (Select) field in DocType 'Web Form Field'
+#: core/doctype/docfield/docfield.json core/doctype/recorder/recorder.json
+#: core/doctype/report_column/report_column.json
+#: core/doctype/report_filter/report_filter.json
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: email/doctype/newsletter/newsletter.js:118
 #: website/doctype/web_form_field/web_form_field.json
-msgctxt "Web Form Field"
 msgid "Time"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Time Format"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Time Interval"
 msgstr ""
 
 #. Label of a Check field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Time Series"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Time Series Based On"
 msgstr ""
 
 #. Label of a Duration field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Time Taken"
 msgstr ""
 
 #. Label of a Int field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Time Window (Seconds)"
 msgstr ""
 
-#: desk/page/setup_wizard/setup_wizard.js:395
-msgid "Time Zone"
-msgstr ""
-
 #. Label of a Select field in DocType 'System Settings'
-#: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
-msgid "Time Zone"
-msgstr ""
-
 #. Label of a Autocomplete field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Time Zone"
-msgstr ""
-
 #. Label of a Data field in DocType 'Web Page View'
+#: core/doctype/system_settings/system_settings.json
+#: core/doctype/user/user.json desk/page/setup_wizard/setup_wizard.js:395
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
 msgid "Time Zone"
 msgstr ""
 
 #. Label of a Text field in DocType 'Country'
 #: geo/doctype/country/country.json
-msgctxt "Country"
 msgid "Time Zones"
 msgstr ""
 
 #. Label of a Data field in DocType 'Country'
 #: geo/doctype/country/country.json
-msgctxt "Country"
 msgid "Time format"
 msgstr ""
 
 #. Label of a Float field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "Time in Queries"
 msgstr ""
 
 #. Description of the 'Expiry time of QR Code Image Page' (Int) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Time in seconds to retain QR code image on server. Min:<strong>240</strong>"
 msgstr ""
 
@@ -33476,7 +25342,6 @@ msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Timed Out"
 msgstr ""
 
@@ -33486,32 +25351,27 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "Timeline"
 msgstr ""
 
 #. Label of a Link field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
 msgid "Timeline DocType"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Timeline Field"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Communication'
 #. Label of a Table field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Timeline Links"
 msgstr ""
 
 #. Label of a Dynamic Link field in DocType 'Activity Log'
 #: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
 msgid "Timeline Name"
 msgstr ""
 
@@ -33525,198 +25385,89 @@ msgstr ""
 
 #. Label of a Duration field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "Timeout"
 msgstr ""
 
 #. Label of a Check field in DocType 'Dashboard Chart Source'
 #: desk/doctype/dashboard_chart_source/dashboard_chart_source.json
-msgctxt "Dashboard Chart Source"
 msgid "Timeseries"
 msgstr ""
 
+#. Label of a Select field in DocType 'Dashboard Chart'
+#: desk/doctype/dashboard_chart/dashboard_chart.json
 #: desk/page/leaderboard/leaderboard.js:123
 #: public/js/frappe/ui/filters/filter.js:28
 msgid "Timespan"
 msgstr ""
 
-#. Label of a Select field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Timespan"
-msgstr ""
-
+#. Label of a Datetime field in DocType 'Access Log'
+#. Label of a Datetime field in DocType 'Transaction Log'
+#: core/doctype/access_log/access_log.json
+#: core/doctype/transaction_log/transaction_log.json
 #: core/report/transaction_log_report/transaction_log_report.py:112
 msgid "Timestamp"
 msgstr ""
 
-#. Label of a Datetime field in DocType 'Access Log'
-#: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
-msgid "Timestamp"
-msgstr ""
-
-#. Label of a Datetime field in DocType 'Transaction Log'
-#: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
-msgid "Timestamp"
-msgstr ""
-
+#. Label of a Data field in DocType 'DocType State'
+#. Label of a Data field in DocType 'Error Log'
+#. Label of a Data field in DocType 'Page'
+#. Label of a Data field in DocType 'Changelog Feed'
+#. Label of a Data field in DocType 'Form Tour'
+#. Label of a Data field in DocType 'Form Tour Step'
+#. Label of a Data field in DocType 'Module Onboarding'
+#. Label of a Data field in DocType 'Note'
+#. Label of a Data field in DocType 'Onboarding Step'
+#. Label of a Data field in DocType 'System Health Report Errors'
+#. Label of a Data field in DocType 'Workspace'
+#. Label of a Data field in DocType 'Email Group'
+#. Label of a Data field in DocType 'Blog Category'
+#. Label of a Data field in DocType 'Blog Post'
+#. Label of a Data field in DocType 'Blog Settings'
+#. Label of a Data field in DocType 'Discussion Topic'
+#. Label of a Data field in DocType 'Help Article'
+#. Label of a Data field in DocType 'Portal Menu Item'
+#. Label of a Data field in DocType 'Web Form'
+#. Label of a Data field in DocType 'Web Page'
+#. Label of a Data field in DocType 'Website Sidebar'
+#. Label of a Data field in DocType 'Website Sidebar Item'
 #: core/doctype/doctype/boilerplate/controller_list.html:14
 #: core/doctype/doctype/boilerplate/controller_list.html:23
-#: public/js/frappe/views/workspace/workspace.js:612
-#: public/js/frappe/views/workspace/workspace.js:941
-#: public/js/frappe/views/workspace/workspace.js:1188
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Blog Category'
-#: website/doctype/blog_category/blog_category.json
-msgctxt "Blog Category"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Blog Post'
-#: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Blog Settings'
-#: website/doctype/blog_settings/blog_settings.json
-msgctxt "Blog Settings"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Changelog Feed'
-#: desk/doctype/changelog_feed/changelog_feed.json
-msgctxt "Changelog Feed"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Discussion Topic'
-#: website/doctype/discussion_topic/discussion_topic.json
-msgctxt "Discussion Topic"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'DocType State'
 #: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Email Group'
-#: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Error Log'
-#: core/doctype/error_log/error_log.json
-msgctxt "Error Log"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Form Tour'
+#: core/doctype/error_log/error_log.json core/doctype/page/page.json
+#: desk/doctype/changelog_feed/changelog_feed.json
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Help Article'
-#: website/doctype/help_article/help_article.json
-msgctxt "Help Article"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Module Onboarding'
 #: desk/doctype/module_onboarding/module_onboarding.json
-msgctxt "Module Onboarding"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Note'
 #: desk/doctype/note/note.json
-msgctxt "Note"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Page'
-#: core/doctype/page/page.json
-msgctxt "Page"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Portal Menu Item'
-#: website/doctype/portal_menu_item/portal_menu_item.json
-msgctxt "Portal Menu Item"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'System Health Report Errors'
 #: desk/doctype/system_health_report_errors/system_health_report_errors.json
-msgctxt "System Health Report Errors"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Web Page'
-#: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Website Sidebar'
-#: website/doctype/website_sidebar/website_sidebar.json
-msgctxt "Website Sidebar"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Website Sidebar Item'
-#: website/doctype/website_sidebar_item/website_sidebar_item.json
-msgctxt "Website Sidebar Item"
-msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
+#: email/doctype/email_group/email_group.json
+#: public/js/frappe/views/workspace/workspace.js:613
+#: public/js/frappe/views/workspace/workspace.js:942
+#: public/js/frappe/views/workspace/workspace.js:1189
+#: website/doctype/blog_category/blog_category.json
+#: website/doctype/blog_post/blog_post.json
+#: website/doctype/blog_settings/blog_settings.json
+#: website/doctype/discussion_topic/discussion_topic.json
+#: website/doctype/help_article/help_article.json
+#: website/doctype/portal_menu_item/portal_menu_item.json
+#: website/doctype/web_form/web_form.json
+#: website/doctype/web_page/web_page.json
+#: website/doctype/website_sidebar/website_sidebar.json
+#: website/doctype/website_sidebar_item/website_sidebar_item.json
 msgid "Title"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Title Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
+#. Label of a Data field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Title Field"
 msgstr ""
 
 #. Label of a Data field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Title Prefix"
 msgstr ""
 
@@ -33728,36 +25479,23 @@ msgstr ""
 msgid "Title of the page"
 msgstr ""
 
+#. Label of a Code field in DocType 'Communication'
+#. Label of a Section Break field in DocType 'Newsletter'
+#: core/doctype/communication/communication.json
+#: email/doctype/newsletter/newsletter.json
 #: public/js/frappe/views/communication.js:53
 #: public/js/frappe/views/inbox/inbox_view.js:70
 msgid "To"
 msgstr ""
 
-#. Label of a Code field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "To"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'Newsletter'
-#: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
-msgid "To"
-msgstr ""
-
-#: website/report/website_analytics/website_analytics.js:14
-msgid "To Date"
-msgstr ""
-
 #. Label of a Date field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
+#: website/report/website_analytics/website_analytics.js:14
 msgid "To Date"
 msgstr ""
 
 #. Label of a Select field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "To Date Field"
 msgstr ""
 
@@ -33777,7 +25515,6 @@ msgstr ""
 
 #. Description of the 'Subject' (Data) field in DocType 'Auto Repeat'
 #: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
 msgid ""
 "To add dynamic subject, use jinja tags like\n"
 "\n"
@@ -33786,7 +25523,6 @@ msgstr ""
 
 #. Description of the 'Subject' (Data) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid ""
 "To add dynamic subject, use jinja tags like\n"
 "\n"
@@ -33795,7 +25531,6 @@ msgstr ""
 
 #. Description of the 'JSON Request Body' (Code) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid ""
 "To add dynamic values from the document, use jinja tags like\n"
 "\n"
@@ -33811,14 +25546,12 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "To and CC"
 msgstr ""
 
 #. Description of the 'Use First Day of Period' (Check) field in DocType 'Auto
 #. Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "To begin the date range at the start of the chosen period. For example, if 'Year' is selected as the period, the report will start from January 1st of the current year."
 msgstr ""
 
@@ -33848,7 +25581,6 @@ msgstr ""
 
 #. Description of the 'Console' (Code) field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "To print output use <code>print(text)</code>"
 msgstr ""
 
@@ -33871,13 +25603,11 @@ msgstr ""
 #. Description of the 'Enable Google indexing' (Check) field in DocType
 #. 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "To use Google Indexing, enable <a href=\"/app/google-settings\">Google Settings</a>."
 msgstr ""
 
 #. Description of the 'Slack Channel' (Link) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "To use Slack Channel, add a <a href=\"#List/Slack%20Webhook%20URL/List\">Slack Webhook URL</a>."
 msgstr ""
 
@@ -33885,21 +25615,17 @@ msgstr ""
 msgid "To version"
 msgstr ""
 
+#. Linked DocType in User's connections
 #. Name of a DocType
 #. Name of a report
-#: desk/doctype/todo/todo.json desk/report/todo/todo.json
+#: core/doctype/user/user.json desk/doctype/todo/todo.json
+#: desk/report/todo/todo.json
 msgid "ToDo"
 msgstr ""
 
 #. Label of a shortcut in the Tools Workspace
 #: automation/workspace/tools/tools.json
 msgctxt "ToDo"
-msgid "ToDo"
-msgstr ""
-
-#. Linked DocType in User's connections
-#: core/doctype/user/user.json
-msgctxt "User"
 msgid "ToDo"
 msgstr ""
 
@@ -33940,36 +25666,25 @@ msgstr ""
 
 #. Option for the 'Response Type' (Select) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid "Token"
 msgstr ""
 
-#. Name of a DocType
-#: integrations/doctype/token_cache/token_cache.json
-msgid "Token Cache"
-msgstr ""
-
-#. Linked DocType in Connected App's connections
-#: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
-msgid "Token Cache"
-msgstr ""
-
 #. Linked DocType in User's connections
+#. Linked DocType in Connected App's connections
+#. Name of a DocType
 #: core/doctype/user/user.json
-msgctxt "User"
+#: integrations/doctype/connected_app/connected_app.json
+#: integrations/doctype/token_cache/token_cache.json
 msgid "Token Cache"
 msgstr ""
 
 #. Label of a Data field in DocType 'Token Cache'
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
 msgid "Token Type"
 msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Token URI"
 msgstr ""
 
@@ -34001,7 +25716,6 @@ msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "Top"
 msgstr ""
 
@@ -34012,31 +25726,23 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Top Bar Items"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Top Center"
-msgstr ""
-
 #. Option for the 'Page Number' (Select) field in DocType 'Print Format'
+#: desk/doctype/form_tour_step/form_tour_step.json
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Top Center"
 msgstr ""
 
 #. Label of a Table field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Top Errors"
 msgstr ""
 
 #. Option for the 'Page Number' (Select) field in DocType 'Print Format'
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Top Left"
 msgstr ""
 
@@ -34049,14 +25755,9 @@ msgid "Top Reviewer"
 msgstr ""
 
 #. Option for the 'Position' (Select) field in DocType 'Form Tour Step'
-#: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
-msgid "Top Right"
-msgstr ""
-
 #. Option for the 'Page Number' (Select) field in DocType 'Print Format'
+#: desk/doctype/form_tour_step/form_tour_step.json
 #: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
 msgid "Top Right"
 msgstr ""
 
@@ -34066,7 +25767,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Discussion Reply'
 #: website/doctype/discussion_reply/discussion_reply.json
-msgctxt "Discussion Reply"
 msgid "Topic"
 msgstr ""
 
@@ -34077,13 +25777,11 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Total Background Workers"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Total Errors (last 1 day)"
 msgstr ""
 
@@ -34093,50 +25791,39 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Total Outgoing Emails"
 msgstr ""
 
 #. Label of a Int field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Total Recipients"
 msgstr ""
 
 #. Label of a Int field in DocType 'Email Group'
-#: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
-msgid "Total Subscribers"
-msgstr ""
-
 #. Label of a Read Only field in DocType 'Newsletter Email Group'
+#: email/doctype/email_group/email_group.json
 #: email/doctype/newsletter_email_group/newsletter_email_group.json
-msgctxt "Newsletter Email Group"
 msgid "Total Subscribers"
 msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Total Users"
 msgstr ""
 
 #. Label of a Int field in DocType 'Newsletter'
 #: email/doctype/newsletter/newsletter.json
-msgctxt "Newsletter"
 msgid "Total Views"
 msgstr ""
 
 #. Label of a Duration field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Total Working Time"
 msgstr ""
 
 #. Description of the 'Initial Sync Count' (Select) field in DocType 'Email
 #. Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Total number of emails to sync in initial sync process "
 msgstr ""
 
@@ -34150,68 +25837,51 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Error Log'
 #: core/doctype/error_log/error_log.json
-msgctxt "Error Log"
 msgid "Trace ID"
 msgstr ""
 
 #. Label of a Code field in DocType 'Patch Log'
 #: core/doctype/patch_log/patch_log.json
-msgctxt "Patch Log"
 msgid "Traceback"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Track Changes"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Track Changes"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Track Email Status"
 msgstr ""
 
 #. Label of a Data field in DocType 'Milestone'
 #: automation/doctype/milestone/milestone.json
-msgctxt "Milestone"
 msgid "Track Field"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Track Seen"
 msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Track Steps"
 msgstr ""
 
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Track Views"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Track Views"
 msgstr ""
 
 #. Description of the 'Track Email Status' (Check) field in DocType 'Email
 #. Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid ""
 "Track if your email has been opened by the recipient.\n"
 "<br>\n"
@@ -34229,7 +25899,6 @@ msgstr ""
 
 #. Label of a Small Text field in DocType 'Transaction Log'
 #: core/doctype/transaction_log/transaction_log.json
-msgctxt "Transaction Log"
 msgid "Transaction Hash"
 msgstr ""
 
@@ -34245,43 +25914,27 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Transition Rules"
 msgstr ""
 
 #. Label of a Table field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Transitions"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Translatable"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Translatable"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Translatable"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "Translate Link Fields"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
+#. Label of a Check field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "Translate Link Fields"
 msgstr ""
 
@@ -34291,7 +25944,6 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Translation'
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
 msgid "Translated Text"
 msgstr ""
 
@@ -34306,25 +25958,18 @@ msgstr ""
 
 #. Option for the 'Email Status' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Trash"
 msgstr ""
 
 #. Option for the 'View' (Select) field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "Tree"
-msgstr ""
-
 #. Option for the 'DocType View' (Select) field in DocType 'Workspace Shortcut'
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
 msgid "Tree"
 msgstr ""
 
 #. Description of the 'Is Tree' (Check) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Tree structures are implemented using Nested Set"
 msgstr ""
 
@@ -34334,7 +25979,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Trigger Method"
 msgstr ""
 
@@ -34348,7 +25992,6 @@ msgstr ""
 
 #. Description of the 'Trigger Method' (Data) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Trigger on valid methods like \"before_insert\", \"after_update\", etc (will depend on the DocType selected)"
 msgstr ""
 
@@ -34362,7 +26005,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Try a Naming Series"
 msgstr ""
 
@@ -34379,133 +26021,58 @@ msgid "Try to use a longer keyboard pattern with more turns"
 msgstr ""
 
 #. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Tuesday"
-msgstr ""
-
-#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Tuesday"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
-#: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
-msgid "Tuesday"
-msgstr ""
-
-#. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Tuesday"
-msgstr ""
-
 #. Option for the 'First Day of the Week' (Select) field in DocType 'System
 #. Settings'
+#. Label of a Check field in DocType 'Event'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
+#: automation/doctype/auto_repeat_day/auto_repeat_day.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Tuesday"
 msgstr ""
 
 #. Label of a Check field in DocType 'Role'
-#: core/doctype/role/role.json
-msgctxt "Role"
-msgid "Two Factor Authentication"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'System Settings'
+#: core/doctype/role/role.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Two Factor Authentication"
 msgstr ""
 
 #. Label of a Select field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Two Factor Authentication method"
 msgstr ""
 
-#: public/js/frappe/views/file/file_view.js:337 www/attribution.html:35
-msgid "Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Type"
-msgstr ""
-
-#. Label of a Data field in DocType 'Console Log'
-#: desk/doctype/console_log/console_log.json
-msgctxt "Console Log"
-msgid "Type"
-msgstr ""
-
-#. Label of a Select field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Type"
-msgstr ""
-
-#. Label of a Select field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Type"
-msgstr ""
-
-#. Label of a Select field in DocType 'Desktop Icon'
-#: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
-msgid "Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Type"
-msgstr ""
-
-#. Label of a Select field in DocType 'Energy Point Log'
-#: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "Type"
-msgstr ""
-
+#. Label of a Select field in DocType 'Customize Form Field'
+#. Label of a Data field in DocType 'Console Log'
+#. Label of a Select field in DocType 'Dashboard Chart'
+#. Label of a Select field in DocType 'Desktop Icon'
 #. Label of a Select field in DocType 'Notification Log'
-#: desk/doctype/notification_log/notification_log.json
-msgctxt "Notification Log"
-msgid "Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'System Console'
-#: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
-msgid "Type"
-msgstr ""
-
-#. Label of a Select field in DocType 'Web Template'
-#: website/doctype/web_template/web_template.json
-msgctxt "Web Template"
-msgid "Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Workspace Link'
-#: desk/doctype/workspace_link/workspace_link.json
-msgctxt "Workspace Link"
-msgid "Type"
-msgstr ""
-
 #. Label of a Select field in DocType 'Workspace Shortcut'
+#. Label of a Select field in DocType 'Energy Point Log'
+#. Label of a Select field in DocType 'Web Template'
+#: core/doctype/communication/communication.json
+#: core/doctype/docfield/docfield.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/console_log/console_log.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/desktop_icon/desktop_icon.json
+#: desk/doctype/notification_log/notification_log.json
+#: desk/doctype/number_card/number_card.json
+#: desk/doctype/system_console/system_console.json
+#: desk/doctype/workspace_link/workspace_link.json
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: public/js/frappe/views/file/file_view.js:337
+#: social/doctype/energy_point_log/energy_point_log.json
+#: website/doctype/web_template/web_template.json www/attribution.html:35
 msgid "Type"
 msgstr ""
 
@@ -34536,107 +26103,63 @@ msgid "Type:"
 msgstr ""
 
 #. Label of a Check field in DocType 'Form Tour'
-#: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
-msgid "UI Tour"
-msgstr ""
-
 #. Label of a Check field in DocType 'Form Tour Step'
+#: desk/doctype/form_tour/form_tour.json
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "UI Tour"
 msgstr ""
 
 #. Label of a Int field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "UID"
-msgstr ""
-
 #. Label of a Data field in DocType 'Email Flag Queue'
-#: email/doctype/email_flag_queue/email_flag_queue.json
-msgctxt "Email Flag Queue"
-msgid "UID"
-msgstr ""
-
 #. Label of a Data field in DocType 'Unhandled Email'
+#: core/doctype/communication/communication.json
+#: email/doctype/email_flag_queue/email_flag_queue.json
 #: email/doctype/unhandled_email/unhandled_email.json
-msgctxt "Unhandled Email"
 msgid "UID"
 msgstr ""
 
 #. Label of a Int field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "UIDNEXT"
-msgstr ""
-
 #. Label of a Data field in DocType 'IMAP Folder'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/imap_folder/imap_folder.json
-msgctxt "IMAP Folder"
 msgid "UIDNEXT"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "UIDVALIDITY"
-msgstr ""
-
 #. Label of a Data field in DocType 'IMAP Folder'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/imap_folder/imap_folder.json
-msgctxt "IMAP Folder"
 msgid "UIDVALIDITY"
 msgstr ""
 
 #. Option for the 'Email Sync Option' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "UNSEEN"
 msgstr ""
 
 #. Description of the 'Redirect URIs' (Text) field in DocType 'OAuth Client'
 #: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
 msgid ""
 "URIs for receiving authorization code once the user allows access, as well as failure responses. Typically a REST endpoint exposed by the Client App.\n"
 "<br>e.g. http://hostname/api/method/frappe.integrations.oauth2_logins.login_via_facebook"
 msgstr ""
 
-#. Label of a Small Text field in DocType 'Integration Request'
-#: integrations/doctype/integration_request/integration_request.json
-msgctxt "Integration Request"
-msgid "URL"
-msgstr ""
-
-#. Label of a Data field in DocType 'Top Bar Item'
-#: website/doctype/top_bar_item/top_bar_item.json
-msgctxt "Top Bar Item"
-msgid "URL"
-msgstr ""
-
-#. Label of a Data field in DocType 'Webhook Request Log'
-#: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
-msgid "URL"
-msgstr ""
-
-#. Label of a Data field in DocType 'Website Slideshow Item'
-#: website/doctype/website_slideshow_item/website_slideshow_item.json
-msgctxt "Website Slideshow Item"
-msgid "URL"
-msgstr ""
-
 #. Option for the 'Type' (Select) field in DocType 'Workspace Shortcut'
 #. Label of a Data field in DocType 'Workspace Shortcut'
+#. Label of a Small Text field in DocType 'Integration Request'
+#. Label of a Data field in DocType 'Webhook Request Log'
+#. Label of a Data field in DocType 'Top Bar Item'
+#. Label of a Data field in DocType 'Website Slideshow Item'
 #: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
+#: integrations/doctype/integration_request/integration_request.json
+#: integrations/doctype/webhook_request_log/webhook_request_log.json
+#: website/doctype/top_bar_item/top_bar_item.json
+#: website/doctype/website_slideshow_item/website_slideshow_item.json
 msgid "URL"
 msgstr ""
 
 #. Description of the 'Documentation Link' (Data) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "URL for documentation or help"
 msgstr ""
 
@@ -34650,13 +26173,11 @@ msgstr ""
 
 #. Description of the 'URL' (Data) field in DocType 'Website Slideshow Item'
 #: website/doctype/website_slideshow_item/website_slideshow_item.json
-msgctxt "Website Slideshow Item"
 msgid "URL to go to on clicking the slideshow image"
 msgstr ""
 
 #. Option for the 'Naming Rule' (Select) field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "UUID"
 msgstr ""
 
@@ -34694,7 +26215,6 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Assignment Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Unassign Condition"
 msgstr ""
 
@@ -34726,29 +26246,19 @@ msgstr ""
 
 #. Label of a Int field in DocType 'System Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Unhandled Emails"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:569
+#: public/js/frappe/views/workspace/workspace.js:570
 msgid "Unhide Workspace"
 msgstr ""
 
-#. Label of a Check field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Unique"
-msgstr ""
-
-#. Label of a Check field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Unique"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocField'
+#. Label of a Check field in DocType 'Custom Field'
+#. Label of a Check field in DocType 'Customize Form Field'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
 msgid "Unique"
 msgstr ""
 
@@ -34783,13 +26293,11 @@ msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Email Flag Queue'
 #: email/doctype/email_flag_queue/email_flag_queue.json
-msgctxt "Email Flag Queue"
 msgid "Unread"
 msgstr ""
 
 #. Label of a Check field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Unread Notification Sent"
 msgstr ""
 
@@ -34803,14 +26311,9 @@ msgid "Unselect All"
 msgstr ""
 
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Unshared"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Unshared"
 msgstr ""
 
@@ -34820,35 +26323,19 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Unsubscribe Method"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Queue'
 #: email/doctype/email_queue/email_queue.json
-msgctxt "Email Queue"
 msgid "Unsubscribe Param"
 msgstr ""
 
-#: email/queue.py:122
-msgid "Unsubscribed"
-msgstr ""
-
 #. Label of a Check field in DocType 'Contact'
-#: contacts/doctype/contact/contact.json
-msgctxt "Contact"
-msgid "Unsubscribed"
-msgstr ""
-
-#. Label of a Check field in DocType 'Email Group Member'
-#: email/doctype/email_group_member/email_group_member.json
-msgctxt "Email Group Member"
-msgid "Unsubscribed"
-msgstr ""
-
 #. Label of a Check field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#. Label of a Check field in DocType 'Email Group Member'
+#: contacts/doctype/contact/contact.json core/doctype/user/user.json
+#: email/doctype/email_group_member/email_group_member.json email/queue.py:122
 msgid "Unsubscribed"
 msgstr ""
 
@@ -34872,7 +26359,9 @@ msgstr ""
 msgid "Upcoming Events for Today"
 msgstr ""
 
+#. Label of a Button field in DocType 'Document Naming Settings'
 #: core/doctype/data_import/data_import_list.js:36
+#: core/doctype/document_naming_settings/document_naming_settings.json
 #: core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.js:23
 #: custom/doctype/customize_form/customize_form.js:438
 #: desk/doctype/bulk_update/bulk_update.js:15
@@ -34881,35 +26370,26 @@ msgstr ""
 #: printing/page/print_format_builder/print_format_builder.js:670
 #: printing/page/print_format_builder/print_format_builder.js:757
 #: public/js/frappe/form/grid_row.js:404
-#: public/js/frappe/views/workspace/workspace.js:660
+#: public/js/frappe/views/workspace/workspace.js:661
 msgid "Update"
 msgstr ""
 
 #. Label of a Button field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
-msgid "Update"
-msgstr ""
-
-#. Label of a Button field in DocType 'Document Naming Settings'
-#: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Update Amendment Naming"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:609
+#: public/js/frappe/views/workspace/workspace.js:610
 msgid "Update Details"
 msgstr ""
 
 #. Option for the 'Import Type' (Select) field in DocType 'Data Import'
 #: core/doctype/data_import/data_import.json
-msgctxt "Data Import"
 msgid "Update Existing Records"
 msgstr ""
 
 #. Label of a Select field in DocType 'Workflow Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Update Field"
 msgstr ""
 
@@ -34924,19 +26404,16 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Update Series Counter"
 msgstr ""
 
 #. Label of a Button field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "Update Series Number"
 msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Update Settings"
 msgstr ""
 
@@ -34945,14 +26422,9 @@ msgid "Update Translations"
 msgstr ""
 
 #. Label of a Small Text field in DocType 'Bulk Update'
-#: desk/doctype/bulk_update/bulk_update.json
-msgctxt "Bulk Update"
-msgid "Update Value"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workflow Document State'
+#: desk/doctype/bulk_update/bulk_update.json
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Update Value"
 msgstr ""
 
@@ -34964,20 +26436,12 @@ msgstr ""
 msgid "Update {0} records"
 msgstr ""
 
+#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
+#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
 #: desk/doctype/desktop_icon/desktop_icon.py:446
 #: public/js/frappe/web_form/web_form.js:427
-msgid "Updated"
-msgstr ""
-
-#. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Updated"
-msgstr ""
-
-#. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Updated"
 msgstr ""
 
@@ -34995,7 +26459,6 @@ msgstr ""
 
 #. Label of a Tab Break field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Updates"
 msgstr ""
 
@@ -35045,13 +26508,11 @@ msgstr ""
 
 #. Label of a Check field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Uploaded To Dropbox"
 msgstr ""
 
 #. Label of a Check field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "Uploaded To Google Drive"
 msgstr ""
 
@@ -35071,85 +26532,59 @@ msgstr ""
 #. Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
 #, python-format
-msgctxt "Onboarding Step"
 msgid "Use % for any non empty value."
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Use ASCII encoding for password"
 msgstr ""
 
 #. Label of a Check field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Use First Day of Period"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Template'
 #: email/doctype/email_template/email_template.json
-msgctxt "Email Template"
 msgid "Use HTML"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Use IMAP"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Use IMAP"
 msgstr ""
 
 #. Label of a Check field in DocType 'SMS Settings'
 #: core/doctype/sms_settings/sms_settings.json
-msgctxt "SMS Settings"
 msgid "Use POST"
 msgstr ""
 
 #. Label of a Check field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Use Report Chart"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Use SSL"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Use SSL"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Use STARTTLS"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Use STARTTLS"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Use TLS"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Use TLS"
 msgstr ""
 
@@ -35159,7 +26594,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Use different Email ID"
 msgstr ""
 
@@ -35177,154 +26611,71 @@ msgstr ""
 
 #. Description of the 'Title Field' (Data) field in DocType 'Customize Form'
 #: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
 msgid "Use this fieldname to generate title"
 msgstr ""
 
 #. Label of a Check field in DocType 'User Email'
 #: core/doctype/user_email/user_email.json
-msgctxt "User Email"
 msgid "Used OAuth"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/user/user.json
-#: core/report/permitted_documents_for_user/permitted_documents_for_user.js:8
-#: desk/page/user_profile/user_profile_controller.js:65
-#: public/js/frappe/form/templates/set_sharing.html:3
-#: templates/emails/energy_points_summary.html:38
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Activity Log'
-#: core/doctype/activity_log/activity_log.json
-msgctxt "Activity Log"
-msgid "User"
-msgstr ""
-
 #. Label of a Link field in DocType 'Assignment Rule User'
-#: automation/doctype/assignment_rule_user/assignment_rule_user.json
-msgctxt "Assignment Rule User"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Blogger'
-#: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Dashboard Settings'
-#: desk/doctype/dashboard_settings/dashboard_settings.json
-msgctxt "Dashboard Settings"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'DocShare'
-#: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Document Follow'
-#: email/doctype/document_follow/document_follow.json
-msgctxt "Document Follow"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Energy Point Log'
-#: social/doctype/energy_point_log/energy_point_log.json
-msgctxt "Energy Point Log"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Google Calendar'
-#: integrations/doctype/google_calendar/google_calendar.json
-msgctxt "Google Calendar"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Log Setting User'
-#: core/doctype/log_setting_user/log_setting_user.json
-msgctxt "Log Setting User"
-msgid "User"
-msgstr ""
-
-#. Linked DocType in Module Profile's connections
-#: core/doctype/module_profile/module_profile.json
-msgctxt "Module Profile"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Note Seen By'
-#: desk/doctype/note_seen_by/note_seen_by.json
-msgctxt "Note Seen By"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Notification Settings'
-#: desk/doctype/notification_settings/notification_settings.json
-msgctxt "Notification Settings"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'OAuth Authorization Code'
-#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'OAuth Bearer Token'
-#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
-msgctxt "OAuth Bearer Token"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'OAuth Client'
-#: integrations/doctype/oauth_client/oauth_client.json
-msgctxt "OAuth Client"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Permission Inspector'
-#: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Personal Data Download Request'
-#: website/doctype/personal_data_download_request/personal_data_download_request.json
-msgctxt "Personal Data Download Request"
-msgid "User"
-msgstr ""
-
 #. Label of a Link field in DocType 'Reminder'
-#: automation/doctype/reminder/reminder.json
-msgctxt "Reminder"
-msgid "User"
-msgstr ""
-
+#. Label of a Link field in DocType 'Activity Log'
+#. Label of a Link field in DocType 'Communication'
+#. Label of a Link field in DocType 'DocShare'
+#. Label of a Link field in DocType 'Log Setting User'
+#. Linked DocType in Module Profile's connections
+#. Label of a Link field in DocType 'Permission Inspector'
 #. Linked DocType in Role Profile's connections
-#: core/doctype/role_profile/role_profile.json
-msgctxt "Role Profile"
-msgid "User"
-msgstr ""
-
+#. Name of a DocType
+#. Label of a Link field in DocType 'User Group Member'
+#. Label of a Link field in DocType 'User Permission'
+#. Label of a Link field in DocType 'Dashboard Settings'
+#. Label of a Link field in DocType 'Note Seen By'
+#. Label of a Link field in DocType 'Notification Settings'
 #. Label of a Link field in DocType 'Route History'
-#: desk/doctype/route_history/route_history.json
-msgctxt "Route History"
-msgid "User"
-msgstr ""
-
+#. Label of a Link field in DocType 'Document Follow'
+#. Label of a Link field in DocType 'Google Calendar'
+#. Label of a Link field in DocType 'OAuth Authorization Code'
+#. Label of a Link field in DocType 'OAuth Bearer Token'
+#. Label of a Link field in DocType 'OAuth Client'
 #. Label of a Link field in DocType 'Token Cache'
+#. Label of a Link field in DocType 'Webhook Request Log'
+#. Label of a Link field in DocType 'Energy Point Log'
+#. Label of a Link field in DocType 'Blogger'
+#. Label of a Link field in DocType 'Personal Data Download Request'
+#. Label of a Link field in DocType 'Workflow Action'
+#: automation/doctype/assignment_rule_user/assignment_rule_user.json
+#: automation/doctype/reminder/reminder.json
+#: core/doctype/activity_log/activity_log.json
+#: core/doctype/communication/communication.json
+#: core/doctype/docshare/docshare.json
+#: core/doctype/log_setting_user/log_setting_user.json
+#: core/doctype/module_profile/module_profile.json
+#: core/doctype/permission_inspector/permission_inspector.json
+#: core/doctype/role_profile/role_profile.json core/doctype/user/user.json
+#: core/doctype/user_group_member/user_group_member.json
+#: core/doctype/user_permission/user_permission.json
+#: core/report/permitted_documents_for_user/permitted_documents_for_user.js:8
+#: desk/doctype/dashboard_settings/dashboard_settings.json
+#: desk/doctype/note_seen_by/note_seen_by.json
+#: desk/doctype/notification_settings/notification_settings.json
+#: desk/doctype/route_history/route_history.json
+#: desk/page/user_profile/user_profile_controller.js:65
+#: email/doctype/document_follow/document_follow.json
+#: integrations/doctype/google_calendar/google_calendar.json
+#: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
+#: integrations/doctype/oauth_bearer_token/oauth_bearer_token.json
+#: integrations/doctype/oauth_client/oauth_client.json
 #: integrations/doctype/token_cache/token_cache.json
-msgctxt "Token Cache"
+#: integrations/doctype/webhook_request_log/webhook_request_log.json
+#: public/js/frappe/form/templates/set_sharing.html:3
+#: social/doctype/energy_point_log/energy_point_log.json
+#: templates/emails/energy_points_summary.html:38
+#: website/doctype/blogger/blogger.json
+#: website/doctype/personal_data_download_request/personal_data_download_request.json
+#: workflow/doctype/workflow_action/workflow_action.json
 msgid "User"
 msgstr ""
 
@@ -35335,33 +26686,8 @@ msgctxt "User"
 msgid "User"
 msgstr ""
 
-#. Label of a Link field in DocType 'User Group Member'
-#: core/doctype/user_group_member/user_group_member.json
-msgctxt "User Group Member"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'User Permission'
-#: core/doctype/user_permission/user_permission.json
-msgctxt "User Permission"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Webhook Request Log'
-#: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
-msgid "User"
-msgstr ""
-
-#. Label of a Link field in DocType 'Workflow Action'
-#: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
-msgid "User"
-msgstr ""
-
 #. Label of a Link field in DocType 'Access Log'
 #: core/doctype/access_log/access_log.json
-msgctxt "Access Log"
 msgid "User "
 msgstr ""
 
@@ -35381,19 +26707,16 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Web Page View'
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
 msgid "User Agent"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "User Cannot Create"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "User Cannot Search"
 msgstr ""
 
@@ -35403,13 +26726,11 @@ msgstr ""
 
 #. Label of a Table field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "User Defaults"
 msgstr ""
 
 #. Label of a Tab Break field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "User Details"
 msgstr ""
 
@@ -35429,13 +26750,11 @@ msgstr ""
 
 #. Label of a Table field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "User Emails"
 msgstr ""
 
 #. Label of a Select field in DocType 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "User Field"
 msgstr ""
 
@@ -35451,19 +26770,16 @@ msgstr ""
 
 #. Label of a Table MultiSelect field in DocType 'User Group'
 #: core/doctype/user_group/user_group.json
-msgctxt "User Group"
 msgid "User Group Members"
 msgstr ""
 
 #. Label of a Data field in DocType 'User Social Login'
 #: core/doctype/user_social_login/user_social_login.json
-msgctxt "User Social Login"
 msgid "User ID"
 msgstr ""
 
 #. Label of a Data field in DocType 'Social Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "User ID Property"
 msgstr ""
 
@@ -35474,13 +26790,11 @@ msgstr ""
 
 #. Label of a Link field in DocType 'Contact'
 #: contacts/doctype/contact/contact.json
-msgctxt "Contact"
 msgid "User Id"
 msgstr ""
 
 #. Label of a Select field in DocType 'User Type'
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
 msgid "User Id Field"
 msgstr ""
 
@@ -35490,7 +26804,6 @@ msgstr ""
 
 #. Label of a Attach Image field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "User Image"
 msgstr ""
 
@@ -35500,18 +26813,13 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Personal Data Download Request'
 #: website/doctype/personal_data_download_request/personal_data_download_request.json
-msgctxt "Personal Data Download Request"
 msgid "User Name"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/user_permission/user_permission.json
-msgid "User Permission"
-msgstr ""
-
 #. Linked DocType in User's connections
+#. Name of a DocType
 #: core/doctype/user/user.json
-msgctxt "User"
+#: core/doctype/user_permission/user_permission.json
 msgid "User Permission"
 msgstr ""
 
@@ -35547,7 +26855,6 @@ msgstr ""
 
 #. Label of a Link field in DocType 'LDAP Group Mapping'
 #: integrations/doctype/ldap_group_mapping/ldap_group_mapping.json
-msgctxt "LDAP Group Mapping"
 msgid "User Role"
 msgstr ""
 
@@ -35572,18 +26879,13 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "User Tags"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/user_type/user_type.json core/doctype/user_type/user_type.py:82
-msgid "User Type"
-msgstr ""
-
 #. Label of a Link field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
+#. Name of a DocType
+#: core/doctype/user/user.json core/doctype/user_type/user_type.json
+#: core/doctype/user_type/user_type.py:82
 msgid "User Type"
 msgstr ""
 
@@ -35593,28 +26895,22 @@ msgctxt "User Type"
 msgid "User Type"
 msgstr ""
 
-#. Name of a DocType
-#: core/doctype/user_type_module/user_type_module.json
-msgid "User Type Module"
-msgstr ""
-
 #. Label of a Table field in DocType 'User Type'
+#. Name of a DocType
 #: core/doctype/user_type/user_type.json
-msgctxt "User Type"
+#: core/doctype/user_type_module/user_type_module.json
 msgid "User Type Module"
 msgstr ""
 
 #. Description of the 'Allow Login using Mobile Number' (Check) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "User can login using Email id or Mobile number"
 msgstr ""
 
 #. Description of the 'Allow Login using User Name' (Check) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "User can login using Email id or User Name"
 msgstr ""
 
@@ -35636,7 +26932,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Document Naming Settings'
 #: core/doctype/document_naming_settings/document_naming_settings.json
-msgctxt "Document Naming Settings"
 msgid "User must always select"
 msgstr ""
 
@@ -35703,23 +26998,13 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Connected App'
 #: integrations/doctype/connected_app/connected_app.json
-msgctxt "Connected App"
 msgid "Userinfo URI"
 msgstr ""
 
-#: www/login.py:103
-msgid "Username"
-msgstr ""
-
 #. Label of a Data field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Username"
-msgstr ""
-
 #. Label of a Data field in DocType 'User Social Login'
-#: core/doctype/user_social_login/user_social_login.json
-msgctxt "User Social Login"
+#: core/doctype/user/user.json
+#: core/doctype/user_social_login/user_social_login.json www/login.py:103
 msgid "Username"
 msgstr ""
 
@@ -35727,28 +27012,19 @@ msgstr ""
 msgid "Username {0} already exists"
 msgstr ""
 
+#. Label of a Table MultiSelect field in DocType 'Assignment Rule'
 #. Name of a Workspace
 #. Label of a Card Break in the Users Workspace
-#: core/workspace/users/users.json
-msgid "Users"
-msgstr ""
-
-#. Label of a Table MultiSelect field in DocType 'Assignment Rule'
-#: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
-msgid "Users"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'System Health Report'
+#: automation/doctype/assignment_rule/assignment_rule.json
+#: core/workspace/users/users.json
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Users"
 msgstr ""
 
 #. Description of the 'Allot Points To Assigned Users' (Check) field in DocType
 #. 'Energy Point Rule'
 #: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
 msgid "Users assigned to the reference document will get points."
 msgstr ""
 
@@ -35766,20 +27042,17 @@ msgstr ""
 
 #. Label of a Percent field in DocType 'System Health Report Workers'
 #: desk/doctype/system_health_report_workers/system_health_report_workers.json
-msgctxt "System Health Report Workers"
 msgid "Utilization"
 msgstr ""
 
 #. Label of a Percent field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Utilization %"
 msgstr ""
 
 #. Option for the 'Validity' (Select) field in DocType 'OAuth Authorization
 #. Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "Valid"
 msgstr ""
 
@@ -35793,19 +27066,13 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Validate Field"
 msgstr ""
 
 #. Label of a Check field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "Validate SSL Certificate"
-msgstr ""
-
 #. Label of a Check field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "Validate SSL Certificate"
 msgstr ""
 
@@ -35815,93 +27082,56 @@ msgstr ""
 
 #. Label of a Select field in DocType 'OAuth Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "Validity"
 msgstr ""
 
+#. Label of a Data field in DocType 'Milestone'
+#. Label of a Text field in DocType 'DefaultValue'
+#. Label of a Data field in DocType 'Document Naming Rule Condition'
+#. Label of a Data field in DocType 'SMS Parameter'
+#. Label of a Data field in DocType 'Query Parameters'
+#. Label of a Small Text field in DocType 'Webhook Header'
+#. Label of a Text field in DocType 'Website Meta Tag'
+#: automation/doctype/milestone/milestone.json
+#: core/doctype/defaultvalue/defaultvalue.json
+#: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
 #: core/doctype/prepared_report/prepared_report.js:8
+#: core/doctype/sms_parameter/sms_parameter.json
 #: desk/doctype/dashboard_chart/dashboard_chart.js:305
 #: desk/doctype/dashboard_chart/dashboard_chart.js:439
 #: desk/doctype/number_card/number_card.js:205
 #: desk/doctype/number_card/number_card.js:336
 #: email/doctype/auto_email_report/auto_email_report.js:92
+#: integrations/doctype/query_parameters/query_parameters.json
+#: integrations/doctype/webhook_header/webhook_header.json
 #: public/js/frappe/list/bulk_operations.js:306
 #: public/js/frappe/list/bulk_operations.js:368
 #: public/js/frappe/list/list_view_permission_restrictions.html:4
 #: website/doctype/web_form/web_form.js:197
-msgid "Value"
-msgstr ""
-
-#. Label of a Text field in DocType 'DefaultValue'
-#: core/doctype/defaultvalue/defaultvalue.json
-msgctxt "DefaultValue"
-msgid "Value"
-msgstr ""
-
-#. Label of a Data field in DocType 'Document Naming Rule Condition'
-#: core/doctype/document_naming_rule_condition/document_naming_rule_condition.json
-msgctxt "Document Naming Rule Condition"
-msgid "Value"
-msgstr ""
-
-#. Label of a Data field in DocType 'Milestone'
-#: automation/doctype/milestone/milestone.json
-msgctxt "Milestone"
-msgid "Value"
-msgstr ""
-
-#. Label of a Data field in DocType 'Query Parameters'
-#: integrations/doctype/query_parameters/query_parameters.json
-msgctxt "Query Parameters"
-msgid "Value"
-msgstr ""
-
-#. Label of a Data field in DocType 'SMS Parameter'
-#: core/doctype/sms_parameter/sms_parameter.json
-msgctxt "SMS Parameter"
-msgid "Value"
-msgstr ""
-
-#. Label of a Small Text field in DocType 'Webhook Header'
-#: integrations/doctype/webhook_header/webhook_header.json
-msgctxt "Webhook Header"
-msgid "Value"
-msgstr ""
-
-#. Label of a Text field in DocType 'Website Meta Tag'
 #: website/doctype/website_meta_tag/website_meta_tag.json
-msgctxt "Website Meta Tag"
 msgid "Value"
 msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Value Based On"
 msgstr ""
 
+#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #. Option for the 'For Document Event' (Select) field in DocType 'Energy Point
 #. Rule'
-#: social/doctype/energy_point_rule/energy_point_rule.json
-msgctxt "Energy Point Rule"
-msgid "Value Change"
-msgstr ""
-
-#. Option for the 'Send Alert On' (Select) field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
+#: social/doctype/energy_point_rule/energy_point_rule.json
 msgid "Value Change"
 msgstr ""
 
 #. Label of a Select field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Value Changed"
 msgstr ""
 
 #. Label of a Data field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "Value To Be Set"
 msgstr ""
 
@@ -35932,7 +27162,6 @@ msgstr ""
 #. Description of the 'Due Date Based On' (Select) field in DocType 'Assignment
 #. Rule'
 #: automation/doctype/assignment_rule/assignment_rule.json
-msgctxt "Assignment Rule"
 msgid "Value from this field will be set as the due date in the ToDo"
 msgstr ""
 
@@ -35946,7 +27175,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Value to Validate"
 msgstr ""
 
@@ -35972,7 +27200,6 @@ msgstr ""
 
 #. Option for the 'Font' (Select) field in DocType 'Print Settings'
 #: printing/doctype/print_settings/print_settings.json
-msgctxt "Print Settings"
 msgid "Verdana"
 msgstr ""
 
@@ -35994,7 +27221,6 @@ msgstr ""
 
 #. Option for the 'Contribution Status' (Select) field in DocType 'Translation'
 #: core/doctype/translation/translation.json
-msgctxt "Translation"
 msgid "Verified"
 msgstr ""
 
@@ -36021,13 +27247,11 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Video URL"
 msgstr ""
 
 #. Label of a Select field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "View"
 msgstr ""
 
@@ -36069,7 +27293,6 @@ msgstr ""
 
 #. Label of a Button field in DocType 'Notification'
 #: email/doctype/notification/notification.json
-msgctxt "Notification"
 msgid "View Properties (via Customize Form)"
 msgstr ""
 
@@ -36079,25 +27302,18 @@ msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "View Report"
 msgstr ""
 
-#. Label of a Section Break field in DocType 'Customize Form'
-#: custom/doctype/customize_form/customize_form.json
-msgctxt "Customize Form"
-msgid "View Settings"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'DocType'
+#. Label of a Section Break field in DocType 'Customize Form'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#: custom/doctype/customize_form/customize_form.json
 msgid "View Settings"
 msgstr ""
 
 #. Label of a Check field in DocType 'Role'
 #: core/doctype/role/role.json
-msgctxt "Role"
 msgid "View Switcher"
 msgstr ""
 
@@ -36136,24 +27352,17 @@ msgstr ""
 
 #. Label of a Data field in DocType 'View Log'
 #: core/doctype/view_log/view_log.json
-msgctxt "View Log"
 msgid "Viewed By"
 msgstr ""
 
-#. Label of a Card Break in the Build Workspace
-#: core/workspace/build/build.json
-msgid "Views"
-msgstr ""
-
 #. Group in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#. Label of a Card Break in the Build Workspace
+#: core/doctype/doctype/doctype.json core/workspace/build/build.json
 msgid "Views"
 msgstr ""
 
 #. Label of a Check field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Virtual"
 msgstr ""
 
@@ -36167,13 +27376,11 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'DocField'
 #: core/doctype/docfield/docfield.json
-msgctxt "DocField"
 msgid "Visibility"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Communication'
 #: core/doctype/communication/communication.json
-msgctxt "Communication"
 msgid "Visit"
 msgstr ""
 
@@ -36183,7 +27390,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Web Page View'
 #: website/doctype/web_page_view/web_page_view.json
-msgctxt "Web Page View"
 msgid "Visitor ID"
 msgstr ""
 
@@ -36193,13 +27399,11 @@ msgstr ""
 
 #. Option for the 'Address Type' (Select) field in DocType 'Address'
 #: contacts/doctype/address/address.json
-msgctxt "Address"
 msgid "Warehouse"
 msgstr ""
 
 #. Option for the 'Style' (Select) field in DocType 'Workflow State'
 #: workflow/doctype/workflow_state/workflow_state.json
-msgctxt "Workflow State"
 msgid "Warning"
 msgstr ""
 
@@ -36213,7 +27417,6 @@ msgstr ""
 
 #. Description of the 'Counter' (Int) field in DocType 'Document Naming Rule'
 #: core/doctype/document_naming_rule/document_naming_rule.json
-msgctxt "Document Naming Rule"
 msgid "Warning: Updating counter may lead to document name conflicts if not done properly"
 msgstr ""
 
@@ -36227,7 +27430,6 @@ msgstr ""
 
 #. Option for the 'Action' (Select) field in DocType 'Onboarding Step'
 #: desk/doctype/onboarding_step/onboarding_step.json
-msgctxt "Onboarding Step"
 msgid "Watch Video"
 msgstr ""
 
@@ -36251,20 +27453,11 @@ msgstr ""
 msgid "Weak"
 msgstr ""
 
-#. Name of a DocType
-#: website/doctype/web_form/web_form.json
-msgid "Web Form"
-msgstr ""
-
 #. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
-msgid "Web Form"
-msgstr ""
-
 #. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
+#. Name of a DocType
+#: core/doctype/doctype/doctype.json core/doctype/module_def/module_def.json
+#: website/doctype/web_form/web_form.json
 msgid "Web Form"
 msgstr ""
 
@@ -36282,7 +27475,6 @@ msgstr ""
 
 #. Label of a Table field in DocType 'Web Form'
 #: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
 msgid "Web Form Fields"
 msgstr ""
 
@@ -36291,14 +27483,10 @@ msgstr ""
 msgid "Web Form List Column"
 msgstr ""
 
-#. Name of a DocType
-#: website/doctype/web_page/web_page.json
-msgid "Web Page"
-msgstr ""
-
 #. Linked DocType in Module Def's connections
+#. Name of a DocType
 #: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
+#: website/doctype/web_page/web_page.json
 msgid "Web Page"
 msgstr ""
 
@@ -36328,20 +27516,12 @@ msgstr ""
 msgid "Web Site"
 msgstr ""
 
-#. Name of a DocType
-#: website/doctype/web_template/web_template.json
-msgid "Web Template"
-msgstr ""
-
 #. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Web Template"
-msgstr ""
-
 #. Label of a Link field in DocType 'Web Page Block'
+#. Name of a DocType
+#: core/doctype/module_def/module_def.json
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
+#: website/doctype/web_template/web_template.json
 msgid "Web Template"
 msgstr ""
 
@@ -36352,7 +27532,6 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Web Page Block'
 #: website/doctype/web_page_block/web_page_block.json
-msgctxt "Web Page Block"
 msgid "Web Template Values"
 msgstr ""
 
@@ -36362,18 +27541,14 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Web View"
 msgstr ""
 
-#. Name of a DocType
-#: integrations/doctype/webhook/webhook.json
-msgid "Webhook"
-msgstr ""
-
 #. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#. Name of a DocType
+#. Label of a Link field in DocType 'Webhook Request Log'
+#: core/doctype/doctype/doctype.json integrations/doctype/webhook/webhook.json
+#: integrations/doctype/webhook_request_log/webhook_request_log.json
 msgid "Webhook"
 msgstr ""
 
@@ -36383,20 +27558,10 @@ msgctxt "Webhook"
 msgid "Webhook"
 msgstr ""
 
-#. Label of a Link field in DocType 'Webhook Request Log'
-#: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgctxt "Webhook Request Log"
-msgid "Webhook"
-msgstr ""
-
-#. Name of a DocType
-#: integrations/doctype/webhook_data/webhook_data.json
-msgid "Webhook Data"
-msgstr ""
-
 #. Label of a Section Break field in DocType 'Webhook'
+#. Name of a DocType
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
+#: integrations/doctype/webhook_data/webhook_data.json
 msgid "Webhook Data"
 msgstr ""
 
@@ -36407,61 +27572,47 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Webhook Headers"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Webhook Request"
 msgstr ""
 
-#. Name of a DocType
-#: integrations/doctype/webhook_request_log/webhook_request_log.json
-msgid "Webhook Request Log"
-msgstr ""
-
 #. Linked DocType in Webhook's connections
+#. Name of a DocType
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
+#: integrations/doctype/webhook_request_log/webhook_request_log.json
 msgid "Webhook Request Log"
 msgstr ""
 
 #. Label of a Password field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Webhook Secret"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Webhook Security"
 msgstr ""
 
 #. Label of a Section Break field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "Webhook Trigger"
 msgstr ""
 
 #. Label of a Data field in DocType 'Slack Webhook URL'
 #: integrations/doctype/slack_webhook_url/slack_webhook_url.json
-msgctxt "Slack Webhook URL"
 msgid "Webhook URL"
 msgstr ""
 
+#. Group in Module Def's connections
 #. Name of a Workspace
+#: core/doctype/module_def/module_def.json
 #: email/doctype/newsletter/newsletter.py:449
 #: public/js/frappe/ui/toolbar/about.js:8
 #: website/workspace/website/website.json
-msgid "Website"
-msgstr ""
-
-#. Group in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
 msgid "Website"
 msgstr ""
 
@@ -36524,7 +27675,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'DocType'
 #: core/doctype/doctype/doctype.json
-msgctxt "DocType"
 msgid "Website Search Field"
 msgstr ""
 
@@ -36544,20 +27694,12 @@ msgctxt "Website Settings"
 msgid "Website Settings"
 msgstr ""
 
-#. Name of a DocType
-#: website/doctype/website_sidebar/website_sidebar.json
-msgid "Website Sidebar"
-msgstr ""
-
 #. Label of a Link field in DocType 'Web Form'
-#: website/doctype/web_form/web_form.json
-msgctxt "Web Form"
-msgid "Website Sidebar"
-msgstr ""
-
 #. Label of a Link field in DocType 'Web Page'
+#. Name of a DocType
+#: website/doctype/web_form/web_form.json
 #: website/doctype/web_page/web_page.json
-msgctxt "Web Page"
+#: website/doctype/website_sidebar/website_sidebar.json
 msgid "Website Sidebar"
 msgstr ""
 
@@ -36588,20 +27730,12 @@ msgstr ""
 msgid "Website Slideshow Item"
 msgstr ""
 
-#. Name of a DocType
-#: website/doctype/website_theme/website_theme.json
-msgid "Website Theme"
-msgstr ""
-
 #. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Website Theme"
-msgstr ""
-
 #. Label of a Link field in DocType 'Website Settings'
+#. Name of a DocType
+#: core/doctype/module_def/module_def.json
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
+#: website/doctype/website_theme/website_theme.json
 msgid "Website Theme"
 msgstr ""
 
@@ -36618,51 +27752,31 @@ msgstr ""
 
 #. Label of a Image field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Website Theme Image"
 msgstr ""
 
 #. Label of a Code field in DocType 'Website Settings'
 #: website/doctype/website_settings/website_settings.json
-msgctxt "Website Settings"
 msgid "Website Theme image link"
 msgstr ""
 
 #. Option for the 'SocketIO Transport Mode' (Select) field in DocType 'System
 #. Health Report'
 #: desk/doctype/system_health_report/system_health_report.json
-msgctxt "System Health Report"
 msgid "Websocket"
 msgstr ""
 
 #. Option for the 'Day' (Select) field in DocType 'Assignment Rule Day'
-#: automation/doctype/assignment_rule_day/assignment_rule_day.json
-msgctxt "Assignment Rule Day"
-msgid "Wednesday"
-msgstr ""
-
-#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Wednesday"
-msgstr ""
-
 #. Option for the 'Day' (Select) field in DocType 'Auto Repeat Day'
-#: automation/doctype/auto_repeat_day/auto_repeat_day.json
-msgctxt "Auto Repeat Day"
-msgid "Wednesday"
-msgstr ""
-
-#. Label of a Check field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Wednesday"
-msgstr ""
-
 #. Option for the 'First Day of the Week' (Select) field in DocType 'System
 #. Settings'
+#. Label of a Check field in DocType 'Event'
+#. Option for the 'Day of Week' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/assignment_rule_day/assignment_rule_day.json
+#: automation/doctype/auto_repeat_day/auto_repeat_day.json
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: desk/doctype/event/event.json
+#: email/doctype/auto_email_report/auto_email_report.json
 msgid "Wednesday"
 msgstr ""
 
@@ -36672,100 +27786,44 @@ msgstr ""
 
 #. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Weekdays"
 msgstr ""
 
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
+#. Option for the 'Frequency' (Select) field in DocType 'User'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'Dropbox
+#. Settings'
+#. Option for the 'Frequency' (Select) field in DocType 'Google Drive'
+#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
+#. Settings'
+#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
+#. 'Energy Point Settings'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/server_script/server_script.json core/doctype/user/user.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/event/event.json desk/doctype/number_card/number_card.json
+#: email/doctype/auto_email_report/auto_email_report.json
+#: integrations/doctype/dropbox_settings/dropbox_settings.json
+#: integrations/doctype/google_drive/google_drive.json
+#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
 #: public/js/frappe/utils/common.js:399
+#: social/doctype/energy_point_settings/energy_point_settings.json
 #: website/report/website_analytics/website_analytics.js:24
 msgid "Weekly"
 msgstr ""
 
-#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
-#. Option for the 'Frequency' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Backup Frequency' (Select) field in DocType 'Dropbox
-#. Settings'
-#: integrations/doctype/dropbox_settings/dropbox_settings.json
-msgctxt "Dropbox Settings"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Point Allocation Periodicity' (Select) field in DocType
-#. 'Energy Point Settings'
-#: social/doctype/energy_point_settings/energy_point_settings.json
-msgctxt "Energy Point Settings"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Repeat On' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Google Drive'
-#: integrations/doctype/google_drive/google_drive.json
-msgctxt "Google Drive"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Backup Frequency' (Select) field in DocType 'S3 Backup
-#. Settings'
-#: integrations/doctype/s3_backup_settings/s3_backup_settings.json
-msgctxt "S3 Backup Settings"
-msgid "Weekly"
-msgstr ""
-
 #. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Weekly"
-msgstr ""
-
 #. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
-msgid "Weekly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
 #: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Weekly Long"
-msgstr ""
-
-#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
 #: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
 msgid "Weekly Long"
 msgstr ""
 
@@ -36773,21 +27831,15 @@ msgstr ""
 msgid "Welcome"
 msgstr ""
 
-#. Label of a Link field in DocType 'Email Group'
-#: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
-msgid "Welcome Email Template"
-msgstr ""
-
 #. Label of a Link field in DocType 'System Settings'
+#. Label of a Link field in DocType 'Email Group'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
+#: email/doctype/email_group/email_group.json
 msgid "Welcome Email Template"
 msgstr ""
 
 #. Label of a Data field in DocType 'Email Group'
 #: email/doctype/email_group/email_group.json
-msgctxt "Email Group"
 msgid "Welcome URL"
 msgstr ""
 
@@ -36811,21 +27863,18 @@ msgstr ""
 #. Description of the 'Allow Guests to Upload Files' (Check) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "When enabled this will allow guests to upload files to your application, You can enable this if you wish to collect files from user without having them to log in, for example in job applications web form."
 msgstr ""
 
 #. Description of the 'Store Attached PDF Document' (Check) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "When sending document using email, store the PDF on Communication. Warning: This can increase your storage usage."
 msgstr ""
 
 #. Description of the 'Force Web Capture Mode for Uploads' (Check) field in
 #. DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "When uploading files, force the use of the web-based image capture. If this is unchecked, the default behavior is to use the mobile native camera when use from a mobile is detected."
 msgstr ""
 
@@ -36833,48 +27882,24 @@ msgstr ""
 msgid "When you Amend a document after Cancel and save it, it will get a new number that is a version of the old number."
 msgstr ""
 
+#. Description of the 'DocType View' (Select) field in DocType 'Workspace
+#. Shortcut'
+#: desk/doctype/workspace_shortcut/workspace_shortcut.json
 #: public/js/frappe/widgets/widget_dialog.js:479
 msgid "Which view of the associated DocType should this shortcut take you to?"
 msgstr ""
 
-#. Description of the 'DocType View' (Select) field in DocType 'Workspace
-#. Shortcut'
-#: desk/doctype/workspace_shortcut/workspace_shortcut.json
-msgctxt "Workspace Shortcut"
-msgid "Which view of the associated DocType should this shortcut take you to?"
-msgstr ""
-
-#: printing/page/print_format_builder/print_format_builder_column_selector.html:8
-msgid "Width"
-msgstr ""
-
-#. Label of a Data field in DocType 'Custom Field'
-#: custom/doctype/custom_field/custom_field.json
-msgctxt "Custom Field"
-msgid "Width"
-msgstr ""
-
-#. Label of a Data field in DocType 'Customize Form Field'
-#: custom/doctype/customize_form_field/customize_form_field.json
-msgctxt "Customize Form Field"
-msgid "Width"
-msgstr ""
-
-#. Label of a Select field in DocType 'Dashboard Chart Link'
-#: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
-msgctxt "Dashboard Chart Link"
-msgid "Width"
-msgstr ""
-
 #. Label of a Data field in DocType 'DocField'
-#: core/doctype/docfield/docfield.json
-msgctxt "DocField"
-msgid "Width"
-msgstr ""
-
 #. Label of a Int field in DocType 'Report Column'
+#. Label of a Data field in DocType 'Custom Field'
+#. Label of a Data field in DocType 'Customize Form Field'
+#. Label of a Select field in DocType 'Dashboard Chart Link'
+#: core/doctype/docfield/docfield.json
 #: core/doctype/report_column/report_column.json
-msgctxt "Report Column"
+#: custom/doctype/custom_field/custom_field.json
+#: custom/doctype/customize_form_field/customize_form_field.json
+#: desk/doctype/dashboard_chart_link/dashboard_chart_link.json
+#: printing/page/print_format_builder/print_format_builder_column_selector.html:8
 msgid "Width"
 msgstr ""
 
@@ -36884,20 +27909,17 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Report Filter'
 #: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
 msgid "Wildcard Filter"
 msgstr ""
 
 #. Description of the 'Wildcard Filter' (Check) field in DocType 'Report
 #. Filter'
 #: core/doctype/report_filter/report_filter.json
-msgctxt "Report Filter"
 msgid "Will add \"%\" before and after the query"
 msgstr ""
 
 #. Description of the 'Short Name' (Data) field in DocType 'Blogger'
 #: website/doctype/blogger/blogger.json
-msgctxt "Blogger"
 msgid "Will be used in url (usually first name)."
 msgstr ""
 
@@ -36912,7 +27934,6 @@ msgstr ""
 #. Description of the 'Run Jobs only Daily if Inactive For (Days)' (Int) field
 #. in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Will run scheduled jobs only once a day for inactive sites. Default 4 days if set to 0."
 msgstr ""
 
@@ -36926,38 +27947,23 @@ msgstr ""
 
 #. Label of a Section Break field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Worker Information"
 msgstr ""
 
 #. Label of a Data field in DocType 'RQ Worker'
 #: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
 msgid "Worker Name"
 msgstr ""
 
-#. Name of a DocType
-#: public/js/workflow_builder/store.js:129
-#: workflow/doctype/workflow/workflow.json
-msgid "Workflow"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Comment'
-#: core/doctype/comment/comment.json
-msgctxt "Comment"
-msgid "Workflow"
-msgstr ""
-
 #. Option for the 'Comment Type' (Select) field in DocType 'Communication'
-#: core/doctype/communication/communication.json
-msgctxt "Communication"
-msgid "Workflow"
-msgstr ""
-
 #. Group in DocType's connections
 #. Linked DocType in DocType's connections
-#: core/doctype/doctype/doctype.json
-msgctxt "DocType"
+#. Name of a DocType
+#: core/doctype/comment/comment.json
+#: core/doctype/communication/communication.json
+#: core/doctype/doctype/doctype.json public/js/workflow_builder/store.js:129
+#: workflow/doctype/workflow/workflow.json
 msgid "Workflow"
 msgstr ""
 
@@ -36981,7 +27987,6 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Workflow Action Master'
 #: workflow/doctype/workflow_action_master/workflow_action_master.json
-msgctxt "Workflow Action Master"
 msgid "Workflow Action Name"
 msgstr ""
 
@@ -36993,7 +27998,6 @@ msgstr ""
 #. Description of the 'Is Optional State' (Check) field in DocType 'Workflow
 #. Document State'
 #: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
 msgid "Workflow Action is not created for optional states"
 msgstr ""
 
@@ -37004,14 +28008,9 @@ msgid "Workflow Builder"
 msgstr ""
 
 #. Label of a Data field in DocType 'Workflow Document State'
-#: workflow/doctype/workflow_document_state/workflow_document_state.json
-msgctxt "Workflow Document State"
-msgid "Workflow Builder ID"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workflow Transition'
+#: workflow/doctype/workflow_document_state/workflow_document_state.json
 #: workflow/doctype/workflow_transition/workflow_transition.json
-msgctxt "Workflow Transition"
 msgid "Workflow Builder ID"
 msgstr ""
 
@@ -37021,7 +28020,6 @@ msgstr ""
 
 #. Label of a JSON field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Workflow Data"
 msgstr ""
 
@@ -37032,24 +28030,18 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Workflow Name"
 msgstr ""
 
-#. Name of a DocType
-#: workflow/doctype/workflow_state/workflow_state.json
-msgid "Workflow State"
-msgstr ""
-
 #. Label of a Data field in DocType 'Workflow Action'
+#. Name of a DocType
 #: workflow/doctype/workflow_action/workflow_action.json
-msgctxt "Workflow Action"
+#: workflow/doctype/workflow_state/workflow_state.json
 msgid "Workflow State"
 msgstr ""
 
 #. Label of a Data field in DocType 'Workflow'
 #: workflow/doctype/workflow/workflow.json
-msgctxt "Workflow"
 msgid "Workflow State Field"
 msgstr ""
 
@@ -37084,22 +28076,13 @@ msgstr ""
 msgid "Workflows allow you to define custom rules for the approval process of a particular document in ERPNext. You can also set complex Workflow Rules and set approval conditions."
 msgstr ""
 
+#. Linked DocType in Module Def's connections
+#. Label of a Section Break field in DocType 'User'
 #. Name of a DocType
+#: core/doctype/module_def/module_def.json core/doctype/user/user.json
 #: desk/doctype/workspace/workspace.json
 #: public/js/frappe/ui/toolbar/search_utils.js:557
 #: public/js/frappe/views/workspace/workspace.js:10
-msgid "Workspace"
-msgstr ""
-
-#. Linked DocType in Module Def's connections
-#: core/doctype/module_def/module_def.json
-msgctxt "Module Def"
-msgid "Workspace"
-msgstr ""
-
-#. Label of a Section Break field in DocType 'User'
-#: core/doctype/user/user.json
-msgctxt "User"
 msgid "Workspace"
 msgstr ""
 
@@ -37153,21 +28136,20 @@ msgstr ""
 msgid "Workspace not found"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:1278
+#: public/js/frappe/views/workspace/workspace.js:1279
 msgid "Workspace {0} Created Successfully"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:907
+#: public/js/frappe/views/workspace/workspace.js:908
 msgid "Workspace {0} Deleted Successfully"
 msgstr ""
 
-#: public/js/frappe/views/workspace/workspace.js:685
+#: public/js/frappe/views/workspace/workspace.js:686
 msgid "Workspace {0} Edited Successfully"
 msgstr ""
 
 #. Option for the 'View' (Select) field in DocType 'Form Tour'
 #: desk/doctype/form_tour/form_tour.json
-msgctxt "Form Tour"
 msgid "Workspaces"
 msgstr ""
 
@@ -37176,26 +28158,12 @@ msgid "Wrapping up"
 msgstr ""
 
 #. Label of a Check field in DocType 'Custom DocPerm'
-#: core/doctype/custom_docperm/custom_docperm.json
-msgctxt "Custom DocPerm"
-msgid "Write"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocPerm'
-#: core/doctype/docperm/docperm.json
-msgctxt "DocPerm"
-msgid "Write"
-msgstr ""
-
 #. Label of a Check field in DocType 'DocShare'
-#: core/doctype/docshare/docshare.json
-msgctxt "DocShare"
-msgid "Write"
-msgstr ""
-
 #. Label of a Check field in DocType 'User Document Type'
+#: core/doctype/custom_docperm/custom_docperm.json
+#: core/doctype/docperm/docperm.json core/doctype/docshare/docshare.json
 #: core/doctype/user_document_type/user_document_type.json
-msgctxt "User Document Type"
 msgid "Write"
 msgstr ""
 
@@ -37209,19 +28177,16 @@ msgstr ""
 
 #. Label of a Select field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "X Field"
 msgstr ""
 
 #. Option for the 'Format' (Select) field in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "XLSX"
 msgstr ""
 
 #. Label of a Table field in DocType 'Dashboard Chart'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
 msgid "Y Axis"
 msgstr ""
 
@@ -37229,100 +28194,63 @@ msgstr ""
 msgid "Y Axis Fields"
 msgstr ""
 
-#: public/js/frappe/views/reports/query_report.js:1148
-msgid "Y Field"
-msgstr ""
-
 #. Label of a Select field in DocType 'Dashboard Chart Field'
 #: desk/doctype/dashboard_chart_field/dashboard_chart_field.json
-msgctxt "Dashboard Chart Field"
+#: public/js/frappe/views/reports/query_report.js:1148
 msgid "Y Field"
 msgstr ""
 
 #. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Yahoo Mail"
 msgstr ""
 
 #. Option for the 'Service' (Select) field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "Yandex.Mail"
 msgstr ""
 
-#. Label of a Data field in DocType 'Company History'
-#: website/doctype/company_history/company_history.json
-msgctxt "Company History"
-msgid "Year"
-msgstr ""
-
 #. Label of a Select field in DocType 'Dashboard Chart'
+#. Label of a Data field in DocType 'Company History'
 #: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
+#: website/doctype/company_history/company_history.json
 msgid "Year"
 msgstr ""
 
+#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
+#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
+#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
+#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
+#. Option for the 'Repeat On' (Select) field in DocType 'Event'
+#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
+#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
+#: automation/doctype/auto_repeat/auto_repeat.json
+#: core/doctype/scheduled_job_type/scheduled_job_type.json
+#: core/doctype/server_script/server_script.json
+#: desk/doctype/dashboard_chart/dashboard_chart.json
+#: desk/doctype/event/event.json desk/doctype/number_card/number_card.json
+#: email/doctype/auto_email_report/auto_email_report.json
 #: public/js/frappe/utils/common.js:403
 msgid "Yearly"
 msgstr ""
 
-#. Option for the 'Period' (Select) field in DocType 'Auto Email Report'
-#: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
-msgid "Yearly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Auto Repeat'
-#: automation/doctype/auto_repeat/auto_repeat.json
-msgctxt "Auto Repeat"
-msgid "Yearly"
-msgstr ""
-
-#. Option for the 'Time Interval' (Select) field in DocType 'Dashboard Chart'
-#: desk/doctype/dashboard_chart/dashboard_chart.json
-msgctxt "Dashboard Chart"
-msgid "Yearly"
-msgstr ""
-
-#. Option for the 'Repeat On' (Select) field in DocType 'Event'
-#: desk/doctype/event/event.json
-msgctxt "Event"
-msgid "Yearly"
-msgstr ""
-
-#. Option for the 'Stats Time Interval' (Select) field in DocType 'Number Card'
-#: desk/doctype/number_card/number_card.json
-msgctxt "Number Card"
-msgid "Yearly"
-msgstr ""
-
-#. Option for the 'Frequency' (Select) field in DocType 'Scheduled Job Type'
-#: core/doctype/scheduled_job_type/scheduled_job_type.json
-msgctxt "Scheduled Job Type"
-msgid "Yearly"
-msgstr ""
-
-#. Option for the 'Event Frequency' (Select) field in DocType 'Server Script'
-#: core/doctype/server_script/server_script.json
-msgctxt "Server Script"
-msgid "Yearly"
-msgstr ""
-
 #. Option for the 'Color' (Select) field in DocType 'DocType State'
-#: core/doctype/doctype_state/doctype_state.json
-msgctxt "DocType State"
-msgid "Yellow"
-msgstr ""
-
 #. Option for the 'Indicator' (Select) field in DocType 'Kanban Board Column'
+#: core/doctype/doctype_state/doctype_state.json
 #: desk/doctype/kanban_board_column/kanban_board_column.json
-msgctxt "Kanban Board Column"
 msgid "Yellow"
 msgstr ""
 
+#. Option for the 'Standard' (Select) field in DocType 'Page'
+#. Option for the 'Is Standard' (Select) field in DocType 'Report'
+#. Option for the 'Require Trusted Certificate' (Select) field in DocType 'LDAP
+#. Settings'
+#. Option for the 'Standard' (Select) field in DocType 'Print Format'
+#: core/doctype/page/page.json core/doctype/report/report.json
+#: integrations/doctype/ldap_settings/ldap_settings.json
 #: integrations/doctype/webhook/webhook.py:130
 #: integrations/doctype/webhook/webhook.py:140
+#: printing/doctype/print_format/print_format.json
 #: public/js/form_builder/utils.js:336
 #: public/js/frappe/form/controls/link.js:475
 #: public/js/frappe/list/list_sidebar_group_by.js:223
@@ -37338,31 +28266,6 @@ msgstr ""
 
 #: public/js/frappe/ui/filters/filter.js:507
 msgctxt "Checkbox is checked"
-msgid "Yes"
-msgstr ""
-
-#. Option for the 'Require Trusted Certificate' (Select) field in DocType 'LDAP
-#. Settings'
-#: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
-msgid "Yes"
-msgstr ""
-
-#. Option for the 'Standard' (Select) field in DocType 'Page'
-#: core/doctype/page/page.json
-msgctxt "Page"
-msgid "Yes"
-msgstr ""
-
-#. Option for the 'Standard' (Select) field in DocType 'Print Format'
-#: printing/doctype/print_format/print_format.json
-msgctxt "Print Format"
-msgid "Yes"
-msgstr ""
-
-#. Option for the 'Is Standard' (Select) field in DocType 'Report'
-#: core/doctype/report/report.json
-msgctxt "Report"
 msgid "Yes"
 msgstr ""
 
@@ -37873,7 +28776,6 @@ msgstr ""
 #. Description of the 'Email Footer Address' (Small Text) field in DocType
 #. 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "Your organization name and address for the email footer."
 msgstr ""
 
@@ -37905,19 +28807,16 @@ msgstr ""
 #. Description of the 'Only Send Records Updated in Last X Hours' (Int) field
 #. in DocType 'Auto Email Report'
 #: email/doctype/auto_email_report/auto_email_report.json
-msgctxt "Auto Email Report"
 msgid "Zero means send records updated at anytime"
 msgstr ""
 
 #. Label of a Link field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "_doctype"
 msgstr ""
 
 #. Label of a Link field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "_report"
 msgstr ""
 
@@ -37935,14 +28834,12 @@ msgstr ""
 
 #. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "after_insert"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "amend"
 msgstr ""
 
@@ -37961,7 +28858,6 @@ msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "blue"
 msgstr ""
 
@@ -37971,7 +28867,6 @@ msgstr ""
 
 #. Label of a Code field in DocType 'Recorder'
 #: core/doctype/recorder/recorder.json
-msgctxt "Recorder"
 msgid "cProfile Output"
 msgstr ""
 
@@ -37982,13 +28877,11 @@ msgstr ""
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "cancel"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "canceled"
 msgstr ""
 
@@ -38003,13 +28896,11 @@ msgstr ""
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "create"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "cyan"
 msgstr ""
 
@@ -38020,7 +28911,6 @@ msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "darkgrey"
 msgstr ""
 
@@ -38030,44 +28920,33 @@ msgstr ""
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "dd-mm-yyyy"
 msgstr ""
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "dd.mm.yyyy"
 msgstr ""
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "dd/mm/yyyy"
 msgstr ""
 
 #. Option for the 'Queue' (Select) field in DocType 'RQ Job'
-#: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
-msgid "default"
-msgstr ""
-
 #. Option for the 'Queue Type(s)' (Select) field in DocType 'RQ Worker'
-#: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
+#: core/doctype/rq_job/rq_job.json core/doctype/rq_worker/rq_worker.json
 msgid "default"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "deferred"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "delete"
 msgstr ""
 
@@ -38083,7 +28962,6 @@ msgstr ""
 #. Description of the 'Email Account Name' (Data) field in DocType 'Email
 #. Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "e.g. \"Support\", \"Sales\", \"Jerry Yang\""
 msgstr ""
 
@@ -38092,33 +28970,22 @@ msgid "e.g. (55 + 434) / 4 or =Math.sin(Math.PI/2)..."
 msgstr ""
 
 #. Description of the 'Incoming Server' (Data) field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "e.g. pop.gmail.com / imap.gmail.com"
-msgstr ""
-
 #. Description of the 'Incoming Server' (Data) field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "e.g. pop.gmail.com / imap.gmail.com"
 msgstr ""
 
 #. Description of the 'Default Incoming' (Check) field in DocType 'Email
 #. Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "e.g. replies@yourcomany.com. All replies will come to this inbox."
 msgstr ""
 
 #. Description of the 'Outgoing Server' (Data) field in DocType 'Email Account'
-#: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
-msgid "e.g. smtp.gmail.com"
-msgstr ""
-
 #. Description of the 'Outgoing Server' (Data) field in DocType 'Email Domain'
+#: email/doctype/email_account/email_account.json
 #: email/doctype/email_domain/email_domain.json
-msgctxt "Email Domain"
 msgid "e.g. smtp.gmail.com"
 msgstr ""
 
@@ -38128,21 +28995,15 @@ msgstr ""
 
 #. Option for the 'Code Editor Type' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "emacs"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
-#: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
-msgid "email"
-msgstr ""
-
 #. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
 #. Settings'
+#: core/doctype/permission_inspector/permission_inspector.json
 #: website/doctype/social_link_settings/social_link_settings.json
-msgctxt "Social Link Settings"
 msgid "email"
 msgstr ""
 
@@ -38158,33 +29019,28 @@ msgstr ""
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "export"
 msgstr ""
 
 #. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
 #. Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
-msgctxt "Social Link Settings"
 msgid "facebook"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "failed"
 msgstr ""
 
 #. Option for the 'Social Login Provider' (Select) field in DocType 'Social
 #. Login Key'
 #: integrations/doctype/social_login_key/social_login_key.json
-msgctxt "Social Login Key"
 msgid "fairlogin"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "finished"
 msgstr ""
 
@@ -38194,19 +29050,16 @@ msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "gray"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "green"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "grey"
 msgstr ""
 
@@ -38225,20 +29078,17 @@ msgstr ""
 
 #. Label of a Data field in DocType 'Page'
 #: core/doctype/page/page.json
-msgctxt "Page"
 msgid "icon"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "import"
 msgstr ""
 
 #. Description of the 'Read Time' (Int) field in DocType 'Blog Post'
 #: website/doctype/blog_post/blog_post.json
-msgctxt "Blog Post"
 msgid "in minutes"
 msgstr ""
 
@@ -38256,26 +29106,22 @@ msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "light-blue"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "link"
 msgstr ""
 
 #. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
 #. Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
-msgctxt "Social Link Settings"
 msgid "linkedin"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "list"
 msgstr ""
 
@@ -38288,14 +29134,8 @@ msgid "login_required"
 msgstr ""
 
 #. Option for the 'Queue' (Select) field in DocType 'RQ Job'
-#: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
-msgid "long"
-msgstr ""
-
 #. Option for the 'Queue Type(s)' (Select) field in DocType 'RQ Worker'
-#: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
+#: core/doctype/rq_job/rq_job.json core/doctype/rq_worker/rq_worker.json
 msgid "long"
 msgstr ""
 
@@ -38315,19 +29155,16 @@ msgstr ""
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "mm-dd-yyyy"
 msgstr ""
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "mm/dd/yyyy"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "module"
 msgstr ""
 
@@ -38345,13 +29182,11 @@ msgstr ""
 
 #. Label of a Int field in DocType 'Email Account'
 #: email/doctype/email_account/email_account.json
-msgctxt "Email Account"
 msgid "no failed attempts"
 msgstr ""
 
 #. Label of a Data field in DocType 'OAuth Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "nonce"
 msgstr ""
 
@@ -38361,7 +29196,6 @@ msgstr ""
 
 #. Label of a Check field in DocType 'Reminder'
 #: automation/doctype/reminder/reminder.json
-msgctxt "Reminder"
 msgid "notified"
 msgstr ""
 
@@ -38375,43 +29209,36 @@ msgstr ""
 
 #. Label of a Data field in DocType 'File'
 #: core/doctype/file/file.json
-msgctxt "File"
 msgid "old_parent"
 msgstr ""
 
 #. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "on_cancel"
 msgstr ""
 
 #. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "on_change"
 msgstr ""
 
 #. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "on_submit"
 msgstr ""
 
 #. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "on_trash"
 msgstr ""
 
 #. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "on_update"
 msgstr ""
 
 #. Option for the 'Doc Event' (Select) field in DocType 'Webhook'
 #: integrations/doctype/webhook/webhook.json
-msgctxt "Webhook"
 msgid "on_update_after_submit"
 msgstr ""
 
@@ -38419,76 +29246,65 @@ msgstr ""
 msgid "one of"
 msgstr ""
 
-#: public/js/frappe/utils/utils.js:393 www/login.html:87 www/login.py:105
+#: public/js/frappe/utils/utils.js:393 www/login.html:87
 msgid "or"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "orange"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "page"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "pink"
 msgstr ""
 
 #. Option for the 'Code challenge method' (Select) field in DocType 'OAuth
 #. Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "plain"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "print"
 msgstr ""
 
 #. Label of a HTML field in DocType 'System Console'
 #: desk/doctype/system_console/system_console.json
-msgctxt "System Console"
 msgid "processlist"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "purple"
 msgstr ""
 
 #. Option for the 'Type' (Select) field in DocType 'Desktop Icon'
 #: desk/doctype/desktop_icon/desktop_icon.json
-msgctxt "Desktop Icon"
 msgid "query-report"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "queued"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "read"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "red"
 msgstr ""
 
@@ -38503,13 +29319,11 @@ msgstr ""
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "report"
 msgstr ""
 
 #. Label of a HTML field in DocType 'Custom Role'
 #: core/doctype/custom_role/custom_role.json
-msgctxt "Custom Role"
 msgid "response"
 msgstr ""
 
@@ -38525,39 +29339,29 @@ msgstr ""
 #. Option for the 'Code challenge method' (Select) field in DocType 'OAuth
 #. Authorization Code'
 #: integrations/doctype/oauth_authorization_code/oauth_authorization_code.json
-msgctxt "OAuth Authorization Code"
 msgid "s256"
 msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "scheduled"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "select"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "share"
 msgstr ""
 
 #. Option for the 'Queue' (Select) field in DocType 'RQ Job'
-#: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
-msgid "short"
-msgstr ""
-
 #. Option for the 'Queue Type(s)' (Select) field in DocType 'RQ Worker'
-#: core/doctype/rq_worker/rq_worker.json
-msgctxt "RQ Worker"
+#: core/doctype/rq_job/rq_job.json core/doctype/rq_worker/rq_worker.json
 msgid "short"
 msgstr ""
 
@@ -38579,7 +29383,6 @@ msgstr ""
 
 #. Option for the 'Status' (Select) field in DocType 'RQ Job'
 #: core/doctype/rq_job/rq_job.json
-msgctxt "RQ Job"
 msgid "started"
 msgstr ""
 
@@ -38590,28 +29393,24 @@ msgstr ""
 #. Description of the 'Group Object Class' (Data) field in DocType 'LDAP
 #. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "string value, i.e. group"
 msgstr ""
 
 #. Description of the 'LDAP Group Member attribute' (Data) field in DocType
 #. 'LDAP Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "string value, i.e. member"
 msgstr ""
 
 #. Description of the 'Custom Group Search' (Data) field in DocType 'LDAP
 #. Settings'
 #: integrations/doctype/ldap_settings/ldap_settings.json
-msgctxt "LDAP Settings"
 msgid "string value, i.e. {0} or uid={0},ou=users,dc=example,dc=com"
 msgstr ""
 
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "submit"
 msgstr ""
 
@@ -38634,7 +29433,6 @@ msgstr ""
 #. Option for the 'Social Link Type' (Select) field in DocType 'Social Link
 #. Settings'
 #: website/doctype/social_link_settings/social_link_settings.json
-msgctxt "Social Link Settings"
 msgid "twitter"
 msgstr ""
 
@@ -38652,7 +29450,6 @@ msgstr ""
 
 #. Label of a HTML field in DocType 'Audit Trail'
 #: core/doctype/audit_trail/audit_trail.json
-msgctxt "Audit Trail"
 msgid "version_table"
 msgstr ""
 
@@ -38667,7 +29464,6 @@ msgstr ""
 
 #. Description of the 'Add Video Conferencing' (Check) field in DocType 'Event'
 #: desk/doctype/event/event.json
-msgctxt "Event"
 msgid "via Google Meet"
 msgstr ""
 
@@ -38685,13 +29481,11 @@ msgstr ""
 
 #. Option for the 'Code Editor Type' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "vim"
 msgstr ""
 
 #. Option for the 'Code Editor Type' (Select) field in DocType 'User'
 #: core/doctype/user/user.json
-msgctxt "User"
 msgid "vscode"
 msgstr ""
 
@@ -38702,7 +29496,6 @@ msgstr ""
 #. Description of the 'Popover Element' (Check) field in DocType 'Form Tour
 #. Step'
 #: desk/doctype/form_tour_step/form_tour_step.json
-msgctxt "Form Tour Step"
 msgid "when clicked on element it will focus popover if present."
 msgstr ""
 
@@ -38713,13 +29506,11 @@ msgstr ""
 #. Option for the 'Permission Type' (Select) field in DocType 'Permission
 #. Inspector'
 #: core/doctype/permission_inspector/permission_inspector.json
-msgctxt "Permission Inspector"
 msgid "write"
 msgstr ""
 
 #. Option for the 'Indicator Color' (Select) field in DocType 'Workspace'
 #: desk/doctype/workspace/workspace.json
-msgctxt "Workspace"
 msgid "yellow"
 msgstr ""
 
@@ -38729,7 +29520,6 @@ msgstr ""
 
 #. Option for the 'Date Format' (Select) field in DocType 'System Settings'
 #: core/doctype/system_settings/system_settings.json
-msgctxt "System Settings"
 msgid "yyyy-mm-dd"
 msgstr ""
 
@@ -39159,15 +29949,15 @@ msgstr ""
 msgid "{0} is not a valid DocType for Dynamic Link"
 msgstr ""
 
-#: email/doctype/email_group/email_group.py:131 utils/__init__.py:190
+#: email/doctype/email_group/email_group.py:131 utils/__init__.py:199
 msgid "{0} is not a valid Email Address"
 msgstr ""
 
-#: utils/__init__.py:158
+#: utils/__init__.py:167
 msgid "{0} is not a valid Name"
 msgstr ""
 
-#: utils/__init__.py:137
+#: utils/__init__.py:146
 msgid "{0} is not a valid Phone Number"
 msgstr ""
 


### PR DESCRIPTION
The original idea was to create many translatable strings to allow granular translation. For example, the label "Sales Invoice" used in a **Payment Entry** and the same label "Sales Invoice" used in a **Delivery Note** would result in two separate translatable strings, with the DocType as the context.

This created many, many duplicate strings. If we want to translate all duplicate strings, we will exceed the string limits of most translation platforms. For this reason, we cannot effectively translate duplicates (with different contexts) on our current translation platform Crowdin. This also applies to strings that really require explicit context. Having many duplicate strings (with different contexts) makes the context feature useless, because we cannot use it to that extent with our translation platform. Also, 99% of these duplicates are not needed in reality.

So it seems best to remove this for now.

However, it is still possible to add a custom translation that overrides a label only for a specific doctype. This part of the code – using the doctype as the context for _fetching_ available translations – remains untouched (#24903).