### PR TITLE
fix: bulk_insert child tables malformed

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1745,12 +1745,12 @@ def bulk_insert(
 	for child_table in doctype_meta.get_table_fields():
 		valid_column_map[child_table.options] = frappe.get_meta(child_table.options).get_valid_columns()
 		values_map[child_table.options] = _document_values_generator(
-			(
+			[
 				ch_doc
 				for ch_doc in (
 					child_docs for doc in documents for child_docs in doc.get(child_table.fieldname)
 				)
-			),
+			],
 			valid_column_map[child_table.options],
 		)
 


### PR DESCRIPTION
Generator within generator caused something funky to happen which meant wrong values being stitched together as one document, sometimes(?)

Via https://github.com/frappe/frappe/pull/22114