### PR TITLE
Revert "fix: use currency number format if present"

### DIFF
--- a/frappe/public/js/frappe/utils/number_format.js
+++ b/frappe/public/js/frappe/utils/number_format.js
@@ -178,7 +178,6 @@ function get_currency_symbol(currency) {
 
 function get_number_format(currency) {
 	return (
-		(currency && frappe.model.get_value(":Currency", currency, "number_format")) ||
 		(frappe.boot && frappe.boot.sysdefaults && frappe.boot.sysdefaults.number_format) ||
 		"#,###.##"
 	);


### PR DESCRIPTION
This reverts commit 454e48c397264addb5cc2a918aa248723b41b053.

This breaks many production systems because the number format set in **Currency** is usually not correct by default.

People are used to the number format coming from **System Settings**. Suddenly using a different number format as per **Currency** is breaking behavior.

When creating a new instance, the **Currency**'s number format is _wrong by default_. (It's taken from the first country with that currency in `country_info.json`. So for all other countries with the same currency, it may not be correct). This didn't matter before, but now many production systems were switched to using the wrong format.