### PR TITLE
fix: Translation Issue for "Search for" Text in Search Box

### DIFF
--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -306,7 +306,7 @@ frappe.search.AwesomeBar = class AwesomeBar {
 			value: __("Search for {0}", [txt]),
 			match: txt,
 			index: 100,
-			default: __("Search"),
+			default: "Search",
 			onclick: function () {
 				frappe.searchdialog.search.init_search(txt, "global_search");
 			},

--- a/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
+++ b/frappe/public/js/frappe/ui/toolbar/awesome_bar.js
@@ -299,14 +299,14 @@ frappe.search.AwesomeBar = class AwesomeBar {
 		this.options.push({
 			label: `
 				<span class="flex justify-between text-medium">
-					<span class="ellipsis">${__("Search for {0}", [frappe.utils.xss_sanitise(txt).bold()])}</span>
+					<span class="ellipsis">${__("Search for") + " " + frappe.utils.xss_sanitise(txt).bold()}</span>
 					<kbd>↵</kbd>
 				</span>
 			`,
 			value: __("Search for {0}", [txt]),
 			match: txt,
 			index: 100,
-			default: "Search",
+			default: __("Search"),
 			onclick: function () {
 				frappe.searchdialog.search.init_search(txt, "global_search");
 			},


### PR DESCRIPTION
resolv a translation issue in the search box where the phrase "**Search for**" was not being translated when searching in a non-English language. The problem was that "**Search for**" was part of a dynamic string, preventing it from being translated properly.
![image](https://github.com/user-attachments/assets/65d03a2a-6279-43df-8ae7-eec058009ab2)

![image](https://github.com/user-attachments/assets/d60ca958-9e80-43f7-a34e-361e51536577)
