### PR TITLE
fix(query_report): don't crash if `execution_time` isn't defined

### DIFF
--- a/frappe/public/js/frappe/form/script_helpers.js
+++ b/frappe/public/js/frappe/form/script_helpers.js
@@ -33,7 +33,7 @@ window.refresh_field = function (n, docname, table_field) {
 };
 
 window.set_field_options = function (n, txt) {
-	cur_frm.set_df_property(n, "options", txt);
+	cur_frm?.set_df_property(n, "options", txt);
 };
 
 window.toggle_field = function (n, hidden) {

--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -462,7 +462,7 @@ frappe.views.QueryReport = class QueryReport extends frappe.views.BaseList {
 
 	setup_progress_bar() {
 		let seconds_elapsed = 0;
-		const execution_time = this.report_settings.execution_time || 0;
+		const execution_time = this.report_settings?.execution_time || 0;
 
 		if (execution_time < 5) return;
 


### PR DESCRIPTION
Prevents a crash when `execution_time` isn't defined

Sentry: FRAPPE-DF, FRAPPE-6JR
