### PR TITLE
fix: header block is not translatable

### DIFF
--- a/frappe/public/js/frappe/views/workspace/blocks/header.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/header.js
@@ -104,7 +104,7 @@ export default class Header extends Block {
 		this._data = this.normalizeData(data);
 
 		if (data.text !== undefined) {
-			let text = this._data.text || "";
+			let text = __(this._data.text) || "";
 			const contains_html_tag = /<[a-z][\s\S]*>/i.test(text);
 			this._element.innerHTML = contains_html_tag
 				? text

--- a/frappe/public/js/frappe/views/workspace/blocks/header.js
+++ b/frappe/public/js/frappe/views/workspace/blocks/header.js
@@ -106,6 +106,14 @@ export default class Header extends Block {
 		if (data.text !== undefined) {
 			let text = __(this._data.text) || "";
 			const contains_html_tag = /<[a-z][\s\S]*>/i.test(text);
+
+			// apply translation to header text
+			let div = document.createElement("div");
+			div.innerHTML = text;
+			let only_text = div.innerText;
+			only_text = frappe.utils.escape_html(only_text);
+			text = text.replace(only_text, __(only_text));
+
 			this._element.innerHTML = contains_html_tag
 				? text
 				: `<span class="h${this._settings.default_size}">${text}</span>`;


### PR DESCRIPTION
Header block in workspace is not translatable.

With this fix it will become translatable but only if exact html is present as a translatable string

![image](https://github.com/user-attachments/assets/9a63d8e4-3540-4f08-bb16-44de76457afb)

Source:
`<span class=\\"h4"\\>Get <i>started</i></span><br>`
Target:
`<span class=\\"h4"\\>Get <i>started</i> Again</span><br>`


Also if the Header text is simple without any inline htmls within text like <i></i> or link then also it gets translated without using exact html.

Header text: `<span class=\\"h4"\\>Get started</span><br>`
Source:
`Get started`
Target:
`Get started Again`