### PR TITLE
feat: add jinja syntax highlighting in notification message

### DIFF
--- a/frappe/core/doctype/server_script/server_script.js
+++ b/frappe/core/doctype/server_script/server_script.js
@@ -16,7 +16,7 @@ frappe.ui.form.on("Server Script", {
 			});
 		}
 
-		frm.call("get_autocompletion_items")
+		frm.call("get_autocompletion_items", { document_type: frm.doc.reference_doctype })
 			.then((r) => r.message)
 			.then((items) => {
 				frm.set_df_property("script", "autocompletions", items);

--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -208,18 +208,47 @@ frappe.ui.form.on("Notification", {
 			.then(function (r) {
 				if (r.message) {
 					frm.set_df_property(
-						"message",
+						"message", // unfortunately, this scoping is a no-op on the global Editor instance
 						"autocompletions",
 						({ editor, session, pos, prefix }) => {
+							// we therefore query the curent session
+							if (session.$modeId !== "ace/mode/jinja") {
+								return [];
+							}
 							var token = session.getTokenAt(pos.row, pos.column);
 							if (token.type === "variable.meta.scope.jinja") {
-								return [...r.message["variables"], ...r.message["functions"]];
+								return [
+									...r.message["variables"],
+									...r.message["jinja-functions"],
+									...r.message["context-functions"],
+								];
 							}
 							if (token.type === "support.function.other.jinja.filter") {
 								return r.message["filters"];
 							}
 							if (token.type === "meta.scope.jinja.tag") {
-								return r.message["functions"];
+								return [
+									...r.message["jinja-functions"],
+									...r.message["context-functions"],
+								];
+							}
+							return [];
+						}
+					);
+					frm.set_df_property(
+						"condition", // unfortunately, this scoping is a no-op on the global Editor instance
+						"autocompletions",
+						({ editor, session, pos, prefix }) => {
+							// we therefore query the curent session
+							if (session.$modeId !== "ace/mode/python") {
+								return [];
+							}
+							var token = session.getTokenAt(pos.row, pos.column);
+							if (token.type === "identifier") {
+								return [
+									...r.message["variables"],
+									...r.message["context-functions"],
+								];
 							}
 							return [];
 						}

--- a/frappe/email/doctype/notification/notification.js
+++ b/frappe/email/doctype/notification/notification.js
@@ -198,6 +198,34 @@ frappe.ui.form.on("Notification", {
 				return dialog;
 			});
 		}
+		frappe
+			.call({
+				method: "frappe.email.doctype.notification.notification.get_autocompletion_items",
+				args: {
+					document_type: frm.doc.document_type,
+				},
+			})
+			.then(function (r) {
+				if (r.message) {
+					frm.set_df_property(
+						"message",
+						"autocompletions",
+						({ editor, session, pos, prefix }) => {
+							var token = session.getTokenAt(pos.row, pos.column);
+							if (token.type === "variable.meta.scope.jinja") {
+								return [...r.message["variables"], ...r.message["functions"]];
+							}
+							if (token.type === "support.function.other.jinja.filter") {
+								return r.message["filters"];
+							}
+							if (token.type === "meta.scope.jinja.tag") {
+								return r.message["functions"];
+							}
+							return [];
+						}
+					);
+				}
+			});
 	},
 	document_type: function (frm) {
 		frappe.notification.setup_fieldname_select(frm);

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -180,7 +180,8 @@
    "fieldtype": "Code",
    "ignore_xss_filter": 1,
    "in_list_view": 1,
-   "label": "Condition"
+   "label": "Condition",
+   "options": "Python"
   },
   {
    "fieldname": "column_break_6",
@@ -291,7 +292,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-07-04 05:53:40.595130",
+ "modified": "2024-09-08 06:13:11.572926",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.json
+++ b/frappe/email/doctype/notification/notification.json
@@ -190,7 +190,7 @@
   {
    "fieldname": "html_7",
    "fieldtype": "HTML",
-   "options": "<p><strong>Condition Examples:</strong></p>\n<pre>doc.status==\"Open\"<br>doc.due_date==nowdate()<br>doc.total &gt; 40000\n</pre>\n"
+   "options": "<p><strong>Condition Examples:</strong></p>\n<pre>(\n<br>  doc.status==\"Open\"<br>  and doc.due_date==nowdate()<br>  and doc.total &gt; 40000\n<br>)</pre>\n"
   },
   {
    "collapsible": 1,
@@ -292,7 +292,7 @@
  "icon": "fa fa-envelope",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-08 06:13:11.572926",
+ "modified": "2024-09-09 11:16:45.838935",
  "modified_by": "Administrator",
  "module": "Email",
  "name": "Notification",

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -739,15 +739,14 @@ def get_autocompletion_items(document_type):
 
 	# Create items list
 	items = {
-		"filters": ([] + [{"value": d[0], "score": d[1], "meta": "filter"} for d in jinja_filter_keys]),
-		"variables": ([] + [{"value": d[0], "score": d[1], "meta": "doc"} for d in context_keys_for_doc]),
-		"functions": (
-			[]
-			+ [
-				{"caption": d[0], "snippet": d[0] + "($0)", "score": d[1], "meta": "functions"}
-				for d in jinja_global_keys
-			]
-			+ [
+		"filters": [{"value": d[0], "score": d[1], "meta": "filter"} for d in jinja_filter_keys],
+		"variables": [{"value": d[0], "score": d[1], "meta": "doc"} for d in context_keys_for_doc],
+		"jinja-functions": [
+			{"caption": d[0], "snippet": d[0] + "($0)", "score": d[1], "meta": "functions"}
+			for d in jinja_global_keys
+		],
+		"context-functions": (
+			[
 				{"caption": d[0], "snippet": d[0] + "($0)", "score": d[1], "meta": "frappe"}
 				for d in context_keys_for_frappe
 			]

--- a/frappe/email/doctype/notification/notification.py
+++ b/frappe/email/doctype/notification/notification.py
@@ -653,8 +653,10 @@ def evaluate_alert(doc: Document, alert, event=None):
 		frappe.throw(msg, title=_("Error in Notification"))
 
 
+Frappe = namedtuple("frappe", ["utils"])
+
+
 def get_context(doc):
-	Frappe = namedtuple("frappe", ["utils"])
 	return {
 		"doc": doc,
 		"nowdate": nowdate,
@@ -697,3 +699,62 @@ def _parse_receiver_by_document_field(s):
 	else:
 		data_field, child_field = fragments[0], None
 	return data_field, child_field
+
+
+@frappe.whitelist()
+def get_autocompletion_items(document_type):
+	"""Generates a list of autocompletion items for Jinja filters and Frappe functions.
+
+	Args:
+	        document_type (str): The document type for which to generate autocompletion items.
+
+	Returns:
+	        list: Returns list of autocompletion items.
+	"""
+	from frappe.core.doctype.server_script.server_script import get_keys_for_autocomplete
+	from frappe.utils.jinja import get_jenv
+
+	# Get Jinja environment
+	jenv = get_jenv()
+
+	# Get Jinja filters
+	jinja_filter_keys = get_keys_for_autocomplete(jenv.filters)
+
+	# Get Jinja globals
+	jinja_globals = jenv.globals
+	jinja_globals.pop("frappe")  # overriden by notification context
+	jinja_global_keys = get_keys_for_autocomplete(jinja_globals, score_offset=10)
+
+	# Create a fake document for the completion context
+	fake_doc = frappe.new_doc(document_type)
+	context = get_context(fake_doc)
+
+	_doc_fields = context.pop("doc").meta.get_valid_columns()
+	context_keys_for_doc = get_keys_for_autocomplete(
+		dict(doc={df: None for df in _doc_fields}), score_offset=20
+	)
+	_frappe = context.pop("frappe", Frappe("frappe"))._asdict()
+	context_keys_for_frappe = get_keys_for_autocomplete(dict(frappe=_frappe), score_offset=20)
+	context_keys_residual = get_keys_for_autocomplete(context, score_offset=10)
+
+	# Create items list
+	items = {
+		"filters": ([] + [{"value": d[0], "score": d[1], "meta": "filter"} for d in jinja_filter_keys]),
+		"variables": ([] + [{"value": d[0], "score": d[1], "meta": "doc"} for d in context_keys_for_doc]),
+		"functions": (
+			[]
+			+ [
+				{"caption": d[0], "snippet": d[0] + "($0)", "score": d[1], "meta": "functions"}
+				for d in jinja_global_keys
+			]
+			+ [
+				{"caption": d[0], "snippet": d[0] + "($0)", "score": d[1], "meta": "frappe"}
+				for d in context_keys_for_frappe
+			]
+			+ [
+				{"caption": d[0], "snippet": d[0] + "($0)", "score": d[1], "meta": "frappe"}
+				for d in context_keys_residual
+			]
+		),
+	}
+	return items

--- a/frappe/public/js/frappe/form/controls/code.js
+++ b/frappe/public/js/frappe/form/controls/code.js
@@ -144,12 +144,21 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 						if (typeof a === "string") {
 							a = { value: a };
 						}
+						if (a.value) {
+							return {
+								name: "frappe",
+								value: a.value,
+								score: a.score,
+								meta: a.meta,
+								caption: a.caption,
+							};
+						}
 						return {
 							name: "frappe",
-							value: a.value,
 							score: a.score,
 							meta: a.meta,
 							caption: a.caption,
+							snippet: a.snippet,
 						};
 					})
 				);
@@ -198,7 +207,7 @@ frappe.ui.form.ControlCode = class ControlCode extends frappe.ui.form.ControlTex
 			JSON: "ace/mode/json",
 			Golang: "ace/mode/golang",
 			Go: "ace/mode/golang",
-			Jinja: "ace/mode/django",
+			Jinja: "ace/mode/jinja",
 			SQL: "ace/mode/sql",
 		};
 		const language = this.df.options;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@vue-flow/core": "^1.16.2",
     "@vue/component-compiler": "^4.2.4",
     "@vueuse/core": "^9.5.0",
-    "ace-builds": "^1.4.8",
+    "ace-builds": "^1.36.2",
     "air-datepicker": "git+https://github.com/frappe/air-datepicker",
     "autoprefixer": "10",
     "awesomplete": "^1.1.5",
@@ -92,5 +92,8 @@
   "optionalDependencies": {
     "bufferutil": "^4.0.8",
     "utf-8-validate": "^6.0.3"
+  },
+  "resolutions": {
+    "ace-builds": "github:ajaxorg/ace-builds#refs/pull/265/head"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,9 @@ accepts@~1.3.4:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-ace-builds@^1.4.8:
-  version "1.31.2"
-  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.31.2.tgz#bd5d0ee4243b9ae4358563889cb5663f4893b3e7"
-  integrity sha512-IeZI9ytPA6mB+goPxPkUPW4vXBoLuaBl5czu2tjtKrMi7mdRgyIUA/8e5JlrI1mqKoMeWHoUujzMTWkyutTdBw==
+ace-builds@^1.36.2, "ace-builds@github:ajaxorg/ace-builds#refs/pull/265/head":
+  version "1.36.2"
+  resolved "https://codeload.github.com/ajaxorg/ace-builds/tar.gz/cceb11e378c0c25bb81dfe2c48e2fd37f4cabc03"
 
 acorn@^7.1.1:
   version "7.4.1"


### PR DESCRIPTION
### Jina Syntax Highlighting & Autocompletion

- sensitive to expressions and statements
- picks up custom filters
- shows `doc.*` variables (valid fields)
- also works on the `condition` field

### Testing

It's a bit unclear to me how the resolver state can fail or stale in multiple ways, but this seemed to have worked for me:
```bash
> frappe
$ rm -rf node_modules/ace-builds
# manually remove the ace-builds block from yarn.lock (!)
$ yarn install
$ bench build --apps frappe
```

### Upstream
- https://github.com/ajaxorg/ace/pull/5639
- https://github.com/ajaxorg/ace-builds/pull/265 (patched build)

### Todos

- [ ] figure out how to embed html completion
- [ ] (not a blocker for merge): run in real world scenarios for a while and gather user feedback

## Screenshots

**Autocompletion & Syntax Highlighting**
![image](https://github.com/user-attachments/assets/cdd6c065-fa35-4be3-8155-0390d379979d)

**Syntax Highlighting**
![image](https://github.com/user-attachments/assets/bb1c5896-b486-4532-90d5-4d7669d91bef)

**Visual clues on statements**
![image](https://github.com/user-attachments/assets/80c302c4-60ad-4906-8090-a403596100ac)


---
`no-docs`
