### PR TITLE
fix(printview): ensure document title is a string

### DIFF
--- a/frappe/www/printview.py
+++ b/frappe/www/printview.py
@@ -8,7 +8,7 @@ import re
 from typing import TYPE_CHECKING, Optional, TypedDict
 
 import frappe
-from frappe import _, get_module_path
+from frappe import _, cstr, get_module_path
 from frappe.core.doctype.access_log.access_log import make_access_log
 from frappe.core.doctype.document_share_key.document_share_key import is_expired
 from frappe.utils import cint, escape_html, strip_html
@@ -68,7 +68,6 @@ def get_context(context) -> PrintContext:
 		doctype=frappe.form_dict.doctype, document=frappe.form_dict.name, file_type="PDF", method="Print"
 	)
 
-	print_style = None
 	body = get_rendered_template(
 		doc,
 		print_format=print_format,
@@ -84,7 +83,7 @@ def get_context(context) -> PrintContext:
 		"body": body,
 		"print_style": print_style,
 		"comment": frappe.session.user,
-		"title": frappe.utils.strip_html(doc.get_title() or doc.name),
+		"title": frappe.utils.strip_html(cstr(doc.get_title() or doc.name)),
 		"lang": frappe.local.lang,
 		"layout_direction": "rtl" if is_rtl() else "ltr",
 		"doctype": frappe.form_dict.doctype,


### PR DESCRIPTION
Nothing is stopping people from setting non-string types as their title

That then fails like:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/website/serve.py", line 18, in get_response
    response = renderer_instance.render()
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 84, in render
    html = self.get_html()
  File "apps/frappe/frappe/website/utils.py", line 517, in cache_html_decorator
    html = func(*args, **kwargs)
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 95, in get_html
    self.update_context()
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 163, in update_context
    data = self.run_pymodule_method("get_context")
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 223, in run_pymodule_method
    return method(self.context)
  File "apps/frappe/frappe/www/printview.py", line 68, in get_context
    "title": frappe.utils.strip_html(doc.get_title() or doc.name),
  File "apps/frappe/frappe/utils/data.py", line 1471, in strip_html
    return _striptags_re.sub("", text)
TypeError: expected string or bytes-like object
```

