### PR TITLE
fix(minor): desk margins and misc

### DIFF
--- a/frappe/public/scss/common/css_variables.scss
+++ b/frappe/public/scss/common/css_variables.scss
@@ -82,6 +82,7 @@ $disabled-input-height: 22px;
 	--subtle-accent: var(--gray-50);
 	--subtle-fg: var(--gray-100);
 	--navbar-bg: var(--neutral);
+	--medium-border-color: var(--gray-500);
 	--fg-hover-color: var(--gray-100);
 	--card-bg: var(--fg-color);
 	--disabled-text-color: var(--gray-600);

--- a/frappe/public/scss/desk/dark.scss
+++ b/frappe/public/scss/desk/dark.scss
@@ -27,6 +27,7 @@ $check-icon-dark: url("data:image/svg+xml, <svg viewBox='0 0 8 7' fill='none' xm
 	--fg-color: var(--gray-900);
 	--subtle-accent: var(--gray-800);
 	--subtle-fg: var(--gray-700);
+	--medium-border-color: var(--gray-600);
 	--fg-hover-color: var(--gray-800);
 	--card-bg: var(--gray-900);
 	--disabled-text-color: var(--gray-400);

--- a/frappe/public/scss/desk/dashboard_view.scss
+++ b/frappe/public/scss/desk/dashboard_view.scss
@@ -2,6 +2,7 @@
 	.dashboard-view {
 		min-height: calc(100vh - 284px);
 		padding: var(--padding-lg) 0;
+		margin: auto var(--margin-md);
 
 		.grid-col-2 {
 			column-gap: 20px;

--- a/frappe/public/scss/desk/desktop.scss
+++ b/frappe/public/scss/desk/desktop.scss
@@ -541,7 +541,7 @@ body {
 			.widget-label .widget-title {
 				color: var(--invert-neutral);
 			}
-			border-color: var(--invert-neutral);
+			border-color: var(--medium-border-color);
 		}
 
 		.widget-label .widget-title {

--- a/frappe/public/scss/desk/form.scss
+++ b/frappe/public/scss/desk/form.scss
@@ -60,7 +60,7 @@
 	}
 
 	.section-body {
-		padding-top: var(--padding-sm);
+		padding-top: var(--padding-md);
 		width: 100%;
 		display: flex;
 		flex-wrap: wrap;
@@ -104,7 +104,7 @@
 .form-section.card-section,
 .form-dashboard-section {
 	border-bottom: 1px solid var(--border-color);
-	padding: var(--padding-md) 0;
+	padding: var(--padding-sm);
 }
 
 .form-section.card-section.hide-border {
@@ -112,6 +112,7 @@
 }
 
 .form-dashboard-section {
+	padding: var(--padding-md) 0;
 	.section-body:first-child {
 		margin-top: 0;
 	}

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -32,7 +32,9 @@
 		flex: 1 0 260px;
 		border-radius: var(--border-radius);
 		padding: var(--padding-md);
-		min-height: calc(100vh - 150px);
+		min-height: calc(
+			100vh - var(--navbar-height) - var(--page-head-height) - var(--margin-sm) * 2
+		);
 
 		.add-card {
 			@include flex(flex, center, center, null);

--- a/frappe/public/scss/desk/kanban.scss
+++ b/frappe/public/scss/desk/kanban.scss
@@ -17,6 +17,7 @@
 	display: flex;
 	gap: 0.5em;
 	overflow-y: hidden;
+	margin: var(--margin-sm);
 
 	-ms-overflow-style: none; /* IE and Edge */
 	scrollbar-width: none; /* Firefox */

--- a/frappe/public/scss/desk/print_preview.scss
+++ b/frappe/public/scss/desk/print_preview.scss
@@ -43,6 +43,7 @@
 }
 
 .layout-side-section.print-preview-sidebar {
+	padding-left: var(--padding-md);
 	padding-right: var(--padding-md);
 
 	.checkbox label {


### PR DESCRIPTION
In few places the desk margins were not set properly. Also, fixed the border color on hover as black color popped up too much on hover.

## Before Dashboard
<img width="1440" alt="dashboard-before" src="https://github.com/user-attachments/assets/67772563-8109-45c3-b932-16eb21809a4b"> 

## After Dashboard
<img width="1440" alt="dashboard-after" src="https://github.com/user-attachments/assets/bb69a649-5e51-499e-8ab1-2dfc407b3f2c">

## Before Kanban
<img width="1440" alt="kanban-before" src="https://github.com/user-attachments/assets/f50e9a13-5bc8-4ed6-8c22-fc6fc859b31b"> 

## After Kanban
<img width="1440" alt="kanban-after" src="https://github.com/user-attachments/assets/d194ce70-35ee-4ff6-96fd-7c198f893dc4">

## Before Form Section
<img width="1440" alt="form-section-before" src="https://github.com/user-attachments/assets/d1dfe3d2-ded8-41ea-8fa8-3803463642d5">

## After Form Section
<img width="1440" alt="form-section-after" src="https://github.com/user-attachments/assets/6577b91c-3daa-41f2-8286-732a33cf6130">

## Before Print View
<img width="1438" alt="print-view-before" src="https://github.com/user-attachments/assets/8e6eaabb-45d4-4e3a-8e39-56132f87b2a0">

## After Print View
<img width="1439" alt="print-view-after" src="https://github.com/user-attachments/assets/201d3426-bd8b-4ff0-85eb-6aa0ca2406e6">

## Before Link Hover
<img width="1440" alt="link-hover-before" src="https://github.com/user-attachments/assets/3f8bb095-8f5e-47fd-9f9f-1c12bf4ab8ad">

## After Link Hover
<img width="1440" alt="link-hover-after" src="https://github.com/user-attachments/assets/a67ac3ad-464f-4351-a590-c05969f24964">