### PR TITLE
fix: add translation function to route label text

### DIFF
--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -918,16 +918,16 @@ Object.assign(frappe.utils, {
 		let route = route_str.split("/");
 
 		if (route[2] === "Report" || route[0] === "query-report") {
-			return __("{0} Report", [route[3] || route[1]]);
+			return __("{0} Report", [__(route[3]) || __(route[1])]);
 		}
 		if (route[0] === "List") {
-			return __("{0} List", [route[1]]);
+			return __("{0} List", [__(route[1])]);
 		}
 		if (route[0] === "modules") {
-			return __("{0} Modules", [route[1]]);
+			return __("{0} Modules", [__(route[1])]);
 		}
 		if (route[0] === "dashboard") {
-			return __("{0} Dashboard", [route[1]]);
+			return __("{0} Dashboard", [__(route[1])]);
 		}
 		return __(frappe.utils.to_title_case(route[0], true));
 	},

--- a/frappe/public/js/frappe/utils/utils.js
+++ b/frappe/public/js/frappe/utils/utils.js
@@ -929,7 +929,7 @@ Object.assign(frappe.utils, {
 		if (route[0] === "dashboard") {
 			return __("{0} Dashboard", [__(route[1])]);
 		}
-		return __(frappe.utils.to_title_case(route[0], true));
+		return __(frappe.utils.to_title_case(__(route[0]), true));
 	},
 	report_column_total: function (values, column, type) {
 		if (column.column.disable_total) {


### PR DESCRIPTION
When using the search box in a language other than English, the name of the **list** or **report** is not translated. This issue occurs because the translation function **(__)** was not applied to the route names.

This commit updates the **get_route_label** function to include the translation function **(__)** for route parts. 
These changes ensure that the labels are properly translated based on the given route parts.

Changes made:
- Added __() 

![before](https://github.com/user-attachments/assets/e14bdabf-eefd-42a5-90eb-286f82ee6cc9)![after](https://github.com/user-attachments/assets/220a3e2e-21eb-4db1-b80a-a55e5462ef65)

> Please
> backport version-15-hotfix
> backport  version-14-hotfix


