### PR TITLE
feat: subject processing to global server script config

### DIFF
--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -16,7 +16,8 @@ frappe.ui.form.on("Server Script", {
 			});
 		}
 
-		frm.call("get_autocompletion_items")
+		frappe
+			.call("frappe.core.doctype.server_script.server_script.get_autocompletion_items")
 			.then((r) => r.message)
 			.then((items) => {
 				frm.set_df_property("script", "autocompletions", items);

--- a/frappe/core/doctype/server_script/server_script.py
+++ b/frappe/core/doctype/server_script/server_script.py
@@ -215,49 +215,50 @@ class ServerScript(Document):
 		if locals["conditions"]:
 			return locals["conditions"]
 
-	@frappe.whitelist()
-	def get_autocompletion_items(self):
-		"""Generate a list of autocompletion strings from the context dict
-		that is used while executing a Server Script.
 
-		e.g., ["frappe.utils.cint", "frappe.get_all", ...]
-		"""
+@frappe.whitelist()
+def get_autocompletion_items():
+	"""Generate a list of autocompletion strings from the context dict
+	that is used while executing a Server Script.
 
-		def get_keys(obj):
-			out = []
-			for key in obj:
-				if key.startswith("_"):
+	e.g., ["frappe.utils.cint", "frappe.get_all", ...]
+	"""
+
+	def get_keys(obj):
+		out = []
+		for key in obj:
+			if key.startswith("_"):
+				continue
+			value = obj[key]
+			if isinstance(value, NamespaceDict | dict) and value:
+				if key == "form_dict":
+					out.append(["form_dict", 7])
 					continue
-				value = obj[key]
-				if isinstance(value, NamespaceDict | dict) and value:
-					if key == "form_dict":
-						out.append(["form_dict", 7])
-						continue
-					for subkey, score in get_keys(value):
-						fullkey = f"{key}.{subkey}"
-						out.append([fullkey, score])
+				for subkey, score in get_keys(value):
+					fullkey = f"{key}.{subkey}"
+					out.append([fullkey, score])
+			else:
+				if isinstance(value, type) and issubclass(value, Exception):
+					score = 0
+				elif isinstance(value, ModuleType):
+					score = 10
+				elif isinstance(value, FunctionType | MethodType):
+					score = 9
+				elif isinstance(value, type):
+					score = 8
+				elif isinstance(value, dict):
+					score = 7
 				else:
-					if isinstance(value, type) and issubclass(value, Exception):
-						score = 0
-					elif isinstance(value, ModuleType):
-						score = 10
-					elif isinstance(value, FunctionType | MethodType):
-						score = 9
-					elif isinstance(value, type):
-						score = 8
-					elif isinstance(value, dict):
-						score = 7
-					else:
-						score = 6
-					out.append([key, score])
-			return out
+					score = 6
+				out.append([key, score])
+		return out
 
-		items = frappe.cache.get_value("server_script_autocompletion_items")
-		if not items:
-			items = get_keys(get_safe_globals())
-			items = [{"value": d[0], "score": d[1]} for d in items]
-			frappe.cache.set_value("server_script_autocompletion_items", items)
-		return items
+	items = frappe.cache.get_value("server_script_autocompletion_items")
+	if not items:
+		items = get_keys(get_safe_globals())
+		items = [{"value": d[0], "score": d[1]} for d in items]
+		frappe.cache.set_value("server_script_autocompletion_items", items)
+	return items
 
 
 def execute_api_server_script(script: ServerScript, *args, **kwargs):


### PR DESCRIPTION
**Prior**

- Downstream users of server script machinery could not conveniently provide auto-complete

**Now**

- The code path is reusable for downstream users
