### PR TITLE
fix: cleanup user data on trash

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -539,6 +539,9 @@ class User(Document):
 		# Remove user link from Workflow Action
 		frappe.db.set_value("Workflow Action", {"user": self.name}, "user", None)
 
+		# Delete user's List Filters
+		frappe.db.delete("List Filter", {"for_user": self.name})
+
 		# Ask user to disable instead if document is still linked
 		try:
 			check_if_doc_is_linked(self)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -536,6 +536,9 @@ class User(Document):
 		# Delete EPS data
 		frappe.db.delete("Energy Point Log", {"user": self.name})
 
+		# Remove user link from Workflow Action
+		frappe.db.set_value("Workflow Action", {"user": self.name}, "user", None)
+
 		# Ask user to disable instead if document is still linked
 		try:
 			check_if_doc_is_linked(self)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -542,6 +542,15 @@ class User(Document):
 		# Delete user's List Filters
 		frappe.db.delete("List Filter", {"for_user": self.name})
 
+		# Remove user from Note's Seen By table
+		seen_notes = frappe.get_all("Note", filters=[["Note Seen By", "user", "=", self.name]], pluck="name")
+		for note_id in seen_notes:
+			note = frappe.get_doc("Note", note_id)
+			for row in note.seen_by:
+				if row.user == self.name:
+					note.remove(row)
+			note.save(ignore_permissions=True)
+
 		# Ask user to disable instead if document is still linked
 		try:
 			check_if_doc_is_linked(self)


### PR DESCRIPTION
- Remove deleted user from **Workflow Action**
- Remove deleted user's personal **List Filters**
- Remove deleted user from **Note**'s _Seen By_ table

Prevents unnecessary `LinkExistsError` when deleting a user.