### PR TITLE
fix: translation in breadcrumbs.html

### DIFF
--- a/frappe/templates/includes/breadcrumbs.html
+++ b/frappe/templates/includes/breadcrumbs.html
@@ -14,7 +14,7 @@
 			{% endfor %}
 			<li itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem" class="breadcrumb-item active" aria-current="page">
 				<span itemprop="item">
-					<span itemprop="name">{{ title }}</span>
+					<span itemprop="name">{{ _(title) }}</span>
 					<meta itemprop="position" content="{{ count }}"/>
 				</span>
 			</li>


### PR DESCRIPTION
fix: translation in breadcrumbs.html

