### PR TITLE
fix: remove spaces from text strings to ensure correct translation.

### DIFF
--- a/frappe/public/js/frappe/translate.js
+++ b/frappe/public/js/frappe/translate.js
@@ -7,7 +7,6 @@ frappe._ = function (txt, replace, context = null) {
 	if (typeof txt != "string") return txt;
 
 	txt = txt.trim();
-
 	let translated_text = "";
 
 	let key = txt; // txt.replace(/\n/g, "");

--- a/frappe/public/js/frappe/translate.js
+++ b/frappe/public/js/frappe/translate.js
@@ -6,6 +6,8 @@ frappe._ = function (txt, replace, context = null) {
 	if (!txt) return txt;
 	if (typeof txt != "string") return txt;
 
+	txt = txt.trim();
+
 	let translated_text = "";
 
 	let key = txt; // txt.replace(/\n/g, "");


### PR DESCRIPTION
Some text strings contain leading or trailing spaces, and when translations are added to these strings, they are not translated correctly unless these spaces are also included in the translation. I added code to remove leading and trailing spaces to ensure that the text is free of spaces and can be translated correctly. This code does not cause any issues and simply ensures the removal of spaces at the beginning and end of the text.
