### PR TITLE
refactor: handle Issue and Lead separately on Communication

### DIFF
--- a/frappe/core/doctype/communication/communication.py
+++ b/frappe/core/doctype/communication/communication.py
@@ -668,7 +668,14 @@ def update_parent_document_on_communication(doc):
 		options = (status_field.options or "").splitlines()
 
 		# if status has a "Open" option and status is "Replied", then update the status for received communication
-		if ("Open" in options) and parent.status == "Replied" and doc.sent_or_received == "Received":
+		if (
+			("Open" in options)
+			and parent.status == "Replied"
+			and doc.sent_or_received == "Received"
+			or (
+				parent.doctype == "Issue" and ("Open" in options) and doc.sent_or_received == "Received"
+			)  # For 'Issue', current status is not considered.
+		):
 			parent.db_set("status", "Open")
 			parent.run_method("handle_hold_time", "Replied")
 			apply_assignment_rule(parent)


### PR DESCRIPTION
regression: https://github.com/frappe/frappe/pull/27627

`Lead` and `Issue` doctypes have different ways of handling communication. This is a temporary workaround.

Proper fix:
All status and SLA related updates on Customer reply has to be moved to Issue doctype itself, preferably on `on_communication_update` controller method. This will be done in a separate PR.