### PR TITLE
fix: don't auto-enable prepared report in developer mode

### DIFF
--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -165,7 +165,7 @@ class Report(Document):
 
 		# automatically set as prepared
 		execution_time = (datetime.datetime.now() - start_time).total_seconds()
-		if execution_time > threshold and not self.prepared_report:
+		if execution_time > threshold and not self.prepared_report and not frappe.conf.developer_mode:
 			frappe.enqueue(enable_prepared_report, report=self.name)
 
 		frappe.cache.hset("report_execution_time", self.name, execution_time)


### PR DESCRIPTION
When developing a report and using a debugger to step through the logic, the "execution time" is usually above 30 seconds. It is very annoying that the framework always re-enables prepared report in these cases.