### PR TITLE
chore: ignore helix folder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,4 +18,4 @@ max_line_length = 99
 [{*.json}]
 insert_final_newline = false
 indent_style = space
-indent_size = 2
+indent_size = 1

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,5 @@ cypress/videos
 
 # JetBrains IDEs
 .idea/
+# Helix Editor
+.helix/


### PR DESCRIPTION
The framework indents json by 1, only.

`.helix` is just a popular editor that some developers use, and local config is sometimes needed for best DevX.
