### PR TITLE
fix: mark genders and salutations as translatable

### DIFF
--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -25,7 +25,7 @@ def install():
 
 
 def update_genders():
-	default_genders = [
+	for gender in (
 		_("Male"),
 		_("Female"),
 		_("Other"),
@@ -33,14 +33,14 @@ def update_genders():
 		_("Genderqueer"),
 		_("Non-Conforming"),
 		_("Prefer not to say"),
-	]
-	records = [{"doctype": "Gender", "gender": d} for d in default_genders]
-	for record in records:
-		frappe.get_doc(record).insert(ignore_permissions=True, ignore_if_duplicate=True)
+	):
+		doc = frappe.new_doc("Gender")
+		doc.gender = gender
+		doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 
 def update_salutations():
-	default_salutations = [
+	for salutation in (
 		_("Mr"),
 		_("Ms"),
 		_("Mx"),
@@ -50,31 +50,23 @@ def update_salutations():
 		_("Miss"),
 		_("Master"),
 		_("Prof"),
-	]
-	records = [{"doctype": "Salutation", "salutation": d} for d in default_salutations]
-	for record in records:
-		doc = frappe.new_doc(record.get("doctype"))
-		doc.update(record)
+	):
+		doc = frappe.new_doc("Salutation")
+		doc.salutation = salutation
 		doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 
 def setup_email_linking():
-	doc = frappe.get_doc(
-		{
-			"doctype": "Email Account",
-			"email_id": "email_linking@example.com",
-		}
-	)
+	doc = frappe.new_doc("Email Account")
+	doc.email_id = "email_linking@example.com"
 	doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 
 def add_unsubscribe():
-	email_unsubscribe = [
+	for unsubscribe in [
 		{"email": "admin@example.com", "global_unsubscribe": 1},
 		{"email": "guest@example.com", "global_unsubscribe": 1},
-	]
-
-	for unsubscribe in email_unsubscribe:
+	]:
 		if not frappe.get_all("Email Unsubscribe", filters=unsubscribe):
 			doc = frappe.new_doc("Email Unsubscribe")
 			doc.update(unsubscribe)

--- a/frappe/desk/page/setup_wizard/install_fixtures.py
+++ b/frappe/desk/page/setup_wizard/install_fixtures.py
@@ -8,6 +8,13 @@ from frappe.desk.doctype.global_search_settings.global_search_settings import (
 from frappe.utils.dashboard import sync_dashboards
 
 
+def _(x, *args, **kwargs):
+	"""Redefine the translation function to return the string as is.
+	We want to create english records but still mark the strings as translatable.
+	The respective DocTypes have 'Translate Link Fields' enabled."""
+	return x
+
+
 def install():
 	update_genders()
 	update_salutations()
@@ -19,13 +26,13 @@ def install():
 
 def update_genders():
 	default_genders = [
-		"Male",
-		"Female",
-		"Other",
-		"Transgender",
-		"Genderqueer",
-		"Non-Conforming",
-		"Prefer not to say",
+		_("Male"),
+		_("Female"),
+		_("Other"),
+		_("Transgender"),
+		_("Genderqueer"),
+		_("Non-Conforming"),
+		_("Prefer not to say"),
 	]
 	records = [{"doctype": "Gender", "gender": d} for d in default_genders]
 	for record in records:
@@ -33,7 +40,17 @@ def update_genders():
 
 
 def update_salutations():
-	default_salutations = ["Mr", "Ms", "Mx", "Dr", "Mrs", "Madam", "Miss", "Master", "Prof"]
+	default_salutations = [
+		_("Mr"),
+		_("Ms"),
+		_("Mx"),
+		_("Dr"),
+		_("Mrs"),
+		_("Madam"),
+		_("Miss"),
+		_("Master"),
+		_("Prof"),
+	]
 	records = [{"doctype": "Salutation", "salutation": d} for d in default_salutations]
 	for record in records:
 		doc = frappe.new_doc(record.get("doctype"))


### PR DESCRIPTION
Redefine the translation function to return the string as is. (Just for creating setup fixtures.)
We want to create english records but still mark the strings as translatable.
The respective DocTypes have 'Translate Link Fields' enabled.

Also refactored the code to avoid useless variables and have a common structure.

Similar PR for ERPNext: https://github.com/frappe/erpnext/pull/42803