### PR TITLE
fix: Map icon color in dark mode

### DIFF
--- a/frappe/public/icons/timeless/icons.svg
+++ b/frappe/public/icons/timeless/icons.svg
@@ -419,7 +419,7 @@
 	</symbol>
 
 	<symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" id="icon-map">
-		<g stroke="#111" stroke-miterlimit="10">
+		<g stroke="var(--icon-stroke)" stroke-miterlimit="10">
 		<path d="M11.467 3.458c1.958 1.957 1.958 5.088.027 7.02L7.97 14l-3.523-3.523a4.945 4.945 0 010-6.993l.026-.026a4.922 4.922 0 016.993 0zm0 0c-.026-.026-.026-.026 0 0z"></path>
 		<path d="M7.971 8.259a1.305 1.305 0 100-2.61 1.305 1.305 0 000 2.61z"></path>
 		</g>


### PR DESCRIPTION
When toggling to dark mode, all the icons in the dropdown button change to white in the list view, except for the **map icon**, which remains black.

Upon reviewing the code for this icon, I found that it had a fixed **black color** assigned `(stroke=#111)`. I replaced it with the variable color value `var(--icon-stroke) `to ensure it changes appropriately with the theme toggle.

![image](https://github.com/frappe/frappe/assets/84626877/932933ce-724d-417e-8104-89dd0ff0242d) ![image](https://github.com/frappe/frappe/assets/84626877/1917896e-a3a9-4c76-ac1d-ca25779be7e7)


>The server must be turned off and on for the code to work