### PR TITLE
fix: Consider default app path for Website User if applicable

### DIFF
--- a/frappe/apps.py
+++ b/frappe/apps.py
@@ -49,6 +49,12 @@ def is_desk_apps(apps):
 
 
 def get_default_path():
+	apps = get_apps()
+	_apps = [app for app in apps if app.get("name") != "frappe"]
+
+	if len(_apps) == 0:
+		return None
+
 	system_default_app = frappe.get_system_settings("default_app")
 	user_default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
 	if system_default_app and not user_default_app:
@@ -56,8 +62,6 @@ def get_default_path():
 	elif user_default_app:
 		return get_route(user_default_app)
 
-	apps = get_apps()
-	_apps = [app for app in apps if app.get("name") != "frappe"]
 	if len(_apps) == 1:
 		return _apps[0].get("route") or "/apps"
 	elif is_desk_apps(_apps):

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -179,12 +179,12 @@ class LoginManager:
 			frappe.local.cookie_manager.set_cookie("system_user", "no")
 			if not resume:
 				frappe.local.response["message"] = "No App"
-				frappe.local.response["home_page"] = "/" + get_home_page()
+				frappe.local.response["home_page"] = get_default_path() or "/" + get_home_page()
 		else:
 			frappe.local.cookie_manager.set_cookie("system_user", "yes")
 			if not resume:
 				frappe.local.response["message"] = "Logged In"
-				frappe.local.response["home_page"] = get_default_path() or "/apps"
+				frappe.local.response["home_page"] = get_default_path()
 
 		if not resume:
 			frappe.response["full_name"] = self.full_name

--- a/frappe/auth.py
+++ b/frappe/auth.py
@@ -184,7 +184,7 @@ class LoginManager:
 			frappe.local.cookie_manager.set_cookie("system_user", "yes")
 			if not resume:
 				frappe.local.response["message"] = "Logged In"
-				frappe.local.response["home_page"] = get_default_path()
+				frappe.local.response["home_page"] = get_default_path() or "/app"
 
 		if not resume:
 			frappe.response["full_name"] = self.full_name

--- a/frappe/core/doctype/user/test_user.py
+++ b/frappe/core/doctype/user/test_user.py
@@ -406,7 +406,7 @@ class TestUser(FrappeTestCase):
 
 		# test redirect URL for website users
 		frappe.set_user("test2@example.com")
-		self.assertEqual(update_password(new_password, old_password=old_password), "/")
+		self.assertEqual(update_password(new_password, old_password=old_password), "me")
 		# reset password
 		update_password(old_password, old_password=new_password)
 
@@ -418,7 +418,7 @@ class TestUser(FrappeTestCase):
 			test_user.reload()
 			link = sendmail.call_args_list[0].kwargs["args"]["link"]
 			key = parse_qs(urlparse(link).query)["key"][0]
