### PR TITLE
fix(multiselect_list): don't crash if a value with space is selected

### DIFF
--- a/frappe/public/js/frappe/form/controls/multiselect_list.js
+++ b/frappe/public/js/frappe/form/controls/multiselect_list.js
@@ -139,7 +139,7 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 		//Unselect old values
 		this.values.forEach((value) => {
 			this.$list_wrapper
-				.find(`.selectable-item[data-value=${value}]`)
+				.find(`.selectable-item[data-value=${CSS.escape(value)}]`)
 				.toggleClass("selected");
 		});
 		this.values = value;
@@ -147,7 +147,7 @@ frappe.ui.form.ControlMultiSelectList = class ControlMultiSelectList extends (
 			this.update_selected_values(value);
 			//Select new values
 			this.$list_wrapper
-				.find(`.selectable-item[data-value=${value}]`)
+				.find(`.selectable-item[data-value=${CSS.escape(value)}]`)
 				.toggleClass("selected");
 		});
 		this.parse_validate_and_set_in_model("");


### PR DESCRIPTION
Spaces or certain other characters don't seem to be well handled by
jQuery, so escape the value before checking.

Introduced in #23906

![image](https://github.com/user-attachments/assets/fe88bd5f-82a1-46f8-9de1-3bb42f580459)

<hr>

Sentry: FRAPPE-6R3
