### PR TITLE
fix(data_exporter): don't sort multiselect dialog fields

### DIFF
--- a/frappe/public/js/frappe/data_import/data_exporter.js
+++ b/frappe/public/js/frappe/data_import/data_exporter.js
@@ -67,6 +67,7 @@ frappe.data_import.DataExporter = class DataExporter {
 					columns: 2,
 					on_change: () => this.update_primary_action(),
 					options: this.get_multicheck_options(this.doctype),
+					sort_options: false,
 				},
 				...frappe.meta.get_table_fields(this.doctype).map((df) => {
 					let doctype = df.options;


### PR DESCRIPTION
By default we currently sort all by default, doesn't make sense to do here
Better to leave it in the order the fields in the doctype are

Reference: support ticket 18084

