### PR TITLE
fix: delete min-height for form-grid

### DIFF
--- a/frappe/public/scss/common/grid.scss
+++ b/frappe/public/scss/common/grid.scss
@@ -2,7 +2,6 @@
 	border: 1px solid var(--table-border-color);
 	border-radius: var(--border-radius-md);
 	color: var(--text-color);
-	min-height: 150px;
 	background-color: var(--subtle-accent);
 }
 


### PR DESCRIPTION
Delete style "min-height" in form-grid

-- Table with fix: 
![image](https://github.com/user-attachments/assets/cdeb80e5-800f-4bdc-9a78-61016b460357)

-- Table without fix: 

![image](https://github.com/user-attachments/assets/16beadab-fd2e-4f4e-a8cd-05beb920b3a7)
