### PR TITLE
feat: implement Clear Button in Link Field

### DIFF
--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -5,7 +5,6 @@
 // custom queries
 // add_fetches
 import Awesomplete from "awesomplete";
-
 frappe.ui.form.recent_link_validations = {};
 
 frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlData {
@@ -15,6 +14,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		$(`<div class="link-field ui-front" style="position: relative;">
 			<input type="text" class="input-with-feedback form-control">
 			<span class="link-btn">
+				<a class="btn-clear no-decoration">
+					${frappe.utils.icon("close-alt", "xs")}
+				</a>
 				<a class="btn-open no-decoration" title="${__("Open Link")}">
 					${frappe.utils.icon("arrow-right", "xs")}
 				</a>
@@ -23,6 +25,7 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 		this.$input_area = $(this.input_area);
 		this.$input = this.$input_area.find("input");
 		this.$link = this.$input_area.find(".link-btn");
+		this.$link_clear = this.$input_area.find(".btn-clear");
 		this.$link_open = this.$link.find(".btn-open");
 		this.set_input_attributes();
 		this.$input.on("focus", function () {
@@ -32,6 +35,10 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					let name = me.get_input_value();
 					me.$link.toggle(true);
 					me.$link_open.attr("href", frappe.utils.get_form_link(doctype, name));
+					me.$link_clear.on("click", function () {
+						me.$input.val("").trigger("input");
+						me.$link.toggle(false); 
+					})
 				}
 
 				if (!me.$input.val()) {
@@ -327,10 +334,6 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 						me.$input.cache[doctype][term] = r.message;
 						me.awesomplete.list = me.$input.cache[doctype][term];
 						me.toggle_href(doctype);
-
-						r.message.forEach((item) => {
-							frappe.utils.add_link_title(doctype, item.value, item.label);
-						});
 					},
 				});
 			}, 500)

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -334,6 +334,9 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 						me.$input.cache[doctype][term] = r.message;
 						me.awesomplete.list = me.$input.cache[doctype][term];
 						me.toggle_href(doctype);
+						r.message.forEach((item) => {
+							frappe.utils.add_link_title(doctype, item.value, item.label);
+						});
 					},
 				});
 			}, 500)

--- a/frappe/public/js/frappe/form/controls/link.js
+++ b/frappe/public/js/frappe/form/controls/link.js
@@ -37,8 +37,8 @@ frappe.ui.form.ControlLink = class ControlLink extends frappe.ui.form.ControlDat
 					me.$link_open.attr("href", frappe.utils.get_form_link(doctype, name));
 					me.$link_clear.on("click", function () {
 						me.$input.val("").trigger("input");
-						me.$link.toggle(false); 
-					})
+						me.$link.toggle(false);
+					});
 				}
 
 				if (!me.$input.val()) {


### PR DESCRIPTION
### **Description:**

This pull request adds a new icon to the link field in Frappe. The new icon is a clear button, located on the right side of the field, before the link open icon. This button allows users to quickly clear the field without having to manually select all the text. This enhancement aims to improve user experience and reduce frustration when removing existing text from the field.

### **Motivation:**

Before this change, users had to select all text in the link field to delete it, which could be inconvenient and time-consuming. The new clear icon has been added to address this issue and enhance usability.

### **Changes:**

- Adds a clear icon to the right side of the link field, before the link open icon.
- The icon allows users to delete the field's content with a single click.

### **How to Test:**

1. Navigate to a link field in Frappe.
2. Enter some text into the field.
3. Tap the new clear icon on the right side, before the link open icon.
4. Verify that the field is cleared correctly.
