### PR TITLE
fix: update country name from Turkey to Türkiye

### DIFF
--- a/frappe/geo/country_info.json
+++ b/frappe/geo/country_info.json
@@ -2731,7 +2731,7 @@
   ],
   "isd": "+216"
  },
- "Turkey": {
+ "Türkiye": {
   "code": "tr",
   "currency": "TRY",
   "currency_fraction": "Kuru\u015f",


### PR DESCRIPTION
Updated the country name from 'Turkey' to 'Türkiye' following the official name change announced by Türkiye in 2021. This change aligns with the United Nations' updated designation and ensures the framework reflects the correct country name.