### PR TITLE
fix: don't trigger `Value Change` notifications for deleted documents

### DIFF
--- a/frappe/model/document.py
+++ b/frappe/model/document.py
@@ -1031,7 +1031,7 @@ class Document(BaseDocument):
 			"on_cancel": "Cancel",
 		}
 
-		if not self.flags.in_insert:
+		if not self.flags.in_insert and not self.flags.in_delete:
 			# value change is not applicable in insert
 			event_map["on_change"] = "Value Change"
 


### PR DESCRIPTION
Reference: support ticket 18783
