### PR TITLE
feat: if running over socket (default), no admin password required

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -29,7 +29,7 @@ from frappe.utils import CallbackManager
 @click.option(
 	"--db-root-username",
 	"--mariadb-root-username",
-	help='Root username for MariaDB or PostgreSQL, Default is "root"',
+	help="Root username for MariaDB or PostgreSQL. Default is current user.",
 )
 @click.option("--db-root-password", "--mariadb-root-password", help="Root password for MariaDB or PostgreSQL")
 @click.option(
@@ -931,7 +931,7 @@ def uninstall(context, app, dry_run, yes, no_backup, force):
 	"--db-root-username",
 	"--mariadb-root-username",
 	"--root-login",
-	help='Root username for MariaDB or PostgreSQL, Default is "root"',
+	help="Root username for MariaDB or PostgreSQL. Default is current user.",
 )
 @click.option(
 	"--db-root-password",
@@ -944,7 +944,7 @@ def uninstall(context, app, dry_run, yes, no_backup, force):
 @click.option("--force", help="Force drop-site even if an error is encountered", is_flag=True, default=False)
 def drop_site(
 	site,
-	db_root_username="root",
+	db_root_username=None,
 	db_root_password=None,
 	archived_sites_path=None,
 	force=False,

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -125,14 +125,12 @@ def check_compatible_versions():
 
 def get_root_connection():
 	if not frappe.local.flags.root_connection:
-		from getpass import getpass
+		from getpass import getpass, getuser
 
 		if not frappe.flags.root_login:
-			frappe.flags.root_login = (
-				frappe.conf.get("root_login") or input("Enter mysql super user [root]: ") or "root"
-			)
+			frappe.flags.root_login = frappe.conf.get("root_login") or getuser()
 
-		if not frappe.flags.root_password:
+		if not frappe.flags.root_password and not frappe.conf.db_socket:
 			frappe.flags.root_password = frappe.conf.get("root_password") or getpass("MySQL root password: ")
 
 		frappe.local.flags.root_connection = frappe.database.get_db(

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -67,7 +67,7 @@ def get_root_connection():
 				frappe.conf.get("root_login") or input("Enter postgres super user [postgres]: ") or "postgres"
 			)
 
-		if not frappe.flags.root_password:
+		if not frappe.flags.root_password and not frappe.conf.db_socket:
 			frappe.flags.root_password = frappe.conf.get("root_password") or getpass(
 				"Postgres super user password: "
 			)

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -142,7 +142,7 @@ def install_db(
 	if not db_type:
 		db_type = frappe.conf.db_type
 
-	if not root_login and db_type == "mariadb":
+	if not root_login and db_type == "mariadb" and not db_socket:
 		root_login = "root"
 	elif not root_login and db_type == "postgres":
 		root_login = "postgres"


### PR DESCRIPTION
**Prior**:

```console
❯ frx //tools/tasks/new-site:run -- --force test-pr-41721.local
2024-08-30 13:15:15 0 [Note] Starting MariaDB 10.11.8-MariaDB source revision 3a069644682e336e445039e48baae9693f9a08ee as process 94183
[ ... ]
2024-08-30 13:15:15 0 [Note] InnoDB: Buffer pool(s) load completed at 240830 13:15:15
MySQL root password:
[ ... ]
```

**Now**

- No manual password entry is required
- If no root user is set, the current user is taken
- On a normal mysql installation, the current user is configured not to require password authentication (while 'root' is)
- Regardless, the current user has root privileges within the default mysql installation

`no-docs`