### PR TITLE
fix: check that query_string isn't null before trying to use it

### DIFF
--- a/frappe/website/path_resolver.py
+++ b/frappe/website/path_resolver.py
@@ -134,7 +134,7 @@ def resolve_redirect(path, query_string=None):
 	for rule in redirects:
 		pattern = rule["source"].strip("/ ") + "$"
 		path_to_match = path
-		if rule.get("match_with_query_string"):
+		if query_string and rule.get("match_with_query_string"):
 			path_to_match = path + "?" + frappe.safe_decode(query_string)
 
 		try:


### PR DESCRIPTION
This seemingly broke background printing for a few sites, without really showing the error anywhere
