### PR TITLE
feat: Workspace Settings - allow enabling and disabling of workspaces during setup

### DIFF
--- a/frappe/core/doctype/doctype/doctype.json
+++ b/frappe/core/doctype/doctype/doctype.json
@@ -10,6 +10,11 @@
  "field_order": [
   "form_builder_tab",
   "form_builder",
+  "permissions_tab",
+  "permissions",
+  "restrict_to_domain",
+  "read_only",
+  "in_create",
   "settings_tab",
   "sb0",
   "module",
@@ -70,11 +75,6 @@
   "sender_field",
   "sender_name_field",
   "subject_field",
-  "sb2",
-  "permissions",
-  "restrict_to_domain",
-  "read_only",
-  "in_create",
   "actions_section",
   "actions",
   "links_section",
@@ -152,8 +152,8 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.istable && !doc.issingle",
-   "description": "Open a dialog with mandatory fields to create a new record quickly",
+   "depends_on": "eval:!doc.istable",
+   "description": "Open a dialog with mandatory fields to create a new record quickly. There must be at least one mandatory field to show in dialog.",
    "fieldname": "quick_entry",
    "fieldtype": "Check",
    "label": "Quick Entry"
@@ -382,12 +382,6 @@
    "label": "Make \"name\" searchable in Global Search"
   },
   {
-   "depends_on": "eval:!doc.istable",
-   "fieldname": "sb2",
-   "fieldtype": "Section Break",
-   "label": "Permission Rules"
-  },
-  {
    "fieldname": "permissions",
    "fieldtype": "Table",
    "label": "Permissions",
@@ -418,6 +412,7 @@
    "oldfieldtype": "Check"
   },
   {
+   "collapsible": 1,
    "depends_on": "eval:doc.custom===0 && !doc.istable",
    "fieldname": "web_view",
    "fieldtype": "Section Break",
@@ -668,6 +663,11 @@
    "fieldname": "sender_name_field",
    "fieldtype": "Data",
    "label": "Sender Name Field"
+  },
+  {
+   "fieldname": "permissions_tab",
+   "fieldtype": "Tab Break",
+   "label": "Permissions"
   }
  ],
  "icon": "fa fa-bolt",
@@ -750,7 +750,7 @@
    "link_fieldname": "reference_doctype"
   }
  ],
- "modified": "2024-03-29 16:09:26.114720",
+ "modified": "2024-08-02 14:48:12.911702",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "DocType",

--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -65,22 +65,20 @@ def sync_standard_items():
 def sync_table(key, hook):
 	navbar_settings = NavbarSettings("Navbar Settings")
 	existing_items = {d.item_label: d for d in navbar_settings.get(key)}
-	new_items = {}
+	all_items = {}
 
 	# add new items
 	count = 0  # matain count because list may come from seperate apps
 	for item in frappe.get_hooks(hook):
 		if item.get("item_label") not in existing_items:
 			navbar_settings.append(key, item, count)
-		new_items[item.get("item_label")] = True
+		all_items[item.get("item_label")] = True
 		count += 1
 
 	# remove unused items
-	def fn(item):
-		if item.is_standard and (item.item_label not in new_items):
-			return False
-		else:
-			return True
+	items = navbar_settings.get(key)
+	for item in navbar_settings.get(key):
+		if item.is_standard and (item.item_label not in all_items):
+			items.remove(item)
 
-	navbar_settings.set(key, filter(lambda item: fn, navbar_settings.get(key)))
 	navbar_settings.save()

--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -77,8 +77,7 @@ def sync_table(key, hook):
 
 	# remove unused items
 	items = navbar_settings.get(key)
-	for item in items:
-		if item.is_standard and (item.item_label not in new_standard_items):
-			items.remove(item)
+	items = [item for item in items if not (item.is_standard and (item.item_label not in new_standard_items))]
+	navbar_settings.set(key, items)
 
 	navbar_settings.save()

--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -53,3 +53,34 @@ def get_app_logo():
 
 def get_navbar_settings():
 	return frappe.get_single("Navbar Settings")
