### PR TITLE
fix(setup_wizard): don't crash if a country doesn't have a timezone specified

### DIFF
--- a/frappe/desk/page/setup_wizard/setup_wizard.js
+++ b/frappe/desk/page/setup_wizard/setup_wizard.js
@@ -604,9 +604,11 @@ frappe.setup.utils = {
 			Bind a slide's country, timezone and currency fields
 		*/
 		slide.get_input("country").on("change", function () {
-			let country = slide.get_input("country").val();
-			let $timezone = slide.get_input("timezone");
 			let data = frappe.setup.data.regional_data;
+			let country = slide.get_input("country").val();
+			if (!(country in data.country_info)) return;
+
+			let $timezone = slide.get_input("timezone");
 
 			$timezone.empty();
 


### PR DESCRIPTION
Currently, this event is getting triggered by the country and its translated value
The translated value isn't present in the country info list, and so doesn't have any data

Reference: support ticket 21874
