### PR TITLE
fix: `get_valid_fields` excludes `show_on_timeline`, breaking migrations

### DIFF
--- a/frappe/model/meta.py
+++ b/frappe/model/meta.py
@@ -232,7 +232,7 @@ class Meta(Document):
 
 	def get_valid_fields(self) -> list[str]:
 		if not hasattr(self, "_valid_fields"):
-			if frappe.flags.in_install and self.name in self.special_doctypes:
+			if (frappe.flags.in_install or frappe.flags.in_migrate) and self.name in self.special_doctypes:
 				self._valid_fields = get_table_columns(self.name)
 			else:
 				self._valid_fields = self.default_fields + [


### PR DESCRIPTION
Introduced via https://github.com/frappe/frappe/pull/27553

## Issue
On migrating a site which does not yet have `show_on_timeline`:

```py
  File "/Users/marica/Bench/develop/env/lib/python3.11/site-packages/pymysql/connections.py", line 563, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
      self = <pymysql.connections.Connection object at 0x107d15d50>
      sql = b"INSERT INTO `tabDocField` (`name`, `owner`, `creation`, `modified`, `modified_by`, `docstatus`, `idx`, `fieldtype`, `fieldname`, `reqd`, `length`, `search_index`, `in_list_view`, `in_standard_filter`, `in_global_search`, `in_preview`, `allow_in_quick_entry`, `bold`, `translatable`, `collapsible`, `fetch_if_empty`, `hidden`, `read_only`, `unique`, `set_only_once`, `allow_bulk_edit`, `permlevel`, `ignore_user_permissions`, `allow_on_submit`, `report_hide`, `remember_last_selected_value`, `ignore_xss_filter`, `in_filter`, `no_copy`, `print_hide`, `print_hide_if_no_value`, `columns`, `hide_days`, `hide_seconds`, `hide_border`, `non_negative`, `show_dashboard`, `is_virtual`, `sort_options`, `not_nullable`, `show_on_timeline`, `parent`, `parentfield`, `parenttype`)\n\t\t\t\t\tVALUES ('krq7j9u9ht', 'Administrator', '2013-02-22 01:27:33', '2024-09-02 11:21:17.539612', 'Administrator', '0', 1, 'Section Break', 'label_and_type', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...
      unbuffered = False
  
  ...
  
  File "/Users/marica/Bench/develop/env/lib/python3.11/site-packages/pymysql/err.py", line 150, in raise_mysql_exception
    raise errorclass(errno, errval)
      data = b"\xff\x1e\x04#42S22Unknown column 'show_on_timeline' in 'field list'"
      errno = 1054
      errval = "Unknown column 'show_on_timeline' in 'field list'"
      errorclass = <class 'pymysql.err.OperationalError'>
pymysql.err.OperationalError: (1054, "Unknown column 'show_on_timeline' in 'field list'")
```

## Fix

> [!CAUTION]
>**This might be a shot in the dark, maintainer please try migrating a site that is in a state prior to the problematic PR**. I could personally replicate this multiple times

- `show_on_timeline` is excluded from the fields while syncing "DocField" on migrate
- Fetching columns from the table on migrate as well as install works. Also "DocField" is one of the `special_doctypes`