### PR TITLE
fix: link fields were not displaying the dropdown values in the portal#18421

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -255,7 +255,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					doctype: doctype,
 					ignore_user_permissions: me.df.ignore_user_permissions,
 					reference_doctype: me.get_reference_doctype() || "",
-					page_length: cint(frappe.boot.sysdefaults.link_field_results_limit) || 10,
+					page_length: cint(frappe.boot.sysdefaults?.link_field_results_limit) || 10,
 				};
 
 				me.set_custom_query(args);


### PR DESCRIPTION
In the Webshop app, Link fields were not displaying the dropdown values.

![Webshop](https://github.com/user-attachments/assets/10b25a01-4581-4a23-b735-5bed090a6bea)
