### PR TITLE
fix(auto_email_report): ensure that a report is selected before we try to apply filters

### DIFF
--- a/frappe/email/doctype/auto_email_report/auto_email_report.js
+++ b/frappe/email/doctype/auto_email_report/auto_email_report.js
@@ -71,6 +71,9 @@ frappe.ui.form.on("Auto Email Report", {
 		}
 	},
 	show_filters: async function (frm) {
+		if (!frm.doc.report) {
+			return;
+		}
 		var wrapper = $(frm.get_field("filters_display").wrapper);
 		wrapper.empty();
 		let reference_report = frappe.query_reports[frm.doc.report];


### PR DESCRIPTION
Reference: support ticket 19915

<hr>

This would sometimes result in an error like this when trying to setup a new auto email report

![image](https://github.com/user-attachments/assets/bce41fb3-28d9-41bf-b57e-ecc302baf15e)

