### PR TITLE
fix: default tree view with default format v14

### DIFF
--- a/frappe/public/js/frappe/router.js
+++ b/frappe/public/js/frappe/router.js
@@ -228,11 +228,15 @@ frappe.router = {
 			} else if (frappe.model.is_single(doctype_route.doctype)) {
 				route = ["Form", doctype_route.doctype, doctype_route.doctype];
 			} else if (meta.default_view) {
-				route = [
-					"List",
-					doctype_route.doctype,
-					this.list_views_route[meta.default_view.toLowerCase()],
-				];
+				if (meta.default_view === "Tree") {
+					route = ["Tree", doctype_route.doctype];
+				} else {
+					route = [
+						"List",
+						doctype_route.doctype,
+						this.list_views_route[meta.default_view.toLowerCase()],
+					];
+				}
 			} else {
 				route = ["List", doctype_route.doctype, "List"];
 			}


### PR DESCRIPTION
Version 14

fixes: #27565

**Before:**
<img width="1440" alt="Screenshot 2024-08-30 at 9 44 45 AM" src="https://github.com/user-attachments/assets/06cfe013-f50b-4154-991f-962880f235da">


**After:**

![image](https://github.com/user-attachments/assets/407bf926-6d49-4a5a-adaf-2b2931519249)
