### PR TITLE
fix: Translation Issue in Navbar Search Placeholder

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -26,7 +26,7 @@
 							id="navbar-search"
 							type="text"
 							class="form-control"
-							placeholder="{%= __('Search or type a command ({0})', [frappe.utils.is_mac() ? '⌘ + G' : 'Ctrl + G']) %}"
+							placeholder="{%= __('Search or type a command') +" "+ [frappe.utils.is_mac() ? '(⌘ + G)' : '(Ctrl + G)'] %}"
 							aria-haspopup="true"
 						>
 						<span class="search-icon">

--- a/frappe/public/js/frappe/ui/toolbar/navbar.html
+++ b/frappe/public/js/frappe/ui/toolbar/navbar.html
@@ -26,7 +26,7 @@
 							id="navbar-search"
 							type="text"
 							class="form-control"
-							placeholder="{%= __('Search or type a command') +" "+ [frappe.utils.is_mac() ? '(⌘ + G)' : '(Ctrl + G)'] %}"
+							placeholder="{%= __('Search or type a command') +' '+ [frappe.utils.is_mac() ? '(⌘ + G)' : '(Ctrl + G)'] %}"
 							aria-haspopup="true"
 						>
 						<span class="search-icon">


### PR DESCRIPTION
resolve a translation issue in the input search placeholder in the navbar when switching to a non-English language. The problem was that the code sent the entire string "**Search or type a command ({0})**" to the translation function instead of just "**Search or type a command (Ctrl + G)**" or "**Search or type a command**".

To fix this, I separated the static text from the variable using the following code:
`placeholder="{%= __('Search or type a command') + ' ' + [frappe.utils.is_mac() ? '(⌘ + G)' : '(Ctrl + G)'] %}"
`
This ensures that the text is translated first, and then the keyboard shortcut is appended.

![before](https://github.com/user-attachments/assets/daf220b6-cce0-411b-9f8e-7465ef679cab)
![after](https://github.com/user-attachments/assets/50dbfe5a-a5cc-4c3e-b7cb-9f665ef178a6)

> Please add this to older versions
> @merifyio backport version-15-hotfix
> @merifyio backport version-14-hotfix

