### PR TITLE
feat: enable bulk edit for doctype with workflow

### DIFF
--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -10,7 +10,7 @@
      "disable_comment_count",
      "disable_sidebar_stats",
      "disable_auto_refresh",
-     "enable_edit",
+     "disable_edit",
      "total_fields",
      "fields_html",
      "fields"
@@ -59,14 +59,14 @@
       "label": "Disable Comment Count"
      },
      {
-      "fieldname": "enable_edit",
-      "fieldtype": "Select",
-      "label": "Enable Edit",
-      "options": "\nYes\nNo"
+      "default": "0",
+      "fieldname": "disable_edit",
+      "fieldtype": "Check",
+      "label": "Disable Edit"
      }
     ],
     "links": [],
-    "modified": "2024-08-14 21:11:08.307688",
+    "modified": "2024-08-15 14:23:18.226666",
     "modified_by": "Administrator",
     "module": "Desk",
     "name": "List View Settings",

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -1,85 +1,92 @@
 {
- "actions": [],
- "autoname": "Prompt",
- "creation": "2019-10-23 15:00:48.392374",
- "doctype": "DocType",
- "editable_grid": 1,
- "engine": "InnoDB",
- "field_order": [
-  "disable_count",
-  "disable_comment_count",
-  "disable_sidebar_stats",
-  "disable_auto_refresh",
-  "total_fields",
-  "fields_html",
-  "fields"
- ],
- "fields": [
-  {
-   "default": "0",
-   "fieldname": "disable_count",
-   "fieldtype": "Check",
-   "label": "Disable Count"
-  },
-  {
-   "default": "0",
-   "fieldname": "disable_sidebar_stats",
-   "fieldtype": "Check",
-   "label": "Disable Sidebar Stats"
-  },
-  {
-   "default": "0",
-   "fieldname": "disable_auto_refresh",
-   "fieldtype": "Check",
-   "label": "Disable Auto Refresh"
-  },
-  {
-   "fieldname": "total_fields",
-   "fieldtype": "Select",
-   "label": "Maximum Number of Fields",
-   "options": "\n4\n5\n6\n7\n8\n9\n10"
-  },
-  {
-   "fieldname": "fields_html",
-   "fieldtype": "HTML",
-   "label": "Fields"
-  },
-  {
-   "fieldname": "fields",
-   "fieldtype": "Code",
-   "hidden": 1,
-   "label": "Fields",
-   "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "disable_comment_count",
-   "fieldtype": "Check",
-   "label": "Disable Comment Count"
-  }
- ],
- "links": [],
- "modified": "2024-03-23 16:03:29.188038",
- "modified_by": "Administrator",
- "module": "Desk",
- "name": "List View Settings",
- "naming_rule": "Set by user",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "read_only": 1,
- "sort_field": "creation",
- "sort_order": "DESC",
- "states": [],
- "track_changes": 1
-}
+    "actions": [],
+    "autoname": "Prompt",
+    "creation": "2019-10-23 15:00:48.392374",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+     "disable_count",
+     "disable_comment_count",
+     "disable_sidebar_stats",
+     "disable_auto_refresh",
+     "enable_edit",
+     "total_fields",
+     "fields_html",
+     "fields"
+    ],
+    "fields": [
+     {
+      "default": "0",
+      "fieldname": "disable_count",
+      "fieldtype": "Check",
+      "label": "Disable Count"
+     },
+     {
+      "default": "0",
+      "fieldname": "disable_sidebar_stats",
+      "fieldtype": "Check",
+      "label": "Disable Sidebar Stats"
+     },
+     {
+      "default": "0",
+      "fieldname": "disable_auto_refresh",
+      "fieldtype": "Check",
+      "label": "Disable Auto Refresh"
+     },
+     {
+      "fieldname": "total_fields",
+      "fieldtype": "Select",
+      "label": "Maximum Number of Fields",
+      "options": "\n4\n5\n6\n7\n8\n9\n10"
+     },
+     {
+      "fieldname": "fields_html",
+      "fieldtype": "HTML",
+      "label": "Fields"
+     },
+     {
+      "fieldname": "fields",
+      "fieldtype": "Code",
+      "hidden": 1,
+      "label": "Fields",
+      "read_only": 1
+     },
+     {
+      "default": "0",
+      "fieldname": "disable_comment_count",
+      "fieldtype": "Check",
+      "label": "Disable Comment Count"
+     },
+     {
+      "fieldname": "enable_edit",
+      "fieldtype": "Select",
+      "label": "Enable Edit",
+      "options": "\nYes\nNo"
+     }
+    ],
+    "links": [],
+    "modified": "2024-08-14 21:11:08.307688",
+    "modified_by": "Administrator",
+    "module": "Desk",
+    "name": "List View Settings",
+    "naming_rule": "Set by user",
+    "owner": "Administrator",
+    "permissions": [
+     {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "print": 1,
+      "read": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+     }
+    ],
+    "read_only": 1,
+    "sort_field": "creation",
+    "sort_order": "DESC",
+    "states": [],
+    "track_changes": 1
+   }

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.json
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.json
@@ -1,92 +1,93 @@
 {
-    "actions": [],
-    "autoname": "Prompt",
-    "creation": "2019-10-23 15:00:48.392374",
-    "doctype": "DocType",
-    "editable_grid": 1,
-    "engine": "InnoDB",
-    "field_order": [
-     "disable_count",
-     "disable_comment_count",
-     "disable_sidebar_stats",
-     "disable_auto_refresh",
-     "disable_edit",
-     "total_fields",
-     "fields_html",
-     "fields"
-    ],
-    "fields": [
-     {
-      "default": "0",
-      "fieldname": "disable_count",
-      "fieldtype": "Check",
-      "label": "Disable Count"
-     },
-     {
-      "default": "0",
-      "fieldname": "disable_sidebar_stats",
-      "fieldtype": "Check",
-      "label": "Disable Sidebar Stats"
-     },
-     {
-      "default": "0",
-      "fieldname": "disable_auto_refresh",
-      "fieldtype": "Check",
-      "label": "Disable Auto Refresh"
-     },
-     {
-      "fieldname": "total_fields",
-      "fieldtype": "Select",
-      "label": "Maximum Number of Fields",
-      "options": "\n4\n5\n6\n7\n8\n9\n10"
-     },
-     {
-      "fieldname": "fields_html",
-      "fieldtype": "HTML",
-      "label": "Fields"
-     },
-     {
-      "fieldname": "fields",
-      "fieldtype": "Code",
-      "hidden": 1,
-      "label": "Fields",
-      "read_only": 1
-     },
-     {
-      "default": "0",
-      "fieldname": "disable_comment_count",
-      "fieldtype": "Check",
-      "label": "Disable Comment Count"
-     },
-     {
-      "default": "0",
-      "fieldname": "disable_edit",
-      "fieldtype": "Check",
-      "label": "Disable Edit"
-     }
-    ],
-    "links": [],
-    "modified": "2024-08-15 14:23:18.226666",
-    "modified_by": "Administrator",
-    "module": "Desk",
-    "name": "List View Settings",
-    "naming_rule": "Set by user",
-    "owner": "Administrator",
-    "permissions": [
-     {
-      "create": 1,
-      "delete": 1,
-      "email": 1,
-      "print": 1,
-      "read": 1,
-      "role": "System Manager",
-      "share": 1,
-      "write": 1
-     }
-    ],
-    "read_only": 1,
-    "sort_field": "creation",
-    "sort_order": "DESC",
-    "states": [],
-    "track_changes": 1
-   }
+ "actions": [],
+ "autoname": "Prompt",
+ "creation": "2019-10-23 15:00:48.392374",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "disable_count",
+  "disable_comment_count",
+  "disable_sidebar_stats",
+  "disable_auto_refresh",
+  "allow_edit",
+  "total_fields",
+  "fields_html",
+  "fields"
+ ],
+ "fields": [
+  {
+   "default": "0",
+   "fieldname": "disable_count",
+   "fieldtype": "Check",
+   "label": "Disable Count"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_sidebar_stats",
+   "fieldtype": "Check",
+   "label": "Disable Sidebar Stats"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_auto_refresh",
+   "fieldtype": "Check",
+   "label": "Disable Auto Refresh"
+  },
+  {
+   "fieldname": "total_fields",
+   "fieldtype": "Select",
+   "label": "Maximum Number of Fields",
+   "options": "\n4\n5\n6\n7\n8\n9\n10"
+  },
+  {
+   "fieldname": "fields_html",
+   "fieldtype": "HTML",
+   "label": "Fields"
+  },
+  {
+   "fieldname": "fields",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Fields",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_comment_count",
+   "fieldtype": "Check",
+   "label": "Disable Comment Count"
+  },
+  {
+   "default": "0",
+   "description": "Allow editing even if the doctype has a workflow set up.\n\nDoes nothing if a workflow isn't set up.",
+   "fieldname": "allow_edit",
+   "fieldtype": "Check",
+   "label": "Allow Bulk Editing"
+  }
+ ],
+ "links": [],
+ "modified": "2024-08-21 18:17:24.889783",
+ "modified_by": "Administrator",
+ "module": "Desk",
+ "name": "List View Settings",
+ "naming_rule": "Set by user",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "read_only": 1,
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 1
+}

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -17,8 +17,8 @@ class ListViewSettings(Document):
 		disable_auto_refresh: DF.Check
 		disable_comment_count: DF.Check
 		disable_count: DF.Check
