### PR TITLE
fix(minor): check permission for ctrl+p shortcut

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -167,6 +167,7 @@ frappe.ui.form.Form = class FrappeForm {
 			shortcut: "ctrl+p",
 			action: () => this.print_doc(),
 			description: __("Print document"),
+			condition: () => frappe.model.can_print(this.doctype, this) && !this.meta.issingle,
 		});
 
 		let grid_shortcut_keys = [


### PR DESCRIPTION
#### Bug
The shortcut to open the print document view is currently not permission sensitive. Even though, the user has no print permissions on the document and the option doesn't show up in the toolbar or the dropdown menu, the user can still use `ctrl+p` to go to the print view.



#### Fix
Add condition to print shortcut to check permissions and type of document.