### PR TITLE
fix: Time field not updating the manual edit to the time picker (editing the values directly in the input field)

### DIFF
--- a/frappe/public/js/frappe/form/controls/time.js
+++ b/frappe/public/js/frappe/form/controls/time.js
@@ -69,7 +69,9 @@ frappe.ui.form.ControlTime = class ControlTime extends frappe.ui.form.ControlDat
 		}
 
 		if (should_refresh) {
-			this.datepicker.selectDate(frappe.datetime.moment_to_date_obj(moment(value, time_format)));
+			this.datepicker.selectDate(
+				frappe.datetime.moment_to_date_obj(moment(value, time_format))
+			);
 		}
 	}
 	set_datepicker() {

--- a/frappe/public/js/frappe/form/controls/time.js
+++ b/frappe/public/js/frappe/form/controls/time.js
@@ -47,14 +47,29 @@ frappe.ui.form.ControlTime = class ControlTime extends frappe.ui.form.ControlDat
 		if (!this.datepicker) {
 			return;
 		}
-		if (
-			value &&
-			((this.last_value && this.last_value !== this.value) ||
-				!this.datepicker.selectedDates.length)
-		) {
-			let time_format = frappe.sys_defaults.time_format || "HH:mm:ss";
-			var date_obj = frappe.datetime.moment_to_date_obj(moment(value, time_format));
-			this.datepicker.selectDate(date_obj);
+		if (!value) {
+			this.datepicker.clear();
+			return;
+		}
+
+		let should_refresh = this.last_value && this.last_value !== value;
+		let time_format = frappe.sys_defaults.time_format || "HH:mm:ss";
+		if (!should_refresh) {
+			if (this.datepicker.selectedDates.length > 0) {
+				// if time is selected but different from value, refresh
+				const selected_date = moment(this.datepicker.selectedDates[0]).format(
+					this.time_format
+				);
+
+				should_refresh = selected_date !== value;
+			} else {
+				// if datepicker has no selected time, refresh
+				should_refresh = true;
+			}
+		}
+
+		if (should_refresh) {
+			this.datepicker.selectDate(frappe.datetime.moment_to_date_obj(moment(value, time_format)));
 		}
 	}
 	set_datepicker() {


### PR DESCRIPTION
### FIX: Time field not updating the manual edit to the time picker (editing the values directly without the picker)
  For Time field, if the user changes the time through keyboard, it was not updating to the datetime picker, so when the user again clicks on the field, it changes to the old value.

  **BEFORE**:

  https://github.com/user-attachments/assets/69efc637-dd26-4946-a29c-4657c4b051d5
  
  **AFTER**: 
  
  https://github.com/user-attachments/assets/88448358-49a0-4e9b-9556-b56ad449a932
