### PR TITLE
feat: Apps page

### DIFF
--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -14,7 +14,7 @@ def get_apps():
 	for app in apps:
 		if app == "frappe":
 			continue
-		app_details = frappe.get_hooks("include_as_app", app_name=app)
+		app_details = frappe.get_hooks("add_to_apps_screen", app_name=app)
 		if not len(app_details):
 			continue
 		for app_detail in app_details:

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -27,9 +27,12 @@ def get_route(app_name):
 
 
 def get_default_path():
-	default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
-	if default_app:
-		return get_route(default_app)
+	system_default_app = frappe.get_system_settings("default_app")
+	user_default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
+	if system_default_app and not user_default_app:
+		return get_route(system_default_app)
+	elif user_default_app:
+		return get_route(user_default_app)
 
 	apps = get_apps()
 	if len(apps) == 2:

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: MIT. See LICENSE
 
+import re
+
 import frappe
 
 
@@ -26,6 +28,15 @@ def get_route(app_name):
 	return "/apps"
 
 
+def is_desk_apps(apps):
+	for app in apps:
+		route = frappe.get_hooks(app_name=app).get("app_icon_route")
+		pattern = r"^/app(/.*)?$"
+		if route and not re.match(pattern, route[0]):
+			return False
+	return True
+
+
 def get_default_path():
 	system_default_app = frappe.get_system_settings("default_app")
 	user_default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
@@ -35,9 +46,11 @@ def get_default_path():
 		return get_route(user_default_app)
 
 	apps = get_apps()
-	if len(apps) == 2:
-		_apps = [app for app in apps if app != "frappe"]
+	_apps = [app for app in apps if app != "frappe"]
+	if len(_apps) == 1:
 		first_app = _apps[0]
 		if first_app:
 			return get_route(first_app)
+	elif is_desk_apps(_apps):
+		return "/app"
 	return "/apps"

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -64,3 +64,9 @@ def get_default_path():
 	elif is_desk_apps(_apps):
 		return "/app"
 	return "/apps"
+
+
+@frappe.whitelist()
+def set_app_as_default(app_name):
+	frappe.db.set_value("User", frappe.session.user, "default_app", app_name)
+	return True

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -68,5 +68,7 @@ def get_default_path():
 
 @frappe.whitelist()
 def set_app_as_default(app_name):
-	frappe.db.set_value("User", frappe.session.user, "default_app", app_name)
-	return True
+	if frappe.db.get_value("User", frappe.session.user, "default_app") == app_name:
+		frappe.db.set_value("User", frappe.session.user, "default_app", "")
+	else:
+		frappe.db.set_value("User", frappe.session.user, "default_app", app_name)

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+
+
+@frappe.whitelist()
+def get_apps():
+	apps = frappe.get_installed_apps()
+	app_list = []
+	for app in apps:
+		if app == "frappe":
+			app_list.append(app)
+		else:
+			app_icon_url = frappe.get_hooks("app_icon_url", app_name=app)
+			app_icon_route = frappe.get_hooks("app_icon_route", app_name=app)
+			if app_icon_url and app_icon_route:
+				app_list.append(app)
+	return app_list
+
+
+def get_route(app_name):
+	hooks = frappe.get_hooks(app_name=app_name)
+	if hooks.get("app_icon_route"):
+		return hooks.get("app_icon_route")[0]
+	return "/apps"
+
+
+def get_default_path():
+	default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
+	if default_app:
+		return get_route(default_app)
+
+	apps = get_apps()
+	if len(apps) == 2:
+		_apps = [app for app in apps if app != "frappe"]
+		first_app = _apps[0]
+		if first_app:
+			return get_route(first_app)
+	return "/apps"

--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -10,28 +10,23 @@ from frappe import _
 @frappe.whitelist()
 def get_apps():
 	apps = frappe.get_installed_apps()
-	app_list = [
-		{
-			"name": "frappe",
-			"icon_url": "/assets/frappe/images/frappe-framework-logo.svg",
-			"title": _("Admin"),
-			"route": "/app",
-		}
-	]
+	app_list = []
 	for app in apps:
 		if app == "frappe":
 			continue
