### PR TITLE
fix: default notification

### DIFF
--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -40,7 +40,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Type",
-   "options": "Mention\nEnergy Point\nAssignment\nShare\nAlert"
+   "options": "\nMention\nEnergy Point\nAssignment\nShare\nAlert"
   },
   {
    "fieldname": "email_content",
@@ -103,7 +103,7 @@
  "hide_toolbar": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:03:31.715461",
+ "modified": "2024-08-03 09:38:10.497711",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Log",

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -28,7 +28,7 @@ class NotificationLog(Document):
 		link: DF.Data | None
 		read: DF.Check
 		subject: DF.Text | None
-		type: DF.Literal["Mention", "Energy Point", "Assignment", "Share", "Alert"]
+		type: DF.Literal["", "Mention", "Energy Point", "Assignment", "Share", "Alert"]
 	# end: auto-generated types
 
 	def after_insert(self):

--- a/frappe/desk/doctype/notification_settings/notification_settings.py
+++ b/frappe/desk/doctype/notification_settings/notification_settings.py
@@ -59,9 +59,10 @@ def is_email_notifications_enabled_for_type(user, notification_type):
 		return False
 
 	fieldname = "enable_email_" + frappe.scrub(notification_type)
-	enabled = frappe.db.get_value("Notification Settings", user, fieldname)
+	enabled = frappe.db.get_value("Notification Settings", user, fieldname, ignore=True)
 	if enabled is None:
 		return True
+
 	return enabled
 
 


### PR DESCRIPTION
[Here](https://github.com/frappe/frappe/blob/develop/frappe/desk/doctype/notification_log/notification_log.py/#L156) we have a Default notification header but If the `type` field is left empty, it will automatically be set to "Mention" (the first selection option).