### PR TITLE
feat: add MultiCheck option in workspace settings

### DIFF
--- a/frappe/desk/doctype/workspace_settings/workspace_settings.js
+++ b/frappe/desk/doctype/workspace_settings/workspace_settings.js
@@ -8,38 +8,38 @@ frappe.ui.form.on("Workspace Settings", {
 
 		// build fields from workspaces
 		let options = frappe.boot.allowed_workspaces
-			.filter(w => w.public)
-			.map(w => {
+		.filter((w) => w.public)
+		.map((w) => {
 				return {
 					label: w.title,
 					value: w.name,
-					checked: workspace_visibilty[w.name] !== 0
+					checked: workspace_visibilty[w.name] !== 0,
 				};
 			});
 
 		// Define MultiCheck field for workspace visibility
 		frm.docfields = [
 			{
-				fieldtype: 'MultiCheck',
-				fieldname: 'workspace_visibility',
+				fieldtype: "MultiCheck",
+				fieldname: "workspace_visibility",
 				options: options,
 				select_all: true,
 				columns: 2,
-				sort_options: false
-			}
+				sort_options: false,
+			},
 		];
 
 		frappe.temp = frm;
 	},
 	validate(frm) {
-		let selected_workspaces = frm.get_field('workspace_visibility').get_value() || [];
+		let selected_workspaces = frm.get_field("workspace_visibility").get_value() || [];
 		let visibility = {};
 
-		selected_workspaces.forEach(workspace => {
+		selected_workspaces.forEach((workspace) => {
 			visibility[workspace] = 1;
 		});
 
-		frappe.boot.allowed_workspaces.forEach(workspace => {
+		frappe.boot.allowed_workspaces.forEach((workspace) => {
 			if (!visibility[workspace.name] && workspace.public) {
 				visibility[workspace.name] = 0;
 			}

--- a/frappe/desk/doctype/workspace_settings/workspace_settings.js
+++ b/frappe/desk/doctype/workspace_settings/workspace_settings.js
@@ -4,34 +4,48 @@
 frappe.ui.form.on("Workspace Settings", {
 	setup(frm) {
 		frm.hide_full_form_button = true;
-		frm.docfields = [];
 		let workspace_visibilty = JSON.parse(frm.doc.workspace_visibility_json || "{}");
 
 		// build fields from workspaces
-		let cnt = 0,
-			column_added = false;
-		for (let w of frappe.boot.allowed_workspaces) {
-			if (w.public) {
-				cnt++;
-				frm.docfields.push({
-					fieldtype: "Check",
-					fieldname: w.name,
+		let options = frappe.boot.allowed_workspaces
+			.filter(w => w.public)
+			.map(w => {
+				return {
 					label: w.title,
-					initial_value: workspace_visibilty[w.name] !== 0, // not set is also visible
-				});
-			}
+					value: w.name,
+					checked: workspace_visibilty[w.name] !== 0
+				};
+			});
 
-			if (cnt >= frappe.boot.allowed_workspaces.length / 2 && !column_added) {
-				// add column break to split into 2 columns
-				frm.docfields.push({ fieldtype: "Column Break" });
-				column_added = true;
+		// Define MultiCheck field for workspace visibility
+		frm.docfields = [
+			{
+				fieldtype: 'MultiCheck',
+				fieldname: 'workspace_visibility',
+				options: options,
+				select_all: true,
+				columns: 2,
+				sort_options: false
 			}
-		}
+		];
 
 		frappe.temp = frm;
 	},
 	validate(frm) {
-		frm.doc.workspace_visibility_json = JSON.stringify(frm.dialog.get_values());
+		let selected_workspaces = frm.get_field('workspace_visibility').get_value() || [];
+		let visibility = {};
+
+		selected_workspaces.forEach(workspace => {
+			visibility[workspace] = 1;
+		});
+
+		frappe.boot.allowed_workspaces.forEach(workspace => {
+			if (!visibility[workspace.name] && workspace.public) {
+				visibility[workspace.name] = 0;
+			}
+		});
+
+		frm.doc.workspace_visibility_json = JSON.stringify(visibility);
 		frm.doc.workspace_setup_completed = 1;
 	},
 	after_save(frm) {

--- a/frappe/desk/doctype/workspace_settings/workspace_settings.js
+++ b/frappe/desk/doctype/workspace_settings/workspace_settings.js
@@ -8,8 +8,8 @@ frappe.ui.form.on("Workspace Settings", {
 
 		// build fields from workspaces
 		let options = frappe.boot.allowed_workspaces
-		.filter((w) => w.public)
-		.map((w) => {
+			.filter((w) => w.public)
+			.map((w) => {
 				return {
 					label: w.title,
 					value: w.name,


### PR DESCRIPTION
**Before:**

![image](https://github.com/user-attachments/assets/5e5006ca-828b-41e7-ae9e-1459f1c79400)

**After:**

- Selecting all the modules one by one can be a time-consuming process. Using the MultiCheck option makes it easier to add or remove all workspaces at once.

https://github.com/user-attachments/assets/393b5128-a866-4d41-8b17-346a9c4540ca

`no-docs`