+
+
+def sync_standard_items():
+	"""Syncs standard items from hooks. Called in migrate"""
+
+	sync_table("settings_dropdown", "standard_navbar_items")
+	sync_table("help_dropdown", "standard_help_items")
+
+
+def sync_table(key, hook):
+	navbar_settings = NavbarSettings("Navbar Settings")
+	existing_items = {d.item_label: d for d in navbar_settings.get(key)}
+	new_items = {}
+
+	# add new items
+	count = 0  # matain count because list may come from seperate apps
+	for item in frappe.get_hooks(hook):
+		if item.get("item_label") not in existing_items:
+			navbar_settings.append(key, item, count)
+		new_items[item.get("item_label")] = True
+		count += 1
+
+	# remove unused items
+	def fn(item):
+		if item.is_standard and (item.item_label not in new_items):
+			return False
+		else:
+			return True
+
+	navbar_settings.set(key, filter(lambda item: fn, navbar_settings.get(key)))
+	navbar_settings.save()

--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -65,20 +65,20 @@ def sync_standard_items():
 def sync_table(key, hook):
 	navbar_settings = NavbarSettings("Navbar Settings")
 	existing_items = {d.item_label: d for d in navbar_settings.get(key)}
-	all_items = {}
+	new_standard_items = {}
 
 	# add new items
 	count = 0  # matain count because list may come from seperate apps
 	for item in frappe.get_hooks(hook):
 		if item.get("item_label") not in existing_items:
 			navbar_settings.append(key, item, count)
-		all_items[item.get("item_label")] = True
+		new_standard_items[item.get("item_label")] = True
 		count += 1
 
 	# remove unused items
 	items = navbar_settings.get(key)
-	for item in navbar_settings.get(key):
-		if item.is_standard and (item.item_label not in all_items):
+	for item in items:
+		if item.is_standard and (item.item_label not in new_standard_items):
 			items.remove(item)
 
 	navbar_settings.save()

--- a/frappe/core/doctype/navbar_settings/navbar_settings.py
+++ b/frappe/core/doctype/navbar_settings/navbar_settings.py
@@ -22,26 +22,6 @@ class NavbarSettings(Document):
 		settings_dropdown: DF.Table[NavbarItem]
 	# end: auto-generated types
 
-	def validate(self):
-		self.validate_standard_navbar_items()
-
-	def validate_standard_navbar_items(self):
-		doc_before_save = self.get_doc_before_save()
-
-		if not doc_before_save:
-			return
-
-		before_save_items = [
-			item
-			for item in doc_before_save.help_dropdown + doc_before_save.settings_dropdown
-			if item.is_standard
-		]
-
-		after_save_items = [item for item in self.help_dropdown + self.settings_dropdown if item.is_standard]
-
-		if not frappe.flags.in_patch and (len(before_save_items) > len(after_save_items)):
-			frappe.throw(_("Please hide the standard navbar items instead of deleting them"))
-
 
 def get_app_logo():
 	app_logo = frappe.db.get_single_value("Navbar Settings", "app_logo", cache=True)

--- a/frappe/core/workspace/users/users.json
+++ b/frappe/core/workspace/users/users.json
@@ -103,6 +103,7 @@
    "link_to": "Document Share Report",
    "link_type": "Report",
    "onboard": 0,
+   "report_ref_doctype": "DocShare",
    "type": "Link"
   },
   {
@@ -158,7 +159,7 @@
    "type": "Link"
   }
  ],
- "modified": "2024-01-02 15:39:13.811700",
+ "modified": "2024-08-03 13:14:36.129599",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Users",

--- a/frappe/desk/doctype/workspace_settings/test_workspace_settings.py
+++ b/frappe/desk/doctype/workspace_settings/test_workspace_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2024, Frappe Technologies and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestWorkspaceSettings(FrappeTestCase):
+	pass

