### PR TITLE
feat(desk): Add Report Count Support to Number Card

### DIFF
--- a/frappe/desk/doctype/number_card/number_card.js
+++ b/frappe/desk/doctype/number_card/number_card.js
@@ -181,7 +181,10 @@ frappe.ui.form.on("Number Card", {
 						"options",
 						frm.field_options.numeric_fields
 					);
-					if (!frm.field_options.numeric_fields.length) {
+					if (
+						frm.doc.report_function !== "Count" &&
+						!frm.field_options.numeric_fields.length
+					) {
 						frappe.msgprint(
 							__("Report has no numeric fields, please change the Report Name")
 						);

--- a/frappe/desk/doctype/number_card/number_card.json
+++ b/frappe/desk/doctype/number_card/number_card.json
@@ -158,11 +158,11 @@
    "options": "Report"
   },
   {
-   "depends_on": "eval: doc.type == 'Report'",
+   "depends_on": "eval: doc.type == 'Report' && doc.report_function !== 'Count'",
    "fieldname": "report_field",
    "fieldtype": "Select",
    "label": "Field",
-   "mandatory_depends_on": "eval: doc.type == 'Report'"
+   "mandatory_depends_on": "eval: doc.type == 'Report' && doc.report_function !== 'Count'"
   },
   {
    "depends_on": "eval: doc.type == 'Custom'",
@@ -191,7 +191,7 @@
    "fieldtype": "Select",
    "label": "Function",
    "mandatory_depends_on": "eval: doc.type == 'Report'",
-   "options": "Sum\nAverage\nMinimum\nMaximum"
+   "options": "Count\nSum\nAverage\nMinimum\nMaximum"
   },
   {
    "depends_on": "eval: doc.type === 'Document Type'",

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -36,7 +36,7 @@ class NumberCard(Document):
 		module: DF.Link | None
 		parent_document_type: DF.Link | None
 		report_field: DF.Literal[None]
-		report_function: DF.Literal["Sum", "Average", "Minimum", "Maximum"]
+		report_function: DF.Literal["Count", "Sum", "Average", "Minimum", "Maximum"]
 		report_name: DF.Link | None
 		show_percentage_stats: DF.Check
 		stats_time_interval: DF.Literal["Daily", "Weekly", "Monthly", "Yearly"]
@@ -62,8 +62,12 @@ class NumberCard(Document):
 				frappe.throw(_("Parent Document Type is required to create a number card"))
 
 		elif self.type == "Report":
-			if not (self.report_name and self.report_field and self.function):
-				frappe.throw(_("Report Name, Report Field and Fucntion are required to create a number card"))
+			if not (self.report_name and self.function):
+				frappe.throw(_("Report Name and Function are required to create a number card"))
+			if self.function != "Count" and not self.report_field:
+				frappe.throw(
+					_("For functions other than Count, the report field is required to create a number card")
+				)
 
 		elif self.type == "Custom":
 			if not self.method:

--- a/frappe/desk/doctype/number_card/number_card.py
+++ b/frappe/desk/doctype/number_card/number_card.py
@@ -66,7 +66,7 @@ class NumberCard(Document):
 				frappe.throw(_("Report Name and Function are required to create a number card"))
 			if self.function != "Count" and not self.report_field:
 				frappe.throw(
-					_("For functions other than Count, the report field is required to create a number card")
+					_("Report field is required to create a number card with function {}").format(self.function)
 				)
 
 		elif self.type == "Custom":

--- a/frappe/public/js/frappe/widgets/number_card_widget.js
+++ b/frappe/public/js/frappe/widgets/number_card_widget.js
@@ -206,14 +206,22 @@ export default class NumberCardWidget extends Widget {
 	}
 
 	get_number_for_report_card(res) {
-		const field = this.card_doc.report_field;
-		const vals = res.result.reduce((acc, col) => {
-			col[field] && acc.push(col[field]);
-			return acc;
-		}, []);
-		const col = res.columns.find((col) => col.fieldname == field);
-		this.number = frappe.report_utils.get_result_of_fn(this.card_doc.report_function, vals);
-		this.set_formatted_number(col, this._generate_common_doc(res.result));
+		if (this.card_doc.report_function !== "Count") {
+			const field = this.card_doc.report_field;
+			const vals = res.result.reduce((acc, col) => {
+				col[field] && acc.push(col[field]);
+				return acc;
+			}, []);
+			const col = res.columns.find((col) => col.fieldname == field);
+			this.number = frappe.report_utils.get_result_of_fn(
+				this.card_doc.report_function,
+				vals
+			);
+			this.set_formatted_number(col, this._generate_common_doc(res.result));
+		} else {
+			let records = res.result.filter((element) => !Array.isArray(element));
+			this.formatted_number = String(records.length);
+		}
 	}
 
 	set_formatted_number(df, doc) {


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/frappe/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Allows number cards to show the count of records returned by a report. 


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

The existing number card supports the Count function but only for types of Document Type, not Report. Before this, the only way to display the number of records in a report was to have the report generate each record with a "count" column containing the number 1 and then using the sum function on this count column to get a total value

closes #27402 
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
