### PR TITLE
fix(file): Remove illegal chars in file_name

### DIFF
--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -670,10 +670,11 @@ class File(Document):
 			return self.save_file_on_filesystem()
 
 	def save_file_on_filesystem(self):
+		safe_file_name = re.sub(r"[/\\%?#]", "_", self.file_name)
 		if self.is_private:
-			self.file_url = f"/private/files/{self.file_name}"
+			self.file_url = f"/private/files/{safe_file_name}"
 		else:
-			self.file_url = f"/files/{self.file_name}"
+			self.file_url = f"/files/{safe_file_name}"
 
 		fpath = self.write_file()
 

--- a/frappe/core/doctype/file/file.py
+++ b/frappe/core/doctype/file/file.py
@@ -407,7 +407,7 @@ class File(Document):
 		elif not self.file_name and self.file_url:
 			self.file_name = self.file_url.split("/")[-1]
 		else:
-			self.file_name = re.sub(r"/", "", self.file_name)
+			self.file_name = re.sub(r"[/\\%?#]", "", self.file_name)
 
 	def generate_content_hash(self):
 		if self.content_hash or not self.file_url or self.is_remote_file:


### PR DESCRIPTION
I tried to upload a file named: ```!"#$%&'()*+,-.:;<=>?@[\]^_`{|}~```, and it didn't work.

Some files where not accessible when containing some characters.

- `/` and `\` cannot work in file names
- `%` is not allowed because of percent encoding
- `?` and `#` are confused with query/hash separators
- `#` is stripped by the browser before doing the request anyways
