### PR TITLE
Fix: Enforced user permissions on report filters for linked doctypes

### DIFF
--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -14,7 +14,7 @@ from frappe.desk.reportview import clean_params, parse_json
 from frappe.model.utils import render_include
 from frappe.modules import get_module_path, scrub
 from frappe.monitor import add_data_to_monitor
-from frappe.permissions import get_role_permissions
+from frappe.permissions import get_role_permissions, has_permission
 from frappe.utils import cint, cstr, flt, format_duration, get_html_format, sbool
 
 
@@ -195,6 +195,7 @@ def run(
 	parent_field=None,
 	are_default_filters=True,
 ):
+	validate_filters_permissions(report_name, filters, user)
 	report = get_report_doc(report_name)
 	if not user:
 		user = frappe.session.user
@@ -780,3 +781,20 @@ def get_user_match_filters(doctypes, user):
 			match_filters[dt] = filter_list
 
 	return match_filters
+
+def validate_filters_permissions(report_name, filters=None, user=None):
+    if isinstance(filters, str):
+        filters = json.loads(filters)
+
+    if filters:
+        report = frappe.get_doc("Report", report_name)
+        for fieldname, value in filters.items():
+            for field in report.filters:
+                if field.fieldname == fieldname and field.fieldtype == "Link":
+                    linked_doctype = field.options
+                    if not has_permission(
+                        doctype=linked_doctype, doc=value, user=user
+                    ):
+                        frappe.throw(
+                            _("You do not have permission to access {0}: {1}.").format(linked_doctype, value)
+                        )

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -782,19 +782,18 @@ def get_user_match_filters(doctypes, user):
 
 	return match_filters
 
-def validate_filters_permissions(report_name, filters=None, user=None):
-    if isinstance(filters, str):
-        filters = json.loads(filters)
 
-    if filters:
-        report = frappe.get_doc("Report", report_name)
-        for fieldname, value in filters.items():
-            for field in report.filters:
-                if field.fieldname == fieldname and field.fieldtype == "Link":
-                    linked_doctype = field.options
-                    if not has_permission(
-                        doctype=linked_doctype, doc=value, user=user
-                    ):
-                        frappe.throw(
-                            _("You do not have permission to access {0}: {1}.").format(linked_doctype, value)
-                        )
+def validate_filters_permissions(report_name, filters=None, user=None):
+	if not filters:
+		return
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+		report = frappe.get_doc("Report", report_name)
+		for fieldname, value in filters.items():
+			for field in report.filters:
+				if field.fieldname == fieldname and field.fieldtype == "Link":
+					linked_doctype = field.options
+					if not has_permission(doctype=linked_doctype, doc=value, user=user):
+						frappe.throw(
+							_("You do not have permission to access {0}: {1}.").format(linked_doctype, value)
+						)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -791,11 +791,10 @@ def validate_filters_permissions(report_name, filters=None, user=None):
 		filters = json.loads(filters)
 
 	report = frappe.get_doc("Report", report_name)
-	for fieldname, value in filters.items():
-		for field in report.filters:
-			if field.fieldname == fieldname and field.fieldtype == "Link":
-				linked_doctype = field.options
-				if not has_permission(doctype=linked_doctype, doc=value, user=user):
-					frappe.throw(
-						_("You do not have permission to access {0}: {1}.").format(linked_doctype, value)
-					)
+	for field in report.filters:
+		if field.fieldname in filters and field.fieldtype == "Link":
+			linked_doctype = field.options
+			if not has_permission(doctype=linked_doctype, doc=filters[field], user=user):
+				frappe.throw(
+					_("You do not have permission to access {0}: {1}.").format(linked_doctype, filters[field])
+				)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -786,14 +786,16 @@ def get_user_match_filters(doctypes, user):
 def validate_filters_permissions(report_name, filters=None, user=None):
 	if not filters:
 		return
+
 	if isinstance(filters, str):
 		filters = json.loads(filters)
-		report = frappe.get_doc("Report", report_name)
-		for fieldname, value in filters.items():
-			for field in report.filters:
-				if field.fieldname == fieldname and field.fieldtype == "Link":
-					linked_doctype = field.options
-					if not has_permission(doctype=linked_doctype, doc=value, user=user):
-						frappe.throw(
-							_("You do not have permission to access {0}: {1}.").format(linked_doctype, value)
-						)
+
+	report = frappe.get_doc("Report", report_name)
+	for fieldname, value in filters.items():
+		for field in report.filters:
+			if field.fieldname == fieldname and field.fieldtype == "Link":
+				linked_doctype = field.options
+				if not has_permission(doctype=linked_doctype, doc=value, user=user):
+					frappe.throw(
+						_("You do not have permission to access {0}: {1}.").format(linked_doctype, value)
+					)

--- a/frappe/desk/query_report.py
+++ b/frappe/desk/query_report.py
@@ -794,7 +794,9 @@ def validate_filters_permissions(report_name, filters=None, user=None):
 	for field in report.filters:
 		if field.fieldname in filters and field.fieldtype == "Link":
 			linked_doctype = field.options
-			if not has_permission(doctype=linked_doctype, doc=filters[field], user=user):
+			if not has_permission(doctype=linked_doctype, doc=filters[field.fieldname], user=user):
 				frappe.throw(
-					_("You do not have permission to access {0}: {1}.").format(linked_doctype, filters[field])
+					_("You do not have permission to access {0}: {1}.").format(
+						linked_doctype, filters[field.fieldname]
+					)
 				)


### PR DESCRIPTION
Previously, users could bypass the link field restrictions in report filters by manually typing in values, allowing access to unauthorized data. This fix ensures that user permissions are strictly validated for all linked doctypes in report filters, preventing access to documents outside of their permissions.
