### PR TITLE
fix: prevent sending emails to System Manager when email notifications are disabled

### DIFF
--- a/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
+++ b/frappe/website/doctype/personal_data_deletion_request/personal_data_deletion_request.py
@@ -7,6 +7,7 @@ import re
 import frappe
 from frappe import _
 from frappe.core.utils import find
+from frappe.desk.doctype.notification_settings.notification_settings import is_email_notifications_enabled
 from frappe.model.document import Document
 from frappe.utils import get_datetime, get_fullname, time_diff_in_hours
 from frappe.utils.user import get_system_managers
@@ -101,10 +102,13 @@ class PersonalDataDeletionRequest(Document):
 		)
 
 	def notify_system_managers(self):
-		system_managers = get_system_managers(only_name=True)
+		recipients = []
+		for manager in get_system_managers(only_name=True):
+			if is_email_notifications_enabled(manager):
+				recipients.append(manager)
 
 		frappe.sendmail(
-			recipients=system_managers,
+			recipients=recipients,
 			subject=_("User {0} has requested for data deletion").format(self.email),
 			template="data_deletion_approval",
 			args={"user": self.email, "url": frappe.utils.get_url(self.get_url())},


### PR DESCRIPTION
Ensures emails are not sent to System Manager users when notifications are disabled. This change also avoids bounce-back issues caused by invalid inboxes, such as api@frappe.io, which do not receive emails.

![image](https://github.com/user-attachments/assets/4894489d-e4b0-4cee-8879-dcd1908084a0)
