### PR TITLE
chore(deps): pin pydyf to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "PyYAML~=6.0.1",
     "RestrictedPython~=7.0",
     "WeasyPrint==59.0",
+    "pydyf==0.10.0",
     "Werkzeug~=3.0.1",
     "Whoosh~=2.7.4",
     "beautifulsoup4~=4.12.2",


### PR DESCRIPTION
weasyprint had a loose requirement of >=0.6.0 earlier
pydyf changed their constructor in 0.11.0

Later versions of weasyprint would work (they did pin their
dependencies, but there's still a conflict due to `bleach[css]`

The conflict is caused by:
```
    weasyprint 62.3 depends on tinycss2>=1.3.0
    bleach[css] 6.0.0 depends on tinycss2<1.2 and >=1.1.0; extra == "css"
```

For now, pinning this is the simplest solution until we upgrade other
packages as well

<hr>

Fixes this crash due to the change in pydyf:

```
  File "env/lib/python3.11/site-packages/weasyprint/pdf/__init__.py", line 120, in generate_pdf
    pdf = pydyf.PDF((version or '1.7'), identifier)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: PDF.__init__() takes 1 positional argument but 3 were given
```


