### PR TITLE
fix(kanban): show "No results found" msg if no results found after filtering

### DIFF
--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -119,7 +119,7 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 
 	toggle_result_area() {
 		if (this.data.length == 0) {
-			frappe.msgprint(__('No results found'));
+			frappe.msgprint(__("No results found"));
 		} else {
 			this.$result.toggle(this.data.length > 0);
 		}

--- a/frappe/public/js/frappe/views/kanban/kanban_view.js
+++ b/frappe/public/js/frappe/views/kanban/kanban_view.js
@@ -118,7 +118,11 @@ frappe.views.KanbanView = class KanbanView extends frappe.views.ListView {
 	}
 
 	toggle_result_area() {
-		this.$result.toggle(this.data.length > 0);
+		if (this.data.length == 0) {
+			frappe.msgprint(__('No results found'));
+		} else {
+			this.$result.toggle(this.data.length > 0);
+		}
 	}
 
 	get_board() {


### PR DESCRIPTION
* Prints message "No results found" if no data found to display
* Prevents showing complete blank page

**version-15**

Avoids complete empty Kanban space if no results are found after filtering. A complete empty filtered Kanban with no warning messages or "No results" div may lead users to consired this an undesired behaviour.

**Before**

![image](https://github.com/user-attachments/assets/e62f2510-31ea-4a27-a792-8e8c4691a749)

![image](https://github.com/user-attachments/assets/b1c99228-8a30-490a-8402-6787f16ef20d)



**After**

Shows messaged explaining what happened and why no results are displayed, and still displays columns.

![image](https://github.com/user-attachments/assets/d2fccfb6-7b98-4dbf-843a-bcd25190fe24)

![image](https://github.com/user-attachments/assets/74e0cc39-571e-4389-af56-3eb5b026cca0)

![image](https://github.com/user-attachments/assets/e90d3d1b-e288-480d-8a85-7c2869890a4b)
