### PR TITLE
fix(grid): TypeError from undefined return value

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -1075,7 +1075,7 @@ export default class Grid {
 
 	setup_allow_bulk_edit() {
 		let me = this;
-		if (this.frm && this.frm.get_docfield(this.df.fieldname).allow_bulk_edit) {
+		if (this.frm && this.frm.get_docfield(this.df.fieldname)?.allow_bulk_edit) {
 			// download
 			this.setup_download();
 


### PR DESCRIPTION
Sentry: FRAPPE-634

TypeError: this.frm.get_docfield(...) is undefined
  at Grid.setup_allow_bulk_edit(../../../../../apps/frappe/frappe/public/js/frappe/form/grid.js:1073:28)
  at Grid.make(../../../../../apps/frappe/frappe/public/js/frappe/form/grid.js:138:8)
  at Grid.refresh(../../../../../apps/frappe/frappe/public/js/frappe/form/grid.js:399:25)
  at frappe.ui.form.ControlTablerefresh_input(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/table.js:141:13)
  at frappe.ui.form.Controlrefresh(../../../../../apps/frappe/frappe/public/js/frappe/form/controls/base_control.js:140:9)
  at frappe.ui.form.Layoutattach_doc_and_docfields(../../../../../apps/frappe/frappe/public/js/frappe/form/layout.js:480:59)
  at frappe.ui.form.Layoutrefresh(../../../../../apps/frappe/frappe/public/js/frappe/form/layout.js:342:8)
  at GridRowForm.render(../../../../../apps/frappe/frappe/public/js/frappe/form/grid_row_form.js:26:15)
  at GridRow.show_form(../../../../../apps/frappe/frappe/public/js/frappe/form/grid_row.js:1328:18)
  at GridRow.toggle_view(../../../../../apps/frappe/frappe/public/js/frappe/form/grid_row.js:1310:9)
  at this.open_form_button(../../../../../apps/frappe/frappe/public/js/frappe/form/grid_row.js:346:11)
  at jQuery.event.dispatch(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:5135:27)
  at elemData.handle(../../../../../apps/frappe/node_modules/jquery/dist/jquery.js:4939:28)
  at sentryWrapped(../../../../../apps/frappe/node_modules/src/helpers.ts:98:1)

