### PR TITLE
fix: show link title in generated form hrefs

### DIFF
--- a/frappe/__init__.py
+++ b/frappe/__init__.py
@@ -2407,8 +2407,11 @@ def logger(module=None, with_more_info=False, allow_site=True, filter=None, max_
 
 
 def get_desk_link(doctype, name):
-	html = '<a href="/app/Form/{doctype}/{name}" style="font-weight: bold;">{doctype_local} {name}</a>'
-	return html.format(doctype=doctype, name=name, doctype_local=_(doctype))
+	meta = get_meta(doctype)
+	title = get_value(doctype, name, meta.get_title_field())
+
+	html = '<a href="/app/Form/{doctype}/{name}" style="font-weight: bold;">{doctype_local} {title_local}</a>'
+	return html.format(doctype=doctype, name=name, doctype_local=_(doctype), title_local=_(title))
 
 
 def bold(text: str) -> str:


### PR DESCRIPTION
If a doctype has a set title field I think it make sense to show that field value in a generated href title instead of the `name` value.

Not sure if this is something that should get translated...

Thoughts?