### PR TITLE
ci: unpin semgrep

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run Semgrep rules
         run: |
-          pip install semgrep==0.97.0
+          pip install semgrep
           semgrep ci --config ./frappe-semgrep-rules/rules --config r/python.lang.correctness
 
   deps-vulnerable-check:


### PR DESCRIPTION
Partial backport of #21678

The older version of semgrep can't parse the current rule set
