### PR TITLE
fix(List View): show escaped content for Code fields

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -784,9 +784,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		}
 
 		const format = () => {
-			if (df.fieldtype === "Code") {
-				return value;
-			} else if (df.fieldtype === "Percent") {
+			if (df.fieldtype === "Percent") {
 				return `<div class="progress" style="margin: 0px;">
 						<div class="progress-bar progress-bar-success" role="progressbar"
 							aria-valuenow="${value}"
@@ -838,11 +836,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 					data-filter="${fieldname},=,${value}">
 					${_value}
 				</a>`;
-			} else if (
-				["Text Editor", "Text", "Small Text", "HTML Editor", "Markdown Editor"].includes(
-					df.fieldtype
-				)
-			) {
+			} else if (frappe.model.html_fieldtypes.includes(df.fieldtype)) {
 				html = `<span class="ellipsis">
 					${_value}
 				</span>`;


### PR DESCRIPTION
#### Bug
Adding a Code field to the List View causes it to render without escaped content.

<details>
<summary>
Example
</summary>
<br>
The Message field in the Email Queue List View contains the entire email content, so it gets displayed with overlapping content.
<br><br>

<img width="1270" alt="Screenshot 2024-07-11 at 2 29 55 PM" src="https://github.com/frappe/frappe/assets/40693548/7f324747-3576-4df5-b47e-90c1385aea8e">

</details>

#### Fix
Use `_value` which is the escaped value for the field instead of the normal value for html field types.

