### PR TITLE
fix: handle invalid image

### DIFF
--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -17,7 +17,7 @@ from frappe.core.api.file import (
 	unzip_file,
 )
 from frappe.core.doctype.file.exceptions import FileTypeNotAllowed
-from frappe.core.doctype.file.utils import get_broken_image_replacement, get_extension
+from frappe.core.doctype.file.utils import get_extension
 from frappe.desk.form.utils import add_comment
 from frappe.exceptions import ValidationError
 from frappe.tests.utils import FrappeTestCase, change_settings
@@ -785,7 +785,7 @@ class TestFileUtils(FrappeTestCase):
 		self.assertFalse(
 			frappe.db.exists("File", {"attached_to_name": communication.name, "is_private": is_private})
 		)
-		self.assertIn(get_broken_image_replacement(), communication.content)
+		self.assertIn('<img src="#broken-image">', communication.content)
 
 	def test_create_new_folder(self):
 		folder = create_new_folder("test_folder", "Home")

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -17,7 +17,7 @@ from frappe.core.api.file import (
 	unzip_file,
 )
 from frappe.core.doctype.file.exceptions import FileTypeNotAllowed
-from frappe.core.doctype.file.utils import get_extension
+from frappe.core.doctype.file.utils import get_corrupted_image_msg, get_extension
 from frappe.desk.form.utils import add_comment
 from frappe.exceptions import ValidationError
 from frappe.tests.utils import FrappeTestCase, change_settings
@@ -785,7 +785,7 @@ class TestFileUtils(FrappeTestCase):
 		self.assertFalse(
 			frappe.db.exists("File", {"attached_to_name": communication.name, "is_private": is_private})
 		)
-		self.assertIn('<img src="#broken-image">', communication.content)
+		self.assertIn(f'<img src="#broken-image" alt="{get_corrupted_image_msg()}">', communication.content)
 
 	def test_create_new_folder(self):
 		folder = create_new_folder("test_folder", "Home")

--- a/frappe/core/doctype/file/test_file.py
+++ b/frappe/core/doctype/file/test_file.py
@@ -17,7 +17,7 @@ from frappe.core.api.file import (
 	unzip_file,
 )
 from frappe.core.doctype.file.exceptions import FileTypeNotAllowed
-from frappe.core.doctype.file.utils import get_extension
+from frappe.core.doctype.file.utils import get_broken_image_replacement, get_extension
 from frappe.desk.form.utils import add_comment
 from frappe.exceptions import ValidationError
 from frappe.tests.utils import FrappeTestCase, change_settings
@@ -767,6 +767,25 @@ class TestFileUtils(FrappeTestCase):
 			frappe.db.exists("File", {"attached_to_name": communication.name, "is_private": is_private})
 		)
 		self.assertRegex(communication.content, r"<img src=\"(.*)/files/pix\.png(.*)\">")
+
+	def test_broken_image(self):
+		"""Ensure that broken inline images don't cause errors."""
+		is_private = not frappe.get_meta("Communication").make_attachments_public
+		communication = frappe.get_doc(
+			doctype="Communication",
+			communication_type="Communication",
+			communication_medium="Email",
+			content='<div class="ql-editor read-mode"><img src="data:image/png;filename=pix.png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CY="></div>',
+			recipients="to <to@test.com>",
+			cc=None,
+			bcc=None,
+			sender="sender@test.com",
+		).insert(ignore_permissions=True)
+
+		self.assertFalse(
+			frappe.db.exists("File", {"attached_to_name": communication.name, "is_private": is_private})
+		)
+		self.assertIn(get_broken_image_replacement(), communication.content)
 
 	def test_create_new_folder(self):
 		folder = create_new_folder("test_folder", "Home")

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -2,6 +2,7 @@ import hashlib
 import mimetypes
 import os
 import re
+from binascii import Error as BinasciiError
 from io import BytesIO
 from typing import TYPE_CHECKING, Optional
 from urllib.parse import unquote
@@ -234,7 +235,12 @@ def extract_images_from_html(doc: "Document", content: str, is_private: bool = F
 			content = content.encode("utf-8")
 		if b"," in content:
 			content = content.split(b",")[1]
-		content = safe_b64decode(content)
+
+		try:
+			content = safe_b64decode(content)
+		except BinasciiError:
+			frappe.flags.has_dataurl = True
+			return '<img src=""'
 
 		if "filename=" in headers:
 			filename = headers.split("filename=")[-1]
@@ -269,8 +275,14 @@ def extract_images_from_html(doc: "Document", content: str, is_private: bool = F
 
 	if content and isinstance(content, str):
 		content = re.sub(r'<img[^>]*src\s*=\s*["\'](?=data:)(.*?)["\']', _save_file, content)
+		content = content.replace('<img src="">', get_broken_image_replacement())
 
 	return content
+
+
+def get_broken_image_replacement() -> str:
+	msg = _("The image at this position could not be parsed.")
+	return f"<span>{msg}</span>"
 
 
 def get_random_filename(content_type: str | None = None) -> str:

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -240,7 +240,7 @@ def extract_images_from_html(doc: "Document", content: str, is_private: bool = F
 			content = safe_b64decode(content)
 		except BinasciiError:
 			frappe.flags.has_dataurl = True
-			return '<img src=""'
+			return '<img src="#broken-image"'
 
 		if "filename=" in headers:
 			filename = headers.split("filename=")[-1]
@@ -275,14 +275,8 @@ def extract_images_from_html(doc: "Document", content: str, is_private: bool = F
 
 	if content and isinstance(content, str):
 		content = re.sub(r'<img[^>]*src\s*=\s*["\'](?=data:)(.*?)["\']', _save_file, content)
-		content = content.replace('<img src="">', get_broken_image_replacement())
 
 	return content
-
-
-def get_broken_image_replacement() -> str:
-	msg = _("The image at this position could not be parsed.")
-	return f"<span>{msg}</span>"
 
 
 def get_random_filename(content_type: str | None = None) -> str:

--- a/frappe/core/doctype/file/utils.py
+++ b/frappe/core/doctype/file/utils.py
@@ -240,7 +240,7 @@ def extract_images_from_html(doc: "Document", content: str, is_private: bool = F
 			content = safe_b64decode(content)
 		except BinasciiError:
 			frappe.flags.has_dataurl = True
-			return '<img src="#broken-image"'
+			return f'<img src="#broken-image" alt="{get_corrupted_image_msg()}"'
 
 		if "filename=" in headers:
 			filename = headers.split("filename=")[-1]
@@ -277,6 +277,10 @@ def extract_images_from_html(doc: "Document", content: str, is_private: bool = F
 		content = re.sub(r'<img[^>]*src\s*=\s*["\'](?=data:)(.*?)["\']', _save_file, content)
 
 	return content
+
+
+def get_corrupted_image_msg():
+	return _("Image: Corrupted Data Stream")
 
 
 def get_random_filename(content_type: str | None = None) -> str:


### PR DESCRIPTION
If the image data is not valid base64, `b64decode` raises a `binascii.Error` which was previously unhandled.

We cannot control incoming images, for example from emails, so we should handle 💩 gracefully. Unhandled errors can, for example, stop successive emails from syncing.