-		app_icon_url = frappe.get_hooks("app_icon_url", app_name=app)
-		app_icon_route = frappe.get_hooks("app_icon_route", app_name=app)
-		if app_icon_url and app_icon_route:
-			app_title = frappe.get_hooks("app_title", app_name=app)
-			icon_title = frappe.get_hooks("app_icon_title", app_name=app)
+		app_details = frappe.get_hooks("include_as_app", app_name=app)
+		if not len(app_details):
+			continue
+		for app_detail in app_details:
+			has_permission_path = app_detail.get("has_permission")
+			if has_permission_path and not frappe.get_attr(has_permission_path)():
+				continue
 			app_list.append(
 				{
 					"name": app,
-					"icon_url": app_icon_url[0],
-					"title": _(icon_title[0] if icon_title else app_title[0] if app_title else app),
-					"route": app_icon_route[0],
+					"logo": app_detail.get("logo"),
+					"title": _(app_detail.get("title")),
+					"route": app_detail.get("route"),
 				}
 			)
 	return app_list

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -12,7 +12,7 @@ import frappe.utils
 import frappe.utils.user
 from frappe import _
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
-from frappe.sessions import Session, clear_sessions, delete_session, get_expiry_in_seconds
+from frappe.sessions import Session, clear_sessions, delete_session, get_default_path, get_expiry_in_seconds
 from frappe.translate import get_language
 from frappe.twofactor import (
 	authenticate_for_2factor,
@@ -183,7 +183,7 @@ class LoginManager:
 			frappe.local.cookie_manager.set_cookie("system_user", "yes")
 			if not resume:
 				frappe.local.response["message"] = "Logged In"
-				frappe.local.response["home_page"] = "/app"
+				frappe.local.response["home_page"] = get_default_path() or "/apps"
 
 		if not resume:
 			frappe.response["full_name"] = self.full_name

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -11,8 +11,9 @@ import frappe.database
 import frappe.utils
 import frappe.utils.user
 from frappe import _
+from frappe.apps import get_default_path
 from frappe.core.doctype.activity_log.activity_log import add_authentication_log
-from frappe.sessions import Session, clear_sessions, delete_session, get_default_path, get_expiry_in_seconds
+from frappe.sessions import Session, clear_sessions, delete_session, get_expiry_in_seconds
 from frappe.translate import get_language
 from frappe.twofactor import (
 	authenticate_for_2factor,

--- a/frappe/core/doctype/system_settings/system_settings.js
+++ b/frappe/core/doctype/system_settings/system_settings.js
@@ -17,6 +17,10 @@ frappe.ui.form.on("System Settings", {
 			},
 		});
 
+		frappe.xcall("frappe.apps.get_apps").then((r) => {
+			frm.set_df_property("default_app", "options", [" ", ...r]);
+		});
+
 		frm.trigger("set_rounding_method_options");
 	},
 	enable_password_policy: function (frm) {

--- a/frappe/core/doctype/system_settings/system_settings.js
+++ b/frappe/core/doctype/system_settings/system_settings.js
@@ -18,7 +18,8 @@ frappe.ui.form.on("System Settings", {
 		});
 
 		frappe.xcall("frappe.apps.get_apps").then((r) => {
-			frm.set_df_property("default_app", "options", [" ", ...r]);
+			let apps = r?.map((r) => r.name) || [];
+			frm.set_df_property("default_app", "options", [" ", ...apps]);
 		});
 
 		frm.trigger("set_rounding_method_options");

--- a/frappe/core/doctype/system_settings/system_settings.json
+++ b/frappe/core/doctype/system_settings/system_settings.json
@@ -79,6 +79,8 @@
   "strip_exif_metadata_from_uploaded_images",
   "column_break_uqma",
   "allowed_file_extensions",
+  "app_tab",
+  "default_app",
   "updates_tab",
   "system_updates_section",
   "disable_system_update_notification",
@@ -656,12 +658,23 @@
    "fieldname": "store_attached_pdf_document",
    "fieldtype": "Check",
    "label": "Store Attached PDF Document"
+  },
+  {
+   "fieldname": "app_tab",
+   "fieldtype": "Tab Break",
+   "label": "App"
+  },
+  {
+   "description": "Redirect to the selected app after login",
+   "fieldname": "default_app",
+   "fieldtype": "Select",
+   "label": "Default App"
   }
  ],
  "icon": "fa fa-cog",
  "issingle": 1,
  "links": [],
- "modified": "2024-03-23 16:03:39.461597",
+ "modified": "2024-08-08 20:10:55.939839",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "System Settings",

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -83,6 +83,7 @@ class SystemSettings(Document):
 		]
 		otp_issuer_name: DF.Data | None
 		password_reset_limit: DF.Int
+		rate_limit_email_link_login: DF.Int
 		reset_password_link_expiry_duration: DF.Duration | None
 		reset_password_template: DF.Link | None
 		rounding_method: DF.Literal["Banker's Rounding (legacy)", "Banker's Rounding", "Commercial Rounding"]

--- a/frappe/core/doctype/system_settings/system_settings.py
+++ b/frappe/core/doctype/system_settings/system_settings.py
@@ -36,6 +36,7 @@ class SystemSettings(Document):
 		date_format: DF.Literal[
 			"yyyy-mm-dd", "dd-mm-yyyy", "dd/mm/yyyy", "dd.mm.yyyy", "mm/dd/yyyy", "mm-dd-yyyy"
 		]
+		default_app: DF.Literal[None]
 		deny_multiple_sessions: DF.Check
 		disable_change_log_notification: DF.Check
 		disable_document_sharing: DF.Check
@@ -82,7 +83,6 @@ class SystemSettings(Document):
 		]
 		otp_issuer_name: DF.Data | None
 		password_reset_limit: DF.Int
