### PR TITLE
fix: allow `rediss` connection scheme

### DIFF
--- a/frappe/utils/connections.py
+++ b/frappe/utils/connections.py
@@ -8,7 +8,7 @@ REDIS_KEYS = ("redis_cache", "redis_queue")
 
 
 def is_open(scheme, hostname, port, path, timeout=10):
-	if scheme in ["redis", "postgres", "mariadb"]:
+	if scheme in ["redis", "rediss", "postgres", "mariadb"]:
 		s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		conn = (hostname, int(port))
 	elif scheme == "unix":


### PR DESCRIPTION
Digital Ocean redis cluster uses `rediss`  schema to connect.
![image](https://github.com/user-attachments/assets/e2bb32a3-efae-4684-a980-9cbdab7044bf)
