### PR TITLE
fix: query report filters

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1480,16 +1480,23 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	get_filters_html_for_print() {
 		const applied_filters = this.get_filter_values();
-		return Object.keys(applied_filters)
+		const filter_html = Object.keys(applied_filters)
 			.map((fieldname) => {
 				const docfield = frappe.query_report.get_filter(fieldname).df;
 				const value = applied_filters[fieldname];
-				return `<h6>${__(docfield.label, null, docfield.parent)}: ${frappe.format(
-					value,
-					docfield
-				)}</h6>`;
+				return `<div class="filter-row">
+					<b>${__(docfield.label, null, docfield.parent)}:</b> ${frappe.format(value, docfield)}
+				</div>`;
 			})
 			.join("");
+
+		return `<div>${filter_html}</div>
+			<style>
+				.filter-row div {
+					/* prevent newline + right alignment of number fields */
+					display: inline-block;
+				}
+			</style>`;
 	}
 
 	export_report() {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -1330,7 +1330,14 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 		raise && this.toggle_message(false);
 
 		return this.filters
-			.filter((f) => f.get_value())
+			.filter((f) => {
+				const filter_value = f.get_value();
+				if (typeof filter_value === "object") {
+					return filter_value.length > 0;
+				} else {
+					return filter_value;
+				}
+			})
 			.map((f) => {
 				var v = f.get_value();
 				// hidden fields dont have $input


### PR DESCRIPTION
- Don't add empty multiselect to filters object

    The convention is that if a filter is not set, then it does not exist in the dictionary. However, empty multiselects used to appear as an empty list, breaking this convention. Now we filter out empty lists just like other falsy values.

- Layout of printed report filters

    Thanks to the change above, empty multiselects will no longer get printed. Also, number values are no longer oddly on a new line and right aligned.

### Before

![Bildschirmfoto 2024-06-28 um 18 39 53](https://github.com/frappe/frappe/assets/14891507/ee04d463-e0cb-4708-86d5-4d920d25d9e8)

### After 

![Bildschirmfoto 2024-06-28 um 18 39 25](https://github.com/frappe/frappe/assets/14891507/38d2c1c9-f897-4abf-b5e4-2648d16f6caf)
