### PR TITLE
feat(auth): Added keycloak as a social login provider

### DIFF
--- a/frappe/integrations/doctype/social_login_key/social_login_key.json
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.json
@@ -52,7 +52,7 @@
    "fieldname": "social_login_provider",
    "fieldtype": "Select",
    "label": "Social Login Provider",
-   "options": "Custom\nFacebook\nFrappe\nGitHub\nGoogle\nOffice 365\nSalesforce\nfairlogin",
+   "options": "Custom\nFacebook\nFrappe\nGitHub\nGoogle\nOffice 365\nSalesforce\nfairlogin\nKeycloak",
    "set_only_once": 1
   },
   {
@@ -176,7 +176,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-23 16:03:38.963265",
+ "modified": "2024-09-06 15:22:46.342392",
  "modified_by": "Administrator",
  "module": "Integrations",
  "name": "Social Login Key",

--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -56,7 +56,15 @@ class SocialLoginKey(Document):
 		redirect_url: DF.Data | None
 		sign_ups: DF.Literal["", "Allow", "Deny"]
 		social_login_provider: DF.Literal[
-			"Custom", "Facebook", "Frappe", "GitHub", "Google", "Office 365", "Salesforce", "fairlogin"
+			"Custom",
+			"Facebook",
+			"Frappe",
+			"GitHub",
+			"Google",
+			"Office 365",
+			"Salesforce",
+			"fairlogin",
+			"Keycloak",
 		]
 		user_id_property: DF.Data | None
 	# end: auto-generated types
@@ -80,6 +88,8 @@ class SocialLoginKey(Document):
 			frappe.throw(
 				_("Please enter Client Secret before social login is enabled"), exc=ClientSecretNotSetError
 			)
+		if self.social_login_provider == "Keycloak":
+			self.api_endpoint = self.base_url + "/protocol/openid-connect/userinfo"
 
 	def set_icon(self):
 		icon_map = {
@@ -203,6 +213,20 @@ class SocialLoginKey(Document):
 			"api_endpoint_args": None,
 			"authorize_url": "https://id.fairkom.net/auth/realms/fairlogin/protocol/openid-connect/auth",
 			"access_token_url": "https://id.fairkom.net/auth/realms/fairlogin/protocol/openid-connect/token",
+			"auth_url_data": json.dumps({"response_type": "code", "scope": "openid"}),
+		}
+
+		providers["Keycloak"] = {
+			"provider_name": "Keycloak",
+			"enable_social_login": 1,
+			"base_url": "realms/master",
+			"custom_base_url": 1,
+			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_keycloak/keycloak",
+			"api_endpoint": "realms/masterl/protocol/openid-connect/userinfo",
+			"api_endpoint_args": None,
+			"authorize_url": "/protocol/openid-connect/auth",
+			"access_token_url": "/protocol/openid-connect/token",
+			"user_id_property": "preferred_username",
 			"auth_url_data": json.dumps({"response_type": "code", "scope": "openid"}),
 		}
 

--- a/frappe/integrations/doctype/social_login_key/social_login_key.py
+++ b/frappe/integrations/doctype/social_login_key/social_login_key.py
@@ -88,8 +88,6 @@ class SocialLoginKey(Document):
 			frappe.throw(
 				_("Please enter Client Secret before social login is enabled"), exc=ClientSecretNotSetError
 			)
-		if self.social_login_provider == "Keycloak":
-			self.api_endpoint = self.base_url + "/protocol/openid-connect/userinfo"
 
 	def set_icon(self):
 		icon_map = {
@@ -219,10 +217,9 @@ class SocialLoginKey(Document):
 		providers["Keycloak"] = {
 			"provider_name": "Keycloak",
 			"enable_social_login": 1,
-			"base_url": "realms/master",
 			"custom_base_url": 1,
 			"redirect_url": "/api/method/frappe.integrations.oauth2_logins.login_via_keycloak/keycloak",
-			"api_endpoint": "realms/masterl/protocol/openid-connect/userinfo",
+			"api_endpoint": "/protocol/openid-connect/userinfo",
 			"api_endpoint_args": None,
 			"authorize_url": "/protocol/openid-connect/auth",
 			"access_token_url": "/protocol/openid-connect/token",

--- a/frappe/integrations/oauth2_logins.py
+++ b/frappe/integrations/oauth2_logins.py
@@ -44,6 +44,11 @@ def login_via_fairlogin(code: str, state: str):
 
 
 @frappe.whitelist(allow_guest=True)
+def login_via_keycloak(code: str, state: str):
+	login_via_oauth2("keycloak", code, state, decoder=decoder_compat)
+
+
+@frappe.whitelist(allow_guest=True)
 def custom(code: str, state: str):
 	"""
 	Callback for processing code and state for user added providers

--- a/frappe/utils/oauth.py
+++ b/frappe/utils/oauth.py
@@ -28,6 +28,11 @@ def get_oauth2_providers() -> dict[str, dict]:
 		if provider.custom_base_url:
 			authorize_url = provider.base_url + provider.authorize_url
 			access_token_url = provider.base_url + provider.access_token_url
+
+		# Keycloak needs this, the base URL also has a route, that urljoin() ignores
+		if provider.name == "keycloak":
+			provider.api_endpoint = provider.base_url + provider.api_endpoint
+
 		out[provider.name] = {
 			"flow_params": {
 				"name": provider.name,


### PR DESCRIPTION
This pull request is a feature request to add keycloak as a social login provider as it is used by many companies and this is really really helpful for us, @akhilnarang can you please review this and accept this if there are no changes , this will pass all the pre-commit tests and I am sure that everything is well set. Please review this and accept as soon as possible. Previous pr accidentally closed due to force push which I had done to make sure that the commit should pass all the tests. And I am really sorry for that. Can you please review and accept this pull request.

It is also requested by people previously in the issues #24563 and in my previous PR