### PR TITLE
fix(translation): Add support for translating text within HTML tags in frappe._ function

### DIFF
--- a/frappe/public/js/frappe/translate.js
+++ b/frappe/public/js/frappe/translate.js
@@ -14,7 +14,28 @@ frappe._ = function (txt, replace, context = null) {
 	}
 
 	if (!translated_text) {
-		translated_text = frappe._messages[key] || txt;
+		translated_text = frappe._messages[key];
+		if (!translated_text) {
+			const isHTML = /<[a-z][\s\S]*>/i.test(txt);
+			if (isHTML) {
+				const parser = new DOMParser();
+				const doc = parser.parseFromString(txt, "text/html");
+				replaceTextNodes(doc.body);
+
+				function replaceTextNodes(node) {
+					if (node.nodeType === Node.TEXT_NODE) {
+						node.textContent = frappe._(node.textContent);
+					} else {
+						node.childNodes.forEach((child) => {
+							replaceTextNodes(child);
+						});
+					}
+				}
+				translated_text = doc.body.innerHTML;
+			} else {
+				translated_text = txt;
+			}
+		}
 	}
 
 	if (replace && typeof replace === "object") {

--- a/frappe/public/js/frappe/translate.js
+++ b/frappe/public/js/frappe/translate.js
@@ -24,14 +24,14 @@ frappe._ = function (txt, replace, context = null) {
 
 				function replaceTextNodes(node) {
 					if (node.nodeType === Node.TEXT_NODE) {
-						node.textContent = frappe._(node.textContent);
+						node.textContent = frappe._(node.textContent, replace, context);
 					} else {
 						node.childNodes.forEach((child) => {
 							replaceTextNodes(child);
 						});
 					}
 				}
-				translated_text = doc.body.innerHTML;
+				return doc.body.innerHTML;
 			} else {
 				translated_text = txt;
 			}

--- a/frappe/public/js/frappe/translate.js
+++ b/frappe/public/js/frappe/translate.js
@@ -20,17 +20,7 @@ frappe._ = function (txt, replace, context = null) {
 			if (isHTML) {
 				const parser = new DOMParser();
 				const doc = parser.parseFromString(txt, "text/html");
-				replaceTextNodes(doc.body, replace, context);
-
-				function replaceTextNodes(node, replace, context) {
-					if (node.nodeType === Node.TEXT_NODE) {
-						node.textContent = frappe._(node.textContent, replace, context);
-					} else {
-						node.childNodes.forEach((child) => {
-							replaceTextNodes(child, replace, context);
-						});
-					}
-				}
+				translateTextNodes(doc.body, replace, context);
 				return doc.body.innerHTML;
 			} else {
 				translated_text = txt;
@@ -43,6 +33,16 @@ frappe._ = function (txt, replace, context = null) {
 	}
 	return translated_text;
 };
+
+function translateTextNodes(node, replace, context) {
+	if (node.nodeType === Node.TEXT_NODE) {
+		node.textContent = frappe._(node.textContent, replace, context);
+	} else {
+		node.childNodes.forEach((child) => {
+			translateTextNodes(child, replace, context);
+		});
+	}
+}
 
 window.__ = frappe._;
 

--- a/frappe/public/js/frappe/translate.js
+++ b/frappe/public/js/frappe/translate.js
@@ -20,14 +20,14 @@ frappe._ = function (txt, replace, context = null) {
 			if (isHTML) {
 				const parser = new DOMParser();
 				const doc = parser.parseFromString(txt, "text/html");
-				replaceTextNodes(doc.body);
+				replaceTextNodes(doc.body, replace, context);
 
-				function replaceTextNodes(node) {
+				function replaceTextNodes(node, replace, context) {
 					if (node.nodeType === Node.TEXT_NODE) {
 						node.textContent = frappe._(node.textContent, replace, context);
 					} else {
 						node.childNodes.forEach((child) => {
-							replaceTextNodes(child);
+							replaceTextNodes(child, replace, context);
 						});
 					}
 				}

--- a/frappe/public/js/frappe/views/workspace/blocks/header.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/header.js
@@ -107,8 +107,8 @@ export default class Header extends Block {
 			let text = this._data.text || "";
 			const contains_html_tag = /<[a-z][\s\S]*>/i.test(text);
 			this._element.innerHTML = contains_html_tag
-				? text
-				: `<span class="h${this._settings.default_size}">${text}</span>`;
+				? __(text)
+				: `<span class="h${this._settings.default_size}">${__(text)}</span>`;
 		}
 
 		if (!this.readOnly && this.wrapper) {

--- a/frappe/public/js/frappe/views/workspace/blocks/header.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/header.js
@@ -104,11 +104,11 @@ export default class Header extends Block {
 		this._data = this.normalizeData(data);
 
 		if (data.text !== undefined) {
-			let text = this._data.text || "";
+			let text = __(this._data.text) || "";
 			const contains_html_tag = /<[a-z][\s\S]*>/i.test(text);
 			this._element.innerHTML = contains_html_tag
-				? __(text)
-				: `<span class="h${this._settings.default_size}">${__(text)}</span>`;
+				? text
+				: `<span class="h${this._settings.default_size}">${text}</span>`;
 		}
 
 		if (!this.readOnly && this.wrapper) {


### PR DESCRIPTION
I resolved an issue related to translating text containing HTML tags
[Translations of text inside workspace textbox](https://discuss.frappe.io/t/translations-of-text-inside-workspace-textbox/106852)

# Problem:
The **workspace** stores **header** and **paragraph** (when bold or link) elements with `HTML tags` in the **database**, and when called, it displays the text according to the `HTML tag (e.g., h1, h2, etc.)`.

Example of header:-
Instead of `Your Shortcuts` the text is saved as
`<span class=\"h4\"><b></b></span><span class=\"h1\"> Your Shortcuts</span><b></b>`

Example of bold paragraph:-
Instead of `My Paragraph` the text is saved as `<b>My Paragraph</b>`

The original translation function `frappe._ (__)` was unable to translate text that included `HTML tags` because the function did not parse HTML and could not identify or translate text nodes within **HTML** content.
So, if no translation is found for the text, it returns itself.

This does not allow translation of text contained within `HTML tags`, even if there is a translation available for text without the HTML tag. Thus, the user must enter the text as it is stored in the database using `HTML tags`, including `classes `and `attributes`, into a `DocType translation`.

This is not possible because it is not allowed to add an HTML tag as a translation source in `DocType Translation`.
And even if we add the ability to add HTML tag as a translation source, the user does not know what `HTML tags` are stored with the `classes `and `attributes`.

# Solution:
Instead of returning the text itself, I added a condition to check if the text contains an `HTML tag` to (`frappe._`) function. If it does not contain an `HTML tag`, it will be returned as is (as the current translation function does). If the text contains an `HTML tag`, it will be parsed as HTML to extract the text, and then the text will be sent to the translation function (`frappe._`) again to be translated correctly. If the text contains more than one tag, the HTML will loop around each tag, extract the text from it, and then send it to the translation function again.
This way, we will ensure the translation of texts stored with HTML tags in the database.

This method will only work if both conditions are met:
1. No translation of the text is found.
2. The text contains an HTML tag.

### before

![after](https://github.com/user-attachments/assets/00c125c8-81b3-4f17-a2d3-37f7e45f2dce)


### after

![after](https://github.com/user-attachments/assets/ac52b3f5-1373-43a3-b03d-a001469ed3d2)




> Please
> backport version-15-hotfix
> backport version-14-hotfix
