### PR TITLE
fix: Email Sent Twice

### DIFF
--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -362,7 +362,11 @@ class User(Document):
 							user=self.name, pwd=new_password, logout_all_sessions=self.logout_all_sessions
 						)
 
-					if not self.flags.no_welcome_mail and cint(self.send_welcome_email) and not self.flags.email_sent:
+					if (
+						not self.flags.no_welcome_mail
+						and cint(self.send_welcome_email)
+						and not self.flags.email_sent
+					):
 						self.send_welcome_mail_to_user()
 						self.flags.email_sent = 1
 						if frappe.session.user != "Guest":

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -353,6 +353,9 @@ class User(Document):
 		# 		frappe.throw(_("Sorry! Sharing with Website User is prohibited."))
 
 	def send_password_notification(self, new_password):
+		if self.flags.email_sent:
+			return
+
 		try:
 			if self.flags.in_insert:
 				if self.name not in STANDARD_USERS:

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -353,9 +353,6 @@ class User(Document):
 		# 		frappe.throw(_("Sorry! Sharing with Website User is prohibited."))
 
 	def send_password_notification(self, new_password):
-		if self.flags.email_sent:
-			return
-
 		try:
 			if self.flags.in_insert:
 				if self.name not in STANDARD_USERS:
@@ -365,7 +362,7 @@ class User(Document):
 							user=self.name, pwd=new_password, logout_all_sessions=self.logout_all_sessions
 						)
 
-					if not self.flags.no_welcome_mail and cint(self.send_welcome_email):
+					if not self.flags.no_welcome_mail and cint(self.send_welcome_email) and not self.flags.email_sent:
 						self.send_welcome_mail_to_user()
 						self.flags.email_sent = 1
 						if frappe.session.user != "Guest":


### PR DESCRIPTION
version 15 and 14

fixes: #27226 & https://discuss.frappe.io/t/email-sent-twice-invite-as-user/124057/8?u=ncp

If the email has already been sent, will not resend it.