### PR TITLE
fix: email record linking via rfc5233 & rfc5322

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -605,16 +605,19 @@ def parse_email(email_strings):
 			user, detail = None, None
 			if "+" in local_part:
 				user, detail = local_part.split("+", 1)
-			if "--" in local_part:
+			elif "--" in local_part:
 				detail, user = local_part.rsplit("--", 1)
 
+			if not detail:
+				continue
+
 			document_parts = None
-			if detail and "=" in detail:
+			if "=" in detail:
 				document_parts = detail.split("=", 1)
-			elif detail and "+" in detail:
+			elif "+" in detail:
 				document_parts = detail.split("+", 1)
 
-			if not document_parts or not len(document_parts) != 2:
+			if not document_parts or len(document_parts) != 2:
 				continue
 
 			doctype = unquote_plus(document_parts[0])

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -593,47 +593,59 @@ def parse_email(email_strings):
 	When automatic email linking is enabled, an email from email_strings can contain
 	a doctype and docname ie in the format `admin+doctype+docname@example.com` or `admin+doctype=docname@example.com`,
 	the email is parsed and doctype and docname is extracted.
+
+	see: RFC5233
 	"""
 	for email_string in email_strings:
 		if not email_string:
 			continue
 
 		for email in email_string.split(","):
-			email_username = email.split("@", 1)[0]
-			email_local_parts = email_username.split("+")
-			docname = doctype = None
-			if len(email_local_parts) == 3:
-				doctype = unquote(email_local_parts[1])
-				docname = unquote(email_local_parts[2])
+			local_part = email.split("@", 1)[0].strip('"')
+			user, detail = None, None
+			if "+" in local_part:
+				user, detail = local_part.split("+", 1)
+			if "--" in local_part:
+				detail, user = local_part.rsplit("--", 1)
 
-			elif len(email_local_parts) == 2:
-				document_parts = email_local_parts[1].split("=", 1)
-				if len(document_parts) != 2:
-					continue
+			document_parts = None
+			if detail and "+" in detail:
+				document_parts = detail.split("+", 1)
+			elif detail:
+				document_parts = detail.split("=", 1)
 
-				doctype = unquote(document_parts[0])
-				docname = unquote(document_parts[1])
+			if not document_parts or not len(document_parts) != 2:
+				continue
 
-			if doctype and docname:
-				yield doctype, docname
+			doctype = unquote(document_parts[0])
+			docname = unquote(document_parts[1])
+			yield doctype, docname
 
 
 def get_email_without_link(email):
 	"""Return email address without doctype links.
 
 	e.g. 'admin@example.com' is returned for email 'admin+doctype+docname@example.com'
+
+	see: RFC5233
 	"""
 	if not frappe.get_all("Email Account", filters={"enable_automatic_linking": 1}):
 		return email
 
 	try:
 		_email = email.split("@")
-		email_id = _email[0].split("+", 1)[0]
-		email_host = _email[1]
+		_local_part = _email[0].strip('"')
+		if "+" in _local_part:
+			user = _local_part.split("+", 1)[0]
+		elif "--" in _local_part:
+			user = _local_part.split("--", 1)[1]
+		else:
+			user = _local_part
+		domain = _email[1]
 	except IndexError:
 		return email
 
-	return f"{email_id}@{email_host}"
+	return f"{user}@{domain}"
 
 
 def update_parent_document_on_communication(doc):

--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -3,7 +3,7 @@
 
 from collections import Counter
 from email.utils import getaddresses
-from urllib.parse import unquote
+from urllib.parse import unquote_plus
 
 from bs4 import BeautifulSoup
 
@@ -609,16 +609,16 @@ def parse_email(email_strings):
 				detail, user = local_part.rsplit("--", 1)
 
 			document_parts = None
-			if detail and "+" in detail:
-				document_parts = detail.split("+", 1)
-			elif detail:
+			if detail and "=" in detail:
 				document_parts = detail.split("=", 1)
+			elif detail and "+" in detail:
+				document_parts = detail.split("+", 1)
 
 			if not document_parts or not len(document_parts) != 2:
 				continue
 
-			doctype = unquote(document_parts[0])
-			docname = unquote(document_parts[1])
+			doctype = unquote_plus(document_parts[0])
+			docname = unquote_plus(document_parts[1])
 			yield doctype, docname
 
 

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -222,11 +222,19 @@ class TestCommunication(FrappeTestCase):
 		to = "Jon Doe <jon.doe@example.org>"
 		cc = """=?UTF-8?Q?Max_Mu=C3=9F?= <max.muss@examle.org>,
 	erp+Customer=Plus%2BCompany@example.org,
-	erp+Customer+Space%20Company@example.org"""
+	erp+Customer+Space%20Company@example.org,
+	erp+Customer+Space+Company+Plus+Encoded@example.org"""
 		bcc = ""
 
 		results = list(parse_email([to, cc, bcc]))
-		self.assertEqual([("Customer", "Plus+Company"), ("Customer", "Space Company")], results)
+		self.assertEqual(
+			[
+				("Customer", "Plus+Company"),
+				("Customer", "Space Company"),
+				("Customer", "Space Company Plus Encoded"),
+			],
+			results,
+		)
 
 		results = list(parse_email([to, bcc]))
 		self.assertEqual(results, [])

--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -221,11 +221,12 @@ class TestCommunication(FrappeTestCase):
 	def test_parse_email(self):
 		to = "Jon Doe <jon.doe@example.org>"
 		cc = """=?UTF-8?Q?Max_Mu=C3=9F?= <max.muss@examle.org>,
-	erp+Customer+that%20company@example.org"""
+	erp+Customer=Plus%2BCompany@example.org,
+	erp+Customer+Space%20Company@example.org"""
 		bcc = ""
 
 		results = list(parse_email([to, cc, bcc]))
-		self.assertEqual([("Customer", "that company")], results)
+		self.assertEqual([("Customer", "Plus+Company"), ("Customer", "Space Company")], results)
 
 		results = list(parse_email([to, bcc]))
 		self.assertEqual(results, [])

--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -3,7 +3,7 @@
 
 import json
 import typing
-from urllib.parse import quote
+from urllib.parse import quote_plus
 
 import frappe
 import frappe.defaults
@@ -384,7 +384,7 @@ def get_document_email(doctype, name):
 		return None
 
 	email = email.split("@")
-	return f"{email[0]}+{quote(doctype)}={quote(cstr(name))}@{email[1]}"
+	return f"{email[0]}+{quote_plus(doctype)}={quote_plus(cstr(name))}@{email[1]}"
 
 
 def get_automatic_email_link():


### PR DESCRIPTION
# Context

- RFC5322
- RFC5233

# Implementation
- Adds receiving support for `:detail -- :user` in addition to `:user + :detail`
- Adds receiving support for quoted local parts `"Foo Bar"@domain` (by a simple `.strip('"')`)
- Uses more widely supported Plus Quoting for spaces when encoding document emails (otherwise seems not to work with Migadu)

# Email Address Handling Updates

## Unchanged
- Supports existing formats:
  - `erp+Customer+Space%20Company@example.org`
  - `erp+Customer=Plus%2BCompany@example.org`

## New Features
- RFC-compliant format: `Customer=Plus%2BCompany--erp@example.org`
- Improved compatibility: Plus encoding
  - Format: `user+doctype=docname+with+spaces@example.com`
  - `+`: user/detail separator, then space placeholder
  - `=`: doctype/docname separator
  
## Rationale
- Some mail servers mishandle `%2B` in local-part
- New encoding reduces roundtrip errors in our specialized addresses
- Improves success rate and compatibility (e.g. Migadu)
