### PR TITLE
chore: bump boto3 to 1.34.143

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "markdownify~=0.11.6",
 
     # integration dependencies
-    "boto3~=1.28.10",
+    "boto3~=1.34.143",
     "dropbox~=11.36.2",
     "google-api-python-client~=2.2.0",
     "google-auth-oauthlib~=0.4.4",


### PR DESCRIPTION
This should resolve the vulnerable dependency check regarding the sub-dependency `urllib3`.

[The changelog](https://github.com/boto/boto3/blob/develop/CHANGELOG.rst) doesn't indicate any breaking changes, especially not regarding our usage of S3.