+		disable_edit: DF.Check
 		disable_sidebar_stats: DF.Check
-		enable_edit: DF.Literal["", "Yes", "No"]
 		fields: DF.Code | None
 		total_fields: DF.Literal["", "4", "5", "6", "7", "8", "9", "10"]
 	# end: auto-generated types

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -18,6 +18,7 @@ class ListViewSettings(Document):
 		disable_comment_count: DF.Check
 		disable_count: DF.Check
 		disable_sidebar_stats: DF.Check
+		enable_edit: DF.Literal["", "Yes", "No"]
 		fields: DF.Code | None
 		total_fields: DF.Literal["", "4", "5", "6", "7", "8", "9", "10"]
 	# end: auto-generated types

--- a/frappe/desk/doctype/list_view_settings/list_view_settings.py
+++ b/frappe/desk/doctype/list_view_settings/list_view_settings.py
@@ -14,10 +14,10 @@ class ListViewSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		allow_edit: DF.Check
 		disable_auto_refresh: DF.Check
 		disable_comment_count: DF.Check
 		disable_count: DF.Check
-		disable_edit: DF.Check
 		disable_sidebar_stats: DF.Check
 		fields: DF.Code | None
 		total_fields: DF.Literal["", "4", "5", "6", "7", "8", "9", "10"]

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1895,6 +1895,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return frappe.perm.has_perm(doctype, 0, "submit");
 		};
 
