### PR TITLE
feat: flesh out boilerplate for script report

### DIFF
--- a/frappe/core/doctype/report/boilerplate/controller.js
+++ b/frappe/core/doctype/report/boilerplate/controller.js
@@ -2,7 +2,12 @@
 // For license information, please see license.txt
 
 frappe.query_reports["{name}"] = {{
-	"filters": [
-
-	]
+	filters: [
+		// {{
+		// 	"fieldname": "my_filter",
+		// 	"label": __("My Filter"),
+		// 	"fieldtype": "Data",
+		// 	"reqd": 1,
+		// }},
+	],
 }};

--- a/frappe/core/doctype/report/boilerplate/controller.py
+++ b/frappe/core/doctype/report/boilerplate/controller.py
@@ -2,8 +2,47 @@
 # For license information, please see license.txt
 
 # import frappe
+from frappe import _
 
 
-def execute(filters=None):
-	columns, data = [], []
+def execute(filters: dict | None = None):
+	"""Return columns and data for the report.
+
+	This is the main entry point for the report. It accepts the filters as a
+	dictionary and should return columns and data. It is called by the framework
+	every time the report is refreshed or a filter is updated.
+	"""
+	columns = get_columns()
+	data = get_data()
+
 	return columns, data
+
+
+def get_columns() -> list[dict]:
+	"""Return columns for the report.
+
+	One field definition per column, just like a DocType field definition.
+	"""
+	return [
+		{{
+			"label": _("Column 1"),
+			"fieldname": "column_1",
+			"fieldtype": "Data",
+		}},
+		{{
+			"label": _("Column 2"),
+			"fieldname": "column_2",
+			"fieldtype": "Int",
+		}},
+	]
+
+
+def get_data() -> list[list]:
+	"""Return data for the report.
+
+	The report data is a list of rows, with each row being a list of cell values.
+	"""
+	return [
+		["Row 1", 1],
+		["Row 2", 2],
+	]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ freezegun = "~=1.2.2"
 [tool.ruff]
 line-length = 110
 target-version = "py310"
+exclude = [
+    "**/doctype/*/boilerplate/*.py" # boilerplate are template strings, not valid python
+]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
This PR enhances the boilerplate for newly created Script Reports. The goal is to improve clarity on what parameters the report accepts and what it is supposed to return.

Note: the boilerplate files have to use double curly braces because they are used as python template strings. These get collapsed to single curly braces in the output.

New look of newly generated report (already shows some data):
![Bildschirmfoto 2024-08-04 um 13 23 00](https://github.com/user-attachments/assets/5d302bab-90b8-477e-9cae-7acab1473273)

New look of newly created JS controller (shows how filter definitions are supposed to look):
![Bildschirmfoto 2024-08-04 um 13 22 22](https://github.com/user-attachments/assets/1efca013-b042-45c1-9a60-cef782a372dd)

> no-docs

(this is self-documenting)