### PR TITLE
fix(form): Fix Geolocation/Signature fields in tabbed layout

### DIFF
--- a/frappe/public/js/frappe/form/form.js
+++ b/frappe/public/js/frappe/form/form.js
@@ -2163,6 +2163,18 @@ frappe.ui.form.Form = class FrappeForm {
 		}
 
 		this.script_manager.trigger("on_tab_change");
+
+		// When switching tabs, we should tell fields to update their display if needed (e.g. Geolocation and Signature fields).
+		// This is done using the already existing on_section_collapse optional method.
+		let in_tab = false;
+		for (const df of this.layout.fields) {
+			const field = this.get_field(df.fieldname);
+			if (df?.fieldtype == "Tab Break") {
+				in_tab = df === tab?.df;
+			} else if (typeof field?.on_section_collapse == "function") {
+				field.on_section_collapse(!in_tab); // hide = !in_tab
+			}
+		}
 	}
 
 	get_active_tab() {


### PR DESCRIPTION
When switching tabs, we should tell fields to update their display if needed (e.g. Geolocation and Signature fields). This is done using the already existing `on_section_collapse` optional method. Might not be the best way to do it.

Please tell me if I should just call a `on_tab_change` method instead of _hijacking_ the `on_section_collapse` method.

---

### Before

The Leaflet library does not detect the correct element size, because it was hidden. Thus is not rendering correctly.

![](https://github.com/user-attachments/assets/7dee12df-0550-45c0-8e38-577d13797b14)

### After

![](https://github.com/user-attachments/assets/3c23ba2c-9c2c-408d-937a-9284d945f352)
