### PR TITLE
fix: deterministic order in exported customizations

### DIFF
--- a/frappe/modules/utils.py
+++ b/frappe/modules/utils.py
@@ -64,16 +64,24 @@ def export_customizations(
 		frappe.throw(_("Only allowed to export customizations in developer mode"))
 
 	custom = {
-		"custom_fields": frappe.get_all("Custom Field", fields="*", filters={"dt": doctype}),
-		"property_setters": frappe.get_all("Property Setter", fields="*", filters={"doc_type": doctype}),
+		"custom_fields": frappe.get_all(
+			"Custom Field", fields="*", filters={"dt": doctype}, order_by="creation asc"
+		),
+		"property_setters": frappe.get_all(
+			"Property Setter", fields="*", filters={"doc_type": doctype}, order_by="creation asc"
+		),
 		"custom_perms": [],
-		"links": frappe.get_all("DocType Link", fields="*", filters={"parent": doctype}),
+		"links": frappe.get_all(
+			"DocType Link", fields="*", filters={"parent": doctype}, order_by="creation asc"
+		),
 		"doctype": doctype,
 		"sync_on_migrate": sync_on_migrate,
 	}
 
 	if with_permissions:
-		custom["custom_perms"] = frappe.get_all("Custom DocPerm", fields="*", filters={"parent": doctype})
+		custom["custom_perms"] = frappe.get_all(
+			"Custom DocPerm", fields="*", filters={"parent": doctype}, order_by="creation asc"
+		)
 
 	# also update the custom fields and property setters for all child tables
 	for d in frappe.get_meta(doctype).get_table_fields():


### PR DESCRIPTION
Adds `order_by="creation asc"` to the queries for exporting customizations.

The goal is to avoid unnecessarily large diffs. For example, changing the `reqd` property of a field just caused me a 200 line diff, because the order of all existing property setters got mixed. (The property setters' `modified` changes for all property setters on every change. In <= v15, the default sort order is `modified desc`.)

This change will likely cause one larger diff on the first export and small ones going ahead. This improves the current situation of a big diff every time.