### PR TITLE
fix(EmailQueue): Log more error onto email queue

### DIFF
--- a/frappe/email/doctype/email_queue/email_queue.py
+++ b/frappe/email/doctype/email_queue/email_queue.py
@@ -264,7 +264,7 @@ class SendMailContext:
 
 	def __exit__(self, exc_type, exc_val, exc_tb):
 		if exc_type:
-			update_fields = {"error": "".join(traceback.format_tb(exc_tb))}
+			update_fields = {"error": frappe.get_traceback()}
 			if self.queue_doc.retry < get_email_retry_limit():
 				update_fields.update(
 					{


### PR DESCRIPTION
Require it to log actual exception raised by Email Delivery Service on plan
limit reached
## Before
![image](https://github.com/user-attachments/assets/4d147e28-3cda-46dd-b5d9-7876f5973709)
## After
![image](https://github.com/user-attachments/assets/56a7ced2-d9d4-4571-84ed-de1c4a0f1258)
