### PR TITLE
fix(Email Account): handle errors during error handling

### DIFF
--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -599,10 +599,15 @@ class EmailAccount(Document):
 				frappe.db.rollback()
 			except Exception:
 				frappe.db.rollback()
-				self.log_error(title="EmailAccount.receive")
-				if self.use_imap:
-					self.handle_bad_emails(mail.uid, mail.raw_message, frappe.get_traceback())
-				exceptions.append(frappe.get_traceback())
+				try:
+					self.log_error(title="EmailAccount.receive")
+					if self.use_imap:
+						self.handle_bad_emails(mail.uid, mail.raw_message, frappe.get_traceback())
+					exceptions.append(frappe.get_traceback())
+				except Exception:
+					frappe.db.rollback()
+				else:
+					frappe.db.commit()
 			else:
 				frappe.db.commit()
 


### PR DESCRIPTION
This aims to make email sync more robust. Previously, if an error occurred during the handling of bad emails, the entire email sync would break. Now, we have two levels of error handling: (1) errors while processing emails (2) errors while processing errors from step 1