### PR TITLE
feat: Custom timeouts for prepared report

### DIFF
--- a/frappe/core/doctype/prepared_report/prepared_report.py
+++ b/frappe/core/doctype/prepared_report/prepared_report.py
@@ -71,11 +71,12 @@ class PreparedReport(Document):
 			job.stop_job() if self.status == "Started" else job.delete()
 
 	def after_insert(self):
+		timeout = frappe.get_value("Report", self.report_name, "timeout")
 		enqueue(
 			generate_report,
 			queue="long",
 			prepared_report=self.name,
-			timeout=REPORT_TIMEOUT,
+			timeout=timeout or REPORT_TIMEOUT,
 			enqueue_after_commit=True,
 		)
 

--- a/frappe/core/doctype/report/report.json
+++ b/frappe/core/doctype/report/report.json
@@ -17,6 +17,7 @@
   "add_total_row",
   "disabled",
   "prepared_report",
+  "timeout",
   "filters_section",
   "filters",
   "columns_section",
@@ -186,12 +187,19 @@
    "fieldname": "client_code_section",
    "fieldtype": "Section Break",
    "label": "Client Code"
+  },
+  {
+   "depends_on": "prepared_report",
+   "description": "Specify a custom timeout, default timeout is 1500 seconds",
+   "fieldname": "timeout",
+   "fieldtype": "Int",
+   "label": "Timeout (In Seconds)"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:03:36.343177",
+ "modified": "2024-08-31 20:34:10.018811",
  "modified_by": "Administrator",
  "module": "Core",
  "name": "Report",

--- a/frappe/core/doctype/report/report.py
+++ b/frappe/core/doctype/report/report.py
@@ -45,6 +45,7 @@ class Report(Document):
 		report_script: DF.Code | None
 		report_type: DF.Literal["Report Builder", "Query Report", "Script Report", "Custom Report"]
 		roles: DF.Table[HasRole]
+		timeout: DF.Int
 	# end: auto-generated types
 
 	def validate(self):


### PR DESCRIPTION
Currently prepared report time is hardcoded in the system. There are cases when there is large amount of data and processing involved the report might timeout in 25 mins.

The feature allows users to define a custom timeout for a specific prepared report

`no-docs`