### PR TITLE
feat: add get_month function to return current or specific month as a…

### DIFF
--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -878,40 +878,6 @@ def get_weekday(datetime: DateTimeLikeObject | None = None) -> str:
 	return weekdays[datetime.weekday()]
 
 
-def get_months() -> dict[int, str]:
-	"""Return a list of weekday names.
-	Return value:
-	    months_dict = {
-	        1: "January",
-	        2: "February",
-	        3: "March",
-	        4: "April",
-	        5: "May",
-	        6: "June",
-	        7: "July",
-	        8: "August",
-	        9: "September",
-	        10: "October",
-	        11: "November",
-	        12: "December",
-	    }
-	"""
-	return {
-		1: "January",
-		2: "February",
-		3: "March",
-		4: "April",
-		5: "May",
-		6: "June",
-		7: "July",
-		8: "August",
-		9: "September",
-		10: "October",
-		11: "November",
-		12: "December",
-	}
-
-
 def get_month(datetime: DateTimeLikeObject | None = None) -> str:
 	"""Return the month name (e.g. 'January') for the given datetime like object (datetime.date, datetime.datetime, string).
 

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -2,6 +2,7 @@
 # License: MIT. See LICENSE
 
 import base64
+import calendar
 import datetime
 import hashlib
 import json
@@ -16,7 +17,6 @@ from typing import Any, Literal, Optional, TypeVar
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlunparse
 
 import pytz
-import calendar 
 from click import secho
 from dateutil import parser
 from dateutil.parser import ParserError

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, Optional, TypeVar
 from urllib.parse import parse_qsl, quote, urlencode, urljoin, urlparse, urlunparse
 
 import pytz
+import calendar 
 from click import secho
 from dateutil import parser
 from dateutil.parser import ParserError
@@ -889,8 +890,7 @@ def get_month(datetime: DateTimeLikeObject | None = None) -> str:
 	if isinstance(datetime, str):
 		datetime = get_datetime(datetime)
 
-	months = get_months()
-	return months[datetime.month]
+	return calendar.month_name[datetime.month]
 
 
 def get_timespan_date_range(

--- a/frappe/utils/data.py
+++ b/frappe/utils/data.py
@@ -878,6 +878,55 @@ def get_weekday(datetime: DateTimeLikeObject | None = None) -> str:
 	return weekdays[datetime.weekday()]
 
 
+def get_months() -> dict[int, str]:
+	"""Return a list of weekday names.
+	Return value:
+	    months_dict = {
+	        1: "January",
+	        2: "February",
+	        3: "March",
+	        4: "April",
+	        5: "May",
+	        6: "June",
+	        7: "July",
+	        8: "August",
+	        9: "September",
+	        10: "October",
+	        11: "November",
+	        12: "December",
+	    }
+	"""
+	return {
+		1: "January",
+		2: "February",
+		3: "March",
+		4: "April",
+		5: "May",
+		6: "June",
+		7: "July",
+		8: "August",
+		9: "September",
+		10: "October",
+		11: "November",
+		12: "December",
+	}
+
+
+def get_month(datetime: DateTimeLikeObject | None = None) -> str:
+	"""Return the month name (e.g. 'January') for the given datetime like object (datetime.date, datetime.datetime, string).
+
+	If `datetime` argument is not provided, the current month name is returned.
+	"""
+	if not datetime:
+		datetime = now_datetime()
+
+	if isinstance(datetime, str):
+		datetime = get_datetime(datetime)
+
+	months = get_months()
+	return months[datetime.month]
+
+
 def get_timespan_date_range(
 	timespan: TimespanOptions,
 ) -> tuple[datetime.datetime, datetime.datetime] | None:

--- a/frappe/utils/safe_exec.py
+++ b/frappe/utils/safe_exec.py
@@ -656,6 +656,7 @@ VALID_UTILS = (
 	"formatdate",
 	"get_user_info_for_avatar",
 	"get_abbr",
+	"get_month",
 )
 
 


### PR DESCRIPTION
The get_month function returns the name of the month as a string. If a specific datetime object is passed, it returns the month corresponding to that date. If no date is provided, it defaults to returning the current month.


`no-docs`