### PR TITLE
fix: remove redundant distinct keyword in get_count function

### DIFF
--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -58,9 +58,8 @@ def get_count() -> int:
 		count = frappe.call(controller.get_count, args=args, **args)
 	else:
 		args.distinct = sbool(args.distinct)
-		distinct = "distinct " if args.distinct else ""
 		args.limit = cint(args.limit)
-		fieldname = f"{distinct}`tab{args.doctype}`.name"
+		fieldname = f"`tab{args.doctype}`.name"
 		args.order_by = None
 
 		if args.limit:

--- a/frappe/desk/reportview.py
+++ b/frappe/desk/reportview.py
@@ -58,8 +58,9 @@ def get_count() -> int:
 		count = frappe.call(controller.get_count, args=args, **args)
 	else:
 		args.distinct = sbool(args.distinct)
+		distinct = get_distinct(args.distinct)
 		args.limit = cint(args.limit)
-		fieldname = f"`tab{args.doctype}`.name"
+		fieldname = f"{distinct}`tab{args.doctype}`.name"
 		args.order_by = None
 
 		if args.limit:
@@ -75,6 +76,12 @@ def get_count() -> int:
 
 def execute(doctype, *args, **kwargs):
 	return DatabaseQuery(doctype).execute(*args, **kwargs)
+
+
+def get_distinct(distinct) -> str:
+	if distinct and frappe.conf.db_type == "mariadb":
+		return "distinct "
+	return ""
 
 
 def get_form_params():


### PR DESCRIPTION
This pull request addresses a syntax error in the `get_count` function caused by the redundant inclusion of the `distinct` keyword in SQL queries. The `distinct` keyword was previously added manually, but since the `execute` function already manages distinct values, this led to SQL syntax errors, particularly when filtering for child table fields of a doctype, as shown in the traceback logs.

### Changes:
- Removed the redundant `distinct` keyword from the `get_count` function.
- Ensured consistency in the construction of the `fieldname` variable.

### Traceback:
```plaintext
Syntax error in query:
select count(*) from ( select distinct distinct cast("tabCourse".name as varchar)
                       from "tabCourse" left join "tabCourse Department College Campus Item" on ("tabCourse Department College Campus Item".parenttype = 'Course' and "tabCourse Department College Campus Item".parent = cast("tabCourse".name as varchar))
                       where "tabCourse Department College Campus Item"."campus" = 'Campus 2023'
                       limit 1001 offset 0 ) p 
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 97, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1619, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 815, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/reportview.py", line 66, in get_count
    count = frappe.db.sql(f"""select count(*) from ( {partial_query} ) p""")[0][0]
  File "apps/frappe/frappe/database/postgres/database.py", line 209, in sql
    return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
  File "apps/frappe/frappe/database/database.py", line 244, in sql
    self._cursor.execute(query, values)
psycopg2.errors.SyntaxError: syntax error at or near "distinct"
LINE 1: select count(*) from ( select distinct distinct cast("tabCou...
```

With these changes, the function will generate valid SQL queries and avoid the previous syntax issues.

Screenshots:
![image](https://github.com/user-attachments/assets/4a007bb4-0a1a-478c-b1a6-fa1f15edd53f)
