### PR TITLE
fix: disable fuzzy matching while updating po files

### DIFF
--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -218,7 +218,7 @@ def update_po(target_app: str | None = None, locale: str | None = None):
 		pot_catalog = get_catalog(app)
 		for locale in locales:
 			po_catalog = get_catalog(app, locale)
-			po_catalog.update(pot_catalog)
+			po_catalog.update(pot_catalog, no_fuzzy_matching=True)
 			po_path = write_catalog(app, po_catalog, locale)
 			print(f"PO file modified at {po_path}")
 


### PR DESCRIPTION
This was annoying because it tried to be smart by adding similar existing translations for new strings, but the translations were mostly wrong (way too fuzzy).
