### PR TITLE
fix: input mode for numbers

### DIFF
--- a/frappe/public/js/frappe/form/controls/data.js
+++ b/frappe/public/js/frappe/form/controls/data.js
@@ -7,10 +7,11 @@ frappe.ui.form.ControlData = class ControlData extends frappe.ui.form.ControlInp
 	make_input() {
 		if (this.$input) return;
 
-		let { html_element, input_type } = this.constructor;
+		let { html_element, input_type, input_mode } = this.constructor;
 
 		this.$input = $("<" + html_element + ">")
 			.attr("type", input_type)
+			.attr("inputmode", input_mode)
 			.attr("autocomplete", "off")
 			.addClass("input-with-feedback form-control")
 			.prependTo(this.input_area);

--- a/frappe/public/js/frappe/form/controls/int.js
+++ b/frappe/public/js/frappe/form/controls/int.js
@@ -1,5 +1,6 @@
 frappe.ui.form.ControlInt = class ControlInt extends frappe.ui.form.ControlData {
 	static trigger_change_on_input_event = false;
+	static input_mode = "numeric";
 	make() {
 		super.make();
 	}


### PR DESCRIPTION
# Context

- Web forms with number fields on cel phone don't show a number keyboard

# Solution

- Use input mode numeric to fix this


# Persisting problems
- Email Field keyboards are typically showing a subset specialized for entering email addresses: https://www.w3schools.com/tags/att_inputmode.asp
- Phone and others would need to use the `type` field (e.g. `type="tel"`) for better support, but that needs a more thorough refactoring of the current field controls
