### PR TITLE
fix(Naming Series): bigint not null default 0

### DIFF
--- a/frappe/database/mariadb/framework_mariadb.sql
+++ b/frappe/database/mariadb/framework_mariadb.sql
@@ -237,7 +237,7 @@ CREATE TABLE `tabDocType` (
 DROP TABLE IF EXISTS `tabSeries`;
 CREATE TABLE `tabSeries` (
   `name` varchar(100),
-  `current` int NOT NULL DEFAULT 0,
+  `current` bigint(20) NOT NULL DEFAULT 0,
   PRIMARY KEY(`name`)
 ) ENGINE=InnoDB ROW_FORMAT=DYNAMIC CHARACTER SET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 


### PR DESCRIPTION
Missing changes in `framework_mariadb.sql` file