### PR TITLE
fix: check both fields for determining prepared report status

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -345,7 +345,10 @@ class Report(Document):
 
 
 def is_prepared_report_disabled(report):
-	return frappe.db.get_value("Report", report, "disable_prepared_report") or 0
+	return (
+		frappe.db.get_value("Report", report, "disable_prepared_report")
+		and not frappe.db.get_value("Report", report, "prepared_report")
+	) or 0
 
 
 def get_report_module_dotted_path(module, report_name):
@@ -381,3 +384,4 @@ def get_group_by_column_label(args, meta):
 
 def enable_prepared_report(report: str):
 	frappe.db.set_value("Report", report, "prepared_report", 1)
+	frappe.db.set_value("Report", report, "disable_prepared_report", 0)

--- a/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
+++ b/frappe/core/doctype/role_permission_for_page_and_report/role_permission_for_page_and_report.py
@@ -69,9 +69,9 @@ class RolePermissionforPageandReport(Document):
 		if self.report:
 			# intentionally written update query in frappe.db.sql instead of frappe.db.set_value
 			frappe.db.sql(
-				"""update `tabReport` set disable_prepared_report = %s
+				"""update `tabReport` set disable_prepared_report = %s, prepared_report = %s
 				where name = %s""",
-				(self.disable_prepared_report, self.report),
+				(self.disable_prepared_report, not self.disable_prepared_report, self.report),
 			)
 
 	def get_args(self, row=None):

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -45,6 +45,7 @@ def get_report_doc(report_name):
 
 		# Follow whatever the custom report has set for prepared report field
 		doc.prepared_report = custom_report_doc.prepared_report
+		doc.disable_prepared_report = custom_report_doc.disable_prepared_report
 
 	if not doc.is_permitted():
 		frappe.throw(


### PR DESCRIPTION
Reference: support ticket 18191

#18940 could be backported otherwise maybe, but seemingly has _some_ breaking changes