### PR TITLE
fix(desk): Improve fieldname parsing in sort selector

### DIFF
--- a/frappe/public/js/frappe/ui/group_by/group_by.js
+++ b/frappe/public/js/frappe/ui/group_by/group_by.js
@@ -189,7 +189,7 @@ frappe.ui.GroupBy = class {
 
 	apply_settings(settings) {
 		let get_fieldname = (name) => name.split(".")[1].replace(/`/g, "");
-		let get_doctype = (name) => name.split(".")[0].replace(/`/g, "").replace("tab", "");
+		let get_doctype = (name) => name.split(".")[0].replace(/`/g, "").replace(/^tab/, "");
 
 		if (!settings.group_by.startsWith("`tab")) {
 			settings.group_by = "`tab" + this.doctype + "`.`" + settings.group_by + "`";

--- a/frappe/public/js/frappe/ui/sort_selector.js
+++ b/frappe/public/js/frappe/ui/sort_selector.js
@@ -63,9 +63,15 @@ frappe.ui.SortSelector = class SortSelector {
 			var order_by = this.args;
 			this.args = {};
 
-			if (order_by.includes("`.`")) {
-				// scrub table name (separated by dot), like `tabTime Log`.`creation` desc`
-				order_by = order_by.split(".")[1];
+			if (order_by.includes(",")) {
+				// only keep first
+				order_by = order_by.split(",")[0];
+			}
+
+			if (order_by.includes("`.")) {
+				// scrub table name (separated by dot), like "`tabTime Log`.`creation` desc"
+				// and is robust to missing backticks
+				order_by = order_by.split(".")[1].replace("`", "");
 			}
 
 			var parts = order_by.split(" ");
@@ -196,12 +202,12 @@ frappe.ui.SortSelector = class SortSelector {
 		}
 	}
 	get_sql_string() {
-		// build string like: `tabSales Invoice`.subject, `tabSales Invoice`.name desc
+		// build string like: `tabSales Invoice`.`subject`, `tabSales Invoice`.`name` desc
 		const table_name = "`tab" + this.doctype + "`";
-		const sort_by = `${table_name}.${this.sort_by}`;
+		const sort_by = `${table_name}.\`${this.sort_by}\``;
 		if (!["name", "creation", "modified"].includes(this.sort_by)) {
 			// add name column for deterministic ordering
-			return `${sort_by} ${this.sort_order}, ${table_name}.name ${this.sort_order}`;
+			return `${sort_by} ${this.sort_order}, ${table_name}.\`name\` ${this.sort_order}`;
 		} else {
 			return `${sort_by} ${this.sort_order}`;
 		}


### PR DESCRIPTION
When saving a Report from the Report View (aka Report Builder), the sort_by fieldname was not serialized such that the SortSelector could not parse it correctly.

Indeed, the `get_sql_string` function returned values such as:

```sql
`tabEvent`.modified
```

instead of the more correct :

```sql
`tabEvent`.`modified`
```

(notice the backticks around the column name)

![image](https://github.com/user-attachments/assets/8b821a7b-ca44-4636-b50b-af7ac06e37c0)


---

This PR addresses both the serialization and parsing:
* ensure that `get_sql_string` always adds backticks around both the table name and the column name
* ensure that `SortSelector.prepare_args` is robust to missing backticks in the column name (backwards compatibility with values in the `__UserSettings`)


---

# Details

<details>

```
Syntax error in query:
select `tabEvent`.`name`, `tabEvent`.`docstatus`, `tabEvent`.`subject`, `tabEvent`.`event_type`, `tabEvent`.`status`, `tabEvent`.`starts_on`, `tabEvent`.`ends_on`
			from `tabEvent`
			where `tabEvent`.`status` = 'Open' and ((`tabEvent`.`event_type`='Public' or `tabEvent`.`owner`='john.doe@demo.com'))
			
			 order by `tabEvent`.`tabEvent`.modified` desc
			limit 20 offset 0 /* FRAPPE_TRACE_ID: 32e7b845-1b8f-46c2-990f-b65e90b8cd33 */ 

```

---

```
{
	"exception": "pymysql.err.ProgrammingError: (1064, \"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '` desc\\n\\t\\t\\tlimit 20 offset 0 /* FRAPPE_TRACE_ID: 32e7b845-1b8f-46c2-990f-b65e9...' at line 5\")",
	"exc_type": "ProgrammingError",
	"_debug_messages": "[\"Syntax error in query:\\nselect `tabEvent`.`name`, `tabEvent`.`docstatus`, `tabEvent`.`subject`, `tabEvent`.`event_type`, `tabEvent`.`status`, `tabEvent`.`starts_on`, `tabEvent`.`ends_on`\\n\\t\\t\\tfrom `tabEvent`\\n\\t\\t\\twhere `tabEvent`.`status` = 'Open' and ((`tabEvent`.`event_type`='Public' or `tabEvent`.`owner`='john.doe@demo.com'))\\n\\t\\t\\t\\n\\t\\t\\t order by `tabEvent`.`tabEvent`.modified` desc\\n\\t\\t\\tlimit 20 offset 0 /* FRAPPE_TRACE_ID: 32e7b845-1b8f-46c2-990f-b65e90b8cd33 */ \"]"
}
```

</details>