### PR TITLE
fix(minor): TypeError for undefined columns in data import

### DIFF
--- a/frappe/core/doctype/data_import/data_import.js
+++ b/frappe/core/doctype/data_import/data_import.js
@@ -376,7 +376,7 @@ frappe.ui.form.on("Data Import", {
 		html += other_warnings
 			.map((warning) => {
 				let header = "";
-				if (warning.col) {
+				if (columns && warning.col) {
 					let column_number = `<span class="text-uppercase">${__("Column {0}", [
 						warning.col,
 					])}</span>`;


### PR DESCRIPTION
Columns initialised with the preview data columns can be `undefined` leading to a TypeError on -

https://github.com/frappe/frappe/blob/8735244f9c4f999bfc9f101a3f6854dbe789d34f/frappe/core/doctype/data_import/data_import.js#L383