### PR TITLE
fix: disabling the email notifications when the user is disabled#18193

### DIFF
--- a/frappe/core/doctype/communication/test_communication.py
+++ b/frappe/core/doctype/communication/test_communication.py
@@ -380,7 +380,8 @@ class TestCommunicationEmailMixin(FrappeTestCase):
 		user = self.new_user(email="bcc+2@test.com", enabled=0)
 		comm = self.new_communication(bcc=bcc_list)
 		res = comm.get_mail_bcc_with_displayname()
-		self.assertCountEqual(res, bcc_list)
+		# Disabled users have thread_notify disabled, so they'll be removed from the list
+		self.assertCountEqual(res, bcc_list[:1])
 		user.delete()
 		comm.delete()
 

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -182,6 +182,12 @@ class User(Document):
 		if (self.name not in ["Administrator", "Guest"]) and (not self.get_social_login_userid("frappe")):
 			self.set_social_login_userid("frappe", frappe.generate_hash(length=39))
 
+	def disable_email_fields_if_user_disabled(self):
+		if not self.enabled:
+			self.thread_notify = 0
+			self.send_me_a_copy = 0
+			self.allowed_in_mentions = 0
+
 	@frappe.whitelist()
 	def populate_role_profile_roles(self):
 		if not self.role_profiles:
@@ -284,6 +290,7 @@ class User(Document):
 
 		# toggle notifications based on the user's status
 		toggle_notifications(self.name, enable=cint(self.enabled), ignore_permissions=True)
+		self.disable_email_fields_if_user_disabled()
 
 	def email_new_password(self, new_password=None):
 		if new_password and not self.flags.in_insert:


### PR DESCRIPTION
Disabling the following on disabling the user to avoid sending the notifications for disabled users.

- Send Notifications For Email Threads
- Send Me A Copy of Outgoing Emails
- Allowed In Mentions

![image](https://github.com/user-attachments/assets/794f2c08-6f1f-4ddf-8a28-de44e82bd140)
