### PR TITLE
fix(email): Try to parse bad email address headers

### DIFF
--- a/frappe/email/receive.py
+++ b/frappe/email/receive.py
@@ -10,6 +10,7 @@ import poplib
 import re
 import ssl
 from contextlib import suppress
+from email.errors import HeaderParseError
 from email.header import decode_header
 
 import _socket
@@ -440,11 +441,19 @@ class Email:
 		self.from_real_name = parse_addr(_from_email)[0] if "@" in _from_email else _from_email
 
 	@staticmethod
-	def decode_email(email):
+	def decode_email(email: bytes | str | None) -> str | None:
 		if not email:
 			return
+		email = frappe.as_unicode(email).replace('"', " ").replace("'", " ")
+		try:
+			parts = decode_header(email)
+		except HeaderParseError:
+			# Fallback: grab just the email addresses
+			emails = re.findall(r"(<.*?>)", email)
+			return ", ".join(emails)
+
 		decoded = ""
-		for part, encoding in decode_header(frappe.as_unicode(email).replace('"', " ").replace("'", " ")):
+		for part, encoding in parts:
 			if encoding:
 				decoded += part.decode(encoding, "replace")
 			else:

--- a/frappe/email/test_email_body.py
+++ b/frappe/email/test_email_body.py
@@ -201,6 +201,10 @@ Reply-To: test2_@erpnext.com
 		)
 		self.assertIn("user@example.com", mail)
 
+	def test_poorly_encoded_messages2(self):
+		mail = Email.decode_email(" =?UTF-8?B?X\xe0\xe0Y?=  <xy@example.com>")
+		self.assertIn("xy@example.com", mail)
+
 
 def fixed_column_width(string, chunk_size):
 	parts = [string[0 + i : chunk_size + i] for i in range(0, len(string), chunk_size)]


### PR DESCRIPTION
Got a weird email from a french anti-spam provider (_SpamEnMoins_) containing invalid characters inside the Reply-To header.

I guess the `��` in the stacktrace come from invalid chars, which I replicated in the test case using the invalid UTF-8 sequence _`E0 E0`_.

### Stacktrace

The stack trace also mentions invalid base64 padding.

```python
  File "apps/frappe/frappe/email/receive.py", line 431, in set_from
    _reply_to = self.decode_email(self.mail.get("Reply-To"))
      self = <frappe.email.receive.InboundMail object at 0x7ffaf34f7640>
      _from_email = 'Lorëm Ipsum <test@example.com>'

  File "apps/frappe/frappe/email/receive.py", line 448, in decode_email
    for part, encoding in decode_header(frappe.as_unicode(email).replace('"', " ").replace("'", " ")):
      email = <email.header.Header object at 0x7ffaf34f6f50>
      decoded = ''

  File "/usr/lib/python3.10/email/header.py", line 128, in decode_header
    raise HeaderParseError('Base64 decoding error')
      header = ' =?UTF-8?B?Lor��m Ipsum?=  <test@example.com>'
      words = [('Lor��m Ipsum', 'b', 'utf-8'), ('  <test@example.com>', None, None)]
      line = ' =?UTF-8?B?Lor��m Ipsum?=  <test@example.com>'
      parts = []
      first = False
      unencoded = '  <test@example.com>'
      charset = 'utf-8'
      encoding = 'b'
      encoded = 'Lor��m Ipsum'
      droplist = []
      n = 1
      w = ('  <test@example.com>', None, None)
      decoded_words = []
      encoded_string = 'Lor��m Ipsum'
      paderr = 0

email.errors.HeaderParseError: Base64 decoding error
```
