### PR TITLE
fix(minor): move Create Workspace button to footer

### DIFF
--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -79,7 +79,7 @@ context("Workspace 2.0", () => {
 		}).as("page_duplicated");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn[data-label=Edit]").click();
+		cy.get(".btn-edit-workspace").click();
 
 		cy.get('.sidebar-item-container[item-name="Test Private Page"]').as("sidebar-item");
 

--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -18,7 +18,7 @@ context("Workspace 2.0", () => {
 		}).as("new_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
+		cy.get('.workspace-footer button[data-label="New"]').click();
 		cy.fill_field("title", "Test Private Page", "Data");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
@@ -48,7 +48,7 @@ context("Workspace 2.0", () => {
 		}).as("new_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
+		cy.get('.workspace-footer button[data-label="New"]').click();
 		cy.fill_field("title", "Test Child Page", "Data");
 		cy.fill_field("parent", "Test Private Page", "Select");
 		cy.get_open_dialog().find(".modal-header").click();
@@ -196,7 +196,7 @@ context("Workspace 2.0", () => {
 		}).as("hide_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn-secondary[data-label=Edit]").click();
+		cy.get(".workspace-footer .btn-secondary[data-label=Edit]").click();
 
 		cy.get('.sidebar-item-container[item-name="Duplicate Page"]')
 			.find(".sidebar-item-control .setting-btn")
@@ -217,7 +217,7 @@ context("Workspace 2.0", () => {
 		}).as("unhide_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn-secondary[data-label=Edit]").click();
+		cy.get(".workspace-footer .btn-secondary[data-label=Edit]").click();
 
 		cy.get('.sidebar-item-container[item-name="Duplicate Page"]')
 			.find('[title="Unhide Workspace"]')
@@ -237,7 +237,7 @@ context("Workspace 2.0", () => {
 		}).as("page_deleted");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn-secondary[data-label=Edit]").click();
+		cy.get(".workspace-footer .btn-secondary[data-label=Edit]").click();
 
 		cy.get('.sidebar-item-container[item-name="Duplicate Page"]')
 			.find(".sidebar-item-control .setting-btn")

--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -18,7 +18,7 @@ context("Workspace 2.0", () => {
 		}).as("new_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.workspace-footer button[data-label="New"]').click();
+		cy.get('.workspace-footer button[data-label="New"]:visible').click();
 		cy.fill_field("title", "Test Private Page", "Data");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
@@ -48,7 +48,7 @@ context("Workspace 2.0", () => {
 		}).as("new_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.workspace-footer button[data-label="New"]').click();
+		cy.get('.workspace-footer button[data-label="New"]:visible').click();
 		cy.fill_field("title", "Test Child Page", "Data");
 		cy.fill_field("parent", "Test Private Page", "Select");
 		cy.get_open_dialog().find(".modal-header").click();

--- a/cypress/integration/workspace.js
+++ b/cypress/integration/workspace.js
@@ -18,7 +18,7 @@ context("Workspace 2.0", () => {
 		}).as("new_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.workspace-footer button[data-label="New"]:visible').click();
+		cy.get(".btn-new-workspace").click();
 		cy.fill_field("title", "Test Private Page", "Data");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
@@ -48,7 +48,7 @@ context("Workspace 2.0", () => {
 		}).as("new_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.workspace-footer button[data-label="New"]:visible').click();
+		cy.get(".btn-new-workspace").click();
 		cy.fill_field("title", "Test Child Page", "Data");
 		cy.fill_field("parent", "Test Private Page", "Select");
 		cy.get_open_dialog().find(".modal-header").click();
@@ -79,7 +79,7 @@ context("Workspace 2.0", () => {
 		}).as("page_duplicated");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn-secondary[data-label=Edit]").click();
+		cy.get(".standard-actions .btn[data-label=Edit]").click();
 
 		cy.get('.sidebar-item-container[item-name="Test Private Page"]').as("sidebar-item");
 
@@ -196,7 +196,7 @@ context("Workspace 2.0", () => {
 		}).as("hide_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".workspace-footer .btn-secondary[data-label=Edit]").click();
+		cy.get(".btn-edit-workspace").click();
 
 		cy.get('.sidebar-item-container[item-name="Duplicate Page"]')
 			.find(".sidebar-item-control .setting-btn")
@@ -217,7 +217,7 @@ context("Workspace 2.0", () => {
 		}).as("unhide_page");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".workspace-footer .btn-secondary[data-label=Edit]").click();
+		cy.get(".btn-edit-workspace").click();
 
 		cy.get('.sidebar-item-container[item-name="Duplicate Page"]')
 			.find('[title="Unhide Workspace"]')
@@ -237,7 +237,7 @@ context("Workspace 2.0", () => {
 		}).as("page_deleted");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".workspace-footer .btn-secondary[data-label=Edit]").click();
+		cy.get(".btn-edit-workspace").click();
 
 		cy.get('.sidebar-item-container[item-name="Duplicate Page"]')
 			.find(".sidebar-item-control .setting-btn")

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -18,7 +18,7 @@ context("Workspace Blocks", () => {
 
 		cy.visit("/app/website");
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.custom-actions button[data-label="Create%20Workspace"]').click();
+		cy.get('.workspace-footer button[data-label="New"]').click();
 		cy.fill_field("title", "Test Block Page", "Data");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -174,7 +174,7 @@ context("Workspace Blocks", () => {
 		cy.get("@number_card").find(".widget-title").should("contain", "Test Number Card");
 
 		// edit number card
-		cy.get(".standard-actions .btn-secondary[data-label=Edit]").click();
+		cy.get(".btn-edit-workspace").click();
 		cy.get("@number_card").realHover().find(".widget-control .edit-button").click();
 		cy.get_field("label", "Data").invoke("val", "ToDo Count");
 		cy.click_modal_primary_button("Save");

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -18,7 +18,7 @@ context("Workspace Blocks", () => {
 
 		cy.visit("/app/website");
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.workspace-footer button[data-label="New"]').click();
+		cy.get('.workspace-footer button[data-label="New"]:visible').click();
 		cy.fill_field("title", "Test Block Page", "Data");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
@@ -159,7 +159,7 @@ context("Workspace Blocks", () => {
 		]);
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn-secondary[data-label=Edit]").click();
+		cy.get(".workspace-footer .btn[data-label=Edit]").click();
 
 		cy.get(".ce-block").first().click({ force: true }).type("{enter}");
 		cy.get(".block-list-container .block-list-item").contains("Number Card").click();

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -18,7 +18,7 @@ context("Workspace Blocks", () => {
 
 		cy.visit("/app/website");
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get('.workspace-footer button[data-label="New"]:visible').click();
+		cy.get(".btn-new-workspace").click();
 		cy.fill_field("title", "Test Block Page", "Data");
 		cy.get_open_dialog().find(".modal-header").click();
 		cy.get_open_dialog().find(".btn-primary").click();
@@ -71,7 +71,7 @@ context("Workspace Blocks", () => {
 		}).as("get_doctype");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn-secondary[data-label=Edit]").click();
+		cy.get(".standard-actions .btn[data-label=Edit]").click();
 
 		// test quick list creation
 		cy.get(".ce-block").first().click({ force: true }).type("{enter}");
@@ -159,7 +159,7 @@ context("Workspace Blocks", () => {
 		]);
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".workspace-footer .btn[data-label=Edit]").click();
+		cy.get(".btn-edit-workspace").click();
 
 		cy.get(".ce-block").first().click({ force: true }).type("{enter}");
 		cy.get(".block-list-container .block-list-item").contains("Number Card").click();

--- a/cypress/integration/workspace_blocks.js
+++ b/cypress/integration/workspace_blocks.js
@@ -71,7 +71,7 @@ context("Workspace Blocks", () => {
 		}).as("get_doctype");
 
 		cy.get(".codex-editor__redactor .ce-block");
-		cy.get(".standard-actions .btn[data-label=Edit]").click();
+		cy.get(".btn-edit-workspace").click();
 
 		// test quick list creation
 		cy.get(".ce-block").first().click({ force: true }).type("{enter}");

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -381,6 +381,16 @@ frappe.views.Workspace = class Workspace {
 		if (!this.body.find("#editorjs")[0]) {
 			this.$page = $(`
 				<div id="editorjs" class="desk-page page-main-content"></div>
+				<div class="workspace-footer">
+					<button data-label="New%20Workspace" class="btn btn-default ellipsis btn-new-workspace">
+						New
+					</button>
+					<button class="btn btn-secondary btn-default btn-sm mr-2 btn-edit-workspace" data-label="Edit">
+						<svg class="es-icon es-line  icon-xs" style="" aria-hidden="true">
+							<use class="" href="#es-line-edit"></use>
+						</svg> <span class="hidden-xs" data-label="Edit"> <span><span class="alt-underline">E</span>dit</span> </span>
+					</button>
+				</div>
 			`).appendTo(this.body);
 		}
 
@@ -456,9 +466,10 @@ frappe.views.Workspace = class Workspace {
 
 		this.clear_page_actions();
 		if (current_page.is_editable) {
-			this.page.set_secondary_action(
-				__("Edit"),
-				async () => {
+			this.body
+				.find(".btn-edit-workspace")
+				.removeClass("hide")
+				.on("click", async () => {
 					if (!this.editor || !this.editor.readOnly) return;
 					this.is_read_only = false;
 					this.toggle_hidden_workspaces(true);
@@ -470,15 +481,21 @@ frappe.views.Workspace = class Workspace {
 						this.show_sidebar_actions();
 						this.make_blocks_sortable();
 					});
-				},
-				"es-line-edit"
-			);
+				});
+		} else {
+			this.body.find(".btn-edit-workspace").addClass("hide");
 		}
 		// need to add option for icons in inner buttons as well
-		if (this.has_create_access)
-			this.page.add_inner_button(__("Create Workspace"), () => {
-				this.initialize_new_page(true);
-			});
+		if (this.has_create_access) {
+			this.body
+				.find(".btn-new-workspace")
+				.removeClass("hide")
+				.on("click", () => {
+					this.initialize_new_page(true);
+				});
+		} else {
+			this.body.find(".btn-new-workspace").addClass("hide");
+		}
 	}
 
 	initialize_editorjs_undo() {

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -388,7 +388,7 @@ frappe.views.Workspace = class Workspace {
 						</svg>
 						<span class="hidden-xs" data-label="Edit">New</span>
 					</button>
-					<button class="btn btn-secondary btn-default btn-sm mr-2 btn-edit-workspace" data-label="Edit">
+					<button class="btn btn-default btn-sm mr-2 btn-edit-workspace" data-label="Edit">
 						<svg class="es-icon es-line  icon-xs" style="" aria-hidden="true">
 							<use class="" href="#es-line-edit"></use>
 						</svg>

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -382,13 +382,19 @@ frappe.views.Workspace = class Workspace {
 			this.$page = $(`
 				<div id="editorjs" class="desk-page page-main-content"></div>
 				<div class="workspace-footer">
-					<button data-label="New%20Workspace" class="btn btn-default ellipsis btn-new-workspace">
-						New
+					<button data-label="New" class="btn btn-default ellipsis btn-new-workspace">
+						<svg class="es-icon es-line  icon-xs" style="" aria-hidden="true">
+							<use class="" href="#es-line-add"></use>
+						</svg>
+						<span class="hidden-xs" data-label="Edit">New</span>
 					</button>
 					<button class="btn btn-secondary btn-default btn-sm mr-2 btn-edit-workspace" data-label="Edit">
 						<svg class="es-icon es-line  icon-xs" style="" aria-hidden="true">
 							<use class="" href="#es-line-edit"></use>
-						</svg> <span class="hidden-xs" data-label="Edit"> <span><span class="alt-underline">E</span>dit</span> </span>
+						</svg>
+						<span class="hidden-xs" data-label="Edit">
+							<span><span class="alt-underline">E</span>dit</span>
+						</span>
 					</button>
 				</div>
 			`).appendTo(this.body);

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -1015,6 +1015,12 @@ body {
 		padding: var(--padding-sm);
 	}
 
+	.workspace-footer {
+		height: 30px;
+		display: flex;
+		flex-direction: row-reverse;
+	}
+
 	.block-menu-item-icon svg {
 		width: 18px;
 		height: 18px;

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -994,6 +994,10 @@ body {
 					.links-widget-box {
 						background-color: var(--bg-color) !important;
 					}
+
+					.workspace-footer {
+						display: none;
+					}
 				}
 			}
 


### PR DESCRIPTION
Stop new users from creating workspace by moving the buttons to the bottom

<img width="1208" alt="Screenshot 2024-07-27 at 12 23 42 PM" src="https://github.com/user-attachments/assets/15b46868-8712-4d16-b4d0-1850a6be947b">
