### PR TITLE
fix(Grid): refresh dependent field properties on value change

### DIFF
--- a/frappe/public/js/frappe/form/grid_row.js
+++ b/frappe/public/js/frappe/form/grid_row.js
@@ -730,21 +730,11 @@ export default class GridRow {
 	}
 
 	set_dependant_property(df) {
-		if (
-			!df.reqd &&
-			df.mandatory_depends_on &&
-			this.evaluate_depends_on_value(df.mandatory_depends_on)
-		) {
-			df.reqd = 1;
-		}
+		if (df.mandatory_depends_on)
+			df.reqd = this.evaluate_depends_on_value(df.mandatory_depends_on);
 
-		if (
-			!df.read_only &&
-			df.read_only_depends_on &&
-			this.evaluate_depends_on_value(df.read_only_depends_on)
-		) {
-			df.read_only = 1;
-		}
+		if (df.read_only_depends_on)
+			df.read_only = this.evaluate_depends_on_value(df.read_only_depends_on);
 	}
 
 	evaluate_depends_on_value(expression) {
@@ -1453,6 +1443,19 @@ export default class GridRow {
 		if (this.grid_form) {
 			this.grid_form.refresh_field(fieldname);
 		}
+
+		// refresh dependent fields
+		this.grid.visible_columns.forEach((col) => {
+			let df = col[0];
+			// check if the visible field is dependent on the changed value
+			if (
+				df.mandatory_depends_on?.includes(fieldname) ||
+				df.read_only_depends_on?.includes(fieldname)
+			) {
+				this.set_dependant_property(df);
+				this.refresh_field(df.fieldname);
+			}
+		});
 	}
 	get_field(fieldname) {
 		let field = this.on_grid_fields_dict[fieldname];


### PR DESCRIPTION
### Bug

When the `mandatory_depends_on` and `read_only_depends_on` conditions are set for a field, the conditions don't get applied appropriately in the Editable Grid. After setting the read only and mandatory conditions such that they get applied to Category B, the following behaviour occurs -

1. Even when the category is set to B, the properties for the first row don't get updated.
2. When a new row is added, these conditions get applied on the first as well as the second row, which should not happen since the second row still has category A set.
3. After deleting all rows and adding a new row, the conditions still get applied until the user hard refreshes.


https://github.com/user-attachments/assets/b444e1a6-5146-4727-bdd9-f0f4f135c3d6

<br>


### Fix

Whenever the value / property for a field is changed, check for all the fields which contain the changed field as a dependent condition in eval, and reset their properties depending on the new value.


https://github.com/user-attachments/assets/83b487e2-4a08-48ab-bd3b-18333556b441


