### PR TITLE
fix: form breadcrumbs

### DIFF
--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -189,7 +189,6 @@ frappe.breadcrumbs = {
 		let docname = frappe.get_route().slice(2).join("/");
 		let docname_title;
 		if (docname.startsWith("new-" + doctype.toLowerCase().replace(/ /g, "-"))) {
-			// using docname instead of doctype to include No like Doctype Name + 1, 2, 3
 			docname_title = __("New {0}", [__(doctype)]);
 		} else {
 			docname_title = __(docname);

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -187,16 +187,15 @@ frappe.breadcrumbs = {
 	set_form_breadcrumb(breadcrumbs, view) {
 		const doctype = breadcrumbs.doctype;
 		let docname = frappe.get_route().slice(2).join("/");
-		let docname_title = docname;
+		let docname_title;
 		if (docname.startsWith("new-" + doctype.toLowerCase().replace(/ /g, "-"))) {
 			// using docname instead of doctype to include No like Doctype Name + 1, 2, 3
-			docname_title = docname_title
-				.slice(0, -10)
-				.replace(/-/g, " ")
-				.replace(/\b\w/g, (l) => l.toUpperCase());
+			docname_title = __("New {0}", [__(doctype)]);
+		} else {
+			docname_title = __(docname);
 		}
-		let form_route = `/app/${frappe.router.slug(doctype)}/${docname_title}`;
-		this.append_breadcrumb_element(form_route, __(docname_title));
+		let form_route = `/app/${frappe.router.slug(doctype)}/${encodeURIComponent(docname)}`;
+		this.append_breadcrumb_element(form_route, docname_title);
 
 		if (view === "form") {
 			let last_crumb = this.$breadcrumbs.find("li").last();


### PR DESCRIPTION
### Before

New form does not show translated breadcrumb:

![new_before](https://github.com/user-attachments/assets/afb9dd64-910a-4815-b6d7-c850fa9704bb)

Special characters in doc name result in broken URL:

![click_before](https://github.com/user-attachments/assets/6c7cc600-9f68-4f3d-b040-fb6660f788a5)

### After

New form shows translated breadcrumb:

![new_after](https://github.com/user-attachments/assets/eb854255-c578-4d9d-8bc3-a8fc951ebeb3)

Special characters in doc name are handled correctly:

![click_after](https://github.com/user-attachments/assets/9a74dd52-2a66-4793-b254-dedd9de337d9)
