### PR TITLE
fix(Web Form): enable no copy for 'Is Standard' flag

### DIFF
--- a/frappe/website/doctype/web_form/web_form.json
+++ b/frappe/website/doctype/web_form/web_form.json
@@ -94,7 +94,8 @@
    "default": "0",
    "fieldname": "is_standard",
    "fieldtype": "Check",
-   "label": "Is Standard"
+   "label": "Is Standard",
+   "no_copy": 1
   },
   {
    "default": "0",
@@ -393,7 +394,7 @@
  "icon": "icon-edit",
  "is_published_field": "published",
  "links": [],
- "modified": "2024-03-23 16:04:01.886581",
+ "modified": "2024-07-27 20:32:06.331745",
  "modified_by": "Administrator",
  "module": "Website",
  "name": "Web Form",


### PR DESCRIPTION
The Is Standard checkbox is read only on prod. So users duplicating a standard form cannot save it. 