--- a/frappe/desk/doctype/workspace_settings/workspace_settings.js
+++ b/frappe/desk/doctype/workspace_settings/workspace_settings.js
@@ -1,0 +1,35 @@
+// Copyright (c) 2024, Frappe Technologies and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Workspace Settings", {
+	setup(frm) {
+		frm.hide_full_form_button = true;
+		frm.docfields = [];
+		let workspace_visibilty = JSON.parse(frm.doc.workspace_visibility_json || "{}");
+
+		// build fields from workspaces
+		for (let w of frappe.boot.allowed_workspaces) {
+			if (w.public) {
+				frm.docfields.push({
+					fieldtype: "Check",
+					fieldname: w.name,
+					label: w.title,
+					initial_value: workspace_visibilty[w.name] !== 0, // not set is also visible
+				});
+			}
+		}
+
+		frappe.temp = frm;
+	},
+	validate(frm) {
+		frm.doc.workspace_visibility_json = JSON.stringify(frm.dialog.get_values());
+		frm.doc.workspace_setup_completed = 1;
+	},
+	after_save(frm) {
+		// reload page to show latest sidebar
+		window.location.reload();
+	},
+	refresh(frm) {
+		frm.dialog.set_alert(__("Select modules you want to see in the sidebar"));
+	},
+});

