### PR TITLE
fix(exporter): don't crash when a `Text Editor` field doesn't have a value

### DIFF
--- a/frappe/core/doctype/data_import/exporter.py
+++ b/frappe/core/doctype/data_import/exporter.py
@@ -143,7 +143,7 @@ class Exporter:
 				if df.fieldtype == "Duration":
 					value = format_duration(flt(value), df.hide_days)
 
-				if df.fieldtype == "Text Editor":
+				if df.fieldtype == "Text Editor" and value:
 					value = frappe.core.utils.html2text(value)
 				row[i] = value
 		return rows


### PR DESCRIPTION
Stacktrace: https://katb.in/rumuxohevar

Resolves #27435

Broke in #26571
