### PR TITLE
fix: preserve exif data in optimized image

### DIFF
--- a/frappe/utils/image.py
+++ b/frappe/utils/image.py
@@ -52,6 +52,7 @@ def optimize_image(content, content_type, max_width=1024, max_height=768, optimi
 
 	try:
 		image = Image.open(io.BytesIO(content))
+		exif = image.getexif()
 		width, height = image.size
 		max_height = max(min(max_height, height * 0.8), 200)
 		max_width = max(min(max_width, width * 0.8), 200)
@@ -66,6 +67,7 @@ def optimize_image(content, content_type, max_width=1024, max_height=768, optimi
 			optimize=optimize,
 			quality=quality,
 			save_all=True if image_format == "gif" else None,
+			exif=exif,
 		)
 		optimized_content = output.getvalue()
 		return optimized_content if len(optimized_content) < len(content) else content


### PR DESCRIPTION
When uploading an image and enabling the "Optimize" checkbox, EXIF data would get lost, regardless of the corresponding system setting. There was no way to keep the EXIF data _and_ shrink the file size.

With this fix, the EXIF data  is maintained on the optimized image. It may only get removed at another point, according to the system setting.