### PR TITLE
fix: check to ensure field is defined

### DIFF
--- a/frappe/public/js/frappe/model/model.js
+++ b/frappe/public/js/frappe/model/model.js
@@ -790,7 +790,9 @@ $.extend(frappe.model, {
 		}
 		for (var i = 0, j = fieldnames.length; i < j; i++) {
 			var fieldname = fieldnames[i];
-			doc[fieldname] = flt(doc[fieldname], precision(fieldname, doc));
+			if (doc[fieldname]) {
+				doc[fieldname] = flt(doc[fieldname], precision(fieldname, doc));
+			}
 		}
 	},
 


### PR DESCRIPTION
TypeError: Cannot read properties of undefined (reading 'qty')
  at <object>.round_floats_in(../../../../../apps/frappe/frappe/public/js/frappe/model/model.js:793:25)
  at erpnext.TransactionControllerconversion_factor(../../../../../apps/erpnext/erpnext/public/js/controllers/transaction.js:1195:17)
  at erpnext.selling.SellingControllerconversion_factor(../../../../../apps/erpnext/erpnext/public/js/utils/sales_common.js:365:11)
  at <anonymous>(../../../../../apps/erpnext/erpnext/public/js/controllers/transaction.js:1254:16)

Sentry FRAPPE-76W
Support 19832
