### PR TITLE
feat: nudge for all DocTypes that can be disabled, not deleted

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -17,7 +17,6 @@ from frappe.desk.doctype.notification_settings.notification_settings import (
 	toggle_notifications,
 )
 from frappe.desk.notifications import clear_notifications
-from frappe.model.delete_doc import check_if_doc_is_linked
 from frappe.model.document import Document
 from frappe.query_builder import DocType
 from frappe.rate_limiter import rate_limit
@@ -535,12 +534,6 @@ class User(Document):
 
 		# Delete EPS data
 		frappe.db.delete("Energy Point Log", {"user": self.name})
-
-		# Ask user to disable instead if document is still linked
-		try:
-			check_if_doc_is_linked(self)
-		except frappe.LinkExistsError:
-			frappe.throw(_("You can disable the user instead of deleting it."), frappe.LinkExistsError)
 
 	def before_rename(self, old_name, new_name, merge=False):
 		# if merging, delete the old user notification settings

--- a/frappe/model/delete_doc.py
+++ b/frappe/model/delete_doc.py
@@ -127,8 +127,17 @@ def delete_doc(
 
 				# check if links exist
 				if not force:
-					check_if_doc_is_linked(doc)
-					check_if_doc_is_dynamically_linked(doc)
+					try:
+						check_if_doc_is_linked(doc)
+						check_if_doc_is_dynamically_linked(doc)
+					except frappe.LinkExistsError as e:
+						if doc.meta.has_field("enabled") or doc.meta.has_field("disabled"):
+							frappe.throw(
+								_("You can disable this {0} instead of deleting it.").format(_(doctype)),
+								frappe.LinkExistsError,
+							)
+						else:
+							raise e
 
 			update_naming_series(doc)
 			delete_from_table(doctype, name, ignore_doctypes, doc)


### PR DESCRIPTION
This reverts commit 081be53e17b9e55a55b5c502e4976008a020f297 because it stopped all other app's `"on_trash"` hooks from getting executed. Instead, we make the nudge generic for all DocTypes that cannot be deleted but disabled. This now runs at the correct time, after all `"on_trash"` hooks.

Resolves https://github.com/frappe/frappe/pull/25248#issuecomment-2220768601