### PR TITLE
fix: Load inter.css directly to allow for use in custom Website Themes

### DIFF
--- a/frappe/public/scss/website/index.scss
+++ b/frappe/public/scss/website/index.scss
@@ -1,5 +1,5 @@
+@use "../../css/fonts/inter/inter.css";
 @import "variables";
-@import "../../css/fonts/inter/inter.scss";
 @import "../common/quill";
 @import "~bootstrap/scss/bootstrap";
 @import "~cropperjs/dist/cropper.min";


### PR DESCRIPTION
fixes #27107