### PR TITLE
fix: use dynamic links for doctype links

### DIFF
--- a/frappe/automation/doctype/milestone/milestone.json
+++ b/frappe/automation/doctype/milestone/milestone.json
@@ -23,9 +23,10 @@
   },
   {
    "fieldname": "reference_name",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "in_list_view": 1,
    "label": "Document",
+   "options": "reference_type",
    "read_only": 1,
    "reqd": 1
   },
@@ -53,7 +54,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:03:29.694506",
+ "modified": "2024-08-05 00:04:12.946710",
  "modified_by": "Administrator",
  "module": "Automation",
  "name": "Milestone",

--- a/frappe/automation/doctype/milestone/milestone.py
+++ b/frappe/automation/doctype/milestone/milestone.py
@@ -15,7 +15,7 @@ class Milestone(Document):
 		from frappe.types import DF
 
 		milestone_tracker: DF.Link | None
-		reference_name: DF.Data
+		reference_name: DF.DynamicLink
 		reference_type: DF.Link
 		track_field: DF.Data
 		value: DF.Data

--- a/frappe/core/doctype/error_log/error_log.json
+++ b/frappe/core/doctype/error_log/error_log.json
@@ -47,10 +47,11 @@
   },
   {
    "fieldname": "reference_name",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Reference Name",
+   "options": "reference_doctype",
    "read_only": 1
   },
   {
@@ -72,7 +73,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-06-05 05:34:35.048489",
+ "modified": "2024-08-05 00:04:50.768897",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Error Log",

--- a/frappe/core/doctype/error_log/error_log.py
+++ b/frappe/core/doctype/error_log/error_log.py
@@ -19,7 +19,7 @@ class ErrorLog(Document):
 		error: DF.Code | None
 		method: DF.Data | None
 		reference_doctype: DF.Link | None
-		reference_name: DF.Data | None
+		reference_name: DF.DynamicLink | None
 		seen: DF.Check
 		trace_id: DF.Data | None
 	# end: auto-generated types

--- a/frappe/core/doctype/file/file.json
+++ b/frappe/core/doctype/file/file.json
@@ -137,8 +137,9 @@
   },
   {
    "fieldname": "attached_to_name",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "label": "Attached To Name",
+   "options": "attached_to_doctype",
    "read_only": 1
   },
   {
@@ -190,7 +191,7 @@
  "icon": "fa fa-file",
  "idx": 1,
  "links": [],
- "modified": "2024-05-09 11:46:42.917146",
+ "modified": "2024-08-04 23:55:17.575893",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "File",

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -45,7 +45,7 @@ class File(Document):
 
 		attached_to_doctype: DF.Link | None
 		attached_to_field: DF.Data | None
-		attached_to_name: DF.Data | None
+		attached_to_name: DF.DynamicLink | None
 		content_hash: DF.Data | None
 		file_name: DF.Data | None
 		file_size: DF.Int

--- a/frappe/core/doctype/version/version.json
+++ b/frappe/core/doctype/version/version.json
@@ -28,9 +28,10 @@
   },
   {
    "fieldname": "docname",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "in_list_view": 1,
    "label": "Document Name",
+   "options": "ref_doctype",
    "reqd": 1
   },
   {
@@ -53,7 +54,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:04:01.627592",
+ "modified": "2024-08-04 23:57:03.667368",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Version",

--- a/frappe/core/doctype/version/version.py
+++ b/frappe/core/doctype/version/version.py
@@ -18,7 +18,7 @@ class Version(Document):
 		from frappe.types import DF
 
 		data: DF.Code | None
-		docname: DF.Data
+		docname: DF.DynamicLink
 		ref_doctype: DF.Link
 	# end: auto-generated types
 

--- a/frappe/desk/doctype/notification_log/notification_log.json
+++ b/frappe/desk/doctype/notification_log/notification_log.json
@@ -56,9 +56,10 @@
   },
   {
    "fieldname": "document_name",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "hidden": 1,
    "label": "Document Link",
+   "options": "document_type",
    "search_index": 1
   },
   {
@@ -103,7 +104,7 @@
  "hide_toolbar": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-08-03 09:38:10.497711",
+ "modified": "2024-08-05 00:03:18.434331",
  "modified_by": "Administrator",
  "module": "Desk",
  "name": "Notification Log",

--- a/frappe/desk/doctype/notification_log/notification_log.py
+++ b/frappe/desk/doctype/notification_log/notification_log.py
@@ -20,7 +20,7 @@ class NotificationLog(Document):
 		from frappe.types import DF
 
 		attached_file: DF.Code | None
-		document_name: DF.Data | None
+		document_name: DF.DynamicLink | None
 		document_type: DF.Link | None
 		email_content: DF.TextEditor | None
 		for_user: DF.Link | None

--- a/frappe/email/doctype/email_queue/email_queue.json
+++ b/frappe/email/doctype/email_queue/email_queue.json
@@ -82,8 +82,9 @@
   },
   {
    "fieldname": "reference_name",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "label": "Reference DocName",
+   "options": "reference_doctype",
    "read_only": 1,
    "search_index": 1
   },
@@ -154,7 +155,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-03-23 16:03:24.379339",
+ "modified": "2024-08-05 00:08:27.490705",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Email Queue",

--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -57,7 +57,7 @@ class EmailQueue(Document):
 		priority: DF.Int
 		recipients: DF.Table[EmailQueueRecipient]
 		reference_doctype: DF.Link | None
-		reference_name: DF.Data | None
+		reference_name: DF.DynamicLink | None
 		retry: DF.Int
 		send_after: DF.Datetime | None
 		sender: DF.Data | None

--- a/frappe/social/doctype/energy_point_log/energy_point_log.json
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.json
@@ -57,8 +57,9 @@
   },
   {
    "fieldname": "reference_name",
-   "fieldtype": "Data",
+   "fieldtype": "Dynamic Link",
    "label": "Reference Name",
+   "options": "reference_doctype",
    "read_only": 1,
    "search_index": 1
   },
@@ -110,7 +111,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:03:25.006938",
+ "modified": "2024-08-04 23:50:41.142741",
  "modified_by": "Administrator",
  "module": "Social",
  "name": "Energy Point Log",

--- a/frappe/social/doctype/energy_point_log/energy_point_log.py
+++ b/frappe/social/doctype/energy_point_log/energy_point_log.py
@@ -30,7 +30,7 @@ class EnergyPointLog(Document):
 		points: DF.Int
 		reason: DF.Text | None
 		reference_doctype: DF.Link | None
-		reference_name: DF.Data | None
+		reference_name: DF.DynamicLink | None
 		revert_of: DF.Link | None
 		reverted: DF.Check
 		rule: DF.Link | None


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
Fix #27298, Fix #27297 

- [x] Energy Point Log (`reference_name` -> DL to `reference_doctype`)
- [ ] Event Update Log (DocType not found)
- [x] Version (`docname` -> DL to `ref_doctype`)
- [x] Notification Log (`document_name` -> DL to `document_type`)
- [x] Milestone (`reference_name` -> DL to `reference_type`)
- [x] Error Log (`reference_name` -> DL to `reference_doctype`)
- [ ] Event Sync Log (DocType not found)
- [x] Email Queue (`reference_name` -> DL to `reference_doctype`)

__Note__: The field names are given here, not labels.

> Please provide enough information so that others can review your pull request:

The relevant fields have been changed to Dynamic Field Type, as is expected.

> Explain the **details** for making this change. What existing problem does the pull request solve?

This PR changes the Data Fields to Dynamic Links associated with the Link to `DocType` DocType.

> Screenshots/GIFs

N/A
