### PR TITLE
fix(sidebar): replace line break with middle dot

### DIFF
--- a/frappe/public/js/frappe/form/sidebar/form_sidebar.js
+++ b/frappe/public/js/frappe/form/sidebar/form_sidebar.js
@@ -92,7 +92,7 @@ frappe.ui.form.Sidebar = class {
 						"{0} edited this {1}",
 						[
 							frappe.user.full_name(this.frm.doc.modified_by).bold(),
-							"<br>" + comment_when(this.frm.doc.modified),
+							" · " + comment_when(this.frm.doc.modified),
 						],
 						"For example, 'Jon Doe edited this 5 minutes ago'."
 					)
@@ -104,7 +104,7 @@ frappe.ui.form.Sidebar = class {
 						"{0} created this {1}",
 						[
 							frappe.user.full_name(this.frm.doc.owner).bold(),
-							"<br>" + comment_when(this.frm.doc.creation),
+							" · " + comment_when(this.frm.doc.creation),
 						],
 						"For example, 'Jon Doe created this 5 minutes ago'."
 					)


### PR DESCRIPTION
### Before
![before](https://github.com/user-attachments/assets/aaf1421e-6be7-4066-b7e9-9e9fff08a77e)


### After

![after](https://github.com/user-attachments/assets/c69687d8-13d4-43ad-b5bb-f9615c095d1e)

(Already a part of v15, along with some bigger changes that shouldn't get backported)