### PR TITLE
chore: exempt draft prs from stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -18,6 +18,9 @@ exemptProjects: false
 # Set to true to ignore issues in a milestone (defaults to false)
 exemptMilestones: true
 
+# Skip the stale action for draft PRs
+exemptDraftPr: true
+
 # Label to use when marking as stale
 staleLabel: inactive
 


### PR DESCRIPTION
Hope this is fine with the general policy!

Closing draft PRs is really nasty and it's not a rare thing that a draft PR may simmer for months, for example to conduct extensive testing, etc.

Closing draft PR deters proper open source workflows.