### PR TITLE
feat(minor): Allow HTML descriptions on Grids

### DIFF
--- a/frappe/public/js/frappe/form/grid.js
+++ b/frappe/public/js/frappe/form/grid.js
@@ -139,7 +139,7 @@ export default class Grid {
 	set_grid_description() {
 		let description_wrapper = $(this.parent).find(".grid-description");
 		if (this.df.description) {
-			description_wrapper.text(__(this.df.description));
+			description_wrapper.html(__(this.df.description));
 		} else {
 			description_wrapper.hide();
 		}


### PR DESCRIPTION
`no-docs`

HTML is allowed on field descriptions:
<img width="511" alt="Screenshot 2024-09-02 at 5 42 39 PM" src="https://github.com/user-attachments/assets/79999880-600b-4701-baf8-942e72c845ca">

But not on grids:
<img width="700" alt="Screenshot 2024-09-02 at 5 45 56 PM" src="https://github.com/user-attachments/assets/26de2335-29b5-44f3-966b-47a98775d012">

Allow them on grids as well:
<img width="700" alt="Screenshot 2024-09-02 at 5 42 12 PM" src="https://github.com/user-attachments/assets/88f540d7-635b-4737-8f76-9992a6261b89">


