### PR TITLE
fix(Form Builder): Fix Code control not updating

### DIFF
--- a/frappe/public/js/form_builder/components/controls/CodeControl.vue
+++ b/frappe/public/js/form_builder/components/controls/CodeControl.vue
@@ -43,7 +43,7 @@ watch(
 	() => content.value,
 	(value) => {
 		update_control.value = false;
-		code_control.value?.set_value(value);
+		code_control.value?.set_value(value ?? "");
 	}
 );
 


### PR DESCRIPTION

* **In the _properties_ sidebar, fix the `Code` controls (e.g. to edit the `Depends On (JS)` field) that where not correctly emptied when switching from a docfield with a value to one without.**
* ~~In the editor, preview `HTML` controls by rendering the HTML value from the `options` field.~~
* ~~In the editor, use the standard (vanilla JS) number controls when rendering for a more faithful preview.~~


> no-docs
