### PR TITLE
fix: don't let `getattr()` raise an `AttributeError`, provide a default

### DIFF
--- a/frappe/desk/form/load.py
+++ b/frappe/desk/form/load.py
@@ -421,7 +421,7 @@ def get_title_values_for_link_and_dynamic_link_fields(doc, link_fields=None):
 		link_fields = meta.get_link_fields() + meta.get_dynamic_link_fields()
 
 	for field in link_fields:
-		link_docname = getattr(doc, field.fieldname)
+		link_docname = getattr(doc, field.fieldname, None)
 
 		if not link_docname:
 			continue


### PR DESCRIPTION
Error: https://katb.in/vujalorefef
Resolves: #27276, #27664
