### PR TITLE
fix!: Skip virtual fields in meta.get_valid_columns

### DIFF
--- a/frappe/model/base_document.py
+++ b/frappe/model/base_document.py
@@ -364,7 +364,7 @@ class BaseDocument:
 		d = _dict()
 		field_values = self.__dict__
 
-		for fieldname in self.meta.get_valid_columns():
+		for fieldname in self.meta.get_valid_fields():
 			value = field_values.get(fieldname)
 
 			# if no need for sanitization and value is None, continue

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -221,7 +221,9 @@ class Meta(Document):
 				self._valid_columns = get_table_columns(self.name)
 			else:
 				self._valid_columns = self.default_fields + [
-					df.fieldname for df in self.get("fields") if df.fieldtype in data_fieldtypes
+					df.fieldname
+					for df in self.get("fields")
+					if not df.is_virtual and df.fieldtype in data_fieldtypes
 				]
 				if self.istable:
 					self._valid_columns += list(child_table_fields)

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -223,7 +223,7 @@ class Meta(Document):
 				self._valid_columns = self.default_fields + [
 					df.fieldname
 					for df in self.get("fields")
-					if not df.is_virtual and df.fieldtype in data_fieldtypes
+					if not df.get("is_virtual") and df.fieldtype in data_fieldtypes
 				]
 				if self.istable:
 					self._valid_columns += list(child_table_fields)

--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -230,6 +230,19 @@ class Meta(Document):
 
 		return self._valid_columns
 
+	def get_valid_fields(self) -> list[str]:
+		if not hasattr(self, "_valid_fields"):
+			if frappe.flags.in_install and self.name in self.special_doctypes:
+				self._valid_fields = get_table_columns(self.name)
+			else:
+				self._valid_fields = self.default_fields + [
+					df.fieldname for df in self.get("fields") if df.fieldtype in data_fieldtypes
+				]
+				if self.istable:
+					self._valid_fields += list(child_table_fields)
+
+		return self._valid_fields
+
 	def get_table_field_doctype(self, fieldname):
 		return TABLE_DOCTYPES_FOR_DOCTYPE.get(fieldname)
 


### PR DESCRIPTION
### Problem

```py
In [10]: set(frappe.get_meta("Submission Queue").get_valid_columns()) - set(frappe.db.get_table_columns("Submission Queue"))
Out[10]: {'created_at', 'enqueued_by'}
```

> NOTE: Submission Queue doctype (in Frappe) has 2 virtual fields

### Discovery

Meta.get_valid_columns used in `Document.bulk_insert` causes query generated to include virtual fields which error since the column does not exist in the Database.

This should've been a part of the original Virtual Docfields PR (#14593), ref: #17751 

> Re-starting previous attempt via https://github.com/frappe/frappe/pull/26877