### PR TITLE
feat: allow disabling background print for a smaller number of documents

### DIFF
--- a/frappe/public/js/frappe/list/bulk_operations.js
+++ b/frappe/public/js/frappe/list/bulk_operations.js
@@ -11,6 +11,7 @@ export default class BulkOperations {
 		const allow_print_for_cancelled = cint(print_settings.allow_print_for_cancelled);
 		const letterheads = this.get_letterhead_options();
 		const MAX_PRINT_LIMIT = 500;
+		const BACKGROUND_PRINT_THRESHOLD = 25;
 
 		const valid_docs = docs
 			.filter((doc) => {
@@ -81,6 +82,13 @@ export default class BulkOperations {
 					depends_on: 'eval:doc.page_size == "Custom"',
 					default: print_settings.pdf_page_width,
 				},
+				{
+					fieldtype: "Check",
+					label: __("Background Print (required for >25 documents)"),
+					fieldname: "background_print",
+					default: valid_docs.length > BACKGROUND_PRINT_THRESHOLD,
+					read_only: valid_docs.length > BACKGROUND_PRINT_THRESHOLD,
+				},
 			],
 		});
 
@@ -105,33 +113,55 @@ export default class BulkOperations {
 				pdf_options = JSON.stringify({ "page-size": args.page_size });
 			}
 
-			frappe
-				.call("frappe.utils.print_format.download_multi_pdf_async", {
-					doctype: this.doctype,
-					name: json_string,
-					format: print_format,
-					no_letterhead: with_letterhead ? "0" : "1",
-					letterhead: letterhead,
-					options: pdf_options,
-				})
-				.then((response) => {
-					let task_id = response.message.task_id;
-					frappe.realtime.task_subscribe(task_id);
-					frappe.realtime.on(`task_complete:${task_id}`, (data) => {
-						frappe.msgprint({
-							title: __("Bulk PDF Export"),
-							message: __("Your PDF is ready for download"),
-							primary_action: {
-								label: __("Download PDF"),
-								client_action: "window.open",
-								args: data.file_url,
-							},
+			if (args.background_print) {
+				frappe
+					.call("frappe.utils.print_format.download_multi_pdf_async", {
+						doctype: this.doctype,
+						name: json_string,
+						format: print_format,
+						no_letterhead: with_letterhead ? "0" : "1",
+						letterhead: letterhead,
+						options: pdf_options,
+					})
+					.then((response) => {
+						let task_id = response.message.task_id;
+						frappe.realtime.task_subscribe(task_id);
+						frappe.realtime.on(`task_complete:${task_id}`, (data) => {
+							frappe.msgprint({
+								title: __("Bulk PDF Export"),
+								message: __("Your PDF is ready for download"),
+								primary_action: {
+									label: __("Download PDF"),
+									client_action: "window.open",
+									args: data.file_url,
+								},
+							});
+							frappe.realtime.task_unsubscribe(task_id);
+							frappe.realtime.off(`task_complete:${task_id}`);
 						});
-						frappe.realtime.task_unsubscribe(task_id);
-						frappe.realtime.off(`task_complete:${task_id}`);
 					});
-					dialog.hide();
-				});
+			} else {
+				const w = window.open(
+					"/api/method/frappe.utils.print_format.download_multi_pdf?" +
+						"doctype=" +
+						encodeURIComponent(this.doctype) +
+						"&name=" +
+						encodeURIComponent(json_string) +
+						"&format=" +
+						encodeURIComponent(print_format) +
+						"&no_letterhead=" +
+						(with_letterhead ? "0" : "1") +
+						"&letterhead=" +
+						encodeURIComponent(letterhead) +
+						"&options=" +
+						encodeURIComponent(pdf_options)
+				);
+
+				if (!w) {
+					frappe.msgprint(__("Please enable pop-ups"));
+				}
+			}
+			dialog.hide();
 		});
 		dialog.show();
 	}


### PR DESCRIPTION
- Saves some storage as the PDFs aren't created as files
- Some sites are facing issues with background print, this can still be used while that's investigated

Reference: #25358

no-docs