### PR TITLE
fix: only change status on communication received if status is Replied & status contain option Open

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -667,8 +667,8 @@ def update_parent_document_on_communication(doc):
 	if status_field:
 		options = (status_field.options or "").splitlines()
 
-		# if status has a "Replied" option, then update the status for received communication
-		if ("Replied" in options) and doc.sent_or_received == "Received":
+		# if status has a "Open" option and status is "Replied", then update the status for received communication
+		if ("Open" in options) and parent.status == "Replied" and doc.sent_or_received == "Received":
 			parent.db_set("status", "Open")
 			parent.run_method("handle_hold_time", "Replied")
 			apply_assignment_rule(parent)


### PR DESCRIPTION
Issue: When Lead status is `Converted` and it receives an email then the status changes to `Open`