### PR TITLE
fix(quick_list_widget): avoid undefined word display if status is undefined

### DIFF
--- a/frappe/public/js/frappe/widgets/quick_list_widget.js
+++ b/frappe/public/js/frappe/widgets/quick_list_widget.js
@@ -151,10 +151,15 @@ export default class QuickListWidget extends Widget {
 			</div>
 		`);
 
-		if (indicator) {
+		if (indicator[2] != "status,=,undefined") {
 			$(`
 				<div class="status indicator-pill ${indicator[1]} ellipsis">
 					${__(indicator[0])}
+				</div>
+			`).appendTo($quick_list_item);
+		} else {
+			$(`
+				<div class="status indicator-pill ellipsis hidden">
 				</div>
 			`).appendTo($quick_list_item);
 		}


### PR DESCRIPTION
* Hides indicator pill if status is undefined
* Avoids displaying the word "undefined"

**version-15**

If doctype status is undefined, the word "undefined" is displayed raw and indicator pill style is not properly formed. By hiding the div if the status is undefined we prevent this from happening and get a coherent style.


**Before**

Task-based quick list

![image](https://github.com/user-attachments/assets/f9723335-c69a-487f-920e-b693f80f48e5)


**After**

Task-based quick list

![image](https://github.com/user-attachments/assets/0600e2a6-a591-452a-a881-e86c279f2fc4)