+		const is_bulk_editable = (doctype) => {
+			if (frappe.listview_settings[doctype] && frappe.listview_settings[doctype].enable_edit!=undefined){
+				return frappe.listview_settings[doctype].enable_edit; 
+			}
+			return !frappe.model.has_workflow(doctype)
+		};
+
 		// utility
 		const bulk_assignment = () => {
 			return {
@@ -2094,7 +2101,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		};
 
 		// bulk edit
-		if (has_editable_fields(doctype) && !frappe.model.has_workflow(doctype)) {
+		if (has_editable_fields(doctype) && is_bulk_editable(doctype)) {
 			actions_menu_items.push(bulk_edit());
 		}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1897,10 +1897,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 		const is_bulk_editable = (doctype) => {
 			if (
-					frappe.listview_settings[doctype] &&
-					frappe.listview_settings[doctype].enable_edit!=undefined
+					this.list_view_settings &&
+					this.list_view_settings.enable_edit &&
+					this.list_view_settings.enable_edit!=''
 			) {
-					return frappe.listview_settings[doctype].enable_edit;
+					return this.list_view_settings.enable_edit=='Yes'?true:false;
 			}
 			return !frappe.model.has_workflow(doctype);
 		};

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1895,11 +1895,12 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 			return frappe.perm.has_perm(doctype, 0, "submit");
 		};
 
-		const is_bulk_editable = (doctype) => {
-			if (this.list_view_settings && this.list_view_settings.disable_edit != undefined) {
-				return !this.list_view_settings.disable_edit;
+		const is_bulk_edit_allowed = (doctype) => {
+			// Check settings if there is a workflow defined, otherwise directly allow
+			if (frappe.model.has_workflow(doctype)) {
+				return !!this.list_view_settings?.allow_edit;
 			}
-			return !frappe.model.has_workflow(doctype);
+			return true;
 		};
 
 		// utility
@@ -2101,7 +2102,7 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		};
 
 		// bulk edit
-		if (has_editable_fields(doctype) && is_bulk_editable(doctype)) {
+		if (has_editable_fields(doctype) && is_bulk_edit_allowed(doctype)) {
 			actions_menu_items.push(bulk_edit());
 		}
 

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1898,12 +1898,11 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		const is_bulk_editable = (doctype) => {
 			if (
 					this.list_view_settings &&
-					this.list_view_settings.enable_edit &&
-					this.list_view_settings.enable_edit!=''
+					this.list_view_settings.disable_edit!=undefined
 			) {
-					return this.list_view_settings.enable_edit=='Yes'?true:false;
+					return !this.list_view_settings.disable_edit;
 			}
-			return !frappe.model.has_workflow(doctype);
+			return !frappe.model.has_workflow(doctype)
 		};
 
 		// utility

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1896,10 +1896,13 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		};
 
 		const is_bulk_editable = (doctype) => {
-			if (frappe.listview_settings[doctype] && frappe.listview_settings[doctype].enable_edit!=undefined){
-				return frappe.listview_settings[doctype].enable_edit; 
+			if (
+					frappe.listview_settings[doctype] &&
+					frappe.listview_settings[doctype].enable_edit!=undefined
+			) {
+					return frappe.listview_settings[doctype].enable_edit;
 			}
-			return !frappe.model.has_workflow(doctype)
+			return !frappe.model.has_workflow(doctype);
 		};
 
 		// utility

--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1896,13 +1896,10 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 		};
 
 		const is_bulk_editable = (doctype) => {
-			if (
-					this.list_view_settings &&
-					this.list_view_settings.disable_edit!=undefined
-			) {
-					return !this.list_view_settings.disable_edit;
+			if (this.list_view_settings && this.list_view_settings.disable_edit != undefined) {
+				return !this.list_view_settings.disable_edit;
 			}
-			return !frappe.model.has_workflow(doctype)
+			return !frappe.model.has_workflow(doctype);
 		};
 
 		// utility


### PR DESCRIPTION
Based on feature request [#26002](https://github.com/frappe/frappe/issues/26002), I have made some modification on *list_view.js* file to check for enable_edit status from the doctype listview settings.

## Modification
I have written a function *is_bulk_editable* to check whether the user hase set *enable_edit* in listview settings of the doctype. If so it will return the value of *enable_edit* else it will check whether the doctype has workflow and return true if workflow is not present for the doctype else will return false.
```js
const is_bulk_editable = (doctype) => {
	if (frappe.listview_settings[doctype] 
	&& frappe.listview_settings[doctype].enable_edit!=undefined){
		return frappe.listview_settings[doctype].enable_edit; 
	}
	return !frappe.model.has_workflow(doctype)
};
		
// bulk edit
if (has_editable_fields(doctype) && is_bulk_editable(doctype)) {
	actions_menu_items.push(bulk_edit());
}
```

## Example
To enable bulk edit for a doctype set *enable_edit* to true in listview settings of the doctype. (when doctype has workflow)
```js
frappe.listview_settings["Doctype Name"] = {
	enable_edit: true,
};
```

To disable bulk edit for a doctype set *enable_edit* to false in listview settings of the doctype
```js
frappe.listview_settings["Doctype Name"] = {
	enable_edit: false,
};
```
