### PR TITLE
feat: Implement OAuth Backend App Flow for Email Accounts

### DIFF
--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -199,7 +199,7 @@ frappe.ui.form.on("Email Account", {
 	},
 
 	show_oauth_authorization_message(frm) {
-		if (frm.doc.auth_method === "OAuth" && frm.doc.connected_app) {
+		if (frm.doc.auth_method === "OAuth" && frm.doc.connected_app && !frm.doc.backend_app_flow) {
 			frappe.call({
 				method: "frappe.integrations.doctype.connected_app.connected_app.has_token",
 				args: {

--- a/frappe/email/doctype/email_account/email_account.js
+++ b/frappe/email/doctype/email_account/email_account.js
@@ -199,7 +199,11 @@ frappe.ui.form.on("Email Account", {
 	},
 
 	show_oauth_authorization_message(frm) {
-		if (frm.doc.auth_method === "OAuth" && frm.doc.connected_app && !frm.doc.backend_app_flow) {
+		if (
+			frm.doc.auth_method === "OAuth" &&
+			frm.doc.connected_app &&
+			!frm.doc.backend_app_flow
+		) {
 			frappe.call({
 				method: "frappe.integrations.doctype.connected_app.connected_app.has_token",
 				args: {

--- a/frappe/email/doctype/email_account/email_account.json
+++ b/frappe/email/doctype/email_account/email_account.json
@@ -18,6 +18,7 @@
   "frappe_mail_site",
   "authentication_column",
   "auth_method",
+  "backend_app_flow",
   "authorize_api_access",
   "validate_frappe_mail_settings",
   "password",
@@ -99,7 +100,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval: doc.service != \"Frappe Mail\"",
+   "depends_on": "eval: doc.service != \"Frappe Mail\" && !doc.backend_app_flow",
    "fieldname": "login_id_is_different",
    "fieldtype": "Check",
    "hide_days": 1,
@@ -581,7 +582,7 @@
    "label": "IMAP Details"
   },
   {
-   "depends_on": "eval: doc.auth_method === \"OAuth\" && doc.connected_app && doc.connected_user",
+   "depends_on": "eval: doc.auth_method === \"OAuth\" && doc.connected_app && doc.connected_user && !doc.backend_app_flow",
    "fieldname": "authorize_api_access",
    "fieldtype": "Button",
    "label": "Authorize API Access"
@@ -610,11 +611,11 @@
    "options": "Connected App"
   },
   {
-   "depends_on": "eval: doc.auth_method === \"OAuth\"",
+   "depends_on": "eval: doc.auth_method === \"OAuth\" && !doc.backend_app_flow",
    "fieldname": "connected_user",
    "fieldtype": "Link",
    "label": "Connected User",
-   "mandatory_depends_on": "eval: doc.auth_method === \"OAuth\"",
+   "mandatory_depends_on": "eval: doc.auth_method === \"OAuth\" && !doc.backend_app_flow",
    "options": "User"
   },
   {
@@ -684,12 +685,19 @@
    "fieldtype": "Password",
    "label": "API Secret",
    "mandatory_depends_on": "eval: doc.service == \"Frappe Mail\" && doc.auth_method == \"Basic\""
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.auth_method === \"OAuth\"",
+   "fieldname": "backend_app_flow",
+   "fieldtype": "Check",
+   "label": "Authenticate as Service Principal"
   }
  ],
  "icon": "fa fa-inbox",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-06-28 08:45:43.565934",
+ "modified": "2024-07-18 11:05:57.193762",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Account",

--- a/frappe/email/doctype/email_account/email_account.py
+++ b/frappe/email/doctype/email_account/email_account.py
@@ -101,7 +101,9 @@ class EmailAccount(Document):
 		password: DF.Password | None
 		send_notification_to: DF.SmallText | None
 		send_unsubscribe_message: DF.Check
-		service: DF.Literal["", "Frappe Mail", "GMail", "Sendgrid", "SparkPost", "Yahoo Mail", "Outlook.com", "Yandex.Mail"]
+		service: DF.Literal[
+			"", "Frappe Mail", "GMail", "Sendgrid", "SparkPost", "Yahoo Mail", "Outlook.com", "Yandex.Mail"
+		]
 		signature: DF.TextEditor | None
 		smtp_port: DF.Data | None
 		smtp_server: DF.Data | None
@@ -783,7 +785,7 @@ class EmailAccount(Document):
 				token = connected_app.get_backend_app_token()
 			else:
 				token = connected_app.get_active_token(self.connected_user)
-			
+
 			return token
 
 
@@ -883,8 +885,10 @@ def pull(now=False):
 	)
 
 	for email_account in email_accounts:
-		if email_account.auth_method == "OAuth" and not email_account.backend_app_flow and not has_token(
-			email_account.connected_app, email_account.connected_user
+		if (
+			email_account.auth_method == "OAuth"
+			and not email_account.backend_app_flow
+			and not has_token(email_account.connected_app, email_account.connected_user)
 		):
 			# don't try to pull from accounts which dont have access token (for Oauth)
 			continue

--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -4,8 +4,8 @@
 import os
 from urllib.parse import urlencode, urljoin
 
-from requests_oauthlib import OAuth2Session
 from oauthlib.oauth2 import BackendApplicationClient
+from requests_oauthlib import OAuth2Session
 
 import frappe
 from frappe import _
@@ -160,16 +160,10 @@ class ConnectedApp(Document):
 			return token_cache
 
 		# Get a new Access token for the App
-		client = BackendApplicationClient(
-			client_id=self.client_id,
-			scope=self.get_scopes()
-		)
+		client = BackendApplicationClient(client_id=self.client_id, scope=self.get_scopes())
 		oauth_session = OAuth2Session(client=client)
 
-		token = oauth_session.fetch_token(
-			self.token_uri,
-			client_secret = self.get_password("client_secret")
-		)
+		token = oauth_session.fetch_token(self.token_uri, client_secret=self.get_password("client_secret"))
 
 		token_cache.update_data(token)
 		token_cache.save(ignore_permissions=True)

--- a/frappe/integrations/doctype/connected_app/connected_app.py
+++ b/frappe/integrations/doctype/connected_app/connected_app.py
@@ -5,6 +5,7 @@ import os
 from urllib.parse import urlencode, urljoin
 
 from requests_oauthlib import OAuth2Session
+from oauthlib.oauth2 import BackendApplicationClient
 
 import frappe
 from frappe import _
@@ -144,6 +145,35 @@ class ConnectedApp(Document):
 				return None
 
 			token_cache.update_data(token)
+
+		return token_cache
+
+	def get_backend_app_token(self):
+		"""Get an Access Token for the Cloud-Registered Service Principal"""
+		# There is no User assigned to the app, so we give it an empty string,
+		# otherwise it will assign the logged in user.
+		token_cache = self.get_token_cache("")
+		if token_cache is None:
+			token_cache = frappe.new_doc("Token Cache")
+			token_cache.connected_app = self.name
+		elif not token_cache.is_expired():
+			return token_cache
+
+		# Get a new Access token for the App
+		client = BackendApplicationClient(
+			client_id=self.client_id,
+			scope=self.get_scopes()
+		)
+		oauth_session = OAuth2Session(client=client)
+
+		token = oauth_session.fetch_token(
+			self.token_uri,
+			client_secret = self.get_password("client_secret")
+		)
+
+		token_cache.update_data(token)
+		token_cache.save(ignore_permissions=True)
+		frappe.db.commit()
 
 		return token_cache
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Added a check-box to the Email Account doctype, labelled "Authenticate as Service Principal" (I'm open to suggestions on this one!). This then hides the "Connected User" text box, as the signing in user is the Email Account itself.

New function added to Connected App `get_backend_app_token`, where it will request an OAuth Access Token, if one doesn't already exist, or if it is expired. Refresh Tokens aren't available for Service Principals, which authenticate just with the App's `client_id` and `client_secret`

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

Email Accounts have until now required to be accessed as a User. We can't therefore use Shared Mailboxes dedicated to Frappe, as Full Access permissions would need to be granted to the user signing into Frappe.

This feature lets Frappe authenticate itself to e.g. Exchange Online, so it can send  and receive emails from the Shared Mailbox, without having to delegate Full Access permissions to each user that accesses Frappe.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

See https://github.com/frappe/frappe/issues/27148 for screenshots of the required setup in Entra ID.

Below are some screenshots of a successfully configured Email Account, that is pulling emails from the IMAP and can send out as the Shared Mailbox as well.

<img width="936" alt="Email Account Details Pane" src="https://github.com/user-attachments/assets/35d7231f-299e-40fa-aedd-38e6a5092ea6">

<img width="934" alt="Email Account Incoming Pane" src="https://github.com/user-attachments/assets/d8a024ca-3414-4219-86f5-33201bcd79aa">

<img width="933" alt="Email Account Outgoing Pane" src="https://github.com/user-attachments/assets/bfe4d44e-f923-42ad-aa81-7d8412d27060">


<!-- Add images/recordings to better visualize the change: expected/current behviour -->

I'm sure some more work may be required before this can be merged. At this stage, I feel like it is now functional, but I'd of course appreciate some help in getting it up to the required standards! 🙂 