### PR TITLE
feat:(notification)allow user group as recipient in notification

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -325,6 +325,17 @@ def get_context(context):
 			if recipient.condition:
 				if not frappe.safe_eval(recipient.condition, None, context):
 					continue
+
+			if recipient.user_group:
+				user_group = frappe.get_list(
+					"User Group Member",
+					filters={"parent": recipient.user_group, "parenttype": "User Group"},
+					parent_doctype="User Group",
+					fields=["user"],
+				)
+				for member in user_group:
+					recipients.append(member.user)
+
 			if recipient.receiver_by_document_field:
 				fields = recipient.receiver_by_document_field.split(",")
 				# fields from child table

--- a/frappe/email/doctype/notification_recipient/notification_recipient.json
+++ b/frappe/email/doctype/notification_recipient/notification_recipient.json
@@ -7,6 +7,7 @@
  "field_order": [
   "receiver_by_document_field",
   "receiver_by_role",
+  "user_group",
   "cc",
   "bcc",
   "condition"
@@ -44,12 +45,19 @@
    "in_list_view": 1,
    "label": "Receiver By Role",
    "options": "Role"
+  },
+  {
+   "fieldname": "user_group",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User Group",
+   "options": "User Group"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-09-01 17:40:27.289105",
+ "modified": "2024-08-06 01:33:48.651585",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification Recipient",
@@ -57,5 +65,6 @@
  "permissions": [],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/frappe/email/doctype/notification_recipient/notification_recipient.py
+++ b/frappe/email/doctype/notification_recipient/notification_recipient.py
@@ -21,5 +21,6 @@ class NotificationRecipient(Document):
 		parenttype: DF.Data
 		receiver_by_document_field: DF.Literal[None]
 		receiver_by_role: DF.Link | None
+		user_group: DF.Link | None
 	# end: auto-generated types
 	pass


### PR DESCRIPTION
re: https://github.com/frappe/frappe/issues/17502

You can send a Notification to a recipient based on document field and by role.

Request:
--
Allow sending to all users in a selected User Group. This would be enormously useful!

Functionality
--
**Notification Creation**
![Notification](https://github.com/user-attachments/assets/0ea41c79-0c09-41e9-953c-49f6c37af5f4)

**Notification Trigger**
![New Item Notification](https://github.com/user-attachments/assets/8ccf52ba-d4f8-4dd6-85c7-2a6fefdc0ef8)