-			self.assertEqual(update_password(new_password, key=key), "/")
+			self.assertEqual(update_password(new_password, key=key), "me")
 			update_password(old_password, old_password=new_password)
 			self.assertEqual(
 				frappe.message_log[0].get("message"),

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -10,6 +10,7 @@ import frappe.defaults
 import frappe.permissions
 import frappe.share
 from frappe import STANDARD_USERS, _, msgprint, throw
+from frappe.apps import get_default_path
 from frappe.auth import MAX_PASSWORD_SIZE
 from frappe.core.doctype.user_type.user_type import user_linked_with_permission_on_doctype
 from frappe.desk.doctype.notification_settings.notification_settings import (
@@ -36,7 +37,7 @@ from frappe.utils.deprecations import deprecated, deprecation_warning
 from frappe.utils.password import check_password, get_password_reset_limit
 from frappe.utils.password import update_password as _update_password
 from frappe.utils.user import get_system_managers
-from frappe.website.utils import is_signup_disabled
+from frappe.website.utils import get_home_page, is_signup_disabled
 
 
 class User(Document):
@@ -866,9 +867,9 @@ def update_password(
 	frappe.db.set_value("User", user, "reset_password_key", "")
 
 	if user_doc.user_type == "System User":
-		return "/app"
+		return get_default_path()
 	else:
-		return redirect_url or "/"
+		return redirect_url or get_default_path() or get_home_page()
 
 
 @frappe.whitelist(allow_guest=True)

--- a/frappe/core/doctype/user/user.py
+++ b/frappe/core/doctype/user/user.py
@@ -867,7 +867,7 @@ def update_password(
 	frappe.db.set_value("User", user, "reset_password_key", "")
 
 	if user_doc.user_type == "System User":
-		return get_default_path()
+		return get_default_path() or "/app"
 	else:
 		return redirect_url or get_default_path() or get_home_page()
 

--- a/frappe/sessions.py
+++ b/frappe/sessions.py
@@ -17,7 +17,6 @@ import frappe.model.meta
 import frappe.translate
 import frappe.utils
 from frappe import _
-from frappe.apps import get_default_path
 from frappe.cache_manager import clear_user_cache
 from frappe.query_builder import Order
 from frappe.utils import cint, cstr, get_assets_json
@@ -169,7 +168,6 @@ def get():
 	bootinfo["disable_async"] = frappe.conf.disable_async
 
 	bootinfo["setup_complete"] = cint(frappe.get_system_settings("setup_complete"))
-	bootinfo["default_path"] = get_default_path()
 
 	bootinfo["desk_theme"] = frappe.db.get_value("User", frappe.session.user, "desk_theme") or "Light"
 	bootinfo["user"]["impersonated_by"] = frappe.session.data.get("impersonated_by")

--- a/frappe/website/js/website.js
+++ b/frappe/website/js/website.js
@@ -351,8 +351,9 @@ $.extend(frappe, {
 	add_switch_to_desk: function () {
 		$(".switch-to-desk").removeClass("hidden");
 	},
-	add_apps: function () {
-		$(".apps").removeClass("hidden");
+	add_apps: function (obj) {
+		$(".logged-in .apps").attr("href", obj.route).text(obj.label);
+		$(".logged-in .apps").removeClass("hidden");
 	},
 	add_link_to_headings: function () {
 		$(".doc-content .from-markdown")
@@ -610,10 +611,26 @@ $(document).ready(function () {
 
 	frappe.bind_navbar_search();
 
+	// add apps link
+	let apps = frappe.boot?.apps_data?.apps;
+	let obj = {
+		label: __("Apps"),
+		route: "/apps",
+	};
+	if (apps?.length) {
+		if (apps.length == 1) {
+			obj = {
+				label: __(apps[0].title),
+				route: apps[0].route,
+			};
+		}
+		let is_desk_apps = frappe.boot?.apps_data?.is_desk_apps;
+		!is_desk_apps && frappe.add_apps(obj);
+	}
+
 	// switch to app link
 	if (frappe.get_cookie("system_user") === "yes" && logged_in) {
 		frappe.add_switch_to_desk();
-		frappe.add_apps();
 	}
 
 	frappe.render_user();

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -10,6 +10,7 @@ import yaml
 from werkzeug.wrappers import Response
 
 import frappe
+from frappe.apps import get_apps, get_default_path, is_desk_apps
 from frappe.model.document import Document
 from frappe.utils import (
 	cint,
@@ -165,6 +166,11 @@ def get_home_page_via_hooks():
 def get_boot_data():
 	return {
 		"lang": frappe.local.lang or "en",
+		"apps_data": {
+			"apps": get_apps(),
+			"is_desk_apps": 1 if bool(is_desk_apps(get_apps())) else 0,
+			"default_path": get_default_path(),
+		},
 		"sysdefaults": {
 			"float_precision": cint(frappe.get_system_settings("float_precision")) or 3,
 			"date_format": frappe.get_system_settings("date_format") or "yyyy-mm-dd",

--- a/frappe/website/utils.py
+++ b/frappe/website/utils.py
@@ -167,9 +167,9 @@ def get_boot_data():
 	return {
 		"lang": frappe.local.lang or "en",
 		"apps_data": {
-			"apps": get_apps(),
+			"apps": get_apps() or [],
 			"is_desk_apps": 1 if bool(is_desk_apps(get_apps())) else 0,
-			"default_path": get_default_path(),
+			"default_path": get_default_path() or "",
 		},
 		"sysdefaults": {
 			"float_precision": cint(frappe.get_system_settings("float_precision")) or 3,

--- a/frappe/www/apps.html
+++ b/frappe/www/apps.html
@@ -12,17 +12,30 @@ endblock -%} {%- block footer -%} {%- endblock -%} {% block content %}
 		<div class="apps" style="grid-template-columns: repeat({{ appsCount }}, 1fr);">
 			{% for app in apps %}
 			<a href="{{ app.route }}" class="app-icon">
-				<img class="app-logo" src="{{ app.logo }}" />
-				<div class="app-title">{{ app.title }}</div>
-				<div
-					app-name="{{ app.name }}"
-					class="set-default btn btn-sm {{ '' if app.is_default else 'hidden'}}"
-					title="Set as default"
-				>
-					<svg class="icon icon-md">
-						<use href="#icon-solid-success"></use>
-					</svg>
+				<div class="app-logo">
+					<img src="{{ app.logo }}" />
+					<div
+						app-name="{{ app.name }}"
+						class="set-default btn btn-sm {{ '' if app.is_default else 'hidden'}}"
+						title="Set as default"
+					>
+						<svg
+							width="18"
+							height="18"
+							viewBox="0 0 16 16"
+							fill="none"
+							xmlns="http://www.w3.org/2000/svg"
+						>
+							<path
+								fill-rule="evenodd"
+								clip-rule="evenodd"
+								d="M8 15C11.866 15 15 11.866 15 8C15 4.13401 11.866 1 8 1C4.13401 1 1 4.13401 1 8C1 11.866 4.13401 15 8 15ZM11.1728 5.98483C11.3484 5.77177 11.3181 5.45664 11.1051 5.28097C10.892 5.10531 10.5769 5.13563 10.4012 5.34869L6.95187 9.5324L5.61031 7.79859C5.44132 7.58019 5.12729 7.54014 4.90889 7.70912C4.69049 7.87811 4.65044 8.19215 4.81942 8.41055L6.54403 10.6394C6.63706 10.7596 6.77974 10.831 6.93174 10.8334C7.08374 10.8357 7.22856 10.7688 7.32526 10.6515L11.1728 5.98483Z"
+								fill="currentColor"
+							/>
+						</svg>
+					</div>
 				</div>
+				<div class="app-title">{{ app.title }}</div>
 			</a>
 			{% endfor %}
 		</div>
@@ -47,27 +60,25 @@ endblock -%} {%- block footer -%} {%- endblock -%} {% block content %}
 		</button>
 	</div>
 </div>
-{% endblock %}
-
-{% block script %}
+{% endblock %} {% block script %}
 <script>
-	$('.set-default').on('click', function(e) {
+	$(".set-default").on("click", function (e) {
 		e.preventDefault();
-		var appName = $(this).attr('app-name');
+		var appName = $(this).attr("app-name");
 		frappe.call({
-			method: 'frappe.apps.set_app_as_default',
+			method: "frappe.apps.set_app_as_default",
 			args: { app_name: appName },
-			callback: function() {
+			callback: function () {
 				location.reload();
-			}
+			},
 		});
 	});
-	$('.logout-btn').on('click', function() {
+	$(".logout-btn").on("click", function () {
 		frappe.call({
-			method: 'logout',
-			callback: function() {
-				window.location.href = '/login';
-			}
+			method: "logout",
+			callback: function () {
+				window.location.href = "/login";
+			},
 		});
 	});
 </script>

--- a/frappe/www/apps.py
+++ b/frappe/www/apps.py
@@ -7,17 +7,11 @@ from frappe.apps import get_apps
 
 
 def get_context():
-	if frappe.session.user == "Guest":
-		frappe.throw(_("You need to be logged in to access this page"), frappe.PermissionError)
-
-	if frappe.session.data.user_type == "Website User":
-		frappe.throw(_("You are not permitted to access this page."), frappe.PermissionError)
+	all_apps = get_apps()
 
 	system_default_app = frappe.get_system_settings("default_app")
 	user_default_app = frappe.db.get_value("User", frappe.session.user, "default_app")
 	default_app = user_default_app if user_default_app else system_default_app
-
-	all_apps = get_apps()
 
 	if len(all_apps) == 0:
 		frappe.local.flags.redirect_location = "/app"

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -27,10 +27,9 @@ def get_context(context):
 
 	if frappe.session.user != "Guest":
 		if not redirect_to:
-			if frappe.session.data.user_type == "Website User":
+			redirect_to = get_default_path()
+			if frappe.session.data.user_type == "Website User" and not redirect_to:
 				redirect_to = get_home_page()
-			else:
-				redirect_to = get_default_path() or "/apps"
 
 		if redirect_to != "login":
 			frappe.local.flags.redirect_location = redirect_to

--- a/frappe/www/login.py
+++ b/frappe/www/login.py
@@ -27,9 +27,10 @@ def get_context(context):
 
 	if frappe.session.user != "Guest":
 		if not redirect_to:
-			redirect_to = get_default_path()
-			if frappe.session.data.user_type == "Website User" and not redirect_to:
-				redirect_to = get_home_page()
+			if frappe.session.data.user_type == "Website User":
+				redirect_to = get_default_path() or get_home_page()
+			else:
+				redirect_to = get_default_path() or "/app"
 
 		if redirect_to != "login":
 			frappe.local.flags.redirect_location = redirect_to


### PR DESCRIPTION
E.g.
Gameplan allows Website User to use Gameplan portal page. So after login he/she should get redirected to Gameplan portal page which was not happening before. 

>**NOTE**: By default we assume that app is allowed by Website User. App developer/maintainer should send if allowed or not using `has_permission` option in hooks.py

hooks.py for Gameplan (Just for example)

```Python
add_to_apps_screen = [
	{
		"name": "gameplan",
		"logo": "/assets/gameplan/manifest/favicon-196.png",
		"title": "Gameplan",
		"route": "/g",
		"has_permission": "gameplan.api.check_app_permission"
	}
]
```

```Python
def check_app_permission():
	if frappe.session.user == "Administrator":
		return True

	roles = frappe.get_roles()
	if any(role in ["System Manager", "Gameplan Admin", "Gameplan Member", "Gameplan Guest"] for role in roles):
		return True

	return False
```

**Changed default icon**
| Before | After |
|------|------|
| <img width="98" alt="image" src="https://github.com/user-attachments/assets/583585d5-ec76-4351-a5ab-412972dbc814"> | <img width="98" alt="image" src="https://github.com/user-attachments/assets/51c3a33f-3c7a-4a98-b14c-6425a2ad43a0"> |


**Show app link if only one app installed**
<kbd>
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/9857c3cc-110b-4621-97fd-fa1542d69121">
</kbd>
**Other wise show `Apps` and don't show any option if all apps installed are desk app**
<kbd>
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/b67d4209-bf9e-4c8e-94d5-01f44ed09829">
</kbd>