### PR TITLE
fix: translate list row subject

### DIFF
--- a/frappe/public/js/frappe/list/list_view.js
+++ b/frappe/public/js/frappe/list/list_view.js
@@ -1090,14 +1090,15 @@ frappe.views.ListView = class ListView extends frappe.views.BaseList {
 
 	get_subject_text(doc, title) {
 		const subject_field = this.columns[0].df;
-		let value = title || doc[subject_field.fieldname];
+		let value = title || doc[subject_field.fieldname] || doc.name;
+
+		if (this.meta.translated_doctype) {
+			value = __(value);
+		}
+
 		if (this.settings.formatters && this.settings.formatters[subject_field.fieldname]) {
 			let formatter = this.settings.formatters[subject_field.fieldname];
 			value = formatter(value, subject_field, doc);
-		}
-
-		if (!value) {
-			value = doc.name;
 		}
 
 		if (frappe.model.html_fieldtypes.includes(subject_field.fieldtype)) {


### PR DESCRIPTION
Example: the DocType **Mode of Payment** has _Translate Link Fields_ enabled. The effect is that users will see the translated name in link fields and as the form heading. However, this had no effect on the list view so far.

### Before

The **Mode of Payment** list view in German shows english values in the _ID_ column.

![Bildschirmfoto 2024-08-22 um 17 04 37](https://github.com/user-attachments/assets/fee583bc-bd03-4482-8670-3f6e226ea59f)

### After

The **Mode of Payment** list view in German shows german values in the _ID_ column.

![Bildschirmfoto 2024-08-22 um 17 05 26](https://github.com/user-attachments/assets/111486b4-e315-4df5-9252-1a9b1da64180)

TODO:

- [ ] See if we can get the english ID and translated title in the list view.