### PR TITLE
backport/24317

### DIFF
--- a/esbuild/esbuild.js
+++ b/esbuild/esbuild.js
@@ -19,7 +19,6 @@ const {
 	assets_path,
 	apps_path,
 	sites_path,
-	get_app_path,
 	get_public_path,
 	log,
 	log_warn,
@@ -82,11 +81,9 @@ const RUN_BUILD_COMMAND = !WATCH_MODE && Boolean(argv["run-build-command"]);
 const TOTAL_BUILD_TIME = `${chalk.black.bgGreen(" DONE ")} Total Build Time`;
 const NODE_PATHS = [].concat(
 	// node_modules of apps directly importable
-	app_list
-		.map((app) => path.resolve(get_app_path(app), "../node_modules"))
-		.filter(fs.existsSync),
+	app_list.map((app) => path.resolve(apps_path, app, "node_modules")).filter(fs.existsSync),
 	// import js file of any app if you provide the full path
-	app_list.map((app) => path.resolve(get_app_path(app), "..")).filter(fs.existsSync)
+	app_list.map((app) => path.resolve(apps_path, app)).filter(fs.existsSync)
 );
 
 execute().catch((e) => {
@@ -441,7 +438,7 @@ function run_build_command_for_apps(apps) {
 	for (let app of apps) {
 		if (app === "frappe") continue;
 
-		let root_app_path = path.resolve(get_app_path(app), "..");
+		let root_app_path = path.resolve(apps_path, app);
 		let package_json = path.resolve(root_app_path, "package.json");
 		if (fs.existsSync(package_json)) {
 			let { scripts } = require(package_json);

--- a/esbuild/sass_options.js
+++ b/esbuild/sass_options.js
@@ -1,11 +1,11 @@
 let path = require("path");
 let { get_app_path, app_list } = require("./utils");
 
-let node_modules_path = path.resolve(get_app_path("frappe"), "..", "node_modules");
 let app_paths = app_list.map(get_app_path).map((app_path) => path.resolve(app_path, ".."));
+let node_modules_path = app_paths.map((app_path) => path.resolve(app_path, "node_modules"));
 
 module.exports = {
-	includePaths: [node_modules_path, ...app_paths],
+	includePaths: [...node_modules_path, ...app_paths],
 	quietDeps: true,
 	importer: function (url) {
 		if (url.startsWith("~")) {

--- a/esbuild/sass_options.js
+++ b/esbuild/sass_options.js
@@ -1,7 +1,7 @@
 let path = require("path");
-let { get_app_path, app_list } = require("./utils");
+let { apps_path, app_list } = require("./utils");
 
-let app_paths = app_list.map(get_app_path).map((app_path) => path.resolve(app_path, ".."));
+let app_paths = app_list.map((app) => path.resolve(apps_path, app));
 let node_modules_path = app_paths.map((app_path) => path.resolve(app_path, "node_modules"));
 
 module.exports = {

--- a/esbuild/utils.js
+++ b/esbuild/utils.js
@@ -9,16 +9,12 @@ const apps_path = path.resolve(bench_path, "apps");
 const assets_path = path.resolve(sites_path, "assets");
 const app_list = get_apps_list();
 
-const app_paths = app_list.reduce((out, app) => {
-	out[app] = path.resolve(apps_path, app, app);
-	return out;
-}, {});
 const public_paths = app_list.reduce((out, app) => {
-	out[app] = path.resolve(app_paths[app], "public");
+	out[app] = path.resolve(apps_path, app, app, "public");
 	return out;
 }, {});
 const public_js_paths = app_list.reduce((out, app) => {
-	out[app] = path.resolve(app_paths[app], "public/js");
+	out[app] = path.resolve(apps_path, app, app, "public/js");
 	return out;
 }, {});
 
@@ -65,8 +61,6 @@ function run_serially(tasks) {
 	});
 	return result;
 }
-
-const get_app_path = (app) => app_paths[app];
 
 function get_apps_list() {
 	return fs
@@ -135,7 +129,6 @@ module.exports = {
 	get_public_path,
 	get_build_json_path,
 	get_build_json,
-	get_app_path,
 	delete_file,
 	run_serially,
 	get_cli_arg,


### PR DESCRIPTION
- feat: import scss from node_modules in apps also (backport #22519)
- chore: remove confusing indirections from esbuild path resolution (backport: #24317)

towards: https://github.com/frappe/frappe/issues/27214

@akhilnarang
