### PR TITLE
fix: validate time on mariadb every throw as updated

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -1061,6 +1061,13 @@ class BaseDocument:
 						seconds=db_value.second,
 						microseconds=db_value.microsecond,
 					)
+				elif isinstance(self_value, datetime.time) and isinstance(db_value, datetime.timedelta):
+					self_value = datetime.timedelta(
+						hours=self_value.hour,
+						minutes=self_value.minute,
+						seconds=self_value.second,
+						microseconds=self_value.microsecond,
+					)
 				if self_value != db_value:
 					frappe.throw(
 						_("{0} Not allowed to change {1} after submission from {2} to {3}").format(


### PR DESCRIPTION
Postgres stores values as `datetime.time`, MariaDB as `timedelta`.

i'm Using mariaDB, with frappe.utils.get_time() return a time on format "datetime.time", Comparing these two values, the system presents as if there was a change, but there was not.

Just for comparing "`datetime.time` != `timedelta`".

**Example:**

Doctype "TESTE" with 2 fields
- posting_time (cannot be edited after suibmit)
- description (allow on submit)

new_doc = frappe.new_doc("TESTE")
new_doc.posting_time = frappe.utils.get_time("09:00:15")
new_doc.description = "my name is"
new_doc.save() # save normaly.

new_doc.submit() # submit normaly

in the same session with doc submited i change the field  "description" and i try to save
new_doc.description = "my name is TTT"


new_doc.save() # here we have a stack, because "new_doc.posting_time" is a datetime.time and value on DB is timedelta








