### PR TITLE
fix: Revert "fix: refresh fields after changing form to read-only (#26439)"

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -671,7 +671,7 @@ frappe.ui.form.Form = class FrappeForm {
 	}
 
 	refresh_fields() {
-		this?.layout?.refresh(this.doc);
+		this.layout.refresh(this.doc);
 		this.layout.primary_button = this.$wrapper.find(".btn-primary");
 
 		// cleanup activities after refresh
@@ -1843,7 +1843,6 @@ frappe.ui.form.Form = class FrappeForm {
 				email: p.email,
 			};
 		});
-		this.refresh_fields();
 	}
 
 	trigger(event, doctype, docname) {


### PR DESCRIPTION
This reverts commit cc8c0f917cefb3eebc2b4a2c7ebba2a8a768763a.

This also reverts the attemped fix: #26983 since there's more breakage than I had initially thought
![image](https://github.com/frappe/frappe/assets/10119037/9d9e20c2-2d51-4e08-9d69-a367cc4341d7)

