### PR TITLE
fix: increase Google Calendar Event ID character limit

### DIFF
--- a/frappe/desk/doctype/event/event.json
+++ b/frappe/desk/doctype/event/event.json
@@ -248,7 +248,8 @@
    "fieldtype": "Data",
    "label": "Google Calendar Event ID",
    "no_copy": 1,
-   "read_only": 1
+   "read_only": 1,
+   "length": 320
   },
   {
    "default": "0",


### PR DESCRIPTION
Increased the length of the field to 320. 

Closes #27603 