### PR TITLE
feat(db): bootstrap only option if database and iser is manage externally to bench (backport: #23170)

### DIFF
--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -43,6 +43,11 @@ from frappe.utils import CallbackManager
 @click.option("--source-sql", "--source_sql", help="Initiate database with a SQL file")
 @click.option("--install-app", multiple=True, help="Install app after installation")
 @click.option("--set-default", is_flag=True, default=False, help="Set the new site as default site")
+@click.option(
+	"--setup-db/--no-setup-db",
+	default=True,
+	help="Create user and database in mariadb/postgres; only boostrap if false",
+)
 def new_site(
 	site,
 	db_root_username=None,
@@ -59,6 +64,7 @@ def new_site(
 	db_host=None,
 	db_port=None,
 	set_default=False,
+	setup_db=True,
 ):
 	"Create a new site"
 	from frappe.installer import _new_site
@@ -80,6 +86,7 @@ def new_site(
 		db_type=db_type,
 		db_host=db_host,
 		db_port=db_port,
+		setup_db=setup_db,
 	)
 
 	if set_default:

--- a/frappe/commands/site.py
+++ b/frappe/commands/site.py
@@ -46,7 +46,7 @@ from frappe.utils import CallbackManager
 @click.option(
 	"--setup-db/--no-setup-db",
 	default=True,
-	help="Create user and database in mariadb/postgres; only boostrap if false",
+	help="Create user and database in mariadb/postgres; only bootstrap if false",
 )
 def new_site(
 	site,

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -8,18 +8,18 @@ from shutil import which
 from frappe.database.database import savepoint
 
 
-def setup_database(force, source_sql=None, verbose=None, no_mariadb_socket=False):
+def setup_database(force, verbose=None, no_mariadb_socket=False):
 	import frappe
 
 	if frappe.conf.db_type == "postgres":
 		import frappe.database.postgres.setup_db
 
-		return frappe.database.postgres.setup_db.setup_database(force, source_sql, verbose)
+		return frappe.database.postgres.setup_db.setup_database()
 	else:
 		import frappe.database.mariadb.setup_db
 
 		return frappe.database.mariadb.setup_db.setup_database(
-			force, source_sql, verbose, no_mariadb_socket=no_mariadb_socket
+			force, verbose, no_mariadb_socket=no_mariadb_socket
 		)
 
 

--- a/frappe/database/__init__.py
+++ b/frappe/database/__init__.py
@@ -23,6 +23,19 @@ def setup_database(force, source_sql=None, verbose=None, no_mariadb_socket=False
 		)
 
 
+def bootstrap_database(db_name, verbose=None, source_sql=None):
+	import frappe
+
+	if frappe.conf.db_type == "postgres":
+		import frappe.database.postgres.setup_db
+
+		return frappe.database.postgres.setup_db.bootstrap_database(db_name, verbose, source_sql)
+	else:
+		import frappe.database.mariadb.setup_db
+
+		return frappe.database.mariadb.setup_db.bootstrap_database(db_name, verbose, source_sql)
+
+
 def drop_user_and_database(db_name, root_login=None, root_password=None):
 	import frappe
 

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -18,7 +18,7 @@ def get_mariadb_version(version_string: str = ""):
 	return version.rsplit(".", 1)
 
 
-def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
+def setup_database(force, verbose, no_mariadb_socket=False):
 	frappe.local.session = frappe._dict({"user": "Administrator"})
 
 	db_name = frappe.local.conf.db_name

--- a/frappe/database/mariadb/setup_db.py
+++ b/frappe/database/mariadb/setup_db.py
@@ -50,8 +50,6 @@ def setup_database(force, source_sql, verbose, no_mariadb_socket=False):
 	# close root connection
 	root_conn.close()
 
-	bootstrap_database(db_name, verbose, source_sql)
-
 
 def drop_user_and_database(db_name, root_login, root_password):
 	frappe.local.db = get_root_connection(root_login, root_password)
@@ -68,8 +66,8 @@ def bootstrap_database(db_name, verbose, source_sql=None):
 	check_compatible_versions()
 
 	import_db_from_sql(source_sql, verbose)
-
 	frappe.connect(db_name=db_name)
+
 	if "tabDefaultValue" not in frappe.db.get_tables(cached=False):
 		from click import secho
 

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -4,7 +4,7 @@ import frappe
 from frappe.database.db_manager import DbManager
 
 
-def setup_database(force, source_sql=None, verbose=False):
+def setup_database():
 	root_conn = get_root_connection(frappe.flags.root_login, frappe.flags.root_password)
 	root_conn.commit()
 	root_conn.sql("end")

--- a/frappe/database/postgres/setup_db.py
+++ b/frappe/database/postgres/setup_db.py
@@ -15,9 +15,6 @@ def setup_database(force, source_sql=None, verbose=False):
 	root_conn.sql(f"GRANT ALL PRIVILEGES ON DATABASE `{frappe.conf.db_name}` TO {frappe.conf.db_name}")
 	root_conn.close()
 
-	bootstrap_database(frappe.conf.db_name, verbose, source_sql=source_sql)
-	frappe.connect()
-
 
 def bootstrap_database(db_name, verbose, source_sql=None):
 	frappe.connect(db_name=db_name)

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -50,6 +50,7 @@ def _new_site(
 	db_type=None,
 	db_host=None,
 	db_port=None,
+	setup_db=True,
 ):
 	"""Install a new Frappe site"""
 
@@ -98,6 +99,7 @@ def _new_site(
 			db_host=db_host,
 			db_port=db_port,
 			no_mariadb_socket=no_mariadb_socket,
+			setup=setup_db,
 		)
 
 		apps_to_install = ["frappe"] + (frappe.conf.get("install_apps") or []) + (list(install_apps) or [])
@@ -133,9 +135,10 @@ def install_db(
 	db_host=None,
 	db_port=None,
 	no_mariadb_socket=False,
+	setup=True,
 ):
 	import frappe.database
-	from frappe.database import setup_database
+	from frappe.database import bootstrap_database, setup_database
 
 	if not db_type:
 		db_type = frappe.conf.db_type
@@ -157,7 +160,15 @@ def install_db(
 
 	frappe.flags.root_login = root_login
 	frappe.flags.root_password = root_password
-	setup_database(force, source_sql, verbose, no_mariadb_socket)
+
+	if setup:
+		setup_database(force, source_sql, verbose, no_mariadb_socket)
+
+	bootstrap_database(
+		db_name=frappe.conf.db_name,
+		verbose=verbose,
+		source_sql=source_sql,
+	)
 
 	frappe.conf.admin_password = frappe.conf.admin_password or admin_password
 

--- a/frappe/installer.py
+++ b/frappe/installer.py
@@ -162,7 +162,7 @@ def install_db(
 	frappe.flags.root_password = root_password
 
 	if setup:
-		setup_database(force, source_sql, verbose, no_mariadb_socket)
+		setup_database(force, verbose, no_mariadb_socket)
 
 	bootstrap_database(
 		db_name=frappe.conf.db_name,


### PR DESCRIPTION
- feat(db): boostrap only option if resource management is exogenous
- fix(db): add missing bootstrap public interface
- fix: typo
- refactor: normalize function signature

towards: https://github.com/frappe/frappe/issues/27214

backport to version-15-hotfix
