### PR TITLE
fix: data filter for status indicator in list

### DIFF
--- a/frappe/public/js/frappe/model/indicator.js
+++ b/frappe/public/js/frappe/model/indicator.js
@@ -97,7 +97,7 @@ frappe.get_indicator = function (doc, doctype, show_workflow_state) {
 
 	// based on status
 	if (doc.status) {
-		return [__(doc.status), frappe.utils.guess_colour(doc.status)];
+		return [__(doc.status), frappe.utils.guess_colour(doc.status), "status,=," + doc.status];
 	}
 
 	// based on enabled


### PR DESCRIPTION
### Bug
The `get_indicator` function does not return the data filter value when the indicator colour is guessed based on the status. This leads the following code to generate the html for that indicator with - `data-filter='undefined'` since the 2nd index for indicator is undefined. 

https://github.com/frappe/frappe/blob/1ed87246d5465e84edfaa4fc2b268693eb7eef13/frappe/public/js/frappe/list/list_view.js#L1084-L1090


When this indicator is clicked inside the list view to apply a filter on that field, the following error pops up -


https://github.com/frappe/frappe/assets/40693548/0921fec9-cfb8-40ce-a034-0afc408ed822


### Fix

Set the value for data filter correctly based on the status for the document.