### PR TITLE
fix: make field labels translatable in Widget Dialog

### DIFF
--- a/frappe/public/js/frappe/widgets/widget_dialog.js
+++ b/frappe/public/js/frappe/widgets/widget_dialog.js
@@ -134,7 +134,7 @@ class ChartDialog extends WidgetDialog {
 			{
 				fieldtype: "Link",
 				fieldname: "chart_name",
-				label: "Chart Name",
+				label: __("Chart Name"),
 				options: "Dashboard Chart",
 				reqd: 1,
 			},
@@ -161,7 +161,7 @@ class QuickListDialog extends WidgetDialog {
 			{
 				fieldtype: "Link",
 				fieldname: "document_type",
-				label: "DocType",
+				label: __("DocType"),
 				options: "DocType",
 				reqd: 1,
 				onchange: () => {
@@ -184,7 +184,7 @@ class QuickListDialog extends WidgetDialog {
 			{
 				fieldtype: "Data",
 				fieldname: "label",
-				label: "Label",
+				label: __("Label"),
 			},
 			{
 				fieldtype: "Section Break",
@@ -233,7 +233,7 @@ class OnboardingDialog extends WidgetDialog {
 			{
 				fieldtype: "Link",
 				fieldname: "onboarding_name",
-				label: "Onboarding Name",
+				label: __("Onboarding Name"),
 				options: "Module Onboarding",
 				reqd: 1,
 			},
@@ -274,7 +274,7 @@ class CardDialog extends WidgetDialog {
 						fieldname: "link_type",
 						fieldtype: "Select",
 						in_list_view: 1,
-						label: "Link Type",
+						label: __("Link Type"),
 						reqd: 1,
 						options: ["DocType", "Page", "Report"],
 					},
@@ -282,7 +282,7 @@ class CardDialog extends WidgetDialog {
 						fieldname: "link_to",
 						fieldtype: "Dynamic Link",
 						in_list_view: 1,
-						label: "Link To",
+						label: __("Link To"),
 						reqd: 1,
 						get_options: (df) => {
 							return df.doc.link_type;
@@ -301,7 +301,7 @@ class CardDialog extends WidgetDialog {
 						fieldname: "label",
 						fieldtype: "Data",
 						in_list_view: 1,
-						label: "Label",
+						label: __("Label"),
 					},
 					{
 						fieldname: "icon",
@@ -315,25 +315,25 @@ class CardDialog extends WidgetDialog {
 					{
 						fieldname: "dependencies",
 						fieldtype: "Data",
-						label: "Dependencies",
+						label: __("Dependencies"),
 					},
 					{
 						fieldname: "only_for",
 						fieldtype: "Link",
-						label: "Only for",
+						label: __("Only for"),
 						options: "Country",
 					},
 					{
 						default: "0",
 						fieldname: "onboard",
 						fieldtype: "Check",
-						label: "Onboard",
+						label: __("Onboard"),
 					},
 					{
 						default: "0",
 						fieldname: "is_query_report",
 						fieldtype: "Check",
-						label: "Is Query Report",
+						label: __("Is Query Report"),
 					},
 				],
 			},
@@ -396,7 +396,7 @@ class ShortcutDialog extends WidgetDialog {
 			{
 				fieldtype: "Select",
 				fieldname: "type",
-				label: "Type",
+				label: __("Type"),
 				reqd: 1,
 				options: "DocType\nReport\nPage\nDashboard\nURL",
 				onchange: () => {
@@ -418,7 +418,7 @@ class ShortcutDialog extends WidgetDialog {
 			{
 				fieldtype: "Data",
 				fieldname: "label",
-				label: "Label",
+				label: __("Label"),
 			},
 			{
 				fieldtype: "Column Break",
@@ -427,7 +427,7 @@ class ShortcutDialog extends WidgetDialog {
 			{
 				fieldtype: "Dynamic Link",
 				fieldname: "link_to",
-				label: "Link To",
+				label: __("Link To"),
 				options: "type",
 				onchange: () => {
 					const doctype = this.dialog.get_value("link_to");
@@ -466,7 +466,7 @@ class ShortcutDialog extends WidgetDialog {
 			{
 				fieldtype: "Data",
 				fieldname: "url",
-				label: "URL",
+				label: __("URL"),
 				default: "",
 				depends_on: (s) => s.type == "URL",
 				mandatory_depends_on: (s) => s.type == "URL",
@@ -474,7 +474,7 @@ class ShortcutDialog extends WidgetDialog {
 			{
 				fieldtype: "Select",
 				fieldname: "doc_view",
-				label: "DocType View",
+				label: __("DocType View"),
 				options: "List\nReport Builder\nDashboard\nTree\nNew\nCalendar\nKanban\nImage",
 				description: __(
 					"Which view of the associated DocType should this shortcut take you to?"
@@ -506,7 +506,7 @@ class ShortcutDialog extends WidgetDialog {
 			{
 				fieldtype: "Link",
 				fieldname: "kanban_board",
-				label: "Kanban Board",
+				label: __("Kanban Board"),
 				options: "Kanban Board",
 				depends_on: () => {
 					let doc_view = this.dialog?.get_value("doc_view");


### PR DESCRIPTION
fix: translation in widget_dialog.js

