### PR TITLE
feat: add command update-csv-from-po

### DIFF
--- a/frappe/commands/gettext.py
+++ b/frappe/commands/gettext.py
@@ -79,6 +79,25 @@ def create_po_file(context, locale: str, app: str | None = None):
 	new_po(locale, app)
 
 
+@click.command("update-csv-from-po")
+@click.argument("app", nargs=1)
+@click.argument("locale", nargs=1)
+def update_csv_from_po(app: str, locale: str) -> None:
+	"""Add missing translations from PO file to CSV file.
+
+	How to:
+	(1) add a [locale].po file in the app's `locale` directory (this can be downloaded from the new translation platform or copied from another branch), then
+	(2) run this command.
+
+	This will add all translations to the CSV file, that are in the PO file but were missing in the CSV file.
+
+	This command is intended for backporting translations from the new translation system to the old one.
+	"""
+	from frappe.gettext.translate import update_csv_from_po
+
+	update_csv_from_po(app, locale)
+
+
 def connect_to_site(site):
 	from frappe import connect
 
@@ -94,4 +113,5 @@ commands = [
 	csv_to_po,
 	update_po_files,
 	create_po_file,
+	update_csv_from_po,
 ]

--- a/frappe/gettext/translate.py
+++ b/frappe/gettext/translate.py
@@ -307,3 +307,40 @@ def get_translations_from_mo(lang, app):
 
 def escape_percent(s: str):
 	return s.replace("%", "&#37;")
+
+
+def update_csv_from_po(app: str, locale: str):
+	"""Writes new strings from PO files to CSV
+
+	Steps:
+
+	1. Generate a POT file holding the app's translatable strings.
+	2. Update the PO file from the POT file. This removes all superfluos translations.
+	3. Read in the catalog from the PO file.
+	4. Read in the CSV file.
+	5. Remove all translations from the catalog that are already in the CSV.
+	6. Append the remaining translations from the catalog to the CSV file.
+	"""
+	generate_pot(app)
+	update_po(app, locale)
+
+	catalog = get_catalog(app, locale)
+	csv_file = Path(frappe.get_app_path(app)) / "translations" / f"{locale.replace('_', '-')}.csv"
+
+	if not csv_file.exists():
+		return
+
+	with open(csv_file) as f:
+		csv_translations = {(row[0], row[2] if len(row) > 2 else None): row[1] for row in csv.reader(f)}
+
+	for message in list(catalog):
+		if (message.id, message.context or "") in csv_translations or not message.string:
+			catalog.delete(message.id, message.context)
+
+	with open(csv_file, "a") as f:
+		writer = csv.writer(f)
+		for message in catalog._messages.values():
+			if message.id == message.string or message.id == message.context or not message.id.strip():
+				continue
+
+			writer.writerow([message.id, message.string, message.context or ""])


### PR DESCRIPTION
Adds a bench command to help with backporting translations from the new translation system to the old one.

``` 
$ bench update-csv-from-po --help
Usage: bench  update-csv-from-po [OPTIONS] APP LOCALE

  Add missing translations from PO file to CSV file.

  How to: (1) add a [locale].po file in the app's `locale` directory (this can
  be downloaded from the new translation platform or copied from another
  branch), then (2) run this command.

  This will add all translations to the CSV file, that are in the PO file but
  were missing in the CSV file.

  This command is intended for backporting translations from the new
  translation system to the old one.

Options:
  --help  Show this message and exit.
```

This command was used for creating https://github.com/frappe/erpnext/pull/42561 and https://github.com/frappe/hrms/pull/2022

Not adding tests since this is developer tooling which will only be used a handful of times. Also, this is built from well-tested components.