### PR TITLE
feat: Allow Setting email, share and print perms via User Type

### DIFF
--- a/frappe/core/doctype/user_document_type/user_document_type.json
+++ b/frappe/core/doctype/user_document_type/user_document_type.json
@@ -16,7 +16,12 @@
   "submit",
   "cancel",
   "amend",
-  "delete"
+  "delete",
+  "additional_permissions_section",
+  "email",
+  "column_break_fjuk",
+  "share",
+  "print"
  ],
  "fields": [
   {
@@ -92,12 +97,39 @@
    "fieldname": "delete",
    "fieldtype": "Check",
    "label": "Delete"
+  },
+  {
+   "fieldname": "additional_permissions_section",
+   "fieldtype": "Section Break",
+   "label": "Additional Permissions"
+  },
+  {
+   "default": "1",
+   "fieldname": "email",
+   "fieldtype": "Check",
+   "label": "Email"
+  },
+  {
+   "fieldname": "column_break_fjuk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "share",
+   "fieldtype": "Check",
+   "label": "Share"
+  },
+  {
+   "default": "1",
+   "fieldname": "print",
+   "fieldtype": "Check",
+   "label": "Print"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-23 16:04:00.313525",
+ "modified": "2024-07-12 17:32:15.721862",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User Document Type",

--- a/frappe/core/doctype/user_document_type/user_document_type.py
+++ b/frappe/core/doctype/user_document_type/user_document_type.py
@@ -19,11 +19,14 @@ class UserDocumentType(Document):
 		create: DF.Check
 		delete: DF.Check
 		document_type: DF.Link
+		email: DF.Check
 		is_custom: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		print: DF.Check
 		read: DF.Check
+		share: DF.Check
 		submit: DF.Check
 		write: DF.Check
 	# end: auto-generated types

--- a/frappe/core/doctype/user_type/test_user_type.py
+++ b/frappe/core/doctype/user_type/test_user_type.py
@@ -31,6 +31,18 @@ class TestUserType(FrappeTestCase):
 		for entry in link_fields:
 			self.assertTrue(entry.options in select_doctypes)
 
+	def test_print_share_email_default(self):
+		"""Test if print, share & email values default to 1. (for backward compatibility)"""
+		# create user type with read, write permissions
+		create_user_type("Test User Type")
+
+		# check if print, share & email values are set to 1
+		perm = frappe.get_all("Custom DocPerm", filters={"role": "_Test User Type"}, fields=["*"])[0]
+
+		self.assertTrue(perm.print == 1)
+		self.assertTrue(perm.share == 1)
+		self.assertTrue(perm.email == 1)
+
 	def tearDown(self):
 		frappe.db.rollback()
 

--- a/frappe/core/doctype/user_type/user_type.py
+++ b/frappe/core/doctype/user_type/user_type.py
@@ -137,13 +137,10 @@ class UserType(Document):
 			user.set("block_modules", block_modules)
 
 	def add_role_permissions_for_user_doctypes(self):
-		perms = ["read", "write", "create", "submit", "cancel", "amend", "delete"]
+		perms = ["read", "write", "create", "submit", "cancel", "amend", "delete", "print", "email", "share"]
 		for row in self.user_doctypes:
 			docperm = add_role_permissions(row.document_type, self.role)
-
 			values = {perm: row.get(perm, default=0) for perm in perms}
-			for perm in ["print", "email", "share"]:
-				values[perm] = 1
 
 			frappe.db.set_value("Custom DocPerm", docperm, values)
 

--- a/frappe/public/js/frappe/form/footer/form_timeline.js
+++ b/frappe/public/js/frappe/form/footer/form_timeline.js
@@ -22,12 +22,14 @@ class FormTimeline extends BaseTimeline {
 	}
 
 	setup_timeline_actions() {
-		this.add_action_button(
-			__("New Email"),
-			() => this.compose_mail(),
-			"es-line-add",
-			"btn-secondary"
-		);
+		if (frappe.model.can_email(null, this.frm)) {
+			this.add_action_button(
+				__("New Email"),
+				() => this.compose_mail(),
+				"es-line-add",
+				"btn-secondary"
+			);
+		}
 		this.setup_new_event_button();
 	}
 


### PR DESCRIPTION
`no-docs` (https://docs.erpnext.com/docs/user/manual/en/limited-user does not go into perm details)

### Feature
- Allow setting additional Permissions (share, print and email) in **User Type**. They default to 1 for backward compatability. Now users can explicitly control these values.
  <img width="1358" alt="Screenshot 2024-07-12 at 6 29 59 PM" src="https://github.com/user-attachments/assets/63bfe8d0-cdd1-460f-8dab-adbaf88ef236">
  
 ### Fix
-  "New Email" button is visible in timeline even if user has no email access. It throws an error on clicking the button. And then again on trying to send the email anyway.
     <img width="1199" alt="Screenshot 2024-07-12 at 6 35 29 PM" src="https://github.com/user-attachments/assets/605aaae8-66ea-491b-a359-4bf1653d83e3">
- Fix (hide the button if user does have email perm to avoid misleading UX) :
   <img width="600" alt="Screenshot 2024-07-12 at 6 34 07 PM" src="https://github.com/user-attachments/assets/d9d90e23-b333-4223-b78b-3e8baf602449">

 