### PR TITLE
fix(quick_list_widget): ensure that the user has create permissions before showing a create button

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -19,7 +19,9 @@ export default class QuickListWidget extends Widget {
 	set_actions() {
 		if (this.in_customize_mode) return;
 
-		this.setup_add_new_button();
+		if (frappe.model.can_create(this.document_type)) {
+			this.setup_add_new_button();
+		}
 		this.setup_refresh_list_button();
 		this.setup_filter_list_button();
 	}
@@ -27,7 +29,7 @@ export default class QuickListWidget extends Widget {
 	setup_add_new_button() {
 		this.add_new_button = $(
 			`<div class="add-new btn btn-xs pull-right"
-			title="${__("Add New")}  ${__(this.document_type)}
+			title="${__("Add New")} ${__(this.document_type)}
 			">
 				${frappe.utils.icon("add", "sm")}
 			</div>`


### PR DESCRIPTION
Users who don't have create permissions on a doctype were also being shown the add new button
Reference: support ticket 18098

Also remove an extra whitespace after `Add New`

<hr>
Previously

![image](https://github.com/frappe/frappe/assets/10119037/043a6448-932a-444e-91a7-de8a042b4d44)


<hr>
Now

![image](https://github.com/frappe/frappe/assets/10119037/29eea722-489f-473f-a330-9afcadffc5bd)


