### PR TITLE
fix: clear doctype cache for tree doctype on modification

### DIFF
--- a/frappe/utils/nestedset.py
+++ b/frappe/utils/nestedset.py
@@ -59,6 +59,7 @@ def update_nsm(doc):
 	# set old parent
 	doc.set(old_parent_field, parent)
 	frappe.db.set_value(doc.doctype, doc.name, old_parent_field, parent or "", update_modified=False)
+	frappe.clear_document_cache(doc.doctype)
 
 	doc.reload()
 
@@ -251,6 +252,8 @@ def remove_subtree(doctype: str, name: str, throw=True):
 	table = frappe.qb.DocType(doctype)
 	frappe.qb.update(table).set(table.lft, table.lft - width).where(table.lft > rgt).run()
 	frappe.qb.update(table).set(table.rgt, table.rgt - width).where(table.rgt > rgt).run()
+
+	frappe.clear_document_cache(doctype)
 
 
 class NestedSet(Document):


### PR DESCRIPTION
Issue:
On Addition/Deletion of doc in Tree Doctype, all the node's positions change but in the cache old positions are set.

Solution:
Clear cache for Tree doctype every time on modification of structure.

closes: https://github.com/frappe/erpnext/issues/41858
closes: https://github.com/frappe/erpnext/issues/41125

Frappe Support Issue:
- https://support.frappe.io/app/hd-ticket/16587
- https://support.frappe.io/app/hd-ticket/17951
- https://support.frappe.io/app/hd-ticket/17346
- https://support.frappe.io/app/hd-ticket/17583
- https://support.frappe.io/app/hd-ticket/17302
- https://support.frappe.io/app/hd-ticket/17276
- https://support.frappe.io/app/hd-ticket/16905
- https://support.frappe.io/app/hd-ticket/15544

