### PR TITLE
fix: correct permissions for user cannot create doctypes

### DIFF
--- a/frappe/core/page/permission_manager/permission_manager.js
+++ b/frappe/core/page/permission_manager/permission_manager.js
@@ -251,7 +251,6 @@ frappe.PermissionEngine = class PermissionEngine {
 
 			this.rights.forEach((r) => {
 				if (!d.is_submittable && ["submit", "cancel", "amend"].includes(r)) return;
-				if (d.in_create && ["create", "delete"].includes(r)) return;
 				this.add_check(perm_container, d, r);
 
 				if (d.if_owner && r == "report") {


### PR DESCRIPTION
The user was not able to update create/delete permission for User Cannot Create Doctype.

Before:
![image](https://github.com/user-attachments/assets/7cfe1ab0-9cd8-43b2-acac-8d0fd633f417)

After:
![image](https://github.com/user-attachments/assets/b0d73996-975c-49ee-8e62-2a7460788cee)



Frappe Support Issue:
https://support.frappe.io/app/hd-ticket/20587
https://support.frappe.io/app/hd-ticket/19162
