### PR TITLE
feat: frm.set_headline_alert permanent

### DIFF
--- a/frappe/public/js/frappe/form/dashboard.js
+++ b/frappe/public/js/frappe/form/dashboard.js
@@ -633,8 +633,8 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	}
 
 	// TODO: Review! code related to headline should be the part of layout/form
-	set_headline(html, color) {
-		this.frm.layout.show_message(html, color);
+	set_headline(html, color, permanent = false) {
+		this.frm.layout.show_message(html, color, permanent);
 	}
 
 	clear_headline() {
@@ -642,7 +642,7 @@ frappe.ui.form.Dashboard = class FormDashboard {
 	}
 
 	add_comment(text, alert_class, permanent) {
-		this.set_headline_alert(text, alert_class);
+		this.set_headline_alert(text, alert_class, permanent);
 		if (!permanent) {
 			setTimeout(() => {
 				this.clear_headline();
@@ -654,9 +654,9 @@ frappe.ui.form.Dashboard = class FormDashboard {
 		this.clear_headline();
 	}
 
-	set_headline_alert(text, color) {
+	set_headline_alert(text, color, permanent = false) {
 		if (text) {
-			this.set_headline(`<div>${text}</div>`, color);
+			this.set_headline(`<div>${text}</div>`, color, permanent);
 		} else {
 			this.clear_headline();
 		}

--- a/frappe/public/js/frappe/form/layout.js
+++ b/frappe/public/js/frappe/form/layout.js
@@ -97,7 +97,7 @@ frappe.ui.form.Layout = class Layout {
 		return fields;
 	}
 
-	show_message(html, color) {
+	show_message(html, color, permanent = false) {
 		if (this.message_color) {
 			// remove previous color
 			this.message.removeClass(this.message_color);
@@ -112,8 +112,10 @@ frappe.ui.form.Layout = class Layout {
 			}
 			this.message.removeClass("hidden").addClass(this.message_color);
 			$(html).appendTo(this.message);
-			close_message.appendTo(this.message);
-			close_message.on("click", () => this.message.empty().addClass("hidden"));
+			if (!permanent) {
+				close_message.appendTo(this.message);
+				close_message.on("click", () => this.message.empty().addClass("hidden"));
+			}
 		} else {
 			this.message.empty().addClass("hidden");
 		}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/777bb9c9-d24c-41e8-ab27-b0baa8e9aac0)

Allow option to set a permanent headline on form. For when you want a user to always be warned.


no-docs since this API is not really documented AFAIK