### PR TITLE
fix: apply workflow permission

### DIFF
--- a/frappe/model/workflow.py
+++ b/frappe/model/workflow.py
@@ -128,13 +128,13 @@ def apply_workflow(doc, action):
 
 	new_docstatus = cint(next_state.doc_status)
 	if doc.docstatus.is_draft() and new_docstatus == DocStatus.draft():
-		doc.save()
+		doc.save(ignore_permissions=True)
 	elif doc.docstatus.is_draft() and new_docstatus == DocStatus.submitted():
-		doc.submit()
+		doc.submit(ignore_permissions=True)
 	elif doc.docstatus.is_submitted() and new_docstatus == DocStatus.submitted():
-		doc.save()
+		doc.save(ignore_permissions=True)
 	elif doc.docstatus.is_submitted() and new_docstatus == DocStatus.cancelled():
-		doc.cancel()
+		doc.cancel(ignore_permissions=True)
 	else:
 		frappe.throw(_("Illegal Document Status for {0}").format(next_state.state))
 


### PR DESCRIPTION
 In workflows where one role (e.g., a document creator) has full read/write access to submit documents for review, and another role (e.g., a reviewer) has only read access, issues arise when the reviewer attempts to approve the workflow.
 
Since the workflow state is a field on the document model, users without write permissions were previously blocked from approving transitions. By adding `ignore_permissions=True`, this change ensures that reviewers can approve workflows even if they are restricted from editing certain fields.

This maintains the integrity of the approval process while respecting the different permission levels for each role.