### PR TITLE
fix(newsletter): prevent `UnboundLocalError` when `doc` is not associated with a value

### DIFF
--- a/frappe/email/doctype/newsletter/newsletter.py
+++ b/frappe/email/doctype/newsletter/newsletter.py
@@ -439,7 +439,11 @@ def newsletter_email_read(recipient_email=None, reference_doctype=None, referenc
 			).run()
 
 	except Exception:
-		doc.log_error(f"Unable to mark as viewed for {recipient_email}")
+		frappe.log_error(
+			title=f"Unable to mark as viewed for {recipient_email}",
+			reference_doctype="Newsletter",
+			reference_name=reference_name,
+		)
 
 	finally:
 		frappe.response.update(frappe.utils.get_imaginary_pixel_response())


### PR DESCRIPTION
If there's an exception before `doc` gets a value assigned, the
attempt to log an error using `doc` causes an `UnboundLocalError`.

Since we have the doctype and docname, we can directly use `log_error`
