### PR TITLE
fix(Google Contacts): use authentication url in absence of authorization code

### DIFF
--- a/frappe/integrations/doctype/google_contacts/google_contacts.py
+++ b/frappe/integrations/doctype/google_contacts/google_contacts.py
@@ -57,7 +57,7 @@ def authorize_access(g_contact, reauthorize=False, code=None):
 	contact = frappe.get_doc("Google Contacts", g_contact)
 	contact.check_permission("write")
 
-	oauth_code = code or contact.get_password("authorization_code")
+	oauth_code = code or contact.get_password("authorization_code", raise_exception=False)
 	oauth_obj = GoogleOAuth("contacts")
 
 	if not oauth_code or reauthorize:


### PR DESCRIPTION
### Bug

While setting up Google Contacts Integration, after the correct credentials are entered in **Home > Integrations > Google Services > Google Settings**, when the user creates a new Google Contact and enters the email id for syncing contacts, since the authentication code is not stored for the newly created record yet, the `get_authentication_url` method should be called so that the user can manually give access. 

However, when the `get_password` method is called and the auth code is not found, it raises an exception and logs the user out. This means the flow never reaches the `get_authentication_url` call even if both the code parameter as well as the stored auth code do not exist.

<details>

<summary>Screen Recording</summary>

<br>


https://github.com/user-attachments/assets/27f3b319-6b17-4852-9f80-a6003dbcb2be


</details>



### Fix

Do not raise an exception while fetching the authorization code, and redirect the user to give access manually.


----

The `get_password` method was added via https://github.com/frappe/frappe/pull/20517 so @barredterra can you please comment if this is the intended flow in case authorization code doesn't already exist for the Google Contact.
