### PR TITLE
fix: split attribution text into multiple lines

### DIFF
--- a/frappe/www/attribution.html
+++ b/frappe/www/attribution.html
@@ -8,8 +8,8 @@
 
 <h1>{{ _("Attribution") }}</h1>
 <p>
-    {{ _("This software is built on top of many open source packages. We would like to thank the authors of these
-    packages for their contribution.") }}
+    {{ _("This software is built on top of many open source packages.") }}
+    {{ _("We would like to thank the authors of these packages for their contribution.") }}
 </p>
 
 {% for app_info in apps %}


### PR DESCRIPTION
Required for extraction of translatable strings.
