### PR TITLE
fix: :bug: show link titles for virtual link fields too

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -421,7 +421,9 @@ def get_title_values_for_link_and_dynamic_link_fields(doc, link_fields=None):
 		link_fields = meta.get_link_fields() + meta.get_dynamic_link_fields()
 
 	for field in link_fields:
-		if not doc.get(field.fieldname):
+		link_docname = getattr(doc, field.fieldname)
+
+		if not link_docname:
 			continue
 
 		doctype = field.options if field.fieldtype == "Link" else doc.get(field.options)
@@ -430,10 +432,8 @@ def get_title_values_for_link_and_dynamic_link_fields(doc, link_fields=None):
 		if not meta or not meta.title_field or not meta.show_title_field_in_link:
 			continue
 
-		link_title = frappe.db.get_value(
-			doctype, doc.get(field.fieldname), meta.title_field, cache=True, order_by=None
-		)
-		link_titles.update({doctype + "::" + doc.get(field.fieldname): link_title})
+		link_title = frappe.db.get_value(doctype, link_docname, meta.title_field, cache=True, order_by=None)
+		link_titles.update({doctype + "::" + link_docname: link_title})
 
 	return link_titles
 


### PR DESCRIPTION
I tried to fix the problem at its root in the `get` method from `BaseDocument` but wasn't able to.

Whatever I tried wouldn't work because the code would get recursively called ad infinitum due to the property `docstatus` in `BaseDocument` which uses `get` itself. I seriously don't understand why there exists a property with the same name as a field (and even returning a different type), although the field is not virtual and was not willing to touch this at all.

I decided on just using `getattr` in `get_title_values_for_link_and_dynamic_link_fields` directly since there is other existing code already doing so without checking beforehand if something is a property or not (see `as_dict` from `BaseDocument` for an example).

I am totally not sure if this is a good fix so please review with care.

If accepted, please backport to version-14 and version-15.

This fixes a small part of https://github.com/frappe/frappe/issues/27247 