### PR TITLE
fix: usability of Phone field

### DIFF
--- a/frappe/public/js/frappe/form/controls/phone.js
+++ b/frappe/public/js/frappe/form/controls/phone.js
@@ -151,6 +151,9 @@ frappe.ui.form.ControlPhone = class ControlPhone extends frappe.ui.form.ControlD
 			await this.setup_country_codes();
 		}
 		if (value && value.includes("-") && value.split("-").length == 2) {
+			if (!this.selected_icon.find("svg").hasClass("hide")) {
+				this.selected_icon.find("svg").toggleClass("hide");
+			}
 			let isd = this.value.split("-")[0];
 			this.get_country_code_and_change_flag(isd);
 			this.country_code_picker.set_country(isd);

--- a/frappe/public/js/frappe/phone_picker/phone_picker.js
+++ b/frappe/public/js/frappe/phone_picker/phone_picker.js
@@ -63,24 +63,26 @@ class PhonePicker {
 			});
 			this.search_input.keyup((e) => {
 				e.preventDefault();
-				this.filter_icons();
+				this.filter_icons(country, info.isd);
 			});
 
 			this.search_input.on("search", () => {
-				this.filter_icons();
+				this.filter_icons(country, info.isd);
 			});
 		});
 	}
 
-	filter_icons() {
+	filter_icons(country, isd) {
 		let value = this.search_input.val();
 		if (!value) {
 			this.phone_wrapper.find(".phone-wrapper").removeClass("hidden");
 		} else {
-			this.phone_wrapper.find(".phone-wrapper").addClass("hidden");
-			this.phone_wrapper
-				.find(`.phone-wrapper[id*='${value.toLowerCase()}']`)
-				.removeClass("hidden");
+			if (!isd.includes(value) && !country.toLowerCase().includes(value.toLowerCase())) {
+				this.phone_wrapper.find(`.phone-wrapper[id='${country.toLowerCase()}']`).addClass("hidden")
+			}
+			else {
+				this.phone_wrapper.find(`.phone-wrapper[id='${country.toLowerCase()}']`).removeClass("hidden")
+			}
 		}
 	}
 

--- a/frappe/public/js/frappe/phone_picker/phone_picker.js
+++ b/frappe/public/js/frappe/phone_picker/phone_picker.js
@@ -78,10 +78,13 @@ class PhonePicker {
 			this.phone_wrapper.find(".phone-wrapper").removeClass("hidden");
 		} else {
 			if (!isd.includes(value) && !country.toLowerCase().includes(value.toLowerCase())) {
-				this.phone_wrapper.find(`.phone-wrapper[id='${country.toLowerCase()}']`).addClass("hidden")
-			}
-			else {
-				this.phone_wrapper.find(`.phone-wrapper[id='${country.toLowerCase()}']`).removeClass("hidden")
+				this.phone_wrapper
+					.find(`.phone-wrapper[id='${country.toLowerCase()}']`)
+					.addClass("hidden");
+			} else {
+				this.phone_wrapper
+					.find(`.phone-wrapper[id='${country.toLowerCase()}']`)
+					.removeClass("hidden");
 			}
 		}
 	}

--- a/frappe/public/scss/common/phone_picker.scss
+++ b/frappe/public/scss/common/phone_picker.scss
@@ -70,6 +70,9 @@
 }
 
 .frappe-control[data-fieldtype="Phone"] {
+	.control-input {
+		position: relative;
+	}
 	input {
 		padding-left: 30px;
 	}
@@ -79,7 +82,9 @@
 		height: 20px;
 		border-radius: 5px;
 		position: absolute;
-		top: calc(50% + 2px);
+		top: 0;
+		bottom: 0;
+		margin: auto;
 		left: 8px;
 		content: " ";
 		align-items: center;
@@ -90,6 +95,7 @@
 			margin-left: 0.6rem;
 			align-items: flex-end;
 			flex-grow: 1;
+			line-height: normal;
 		}
 
 		img {


### PR DESCRIPTION
### Usability Fixes and Improvements for Phone Field in Frappe

This PR addresses several usability issues and enhancements in the phone field of Frappe:

### Problems Addressed

1. **Country Search**: Users can't search for a country using the country code.
2. **Alignment Issues**: The country code and phone number are misaligned in the input field.
3. **Chevron Icon**: The chevron icon does not disappear when the country code is manually typed in with a hyphen. This is causing overlap with the phone number.
4. **Flag Display**: The associated country flag does not disappear after manually typing the country code and  clearing.

### Fixes Made

- [x] **Country Code Search**: Added functionality to search by country code.
- [x] **Alignment Fix**: Fixed the alignment of the country code and phone number.
- [x] **Chevron Icon**: The chevron icon now hides when the country code is manually added.
- [x] **Flag Display**: The country flag is now hidden when the country code is cleared from the input field.

### Before and After Screenshots
Before <br>
![before](https://github.com/frappe/frappe/assets/99407382/2e8f2ab6-6ecf-4923-b677-9536e683ffc4)
![Before](https://github.com/frappe/frappe/assets/99407382/a0bb36a0-97b4-4184-876a-f1f818d5568f)
<br> 
After<br> 
![Search using country code](https://github.com/frappe/frappe/assets/99407382/bb0b9f29-bc84-42a0-bf3b-c0e5c54010c6)<br>
![After](https://github.com/frappe/frappe/assets/99407382/8c66129c-dc37-43ba-b77e-4a415fc13a4b)

Please review the changes and provide any feedback.
