### PR TITLE
fix(sanitize_html): sanitize all string inputs if specified

### DIFF
--- a/frappe/core/doctype/comment/comment.py
+++ b/frappe/core/doctype/comment/comment.py
@@ -62,7 +62,7 @@ class Comment(Document):
 	def validate(self):
 		if not self.comment_email:
 			self.comment_email = frappe.session.user
-		self.content = frappe.utils.sanitize_html(self.content)
+		self.content = frappe.utils.sanitize_html(self.content, always_sanitize=True)
 
 	def on_update(self):
 		update_comment_in_doc(self)

--- a/frappe/utils/html_utils.py
+++ b/frappe/utils/html_utils.py
@@ -142,12 +142,12 @@ def clean_script_and_style(html):
 	return frappe.as_unicode(soup)
 
 
-def sanitize_html(html, linkify=False):
+def sanitize_html(html, linkify=False, always_sanitize=False):
 	"""
 	Sanitize HTML tags, attributes and style to prevent XSS attacks
 	Based on bleach clean, bleach whitelist and html5lib's Sanitizer defaults
 
-	Does not sanitize JSON, as it could lead to future problems
+	Does not sanitize JSON unless explicitly specified, as it could lead to future problems
 	"""
 	import bleach
 	from bleach.css_sanitizer import CSSSanitizer
@@ -156,11 +156,12 @@ def sanitize_html(html, linkify=False):
 	if not isinstance(html, str):
 		return html
 
-	elif is_json(html):
-		return html
+	if not always_sanitize:
+		if is_json(html):
+			return html
 
-	if not bool(BeautifulSoup(html, "html.parser").find()):
-		return html
+		if not bool(BeautifulSoup(html, "html.parser").find()):
+			return html
 
 	tags = (
 		acceptable_elements


### PR DESCRIPTION
Let the caller decide whether to sanitize all in put - bs4 sometimes can think something is invalid HTML and we end up skipping it, although the browser is happy to render it.

Thanks to Huseyn Gadashov for reporting possible XSS through this.