### PR TITLE
fix(notification): can't use `message` where it isn't defined

### DIFF
--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -612,8 +612,8 @@ def evaluate_alert(doc: Document, alert, event):
 		frappe.throw(message, title=_("Error in Notification"))
 	except Exception as e:
 		title = str(e)
-		frappe.log_error(title=title)
-
+		message = frappe.get_traceback(with_context=True)
+		frappe.log_error(title=title, message=message)
 		msg = f"<details><summary>{title}</summary>{message}</details>"
 		frappe.throw(msg, title=_("Error in Notification"))
 


### PR DESCRIPTION
Sentry FRAPPE-7VT

Partial revert of 8a7707e3fac802e799ef1eb5079e672c0659271a

```
UnboundLocalError: cannot access local variable 'message' where it is not associated with a value
  File "frappe/app.py", line 114, in application
    response = frappe.api.handle(request)
  File "frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
  File "frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
  File "frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "__init__.py", line 1768, in call
    return fn(*args, **newargs)
  File "frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "frappe/desk/form/save.py", line 37, in savedocs
    doc.submit()
  File "frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "frappe/model/document.py", line 1048, in submit
    return self._submit()
  File "frappe/model/document.py", line 1031, in _submit
    return self.save()
  File "frappe/model/document.py", line 337, in save
    return self._save(*args, **kwargs)
  File "frappe/model/document.py", line 390, in _save
    self.run_post_save_methods()
  File "frappe/model/document.py", line 1131, in run_post_save_methods
    self.run_method("on_submit")
  File "frappe/model/document.py", line 964, in run_method
    self.run_notifications(method)
  File "frappe/model/document.py", line 1024, in run_notifications
    _evaluate_alert(alert)
  File "frappe/model/document.py", line 1007, in _evaluate_alert
    evaluate_alert(self, alert.name, alert.event)
  File "frappe/email/doctype/notification/notification.py", line 517, in evaluate_alert
    msg = f"<details><summary>{title}</summary>{message}</details>"
```
