### PR TITLE
fix: workflow typos

### DIFF
--- a/frappe/translate.py
+++ b/frappe/translate.py
@@ -351,7 +351,7 @@ def get_messages_from_workflow(doctype=None, app_name=None):
 	else:
 		fixtures = frappe.get_hooks("fixtures", app_name=app_name) or []
 		for fixture in fixtures:
-			if isinstance(fixture, str) and fixture == "Worflow":
+			if isinstance(fixture, str) and fixture == "Workflow":
 				workflows = frappe.get_all("Workflow")
 				break
 			elif isinstance(fixture, dict) and fixture.get("dt", fixture.get("doctype")) == "Workflow":

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -127,8 +127,8 @@ frappe.ui.form.on("Workflow", {
 			</p>
 			<p>
 				${__(
-					"There are documents which have workflow states that do not exist in this Workflow. It is recommended that you add these states to the Workflow and change their states before removing these states."
-				)}
+			"There are documents which have workflow states that do not exist in this Workflow. It is recommended that you add these states to the Workflow and change their states before removing these states."
+		)}
 			</p>`;
 		const message_html = warning_html + frm.state_table_html;
 		let proceed_action = () => {
@@ -137,7 +137,7 @@ frappe.ui.form.on("Workflow", {
 		};
 
 		frappe.warn(
-			__("Worflow States Don't Exist"),
+			__("Workflow States Don't Exist"),
 			message_html,
 			proceed_action,
 			__("Save Anyway")

--- a/frappe/workflow/doctype/workflow/workflow.js
+++ b/frappe/workflow/doctype/workflow/workflow.js
@@ -127,8 +127,8 @@ frappe.ui.form.on("Workflow", {
 			</p>
 			<p>
 				${__(
-			"There are documents which have workflow states that do not exist in this Workflow. It is recommended that you add these states to the Workflow and change their states before removing these states."
-		)}
+					"There are documents which have workflow states that do not exist in this Workflow. It is recommended that you add these states to the Workflow and change their states before removing these states."
+				)}
 			</p>`;
 		const message_html = warning_html + frm.state_table_html;
 		let proceed_action = () => {


### PR DESCRIPTION
Fix Workflow Typos:  "Worflow' => "Workflow"
