### PR TITLE
fix: Translation Issue for shortcut label in workspace

### DIFF
--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -85,9 +85,10 @@ export default class ShortcutWidget extends Widget {
 	}
 
 	set_count(count) {
+		this.format = __(this.format.replace(/{}/g, "").trim());
 		const get_label = () => {
 			if (this.format) {
-				return __(this.format).replace(/{}/g, count);
+				return this.format + " " + count;
 			}
 			return count;
 		};

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -85,7 +85,7 @@ export default class ShortcutWidget extends Widget {
 	}
 
 	set_count(count) {
-		this.format = __(this.format.replace(/{}/g, "").trim());
+		let translate_format = __(this.format.replace(/{}/g, "").trim());
 		const get_label = () => {
 			if (this.format) {
 				return this.format + " " + count;

--- a/frappe/public/js/frappe/widgets/shortcut_widget.js
+++ b/frappe/public/js/frappe/widgets/shortcut_widget.js
@@ -88,7 +88,7 @@ export default class ShortcutWidget extends Widget {
 		let translate_format = __(this.format.replace(/{}/g, "").trim());
 		const get_label = () => {
 			if (this.format) {
-				return this.format + " " + count;
+				return translate_format + " " + count;
 			}
 			return count;
 		};


### PR DESCRIPTION
resolv a translation issue in the **workspace** where the text above the shortcut of  **DocType** name indicating a specific filter or the number of items within the **DocType** was not being translated.
The issue was that the text was sent to the translation function with "{}" included, which prevented it from being translated.
![image](https://github.com/user-attachments/assets/b79c2080-3d88-4600-b70e-53363ee8702b)



The "{}" is added in the JSON file of the workspace to be replaced later with the item count through the code:
`return __(this.format).replace(/{}/g, count);
`
To fix this, I created a variable:
`let translate_format = __(this.format.replace(/{}/g, "").trim());
`
This variable removes "{}" and extracts the text, sending only the text to the translation function to be translated. Finally, it returns the translated text along with the item count.
`return translate_format + " " + count;`

![image](https://github.com/user-attachments/assets/0d7748a3-a21d-4dab-87e8-1fc189fa6337)
![image](https://github.com/user-attachments/assets/5c9b1f22-2506-4cb8-a26a-a8754c5dd4ae)
