### PR TITLE
fix(rate_limiter): we can't call str.join([]) with NoneTypes in the list

### DIFF
--- a/frappe/rate_limiter.py
+++ b/frappe/rate_limiter.py
@@ -126,7 +126,7 @@ def rate_limit(
 
 			ip = frappe.local.request_ip if ip_based is True else None
 
-			user_key = frappe.form_dict.get(key)
+			user_key = frappe.form_dict.get(key, "")
 
 			identity = None
 


### PR DESCRIPTION
Default to an empty string for `user_key`

Otherwise we can get `builtins.TypeError: sequence item 1: expected str instance, NoneType found` here

Follow up to #27481