--- a/frappe/desk/doctype/workspace_settings/workspace_settings.js
+++ b/frappe/desk/doctype/workspace_settings/workspace_settings.js
@@ -8,14 +8,23 @@ frappe.ui.form.on("Workspace Settings", {
 		let workspace_visibilty = JSON.parse(frm.doc.workspace_visibility_json || "{}");
 
 		// build fields from workspaces
+		let cnt = 0,
+			column_added = false;
 		for (let w of frappe.boot.allowed_workspaces) {
 			if (w.public) {
+				cnt++;
 				frm.docfields.push({
 					fieldtype: "Check",
 					fieldname: w.name,
 					label: w.title,
 					initial_value: workspace_visibilty[w.name] !== 0, // not set is also visible
 				});
+			}
+
+			if (cnt >= frappe.boot.allowed_workspaces.length / 2 && !column_added) {
+				// add column break to split into 2 columns
+				frm.docfields.push({ fieldtype: "Column Break" });
+				column_added = true;
 			}
 		}
 

--- a/frappe/desk/doctype/workspace_settings/workspace_settings.json
+++ b/frappe/desk/doctype/workspace_settings/workspace_settings.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2024-08-02 14:20:30.177818",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "select_workspaces_section",
+  "workspace_visibility_json",
+  "workspace_setup_completed"
+ ],
+ "fields": [
+  {
+   "fieldname": "select_workspaces_section",
+   "fieldtype": "Section Break",
+   "label": "Select Workspaces"
+  },
+  {
+   "fieldname": "workspace_visibility_json",
+   "fieldtype": "JSON",
+   "in_list_view": 1,
+   "label": "Workspace Visibility",
+   "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "workspace_setup_completed",
+   "fieldtype": "Check",
+   "label": "Workspace Setup Completed"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2024-08-03 19:34:16.757871",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "Workspace Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "quick_entry": 1,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe/desk/doctype/workspace_settings/workspace_settings.py
+++ b/frappe/desk/doctype/workspace_settings/workspace_settings.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2024, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WorkspaceSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		workspace_setup_completed: DF.Check
+		workspace_visibility_json: DF.JSON
+	# end: auto-generated types
+
+	pass

--- a/frappe/hooks.py
+++ b/frappe/hooks.py
@@ -460,15 +460,15 @@ export_python_type_annotations = True
 
 standard_navbar_items = [
 	{
-		"item_label": "My Profile",
-		"item_type": "Route",
-		"route": "/app/user-profile",
+		"item_label": "User Settings",
+		"item_type": "Action",
+		"action": "frappe.ui.toolbar.route_to_user()",
 		"is_standard": 1,
 	},
 	{
-		"item_label": "My Settings",
+		"item_label": "Workspace Settings",
 		"item_type": "Action",
-		"action": "frappe.ui.toolbar.route_to_user()",
+		"action": "frappe.quick_edit('Workspace Settings')",
 		"is_standard": 1,
 	},
 	{

--- a/frappe/migrate.py
+++ b/frappe/migrate.py
@@ -13,6 +13,7 @@ import frappe.modules.patch_handler
 import frappe.translate
 from frappe.cache_manager import clear_global_cache
 from frappe.core.doctype.language.language import sync_languages
+from frappe.core.doctype.navbar_settings.navbar_settings import sync_standard_items
 from frappe.core.doctype.scheduled_job_type.scheduled_job_type import sync_jobs
 from frappe.database.schema import add_column
 from frappe.deferred_insert import save_to_db as flush_deferred_inserts
@@ -141,6 +142,7 @@ class SiteMigration:
 
 		print("Syncing fixtures...")
 		sync_fixtures()
+		sync_standard_items()
 
 		print("Syncing dashboards...")
 		sync_dashboards()

--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -252,7 +252,7 @@ class BaseDocument:
 		if key in self.__dict__:
 			del self.__dict__[key]
 
-	def append(self, key: str, value: D | dict | None = None) -> D:
+	def append(self, key: str, value: D | dict | None = None, position: int = -1) -> D:
 		"""Append an item to a child table.
 
 		Example:
@@ -268,13 +268,22 @@ class BaseDocument:
 		if (table := self.__dict__.get(key)) is None:
 			self.__dict__[key] = table = []
 
-		ret_value = self._init_child(value, key)
-		table.append(ret_value)
+		d = self._init_child(value, key)
+
+		if position == -1:
+			table.append(d)
+		else:
+			# insert at specific position
+			table.insert(position, d)
+
+			# re number idx
+			for i, _d in enumerate(table):
+				_d.idx = i + 1
 
 		# reference parent document but with weak reference, parent_doc will be deleted if self is garbage collected.
-		ret_value.parent_doc = weakref.ref(self)
+		d.parent_doc = weakref.ref(self)
 
-		return ret_value
+		return d
 
 	@property
 	def parent_doc(self):

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -237,5 +237,5 @@ frappe.patches.v15_0.migrate_session_data
 frappe.custom.doctype.property_setter.patches.remove_invalid_fetch_from_expressions
 frappe.patches.v16_0.switch_default_sort_order
 frappe.integrations.doctype.oauth_client.patches.set_default_allowed_role_in_oauth_client
-execute:frappe.db.set_single_value("Website Settings", "workspace_setup_completed", 1)
+execute:frappe.db.set_single_value("Workspace Settings", "workspace_setup_completed", 1)
 

--- a/frappe/patches.txt
+++ b/frappe/patches.txt
@@ -237,3 +237,5 @@ frappe.patches.v15_0.migrate_session_data
 frappe.custom.doctype.property_setter.patches.remove_invalid_fetch_from_expressions
 frappe.patches.v16_0.switch_default_sort_order
 frappe.integrations.doctype.oauth_client.patches.set_default_allowed_role_in_oauth_client
+execute:frappe.db.set_single_value("Website Settings", "workspace_setup_completed", 1)
+

--- a/frappe/public/js/frappe/form/controls/base_input.js
+++ b/frappe/public/js/frappe/form/controls/base_input.js
@@ -7,6 +7,11 @@ frappe.ui.form.ControlInput = class ControlInput extends frappe.ui.form.Control 
 
 		// set description
 		this.set_max_width();
+
+		// set initial value if set
+		if (this.df.initial_value) {
+			this.set_value(this.df.initial_value);
+		}
 	}
 	make_wrapper() {
 		if (this.only_input) {

--- a/frappe/public/js/frappe/form/quick_entry.js
+++ b/frappe/public/js/frappe/form/quick_entry.js
@@ -1,6 +1,7 @@
 frappe.provide("frappe.ui.form");
 
 frappe.quick_edit = function (doctype, name) {
+	if (!name) name = doctype; // single
 	frappe.db.get_doc(doctype, name).then((doc) => {
 		frappe.ui.form.make_quick_entry(doctype, null, null, doc);
 	});
@@ -39,6 +40,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 				this.check_quick_entry_doc();
 				this.set_meta_and_mandatory_fields();
 				if (this.is_quick_entry() || this.force) {
+					this.setup_script_manager();
 					this.render_dialog();
 					resolve(this);
 				} else {
@@ -60,7 +62,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 		this.meta = frappe.get_meta(this.doctype);
 		let fields = this.meta.fields;
 
-		this.mandatory = fields.filter((df) => {
+		this.docfields = fields.filter((df) => {
 			return (
 				(df.reqd || df.allow_in_quick_entry) &&
 				!df.read_only &&
@@ -83,7 +85,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 
 		this.validate_for_prompt_autoname();
 
-		if (this.has_child_table() || !this.mandatory.length) {
+		if (this.has_child_table() || !this.docfields.length) {
 			return false;
 		}
 
@@ -91,7 +93,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 	}
 
 	too_many_mandatory_fields() {
-		if (this.mandatory.length > 7) {
+		if (this.docfields.length > 7) {
 			// too many fields, show form
 			return true;
 		}
@@ -100,7 +102,7 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 
 	has_child_table() {
 		if (
-			$.map(this.mandatory, function (d) {
+			$.map(this.docfields, function (d) {
 				return d.fieldtype === "Table" ? d : null;
 			}).length
 		) {
@@ -112,38 +114,36 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 
 	validate_for_prompt_autoname() {
 		if (this.meta.autoname && this.meta.autoname.toLowerCase() === "prompt") {
-			this.mandatory = [
+			this.docfields = [
 				{
 					fieldname: "__newname",
 					label: __("{0} Name", [__(this.meta.name)]),
 					reqd: 1,
 					fieldtype: "Data",
 				},
-			].concat(this.mandatory);
+			].concat(this.docfields);
 		}
+	}
+
+	setup_script_manager() {
+		this.script_manager = new frappe.ui.form.ScriptManager({
+			frm: this,
+		});
+		this.script_manager.setup();
 	}
 
 	render_dialog() {
 		var me = this;
+
 		this.dialog = new frappe.ui.Dialog({
-			title: __("New {0}", [__(this.doctype)]),
-			fields: this.mandatory,
+			title: this.get_title(),
+			fields: this.docfields,
 			doc: this.doc,
 		});
 
 		this.register_primary_action();
-		!this.force && this.render_edit_in_full_page_link();
-		// ctrl+enter to save
-		this.dialog.wrapper.keydown(function (e) {
-			if ((e.ctrlKey || e.metaKey) && e.which == 13) {
-				if (!frappe.request.ajax_count) {
-					// not already working -- double entry
-					me.dialog.get_primary_btn().trigger("click");
-					e.preventDefault();
-					return false;
-				}
-			}
-		});
+		this.render_edit_in_full_page_link();
+		this.setup_cmd_enter_for_save();
 
 		this.dialog.onhide = () => (frappe.quick_entry = null);
 		this.dialog.show();
@@ -151,8 +151,20 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 		this.dialog.refresh_dependency();
 		this.set_defaults();
 
+		this.script_manager.trigger("refresh");
+
 		if (this.init_callback) {
 			this.init_callback(this.dialog);
+		}
+	}
+
+	get_title() {
+		if (this.title) {
+			return this.title;
+		} else if (this.meta.issingle) {
+			return __(this.doctype);
+		} else {
+			return __("New {0}", [__(this.doctype)]);
 		}
 	}
 
@@ -166,16 +178,15 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 
 			if (data) {
 				me.dialog.working = true;
-				me.insert().then(() => {
-					let messagetxt = __("New {0} {1} created", [
-						__(me.doctype),
-						this.doc.name.bold(),
-					]);
-					me.dialog.animation_speed = "slow";
-					me.dialog.hide();
-					setTimeout(function () {
-						frappe.show_alert({ message: messagetxt, indicator: "green" }, 3);
-					}, 500);
+				me.script_manager.trigger("validate").then(() => {
+					me.insert().then(() => {
+						let messagetxt = __("{1} saved", [__(me.doctype), this.doc.name.bold()]);
+						me.dialog.animation_speed = "slow";
+						me.dialog.hide();
+						setTimeout(function () {
+							frappe.show_alert({ message: messagetxt, indicator: "green" }, 3);
+						}, 500);
+					});
 				});
 			}
 		});
@@ -238,7 +249,9 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 		// delete the old doc
 		frappe.model.clear_doc(this.dialog.doc.doctype, this.dialog.doc.name);
 		this.dialog.doc = r.message;
-		if (frappe._from_link) {
+		if (this.script_manager.has_handler("after_save")) {
+			return this.script_manager.trigger("after_save");
+		} else if (frappe._from_link) {
 			frappe.ui.form.update_calling_link(this.dialog.doc);
 		} else if (this.after_insert) {
 			this.after_insert(this.dialog.doc);
@@ -247,7 +260,23 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 		}
 	}
 
+	setup_cmd_enter_for_save() {
+		var me = this;
+		// ctrl+enter to save
+		this.dialog.wrapper.keydown(function (e) {
+			if ((e.ctrlKey || e.metaKey) && e.which == 13) {
+				if (!frappe.request.ajax_count) {
+					// not already working -- double entry
+					me.dialog.get_primary_btn().trigger("click");
+					e.preventDefault();
+					return false;
+				}
+			}
+		});
+	}
+
 	open_form_if_not_list() {
+		if (this.meta.issingle) return;
 		let route = frappe.get_route();
 		let doc = this.dialog.doc;
 		if (route && !(route[0] === "List" && route[1] === doc.doctype)) {
@@ -279,8 +308,8 @@ frappe.ui.form.QuickEntryForm = class QuickEntryForm {
 	}
 
 	render_edit_in_full_page_link() {
-		var me = this;
-		this.dialog.add_custom_action(__("Edit Full Form"), () => me.open_doc(true));
+		if (this.force || this.hide_full_form_button) return;
+		this.dialog.add_custom_action(__("Edit Full Form"), () => this.open_doc(true));
 	}
 
 	set_defaults() {

--- a/frappe/public/js/frappe/form/script_manager.js
+++ b/frappe/public/js/frappe/form/script_manager.js
@@ -140,6 +140,13 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 		// run them serially
 		return frappe.run_serially(tasks);
 	}
+	has_handler(event_name) {
+		// return true if there exist an event handler (new style only)
+		return (
+			frappe.ui.form.handlers[this.frm.doctype] &&
+			frappe.ui.form.handlers[this.frm.doctype][event_name]
+		);
+	}
 	has_handlers(event_name, doctype) {
 		let handlers = this.get_handlers(event_name, doctype);
 		return handlers && (handlers.old_style.length || handlers.new_style.length);
@@ -156,10 +163,10 @@ frappe.ui.form.ScriptManager = class ScriptManager {
 				handlers.new_style.push(fn);
 			});
 		}
-		if (this.frm.cscript[event_name]) {
+		if (this.frm.cscript && this.frm.cscript[event_name]) {
 			handlers.old_style.push(event_name);
 		}
-		if (this.frm.cscript["custom_" + event_name]) {
+		if (this.frm.cscript && this.frm.cscript["custom_" + event_name]) {
 			handlers.old_style.push("custom_" + event_name);
 		}
 		return handlers;

--- a/frappe/public/js/frappe/ui/dialog.js
+++ b/frappe/public/js/frappe/ui/dialog.js
@@ -164,6 +164,20 @@ frappe.ui.Dialog = class Dialog extends frappe.ui.FieldGroup {
 		return this.$wrapper.find(".modal-header .btn-modal-minimize");
 	}
 
+	set_alert(text, alert_class = "info") {
+		this.clear_alert();
+		this.$alert = $(`<div class="alert alert-${alert_class}">${text}</div>`).prependTo(
+			this.body
+		);
+		this.$message.text(text);
+	}
+
+	clear_alert() {
+		if (this.$alert) {
+			this.$alert.remove();
+		}
+	}
+
 	set_message(text) {
 		this.$message.removeClass("hide");
 		this.$body.addClass("hide");

--- a/frappe/public/js/frappe/views/workspace/workspace.js
+++ b/frappe/public/js/frappe/views/workspace/workspace.js
@@ -70,6 +70,9 @@ frappe.views.Workspace = class Workspace {
 		this.all_pages = this.sidebar_pages.pages;
 		this.has_access = this.sidebar_pages.has_access;
 		this.has_create_access = this.sidebar_pages.has_create_access;
+		if (!this.sidebar_pages.workspace_setup_completed) {
+			frappe.quick_edit("Workspace Settings");
+		}
 
 		this.all_pages.forEach((page) => {
 			page.is_editable = !page.public || this.has_access;
@@ -80,11 +83,14 @@ frappe.views.Workspace = class Workspace {
 
 		if (this.all_pages) {
 			frappe.workspaces = {};
+			frappe.workspace_list = [];
 			for (let page of this.all_pages) {
 				frappe.workspaces[frappe.router.slug(page.name)] = {
 					title: page.title,
 					public: page.public,
 				};
+
+				frappe.workspace_list.push(page);
 			}
 			this.make_sidebar();
 			reload && this.show();
@@ -240,7 +246,12 @@ frappe.views.Workspace = class Workspace {
 	}
 
 	prepare_sidebar(items, child_container, item_container) {
-		items.forEach((item) => this.append_item(item, child_container));
+		for (let item of items) {
+			// visibility not explicitly set to 0
+			if (item.visibility !== 0) {
+				this.append_item(item, child_container);
+			}
+		}
 		child_container.appendTo(item_container);
 	}
 

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -449,7 +449,7 @@ def create_test_user(username=None):
 
 	user.save()
 
-	frappe.db.set_single_value("Website Settings", "workspace_setup_completed", 1)
+	frappe.db.set_single_value("Workspace Settings", "workspace_setup_completed", 1)
 
 
 @whitelist_for_tests

--- a/frappe/tests/ui_test_helpers.py
+++ b/frappe/tests/ui_test_helpers.py
@@ -449,6 +449,8 @@ def create_test_user(username=None):
 
 	user.save()
 
+	frappe.db.set_single_value("Website Settings", "workspace_setup_completed", 1)
+
 
 @whitelist_for_tests
 def setup_tree_doctype():

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -181,6 +181,8 @@ def complete_setup_wizard():
 		}
 	)
 
+	frappe.db.set_single_value("Website Settings", "workspace_setup_completed", 1)
+
 
 def add_standard_navbar_items():
 	navbar_settings = frappe.get_single("Navbar Settings")

--- a/frappe/utils/install.py
+++ b/frappe/utils/install.py
@@ -181,8 +181,6 @@ def complete_setup_wizard():
 		}
 	)
 
-	frappe.db.set_single_value("Website Settings", "workspace_setup_completed", 1)
-
 
 def add_standard_navbar_items():
 	navbar_settings = frappe.get_single("Navbar Settings")


### PR DESCRIPTION
## Workspace Settings

This is a new single doctype that allows setting up workspaces. Called once during setup

<img width="1143" alt="Screenshot 2024-08-04 at 1 43 09 PM" src="https://github.com/user-attachments/assets/87a45ca8-c378-474e-aacd-112a46016e0e">

### Features:

* When you save, it will hide objects from the sidebar.
* Values are stored as JSON in Workspace Settings
* "Visibility" property added to Workspace while loading from desktop

### Quick Entry

Some updates to quick entry

* Allow Single DocTypes
* Basic scripting support in quick entry

### Navbar Settings

* Sync settings via migrate

### Framework API updates

* Document API: `doc.append` now takes position (`doc.append("tablefield", d, position = 0)`)
* Controls: You can now set `initial_value` in field config (`df`). This is not default, but a value you want the control to have when setup
* Dialog: `set_alert` method will allow you to add an alert.
* Standard `Navbar Settings` (dropdowns) will get synchronised when migrating from hooks