### PR TITLE
fix: on load of beta print format set iframe height

### DIFF
--- a/frappe/printing/page/print/print.js
+++ b/frappe/printing/page/print/print.js
@@ -427,6 +427,9 @@ frappe.ui.form.PrintView = class {
 			params.append("letterhead", letterhead);
 		}
 		iframe.prop("src", `/printpreview?${params.toString()}`);
+		setTimeout(() => {
+			iframe.css("height", "calc(100vh - var(--page-head-height) - var(--navbar-height))");
+		}, 500);
 	}
 
 	setup_print_format_dom(out, $print_format) {


### PR DESCRIPTION
there was a edge case where when print format beta was set to default which never ran code which sets the size for container that holds format. fixed that by make iframe height to 100vh minus navbar and heading on load of beta print format