### PR TITLE
fix(rate_limiter): prevent KeyError if the key isn't defined in form_dict

### DIFF
--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -126,7 +126,7 @@ def rate_limit(
 
 			ip = frappe.local.request_ip if ip_based is True else None
 
-			user_key = frappe.form_dict[key] if key else None
+			user_key = frappe.form_dict.get(key)
 
 			identity = None
 


### PR DESCRIPTION
Use dict.get(), it'll just return `None` if the key isn't present
(also will handle a `None` key just fine)
