### PR TITLE
fix: set `no_feed_on_delete` for Comment and Data Import Log

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -53,6 +53,8 @@ class Comment(Document):
 		subject: DF.Text | None
 	# end: auto-generated types
 
+	no_feed_on_delete = True
+
 	def after_insert(self):
 		notify_mentions(self.reference_doctype, self.reference_name, self.content)
 		self.notify_change("add")

--- a/frappe/core/doctype/data_import_log/data_import_log.py
+++ b/frappe/core/doctype/data_import_log/data_import_log.py
@@ -23,4 +23,6 @@ class DataImportLog(Document):
 		success: DF.Check
 	# end: auto-generated types
 
+	no_feed_on_delete = True
+
 	pass


### PR DESCRIPTION
- fix: don't create another comment when deleting a comment
- fix: don't create a comment when deleting a Data Import Log
