### PR TITLE
feat: doctype casting

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -24,7 +24,7 @@ import sys
 import traceback
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, overload
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union, overload
 
 import click
 from werkzeug.local import Local, release_local
@@ -1085,6 +1085,12 @@ def only_has_select_perm(doctype, user=None, ignore_permissions=False):
 	return permissions.get("select") and not permissions.get("read")
 
 
+def requires_permission(*args):
+	from frappe.permissions import requires_permission
+
+	return requires_permission(*args)
+
+
 def has_permission(
 	doctype=None,
 	ptype="read",
@@ -1215,20 +1221,90 @@ def new_doc(
 	as_dict: bool = False,
 	**kwargs,
 ) -> "Document":
-	"""Return a new document of the given DocType with defaults set.
-
-	:param doctype: DocType of the new document.
-	:param parent_doc: [optional] add to parent document.
-	:param parentfield: [optional] add against this `parentfield`.
-	:param as_dict: [optional] return as dictionary instead of Document.
-	:param kwargs: [optional] You can specify fields as field=value pairs in function call.
 	"""
+	Creates and returns a new document of the specified DocType with defaults set.
 
-	from frappe.model.create_new import get_new_doc
+	This function initializes a new document, sets default values, and optionally
+	adds it to a parent document or updates it with provided field values.
 
-	new_doc = get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
+	Args:
+	    doctype (str): The DocType of the new document to be created.
+	    parent_doc (Optional[Document]): If provided, the new document will be added
+	        as a child to this parent document.
+	    parentfield (Optional[str]): The name of the table field in the parent document
+	        where the new document should be added. Required if parent_doc is specified.
+	    as_dict (bool): If True, returns the document as a dictionary instead of a Document object.
+	    **kwargs: Additional fields and their values to be set in the new document.
+
+	Returns:
+	    Document | dict: A new document of the specified DocType, either as a Document object
+	    or as a dictionary, depending on the 'as_dict' parameter.
+
+	Examples:
+	    >>> new_doc("Task")
+	    >>> new_doc("Task", subject="New Task", description="This is a new task")
+	    >>> new_doc("Task Item", parent_doc=project_doc, parentfield="tasks")
+	"""
+	from frappe.model.document import Document
+
+	new_doc = Document.new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
 
 	return new_doc.update(kwargs)
+
+
+_SourceDoc: TypeAlias = Union[str, "Document"]
+
+
+@overload
+def new_doc_from(
+	doctype: str, source_doc: str, source_name: str, whitelist_permissions: bool = False
+) -> "Document":
+	...
+
+
+@overload
+def new_doc_from(
+	doctype: str, source_doc: "Document", source_name: Literal[""], whitelist_permissions: bool = False
+) -> "Document":
+	...
+
+
+def new_doc_from(
+	doctype: str, source_doc: _SourceDoc, source_name: str = "", whitelist_permissions: bool = False
+) -> "Document":
+	"""
+	Create a new document of 'doctype' from an existing document of 'source_doc'.
+
+	This function attempts to convert an existing document into a new document of a different DocType.
+	It uses conversion methods defined in either the source or target DocType.
+
+	Args:
+	    doctype (str): The DocType of the new document to be created.
+	    source_doc (str | Document): The DocType of the existing document to convert from,
+	        or the Document instance itself.
+	    source_name (str, optional): The name (ID) of the existing document to convert from.
+	        Not required if source_doc is a Document instance.
+	    whitelist_permissions (bool, optional): If True, ignores checks for declared permissions during the conversion.
+	        Defaults to False.
+
+	Returns:
+	    Document: A new document of 'doctype' with data converted from the source document.
+
+	Raises:
+	    NotImplementedError: If no suitable conversion method is found in either DocType.
+
+	Examples:
+	    >>> new_doc_from("Sales Invoice", "Sales Order", "SO-0001")
+	    >>> new_doc_from("Delivery Note", "Sales Invoice", "INV-0001")
+	>>> source_doc = frappe.get_doc("Sales Order", "SO-0001")
+	>>> new_doc_from("Sales Invoice", source_doc)
+
+	Note:
+	    This function requires either a '_from_*' method in the target DocType or
+	    an '_into_*' method in the source DocType to perform the conversion.
+	"""
+	doc = new_doc(doctype)
+	return doc.from_doc(source_doc, source_name, whitelist_permissions=whitelist_permissions)
 
 
 def set_value(doctype, docname, fieldname, value=None):

--- a/frappe/exceptions.py
+++ b/frappe/exceptions.py
@@ -11,6 +11,12 @@ class SiteNotSpecifiedError(Exception):
 		super(Exception, self).__init__(self.message)
 
 
+class DatabaseModificationError(Exception):
+	"""Error raised when attempting to modify the database in a read-only document context."""
+
+	pass
+
+
 class UrlSchemeNotSupported(Exception):
 	pass
 

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -249,9 +249,11 @@ class Document(BaseDocument):
 
 		# All methods use @frappe.require_permission, handling whitelist_permissions
 		if hasattr(self, from_converter_method):
-			getattr(self, from_converter_method)(source_doc, whitelist_permissions=whitelist_permissions)
+			with read_only_document():
+				getattr(self, from_converter_method)(source_doc, whitelist_permissions=whitelist_permissions)
 		elif hasattr(source_doc, into_converter_method):
-			getattr(source_doc, into_converter_method)(self, whitelist_permissions=whitelist_permissions)
+			with read_only_document():
+				getattr(source_doc, into_converter_method)(self, whitelist_permissions=whitelist_permissions)
 		else:
 			frappe.throw(
 				_(
@@ -292,9 +294,11 @@ class Document(BaseDocument):
 
 		# All methods use @frappe.require_permission, handling whitelist_permissions
 		if hasattr(self, into_converter_method):
-			getattr(self, into_converter_method)(new_doc, whitelist_permissions=whitelist_permissions)
+			with read_only_document():
+				getattr(self, into_converter_method)(new_doc, whitelist_permissions=whitelist_permissions)
 		elif hasattr(new_doc, from_converter_method):
-			getattr(new_doc, from_converter_method)(self, whitelist_permissions=whitelist_permissions)
+			with read_only_document():
+				getattr(new_doc, from_converter_method)(self, whitelist_permissions=whitelist_permissions)
 		else:
 			frappe.throw(
 				_(

--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import time
 from collections.abc import Generator, Iterable
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeAlias, Union, overload
 
 from werkzeug.exceptions import NotFound
 
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
 DOCUMENT_LOCK_EXPIRTY = 12 * 60 * 60  # All locks expire in 12 hours automatically
 DOCUMENT_LOCK_SOFT_EXPIRY = 60 * 60  # Let users force-unlock after 60 minutes
+
+_SourceDoc: TypeAlias = Union[str, "Document"]
 
 
 def get_doc(*args, **kwargs):
@@ -141,6 +143,132 @@ class Document(BaseDocument):
 		else:
 			# incorrect arguments. let's not proceed.
 			raise ValueError("Illegal arguments")
+
+	@staticmethod
+	def new_doc(doctype, parent_doc=None, parentfield=None, as_dict=False):
+		"""
+		Creates and returns a new document of the specified DocType with defaults set.
+
+		Args:
+		    doctype (str): The DocType of the new document to be created.
+		    parent_doc (Document, optional): Parent document for child DocTypes.
+		    parentfield (str, optional): The parentfield for child DocTypes.
+		    as_dict (bool, optional): If True, returns the document as a dict.
+
+		Returns:
+		    Document or dict: A new document of the specified DocType.
+		"""
+		from frappe.model.create_new import get_new_doc
+
+		return get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
+
+	@overload
+	def from_doc(self, source_doc: str, source_name: str, whitelist_permissions: bool = False) -> "Document":
+		...
+
+	@overload
+	def from_doc(
+		self, source_doc: "Document", source_name: Literal[""], whitelist_permissions: bool = False
+	) -> "Document":
+		...
+
+	def from_doc(
+		self, source_doc: _SourceDoc, source_name: str = "", whitelist_permissions: bool = False
+	) -> "Document":
+		"""
+		Create a new document of 'doctype' from an existing document of 'source_doc'.
+		This method attempts to use conversion methods in the following order:
+		1. The new document's '_from_*' method
+		2. The source document's '_into_*' method
+
+		If neither method is found, it raises an exception.
+
+		Args:
+		    source_doc (str | Document): The DocType of the source document,
+		        or the Document instance itself.
+		    source_name (str, optional): The name (ID) of the source document.
+		        Not required if source_doc is a Document instance.
+		    whitelist_permissions (bool, optional): If True, ignores checks for declared permissions during the conversion.
+		        Defaults to False.
+
+		Returns:
+		    Document: The current document updated with data converted from the source document.
+
+		Raises:
+		    NotImplementedError: If no suitable conversion method is found.
+
+		Example:
+		    >>> target_doc = frappe.get_doc("Sales Invoice", "INV-0001")
+		    >>> updated_doc = target_doc.from_doc("Sales Order", "SO-0001")
+		    >>> # Or using a Document instance
+		    >>> source_doc = frappe.get_doc("Sales Order", "SO-0001")
+		    >>> updated_doc = target_doc.from_doc(source_doc)
+		"""
+		if isinstance(source_doc, Document):
+			source_doctype = source_doc.doctype
+		else:
+			source_doctype = source_doc
+			source_doc = frappe.get_doc(source_doctype, source_name)
+
+		from_converter_method = f"_from_{frappe.scrub(source_doctype)}"
+		into_converter_method = f"_into_{frappe.scrub(self.doctype)}"
+
+		# All methods use @frappe.require_permission, handling whitelist_permissions
+		if hasattr(self, from_converter_method):
+			getattr(self, from_converter_method)(source_doc, whitelist_permissions=whitelist_permissions)
+		elif hasattr(source_doc, into_converter_method):
+			getattr(source_doc, into_converter_method)(self, whitelist_permissions=whitelist_permissions)
+		else:
+			frappe.throw(
+				_(
+					"No conversion method found. {0} does not implement '{1}', and {2} does not implement '{3}'."
+				).format(self.doctype, from_converter_method, source_doctype, into_converter_method),
+				NotImplementedError,
+			)
+
+		return self
+
+	def into(self, target_doctype: str, whitelist_permissions: bool = False):
+		"""
+		Convert this document into a new document of 'target_doctype'.
+		This method attempts to use conversion methods in the following order:
+		1. The current document's '_into_*' method
+		2. The target document's '_from_*' method
+
+		If neither method is found, it raises a NotImplementedError.
+
+		Args:
+		    target_doctype (str): The DocType of the new document to be created.
+		    whitelist_permissions (bool, optional): If True, ignores checks for declared permissions during the conversion.
+		        Defaults to False.
+
+		Returns:
+		    Document: A new document of 'target_doctype' with data converted from the current document.
+
+		Raises:
+		    NotImplementedError: If no suitable conversion method is found.
+
+		Example:
+		    >>> sales_order = frappe.get_doc("Sales Order", "SO-0001")
+		    >>> invoice = sales_order.into("Sales Invoice")
+		"""
+		new_doc = frappe.new_doc(target_doctype)
+		into_converter_method = f"_into_{frappe.scrub(target_doctype)}"
+		from_converter_method = f"_from_{frappe.scrub(self.doctype)}"
+
+		# All methods use @frappe.require_permission, handling whitelist_permissions
+		if hasattr(self, into_converter_method):
+			getattr(self, into_converter_method)(new_doc, whitelist_permissions=whitelist_permissions)
+		elif hasattr(new_doc, from_converter_method):
+			getattr(new_doc, from_converter_method)(self, whitelist_permissions=whitelist_permissions)
+		else:
+			frappe.throw(
+				_(
+					"No conversion method found. {0} does not implement '{1}', and {2} does not implement '{3}'."
+				).format(self.doctype, into_converter_method, target_doctype, from_converter_method),
+				NotImplementedError,
+			)
+		return new_doc
 
 	@property
 	def is_locked(self):

--- a/frappe/tests/test_document_casting.py
+++ b/frappe/tests/test_document_casting.py
@@ -1,0 +1,292 @@
+import types
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import frappe
+from frappe.model.document import Document
+from frappe.permissions import FUNC_CLOSURE_PERMISSION_REQUIREMENTS, requires_permission
+
+
+def create_test_doctypes():
+	if not frappe.db.exists("DocType", "TestDocType"):
+		frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "TestDocType",
+				"module": "Custom",
+				"custom": 1,
+				"fields": [{"fieldname": "test_field", "fieldtype": "Data"}],
+			}
+		).insert()
+
+	if not frappe.db.exists("DocType", "SourceDocType"):
+		frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "SourceDocType",
+				"module": "Custom",
+				"custom": 1,
+				"fields": [{"fieldname": "source_field", "fieldtype": "Data"}],
+			}
+		).insert()
+
+	if not frappe.db.exists("DocType", "TargetDocType"):
+		frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "TargetDocType",
+				"module": "Custom",
+				"custom": 1,
+				"fields": [{"fieldname": "target_field", "fieldtype": "Data"}],
+			}
+		).insert()
+
+
+class WithTestDocuments(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		create_test_doctypes()
+
+	def setUp(self):
+		self.source_doc = frappe.new_doc(
+			"SourceDocType",
+			**{
+				"name": "SOURCE-001",
+				"source_field": "source value",
+			},
+		).insert()
+		self.test_doc = frappe.new_doc(
+			"TestDocType",
+			**{
+				"name": "TEST-001",
+				"test_field": "test value",
+			},
+		).insert()
+		self.target_doc = frappe.new_doc(
+			"TargetDocType",
+			**{
+				"name": "TARGET-001",
+				"target_field": "target value",
+			},
+		).insert()
+		frappe.db.commit()
+		# Mock the conversion methods
+		self.source_doc._into_testdoctype = MagicMock()
+		self.test_doc._from_sourcedoctype = MagicMock()
+		self.test_doc._into_targetdoctype = MagicMock()
+		self.target_doc._from_testdoctype = MagicMock()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		for doctype in ["TestDocType", "SourceDocType", "TargetDocType"]:
+			frappe.db.delete(doctype)
+			frappe.db.commit()
+		# Custom Doctypes have no dedicated classes
+		if hasattr(Document, "_into_testdoctype"):
+			del Document._into_testdoctype
+		if hasattr(Document, "_from_sourcedoctype"):
+			del Document._from_sourcedoctype
+		if hasattr(Document, "_into_targetdoctype"):
+			del Document._into_targetdoctype
+		if hasattr(Document, "_from_testdoctype"):
+			del Document._from_testdoctype
+
+
+class TestDocumentCaster(WithTestDocuments):
+	# Tests for from_doc method
+	@patch("frappe.get_doc")
+	def test_from_doc_with_from_method(self, mock_get_doc):
+		mock_get_doc.return_value = self.source_doc
+		self.test_doc.from_doc("SourceDocType", "SOURCE-001")
+		self.test_doc._from_sourcedoctype.assert_called_once_with(
+			self.source_doc, whitelist_permissions=False
+		)
+
+	@patch("frappe.get_doc")
+	def test_from_doc_with_into_method(self, mock_get_doc):
+		mock_get_doc.return_value = self.source_doc
+		# Remove existing preferenctial conversion method
+		del self.test_doc._from_sourcedoctype
+		self.test_doc.from_doc("SourceDocType", "SOURCE-001")
+		self.source_doc._into_testdoctype.assert_called_once_with(self.test_doc, whitelist_permissions=False)
+
+	@patch("frappe.get_doc")
+	def test_from_doc_no_conversion_method(self, mock_get_doc):
+		mock_get_doc.return_value = self.source_doc
+		# Remove any existing conversion methods
+		del self.test_doc._from_sourcedoctype
+		del self.source_doc._into_testdoctype
+
+		with self.assertRaises(NotImplementedError) as context:
+			self.test_doc.from_doc("SourceDocType", "SOURCE-001")
+
+		self.assertIn("No conversion method found", str(context.exception))
+		self.assertIn("TestDocType does not implement '_from_sourcedoctype'", str(context.exception))
+		self.assertIn("SourceDocType does not implement '_into_testdoctype'", str(context.exception))
+
+	@patch("frappe.get_doc")
+	def test_from_doc_whitelist_permissions(self, mock_get_doc):
+		mock_get_doc.return_value = self.source_doc
+		self.test_doc.from_doc("SourceDocType", "SOURCE-001", whitelist_permissions=True)
+		self.test_doc._from_sourcedoctype.assert_called_once_with(self.source_doc, whitelist_permissions=True)
+
+	# Tests for into method
+	@patch("frappe.get_doc")
+	def test_into_with_into_method(self, mock_get_doc):
+		mock_get_doc.return_value = self.target_doc
+		result = self.test_doc.into("TargetDocType")
+		self.assertIsInstance(result, Document)
+		self.assertEqual(result.doctype, "TargetDocType")
+		self.test_doc._into_targetdoctype.assert_called_once_with(
+			self.target_doc, whitelist_permissions=False
+		)
+
+	@patch("frappe.get_doc")
+	def test_into_with_from_method(self, mock_get_doc):
+		mock_get_doc.return_value = self.target_doc
+		# Remove existing preferenctial conversion method
+		del self.test_doc._into_targetdoctype
+		result = self.test_doc.into("TargetDocType")
+		self.assertIsInstance(result, Document)
+		self.assertEqual(result.doctype, "TargetDocType")
+		self.target_doc._from_testdoctype.assert_called_once_with(self.test_doc, whitelist_permissions=False)
+
+	def test_into_no_conversion_method(self):
+		# Remove any existing conversion methods
+		if hasattr(self.target_doc, "_from_testdoctype"):
+			del self.target_doc._from_testdoctype
+		if hasattr(self.test_doc, "_into_targetdoctype"):
+			del self.test_doc._into_targetdoctype
+
+		with self.assertRaises(NotImplementedError) as context:
+			self.test_doc.into("TargetDocType")
+
+		self.assertIn("No conversion method found", str(context.exception))
+		self.assertIn("TestDocType does not implement '_into_targetdoctype'", str(context.exception))
+		self.assertIn("TargetDocType does not implement '_from_testdoctype'", str(context.exception))
+
+	@patch("frappe.get_doc")
+	def test_into_whitelist_permissions(self, mock_get_doc):
+		mock_get_doc.return_value = self.target_doc
+		result = self.test_doc.into("TargetDocType", whitelist_permissions=True)
+		self.assertIsInstance(result, Document)
+		self.assertEqual(result.doctype, "TargetDocType")
+		self.test_doc._into_targetdoctype.assert_called_once_with(result, whitelist_permissions=True)
+
+
+class TestDocCastingFlow(WithTestDocuments):
+	def test_new_doc_from(self):
+		def _from_sourcedoctype(self, source_doc, whitelist_permissions=False):
+			# This side effect will set a custom attribute on the target document
+			self.test_field = source_doc.source_field
+
+		Document._from_sourcedoctype = _from_sourcedoctype
+		# doctype + docname calling convention
+		result = frappe.new_doc_from("TestDocType", "SourceDocType", self.source_doc.name)
+		self.assertEqual(result.doctype, "TestDocType")
+		self.assertEqual(result.test_field, self.source_doc.source_field)
+
+		# doc instance calling convention
+		result = frappe.new_doc_from("TestDocType", self.source_doc)
+		self.assertEqual(result.doctype, "TestDocType")
+		self.assertEqual(result.test_field, self.source_doc.source_field)
+
+	def test_doc_from_doc(self):
+		def _from_sourcedoctype(self, source_doc, whitelist_permissions=False):
+			# This side effect will set a custom attribute on the target document
+			self.test_field = source_doc.source_field
+
+		self.test_doc._from_sourcedoctype = types.MethodType(_from_sourcedoctype, self.test_doc)
+		# doctype + docname calling convention
+		result = self.test_doc.from_doc("SourceDocType", self.source_doc.name)
+		self.assertEqual(result.doctype, "TestDocType")
+		self.assertEqual(result.test_field, self.source_doc.source_field)
+
+		# doc instance calling convention
+		result = self.test_doc.from_doc(self.source_doc)
+		self.assertEqual(result.doctype, "TestDocType")
+		self.assertEqual(result.test_field, self.source_doc.source_field)
+
+	def test_doc_into(self):
+		def _into_targetdoctype(self, target_doc, whitelist_permissions=False):
+			# This side effect will set a custom attribute on the target document
+			target_doc.target_field = self.test_field
+
+		self.test_doc._into_targetdoctype = types.MethodType(_into_targetdoctype, self.test_doc)
+		result = self.test_doc.into("TargetDocType")
+		self.assertEqual(result.doctype, "TargetDocType")
+		self.assertEqual(result.target_field, self.test_doc.test_field)
+
+
+class TestRequiresPermission(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		create_test_doctypes()
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		FUNC_CLOSURE_PERMISSION_REQUIREMENTS.clear()
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		FUNC_CLOSURE_PERMISSION_REQUIREMENTS.clear()
+
+	def test_single_permission_requirement(self):
+		@requires_permission("TestDocType", "read")
+		def test_func():
+			return "Success"
+
+		self.assertEqual(test_func(), "Success")
+
+	def test_multiple_permission_requirements(self):
+		@requires_permission("TestDocType", "read")
+		@requires_permission("TestDocType", "write")
+		def test_func():
+			return "Success"
+
+		self.assertEqual(test_func(), "Success")
+
+	def test_list_permission_requirements(self):
+		@requires_permission([("TestDocType", "read"), ("TestDocType", "write")])
+		def test_func():
+			return "Success"
+
+		self.assertEqual(test_func(), "Success")
+
+	def test_permission_denied(self):
+		@requires_permission("TestDocType", "delete")
+		def test_func():
+			return "Success"
+
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError):
+			test_func()
+
+	def test_whitelist_permissions(self):
+		@requires_permission("TestDocType", "delete")
+		def test_func():
+			return "Success"
+
+		frappe.set_user("Guest")
+		self.assertEqual(test_func(whitelist_permissions=True), "Success")
+
+	def test_multiple_doctypes_permissions(self):
+		@requires_permission("TestDocType", "read")
+		@requires_permission("SourceDocType", "write")
+		def test_func():
+			return "Success"
+
+		self.assertEqual(test_func(), "Success")
+
+	def test_permission_error_message(self):
+		@requires_permission("TestDocType", "delete")
+		@requires_permission("SourceDocType", "write")
+		def test_func():
+			return "Success"
+
+		frappe.set_user("Guest")
+		with self.assertRaises(frappe.PermissionError) as context:
+			test_func()
+
+		self.assertIn("No delete permission for TestDocType", str(context.exception))
+		self.assertIn("No write permission for SourceDocType", str(context.exception))

--- a/frappe/tests/test_document_ro_mode.py
+++ b/frappe/tests/test_document_ro_mode.py
@@ -1,0 +1,134 @@
+import unittest
+from contextlib import contextmanager
+
+import frappe
+from frappe.model.document import Document, read_only_document
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestReadOnlyDocument(FrappeTestCase):
+	def setUp(self):
+		# Create a test document
+		self.test_doc = frappe.get_doc({"doctype": "ToDo", "description": "Test ToDo"})
+		self.test_doc.insert()
+
+	def tearDown(self):
+		# Delete the test document
+		frappe.delete_doc("ToDo", self.test_doc.name)
+
+	def test_read_only_save(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.save()
+
+	def test_read_only_insert(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				frappe.get_doc({"doctype": "ToDo", "description": "Another Test ToDo"}).insert()
+
+	def test_read_only_delete(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.delete()
+
+	def test_read_only_submit(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.submit()
+
+	def test_read_only_cancel(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.cancel()
+
+	def test_read_only_db_set(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				self.test_doc.db_set("status", "Closed")
+
+	def test_read_only_nested_calls(self):
+		def nested_save():
+			self.test_doc.save()
+
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				nested_save()
+
+	def test_read_only_context_manager_restoration(self):
+		original_save = Document.save
+
+		with read_only_document():
+			self.assertNotEqual(Document.save, original_save)
+
+		self.assertEqual(Document.save, original_save)
+
+	def test_read_only_multiple_documents(self):
+		doc1 = frappe.get_doc({"doctype": "ToDo", "description": "Test ToDo 1"})
+		doc2 = frappe.get_doc({"doctype": "ToDo", "description": "Test ToDo 2"})
+
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				doc1.insert()
+			with self.assertRaises(frappe.DatabaseModificationError):
+				doc2.insert()
+
+	def test_read_only_custom_method(self):
+		class CustomDocument(Document):
+			def custom_save(self):
+				self.save()
+
+		custom_doc = CustomDocument({"doctype": "ToDo", "description": "Custom Test ToDo"})
+
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError):
+				custom_doc.custom_save()
+
+	def test_read_only_exception_handling(self):
+		@contextmanager
+		def exception_raiser():
+			raise Exception("Test exception")
+			yield
+
+		try:
+			with read_only_document(), exception_raiser():
+				pass
+		except Exception:
+			pass
+
+		# Ensure methods are restored even if an exception occurs
+		self.assertEqual(Document.save, self.test_doc.__class__.save)
+
+	def test_read_only_nested_context_managers(self):
+		original_save = Document.save
+
+		with read_only_document():
+			self.assertNotEqual(Document.save, original_save)
+
+			with read_only_document():
+				self.assertNotEqual(Document.save, original_save)
+
+			self.assertNotEqual(Document.save, original_save)
+
+		self.assertEqual(Document.save, original_save)
+
+	def test_read_only_method_call_details(self):
+		with read_only_document():
+			with self.assertRaises(frappe.DatabaseModificationError) as cm:
+				self.test_doc.save()
+
+			self.assertIn("Cannot call save in read-only document mode", str(cm.exception))
+
+	def test_read_only_does_not_affect_reads(self):
+		with read_only_document():
+			# These operations should not raise exceptions
+			doc = frappe.get_doc("ToDo", self.test_doc.name)
+			self.assertEqual(doc.description, "Test ToDo")
+
+			docs = frappe.get_all("ToDo", filters={"name": self.test_doc.name})
+			self.assertEqual(len(docs), 1)
+
+	def test_read_only_with_new_document_instance(self):
+		with read_only_document():
+			new_doc = frappe.new_doc("ToDo")
+			with self.assertRaises(frappe.DatabaseModificationError):
+				new_doc.insert()

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -202,6 +202,7 @@ def get_safe_globals():
 			qb=frappe.qb,
 			get_meta=frappe.get_meta,
 			new_doc=frappe.new_doc,
+			new_doc_from=frappe.new_doc_from,
 			get_doc=frappe.get_doc,
 			get_mapped_doc=get_mapped_doc,
 			get_last_doc=frappe.get_last_doc,


### PR DESCRIPTION
# Context

- Rust does it
- Lack of this feature is a significant source of hard to maintain spaghetti code
- There is a subtle issue with server scripts and mapper implementations as evidenced by: https://github.com/frappe/erpnext/pull/42160#issuecomment-2208464595


# Solution

- Implement document casting as per this PR

# Additional Info

- While both implementations (from & into) are leveraged interchangably (XOR), if both a present, the "nearer" implementation takes precedence (`_into_*` for `into()` and `_from_*` for `from_doc()`).
- This corresponding semgrep rule exerts conscientious and explicit ("upfront") declaration of the security context when crossing two doctype's security boundary via these casters https://github.com/frappe/semgrep-rules/pull/28
- Casting onto a pre-existing document with preset values (useful in cases where their preexistence is significant to the casting routine) is limited to `frappe.doc_from` / `doc.from_doc` but not available in `frappe.doc_into` / `doc.into`. This ensures the implementation of the business logic is always kept in code vicinity to the state which triggers variations in its implementation, ergo: more maintainable.
- Precendent implementation in the above: https://github.com/frappe/erpnext/pull/42160
- To implement cross-app import guards, simply put the imports inside the conversion function, it will never be reached through regular api use if the involved doctypes are not currently installed.

## Todos:

- [x] ~~Make these methods pretty much inaccessible except through the api via `__foo` method names ("python name mangling") and appropriate calling.~~ (doesn't work well with class inheritance)
- [x] Override the `flags` setter for `ignore_permissions` such that changing that value will be ignored if `whitelist_permissions` is set to `True` in order to enable a smooth and gradual transition to a more restrictive security escalation model throughout existing (then: legacy) code.
- [x] Prohibit `doc.save` / `doc.insert` / etc on the `Document` class during conversion as a measure to keep a uniform api, the code sane, clean and the control logic maintainable at the calling site. Allowing programmers to persist side effects during conversion would otherwise risk to encourage runaway complexity.

## Example Interaction
```python

class PaymentEntry:
    @frappe.requires_permissions("Customer", "read")  # no propagation
    @frappe.requires_permissions("Payment Entry", "write")
    def _from_customer(self, customer):
        ...

    @frappe.requires_permissions("Lead", "read")
    @frappe.requires_permissions("Customer", "read")  # not propagated
    @frappe.requires_permissions("Payment Entry", "write")
    def _from_lead(self, lead):
        self.from_doc("Customer", lead.customer)
        ...