### PR TITLE
fix: send 2FA OTP email synchronously

### DIFF
--- a/frappe/templates/includes/login/login.js
+++ b/frappe/templates/includes/login/login.js
@@ -329,7 +329,7 @@ var request_otp = function (r) {
 	$('.login-content:visible').append(
 		`<div id="twofactor_div">
 			<form class="form-verify">
-				<div class="page-card-head">
+				<div class="page-card-head p-0">
 					<span class="indicator blue" data-text="Verification">{{ _("Verification") | e }}</span>
 				</div>
 				<div id="otp_div"></div>

--- a/frappe/twofactor.py
+++ b/frappe/twofactor.py
@@ -344,30 +344,14 @@ def send_token_via_email(user, token, otp_secret, otp_issuer, subject=None, mess
 	hotp = pyotp.HOTP(otp_secret)
 	otp = hotp.at(int(token))
 	template_args = {"otp": otp, "otp_issuer": otp_issuer}
-	if not subject:
-		subject = get_email_subject_for_2fa(template_args)
-	if not message:
-		message = get_email_body_for_2fa(template_args)
 
-	email_args = {
-		"recipients": user_email,
-		"sender": None,
-		"subject": subject,
-		"message": message,
-		"header": [_("Verfication Code"), "blue"],
-		"delayed": False,
-		"retry": 3,
-	}
-
-	enqueue(
-		method=frappe.sendmail,
-		queue="short",
-		timeout=300,
-		event=None,
-		is_async=True,
-		job_name=None,
-		now=False,
-		**email_args,
+	frappe.sendmail(
+		recipients=user_email,
+		subject=subject or get_email_subject_for_2fa(template_args),
+		message=message or get_email_body_for_2fa(template_args),
+		header=[_("Verfication Code"), "blue"],
+		delayed=False,
+		retry=3,
 	)
 	return True
 


### PR DESCRIPTION
Currently, the email for the 2FA token is sent asynchronously. When 2FA is enabled and user logs in using their credentials, the dialog for entering the OTP is shown immediately. However, in the backend, the task of sending the email is added to the background jobs queue. If the task is picked up from the queue immediately, the user can add the OTP and login successfully. However, in most cases, it is not immediately picked up from the queue and the email gets sent after ~5 mins. This leads to some confusion from the end of the user as well as being unable to login using the OTP. 

Directly sending the email over adding it in the queue makes more sense in case of 2FA ig. Making it synchronous would also solve the problem of showing the sent message to the user even if that process failed somehow leading to less confusion.