### PR TITLE
fix: Number Card created against custom type not accessible for users without System Manager role

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -109,6 +109,8 @@ def get_permission_query_conditions(user=None):
 
 
 def has_permission(doc, ptype, user):
+	if doc.type == "Custom":
+		return
 	roles = frappe.get_roles(user)
 	if "System Manager" in roles:
 		return True


### PR DESCRIPTION
issue no #21099 
Number Card created against custom type not accessible for users without System Manager role

