### PR TITLE
fix: extract translatable headings and paragraphs from workspaces

### DIFF
--- a/frappe/gettext/extractors/workspace.py
+++ b/frappe/gettext/extractors/workspace.py
@@ -62,3 +62,14 @@ def extract(fileobj, *args, **kwargs):
 		)
 		for shortcut in data.get("shortcuts", [])
 	)
+
+	content = json.loads(data.get("content", "[]"))
+	for item in content:
+		item_type = item.get("type")
+		if item_type in ("header", "paragraph"):
+			yield (
+				None,
+				"_",
+				item.get("data", {}).get("text"),
+				[f"{item_type.title()} text in the {workspace_name} Workspace"],
+			)


### PR DESCRIPTION
Companion to #27278. We need to automatically extract these texts, so people are able to translate them.
