### PR TITLE
fix(System Health Report): Modified the `fetch_scheduler` function to use different SQL queries based on the database type.

### DIFF
--- a/frappe/desk/doctype/system_health_report/system_health_report.py
+++ b/frappe/desk/doctype/system_health_report/system_health_report.py
@@ -186,7 +186,7 @@ class SystemHealthReport(Document):
 		# Exclude "maybe" curently executing job
 		upper_threshold = add_to_date(None, minutes=-30, as_datetime=True)
 		self.scheduler_status = get_scheduler_status().get("status")
-  
+
 		mariadb_query = """
   				SELECT scheduled_job_type,
 					AVG(CASE WHEN status != 'Complete' THEN 1 ELSE 0 END) * 100 AS failure_rate
@@ -198,10 +198,10 @@ class SystemHealthReport(Document):
 				GROUP BY scheduled_job_type
 				HAVING failure_rate > 0
 				ORDER BY failure_rate DESC
-				LIMIT 5  						
+				LIMIT 5
 		"""
 
-		postgres_query = """ 
+		postgres_query = """
   				SELECT scheduled_job_type,
 					AVG(CASE WHEN status != 'Complete' THEN 1 ELSE 0 END) * 100 AS "failure_rate"
 				FROM "tabScheduled Job Log"
@@ -214,8 +214,8 @@ class SystemHealthReport(Document):
 				ORDER BY "failure_rate" DESC
 				LIMIT 5
     	"""
-  
-		failing_jobs = frappe.db.multisql( 
+
+		failing_jobs = frappe.db.multisql(
 			{
 				"mariadb": mariadb_query,
 				"postgres": postgres_query,

--- a/frappe/desk/doctype/system_health_report/system_health_report.py
+++ b/frappe/desk/doctype/system_health_report/system_health_report.py
@@ -186,19 +186,40 @@ class SystemHealthReport(Document):
 		# Exclude "maybe" curently executing job
 		upper_threshold = add_to_date(None, minutes=-30, as_datetime=True)
 		self.scheduler_status = get_scheduler_status().get("status")
-		failing_jobs = frappe.db.sql(
-			"""
-			select scheduled_job_type,
-				   avg(CASE WHEN status != 'Complete' THEN 1 ELSE 0 END) * 100 as failure_rate
-			from `tabScheduled Job Log`
-			where
-				creation > %(lower_threshold)s
-				and modified > %(lower_threshold)s
-				and creation < %(upper_threshold)s
-			group by scheduled_job_type
-			having failure_rate > 0
-			order by failure_rate desc
-			limit 5""",
+  
+		mariadb_query = """
+  				SELECT scheduled_job_type,
+					AVG(CASE WHEN status != 'Complete' THEN 1 ELSE 0 END) * 100 AS failure_rate
+				FROM `tabScheduled Job Log`
+				WHERE
+					creation > %(lower_threshold)s
+					AND modified > %(lower_threshold)s
+					AND creation < %(upper_threshold)s
+				GROUP BY scheduled_job_type
+				HAVING failure_rate > 0
+				ORDER BY failure_rate DESC
+				LIMIT 5  						
+		"""
+
+		postgres_query = """ 
+  				SELECT scheduled_job_type,
+					AVG(CASE WHEN status != 'Complete' THEN 1 ELSE 0 END) * 100 AS "failure_rate"
+				FROM "tabScheduled Job Log"
+				WHERE
+					creation > %(lower_threshold)s
+					AND modified > %(lower_threshold)s
+					AND creation < %(upper_threshold)s
+				GROUP BY scheduled_job_type
+				HAVING AVG(CASE WHEN status != 'Complete' THEN 1 ELSE 0 END) * 100 > 0
+				ORDER BY "failure_rate" DESC
+				LIMIT 5
+    	"""
+  
+		failing_jobs = frappe.db.multisql( 
+			{
+				"mariadb": mariadb_query,
+				"postgres": postgres_query,
+			},
 			{"lower_threshold": lower_threshold, "upper_threshold": upper_threshold},
 			as_dict=True,
 		)


### PR DESCRIPTION

### Fix System Health Report for PostgreSQL Compatibility

#### Description
This pull request fixes the issue with the System Health Report not working correctly with PostgreSQL. The error was due to PostgreSQL not supporting aliasing in the `HAVING` clause. The solution involves repeating the calculation for `failure_rate` in the `HAVING` clause for PostgreSQL.

#### Changes
- Modified the `fetch_scheduler` function to use different SQL queries based on the database type.

#### Testing
- Tested the changes locally with PostgreSQL.
- Verified that the System Health Report loads without errors.


#### Screenshots

Before: 

<img width="1440" alt="Screenshot 2024-07-04 at 6 34 45 PM" src="https://github.com/frappe/frappe/assets/128922392/f05e3c25-49b2-43a7-b371-c5140000fed1">

After:

<img width="1440" alt="Screenshot 2024-07-04 at 6 38 44 PM" src="https://github.com/frappe/frappe/assets/128922392/129d5b47-b196-4b64-aa94-338f6489657f">