-		rate_limit_email_link_login: DF.Int
 		reset_password_link_expiry_duration: DF.Duration | None
 		reset_password_template: DF.Link | None
 		rounding_method: DF.Literal["Banker's Rounding (legacy)", "Banker's Rounding", "Commercial Rounding"]

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -103,6 +103,10 @@ frappe.ui.form.on("User", {
 	refresh: function (frm) {
 		let doc = frm.doc;
 
+		frappe.xcall("frappe.apps.get_apps").then((r) => {
+			frm.set_df_property("default_app", "options", [" ", ...r]);
+		});
+
 		if (frm.is_new()) {
 			frm.set_value("time_zone", frappe.sys_defaults.time_zone);
 		}

--- a/frappe/core/doctype/user/user.js
+++ b/frappe/core/doctype/user/user.js
@@ -104,7 +104,8 @@ frappe.ui.form.on("User", {
 		let doc = frm.doc;
 
 		frappe.xcall("frappe.apps.get_apps").then((r) => {
-			frm.set_df_property("default_app", "options", [" ", ...r]);
+			let apps = r?.map((r) => r.name) || [];
+			frm.set_df_property("default_app", "options", [" ", ...apps]);
 		});
 
 		if (frm.is_new()) {

--- a/frappe/core/doctype/user/user.json
+++ b/frappe/core/doctype/user/user.json
@@ -74,6 +74,8 @@
   "user_emails",
   "workspace_section",
   "default_workspace",
+  "app_section",
+  "default_app",
   "sb2",
   "defaults",
   "sb3",
@@ -736,6 +738,19 @@
    "fieldtype": "Select",
    "label": "Code Editor Type",
    "options": "vscode\nvim\nemacs"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "app_section",
+   "fieldtype": "Section Break",
+   "label": "App"
+  },
+  {
+   "description": "Redirect to the selected app after login",
+   "fieldname": "default_app",
+   "fieldtype": "Select",
+   "label": "Default App",
+   "options": ""
   }
  ],
  "icon": "fa fa-user",
@@ -798,7 +813,7 @@
    "link_fieldname": "user"
   }
  ],
- "modified": "2024-07-15 18:40:18.842915",
+ "modified": "2024-08-08 19:09:17.399748",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "User",

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -63,6 +63,7 @@ class User(Document):
 		block_modules: DF.Table[BlockModule]
 		bypass_restrict_ip_check_if_2fa_enabled: DF.Check
 		code_editor_type: DF.Literal["vscode", "vim", "emacs"]
+		default_app: DF.Literal[None]
 		default_workspace: DF.Link | None
 		defaults: DF.Table[DefaultValue]
 		desk_theme: DF.Literal["Light", "Dark", "Automatic"]

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -32,7 +32,7 @@ frappe.setup = {
 
 frappe.pages["setup-wizard"].on_page_load = function (wrapper) {
 	if (frappe.boot.setup_complete) {
-		window.location.href = "/app";
+		window.location.href = frappe.boot.default_path || "/app";
 	}
 	let requires = frappe.boot.setup_wizard_requires || [];
 	frappe.require(requires, function () {
@@ -207,7 +207,7 @@ frappe.setup.SetupWizard = class SetupWizard extends frappe.ui.Slides {
 		}
 		setTimeout(function () {
 			// Reload
-			window.location.href = "/app";
+			window.location.href = frappe.boot.default_path || "/app";
 		}, 2000);
 	}
 

--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -415,13 +415,6 @@ frappe.setup.slides_settings = [
 				default: cint(frappe.telemetry.can_enable()),
 				depends_on: "eval:frappe.telemetry.can_enable()",
 			},
-			{
-				fieldname: "allow_recording_first_session",
-				label: __("Allow recording my first session to improve user experience"),
-				fieldtype: "Check",
-				default: 0,
-				depends_on: "eval:frappe.telemetry.can_enable()",
-			},
 		],
 
 		onload: function (slide) {

--- a/frappe/desk/page/setup_wizard/setup_wizard.py
+++ b/frappe/desk/page/setup_wizard/setup_wizard.py
@@ -187,7 +187,7 @@ def update_system_settings(args):  # nosemgrep
 		}
 	)
 	system_settings.save()
-	if args.get("allow_recording_first_session"):
+	if args.get("enable_telemetry"):
 		frappe.db.set_default("session_recording_start", now())
 
 

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -490,6 +490,12 @@ standard_navbar_items = [
 		"is_standard": 1,
 	},
 	{
+		"item_label": "App Launcher",
+		"item_type": "Route",
+		"route": "/apps",
+		"is_standard": 1,
+	},
+	{
 		"item_label": "Toggle Full Width",
 		"item_type": "Action",
 		"action": "frappe.ui.toolbar.toggle_full_width()",

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -490,7 +490,7 @@ standard_navbar_items = [
 		"is_standard": 1,
 	},
 	{
-		"item_label": "App Launcher",
+		"item_label": "Apps",
 		"item_type": "Route",
 		"route": "/apps",
 		"is_standard": 1,

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -237,3 +237,4 @@ frappe.patches.v15_0.migrate_session_data
 frappe.custom.doctype.property_setter.patches.remove_invalid_fetch_from_expressions
 frappe.patches.v16_0.switch_default_sort_order
 frappe.integrations.doctype.oauth_client.patches.set_default_allowed_role_in_oauth_client
+frappe.patches.v16_0.add_app_launcher_in_navbar_settings

--- a/frappe/patches/v16_0/add_app_launcher_in_navbar_settings.py
+++ b/frappe/patches/v16_0/add_app_launcher_in_navbar_settings.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+import frappe
+
+
+def execute():
+	if frappe.db.exists("Navbar Item", {"item_label": "Apps"}):
+		return
+
+	navbar_settings = frappe.get_single("Navbar Settings")
+	settings_items = navbar_settings.as_dict().settings_dropdown
+
+	view_website_item_idx = -1
+	for i, item in enumerate(navbar_settings.settings_dropdown):
+		if item.get("item_label") == "View Website":
+			view_website_item_idx = i
+
+	settings_items.insert(
+		view_website_item_idx + 1,
+		{
+			"item_label": "Apps",
+			"item_type": "Route",
+			"route": "/apps",
+			"is_standard": 1,
+		},
+	)
+
+	navbar_settings.set("settings_dropdown", settings_items)
+	navbar_settings.save()

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -17,6 +17,7 @@ import frappe.model.meta
 import frappe.translate
 import frappe.utils
 from frappe import _
+from frappe.apps import get_default_path
 from frappe.cache_manager import clear_user_cache
 from frappe.query_builder import Order
 from frappe.utils import cint, cstr, get_assets_json
@@ -119,18 +120,6 @@ def clear_expired_sessions():
 	"""This function is meant to be called from scheduler"""
 	for sid in get_expired_sessions():
 		delete_session(sid, reason="Session Expired")
-
-
-def get_default_path():
-	installed_apps = frappe.get_installed_apps()
-	if len(installed_apps) == 2:
-		_installed_apps = [app for app in installed_apps if app != "frappe"]
-		installed_app = _installed_apps[0]
-		if installed_app:
-			hooks = frappe.get_hooks(app_name=installed_app)
-			if hooks.get("app_icon_route"):
-				return hooks.get("app_icon_route")[0]
-	return "/apps"
 
 
 def get():

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -121,6 +121,18 @@ def clear_expired_sessions():
 		delete_session(sid, reason="Session Expired")
 
 
+def get_default_path():
+	installed_apps = frappe.get_installed_apps()
+	if len(installed_apps) == 2:
+		_installed_apps = [app for app in installed_apps if app != "frappe"]
+		installed_app = _installed_apps[0]
+		if installed_app:
+			hooks = frappe.get_hooks(app_name=installed_app)
+			if hooks.get("app_icon_route"):
+				return hooks.get("app_icon_route")[0]
+	return "/apps"
+
+
 def get():
 	"""get session boot info"""
 	from frappe.boot import get_bootinfo, get_unseen_notes
@@ -166,6 +178,7 @@ def get():
 	bootinfo["disable_async"] = frappe.conf.disable_async
 
 	bootinfo["setup_complete"] = cint(frappe.get_system_settings("setup_complete"))
+	bootinfo["default_path"] = get_default_path()
 
 	bootinfo["desk_theme"] = frappe.db.get_value("User", frappe.session.user, "desk_theme") or "Light"
 	bootinfo["user"]["impersonated_by"] = frappe.session.data.get("impersonated_by")

--- a/frappe/templates/includes/navbar/navbar_login.html
+++ b/frappe/templates/includes/navbar/navbar_login.html
@@ -15,7 +15,7 @@
 			{%- endif -%}
 			{%- endfor -%}
 			<a class="dropdown-item switch-to-desk hidden" href="/app">{{ _('Switch To Desk') }}</a>
-			<a class="dropdown-item" href="/apps">{{ _('Apps') }}</a>
+			<a class="dropdown-item apps hidden" href="/apps">{{ _('Apps') }}</a>
 		</ul>
 	</li>
 	{% endif %}

--- a/frappe/templates/includes/navbar/navbar_login.html
+++ b/frappe/templates/includes/navbar/navbar_login.html
@@ -15,6 +15,7 @@
 			{%- endif -%}
 			{%- endfor -%}
 			<a class="dropdown-item switch-to-desk hidden" href="/app">{{ _('Switch To Desk') }}</a>
+			<a class="dropdown-item" href="/apps">{{ _('Apps') }}</a>
 		</ul>
 	</li>
 	{% endif %}

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -392,13 +392,15 @@ app_license = "{app_license}"
 # required_apps = []
 
 # Each item in the list will be shown an app in the apps page
-# include_as_app = [{
-#  "name": "{app_name}",
-#  "logo": "/assets/{app_name}/logo.png",
-#  "title": "{app_title}",
-#  "route": "/{app_name}",
-#  "has_permission": "{app_name}.api.permission.has_app_permission"
-# }]
+# include_as_app = [
+# 	{{
+# 		"name": "{app_name}",
+# 		"logo": "/assets/{app_name}/logo.png",
+# 		"title": "{app_title}",
+# 		"route": "/{app_name}",
+# 		"has_permission": "{app_name}.api.permission.has_app_permission"
+# 	}}
+# ]
 
 # Includes in <head>
 # ------------------

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -392,7 +392,7 @@ app_license = "{app_license}"
 # required_apps = []
 
 # Each item in the list will be shown an app in the apps page
-# include_as_app = [
+# add_to_apps_screen = [
 # 	{{
 # 		"name": "{app_name}",
 # 		"logo": "/assets/{app_name}/logo.png",

--- a/frappe/utils/boilerplate.py
+++ b/frappe/utils/boilerplate.py
@@ -385,7 +385,20 @@ app_publisher = "{app_publisher}"
 app_description = "{app_description}"
 app_email = "{app_email}"
 app_license = "{app_license}"
+
+# Apps
+# ------------------
+
 # required_apps = []
+
+# Each item in the list will be shown an app in the apps page
+# include_as_app = [{
+#  "name": "{app_name}",
+#  "logo": "/assets/{app_name}/logo.png",
+#  "title": "{app_title}",
+#  "route": "/{app_name}",
+#  "has_permission": "{app_name}.api.permission.has_app_permission"
+# }]
 
 # Includes in <head>
 # ------------------

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -351,6 +351,9 @@ $.extend(frappe, {
 	add_switch_to_desk: function () {
 		$(".switch-to-desk").removeClass("hidden");
 	},
+	add_apps: function () {
+		$(".apps").removeClass("hidden");
+	},
 	add_link_to_headings: function () {
 		$(".doc-content .from-markdown")
 			.find("h2, h3, h4, h5, h6")
@@ -610,6 +613,7 @@ $(document).ready(function () {
 	// switch to app link
 	if (frappe.get_cookie("system_user") === "yes" && logged_in) {
 		frappe.add_switch_to_desk();
+		frappe.add_apps();
 	}
 
 	frappe.render_user();

--- a/frappe/www/apps.css
+++ b/frappe/www/apps.css
@@ -41,6 +41,17 @@
 	align-items: center;
 	justify-content: center;
 	text-decoration: none;
+	position: relative;
+}
+
+.app-icon:hover .set-default {
+	display: block !important;
+}
+
+.set-default {
+	position: absolute;
+	top: -20px;
+	right: -20px;
 }
 
 .app-logo {

--- a/frappe/www/apps.css
+++ b/frappe/www/apps.css
@@ -1,37 +1,43 @@
 .container {
-	max-width: 1000px;
-	padding: 0 1.25rem;
-}
-
-.apps-navbar {
 	display: flex;
+	flex-direction: column;
+	justify-content: center;
 	align-items: center;
-	justify-content: space-between;
-	height: 3rem;
-	border-bottom: 1px solid var(--border-color);
-}
-
-.apps-wrapper {
-	margin-top: 2.5rem;
+	height: 100vh;
+	max-width: 100vw;
+	padding: 0;
+	margin: 0;
+	background: var(--bg-light-gray);
 }
 
 .apps-container {
-	margin-top: 2rem;
-	margin-bottom: 2rem;
-	display: grid;
-	grid-template-columns: repeat(6, 60px);
-	row-gap: 50px;
-	justify-content: space-between;
+	display: flex;
+	flex-direction: column;
+	gap: 40px;
+	align-items: center;
+	justify-content: center;
+	background: var(--fg-color);
+	padding: 45px 80px;
+	border-radius: var(--border-radius-md);
+	border: 1px solid var(--border-color);
 }
 
-.apps-title {
-	margin: 0;
+.title {
 	font-size: var(--font-size-xl);
+	font-weight: 600;
+}
+
+.apps {
+	gap: 30px;
+	display: grid;
 }
 
 .app-icon {
 	display: flex;
 	flex-direction: column;
+	gap: 12px;
+	height: fit-content;
+	width: fit-content;
 	align-items: center;
 	justify-content: center;
 	text-decoration: none;
@@ -54,26 +60,60 @@
 }
 
 .app-title {
-	margin-top: 0.5rem;
-	font-size: 0.875rem;
-	font-weight: 400;
-	white-space: nowrap;
-	letter-spacing: 0.05em;
-	color: var(--gray-900);
+	color: var(--gray-900, #171717);
+	font-size: var(--font-size-md);
+	height: fit-content;
+	letter-spacing: 0.24px;
+	line-height: 115%;
+	min-width: 30px;
+	width: fit-content;
+	text-decoration: none;
+}
+
+.logout-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+	border-radius: var(--border-radius-md);
+	background-color: #fff !important;
+}
+
+.logout-btn:hover {
+	background-color: var(--bg-light-gray) !important;
+}
+
+.logout-btn a {
+	text-decoration: none;
 }
 
 @media (max-width: 900px) {
-	.apps-container {
-		grid-template-columns: repeat(6, 60px);
+	.apps {
+		grid-template-columns: repeat(4, 1fr) !important;
 	}
 }
 
 @media (max-width: 575px) {
 	.apps-container {
-		grid-template-columns: repeat(4, 60px);
+		background: var(--fg-color);
+		gap: 30px;
+		padding: var(--padding-lg);
+		border: none;
+	}
+
+	.container {
+		background: var(--fg-color);
+	}
+
+	.title {
+		font-size: var(--font-size-md);
+	}
+
+	.apps {
+		grid-template-columns: repeat(3, 1fr) !important;
 	}
 
 	.app-title {
-		font-size: 0.75rem;
+		font-size: var(--font-size-sm);
 	}
 }

--- a/frappe/www/apps.css
+++ b/frappe/www/apps.css
@@ -1,0 +1,79 @@
+.container {
+	max-width: 1000px;
+	padding: 0 1.25rem;
+}
+
+.apps-navbar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 3rem;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.apps-wrapper {
+	margin-top: 2.5rem;
+}
+
+.apps-container {
+	margin-top: 2rem;
+	margin-bottom: 2rem;
+	display: grid;
+	grid-template-columns: repeat(6, 60px);
+	row-gap: 50px;
+	justify-content: space-between;
+}
+
+.apps-title {
+	margin: 0;
+	font-size: var(--font-size-xl);
+}
+
+.app-icon {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	text-decoration: none;
+}
+
+.app-logo {
+	width: 60px;
+	height: 60px;
+	object-fit: cover;
+	transition: transform 0.2s;
+	border-radius: 13px;
+}
+
+.app-icon:hover {
+	text-decoration: none;
+}
+
+.app-icon:hover .app-logo {
+	transform: scale(1.05);
+}
+
+.app-title {
+	margin-top: 0.5rem;
+	font-size: 0.875rem;
+	font-weight: 400;
+	white-space: nowrap;
+	letter-spacing: 0.05em;
+	color: var(--gray-900);
+}
+
+@media (max-width: 900px) {
+	.apps-container {
+		grid-template-columns: repeat(6, 60px);
+	}
+}
+
+@media (max-width: 575px) {
+	.apps-container {
+		grid-template-columns: repeat(4, 60px);
+	}
+
+	.app-title {
+		font-size: 0.75rem;
+	}
+}

--- a/frappe/www/apps.html
+++ b/frappe/www/apps.html
@@ -1,0 +1,69 @@
+---
+base_template: 'templates/base.html'
+no_cache: 1
+---
+
+{%- block navbar -%}
+
+{% from "frappe/templates/includes/avatar_macro.html" import avatar %}
+
+<nav class="apps-navbar">
+	<div class="container">
+		<div class="d-flex align-items-center justify-content-between">
+			<a class="navbar-brand" href="{{ url_prefix }}{{ home_page or "/" }}">
+				{%- if brand_html -%}
+					{{ brand_html }}
+				{%- elif banner_image -%}
+					<img src='{{ banner_image }}'>
+				{%- else -%}
+					<span>{{ (frappe.get_hooks("brand_html") or [_("Home")])[0] }}</span>
+				{%- endif -%}
+			</a>
+			<div class="dropdown">
+				<button class="btn" data-toggle="dropdown">
+					<div class="d-flex align-items-center">
+						{% set user = frappe.utils.get_user_info_for_avatar(frappe.session.user) %}
+						{{ avatar(full_name=user.name, image=user.image) }}
+						<span class="ml-1">{{ user.name }}</span>
+						<span class="ml-2 d-flex">
+							<svg class="es-icon icon-xs"><use href="#es-line-down"></use></svg>
+						</span>
+					</div>
+				</button>
+				<div class="dropdown-menu dropdown-menu-right" role="menu">
+					<a class="dropdown-item" href="/app">
+						{{ _('Switch to Admin') }}
+					</a>
+					<a class="dropdown-item" href="/api/method/web_logout">
+						{{ _('Logout') }}
+					</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</nav>
+{%- endblock -%}
+
+{%- block footer -%}
+{%- endblock -%}
+
+{% block content %}
+<div class="container">
+	<div class="apps-wrapper">
+		<div class="d-flex justify-content-between">
+			<h2 class="apps-title">{{ _("Apps") }}</h2>
+			<a class="btn btn-default" href="/me">{{ _('My Account') }}</a>
+		</div>
+		<div class="apps-container">
+			{% for app in apps %}
+			<a href="{{ app.route }}" class="app-icon">
+				<img class="app-logo" src="{{ app.icon_url }}" />
+				<div class="app-title">
+					{{ app.title }}
+				</div>
+			</a>
+			{% endfor %}
+		</div>
+	</div>
+</div>
+{% endblock %}

--- a/frappe/www/apps.html
+++ b/frappe/www/apps.html
@@ -1,69 +1,41 @@
 ---
-base_template: 'templates/base.html'
+base_template: "templates/base.html"
 no_cache: 1
 ---
 
-{%- block navbar -%}
-
-{% from "frappe/templates/includes/avatar_macro.html" import avatar %}
-
-<nav class="apps-navbar">
-	<div class="container">
-		<div class="d-flex align-items-center justify-content-between">
-			<a class="navbar-brand" href="{{ url_prefix }}{{ home_page or "/" }}">
-				{%- if brand_html -%}
-					{{ brand_html }}
-				{%- elif banner_image -%}
-					<img src='{{ banner_image }}'>
-				{%- else -%}
-					<span>{{ (frappe.get_hooks("brand_html") or [_("Home")])[0] }}</span>
-				{%- endif -%}
-			</a>
-			<div class="dropdown">
-				<button class="btn" data-toggle="dropdown">
-					<div class="d-flex align-items-center">
-						{% set user = frappe.utils.get_user_info_for_avatar(frappe.session.user) %}
-						{{ avatar(full_name=user.name, image=user.image) }}
-						<span class="ml-1">{{ user.name }}</span>
-						<span class="ml-2 d-flex">
-							<svg class="es-icon icon-xs"><use href="#es-line-down"></use></svg>
-						</span>
-					</div>
-				</button>
-				<div class="dropdown-menu dropdown-menu-right" role="menu">
-					<a class="dropdown-item" href="/app">
-						{{ _('Switch to Admin') }}
-					</a>
-					<a class="dropdown-item" href="/api/method/web_logout">
-						{{ _('Logout') }}
-					</a>
-				</div>
-			</div>
-		</div>
-	</div>
-</nav>
-{%- endblock -%}
-
-{%- block footer -%}
-{%- endblock -%}
-
-{% block content %}
+{%- block navbar -%} {% from "frappe/templates/includes/avatar_macro.html" import avatar %} {%-
+endblock -%} {%- block footer -%} {%- endblock -%} {% block content %}
 <div class="container">
-	<div class="apps-wrapper">
-		<div class="d-flex justify-content-between">
-			<h2 class="apps-title">{{ _("Apps") }}</h2>
-			<a class="btn btn-default" href="/me">{{ _('My Account') }}</a>
-		</div>
-		<div class="apps-container">
+	<div class="apps-container">
+		<div class="title">{{ _('Select the app to continue') }}</div>
+		{% set appsCount = apps|length if apps|length <= 6 else 6 %}
+		<div class="apps" style="grid-template-columns: repeat({{ appsCount }}, 1fr);">
 			{% for app in apps %}
 			<a href="{{ app.route }}" class="app-icon">
 				<img class="app-logo" src="{{ app.logo }}" />
-				<div class="app-title">
-					{{ app.title }}
-				</div>
+				<div class="app-title">{{ app.title }}</div>
 			</a>
 			{% endfor %}
 		</div>
+		<a href="/api/method/web_logout" class="logout-btn btn btn-default">
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="1.5"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+				class="lucide lucide-log-out"
+			>
+				<path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+				<polyline points="16 17 21 12 16 7" />
+				<line x1="21" x2="9" y1="12" y2="12" />
+			</svg>
+			<span> {{ _('Logout') }} </span>
+		</a>
 	</div>
 </div>
 {% endblock %}

--- a/frappe/www/apps.html
+++ b/frappe/www/apps.html
@@ -57,7 +57,7 @@ no_cache: 1
 		<div class="apps-container">
 			{% for app in apps %}
 			<a href="{{ app.route }}" class="app-icon">
-				<img class="app-logo" src="{{ app.icon_url }}" />
+				<img class="app-logo" src="{{ app.logo }}" />
 				<div class="app-title">
 					{{ app.title }}
 				</div>

--- a/frappe/www/apps.html
+++ b/frappe/www/apps.html
@@ -14,6 +14,15 @@ endblock -%} {%- block footer -%} {%- endblock -%} {% block content %}
 			<a href="{{ app.route }}" class="app-icon">
 				<img class="app-logo" src="{{ app.logo }}" />
 				<div class="app-title">{{ app.title }}</div>
+				<div
+					app-name="{{ app.name }}"
+					class="set-default btn btn-xs {{ '' if app.is_default else 'hidden'}}"
+					title="set app as default"
+				>
+					<svg class="icon icon-sm">
+						<use href="#icon-solid-success"></use>
+					</svg>
+				</div>
 			</a>
 			{% endfor %}
 		</div>
@@ -38,4 +47,20 @@ endblock -%} {%- block footer -%} {%- endblock -%} {% block content %}
 		</a>
 	</div>
 </div>
+{% endblock %}
+
+{% block script %}
+<script>
+	$('.set-default').on('click', function(e) {
+		e.preventDefault();
+		var appName = $(this).attr('app-name');
+		frappe.call({
+			method: 'frappe.apps.set_app_as_default',
+			args: { app_name: appName },
+			callback: function() {
+				location.reload();
+			}
+		});
+	});
+</script>
 {% endblock %}

--- a/frappe/www/apps.py
+++ b/frappe/www/apps.py
@@ -19,6 +19,10 @@ def get_context():
 
 	all_apps = get_apps()
 
+	if len(all_apps) == 0:
+		frappe.local.flags.redirect_location = "/app"
+		raise frappe.Redirect
+
 	for app in all_apps:
 		app["is_default"] = True if app.get("name") == default_app else False
 

--- a/frappe/www/apps.py
+++ b/frappe/www/apps.py
@@ -13,4 +13,13 @@ def get_context():
 	if frappe.session.data.user_type == "Website User":
 		frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
 
-	return {"apps": get_apps()}
+	system_default_app = frappe.get_system_settings("default_app")
+	user_default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
+	default_app = user_default_app if user_default_app else system_default_app
+
+	all_apps = get_apps()
+
+	for app in all_apps:
+		app["is_default"] = True if app.get("name") == default_app else False
+
+	return {"apps": all_apps}

--- a/frappe/www/apps.py
+++ b/frappe/www/apps.py
@@ -3,9 +3,16 @@
 
 import frappe
 from frappe import _
+from frappe.website.utils import get_home_page
 
 
 def get_context():
+	if frappe.session.user == "Guest":
+		frappe.throw(_("You need to be logged in to access this page"), frappe.PermissionError)
+
+	if frappe.session.data.user_type == "Website User":
+		frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
+
 	_apps = frappe.get_installed_apps()
 	app_shortcuts = [
 		{

--- a/frappe/www/apps.py
+++ b/frappe/www/apps.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+import frappe
+from frappe import _
+
+
+def get_context():
+	_apps = frappe.get_installed_apps()
+	app_shortcuts = [
+		{
+			"name": "frappe",
+			"icon_url": "/assets/frappe/images/frappe-framework-logo.svg",
+			"title": _("Admin"),
+			"route": "/app",
+		}
+	]
+	for app in _apps:
+		app_icon_url = frappe.get_hooks("app_icon_url", app_name=app)
+		app_icon_route = frappe.get_hooks("app_icon_route", app_name=app)
+		if app_icon_url and app_icon_route:
+			app_title = frappe.get_hooks("app_title", app_name=app)
+			icon_title = frappe.get_hooks("app_icon_title", app_name=app)
+			app_shortcuts.append(
+				{
+					"name": app,
+					"icon_url": app_icon_url[0],
+					"title": _(icon_title[0] if icon_title else app_title[0] if app_title else app),
+					"route": app_icon_route[0],
+				}
+			)
+	return {"apps": app_shortcuts}

--- a/frappe/www/apps.py
+++ b/frappe/www/apps.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.website.utils import get_home_page
+from frappe.apps import get_apps
 
 
 def get_context():
@@ -13,27 +13,4 @@ def get_context():
 	if frappe.session.data.user_type == "Website User":
 		frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
 
-	_apps = frappe.get_installed_apps()
-	app_shortcuts = [
-		{
-			"name": "frappe",
-			"icon_url": "/assets/frappe/images/frappe-framework-logo.svg",
-			"title": _("Admin"),
-			"route": "/app",
-		}
-	]
-	for app in _apps:
-		app_icon_url = frappe.get_hooks("app_icon_url", app_name=app)
-		app_icon_route = frappe.get_hooks("app_icon_route", app_name=app)
-		if app_icon_url and app_icon_route:
-			app_title = frappe.get_hooks("app_title", app_name=app)
-			icon_title = frappe.get_hooks("app_icon_title", app_name=app)
-			app_shortcuts.append(
-				{
-					"name": app,
-					"icon_url": app_icon_url[0],
-					"title": _(icon_title[0] if icon_title else app_title[0] if app_title else app),
-					"route": app_icon_route[0],
-				}
-			)
-	return {"apps": app_shortcuts}
+	return {"apps": get_apps()}

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -9,6 +9,7 @@ import frappe.utils
 from frappe import _
 from frappe.auth import LoginManager
 from frappe.rate_limiter import rate_limit
+from frappe.sessions import get_default_path
 from frappe.utils import cint, get_url
 from frappe.utils.data import escape_html
 from frappe.utils.html_utils import get_icon_html
@@ -29,7 +30,7 @@ def get_context(context):
 			if frappe.session.data.user_type == "Website User":
 				redirect_to = get_home_page()
 			else:
-				redirect_to = "/app"
+				redirect_to = get_default_path() or "/apps"
 
 		if redirect_to != "login":
 			frappe.local.flags.redirect_location = redirect_to

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -7,9 +7,9 @@ from urllib.parse import urlparse
 import frappe
 import frappe.utils
 from frappe import _
+from frappe.apps import get_default_path
 from frappe.auth import LoginManager
 from frappe.rate_limiter import rate_limit
-from frappe.sessions import get_default_path
 from frappe.utils import cint, get_url
 from frappe.utils.data import escape_html
 from frappe.utils.html_utils import get_icon_html


### PR DESCRIPTION
Resuming https://github.com/frappe/frappe/pull/22593

Continue:
https://github.com/frappe/frappe/pull/27372
https://github.com/frappe/frappe/pull/27376
https://github.com/frappe/frappe/pull/27417

<kbd>
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/a9cc4a7a-8a6f-4a7e-a7e7-db6b3bbedb45">
</kbd>
<kbd>
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/e10ce2cc-1413-4f9b-97a1-ab0a6556c58f">
</kbd>

- [x] Show app selector page by default?
- [x] If there's only one app installed, framework should automatically redirect to app's portal page (if available).
- [x] If all installed apps are desk app then redirect to /app e.g (frappe, erpnext, hrms)
- [x] Option to set default app at user level.
- [x] Option to set default app at system level.
- [x] Set app as default from apps page
- [x] Simple permission check for apps (many apps are not accessible to all).

If you need your app to be included in apps page add these details in hooks.py
```
# Each item in the list will be shown as an app in the apps page
add_to_apps_screen = [{
    "name": "crm",
    "logo": "/assets/crm/logo.png",
    "title": "CRM",
    "route": "/crm",
    "has_permission": "crm.api.permission.has_app_permission"
}]
```

>no-docs