### PR TITLE
fix: remove context from translatable strings in Workspace

### DIFF
--- a/frappe/gettext/extractors/workspace.py
+++ b/frappe/gettext/extractors/workspace.py
@@ -29,8 +29,8 @@ def extract(fileobj, *args, **kwargs):
 	yield from (
 		(
 			None,
-			"pgettext",
-			(link.get("link_to") if link.get("link_type") == "DocType" else None, link.get("label")),
+			"_",
+			link.get("label"),
 			[f"Label of a {link.get('type')} in the {workspace_name} Workspace"],
 		)
 		for link in data.get("links", [])
@@ -38,8 +38,8 @@ def extract(fileobj, *args, **kwargs):
 	yield from (
 		(
 			None,
-			"pgettext",
-			(link.get("link_to") if link.get("link_type") == "DocType" else None, link.get("description")),
+			"_",
+			link.get("description"),
 			[f"Description of a {link.get('type')} in the {workspace_name} Workspace"],
 		)
 		for link in data.get("links", [])
@@ -47,8 +47,8 @@ def extract(fileobj, *args, **kwargs):
 	yield from (
 		(
 			None,
-			"pgettext",
-			(shortcut.get("link_to") if shortcut.get("type") == "DocType" else None, shortcut.get("label")),
+			"_",
+			shortcut.get("label"),
 			[f"Label of a shortcut in the {workspace_name} Workspace"],
 		)
 		for shortcut in data.get("shortcuts", [])
@@ -56,8 +56,8 @@ def extract(fileobj, *args, **kwargs):
 	yield from (
 		(
 			None,
-			"pgettext",
-			(shortcut.get("link_to") if shortcut.get("type") == "DocType" else None, shortcut.get("format")),
+			"_",
+			shortcut.get("format"),
 			[f"Count format of shortcut in the {workspace_name} Workspace"],
 		)
 		for shortcut in data.get("shortcuts", [])


### PR DESCRIPTION
This removes many useless entries from the translation files. E.g., for **Activity Log**:

### Before

```
#. Name of a DocType
#: core/doctype/activity_log/activity_log.json
msgid "Activity Log"
msgstr ""

#. Label of a Link in the Build Workspace
#. Label of a Link in the Users Workspace
#: core/workspace/build/build.json core/workspace/users/users.json
msgctxt "Activity Log"
msgid "Activity Log"
msgstr ""
```

### After

```
#. Name of a DocType
#. Label of a Link in the Build Workspace
#. Label of a Link in the Users Workspace
#: core/doctype/activity_log/activity_log.json core/workspace/build/build.json
#: core/workspace/users/users.json
msgid "Activity Log"
msgstr ""
``` 